### PR TITLE
overlord: make patch1_test more robust

### DIFF
--- a/overlord/patch/export_test.go
+++ b/overlord/patch/export_test.go
@@ -16,8 +16,3 @@ func MockReadInfo(f func(name string, si *snap.SideInfo) (*snap.Info, error)) (r
 	readInfo = f
 	return func() { readInfo = old }
 }
-
-var (
-	ApplyOne = applyOne
-	Patch1   = patch1
-)

--- a/overlord/patch/export_test.go
+++ b/overlord/patch/export_test.go
@@ -16,3 +16,8 @@ func MockReadInfo(f func(name string, si *snap.SideInfo) (*snap.Info, error)) (r
 	readInfo = f
 	return func() { readInfo = old }
 }
+
+var (
+	ApplyOne = applyOne
+	Patch1   = patch1
+)

--- a/overlord/patch/export_test.go
+++ b/overlord/patch/export_test.go
@@ -16,3 +16,10 @@ func MockReadInfo(f func(name string, si *snap.SideInfo) (*snap.Info, error)) (r
 	readInfo = f
 	return func() { readInfo = old }
 }
+
+// MockLevel replaces the current implemented patch level
+func MockLevel(lv int) (restorer func()) {
+	old := Level
+	Level = lv
+	return func() { Level = old }
+}

--- a/overlord/patch/patch1_test.go
+++ b/overlord/patch/patch1_test.go
@@ -28,9 +28,9 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -99,11 +99,12 @@ func (s *patch1Suite) TestPatch1(c *C) {
 	restore := patch.MockReadInfo(s.readInfo)
 	defer restore()
 
-	ovld, err := overlord.New()
+	r, err := os.Open(dirs.SnapStateFile)
 	c.Assert(err, IsNil)
-	st := ovld.State()
+	st, err := state.ReadState(nil, r)
+	c.Assert(err, IsNil)
 
-	err = patch.Apply(st)
+	err = patch.ApplyOne(patch.Patch1, st, 1)
 	c.Assert(err, IsNil)
 
 	st.Lock()

--- a/overlord/patch/patch1_test.go
+++ b/overlord/patch/patch1_test.go
@@ -106,7 +106,9 @@ func (s *patch1Suite) TestPatch1(c *C) {
 	c.Assert(err, IsNil)
 
 	// go from patch-level 0 to patch-level 1
-	patch.Level = 1
+	restorer := patch.MockLevel(1)
+	defer restorer()
+
 	err = patch.Apply(st)
 	c.Assert(err, IsNil)
 
@@ -133,6 +135,7 @@ func (s *patch1Suite) TestPatch1(c *C) {
 	}
 
 	// ensure we only moved forward to patch-level 1
+	var patchLevel int
 	err = st.Get("patch-level", &patchLevel)
 	c.Assert(err, IsNil)
 	c.Assert(patchLevel, Equals, 1)

--- a/overlord/patch/patch1_test.go
+++ b/overlord/patch/patch1_test.go
@@ -102,6 +102,7 @@ func (s *patch1Suite) TestPatch1(c *C) {
 
 	r, err := os.Open(dirs.SnapStateFile)
 	c.Assert(err, IsNil)
+	defer r.Close()
 	st, err := state.ReadState(nil, r)
 	c.Assert(err, IsNil)
 

--- a/overlord/patch/patch1_test.go
+++ b/overlord/patch/patch1_test.go
@@ -41,6 +41,7 @@ var _ = Suite(&patch1Suite{})
 var statePatch1JSON = []byte(`
 {
 	"data": {
+                "patch-level": 0,
 		"snaps": {
 			"foo": {
 				"sequence": [{
@@ -104,7 +105,9 @@ func (s *patch1Suite) TestPatch1(c *C) {
 	st, err := state.ReadState(nil, r)
 	c.Assert(err, IsNil)
 
-	err = patch.ApplyOne(patch.Patch1, st, 1)
+	// go from patch-level 0 to patch-level 1
+	patch.Level = 1
+	err = patch.Apply(st)
 	c.Assert(err, IsNil)
 
 	st.Lock()
@@ -128,6 +131,11 @@ func (s *patch1Suite) TestPatch1(c *C) {
 		c.Check(snap.Type(snapst.SnapType), Equals, exp.typ)
 		c.Check(snapst.Current, Equals, exp.cur)
 	}
+
+	// ensure we only moved forward to patch-level 1
+	err = st.Get("patch-level", &patchLevel)
+	c.Assert(err, IsNil)
+	c.Assert(patchLevel, Equals, 1)
 }
 
 func (s *patch1Suite) readInfo(name string, si *snap.SideInfo) (*snap.Info, error) {


### PR DESCRIPTION
Make patch1 tests data more robust by using a json dump to ensure robustness of the test against future implementation changes of the state data.