### PR TITLE
many: install snaps in devmode on distributions without complete apparmor and seccomp support

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -593,7 +593,7 @@ func withEnsureUbuntuCore(st *state.State, targetSnap string, userID int, instal
 
 func snapInstall(inst *snapInstruction, st *state.State) (string, []*state.TaskSet, error) {
 	flags := snapstate.Flags(0)
-	if inst.DevMode || release.ReleaseInfo.IsDevModeDistro() {
+	if inst.DevMode || release.ReleaseInfo.ForceDevMode() {
 		flags |= snapstate.DevMode
 	}
 
@@ -773,7 +773,7 @@ func sideloadSnap(c *Command, r *http.Request, user *auth.UserState) Response {
 	if len(form.Value["devmode"]) > 0 && form.Value["devmode"][0] == "true" {
 		flags |= snapstate.DevMode
 	}
-	if release.ReleaseInfo.IsDevModeDistro() {
+	if release.ReleaseInfo.ForceDevMode() {
 		flags |= snapstate.DevMode
 	}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -593,7 +593,7 @@ func withEnsureUbuntuCore(st *state.State, targetSnap string, userID int, instal
 
 func snapInstall(inst *snapInstruction, st *state.State) (string, []*state.TaskSet, error) {
 	flags := snapstate.Flags(0)
-	if inst.DevMode {
+	if inst.DevMode || release.ReleaseInfo.IsDevModeDistro() {
 		flags |= snapstate.DevMode
 	}
 
@@ -771,6 +771,9 @@ func sideloadSnap(c *Command, r *http.Request, user *auth.UserState) Response {
 	var flags snapstate.Flags
 
 	if len(form.Value["devmode"]) > 0 && form.Value["devmode"][0] == "true" {
+		flags |= snapstate.DevMode
+	}
+	if release.ReleaseInfo.IsDevModeDistro() {
 		flags |= snapstate.DevMode
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
@@ -1117,20 +1118,33 @@ func (s *apiSuite) TestPostSnapDispatch(c *check.C) {
 	}
 }
 
-func (s *apiSuite) TestSideloadSnap(c *check.C) {
+var sideLoadBodyWithoutDevMode = "" +
+	"----hello--\r\n" +
+	"Content-Disposition: form-data; name=\"snap\"; filename=\"x\"\r\n" +
+	"\r\n" +
+	"xyzzy\r\n" +
+	"----hello--\r\n" +
+	"Content-Disposition: form-data; name=\"snap-path\"\r\n" +
+	"\r\n" +
+	"a/b/local.snap\r\n" +
+	"----hello--\r\n"
+
+func (s *apiSuite) TestSideloadSnapOnNonDevModeDistro(c *check.C) {
 	// try a multipart/form-data upload
-	body := "" +
-		"----hello--\r\n" +
-		"Content-Disposition: form-data; name=\"snap\"; filename=\"x\"\r\n" +
-		"\r\n" +
-		"xyzzy\r\n" +
-		"----hello--\r\n" +
-		"Content-Disposition: form-data; name=\"snap-path\"\r\n" +
-		"\r\n" +
-		"a/b/local.snap\r\n" +
-		"----hello--\r\n"
+	body := sideLoadBodyWithoutDevMode
 	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
+	restore := release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
+	defer restore()
 	chgSummary := s.sideloadCheck(c, body, head, 0, false)
+	c.Check(chgSummary, check.Equals, `Install "local" snap from file "a/b/local.snap"`)
+}
+func (s *apiSuite) TestSideloadSnapOnDevModeDistro(c *check.C) {
+	// try a multipart/form-data upload
+	body := sideLoadBodyWithoutDevMode
+	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
+	restore := release.MockReleaseInfo(&release.OS{ID: "x-devmode-distro"})
+	defer restore()
+	chgSummary := s.sideloadCheck(c, body, head, snapstate.DevMode, false)
 	c.Check(chgSummary, check.Equals, `Install "local" snap from file "a/b/local.snap"`)
 }
 
@@ -1147,6 +1161,8 @@ func (s *apiSuite) TestSideloadSnapDevMode(c *check.C) {
 		"----hello--\r\n"
 	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
 	// try a multipart/form-data upload
+	restore := release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
+	defer restore()
 	chgSummary := s.sideloadCheck(c, body, head, snapstate.DevMode, true)
 	c.Check(chgSummary, check.Equals, `Install "local" snap from file "x"`)
 }
@@ -1391,9 +1407,18 @@ func (s *apiSuite) TestAppIconGetNoApp(c *check.C) {
 	c.Check(rec.Code, check.Equals, 404)
 }
 
-func (s *apiSuite) TestInstall(c *check.C) {
+func (s *apiSuite) TestInstalOnNonDevModeDistro(c *check.C) {
+	s.testInstall(c, &release.OS{ID: "ubuntu"}, snapstate.Flags(0))
+}
+func (s *apiSuite) TestInstalOnDevModeDistro(c *check.C) {
+	s.testInstall(c, &release.OS{ID: "x-devmode-distro"}, snapstate.DevMode)
+}
+
+func (s *apiSuite) testInstall(c *check.C, releaseInfo *release.OS, flags snapstate.Flags) {
 	calledFlags := snapstate.Flags(42)
 	installQueue := []string{}
+	restore := release.MockReleaseInfo(releaseInfo)
+	defer restore()
 
 	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
 		// we have ubuntu-core
@@ -1434,7 +1459,7 @@ func (s *apiSuite) TestInstall(c *check.C) {
 	st.Lock()
 
 	c.Check(chg.Status(), check.Equals, state.DoneStatus)
-	c.Check(calledFlags, check.Equals, snapstate.Flags(0))
+	c.Check(calledFlags, check.Equals, flags)
 	c.Check(err, check.IsNil)
 	c.Check(installQueue, check.DeepEquals, []string{"some-snap"})
 	c.Check(chg.Kind(), check.Equals, "install-snap")

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -226,9 +226,7 @@ var securityBackends = []interfaces.SecurityBackend{
 }
 
 func init() {
-	switch release.ReleaseInfo.ID {
-	case "ubuntu":
-		// Enable apparmor support when running on Ubuntu
+	if !release.ReleaseInfo.IsDevModeDistro() {
 		securityBackends = append(securityBackends, &apparmor.Backend{})
 	}
 }

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -226,7 +226,7 @@ var securityBackends = []interfaces.SecurityBackend{
 }
 
 func init() {
-	if !release.ReleaseInfo.IsDevModeDistro() {
+	if !release.ReleaseInfo.ForceDevMode() {
 		securityBackends = append(securityBackends, &apparmor.Backend{})
 	}
 }

--- a/release/release.go
+++ b/release/release.go
@@ -38,9 +38,9 @@ type OS struct {
 	Codename string
 }
 
-// IsDevModeDistro returns true if the distribution doesn't implement required
-// security features for confinement.
-func (os *OS) IsDevModeDistro() bool {
+// ForceDevMode returns true if the distribution doesn't implement required
+// security features for confinement and devmode is forced.
+func (os *OS) ForceDevMode() bool {
 	switch os.ID {
 	case "ubuntu":
 		return false

--- a/release/release.go
+++ b/release/release.go
@@ -38,6 +38,21 @@ type OS struct {
 	Codename string
 }
 
+// IsDevModeDistro returns true if the distribution doesn't implement required
+// security features for confinement.
+func (os *OS) IsDevModeDistro() bool {
+	switch os.ID {
+	case "ubuntu":
+		return false
+	default:
+		// NOTE: Other distributions can move out of devmode by
+		// integrating with the interface security backends. This will
+		// be documented separately in the porting guide.
+		return true
+	}
+
+}
+
 var osReleasePath = "/etc/os-release"
 
 // readOSRelease returns the os-release information of the current system.

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -100,3 +100,26 @@ func (s *ReleaseTestSuite) TestReleaseInfo(c *C) {
 	defer reset()
 	c.Assert(release.ReleaseInfo.ID, Equals, "distro-id")
 }
+
+func (s *ReleaseTestSuite) TestIsDevModeDistro(c *C) {
+	// Restore real OS info at the end of this function.
+	defer release.MockReleaseInfo(&release.OS{})()
+	distros := []struct {
+		id      string
+		devmode bool
+	}{
+		// Please keep this list sorted
+		{"arch", true},
+		{"debian", true},
+		{"fedora", true},
+		{"gentoo", true},
+		{"opensuse", true},
+		{"rhel", true},
+		{"ubuntu", false},
+	}
+	for _, distro := range distros {
+		c.Logf("checking distribution %q", distro.id)
+		release.MockReleaseInfo(&release.OS{ID: distro.id})
+		c.Assert(release.ReleaseInfo.IsDevModeDistro(), Equals, distro.devmode)
+	}
+}

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -101,7 +101,7 @@ func (s *ReleaseTestSuite) TestReleaseInfo(c *C) {
 	c.Assert(release.ReleaseInfo.ID, Equals, "distro-id")
 }
 
-func (s *ReleaseTestSuite) TestIsDevModeDistro(c *C) {
+func (s *ReleaseTestSuite) TestForceDevMode(c *C) {
 	// Restore real OS info at the end of this function.
 	defer release.MockReleaseInfo(&release.OS{})()
 	distros := []struct {
@@ -120,6 +120,6 @@ func (s *ReleaseTestSuite) TestIsDevModeDistro(c *C) {
 	for _, distro := range distros {
 		c.Logf("checking distribution %q", distro.id)
 		release.MockReleaseInfo(&release.OS{ID: distro.id})
-		c.Assert(release.ReleaseInfo.IsDevModeDistro(), Equals, distro.devmode)
+		c.Assert(release.ReleaseInfo.ForceDevMode(), Equals, distro.devmode)
 	}
 }


### PR DESCRIPTION
This branch changes the release module to add APIs for detecting distributions that don't yet support all of the apparmor and seccomp features that constitute the security system. On distributions like that the daemon will now unconditionally set the devmode flag on install and sideload requests.