### PR TITLE
client,cmd,daemon,release: better version info

### DIFF
--- a/classic/create.go
+++ b/classic/create.go
@@ -34,7 +34,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/progress"
-	"github.com/snapcore/snapd/release"
 )
 
 var (
@@ -47,7 +46,7 @@ var getgrnam = osutil.Getgrnam
 
 func findDownloadPathFromLxdIndex(r io.Reader) (string, error) {
 	arch := arch.UbuntuArchitecture()
-	codename := release.ReleaseInfo.Codename
+	codename := "xenial"
 
 	needle := fmt.Sprintf("ubuntu;%s;%s;default;", codename, arch)
 	scanner := bufio.NewScanner(r)

--- a/classic/create_test.go
+++ b/classic/create_test.go
@@ -85,8 +85,8 @@ func makeMockLxdIndexSystem() string {
 
 	s := fmt.Sprintf(`
 ubuntu;xenial;otherarch;default;20151126_03:49;/images/ubuntu/xenial/armhf/default/20151126_03:49/
-ubuntu;%s;%s;default;20151126_03:49;/images/ubuntu/CODENAME/ARCH/default/20151126_03:49/
-`, release.ReleaseInfo.Codename, arch)
+ubuntu;xenial;%s;default;20151126_03:49;/images/ubuntu/CODENAME/ARCH/default/20151126_03:49/
+`, arch)
 
 	return s
 }

--- a/client/client.go
+++ b/client/client.go
@@ -221,11 +221,7 @@ func (client *Client) ServerVersion() (string, error) {
 		version = "unknown"
 	}
 
-	if sysInfo.OnClassic {
-		return fmt.Sprintf("%s (series %s, os: %s, classic)", version, sysInfo.Series, sysInfo.OS), nil
-	} else {
-		return fmt.Sprintf("%s (series %s, os: %s)", version, sysInfo.Series, sysInfo.OS), nil
-	}
+	return fmt.Sprintf("%s (series %s, os-id: %s)", version, sysInfo.Series, sysInfo.OSRelease.ID), nil
 }
 
 // A response produced by the REST API will usually fit in this
@@ -269,12 +265,19 @@ func IsTwoFactorError(err error) bool {
 	return e.Kind == ErrorKindTwoFactorFailed || e.Kind == ErrorKindTwoFactorRequired
 }
 
+// OSRelease contains information about the system extracted from /etc/os-release.
+type OSRelease struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Release  string `json:"release,omitempty"`
+	Codename string `json:"codename,omitempty"`
+}
+
 // SysInfo holds system information
 type SysInfo struct {
-	Series    string `json:"series,omitempty"`
-	Version   string `json:"version,omitempty"`
-	OS        string `json:"os-id,omitempty"`
-	OnClassic bool   `json:"on-classic,omitempty"`
+	Series    string    `json:"series,omitempty"`
+	Version   string    `json:"version,omitempty"`
+	OSRelease OSRelease `json:"os-release"`
 }
 
 func (rsp *response) err() error {

--- a/client/client.go
+++ b/client/client.go
@@ -221,12 +221,16 @@ func (client *Client) ServerVersion() (string, error) {
 		serverVersion = "unknown"
 	}
 
-	versionStr := fmt.Sprintf(""+
-		"snapd:  %s\n"+
-		"series: %s\n", serverVersion, sysInfo.Series)
-	if sysInfo.OnClassic {
-		versionStr += fmt.Sprintf("%s %s\n", sysInfo.OSRelease.ID, sysInfo.OSRelease.VersionID)
+	what := "classic"
+	if !sysInfo.OnClassic {
+		what = "unspecified"
+		// what = machine info (e.g. RPi3 etc)
 	}
+
+	// where := "localhost" ... :-)
+
+	versionStr := fmt.Sprintf("%s/%s/%s/%s", serverVersion, sysInfo.Series, sysInfo.OSRelease.PrettyName, what)
+
 	return versionStr, nil
 }
 
@@ -273,10 +277,11 @@ func IsTwoFactorError(err error) bool {
 
 // OSRelease contains information about the system extracted from /etc/os-release.
 type OSRelease struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	VersionID string `json:"version-id,omitempty"`
-	Codename  string `json:"codename,omitempty"`
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	VersionID  string `json:"version-id,omitempty"`
+	Codename   string `json:"codename,omitempty"`
+	PrettyName string `json:"pretty-name,omitempty"`
 }
 
 // SysInfo holds system information

--- a/client/client.go
+++ b/client/client.go
@@ -221,7 +221,11 @@ func (client *Client) ServerVersion() (string, error) {
 		version = "unknown"
 	}
 
-	return fmt.Sprintf("%s (series %s)", version, sysInfo.Series), nil
+	if sysInfo.OnClassic {
+		return fmt.Sprintf("%s (series %s, os: %s, classic)", version, sysInfo.Series, sysInfo.OS), nil
+	} else {
+		return fmt.Sprintf("%s (series %s, os: %s)", version, sysInfo.Series, sysInfo.OS), nil
+	}
 }
 
 // A response produced by the REST API will usually fit in this

--- a/client/client.go
+++ b/client/client.go
@@ -216,20 +216,14 @@ func (client *Client) ServerVersion() (string, error) {
 		return "unknown", err
 	}
 
-	// FIXME: get snap version generated at build time
-	clientVersion := ""
-	if clientVersion == "" {
-		clientVersion = "unknown"
-	}
 	serverVersion := sysInfo.Version
 	if serverVersion == "" {
 		serverVersion = "unknown"
 	}
 
 	versionStr := fmt.Sprintf(""+
-		"snap:   %s\n"+
 		"snapd:  %s\n"+
-		"series: %s\n", clientVersion, serverVersion, sysInfo.Series)
+		"series: %s\n", serverVersion, sysInfo.Series)
 	if sysInfo.OnClassic {
 		versionStr += fmt.Sprintf("%s %s", sysInfo.OSRelease.ID, sysInfo.OSRelease.VersionID)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -225,7 +225,7 @@ func (client *Client) ServerVersion() (string, error) {
 		"snapd:  %s\n"+
 		"series: %s\n", serverVersion, sysInfo.Series)
 	if sysInfo.OnClassic {
-		versionStr += fmt.Sprintf("%s %s", sysInfo.OSRelease.ID, sysInfo.OSRelease.VersionID)
+		versionStr += fmt.Sprintf("%s %s\n", sysInfo.OSRelease.ID, sysInfo.OSRelease.VersionID)
 	}
 	return versionStr, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -216,12 +216,24 @@ func (client *Client) ServerVersion() (string, error) {
 		return "unknown", err
 	}
 
-	version := sysInfo.Version
-	if version == "" {
-		version = "unknown"
+	// FIXME: get snap version generated at build time
+	clientVersion := ""
+	if clientVersion == "" {
+		clientVersion = "unknown"
+	}
+	serverVersion := sysInfo.Version
+	if serverVersion == "" {
+		serverVersion = "unknown"
 	}
 
-	return fmt.Sprintf("%s (series %s, os-id: %s)", version, sysInfo.Series, sysInfo.OSRelease.ID), nil
+	versionStr := fmt.Sprintf(""+
+		"snap:   %s\n"+
+		"snapd:  %s\n"+
+		"series: %s\n", clientVersion, serverVersion, sysInfo.Series)
+	if sysInfo.OnClassic {
+		versionStr += fmt.Sprintf("%s %s", sysInfo.OSRelease.ID, sysInfo.OSRelease.VersionID)
+	}
+	return versionStr, nil
 }
 
 // A response produced by the REST API will usually fit in this
@@ -267,10 +279,10 @@ func IsTwoFactorError(err error) bool {
 
 // OSRelease contains information about the system extracted from /etc/os-release.
 type OSRelease struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Release  string `json:"release,omitempty"`
-	Codename string `json:"codename,omitempty"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	VersionID string `json:"version-id,omitempty"`
+	Codename  string `json:"codename,omitempty"`
 }
 
 // SysInfo holds system information
@@ -278,6 +290,7 @@ type SysInfo struct {
 	Series    string    `json:"series,omitempty"`
 	Version   string    `json:"version,omitempty"`
 	OSRelease OSRelease `json:"os-release"`
+	OnClassic bool      `json:"on-classic"`
 }
 
 func (rsp *response) err() error {

--- a/client/client.go
+++ b/client/client.go
@@ -267,8 +267,10 @@ func IsTwoFactorError(err error) bool {
 
 // SysInfo holds system information
 type SysInfo struct {
-	Series  string `json:"series,omitempty"`
-	Version string `json:"version,omitempty"`
+	Series    string `json:"series,omitempty"`
+	Version   string `json:"version,omitempty"`
+	OS        string `json:"os-id,omitempty"`
+	OnClassic bool   `json:"on-classic,omitempty"`
 }
 
 func (rsp *response) err() error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -143,8 +143,8 @@ func (cs *clientSuite) TestClientSysInfo(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"series": "16",
                       "version": "2",
-					  "os-release": {"id": "ubuntu", "version-id": "16.04"},
-				      "on-classic": true}}`
+                      "os-release": {"id": "ubuntu", "version-id": "16.04"},
+                      "on-classic": true}}`
 	sysInfo, err := cs.cli.SysInfo()
 	c.Check(err, check.IsNil)
 	c.Check(sysInfo, check.DeepEquals, &client.SysInfo{
@@ -162,7 +162,7 @@ func (cs *clientSuite) TestServerVersion(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"series": "16",
                       "version": "2",
-					  "os-release": {"id": "ubuntu", "version-id": "16.04"}}}`
+                      "os-release": {"id": "ubuntu", "version-id": "16.04"}}}`
 	version, err := cs.cli.ServerVersion()
 	c.Check(err, check.IsNil)
 	c.Check(version, check.Equals, ""+
@@ -175,8 +175,8 @@ func (cs *clientSuite) TestServerVersionOnClassic(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"series": "16",
                       "version": "2",
-					  "os-release": {"id": "ubuntu", "version-id": "16.04"},
-				      "on-classic": true}}`
+                      "os-release": {"id": "ubuntu", "version-id": "16.04"},
+                      "on-classic": true}}`
 	version, err := cs.cli.ServerVersion()
 	c.Check(err, check.IsNil)
 	c.Check(version, check.Equals, ""+

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -143,16 +143,47 @@ func (cs *clientSuite) TestClientSysInfo(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"series": "16",
                       "version": "2",
-					  "os-release": {"id": "ubuntu"}}}`
+					  "os-release": {"id": "ubuntu", "version-id": "16.04"},
+				      "on-classic": true}}`
 	sysInfo, err := cs.cli.SysInfo()
 	c.Check(err, check.IsNil)
 	c.Check(sysInfo, check.DeepEquals, &client.SysInfo{
 		Version: "2",
 		Series:  "16",
 		OSRelease: client.OSRelease{
-			ID: "ubuntu",
+			ID:        "ubuntu",
+			VersionID: "16.04",
 		},
+		OnClassic: true,
 	})
+}
+
+func (cs *clientSuite) TestServerVersion(c *check.C) {
+	cs.rsp = `{"type": "sync", "result":
+                     {"series": "16",
+                      "version": "2",
+					  "os-release": {"id": "ubuntu", "version-id": "16.04"}}}`
+	version, err := cs.cli.ServerVersion()
+	c.Check(err, check.IsNil)
+	c.Check(version, check.Equals, ""+
+		"snap:   unknown\n"+
+		"snapd:  2\n"+
+		"series: 16\n")
+}
+
+func (cs *clientSuite) TestServerVersionOnClassic(c *check.C) {
+	cs.rsp = `{"type": "sync", "result":
+                     {"series": "16",
+                      "version": "2",
+					  "os-release": {"id": "ubuntu", "version-id": "16.04"},
+				      "on-classic": true}}`
+	version, err := cs.cli.ServerVersion()
+	c.Check(err, check.IsNil)
+	c.Check(version, check.Equals, ""+
+		"snap:   unknown\n"+
+		"snapd:  2\n"+
+		"series: 16\n"+
+		"ubuntu 16.04")
 }
 
 func (cs *clientSuite) TestClientIntegration(c *check.C) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -162,26 +162,22 @@ func (cs *clientSuite) TestServerVersion(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"series": "16",
                       "version": "2",
-                      "os-release": {"id": "ubuntu", "version-id": "16.04"}}}`
+                      "os-release": {"pretty-name": "Ubuntu 16.04 LTS"}}}`
 	version, err := cs.cli.ServerVersion()
 	c.Check(err, check.IsNil)
-	c.Check(version, check.Equals, ""+
-		"snapd:  2\n"+
-		"series: 16\n")
+	c.Check(version, check.Equals, "2/16/Ubuntu 16.04 LTS/unspecified")
+
 }
 
 func (cs *clientSuite) TestServerVersionOnClassic(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"series": "16",
                       "version": "2",
-                      "os-release": {"id": "ubuntu", "version-id": "16.04"},
+                      "os-release": {"pretty-name": "Ubuntu 16.04 LTS"},
                       "on-classic": true}}`
 	version, err := cs.cli.ServerVersion()
 	c.Check(err, check.IsNil)
-	c.Check(version, check.Equals, ""+
-		"snapd:  2\n"+
-		"series: 16\n"+
-		"ubuntu 16.04\n")
+	c.Check(version, check.Equals, "2/16/Ubuntu 16.04 LTS/classic")
 }
 
 func (cs *clientSuite) TestClientIntegration(c *check.C) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -162,22 +162,15 @@ func (cs *clientSuite) TestServerVersion(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"series": "16",
                       "version": "2",
-                      "os-release": {"pretty-name": "Ubuntu 16.04 LTS"}}}`
+                      "os-release": {"id": "zyggy", "version-id": "123"}}}`
 	version, err := cs.cli.ServerVersion()
 	c.Check(err, check.IsNil)
-	c.Check(version, check.Equals, "2/16/Ubuntu 16.04 LTS/unspecified")
-
-}
-
-func (cs *clientSuite) TestServerVersionOnClassic(c *check.C) {
-	cs.rsp = `{"type": "sync", "result":
-                     {"series": "16",
-                      "version": "2",
-                      "os-release": {"pretty-name": "Ubuntu 16.04 LTS"},
-                      "on-classic": true}}`
-	version, err := cs.cli.ServerVersion()
-	c.Check(err, check.IsNil)
-	c.Check(version, check.Equals, "2/16/Ubuntu 16.04 LTS/classic")
+	c.Check(version, check.DeepEquals, &client.ServerVersion{
+		Version:     "2",
+		Series:      "16",
+		OSID:        "zyggy",
+		OSVersionID: "123",
+	})
 }
 
 func (cs *clientSuite) TestClientIntegration(c *check.C) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -166,7 +166,6 @@ func (cs *clientSuite) TestServerVersion(c *check.C) {
 	version, err := cs.cli.ServerVersion()
 	c.Check(err, check.IsNil)
 	c.Check(version, check.Equals, ""+
-		"snap:   unknown\n"+
 		"snapd:  2\n"+
 		"series: 16\n")
 }
@@ -180,7 +179,6 @@ func (cs *clientSuite) TestServerVersionOnClassic(c *check.C) {
 	version, err := cs.cli.ServerVersion()
 	c.Check(err, check.IsNil)
 	c.Check(version, check.Equals, ""+
-		"snap:   unknown\n"+
 		"snapd:  2\n"+
 		"series: 16\n"+
 		"ubuntu 16.04")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -142,12 +142,15 @@ func (cs *clientSuite) TestClientSetsAuthorization(c *check.C) {
 func (cs *clientSuite) TestClientSysInfo(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"series": "16",
-                      "version": "2"}}`
+                      "version": "2",
+                      "os-id": "ubuntu"}}`
 	sysInfo, err := cs.cli.SysInfo()
 	c.Check(err, check.IsNil)
 	c.Check(sysInfo, check.DeepEquals, &client.SysInfo{
-		Version: "2",
-		Series:  "16",
+		Version:   "2",
+		Series:    "16",
+		OS:        "ubuntu",
+		OnClassic: false,
 	})
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -143,14 +143,15 @@ func (cs *clientSuite) TestClientSysInfo(c *check.C) {
 	cs.rsp = `{"type": "sync", "result":
                      {"series": "16",
                       "version": "2",
-                      "os-id": "ubuntu"}}`
+					  "os-release": {"id": "ubuntu"}}}`
 	sysInfo, err := cs.cli.SysInfo()
 	c.Check(err, check.IsNil)
 	c.Check(sysInfo, check.DeepEquals, &client.SysInfo{
-		Version:   "2",
-		Series:    "16",
-		OS:        "ubuntu",
-		OnClassic: false,
+		Version: "2",
+		Series:  "16",
+		OSRelease: client.OSRelease{
+			ID: "ubuntu",
+		},
 	})
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -181,7 +181,7 @@ func (cs *clientSuite) TestServerVersionOnClassic(c *check.C) {
 	c.Check(version, check.Equals, ""+
 		"snapd:  2\n"+
 		"series: 16\n"+
-		"ubuntu 16.04")
+		"ubuntu 16.04\n")
 }
 
 func (cs *clientSuite) TestClientIntegration(c *check.C) {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -103,7 +103,7 @@ func Parser() *flags.Parser {
 			cv = i18n.G("unavailable") + "\n"
 		}
 
-		fmt.Fprintf(Stdout, "snap:   %s\n%s", cmd.Version, cv)
+		fmt.Fprintf(Stdout, "snap:  %s\nsnapd: %s\n", cmd.Version, cv)
 
 		os.Exit(0)
 	}

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -100,10 +100,10 @@ func Parser() *flags.Parser {
 	optionsData.Version = func() {
 		cv, err := Client().ServerVersion()
 		if err != nil {
-			cv = i18n.G("unavailable")
+			cv = i18n.G("unavailable") + "\n"
 		}
 
-		fmt.Fprintf(Stdout, "snap  %s\nsnapd %s\n", cmd.Version, cv)
+		fmt.Fprintf(Stdout, "snap:   %s\n%s", cmd.Version, cv)
 
 		os.Exit(0)
 	}

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -98,12 +98,23 @@ type parserSetter interface {
 // from each other.
 func Parser() *flags.Parser {
 	optionsData.Version = func() {
-		cv, err := Client().ServerVersion()
+		sv, err := Client().ServerVersion()
 		if err != nil {
-			cv = i18n.G("unavailable") + "\n"
+			sv = &client.ServerVersion{
+				Version:     i18n.G("unavailable"),
+				Series:      "-",
+				OSID:        "-",
+				OSVersionID: "-",
+			}
 		}
 
-		fmt.Fprintf(Stdout, "snap:  %s\nsnapd: %s\n", cmd.Version, cv)
+		w := tabWriter()
+
+		fmt.Fprintf(w, "snap\t%s\n", cmd.Version)
+		fmt.Fprintf(w, "snapd\t%s\n", sv.Version)
+		fmt.Fprintf(w, "series\t%s\n", sv.Series)
+		fmt.Fprintf(w, "%s\t%s\n", sv.OSID, sv.OSVersionID)
+		w.Flush()
 
 		os.Exit(0)
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -182,8 +182,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	m := map[string]interface{}{
 		"series":     release.Series,
 		"version":    c.d.Version,
-		"os-id":      release.ReleaseInfo.ID,
-		"on-classic": release.OnClassic,
+		"os-release": release.ReleaseInfo,
 	}
 
 	return SyncResponse(m, nil)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -179,9 +179,11 @@ func tbd(c *Command, r *http.Request, user *auth.UserState) Response {
 }
 
 func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
-	m := map[string]string{
-		"series":  release.Series,
-		"version": c.d.Version,
+	m := map[string]interface{}{
+		"series":     release.Series,
+		"version":    c.d.Version,
+		"os-id":      release.ReleaseInfo.ID,
+		"on-classic": release.OnClassic,
 	}
 
 	return SyncResponse(m, nil)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -183,6 +183,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		"series":     release.Series,
 		"version":    c.d.Version,
 		"os-release": release.ReleaseInfo,
+		"on-classic": release.OnClassic,
 	}
 
 	return SyncResponse(m, nil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -394,7 +394,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 
 	s.daemon(c).Version = "42b1"
 
-	restore := release.MockReleaseInfo(&release.OS{ID: "distro-id"})
+	restore := release.MockReleaseInfo(&release.OS{ID: "distro-id", Name: "distro-name"})
 	defer restore()
 	restore = release.MockOnClassic(true)
 	defer restore()
@@ -403,10 +403,12 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
 
 	expected := map[string]interface{}{
-		"series":     "16",
-		"version":    "42b1",
-		"os-id":      "distro-id",
-		"on-classic": true,
+		"series":  "16",
+		"version": "42b1",
+		"os-release": map[string]interface{}{
+			"id":   "distro-id",
+			"name": "distro-name",
+		},
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -409,6 +409,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 			"id":   "distro-id",
 			"name": "distro-name",
 		},
+		"on-classic": true,
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -394,7 +394,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 
 	s.daemon(c).Version = "42b1"
 
-	restore := release.MockReleaseInfo(&release.OS{ID: "distro-id", Name: "distro-name"})
+	restore := release.MockReleaseInfo(&release.OS{ID: "distro-id", VersionID: "1.2"})
 	defer restore()
 	restore = release.MockOnClassic(true)
 	defer restore()
@@ -406,8 +406,8 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 		"series":  "16",
 		"version": "42b1",
 		"os-release": map[string]interface{}{
-			"id":   "distro-id",
-			"name": "distro-name",
+			"id":         "distro-id",
+			"version-id": "1.2",
 		},
 		"on-classic": true,
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -394,13 +394,19 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 
 	s.daemon(c).Version = "42b1"
 
+	restore := release.MockReleaseInfo(&release.OS{ID: "distro-id"})
+	defer restore()
+	restore = release.MockOnClassic(true)
+	defer restore()
 	sysInfoCmd.GET(sysInfoCmd, nil, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)
 	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
 
 	expected := map[string]interface{}{
-		"series":  "16",
-		"version": "42b1",
+		"series":     "16",
+		"version":    "42b1",
+		"os-id":      "distro-id",
+		"on-classic": true,
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/po/snappy.pot
+++ b/po/snappy.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: snappy\n"
         "Report-Msgid-Bugs-To: snappy-devel@lists.ubuntu.com\n"
-        "POT-Creation-Date: 2016-06-07 10:40+0100\n"
+        "POT-Creation-Date: 2016-06-27 11:23+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,6 +20,9 @@ msgid   "Abort a pending change"
 msgstr  ""
 
 msgid   "Adds an assertion to the system"
+msgstr  ""
+
+msgid   "All snaps up-to-date."
 msgstr  ""
 
 msgid   "Authenticates on snapd and the store"
@@ -54,6 +57,13 @@ msgstr  ""
 
 #, c-format
 msgid   "Copy snap %q data"
+msgstr  ""
+
+#, c-format
+msgid   "Created user %q\n"
+msgstr  ""
+
+msgid   "Creates a local system user"
 msgstr  ""
 
 #, c-format
@@ -186,6 +196,12 @@ msgstr  ""
 msgid   "Rollback %q snap"
 msgstr  ""
 
+msgid   "Run the given snap command"
+msgstr  ""
+
+msgid   "Run the given snap command with the right confinement and environment"
+msgstr  ""
+
 msgid   "Runs unsupported experimental commands"
 msgstr  ""
 
@@ -268,6 +284,13 @@ msgid   "\n"
 msgstr  ""
 
 msgid   "\n"
+        "The create-user command creates a local system user with the username and SSH\n"
+        "keys registered on the store account identified by the provided email address.\n"
+        "\n"
+        "An account can be setup at https://login.ubuntu.com.\n"
+msgstr  ""
+
+msgid   "\n"
         "The disconnect command disconnects a plug from a slot.\n"
         "It may be called in the following ways:\n"
         "\n"
@@ -332,7 +355,7 @@ msgid   "\n"
         "into the ~/.snap/auth.json file. Further communication with snapd will then be made\n"
         "using those credentials.\n"
         "\n"
-        "Login only works for local users in the sudo or admin groups.\n"
+        "Login only works for local users in the sudo, admin or wheel groups.\n"
         "\n"
         "An account can be setup at https://login.ubuntu.com\n"
 msgstr  ""
@@ -359,6 +382,9 @@ msgid   "\n"
         "\n"
         "The home directory is shared between snappy and the classic dimension.\n"
         "Run \"exit\" to leave the classic shell.\n"
+msgstr  ""
+
+msgid   "bought"
 msgstr  ""
 
 msgid   "no changes found"

--- a/release/export_test.go
+++ b/release/export_test.go
@@ -23,6 +23,11 @@ var ReadOSRelease = readOSRelease
 
 func MockOSReleasePath(filename string) (restore func()) {
 	old := osReleasePath
+	oldFallback := fallbackOsReleasePath
 	osReleasePath = filename
-	return func() { osReleasePath = old }
+	fallbackOsReleasePath = filename
+	return func() {
+		osReleasePath = old
+		fallbackOsReleasePath = oldFallback
+	}
 }

--- a/release/release.go
+++ b/release/release.go
@@ -32,10 +32,10 @@ var Series = "16"
 
 // OS contains information about the system extracted from /etc/os-release.
 type OS struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Release  string `json:"release,omitempty"`
-	Codename string `json:"codename,omitempty"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	VersionID string `json:"version-id,omitempty"`
+	Codename  string `json:"codename,omitempty"`
 }
 
 // ForceDevMode returns true if the distribution doesn't implement required
@@ -85,7 +85,7 @@ func readOSRelease() (*OS, error) {
 		}
 		if strings.HasPrefix(line, "VERSION_ID=") {
 			tmp := strings.SplitN(line, "=", 2)
-			osRelease.Release = strings.Trim(tmp[1], "\"")
+			osRelease.VersionID = strings.Trim(tmp[1], "\"")
 		}
 		if strings.HasPrefix(line, "UBUNTU_CODENAME=") {
 			tmp := strings.SplitN(line, "=", 2)

--- a/release/release.go
+++ b/release/release.go
@@ -32,10 +32,10 @@ var Series = "16"
 
 // OS contains information about the system extracted from /etc/os-release.
 type OS struct {
-	ID       string
-	Name     string
-	Release  string
-	Codename string
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Release  string `json:"release,omitempty"`
+	Codename string `json:"codename,omitempty"`
 }
 
 // ForceDevMode returns true if the distribution doesn't implement required

--- a/release/release.go
+++ b/release/release.go
@@ -21,7 +21,6 @@ package release
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strings"
 
@@ -34,11 +33,8 @@ var Series = "16"
 
 // OS contains information about the system extracted from /etc/os-release.
 type OS struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	VersionID  string `json:"version-id,omitempty"`
-	Codename   string `json:"codename,omitempty"`
-	PrettyName string `json:"pretty-name,omitempty"`
+	ID        string `json:"id"`
+	VersionID string `json:"version-id,omitempty"`
 }
 
 // ForceDevMode returns true if the distribution doesn't implement required
@@ -66,15 +62,27 @@ func (os *OS) ForceDevMode() bool {
 
 }
 
-var osReleasePath = "/etc/os-release"
+var (
+	osReleasePath         = "/etc/os-release"
+	fallbackOsReleasePath = "/usr/lib/os-release"
+)
 
 // readOSRelease returns the os-release information of the current system.
-func readOSRelease() (*OS, error) {
-	osRelease := &OS{}
+func readOSRelease() OS {
+	// TODO: separate this out into its own thing maybe (if made more general)
+	osRelease := OS{
+		VersionID: "unknown",
+		// from os-release(5): If not set, defaults to "ID=linux".
+		ID: "linux",
+	}
 
 	f, err := os.Open(osReleasePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot open os-release: %s", err)
+		// this fallback is as per os-release(5)
+		f, err = os.Open(fallbackOsReleasePath)
+		if err != nil {
+			return osRelease
+		}
 	}
 
 	scanner := bufio.NewScanner(f)
@@ -86,24 +94,16 @@ func readOSRelease() (*OS, error) {
 
 		k := strings.TrimSpace(ws[0])
 		v := strings.TrimFunc(ws[1], func(r rune) bool { return r == '"' || unicode.IsSpace(r) })
+		// XXX: should also unquote things as per os-release(5) but not needed yet in practice
 		switch k {
 		case "ID":
 			osRelease.ID = v
-		case "NAME":
-			osRelease.Name = v
 		case "VERSION_ID":
 			osRelease.VersionID = v
-		case "UBUNTU_CODENAME":
-			osRelease.Codename = v
-		case "PRETTY_NAME":
-			osRelease.PrettyName = v
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("cannot read os-release: %s", err)
-	}
 
-	return osRelease, nil
+	return osRelease
 }
 
 // OnClassic states whether the process is running inside a
@@ -114,21 +114,13 @@ var OnClassic bool
 var ReleaseInfo OS
 
 func init() {
-	osRelease, err := readOSRelease()
-	if err != nil {
-		// Values recommended by os-release(5) as defaults
-		osRelease = &OS{
-			Name: "Linux",
-			ID:   "linux",
-		}
-	}
-	ReleaseInfo = *osRelease
+	ReleaseInfo = readOSRelease()
 	// Assume that we are running on Classic
 	OnClassic = true
 	// On Ubuntu, dpkg is not present in an all-snap image so the presence of
 	// dpkg status file can be used as an indicator for a classic vs all-snap
 	// system.
-	if osRelease.ID == "ubuntu" {
+	if ReleaseInfo.ID == "ubuntu" {
 		OnClassic = osutil.FileExists("/var/lib/dpkg/status")
 	}
 }

--- a/release/release.go
+++ b/release/release.go
@@ -103,10 +103,6 @@ func readOSRelease() (*OS, error) {
 		return nil, fmt.Errorf("cannot read os-release: %s", err)
 	}
 
-	if osRelease.Name == "ubuntu" && osRelease.Codename == "" {
-		osRelease.Codename = "xenial" // or maybe "rolling"?
-	}
-
 	return osRelease, nil
 }
 

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -71,7 +71,7 @@ func (s *ReleaseTestSuite) TestReadOSRelease(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(os.ID, Equals, "ubuntu")
 	c.Assert(os.Name, Equals, "Ubuntu")
-	c.Assert(os.Release, Equals, "18.09")
+	c.Assert(os.VersionID, Equals, "18.09")
 	c.Assert(os.Codename, Equals, "awesome")
 }
 

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -67,21 +67,17 @@ func (s *ReleaseTestSuite) TestReadOSRelease(c *C) {
 	reset := release.MockOSReleasePath(mockOSRelease(c))
 	defer reset()
 
-	os, err := release.ReadOSRelease()
-	c.Assert(err, IsNil)
+	os := release.ReadOSRelease()
 	c.Check(os.ID, Equals, "ubuntu")
-	c.Check(os.Name, Equals, "Ubuntu")
 	c.Check(os.VersionID, Equals, "18.09")
-	c.Check(os.Codename, Equals, "awesome")
-	c.Check(os.PrettyName, Equals, "I'm not real!")
 }
 
 func (s *ReleaseTestSuite) TestReadOSReleaseNotFound(c *C) {
 	reset := release.MockOSReleasePath("not-there")
 	defer reset()
 
-	_, err := release.ReadOSRelease()
-	c.Assert(err, ErrorMatches, "cannot open os-release:.*")
+	os := release.ReadOSRelease()
+	c.Assert(os, DeepEquals, release.OS{ID: "linux", VersionID: "unknown"})
 }
 
 func (s *ReleaseTestSuite) TestOnClassic(c *C) {

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -69,10 +69,11 @@ func (s *ReleaseTestSuite) TestReadOSRelease(c *C) {
 
 	os, err := release.ReadOSRelease()
 	c.Assert(err, IsNil)
-	c.Assert(os.ID, Equals, "ubuntu")
-	c.Assert(os.Name, Equals, "Ubuntu")
-	c.Assert(os.VersionID, Equals, "18.09")
-	c.Assert(os.Codename, Equals, "awesome")
+	c.Check(os.ID, Equals, "ubuntu")
+	c.Check(os.Name, Equals, "Ubuntu")
+	c.Check(os.VersionID, Equals, "18.09")
+	c.Check(os.Codename, Equals, "awesome")
+	c.Check(os.PrettyName, Equals, "I'm not real!")
 }
 
 func (s *ReleaseTestSuite) TestReadOSReleaseNotFound(c *C) {
@@ -80,7 +81,7 @@ func (s *ReleaseTestSuite) TestReadOSReleaseNotFound(c *C) {
 	defer reset()
 
 	_, err := release.ReadOSRelease()
-	c.Assert(err, ErrorMatches, "cannot read os-release:.*")
+	c.Assert(err, ErrorMatches, "cannot open os-release:.*")
 }
 
 func (s *ReleaseTestSuite) TestOnClassic(c *C) {
@@ -122,7 +123,7 @@ func (s *ReleaseTestSuite) TestForceDevMode(c *C) {
 		{id: "ubuntu", devmode: false},
 	}
 	for _, distro := range distros {
-		rel := &release.OS{ID: distro.id, Release: distro.idVersion}
+		rel := &release.OS{ID: distro.id, VersionID: distro.idVersion}
 		c.Logf("checking distribution %#v", rel)
 		release.MockReleaseInfo(rel)
 		c.Assert(release.ReleaseInfo.ForceDevMode(), Equals, distro.devmode)


### PR DESCRIPTION
Resurrect @zyga's old #1222 and further tweak it:
```
snap:  2.0.24
snapd: 2.0.24/16/Ubuntu 16.04 LTS/classic
``` 