### PR TITLE
integration-tests: fix another i386 autopkgtest failure.

### DIFF
--- a/integration-tests/tests/unity_test.go
+++ b/integration-tests/tests/unity_test.go
@@ -45,6 +45,10 @@ type unitySuite struct {
 }
 
 func (s *unitySuite) TestUnitySnapCanBeStarted(c *check.C) {
+	if runtime.GOARCH != "amd64" {
+		c.Skip("all find results are only available on amd64")
+	}
+
 	_, err := cli.ExecCommandErr("sudo", "snap", "install", appName)
 	c.Assert(err, check.IsNil)
 	defer cli.ExecCommand(c, "sudo", "snap", "remove", appName)

--- a/integration-tests/tests/unity_test.go
+++ b/integration-tests/tests/unity_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	"github.com/snapcore/snapd/integration-tests/testutils/cli"
 	"github.com/snapcore/snapd/integration-tests/testutils/common"


### PR DESCRIPTION
skip unity7 test on non-amd64 arches (calculator only available on amd64