### PR TITLE
snapstate: add logging after a successful doLinkSnap

### DIFF
--- a/overlord/snapstate/link_snap_test.go
+++ b/overlord/snapstate/link_snap_test.go
@@ -243,6 +243,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessCoreRestarts(c *C) {
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
 	c.Check(s.stateBackend.restartRequested, Equals, true)
-	c.Check(t.Log(), HasLen, 1)
-	c.Check(t.Log()[0], Matches, `.*INFO Restarting snapd\.\.\.`)
+	c.Check(t.Log(), HasLen, 2)
+	c.Check(t.Log()[0], Matches, `.*INFO snap "core" at rev 33 linked`)
+	c.Check(t.Log()[1], Matches, `.*INFO Restarting snapd\.\.\.`)
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -716,6 +716,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		return err
 	}
+	t.Logf("snap %q at rev %s linked", newInfo.Name(), newInfo.Revision)
 
 	// save for undoLinkSnap
 	t.Set("old-trymode", oldTryMode)


### PR DESCRIPTION
While looking at https://bugs.launchpad.net/snappy/+bug/1594330 I noticed that the log is missing some data that would have helped to confirm my theory about what happened. This branch adds a tiny bit of debug code to linkSnap so that we can get data from syslog what revision to linked on e.g. refresh (or install).