### PR TITLE
overlord/ifacestate: enable apparmor security backend on ubuntu

### DIFF
--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -221,5 +222,13 @@ func setConns(st *state.State, conns map[string]connState) {
 }
 
 var securityBackends = []interfaces.SecurityBackend{
-	&apparmor.Backend{}, &seccomp.Backend{}, &dbus.Backend{}, &udev.Backend{},
+	&seccomp.Backend{}, &dbus.Backend{}, &udev.Backend{},
+}
+
+func init() {
+	switch release.ReleaseInfo.ID {
+	case "ubuntu":
+		// Enable apparmor support when running on Ubuntu
+		securityBackends = append(securityBackends, &apparmor.Backend{})
+	}
 }


### PR DESCRIPTION
Ubuntu carries all the relevant apparmor support patches in the kernel
(as well as userspace tools) so it can use all of the apparmor security
fatures. Other distributions may not have this enabled so as a first
safe option they don't have apparmor and will (soon) require --devmode
installation to work.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>