### PR TITLE
overlord/state,daemon: make abort proceed immediately, fix doc comment, improve tests

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -552,6 +552,12 @@ var snapstateInstallPath = snapstate.InstallPath
 var snapstateTryPath = snapstate.TryPath
 var snapstateGet = snapstate.Get
 
+func ensureStateSoonImpl(st *state.State) {
+	st.EnsureBefore(0)
+}
+
+var ensureStateSoon = ensureStateSoonImpl
+
 var errNothingToInstall = errors.New("nothing to install")
 
 func ensureUbuntuCore(st *state.State, targetSnap string, userID int) (*state.TaskSet, error) {
@@ -697,17 +703,20 @@ func postSnap(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("cannot %s %q: %v", inst.Action, inst.snap, err)
 	}
 
-	chg := newChange(state, inst.Action+"-snap", msg, tsets)
-	chg.Set("snap-names", []string{inst.snap})
-	state.EnsureBefore(0)
+	chg := newChange(state, inst.Action+"-snap", msg, tsets, []string{inst.snap})
+
+	ensureStateSoon(state)
 
 	return AsyncResponse(nil, &Meta{Change: chg.ID()})
 }
 
-func newChange(st *state.State, kind, summary string, tsets []*state.TaskSet) *state.Change {
+func newChange(st *state.State, kind, summary string, tsets []*state.TaskSet, snapNames []string) *state.Change {
 	chg := st.NewChange(kind, summary)
 	for _, ts := range tsets {
 		chg.AddAll(ts)
+	}
+	if snapNames != nil {
+		chg.Set("snap-names", snapNames)
 	}
 	return chg
 }
@@ -737,10 +746,10 @@ func trySnap(c *Command, r *http.Request, user *auth.UserState, trydir string, f
 	}
 
 	msg := fmt.Sprintf(i18n.G("Try %q snap from %q"), info.Name(), trydir)
-	chg := newChange(st, "try-snap", msg, []*state.TaskSet{tsets})
+	chg := newChange(st, "try-snap", msg, []*state.TaskSet{tsets}, []string{info.Name()})
 	chg.Set("api-data", map[string]string{"snap-name": info.Name()})
 
-	st.EnsureBefore(0)
+	ensureStateSoon(st)
 
 	return AsyncResponse(nil, &Meta{Change: chg.ID()})
 }
@@ -855,9 +864,8 @@ out:
 		return InternalError("cannot install snap file: %v", err)
 	}
 
-	chg := newChange(st, "install-snap", msg, tsets)
+	chg := newChange(st, "install-snap", msg, tsets, []string{snapName})
 	chg.Set("api-data", map[string]string{"snap-name": snapName})
-	chg.Set("snap-names", []string{snapName})
 
 	go func() {
 		// XXX this needs to be a task in the manager; this is a hack to keep this branch smaller
@@ -865,7 +873,7 @@ out:
 		os.Remove(tempPath)
 	}()
 
-	st.EnsureBefore(0)
+	ensureStateSoon(st)
 
 	return AsyncResponse(nil, &Meta{Change: chg.ID()})
 }
@@ -1222,6 +1230,8 @@ func abortChange(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	chg.Abort()
+
+	ensureStateSoon(state)
 
 	return SyncResponse(change2changeInfo(chg), nil)
 }

--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -418,7 +418,7 @@ func (c *Change) Tasks() []*Task {
 	return c.state.tasksIn(c.taskIDs)
 }
 
-// Abort cancels the change, whether in progress or not.
+// Abort flags the change for cancellation, whether in progress or not. Cancellation will proceed at the next ensure pass.
 func (c *Change) Abort() {
 	c.state.writing()
 	for _, tid := range c.taskIDs {


### PR DESCRIPTION
This adds an EnsureBefore call after we request an Abort in the api to make it proceed immediately. As I clarified in the doc comment Change.Abort actually only flags the change, cancellation proceeds at the next Ensure.

The other approach would have been to move the EnsureBefore inside Change.Abort but doesn't quite fit the style of the methods there, another approach yet was to have both a renamed Change.Abort (FlagForAbort?) and a State.Abort(chg) doing also EnsureBefore as needed.

Also improved various tests, and added snap-names to try-snap change.