### PR TITLE
interfaces: add socketcall() to the network/network-bind interfaces

### DIFF
--- a/integration-tests/data/snaps/network-consumer/bin/consumer
+++ b/integration-tests/data/snaps/network-consumer/bin/consumer
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-import sys
+import sys, os
 from socket import timeout
 import urllib.request
 
@@ -16,5 +16,7 @@ try:
     print(decoded_response.replace('<!doctype html>', ''), end="")
 except urllib.error.URLError as e:
   print("Error, reason: ", e.reason)
+  os.exit(1)
 except timeout:
   print("request timeout")
+  os.exit(1)

--- a/integration-tests/tests/network_bind_interface_test.go
+++ b/integration-tests/tests/network_bind_interface_test.go
@@ -50,6 +50,6 @@ func (s *networkBindInterfaceSuite) TestPlugDisconnectionDisablesClientConnectio
 	output = cli.ExecCommand(c, "snap", "interfaces")
 	c.Assert(output, check.Matches, disconnectedPattern(s.slot, s.plug))
 
-	output = cli.ExecCommand(c, "network-consumer", providerURL)
-	c.Assert(output, check.Equals, "request timeout\n")
+	output, err := cli.ExecCommandErr("network-consumer", providerURL)
+	c.Assert(err, check.NotNil)
 }

--- a/integration-tests/tests/network_interface_test.go
+++ b/integration-tests/tests/network_interface_test.go
@@ -50,6 +50,6 @@ func (s *networkInterfaceSuite) TestPlugDisconnectionDisablesFunctionality(c *ch
 	output = cli.ExecCommand(c, "snap", "interfaces")
 	c.Assert(output, check.Matches, disconnectedPattern(s.slot, s.plug))
 
-	output = cli.ExecCommand(c, "network-consumer", providerURL)
-	c.Assert(output, check.Equals, "Error, reason:  [Errno 13] Permission denied\n")
+	output, err := cli.ExecCommandErr("network-consumer", providerURL)
+	c.Check(err, check.NotNil)
 }

--- a/integration-tests/tests/snap_find_test.go
+++ b/integration-tests/tests/snap_find_test.go
@@ -21,6 +21,8 @@
 package tests
 
 import (
+	"runtime"
+
 	"github.com/snapcore/snapd/integration-tests/testutils/cli"
 	"github.com/snapcore/snapd/integration-tests/testutils/common"
 
@@ -50,6 +52,10 @@ func (s *searchSuite) TestSearchMustPrintMatch(c *check.C) {
 
 // SNAP_FIND_001: list all packages available on the store
 func (s *searchSuite) TestFindMustPrintCompleteList(c *check.C) {
+	if runtime.GOARCH != "amd64" {
+		c.Skip("all find results are only available on amd64")
+	}
+
 	fullListPattern := "(?ms)" +
 		"Name +Version +(Price +)?Summary *\n" +
 		".*" +
@@ -73,6 +79,10 @@ func (s *searchSuite) TestFindMustPrintCompleteList(c *check.C) {
 
 // SNAP_FIND_002: find packages on store with different name formats
 func (s *searchSuite) TestFindWorksWithDifferentFormats(c *check.C) {
+	if runtime.GOARCH != "amd64" {
+		c.Skip("all find results are only available on amd64")
+	}
+
 	for _, snapName := range []string{"http", "ubuntu-clock-app", "go-example-webserver"} {
 		expected := "(?ms)" +
 			"Name +Version +(Price +)?Summary *\n" +

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -57,7 +57,7 @@ socket
 # of socket(), bind(), connect(), etc individually. While we could allow it,
 # we wouldn't be able to properly arg filter socketcall for AF_INET/AF_INET6
 # when LP: #1446748 is implemented.
-#socketcall
+socketcall
 `
 
 // NewNetworkInterface returns a new "network" interface.

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -89,7 +89,7 @@ socket
 # of socket(), bind(), connect(), etc individually. While we could allow it,
 # we wouldn't be able to properly arg filter socketcall for AF_INET/AF_INET6
 # when LP: #1446748 is implemented.
-#socketcall
+socketcall
 `
 
 // NewNetworkBindInterface returns a new "network-bind" interface.


### PR DESCRIPTION
Upon investigating the autopkgtest failure of snapd on i386 (https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-xenial/xenial/i386/s/snapd/20160519_224511@/log.gz) I found that we get a seccomp denial for syscall 102 which is:
```
$ scmp_sys_resolver 102
socketcall
```
Running the test with this branch via `CGO_ENABLED=1  GOARCH=386 go run  integration-tests/main.go  --ip localhost -port 11022 --filter networkBindInterfaceSuite --snappy-from-branch` make the integration tests work on i386.

Some more changes were needed because the failure mode of the network integration tests now include getting killed from seccomp. So instead of using c.ExecCommand() I switched to c.ExecCommandErr() where failures are expected.