### PR TITLE
tests, integration-tests: port the op remove test to spread

### DIFF
--- a/integration-tests/tests/snap_op_test.go
+++ b/integration-tests/tests/snap_op_test.go
@@ -45,44 +45,6 @@ type snapOpSuite struct {
 	common.SnappySuite
 }
 
-func (s *snapOpSuite) testInstallRemove(c *check.C, snapName, displayName string) {
-	installOutput := common.InstallSnap(c, snapName)
-	expected := "(?ms)" +
-		"Name +Version +Rev +Developer +Notes\n" +
-		".*" +
-		displayName + " +.*\n" +
-		".*"
-	c.Assert(installOutput, check.Matches, expected)
-
-	removeOutput := common.RemoveSnap(c, snapName)
-	c.Assert(removeOutput, check.Not(testutil.Contains), snapName)
-}
-
-func (s *snapOpSuite) TestInstallRemoveAliasWorks(c *check.C) {
-	s.testInstallRemove(c, "hello-world", "hello-world")
-}
-
-func (s *snapOpSuite) TestRemoveRemovesAllRevisions(c *check.C) {
-	snapPath, err := build.LocalSnap(c, data.BasicSnapName)
-	defer os.Remove(snapPath)
-	c.Assert(err, check.IsNil, check.Commentf("Error building local snap: %s", err))
-
-	// install two revisions
-	common.InstallSnap(c, snapPath)
-	installOutput := common.InstallSnap(c, snapPath)
-	c.Assert(installOutput, testutil.Contains, data.BasicSnapName)
-	// double check, sideloaded snaps have revnos like xNN
-	revnos, _ := filepath.Glob(filepath.Join(dirs.SnapSnapsDir, data.BasicSnapName, "x*"))
-	c.Check(len(revnos) >= 2, check.Equals, true)
-
-	removeOutput := common.RemoveSnap(c, data.BasicSnapName)
-	c.Assert(removeOutput, check.Not(testutil.Contains), data.BasicSnapName)
-	// gone from disk
-	revnos, err = filepath.Glob(filepath.Join(dirs.SnapSnapsDir, data.BasicSnapName, "1*"))
-	c.Assert(err, check.IsNil)
-	c.Check(revnos, check.HasLen, 0)
-}
-
 // TestRemoveBusyRetries is a regression test for LP:#1571721
 func (s *snapOpSuite) TestRemoveBusyRetries(c *check.C) {
 	// install the binaries snap

--- a/tests/main/op-remove/task.yaml
+++ b/tests/main/op-remove/task.yaml
@@ -1,12 +1,21 @@
 summary: Check snap remove operations.
 
+restore: |
+  rm -f basic_1.0_all.snap
+
 execute: |
   echo "Given two revisions of a snap have been installed"
+  snapbuild $TESTSLIB/snaps/basic .
+  snap install basic_1.0_all.snap
+  snap install basic_1.0_all.snap
 
   echo "Then the two revisions are available on disk"
+  [ $(find /snap/basic/ -maxdepth 1 -type d -name "x*" | wc -l) -eq 2 ]
 
   echo "When the snap is removed"
+  snap remove basic
 
   echo "Then the two revisions are removed from disk"
+  [ $(find /snap/basic/ -maxdepth 1 -type d -name "x*" | wc -l) -eq 0 ]
 
   echo "================================================"

--- a/tests/main/op-remove/task.yaml
+++ b/tests/main/op-remove/task.yaml
@@ -1,0 +1,12 @@
+summary: Check snap remove operations.
+
+execute: |
+  echo "Given two revisions of a snap have been installed"
+
+  echo "Then the two revisions are available on disk"
+
+  echo "When the snap is removed"
+
+  echo "Then the two revisions are removed from disk"
+
+  echo "================================================"

--- a/tests/main/op-remove/task.yaml
+++ b/tests/main/op-remove/task.yaml
@@ -17,5 +17,3 @@ execute: |
 
   echo "Then the two revisions are removed from disk"
   [ $(find /snap/basic/ -maxdepth 1 -type d -name "x*" | wc -l) -eq 0 ]
-
-  echo "================================================"

--- a/tests/main/op-remove/task.yaml
+++ b/tests/main/op-remove/task.yaml
@@ -4,16 +4,21 @@ restore: |
   rm -f basic_1.0_all.snap
 
 execute: |
+  snap_revisions(){
+    local snap_name=$1
+    echo -n $(find /snap/"$snap_name"/ -maxdepth 1 -type d -name "x*" | wc -l)
+  }
+
   echo "Given two revisions of a snap have been installed"
   snapbuild $TESTSLIB/snaps/basic .
   snap install basic_1.0_all.snap
   snap install basic_1.0_all.snap
 
   echo "Then the two revisions are available on disk"
-  [ $(find /snap/basic/ -maxdepth 1 -type d -name "x*" | wc -l) -eq 2 ]
+  [ $(snap_revisions basic) = "2" ]
 
   echo "When the snap is removed"
   snap remove basic
 
   echo "Then the two revisions are removed from disk"
-  [ $(find /snap/basic/ -maxdepth 1 -type d -name "x*" | wc -l) -eq 0 ]
+  [ $(snap_revisions basic) = "0" ]


### PR DESCRIPTION
Also removed `TestInstallRemoveAliasWorks`, already covered