### PR TITLE
many: move over from snappy to snapstate/backend SetupSnap and related code

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -23,7 +23,6 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snappy"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -40,11 +39,11 @@ type StoreService interface {
 type managerBackend interface {
 	// install releated
 	Download(name, channel string, checker func(*snap.Info) error, meter progress.Meter, store StoreService, auther store.Authenticator) (*snap.Info, string, error)
-	SetupSnap(snapFilePath string, si *snap.SideInfo) error
+	SetupSnap(snapFilePath string, si *snap.SideInfo, meter progress.Meter) error
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 	LinkSnap(info *snap.Info) error
 	// the undoers for install
-	UndoSetupSnap(s snap.PlaceInfo) error
+	UndoSetupSnap(s snap.PlaceInfo, meter progress.Meter) error
 	UndoCopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 
 	// remove releated
@@ -83,23 +82,4 @@ func (b *defaultBackend) Download(name, channel string, checker func(*snap.Info)
 	}
 
 	return snap, downloadedSnapFile, nil
-}
-
-func (b *defaultBackend) SetupSnap(snapFilePath string, sideInfo *snap.SideInfo) error {
-	meter := &progress.NullProgress{}
-	// XXX: pass 0 for flags temporarely, until SetupSnap is moved over,
-	// anyway they aren't used atm, and probably we don't want to pass flags
-	// as before but more precise information
-	_, err := snappy.SetupSnap(snapFilePath, sideInfo, 0, meter)
-	return err
-}
-
-func (b *defaultBackend) UndoSetupSnap(s snap.PlaceInfo) error {
-	meter := &progress.NullProgress{}
-	snappy.UndoSetupSnap(s, meter)
-	return nil
-}
-
-func (b *defaultBackend) RemoveSnapFiles(s snap.PlaceInfo, meter progress.Meter) error {
-	return snappy.RemoveSnapFiles(s, meter)
 }

--- a/overlord/snapstate/backend/backend.go
+++ b/overlord/snapstate/backend/backend.go
@@ -20,5 +20,26 @@
 // Package backend implements the low-level primitives to manage the snaps and their installation on disk.
 package backend
 
+import (
+	"github.com/snapcore/snapd/snap"
+)
+
 // Backend exposes all the low-level primitives to manage snaps and their installation on disk.
 type Backend struct{}
+
+// OpenSnapFile opens a snap blob returning both a snap.Info completed
+// with sideInfo (if not nil) and a corresponding snap.Container.
+// Assumes the file was verified beforehand or the user asked for devmode.
+func OpenSnapFile(snapPath string, sideInfo *snap.SideInfo) (*snap.Info, snap.Container, error) {
+	snapf, err := snap.Open(snapPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	info, err := snap.ReadInfoFromSnapFile(snapf, sideInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return info, snapf, nil
+}

--- a/overlord/snapstate/backend/backend_test.go
+++ b/overlord/snapstate/backend/backend_test.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snap/squashfs"
+
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+)
+
+func TestBackend(t *testing.T) { TestingT(t) }
+
+func makeTestSnap(c *C, snapYamlContent string) string {
+	return snaptest.MakeTestSnapWithFiles(c, snapYamlContent, nil)
+}
+
+type backendSuite struct{}
+
+var _ = Suite(&backendSuite{})
+
+func (s *backendSuite) TestOpenSnapFile(c *C) {
+	const yaml = `name: hello
+version: 1.0
+apps:
+ bin:
+   command: bin
+`
+
+	snapPath := makeTestSnap(c, yaml)
+	info, snapf, err := backend.OpenSnapFile(snapPath, nil)
+	c.Assert(err, IsNil)
+
+	c.Assert(snapf, FitsTypeOf, &squashfs.Snap{})
+	c.Check(info.Name(), Equals, "hello")
+}
+
+func (s *backendSuite) TestOpenSnapFilebSideInfo(c *C) {
+	const yaml = `name: foo
+apps:
+ bar:
+  command: bin/bar
+plugs:
+  plug:
+slots:
+ slot:
+`
+
+	snapPath := makeTestSnap(c, yaml)
+	si := snap.SideInfo{OfficialName: "blessed", Revision: snap.R(42)}
+	info, _, err := backend.OpenSnapFile(snapPath, &si)
+	c.Assert(err, IsNil)
+
+	// check side info
+	c.Check(info.Name(), Equals, "blessed")
+	c.Check(info.Revision, Equals, snap.R(42))
+
+	c.Check(info.SideInfo, DeepEquals, si)
+
+	// ensure that all leaf objects link back to the same snap.Info
+	// and not to some copy.
+	// (we had a bug around this)
+	c.Check(info.Apps["bar"].Snap, Equals, info)
+	c.Check(info.Plugs["plug"].Snap, Equals, info)
+	c.Check(info.Slots["slot"].Snap, Equals, info)
+
+}

--- a/overlord/snapstate/backend/export_test.go
+++ b/overlord/snapstate/backend/export_test.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+var (
+	AddMountUnit    = addMountUnit
+	RemoveMountUnit = removeMountUnit
+)

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -21,7 +21,6 @@ package backend_test
 
 import (
 	"path/filepath"
-	"testing"
 
 	. "gopkg.in/check.v1"
 
@@ -34,8 +33,6 @@ import (
 
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 )
-
-func TestBackend(t *testing.T) { TestingT(t) }
 
 type linkSuite struct {
 	be           backend.Backend

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+)
+
+func stripGlobalRootDir(dir string) string {
+	if dirs.GlobalRootDir == "/" {
+		return dir
+	}
+
+	return dir[len(dirs.GlobalRootDir):]
+}
+
+func addMountUnit(s *snap.Info, meter progress.Meter) error {
+	squashfsPath := stripGlobalRootDir(s.MountFile())
+	whereDir := stripGlobalRootDir(s.MountDir())
+
+	sysd := systemd.New(dirs.GlobalRootDir, meter)
+	mountUnitName, err := sysd.WriteMountUnitFile(s.Name(), squashfsPath, whereDir)
+	if err != nil {
+		return err
+	}
+
+	// we always enable the mount unit even in inhibit hooks
+	if err := sysd.Enable(mountUnitName); err != nil {
+		return err
+	}
+
+	return sysd.Start(mountUnitName)
+}
+
+func removeMountUnit(baseDir string, meter progress.Meter) error {
+	sysd := systemd.New(dirs.GlobalRootDir, meter)
+	unit := systemd.MountUnitPath(stripGlobalRootDir(baseDir), "mount")
+	if osutil.FileExists(unit) {
+		if err := sysd.Stop(filepath.Base(unit), time.Duration(1*time.Second)); err != nil {
+			return err
+		}
+		if err := sysd.Disable(filepath.Base(unit)); err != nil {
+			return err
+		}
+		if err := os.Remove(unit); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -1,0 +1,111 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+)
+
+type mountunitSuite struct {
+	nullProgress progress.NullProgress
+	prevctlCmd   func(...string) ([]byte, error)
+}
+
+var _ = Suite(&mountunitSuite{})
+
+func (s *mountunitSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc", "systemd", "system", "multi-user.target.wants"), 0755)
+	c.Assert(err, IsNil)
+
+	s.prevctlCmd = systemd.SystemctlCmd
+	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+		return []byte("ActiveState=inactive\n"), nil
+	}
+}
+
+func (s *mountunitSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+	systemd.SystemctlCmd = s.prevctlCmd
+}
+
+func (s *mountunitSuite) TestAddMountUnit(c *C) {
+	info := &snap.Info{
+		SideInfo: snap.SideInfo{
+			OfficialName: "foo",
+			Revision:     snap.R(13),
+		},
+		Version:       "1.1",
+		Architectures: []string{"all"},
+	}
+	err := backend.AddMountUnit(info, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	// ensure correct mount unit
+	mount, err := ioutil.ReadFile(filepath.Join(dirs.SnapServicesDir, "snap-foo-13.mount"))
+	c.Assert(err, IsNil)
+	c.Assert(string(mount), Equals, `[Unit]
+Description=Mount unit for foo
+
+[Mount]
+What=/var/lib/snapd/snaps/foo_13.snap
+Where=/snap/foo/13
+
+[Install]
+WantedBy=multi-user.target
+`)
+
+}
+
+func (s *mountunitSuite) TestRemoveMountUnit(c *C) {
+	info := &snap.Info{
+		SideInfo: snap.SideInfo{
+			OfficialName: "foo",
+			Revision:     snap.R(13),
+		},
+		Version:       "1.1",
+		Architectures: []string{"all"},
+	}
+
+	err := backend.AddMountUnit(info, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	// ensure we have the files
+	p := filepath.Join(dirs.SnapServicesDir, "snap-foo-13.mount")
+	c.Assert(osutil.FileExists(p), Equals, true)
+
+	// now call remove and ensure they are gone
+	err = backend.RemoveMountUnit(info.MountDir(), &s.nullProgress)
+	c.Assert(err, IsNil)
+	p = filepath.Join(dirs.SnapServicesDir, "snaps-foo-13.mount")
+	c.Assert(osutil.FileExists(p), Equals, false)
+}

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -1,0 +1,106 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+)
+
+// SetupSnap does prepare and mount the snap for further processing.
+func (b Backend) SetupSnap(snapFilePath string, sideInfo *snap.SideInfo, meter progress.Meter) error {
+	// This assumes that the snap was already verified or devmode was requested.
+
+	s, snapf, err := OpenSnapFile(snapFilePath, sideInfo)
+	if err != nil {
+		return err
+	}
+	instdir := s.MountDir()
+
+	if err := os.MkdirAll(instdir, 0755); err != nil {
+		return err
+	}
+
+	if err := snapf.Install(s.MountFile(), instdir); err != nil {
+		return err
+	}
+
+	// generate the mount unit for the squashfs
+	if err := addMountUnit(s, meter); err != nil {
+		return err
+	}
+
+	// FIXME: special handling is bad 'mkay
+	if s.Type == snap.TypeKernel {
+		if err := boot.ExtractKernelAssets(s, meter); err != nil {
+			return fmt.Errorf("cannot install kernel: %s", err)
+		}
+	}
+
+	return err
+}
+
+// RemoveSnapFiles removes the snap files from the disk after unmounting the snap.
+func (b Backend) RemoveSnapFiles(s snap.PlaceInfo, meter progress.Meter) error {
+	mountDir := s.MountDir()
+
+	// this also ensures that the mount unit stops
+	if err := removeMountUnit(mountDir, meter); err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(mountDir); err != nil {
+		return err
+	}
+
+	snapPath := s.MountFile()
+
+	if osutil.FileExists(snapPath) {
+		// XXX: would be better if this information was in the state directly
+		info, _, err := OpenSnapFile(snapPath, nil)
+		if err != nil {
+			return fmt.Errorf("cannot read snap file %q to determine snap type: %v", snapPath, err)
+		}
+
+		// remove the kernel assets (if any)
+		if info.Type == snap.TypeKernel {
+			if err := boot.RemoveKernelAssets(s, meter); err != nil {
+				return err
+			}
+		}
+
+		// remove the snap
+		if err := os.RemoveAll(snapPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UndoSetupSnap undoes the work of SetupSnap using RemoveSnapFiles.
+func (b Backend) UndoSetupSnap(s snap.PlaceInfo, meter progress.Meter) error {
+	return b.RemoveSnapFiles(s, meter)
+}

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -1,0 +1,241 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/boot/boottest"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/partition"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/systemd"
+)
+
+type setupSuite struct {
+	be           backend.Backend
+	nullProgress progress.NullProgress
+	prevctlCmd   func(...string) ([]byte, error)
+}
+
+var _ = Suite(&setupSuite{})
+
+func (s *setupSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc", "systemd", "system", "multi-user.target.wants"), 0755)
+	c.Assert(err, IsNil)
+
+	s.prevctlCmd = systemd.SystemctlCmd
+	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+		return []byte("ActiveState=inactive\n"), nil
+	}
+}
+
+func (s *setupSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+	partition.ForceBootloader(nil)
+	systemd.SystemctlCmd = s.prevctlCmd
+}
+
+func (s *setupSuite) TestSetupDoUndoSimple(c *C) {
+	snapPath := makeTestSnap(c, helloYaml1)
+
+	si := snap.SideInfo{
+		OfficialName: "hello",
+		Revision:     snap.R(14),
+	}
+
+	err := s.be.SetupSnap(snapPath, &si, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	// after setup the snap file is in the right dir
+	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello_14.snap")), Equals, true)
+
+	// ensure the right unit is created
+	mup := systemd.MountUnitPath("/snap/hello/14", "mount")
+	content, err := ioutil.ReadFile(mup)
+	c.Assert(err, IsNil)
+	c.Assert(string(content), Matches, "(?ms).*^Where=/snap/hello/14")
+	c.Assert(string(content), Matches, "(?ms).*^What=/var/lib/snapd/snaps/hello_14.snap")
+
+	minInfo := snap.MinimalPlaceInfo("hello", snap.R(14))
+	// mount dir was created
+	c.Assert(osutil.FileExists(minInfo.MountDir()), Equals, true)
+
+	// undo undoes the mount unit and the instdir creation
+	err = s.be.UndoSetupSnap(minInfo, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	l, _ := filepath.Glob(filepath.Join(dirs.SnapServicesDir, "*.mount"))
+	c.Assert(l, HasLen, 0)
+	c.Assert(osutil.FileExists(minInfo.MountDir()), Equals, false)
+
+	c.Assert(osutil.FileExists(minInfo.MountFile()), Equals, false)
+
+}
+
+func (s *setupSuite) TestSetupDoUndoKernelUboot(c *C) {
+	bootloader := boottest.NewMockBootloader("mock", c.MkDir())
+	partition.ForceBootloader(bootloader)
+	// we don't get real mounting
+	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
+	defer os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
+
+	testFiles := [][]string{
+		{"kernel.img", "kernel"},
+		{"initrd.img", "initrd"},
+		{"modules/4.4.0-14-generic/foo.ko", "a module"},
+		{"firmware/bar.bin", "some firmware"},
+		{"meta/kernel.yaml", "version: 4.2"},
+	}
+	snapPath := snaptest.MakeTestSnapWithFiles(c, `name: kernel
+version: 1.0
+type: kernel
+`, testFiles)
+
+	si := snap.SideInfo{
+		OfficialName: "kernel",
+		Revision:     snap.R(140),
+	}
+
+	err := s.be.SetupSnap(snapPath, &si, &s.nullProgress)
+	c.Assert(err, IsNil)
+	l, _ := filepath.Glob(filepath.Join(bootloader.Dir(), "*"))
+	c.Assert(l, HasLen, 1)
+
+	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
+
+	// undo deletes the kernel assets again
+	err = s.be.UndoSetupSnap(minInfo, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	l, _ = filepath.Glob(filepath.Join(bootloader.Dir(), "*"))
+	c.Assert(l, HasLen, 0)
+}
+
+func (s *setupSuite) TestSetupDoIdempotent(c *C) {
+	// make sure that a retry wouldn't stumble on partial work
+	// use a kernel because that does and need to do strictly more
+
+	// this cannot check systemd own behavior though around mounts!
+
+	bootloader := boottest.NewMockBootloader("mock", c.MkDir())
+	partition.ForceBootloader(bootloader)
+	// we don't get real mounting
+	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
+	defer os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
+
+	testFiles := [][]string{
+		{"kernel.img", "kernel"},
+		{"initrd.img", "initrd"},
+		{"modules/4.4.0-14-generic/foo.ko", "a module"},
+		{"firmware/bar.bin", "some firmware"},
+		{"meta/kernel.yaml", "version: 4.2"},
+	}
+	snapPath := snaptest.MakeTestSnapWithFiles(c, `name: kernel
+version: 1.0
+type: kernel
+`, testFiles)
+
+	si := snap.SideInfo{
+		OfficialName: "kernel",
+		Revision:     snap.R(140),
+	}
+
+	err := s.be.SetupSnap(snapPath, &si, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	// retry run
+	err = s.be.SetupSnap(snapPath, &si, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
+
+	// sanity checks
+	l, _ := filepath.Glob(filepath.Join(dirs.SnapServicesDir, "*.mount"))
+	c.Assert(l, HasLen, 1)
+	c.Assert(osutil.FileExists(minInfo.MountDir()), Equals, true)
+
+	c.Assert(osutil.FileExists(minInfo.MountFile()), Equals, true)
+
+	l, _ = filepath.Glob(filepath.Join(bootloader.Dir(), "*"))
+	c.Assert(l, HasLen, 1)
+}
+
+func (s *setupSuite) TestSetupUndoIdempotent(c *C) {
+	// make sure that a retry wouldn't stumble on partial work
+	// use a kernel because that does and need to do strictly more
+
+	// this cannot check systemd own behavior though around mounts!
+
+	bootloader := boottest.NewMockBootloader("mock", c.MkDir())
+	partition.ForceBootloader(bootloader)
+	// we don't get real mounting
+	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
+	defer os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
+
+	testFiles := [][]string{
+		{"kernel.img", "kernel"},
+		{"initrd.img", "initrd"},
+		{"modules/4.4.0-14-generic/foo.ko", "a module"},
+		{"firmware/bar.bin", "some firmware"},
+		{"meta/kernel.yaml", "version: 4.2"},
+	}
+	snapPath := snaptest.MakeTestSnapWithFiles(c, `name: kernel
+version: 1.0
+type: kernel
+`, testFiles)
+
+	si := snap.SideInfo{
+		OfficialName: "kernel",
+		Revision:     snap.R(140),
+	}
+
+	err := s.be.SetupSnap(snapPath, &si, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
+
+	err = s.be.UndoSetupSnap(minInfo, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	// retry run
+	err = s.be.UndoSetupSnap(minInfo, &s.nullProgress)
+	c.Assert(err, IsNil)
+
+	// sanity checks
+	l, _ := filepath.Glob(filepath.Join(dirs.SnapServicesDir, "*.mount"))
+	c.Assert(l, HasLen, 0)
+	c.Assert(osutil.FileExists(minInfo.MountDir()), Equals, false)
+
+	c.Assert(osutil.FileExists(minInfo.MountFile()), Equals, false)
+
+	l, _ = filepath.Glob(filepath.Join(bootloader.Dir(), "*"))
+	c.Assert(l, HasLen, 0)
+}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -105,7 +105,8 @@ func (f *fakeSnappyBackend) OpenSnapFile(snapFilePath string, si *snap.SideInfo)
 	return &snap.Info{Architectures: []string{"all"}}, nil, nil
 }
 
-func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo) error {
+func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p progress.Meter) error {
+	p.Notify("setup-snap")
 	revno := snap.R(0)
 	if si != nil {
 		revno = si.Revision
@@ -157,7 +158,8 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info) error {
 	return nil
 }
 
-func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo) error {
+func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo, p progress.Meter) error {
+	p.Notify("setup-snap")
 	f.ops = append(f.ops, fakeOp{
 		op:   "undo-setup-snap",
 		name: s.MountDir(),

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -49,23 +50,7 @@ func checkAssumes(s *snap.Info) error {
 	return nil
 }
 
-// openSnapFile opens a snap blob returning both a snap.Info completed
-// with sideInfo (if not nil) and a corresponding snap.Container.
-func openSnapFileImpl(snapPath string, sideInfo *snap.SideInfo) (*snap.Info, snap.Container, error) {
-	snapf, err := snap.Open(snapPath)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	info, err := snap.ReadInfoFromSnapFile(snapf, sideInfo)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return info, snapf, nil
-}
-
-var openSnapFile = openSnapFileImpl
+var openSnapFile = backend.OpenSnapFile
 
 // checkSnap ensures that the snap can be installed.
 func checkSnap(state *state.State, snapFilePath string, curInfo *snap.Info, flags Flags) error {

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-	"github.com/snapcore/snapd/snap/squashfs"
 
 	"github.com/snapcore/snapd/overlord/snapstate"
 )
@@ -45,53 +44,6 @@ func (s *checkSnapSuite) SetUpTest(c *C) {
 
 func (s *checkSnapSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-}
-
-func (s *checkSnapSuite) TestOpenSnapFile(c *C) {
-	const yaml = `name: hello
-version: 1.0
-apps:
- bin:
-   command: bin
-`
-
-	snapPath := makeTestSnap(c, yaml)
-	info, snapf, err := snapstate.OpenSnapFileImpl(snapPath, nil)
-	c.Assert(err, IsNil)
-
-	c.Assert(snapf, FitsTypeOf, &squashfs.Snap{})
-	c.Check(info.Name(), Equals, "hello")
-}
-
-func (s *checkSnapSuite) TestOpenSnapFilebSideInfo(c *C) {
-	const yaml = `name: foo
-apps:
- bar:
-  command: bin/bar
-plugs:
-  plug:
-slots:
- slot:
-`
-
-	snapPath := makeTestSnap(c, yaml)
-	si := snap.SideInfo{OfficialName: "blessed", Revision: snap.R(42)}
-	info, _, err := snapstate.OpenSnapFileImpl(snapPath, &si)
-	c.Assert(err, IsNil)
-
-	// check side info
-	c.Check(info.Name(), Equals, "blessed")
-	c.Check(info.Revision, Equals, snap.R(42))
-
-	c.Check(info.SideInfo, DeepEquals, si)
-
-	// ensure that all leaf objects link back to the same snap.Info
-	// and not to some copy.
-	// (we had a bug around this)
-	c.Check(info.Apps["bar"].Snap, Equals, info)
-	c.Check(info.Plugs["plug"].Snap, Equals, info)
-	c.Check(info.Slots["slot"].Snap, Equals, info)
-
 }
 
 func (s *checkSnapSuite) TestCheckSnapErrorOnUnsupportedArchitecture(c *C) {

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -71,11 +71,10 @@ func MockReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, error))
 	return func() { readInfo = snap.ReadInfo }
 }
 
-var OpenSnapFileImpl = openSnapFileImpl
-
 func MockOpenSnapFile(mock func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error)) (restore func()) {
+	prevOpenSnapFile := openSnapFile
 	openSnapFile = mock
-	return func() { openSnapFile = openSnapFileImpl }
+	return func() { openSnapFile = prevOpenSnapFile }
 }
 
 var (

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -477,7 +477,8 @@ func (m *SnapManager) undoMountSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	return m.backend.UndoSetupSnap(ss.placeInfo())
+	pb := &TaskProgressAdapter{task: t}
+	return m.backend.UndoSetupSnap(ss.placeInfo(), pb)
 }
 
 func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
@@ -504,9 +505,10 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	pb := &TaskProgressAdapter{task: t}
 	// TODO Use ss.Revision to obtain the right info to mount
 	//      instead of assuming the candidate is the right one.
-	return m.backend.SetupSnap(ss.SnapPath, snapst.Candidate)
+	return m.backend.SetupSnap(ss.SnapPath, snapst.Candidate, pb)
 }
 
 func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -788,7 +789,7 @@ func makeTestSnap(c *C, snapYamlContent string) (snapFilePath string) {
 
 func (s *snapmgrTestSuite) TestInstallFirstLocalRunThrough(c *C) {
 	// use the real thing for this one
-	snapstate.MockOpenSnapFile(snapstate.OpenSnapFileImpl)
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -847,7 +848,7 @@ version: 1.0`)
 
 func (s *snapmgrTestSuite) TestInstallSubsequentLocalRunThrough(c *C) {
 	// use the real thing for this one
-	snapstate.MockOpenSnapFile(snapstate.OpenSnapFileImpl)
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -924,7 +925,7 @@ version: 1.0`)
 
 func (s *snapmgrTestSuite) TestInstallOldSubsequentLocalRunThrough(c *C) {
 	// use the real thing for this one
-	snapstate.MockOpenSnapFile(snapstate.OpenSnapFileImpl)
+	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
This moves over SetupSnap, UndoSetupSnap and RemoveSnapFiles from snappy to snapstate/backend and their helper code.

Most of the change is actually ported tests and variations to test for idempotence of the backend implementations.

Added also OpenSnapFile to the backend package from snapstate because it is needed in both places.