### PR TITLE
interfaces: miscelleneous policy updates for default, log-observe and system-observe

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -226,6 +226,7 @@ var defaultTemplate = []byte(`
   @{PROC}/sys/fs/file-max r,
   @{PROC}/sys/kernel/pid_max r,
   @{PROC}/sys/kernel/random/uuid r,
+  /{,usr/}lib/ r,
 
   # Reads of oom_adj and oom_score_adj are safe
   owner @{PROC}/@{pid}/oom_{,score_}adj r,

--- a/interfaces/builtin/log_observe.go
+++ b/interfaces/builtin/log_observe.go
@@ -30,6 +30,8 @@ const logObserveConnectedPlugAppArmor = `
 
 /var/log/ r,
 /var/log/** r,
+/run/log/journal/ r,
+/run/log/journal/** r,
 
 # Allow sysctl -w kernel.printk_ratelimit=#
 /{,usr/}sbin/sysctl ixr,

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -47,6 +47,7 @@ ptrace (read),
 deny ptrace (trace),
 
 # Other miscellaneous accesses for observing the system
+@{PROC}/stat r,
 @{PROC}/vmstat r,
 
 # These are not process-specific (/proc/*/... and /proc/*/task/*/...)


### PR DESCRIPTION
* interfaces: allow reading /lib/ and /usr/lib/ in default policy
* interfaces: allow read of /run/log/journal/** in log-observe
* interfaces: allow read of @{PROC}/stat in system-observe