### PR TITLE
asserts: stronger crypto choices

### DIFF
--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -24,7 +24,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	_ "crypto/sha256" // be explicit about needing SHA256
+	_ "crypto/sha512" // be explicit about needing SHA512
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -83,7 +83,7 @@ func encodeKey(key keyEncoder, kind string) ([]byte, error) {
 }
 
 var openpgpConfig = &packet.Config{
-	DefaultHash: crypto.SHA256,
+	DefaultHash: crypto.SHA512,
 }
 
 func signContent(content []byte, privateKey PrivateKey) ([]byte, error) {
@@ -290,7 +290,7 @@ func OpenPGPPrivateKey(privk *packet.PrivateKey) PrivateKey {
 }
 
 func generatePrivateKey() (*packet.PrivateKey, error) {
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -168,7 +168,7 @@ func verifyContentSignature(content []byte, sig Signature, pubKey *packet.Public
 		panic(fmt.Errorf("not an internally supported Signature: %T", sig))
 	}
 
-	h := openpgpConfig.Hash().New()
+	h := opgSig.sig.Hash.New()
 	h.Write(content)
 	return pubKey.VerifySignature(h, opgSig.sig)
 }

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -24,6 +24,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	_ "crypto/sha256" // be explicit about supporting SHA256
 	_ "crypto/sha512" // be explicit about needing SHA512
 	"encoding/base64"
 	"encoding/hex"

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -584,3 +584,72 @@ func (res *revisionErrorSuite) TestErrorText(c *C) {
 		c.Check(test.err, ErrorMatches, test.expected)
 	}
 }
+
+type signatureBackwardCompSuite struct{}
+
+var _ = Suite(&signatureBackwardCompSuite{})
+
+func (sbcs *signatureBackwardCompSuite) TestOldSHA256SignaturesWork(c *C) {
+	// these were using SHA256
+
+	const (
+		testTrustedKey = `type: account-key
+authority-id: can0nical
+account-id: can0nical
+public-key-id: 844efa9730eec4be
+public-key-fingerprint: 716ff3cec4b9364a2bd930dc844efa9730eec4be
+since: 2016-01-14T15:00:00Z
+until: 2023-01-14T15:00:00Z
+body-length: 376
+
+openpgp xsBNBFaXv40BCADIlqLKFZaPaoe4TNLQv77vh4JWTlt7Z3IN2ducNqfg50q5mnkyUD2D
+SckvsMy1440+a0Z83m/A7aPaO1JkLpMGfLr23VLyKCaAe0k6hg69/6aEfXhfy0yYvEOgGcBiX+fN
+T6tqdRCsd+08LtisjYez7iJvmVwQ/syeduoTU4EiSVO1zlgc3eeq3TFyvcN0E1EsZ/7l2A33amTo
+mtAPVyQsa1B+lTeaUgwuPBWV0oTuYcUSfYsmmsXEKx/PnzkliicnrC9QZ5CcisskVve3QwPAuLUz
+2nV7/6vSRF22T4cUPF4QntjZBB6xjopdDH6wQsKyzLTTRak74moWksx8MEmVABEBAAE=
+
+openpgp wsBcBAABCAAQBQJWl8DiCRCETvqXMO7EvgAAhjkIAEoINWjQkujtx/TFYsKh0yYcQSpT
+v8O83mLRP7Ty+mH99uQ0/DbeQ1hM5st8cFgzU8SzlDCh6BUMnAl/bR/hhibFD40CBLd13kDXl1aN
+APybmSYoDVRQPAPop44UF0aCrTIw4Xds3E56d2Rsn+CkNML03kRc/i0Q53uYzZwxXVnzW/gVOXDL
+u/IZtjeo3KsB645MVEUxJLQmjlgMOwMvCHJgWhSvZOuf7wC0soBCN9Ufa/0M/PZFXzzn8LpjKVrX
+iDXhV7cY5PceG8ZV7Duo1JadOCzpkOHmai4DcrN7ZeY8bJnuNjOwvTLkrouw9xci4IxpPDRu0T/i
+K9qaJtUo4cA=`
+		testAccKey = `type: account-key
+authority-id: can0nical
+account-id: developer1
+public-key-id: adea89b00094c337
+public-key-fingerprint: 5fa7b16ad5e8c8810d5a0686adea89b00094c337
+since: 2016-01-14T15:00:00Z
+until: 2023-01-14T15:00:00Z
+body-length: 376
+
+openpgp xsBNBFaXv5MBCACkK//qNb3UwRtDviGcCSEi8Z6d5OXok3yilQmEh0LuW6DyP9sVpm08
+Vb1LGewOa5dThWGX4XKRBI/jCUnjCJQ6v15lLwHe1N7MJQ58DUxKqWFMV9yn4RcDPk6LqoFpPGdR
+rbp9Ivo3PqJRMyD0wuJk9RhbaGZmILcL//BLgomE9NgQdAfZbiEnGxtkqAjeVtBtcJIj5TnCC658
+ZCqwugQeO9iJuIn3GosYvvTB6tReq6GP6b4dqvoi7SqxHVhtt2zD4Y6FUZIVmvZK0qwkV0gua2az
+LzPOeoVcU1AEl7HVeBk7G6GiT5jx+CjjoGa0j22LdJB9S3JXHtGYk5p9CAwhABEBAAE=
+
+openpgp wsBcBAABCAAQBQJWl8HNCRCETvqXMO7EvgAAeuAIABn/1i8qGyaIhxOWE2cHIPYW3hq2
+PWpq7qrPN5Dbp/00xrTvc6tvMQWsXlMrAsYuq3sBCxUp3JRp9XhGiQeJtb8ft10g3+3J7e8OGHjl
+CfXJ3A5el8Xxp5qkFywCsLdJgNtF6+uSQ4dO8SrAwzkM7c3JzntxdiFOjDLUSyZ+rXL42jdRagTY
+8bcZfb47vd68Hyz3EvSvJuHSDbcNSTd3B832cimpfq5vJ7FoDrchVn3sg+3IwekuPhG3LQn5BVtc
+0ontHd+V1GaandhqBaDA01cGZN0gnqv2Haogt0P/h3nZZZJ1nTW5PLC6hs8TZdBdl3Lel8yAHD5L
+ZF5jSvRDLgI=`
+	)
+
+	tKey, err := asserts.Decode([]byte(testTrustedKey))
+	c.Assert(err, IsNil)
+
+	cfg := &asserts.DatabaseConfig{
+		KeypairManager: asserts.NewMemoryKeypairManager(),
+		TrustedKeys:    []*asserts.AccountKey{tKey.(*asserts.AccountKey)},
+	}
+	db, err := asserts.OpenDatabase(cfg)
+	c.Assert(err, IsNil)
+
+	a, err := asserts.Decode([]byte(testAccKey))
+	c.Assert(err, IsNil)
+
+	err = db.Check(a)
+	c.Check(err, IsNil)
+}

--- a/asserts/digest.go
+++ b/asserts/digest.go
@@ -29,8 +29,6 @@ import (
 func EncodeDigest(hash crypto.Hash, hashDigest []byte) (string, error) {
 	algo := ""
 	switch hash {
-	case crypto.SHA256:
-		algo = "sha256"
 	case crypto.SHA512:
 		algo = "sha512"
 	default:
@@ -39,5 +37,5 @@ func EncodeDigest(hash crypto.Hash, hashDigest []byte) (string, error) {
 	if len(hashDigest) != hash.Size() {
 		return "", fmt.Errorf("hash digest by %s should be %d bytes", algo, hash.Size())
 	}
-	return fmt.Sprintf("%s %s", algo, base64.RawURLEncoding.EncodeToString(hashDigest)), nil
+	return fmt.Sprintf("%s-%s", algo, base64.RawURLEncoding.EncodeToString(hashDigest)), nil
 }

--- a/asserts/digest.go
+++ b/asserts/digest.go
@@ -31,6 +31,8 @@ func EncodeDigest(hash crypto.Hash, hashDigest []byte) (string, error) {
 	switch hash {
 	case crypto.SHA256:
 		algo = "sha256"
+	case crypto.SHA512:
+		algo = "sha512"
 	default:
 		return "", fmt.Errorf("unsupported hash")
 	}

--- a/asserts/digest_test.go
+++ b/asserts/digest_test.go
@@ -41,8 +41,8 @@ func (eds *encodeDigestSuite) TestEncodeDigestOK(c *C) {
 	encoded, err := asserts.EncodeDigest(crypto.SHA512, digest)
 	c.Assert(err, IsNil)
 
-	c.Check(strings.HasPrefix(encoded, "sha512 "), Equals, true)
-	decoded, err := base64.RawURLEncoding.DecodeString(encoded[len("sha512 "):])
+	c.Check(strings.HasPrefix(encoded, "sha512-"), Equals, true)
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded[len("sha512-"):])
 	c.Assert(err, IsNil)
 	c.Check(decoded, DeepEquals, digest)
 }
@@ -51,6 +51,6 @@ func (eds *encodeDigestSuite) TestEncodeDigestErrors(c *C) {
 	_, err := asserts.EncodeDigest(crypto.SHA1, nil)
 	c.Check(err, ErrorMatches, "unsupported hash")
 
-	_, err = asserts.EncodeDigest(crypto.SHA256, []byte{1, 2})
-	c.Check(err, ErrorMatches, "hash digest by sha256 should be 32 bytes")
+	_, err = asserts.EncodeDigest(crypto.SHA512, []byte{1, 2})
+	c.Check(err, ErrorMatches, "hash digest by sha256 should be 64 bytes")
 }

--- a/asserts/digest_test.go
+++ b/asserts/digest_test.go
@@ -52,5 +52,5 @@ func (eds *encodeDigestSuite) TestEncodeDigestErrors(c *C) {
 	c.Check(err, ErrorMatches, "unsupported hash")
 
 	_, err = asserts.EncodeDigest(crypto.SHA512, []byte{1, 2})
-	c.Check(err, ErrorMatches, "hash digest by sha256 should be 64 bytes")
+	c.Check(err, ErrorMatches, "hash digest by sha512 should be 64 bytes")
 }

--- a/asserts/digest_test.go
+++ b/asserts/digest_test.go
@@ -35,14 +35,14 @@ type encodeDigestSuite struct{}
 var _ = Suite(&encodeDigestSuite{})
 
 func (eds *encodeDigestSuite) TestEncodeDigestOK(c *C) {
-	h := crypto.SHA256.New()
+	h := crypto.SHA512.New()
 	h.Write([]byte("some stuff to hash"))
 	digest := h.Sum(nil)
-	encoded, err := asserts.EncodeDigest(crypto.SHA256, digest)
+	encoded, err := asserts.EncodeDigest(crypto.SHA512, digest)
 	c.Assert(err, IsNil)
 
-	c.Check(strings.HasPrefix(encoded, "sha256 "), Equals, true)
-	decoded, err := base64.RawURLEncoding.DecodeString(encoded[len("sha256 "):])
+	c.Check(strings.HasPrefix(encoded, "sha512 "), Equals, true)
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded[len("sha512 "):])
 	c.Assert(err, IsNil)
 	c.Check(decoded, DeepEquals, digest)
 }


### PR DESCRIPTION
notice that old signatures are still supported, they are self describing and we keep importing sha256