### PR TITLE
snap-internal: add new `/usr/lib/snapd/snap-internal` to support ubuntu-image

### DIFF
--- a/cmd/snap-internal/cmd_download.go
+++ b/cmd/snap-internal/cmd_download.go
@@ -1,0 +1,95 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/store"
+)
+
+type cmdDownload struct {
+	Positional struct {
+		Snap string `positional-arg-name:"<snap>"`
+	} `positional-args:"yes" required:"yes"`
+
+	TargetDir string `long:"targetdir"`
+	Channel   string `long:"channel"`
+	Series    string `long:"series"`
+	StoreID   string `long:"store-id"`
+}
+
+func (x *cmdDownload) downloadSnapWithSideInfo() (string, error) {
+	if x.Series != "" {
+		release.Series = x.Series
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	targetDir := x.TargetDir
+	if targetDir == "" {
+		targetDir = pwd
+	}
+
+	m := store.NewUbuntuStoreSnapRepository(nil, x.StoreID)
+	snap, err := m.Snap(x.Positional.Snap, x.Channel, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to find snap: %s", err)
+	}
+	pb := progress.NewTextProgress()
+	tmpName, err := m.Download(snap, pb, nil)
+	if err != nil {
+		return "", err
+	}
+	baseName := filepath.Base(snap.MountFile())
+
+	path := filepath.Join(targetDir, baseName)
+	if err := os.Rename(tmpName, path); err != nil {
+		return "", err
+	}
+
+	out, err := json.Marshal(snap)
+	if err != nil {
+		return "", err
+	}
+	if err := ioutil.WriteFile(path+".sideinfo", []byte(out), 0644); err != nil {
+		return "", err
+	}
+
+	return path, nil
+}
+
+func (x *cmdDownload) Execute([]string) error {
+	path, err := x.downloadSnapWithSideInfo()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Downloaded snap to %q and %q\n", path, path+".sideinfo")
+
+	return nil
+}

--- a/cmd/snap-internal/cmd_setboot.go
+++ b/cmd/snap-internal/cmd_setboot.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/partition"
+)
+
+type cmdSetBoot struct {
+	Positional struct {
+		Name  string `positional-arg-name:"<name>"`
+		Value string `positional-arg-name:"<value>"`
+	} `positional-args:"yes" required:"yes"`
+
+	RootDir string `long:"rootdir"`
+}
+
+func (x *cmdSetBoot) Execute([]string) error {
+	if x.RootDir != "" {
+		dirs.SetRootDir(x.RootDir)
+	}
+
+	bootloader, err := partition.FindBootloader()
+	if err != nil {
+		return err
+	}
+
+	return bootloader.SetBootVar(x.Positional.Name, x.Positional.Value)
+}

--- a/cmd/snap-internal/main.go
+++ b/cmd/snap-internal/main.go
@@ -33,12 +33,16 @@ func main() {
 	}
 }
 
+var shortDescr = "internal command"
+var longDescr = "internal command please do not use"
+
 func run() error {
 	var opts struct {
 	}
 
 	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
-	parser.AddCommand("set-boot", "set-boot", "set-boot", &cmdSetBoot{})
+	parser.AddCommand("set-boot", shortDescr, longDescr, &cmdSetBoot{})
+	parser.AddCommand("download", shortDescr, longDescr, &cmdDownload{})
 
 	_, err := parser.Parse()
 	if err != nil {

--- a/cmd/snap-internal/main.go
+++ b/cmd/snap-internal/main.go
@@ -1,0 +1,49 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Printf("cannot snap-internal: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var opts struct {
+	}
+
+	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
+	parser.AddCommand("set-boot", "set-boot", "set-boot", &cmdSetBoot{})
+
+	_, err := parser.Parse()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/debian/snapd.install
+++ b/debian/snapd.install
@@ -1,6 +1,7 @@
 /usr/bin/snap
 /usr/bin/snapd usr/lib/snapd
 /usr/bin/snap-exec usr/lib/snapd
+/usr/bin/snap-internal usr/lib/snapd
 data/completion/snap /usr/share/bash-completion/completions/
 # i18n stuff
 ../../share /usr

--- a/tests/snap-internal/task.yaml
+++ b/tests/snap-internal/task.yaml
@@ -1,0 +1,11 @@
+summary: Check that cmdline for channel shortcuts work
+execute: |
+    echo Ensure that snap-internal download works 
+    /usr/lib/snapd/snap-internal download --targetdir /tmp/ hello-world
+    ls /tmp/hello-world_*.snap
+    ls /tmp/hello-world_*.snap.sideinfo
+    echo Ensure that metadata looks valid
+    grep '"snap-id":"buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ"' /tmp/hello-world_*.snap.sideinfo
+restore:
+    rm -f /tmp/hello-world_*
+


### PR DESCRIPTION
This branch adds support for a new `snap-internal` command that supports "set-boot" and "download". Both are required for ubuntu-image so that it can download the kernel/os/gadget/additional snaps (with sideinfo) and to do the bootloader interaction required for ubuntu-image.