### PR TITLE
snapstate: remove the concept of "active" from snapstate.SnapState

### DIFF
--- a/daemon/api_mock_test.go
+++ b/daemon/api_mock_test.go
@@ -43,7 +43,6 @@ func (s *apiSuite) mockSnap(c *C, yamlText string) *snap.Info {
 
 	// Put a side info into the state
 	snapstate.Set(st, snapInfo.Name(), &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{{Revision: snapInfo.Revision}},
 		Current:  snapInfo.Revision,
 	})

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -132,7 +132,8 @@ type appJSON struct {
 
 func mapLocal(localSnap *snap.Info, snapst *snapstate.SnapState) map[string]interface{} {
 	status := "installed"
-	if snapst.Active {
+
+	if snapst.Current == localSnap.Revision {
 		status = "active"
 	}
 

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -206,7 +206,6 @@ func (s *interfaceManagerSuite) mockSnap(c *C, yamlText string) *snap.Info {
 
 	// Put a side info into the state
 	snapstate.Set(s.state, snapInfo.Name(), &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfo},
 		Current:  sideInfo.Revision,
 	})

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -124,7 +124,6 @@ type: gadget
 version: 1
 `, si)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{si},
 		Current:  si.Revision,
 	})
@@ -164,7 +163,6 @@ type: gadget
 version: 1
 `, si)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{si},
 		Current:  si.Revision,
 	})

--- a/overlord/snapstate/discard_snap_test.go
+++ b/overlord/snapstate/discard_snap_test.go
@@ -63,7 +63,6 @@ func (s *discardSnapSuite) TestDoDiscardSnapSuccess(c *C) {
 			{OfficialName: "foo", Revision: snap.R(3)},
 			{OfficialName: "foo", Revision: snap.R(33)},
 		},
-		Current: snap.R(33),
 	})
 	t := s.state.NewTask("discard-snap", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
@@ -84,7 +83,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapSuccess(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapst.Sequence, HasLen, 1)
-	c.Check(snapst.Current, Equals, snap.R(3))
+	c.Check(snapst.Current.Unset(), Equals, true)
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
 
@@ -122,7 +121,6 @@ func (s *discardSnapSuite) TestDoDiscardSnapErrorsForActive(c *C) {
 			{OfficialName: "foo", Revision: snap.R(3)},
 		},
 		Current: snap.R(3),
-		Active:  true,
 	})
 	t := s.state.NewTask("discard-snap", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
@@ -152,7 +150,6 @@ func (s *discardSnapSuite) TestDoDiscardSnapNoErrorsForActive(c *C) {
 			{OfficialName: "foo", Revision: snap.R(33)},
 		},
 		Current: snap.R(33),
-		Active:  true,
 	})
 	t := s.state.NewTask("discard-snap", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{

--- a/overlord/snapstate/discard_snap_test.go
+++ b/overlord/snapstate/discard_snap_test.go
@@ -114,34 +114,6 @@ func (s *discardSnapSuite) TestDoDiscardSnapToEmpty(c *C) {
 	c.Assert(err, Equals, state.ErrNoState)
 }
 
-func (s *discardSnapSuite) TestDoDiscardSnapErrorsForActive(c *C) {
-	s.state.Lock()
-	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{OfficialName: "foo", Revision: snap.R(3)},
-		},
-		Current: snap.R(3),
-	})
-	t := s.state.NewTask("discard-snap", "test")
-	t.Set("snap-setup", &snapstate.SnapSetup{
-		Name:     "foo",
-		Revision: snap.R(3),
-	})
-	chg := s.state.NewChange("dummy", "...")
-	chg.AddTask(t)
-
-	s.state.Unlock()
-
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Check(chg.Err(), ErrorMatches, `(?s).*internal error: cannot discard snap "foo": still active.*`)
-}
-
 func (s *discardSnapSuite) TestDoDiscardSnapNoErrorsForActive(c *C) {
 	s.state.Lock()
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{

--- a/overlord/snapstate/link_snap_test.go
+++ b/overlord/snapstate/link_snap_test.go
@@ -106,7 +106,6 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccess(c *C) {
 	c.Check(err, IsNil)
 	c.Check(typ, Equals, snap.TypeApp)
 
-	c.Check(snapst.Active, Equals, true)
 	c.Check(snapst.Sequence, HasLen, 1)
 	c.Check(snapst.Current, Equals, snap.R(33))
 	c.Check(snapst.Candidate, IsNil)
@@ -148,7 +147,6 @@ func (s *linkSnapSuite) TestDoUndoLinkSnap(c *C) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "foo", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.Active, Equals, false)
 	c.Check(snapst.Sequence, HasLen, 0)
 	c.Check(snapst.Current, Equals, snap.Revision{})
 	c.Check(snapst.Candidate, DeepEquals, si)
@@ -185,7 +183,6 @@ func (s *linkSnapSuite) TestDoLinkSnapTryToCleanupOnError(c *C) {
 	var snapst snapstate.SnapState
 	err := snapstate.Get(s.state, "foo", &snapst)
 	c.Assert(err, IsNil)
-	c.Check(snapst.Active, Equals, false)
 	c.Check(snapst.Sequence, HasLen, 0)
 	c.Check(snapst.Candidate, DeepEquals, si)
 	c.Check(snapst.Channel, Equals, "")

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -372,8 +372,6 @@ func (m *SnapManager) doUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// mark as inactive
-	snapst.Current = snap.R(0)
 	Set(st, ss.Name, snapst)
 	return nil
 }
@@ -415,10 +413,6 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	st.Unlock()
 	if err != nil {
 		return err
-	}
-
-	if snapst.Current == ss.Revision {
-		return fmt.Errorf("internal error: cannot discard snap %q: still active", ss.Name)
 	}
 
 	if len(snapst.Sequence) == 1 {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -108,7 +108,6 @@ type SnapState struct {
 	Sequence  []*snap.SideInfo `json:"sequence"`
 	Current   snap.Revision    `json:"current"`
 	Candidate *snap.SideInfo   `json:"candidate,omitempty"`
-	Active    bool             `json:"active,omitempty"`
 	Channel   string           `json:"channel,omitempty"`
 	Flags     SnapStateFlags   `json:"flags,omitempty"`
 	// incremented revision used for local installs
@@ -374,7 +373,7 @@ func (m *SnapManager) doUnlinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// mark as inactive
-	snapst.Active = false
+	snapst.Current = snap.R(0)
 	Set(st, ss.Name, snapst)
 	return nil
 }
@@ -418,7 +417,7 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	if snapst.Current == ss.Revision && snapst.Active {
+	if snapst.Current == ss.Revision {
 		return fmt.Errorf("internal error: cannot discard snap %q: still active", ss.Name)
 	}
 
@@ -567,7 +566,6 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	snapst.Active = true
 	st.Unlock()
 	err = m.backend.LinkSnap(oldInfo)
 	st.Lock()
@@ -596,8 +594,6 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		return err
 	}
-
-	snapst.Active = false
 
 	pb := &TaskProgressAdapter{task: t}
 	st.Unlock() // pb itself will ask for locking
@@ -684,7 +680,6 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	oldCurrent := snapst.Current
 	snapst.Current = snapst.Candidate.Revision
 	snapst.Candidate = nil
-	snapst.Active = true
 	oldChannel := snapst.Channel
 	if ss.Channel != "" {
 		snapst.Channel = ss.Channel
@@ -770,7 +765,6 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.Candidate = snapst.Sequence[len(snapst.Sequence)-1]
 	snapst.Sequence = snapst.Sequence[:len(snapst.Sequence)-1]
 	snapst.Current = oldCurrent
-	snapst.Active = false
 	snapst.Channel = oldChannel
 	snapst.SetTryMode(oldTryMode)
 

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -181,7 +181,6 @@ func (s *snapmgrTestSuite) TestUpdateTasks(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Channel:  "edge",
 		Sequence: []*snap.SideInfo{{OfficialName: "some-snap", Revision: snap.R(11)}},
 		Current:  snap.R(11),
@@ -203,7 +202,6 @@ func (s *snapmgrTestSuite) TestUpdateChannelFallback(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Channel:  "edge",
 		Sequence: []*snap.SideInfo{{OfficialName: "some-snap", Revision: snap.R(11)}},
 		Current:  snap.R(11),
@@ -224,7 +222,6 @@ func (s *snapmgrTestSuite) TestUpdateConflict(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{{OfficialName: "some-snap", Revision: snap.R(11)}},
 		Current:  snap.R(11),
 	})
@@ -243,7 +240,6 @@ func (s *snapmgrTestSuite) TestRemoveTasks(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "foo", &snapstate.SnapState{
-		Active: true,
 		Sequence: []*snap.SideInfo{
 			{OfficialName: "foo", Revision: snap.R(11)},
 		},
@@ -273,7 +269,6 @@ func (s *snapmgrTestSuite) TestRemoveConflict(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{{OfficialName: "some-snap", Revision: snap.R(11)}},
 		Current:  snap.R(11),
 	})
@@ -379,7 +374,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Assert(err, IsNil)
 
 	snapst := snaps["some-snap"]
-	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Current, Equals, snap.R(11))
 	c.Assert(snapst.Channel, Equals, "some-channel")
 	c.Assert(snapst.Candidate, IsNil)
 	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
@@ -400,7 +395,6 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{&si},
 		Current:  si.Revision,
 	})
@@ -501,7 +495,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
 
-	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Current, Equals, snap.R(11))
 	c.Assert(snapst.Candidate, IsNil)
 	c.Assert(snapst.Sequence, HasLen, 2)
 	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
@@ -527,7 +521,6 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{&si},
 		Current:  si.Revision,
 	})
@@ -631,7 +624,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
 
-	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Current, Equals, snap.R(7))
 	c.Assert(snapst.Candidate, IsNil)
 	c.Assert(snapst.Sequence, HasLen, 1)
 	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
@@ -651,7 +644,6 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{&si},
 		Channel:  "stable",
 		Current:  si.Revision,
@@ -762,7 +754,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
 
-	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Current, Equals, snap.R(7))
 	c.Assert(snapst.Channel, Equals, "stable")
 	c.Assert(snapst.Candidate, IsNil)
 	c.Assert(snapst.Sequence, HasLen, 1)
@@ -783,7 +775,6 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{&si},
 		Current:  si.Revision,
 	})
@@ -813,7 +804,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionRunThrough(c *C) {
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
 
-	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Current, Equals, snap.R(7))
 	c.Assert(snapst.Candidate, IsNil)
 	c.Assert(snapst.Sequence, HasLen, 1)
 	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
@@ -876,7 +867,7 @@ version: 1.0`)
 	err = snapstate.Get(s.state, "mock", &snapst)
 	c.Assert(err, IsNil)
 
-	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Current, Equals, snap.R(-1))
 	c.Assert(snapst.Candidate, IsNil)
 	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
 		OfficialName: "",
@@ -894,7 +885,6 @@ func (s *snapmgrTestSuite) TestInstallSubsequentLocalRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "mock", &snapstate.SnapState{
-		Active:        true,
 		Sequence:      []*snap.SideInfo{{Revision: snap.R(-2)}},
 		LocalRevision: snap.R(-2),
 		Current:       snap.R(-2),
@@ -953,7 +943,7 @@ version: 1.0`)
 	err = snapstate.Get(s.state, "mock", &snapst)
 	c.Assert(err, IsNil)
 
-	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Current, Equals, snap.R(-3))
 	c.Assert(snapst.Candidate, IsNil)
 	c.Assert(snapst.Sequence, HasLen, 2)
 	c.Assert(snapst.CurrentSideInfo(), DeepEquals, &snap.SideInfo{
@@ -972,7 +962,6 @@ func (s *snapmgrTestSuite) TestInstallOldSubsequentLocalRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "mock", &snapstate.SnapState{
-		Active:        true,
 		Sequence:      []*snap.SideInfo{{Revision: snap.R(100001)}},
 		LocalRevision: snap.R(100001),
 		Current:       snap.R(100001),
@@ -1004,7 +993,7 @@ version: 1.0`)
 	err = snapstate.Get(s.state, "mock", &snapst)
 	c.Assert(err, IsNil)
 
-	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Current, Equals, snap.R(-1))
 	c.Assert(snapst.Candidate, IsNil)
 	c.Assert(snapst.Sequence, HasLen, 2)
 	c.Assert(snapst.CurrentSideInfo(), DeepEquals, &snap.SideInfo{
@@ -1025,7 +1014,6 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{&si},
 		Current:  si.Revision,
 	})
@@ -1116,7 +1104,6 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{&si5, &si3, &si7},
 		Current:  si7.Revision,
 	})
@@ -1220,7 +1207,6 @@ func (s *snapmgrTestSuite) TestRemoveRefused(c *C) {
 	defer s.state.Unlock()
 
 	snapstate.Set(s.state, "gadget", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{&si},
 		Current:  si.Revision,
 	})
@@ -1259,7 +1245,6 @@ version: 1.2
 description: |
     Lots of text`, sideInfo12)
 	snapstate.Set(st, "name1", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfo11, sideInfo12},
 		Current:  sideInfo12.Revision,
 	})
@@ -1328,7 +1313,6 @@ type: gadget
 version: gadget
 `, sideInfoGadget)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
-		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfoGadget},
 		Current:  sideInfoGadget.Revision,
 	})
@@ -1359,7 +1343,7 @@ func (s *snapmgrQuerySuite) TestAll(c *C) {
 		snapst = sst
 	}
 
-	c.Check(snapst.Active, Equals, true)
+	c.Check(snapst.Current, Equals, snap.R(12))
 	c.Check(snapst.CurrentSideInfo(), NotNil)
 
 	info12, err := snap.ReadInfo("name1", snapst.CurrentSideInfo())
@@ -1549,17 +1533,23 @@ func (s *snapStateSuite) TestCurrentSideInfoOutOfOrder(c *C) {
 	c.Check(snapst.CurrentSideInfo(), DeepEquals, si1)
 }
 
-func (s *snapStateSuite) TestCurrentSideInfoInconsistent(c *C) {
+func (s *snapStateSuite) TestCurrentSideInfoCurrentUnset(c *C) {
 	snapst := snapstate.SnapState{
 		Sequence: []*snap.SideInfo{
 			{Revision: snap.R(1)},
 		},
 	}
+	c.Check(snapst.Current.Unset(), Equals, true)
 	c.Check(func() { snapst.CurrentSideInfo() }, PanicMatches, `snapst.Current and snapst.Sequence out of sync:.*`)
 }
 
 func (s *snapStateSuite) TestCurrentSideInfoInconsistentWithCurrent(c *C) {
-	snapst := snapstate.SnapState{Current: snap.R(17)}
+	snapst := snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{Revision: snap.R(1)},
+		},
+		Current: snap.R(17),
+	}
 	c.Check(func() { snapst.CurrentSideInfo() }, PanicMatches, `cannot find snapst.Current in the snapst.Sequence`)
 }
 

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -1028,6 +1028,7 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
+	c.Assert(chg.Err(), IsNil)
 	c.Assert(s.fakeBackend.ops, HasLen, 6)
 	expected := []fakeOp{
 		{
@@ -1118,6 +1119,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
+	c.Assert(chg.Err(), IsNil)
 	c.Assert(s.fakeBackend.ops, HasLen, 10)
 	expected := []fakeOp{
 		{


### PR DESCRIPTION
This removes the concept of an active snap from snapstate.