### PR TITLE
many: have the installation of the core snap request a restart (on classic)

### DIFF
--- a/overlord/backend.go
+++ b/overlord/backend.go
@@ -26,8 +26,9 @@ import (
 )
 
 type overlordStateBackend struct {
-	path         string
-	ensureBefore func(d time.Duration)
+	path           string
+	ensureBefore   func(d time.Duration)
+	requestRestart func()
 }
 
 func (osb *overlordStateBackend) Checkpoint(data []byte) error {
@@ -36,4 +37,8 @@ func (osb *overlordStateBackend) Checkpoint(data []byte) error {
 
 func (osb *overlordStateBackend) EnsureBefore(d time.Duration) {
 	osb.ensureBefore(d)
+}
+
+func (osb *overlordStateBackend) RequestRestart() {
+	osb.requestRestart()
 }

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -452,3 +452,25 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 	c.Check(err, IsNil)
 	c.Check(v, Equals, 2)
 }
+
+func (ovs *overlordSuite) TestRequestRestartNoHandler(c *C) {
+	o, err := overlord.New()
+	c.Assert(err, IsNil)
+
+	o.State().RequestRestart()
+}
+
+func (ovs *overlordSuite) TestRequestRestartHandler(c *C) {
+	o, err := overlord.New()
+	c.Assert(err, IsNil)
+
+	restartRequested := false
+
+	o.SetRestartHandler(func() {
+		restartRequested = true
+	})
+
+	o.State().RequestRestart()
+
+	c.Check(restartRequested, Equals, true)
+}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -125,6 +125,9 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 	if name == "gadget" {
 		info.Type = snap.TypeGadget
 	}
+	if name == "core" {
+		info.Type = snap.TypeOS
+	}
 	return info, nil
 }
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 )
@@ -679,6 +680,15 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	Set(st, ss.Name, snapst)
 	// Make sure if state commits and snapst is mutated we won't be rerun
 	t.SetStatus(state.DoneStatus)
+
+	// if we just installed a core snap, request a restart
+	// so that we switch executing its snapd
+	if newInfo.Type == snap.TypeOS && release.OnClassic {
+		st.Unlock()
+		st.RequestRestart()
+		st.Lock()
+	}
+
 	return nil
 }
 

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -34,10 +34,12 @@ import (
 )
 
 // A Backend is used by State to checkpoint on every unlock operation
-// and to mediate requests to ensure the state sooner.
+// and to mediate requests to ensure the state sooner or request restarts.
 type Backend interface {
 	Checkpoint(data []byte) error
 	EnsureBefore(d time.Duration)
+	// TODO: take flags to ask for reboot vs restart?
+	RequestRestart()
 }
 
 type customData map[string]*json.RawMessage
@@ -217,6 +219,13 @@ func (s *State) Unlock() {
 func (s *State) EnsureBefore(d time.Duration) {
 	if s.backend != nil {
 		s.backend.EnsureBefore(d)
+	}
+}
+
+// RequestRestart asks for a restart of the managing process.
+func (s *State) RequestRestart() {
+	if s.backend != nil {
+		s.backend.RequestRestart()
 	}
 }
 

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -134,9 +134,10 @@ func (ss *stateSuite) TestCache(c *C) {
 }
 
 type fakeStateBackend struct {
-	checkpoints  [][]byte
-	error        func() error
-	ensureBefore time.Duration
+	checkpoints      [][]byte
+	error            func() error
+	ensureBefore     time.Duration
+	restartRequested bool
 }
 
 func (b *fakeStateBackend) Checkpoint(data []byte) error {
@@ -149,6 +150,10 @@ func (b *fakeStateBackend) Checkpoint(data []byte) error {
 
 func (b *fakeStateBackend) EnsureBefore(d time.Duration) {
 	b.ensureBefore = d
+}
+
+func (b *fakeStateBackend) RequestRestart() {
+	b.restartRequested = true
 }
 
 func (ss *stateSuite) TestImplicitCheckpointAndRead(c *C) {
@@ -636,4 +641,13 @@ func (ss *stateSuite) TestPrune(c *C) {
 	c.Assert(t4.Status(), Equals, state.DoStatus)
 
 	c.Check(st.NumTask(), Equals, 3)
+}
+
+func (ss *stateSuite) TestRequestRestart(c *C) {
+	b := new(fakeStateBackend)
+	st := state.New(b)
+
+	st.RequestRestart()
+
+	c.Check(b.restartRequested, Equals, true)
 }


### PR DESCRIPTION
This has the code to have an installation of the core snap (on classic) end up requesting a restart of snapd so that it can switch to executing the new one.

Still to do:
* wire the restart in the daemon, something like?
```
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -221,6 +221,9 @@ func (d *Daemon) addRoutes() {
 
 // Start the Daemon
 func (d *Daemon) Start() {
+       d.overlord.SetRestartHandler(func() {
+               d.tomb.Kill(nil)
+       })
        // the loop runs in its own goroutine
        d.overlord.Loop()

```
* Add a Restart clause to snapd.service
* Try this
* What happens to a snap client command that triggers this?

given that the RequestRestart ends up a noop in this, this can be landed on its own though!