### PR TITLE
change API of snapstate.Get() to return a snapstate.SnapState

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -581,9 +581,7 @@ func ensureUbuntuCore(st *state.State, targetSnap string, userID int) (*state.Ta
 		return nil, errNothingToInstall
 	}
 
-	var ss snapstate.SnapState
-
-	err := snapstateGet(st, ubuntuCore, &ss)
+	_, err := snapstateGet(st, ubuntuCore)
 	if err != state.ErrNoState {
 		return nil, err
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -193,8 +193,7 @@ version: %s
 		st.Lock()
 		defer st.Unlock()
 
-		var snapst snapstate.SnapState
-		snapstate.Get(st, name, &snapst)
+		snapst, _ := snapstate.Get(st, name)
 		snapst.Active = active
 		snapst.Sequence = append(snapst.Sequence, &snapInfo.SideInfo)
 		snapst.Current = snapInfo.SideInfo.Revision
@@ -1322,12 +1321,13 @@ func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]str
 		return &snap.Info{SuggestedName: "local"}, nil
 	}
 
-	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
+	snapstateGet = func(s *state.State, name string) (snapstate.SnapState, error) {
+		var snapst snapstate.SnapState
 		if hasUbuntuCore {
-			return nil
+			return snapst, nil
 		}
 		// pretend we do not have a state for ubuntu-core
-		return state.ErrNoState
+		return snapst, state.ErrNoState
 	}
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
 		// NOTE: ubuntu-core is not installed in developer mode
@@ -1488,9 +1488,9 @@ func (s *apiSuite) testInstall(c *check.C, releaseInfo *release.OS, flags snapst
 	restore := release.MockReleaseInfo(releaseInfo)
 	defer restore()
 
-	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
+	snapstateGet = func(s *state.State, name string) (snapstate.SnapState, error) {
 		// we have ubuntu-core
-		return nil
+		return snapstate.SnapState{}, nil
 	}
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
 		calledFlags = flags
@@ -1539,9 +1539,9 @@ func (s *apiSuite) TestRefresh(c *check.C) {
 	calledUserID := 0
 	installQueue := []string{}
 
-	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
+	snapstateGet = func(s *state.State, name string) (snapstate.SnapState, error) {
 		// we have ubuntu-core
-		return nil
+		return snapstate.SnapState{}, nil
 	}
 	snapstateUpdate = func(s *state.State, name, channel string, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
 		calledFlags = flags
@@ -1575,9 +1575,9 @@ func (s *apiSuite) TestRefresh(c *check.C) {
 func (s *apiSuite) TestInstallMissingUbuntuCore(c *check.C) {
 	installQueue := []*state.Task{}
 
-	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
+	snapstateGet = func(s *state.State, name string) (snapstate.SnapState, error) {
 		// pretend we do not have a state for ubuntu-core
-		return state.ErrNoState
+		return snapstate.SnapState{}, state.ErrNoState
 	}
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
 		t1 := s.NewTask("fake-install-snap", name)
@@ -1624,9 +1624,9 @@ func (s *apiSuite) TestInstallMissingUbuntuCore(c *check.C) {
 func (s *apiSuite) TestInstallUbuntuCoreWhenMissing(c *check.C) {
 	installQueue := []*state.Task{}
 
-	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
+	snapstateGet = func(s *state.State, name string) (snapstate.SnapState, error) {
 		// pretend we do not have a state for ubuntu-core
-		return state.ErrNoState
+		return snapstate.SnapState{}, state.ErrNoState
 	}
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
 		t1 := s.NewTask("fake-install-snap", name)
@@ -1655,9 +1655,9 @@ func (s *apiSuite) TestInstallUbuntuCoreWhenMissing(c *check.C) {
 }
 
 func (s *apiSuite) TestInstallFails(c *check.C) {
-	snapstateGet = func(s *state.State, name string, snapst *snapstate.SnapState) error {
+	snapstateGet = func(s *state.State, name string) (snapstate.SnapState, error) {
 		// we have ubuntu-core
-		return nil
+		return snapstate.SnapState{}, nil
 	}
 
 	snapstateInstall = func(s *state.State, name, channel string, userID int, flags snapstate.Flags) (*state.TaskSet, error) {

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -59,8 +59,7 @@ func localSnapInfo(st *state.State, name string) (*snap.Info, *snapstate.SnapSta
 	st.Lock()
 	defer st.Unlock()
 
-	var snapst snapstate.SnapState
-	err := snapstate.Get(st, name, &snapst)
+	snapst, err := snapstate.Get(st, name)
 	if err != nil && err != state.ErrNoState {
 		return nil, nil, fmt.Errorf("cannot consult state: %v", err)
 	}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -46,8 +46,8 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	}
 	snap.AddImplicitSlots(snapInfo)
 	snapName := snapInfo.Name()
-	var snapState snapstate.SnapState
-	if err := snapstate.Get(task.State(), snapName, &snapState); err != nil {
+	snapState, err := snapstate.Get(task.State(), snapName)
+	if err != nil {
 		task.Errorf("cannot get state of snap %q: %s", snapName, err)
 		return err
 	}
@@ -124,8 +124,7 @@ func (m *InterfaceManager) doRemoveProfiles(task *state.Task, _ *tomb.Tomb) erro
 	snapName := snapSetup.Name
 
 	// Get SnapState for this snap
-	var snapState snapstate.SnapState
-	err = snapstate.Get(st, snapName, &snapState)
+	snapState, err := snapstate.Get(st, snapName)
 	if err != nil && err != state.ErrNoState {
 		return err
 	}
@@ -193,8 +192,7 @@ func (m *InterfaceManager) doDiscardConns(task *state.Task, _ *tomb.Tomb) error 
 
 	snapName := snapSetup.Name
 
-	var snapState snapstate.SnapState
-	err = snapstate.Get(st, snapName, &snapState)
+	snapState, err := snapstate.Get(st, snapName)
 	if err != nil && err != state.ErrNoState {
 		return err
 	}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -108,7 +108,8 @@ func setupSnapSecurity(task *state.Task, snapInfo *snap.Info, repo *interfaces.R
 	st := task.State()
 	var snapState snapstate.SnapState
 	snapName := snapInfo.Name()
-	if err := snapstate.Get(st, snapName, &snapState); err != nil {
+	snapState, err := snapstate.Get(st, snapName)
+	if err != nil {
 		task.Errorf("cannot get state of snap %q: %s", snapName, err)
 		return err
 	}

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -221,8 +221,7 @@ func (s *interfaceManagerSuite) mockUpdatedSnap(c *C, yamlText string, revision 
 	defer s.state.Unlock()
 
 	// Put the new revision (stored in SideInfo) into the state
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, snapInfo.Name(), &snapst)
+	snapst, err := snapstate.Get(s.state, snapInfo.Name())
 	c.Assert(err, IsNil)
 	snapst.Sequence = append(snapst.Sequence, sideInfo)
 	snapstate.Set(s.state, snapInfo.Name(), &snapst)
@@ -536,8 +535,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].DevMode, Equals, true)
 
 	// SnapState stored the value of DevMode
-	var snapState snapstate.SnapState
-	err := snapstate.Get(s.state, snapInfo.Name(), &snapState)
+	snapState, err := snapstate.Get(s.state, snapInfo.Name())
 	c.Assert(err, IsNil)
 	c.Check(snapState.DevMode(), Equals, true)
 
@@ -649,8 +647,7 @@ func (s *interfaceManagerSuite) undoDevModeCheck(c *C, flags snapstate.Flags, de
 	c.Check(change.Status(), Equals, state.UndoneStatus)
 
 	// SnapState.Flags now holds the original value of DevMode
-	var snapState snapstate.SnapState
-	err := snapstate.Get(s.state, snapInfo.Name(), &snapState)
+	snapState, err := snapstate.Get(s.state, snapInfo.Name())
 	c.Assert(err, IsNil)
 	c.Check(snapState.DevMode(), Equals, devMode)
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -422,11 +422,7 @@ func (ms *mgrsSuite) installLocalTestSnap(c *C, snapYamlContent string) *snap.In
 	info, err := snap.ReadInfoFromSnapFile(snapf, nil)
 	c.Assert(err, IsNil)
 
-	// store current state
 	snapName := info.Name()
-	var snapst snapstate.SnapState
-	snapstate.Get(st, snapName, &snapst)
-
 	ts, err := snapstate.InstallPath(st, snapName, snapPath, "", snapstate.DevMode)
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")

--- a/overlord/patch/patch1_test.go
+++ b/overlord/patch/patch1_test.go
@@ -119,8 +119,7 @@ func (s *patch1Suite) TestPatch1(c *C) {
 	}
 
 	for _, exp := range expected {
-		var snapst snapstate.SnapState
-		err := snapstate.Get(st, exp.name, &snapst)
+		snapst, err := snapstate.Get(st, exp.name)
 		c.Assert(err, IsNil)
 		c.Check(snap.Type(snapst.SnapType), Equals, exp.typ)
 		c.Check(snapst.Current, Equals, exp.cur)

--- a/overlord/snapstate/discard_snap_test.go
+++ b/overlord/snapstate/discard_snap_test.go
@@ -79,8 +79,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapSuccess(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 
 	c.Check(snapst.Sequence, HasLen, 1)
@@ -110,8 +109,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapToEmpty(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	_, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, Equals, state.ErrNoState)
 }
 
@@ -170,8 +168,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapNoErrorsForActive(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 
 	c.Check(snapst.Sequence, HasLen, 1)

--- a/overlord/snapstate/download_snap_test.go
+++ b/overlord/snapstate/download_snap_test.go
@@ -100,8 +100,7 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatbility(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(snapst.Candidate, DeepEquals, &snap.SideInfo{
 		OfficialName: "foo",
@@ -149,8 +148,7 @@ func (s *downloadSnapSuite) TestDoDownloadSnapNormal(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	// candidate comes from your SnapSetup.Candidate
 	c.Check(snapst.Candidate, DeepEquals, si)
@@ -192,8 +190,7 @@ func (s *downloadSnapSuite) TestDoUndoDownloadSnap(c *C) {
 	c.Check(t.Status(), Equals, state.UndoneStatus)
 
 	// and nothing is in the state for "foo"
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	_, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, Equals, state.ErrNoState)
 
 }

--- a/overlord/snapstate/link_snap_test.go
+++ b/overlord/snapstate/link_snap_test.go
@@ -98,8 +98,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccess(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 
 	typ, err := snapst.Type()
@@ -145,8 +144,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnap(c *C) {
 	}
 
 	s.state.Lock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, false)
 	c.Check(snapst.Sequence, HasLen, 0)
@@ -182,8 +180,7 @@ func (s *linkSnapSuite) TestDoLinkSnapTryToCleanupOnError(c *C) {
 	s.state.Lock()
 
 	// state as expected
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, false)
 	c.Check(snapst.Sequence, HasLen, 0)
@@ -233,8 +230,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessCoreRestarts(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "core", &snapst)
+	snapst, err := snapstate.Get(s.state, "core")
 	c.Assert(err, IsNil)
 
 	typ, err := snapst.Type()
@@ -283,8 +279,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapSequenceDidNotHaveCandidate(c *C) {
 	}
 
 	s.state.Lock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, false)
 	c.Check(snapst.Sequence, HasLen, 1)
@@ -329,8 +324,7 @@ func (s *linkSnapSuite) TestDoUndoLinkSnapSequenceHadCandidate(c *C) {
 	}
 
 	s.state.Lock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, false)
 	c.Check(snapst.Sequence, HasLen, 2)

--- a/overlord/snapstate/prepare_snap_test.go
+++ b/overlord/snapstate/prepare_snap_test.go
@@ -71,8 +71,7 @@ func (s *prepareSnapSuite) TestDoPrepareSnapSimple(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(snapst.Candidate, DeepEquals, &snap.SideInfo{
 		Revision: snap.R(-1),
@@ -111,8 +110,7 @@ func (s *prepareSnapSuite) TestDoPrepareSnapSetsCandidate(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(snapst.Candidate, DeepEquals, si1)
 	c.Check(t.Status(), Equals, state.DoneStatus)
@@ -157,8 +155,7 @@ func (s *prepareSnapSuite) TestDoUndoPrepareSnap(c *C) {
 
 	s.state.Lock()
 
-	var snapst snapstate.SnapState
-	err := snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(snapst.Active, Equals, true)
 	c.Check(snapst.Candidate, IsNil)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -628,11 +628,11 @@ func snapSetupAndState(t *state.Task) (*SnapSetup, *SnapState, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	var snapst SnapState
-	err = Get(t.State(), ss.Name, &snapst)
+	snapst, err := Get(t.State(), ss.Name)
 	if err != nil && err != state.ErrNoState {
 		return nil, nil, err
 	}
+
 	return ss, &snapst, nil
 }
 

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -545,8 +545,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	})
 
 	// verify snaps in the system state
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	snapst, err := snapstate.Get(s.state, "some-snap")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -674,8 +673,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
 	// verify snaps in the system state
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	snapst, err := snapstate.Get(s.state, "some-snap")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -804,8 +802,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
 	// verify snaps in the system state
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	snapst, err := snapstate.Get(s.state, "some-snap")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -887,8 +884,7 @@ version: 1.0`)
 	})
 
 	// verify snaps in the system state
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "mock", &snapst)
+	snapst, err := snapstate.Get(s.state, "mock")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -964,8 +960,7 @@ version: 1.0`)
 	})
 
 	// verify snaps in the system state
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "mock", &snapst)
+	snapst, err := snapstate.Get(s.state, "mock")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -1015,8 +1010,7 @@ version: 1.0`)
 	c.Check(ops[1].name, Matches, `.*/mock_1.0_all.snap`)
 	c.Check(ops[1].revno, Equals, snap.R("x1"))
 
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "mock", &snapst)
+	snapst, err := snapstate.Get(s.state, "mock")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -1106,8 +1100,7 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 	}
 
 	// verify snaps in the system state
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	_, err = snapstate.Get(s.state, "some-snap")
 	c.Assert(err, Equals, state.ErrNoState)
 }
 
@@ -1220,8 +1213,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 	}
 
 	// verify snaps in the system state
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	_, err = snapstate.Get(s.state, "some-snap")
 	c.Assert(err, Equals, state.ErrNoState)
 }
 
@@ -1393,8 +1385,7 @@ func (s *snapmgrTestSuite) TestRevertRunThrough(c *C) {
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
 	// verify that the R(2) version is active now and R(7) is still there
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	snapst, err := snapstate.Get(s.state, "some-snap")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -1470,8 +1461,7 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNewVersion(c *C) {
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
 	// verify that the R(7) version is active now
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	snapst, err := snapstate.Get(s.state, "some-snap")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -1557,8 +1547,7 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 	c.Check(s.fakeBackend.ops, DeepEquals, expected)
 
 	// verify snaps in the system state
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	snapst, err := snapstate.Get(s.state, "some-snap")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -1639,8 +1628,7 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
 	// verify snaps in the system state
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "some-snap", &snapst)
+	snapst, err := snapstate.Get(s.state, "some-snap")
 	c.Assert(err, IsNil)
 
 	c.Assert(snapst.Active, Equals, true)
@@ -1714,8 +1702,7 @@ func (s *snapmgrQuerySuite) TestSnapStateCurrentInfo(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	var snapst snapstate.SnapState
-	err := snapstate.Get(st, "name1", &snapst)
+	snapst, err := snapstate.Get(st, "name1")
 	c.Assert(err, IsNil)
 
 	info, err := snapst.CurrentInfo("name1")
@@ -1808,8 +1795,7 @@ func (s *snapmgrQuerySuite) TestPreviousSideInfo(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	var snapst snapstate.SnapState
-	err := snapstate.Get(st, "name1", &snapst)
+	snapst, err := snapstate.Get(st, "name1")
 	c.Assert(err, IsNil)
 	c.Assert(snapst.CurrentSideInfo(), NotNil)
 	c.Assert(snapst.CurrentSideInfo().Revision, Equals, snap.R(12))
@@ -1907,8 +1893,7 @@ func (s *snapmgrTestSuite) TestTrySetsTryMode(c *C) {
 	s.state.Lock()
 
 	// verify snap is in TryMode
-	var snapst snapstate.SnapState
-	err = snapstate.Get(s.state, "foo", &snapst)
+	snapst, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
 	c.Check(snapst.TryMode(), Equals, true)
 }
@@ -1945,9 +1930,9 @@ func (s *snapmgrTestSuite) TestTryUndoRemovesTryFlag(c *C) {
 	s.state.Lock()
 
 	// verify snap is not in try mode, the state got undone
-	err = snapstate.Get(s.state, "foo", &snapst)
+	snapst2, err := snapstate.Get(s.state, "foo")
 	c.Assert(err, IsNil)
-	c.Check(snapst.TryMode(), Equals, false)
+	c.Check(snapst2.TryMode(), Equals, false)
 }
 
 type snapStateSuite struct{}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -142,8 +142,7 @@ func checkChangeConflict(s *state.State, snapName string) error {
 // InstallPath returns a set of tasks for installing snap from a file path.
 // Note that the state must be locked by the caller.
 func InstallPath(s *state.State, name, path, channel string, flags Flags) (*state.TaskSet, error) {
-	var snapst SnapState
-	err := Get(s, name, &snapst)
+	snapst, err := Get(s, name)
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
@@ -169,8 +168,7 @@ func TryPath(s *state.State, name, path string, flags Flags) (*state.TaskSet, er
 // Install returns a set of tasks for installing snap.
 // Note that the state must be locked by the caller.
 func Install(s *state.State, name, channel string, userID int, flags Flags) (*state.TaskSet, error) {
-	var snapst SnapState
-	err := Get(s, name, &snapst)
+	snapst, err := Get(s, name)
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
@@ -198,8 +196,7 @@ func Install(s *state.State, name, channel string, userID int, flags Flags) (*st
 // Update initiates a change updating a snap.
 // Note that the state must be locked by the caller.
 func Update(s *state.State, name, channel string, userID int, flags Flags) (*state.TaskSet, error) {
-	var snapst SnapState
-	err := Get(s, name, &snapst)
+	snapst, err := Get(s, name)
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
@@ -272,8 +269,7 @@ func Remove(s *state.State, name string) (*state.TaskSet, error) {
 		return nil, err
 	}
 
-	var snapst SnapState
-	err := Get(s, name, &snapst)
+	snapst, err := Get(s, name)
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
@@ -342,8 +338,7 @@ func Remove(s *state.State, name string) (*state.TaskSet, error) {
 // Revert returns a set of tasks for reverting to the pervious version of the snap.
 // Note that the state must be locked by the caller.
 func Revert(s *state.State, name string) (*state.TaskSet, error) {
-	var snapst SnapState
-	err := Get(s, name, &snapst)
+	snapst, err := Get(s, name)
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
@@ -356,8 +351,7 @@ func Revert(s *state.State, name string) (*state.TaskSet, error) {
 }
 
 func revertToRevision(s *state.State, name string, rev snap.Revision) (*state.TaskSet, error) {
-	var snapst SnapState
-	err := Get(s, name, &snapst)
+	snapst, err := Get(s, name)
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
@@ -389,8 +383,7 @@ var readInfo = snap.ReadInfo
 // Info returns the information about the snap with given name and revision.
 // Works also for a mounted candidate snap in the process of being installed.
 func Info(s *state.State, name string, revision snap.Revision) (*snap.Info, error) {
-	var snapst SnapState
-	err := Get(s, name, &snapst)
+	snapst, err := Get(s, name)
 	if err == state.ErrNoState {
 		return nil, fmt.Errorf("cannot find snap %q", name)
 	}
@@ -413,8 +406,7 @@ func Info(s *state.State, name string, revision snap.Revision) (*snap.Info, erro
 
 // CurrentInfo returns the information about the current revision of a snap with the given name.
 func CurrentInfo(s *state.State, name string) (*snap.Info, error) {
-	var snapst SnapState
-	err := Get(s, name, &snapst)
+	snapst, err := Get(s, name)
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
@@ -426,21 +418,22 @@ func CurrentInfo(s *state.State, name string) (*snap.Info, error) {
 }
 
 // Get retrieves the SnapState of the given snap.
-func Get(s *state.State, name string, snapst *SnapState) error {
+func Get(s *state.State, name string) (SnapState, error) {
 	var snaps map[string]*json.RawMessage
+	var snapst SnapState
 	err := s.Get("snaps", &snaps)
 	if err != nil {
-		return err
+		return snapst, err
 	}
 	raw, ok := snaps[name]
 	if !ok {
-		return state.ErrNoState
+		return snapst, state.ErrNoState
 	}
 	err = json.Unmarshal([]byte(*raw), &snapst)
 	if err != nil {
-		return fmt.Errorf("cannot unmarshal snap state: %v", err)
+		return snapst, fmt.Errorf("cannot unmarshal snap state: %v", err)
 	}
-	return nil
+	return snapst, nil
 }
 
 // All retrieves return a map from name to SnapState for all current snaps in the system state.


### PR DESCRIPTION
We briefly talked about this last week that it might be nicer to have snapstate.Get() have the signature `func snapstate.Get(st, name string) (SnapState, error)` instead of the current `func snapstate.Get(st, name string, snapst *SnapState) error`. Feel free to close if this is not actually what we want.