### PR TITLE
classic: skip tests when running on other platforms

### DIFF
--- a/classic/create_test.go
+++ b/classic/create_test.go
@@ -52,6 +52,9 @@ var _ = Suite(&CreateTestSuite{})
 
 func (t *CreateTestSuite) SetUpTest(c *C) {
 	t.BaseTest.SetUpTest(c)
+	if release.ReleaseInfo.ID != "ubuntu" {
+		c.Skip("classic test only work on ubuntu")
+	}
 
 	dirs.SetRootDir(c.MkDir())
 


### PR DESCRIPTION
Some of the classic tests require the host OS to look like ubuntu. For simplicity those tests are disabled outside of ubuntu.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>