### PR TITLE
spread: cleanup

### DIFF
--- a/tests/main/abort/task.yaml
+++ b/tests/main/abort/task.yaml
@@ -3,29 +3,34 @@ environment:
   SNAP_NAME: hello-world
 execute: |
   echo "Abort with invalid id"
-  invalidID="10000000"
-  expected="error: cannot find change with id \"$invalidID\""
-  actual=$(snap abort $invalidID 2>&1) || EXPECTED_FAILED="abort-invalid"
-  [ "$EXPECTED_FAILED" = "abort-invalid" ] || exit 1
-  echo "$actual" | grep -Pq "$expected" || exit 1
+  if snap abort 10000000; then
+    echo "abort with invalid id should fail"
+    exit 1
+  fi
+
+  echo "===================================="
 
   echo "Abort with valid id - error"
   subdirPath="/snap/$SNAP_NAME/current/foo"
   mkdir -p $subdirPath
-  snap install $SNAP_NAME || EXPECTED_FAILED=install
-  [ "$EXPECTED_FAILED" = "install" ] || exit 1
-  id="1"
-  expected="error: cannot abort change $id with nothing pending"
-  actual=$(snap abort $id 2>&1) || EXPECTED_FAILED="abort-error"
-  [ "$EXPECTED_FAILED" = "abort-error" ] || exit 1
-  echo "$actual" | grep -Pq "$expected" || exit 1
-
+  if snap install $SNAP_NAME; then
+    echo "install should fail when the target directory exists"
+    exit 1
+  fi
+  if snap abort 1; then
+    echo "abort with valid failed id should fail"
+    exit 1
+  fi
   rm -rf $subdirPath
+
+  echo "===================================="
+
 
   echo "Abort with valid id - done"
   snap install $SNAP_NAME
-  id="2"
-  expected="error: cannot abort change $id with nothing pending"
-  actual=$(snap abort $id 2>&1) || EXPECTED_FAILED="abort-done"
-  [ "$EXPECTED_FAILED" = "abort-done" ] || exit 1
-  echo "$actual" | grep -Pq "$expected" || exit 1
+  if snap abort 2; then
+    echo "abort with valid done id should fail"
+    exit 1
+  fi
+
+  echo "===================================="

--- a/tests/main/help/task.yaml
+++ b/tests/main/help/task.yaml
@@ -9,5 +9,4 @@ environment:
 execute: |
   echo "Checking help for command $CMD"
   expected="(?s)Usage:\n  snap \[OPTIONS\] $CMD.*?\n\nThe $CMD command .*?\nHelp Options:\n  -h, --help +Show this help message\n.*?"
-  actual=$(snap $CMD --help)
-  echo "$actual" | grep -Pzq "$expected" || exit 1
+  snap $CMD --help | grep -Pzq "$expected" || exit 1

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -35,10 +35,11 @@ execute: |
   echo "============================================"
 
   echo "Install points to login when not authenticated"
-  expected="snap login --help"
-  actual=$(sudo -i -u test /bin/sh -c "snap install hello-world 2>&1") || EXPECTED_FAILURE="unauthenticated"
-  [ "$EXPECTED_FAILURE" = "unauthenticated" ]
-  echo "$actual" | grep -q "$expected"
+  if sudo -i -u test /bin/sh -c "snap install hello-world 2>${PWD}/install.output"; then
+    echo "Unauthenticated install should fail"
+    exit 1
+  fi
+  grep "snap login --help" install.output
 
   echo "============================================"
 

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -19,19 +19,18 @@ restore: |
 
 execute: |
   echo "Install unexisting snap prints error"
-  expected="(?s)error: cannot perform the following tasks:\n\
-  - Download snap \"unexisting.canonical\" from channel \"stable\" \\(snap not found\\)\n"
-  actual=$(snap install unexisting.canonical 2>&1) || EXPECTED_FAILURE="unexisting"
-  [ "$EXPECTED_FAILURE" = "unexisting" ]
-  echo "$actual" | grep -Pzq "$expected"
+  if snap install unexisting.canonical; then
+    echo "Installing unexisting snap should fail"
+    exit 1
+  fi
 
   echo "============================================"
 
   echo "Install without snap name shows error"
-  expected="(?s)error: the required argument \`<snap>\` was not provided\n"
-  actual=$(snap install 2>&1) || EXPECTED_FAILURE="nosnap"
-  [ "$EXPECTED_FAILURE" = "nosnap" ]
-  echo "$actual" | grep -Pzq "$expected"
+  if snap install; then
+    echo "Installing without snap name should fail"
+    exit 1
+  fi
 
   echo "============================================"
 
@@ -39,22 +38,22 @@ execute: |
   expected="snap login --help"
   actual=$(sudo -i -u test /bin/sh -c "snap install hello-world 2>&1") || EXPECTED_FAILURE="unauthenticated"
   [ "$EXPECTED_FAILURE" = "unauthenticated" ]
-  echo "$actual" | grep -Pzq "$expected"
+  echo "$actual" | grep -q "$expected"
 
   echo "============================================"
 
-  echo "When a failing command from a snap is called"
-  basic-binaries.fail || EXPECTED_FAILURE="command-failed"
-
-  echo "Then it must fail"
-  [ "$EXPECTED_FAILURE" = "command-failed" ]
+  echo "Calñling a failing command from a snap should fail"
+  if basic-binaries.fail; then
+    echo "Failing snap commands should keep failing after installed"
+    exit 1
+  fi
 
   echo "============================================"
 
-  echo "When we try to install a snap already installed from the store"
-  snap install $STORE_SNAP_NAME || EXPECTED_FAILURE="install-failed"
-
-  echo "Then it must fail"
-  [ "$EXPECTED_FAILURE" = "install-failed" ]
+  echo "Install a snap already installed fails"
+  if snap install $STORE_SNAP_NAME; then
+    echo "Trying to install an already installed snap should fail"
+    exit 1
+  fi
 
   echo "============================================"

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -22,7 +22,7 @@ execute: |
   expected="(?s)error: cannot perform the following tasks:\n\
   - Download snap \"unexisting.canonical\" from channel \"stable\" \\(snap not found\\)\n"
   actual=$(snap install unexisting.canonical 2>&1) || EXPECTED_FAILURE="unexisting"
-  [ "$EXPECTED_FAILURE" = "unexisting" ] || exit 1
+  [ "$EXPECTED_FAILURE" = "unexisting" ]
   echo "$actual" | grep -Pzq "$expected"
 
   echo "============================================"
@@ -30,7 +30,7 @@ execute: |
   echo "Install without snap name shows error"
   expected="(?s)error: the required argument \`<snap>\` was not provided\n"
   actual=$(snap install 2>&1) || EXPECTED_FAILURE="nosnap"
-  [ "$EXPECTED_FAILURE" = "nosnap" ] || exit 1
+  [ "$EXPECTED_FAILURE" = "nosnap" ]
   echo "$actual" | grep -Pzq "$expected"
 
   echo "============================================"
@@ -38,7 +38,7 @@ execute: |
   echo "Install points to login when not authenticated"
   expected="snap login --help"
   actual=$(sudo -i -u test /bin/sh -c "snap install hello-world 2>&1") || EXPECTED_FAILURE="unauthenticated"
-  [ "$EXPECTED_FAILURE" = "unauthenticated" ] || exit 1
+  [ "$EXPECTED_FAILURE" = "unauthenticated" ]
   echo "$actual" | grep -Pzq "$expected"
 
   echo "============================================"
@@ -47,7 +47,7 @@ execute: |
   basic-binaries.fail || EXPECTED_FAILURE="command-failed"
 
   echo "Then it must fail"
-  [ "$EXPECTED_FAILURE" = "command-failed" ] || exit 1
+  [ "$EXPECTED_FAILURE" = "command-failed" ]
 
   echo "============================================"
 
@@ -55,6 +55,6 @@ execute: |
   snap install $STORE_SNAP_NAME || EXPECTED_FAILURE="install-failed"
 
   echo "Then it must fail"
-  [ "$EXPECTED_FAILURE" = "install-failed" ] || exit 1
+  [ "$EXPECTED_FAILURE" = "install-failed" ]
 
   echo "============================================"

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -14,13 +14,12 @@ execute: |
   expected="(?s)Name +Version +Rev +Developer +Notes\n\
   basic +.*? *\n\
   .*"
-  actual=$(snap install ./basic_1.0_all.snap)
-  echo "$actual" | grep -Pzq "$expected" || exit 1
+  snap install ./basic_1.0_all.snap | grep -Pzq "$expected"
 
   echo "Sideloaded snap executes commands"
   snap install ./basic-binaries_1.0_all.snap
   basic-binaries.success
-  [ "$(basic-binaries.echo)" = "From basic-binaries snap" ] || exit 1
+  [ "$(basic-binaries.echo)" = "From basic-binaries snap" ]
 
   echo "Sideload desktop snap"
   snap install ./basic-desktop_1.0_all.snap
@@ -28,5 +27,4 @@ execute: |
   Name=Echo\n\
   Comment=It echos stuff\n\
   Exec=\/snap\/bin\/basic-desktop.echo\n"
-  actual=$(cat /var/lib/snapd/desktop/applications/basic-desktop_echo.desktop)
-  echo "$actual" | grep -Pzq "$expected" || exit 1
+  cat /var/lib/snapd/desktop/applications/basic-desktop_echo.desktop | grep -Pzq "$expected"

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -8,16 +8,14 @@ execute: |
   $SNAP_NAME .*? canonical +-\n"
   for channel in edge beta candidate stable
   do
-    actual=$(snap install $SNAP_NAME --channel=$channel)
-    echo "$actual" | grep -Pzq "$expected" || exit 1
+    snap install $SNAP_NAME --channel=$channel | grep -Pzq "$expected"
     snap remove $SNAP_NAME
   done
 
   echo "Install non-devmode snap with devmode option"
   expected="(?s)Name +Version +Rev +Developer +Notes\n\
   $SNAP_NAME .*? canonical +devmode\n"
-  actual=$(snap install $SNAP_NAME --devmode)
-  echo "$actual" | grep -Pzq "$expected" || exit 1
+  snap install $SNAP_NAME --devmode | grep -Pzq "$expected"
 
   echo "Install devmode snap without devmode option"
   expected="snap not found"

--- a/tests/main/interfaces-cli/task.yaml
+++ b/tests/main/interfaces-cli/task.yaml
@@ -18,17 +18,13 @@ execute: |
   :$PLUG +$SNAP_NAME"
 
   echo "When the interfaces list is restricted by slot"
-  actual=$(snap interfaces -i $PLUG)
-
   echo "Then only the requested slots are shown"
-  echo "$actual" | grep -Pzq "$expected"
+  snap interfaces -i $PLUG | grep -Pzq "$expected"
 
   echo "==============================================="
 
   echo "When the interfaces list is restricted by slot and snap"
-  actual=$(snap interfaces -i $PLUG $SNAP_NAME)
-
   echo "Then only the requested slots are shown"
-  echo "$actual" | grep -Pzq "$expected"
+  snap interfaces -i $PLUG $SNAP_NAME | grep -Pzq "$expected"
 
   echo "==============================================="

--- a/tests/main/interfaces-home/task.yaml
+++ b/tests/main/interfaces-home/task.yaml
@@ -41,33 +41,32 @@ execute: |
   - +home-consumer:home"
 
   echo "Then the snap is listed as connected"
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "============================================"
 
   echo "When the plug is disconnected"
   snap disconnect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "Then the plug can be connected again"
   snap connect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "============================================"
 
   echo "When the plug is connected"
   snap connect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "Then the snap is able to read home files"
-  response=$(home-consumer.reader $READABLE_FILE)
-  echo "$response" | grep -Pqz ok
+  home-consumer.reader $READABLE_FILE | grep -Pqz ok
 
   echo "============================================"
 
   echo "When the plug is disconnected"
   snap disconnect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "Then snap can't read home files"
   if home-consumer.reader $READABLE_FILE; then
@@ -78,7 +77,7 @@ execute: |
 
   echo "When the plug is connected"
   snap connect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "Then the snap is able to append to home files"
   home-consumer.writer "$WRITABLE_FILE"
@@ -88,7 +87,7 @@ execute: |
 
   echo "When the plug is disconnected"
   snap disconnect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "Then snap can't append to home files"
   if home-consumer.writer "$WRITABLE_FILE"; then
@@ -99,7 +98,7 @@ execute: |
 
   echo "When the plug is connected"
   snap connect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "Then the snap is able to create home files"
   home-consumer.writer "$CREATABLE_FILE"
@@ -109,7 +108,7 @@ execute: |
 
   echo "When the plug is disconnected"
   snap disconnect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "Then snap can't create home files"
   if home-consumer.writer "$CREATABLE_FILE"; then
@@ -120,7 +119,7 @@ execute: |
 
   echo "When the plug is connected"
   snap connect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "Then the snap is not able to read hidden home files"
   if home-consumer.reader "$HIDDEN_READABLE_FILE"; then
@@ -131,7 +130,7 @@ execute: |
 
   echo "When the plug is connected"
   snap connect home-consumer:home ubuntu-core:home
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "Then the snap is not able to write hidden home files"
   if home-consumer.writer "$HIDDEN_CREATABLE_FILE"; then

--- a/tests/main/interfaces-log-observe/task.yaml
+++ b/tests/main/interfaces-log-observe/task.yaml
@@ -31,36 +31,36 @@ execute: |
   - +$SNAP_NAME:$PLUG"
 
   echo "Then the snap is not listed as connected"
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "============================================"
 
   echo "When the plug is connected"
   snap connect $SNAP_NAME:$PLUG ubuntu-core:$PLUG
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "Then the plug can be disconnected again"
   snap disconnect $SNAP_NAME:$PLUG ubuntu-core:$PLUG
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "============================================"
 
   echo "When the plug is connected"
   snap connect $SNAP_NAME:$PLUG ubuntu-core:$PLUG
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "Then the snap is able to access the system logs"
-  response=$(log-observe-consumer)
-  echo "$response" | grep -Pqz "ok\n"
+  log-observe-consumer | grep -Pqz "ok\n"
 
   echo "============================================"
 
   echo "When the plug is disconnected"
   snap disconnect $SNAP_NAME:$PLUG ubuntu-core:$PLUG
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "Then snap can't access the system logs"
   if log-observe-consumer; then
-    echo "System log shouldn't be accessible" && exit 1
+    echo "System log shouldn't be accessible"
+    exit 1
   fi
   echo "============================================"

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -41,33 +41,32 @@ execute: |
   - +$SNAP_NAME:network-bind"
 
   echo "Then the snap is listed as connected"
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "============================================"
 
   echo "When the plug is disconnected"
   snap disconnect $SNAP_NAME:network-bind ubuntu-core:network-bind
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "Then the plug can be connected again"
   snap connect $SNAP_NAME:network-bind ubuntu-core:network-bind
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "============================================"
 
   echo "When the plug is connected"
   snap connect $SNAP_NAME:network-bind ubuntu-core:network-bind
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "Then the service is accessible by a client"
-  response=$(nc -w 2 localhost "$PORT" < $REQUEST_FILE)
-  echo "$response" | grep -Pqz "ok\n"
+  nc -w 2 localhost "$PORT" < $REQUEST_FILE | grep -Pqz "ok\n"
 
   echo "============================================"
 
   echo "When the plug is disconnected"
   snap disconnect $SNAP_NAME:network-bind ubuntu-core:network-bind
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "Then the service is not accessible by a client"
   response=$(nc -w 2 localhost "$PORT" < $REQUEST_FILE)

--- a/tests/main/interfaces-network/task.yaml
+++ b/tests/main/interfaces-network/task.yaml
@@ -40,37 +40,37 @@ execute: |
   - +$SNAP_NAME:network"
 
   echo "Then the snap is listed as connected"
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "============================================"
 
   echo "When the plug is disconnected"
   snap disconnect $SNAP_NAME:network ubuntu-core:network
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "Then the plug can be connected again"
   snap connect $SNAP_NAME:network ubuntu-core:network
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "============================================"
 
   echo "When the plug is connected"
   snap connect $SNAP_NAME:network ubuntu-core:network
-  echo "$(snap interfaces)" | grep -Pzq "$CONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
   echo "Then the snap is able to access a network service"
-  response=$(network-consumer http://127.0.0.1:$PORT)
-  echo "$response" | grep -Pqz "ok\n"
+  network-consumer http://127.0.0.1:$PORT | grep -Pqz "ok\n"
 
   echo "============================================"
 
   echo "When the plug is disconnected"
   snap disconnect $SNAP_NAME:network ubuntu-core:network
-  echo "$(snap interfaces)" | grep -Pzq "$DISCONNECTED_PATTERN"
+  snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
   echo "Then snap can't access a network service"
   if network-consumer http://127.0.0.1:$PORT; then
-    echo "Network shouldn't be accessible" && exit 1
+    echo "Network shouldn't be accessible"
+    exit 1
   fi
 
   echo "============================================"

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -4,10 +4,8 @@ prepare: |
 execute: |
   echo "List prints core snap version"
   expected="^ubuntu-core +.*? +((\d{2}\.\d{2}\+\d{8}\.\d*\-\d*)|\w{12}) + \d+ +canonical +- *"
-  actual=$(snap list)
-  echo "$actual" | grep -Pq "$expected" || exit 1
+  snap list | grep -Pq "$expected" || exit 1
 
   echo "List prints installed snap version"
   expected="^hello-world +(\\d+)(\\.\\d+)* +[0-9]+ +\\S+ +- *"
-  actual=$(snap list)
-  echo "$actual" | grep -Pq "$expected" || exit 1
+  snap list | grep -Pq "$expected" || exit 1

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -43,7 +43,7 @@ execute: |
 
   echo "Then the new version is available for the snap to be refreshed"
   expected="$SNAP_NAME +\d+\.\d+\+fake1 +\d+ +canonical"
-  echo "$(snap refresh --list)" | grep -Pzq "$expected"
+  snap refresh --list | grep -Pzq "$expected"
 
   echo "================================="
 
@@ -52,6 +52,6 @@ execute: |
 
   echo "Then the new version is listed"
   expected="$SNAP_NAME +\d+\.\d+\+fake1 +\d+ +canonical"
-  echo "$(snap list)" | grep -Pzq "$expected"
+  snap list | grep -Pzq "$expected"
 
   echo "================================="

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -7,8 +7,7 @@ execute: |
   .*?\
   xkcd-webserver +.*? *\n\
   .*"
-  actual=$(snap find)
-  echo "$actual" | grep -Pzq "$expected" || exit 1
+  snap find | grep -Pzq "$expected"
 
   echo "Exact matches"
   for snapName in hello-world xkcd-webserver
@@ -17,8 +16,7 @@ execute: |
   .*?\n\
   $snapName +.*? *\n\
   .*"
-    actual=$(snap find $snapName)
-    echo "$actual" | grep -Pzq "$expected" || exit 1
+    snap find $snapName | grep -Pzq "$expected"
   done
 
   echo "Partial terms work too"
@@ -26,5 +24,4 @@ execute: |
   .*?\n\
   hello-world +.*? *\n\
   .*"
-  actual=$(snap find hello-)
-  echo "$actual" | grep -Pzq "$expected" || exit 1
+  snap find hello- | grep -Pzq "$expected"


### PR DESCRIPTION
* Replaced the patterns:
```
actual="$(some_command)"
echo "$actual" | grep ...
```
and
```
echo "$(some_command)" | grep ...
```
with
```
some_command | grep ...
```

* Removed unneeded `|| exit 1` at the end of comparisons
* Replaced the pattern:
```
some_command || EXPECTED_FAILED=some_failure
[ "$EXPECTED_FAILED" = "some_failure" ] || exit 1
```
with
```
if some_command; then
  echo "some error"
  exit 1
fi
```