### PR TITLE
debian: make `snap refresh` times more random (LP: #1537793)

### DIFF
--- a/debian/snapd.refresh.timer
+++ b/debian/snapd.refresh.timer
@@ -2,8 +2,8 @@
 Description=Timer to automatically refresh installed snaps
 
 [Timer]
-OnCalendar=3:00
-RandomizedDelaySec=2h
+OnCalendar=23,05,11,17:00
+RandomizedDelaySec=6h
 AccuracySec=10min
 Persistent=true
 


### PR DESCRIPTION
This avoids that we DoS the store because all desktop machines will start at 8:00 in the morning and because: 3am + random(2h) all desktop machine will auto-refresh at 8:00am. The new timer will fix this.