### PR TITLE
save a fork()

### DIFF
--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -54,7 +54,7 @@ export HOME="$SNAP_USER_DATA"
 # Snap name is: {{.App.Snap.Name}}
 # App name is: {{.App.Name}}
 
-{{.App.LauncherCommand}} "$@"
+exec {{.App.LauncherCommand}} "$@"
 `
 
 	if err := snap.ValidateApp(app); err != nil {

--- a/wrappers/binaries_gen_test.go
+++ b/wrappers/binaries_gen_test.go
@@ -54,7 +54,7 @@ export HOME="$SNAP_USER_DATA"
 # Snap name is: pastebinit
 # App name is: pastebinit
 
-/usr/bin/ubuntu-core-launcher snap.pastebinit.pastebinit snap.pastebinit.pastebinit /snap/pastebinit/44/bin/pastebinit "$@"
+exec /usr/bin/ubuntu-core-launcher snap.pastebinit.pastebinit snap.pastebinit.pastebinit /snap/pastebinit/44/bin/pastebinit "$@"
 `
 
 func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -78,7 +78,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	c.Assert(err, IsNil)
 
 	needle := fmt.Sprintf(`
-/usr/bin/ubuntu-core-launcher snap.hello-snap.hello snap.hello-snap.hello %s/snap/hello-snap/11/bin/hello "$@"
+exec /usr/bin/ubuntu-core-launcher snap.hello-snap.hello snap.hello-snap.hello %s/snap/hello-snap/11/bin/hello "$@"
 `, s.tempdir)
 
 	c.Assert(string(content), Matches, "(?ms).*"+regexp.QuoteMeta(needle)+".*")


### PR DESCRIPTION
spawn ubuntu-core-launcher with exec,
to avoid forking and having a spare shell waiting.