### PR TITLE
snap: make app names more restrictive.

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -118,7 +118,7 @@ func ValidateApp(app *AppInfo) error {
 
 	// Validate app name
 	if !validAppName.MatchString(app.Name) {
-		return fmt.Errorf("cannot use %q as app name (app names are letters/digits with dash as separator)", app.Name)
+		return fmt.Errorf("cannot have %q as app name - use letters, digits, and dash as separator", app.Name)
 	}
 
 	// Validate the rest of the app info

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -105,6 +105,7 @@ func validateField(name, cont string, whitelist *regexp.Regexp) error {
 // appContentWhitelist is the whitelist of legal chars in the "apps"
 // section of snap.yaml
 var appContentWhitelist = regexp.MustCompile(`^[A-Za-z0-9/. _#:-]*$`)
+var validAppName = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$")
 
 // ValidateApp verifies the content in the app info.
 func ValidateApp(app *AppInfo) error {
@@ -115,8 +116,17 @@ func ValidateApp(app *AppInfo) error {
 		return fmt.Errorf(`"daemon" field contains invalid value %q`, app.Daemon)
 	}
 
+	// Validate app name
+	if app.Name == "" {
+		return fmt.Errorf("snap app name cannot be empty")
+	}
+
+	if !validAppName.MatchString(app.Name) {
+		return fmt.Errorf("invalid snap app name: %q", app.Name)
+	}
+
+	// Validate the rest of the app info
 	checks := map[string]string{
-		"name":              app.Name,
 		"command":           app.Command,
 		"stop-command":      app.StopCommand,
 		"post-stop-command": app.PostStopCommand,

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -117,12 +117,8 @@ func ValidateApp(app *AppInfo) error {
 	}
 
 	// Validate app name
-	if app.Name == "" {
-		return fmt.Errorf("snap app name cannot be empty")
-	}
-
 	if !validAppName.MatchString(app.Name) {
-		return fmt.Errorf("invalid snap app name: %q", app.Name)
+		return fmt.Errorf("cannot use %q as app name (app names are letters/digits with dash as separator)", app.Name)
 	}
 
 	// Validate the rest of the app info

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -124,7 +124,7 @@ func (s *ValidateSuite) TestValidateAppName(c *C) {
 	}
 	for _, name := range invalidAppNames {
 		err := ValidateApp(&AppInfo{Name: name})
-		c.Assert(err, ErrorMatches, `cannot use ".*" as app name.*`)
+		c.Assert(err, ErrorMatches, `cannot have ".*" as app name.*`)
 	}
 }
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -110,33 +110,53 @@ func (s *ValidateSuite) TestValidateHook(c *C) {
 
 // ValidateApp
 
+func (s *ValidateSuite) TestValidateAppName(c *C) {
+	validAppNames := []string{
+		"1", "a", "aa", "aaa", "aaaa", "Aa", "aA", "1a", "a1", "1-a", "a-1",
+		"a-a", "aa-a", "a-aa", "a-b-c", "0a-a", "a-0a",
+	}
+	for _, name := range validAppNames {
+		c.Check(ValidateApp(&AppInfo{Name: name}), IsNil)
+	}
+	invalidAppNames := []string{
+		"-", "--", "a--a", "a-", "a ", " a", "a a", "日本語", "한글",
+		"ру́сский язы́к", ":a", "a:", "a:a", "_a", "a_", "a_a",
+	}
+	for _, name := range invalidAppNames {
+		err := ValidateApp(&AppInfo{Name: name})
+		c.Assert(err, ErrorMatches, `invalid snap app name: ".*"`)
+	}
+
+	// Also check empty name
+	c.Assert(ValidateApp(&AppInfo{Name: ""}), ErrorMatches, `snap app name cannot be empty`)
+}
+
 func (s *ValidateSuite) TestAppWhitelistSimple(c *C) {
-	c.Check(ValidateApp(&AppInfo{Name: "foo"}), IsNil)
-	c.Check(ValidateApp(&AppInfo{Command: "foo"}), IsNil)
-	c.Check(ValidateApp(&AppInfo{StopCommand: "foo"}), IsNil)
-	c.Check(ValidateApp(&AppInfo{PostStopCommand: "foo"}), IsNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", Command: "foo"}), IsNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", StopCommand: "foo"}), IsNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", PostStopCommand: "foo"}), IsNil)
 }
 
 func (s *ValidateSuite) TestAppWhitelistIllegal(c *C) {
 	c.Check(ValidateApp(&AppInfo{Name: "x\n"}), NotNil)
 	c.Check(ValidateApp(&AppInfo{Name: "test!me"}), NotNil)
-	c.Check(ValidateApp(&AppInfo{Command: "foo\n"}), NotNil)
-	c.Check(ValidateApp(&AppInfo{StopCommand: "foo\n"}), NotNil)
-	c.Check(ValidateApp(&AppInfo{PostStopCommand: "foo\n"}), NotNil)
-	c.Check(ValidateApp(&AppInfo{SocketMode: "foo\n"}), NotNil)
-	c.Check(ValidateApp(&AppInfo{ListenStream: "foo\n"}), NotNil)
-	c.Check(ValidateApp(&AppInfo{BusName: "foo\n"}), NotNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", Command: "foo\n"}), NotNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", StopCommand: "foo\n"}), NotNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", PostStopCommand: "foo\n"}), NotNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", SocketMode: "foo\n"}), NotNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", ListenStream: "foo\n"}), NotNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", BusName: "foo\n"}), NotNil)
 }
 
 func (s *ValidateSuite) TestAppDaemonValue(c *C) {
-	c.Check(ValidateApp(&AppInfo{Daemon: "oneshot"}), IsNil)
-	c.Check(ValidateApp(&AppInfo{Daemon: "nono"}), ErrorMatches, `"daemon" field contains invalid value "nono"`)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", Daemon: "oneshot"}), IsNil)
+	c.Check(ValidateApp(&AppInfo{Name: "foo", Daemon: "nono"}), ErrorMatches, `"daemon" field contains invalid value "nono"`)
 }
 
 func (s *ValidateSuite) TestAppWhitelistError(c *C) {
-	err := ValidateApp(&AppInfo{Name: "x\n"})
+	err := ValidateApp(&AppInfo{Name: "foo", Command: "x\n"})
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, `app description field 'name' contains illegal "x\n" (legal: '^[A-Za-z0-9/. _#:-]*$')`)
+	c.Check(err.Error(), Equals, `app description field 'command' contains illegal "x\n" (legal: '^[A-Za-z0-9/. _#:-]*$')`)
 }
 
 // Validate

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -119,16 +119,13 @@ func (s *ValidateSuite) TestValidateAppName(c *C) {
 		c.Check(ValidateApp(&AppInfo{Name: name}), IsNil)
 	}
 	invalidAppNames := []string{
-		"-", "--", "a--a", "a-", "a ", " a", "a a", "日本語", "한글",
-		"ру́сский язы́к", ":a", "a:", "a:a", "_a", "a_", "a_a",
+		"", "-", "--", "a--a", "a-", "a ", " a", "a a", "日本語", "한글",
+		"ру́сский язы́к", "ໄຂ່​ອີ​ສ​ເຕີ້", ":a", "a:", "a:a", "_a", "a_", "a_a",
 	}
 	for _, name := range invalidAppNames {
 		err := ValidateApp(&AppInfo{Name: name})
-		c.Assert(err, ErrorMatches, `invalid snap app name: ".*"`)
+		c.Assert(err, ErrorMatches, `cannot use ".*" as app name.*`)
 	}
-
-	// Also check empty name
-	c.Assert(ValidateApp(&AppInfo{Name: ""}), ErrorMatches, `snap app name cannot be empty`)
 }
 
 func (s *ValidateSuite) TestAppWhitelistSimple(c *C) {

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -273,6 +273,7 @@ func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileWithSocket(c *C) {
 
 func (s *servicesWrapperGenSuite) TestGenerateSnapSocketFileMode(c *C) {
 	srv := &snap.AppInfo{
+		Name: "foo",
 		Snap: &snap.Info{},
 	}
 


### PR DESCRIPTION
Snapd currently accepts app names that can cause problems in the rest of the system (e.g. result in invalid AppArmor profile names, or clash with hook names). This commit resolves LP: [#1589613](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1589613) by locking them down to be closer to snap names, specifically: `^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$`.