### PR TITLE
daemon,client,snap: revisions are now strings

### DIFF
--- a/client/revision_test.go
+++ b/client/revision_test.go
@@ -63,10 +63,16 @@ func (s revisionSuite) TestJSON(c *C) {
 		r := Revision{n}
 		data, err := json.Marshal(Revision{n})
 		c.Assert(err, IsNil)
-		c.Assert(string(data), Equals, strconv.Itoa(n))
+		c.Assert(string(data), Equals, `"` + r.String() + `"`)
 
 		var got Revision
 		err = json.Unmarshal(data, &got)
+		c.Assert(err, IsNil)
+		c.Assert(got, Equals, r)
+
+		got = Revision{}
+		err = json.Unmarshal([]byte(strconv.Itoa(r.N)), &got)
+		c.Assert(err, IsNil)
 		c.Assert(got, Equals, r)
 	}
 }

--- a/client/revision_test.go
+++ b/client/revision_test.go
@@ -63,7 +63,7 @@ func (s revisionSuite) TestJSON(c *C) {
 		r := Revision{n}
 		data, err := json.Marshal(Revision{n})
 		c.Assert(err, IsNil)
-		c.Assert(string(data), Equals, `"` + r.String() + `"`)
+		c.Assert(string(data), Equals, `"`+r.String()+`"`)
 
 		var got Revision
 		err = json.Unmarshal(data, &got)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -707,7 +707,7 @@ func (s *apiSuite) TestSnapsInfoOnePerIntegration(c *check.C) {
 		}
 		c.Check(got["name"], check.Equals, s.name)
 		c.Check(got["version"], check.Equals, s.ver)
-		c.Check(got["revision"], check.Equals, float64(s.rev))
+		c.Check(got["revision"], check.Equals, snap.R(s.rev).String())
 		c.Check(got["developer"], check.Equals, s.dev)
 	}
 }

--- a/snap/revision_test.go
+++ b/snap/revision_test.go
@@ -63,10 +63,16 @@ func (s revisionSuite) TestJSON(c *C) {
 		r := Revision{n}
 		data, err := json.Marshal(Revision{n})
 		c.Assert(err, IsNil)
-		c.Assert(string(data), Equals, strconv.Itoa(n))
+		c.Assert(string(data), Equals, `"` + r.String() + `"`)
 
 		var got Revision
 		err = json.Unmarshal(data, &got)
+		c.Assert(err, IsNil)
+		c.Assert(got, Equals, r)
+
+		got = Revision{}
+		err = json.Unmarshal([]byte(strconv.Itoa(r.N)), &got)
+		c.Assert(err, IsNil)
 		c.Assert(got, Equals, r)
 	}
 }

--- a/snap/revision_test.go
+++ b/snap/revision_test.go
@@ -63,7 +63,7 @@ func (s revisionSuite) TestJSON(c *C) {
 		r := Revision{n}
 		data, err := json.Marshal(Revision{n})
 		c.Assert(err, IsNil)
-		c.Assert(string(data), Equals, `"` + r.String() + `"`)
+		c.Assert(string(data), Equals, `"`+r.String()+`"`)
 
 		var got Revision
 		err = json.Unmarshal(data, &got)


### PR DESCRIPTION
This also changes the stored format of revisions in state
to become strings. The marshaler/unmarshaler will handle
upgrading transparent to code.