### PR TITLE
many: more snappy package related clean outs

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -58,7 +58,6 @@ type apiSuite struct {
 	searchTerm        string
 	channel           string
 	suggestedCurrency string
-	overlord          *fakeOverlord
 	d                 *Daemon
 	auther            store.Authenticator
 	restoreBackends   func()
@@ -121,9 +120,6 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	s.channel = ""
 	s.err = nil
 	s.vars = nil
-	s.overlord = &fakeOverlord{
-		configs: map[string]string{},
-	}
 	s.auther = nil
 	s.d = nil
 	s.refreshCandidates = nil
@@ -1119,21 +1115,6 @@ func (s *apiSuite) TestPostSnapDispatch(c *check.C) {
 		// do you feel dirty yet?
 		c.Check(fmt.Sprintf("%p", action.impl), check.Equals, fmt.Sprintf("%p", inst.dispatch()))
 	}
-}
-
-type fakeOverlord struct {
-	configs map[string]string
-}
-
-func (o *fakeOverlord) Configure(s *snappy.Snap, c []byte) ([]byte, error) {
-	if len(c) > 0 {
-		o.configs[s.Name()] = string(c)
-	}
-	config, ok := o.configs[s.Name()]
-	if !ok {
-		return nil, fmt.Errorf("no config for %q", s.Name())
-	}
-	return []byte(config), nil
 }
 
 func (s *apiSuite) TestSideloadSnap(c *check.C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -151,22 +151,6 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	return d
 }
 
-func (s *apiSuite) mkManifest(c *check.C, pkgType snap.Type) {
-	// creating the part to get its manifest path is cheating, a little
-	sideInfo := snap.SideInfo{
-		OfficialName:      "foo",
-		Developer:         "bar",
-		Revision:          snap.R(2147483647),
-		EditedDescription: " bla bla bla",
-	}
-
-	c.Assert(snappy.SaveManifest(&snap.Info{
-		Type:     pkgType,
-		Version:  "1",
-		SideInfo: sideInfo,
-	}), check.IsNil)
-}
-
 func (s *apiSuite) mkInstalled(c *check.C, name, developer, version string, revno snap.Revision, active bool, extraYaml string) *snap.Info {
 	return s.mkInstalledInState(c, nil, name, developer, version, revno, active, extraYaml)
 }
@@ -195,9 +179,6 @@ version: %s
 	guidir := filepath.Join(metadir, "gui")
 	c.Assert(os.MkdirAll(guidir, 0755), check.IsNil)
 	c.Check(ioutil.WriteFile(filepath.Join(guidir, "icon.svg"), []byte("yadda icon"), 0644), check.IsNil)
-
-	err := snappy.SaveManifest(snapInfo)
-	c.Assert(err, check.IsNil)
 
 	if daemon != nil {
 		st := daemon.overlord.State()

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -46,7 +46,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-	"github.com/snapcore/snapd/snappy"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -275,9 +274,6 @@ func (s *apiSuite) TestSnapInfoWithAuth(c *check.C) {
 }
 
 func (s *apiSuite) TestSnapInfoNotFound(c *check.C) {
-	s.vars = map[string]string{"name": "foo"}
-	s.err = snappy.ErrPackageNotFound
-
 	req, err := http.NewRequest("GET", "/v2/snaps/gfoo", nil)
 	c.Assert(err, check.IsNil)
 	c.Check(getSnapInfo(snapCmd, req, nil).(*resp).Status, check.Equals, http.StatusNotFound)

--- a/overlord/snapstate/flagscompat_test.go
+++ b/overlord/snapstate/flagscompat_test.go
@@ -56,8 +56,6 @@ func (s *flagscompatSuite) TestCopiedConstsSanity(c *C) {
 	c.Check(snappy.LegacyInstallFlags(snappyDoInstallGC), Equals, snappy.LegacyDoInstallGC)
 	c.Check(snappy.LegacyInstallFlags(snappyAllowGadget), Equals, snappy.LegacyAllowGadget)
 
-	c.Check(snappy.LegacyInstallFlags(snappyDeveloperMode), Equals, snappy.InterimDeveloperMode)
-	c.Check(snappy.LegacyInstallFlags(snappyTryMode), Equals, snappy.InterimTryMode)
 }
 
 func (s *flagscompatSuite) TestSnapSetupNewValuesUnchanged(c *C) {

--- a/snappy/install.go
+++ b/snappy/install.go
@@ -43,10 +43,9 @@ const (
 	LegacyDoInstallGC
 	// AllowGadget allows the installation of Gadget packages, this does not affect updates.
 	LegacyAllowGadget
-	// DeveloperMode will install the snap without confinement
-	InterimDeveloperMode
-	// TryMode indicates the snap is in try (unpacked directory) mode
-	InterimTryMode
+
+	// Do not add new flags here! this is all going away soon! just kept alive as long as we may need to quickly patch up u-d-f.
+	DO_NOT_ADD_NEW_FLAGS_HERE
 )
 
 func installRemote(mStore *store.SnapUbuntuStoreRepository, remoteSnap *snap.Info, flags LegacyInstallFlags, meter progress.Meter) (string, error) {

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -61,8 +61,8 @@ func checkAssumes(s *snap.Info) error {
 	return nil
 }
 
-// CheckSnap ensures that the snap can be installed
-func CheckSnap(snapFilePath string, curInfo *snap.Info, flags LegacyInstallFlags, meter progress.Meter) error {
+// checkSnap ensures that the snap can be installed
+func checkSnap(snapFilePath string, curInfo *snap.Info, flags LegacyInstallFlags, meter progress.Meter) error {
 	allowGadget := (flags & LegacyAllowGadget) != 0
 	allowUnauth := (flags & LegacyAllowUnauthenticated) != 0
 
@@ -411,7 +411,7 @@ func (o *Overlord) InstallWithSideInfo(snapFilePath string, sideInfo *snap.SideI
 		}
 	}
 
-	if err := CheckSnap(snapFilePath, oldInfo, flags, meter); err != nil {
+	if err := checkSnap(snapFilePath, oldInfo, flags, meter); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This deletes some more obsolete/pointless uses of snappy bits. And unexport/removes bits of snappy.