### PR TITLE
many: replace ubuntu-core with base (snap)

### DIFF
--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -78,9 +78,10 @@ func (x *cmdInterfaces) Execute(args []string) error {
 			if x.Interface != "" && slot.Interface != x.Interface {
 				continue
 			}
-			// The OS snap (always ubuntu-core) is special and enable abbreviated
+			// The OS snap (always base) is special and enable abbreviated
 			// display syntax on the slot-side of the connection.
-			if slot.Snap == "ubuntu-core" {
+			// TODO: remove ubuntu-core after a while
+			if slot.Snap == "base" || slot.Snap == "ubuntu-core" {
 				fmt.Fprintf(w, ":%s\t", slot.Name)
 			} else {
 				fmt.Fprintf(w, "%s:%s\t", slot.Snap, slot.Name)

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -299,7 +299,7 @@ func (s *SnapSuite) TestInterfacesOsSnapSlots(c *C) {
 			"result": client.Interfaces{
 				Slots: []client.Slot{
 					{
-						Snap:      "ubuntu-core",
+						Snap:      "base",
 						Name:      "network-listening",
 						Interface: "network-listening",
 						Label:     "Ability to be a network service",
@@ -323,7 +323,7 @@ func (s *SnapSuite) TestInterfacesOsSnapSlots(c *C) {
 						Label:     "Ability to be a network service",
 						Connections: []client.SlotRef{
 							{
-								Snap: "ubuntu-core",
+								Snap: "base",
 								Name: "network-listening",
 							},
 						},
@@ -335,7 +335,7 @@ func (s *SnapSuite) TestInterfacesOsSnapSlots(c *C) {
 						Label:     "Ability to be a network service",
 						Connections: []client.SlotRef{
 							{
-								Snap: "ubuntu-core",
+								Snap: "base",
 								Name: "network-listening",
 							},
 						},
@@ -372,7 +372,7 @@ func (s *SnapSuite) TestInterfacesTwoSlotsAndFiltering(c *C) {
 						Label:     "Serial port on the expansion header",
 						Connections: []client.PlugRef{
 							{
-								Snap: "ubuntu-core",
+								Snap: "base",
 								Name: "debug-console",
 							},
 						},
@@ -398,7 +398,7 @@ func (s *SnapSuite) TestInterfacesTwoSlotsAndFiltering(c *C) {
 	c.Assert(rest, DeepEquals, []string{})
 	expectedStdout := "" +
 		"Slot                         Plug\n" +
-		"canonical-pi2:debug-console  ubuntu-core\n"
+		"canonical-pi2:debug-console  base\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -505,7 +505,7 @@ var snapstateGet = snapstate.Get
 var errNothingToInstall = errors.New("nothing to install")
 
 func ensureUbuntuCore(st *state.State, targetSnap string, userID int) (*state.TaskSet, error) {
-	ubuntuCore := "ubuntu-core"
+	ubuntuCore := "base"
 
 	if targetSnap == ubuntuCore {
 		return nil, errNothingToInstall

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1139,11 +1139,11 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]str
 		if hasUbuntuCore {
 			return nil
 		}
-		// pretend we do not have a state for ubuntu-core
+		// pretend we do not have a state for base snap
 		return state.ErrNoState
 	}
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
-		// NOTE: ubuntu-core is not installed in developer mode
+		// NOTE: base snap is not installed in developer mode
 		c.Check(flags, check.Equals, snappy.InstallFlags(0))
 		installQueue = append(installQueue, name)
 
@@ -1178,7 +1178,7 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]str
 	}
 	c.Assert(installQueue, check.HasLen, n)
 	if !hasUbuntuCore {
-		c.Check(installQueue[0], check.Equals, "ubuntu-core")
+		c.Check(installQueue[0], check.Equals, "base")
 	}
 	c.Check(installQueue[n-1], check.Matches, "local::.*/snapd-sideload-pkg-.*")
 
@@ -1280,7 +1280,7 @@ func (s *apiSuite) TestInstall(c *check.C) {
 	installQueue := []string{}
 
 	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
-		// we have ubuntu-core
+		// we have base snap
 		return nil
 	}
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
@@ -1331,7 +1331,7 @@ func (s *apiSuite) TestRefresh(c *check.C) {
 	installQueue := []string{}
 
 	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
-		// we have ubuntu-core
+		// we have base snap
 		return nil
 	}
 	snapstateUpdate = func(s *state.State, name, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
@@ -1367,7 +1367,7 @@ func (s *apiSuite) TestInstallMissingUbuntuCore(c *check.C) {
 	installQueue := []*state.Task{}
 
 	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
-		// pretend we do not have a state for ubuntu-core
+		// pretend we do not have a state for base snap
 		return state.ErrNoState
 	}
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
@@ -1400,8 +1400,8 @@ func (s *apiSuite) TestInstallMissingUbuntuCore(c *check.C) {
 	c.Check(chg.Tasks(), check.HasLen, 4)
 
 	c.Check(installQueue, check.HasLen, 4)
-	// the two "ubuntu-core" install tasks
-	c.Check(installQueue[0].Summary(), check.Equals, "ubuntu-core")
+	// the two "base" install tasks
+	c.Check(installQueue[0].Summary(), check.Equals, "base")
 	c.Check(installQueue[0].WaitTasks(), check.HasLen, 0)
 	c.Check(installQueue[1].WaitTasks(), check.HasLen, 0)
 	// the two "some-snap" install tasks
@@ -1410,13 +1410,13 @@ func (s *apiSuite) TestInstallMissingUbuntuCore(c *check.C) {
 	c.Check(installQueue[3].WaitTasks(), check.HasLen, 2)
 }
 
-// Installing ubuntu-core when not having ubuntu-core doesn't misbehave and try
-// to install ubuntu-core twice.
+// Installing base snap when not having base snap doesn't misbehave and try
+// to install the base snap twice.
 func (s *apiSuite) TestInstallUbuntuCoreWhenMissing(c *check.C) {
 	installQueue := []*state.Task{}
 
 	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
-		// pretend we do not have a state for ubuntu-core
+		// pretend we do not have a state for the base snap
 		return state.ErrNoState
 	}
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snappy.InstallFlags) (*state.TaskSet, error) {
@@ -1429,7 +1429,7 @@ func (s *apiSuite) TestInstallUbuntuCoreWhenMissing(c *check.C) {
 	d := s.daemon(c)
 	inst := &snapInstruction{
 		Action: "install",
-		snap:   "ubuntu-core",
+		snap:   "base",
 	}
 
 	st := d.overlord.State()
@@ -1439,15 +1439,15 @@ func (s *apiSuite) TestInstallUbuntuCoreWhenMissing(c *check.C) {
 	c.Check(err, check.IsNil)
 
 	c.Check(installQueue, check.HasLen, 2)
-	// the only "ubuntu-core" install tasks
-	c.Check(installQueue[0].Summary(), check.Equals, "ubuntu-core")
+	// the only "base" snap install tasks
+	c.Check(installQueue[0].Summary(), check.Equals, "base")
 	c.Check(installQueue[0].WaitTasks(), check.HasLen, 0)
 	c.Check(installQueue[1].WaitTasks(), check.HasLen, 0)
 }
 
 func (s *apiSuite) TestInstallFails(c *check.C) {
 	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
-		// we have ubuntu-core
+		// we have base snap
 		return nil
 	}
 

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -1,4 +1,4 @@
-# Snappy Ubuntu Core REST API
+# Snapd REST API
 
 Version: v2pre0
 
@@ -274,14 +274,14 @@ Sample result:
       "revision": 1834,
       "channel": "stable"
     }, {
-      "summary": "The ubuntu-core OS snap",
+      "summary": "Base content for snapd",
       "description": "A secure, minimal transactional OS for devices and containers.",
       "icon": "",                  // core might not have an icon
       "installed-size": 67784704,
       "install-date": "2016-03-08T11:29:21Z",
-      "name": "ubuntu-core",
+      "name": "base",
       "developer": "canonical",
-      "resource": "/v2/snaps/ubuntu-core",
+      "resource": "/v2/snaps/base",
       "status": "active",
       "type": "os",
       "update-available": 247,

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -41,7 +41,7 @@ const (
 	dataOutputDir    = "integration-tests/data/output/"
 
 	defaultKernel = "canonical-pc-linux"
-	defaultOS     = "ubuntu-core"
+	defaultOS     = "base"
 	defaultGadget = "canonical-pc"
 )
 

--- a/integration-tests/manual-tests.md
+++ b/integration-tests/manual-tests.md
@@ -9,7 +9,7 @@
     +++ generic-amd64/meta/snap.yaml	2015-11-09 16:26:12 +0000
     @@ -7,6 +7,8 @@
      config:
-         ubuntu-core:
+         base:
              autopilot: true
     +    config-example-bash:
     +      msg: "huzzah\n"
@@ -55,7 +55,7 @@
     +++ generic-amd64/meta/snap.yaml	2015-11-12 10:14:30 +0000
     @@ -7,6 +7,7 @@
      config:
-         ubuntu-core:
+         base:
              autopilot: true
     +        load-kernel-modules: [tea]
 

--- a/integration-tests/tests/home_interface_test.go
+++ b/integration-tests/tests/home_interface_test.go
@@ -43,7 +43,7 @@ type homeInterfaceSuite struct {
 
 func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesRead(c *check.C) {
 	cli.ExecCommand(c, "sudo", "snap", "connect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	fileName, err := createHomeFile("readable", okOutput)
 	c.Assert(err, check.IsNil)
@@ -53,7 +53,7 @@ func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesRead(c *check.C) {
 	c.Assert(output, check.Equals, okOutput)
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	output, err = cli.ExecCommandErr("home-consumer.reader", fileName)
 	c.Assert(err, check.NotNil)
@@ -62,7 +62,7 @@ func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesRead(c *check.C) {
 
 func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesAppend(c *check.C) {
 	cli.ExecCommand(c, "sudo", "snap", "connect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	previousContent := "previous content\n"
 	fileName, err := createHomeFile("writable", previousContent)
@@ -78,7 +78,7 @@ func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesAppend(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	_, err = cli.ExecCommandErr("home-consumer.writer", fileName)
 	c.Assert(err, check.NotNil)
@@ -86,7 +86,7 @@ func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesAppend(c *check.C) {
 
 func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesCreate(c *check.C) {
 	cli.ExecCommand(c, "sudo", "snap", "connect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	home := os.Getenv("HOME")
 	fileName := filepath.Join(home, "writable")
@@ -101,7 +101,7 @@ func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesCreate(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	_, err = cli.ExecCommandErr("home-consumer.writer", fileName)
 	c.Assert(err, check.NotNil)
@@ -109,7 +109,7 @@ func (s *homeInterfaceSuite) TestPlugDisconnectionDisablesCreate(c *check.C) {
 
 func (s *homeInterfaceSuite) TestReadHiddenFilesForbidden(c *check.C) {
 	cli.ExecCommand(c, "sudo", "snap", "connect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	fileName, err := createHomeFile(".readable", okOutput)
 	c.Assert(err, check.IsNil)
@@ -122,7 +122,7 @@ func (s *homeInterfaceSuite) TestReadHiddenFilesForbidden(c *check.C) {
 
 func (s *homeInterfaceSuite) TestWriteHiddenFilesForbidden(c *check.C) {
 	cli.ExecCommand(c, "sudo", "snap", "connect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	previousContent := "previous content\n"
 	fileName, err := createHomeFile(".writable", previousContent)

--- a/integration-tests/tests/interfaces_test.go
+++ b/integration-tests/tests/interfaces_test.go
@@ -93,17 +93,17 @@ func (s *interfaceSuite) TestPlugAutoconnect(c *check.C) {
 func (s *interfaceSuite) TestPlugCanBeReconnected(c *check.C) {
 	if !s.autoconnect {
 		cli.ExecCommand(c, "sudo", "snap", "connect",
-			s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+			s.plug+":"+s.slot, "base:"+s.slot)
 	}
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	output := cli.ExecCommand(c, "snap", "interfaces")
 	c.Assert(output, check.Matches, disconnectedPattern(s.slot, s.plug))
 
 	cli.ExecCommand(c, "sudo", "snap", "connect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	output = cli.ExecCommand(c, "snap", "interfaces")
 	c.Assert(output, check.Matches, connectedPattern(s.slot, s.plug))

--- a/integration-tests/tests/log_observe_interface_test.go
+++ b/integration-tests/tests/log_observe_interface_test.go
@@ -39,7 +39,7 @@ type logObserveInterfaceSuite struct {
 
 func (s *logObserveInterfaceSuite) TestConnectedPlugAllowsLogObserve(c *check.C) {
 	cli.ExecCommand(c, "sudo", "snap", "connect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	output := cli.ExecCommand(c, "network-consumer", "http://127.0.0.1:8081")
 	c.Assert(output, check.Equals, "ok\n")

--- a/integration-tests/tests/network_bind_interface_test.go
+++ b/integration-tests/tests/network_bind_interface_test.go
@@ -45,7 +45,7 @@ func (s *networkBindInterfaceSuite) TestPlugDisconnectionDisablesClientConnectio
 	c.Assert(output, check.Equals, "ok\n")
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	output = cli.ExecCommand(c, "snap", "interfaces")
 	c.Assert(output, check.Matches, disconnectedPattern(s.slot, s.plug))

--- a/integration-tests/tests/network_interface_test.go
+++ b/integration-tests/tests/network_interface_test.go
@@ -45,7 +45,7 @@ func (s *networkInterfaceSuite) TestPlugDisconnectionDisablesFunctionality(c *ch
 	c.Assert(output, check.Equals, "ok\n")
 
 	cli.ExecCommand(c, "sudo", "snap", "disconnect",
-		s.plug+":"+s.slot, "ubuntu-core:"+s.slot)
+		s.plug+":"+s.slot, "base:"+s.slot)
 
 	output = cli.ExecCommand(c, "snap", "interfaces")
 	c.Assert(output, check.Matches, disconnectedPattern(s.slot, s.plug))

--- a/integration-tests/tests/snap_example_test.go
+++ b/integration-tests/tests/snap_example_test.go
@@ -44,8 +44,8 @@ func (s *snapHelloWorldExampleSuite) TestCallHelloWorldBinary(c *check.C) {
 		common.RemoveSnap(c, "hello-world")
 	})
 
-	// note that this also checks that we have a working ubuntu-core
-	// snap installed, without the ubuntu-core snap the launcher will
+	// note that this also checks that we have a working base
+	// snap installed, without the base snap the launcher will
 	// not work and no "Hello World!\n" output
 	echoOutput := cli.ExecCommand(c, "hello-world.echo")
 	c.Assert(echoOutput, check.Equals, "Hello World!\n",

--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -63,7 +63,7 @@ func (s *searchSuite) TestFindMustPrintCompleteList(c *check.C) {
 		".*" +
 		"^ubuntu-clock-app +.* *\n" +
 		".*" +
-		"^ubuntu-core +.* *\n" +
+		"^base +.* *\n" +
 		".*"
 
 	searchOutput := cli.ExecCommand(c, "snap", "find")

--- a/integration-tests/tests/snap_op_test.go
+++ b/integration-tests/tests/snap_op_test.go
@@ -118,7 +118,7 @@ func (s *snapOpSuite) TestRemoveBusyRetries(c *check.C) {
 		wait.ForInactiveService(c, blockerSrv)
 
 		// this triggers an Ensure in the overlord
-		cli.ExecCommandErr("sudo", "snap", "refresh", "ubuntu-core")
+		cli.ExecCommandErr("sudo", "snap", "refresh", "base")
 		ch <- 1
 	}()
 

--- a/integration-tests/tests/snap_remove_test.go
+++ b/integration-tests/tests/snap_remove_test.go
@@ -62,11 +62,11 @@ func (s *removeSuite) TestRemoveInvalidPackageShowsError(c *check.C) {
 	c.Assert(actual, check.Matches, expected)
 }
 
-// SNAP_REMOVE_007: - ubuntu-core
+// SNAP_REMOVE_007: - base
 func (s *removeSuite) TestRemoveUbuntuCoreShowsError(c *check.C) {
-	expected := `error: cannot remove "ubuntu-core": snap "ubuntu-core" is not removable\n`
+	expected := `error: cannot remove "base": snap "base" is not removable\n`
 
-	actual, err := cli.ExecCommandErr("sudo", "snap", "remove", "ubuntu-core")
+	actual, err := cli.ExecCommandErr("sudo", "snap", "remove", "base")
 
 	c.Assert(err, check.NotNil)
 	c.Assert(actual, check.Matches, expected)

--- a/integration-tests/tests/update_rollback_stress_test.go
+++ b/integration-tests/tests/update_rollback_stress_test.go
@@ -195,7 +195,7 @@ func (s *updateRollbackSuite) TestUpdateRollbackStress(c *check.C) {
 		// after update
 		doAfterUpdateActions(c, s.cm)
 
-		cli.ExecCommand(c, "sudo", "snappy", "rollback", "ubuntu-core")
+		cli.ExecCommand(c, "sudo", "snappy", "rollback", "base")
 
 	} else {
 		c.Log("Unknown update-rollback status:", s.cm.status)

--- a/integration-tests/testutils/common/common.go
+++ b/integration-tests/testutils/common/common.go
@@ -95,7 +95,7 @@ func (s *SnappySuite) SetUpSuite(c *check.C) {
 
 // SetUpTest handles reboots and stores version information. It will run before
 // all the integration tests. Before running a test, it will save the
-// ubuntu-core version. If a reboot was requested by a previous test, it
+// base snap version. If a reboot was requested by a previous test, it
 // will skip all the following tests. If the suite is being called after the
 // test bed was rebooted, it will resume the test that requested the reboot.
 func (s *SnappySuite) SetUpTest(c *check.C) {
@@ -129,13 +129,13 @@ func GetCurrentVersion(c *check.C, packageName string) string {
 	match := re.FindStringSubmatch(string(output))
 	c.Assert(match, check.NotNil, check.Commentf("Version of %s not found in %s", packageName, output))
 
-	// match is like "ubuntu-core   2015-06-18 93        ubuntu"
+	// match is like "base 2015-06-18 93        ubuntu"
 	items := strings.Fields(match[0])
 	return items[2]
 }
 
 // GetCurrentUbuntuCoreVersion returns the version number of the installed and
-// active ubuntu-core.
+// active base snap.
 func GetCurrentUbuntuCoreVersion(c *check.C) string {
 	if snap := partition.OSSnapName(c); snap != "" {
 		return GetCurrentVersion(c, snap)

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -55,7 +55,7 @@ var _ = Suite(&BoolFileInterfaceSuite{
 
 func (s *BoolFileInterfaceSuite) SetUpTest(c *C) {
 	info, err := snap.InfoFromSnapYaml([]byte(`
-name: ubuntu-core
+name: base
 slots:
     gpio:
         interface: bool-file

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -48,7 +48,7 @@ func (iface *commonInterface) Name() string {
 
 // SanitizeSlot checks and possibly modifies a slot.
 //
-// If the reservedForOS flag is set then only slots on the "ubuntu-core" snap
+// If the reservedForOS flag is set then only slots on the "base" snap
 // are allowed.
 func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&FirewallControlInterfaceSuite{
 	iface: builtin.NewFirewallControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "firewall-control",
 			Interface: "firewall-control",
 		},

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&HomeInterfaceSuite{
 	iface: builtin.NewHomeInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "home",
 			Interface: "home",
 		},

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&LocaleControlInterfaceSuite{
 	iface: builtin.NewLocaleControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "locale-control",
 			Interface: "locale-control",
 		},

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&LogObserveInterfaceSuite{
 	iface: builtin.NewLogObserveInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "log-observe",
 			Interface: "log-observe",
 		},

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&MountObserveInterfaceSuite{
 	iface: builtin.NewMountObserveInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "mount-observe",
 			Interface: "mount-observe",
 		},

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&NetworkBindInterfaceSuite{
 	iface: builtin.NewNetworkBindInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "network-bind",
 			Interface: "network-bind",
 		},

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&NetworkControlInterfaceSuite{
 	iface: builtin.NewNetworkControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "network-control",
 			Interface: "network-control",
 		},

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&NetworkObserveInterfaceSuite{
 	iface: builtin.NewNetworkObserveInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "network-observe",
 			Interface: "network-observe",
 		},

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&NetworkInterfaceSuite{
 	iface: builtin.NewNetworkInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "network",
 			Interface: "network",
 		},

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&SnapdControlInterfaceSuite{
 	iface: builtin.NewSnapdControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "snapd-control",
 			Interface: "snapd-control",
 		},

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&SystemObserveInterfaceSuite{
 	iface: builtin.NewSystemObserveInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "system-observe",
 			Interface: "system-observe",
 		},

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&TimeserverControlInterfaceSuite{
 	iface: builtin.NewTimeserverControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "timeserver-control",
 			Interface: "timeserver-control",
 		},

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&TimezoneControlInterfaceSuite{
 	iface: builtin.NewTimezoneControlInterface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "timezone-control",
 			Interface: "timezone-control",
 		},

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&Unity7InterfaceSuite{
 	iface: builtin.NewUnity7Interface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "unity7",
 			Interface: "unity7",
 		},

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -38,7 +38,7 @@ var _ = Suite(&X11InterfaceSuite{
 	iface: builtin.NewX11Interface(),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "base", Type: snap.TypeOS},
 			Name:      "x11",
 			Interface: "x11",
 		},

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -267,7 +267,7 @@ func (s *interfaceManagerSuite) addDiscardConnsChange(c *C, snapName string) *st
 }
 
 var osSnapYaml = `
-name: ubuntu-core
+name: base
 version: 1
 type: os
 `
@@ -365,7 +365,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyAutoConnects(c *C) {
 	err := s.state.Get("conns", &conns)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, map[string]interface{}{
-		"snap:network ubuntu-core:network": map[string]interface{}{
+		"snap:network base:network": map[string]interface{}{
 			"interface": "network", "auto": true,
 		},
 	})
@@ -392,7 +392,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyKeepsExistingConnectionSt
 	// Put fake information about connections for another snap into the state.
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
-		"other-snap:network ubuntu-core:network": map[string]interface{}{
+		"other-snap:network base:network": map[string]interface{}{
 			"interface": "network",
 		},
 	})
@@ -416,12 +416,12 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyKeepsExistingConnectionSt
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, map[string]interface{}{
 		// The sample snap was auto-connected, as expected.
-		"snap:network ubuntu-core:network": map[string]interface{}{
+		"snap:network base:network": map[string]interface{}{
 			"interface": "network", "auto": true,
 		},
 		// Connection state for the fake snap is preserved.
 		// The task didn't alter state of other snaps.
-		"other-snap:network ubuntu-core:network": map[string]interface{}{
+		"other-snap:network base:network": map[string]interface{}{
 			"interface": "network",
 		},
 	})
@@ -560,7 +560,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesUsesFreshSnapInfo(c *C) {
 	// and so that the previously broken code path is exercised.
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
-		"snap:network ubuntu-core:network": map[string]interface{}{"interface": "network"},
+		"snap:network base:network": map[string]interface{}{"interface": "network"},
 	})
 	s.state.Unlock()
 

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -31,7 +31,7 @@ import (
 )
 
 // featureSet contains the flag values that can be listed in assumes entries
-// that this ubuntu-core actually provides.
+// that this base actually provides.
 var featureSet = map[string]bool{
 	// Support for common data directory across revisions of a snap.
 	"common-data-dir": true,
@@ -45,7 +45,7 @@ func checkAssumes(s *snap.Info) error {
 		}
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("snap %q assumes unsupported features: %s (try new ubuntu-core)", s.Name(), strings.Join(missing, ", "))
+		return fmt.Errorf("snap %q assumes unsupported features: %s (try new base snap)", s.Name(), strings.Join(missing, ", "))
 	}
 	return nil
 }

--- a/snappy/firstboot_test.go
+++ b/snappy/firstboot_test.go
@@ -128,7 +128,7 @@ func (s *FirstBootTestSuite) TestEnableFirstEtherBadEthDir(c *C) {
 }
 
 var mockOSYaml = `
-name: ubuntu-core
+name: base
 version: 1.0
 type: os
 `

--- a/snappy/kernel_os_test.go
+++ b/snappy/kernel_os_test.go
@@ -48,8 +48,8 @@ func (s *kernelTestSuite) TestNameAndRevnoFromSnap(c *C) {
 	c.Check(name, Equals, "canonical-pc-linux.canonical")
 	c.Check(revno, Equals, snap.R(101))
 
-	name, revno = nameAndRevnoFromSnap("ubuntu-core.canonical_103.snap")
-	c.Check(name, Equals, "ubuntu-core.canonical")
+	name, revno = nameAndRevnoFromSnap("base.canonical_103.snap")
+	c.Check(name, Equals, "base.canonical")
 	c.Check(revno, Equals, snap.R(103))
 }
 

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -42,7 +42,7 @@ type Overlord struct {
 }
 
 // featureSet contains the flag values that can be listed in assumes entries
-// that this ubuntu-core actually provides.
+// that this base actually provides.
 var featureSet = map[string]bool{
 	// Support for common data directory across revisions of a snap.
 	"common-data-dir": true,
@@ -56,7 +56,7 @@ func checkAssumes(s *snap.Info) error {
 		}
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("snap %q assumes unsupported features: %s (try new ubuntu-core)", s.Name(), strings.Join(missing, ", "))
+		return fmt.Errorf("snap %q assumes unsupported features: %s (try new base snap)", s.Name(), strings.Join(missing, ", "))
 	}
 	return nil
 }

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -224,7 +224,7 @@ func (s *SquashfsTestSuite) TestRemoveViaSquashfsWorks(c *C) {
 }
 
 const packageOS = `
-name: ubuntu-core
+name: base
 version: 15.10-1
 type: os
 vendor: Someone
@@ -236,14 +236,14 @@ func (s *SquashfsTestSuite) TestInstallOsSnapUpdatesBootloader(c *C) {
 
 	snapPkg := makeTestSnapPackage(c, packageOS)
 	si := &snap.SideInfo{
-		OfficialName: "ubuntu-core",
+		OfficialName: "base",
 		Revision:     snap.R(160),
 	}
 	_, err := (&Overlord{}).InstallWithSideInfo(snapPkg, si, 0, &MockProgressMeter{})
 	c.Assert(err, IsNil)
 
 	c.Assert(s.bootloader.bootvars, DeepEquals, map[string]string{
-		"snappy_os":   "ubuntu-core_160.snap",
+		"snappy_os":   "base_160.snap",
 		"snappy_mode": "try",
 	})
 }
@@ -373,7 +373,7 @@ func (s *SquashfsTestSuite) TestInstallOsRebootRequired(c *C) {
 	c.Assert(err, IsNil)
 
 	snap.isActive = false
-	s.bootloader.bootvars["snappy_os"] = "ubuntu-core_160.snap"
+	s.bootloader.bootvars["snappy_os"] = "base_160.snap"
 	c.Assert(snap.NeedsReboot(), Equals, true)
 }
 


### PR DESCRIPTION
This branch replaces most occurrences of "ubuntu-core" with "base".

Note that currently integration tests will not work as ubuntu-core-launcher is hardcoded to look for the ubuntu-core snap. In addition installing the base snap will keep the ubuntu-core snap installed with somewhat awkward results.

This branch is here to drive the process to complete the transition. It should only land after ubuntu-core upgrades to base without a trace of the old snap.