### PR TITLE
integration-tests: wait for listening port instead of active service reported by systemd

### DIFF
--- a/integration-tests/tests/tryapp_test.go
+++ b/integration-tests/tests/tryapp_test.go
@@ -104,7 +104,7 @@ func (s *trySuite) TestTryConfinmentAllows(c *check.C) {
 	defer common.RemoveSnap(c, data.NetworkConsumerSnapName)
 
 	// confinment works in try mode:
-	wait.ForActiveService(c, "snap.network-bind-consumer.network-consumer.service")
+	wait.ForServerOnPort(c, "tcp", 8081)
 	providerURL := "http://127.0.0.1:8081"
 	output := cli.ExecCommand(c, "network-consumer", providerURL)
 	c.Assert(output, check.Equals, "ok\n")


### PR DESCRIPTION
Until the try app tests are ported to spread this will prevent flaky errors like:
```
****** Running trySuite.TestTryConfinmentAllows
PASS: <autogenerated>:42: trySuite.SetUpTest 0.000s

integration-tests/tests/tryapp_test.go:109:
    output := cli.ExecCommand(c, "network-consumer", providerURL)
integration-tests/testutils/cli/cli.go:42:
    c.Assert(err, check.IsNil, check.Commentf("Error for %v: %v", cmds, output))
... value *exec.ExitError = &exec.ExitError{ProcessState:(*os.ProcessState)(0xc8202bff40), Stderr:[]uint8(nil)} ("exit status 1")
... Error for [network-consumer http://127.0.0.1:8081]: Error, reason:  [Errno 111] Connection refused


START: <autogenerated>:44: trySuite.TearDownTest
PASS: <autogenerated>:44: trySuite.TearDownTest 0.000s

FAIL: integration-tests/tests/tryapp_test.go:91: trySuite.TestTryConfinmentAllows
```