### PR TITLE
snap: add `snap run --shell`

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -67,6 +67,8 @@ func run() error {
 func findCommand(app *snap.AppInfo, command string) (string, error) {
 	var cmd string
 	switch command {
+	case "debug-shell":
+		cmd = "/bin/sh"
 	case "stop":
 		cmd = app.StopCommand
 	case "post-stop":

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -67,7 +67,7 @@ func run() error {
 func findCommand(app *snap.AppInfo, command string) (string, error) {
 	var cmd string
 	switch command {
-	case "debug-shell":
+	case "shell":
 		cmd = "/bin/sh"
 	case "stop":
 		cmd = app.StopCommand

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -68,7 +68,7 @@ func findCommand(app *snap.AppInfo, command string) (string, error) {
 	var cmd string
 	switch command {
 	case "shell":
-		cmd = "/bin/sh"
+		cmd = "/bin/bash"
 	case "stop":
 		cmd = app.StopCommand
 	case "post-stop":

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -45,10 +45,10 @@ type cmdRun struct {
 		SnapApp string `positional-arg-name:"<app name>" description:"the snap (e.g. hello-world) or application to run (e.g. hello-world.env)"`
 	} `positional-args:"yes" required:"yes"`
 
-	Command    string `long:"command" description:"alternative command to run" hidden:"yes"`
-	Hook       string `long:"hook" description:"hook to run" hidden:"yes"`
-	Revision   string `short:"r" description:"use a specific snap revision when running hook" hidden:"yes"`
-	DebugShell bool   `long:"debug-shell" description:"run shell instead of command (useful for debugging)"`
+	Command  string `long:"command" description:"alternative command to run" hidden:"yes"`
+	Hook     string `long:"hook" description:"hook to run" hidden:"yes"`
+	Revision string `short:"r" description:"use a specific snap revision when running hook" hidden:"yes"`
+	Shell    bool   `long:"shell" description:"run a shell instead of the command (useful for debugging)"`
 }
 
 func init() {
@@ -77,9 +77,9 @@ func (x *cmdRun) Execute(args []string) error {
 		return snapRunHook(x.Positional.SnapApp, x.Hook, x.Revision)
 	}
 
-	// pass debug-shell as a special command to snap-exec
-	if x.DebugShell {
-		x.Command = "debug-shell"
+	// pass shell as a special command to snap-exec
+	if x.Shell {
+		x.Command = "shell"
 	}
 
 	return snapRunApp(x.Positional.SnapApp, x.Command, args)

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -45,9 +45,10 @@ type cmdRun struct {
 		SnapApp string `positional-arg-name:"<app name>" description:"the snap (e.g. hello-world) or application to run (e.g. hello-world.env)"`
 	} `positional-args:"yes" required:"yes"`
 
-	Command  string `long:"command" description:"alternative command to run" hidden:"yes"`
-	Hook     string `long:"hook" description:"hook to run" hidden:"yes"`
-	Revision string `short:"r" description:"use a specific snap revision when running hook" hidden:"yes"`
+	Command    string `long:"command" description:"alternative command to run" hidden:"yes"`
+	Hook       string `long:"hook" description:"hook to run" hidden:"yes"`
+	Revision   string `short:"r" description:"use a specific snap revision when running hook" hidden:"yes"`
+	DebugShell bool   `long:"debug-shell" description:"run shell instead of command (useful for debugging)"`
 }
 
 func init() {
@@ -74,6 +75,11 @@ func (x *cmdRun) Execute(args []string) error {
 	// Now actually handle the dispatching
 	if x.Hook != "" {
 		return snapRunHook(x.Positional.SnapApp, x.Hook, x.Revision)
+	}
+
+	// pass debug-shell as a special command to snap-exec
+	if x.DebugShell {
+		x.Command = "debug-shell"
 	}
 
 	return snapRunApp(x.Positional.SnapApp, x.Command, args)


### PR DESCRIPTION
Tiny branch that helps debugging applications by providing a way to drop into exactly the same environment in a shell as the application gets. For convenience I added a extra `snap run --debug-shell` but internally its just mapped to a snap command. 

Note that this can only be used once we have a new snap-exec in the ubuntu-core snap (because snap-exec is run from inside the confinement/inside the ubuntu-core mounts).