### PR TITLE
interfaces/builtin: add opencl interface

### DIFF
--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -51,4 +51,5 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewUnity7Interface())
 	c.Check(all, DeepContains, builtin.NewX11Interface())
 	c.Check(all, DeepContains, builtin.NewOpenglInterface())
+	c.Check(all, DeepContains, builtin.NewOpenclInterface())
 }

--- a/interfaces/builtin/opencl.go
+++ b/interfaces/builtin/opencl.go
@@ -23,31 +23,31 @@ import (
 	"github.com/ubuntu-core/snappy/interfaces"
 )
 
-var allInterfaces = []interfaces.Interface{
-	&BoolFileInterface{},
-	&BluezInterface{},
-	&LocationObserveInterface{},
-	&NetworkManagerInterface{},
-	NewFirewallControlInterface(),
-	NewHomeInterface(),
-	NewLocaleControlInterface(),
-	NewLogObserveInterface(),
-	NewMountObserveInterface(),
-	NewNetworkInterface(),
-	NewNetworkBindInterface(),
-	NewNetworkControlInterface(),
-	NewNetworkObserveInterface(),
-	NewSnapdControlInterface(),
-	NewSystemObserveInterface(),
-	NewTimeserverControlInterface(),
-	NewTimezoneControlInterface(),
-	NewUnity7Interface(),
-	NewX11Interface(),
-	NewOpenglInterface(),
-	NewOpenclInterface(),
-}
+const openclConnectedPlugAppArmor = `
+# Description: Can access opencl. 
+# Usage: reserved
 
-// Interfaces returns all of the built-in interfaces.
-func Interfaces() []interfaces.Interface {
-	return allInterfaces
+  # OpenCL Installable Client Driver (ICD) Loader
+  /etc/OpenCL/vendors/** r,
+
+  # nvidia
+  /dev/nvidia* rw,
+`
+
+const openclConnectedPlugSecComp = `
+# Description: Can access opencl. 
+# Usage: reserved
+
+getsockopt
+`
+
+// NewOpenclInterface returns a new "opencl" interface.
+func NewOpenclInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "opencl",
+		connectedPlugAppArmor: openclConnectedPlugAppArmor,
+		connectedPlugSecComp:  openclConnectedPlugSecComp,
+		reservedForOS:         true,
+		autoConnect:           true,
+	}
 }

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -451,7 +451,7 @@ func (s *interfaceManagerSuite) TestDoSetupProfilesAddsImplicitSlots(c *C) {
 	// Ensure that we have slots on the OS snap.
 	repo := mgr.Repository()
 	slots := repo.Slots(snapInfo.Name())
-	c.Assert(slots, HasLen, 17)
+	c.Assert(slots, HasLen, 18)
 }
 
 func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyReloadsConnectionsWhenInvokedOnPlugSide(c *C) {

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -41,6 +41,7 @@ var implicitClassicSlots = []string{
 	"unity7",
 	"x11",
 	"opengl",
+	"opencl",
 	"network-manager",
 }
 

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 17)
+	c.Assert(info.Slots, HasLen, 18)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
- allows a snap to access and use the OpenCL libraries.
- I signed the Canonical contributor licence agreement.

It is only for discussion. This two tests are failing (can't see why)
```
=== RUN   TestRunnerPipesOutput
OOPS: 1 passed, 1 FAILED
--- PASS: TestRunnerPipesOutput (0.00s)
=== RUN   TestRunnerAcceptsStreamFlag
OOPS: 1 passed, 1 FAILED
--- PASS: TestRunnerAcceptsStreamFlag (0.00s)
=== RUN   TestRunnerAcceptsFilterFlag
```