### PR TITLE
interfaces: add zigbee-dongle interface

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -36,6 +36,7 @@ var allInterfaces = []interfaces.Interface{
 	&PppInterface{},
 	&SerialPortInterface{},
 	&PulseAudioInterface{},
+	&ZigbeeDongleInterface{},
 	NewFirewallControlInterface(),
 	NewGsettingsInterface(),
 	NewHardwareObserveInterface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -40,6 +40,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.MprisInterface{})
 	c.Check(all, Contains, &builtin.SerialPortInterface{})
 	c.Check(all, Contains, &builtin.PulseAudioInterface{})
+	c.Check(all, Contains, &builtin.ZigbeeDongleInterface{})
 	c.Check(all, DeepContains, builtin.NewFirewallControlInterface())
 	c.Check(all, DeepContains, builtin.NewGsettingsInterface())
 	c.Check(all, DeepContains, builtin.NewHomeInterface())

--- a/interfaces/builtin/zigbee_dongle.go
+++ b/interfaces/builtin/zigbee_dongle.go
@@ -1,0 +1,137 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+// ZigbeeDongleInterface is the type for serial port interfaces.
+type ZigbeeDongleInterface struct{}
+
+// Name of the zigbee-dongle interface.
+func (iface *ZigbeeDongleInterface) Name() string {
+	return "zigbee-dongle"
+}
+
+func (iface *ZigbeeDongleInterface) String() string {
+	return iface.Name()
+}
+
+var zigbeeDongleDevPath = "/dev/zigbee/*"
+
+var zigbeeDonglePermanentSlotUdev = []byte(`
+IMPORT{builtin}="usb_id"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idProduct}=="0003", ATTRS{idVendor}=="10c4", SYMLINK+="zigbee/$env{ID_SERIAL}"
+`)
+
+// SanitizeSlot checks slot validity
+func (iface *ZigbeeDongleInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	// check slot name
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("slot is not of interface %q", iface))
+	}
+	return nil
+}
+
+// PermanentSlotSnippet - no permissions given to slot permanently
+func (iface *ZigbeeDongleInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityMount:
+		return nil, nil
+	case interfaces.SecurityUDev:
+		return zigbeeDonglePermanentSlotUdev, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedSlotSnippet - no permissions given to slot on connection
+func (iface *ZigbeeDongleInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecurityDBus, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// SanitizePlug checks plug validity
+func (iface *ZigbeeDongleInterface) SanitizePlug(slot *interfaces.Plug) error {
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("plug is not of interface %q", iface))
+	}
+	return nil
+}
+
+// PermanentPlugSnippet no permissions provided to plug permanently
+func (iface *ZigbeeDongleInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedPlugSnippet returns security snippet specific to the plug
+func (iface *ZigbeeDongleInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		paths, err := iface.zigbeeDevPaths(slot)
+		if err != nil {
+			return nil, fmt.Errorf("cannot compute plug security snippet: %v", err)
+		}
+		var snippet bytes.Buffer
+		for _, path := range paths {
+			snippet.WriteString(fmt.Sprintf("%s rwk,\n", path))
+		}
+		return snippet.Bytes(), nil
+	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *ZigbeeDongleInterface) zigbeeDevPaths(slot *interfaces.Slot) ([]string, error) {
+	var devPaths []string
+	matches, globErr := filepath.Glob(zigbeeDongleDevPath)
+	if globErr != nil {
+		return nil, globErr
+	}
+	for _, path := range matches {
+		deref, symErr := evalSymlinks(path)
+		if symErr != nil {
+			return nil, symErr
+		}
+		devPaths = append(devPaths, deref)
+	}
+	return devPaths, nil
+}
+
+// AutoConnect indicates whether this type of interface should allow autoconnect
+func (iface *ZigbeeDongleInterface) AutoConnect() bool {
+	return false
+}

--- a/interfaces/builtin/zigbee_dongle_test.go
+++ b/interfaces/builtin/zigbee_dongle_test.go
@@ -1,0 +1,143 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type ZigbeeDongleInterfaceSuite struct {
+	testutil.BaseTest
+	iface            interfaces.Interface
+	zigbeeAccessSlot *interfaces.Slot
+	badInterfaceSlot *interfaces.Slot
+	plug             *interfaces.Plug
+	badInterfacePlug *interfaces.Plug
+}
+
+var _ = Suite(&ZigbeeDongleInterfaceSuite{
+	iface: &builtin.ZigbeeDongleInterface{},
+})
+
+func (s *ZigbeeDongleInterfaceSuite) SetUpTest(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: ubuntu-core
+slots:
+    zigbee-access:
+        interface: zigbee-dongle
+    bad-interface: other-interface
+plugs:
+    plug: zigbee-dongle
+    bad-interface: other-interface
+`))
+	c.Assert(err, IsNil)
+	s.zigbeeAccessSlot = &interfaces.Slot{SlotInfo: info.Slots["zigbee-access"]}
+	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-interface"]}
+	s.plug = &interfaces.Plug{PlugInfo: info.Plugs["plug"]}
+	s.badInterfacePlug = &interfaces.Plug{PlugInfo: info.Plugs["bad-interface"]}
+}
+
+func (s *ZigbeeDongleInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "zigbee-dongle")
+}
+
+func (s *ZigbeeDongleInterfaceSuite) TestPermanentSlotSnippetUdevPermissions(c *C) {
+	expectedSlotSnippet := []byte(`
+IMPORT{builtin}="usb_id"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idProduct}=="0003", ATTRS{idVendor}=="10c4", SYMLINK+="zigbee/$env{ID_SERIAL}"
+`)
+	snippet, err := s.iface.PermanentSlotSnippet(s.zigbeeAccessSlot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedSlotSnippet)
+}
+
+func (s *ZigbeeDongleInterfaceSuite) TestPermanentSlotSnippetUnusedSecuritySystems(c *C) {
+	// No extra apparmor permissions for slot
+	snippet, err := s.iface.PermanentSlotSnippet(s.zigbeeAccessSlot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra seccomp permissions for slot
+	snippet, err = s.iface.PermanentSlotSnippet(s.zigbeeAccessSlot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra dbus permissions for slot
+	snippet, err = s.iface.PermanentSlotSnippet(s.zigbeeAccessSlot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// Other security types are not recognized
+	snippet, err = s.iface.PermanentSlotSnippet(s.zigbeeAccessSlot, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system`)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *ZigbeeDongleInterfaceSuite) TestConnectedSlotSnippetUnusedSecuritySystems(c *C) {
+	// No extra apparmor permissions for slot
+	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.zigbeeAccessSlot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra seccomp permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.zigbeeAccessSlot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra dbus permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.zigbeeAccessSlot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra udev permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.zigbeeAccessSlot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// Other security types are not recognized
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.zigbeeAccessSlot, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system`)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *ZigbeeDongleInterfaceSuite) TestPermanentPlugSnippetUnusedSecuritySystems(c *C) {
+	// No extra apparmor permissions for plug
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra seccomp permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra dbus permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra udev permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// Other security types are not recognized
+	snippet, err = s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system`)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *ZigbeeDongleInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(), Equals, false)
+}


### PR DESCRIPTION
An interface that allows a usb removable zigbee dongle to be exposed through plugs & slots. 

At the moment this only supports one of these devices as indicated by the udev snippet.
Any plug which is connected to a slot of this type would gain the AppArmor permissions to read&write to the device node of any and all devices the interface supports (no matter how many are attached to the system).