### PR TITLE
cmd/snap: also print slots that connect to the wanted snap (LP: #1590704)

### DIFF
--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -69,8 +69,14 @@ func (x *cmdInterfaces) Execute(args []string) error {
 		fmt.Fprintln(w, i18n.G("Slot\tPlug"))
 		defer w.Flush()
 		for _, slot := range ifaces.Slots {
-			if x.Positionals.Query.Snap != "" && x.Positionals.Query.Snap != slot.Snap {
-				continue
+			if wanted := x.Positionals.Query.Snap; wanted != "" {
+				ok := wanted == slot.Snap
+				for i := 0; i < len(slot.Connections) && !ok; i++ {
+					ok = wanted == slot.Connections[i].Snap
+				}
+				if !ok {
+					continue
+				}
 			}
 			if x.Positionals.Query.Name != "" && x.Positionals.Query.Name != slot.Name {
 				continue

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -177,6 +177,22 @@ func (s *SnapSuite) TestInterfacesOneSlotOnePlug(c *C) {
 		"canonical-pi2:pin-13  keyboard-lights:capslock-led\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")
+
+	s.SetUpTest(c)
+	// should be the same
+	rest, err = Parser().ParseArgs([]string{"interfaces", "canonical-pi2"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+
+	s.SetUpTest(c)
+	// and the same again
+	rest, err = Parser().ParseArgs([]string{"interfaces", "keyboard-lights"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
 }
 
 func (s *SnapSuite) TestInterfacesTwoPlugs(c *C) {


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/snappy/+bug/1590704