### PR TITLE
release,classic: tweak release API to reflect /etc/os-release better

### DIFF
--- a/classic/create.go
+++ b/classic/create.go
@@ -47,13 +47,9 @@ var getgrnam = osutil.Getgrnam
 
 func findDownloadPathFromLxdIndex(r io.Reader) (string, error) {
 	arch := arch.UbuntuArchitecture()
-	osRelease, err := release.ReadOSRelease()
-	if err != nil {
-		return "", err
-	}
-	release := osRelease.Codename
+	codename := release.ReleaseInfo.Codename
 
-	needle := fmt.Sprintf("ubuntu;%s;%s;default;", release, arch)
+	needle := fmt.Sprintf("ubuntu;%s;%s;default;", codename, arch)
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		if strings.HasPrefix(scanner.Text(), needle) {

--- a/classic/create.go
+++ b/classic/create.go
@@ -47,11 +47,11 @@ var getgrnam = osutil.Getgrnam
 
 func findDownloadPathFromLxdIndex(r io.Reader) (string, error) {
 	arch := arch.UbuntuArchitecture()
-	lsb, err := release.ReadLSB()
+	osRelease, err := release.ReadOSRelease()
 	if err != nil {
 		return "", err
 	}
-	release := lsb.Codename
+	release := osRelease.Codename
 
 	needle := fmt.Sprintf("ubuntu;%s;%s;default;", release, arch)
 	scanner := bufio.NewScanner(r)

--- a/classic/create_test.go
+++ b/classic/create_test.go
@@ -78,7 +78,7 @@ func (t *CreateTestSuite) SetUpTest(c *C) {
 }
 
 func makeMockLxdIndexSystem() string {
-	lsb, err := release.ReadLSB()
+	osRelease, err := release.ReadOSRelease()
 	if err != nil {
 		panic(err)
 	}
@@ -87,7 +87,7 @@ func makeMockLxdIndexSystem() string {
 	s := fmt.Sprintf(`
 ubuntu;xenial;otherarch;default;20151126_03:49;/images/ubuntu/xenial/armhf/default/20151126_03:49/
 ubuntu;%s;%s;default;20151126_03:49;/images/ubuntu/CODENAME/ARCH/default/20151126_03:49/
-`, lsb.Codename, arch)
+`, osRelease.Codename, arch)
 
 	return s
 }

--- a/classic/create_test.go
+++ b/classic/create_test.go
@@ -78,16 +78,12 @@ func (t *CreateTestSuite) SetUpTest(c *C) {
 }
 
 func makeMockLxdIndexSystem() string {
-	osRelease, err := release.ReadOSRelease()
-	if err != nil {
-		panic(err)
-	}
 	arch := arch.UbuntuArchitecture()
 
 	s := fmt.Sprintf(`
 ubuntu;xenial;otherarch;default;20151126_03:49;/images/ubuntu/xenial/armhf/default/20151126_03:49/
 ubuntu;%s;%s;default;20151126_03:49;/images/ubuntu/CODENAME/ARCH/default/20151126_03:49/
-`, osRelease.Codename, arch)
+`, release.ReleaseInfo.Codename, arch)
 
 	return s
 }

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -19,6 +19,8 @@
 
 package release
 
+var ReadOSRelease = readOSRelease
+
 func MockOSReleasePath(filename string) (restore func()) {
 	old := osReleasePath
 	osReleasePath = filename

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -19,8 +19,8 @@
 
 package release
 
-func MockLSBReleasePath(filename string) (restore func()) {
-	old := lsbReleasePath
-	lsbReleasePath = filename
-	return func() { lsbReleasePath = old }
+func MockOSReleasePath(filename string) (restore func()) {
+	old := osReleasePath
+	osReleasePath = filename
+	return func() { osReleasePath = old }
 }

--- a/release/release.go
+++ b/release/release.go
@@ -40,8 +40,8 @@ type OSRelease struct {
 
 var osReleasePath = "/etc/os-release"
 
-// ReadOSRelease returns the os-release information of the current system.
-func ReadOSRelease() (*OSRelease, error) {
+// readOSRelease returns the os-release information of the current system.
+func readOSRelease() (*OSRelease, error) {
 	osRelease := &OSRelease{}
 
 	content, err := ioutil.ReadFile(osReleasePath)
@@ -82,7 +82,7 @@ var OnClassic bool
 var ReleaseInfo OSRelease
 
 func init() {
-	osRelease, err := ReadOSRelease()
+	osRelease, err := readOSRelease()
 	if err != nil {
 		// Values recommended by os-release(5) as defaults
 		osRelease = &OSRelease{

--- a/release/release.go
+++ b/release/release.go
@@ -30,8 +30,8 @@ import (
 // Series holds the Ubuntu Core series for snapd to use.
 var Series = "16"
 
-// OSRelease contains information about the system extracted from /etc/os-release.
-type OSRelease struct {
+// OS contains information about the system extracted from /etc/os-release.
+type OS struct {
 	ID       string
 	Name     string
 	Release  string
@@ -41,8 +41,8 @@ type OSRelease struct {
 var osReleasePath = "/etc/os-release"
 
 // readOSRelease returns the os-release information of the current system.
-func readOSRelease() (*OSRelease, error) {
-	osRelease := &OSRelease{}
+func readOSRelease() (*OS, error) {
+	osRelease := &OS{}
 
 	content, err := ioutil.ReadFile(osReleasePath)
 	if err != nil {
@@ -79,13 +79,13 @@ func readOSRelease() (*OSRelease, error) {
 var OnClassic bool
 
 // ReleaseInfo contains data loaded from /etc/os-release on startup.
-var ReleaseInfo OSRelease
+var ReleaseInfo OS
 
 func init() {
 	osRelease, err := readOSRelease()
 	if err != nil {
 		// Values recommended by os-release(5) as defaults
-		osRelease = &OSRelease{
+		osRelease = &OS{
 			Name: "Linux",
 			ID:   "linux",
 		}
@@ -111,8 +111,8 @@ func MockOnClassic(onClassic bool) (restore func()) {
 
 // MockReleaseInfo fakes a given information to appear in ReleaseInfo,
 // as if it was read /etc/os-release on startup.
-func MockReleaseInfo(os *OSRelease) (restore func()) {
+func MockReleaseInfo(osRelease *OS) (restore func()) {
 	old := ReleaseInfo
-	ReleaseInfo = *os
+	ReleaseInfo = *osRelease
 	return func() { ReleaseInfo = old }
 }

--- a/release/release.go
+++ b/release/release.go
@@ -74,7 +74,15 @@ func ReadLSB() (*LSB, error) {
 var OnClassic bool
 
 func init() {
-	OnClassic = osutil.FileExists("/var/lib/dpkg/status")
+	lsb, err := ReadLSB()
+	// Assume that we are running on Classic
+	OnClassic = true
+	// On Ubuntu, dpkg is not present in an all-snap image so the presence of
+	// dpkg status file can be used as an indicator for a classic vs all-snap
+	// system.
+	if err == nil && lsb.ID == "ubuntu" {
+		OnClassic = osutil.FileExists("/var/lib/dpkg/status")
+	}
 }
 
 // MockOnClassic forces the process to appear inside a classic

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -41,10 +41,10 @@ func (s *ReleaseTestSuite) TestSetup(c *C) {
 	c.Check(release.Series, Equals, "16")
 }
 
-func makeMockLSBRelease(c *C) string {
+func makeMockOSRelease(c *C) string {
 	// FIXME: use AddCleanup here once available so that we
 	//        can do release.SetLSBReleasePath() here directly
-	mockLSBRelease := filepath.Join(c.MkDir(), "mock-lsb-release")
+	mockOSRelease := filepath.Join(c.MkDir(), "mock-os-release")
 	s := `
 NAME="Ubuntu"
 VERSION="18.09 (Awesome Artichoke)"
@@ -57,29 +57,29 @@ SUPPORT_URL="http://help.ubuntu.com/"
 BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
 UBUNTU_CODENAME=awesome
 `
-	err := ioutil.WriteFile(mockLSBRelease, []byte(s), 0644)
+	err := ioutil.WriteFile(mockOSRelease, []byte(s), 0644)
 	c.Assert(err, IsNil)
 
-	return mockLSBRelease
+	return mockOSRelease
 }
 
-func (s *ReleaseTestSuite) TestReadLSB(c *C) {
-	reset := release.MockLSBReleasePath(makeMockLSBRelease(c))
+func (s *ReleaseTestSuite) TestReadOSRelease(c *C) {
+	reset := release.MockOSReleasePath(makeMockOSRelease(c))
 	defer reset()
 
-	lsb, err := release.ReadLSB()
+	os, err := release.ReadOSRelease()
 	c.Assert(err, IsNil)
-	c.Assert(lsb.ID, Equals, "ubuntu")
-	c.Assert(lsb.Name, Equals, "Ubuntu")
-	c.Assert(lsb.Release, Equals, "18.09")
-	c.Assert(lsb.Codename, Equals, "awesome")
+	c.Assert(os.ID, Equals, "ubuntu")
+	c.Assert(os.Name, Equals, "Ubuntu")
+	c.Assert(os.Release, Equals, "18.09")
+	c.Assert(os.Codename, Equals, "awesome")
 }
 
-func (s *ReleaseTestSuite) TestReadLSBNotFound(c *C) {
-	reset := release.MockLSBReleasePath("not-there")
+func (s *ReleaseTestSuite) TestReadOSReleaseNotFound(c *C) {
+	reset := release.MockOSReleasePath("not-there")
 	defer reset()
 
-	_, err := release.ReadLSB()
+	_, err := release.ReadOSRelease()
 	c.Assert(err, ErrorMatches, "cannot read os-release:.*")
 }
 
@@ -93,10 +93,10 @@ func (s *ReleaseTestSuite) TestOnClassic(c *C) {
 	c.Assert(release.OnClassic, Equals, false)
 }
 
-func (s *ReleaseTestSuite) TestLSBInfo(c *C) {
-	reset := release.MockLSB(&release.LSB{
+func (s *ReleaseTestSuite) TestReleaseInfo(c *C) {
+	reset := release.MockReleaseInfo(&release.OSRelease{
 		ID: "distro-id",
 	})
 	defer reset()
-	c.Assert(release.LSBInfo.ID, Equals, "distro-id")
+	c.Assert(release.ReleaseInfo.ID, Equals, "distro-id")
 }

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -69,7 +69,8 @@ func (s *ReleaseTestSuite) TestReadLSB(c *C) {
 
 	lsb, err := release.ReadLSB()
 	c.Assert(err, IsNil)
-	c.Assert(lsb.ID, Equals, "Ubuntu")
+	c.Assert(lsb.ID, Equals, "ubuntu")
+	c.Assert(lsb.Name, Equals, "Ubuntu")
 	c.Assert(lsb.Release, Equals, "18.09")
 	c.Assert(lsb.Codename, Equals, "awesome")
 }
@@ -90,4 +91,12 @@ func (s *ReleaseTestSuite) TestOnClassic(c *C) {
 	reset = release.MockOnClassic(false)
 	defer reset()
 	c.Assert(release.OnClassic, Equals, false)
+}
+
+func (s *ReleaseTestSuite) TestLSBInfo(c *C) {
+	reset := release.MockLSB(&release.LSB{
+		ID: "distro-id",
+	})
+	defer reset()
+	c.Assert(release.LSBInfo.ID, Equals, "distro-id")
 }

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -94,7 +94,7 @@ func (s *ReleaseTestSuite) TestOnClassic(c *C) {
 }
 
 func (s *ReleaseTestSuite) TestReleaseInfo(c *C) {
-	reset := release.MockReleaseInfo(&release.OSRelease{
+	reset := release.MockReleaseInfo(&release.OS{
 		ID: "distro-id",
 	})
 	defer reset()

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -41,7 +41,7 @@ func (s *ReleaseTestSuite) TestSetup(c *C) {
 	c.Check(release.Series, Equals, "16")
 }
 
-func makeMockOSRelease(c *C) string {
+func mockOSRelease(c *C) string {
 	// FIXME: use AddCleanup here once available so that we
 	//        can do release.SetLSBReleasePath() here directly
 	mockOSRelease := filepath.Join(c.MkDir(), "mock-os-release")
@@ -64,7 +64,7 @@ UBUNTU_CODENAME=awesome
 }
 
 func (s *ReleaseTestSuite) TestReadOSRelease(c *C) {
-	reset := release.MockOSReleasePath(makeMockOSRelease(c))
+	reset := release.MockOSReleasePath(mockOSRelease(c))
 	defer reset()
 
 	os, err := release.ReadOSRelease()


### PR DESCRIPTION
This branch contains some tweaks to the release module. In addition it makes the test for OnClassic better suited for other distributions. On Ubuntu we still look for dpkg/status but on other distributions we just assume to run on "classic"