### PR TITLE
many: add optical-drive interface

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -78,6 +78,13 @@ allows adjusting settings of other applications.
 Usage: reserved
 Auto-Connect: yes
 
+### optical-drive
+
+Can access the first optical drive in read-only mode. Suitable for CD/DVD playback.
+
+Usage: common
+Auto-Connect: yes
+
 ## Supported Interfaces - Advanced
 
 ### cups-control

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -51,6 +51,7 @@ var allInterfaces = []interfaces.Interface{
 	NewOpenglInterface(),
 	NewPulseAudioInterface(),
 	NewCupsControlInterface(),
+	NewOpticalDriveInterface(),
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -56,4 +56,5 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewOpenglInterface())
 	c.Check(all, DeepContains, builtin.NewPulseAudioInterface())
 	c.Check(all, DeepContains, builtin.NewCupsControlInterface())
+	c.Check(all, DeepContains, builtin.NewOpticalDriveInterface())
 }

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -25,6 +25,7 @@ import (
 
 const opticalDriveConnectedPlugAppArmor = `
 /dev/sr0 r,
+/dev/scd0 r,
 `
 
 // NewOpticalDriveInterface returns a new "optical-drive" interface.

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -1,0 +1,43 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const opticalDriveConnectedPlugAppArmor = `
+/dev/sr0 r,
+`
+
+const opticalDriveConnectedPlugSecComp = `
+ioctl
+`
+
+// NewOpticalDriveInterface returns a new "optical-drive" interface.
+func NewOpticalDriveInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "optical-drive",
+		connectedPlugAppArmor: opticalDriveConnectedPlugAppArmor,
+		connectedPlugSecComp:  opticalDriveConnectedPlugSecComp,
+		reservedForOS:         true,
+		autoConnect:           true,
+	}
+}

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -27,16 +27,11 @@ const opticalDriveConnectedPlugAppArmor = `
 /dev/sr0 r,
 `
 
-const opticalDriveConnectedPlugSecComp = `
-ioctl
-`
-
 // NewOpticalDriveInterface returns a new "optical-drive" interface.
 func NewOpticalDriveInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "optical-drive",
 		connectedPlugAppArmor: opticalDriveConnectedPlugAppArmor,
-		connectedPlugSecComp:  opticalDriveConnectedPlugSecComp,
 		reservedForOS:         true,
 		autoConnect:           true,
 	}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -53,6 +53,7 @@ var implicitClassicSlots = []string{
 	"unity7",
 	"x11",
 	"modem-manager",
+	"optical-drive",
 }
 
 // AddImplicitSlots adds implicitly defined slots to a given snap.

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 22)
+	c.Assert(info.Slots, HasLen, 23)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
This branch adds a very basic optical-drive interface. The interface is suitable for read-only access to the first optical disk drive (/dev/sr0). In the future it can be expanded with attributes that model particular optical drives.