### PR TITLE
snap-exec: os.Exec() needs argv0 in the args[] slice too

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -112,5 +112,7 @@ func snapExec(snapApp, revision, command string, args []string) error {
 
 	// run the command
 	fullCmd := filepath.Join(app.Snap.MountDir(), cmd)
-	return syscallExec(fullCmd, args, env)
+	fullCmdArgs := []string{fullCmd}
+	fullCmdArgs = append(fullCmdArgs, args...)
+	return syscallExec(fullCmd, fullCmdArgs, env)
 }

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -113,6 +113,6 @@ func (s *snapExecSuite) TestSnapLaunchIntegration(c *C) {
 	err := snapExec("snapname.app", "42", "stop", []string{"arg1", "arg2"})
 	c.Assert(err, IsNil)
 	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/42/stop-app", dirs.SnapSnapsDir))
-	c.Check(execArgs, DeepEquals, []string{"arg1", "arg2"})
+	c.Check(execArgs, DeepEquals, []string{execArgv0, "arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "LD_LIBRARY_PATH=/some/path\n")
 }


### PR DESCRIPTION
This fixes argument an passing bug in the snap-exec helper.