### PR TITLE
asserts: error style, use "cannot" instead of "failed to" following the main decided style

### DIFF
--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -78,7 +78,7 @@ func encodeKey(key keyEncoder, kind string) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	err := key.keyEncode(buf)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode %s: %v", kind, err)
+		return nil, fmt.Errorf("cannot encode %s: %v", kind, err)
 	}
 	return encodeFormatAndData(key.keyFormat(), buf.Bytes()), nil
 }

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -303,13 +303,17 @@ func OpenPGPPrivateKey(privk *packet.PrivateKey) PrivateKey {
 	return openpgpPrivateKey{privk}
 }
 
-// GenerateKey generates a private/public key pair.
-func GenerateKey() (PrivateKey, error) {
-	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+func generateKey(bits int) (PrivateKey, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
 		return nil, err
 	}
 	return OpenPGPPrivateKey(packet.NewRSAPrivateKey(time.Now(), priv)), nil
+}
+
+// GenerateKey generates a private/public key pair.
+func GenerateKey() (PrivateKey, error) {
+	return generateKey(4096)
 }
 
 func encodePrivateKey(privKey PrivateKey) ([]byte, error) {

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -28,6 +28,9 @@ import (
 
 // expose test-only things here
 
+// GenerateTestKey lets the test generate keys of given length
+var GenerateTestKey = generateKey
+
 // access internal openpgp lib packet
 func PrivateKeyPacket(pk PrivateKey) *packet.PrivateKey {
 	return pk.(openpgpPrivateKey).privk

--- a/asserts/fsbackstore.go
+++ b/asserts/fsbackstore.go
@@ -57,11 +57,11 @@ func (fsbs *filesystemBackstore) readAssertion(assertType *AssertionType, diskPr
 		return nil, ErrNotFound
 	}
 	if err != nil {
-		return nil, fmt.Errorf("broken assertion storage, failed to read assertion: %v", err)
+		return nil, fmt.Errorf("broken assertion storage, cannot read assertion: %v", err)
 	}
 	assert, err := Decode(encoded)
 	if err != nil {
-		return nil, fmt.Errorf("broken assertion storage, failed to decode assertion: %v", err)
+		return nil, fmt.Errorf("broken assertion storage, cannot decode assertion: %v", err)
 	}
 	if assert.Type() != assertType {
 		return nil, fmt.Errorf("assertion that is not of type %q under their storage tree", assertType.Name)
@@ -103,7 +103,7 @@ func (fsbs *filesystemBackstore) Put(assertType *AssertionType, assert Assertion
 	}
 	err = atomicWriteEntry(Encode(assert), false, fsbs.top, assertType.Name, diskPrimaryPath)
 	if err != nil {
-		return fmt.Errorf("broken assertion storage, failed to write assertion: %v", err)
+		return fmt.Errorf("broken assertion storage, cannot write assertion: %v", err)
 	}
 	return nil
 }

--- a/asserts/fsbackstore_test.go
+++ b/asserts/fsbackstore_test.go
@@ -58,7 +58,7 @@ func (fsbss *fsBackstoreSuite) TestOpenCreateFail(c *C) {
 	c.Assert(err, IsNil)
 
 	bs, err := asserts.OpenFSBackstore(topDir)
-	c.Assert(err, ErrorMatches, "failed to create assert storage root: .*")
+	c.Assert(err, ErrorMatches, "cannot create assert storage root: .*")
 	c.Check(bs, IsNil)
 }
 

--- a/asserts/fsentryutils.go
+++ b/asserts/fsentryutils.go
@@ -33,11 +33,11 @@ import (
 func ensureTop(path string) error {
 	err := os.MkdirAll(path, 0775)
 	if err != nil {
-		return fmt.Errorf("failed to create assert storage root: %v", err)
+		return fmt.Errorf("cannot create assert storage root: %v", err)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("failed to create assert storage root: %v", err)
+		return fmt.Errorf("cannot create assert storage root: %v", err)
 	}
 	if info.Mode().Perm()&0002 != 0 {
 		return fmt.Errorf("assert storage root unexpectedly world-writable: %v", path)

--- a/asserts/fskeypairmgr.go
+++ b/asserts/fskeypairmgr.go
@@ -60,7 +60,7 @@ func (fskm *filesystemKeypairManager) Put(authorityID string, privKey PrivateKey
 	}
 	encoded, err := encodePrivateKey(privKey)
 	if err != nil {
-		return fmt.Errorf("failed to store private key: %v", err)
+		return fmt.Errorf("cannot store private key: %v", err)
 	}
 
 	fskm.mu.Lock()
@@ -68,7 +68,7 @@ func (fskm *filesystemKeypairManager) Put(authorityID string, privKey PrivateKey
 
 	err = atomicWriteEntry(encoded, true, fskm.top, escapedAuthorityID, keyID)
 	if err != nil {
-		return fmt.Errorf("failed to store private key: %v", err)
+		return fmt.Errorf("cannot store private key: %v", err)
 	}
 	return nil
 }
@@ -84,11 +84,11 @@ func (fskm *filesystemKeypairManager) Get(authorityID, keyID string) (PrivateKey
 		return nil, errKeypairNotFound
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to read key pair: %v", err)
+		return nil, fmt.Errorf("cannot read key pair: %v", err)
 	}
 	privKey, err := decodePrivateKey(encoded)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode key pair: %v", err)
+		return nil, fmt.Errorf("cannot decode key pair: %v", err)
 	}
 	return privKey, nil
 }

--- a/asserts/privkeys_for_test.go
+++ b/asserts/privkeys_for_test.go
@@ -35,7 +35,7 @@ var (
 )
 
 func genTestPrivKey() asserts.PrivateKey {
-	// use a shorter key length here for test key because otherwise
+	// use a shorter key length here for test keys because otherwise
 	// they take too long to generate;
 	// the ones that care use pregenerated keys of the right length
 	// or use GenerateKey directly

--- a/asserts/privkeys_for_test.go
+++ b/asserts/privkeys_for_test.go
@@ -35,7 +35,11 @@ var (
 )
 
 func genTestPrivKey() asserts.PrivateKey {
-	privKey, err := asserts.GenerateKey()
+	// use a shorter key length here for test key because otherwise
+	// they take too long to generate;
+	// the ones that care use pregenerated keys of the right length
+	// or use GenerateKey directly
+	privKey, err := asserts.GenerateTestKey(752)
 	if err != nil {
 		panic(fmt.Errorf("failed to create priv key for tests: %v", err))
 	}


### PR DESCRIPTION
This addresses error message style.

Also a drive-by about test speed because of test key gen.