### PR TITLE
integration-tests: wait for network-bind service in try test

### DIFF
--- a/integration-tests/tests/tryapp_test.go
+++ b/integration-tests/tests/tryapp_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/integration-tests/testutils/cli"
 	"github.com/snapcore/snapd/integration-tests/testutils/common"
 	"github.com/snapcore/snapd/integration-tests/testutils/data"
+	"github.com/snapcore/snapd/integration-tests/testutils/wait"
 	"github.com/snapcore/snapd/testutil"
 
 	"gopkg.in/check.v1"
@@ -103,6 +104,7 @@ func (s *trySuite) TestTryConfinmentAllows(c *check.C) {
 	defer common.RemoveSnap(c, data.NetworkConsumerSnapName)
 
 	// confinment works in try mode:
+	wait.ForActiveService(c, "snap.network-bind-consumer.network-consumer.service")
 	providerURL := "http://127.0.0.1:8081"
 	output := cli.ExecCommand(c, "network-consumer", providerURL)
 	c.Assert(output, check.Equals, "ok\n")


### PR DESCRIPTION
This will prevent flaky errors like:
```
****** Running trySuite.TestTryConfinmentAllows
PASS: <autogenerated>:84: trySuite.SetUpTest	0.000s

integration-tests/tests/tryapp_test.go:107:
    output := cli.ExecCommand(c, "network-consumer", providerURL)
integration-tests/testutils/cli/cli.go:42:
    c.Assert(err, check.IsNil, check.Commentf("Error for %v: %v", cmds, output))
... value *exec.ExitError = &exec.ExitError{ProcessState:(*os.ProcessState)(0xc8203868a0), Stderr:[]uint8(nil)} ("exit status 1")
... Error for [network-consumer http://127.0.0.1:8081]: Error, reason:  [Errno 111] Connection refused


START: <autogenerated>:86: trySuite.TearDownTest
PASS: <autogenerated>:86: trySuite.TearDownTest	0.000s

FAIL: integration-tests/tests/tryapp_test.go:90: trySuite.TestTryConfinmentAllows
```