### PR TITLE
interfaces: autoconnect home and doc updates

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -55,7 +55,7 @@ Auto-Connect: yes
 
 ### opengl
 
-Can access the opengl hardware. 
+Can access the opengl hardware.
 
 Usage: reserved
 Auto-Connect: yes
@@ -67,8 +67,17 @@ This is restricted because it gives file access to the user's
 `$HOME`.
 
 Usage: reserved
+Auto-Connect: yes
 
 ## Supported Interfaces - Advanced
+
+### cups-control
+
+Can access cups control socket. This is restricted because it provides
+privileged access to configure printing.
+
+Usage: reserved
+Auto-Connect: no
 
 ### firewall-control
 
@@ -76,18 +85,21 @@ Can configure firewall. This is restricted because it gives privileged access
 to networking and should only be used with trusted apps.
 
 Usage: reserved
+Auto-Connect: no
 
 ### locale-control
 
 Can manage locales directly separate from 'config ubuntu-core'.
 
 Usage: reserved
+Auto-Connect: no
 
 ### log-observe
 
 Can read system logs and set kernel log rate-limiting.
 
 Usage: reserved
+Auto-Connect: no
 
 ### mount-observe
 
@@ -96,6 +108,7 @@ privileged read access to mount arguments and should only be used with trusted
 apps.
 
 Usage: reserved
+Auto-Connect: no
 
 ### network-control
 
@@ -103,6 +116,7 @@ Can configure networking. This is restricted because it gives wide, privileged
 access to networking and should only be used with trusted apps.
 
 Usage: reserved
+Auto-Connect: no
 
 ### network-observe
 
@@ -111,12 +125,14 @@ privileged read-only access to networking information and should only be used
 with trusted apps.
 
 Usage: reserved
+Auto-Connect: no
 
 ### snapd-control
 
 Can manage snaps via snapd.
 
 Usage: reserved
+Auto-Connect: no
 
 ### system-observe
 
@@ -125,16 +141,11 @@ privileged read access to all processes on the system and should only be used
 with trusted apps.
 
 Usage: reserved
+Auto-Connect: no
 
 ### timeserver-control
 
 Can manage timeservers directly separate from config ubuntu-core.
 
 Usage: reserved
-
-### cups-control
-
-Can access cups control socket. This is restricted because it provides
-privileged access to configure printing.
-
-Usage: reserved
+Auto-Connect: no

--- a/integration-tests/tests/home_interface_test.go
+++ b/integration-tests/tests/home_interface_test.go
@@ -35,7 +35,8 @@ var _ = check.Suite(&homeInterfaceSuite{
 	interfaceSuite: interfaceSuite{
 		sampleSnaps: []string{data.HomeConsumerSnapName},
 		slot:        "home",
-		plug:        "home-consumer"}})
+		plug:        "home-consumer",
+		autoconnect: true}})
 
 type homeInterfaceSuite struct {
 	interfaceSuite

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -49,5 +49,6 @@ func NewHomeInterface() interfaces.Interface {
 		name: "home",
 		connectedPlugAppArmor: homeConnectedPlugAppArmor,
 		reservedForOS:         true,
+		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -124,5 +124,5 @@ func (s *HomeInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 }
 
 func (s *HomeInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.AutoConnect(), Equals, true)
 }


### PR DESCRIPTION
Per interfaces team, home should autoconnect.

Adjust documentation for home, explicitly state which interfaces are manually
connected, fix whitespace and put cups-control before firewall-control.