### PR TITLE
interfaces: add a serial-port interface

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -136,6 +136,14 @@ with trusted apps.
 Usage: reserved
 Auto-Connect: no
 
+### serial-port
+
+Can access serial ports. This is restricted because it provides privileged
+access to configure serial port hardware.
+
+Usage: reserved
+Auto-Connect: no
+
 ### snapd-control
 
 Can manage snaps via snapd.

--- a/integration-tests/manual-tests.md
+++ b/integration-tests/manual-tests.md
@@ -150,3 +150,30 @@
    be checked in the ubuntu-control-center under the printers applet. Right
    click on the default printer and look at the queue. Ensure it contains the
    new item.
+
+# Test serial-port interface using miniterm app
+
+1. Using Ubuntu classic build and install a simple snap containing the Python
+   pySerial module. Define a app that runs the module and starts miniterm.
+
+```yaml
+  name: miniterm
+  version: 1
+  summary: pySerial miniterm in a snap
+  description: |
+    Simple snap that contains the modules necessary to run
+    pySerial. Useful for testing serial ports.
+  confinement: strict
+  apps:
+    open:
+      command: python3 -m serial.tools.miniterm
+      plugs: [serial-port]
+  parts:
+    my-part:
+      plugin: nil
+      stage-packages:
+        - python3-serial
+```
+
+2. Ensure the 'serial-port' interface is connected to miniterm
+3. Use sudo miniterm.open /dev/tty<DEV> to open a serial port

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -31,6 +31,7 @@ var allInterfaces = []interfaces.Interface{
 	&ModemManagerInterface{},
 	&NetworkManagerInterface{},
 	&PppInterface{},
+	&SerialPortInterface{},
 	NewFirewallControlInterface(),
 	NewGsettingsInterface(),
 	NewHomeInterface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -36,6 +36,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.BluezInterface{})
 	c.Check(all, Contains, &builtin.LocationControlInterface{})
 	c.Check(all, Contains, &builtin.LocationObserveInterface{})
+	c.Check(all, Contains, &builtin.SerialPortInterface{})
 	c.Check(all, DeepContains, builtin.NewFirewallControlInterface())
 	c.Check(all, DeepContains, builtin.NewGsettingsInterface())
 	c.Check(all, DeepContains, builtin.NewHomeInterface())

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -79,11 +79,7 @@ func (iface *SerialPortInterface) SanitizePlug(slot *interfaces.Plug) error {
 func (iface *SerialPortInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
-		path, err := iface.path(slot)
-		if err != nil {
-			return nil, fmt.Errorf("cannot compute slot security snippet: %v", err)
-		}
-		return []byte(fmt.Sprintf("\n%s rwk,\n", path)), nil
+		return []byte(fmt.Sprintf("\n%s rwk,\n", iface.path(slot))), nil
 	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
 		return nil, nil
 	default:
@@ -115,13 +111,7 @@ func (iface *SerialPortInterface) PermanentPlugSnippet(plug *interfaces.Plug, se
 func (iface *SerialPortInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
-		// Allow write and lock on the file designated by the path.
-		// Dereference symbolic links to file path handed out to apparmor
-		path, err := iface.path(slot)
-		if err != nil {
-			return nil, fmt.Errorf("cannot compute plug security snippet: %v", err)
-		}
-		return []byte(fmt.Sprintf("%s rwk,\n", path)), nil
+		return []byte(fmt.Sprintf("%s rwk,\n", iface.path(slot))), nil
 	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
 		return nil, nil
 	default:
@@ -129,9 +119,9 @@ func (iface *SerialPortInterface) ConnectedPlugSnippet(plug *interfaces.Plug, sl
 	}
 }
 
-func (iface *SerialPortInterface) path(slot *interfaces.Slot) (string, error) {
+func (iface *SerialPortInterface) path(slot *interfaces.Slot) string {
 	if path, ok := slot.Attrs["path"].(string); ok {
-		return filepath.Clean(path), nil
+		return filepath.Clean(path)
 	}
 	panic("slot is not sanitized")
 }

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -1,0 +1,152 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+// SerialPortInterface is the type for serial port interfaces.
+type SerialPortInterface struct{}
+
+// Name of the serial-port interface.
+func (iface *SerialPortInterface) Name() string {
+	return "serial-port"
+}
+
+func (iface *SerialPortInterface) String() string {
+	return iface.Name()
+}
+
+// Slots will be allowed to access any files matched here
+const serialSlotAppArmorSnippet = `
+/dev/tty[A-Z]{1,3}[0-9]{1,3}$ rw,
+`
+
+// Pattern to match allowed serial device nodes, path attributes will be
+// compared to this for validity
+var serialAllowedPathPattern = regexp.MustCompile("^/dev/tty[A-Z]{1,3}[0-9]{1,3}$")
+
+// SanitizeSlot checks validity of the defined slot
+func (iface *SerialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	// Check slot is of right type
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("slot is not of interface %q", iface))
+	}
+
+	// Check slot has a path attribute identify serial device
+	path, ok := slot.Attrs["path"].(string)
+	if !ok || path == "" {
+		return fmt.Errorf("serial-port slot must have a path attribute")
+	}
+
+	// Check the path attribute is in the allowable pattern
+	if serialAllowedPathPattern.MatchString(path) {
+		return nil
+	}
+	return fmt.Errorf("serial-port path attribute must be a valid device node")
+}
+
+// SanitizePlug checks and possibly modifies a plug.
+func (iface *SerialPortInterface) SanitizePlug(slot *interfaces.Plug) error {
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("plug is not of interface %q", iface))
+	}
+	// NOTE: currently we don't check anything on the plug side.
+	return nil
+}
+
+// PermanentSlotSnippet returns snippets granted on install
+func (iface *SerialPortInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		if iface.isSerialDevice(slot) {
+			return []byte(serialSlotAppArmorSnippet), nil
+		}
+		return nil, nil
+	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedSlotSnippet no extra permissions granted on connection
+func (iface *SerialPortInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// PermanentPlugSnippet return  snippet required to use a bool-file interface.
+func (iface *SerialPortInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedPlugSnippet returns security snippet specific to the plug
+func (iface *SerialPortInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		// Allow write and lock on the file designated by the path.
+		// Dereference symbolic links to file path handed out to apparmor
+		path, err := iface.path(slot)
+		if err != nil {
+			return nil, fmt.Errorf("cannot compute plug security snippet: %v", err)
+		}
+		return []byte(fmt.Sprintf("%s rwk,\n", path)), nil
+	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *SerialPortInterface) path(slot *interfaces.Slot) (string, error) {
+	if path, ok := slot.Attrs["path"].(string); ok {
+		return filepath.Clean(path), nil
+	}
+	panic("slot is not sanitized")
+}
+
+// isSerialDevice checks if a given serial-port slot has sensible path
+func (iface *SerialPortInterface) isSerialDevice(slot *interfaces.Slot) bool {
+	if path, ok := slot.Attrs["path"].(string); ok {
+		path = filepath.Clean(path)
+		return serialAllowedPathPattern.MatchString(path)
+	}
+	panic("slot is not sanitized")
+}
+
+// AutoConnect indicates whether this type of interface should allow autoconnect
+func (iface *SerialPortInterface) AutoConnect() bool {
+	return false
+}

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -182,14 +182,34 @@ func (s *SerialPortInterfaceSuite) TestPermanentPlugSnippetUnusedSecuritySystems
 }
 
 func (s *SerialPortInterfaceSuite) TestPermanentSlotSnippetGivesExtraPermissions(c *C) {
-	expectedSlotSnippet := []byte(`
-/dev/tty[A-Z]{1,3}[0-9]{1,3}$ rw,
+	// slot snippet 1
+	expectedSlotSnippet1 := []byte(`
+/dev/ttyS0 rwk,
 `)
-	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2, s.testSlot3, s.testSlot4} {
-		snippet, err := s.iface.PermanentSlotSnippet(slot, interfaces.SecurityAppArmor)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, DeepEquals, expectedSlotSnippet)
-	}
+	snippet, err := s.iface.PermanentSlotSnippet(s.testSlot1, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedSlotSnippet1)
+	// slot snippet 2
+	expectedSlotSnippet2 := []byte(`
+/dev/ttyAMA2 rwk,
+`)
+	snippet, err = s.iface.PermanentSlotSnippet(s.testSlot2, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedSlotSnippet2)
+	// slot snippet 3
+	expectedSlotSnippet3 := []byte(`
+/dev/ttyUSB927 rwk,
+`)
+	snippet, err = s.iface.PermanentSlotSnippet(s.testSlot3, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedSlotSnippet3)
+	// slot snippet 4
+	expectedSlotSnippet4 := []byte(`
+/dev/ttyS42 rwk,
+`)
+	snippet, err = s.iface.PermanentSlotSnippet(s.testSlot4, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedSlotSnippet4)
 }
 
 func (s *SerialPortInterfaceSuite) TestPermanentSlotSnippetPanicsOnUnsanitizedSlots(c *C) {

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -1,0 +1,246 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SerialPortInterfaceSuite struct {
+	testutil.BaseTest
+	iface            interfaces.Interface
+	testSlot1        *interfaces.Slot
+	testSlot2        *interfaces.Slot
+	testSlot3        *interfaces.Slot
+	testSlot4        *interfaces.Slot
+	missingPathSlot  *interfaces.Slot
+	badPathSlot1     *interfaces.Slot
+	badPathSlot2     *interfaces.Slot
+	badPathSlot3     *interfaces.Slot
+	badInterfaceSlot *interfaces.Slot
+	plug             *interfaces.Plug
+	badInterfacePlug *interfaces.Plug
+}
+
+var _ = Suite(&SerialPortInterfaceSuite{
+	iface: &builtin.SerialPortInterface{},
+})
+
+func (s *SerialPortInterfaceSuite) SetUpTest(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: ubuntu-core
+slots:
+    test-port-1:
+        interface: serial-port
+        path: /dev/ttyS0
+    test-port-2:
+        interface: serial-port
+        path: /dev/ttyAMA2
+    test-port-3:
+        interface: serial-port
+        path: /dev/ttyUSB927
+    test-port-4:
+        interface: serial-port
+        path: /dev/ttyS42
+    missing-path: serial-port
+    bad-path-1:
+        interface: serial-port
+        path: path
+    bad-path-2:
+        interface: serial-port
+        path: /dev/tty0
+    bad-path-3:
+        interface: serial-port
+        path: /dev/ttyUSB9271
+    bad-interface: other-interface
+plugs:
+    plug: serial-port
+    bad-interface: other-interface
+`))
+	c.Assert(err, IsNil)
+	s.testSlot1 = &interfaces.Slot{SlotInfo: info.Slots["test-port-1"]}
+	s.testSlot2 = &interfaces.Slot{SlotInfo: info.Slots["test-port-2"]}
+	s.testSlot3 = &interfaces.Slot{SlotInfo: info.Slots["test-port-3"]}
+	s.testSlot4 = &interfaces.Slot{SlotInfo: info.Slots["test-port-4"]}
+	s.missingPathSlot = &interfaces.Slot{SlotInfo: info.Slots["missing-path"]}
+	s.badPathSlot1 = &interfaces.Slot{SlotInfo: info.Slots["bad-path-1"]}
+	s.badPathSlot2 = &interfaces.Slot{SlotInfo: info.Slots["bad-path-2"]}
+	s.badPathSlot3 = &interfaces.Slot{SlotInfo: info.Slots["bad-path-3"]}
+	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-interface"]}
+	s.plug = &interfaces.Plug{PlugInfo: info.Plugs["plug"]}
+	s.badInterfacePlug = &interfaces.Plug{PlugInfo: info.Plugs["bad-interface"]}
+}
+
+func (s *SerialPortInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "serial-port")
+}
+
+func (s *SerialPortInterfaceSuite) TestSanitizeSlot(c *C) {
+	// Test good slot examples
+	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2, s.testSlot3, s.testSlot4} {
+		err := s.iface.SanitizeSlot(slot)
+		c.Assert(err, IsNil)
+	}
+	// Slots without the "path" attribute are rejected.
+	err := s.iface.SanitizeSlot(s.missingPathSlot)
+	c.Assert(err, ErrorMatches,
+		"serial-port slot must have a path attribute")
+	// Slots with incorrect value of the "path" attribute are rejected.
+	for _, slot := range []*interfaces.Slot{s.badPathSlot1, s.badPathSlot2, s.badPathSlot3} {
+		err := s.iface.SanitizeSlot(slot)
+		c.Assert(err, ErrorMatches,
+			"serial-port path attribute must be a valid device node")
+	}
+	// It is impossible to use "bool-file" interface to sanitize slots with other interfaces.
+	c.Assert(func() { s.iface.SanitizeSlot(s.badInterfaceSlot) }, PanicMatches,
+		`slot is not of interface "serial-port"`)
+}
+
+func (s *SerialPortInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+	// It is impossible to use "bool-file" interface to sanitize plugs of different interface.
+	c.Assert(func() { s.iface.SanitizePlug(s.badInterfacePlug) }, PanicMatches,
+		`plug is not of interface "serial-port"`)
+}
+
+func (s *SerialPortInterfaceSuite) TestConnectedPlugSnippetPanicsOnUnsanitizedSlots(c *C) {
+	// Unsanitized slots should never be used and cause a panic.
+	c.Assert(func() {
+		s.iface.ConnectedPlugSnippet(s.plug, s.missingPathSlot, interfaces.SecurityAppArmor)
+	}, PanicMatches, "slot is not sanitized")
+}
+
+func (s *SerialPortInterfaceSuite) TestConnectedPlugSnippetUnusedSecuritySystems(c *C) {
+	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2, s.testSlot3, s.testSlot4} {
+		// No extra seccomp permissions for plug
+		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecuritySecComp)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra dbus permissions for plug
+		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityDBus)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra udev permissions for plug
+		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityUDev)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra udev permissions for plug
+		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityUDev)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// Other security types are not recognized
+		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, slot, "foo")
+		c.Assert(err, ErrorMatches, `unknown security system`)
+		c.Assert(snippet, IsNil)
+	}
+}
+
+func (s *SerialPortInterfaceSuite) TestPermanentPlugSnippetUnusedSecuritySystems(c *C) {
+	// No extra seccomp permissions for plug
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra dbus permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra udev permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra udev permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// Other security types are not recognized
+	snippet, err = s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system`)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *SerialPortInterfaceSuite) TestPermanentSlotSnippetGivesExtraPermissions(c *C) {
+	expectedSlotSnippet := []byte(`
+/dev/tty[A-Z]{1,3}[0-9]{1,3}$ rw,
+`)
+	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2, s.testSlot3, s.testSlot4} {
+		snippet, err := s.iface.PermanentSlotSnippet(slot, interfaces.SecurityAppArmor)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, DeepEquals, expectedSlotSnippet)
+	}
+}
+
+func (s *SerialPortInterfaceSuite) TestPermanentSlotSnippetPanicsOnUnsanitizedSlots(c *C) {
+	// Unsanitized slots should never be used and cause a panic.
+	c.Assert(func() {
+		s.iface.PermanentSlotSnippet(s.missingPathSlot, interfaces.SecurityAppArmor)
+	}, PanicMatches, "slot is not sanitized")
+}
+
+func (s *SerialPortInterfaceSuite) TestConnectedSlotSnippetUnusedSecuritySystems(c *C) {
+	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2, s.testSlot3, s.testSlot4} {
+		// No extra seccomp permissions for slot
+		snippet, err := s.iface.ConnectedSlotSnippet(s.plug, slot, interfaces.SecuritySecComp)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra dbus permissions for slot
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, slot, interfaces.SecurityDBus)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra udev permissions for slot
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, slot, interfaces.SecurityUDev)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// Other security types are not recognized
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, slot, "foo")
+		c.Assert(err, ErrorMatches, `unknown security system`)
+		c.Assert(snippet, IsNil)
+	}
+}
+
+func (s *SerialPortInterfaceSuite) TestPermanentSlotSnippetUnusedSecuritySystems(c *C) {
+	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2, s.testSlot3, s.testSlot4} {
+		// No extra seccomp permissions for slot
+		snippet, err := s.iface.PermanentSlotSnippet(slot, interfaces.SecuritySecComp)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra dbus permissions for slot
+		snippet, err = s.iface.PermanentSlotSnippet(slot, interfaces.SecurityDBus)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra udev permissions for slot
+		snippet, err = s.iface.PermanentSlotSnippet(slot, interfaces.SecurityUDev)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// Other security types are not recognized
+		snippet, err = s.iface.PermanentSlotSnippet(slot, "foo")
+		c.Assert(err, ErrorMatches, `unknown security system`)
+		c.Assert(snippet, IsNil)
+	}
+}
+
+func (s *SerialPortInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(), Equals, false)
+}


### PR DESCRIPTION
A new builtin interface that allows basic access to serial ports. Uses just AppArmor snippets to provider access to /dev/tty[A-Z]{1,3}[0-9]{1,3}$