### PR TITLE
cmd/snap: have 'snap list' display helper message on stderr

### DIFF
--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -60,7 +60,7 @@ func listSnaps(names []string) error {
 	if err != nil {
 		return err
 	} else if len(snaps) == 0 {
-		fmt.Fprintln(Stdout, i18n.G("No snaps are installed yet. Try 'snap install hello-world'."))
+		fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet. Try 'snap install hello-world'."))
 		return nil
 	}
 	sort.Sort(snapsByName(snaps))

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -69,8 +69,8 @@ func (s *SnapSuite) TestListEmpty(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"list"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, "No snaps are installed yet. Try 'snap install hello-world'.\n")
-	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Matches, "No snaps are installed yet. Try 'snap install hello-world'.\n")
 }
 
 func (s *SnapSuite) TestListWithQuery(c *check.C) {


### PR DESCRIPTION
This is just a follow up for the bug fix linked below. If there are not
snaps to show the helper message is printed to stdout. This can cause
some undesired confusion when coupled with a tool like grep where it
will apparently "find" something while nothing was really available.

This patch changes the helper message to be displayed on stderr .

Fixes: https://bugs.launchpad.net/snappy/+bug/1587445
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>