### PR TITLE
integration-tests: do not try to kill ubuntu-clock-app.clock (no longer a process)

### DIFF
--- a/integration-tests/tests/unity_test.go
+++ b/integration-tests/tests/unity_test.go
@@ -83,7 +83,7 @@ func (s *unitySuite) TestUnitySnapCanBeStarted(c *check.C) {
 	err = mainCmd.Process.Kill()
 	c.Assert(err, check.IsNil, check.Commentf("error interrupting %s, %v", appName, err))
 
-	// at this point the Xvfb, ubuntu-clock-app.clock and qmlscene processes are still alive
+	// at this point the Xvfb and qmlscene processes are still alive
 	//and the snap can't be removed
-	cli.ExecCommand(c, "sudo", "killall", "-9", appBinaryName, "Xvfb", "qmlscene")
+	cli.ExecCommand(c, "sudo", "killall", "-9", "Xvfb", "qmlscene")
 }


### PR DESCRIPTION
We needed to stop the `ubuntu-clock-app.clock` process in order to restore the state after running `unitySuite.TestUnitySnapCanBeStarted`, the process is no longer present in the system, and stopping `qmlscene` is enough to effectively kill the app and allow the snap removal. This will prevent the error:
```
integration-tests/tests/unity_test.go:88:
    // at this point the Xvfb, ubuntu-clock-app.clock and qmlscene processes are still alive
    //and the snap can't be removed
    cli.ExecCommand(c, "sudo", "killall", "-9", appBinaryName, "Xvfb", "qmlscene")
integration-tests/testutils/cli/cli.go:42:
    c.Assert(err, check.IsNil, check.Commentf("Error for %v: %v", cmds, output))
... value *exec.ExitError = &exec.ExitError{ProcessState:(*os.ProcessState)(0xc8203adf80), Stderr:[]uint8(nil)} ("exit status 1")
... Error for [sudo killall -9 ubuntu-clock-app.clock Xvfb qmlscene]: ubuntu-clock-app.clock: no process found


START: <autogenerated>:94: unitySuite.TearDownTest
PASS: <autogenerated>:94: unitySuite.TearDownTest	0.000s

FAIL: integration-tests/tests/unity_test.go:48: unitySuite.TestUnitySnapCanBeStarted
```