### PR TITLE
asserts: allow to load also account assertions into the trusted set

### DIFF
--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -195,7 +195,7 @@ func (aks *accountKeySuite) openDB(c *C) *asserts.Database {
 	cfg := &asserts.DatabaseConfig{
 		Backstore:      bs,
 		KeypairManager: asserts.NewMemoryKeypairManager(),
-		TrustedKeys:    []*asserts.AccountKey{asserts.BootstrapAccountKeyForTest("canonical", trustedKey.PublicKey())},
+		Trusted:        []asserts.Assertion{asserts.BootstrapAccountKeyForTest("canonical", trustedKey.PublicKey())},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -74,8 +74,8 @@ type KeypairManager interface {
 
 // DatabaseConfig for an assertion database.
 type DatabaseConfig struct {
-	// trusted account keys
-	TrustedKeys []*AccountKey
+	// trusted assertions (account and account-key supported)
+	Trusted []Assertion
 	// backstore for assertions, left unset storing assertions will error
 	Backstore Backstore
 	// manager/backstore for keypairs, mandatory
@@ -148,10 +148,23 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 
 	trustedBackstore := NewMemoryBackstore()
 
-	for _, accKey := range cfg.TrustedKeys {
-		err := trustedBackstore.Put(AccountKeyType, accKey)
-		if err != nil {
-			return nil, fmt.Errorf("error loading for use trusted account key %q for %q: %v", accKey.PublicKeyID(), accKey.AuthorityID(), err)
+	for _, a := range cfg.Trusted {
+		switch a.Type() {
+		case AccountKeyType:
+			accKey := a.(*AccountKey)
+			err := trustedBackstore.Put(AccountKeyType, accKey)
+			if err != nil {
+				return nil, fmt.Errorf("error loading for use trusted account key %q for %q: %v", accKey.PublicKeyID(), accKey.AccountID(), err)
+			}
+
+		case AccountType:
+			acct := a.(*Account)
+			err := trustedBackstore.Put(AccountType, acct)
+			if err != nil {
+				return nil, fmt.Errorf("error loading for use trusted account %q: %v", acct.DisplayName(), err)
+			}
+		default:
+			return nil, fmt.Errorf("cannot load trusted assertions that are not account-key or account: %s", a.Type().Name)
 		}
 	}
 

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -149,16 +149,16 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 	trustedBackstore := NewMemoryBackstore()
 
 	for _, a := range cfg.Trusted {
-		switch a.Type() {
-		case AccountKeyType:
-			accKey := a.(*AccountKey)
+		switch accepted := a.(type) {
+		case *AccountKey:
+			accKey := accepted
 			err := trustedBackstore.Put(AccountKeyType, accKey)
 			if err != nil {
 				return nil, fmt.Errorf("error loading for use trusted account key %q for %q: %v", accKey.PublicKeyID(), accKey.AccountID(), err)
 			}
 
-		case AccountType:
-			acct := a.(*Account)
+		case *Account:
+			acct := accepted
 			err := trustedBackstore.Put(AccountType, acct)
 			if err != nil {
 				return nil, fmt.Errorf("error loading for use trusted account %q: %v", acct.DisplayName(), err)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -58,6 +58,50 @@ func (opens *openSuite) TestOpenDatabasePanicOnUnsetBackstores(c *C) {
 	c.Assert(func() { asserts.OpenDatabase(cfg) }, PanicMatches, "database cannot be used without setting a keypair manager")
 }
 
+func (opens *openSuite) TestOpenDatabaseTrustedAccount(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+		"account-id":   "trusted",
+		"display-name": "Trusted",
+		"validation":   "certified",
+		"timestamp":    "2015-01-01T14:00:00Z",
+	}
+	acct, err := asserts.AssembleAndSignInTest(asserts.AccountType, headers, nil, testPrivKey0)
+	c.Assert(err, IsNil)
+
+	cfg := &asserts.DatabaseConfig{
+		KeypairManager: asserts.NewMemoryKeypairManager(),
+		Trusted:        []asserts.Assertion{acct},
+	}
+
+	db, err := asserts.OpenDatabase(cfg)
+	c.Assert(err, IsNil)
+
+	a, err := db.Find(asserts.AccountType, map[string]string{
+		"account-id": "trusted",
+	})
+	c.Assert(err, IsNil)
+	acct1 := a.(*asserts.Account)
+	c.Check(acct1.AccountID(), Equals, "trusted")
+	c.Check(acct1.DisplayName(), Equals, "Trusted")
+}
+
+func (opens *openSuite) TestOpenDatabaseTrustedWrongType(c *C) {
+	headers := map[string]string{
+		"authority-id": "canonical",
+		"primary-key":  "0",
+	}
+	a, err := asserts.AssembleAndSignInTest(asserts.TestOnlyType, headers, nil, testPrivKey0)
+
+	cfg := &asserts.DatabaseConfig{
+		KeypairManager: asserts.NewMemoryKeypairManager(),
+		Trusted:        []asserts.Assertion{a},
+	}
+
+	_, err = asserts.OpenDatabase(cfg)
+	c.Assert(err, ErrorMatches, "cannot load trusted assertions that are not account-key or account: test-only")
+}
+
 type databaseSuite struct {
 	topDir string
 	db     *asserts.Database
@@ -184,7 +228,7 @@ func (chks *checkSuite) TestCheckExpiredPubKey(c *C) {
 	cfg := &asserts.DatabaseConfig{
 		Backstore:      chks.bs,
 		KeypairManager: asserts.NewMemoryKeypairManager(),
-		TrustedKeys:    []*asserts.AccountKey{asserts.ExpiredAccountKeyForTest("canonical", trustedKey.PublicKey())},
+		Trusted:        []asserts.Assertion{asserts.ExpiredAccountKeyForTest("canonical", trustedKey.PublicKey())},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
@@ -199,7 +243,7 @@ func (chks *checkSuite) TestCheckForgery(c *C) {
 	cfg := &asserts.DatabaseConfig{
 		Backstore:      chks.bs,
 		KeypairManager: asserts.NewMemoryKeypairManager(),
-		TrustedKeys:    []*asserts.AccountKey{asserts.BootstrapAccountKeyForTest("canonical", trustedKey.PublicKey())},
+		Trusted:        []asserts.Assertion{asserts.BootstrapAccountKeyForTest("canonical", trustedKey.PublicKey())},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
@@ -258,7 +302,7 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 	cfg := &asserts.DatabaseConfig{
 		Backstore:      bs,
 		KeypairManager: asserts.NewMemoryKeypairManager(),
-		TrustedKeys:    []*asserts.AccountKey{asserts.BootstrapAccountKeyForTest("canonical", trustedKey.PublicKey())},
+		Trusted:        []asserts.Assertion{asserts.BootstrapAccountKeyForTest("canonical", trustedKey.PublicKey())},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)
@@ -633,7 +677,7 @@ ZF5jSvRDLgI=`
 
 	cfg := &asserts.DatabaseConfig{
 		KeypairManager: asserts.NewMemoryKeypairManager(),
-		TrustedKeys:    []*asserts.AccountKey{tKey.(*asserts.AccountKey)},
+		Trusted:        []asserts.Assertion{tKey.(*asserts.AccountKey)},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -62,6 +62,7 @@ func makeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, validYea
 	return &AccountKey{
 		assertionBase: assertionBase{
 			headers: map[string]string{
+				"type":          "account-key",
 				"authority-id":  authorityID,
 				"account-id":    authorityID,
 				"public-key-id": openPGPPubKey.ID(),

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -190,7 +190,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigning(c *C) {
 	checkDB, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
 		KeypairManager: asserts.NewMemoryKeypairManager(),
 		Backstore:      asserts.NewMemoryBackstore(),
-		TrustedKeys:    []*asserts.AccountKey{trustedAccKey.(*asserts.AccountKey)},
+		Trusted:        []asserts.Assertion{trustedAccKey.(*asserts.AccountKey)},
 	})
 	c.Assert(err, IsNil)
 	err = checkDB.Add(devAccKey)

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -241,7 +241,7 @@ func makeSignAndCheckDbWithAccountKey(c *C, accountID string) (signingKeyID stri
 	cfg := &asserts.DatabaseConfig{
 		Backstore:      bs,
 		KeypairManager: asserts.NewMemoryKeypairManager(),
-		TrustedKeys:    []*asserts.AccountKey{asserts.BootstrapAccountKeyForTest("canonical", trustedKey.PublicKey())},
+		Trusted:        []asserts.Assertion{asserts.BootstrapAccountKeyForTest("canonical", trustedKey.PublicKey())},
 	}
 	checkDB, err = asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/sysdb.go
+++ b/asserts/sysdb.go
@@ -42,7 +42,7 @@ func openDatabaseAt(path string, cfg *DatabaseConfig) (*Database, error) {
 
 // OpenSysDatabase opens the installation-wide assertion database. Uses the given trusted account key.
 func OpenSysDatabase(trustedAccountKey string) (*Database, error) {
-	var trustedKeys []*AccountKey
+	var trusted []Assertion
 
 	// XXX: temporary, allow to set up without trusted keys
 	// until we have and install a firm trusted key with snappy itself
@@ -63,11 +63,11 @@ func OpenSysDatabase(trustedAccountKey string) (*Database, error) {
 		default:
 			return nil, fmt.Errorf("trusted account key is %T, not an account-key", trustedAccKey)
 		}
-		trustedKeys = []*AccountKey{trustedKey}
+		trusted = []Assertion{trustedKey}
 	}
 
 	cfg := &DatabaseConfig{
-		TrustedKeys: trustedKeys,
+		Trusted: trusted,
 	}
 	return openDatabaseAt(dirs.SnapAssertsDBDir, cfg)
 }


### PR DESCRIPTION
This allows to load also account assertions into the trusted of an assertion database, we want support pairing them with their account keys.