### PR TITLE
release: enable full confinement on Elementary 0.4

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -44,6 +44,13 @@ func (os *OS) ForceDevMode() bool {
 	switch os.ID {
 	case "ubuntu":
 		return false
+	case "elementary":
+		switch os.Release {
+		case "0.4":
+			return false
+		default:
+			return true
+		}
 	default:
 		// NOTE: Other distributions can move out of devmode by
 		// integrating with the interface security backends. This will

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -105,21 +105,25 @@ func (s *ReleaseTestSuite) TestForceDevMode(c *C) {
 	// Restore real OS info at the end of this function.
 	defer release.MockReleaseInfo(&release.OS{})()
 	distros := []struct {
-		id      string
-		devmode bool
+		id        string
+		idVersion string
+		devmode   bool
 	}{
 		// Please keep this list sorted
-		{"arch", true},
-		{"debian", true},
-		{"fedora", true},
-		{"gentoo", true},
-		{"opensuse", true},
-		{"rhel", true},
-		{"ubuntu", false},
+		{id: "arch", devmode: true},
+		{id: "debian", devmode: true},
+		{id: "elementary", devmode: true},
+		{id: "elementary", idVersion: "0.4", devmode: false},
+		{id: "fedora", devmode: true},
+		{id: "gentoo", devmode: true},
+		{id: "opensuse", devmode: true},
+		{id: "rhel", devmode: true},
+		{id: "ubuntu", devmode: false},
 	}
 	for _, distro := range distros {
-		c.Logf("checking distribution %q", distro.id)
-		release.MockReleaseInfo(&release.OS{ID: distro.id})
+		rel := &release.OS{ID: distro.id, Release: distro.idVersion}
+		c.Logf("checking distribution %#v", rel)
+		release.MockReleaseInfo(rel)
 		c.Assert(release.ReleaseInfo.ForceDevMode(), Equals, distro.devmode)
 	}
 }


### PR DESCRIPTION
Elementary 0.4 (Loki) is Derived from Ubuntu 16.04 and has all the
required kernel features available, we just have to use them.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>