### PR TITLE
interfaces: auto-connect home if running on classic

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -64,7 +64,8 @@ Auto-Connect: yes
 
 Can access non-hidden files in user's `$HOME` to read/write/lock.
 This is restricted because it gives file access to the user's
-`$HOME`.
+`$HOME`. This interface is auto-connected on classic systems and
+manually connected on non-classic.
 
 Usage: reserved
 Auto-Connect: yes

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -21,6 +21,7 @@ package builtin
 
 import (
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/release"
 )
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/home
@@ -49,6 +50,6 @@ func NewHomeInterface() interfaces.Interface {
 		name: "home",
 		connectedPlugAppArmor: homeConnectedPlugAppArmor,
 		reservedForOS:         true,
-		autoConnect:           true,
+		autoConnect:           release.OnClassic,
 	}
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -123,6 +124,14 @@ func (s *HomeInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 	c.Assert(snippet, IsNil)
 }
 
-func (s *HomeInterfaceSuite) TestAutoConnect(c *C) {
+func (s *HomeInterfaceSuite) TestAutoConnectOnClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
 	c.Check(s.iface.AutoConnect(), Equals, true)
+}
+
+func (s *HomeInterfaceSuite) TestAutoConnectOnCore(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+	c.Check(s.iface.AutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -127,11 +127,13 @@ func (s *HomeInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
 func (s *HomeInterfaceSuite) TestAutoConnectOnClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	iface := builtin.NewHomeInterface()
+	c.Check(iface.AutoConnect(), Equals, true)
 }
 
 func (s *HomeInterfaceSuite) TestAutoConnectOnCore(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	iface := builtin.NewHomeInterface()
+	c.Check(iface.AutoConnect(), Equals, false)
 }


### PR DESCRIPTION
Note, testsuite fails with:

```
FAIL: home_test.go:133: HomeInterfaceSuite.TestAutoConnectOnCore

home_test.go:136:
    c.Check(s.iface.AutoConnect(), Equals, false)
... obtained bool = true
... expected bool = false

OOPS: 202 passed, 1 FAILED
```

I tried to mock classic mode with:
```
func (s *HomeInterfaceSuite) TestAutoConnectOnClassic(c *C) {
	restore := release.MockOnClassic(true)
	defer restore()
 	c.Check(s.iface.AutoConnect(), Equals, true)
 }

func (s *HomeInterfaceSuite) TestAutoConnectOnCore(c *C) {
	restore := release.MockOnClassic(false)
	defer restore()
	c.Check(s.iface.AutoConnect(), Equals, false)
}
```

but that doesn't work. Please advise.