### PR TITLE
release: don't force KDE Neon into devmode.

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -42,8 +42,11 @@ type OS struct {
 // security features for confinement and devmode is forced.
 func (os *OS) ForceDevMode() bool {
 	switch os.ID {
+	case "neon":
+		fallthrough
 	case "ubuntu":
 		return false
+
 	case "elementary":
 		switch os.Release {
 		case "0.4":

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -116,6 +116,7 @@ func (s *ReleaseTestSuite) TestForceDevMode(c *C) {
 		{id: "elementary", idVersion: "0.4", devmode: false},
 		{id: "fedora", devmode: true},
 		{id: "gentoo", devmode: true},
+		{id: "neon", devmode: false},
 		{id: "opensuse", devmode: true},
 		{id: "rhel", devmode: true},
 		{id: "ubuntu", devmode: false},


### PR DESCRIPTION
KDE Neon is an Ubuntu derivative that supports all security features. This PR fixes LP: [#1593255](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1593255) by enabling it as such.

Note that this was tested with both the `hello` snap and the `nextcloud` snap. Neither of them worked before this patch, and both of them work afterward.