### PR TITLE
tests: wait for snapd listening after reset

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -15,7 +15,7 @@ rm -rf /var/lib/snapd/*
 rm -f /etc/systemd/system/snap[-.]*.{mount,service}
 rm -f /etc/systemd/system/multi-user.target.wants/snap[-.]*.{mount,service}
 
-if [ "$1" = "--reuse-core" ]; then 
+if [ "$1" = "--reuse-core" ]; then
 	$(cd / && tar xzf $SPREAD_PATH/snapd-state.tar.gz)
 	mounts="$(systemctl list-unit-files | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
 	services="$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"
@@ -25,3 +25,6 @@ if [ "$1" = "--reuse-core" ]; then
 	done
 fi
 systemctl start snapd
+
+# wait for snapd listening
+while ! printf "GET / HTTP/1.0\r\n\r\n" | nc -U -q 1 /run/snapd.socket; do sleep 0.5; done


### PR DESCRIPTION
This aims to prevent errors happening when trying to access snapd before it's up.