### PR TITLE
debian: do not ship  /etc/ld.so.conf.d/snappy.conf (LP: #1589006)

### DIFF
--- a/debian/snapd.install
+++ b/debian/snapd.install
@@ -8,8 +8,6 @@ data/completion/snap /usr/share/bash-completion/completions/
 etc/profile.d
 # etc/X11/Xsession.d will add to XDG_DATA_DIRS so that we have .desktop support
 etc/X11
-# etc/ld.so.conf.d contains the SNAP_LIBRARY_PATH directories
-etc/ld.so.conf.d
 
 # systemd stuff
 

--- a/debian/snapd.maintscript
+++ b/debian/snapd.maintscript
@@ -1,3 +1,5 @@
 
 # we used to ship a custom grub config that is no longer needed
 rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
+# keep mount point busy
+rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~

--- a/debian/snapd.postinst
+++ b/debian/snapd.postinst
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+#DEBHELPER#
+
+
+case "$1" in
+    configure)
+        # ensure /var/lib/snapd/lib/gl is cleared
+        if dpkg --compare-versions "$2" lt-nl "2.0.7"; then
+            ldconfig
+        fi
+esac

--- a/etc/ld.so.conf.d/snappy.conf
+++ b/etc/ld.so.conf.d/snappy.conf
@@ -1,2 +1,0 @@
-# snappy looks for additional gl drivers here
-/var/lib/snapd/lib/gl


### PR DESCRIPTION
This avoid the "mount point busy" error on uninstalling the nvidia-361 deb.