### PR TITLE
integration-tests: wait until the network-bind service is up before testing

### DIFF
--- a/integration-tests/tests/network_bind_interface_test.go
+++ b/integration-tests/tests/network_bind_interface_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/integration-tests/testutils/cli"
 	"github.com/snapcore/snapd/integration-tests/testutils/data"
+	"github.com/snapcore/snapd/integration-tests/testutils/wait"
 )
 
 const providerURL = "http://127.0.0.1:8081"
@@ -41,6 +42,8 @@ type networkBindInterfaceSuite struct {
 }
 
 func (s *networkBindInterfaceSuite) TestPlugDisconnectionDisablesClientConnection(c *check.C) {
+	wait.ForActiveService(c, "snap.network-bind-consumer.network-consumer.service")
+
 	output := cli.ExecCommand(c, "network-consumer", providerURL)
 	c.Assert(output, check.Equals, "ok\n")
 


### PR DESCRIPTION
This will prevent this flaky result:
```
****** Running networkBindInterfaceSuite.TestPlugDisconnectionDisablesClientConnection
PASS: <autogenerated>:21: networkBindInterfaceSuite.SetUpTest	1.594s

integration-tests/tests/network_bind_interface_test.go:44:
    output := cli.ExecCommand(c, "network-consumer", providerURL)
integration-tests/testutils/cli/cli.go:42:
    c.Assert(err, check.IsNil, check.Commentf("Error for %v: %v", cmds, output))
... value *exec.ExitError = &exec.ExitError{ProcessState:(*os.ProcessState)(0xc82042d480), Stderr:[]uint8(nil)} ("exit status 1")
... Error for [network-consumer http://127.0.0.1:8081]: Error, reason:  [Errno 111] Connection refused


START: <autogenerated>:22: networkBindInterfaceSuite.TearDownTest
PASS: <autogenerated>:22: networkBindInterfaceSuite.TearDownTest	2.683s

FAIL: integration-tests/tests/network_bind_interface_test.go:43: networkBindInterfaceSuite.TestPlugDisconnectionDisablesClientConnection
```