### PR TITLE
snap: add the magic redirect part of `snap run`

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -167,8 +167,12 @@ func main() {
 	if osutil.IsSymlink(filepath.Join(dirs.SnapBinariesDir, snapApp)) {
 		cmd := &cmdRun{}
 		cmd.Positional.SnapApp = snapApp
-		cmd.Execute(os.Args[1:])
-		return
+		// this will call syscall.Exec() so it does not return
+		// *unless* there is an error, i.e. we setup a wrong
+		// symlink
+		err := cmd.Execute(os.Args[1:])
+		fmt.Fprintf(Stderr, "internal error, please report: running %q failed: %s\n", snapApp, err)
+		os.Exit(46)
 	}
 
 	// no magic /o\

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -169,7 +169,7 @@ func main() {
 		cmd.Positional.SnapApp = snapApp
 		// this will call syscall.Exec() so it does not return
 		// *unless* there is an error, i.e. we setup a wrong
-		// symlink
+		// symlink (or syscall.Exec() fails for strange reasons)
 		err := cmd.Execute(os.Args[1:])
 		fmt.Fprintf(Stderr, "internal error, please report: running %q failed: %s\n", snapApp, err)
 		os.Exit(46)

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd"
@@ -165,11 +164,11 @@ func main() {
 
 	// magic \o/
 	arg0 := os.Args[0]
-	if osutil.IsSymlink(filepath.Join(dirs.SnapBinariesDir, filepath.Base(arg0))) {
-		snapApp := filepath.Base(arg0)
-		cmd := []string{"/usr/bin/snap", "run", snapApp}
-		cmd = append(cmd, os.Args[1:]...)
-		syscall.Exec(cmd[0], cmd, os.Environ())
+	snapApp := filepath.Base(arg0)
+	if osutil.IsSymlink(filepath.Join(dirs.SnapBinariesDir, snapApp)) {
+		cmd := &cmdRun{}
+		cmd.Positional.SnapApp = snapApp
+		cmd.Execute(os.Args[1:])
 	}
 
 	// no magic /o\

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -163,8 +163,7 @@ func main() {
 	cmd.ExecInCoreSnap()
 
 	// magic \o/
-	arg0 := os.Args[0]
-	snapApp := filepath.Base(arg0)
+	snapApp := filepath.Base(os.Args[0])
 	if osutil.IsSymlink(filepath.Join(dirs.SnapBinariesDir, snapApp)) {
 		cmd := &cmdRun{}
 		cmd.Positional.SnapApp = snapApp

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -168,6 +168,7 @@ func main() {
 		cmd := &cmdRun{}
 		cmd.Positional.SnapApp = snapApp
 		cmd.Execute(os.Args[1:])
+		return
 	}
 
 	// no magic /o\

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -23,12 +23,16 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -158,6 +162,17 @@ func init() {
 
 func main() {
 	cmd.ExecInCoreSnap()
+
+	// magic \o/
+	arg0 := os.Args[0]
+	if osutil.IsSymlink(filepath.Join(dirs.SnapBinariesDir, filepath.Base(arg0))) {
+		snapApp := filepath.Base(arg0)
+		cmd := []string{"/usr/bin/snap", "run", snapApp}
+		cmd = append(cmd, os.Args[1:]...)
+		syscall.Exec(cmd[0], cmd, os.Environ())
+	}
+
+	// no magic /o\
 	if err := run(); err != nil {
 		fmt.Fprintf(Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/osutil/stat.go
+++ b/osutil/stat.go
@@ -45,3 +45,13 @@ func IsDirectory(path string) bool {
 func IsDevice(mode os.FileMode) bool {
 	return (mode & (os.ModeDevice | os.ModeCharDevice)) != 0
 }
+
+// IsSymlink returns true if the given file is a symlink
+func IsSymlink(path string) bool {
+	fileInfo, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+
+	return (fileInfo.Mode() & os.ModeSymlink) != 0
+}

--- a/osutil/stat_test.go
+++ b/osutil/stat_test.go
@@ -62,3 +62,15 @@ func (ts *StatTestSuite) TestIsDirectorySimple(c *C) {
 
 	c.Assert(IsDirectory(dname), Equals, true)
 }
+
+func (ts *StatTestSuite) TestIsSymlink(c *C) {
+	sname := filepath.Join(c.MkDir(), "symlink")
+	err := os.Symlink("/", sname)
+	c.Assert(err, IsNil)
+
+	c.Assert(IsSymlink(sname), Equals, true)
+}
+
+func (ts *StatTestSuite) TestIsSymlinkNoSymlink(c *C) {
+	c.Assert(IsSymlink(c.MkDir()), Equals, false)
+}

--- a/tests/snap-run-symlink-error/task.yaml
+++ b/tests/snap-run-symlink-error/task.yaml
@@ -12,6 +12,7 @@ execute: |
     # FIXME: remove "SNAP_REEXEC" once we have `snap run` inside the os snap
     export SNAP_REEXEC=0
     echo Setting up incorrect symlink for snap run
+    sudo mkdir -p /snap/bin
     sudo ln -s /usr/bin/snap /snap/bin/xxx
     echo Running unknown command
     expected='internal error, please report: running "xxx" failed: cannot find snap "xxx"'

--- a/tests/snap-run-symlink-error/task.yaml
+++ b/tests/snap-run-symlink-error/task.yaml
@@ -1,4 +1,13 @@
 summary: Check error handling in symlinks to /usr/bin/snap
+restore: |
+    echo Resetting snapd state...
+    systemctl stop snapd || true
+    umount /var/lib/snapd/snaps/*.snap 2>&1 || true
+    rm -rf /snap/*
+    rm -rf /var/lib/snapd/*
+    rm -f /etc/systemd/system/snap-*.{mount,service}
+    rm -f /etc/systemd/system/multi-user.target.wants/snap-*.mount
+    systemctl start snapd
 execute: |
     # FIXME: remove "SNAP_REEXEC" once we have `snap run` inside the os snap
     export SNAP_REEXEC=0

--- a/tests/snap-run-symlink-error/task.yaml
+++ b/tests/snap-run-symlink-error/task.yaml
@@ -1,0 +1,17 @@
+summary: Check error handling in symlinks to /usr/bin/snap
+execute: |
+    # FIXME: remove "SNAP_REEXEC" once we have `snap run` inside the os snap
+    export SNAP_REEXEC=0
+    echo Setting up incorrect symlink for snap run
+    sudo ln -s /usr/bin/snap /snap/bin/xxx
+    echo Running unknown command
+    expected='internal error, please report: running "xxx" failed: cannot find snap "xxx"'
+    output="$(/snap/bin/xxx 2>&1 )" && exit 1
+    echo $output
+    err=$?
+    echo Verifying error message
+    if [ $err -ne 46 ]; then
+       echo Wrong error code $err
+    fi
+    [ "$output" = "$expected" ] || exit 1
+

--- a/tests/snap-run-symlink/task.yaml
+++ b/tests/snap-run-symlink/task.yaml
@@ -1,8 +1,17 @@
 summary: Check that symlinks to /usr/bin/snap trigger `snap run`
 prepare: |
-    echo Ensure we have a os snap with `snap run`
+    echo Ensure we have a os snap with snap run
     sudo snap install --channel=beta ubuntu-core
     sudo snap install hello-world
+restore: |
+    echo Resetting snapd state...
+    systemctl stop snapd || true
+    umount /var/lib/snapd/snaps/*.snap 2>&1 || true
+    rm -rf /snap/*
+    rm -rf /var/lib/snapd/*
+    rm -f /etc/systemd/system/snap-*.{mount,service}
+    rm -f /etc/systemd/system/multi-user.target.wants/snap-*.mount
+    systemctl start snapd
 environment:
     APP/helloworld: hello-world
     APP/helloworldecho: hello-world.echo
@@ -14,7 +23,8 @@ execute: |
     sudo rm /snap/bin/$APP
     sudo ln -s /usr/bin/snap /snap/bin/$APP
 
-    $APP
-    $APP > new.txt 2>&1 
+    # FIXME: remove "SNAP_REEXEC" once we have `snap run` inside the os snap
+    SNAP_REEXEC=0 $APP
+    SNAP_REEXEC=0 $APP > new.txt 2>&1 
 
     diff -u orig.txt new.txt

--- a/tests/snap-run-symlink/task.yaml
+++ b/tests/snap-run-symlink/task.yaml
@@ -1,10 +1,8 @@
 summary: Check that symlinks to /usr/bin/snap trigger `snap run`
-prepare:
+prepare: |
     echo Ensure we have a os snap with `snap run`
-    sudo snap refresh --channel=beta ubuntu-core
+    sudo snap install --channel=beta ubuntu-core
     sudo snap install hello-world
-restore:
-    sudo snap remove hello-world
 environment:
     APP/helloworld: hello-world
     APP/helloworldecho: hello-world.echo

--- a/tests/snap-run-symlink/task.yaml
+++ b/tests/snap-run-symlink/task.yaml
@@ -1,0 +1,22 @@
+summary: Check that symlinks to /usr/bin/snap trigger `snap run`
+prepare:
+    echo Ensure we have a os snap with `snap run`
+    sudo snap refresh --channel=beta ubuntu-core
+    sudo snap install hello-world
+restore:
+    sudo snap remove hello-world
+environment:
+    APP/helloworld: hello-world
+    APP/helloworldecho: hello-world.echo
+execute: |
+    echo Testing that replacing the wrapper with a symlink works
+    $APP
+    $APP > orig.txt 2>&1 
+
+    sudo rm /snap/bin/$APP
+    sudo ln -s /usr/bin/snap /snap/bin/$APP
+
+    $APP
+    $APP > new.txt 2>&1 
+
+    diff -u orig.txt new.txt


### PR DESCRIPTION
This is yet another preparation step for replacing the wrappers /snap/bin/ with generic symlinks. With that /usr/bin/snap will check how it got called and enter the special `snap run` mode if it was called from a /snap/bin/ location. With that on the OS snap we can start using it.