### PR TITLE
many: split out relatively stable bits of snappy/kernel_os.go to boot package

### DIFF
--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -1,0 +1,189 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/partition"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+)
+
+// RemoveKernelAssets removes the unpacked kernel/initrd for the given
+// kernel snap.
+func RemoveKernelAssets(s snap.PlaceInfo, inter progress.Meter) error {
+	bootloader, err := partition.FindBootloader()
+	if err != nil {
+		return fmt.Errorf("no not remove kernel assets: %s", err)
+	}
+
+	// remove the kernel blob
+	blobName := filepath.Base(s.MountFile())
+	dstDir := filepath.Join(bootloader.Dir(), blobName)
+	if err := os.RemoveAll(dstDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copyAll(src, dst string) error {
+	if output, err := exec.Command("cp", "-a", src, dst).CombinedOutput(); err != nil {
+		return fmt.Errorf("cannot copy %q -> %q: %s (%s)", src, dst, err, output)
+	}
+	return nil
+}
+
+// ExtractKernelAssets extracts kernel/initrd/dtb data from the given
+// Snap if required to a versioned bootloader directory so that the bootloader
+// can use it.
+func ExtractKernelAssets(s *snap.Info, inter progress.Meter) error {
+	if s.Type != snap.TypeKernel {
+		return fmt.Errorf("cannot extract kernel assets from snap type %q", s.Type)
+	}
+
+	// sanity check that we have the new kernel format
+	_, err := snap.ReadKernelInfo(s)
+	if err != nil {
+		return err
+	}
+
+	bootloader, err := partition.FindBootloader()
+	if err != nil {
+		return fmt.Errorf("cannot extract kernel assets: %s", err)
+	}
+
+	if bootloader.Name() == "grub" {
+		return nil
+	}
+
+	// now do the kernel specific bits
+	blobName := filepath.Base(s.MountFile())
+	dstDir := filepath.Join(bootloader.Dir(), blobName)
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		return err
+	}
+	dir, err := os.Open(dstDir)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
+	for _, src := range []string{
+		filepath.Join(s.MountDir(), "kernel.img"),
+		filepath.Join(s.MountDir(), "initrd.img"),
+	} {
+		if err := copyAll(src, dstDir); err != nil {
+			return err
+		}
+		if err := dir.Sync(); err != nil {
+			return err
+		}
+	}
+
+	srcDir := filepath.Join(s.MountDir(), "dtbs")
+	if osutil.IsDirectory(srcDir) {
+		if err := copyAll(srcDir, dstDir); err != nil {
+			return err
+		}
+	}
+
+	return dir.Sync()
+}
+
+// SetNextBoot will schedule the given os or kernel snap to be used in
+// the next boot
+func SetNextBoot(s *snap.Info) error {
+	if release.OnClassic {
+		return nil
+	}
+	if s.Type != snap.TypeOS && s.Type != snap.TypeKernel {
+		return nil
+	}
+
+	bootloader, err := partition.FindBootloader()
+	if err != nil {
+		return fmt.Errorf("cannot set next boot: %s", err)
+	}
+
+	var bootvar string
+	switch s.Type {
+	case snap.TypeOS:
+		bootvar = "snappy_os"
+	case snap.TypeKernel:
+		bootvar = "snappy_kernel"
+	}
+	blobName := filepath.Base(s.MountFile())
+	if err := bootloader.SetBootVar(bootvar, blobName); err != nil {
+		return err
+	}
+
+	if err := bootloader.SetBootVar("snappy_mode", "try"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// KernelOrOsRebootRequired returns whether a reboot is required to swith to the given OS or Kernel snap.
+func KernelOrOsRebootRequired(s *snap.Info) bool {
+	if s.Type != snap.TypeKernel && s.Type != snap.TypeOS {
+		return false
+	}
+
+	bootloader, err := partition.FindBootloader()
+	if err != nil {
+		logger.Noticef("cannot get boot settings: %s", err)
+		return false
+	}
+
+	var nextBoot, goodBoot string
+	switch s.Type {
+	case snap.TypeKernel:
+		nextBoot = "snappy_kernel"
+		goodBoot = "snappy_good_kernel"
+	case snap.TypeOS:
+		nextBoot = "snappy_os"
+		goodBoot = "snappy_good_os"
+	}
+
+	nextBootVer, err := bootloader.GetBootVar(nextBoot)
+	if err != nil {
+		return false
+	}
+	goodBootVer, err := bootloader.GetBootVar(goodBoot)
+	if err != nil {
+		return false
+	}
+
+	squashfsName := filepath.Base(s.MountFile())
+	if nextBootVer == squashfsName && goodBootVer != nextBootVer {
+		return true
+	}
+
+	return false
+}

--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -59,8 +59,8 @@ func copyAll(src, dst string) error {
 }
 
 // ExtractKernelAssets extracts kernel/initrd/dtb data from the given
-// Snap if required to a versioned bootloader directory so that the bootloader
-// can use it.
+// kernel snap, if required, to a versioned bootloader directory so
+// that the bootloader can use it.
 func ExtractKernelAssets(s *snap.Info, inter progress.Meter) error {
 	if s.Type != snap.TypeKernel {
 		return fmt.Errorf("cannot extract kernel assets from snap type %q", s.Type)
@@ -115,7 +115,7 @@ func ExtractKernelAssets(s *snap.Info, inter progress.Meter) error {
 	return dir.Sync()
 }
 
-// SetNextBoot will schedule the given os or kernel snap to be used in
+// SetNextBoot will schedule the given OS or kernel snap to be used in
 // the next boot
 func SetNextBoot(s *snap.Info) error {
 	if release.OnClassic {
@@ -149,7 +149,7 @@ func SetNextBoot(s *snap.Info) error {
 	return nil
 }
 
-// KernelOrOsRebootRequired returns whether a reboot is required to swith to the given OS or Kernel snap.
+// KernelOrOsRebootRequired returns whether a reboot is required to swith to the given OS or kernel snap.
 func KernelOrOsRebootRequired(s *snap.Info) bool {
 	if s.Type != snap.TypeKernel && s.Type != snap.TypeOS {
 		return false

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
-func TestKernelOS(t *testing.T) { TestingT(t) }
+func TestBoot(t *testing.T) { TestingT(t) }
 
 // XXX: share this
 // mockBootloader mocks the bootloader interface and records all

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -1,0 +1,244 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package boot_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/partition"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+)
+
+func TestKernelOS(t *testing.T) { TestingT(t) }
+
+// XXX: share this
+// mockBootloader mocks the bootloader interface and records all
+// set/get calls
+type mockBootloader struct {
+	bootvars map[string]string
+	bootdir  string
+	name     string
+}
+
+func newMockBootloader(bootdir string) *mockBootloader {
+	return &mockBootloader{
+		bootvars: make(map[string]string),
+		bootdir:  bootdir,
+		name:     "mocky",
+	}
+}
+
+func (b *mockBootloader) SetBootVar(key, value string) error {
+	b.bootvars[key] = value
+	return nil
+}
+
+func (b *mockBootloader) GetBootVar(key string) (string, error) {
+	return b.bootvars[key], nil
+}
+
+func (b *mockBootloader) Dir() string {
+	return b.bootdir
+}
+
+func (b *mockBootloader) Name() string {
+	return b.name
+}
+
+type kernelOSSuite struct {
+	bootloader *mockBootloader
+}
+
+var _ = Suite(&kernelOSSuite{})
+
+func (s *kernelOSSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	s.bootloader = newMockBootloader(c.MkDir())
+	partition.ForceBootloader(s.bootloader)
+}
+
+func (s *kernelOSSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+	partition.ForceBootloader(nil)
+}
+
+func populate(c *C, dir string, files [][]string) {
+	for _, def := range files {
+		filename := def[0]
+		content := def[1]
+		basedir := filepath.Dir(filepath.Join(dir, filename))
+		err := os.MkdirAll(basedir, 0755)
+		c.Assert(err, IsNil)
+		err = ioutil.WriteFile(filepath.Join(dir, filename), []byte(content), 0644)
+		c.Assert(err, IsNil)
+	}
+}
+
+const packageKernel = `
+name: ubuntu-kernel
+version: 4.0-1
+type: kernel
+vendor: Someone
+`
+
+func (s *kernelOSSuite) TestExtractKernelAssetsAndRemove(c *C) {
+	files := [][]string{
+		{"kernel.img", "I'm a kernel"},
+		{"initrd.img", "...and I'm an initrd"},
+		{"dtbs/foo.dtb", "g'day, I'm foo.dtb"},
+		{"dtbs/bar.dtb", "hello, I'm bar.dtb"},
+		// must be last
+		{"meta/kernel.yaml", "version: 4.2"},
+	}
+
+	si := &snap.SideInfo{
+		OfficialName: "ubuntu-kernel",
+		Revision:     snap.R(42),
+	}
+	snap := snaptest.MockSnap(c, packageKernel, si)
+	populate(c, snap.MountDir(), files)
+
+	err := boot.ExtractKernelAssets(snap, &progress.NullProgress{})
+	c.Assert(err, IsNil)
+
+	// this is where the kernel/initrd is unpacked
+	bootdir := s.bootloader.Dir()
+
+	kernelAssetsDir := filepath.Join(bootdir, "ubuntu-kernel_42.snap")
+
+	for _, def := range files {
+		if def[0] == "meta/kernel.yaml" {
+			break
+		}
+
+		fullFn := filepath.Join(kernelAssetsDir, def[0])
+		content, err := ioutil.ReadFile(fullFn)
+		c.Assert(err, IsNil)
+		c.Assert(string(content), Equals, def[1])
+	}
+
+	// remove
+	err = boot.RemoveKernelAssets(snap, &progress.NullProgress{})
+	c.Assert(err, IsNil)
+
+	c.Check(osutil.FileExists(kernelAssetsDir), Equals, false)
+}
+
+func (s *kernelOSSuite) TestExtractKernelAssetsNoUnpacksKernelForGrub(c *C) {
+	// pretend to be a grub system
+	s.bootloader.name = "grub"
+
+	files := [][]string{
+		{"kernel.img", "I'm a kernel"},
+		{"initrd.img", "...and I'm an initrd"},
+		{"meta/kernel.yaml", "version: 4.2"},
+	}
+	si := &snap.SideInfo{
+		OfficialName: "ubuntu-kernel",
+		Revision:     snap.R(42),
+	}
+	snap := snaptest.MockSnap(c, packageKernel, si)
+	populate(c, snap.MountDir(), files)
+
+	err := boot.ExtractKernelAssets(snap, &progress.NullProgress{})
+	c.Assert(err, IsNil)
+
+	// kernel is *not* here
+	kernimg := filepath.Join(s.bootloader.Dir(), "ubuntu-kernel_42.snap", "kernel.img")
+	c.Assert(osutil.FileExists(kernimg), Equals, false)
+}
+
+func (s *kernelOSSuite) TestExtractKernelAssetsError(c *C) {
+	info := &snap.Info{}
+	info.Type = snap.TypeApp
+
+	err := boot.ExtractKernelAssets(info, nil)
+	c.Assert(err, ErrorMatches, `cannot extract kernel assets from snap type "app"`)
+}
+
+// SetNextBoot should do nothing on classic LP: #1580403
+func (s *kernelOSSuite) TestSetNextBootOnClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// Create a fake OS snap that we try to update
+	snapInfo := snaptest.MockSnap(c, "type: os", &snap.SideInfo{Revision: snap.R(42)})
+	err := boot.SetNextBoot(snapInfo)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.bootloader.bootvars, HasLen, 0)
+}
+
+func (s *kernelOSSuite) TestSetNextBootForCore(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	info := &snap.Info{}
+	info.Type = snap.TypeOS
+	info.OfficialName = "core"
+	info.Revision = snap.R(100)
+
+	err := boot.SetNextBoot(info)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.bootloader.bootvars, DeepEquals, map[string]string{
+		"snappy_os":   "core_100.snap",
+		"snappy_mode": "try",
+	})
+
+	c.Check(boot.KernelOrOsRebootRequired(info), Equals, true)
+}
+
+func (s *kernelOSSuite) TestSetNextBootForKernel(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	info := &snap.Info{}
+	info.Type = snap.TypeKernel
+	info.OfficialName = "krnl"
+	info.Revision = snap.R(42)
+
+	err := boot.SetNextBoot(info)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.bootloader.bootvars, DeepEquals, map[string]string{
+		"snappy_kernel": "krnl_42.snap",
+		"snappy_mode":   "try",
+	})
+
+	s.bootloader.bootvars["snappy_good_kernel"] = "krnl_40.snap"
+	s.bootloader.bootvars["snappy_kernel"] = "krnl_42.snap"
+	c.Check(boot.KernelOrOsRebootRequired(info), Equals, true)
+
+	// simulate good boot
+	s.bootloader.bootvars["snappy_good_kernel"] = "krnl_42.snap"
+	c.Check(boot.KernelOrOsRebootRequired(info), Equals, false)
+}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -42,8 +42,6 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-	// XXX: here until we split out kernel_os
-	"github.com/snapcore/snapd/snappy"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
@@ -84,7 +82,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 
 func (ms *mgrsSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "")
+	os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
 	systemd.SystemctlCmd = ms.prevctlCmd
 	ms.udev.Restore()
 	ms.aa.Restore()
@@ -411,13 +409,8 @@ func (b *mockBootloader) Name() string {
 
 func (ms *mgrsSuite) TestInstallCoreSnapUpdatesBootloader(c *C) {
 	bootloader := newMockBootloader(c.MkDir())
-	oldFB := snappy.FindBootloader
-	snappy.FindBootloader = func() (partition.Bootloader, error) {
-		return bootloader, nil
-	}
-	defer func() {
-		snappy.FindBootloader = oldFB
-	}()
+	partition.ForceBootloader(bootloader)
+	defer partition.ForceBootloader(nil)
 
 	restore := release.MockOnClassic(false)
 	defer restore()
@@ -454,13 +447,8 @@ type: os
 
 func (ms *mgrsSuite) TestInstallKernelSnapUpdatesBootloader(c *C) {
 	bootloader := newMockBootloader(c.MkDir())
-	oldFB := snappy.FindBootloader
-	snappy.FindBootloader = func() (partition.Bootloader, error) {
-		return bootloader, nil
-	}
-	defer func() {
-		snappy.FindBootloader = oldFB
-	}()
+	partition.ForceBootloader(bootloader)
+	defer partition.ForceBootloader(nil)
 
 	restore := release.MockOnClassic(false)
 	defer restore()

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -24,11 +24,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
-	// XXX: eventually not needed
-	"github.com/snapcore/snapd/snappy"
 	"github.com/snapcore/snapd/wrappers"
 )
 
@@ -64,7 +63,7 @@ func (b Backend) LinkSnap(info *snap.Info) error {
 	}
 
 	// XXX/TODO: this needs to be a task with proper undo and tests!
-	if err := snappy.SetNextBoot(info); err != nil {
+	if err := boot.SetNextBoot(info); err != nil {
 		return err
 	}
 

--- a/partition/bootloader.go
+++ b/partition/bootloader.go
@@ -58,9 +58,15 @@ type Bootloader interface {
 	Name() string
 }
 
+var forcedBootloader Bootloader
+
 // FindBootloader returns the bootloader for the given system
 // or an error if no bootloader is found
 func FindBootloader() (Bootloader, error) {
+	if forcedBootloader != nil {
+		return forcedBootloader, nil
+	}
+
 	// try uboot
 	if uboot := newUboot(); uboot != nil {
 		return uboot, nil
@@ -73,6 +79,11 @@ func FindBootloader() (Bootloader, error) {
 
 	// no, weeeee
 	return nil, ErrBootloader
+}
+
+// ForceBootloader can be used to force setting a booloader to that FindBootloader will not use the usual lookup process, use nil to reset to normal lookup.
+func ForceBootloader(booloader Bootloader) {
+	forcedBootloader = booloader
 }
 
 // MarkBootSuccessful marks the current boot as sucessful. This means

--- a/partition/bootloader_test.go
+++ b/partition/bootloader_test.go
@@ -68,6 +68,16 @@ func (s *PartitionTestSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *PartitionTestSuite) TestForceBootloader(c *C) {
+	b := newMockBootloader()
+	ForceBootloader(b)
+	defer ForceBootloader(nil)
+
+	got, err := FindBootloader()
+	c.Assert(err, IsNil)
+	c.Check(got, Equals, b)
+}
+
 func (s *PartitionTestSuite) TestMarkBootSuccessfulAllSnap(c *C) {
 	b := newMockBootloader()
 	b.bootVars["snappy_os"] = "os1"

--- a/snappy/kernel_os.go
+++ b/snappy/kernel_os.go
@@ -21,177 +21,12 @@ package snappy
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
-	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/partition"
-	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
-
-// override in tests
-// XXX: just made it exported as quick hack until we split out this
-// from snappy and decide a proper testing interface
-var FindBootloader = partition.FindBootloader
-
-// removeKernelAssets removes the unpacked kernel/initrd for the given
-// kernel snap
-func removeKernelAssets(s snap.PlaceInfo, inter interacter) error {
-	bootloader, err := FindBootloader()
-	if err != nil {
-		return fmt.Errorf("no not remove kernel assets: %s", err)
-	}
-
-	// remove the kernel blob
-	blobName := filepath.Base(s.MountFile())
-	dstDir := filepath.Join(bootloader.Dir(), blobName)
-	if err := os.RemoveAll(dstDir); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func copyAll(src, dst string) error {
-	if output, err := exec.Command("cp", "-a", src, dst).CombinedOutput(); err != nil {
-		return fmt.Errorf("cannot copy %q -> %q: %s (%s)", src, dst, err, output)
-	}
-	return nil
-}
-
-// extractKernelAssets extracts kernel/initrd/dtb data from the given
-// Snap to a versionized bootloader directory so that the bootloader
-// can use it.
-func extractKernelAssets(s *snap.Info, flags LegacyInstallFlags, inter progress.Meter) error {
-	if s.Type != snap.TypeKernel {
-		return fmt.Errorf("cannot extract kernel assets from snap type %q", s.Type)
-	}
-
-	// sanity check that we have the new kernel format
-	_, err := snap.ReadKernelInfo(s)
-	if err != nil {
-		return err
-	}
-
-	bootloader, err := FindBootloader()
-	if err != nil {
-		return fmt.Errorf("cannot extract kernel assets: %s", err)
-	}
-
-	if bootloader.Name() == "grub" {
-		return nil
-	}
-
-	// now do the kernel specific bits
-	blobName := filepath.Base(s.MountFile())
-	dstDir := filepath.Join(bootloader.Dir(), blobName)
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
-		return err
-	}
-	dir, err := os.Open(dstDir)
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-
-	for _, src := range []string{
-		filepath.Join(s.MountDir(), "kernel.img"),
-		filepath.Join(s.MountDir(), "initrd.img"),
-	} {
-		if err := copyAll(src, dstDir); err != nil {
-			return err
-		}
-		if err := dir.Sync(); err != nil {
-			return err
-		}
-	}
-
-	srcDir := filepath.Join(s.MountDir(), "dtbs")
-	if osutil.IsDirectory(srcDir) {
-		if err := copyAll(srcDir, dstDir); err != nil {
-			return err
-		}
-	}
-
-	return dir.Sync()
-}
-
-// SetNextBoot will schedule the given os or kernel snap to be used in
-// the next boot
-func SetNextBoot(s *snap.Info) error {
-	if release.OnClassic {
-		return nil
-	}
-	if s.Type != snap.TypeOS && s.Type != snap.TypeKernel {
-		return nil
-	}
-
-	bootloader, err := FindBootloader()
-	if err != nil {
-		return fmt.Errorf("cannot set next boot: %s", err)
-	}
-
-	var bootvar string
-	switch s.Type {
-	case snap.TypeOS:
-		bootvar = "snappy_os"
-	case snap.TypeKernel:
-		bootvar = "snappy_kernel"
-	}
-	blobName := filepath.Base(s.MountFile())
-	if err := bootloader.SetBootVar(bootvar, blobName); err != nil {
-		return err
-	}
-
-	if err := bootloader.SetBootVar("snappy_mode", "try"); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func kernelOrOsRebootRequired(s *snap.Info) bool {
-	if s.Type != snap.TypeKernel && s.Type != snap.TypeOS {
-		return false
-	}
-
-	bootloader, err := FindBootloader()
-	if err != nil {
-		logger.Noticef("cannot get boot settings: %s", err)
-		return false
-	}
-
-	var nextBoot, goodBoot string
-	switch s.Type {
-	case snap.TypeKernel:
-		nextBoot = "snappy_kernel"
-		goodBoot = "snappy_good_kernel"
-	case snap.TypeOS:
-		nextBoot = "snappy_os"
-		goodBoot = "snappy_good_os"
-	}
-
-	nextBootVer, err := bootloader.GetBootVar(nextBoot)
-	if err != nil {
-		return false
-	}
-	goodBootVer, err := bootloader.GetBootVar(goodBoot)
-	if err != nil {
-		return false
-	}
-
-	squashfsName := filepath.Base(s.MountFile())
-	if nextBootVer == squashfsName && goodBootVer != nextBootVer {
-		return true
-	}
-
-	return false
-}
 
 func nameAndRevnoFromSnap(sn string) (string, snap.Revision) {
 	name := strings.Split(sn, "_")[0]
@@ -214,7 +49,7 @@ func SyncBoot() error {
 	if release.OnClassic {
 		return nil
 	}
-	bootloader, err := FindBootloader()
+	bootloader, err := partition.FindBootloader()
 	if err != nil {
 		return fmt.Errorf("cannot run SyncBoot: %s", err)
 	}

--- a/snappy/kernel_os_test.go
+++ b/snappy/kernel_os_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/snapcore/snapd/partition"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/snaptest"
 
 	. "gopkg.in/check.v1"
 )
@@ -38,9 +37,11 @@ var _ = Suite(&kernelTestSuite{})
 func (s *kernelTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.bootloader = newMockBootloader(c.MkDir())
-	FindBootloader = func() (partition.Bootloader, error) {
-		return s.bootloader, nil
-	}
+	partition.ForceBootloader(s.bootloader)
+}
+
+func (s *kernelTestSuite) TearDownTest(c *C) {
+	partition.ForceBootloader(nil)
 }
 
 func (s *kernelTestSuite) TestNameAndRevnoFromSnap(c *C) {
@@ -111,15 +112,4 @@ func (s *kernelTestSuite) TestSyncBoot(c *C) {
 	c.Assert(found[0].Revision(), Equals, snap.R(20))
 	c.Assert(found[0].Version(), Equals, "v1")
 	c.Assert(found[0].IsActive(), Equals, true)
-}
-
-// SetNextBoot should do nothing on classic LP: #1580403
-func (s *kernelTestSuite) TestSetNextBootOnClassic(c *C) {
-	restore := release.MockOnClassic(true)
-	defer restore()
-
-	// Create a fake OS snap that we try to update
-	snapInfo := snaptest.MockSnap(c, "type: os", &snap.SideInfo{Revision: snap.R(42)})
-	err := SetNextBoot(snapInfo)
-	c.Assert(err, IsNil)
 }

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -115,7 +116,7 @@ func SetupSnap(snapFilePath string, sideInfo *snap.SideInfo, flags LegacyInstall
 
 	// FIXME: special handling is bad 'mkay
 	if s.Type == snap.TypeKernel {
-		if err := extractKernelAssets(s, flags, meter); err != nil {
+		if err := boot.ExtractKernelAssets(s, meter); err != nil {
 			return s, fmt.Errorf("cannot install kernel: %s", err)
 		}
 	}
@@ -277,7 +278,7 @@ func updateCurrentSymlink(info *snap.Info, inter interacter) error {
 
 	// FIXME: create {Os,Kernel}Snap type instead of adding special
 	//        cases here
-	if err := SetNextBoot(info); err != nil {
+	if err := boot.SetNextBoot(info); err != nil {
 		return err
 	}
 
@@ -509,7 +510,7 @@ func RemoveSnapFiles(s snap.PlaceInfo, meter progress.Meter) error {
 
 	// remove the kernel assets (if any)
 	if typ == snap.TypeKernel {
-		if err := removeKernelAssets(s, meter); err != nil {
+		if err := boot.RemoveKernelAssets(s, meter); err != nil {
 			logger.Noticef("removing kernel assets failed with %s", err)
 		}
 	}

--- a/snappy/snap_local.go
+++ b/snappy/snap_local.go
@@ -27,6 +27,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
@@ -141,5 +142,5 @@ func (s *Snap) Info() *snap.Info {
 
 // NeedsReboot returns true if the snap becomes active on the next reboot
 func (s *Snap) NeedsReboot() bool {
-	return kernelOrOsRebootRequired(s.info)
+	return boot.KernelOrOsRebootRequired(s.info)
 }

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -90,11 +90,9 @@ func (s *SquashfsTestSuite) SetUpTest(c *C) {
 
 	// mock the boot variable writing for the tests
 	s.bootloader = newMockBootloader(c.MkDir())
-	FindBootloader = func() (partition.Bootloader, error) {
-		return s.bootloader, nil
-	}
+	partition.ForceBootloader(s.bootloader)
 
-	s.AddCleanup(func() { FindBootloader = partition.FindBootloader })
+	s.AddCleanup(func() { partition.ForceBootloader(nil) })
 }
 
 func (s *SquashfsTestSuite) TearDownTest(c *C) {
@@ -302,15 +300,6 @@ func (s *SquashfsTestSuite) TestActiveKernelNotRemovable(c *C) {
 
 	snap.isActive = true
 	c.Assert((&Overlord{}).Uninstall(snap, &MockProgressMeter{}), Equals, ErrPackageNotRemovable)
-}
-
-func (s *SquashfsTestSuite) TestInstallKernelSnapUnpacksKernelErrors(c *C) {
-	snapPkg := makeTestSnapPackage(c, packageHello)
-	snap, _, err := openSnapFile(snapPkg, true, nil)
-	c.Assert(err, IsNil)
-
-	err = extractKernelAssets(snap, 0, nil)
-	c.Assert(err, ErrorMatches, `cannot extract kernel assets from snap type "app"`)
 }
 
 func (s *SquashfsTestSuite) TestActiveOSNotRemovable(c *C) {

--- a/snappy/undo_test.go
+++ b/snappy/undo_test.go
@@ -50,7 +50,7 @@ func (s *undoTestSuite) SetUpTest(c *C) {
 }
 
 func (s *undoTestSuite) TearDownTest(c *C) {
-	FindBootloader = partition.FindBootloader
+	partition.ForceBootloader(nil)
 }
 
 var helloSnap = `name: hello-snap
@@ -80,9 +80,7 @@ func (s *undoTestSuite) TestUndoForSetupSnapSimple(c *C) {
 
 func (s *undoTestSuite) TestUndoForSetupSnapKernelUboot(c *C) {
 	bootloader := newMockBootloader(c.MkDir())
-	FindBootloader = func() (partition.Bootloader, error) {
-		return bootloader, nil
-	}
+	partition.ForceBootloader(bootloader)
 
 	testFiles := [][]string{
 		{"kernel.img", "kernel"},


### PR DESCRIPTION
This creates a new boot package with the relatively stable/not broken bits of snappy/kernel_os.go (SyncBoot for example is highly likely broken atm).

Also adds a way to override the bootloader found with FindBootloader for tests and other uses.

Not done yet but after this it would seem natural to merge partition and boot packages, but discussed with @mvo5 that it can wait for later.