### PR TITLE
snap: make snaps vanishing less fatal for the system

### DIFF
--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -244,7 +244,7 @@ func (s *SnapSuite) TestSnapRunHookMissingRevisionIntegration(c *check.C) {
 	// Attempt to run a hook on revision 41, which doesn't exist
 	err := snaprun.SnapRunHook("snapname", "hook-name", "41")
 	c.Assert(err, check.NotNil)
-	c.Check(err, check.ErrorMatches, "cannot find mounted snap \"snapname\" at revision 41")
+	c.Check(err, check.ErrorMatches, "cannot find installed snap \"snapname\" at revision 41")
 }
 
 func (s *SnapSuite) TestSnapRunHookInvalidRevisionIntegration(c *check.C) {

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -99,6 +99,9 @@ func allLocalSnapInfos(st *state.State) ([]aboutSnap, error) {
 	for name, snapState := range snapStates {
 		info, err := snap.ReadInfo(name, snapState.CurrentSideInfo())
 		if err != nil {
+			if _, ok := err.(*snap.SnapVanishedError); ok {
+				continue
+			}
 			// XXX: aggregate instead?
 			if firstErr == nil {
 				firstErr = err

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -99,7 +99,11 @@ func allLocalSnapInfos(st *state.State) ([]aboutSnap, error) {
 	for name, snapState := range snapStates {
 		info, err := snap.ReadInfo(name, snapState.CurrentSideInfo())
 		if err != nil {
-			if _, ok := err.(*snap.SnapVanishedError); ok {
+			// FIXME: this is just a tiny step forward to not
+			//        totally break if a snap can no longer
+			//        be found. we will add more smartness to
+			//        this
+			if _, ok := err.(*snap.NotFoundError); ok {
 				continue
 			}
 			// XXX: aggregate instead?

--- a/snap/info.go
+++ b/snap/info.go
@@ -357,12 +357,21 @@ func infoFromSnapYamlWithSideInfo(meta []byte, si *SideInfo) (*Info, error) {
 	return info, nil
 }
 
+type SnapVanishedError struct {
+	Snap     string
+	Revision Revision
+}
+
+func (e SnapVanishedError) Error() string {
+	return fmt.Sprintf("cannot find mounted snap %q at revision %s", e.Snap, e.Revision)
+}
+
 // ReadInfo reads the snap information for the installed snap with the given name and given side-info.
 func ReadInfo(name string, si *SideInfo) (*Info, error) {
 	snapYamlFn := filepath.Join(MountDir(name, si.Revision), "meta", "snap.yaml")
 	meta, err := ioutil.ReadFile(snapYamlFn)
 	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("cannot find mounted snap %q at revision %s", name, si.Revision)
+		return nil, &SnapVanishedError{Snap: name, Revision: si.Revision}
 	}
 	if err != nil {
 		return nil, err

--- a/snap/info.go
+++ b/snap/info.go
@@ -357,13 +357,13 @@ func infoFromSnapYamlWithSideInfo(meta []byte, si *SideInfo) (*Info, error) {
 	return info, nil
 }
 
-type SnapVanishedError struct {
+type NotFoundError struct {
 	Snap     string
 	Revision Revision
 }
 
-func (e SnapVanishedError) Error() string {
-	return fmt.Sprintf("cannot find mounted snap %q at revision %s", e.Snap, e.Revision)
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("cannot find installed snap %q at revision %s", e.Snap, e.Revision)
 }
 
 // ReadInfo reads the snap information for the installed snap with the given name and given side-info.
@@ -371,7 +371,7 @@ func ReadInfo(name string, si *SideInfo) (*Info, error) {
 	snapYamlFn := filepath.Join(MountDir(name, si.Revision), "meta", "snap.yaml")
 	meta, err := ioutil.ReadFile(snapYamlFn)
 	if os.IsNotExist(err) {
-		return nil, &SnapVanishedError{Snap: name, Revision: si.Revision}
+		return nil, &NotFoundError{Snap: name, Revision: si.Revision}
 	}
 	if err != nil {
 		return nil, err

--- a/tests/main/try-snap-goes-away/task.yaml
+++ b/tests/main/try-snap-goes-away/task.yaml
@@ -1,0 +1,15 @@
+summary: Check that snaps vanishing are handled gracefully
+restore: |
+  rm -rf $TRYDIR
+execute: |
+  TRYDIR="$(mktemp -d)"
+  export TRYDIR
+  cp -ar  $TESTSLIB/snaps/basic-binaries/* $TRYDIR
+
+  echo Trying a snap
+  snap try $TRYDIR
+  snap list |grep basic
+
+  echo Removing a snap try dir does not break everything
+  rm -rf $TRYDIR
+  snap list |grep core


### PR DESCRIPTION
This is a first step towards making snaps that vanish (e.g. because a `snap try` dir gets removed) less fatal to the system.

This does not do any cleanup. We need to discuss the best way to do this next. One possible way would be to make ReadInfo() return some Info with a "vanished" flag so the user can see that its in a broken state and can manually clean up. But thats just a strawman, ideas welcome.