### PR TITLE
tests: temporary fix for state reset

### DIFF
--- a/tests/interfaces-network-bind/task.yaml
+++ b/tests/interfaces-network-bind/task.yaml
@@ -30,7 +30,7 @@ prepare: |
   EOF
 
 restore: |
-  echo "FIXME: no need to remove snaps when the state is reset in an upper level restore"
+  echo "FIXME: once the state is properly reset in the upper levels this remove can go away"
   snap remove $SNAP_NAME
   rm -f $SNAP_FILE $REQUEST_FILE
 

--- a/tests/interfaces-network-bind/task.yaml
+++ b/tests/interfaces-network-bind/task.yaml
@@ -30,6 +30,8 @@ prepare: |
   EOF
 
 restore: |
+  echo "FIXME: no need to remove snaps when the state is reset in an upper level restore"
+  snap remove $SNAP_NAME
   rm -f $SNAP_FILE $REQUEST_FILE
 
 execute: |


### PR DESCRIPTION
The service installed by the network-bind-consumer snap is being left behind. This temporary fix should be removed when the state is properly reset for all the tasks.