### PR TITLE
tests: manage the socket unit when reseting state

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -77,6 +77,7 @@ suites:
                 for unit in $mounts $services; do
                     systemctl start $unit
                 done
+                systemctl start snapd.socket
             fi
         restore: |
             $TESTSLIB/reset.sh

--- a/spread.yaml
+++ b/spread.yaml
@@ -65,7 +65,7 @@ suites:
                 snap remove hello-world
                 rmdir /snap/hello-world # Should be done by snapd.
 
-                systemctl stop snapd.{service,socket} || true
+                systemctl stop snapd.service snapd.socket
                 systemctl daemon-reload
                 mounts="$(systemctl list-unit-files | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
                 services="$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"

--- a/spread.yaml
+++ b/spread.yaml
@@ -65,7 +65,7 @@ suites:
                 snap remove hello-world
                 rmdir /snap/hello-world # Should be done by snapd.
 
-                systemctl stop snapd
+                systemctl stop snapd.{service,socket} || true
                 systemctl daemon-reload
                 mounts="$(systemctl list-unit-files | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
                 services="$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -2,7 +2,7 @@
 
 set -e -x
 
-systemctl stop snapd || true
+systemctl stop snapd.{service,socket} || true
 mounts="$(systemctl list-unit-files | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
 services="$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"
 for unit in $services $mounts; do
@@ -24,7 +24,7 @@ if [ "$1" = "--reuse-core" ]; then
 	    systemctl start $unit
 	done
 fi
-systemctl start snapd
+systemctl start snapd.socket
 
 # wait for snapd listening
 while ! printf "GET / HTTP/1.0\r\n\r\n" | nc -U -q 1 /run/snapd.socket; do sleep 0.5; done

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -2,7 +2,7 @@
 
 set -e -x
 
-systemctl stop snapd.{service,socket} || true
+systemctl stop snapd.service snapd.socket
 mounts="$(systemctl list-unit-files | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
 services="$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"
 for unit in $services $mounts; do


### PR DESCRIPTION
Previously only the snapd.service unit was being topped/started when reseting the state between jobs, these changes make sure that the socket is also reloaded.