### PR TITLE
many: add new snap-exec

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -84,9 +84,14 @@ func findCommand(app *snap.AppInfo, command string) (string, error) {
 }
 
 func snapExec(snapApp, revision, command string, args []string) error {
+	rev, err := snap.ParseRevision(revision)
+	if err != nil {
+		return err
+	}
+
 	snapName, appName := snap.SplitSnapApp(snapApp)
 	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
-		Revision: snap.R(revision),
+		Revision: rev,
 	})
 	if err != nil {
 		return err

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -70,15 +70,6 @@ func splitSnapApp(snapApp string) (snap, app string) {
 	return l[0], l[1]
 }
 
-func findApp(info *snap.Info, appName string) *snap.AppInfo {
-	for _, app := range info.Apps {
-		if app.Name == appName {
-			return app
-		}
-	}
-	return nil
-}
-
 func findCommand(app *snap.AppInfo, command string) (string, error) {
 	var cmd string
 	switch command {
@@ -107,7 +98,7 @@ func snapLaunch(snapApp, command string, args []string) error {
 		return err
 	}
 
-	app := findApp(info, appName)
+	app := info.Apps[appName]
 	if app == nil {
 		return fmt.Errorf("cannot find app %q in %q", appName, snapName)
 	}

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -57,7 +57,7 @@ func run() error {
 	}
 
 	snapApp := opts.Positional.SnapApp
-	return snapLaunch(snapApp, opts.Command, args)
+	return snapExec(snapApp, opts.Command, args)
 }
 
 func splitSnapApp(snapApp string) (snap, app string) {
@@ -87,7 +87,7 @@ func findCommand(app *snap.AppInfo, command string) (string, error) {
 	return cmd, nil
 }
 
-func snapLaunch(snapApp, command string, args []string) error {
+func snapExec(snapApp, command string, args []string) error {
 	snapName, appName := splitSnapApp(snapApp)
 	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
 		Revision: snap.R(os.Getenv("SNAP_REVISION")),

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -62,10 +62,10 @@ func run() error {
 	return snapLaunch(snapApp, opts.Command, args)
 }
 
-func splitSnapApp(snapCmd string) (snap, app string) {
-	l := strings.SplitN(snapCmd, ".", 2)
+func splitSnapApp(snapApp string) (snap, app string) {
+	l := strings.SplitN(snapApp, ".", 2)
 	if len(l) < 2 {
-		return l[0], ""
+		return l[0], l[0]
 	}
 	return l[0], l[1]
 }

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -31,10 +31,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-var (
-	snapReadInfo = snap.ReadInfo
-	syscallExec  = syscall.Exec
-)
+// for the tests
+var syscallExec = syscall.Exec
 
 func main() {
 	if err := run(); err != nil {
@@ -91,7 +89,7 @@ func findCommand(app *snap.AppInfo, command string) (string, error) {
 
 func snapLaunch(snapApp, command string, args []string) error {
 	snapName, appName := splitSnapApp(snapApp)
-	info, err := snapReadInfo(snapName, &snap.SideInfo{
+	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
 		Revision: snap.R(os.Getenv("SNAP_REVISION")),
 	})
 	if err != nil {

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -1,0 +1,126 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+var (
+	snapReadInfo = snap.ReadInfo
+	syscallExec  = syscall.Exec
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Printf("cannot snap-exec: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var opts struct {
+		Positional struct {
+			SnapApp string `positional-arg-name:"<snapApp>" description:"the application to run, e.g. hello-world.env"`
+		} `positional-args:"yes" required:"yes"`
+
+		Command string `long:"command" description:"use a different command like {stop,post-stop} from the app"`
+	}
+
+	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
+	args, err := parser.Parse()
+	if err != nil {
+		return err
+	}
+
+	snapApp := opts.Positional.SnapApp
+	return snapLaunch(snapApp, opts.Command, args)
+}
+
+func splitSnapApp(snapCmd string) (snap, app string) {
+	l := strings.SplitN(snapCmd, ".", 2)
+	if len(l) < 2 {
+		return l[0], ""
+	}
+	return l[0], l[1]
+}
+
+func findApp(info *snap.Info, appName string) *snap.AppInfo {
+	for _, app := range info.Apps {
+		if app.Name == appName {
+			return app
+		}
+	}
+	return nil
+}
+
+func findCommand(app *snap.AppInfo, command string) (string, error) {
+	var cmd string
+	switch command {
+	case "stop":
+		cmd = app.StopCommand
+	case "post-stop":
+		cmd = app.PostStopCommand
+	case "":
+		cmd = app.Command
+	default:
+		return "", fmt.Errorf("cannot use %q command", command)
+	}
+
+	if cmd == "" {
+		return "", fmt.Errorf("no %q command found for %q", command, app.Name)
+	}
+	return cmd, nil
+}
+
+func snapLaunch(snapApp, command string, args []string) error {
+	snapName, appName := splitSnapApp(snapApp)
+	info, err := snapReadInfo(snapName, &snap.SideInfo{
+		Revision: snap.R(os.Getenv("SNAP_REVISION")),
+	})
+	if err != nil {
+		return err
+	}
+
+	app := findApp(info, appName)
+	if app == nil {
+		return fmt.Errorf("cannot find app %q in %q", appName, snapName)
+	}
+
+	cmd, err := findCommand(app, command)
+	if err != nil {
+		return err
+	}
+
+	// build the evnironment from the yamle
+	env := append(os.Environ(), app.Env()...)
+
+	// run the command
+	fullCmd := filepath.Join(app.Snap.MountDir(), cmd)
+	return syscallExec(fullCmd, args, env)
+}

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -56,8 +56,11 @@ func run() error {
 		return err
 	}
 
+	// the SNAP_REVISION is set by `snap run`
+	revision := os.Getenv("SNAP_REVISION")
+
 	snapApp := opts.Positional.SnapApp
-	return snapExec(snapApp, opts.Command, args)
+	return snapExec(snapApp, revision, opts.Command, args)
 }
 
 func splitSnapApp(snapApp string) (snap, app string) {
@@ -87,10 +90,10 @@ func findCommand(app *snap.AppInfo, command string) (string, error) {
 	return cmd, nil
 }
 
-func snapExec(snapApp, command string, args []string) error {
+func snapExec(snapApp, revision, command string, args []string) error {
 	snapName, appName := splitSnapApp(snapApp)
 	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
-		Revision: snap.R(os.Getenv("SNAP_REVISION")),
+		Revision: snap.R(revision),
 	})
 	if err != nil {
 		return err

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -55,7 +55,9 @@ func run() error {
 		return err
 	}
 
-	// the SNAP_REVISION is set by `snap run`
+	// the SNAP_REVISION is set by `snap run` - we can not (easily)
+	// find it in `snap-exec` because `snap-exec` is run inside the
+	// confinement and (generally) can not talk to snapd
 	revision := os.Getenv("SNAP_REVISION")
 
 	snapApp := opts.Positional.SnapApp

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/jessevdk/go-flags"
@@ -63,14 +62,6 @@ func run() error {
 	return snapExec(snapApp, revision, opts.Command, args)
 }
 
-func splitSnapApp(snapApp string) (snap, app string) {
-	l := strings.SplitN(snapApp, ".", 2)
-	if len(l) < 2 {
-		return l[0], l[0]
-	}
-	return l[0], l[1]
-}
-
 func findCommand(app *snap.AppInfo, command string) (string, error) {
 	var cmd string
 	switch command {
@@ -91,7 +82,7 @@ func findCommand(app *snap.AppInfo, command string) (string, error) {
 }
 
 func snapExec(snapApp, revision, command string, args []string) error {
-	snapName, appName := splitSnapApp(snapApp)
+	snapName, appName := snap.SplitSnapApp(snapApp)
 	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
 		Revision: snap.R(revision),
 	})

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -116,19 +116,3 @@ func (s *snapExecSuite) TestSnapLaunchIntegration(c *C) {
 	c.Check(execArgs, DeepEquals, []string{"arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "LD_LIBRARY_PATH=/some/path\n")
 }
-
-func (s *snapExecSuite) TestSplitSnapApp(c *C) {
-	for _, t := range []struct {
-		in  string
-		out []string
-	}{
-		// normal cases
-		{"foo.bar", []string{"foo", "bar"}},
-		{"foo.bar.baz", []string{"foo", "bar.baz"}},
-		// special case, snapName == appName
-		{"foo", []string{"foo", "foo"}},
-	} {
-		snap, app := splitSnapApp(t.in)
-		c.Check([]string{snap, app}, DeepEquals, t.out)
-	}
-}

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -1,0 +1,131 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !integrationcoverage
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type snapExecSuite struct {
+}
+
+var _ = Suite(&snapExecSuite{})
+
+func (s *snapExecSuite) SetUpTest(c *C) {
+	snapReadInfo = snap.ReadInfo
+	syscallExec = syscall.Exec
+}
+
+func (s *snapExecSuite) TestFindAppNoApp(c *C) {
+	app := findApp(&snap.Info{}, "foo")
+	c.Check(app, IsNil)
+}
+
+var mockYaml = []byte(`name: snapname
+version: 1.0
+apps:
+ app:
+  command: run-app
+  stop-command: stop-app
+  post-stop-command: post-stop-app
+  environment:
+   LD_LIBRARY_PATH: /some/path
+ nostop:
+  command: nostop
+`)
+
+func (s *snapExecSuite) TestFindApp(c *C) {
+	info, err := snap.InfoFromSnapYaml(mockYaml)
+	c.Assert(err, IsNil)
+
+	app := findApp(info, "app")
+	c.Check(app.Name, Equals, "app")
+	c.Check(app.Command, Equals, "run-app")
+}
+
+func (s *snapExecSuite) TestFindCommand(c *C) {
+	info, err := snap.InfoFromSnapYaml(mockYaml)
+	c.Assert(err, IsNil)
+
+	for _, t := range []struct {
+		cmd      string
+		expected string
+	}{
+		{cmd: "", expected: "run-app"},
+		{cmd: "stop", expected: "stop-app"},
+		{cmd: "post-stop", expected: "post-stop-app"},
+	} {
+		cmd, err := findCommand(info.Apps["app"], t.cmd)
+		c.Check(err, IsNil)
+		c.Check(cmd, Equals, t.expected)
+	}
+}
+
+func (s *snapExecSuite) TestFindCommandInvalidCommand(c *C) {
+	info, err := snap.InfoFromSnapYaml(mockYaml)
+	c.Assert(err, IsNil)
+
+	_, err = findCommand(info.Apps["app"], "xxx")
+	c.Check(err, ErrorMatches, `cannot use "xxx" command`)
+}
+
+func (s *snapExecSuite) TestFindCommandNoCommand(c *C) {
+	info, err := snap.InfoFromSnapYaml(mockYaml)
+	c.Assert(err, IsNil)
+
+	_, err = findCommand(info.Apps["nostop"], "stop")
+	c.Check(err, ErrorMatches, `no "stop" command found for "nostop"`)
+}
+
+func (s *snapExecSuite) TestSnapLaunchIntegration(c *C) {
+	os.Setenv("SNAP_REVISION", "42")
+	snapReadInfo = func(string, *snap.SideInfo) (*snap.Info, error) {
+		info, err := snap.InfoFromSnapYaml(mockYaml)
+		info.SideInfo.Revision = snap.R(os.Getenv("SNAP_REVISION"))
+		return info, err
+	}
+
+	execArgv0 := ""
+	execArgs := []string{}
+	execEnv := []string{}
+	syscallExec = func(argv0 string, argv []string, env []string) error {
+		execArgv0 = argv0
+		execArgs = argv
+		execEnv = env
+		return nil
+	}
+
+	err := snapLaunch("snap.app", "stop", []string{"arg1", "arg2"})
+	c.Assert(err, IsNil)
+	c.Check(execArgv0, Equals, "/snap/snapname/42/stop-app")
+	c.Check(execArgs, DeepEquals, []string{"arg1", "arg2"})
+	c.Check(execEnv, testutil.Contains, "LD_LIBRARY_PATH=/some/path\n")
+}

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -129,3 +129,19 @@ func (s *snapExecSuite) TestSnapLaunchIntegration(c *C) {
 	c.Check(execArgs, DeepEquals, []string{"arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "LD_LIBRARY_PATH=/some/path\n")
 }
+
+func (s *snapExecSuite) TestSplitSnapApp(c *C) {
+	for _, t := range []struct {
+		in  string
+		out []string
+	}{
+		// normal cases
+		{"foo.bar", []string{"foo", "bar"}},
+		{"foo.bar.baz", []string{"foo", "bar.baz"}},
+		// special case, snapName == appName
+		{"foo", []string{"foo", "foo"}},
+	} {
+		snap, app := splitSnapApp(t.in)
+		c.Check([]string{snap, app}, DeepEquals, t.out)
+	}
+}

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -44,11 +44,6 @@ func (s *snapExecSuite) SetUpTest(c *C) {
 	syscallExec = syscall.Exec
 }
 
-func (s *snapExecSuite) TestFindAppNoApp(c *C) {
-	app := findApp(&snap.Info{}, "foo")
-	c.Check(app, IsNil)
-}
-
 var mockYaml = []byte(`name: snapname
 version: 1.0
 apps:
@@ -61,15 +56,6 @@ apps:
  nostop:
   command: nostop
 `)
-
-func (s *snapExecSuite) TestFindApp(c *C) {
-	info, err := snap.InfoFromSnapYaml(mockYaml)
-	c.Assert(err, IsNil)
-
-	app := findApp(info, "app")
-	c.Check(app.Name, Equals, "app")
-	c.Check(app.Command, Equals, "run-app")
-}
 
 func (s *snapExecSuite) TestFindCommand(c *C) {
 	info, err := snap.InfoFromSnapYaml(mockYaml)

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -22,7 +22,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"syscall"
 	"testing"
 
@@ -97,7 +96,7 @@ func (s *snapExecSuite) TestFindCommandNoCommand(c *C) {
 func (s *snapExecSuite) TestSnapLaunchIntegration(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
-		Revision: snap.R("x42"),
+		Revision: snap.R("42"),
 	})
 
 	execArgv0 := ""
@@ -110,13 +109,10 @@ func (s *snapExecSuite) TestSnapLaunchIntegration(c *C) {
 		return nil
 	}
 
-	// this environment is always set by `snap run`
-	os.Setenv("SNAP_REVISION", "x42")
-
 	// launch and verify its run the right way
-	err := snapExec("snapname.app", "stop", []string{"arg1", "arg2"})
+	err := snapExec("snapname.app", "42", "stop", []string{"arg1", "arg2"})
 	c.Assert(err, IsNil)
-	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/x42/stop-app", dirs.SnapSnapsDir))
+	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/42/stop-app", dirs.SnapSnapsDir))
 	c.Check(execArgs, DeepEquals, []string{"arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "LD_LIBRARY_PATH=/some/path\n")
 }

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -93,9 +93,13 @@ func (s *snapExecSuite) TestFindCommandNoCommand(c *C) {
 
 func (s *snapExecSuite) TestSnapLaunchIntegration(c *C) {
 	os.Setenv("SNAP_REVISION", "42")
-	snapReadInfo = func(string, *snap.SideInfo) (*snap.Info, error) {
+
+	snapReadInfo = func(snapName string, si *snap.SideInfo) (*snap.Info, error) {
+		c.Check(snapName, Equals, "snapname")
+		c.Check(si.Revision, Equals, snap.R(42))
+
 		info, err := snap.InfoFromSnapYaml(mockYaml)
-		info.SideInfo.Revision = snap.R(os.Getenv("SNAP_REVISION"))
+		info.SideInfo = *si
 		return info, err
 	}
 
@@ -109,7 +113,7 @@ func (s *snapExecSuite) TestSnapLaunchIntegration(c *C) {
 		return nil
 	}
 
-	err := snapLaunch("snap.app", "stop", []string{"arg1", "arg2"})
+	err := snapLaunch("snapname.app", "stop", []string{"arg1", "arg2"})
 	c.Assert(err, IsNil)
 	c.Check(execArgv0, Equals, "/snap/snapname/42/stop-app")
 	c.Check(execArgs, DeepEquals, []string{"arg1", "arg2"})

--- a/debian/snapd.install
+++ b/debian/snapd.install
@@ -1,5 +1,6 @@
 /usr/bin/snap
 /usr/bin/snapd usr/lib/snapd
+/usr/bin/snap-exec usr/lib/snapd
 data/completion/snap /usr/share/bash-completion/completions/
 # i18n stuff
 ../../share /usr

--- a/snap/info.go
+++ b/snap/info.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/systemd"
@@ -348,4 +349,15 @@ func ReadInfoFromSnapFile(snapf Container, si *SideInfo) (*Info, error) {
 	}
 
 	return info, nil
+}
+
+// SplitSnapApp will split a string of the form `snap.app` into
+// the `snap` and the `app` part. It also deals with the special
+// case of snapName == appName.
+func SplitSnapApp(snapApp string) (snap, app string) {
+	l := strings.SplitN(snapApp, ".", 2)
+	if len(l) < 2 {
+		return l[0], l[0]
+	}
+	return l[0], l[1]
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -280,6 +280,28 @@ func (app *AppInfo) ServiceSocketFile() string {
 	return filepath.Join(dirs.SnapServicesDir, app.SecurityTag()+".socket")
 }
 
+func copyEnv(in map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
+// Env returns the app specific environment overrides
+func (app *AppInfo) Env() []string {
+	env := []string{}
+	appEnv := copyEnv(app.Snap.Environment)
+	for k, v := range app.Environment {
+		appEnv[k] = v
+	}
+	for k, v := range appEnv {
+		env = append(env, fmt.Sprintf("%s=%s\n", k, v))
+	}
+	return env
+}
+
 func infoFromSnapYamlWithSideInfo(meta []byte, si *SideInfo) (*Info, error) {
 	info, err := InfoFromSnapYaml(meta)
 	if err != nil {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 
 	. "gopkg.in/check.v1"
 
@@ -239,4 +240,51 @@ confinement: foo`
 
 	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
 	c.Assert(err, ErrorMatches, ".*invalid confinement type.*")
+}
+
+func (s *infoSuite) TestAppEnvSimple(c *C) {
+	yaml := `name: foo
+version: 1.0
+type: app
+environment:
+ global-k: global-v
+apps:
+ foo:
+  environment:
+   app-k: app-v
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yaml))
+	c.Assert(err, IsNil)
+
+	env := info.Apps["foo"].Env()
+	sort.Strings(env)
+	c.Check(env, DeepEquals, []string{
+		"app-k=app-v\n",
+		"global-k=global-v\n",
+	})
+}
+
+func (s *infoSuite) TestAppEnvOverrideGlobal(c *C) {
+	yaml := `name: foo
+version: 1.0
+type: app
+environment:
+ global-k: global-v
+ global-and-local: global-v
+apps:
+ foo:
+  environment:
+   app-k: app-v
+   global-and-local: local-v
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yaml))
+	c.Assert(err, IsNil)
+
+	env := info.Apps["foo"].Env()
+	sort.Strings(env)
+	c.Check(env, DeepEquals, []string{
+		"app-k=app-v\n",
+		"global-and-local=local-v\n",
+		"global-k=global-v\n",
+	})
 }

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -20,6 +20,7 @@
 package snap_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -287,4 +288,30 @@ apps:
 		"global-and-local=local-v\n",
 		"global-k=global-v\n",
 	})
+}
+
+func (s *infoSuite) TestSplitSnapApp(c *C) {
+	for _, t := range []struct {
+		in  string
+		out []string
+	}{
+		// normal cases
+		{"foo.bar", []string{"foo", "bar"}},
+		{"foo.bar.baz", []string{"foo", "bar.baz"}},
+		// special case, snapName == appName
+		{"foo", []string{"foo", "foo"}},
+	} {
+		snap, app := snap.SplitSnapApp(t.in)
+		c.Check([]string{snap, app}, DeepEquals, t.out)
+	}
+}
+
+func ExampleSpltiSnapApp() {
+	fmt.Println(snap.SplitSnapApp("hello-world.env"))
+	// Output: hello-world env
+}
+
+func ExampleSpltiSnapAppShort() {
+	fmt.Println(snap.SplitSnapApp("hello-world"))
+	// Output: hello-world hello-world
 }


### PR DESCRIPTION
Based on https://github.com/snapcore/snapd/pull/1242/files

This implements `snap-exec` which will be used from inside the confinement to run a snap. This is a prerequisite for the future work as this command needs to be available in the stable version of the OS snap before we can continue with pushing `snap run` (note that we will also have to have landed a snapd with automatic refresh of the OS snap for this to work).