### PR TITLE
Ensure that Qt apps can export appmenu

### DIFF
--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -249,21 +249,21 @@ dbus (send)
 # dbusmenu
 dbus (send)
     bus=session
-    path=/MenuBar
+    path=/MenuBar{,/[0-9]*}
     interface=com.canonical.dbusmenu
     member="{LayoutUpdated,ItemsPropertiesUpdated}"
     peer=(name=org.freedesktop.DBus, label=unconfined),
 
 dbus (receive)
     bus=session
-    path=/MenuBar
+    path=/MenuBar{,/[0-9]*}
     interface="{com.canonical.dbusmenu,org.freedesktop.DBus.Properties}"
     member=Get*
     peer=(label=unconfined),
 
 dbus (receive)
     bus=session
-    path=/MenuBar
+    path=/MenuBar{,/[0-9]*}
     interface=com.canonical.dbusmenu
     member="{AboutTo*,Event*}"
     peer=(label=unconfined),


### PR DESCRIPTION
Test case:
clone https://github.com/ubuntu/snapcraft-desktop-helpers
cd demos/qt5 and snapcraft it.
Install without devmode, and see that the menubar isn't exported without
that apparmor profile patch.
-> appmenu-qt is exporting menus to /MenuBar/1 instead of /MenuBar