### PR TITLE
interfaces/builtin: allow other sr*/scd* optical devices

### DIFF
--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -24,8 +24,8 @@ import (
 )
 
 const opticalDriveConnectedPlugAppArmor = `
-/dev/sr0 r,
-/dev/scd0 r,
+/dev/sr[0-9]* r,
+/dev/scd[0-9]* r,
 `
 
 // NewOpticalDriveInterface returns a new "optical-drive" interface.


### PR DESCRIPTION
Optical disk devices can easily show up as sr1 or sr2 on the system, and I have personal experience with such changes even when using a single external drive. Let's please not limit it to the first.