### PR TITLE
snap: make `snap change <taskid>` show task progress

### DIFF
--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -126,7 +126,11 @@ func (c *cmdChange) Execute([]string) error {
 		if t.ReadyTime.IsZero() {
 			readyTime = "-"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Status, spawnTime, readyTime, t.Summary)
+		summary := t.Summary
+		if t.Status == "Doing" && t.Progress.Total > 1 {
+			summary = fmt.Sprintf("%s (%.2f%%)", summary, float64(t.Progress.Done)/float64(t.Progress.Total)*100.0)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Status, spawnTime, readyTime, summary)
 	}
 
 	w.Flush()

--- a/cmd/snap/cmd_changes_test.go
+++ b/cmd/snap/cmd_changes_test.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+// +build !integrationcoverage
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/check.v1"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+var mockChangeJSON = `{"type": "sync", "result": {
+  "id":   "uno",
+  "kind": "foo",
+  "summary": "...",
+  "status": "Do",
+  "ready": false,
+  "spawn-time": "2016-04-21T01:02:03Z",
+  "ready-time": "2016-04-21T01:02:04Z",
+  "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z"}]
+}}`
+
+func (s *SnapSuite) TestChangeSimple(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, mockChangeJSON)
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser().ParseArgs([]string{"change", "42"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?ms)Status +Spawn +Ready +Summary
+Do +2016-04-21T01:02:03Z +2016-04-21T01:02:04Z +some summary
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+var mockChangeInProgressJSON = `{"type": "sync", "result": {
+  "id":   "uno",
+  "kind": "foo",
+  "summary": "...",
+  "status": "Do",
+  "ready": false,
+  "spawn-time": "2016-04-21T01:02:03Z",
+  "ready-time": "2016-04-21T01:02:04Z",
+  "tasks": [{"kind": "bar", "summary": "some summary", "status": "Doing", "progress": {"done": 50, "total": 100}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z"}]
+}}`
+
+func (s *SnapSuite) TestChangeProgress(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, mockChangeInProgressJSON)
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser().ParseArgs([]string{"change", "42"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?ms)Status +Spawn +Ready +Summary
+Doing +2016-04-21T01:02:03Z +2016-04-21T01:02:04Z +some summary \(50.00%\)
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+}


### PR DESCRIPTION
This is a bit of a drive-by change, inspired by an earlier irc conversation. It will show the task completion in `snap change <id>` in the summary if we have that information.

E.g.:
```
$ snap change 355
Status  Spawn                 Ready  Summary
Doing   2016-06-17T06:07:42Z  -      Download snap "krita" from channel "stable" (37.87%)
Do      2016-06-17T06:07:42Z  -      Mount snap "krita"
Do      2016-06-17T06:07:42Z  -      Copy snap "krita" data
Do      2016-06-17T06:07:42Z  -      Setup snap "krita" security profiles
Do      2016-06-17T06:07:42Z  -      Make snap "krita" available to the system
```

Useful when the original terminal of `snap install` is no longer available or if it was triggered by someone else or via webdm etc.

It also adds tests to `snap change` along the way :)
 