### PR TITLE
snap: ensure `snap try` work with relative paths

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -22,6 +22,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -222,7 +223,13 @@ func (x *cmdTry) Execute([]string) error {
 	opts := &client.SnapOptions{
 		DevMode: x.DevMode,
 	}
-	changeID, err := cli.Try(name, opts)
+
+	path, err := filepath.Abs(name)
+	if err != nil {
+		return fmt.Errorf("cannot get full path for %q: %s", name, err)
+	}
+
+	changeID, err := cli.Try(path, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -175,14 +175,19 @@ func (s *SnapOpSuite) TestInstallPathDevMode(c *check.C) {
 }
 
 func (s *SnapOpSuite) runTryTest(c *check.C, devmode bool) {
-	tryDir := c.MkDir()
+	// pass relative path to cmd
+	tryDir := "some-dir"
 
 	s.srv.checker = func(r *http.Request) {
+		// ensure the client always sends the absolute path
+		fullTryDir, err := filepath.Abs(tryDir)
+		c.Assert(err, check.IsNil)
+
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps")
 		postData, err := ioutil.ReadAll(r.Body)
 		c.Assert(err, check.IsNil)
 		c.Assert(string(postData), check.Matches, "(?s).*Content-Disposition: form-data; name=\"action\"\r\n\r\ntry\r\n.*")
-		c.Assert(string(postData), check.Matches, fmt.Sprintf("(?s).*Content-Disposition: form-data; name=\"snap-path\"\r\n\r\n%s\r\n.*", tryDir))
+		c.Assert(string(postData), check.Matches, fmt.Sprintf("(?s).*Content-Disposition: form-data; name=\"snap-path\"\r\n\r\n%s\r\n.*", fullTryDir))
 		c.Assert(string(postData), check.Matches, fmt.Sprintf("(?s).*Content-Disposition: form-data; name=\"devmode\"\r\n\r\n%s\r\n.*", strconv.FormatBool(devmode)))
 	}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -681,6 +681,9 @@ func trySnap(c *Command, r *http.Request, user *auth.UserState, trydir string, f
 	st.Lock()
 	defer st.Unlock()
 
+	if !filepath.IsAbs(trydir) {
+		return BadRequest("cannot try %q: need an absolute path", trydir)
+	}
 	if !osutil.IsDirectory(trydir) {
 		return BadRequest("cannot try %q: not a snap directory", trydir)
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1170,6 +1170,24 @@ func (s *apiSuite) TestTrySnap(c *check.C) {
 
 }
 
+func (s *apiSuite) TestTrySnapRelative(c *check.C) {
+	req, err := http.NewRequest("POST", "/v2/snaps", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := trySnap(snapsCmd, req, nil, "relative-path", 0).(*resp)
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "need an absolute path")
+}
+
+func (s *apiSuite) TestTrySnapNotDir(c *check.C) {
+	req, err := http.NewRequest("POST", "/v2/snaps", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := trySnap(snapsCmd, req, nil, "/does/not/exist", 0).(*resp)
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "not a snap directory")
+}
+
 func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]string, expectedFlags snappy.InstallFlags, hasUbuntuCore bool) string {
 	d := newTestDaemon(c)
 	d.overlord.Loop()


### PR DESCRIPTION
The new `snap try` command currently requires an absolute path to work.This is a bit silly and this branch fixes it.