### PR TITLE
many: add the camera interface

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -78,6 +78,13 @@ allows adjusting settings of other applications.
 Usage: reserved
 Auto-Connect: yes
 
+### optical-drive
+
+Can access the first optical drive in read-only mode. Suitable for CD/DVD playback.
+
+Usage: common
+Auto-Connect: yes
+
 ## Supported Interfaces - Advanced
 
 ### cups-control

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -85,6 +85,14 @@ Can access the first optical drive in read-only mode. Suitable for CD/DVD playba
 Usage: common
 Auto-Connect: yes
 
+### camera
+
+Can access the first video camera. Suitable for programs wanting to use the
+webcams.
+
+Usage: common
+Auto-Connect: no
+
 ## Supported Interfaces - Advanced
 
 ### cups-control

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -51,6 +51,7 @@ var allInterfaces = []interfaces.Interface{
 	NewOpenglInterface(),
 	NewPulseAudioInterface(),
 	NewCupsControlInterface(),
+	NewOpticalDriveInterface(),
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -52,6 +52,7 @@ var allInterfaces = []interfaces.Interface{
 	NewPulseAudioInterface(),
 	NewCupsControlInterface(),
 	NewOpticalDriveInterface(),
+	NewCameraInterface(),
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -57,4 +57,5 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewPulseAudioInterface())
 	c.Check(all, DeepContains, builtin.NewCupsControlInterface())
 	c.Check(all, DeepContains, builtin.NewOpticalDriveInterface())
+	c.Check(all, DeepContains, builtin.NewCameraInterface())
 }

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -56,4 +56,5 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewOpenglInterface())
 	c.Check(all, DeepContains, builtin.NewPulseAudioInterface())
 	c.Check(all, DeepContains, builtin.NewCupsControlInterface())
+	c.Check(all, DeepContains, builtin.NewOpticalDriveInterface())
 }

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -27,18 +27,11 @@ const cameraConnectedPlugAppArmor = `
 /dev/video0 rw,
 `
 
-const cameraConnectedPlugSecComp = `
-read
-write
-ioctl
-`
-
 // NewCameraInterface returns a new "camera" interface.
 func NewCameraInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "camera",
 		connectedPlugAppArmor: cameraConnectedPlugAppArmor,
-		connectedPlugSecComp:  cameraConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const cameraConnectedPlugAppArmor = `
+/dev/video0 rw,
+`
+
+const cameraConnectedPlugSecComp = `
+read
+write
+ioctl
+`
+
+// NewCameraInterface returns a new "camera" interface.
+func NewCameraInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "camera",
+		connectedPlugAppArmor: cameraConnectedPlugAppArmor,
+		connectedPlugSecComp:  cameraConnectedPlugSecComp,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -1,0 +1,43 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const opticalDriveConnectedPlugAppArmor = `
+/dev/sr0 r,
+`
+
+const opticalDriveConnectedPlugSecComp = `
+ioctl
+`
+
+// NewOpticalDriveInterface returns a new "optical-drive" interface.
+func NewOpticalDriveInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "optical-drive",
+		connectedPlugAppArmor: opticalDriveConnectedPlugAppArmor,
+		connectedPlugSecComp:  opticalDriveConnectedPlugSecComp,
+		reservedForOS:         true,
+		autoConnect:           true,
+	}
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -53,6 +53,7 @@ var implicitClassicSlots = []string{
 	"unity7",
 	"x11",
 	"modem-manager",
+	"optical-drive",
 }
 
 // AddImplicitSlots adds implicitly defined slots to a given snap.

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -54,6 +54,7 @@ var implicitClassicSlots = []string{
 	"x11",
 	"modem-manager",
 	"optical-drive",
+	"camera",
 }
 
 // AddImplicitSlots adds implicitly defined slots to a given snap.

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 23)
+	c.Assert(info.Slots, HasLen, 24)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 22)
+	c.Assert(info.Slots, HasLen, 23)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
This branch builds on #1368 

This branch adds the camera interface. It is again very basic and suitable for exposing things like webcams. Like the optical-drive interface it can be extended with additional attributes later.

Unlike the optical-drive, camera doesn't auto-connect.