### PR TITLE
systemd: add support for squashfuse

### DIFF
--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -44,7 +44,7 @@ func addMountUnit(s *snap.Info, meter progress.Meter) error {
 	whereDir := stripGlobalRootDir(s.MountDir())
 
 	sysd := systemd.New(dirs.GlobalRootDir, meter)
-	mountUnitName, err := sysd.WriteMountUnitFile(s.Name(), squashfsPath, whereDir)
+	mountUnitName, err := sysd.WriteMountUnitFile(s.Name(), squashfsPath, whereDir, "squashfs")
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -79,6 +79,7 @@ Description=Mount unit for foo
 [Mount]
 What=/var/lib/snapd/snaps/foo_13.snap
 Where=/snap/foo/13
+Type=squashfs
 
 [Install]
 WantedBy=multi-user.target

--- a/snappy/overlord.go
+++ b/snappy/overlord.go
@@ -133,7 +133,7 @@ func addMountUnit(s *snap.Info, noMount bool, inter interacter) error {
 	whereDir := stripGlobalRootDir(s.MountDir())
 
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
-	mountUnitName, err := sysd.WriteMountUnitFile(s.Name(), squashfsPath, whereDir)
+	mountUnitName, err := sysd.WriteMountUnitFile(s.Name(), squashfsPath, whereDir, "squashfs")
 	if err != nil {
 		return err
 	}

--- a/snappy/snapp_snapfs_test.go
+++ b/snappy/snapp_snapfs_test.go
@@ -168,6 +168,7 @@ Description=Mount unit for foo
 [Mount]
 What=/var/lib/snapd/snaps/foo_13.snap
 Where=/snap/foo/13
+Type=squashfs
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -406,8 +406,8 @@ func (l Log) String() string {
 	return fmt.Sprintf("%s %s %s", l.Timestamp(), l.SID(), l.Message())
 }
 
-// UseFuse detects if we should be using squashfuse instead
-func UseFuse() bool {
+// useFuse detects if we should be using squashfuse instead
+func useFuse() bool {
 	if !osutil.FileExists("/dev/fuse") {
 		return false
 	}
@@ -443,7 +443,7 @@ func (s *systemd) WriteMountUnitFile(name, what, where, fstype string) (string, 
 		fstype = "none"
 	}
 
-	if fstype == "squashfs" && UseFuse() {
+	if fstype == "squashfs" && useFuse() {
 		fstype = "fuse.squashfuse"
 	}
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -285,7 +285,7 @@ func (s *SystemdTestSuite) TestWriteMountUnit(c *C) {
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", mockSnapPath, "/apps/foo/1.0")
+	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", mockSnapPath, "/apps/foo/1.0", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -297,6 +297,7 @@ Description=Mount unit for foo
 [Mount]
 What=%s
 Where=/apps/foo/1.0
+Type=squashfs
 
 [Install]
 WantedBy=multi-user.target
@@ -306,7 +307,7 @@ WantedBy=multi-user.target
 func (s *SystemdTestSuite) TestWriteMountUnitForDirs(c *C) {
 	// a directory instead of a file produces a different output
 	snapDir := c.MkDir()
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foodir", snapDir, "/apps/foo/1.0")
+	mountUnitName, err := New("", nil).WriteMountUnitFile("foodir", snapDir, "/apps/foo/1.0", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
@@ -318,8 +319,8 @@ Description=Mount unit for foodir
 [Mount]
 What=%s
 Where=/apps/foo/1.0
-Options=bind
 Type=none
+Options=bind
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This attempts to detect cases where a straight squashfs mount won't work
and if squashfuse is available, uses that instead.

The motivation for this is to support snapd running inside containers.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>