### PR TITLE
Allow snaps to write to pulseaudio buffers

### DIFF
--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -26,7 +26,7 @@ import (
 const pulseaudioConnectedPlugAppArmor = `
 /etc/pulse/ r,
 /etc/pulse/* r,
-/{run,dev}/shm/pulse-shm-* rk,
+/{run,dev}/shm/pulse-shm-* rwk,
 owner /{,var/}run/user/*/pulse/ r,
 owner /{,var/}run/user/*/pulse/native rwk,
 `


### PR DESCRIPTION
This patch changes the plug side of the pulseaudio interface to allow
snaps to write to various pulseaudio buffers.

Fixes: https://bugs.launchpad.net/snapcraft/+bug/1594318
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>