### PR TITLE
debian: drop run/build dependency on lsb-release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+snapd (2.0.6) UNRELEASED; urgency=medium
+
+  * Drop build and runtime dependency on lsb-release. Snapd uses
+    /etc/os-release which is in base-files so no dependency is required.
+
+ -- Zygmunt Krynicki <zygmunt.krynicki@canonical.com>  Wed, 01 Jun 2016 16:35:20 +0200
+
 snapd (2.0.5) xenial; urgency=medium
 
   * New upstream release: LP: #1583085

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,6 @@ Build-Depends: bash-completion,
                golang-yaml.v2-dev,
                golang-gopkg-tomb.v2-dev,
                golang-websocket-dev,
-               lsb-release,
                python3,
                python3-markdown,
                squashfs-tools
@@ -42,7 +41,7 @@ Description: snappy development go packages.
 
 Package: snapd
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, lsb-release,
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser
  squashfs-tools, ubuntu-core-launcher (>= 1.0.23),
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)


### PR DESCRIPTION
This patch removes lsb-release from all dependencies. Since the last
release snapd reads and uses /etc/os-release instead.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>