### PR TITLE
debian: make snapd get its environ from /etc/environment

### DIFF
--- a/debian/snapd.service
+++ b/debian/snapd.service
@@ -7,6 +7,7 @@ Requires=snapd.socket
 
 [Service]
 ExecStart=/usr/lib/snapd/snapd
+EnvironmentFile=/etc/environment
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes [lp:1579652](https://bugs.launchpad.net/snappy/+bug/1579652).