### PR TITLE
integration-tests: add verbose flag

### DIFF
--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -124,6 +124,7 @@ func main() {
 			"TEST_USER_NAME":     os.Getenv("TEST_USER_NAME"),
 			"TEST_USER_PASSWORD": os.Getenv("TEST_USER_PASSWORD"),
 		},
+		Verbose: *verbose,
 	}
 	if !remoteTestbed {
 		img := &image.Image{

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -79,14 +79,10 @@ func main() {
 		shellOnFail   = flag.Bool("shell-fail", false, "Run a shell in the testbed if the suite fails.")
 		testBuildTags = flag.String("test-build-tags", "", "Build tags to be passed to the go test command")
 		httpProxy     = flag.String("http-proxy", "", "HTTP proxy to set in the testbed.")
+		verbose       = flag.Bool("v", false, "Show complete test output")
 	)
 
 	flag.Parse()
-
-	build.Assets(&build.Config{
-		UseSnappyFromBranch: *useSnappyFromBranch,
-		Arch:                *arch,
-		TestBuildTags:       *testBuildTags})
 
 	// TODO: generate the files out of the source tree. --elopio - 2015-07-15
 	testutils.PrepareTargetDir(dataOutputDir)
@@ -104,8 +100,14 @@ func main() {
 		Update:        *update,
 		Rollback:      *rollback,
 		FromBranch:    *useSnappyFromBranch,
+		Verbose:       *verbose,
 	}
 	cfg.Write()
+
+	build.Assets(&build.Config{
+		UseSnappyFromBranch: *useSnappyFromBranch,
+		Arch:                *arch,
+		TestBuildTags:       *testBuildTags})
 
 	rootPath := testutils.RootPath()
 

--- a/integration-tests/testutils/autopkgtest/autopkgtest.go
+++ b/integration-tests/testutils/autopkgtest/autopkgtest.go
@@ -56,6 +56,8 @@ type AutoPkgTest struct {
 	ShellOnFail bool
 	// Env is a map with the environment variables to set on the test bed and their values.
 	Env map[string]string
+	// Verbose controls the amount of output printed
+	Verbose bool
 }
 
 // AdtRunLocal starts a kvm running the image passed as argument and runs the
@@ -80,11 +82,15 @@ func (a *AutoPkgTest) adtRun(testbedOptions string) (err error) {
 	prepareTargetDir(outputDir)
 
 	cmd := []string{
-		"adt-run", "-B", "-q",
+		"adt-run", "-B"}
+	if !a.Verbose {
+		cmd = append(cmd, "-q")
+	}
+	cmd = append(cmd, []string{
 		"--override-control", controlFile,
 		"--built-tree", a.SourceCodePath,
 		"--output-dir", outputDir,
-		"--setup-commands", "touch /run/autopkgtest_no_reboot.stamp"}
+		"--setup-commands", "touch /run/autopkgtest_no_reboot.stamp"}...)
 	for envVar, value := range a.Env {
 		cmd = append(cmd, "--env")
 		cmd = append(cmd, fmt.Sprintf("%s=%s", envVar, value))

--- a/integration-tests/testutils/autopkgtest/autopkgtest.go
+++ b/integration-tests/testutils/autopkgtest/autopkgtest.go
@@ -80,7 +80,7 @@ func (a *AutoPkgTest) adtRun(testbedOptions string) (err error) {
 	prepareTargetDir(outputDir)
 
 	cmd := []string{
-		"adt-run", "-B",
+		"adt-run", "-B", "-q",
 		"--override-control", controlFile,
 		"--built-tree", a.SourceCodePath,
 		"--output-dir", outputDir,

--- a/integration-tests/testutils/autopkgtest/autopkgtest_test.go
+++ b/integration-tests/testutils/autopkgtest/autopkgtest_test.go
@@ -224,6 +224,35 @@ func (s *AutoPkgTestSuite) TestAdtRunEnv(c *check.C) {
 		check.Commentf("Expected call %s not executed 1 time", expectedCommandCall))
 }
 
+func (s *AutoPkgTestSuite) TestAdtRunLocalAddsQuietFlag(c *check.C) {
+	s.adtRunAddsQuietFlag(c, true)
+}
+
+func (s *AutoPkgTestSuite) TestAdtRunRemoteAddsQuietFlag(c *check.C) {
+	s.adtRunAddsQuietFlag(c, false)
+}
+
+func (s *AutoPkgTestSuite) adtRunAddsQuietFlag(c *check.C, local bool) {
+	s.subject.Verbose = true
+
+	if local {
+		s.subject.AdtRunLocal(imgPath)
+	} else {
+		s.subject.AdtRunRemote(testbedIP, testbedPort)
+	}
+
+	match := false
+	for call := range s.execCalls {
+		if strings.HasPrefix(call, "adt-run") {
+			if strings.Contains(call, " -q ") {
+				match = true
+				break
+			}
+		}
+	}
+	c.Assert(match, check.Equals, false, check.Commentf("quiet flag found in adt-run call with verbose=true"))
+}
+
 func tplExecuteCmd(tplFile, outputFile string, data interface{}) string {
 	return fmt.Sprint(tplFile, outputFile, data)
 }

--- a/integration-tests/testutils/autopkgtest/autopkgtest_test.go
+++ b/integration-tests/testutils/autopkgtest/autopkgtest_test.go
@@ -43,7 +43,7 @@ const (
 	imgPath             = "imgPath"
 	testbedIP           = "1.1.1.1"
 	testbedPort         = 90
-	adtrunTpl           = "adt-run -B --override-control %s --built-tree %s --output-dir %s --setup-commands touch /run/autopkgtest_no_reboot.stamp %s"
+	adtrunTpl           = "adt-run -B -q --override-control %s --built-tree %s --output-dir %s --setup-commands touch /run/autopkgtest_no_reboot.stamp %s"
 )
 
 type AutoPkgTestSuite struct {

--- a/integration-tests/testutils/cli/cli.go
+++ b/integration-tests/testutils/cli/cli.go
@@ -71,10 +71,18 @@ func ExecCommandErr(cmds ...string) (output string, err error) {
 
 // ExecCommandWrapper decorates the execution of the given command
 func ExecCommandWrapper(cmd *exec.Cmd) (output string, err error) {
-	fmt.Println(strings.Join(cmd.Args, " "))
+	cfg, err := config.ReadConfig(config.DefaultFileName)
+	if err != nil {
+		return "", err
+	}
+	if cfg.Verbose {
+		fmt.Println(strings.Join(cmd.Args, " "))
+	}
 	outputByte, err := cmd.CombinedOutput()
 	output = removeCoverageInfo(string(outputByte))
-	fmt.Print(output)
+	if cfg.Verbose {
+		fmt.Print(output)
+	}
 	return
 }
 

--- a/integration-tests/testutils/config/config.go
+++ b/integration-tests/testutils/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Update        bool
 	Rollback      bool
 	FromBranch    bool
+	Verbose       bool
 }
 
 // Write writes the config to a file that will be copied to the test bed.

--- a/integration-tests/testutils/config/config_test.go
+++ b/integration-tests/testutils/config/config_test.go
@@ -48,7 +48,7 @@ func testConfigStruct(fileName string) *Config {
 	return &Config{
 		fileName,
 		"testrelease", "testchannel",
-		true, true, true, true}
+		true, true, true, true, true}
 }
 func testConfigContents(fileName string) string {
 	return `{` +
@@ -58,7 +58,8 @@ func testConfigContents(fileName string) string {
 		`"RemoteTestbed":true,` +
 		`"Update":true,` +
 		`"Rollback":true,` +
-		`"FromBranch":true` +
+		`"FromBranch":true,` +
+		`"Verbose":true` +
 		`}`
 }
 
@@ -103,14 +104,15 @@ func (s *ConfigSuite) TestReadConfigLocalTestBed(c *check.C) {
 		`"RemoteTestbed":false,` +
 		`"Update":true,` +
 		`"Rollback":true,` +
-		`"FromBranch":true` +
+		`"FromBranch":true,` +
+		`"Verbose":true` +
 		`}`
 
 	ioutil.WriteFile(configFileName, []byte(configContents), 0644)
 
 	cfg, err := ReadConfig(configFileName)
 
-	testConfigStruct := &Config{configFileName, "testrelease", "testchannel", false, true, true, true}
+	testConfigStruct := &Config{configFileName, "testrelease", "testchannel", false, true, true, true, true}
 
 	c.Assert(err, check.IsNil, check.Commentf("Error reading config: %v", err))
 	c.Assert(cfg, check.DeepEquals, testConfigStruct)

--- a/integration-tests/testutils/config/config_test.go
+++ b/integration-tests/testutils/config/config_test.go
@@ -46,9 +46,9 @@ func testConfigFileName(c *check.C) string {
 
 func testConfigStruct(fileName string) *Config {
 	return &Config{
-		fileName,
-		"testrelease", "testchannel",
-		true, true, true, true, true}
+		FileName: fileName,
+		Release:  "testrelease", Channel: "testchannel",
+		RemoteTestbed: true, Update: true, Rollback: true, FromBranch: true, Verbose: true}
 }
 func testConfigContents(fileName string) string {
 	return `{` +
@@ -112,7 +112,9 @@ func (s *ConfigSuite) TestReadConfigLocalTestBed(c *check.C) {
 
 	cfg, err := ReadConfig(configFileName)
 
-	testConfigStruct := &Config{configFileName, "testrelease", "testchannel", false, true, true, true, true}
+	testConfigStruct := &Config{FileName: configFileName,
+		Release: "testrelease", Channel: "testchannel",
+		RemoteTestbed: false, Update: true, Rollback: true, FromBranch: true, Verbose: true}
 
 	c.Assert(err, check.IsNil, check.Commentf("Error reading config: %v", err))
 	c.Assert(cfg, check.DeepEquals, testConfigStruct)

--- a/integration-tests/testutils/testutils/testutils.go
+++ b/integration-tests/testutils/testutils/testutils.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/snapcore/snapd/integration-tests/testutils/config"
 )
 
 // PrepareTargetDir creates the given target directory, removing it previously if it didn't exist
@@ -48,13 +50,18 @@ func RootPath() string {
 
 // ExecCommand executes the given command and pipes the results to os.Stdout and os.Stderr, returning the resulting error
 func ExecCommand(cmds ...string) error {
-	fmt.Println(strings.Join(cmds, " "))
-
+	cfg, err := config.ReadConfig(config.DefaultFileName)
+	if err != nil {
+		return err
+	}
+	if cfg.Verbose {
+		fmt.Println(strings.Join(cmds, " "))
+	}
 	cmd := exec.Command(cmds[0], cmds[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		log.Panicf("Error while running %s: %s\n", cmd.Args, err)
 	}


### PR DESCRIPTION
With this verbose flag all commands sent through the `integration-tests/testutils/cli` package functions won't print the given command nor its output. This is the default behaviour, can be changed to the previous verbose mode by passing `-v` to the integration-tests execution command.