### PR TITLE
snap, wrappers: add per-app environment file

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -225,6 +225,8 @@ type AppInfo struct {
 
 	Plugs map[string]*PlugInfo
 	Slots map[string]*SlotInfo
+
+	Environment map[string]string
 }
 
 // SecurityTag returns application-specific security tag.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -124,13 +124,10 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 		Apps:                make(map[string]*AppInfo),
 		Plugs:               make(map[string]*PlugInfo),
 		Slots:               make(map[string]*SlotInfo),
-		Environment:         make(map[string]string),
+		Environment:         y.Environment,
 	}
 	sort.Strings(snap.Assumes)
-	// Environment
-	for k, v := range y.Environment {
-		snap.Environment[k] = v
-	}
+
 	// Collect top-level definitions of plugs
 	for name, data := range y.Plugs {
 		iface, label, attrs, err := convertToSlotOrPlugData("plug", name, data)

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -77,6 +77,8 @@ type appYaml struct {
 
 	BusName string `yaml:"bus-name,omitempty"`
 
+	Environment map[string]string `yaml:"environment,omitempty"`
+
 	Socket       bool   `yaml:"socket,omitempty"`
 	ListenStream string `yaml:"listen-stream,omitempty"`
 	SocketMode   string `yaml:"socket-mode,omitempty"`
@@ -178,6 +180,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 			SocketMode:      yApp.SocketMode,
 			ListenStream:    yApp.ListenStream,
 			BusName:         yApp.BusName,
+			Environment:     yApp.Environment,
 		}
 		if len(y.Plugs) > 0 || len(yApp.PlugNames) > 0 {
 			app.Plugs = make(map[string]*PlugInfo)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -959,3 +959,21 @@ environment:
 		"baz": "boom",
 	})
 }
+
+func (s *YamlSuite) TestSnapYamlPerAppEnvironment(c *C) {
+	y := []byte(`
+name: foo
+version: 1.0
+apps:
+ foo:
+  environment:
+   k1: v1
+   k2: v2
+`)
+	info, err := snap.InfoFromSnapYaml(y)
+	c.Assert(err, IsNil)
+	c.Assert(info.Apps["foo"].Environment, DeepEquals, map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	})
+}

--- a/wrappers/environment.go
+++ b/wrappers/environment.go
@@ -29,21 +29,33 @@ import (
 	"github.com/ubuntu-core/snappy/snap"
 )
 
+func copyEnv(in map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
 func AddSnapEnvironment(s *snap.Info) error {
 	if err := os.MkdirAll(dirs.SnapEnvironmentDir, 0755); err != nil {
 		return err
 	}
 
-	globalEnv := bytes.NewBuffer(nil)
-	for k, v := range s.Environment {
-		fmt.Fprintf(globalEnv, "%s=%s\n", k, v)
-	}
-
 	for _, app := range s.Apps {
-		// FIXME: add support for per-app specific environment map
-		//        in snap.yaml too
+		// init with global env, but per-app env wins on conflict
+		appEnv := copyEnv(s.Environment)
+		for k, v := range app.Environment {
+			appEnv[k] = v
+		}
 
-		if err := osutil.AtomicWriteFile(app.EnvironmentFile(), globalEnv.Bytes(), 0755, 0); err != nil {
+		env := bytes.NewBuffer(nil)
+		for k, v := range appEnv {
+			fmt.Fprintf(env, "%s=%s\n", k, v)
+		}
+
+		if err := osutil.AtomicWriteFile(app.EnvironmentFile(), env.Bytes(), 0755, 0); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This branch adds an environment key on each application (in addition to the global one) as discussed during the sprint.