### PR TITLE
interfaces: extend pulseaudio interface with slot side

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -29,6 +29,7 @@ var allInterfaces = []interfaces.Interface{
 	&LocationControlInterface{},
 	&LocationObserveInterface{},
 	&NetworkManagerInterface{},
+	&PulseAudioInterface{},
 	NewFirewallControlInterface(),
 	NewHomeInterface(),
 	NewLocaleControlInterface(),
@@ -45,7 +46,6 @@ var allInterfaces = []interfaces.Interface{
 	NewUnity7Interface(),
 	NewX11Interface(),
 	NewOpenglInterface(),
-	NewPulseAudioInterface(),
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -36,6 +36,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.BluezInterface{})
 	c.Check(all, Contains, &builtin.LocationControlInterface{})
 	c.Check(all, Contains, &builtin.LocationObserveInterface{})
+	c.Check(all, Contains, &builtin.PulseAudioInterface{})
 	c.Check(all, DeepContains, builtin.NewFirewallControlInterface())
 	c.Check(all, DeepContains, builtin.NewHomeInterface())
 	c.Check(all, DeepContains, builtin.NewLocaleControlInterface())
@@ -52,5 +53,4 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewUnity7Interface())
 	c.Check(all, DeepContains, builtin.NewX11Interface())
 	c.Check(all, DeepContains, builtin.NewOpenglInterface())
-	c.Check(all, DeepContains, builtin.NewPulseAudioInterface())
 }

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -23,27 +23,157 @@ import (
 	"github.com/ubuntu-core/snappy/interfaces"
 )
 
-const pulseaudioConnectedPlugAppArmor = `
+var pulseaudioConnectedPlugAppArmor = []byte(`
+capability dac_override,
+
+/etc/machine-id r,
+
+/{run,dev}/shm/pulse-shm-* rwk,
+
+# FIXME Desktop-only
+owner /{,var/}run/user/*/pulse/ rwk,
+owner /{,var/}run/user/*/pulse/native rwk,
+
+# Running as system instance
+owner /{,var/}run/pulse rwk,
+owner /{,var/}run/pulse/native rwk,
+`)
+
+var pulseaudioConnectedPlugAppArmorDesktop = []byte(`
+# Only on desktop we need access to /etc/pulse for any PulseAudio client
+# to read available client side configuration settings. On an Ubuntu Core
+# device those things will be stored inside the snap directory.
 /etc/pulse/ r,
 /etc/pulse/* r,
-/{run,dev}/shm/pulse-shm-* rk,
-owner /{,var/}run/user/*/pulse/ r,
-owner /{,var/}run/user/*/pulse/native rwk,
-`
+`)
 
-const pulseaudioConnectedPlugSecComp = `
+var pulseaudioConnectedPlugSecComp = []byte(`
 setsockopt
+getsockopt
 connect
 sendto
-`
+shmctl
+getsockname
+getpeername
+sendmsg
+recvmsg
+`)
 
-// NewPulseAudioInterface returns a new "pulseaudio" interface.
-func NewPulseAudioInterface() interfaces.Interface {
-	return &commonInterface{
-		name: "pulseaudio",
-		connectedPlugAppArmor: pulseaudioConnectedPlugAppArmor,
-		connectedPlugSecComp:  pulseaudioConnectedPlugSecComp,
-		reservedForOS:         true,
-		autoConnect:           true,
+var pulseaudioPermanentSlotAppArmor = []byte(`
+# When running PulseAudio in system mode it will switch to the at
+# build time configured user/group on startup.
+capability setuid,
+capability setgid,
+
+capability sys_nice,
+capability sys_resource,
+
+@{PROC}/self/exe r,
+/etc/machine-id r,
+
+# Audio related
+@{PROC}/asound/devices r,
+@{PROC}/asound/card** r,
+/dev/snd/pcm* rw,
+/dev/snd/control* rw,
+/dev/snd/timer r,
+/sys/**/sound/** r,
+
+# For udev
+network netlink raw,
+/sys/devices/virtual/dmi/id/sys_vendor r,
+/sys/devices/virtual/dmi/id/bios_vendor r,
+/run/udev/data/** r,
+
+owner /{,var/}run/pulse/ rwk,
+owner /{,var/}run/pulse/native rwk,
+owner /{,var/}run/pulse/pid rwk,
+owner /{,var/}run/pulse/.config/ rwk,
+owner /{,var/}run/pulse/.config/pulse/ rwk,
+
+# Shared memory based communication with clients
+/{run,dev}/shm/pulse-shm-* rwkcix,
+owner /{,var/}run/pulse/.config/pulse/cookie rwk,
+`)
+
+var pulseaudioPermanentSlotSecComp = []byte(`
+personality
+setpriority
+setsockopt
+getsockname
+bind
+listen
+sendto
+recvfrom
+accept4
+shmctl
+getsockname
+getpeername
+sendmsg
+recvmsg
+# Needed to set root as group for different state dirs
+# pulseaudio creates on startup.
+setgroups
+`)
+
+type PulseAudioInterface struct{}
+
+func (iface *PulseAudioInterface) Name() string {
+	return "pulseaudio"
+}
+
+func (iface *PulseAudioInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
 	}
+}
+
+func (iface *PulseAudioInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		return pulseaudioConnectedPlugAppArmor, nil
+	case interfaces.SecuritySecComp:
+		return pulseaudioConnectedPlugSecComp, nil
+	case interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *PulseAudioInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		return pulseaudioPermanentSlotAppArmor, nil
+	case interfaces.SecuritySecComp:
+		return pulseaudioPermanentSlotSecComp, nil
+	case interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *PulseAudioInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *PulseAudioInterface) SanitizePlug(slot *interfaces.Plug) error {
+	return nil
+}
+
+func (iface *PulseAudioInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	return nil
+}
+
+func (iface *PulseAudioInterface) AutoConnect() bool {
+	return false
 }


### PR DESCRIPTION
This adds the slot side implementation to the pulseaudio interface.

The implementation itself is very rough at the moment but enables a pulseaudio snap build from https://code.launchpad.net/~morphis/snappy-hwe-snaps/+git/pulseaudio/+ref/add-initial-packaging being able to run, detect audio devices and record/play audio content.

I share this here for a initial discussion and review.

Open point:
- Add missing unit tests
- Identify desktop/core differentiation points
- Review and optimize security policy