### PR TITLE
daemon: extend privileged access to users in "wheel" group

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -86,7 +86,7 @@ func (c *Command) canAccess(r *http.Request, user *auth.UserState) bool {
 			return true
 		}
 
-		if c.SudoerOK && isUIDInAny(uid, "sudo", "admin") {
+		if c.SudoerOK && isUIDInAny(uid, "sudo", "admin", "wheel") {
 			// If user is in a group that grants sudo in
 			// the default install, and the command says
 			// that's ok, then it's ok.


### PR DESCRIPTION
This patch extends the list of groups that snapd treats as allowed to
perform many operations to include "wheel" in addition to the existing
"sudo" and "admin".

This in particular makes snapd behave better on Fedora and similar
distributions that use the wheel group.

Fixes: https://bugs.launchpad.net/snappy/+bug/1593371
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>