### PR TITLE
daemon,overlord/auth,store: update macaroon authentication to use the new endpoints

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -206,7 +206,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot decode login data from request body: %v", err)
 	}
 
-	macaroon, err := store.RequestPackageAccessMacaroon()
+	macaroon, err := store.RequestStoreMacaroon()
 	if err != nil {
 		return InternalError(err.Error())
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -206,12 +206,18 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot decode login data from request body: %v", err)
 	}
 
-	macaroon, err := store.RequestStoreMacaroon()
+	serializedMacaroon, err := store.RequestStoreMacaroon()
 	if err != nil {
 		return InternalError(err.Error())
 	}
+	macaroon, err := auth.MacaroonDeserialize(serializedMacaroon)
 
-	discharge, err := store.DischargeAuthCaveat(loginData.Username, loginData.Password, macaroon, loginData.Otp)
+	// get SSO 3rd party caveat, and request discharge
+	loginCaveat, err := auth.LoginCaveatID(macaroon)
+	if err != nil {
+		return InternalError(err.Error())
+	}
+	discharge, err := store.DischargeAuthCaveat(loginData.Username, loginData.Password, loginCaveat, loginData.Otp)
 	switch err {
 	case store.ErrAuthenticationNeeds2fa:
 		return SyncResponse(&resp{
@@ -240,14 +246,14 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	overlord := c.d.overlord
 	state := overlord.State()
 	state.Lock()
-	_, err = auth.NewUser(state, loginData.Username, macaroon, []string{discharge})
+	_, err = auth.NewUser(state, loginData.Username, serializedMacaroon, []string{discharge})
 	state.Unlock()
 	if err != nil {
 		return InternalError("cannot persist authentication details: %v", err)
 	}
 
 	result := loginResponseData{
-		Macaroon:   macaroon,
+		Macaroon:   serializedMacaroon,
 		Discharges: []string{discharge},
 	}
 	return SyncResponse(result, nil)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -217,7 +217,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	discharge, err := store.DischargeAuthCaveat(loginData.Username, loginData.Password, loginCaveat, loginData.Otp)
+	discharge, err := store.DischargeAuthCaveat(loginCaveat, loginData.Username, loginData.Password, loginData.Otp)
 	switch err {
 	case store.ErrAuthenticationNeeds2fa:
 		return SyncResponse(&resp{

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -562,7 +562,7 @@ func (s *apiSuite) TestLoginUserMyAppsError(c *check.C) {
 
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, http.StatusInternalServerError)
-	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "cannot get access permission")
+	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "cannot get snap access permission")
 }
 
 func (s *apiSuite) TestLoginUserTwoFactorRequiredError(c *check.C) {
@@ -631,7 +631,7 @@ func (s *apiSuite) TestLoginUserInvalidCredentialsError(c *check.C) {
 
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, http.StatusUnauthorized)
-	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "cannot get discharge macaroon")
+	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "cannot authenticate on snap store")
 }
 
 func (s *apiSuite) TestUserFromRequestNoHeader(c *check.C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -429,7 +429,7 @@ func (s *apiSuite) makeMyAppsServer(statusCode int, data string) *httptest.Serve
 		w.WriteHeader(statusCode)
 		io.WriteString(w, data)
 	}))
-	store.MyAppsPackageAccessAPI = mockMyAppsServer.URL + "/acl/package_access/"
+	store.MyAppsMacaroonACLAPI = mockMyAppsServer.URL + "/acl/"
 	return mockMyAppsServer
 }
 
@@ -529,7 +529,7 @@ func (s *apiSuite) TestLoginUserMyAppsError(c *check.C) {
 
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, http.StatusInternalServerError)
-	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "cannot get package access macaroon")
+	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "cannot get access permission")
 }
 
 func (s *apiSuite) TestLoginUserTwoFactorRequiredError(c *check.C) {

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -213,18 +213,22 @@ func (ma *MacaroonAuthenticator) Authenticate(r *http.Request) {
 	// deserialize root macaroon (we need its signature to do the discharge binding)
 	root, err := MacaroonDeserialize(ma.Macaroon)
 	if err != nil {
-		logger.Noticef("cannot deserialize root macaroon: %v", err)
+		logger.Debugf("cannot deserialize root macaroon: %v", err)
 		return
 	}
 
 	for _, d := range ma.Discharges {
 		// prepare discharge for request
 		discharge, err := MacaroonDeserialize(d)
+		if err != nil {
+			logger.Debugf("cannot deserialize discharge macaroon: %v", err)
+			return
+		}
 		discharge.Bind(root.Signature())
 
 		serializedDischarge, err := MacaroonSerialize(discharge)
 		if err != nil {
-			logger.Noticef("cannot re-serialize discharge macaroon: %v", err)
+			logger.Debugf("cannot re-serialize discharge macaroon: %v", err)
 			return
 		}
 		fmt.Fprintf(&buf, `, discharge="%s"`, serializedDischarge)

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -268,7 +268,7 @@ func (as *authSuite) TestMacaroonSerialize(c *C) {
 	c.Check(deserialized, DeepEquals, m)
 }
 
-func (as *authSuite) TestMacaroonDeserializeStoreMacaroon(c *C) {
+func (as *authSuite) TestMacaroonSerializeDeserializeStoreMacaroon(c *C) {
 	// sample serialized macaroon using store server setup.
 	serialized := `MDAxNmxvY2F0aW9uIGxvY2F0aW9uCjAwMTdpZGVudGlmaWVyIHNvbWUgaWQKMDAwZmNpZCBjYXZlYXQKMDAxOWNpZCAzcmQgcGFydHkgY2F2ZWF0CjAwNTF2aWQgcyvpXSVlMnj9wYw5b-WPCLjTnO_8lVzBrRr8tJfu9tOhPORbsEOFyBwPOM_YiiXJ_qh-Pp8HY0HsUueCUY4dxONLIxPWTdMzCjAwMTJjbCByZW1vdGUuY29tCjAwMmZzaWduYXR1cmUgcm_Gdz75wUCWF9KGXZQEANhwfvBcLNt9xXGfAmxurPMK`
 
@@ -282,6 +282,11 @@ func (as *authSuite) TestMacaroonDeserializeStoreMacaroon(c *C) {
 	err = expected.UnmarshalJSON(jsonData)
 	c.Check(err, IsNil)
 	c.Check(deserialized, DeepEquals, &expected)
+
+	// reserializing the macaroon should give us the same original store serialization
+	reserialized, err := auth.MacaroonSerialize(deserialized)
+	c.Check(err, IsNil)
+	c.Check(reserialized, Equals, serialized)
 }
 
 func (as *authSuite) TestMacaroonDeserializeInvalidData(c *C) {

--- a/spread.yaml
+++ b/spread.yaml
@@ -29,7 +29,7 @@ prepare: |
     apt purge -y snapd || true
     apt update
     # utilities
-    apt install -y devscripts jq  software-properties-common
+    apt install -y devscripts expect jq software-properties-common
 
     # needed so that we have golang-gopkg-macaroon.v1 which is not (yet)
     # in trusty

--- a/store/auth.go
+++ b/store/auth.go
@@ -101,13 +101,13 @@ func RequestStoreMacaroon() (string, error) {
 }
 
 // DischargeAuthCaveat returns a macaroon with the store auth caveat discharged.
-func DischargeAuthCaveat(username, password, macaroon, otp string) (string, error) {
+func DischargeAuthCaveat(username, password, caveat, otp string) (string, error) {
 	const errorPrefix = "cannot get discharge macaroon from store: "
 
 	data := map[string]string{
-		"email":    username,
-		"password": password,
-		"macaroon": macaroon,
+		"email":     username,
+		"password":  password,
+		"caveat_id": caveat,
 	}
 	if otp != "" {
 		data["otp"] = otp

--- a/store/auth.go
+++ b/store/auth.go
@@ -28,9 +28,9 @@ import (
 
 var (
 	myappsAPIBase = myappsURL()
-	// MyAppsPackageAccessAPI points to MyApps endpoint to get a package access macaroon
-	MyAppsPackageAccessAPI = myappsAPIBase + "api/2.0/acl/package_access/"
-	ubuntuoneAPIBase       = authURL()
+	// MyAppsMacaroonACLAPI points to MyApps endpoint to get a ACL macaroon
+	MyAppsMacaroonACLAPI = myappsAPIBase + "dev/api/acl/"
+	ubuntuoneAPIBase     = authURL()
 	// UbuntuoneLocation is the Ubuntuone location as defined in the store macaroon
 	UbuntuoneLocation = authLocation()
 	// UbuntuoneDischargeAPI points to SSO endpoint to discharge a macaroon
@@ -57,12 +57,16 @@ func httpStatusCodeClientError(httpStatusCode int) bool {
 	return httpStatusCode/100 == 4
 }
 
-// RequestPackageAccessMacaroon requests a macaroon for accessing package data from the ubuntu store.
-func RequestPackageAccessMacaroon() (string, error) {
-	const errorPrefix = "cannot get package access macaroon from store: "
+// RequestStoreMacaroon requests a macaroon for accessing package data from the ubuntu store.
+func RequestStoreMacaroon() (string, error) {
+	const errorPrefix = "cannot get access permission from store: "
 
-	emptyJSONData := "{}"
-	req, err := http.NewRequest("POST", MyAppsPackageAccessAPI, strings.NewReader(emptyJSONData))
+	data := map[string]interface{}{
+		"permissions": []string{"package_access", "package_purchase"},
+	}
+	macaroonJSONData, err := json.Marshal(data)
+
+	req, err := http.NewRequest("POST", MyAppsMacaroonACLAPI, strings.NewReader(string(macaroonJSONData)))
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}

--- a/store/auth.go
+++ b/store/auth.go
@@ -59,7 +59,7 @@ func httpStatusCodeClientError(httpStatusCode int) bool {
 
 // RequestStoreMacaroon requests a macaroon for accessing package data from the ubuntu store.
 func RequestStoreMacaroon() (string, error) {
-	const errorPrefix = "cannot get access permission from store: "
+	const errorPrefix = "cannot get snap access permission from store: "
 
 	data := map[string]interface{}{
 		"permissions": []string{"package_access", "package_purchase"},
@@ -71,8 +71,8 @@ func RequestStoreMacaroon() (string, error) {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("accept", "application/json")
-	req.Header.Set("content-type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -101,8 +101,8 @@ func RequestStoreMacaroon() (string, error) {
 }
 
 // DischargeAuthCaveat returns a macaroon with the store auth caveat discharged.
-func DischargeAuthCaveat(username, password, caveat, otp string) (string, error) {
-	const errorPrefix = "cannot get discharge macaroon from store: "
+func DischargeAuthCaveat(caveat, username, password, otp string) (string, error) {
+	const errorPrefix = "cannot authenticate on snap store: "
 
 	data := map[string]string{
 		"email":     username,
@@ -122,8 +122,8 @@ func DischargeAuthCaveat(username, password, caveat, otp string) (string, error)
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
 	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("accept", "application/json")
-	req.Header.Set("content-type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -115,7 +115,7 @@ func (s *authTestSuite) TestDischargeAuthCaveat(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("guy@example.com", "passwd", "root-macaroon", "")
+	discharge, err := DischargeAuthCaveat("guy@example.com", "passwd", "third-party-caveat", "")
 	c.Assert(err, IsNil)
 	c.Assert(discharge, Equals, "the-discharge-macaroon-serialized-data")
 }
@@ -128,7 +128,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatNeeds2fa(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
 	c.Assert(err, Equals, ErrAuthenticationNeeds2fa)
 	c.Assert(discharge, Equals, "")
 }
@@ -141,7 +141,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatFails2fa(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
 	c.Assert(err, Equals, Err2faFailed)
 	c.Assert(discharge, Equals, "")
 }
@@ -154,7 +154,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatInvalidLogin(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
 	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: Provided email/password is not correct.")
 	c.Assert(discharge, Equals, "")
 }
@@ -166,7 +166,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatMissingData(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
 	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: empty macaroon returned")
 	c.Assert(discharge, Equals, "")
 }
@@ -178,7 +178,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatError(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "root-macaroon", "")
+	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
 	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: server returned status 500")
 	c.Assert(discharge, Equals, "")
 }

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -72,39 +72,39 @@ const mockStoreReturnDischarge = `
 
 const mockStoreReturnNoMacaroon = `{}`
 
-func (s *authTestSuite) TestRequestPackageAccessMacaroon(c *C) {
+func (s *authTestSuite) TestRequestStoreMacaroon(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, mockStoreReturnMacaroon)
 	}))
 	defer mockServer.Close()
-	MyAppsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
+	MyAppsMacaroonACLAPI = mockServer.URL + "/acl/"
 
-	macaroon, err := RequestPackageAccessMacaroon()
+	macaroon, err := RequestStoreMacaroon()
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
 
-func (s *authTestSuite) TestRequestPackageAccessMacaroonMissingData(c *C) {
+func (s *authTestSuite) TestRequestStoreMacaroonMissingData(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, mockStoreReturnNoMacaroon)
 	}))
 	defer mockServer.Close()
-	MyAppsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
+	MyAppsMacaroonACLAPI = mockServer.URL + "/acl/"
 
-	macaroon, err := RequestPackageAccessMacaroon()
-	c.Assert(err, ErrorMatches, "cannot get package access macaroon from store: empty macaroon returned")
+	macaroon, err := RequestStoreMacaroon()
+	c.Assert(err, ErrorMatches, "cannot get access permission from store: empty macaroon returned")
 	c.Assert(macaroon, Equals, "")
 }
 
-func (s *authTestSuite) TestRequestPackageAccessMacaroonError(c *C) {
+func (s *authTestSuite) TestRequestStoreMacaroonError(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
 	defer mockServer.Close()
-	MyAppsPackageAccessAPI = mockServer.URL + "/acl/package_access/"
+	MyAppsMacaroonACLAPI = mockServer.URL + "/acl/"
 
-	macaroon, err := RequestPackageAccessMacaroon()
-	c.Assert(err, ErrorMatches, "cannot get package access macaroon from store: store server returned status 500")
+	macaroon, err := RequestStoreMacaroon()
+	c.Assert(err, ErrorMatches, "cannot get access permission from store: store server returned status 500")
 	c.Assert(macaroon, Equals, "")
 }
 

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -92,7 +92,7 @@ func (s *authTestSuite) TestRequestStoreMacaroonMissingData(c *C) {
 	MyAppsMacaroonACLAPI = mockServer.URL + "/acl/"
 
 	macaroon, err := RequestStoreMacaroon()
-	c.Assert(err, ErrorMatches, "cannot get access permission from store: empty macaroon returned")
+	c.Assert(err, ErrorMatches, "cannot get snap access permission from store: empty macaroon returned")
 	c.Assert(macaroon, Equals, "")
 }
 
@@ -104,7 +104,7 @@ func (s *authTestSuite) TestRequestStoreMacaroonError(c *C) {
 	MyAppsMacaroonACLAPI = mockServer.URL + "/acl/"
 
 	macaroon, err := RequestStoreMacaroon()
-	c.Assert(err, ErrorMatches, "cannot get access permission from store: store server returned status 500")
+	c.Assert(err, ErrorMatches, "cannot get snap access permission from store: store server returned status 500")
 	c.Assert(macaroon, Equals, "")
 }
 
@@ -115,7 +115,7 @@ func (s *authTestSuite) TestDischargeAuthCaveat(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("guy@example.com", "passwd", "third-party-caveat", "")
+	discharge, err := DischargeAuthCaveat("third-party-caveat", "guy@example.com", "passwd", "")
 	c.Assert(err, IsNil)
 	c.Assert(discharge, Equals, "the-discharge-macaroon-serialized-data")
 }
@@ -128,7 +128,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatNeeds2fa(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
+	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
 	c.Assert(err, Equals, ErrAuthenticationNeeds2fa)
 	c.Assert(discharge, Equals, "")
 }
@@ -141,7 +141,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatFails2fa(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
+	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
 	c.Assert(err, Equals, Err2faFailed)
 	c.Assert(discharge, Equals, "")
 }
@@ -154,8 +154,8 @@ func (s *authTestSuite) TestDischargeAuthCaveatInvalidLogin(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
-	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: Provided email/password is not correct.")
+	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
+	c.Assert(err, ErrorMatches, "cannot authenticate on snap store: Provided email/password is not correct.")
 	c.Assert(discharge, Equals, "")
 }
 
@@ -166,8 +166,8 @@ func (s *authTestSuite) TestDischargeAuthCaveatMissingData(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
-	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: empty macaroon returned")
+	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
+	c.Assert(err, ErrorMatches, "cannot authenticate on snap store: empty macaroon returned")
 	c.Assert(discharge, Equals, "")
 }
 
@@ -178,7 +178,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatError(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("foo@example.com", "passwd", "third-party-caveat", "")
-	c.Assert(err, ErrorMatches, "cannot get discharge macaroon from store: server returned status 500")
+	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
+	c.Assert(err, ErrorMatches, "cannot authenticate on snap store: server returned status 500")
 	c.Assert(discharge, Equals, "")
 }

--- a/tests/main/login/missing_email_error.exp
+++ b/tests/main/login/missing_email_error.exp
@@ -1,0 +1,9 @@
+spawn snap login
+
+expect {
+    "required argument `email` was not provided" {
+        exit 0
+    } default {
+        exit 1
+    }
+}

--- a/tests/main/login/successful_login.exp
+++ b/tests/main/login/successful_login.exp
@@ -1,0 +1,12 @@
+spawn snap login $env(SPREAD_STORE_USER)
+
+expect "Password: "
+send "$env(SPREAD_STORE_PASSWORD)\n"
+
+expect {
+    "Login successful" {
+        exit 0
+    } default {
+        exit 1
+    }
+}

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -1,13 +1,17 @@
 summary: Checks for snap login
+
+restore: |
+    snap logout || true
+
 execute: |
-  echo "Checking missing email error"
-  expect -f missing_email_error.exp
+    echo "Checking missing email error"
+    expect -f missing_email_error.exp
 
-  echo "Checking wrong password error"
-  expect -f unsuccessful_login.exp
+    echo "Checking wrong password error"
+    expect -f unsuccessful_login.exp
 
-  if [[ $SPREAD_STORE_USER && $SPREAD_STORE_PASSWORD ]]; then
-    echo "Checking successful login"
-    expect -f successful_login.exp
-    snap logout
-  fi
+    if [[ $SPREAD_STORE_USER && $SPREAD_STORE_PASSWORD ]]; then
+        echo "Checking successful login"
+        expect -f successful_login.exp
+        snap logout
+    fi

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -1,0 +1,13 @@
+summary: Checks for snap login
+execute: |
+  echo "Checking missing email error"
+  expect -f missing_email_error.exp
+
+  echo "Checking wrong password error"
+  expect -f unsuccessful_login.exp
+
+  if [[ $SPREAD_STORE_USER && $SPREAD_STORE_PASSWORD ]]; then
+    echo "Checking successful login"
+    expect -f successful_login.exp
+    snap logout
+  fi

--- a/tests/main/login/unsuccessful_login.exp
+++ b/tests/main/login/unsuccessful_login.exp
@@ -1,0 +1,12 @@
+spawn snap login someemail@testing.com
+
+expect "Password: "
+send "wrong-password\n"
+
+expect {
+    "not correct" {
+        exit 0
+    } default {
+        exit 1
+    }
+}


### PR DESCRIPTION
Request store macaroon and its discharge from the updated flow endpoints. Users with previously existing macaroons from the old flow will need to re-login.