### PR TITLE
overlord/snapstate,daemon: clarify active vs current, add SnapState.HasCurrent,CurrentInfo

### DIFF
--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -65,12 +65,10 @@ func localSnapInfo(st *state.State, name string) (*snap.Info, *snapstate.SnapSta
 		return nil, nil, fmt.Errorf("cannot consult state: %v", err)
 	}
 
-	cur := snapst.CurrentSideInfo()
-	if cur == nil {
+	info, err := snapst.CurrentInfo(name)
+	if err == snapstate.ErrNoCurrent {
 		return nil, nil, errNoSnap
 	}
-
-	info, err := snap.ReadInfo(name, cur)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot read snap details: %v", err)
 	}
@@ -97,7 +95,7 @@ func allLocalSnapInfos(st *state.State) ([]aboutSnap, error) {
 
 	var firstErr error
 	for name, snapState := range snapStates {
-		info, err := snap.ReadInfo(name, snapState.CurrentSideInfo())
+		info, err := snapState.CurrentInfo(name)
 		if err != nil {
 			// FIXME: this is just a tiny step forward to not
 			//        totally break if a snap can no longer
@@ -132,7 +130,7 @@ type appJSON struct {
 
 func mapLocal(localSnap *snap.Info, snapst *snapstate.SnapState) map[string]interface{} {
 	status := "installed"
-	if snapst.Active {
+	if snapst.Active && localSnap.Revision == snapst.Current {
 		status = "active"
 	}
 

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -124,6 +124,7 @@ type: gadget
 version: 1
 `, si)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
+		SnapType: "gadget",
 		Active:   true,
 		Sequence: []*snap.SideInfo{si},
 		Current:  si.Revision,
@@ -164,6 +165,7 @@ type: gadget
 version: 1
 `, si)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
+		SnapType: "gadget",
 		Active:   true,
 		Sequence: []*snap.SideInfo{si},
 		Current:  si.Revision,

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -105,13 +105,16 @@ type SnapStateFlags Flags
 
 // SnapState holds the state for a snap installed in the system.
 type SnapState struct {
-	SnapType  string           `json:"type"` // Use Type and SetType
-	Sequence  []*snap.SideInfo `json:"sequence"`
-	Active    bool             `json:"active,omitempty"`
-	Current   snap.Revision    `json:"current"` // Indicates the current active revision if Active is true or the last active revision if Active is false
-	Candidate *snap.SideInfo   `json:"candidate,omitempty"`
-	Channel   string           `json:"channel,omitempty"`
-	Flags     SnapStateFlags   `json:"flags,omitempty"`
+	SnapType string           `json:"type"` // Use Type and SetType
+	Sequence []*snap.SideInfo `json:"sequence"`
+	Active   bool             `json:"active,omitempty"`
+	// Current indicates the current active revision if Active is
+	// true or the last active revision if Active is false
+	// (usually while a snap is being operated on or disabled)
+	Current   snap.Revision  `json:"current"`
+	Candidate *snap.SideInfo `json:"candidate,omitempty"`
+	Channel   string         `json:"channel,omitempty"`
+	Flags     SnapStateFlags `json:"flags,omitempty"`
 	// incremented revision used for local installs
 	LocalRevision snap.Revision `json:"local-revision,omitempty"`
 }
@@ -141,6 +144,8 @@ func (snapst *SnapState) HasCurrent() bool {
 	}
 	return true
 }
+
+// TODO: unexport CurrentSideInfo?
 
 // CurrentSideInfo returns the side info for the revision indicated by snapst.Current in the snap revision sequence if there is one.
 func (snapst *SnapState) CurrentSideInfo() *snap.SideInfo {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -145,7 +145,7 @@ func (snapst *SnapState) HasCurrent() bool {
 	return true
 }
 
-// TODO: unexport CurrentSideInfo?
+// TODO: unexport CurrentSideInfo and HasCurrent?
 
 // CurrentSideInfo returns the side info for the revision indicated by snapst.Current in the snap revision sequence if there is one.
 func (snapst *SnapState) CurrentSideInfo() *snap.SideInfo {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -21,6 +21,7 @@
 package snapstate
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -106,9 +107,9 @@ type SnapStateFlags Flags
 type SnapState struct {
 	SnapType  string           `json:"type"` // Use Type and SetType
 	Sequence  []*snap.SideInfo `json:"sequence"`
-	Current   snap.Revision    `json:"current"`
-	Candidate *snap.SideInfo   `json:"candidate,omitempty"`
 	Active    bool             `json:"active,omitempty"`
+	Current   snap.Revision    `json:"current"` // Indicates the current active revision if Active is true or the last active revision if Active is false
+	Candidate *snap.SideInfo   `json:"candidate,omitempty"`
 	Channel   string           `json:"channel,omitempty"`
 	Flags     SnapStateFlags   `json:"flags,omitempty"`
 	// incremented revision used for local installs
@@ -129,13 +130,21 @@ func (snapst *SnapState) SetType(typ snap.Type) {
 	snapst.SnapType = string(typ)
 }
 
-// CurrentSideInfo returns the side info for the current revision in the snap revision sequence if there is one.
-func (snapst *SnapState) CurrentSideInfo() *snap.SideInfo {
+// HasCurrent returns whether snapst.Current is set.
+func (snapst *SnapState) HasCurrent() bool {
 	if snapst.Current.Unset() {
 		if len(snapst.Sequence) > 0 {
 			panic(fmt.Sprintf("snapst.Current and snapst.Sequence out of sync: %#v %#v", snapst.Current, snapst.Sequence))
 		}
 
+		return false
+	}
+	return true
+}
+
+// CurrentSideInfo returns the side info for the revision indicated by snapst.Current in the snap revision sequence if there is one.
+func (snapst *SnapState) CurrentSideInfo() *snap.SideInfo {
+	if !snapst.HasCurrent() {
 		return nil
 	}
 	seq := snapst.Sequence
@@ -145,6 +154,17 @@ func (snapst *SnapState) CurrentSideInfo() *snap.SideInfo {
 		}
 	}
 	panic("cannot find snapst.Current in the snapst.Sequence")
+}
+
+var ErrNoCurrent = errors.New("snap has no current revision")
+
+// CurrentInfo returns the information about the current active revision or the last active revision (if the snap is inactive). It returns the ErrNoCurrent error if snapst.Current is unset.
+func (snapst *SnapState) CurrentInfo(name string) (*snap.Info, error) {
+	cur := snapst.CurrentSideInfo()
+	if cur == nil {
+		return nil, ErrNoCurrent
+	}
+	return readInfo(name, cur)
 }
 
 // DevMode returns true if the snap is installed in developer mode.
@@ -529,14 +549,9 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	var curInfo *snap.Info
-	if cur := snapst.CurrentSideInfo(); cur != nil {
-		var err error
-		curInfo, err = readInfo(ss.Name, cur)
-		if err != nil {
-			return err
-		}
-
+	curInfo, err := snapst.CurrentInfo(ss.Name)
+	if err != nil && err != ErrNoCurrent {
+		return err
 	}
 
 	m.backend.CurrentInfo(curInfo)
@@ -562,7 +577,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	oldInfo, err := readInfo(ss.Name, snapst.CurrentSideInfo())
+	oldInfo, err := snapst.CurrentInfo(ss.Name)
 	if err != nil {
 		return err
 	}
@@ -592,7 +607,7 @@ func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	oldInfo, err := readInfo(ss.Name, snapst.CurrentSideInfo())
+	oldInfo, err := snapst.CurrentInfo(ss.Name)
 	if err != nil {
 		return err
 	}
@@ -625,14 +640,9 @@ func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	var oldInfo *snap.Info
-	if cur := snapst.CurrentSideInfo(); cur != nil {
-		var err error
-		oldInfo, err = readInfo(ss.Name, cur)
-		if err != nil {
-			return err
-		}
-
+	oldInfo, err := snapst.CurrentInfo(ss.Name)
+	if err != nil && err != ErrNoCurrent {
+		return err
 	}
 
 	pb := &TaskProgressAdapter{task: t}
@@ -652,14 +662,9 @@ func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	var oldInfo *snap.Info
-	if cur := snapst.CurrentSideInfo(); cur != nil {
-		var err error
-		oldInfo, err = readInfo(ss.Name, cur)
-		if err != nil {
-			return err
-		}
-
+	oldInfo, err := snapst.CurrentInfo(ss.Name)
+	if err != nil && err != ErrNoCurrent {
+		return err
 	}
 
 	pb := &TaskProgressAdapter{task: t}

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -1263,6 +1263,11 @@ description: |
 		Sequence: []*snap.SideInfo{sideInfo11, sideInfo12},
 		Current:  sideInfo12.Revision,
 	})
+
+	// have also a snap being installed
+	snapstate.Set(st, "installing", &snapstate.SnapState{
+		Candidate: &snap.SideInfo{OfficialName: "installing", Revision: snap.R(1)},
+	})
 }
 
 func (s *snapmgrQuerySuite) TearDownTest(c *C) {
@@ -1284,7 +1289,33 @@ func (s *snapmgrQuerySuite) TestInfo(c *C) {
 	c.Check(info.Description(), Equals, "Lots of text")
 }
 
-func (s *snapmgrQuerySuite) TestCurrent(c *C) {
+func (s *snapmgrQuerySuite) TestSnapStateCurrentInfo(c *C) {
+	st := s.st
+	st.Lock()
+	defer st.Unlock()
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(st, "name1", &snapst)
+	c.Assert(err, IsNil)
+
+	info, err := snapst.CurrentInfo("name1")
+	c.Assert(err, IsNil)
+
+	c.Check(info.Name(), Equals, "name1")
+	c.Check(info.Revision, Equals, snap.R(12))
+	c.Check(info.Summary(), Equals, "s12")
+	c.Check(info.Version, Equals, "1.2")
+	c.Check(info.Description(), Equals, "Lots of text")
+}
+
+func (s *snapmgrQuerySuite) TestSnapStateCurrentInfoErrNoCurrent(c *C) {
+	snapst := new(snapstate.SnapState)
+	_, err := snapst.CurrentInfo("notthere")
+	c.Assert(err, Equals, snapstate.ErrNoCurrent)
+
+}
+
+func (s *snapmgrQuerySuite) TestCurrentInfo(c *C) {
 	st := s.st
 	st.Lock()
 	defer st.Unlock()
@@ -1294,6 +1325,15 @@ func (s *snapmgrQuerySuite) TestCurrent(c *C) {
 
 	c.Check(info.Name(), Equals, "name1")
 	c.Check(info.Revision, Equals, snap.R(12))
+}
+
+func (s *snapmgrQuerySuite) TestCurrentInfoAbsent(c *C) {
+	st := s.st
+	st.Lock()
+	defer st.Unlock()
+
+	_, err := snapstate.CurrentInfo(st, "absent")
+	c.Assert(err, ErrorMatches, `cannot find snap "absent"`)
 }
 
 func (s *snapmgrQuerySuite) TestActiveInfos(c *C) {

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -1259,6 +1259,7 @@ version: 1.2
 description: |
     Lots of text`, sideInfo12)
 	snapstate.Set(st, "name1", &snapstate.SnapState{
+		SnapType: "app",
 		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfo11, sideInfo12},
 		Current:  sideInfo12.Revision,
@@ -1368,6 +1369,7 @@ type: gadget
 version: gadget
 `, sideInfoGadget)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
+		SnapType: "gadget",
 		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfoGadget},
 		Current:  sideInfoGadget.Revision,

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -441,25 +441,24 @@ func ActiveInfos(s *state.State) ([]*snap.Info, error) {
 	return infos, nil
 }
 
-// GadgetInfo finds the current gadget snap's info
+// GadgetInfo finds the current gadget snap's info.
 func GadgetInfo(s *state.State) (*snap.Info, error) {
-	// XXX this would be so much prettier if state had the type
 	var stateMap map[string]*SnapState
 	if err := s.Get("snaps", &stateMap); err != nil && err != state.ErrNoState {
 		return nil, err
 	}
 	for snapName, snapState := range stateMap {
-		snapInfo, err := snapState.CurrentInfo(snapName)
-		if err == ErrNoCurrent {
+		if !snapState.HasCurrent() {
 			continue
 		}
+		typ, err := snapState.Type()
 		if err != nil {
-			logger.Noticef("cannot retrieve info for snap %q: %s", snapName, err)
+			return nil, err
+		}
+		if typ != snap.TypeGadget {
 			continue
 		}
-		if snapInfo.Type == snap.TypeGadget {
-			return snapInfo, nil
-		}
+		return snapState.CurrentInfo(snapName)
 	}
 
 	return nil, state.ErrNoState


### PR DESCRIPTION
This clarifies the concepts of active vs current (current active, or last active revision while a snap is being operated on usually).

It introduces SnapState.HasCurrent and SnapState.CurrentInfo(name), drops most usages of SnapState.CurrentSideInfo, improves coverage a bit and also switches GadgetInfo to use the snap type we keep now in state.