### PR TITLE
snap,wrappers: use snap-run instead of ubuntu-core-launcher

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -252,8 +252,7 @@ func (app *AppInfo) WrapperPath() string {
 }
 
 func (app *AppInfo) launcherCommand(command string) string {
-	securityTag := app.SecurityTag()
-	return fmt.Sprintf("/usr/bin/ubuntu-core-launcher %s %s %s", securityTag, securityTag, filepath.Join(app.Snap.MountDir(), command))
+	return fmt.Sprintf("/usr/bin/snap-run %s %s", app.SecurityTag(), filepath.Join(app.Snap.MountDir(), command))
 
 }
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -96,8 +96,8 @@ apps:
 	c.Assert(err, IsNil)
 	info.Revision = snap.R(42)
 
-	c.Check(info.Apps["bar"].LauncherCommand(), Equals, "/usr/bin/ubuntu-core-launcher snap.foo.bar snap.foo.bar /snap/foo/42/bar-bin -x")
-	c.Check(info.Apps["foo"].LauncherCommand(), Equals, "/usr/bin/ubuntu-core-launcher snap.foo.foo snap.foo.foo /snap/foo/42/foo-bin")
+	c.Check(info.Apps["bar"].LauncherCommand(), Equals, "/usr/bin/snap-run snap.foo.bar /snap/foo/42/bar-bin -x")
+	c.Check(info.Apps["foo"].LauncherCommand(), Equals, "/usr/bin/snap-run snap.foo.foo /snap/foo/42/foo-bin")
 }
 
 const sampleYaml = `

--- a/wrappers/binaries_gen_test.go
+++ b/wrappers/binaries_gen_test.go
@@ -54,7 +54,7 @@ export HOME="$SNAP_USER_DATA"
 # Snap name is: pastebinit
 # App name is: pastebinit
 
-/usr/bin/ubuntu-core-launcher snap.pastebinit.pastebinit snap.pastebinit.pastebinit /snap/pastebinit/44/bin/pastebinit "$@"
+/usr/bin/snap-run snap.pastebinit.pastebinit /snap/pastebinit/44/bin/pastebinit "$@"
 `
 
 func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -78,7 +78,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	c.Assert(err, IsNil)
 
 	needle := fmt.Sprintf(`
-/usr/bin/ubuntu-core-launcher snap.hello-snap.hello snap.hello-snap.hello %s/snap/hello-snap/11/bin/hello "$@"
+/usr/bin/snap-run snap.hello-snap.hello %s/snap/hello-snap/11/bin/hello "$@"
 `, s.tempdir)
 
 	c.Assert(string(content), Matches, "(?ms).*"+regexp.QuoteMeta(needle)+".*")

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -42,12 +42,12 @@ Description=Service for snap application snap.app
 X-Snappy=yes
 
 [Service]
-ExecStart=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app /snap/snap/44/bin/start
+ExecStart=/usr/bin/snap-run snap.snap.app /snap/snap/44/bin/start
 Restart=on-failure
 WorkingDirectory=/var/snap/snap/44
 Environment="SNAP=/snap/snap/44" "SNAP_DATA=/var/snap/snap/44" "SNAP_NAME=snap" "SNAP_VERSION=1.0" "SNAP_REVISION=44" "SNAP_ARCH=%[3]s" "SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:" "SNAP_USER_DATA=/root/snap/snap/44"
-ExecStop=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app /snap/snap/44/bin/stop
-ExecStopPost=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app /snap/snap/44/bin/stop --post
+ExecStop=/usr/bin/snap-run snap.snap.app /snap/snap/44/bin/stop
+ExecStopPost=/usr/bin/snap-run snap.snap.app /snap/snap/44/bin/stop --post
 TimeoutStopSec=10
 %[2]s
 
@@ -68,12 +68,12 @@ Description=Service for snap application xkcd-webserver.xkcd-webserver
 X-Snappy=yes
 
 [Service]
-ExecStart=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo start
+ExecStart=/usr/bin/snap-run snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo start
 Restart=on-failure
 WorkingDirectory=/var/snap/xkcd-webserver/44
 Environment="SNAP=/snap/xkcd-webserver/44" "SNAP_DATA=/var/snap/xkcd-webserver/44" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_REVISION=44" "SNAP_ARCH=%[3]s" "SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:" "SNAP_USER_DATA=/root/snap/xkcd-webserver/44"
-ExecStop=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo stop
-ExecStopPost=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo post-stop
+ExecStop=/usr/bin/snap-run snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo stop
+ExecStopPost=/usr/bin/snap-run snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo post-stop
 TimeoutStopSec=30
 %[2]s
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -79,7 +79,7 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 	verbs := []string{"Start", "Stop", "StopPost"}
 	bins := []string{"hello", "goodbye", "missya"}
 	for i := range verbs {
-		expected := fmt.Sprintf("Exec%s=/usr/bin/ubuntu-core-launcher snap.hello-snap.svc1 snap.hello-snap.svc1 %s/bin/%s",
+		expected := fmt.Sprintf("Exec%s=/usr/bin/snap-run snap.hello-snap.svc1 %s/bin/%s",
 			verbs[i], mountDir, bins[i])
 		c.Check(string(content), Matches, "(?ms).*^"+regexp.QuoteMeta(expected)) // check.v1 adds ^ and $ around the regexp provided
 	}


### PR DESCRIPTION
NOTE: Do not land this please. We need to first complete the transition to snap-run in Ubuntu.

Currently the syntax is of snap-run is very similar to that of ubuntu-core-lalucnher. The only difference is that it takes the security tag once, not twice (needlessly).

This branch will evolve alongside snap-run. I plan to change it so that it can be called like this:

```snap-run snap.app [arguments]```

Where snap.app is the identifier of the application to run and arguments are any optional arguments to pass to the application.
