### PR TITLE
integration-tests: report Asset build errors instead of silently ignoring them

### DIFF
--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -104,10 +104,14 @@ func main() {
 	}
 	cfg.Write()
 
-	build.Assets(&build.Config{
+	err := build.Assets(&build.Config{
 		UseSnappyFromBranch: *useSnappyFromBranch,
 		Arch:                *arch,
 		TestBuildTags:       *testBuildTags})
+	if err != nil {
+		log.Printf("Assets building failed: %s", err)
+		os.Exit(1)
+	}
 
 	rootPath := testutils.RootPath()
 

--- a/integration-tests/testutils/build/build.go
+++ b/integration-tests/testutils/build/build.go
@@ -66,7 +66,7 @@ type Config struct {
 
 // Assets builds the snappy and integration tests binaries for the target
 // architecture.
-func Assets(cfg *Config) {
+func Assets(cfg *Config) error {
 	tmp := "/tmp/snappy-build"
 	_, filename, _, _ := runtime.Caller(1)
 	dir, _ := filepath.Abs(filepath.Join(path.Dir(filename), ".."))
@@ -81,36 +81,42 @@ func Assets(cfg *Config) {
 		coverpkg := getCoverPkg()
 		// FIXME We need to build an image that has the snappy from the branch
 		// installed. --elopio - 2015-06-25.
-		buildSnapd(cfg.Arch, coverpkg)
-		buildSnapCLI(cfg.Arch, coverpkg)
+		if err := buildSnapd(cfg.Arch, coverpkg); err != nil {
+			return err
+		}
+		if err := buildSnapCLI(cfg.Arch, coverpkg); err != nil {
+			return err
+		}
 	}
-	buildSnapbuild(cfg.Arch)
-	buildTests(cfg.Arch, cfg.TestBuildTags)
+	if err := buildSnapbuild(cfg.Arch); err != nil {
+		return err
+	}
+	return buildTests(cfg.Arch, cfg.TestBuildTags)
 }
 
-func buildSnapd(arch, coverpkg string) {
+func buildSnapd(arch, coverpkg string) error {
 	fmt.Println("Building snapd...")
 	buildSnapdCmd := getBinaryBuildCmd("snapd", coverpkg)
 
-	goCall(arch, buildSnapdCmd)
+	return goCall(arch, buildSnapdCmd)
 }
 
-func buildSnapCLI(arch, coverpkg string) {
+func buildSnapCLI(arch, coverpkg string) error {
 	fmt.Println("Building snap...")
 
 	buildSnapCliCmd := getBinaryBuildCmd("snap", coverpkg)
-	goCall(arch, buildSnapCliCmd)
+	return goCall(arch, buildSnapCliCmd)
 }
 
-func buildSnapbuild(arch string) {
+func buildSnapbuild(arch string) error {
 	fmt.Println("Building snapbuild...")
 
 	buildSnapbuildCmd := "go build" +
 		" -o " + filepath.Join(testsBinDir, filepath.Base(snapbuildPkg)) + " " + snapbuildPkg
-	goCall(arch, buildSnapbuildCmd)
+	return goCall(arch, buildSnapbuildCmd)
 }
 
-func buildTests(arch, testBuildTags string) {
+func buildTests(arch, testBuildTags string) error {
 	fmt.Println("Building tests...")
 
 	var tagText string
@@ -119,13 +125,15 @@ func buildTests(arch, testBuildTags string) {
 	}
 	cmd := fmt.Sprintf(buildTestCmdFmt, tagText)
 
-	goCall(arch, cmd)
+	if err := goCall(arch, cmd); err != nil {
+		return err
+	}
 	// XXX Go test 1.3 does not have the output flag, so we move the
 	// binaries after they are generated.
-	osRename("tests.test", testsBinDir+IntegrationTestName)
+	return osRename("tests.test", testsBinDir+IntegrationTestName)
 }
 
-func goCall(arch string, cmd string) {
+func goCall(arch string, cmd string) error {
 	if arch != "" {
 		defer osSetenv("GOARCH", osGetenv("GOARCH"))
 		osSetenv("GOARCH", arch)
@@ -144,7 +152,11 @@ func goCall(arch string, cmd string) {
 	cmdElems := strings.Fields(cmd)
 	command := exec.Command(cmdElems[0], cmdElems[1:]...)
 	command.Dir = filepath.Join(os.Getenv("GOPATH"), projectSrcPath)
-	execCommand(command)
+	output, err := execCommand(command)
+	if err != nil {
+		return fmt.Errorf("command %q failed: %q (%s)", cmdElems, err, output)
+	}
+	return nil
 }
 
 func getBinaryBuildCmd(binary, coverpkg string) string {

--- a/integration-tests/testutils/cli/cli.go
+++ b/integration-tests/testutils/cli/cli.go
@@ -83,7 +83,7 @@ func ExecCommandWrapper(cmd *exec.Cmd) (output string, err error) {
 	if cfg.Verbose {
 		fmt.Print(output)
 	}
-	return
+	return output, err
 }
 
 // AddOptionsToCommand inserts the required coverage options in


### PR DESCRIPTION
With this branch we get:
```
$ go run  integration-tests/main.go  --ip localhost -port 11022 --filter listSuite --snappy-from-branch
Building snapd...
Building snap...
Building snapbuild...
Building tests...
2016/06/06 08:34:19 Assets building failed: command ["go" "test" "-tags=allsnaps" "-c" "./integration-tests/tests"] failed: "exit status 2" (# github.com/snapcore/snapd/integration-tests/tests
integration-tests/tests/base_test.go:54: undefined: xxx
)
exit status 1
```
if there is a syntax error in the code instead of the current (somewhat hard to read):
```
$ go run  integration-tests/main.go  --ip localhost -port 11022 --filter listSuite --snappy-from-branch
Building snapd...
Building snap...
Building snapbuild...
Building tests...
Calling adt-run...
./integration-tests/scripts/test-wrapper: 45: ./integration-tests/scripts/test-wrapper: integration.test: not found
command1             FAIL non-zero exit status 127
Exit request sent.
2016/06/06 08:37:02 Error while running [adt-run -B -q --override-control integration-tests/data/output/control --built-tree /home/egon/devel/go/src/github.com/snapcore/snapd --output-dir /tmp/snappy-test/output --setup-commands touch /run/autopkgtest_no_reboot.stamp --env TEST_USER_NAME= --env TEST_USER_PASSWORD= --env no_proxy=127.0.0.1,127.0.1.1,localhost,login.ubuntu.com --env http_proxy= --env https_proxy= --- ssh -H localhost -p 11022 -l ubuntu -i /home/egon/.ssh/id_rsa --reboot --timeout-ssh 600]: exit status 4
panic: Error while running [adt-run -B -q --override-control integration-tests/data/output/control --built-tree /home/egon/devel/go/src/github.com/snapcore/snapd --output-dir /tmp/snappy-test/output --setup-commands touch /run/autopkgtest_no_reboot.stamp --env TEST_USER_NAME= --env TEST_USER_PASSWORD= --env no_proxy=127.0.0.1,127.0.1.1,localhost,login.ubuntu.com --env http_proxy= --env https_proxy= --- ssh -H localhost -p 11022 -l ubuntu -i /home/egon/.ssh/id_rsa --reboot --timeout-ssh 600]: exit status 4

```