### PR TITLE
store: switch search to new snap-specific endpoint

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -184,27 +184,21 @@ apps:
 }
 
 const fooSearchHit = `{
-    "_embedded": {
-        "clickindex:package": [
-            {
-                "anon_download_url": "@URL@",
-                "architecture": [
-                    "all"
-                ],
-                "channel": "stable",
-                "content": "application",
-                "description": "this is a description",
-                "download_url": "@URL@",
-                "icon_url": "@ICON@",
-                "origin": "bar",
-                "package_name": "foo",
-                "revision": @REVISION@,
-                "snap_id": "idididididididididididididididid",
-                "summary": "Foo",
-                "version": "@VERSION@"
-            }
-        ]
-    }
+	"anon_download_url": "@URL@",
+	"architecture": [
+	    "all"
+	],
+	"channel": "stable",
+	"content": "application",
+	"description": "this is a description",
+	"download_url": "@URL@",
+	"icon_url": "@ICON@",
+	"origin": "bar",
+	"package_name": "foo",
+	"revision": @REVISION@,
+	"snap_id": "idididididididididididididididid",
+	"summary": "Foo",
+	"version": "@VERSION@"
 }`
 
 func (ms *mgrsSuite) TestHappyRemoteInstallAndUpgradeSvc(c *C) {
@@ -232,7 +226,7 @@ apps:
 	var baseURL string
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/search":
+		case "/details/foo":
 			w.WriteHeader(http.StatusOK)
 			output := strings.Replace(fooSearchHit, "@URL@", baseURL+"/snap", -1)
 			output = strings.Replace(output, "@ICON@", baseURL+"/icon", -1)
@@ -250,10 +244,10 @@ apps:
 
 	baseURL = mockServer.URL
 
-	searchURL, err := url.Parse(baseURL + "/search")
+	detailsURL, err := url.Parse(baseURL + "/details/")
 	c.Assert(err, IsNil)
 	storeCfg := store.SnapUbuntuStoreConfig{
-		SearchURI: searchURL,
+		DetailsURI: detailsURL,
 	}
 
 	mStore := store.NewUbuntuStoreSnapRepository(&storeCfg, "")

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -191,6 +191,7 @@ const fooSearchHit = `{
 	"channel": "stable",
 	"content": "application",
 	"description": "this is a description",
+        "developer_id": "devdevdev",
 	"download_url": "@URL@",
 	"icon_url": "@ICON@",
 	"origin": "bar",
@@ -274,6 +275,7 @@ apps:
 
 	c.Check(info.Revision, Equals, snap.R(42))
 	c.Check(info.SnapID, Equals, "idididididididididididididididid")
+	c.Check(info.DeveloperID, Equals, "devdevdev")
 	c.Check(info.Version, Equals, "1.0")
 	c.Check(info.Summary(), Equals, "Foo")
 	c.Check(info.Description(), Equals, "this is a description")
@@ -312,6 +314,7 @@ apps:
 
 	c.Check(info.Revision, Equals, snap.R(50))
 	c.Check(info.SnapID, Equals, "idididididididididididididididid")
+	c.Check(info.DeveloperID, Equals, "devdevdev")
 	c.Check(info.Version, Equals, "2.0")
 
 	// check udpated wrapper

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -334,6 +334,9 @@ func cachedStore(s *state.State) StoreService {
 	return ubuntuStore.(StoreService)
 }
 
+// the store implementation has the interface consumed here
+var _ StoreService = (*store.SnapUbuntuStoreRepository)(nil)
+
 // Store returns the store service used by the snapstate package.
 func Store(s *state.State) StoreService {
 	if cachedStore := cachedStore(s); cachedStore != nil {

--- a/snappy/install_test.go
+++ b/snappy/install_test.go
@@ -126,15 +126,15 @@ func (s *SnapTestSuite) TestInstallAppTwiceFails(c *C) {
 	var dlURL, iconURL string
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/search":
-			io.WriteString(w, `{"_embedded": {"clickindex:package": [{
+		case "/details/foo":
+			io.WriteString(w, `{
 "package_name": "foo",
 "version": "2",
 "developer": "test",
 "anon_download_url": "`+dlURL+`",
 "download_url": "`+dlURL+`",
 "icon_url": "`+iconURL+`"
-}]}}`)
+}`)
 		case "/dl":
 			snapR.Seek(0, 0)
 			io.Copy(w, snapR)
@@ -150,7 +150,7 @@ func (s *SnapTestSuite) TestInstallAppTwiceFails(c *C) {
 	dlURL = mockServer.URL + "/dl"
 	iconURL = mockServer.URL + "/icon"
 
-	s.storeCfg.SearchURI, err = url.Parse(mockServer.URL + "/search")
+	s.storeCfg.DetailsURI, err = url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
 
 	name, err := install("foo", "ch", LegacyInhibitHooks, &progress.NullProgress{})
@@ -178,19 +178,19 @@ func (s *SnapTestSuite) TestInstallAppPackageNameFails(c *C) {
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/search":
-			io.WriteString(w, `{"_embedded": {"clickindex:package": [{
+		case "/details/hello-snap":
+			io.WriteString(w, `{
 "developer": "potato",
 "package_name": "hello-snap",
 "version": "2",
 "anon_download_url": "blah"
-}]}}`)
+}`)
 		default:
 			panic("unexpected url path: " + r.URL.Path)
 		}
 	}))
 
-	s.storeCfg.SearchURI, err = url.Parse(mockServer.URL + "/search")
+	s.storeCfg.DetailsURI, err = url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
 
 	c.Assert(mockServer, NotNil)

--- a/store/errors.go
+++ b/store/errors.go
@@ -29,10 +29,6 @@ var (
 	// ErrSnapNotFound is returned when a snap can not be found
 	ErrSnapNotFound = errors.New("snap not found")
 
-	// ErrSnapNeedsDevMode is returned when a snap wants devmode
-	// confinement and it has not been requested nor overridden
-	ErrSnapNeedsDevMode = errors.New("snap wants devmode")
-
 	// ErrAssertionNotFound is returned when an assertion can not be found
 	ErrAssertionNotFound = errors.New("assertion not found")
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -29,6 +29,10 @@ var (
 	// ErrSnapNotFound is returned when a snap can not be found
 	ErrSnapNotFound = errors.New("snap not found")
 
+	// ErrSnapNeedsDevMode is returned when a snap wants devmode
+	// confinement and it has not been requested nor overridden
+	ErrSnapNeedsDevMode = errors.New("snap wants devmode")
+
 	// ErrAssertionNotFound is returned when an assertion can not be found
 	ErrAssertionNotFound = errors.New("assertion not found")
 

--- a/store/store.go
+++ b/store/store.go
@@ -333,8 +333,7 @@ func (s *SnapUbuntuStoreRepository) setUbuntuStoreHeaders(req *http.Request, cha
 	}
 }
 
-// read all the available metadata from the store response and cache
-func (s *SnapUbuntuStoreRepository) checkStoreResponse(resp *http.Response) {
+func (s *SnapUbuntuStoreRepository) extractSuggestedCurrency(resp *http.Response) {
 	suggestedCurrency := resp.Header.Get("X-Suggested-Currency")
 
 	if suggestedCurrency != "" {
@@ -547,8 +546,6 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string, devmode bool, aut
 		return nil, fmt.Errorf(tpl, resp.StatusCode, name, channel)
 	}
 
-	s.checkStoreResponse(resp)
-
 	// and decode json
 	var remote snapDetails
 	dec := json.NewDecoder(resp.Body)
@@ -566,8 +563,9 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string, devmode bool, aut
 		logger.Noticef("cannot get user purchases: %v", err)
 	}
 
-	return info, nil
+	s.extractSuggestedCurrency(resp)
 
+	return info, nil
 }
 
 // Find finds  (installable) snaps from the store, matching the
@@ -621,7 +619,7 @@ func (s *SnapUbuntuStoreRepository) Find(searchTerm string, channel string, auth
 		logger.Noticef("cannot get user purchases: %v", err)
 	}
 
-	s.checkStoreResponse(resp)
+	s.extractSuggestedCurrency(resp)
 
 	return snaps, nil
 }
@@ -734,7 +732,7 @@ func (s *SnapUbuntuStoreRepository) ListRefresh(installed []*RefreshCandidate, a
 		res = append(res, infoFromRemote(rsnap))
 	}
 
-	s.checkStoreResponse(resp)
+	s.extractSuggestedCurrency(resp)
 
 	return res, nil
 }

--- a/store/store.go
+++ b/store/store.go
@@ -521,6 +521,9 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string, devmode bool, aut
 	}
 
 	// if devmode then don't restrict by confinement as either is fine
+	// XXX: what we really want to do is have the store not specify
+	//      devmode, and have the business logic wrt what to do with
+	//      unwanted devmode further up
 	if !devmode {
 		query.Set("confinement", string(snap.StrictConfinement))
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -193,7 +193,7 @@ func init() {
 		panic(err)
 	}
 
-	defaultConfig.SearchURI, err = storeBaseURI.Parse("search")
+	defaultConfig.SearchURI, err = storeBaseURI.Parse("snaps/search")
 	if err != nil {
 		panic(err)
 	}
@@ -584,15 +584,14 @@ func (s *SnapUbuntuStoreRepository) Find(searchTerm string, channel string, auth
 	u := *s.searchURI // make a copy, so we can mutate it
 	q := u.Query()
 	q.Set("q", searchTerm)
+	q.Set("channel", channel)
+	q.Set("confinement", "strict")
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := s.newRequest("GET", u.String(), nil, auther)
 	if err != nil {
 		return nil, err
 	}
-
-	// set headers
-	s.setUbuntuStoreHeaders(req, channel, false, auther)
 
 	resp, err := s.client.Do(req)
 	if err != nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -199,44 +199,14 @@ const (
 )
 
 /* acquired via
-curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://search.apps.ubuntu.com/api/v1/search?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&q=package_name%3A%22hello-world%22' | python -m json.tool | xsel -b
+
+http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha512,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
+
+on 2016-07-03. Then, by hand:
+ * set prices to {"EUR": 0.99, "USD": 1.23}.
+
 */
 const MockDetailsJSON = `{
-    "_embedded": {
-        "clickindex:package": [
-            {
-                "_links": {
-                    "self": {
-                        "href": "https://search.apps.ubuntu.com/api/v1/package/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ"
-                    }
-                },
-                "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_25.snap",
-                "architecture": [
-                    "all"
-                ],
-                "binary_filesize": 20480,
-                "channel": "edge",
-                "content": "application",
-                "description": "This is a simple hello world example.",
-                "download_sha512": "4bf23ce93efa1f32f0aeae7ec92564b7b0f9f8253a0bd39b2741219c1be119bb676c21208c6845ccf995e6aabe791d3f28a733ebcbbc3171bb23f67981f4068e",
-                "download_url": "https://public.apps.ubuntu.com/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_25.snap",
-                "icon_url": "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
-                "last_updated": "2016-04-19T19:50:50.435291Z",
-                "origin": "canonical",
-                "package_name": "hello-world",
-                "prices": {"EUR": 0.99, "USD": 1.23},
-                "publisher": "Canonical",
-                "ratings_average": 0.0,
-                "revision": 25,
-                "snap_id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
-                "summary": "Hello world example",
-                "support_url": "mailto:snappy-devel@lists.ubuntu.com",
-                "title": "hello-world",
-                "version": "6.0",
-                "private": true
-            }
-        ]
-    },
     "_links": {
         "curies": [
             {
@@ -245,18 +215,37 @@ const MockDetailsJSON = `{
                 "templated": true
             }
         ],
-        "first": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=package_name%3A%22hello-world%22&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
-        },
-        "last": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=package_name%3A%22hello-world%22&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
-        },
         "self": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=package_name%3A%22hello-world%22&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
+            "href": "https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cprivate%2Cconfinement&channel=edge"
         }
-    }
-}
-`
+    },
+    "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_26.snap",
+    "architecture": [
+        "all"
+    ],
+    "binary_filesize": 20480,
+    "channel": "edge",
+    "confinement": "strict",
+    "content": "application",
+    "description": "This is a simple hello world example.",
+    "developer_id": "canonical",
+    "download_sha512": "345f33c06373f799b64c497a778ef58931810dd7ae85279d6917d8b4f43d38abaf37e68239cb85914db276cb566a0ef83ea02b6f2fd064b54f9f2508fa4ca1f1",
+    "download_url": "https://public.apps.ubuntu.com/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_26.snap",
+    "icon_url": "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
+    "last_updated": "2016-05-31T07:02:32.586839Z",
+    "origin": "canonical",
+    "package_name": "hello-world",
+    "prices": {"EUR": 0.99, "USD": 1.23},
+    "publisher": "Canonical",
+    "ratings_average": 0.0,
+    "revision": 26,
+    "snap_id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+    "summary": "Hello world example",
+    "support_url": "mailto:snappy-devel@lists.ubuntu.com",
+    "title": "hello-world",
+    "version": "6.1"
+}`
+
 const mockPurchasesJSON = `[
   {
     "open_id": "https://login.staging.ubuntu.com/+id/open_id",
@@ -322,14 +311,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 		storeID := r.Header.Get("X-Ubuntu-Store")
 		c.Check(storeID, Equals, "")
 
-		c.Check(r.URL.Path, Equals, "/search")
+		c.Check(r.URL.Path, Equals, "/details/hello-world")
 
-		q := r.URL.Query()
-		c.Check(q.Get("q"), Equals, "package_name:\"hello-world\"")
-		c.Check(r.Header.Get("X-Ubuntu-Device-Channel"), Equals, "edge")
-		c.Check(r.Header.Get("X-Ubuntu-Confinement"), Equals, "devmode")
+		c.Check(r.URL.Query().Get("channel"), Equals, "edge")
 
-		c.Check(q.Get("fields"), Equals, strings.Join(detailFields, ","))
+		c.Check(r.Header.Get("X-Ubuntu-Device-Channel"), Equals, "")
+		c.Check(r.Header.Get("X-Ubuntu-Confinement"), Equals, "")
 
 		w.Header().Set("X-Suggested-Currency", "GBP")
 		w.WriteHeader(http.StatusOK)
@@ -340,10 +327,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	searchURI, err := url.Parse(mockServer.URL + "/search")
+	detailsURI, err := url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		SearchURI: searchURI,
+		DetailsURI: detailsURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
 	c.Assert(repo, NotNil)
@@ -353,11 +340,11 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 	c.Check(result.Architectures, DeepEquals, []string{"all"})
-	c.Check(result.Revision, Equals, snap.R(25))
+	c.Check(result.Revision, Equals, snap.R(26))
 	c.Check(result.SnapID, Equals, helloWorldSnapID)
 	c.Check(result.Developer, Equals, "canonical")
-	c.Check(result.Version, Equals, "6.0")
-	c.Check(result.Sha512, Equals, "4bf23ce93efa1f32f0aeae7ec92564b7b0f9f8253a0bd39b2741219c1be119bb676c21208c6845ccf995e6aabe791d3f28a733ebcbbc3171bb23f67981f4068e")
+	c.Check(result.Version, Equals, "6.1")
+	c.Check(result.Sha512, Matches, `[[:xdigit:]]{128}`)
 	c.Check(result.Size, Equals, int64(20480))
 	c.Check(result.Channel, Equals, "edge")
 	c.Check(result.Description(), Equals, "This is a simple hello world example.")
@@ -369,7 +356,46 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(result.Epoch, Equals, "0")
 
 	c.Check(repo.SuggestedCurrency(), Equals, "GBP")
-	c.Check(result.Private, Equals, true)
+
+	// skip this one until the store supports it
+	// c.Check(result.Private, Equals, true)
+
+	c.Check(snap.Validate(result), IsNil)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsDevmode(c *C) {
+	mockDevmodeJSON := strings.Replace(MockDetailsJSON, `"strict"`, `"devmode"`, -1)
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		c.Check(r.URL.Path, Equals, "/details/hello-world")
+
+		c.Check(r.URL.Query().Get("channel"), Equals, "edge")
+
+		w.Header().Set("X-Suggested-Currency", "GBP")
+		w.WriteHeader(http.StatusOK)
+
+		io.WriteString(w, mockDevmodeJSON)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	detailsURI, err := url.Parse(mockServer.URL + "/details/")
+	c.Assert(err, IsNil)
+	cfg := SnapUbuntuStoreConfig{
+		DetailsURI: detailsURI,
+	}
+	repo := NewUbuntuStoreSnapRepository(&cfg, "")
+	c.Assert(repo, NotNil)
+
+	// the actual test
+	result, err := repo.Snap("hello-world", "edge", false, nil)
+	c.Check(err, Equals, ErrSnapNeedsDevMode)
+	c.Check(result, IsNil)
+	result, err = repo.Snap("hello-world", "edge", true, nil)
+	c.Assert(err, IsNil)
+	c.Check(result, NotNil)
 
 	c.Check(snap.Validate(result), IsNil)
 }
@@ -400,12 +426,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsSetsAuth(c *C) {
 	c.Assert(mockPurchasesServer, NotNil)
 	defer mockPurchasesServer.Close()
 
-	searchURI, err := url.Parse(mockServer.URL + "/search")
+	detailsURI, err := url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		SearchURI:    searchURI,
+		DetailsURI:   detailsURI,
 		PurchasesURI: purchasesURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
@@ -420,11 +446,8 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsSetsAuth(c *C) {
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsOopses(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.URL.Path, Equals, "/search")
-
-		q := r.URL.Query()
-		c.Check(q.Get("q"), Equals, `package_name:"hello-world"`)
-		c.Check(r.Header.Get("X-Ubuntu-Device-Channel"), Equals, "edge")
+		c.Check(r.URL.Path, Equals, "/details/hello-world")
+		c.Check(r.URL.Query().Get("channel"), Equals, "edge")
 
 		w.Header().Set("X-Oops-Id", "OOPS-d4f46f75a5bcc10edcacc87e1fc0119f")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -435,52 +458,39 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsOopses(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	searchURI, err := url.Parse(mockServer.URL + "/search")
+	detailsURI, err := url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		SearchURI: searchURI,
+		DetailsURI: detailsURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
 	c.Assert(repo, NotNil)
 
 	// the actual test
 	_, err = repo.Snap("hello-world", "edge", false, nil)
-	c.Assert(err, ErrorMatches, `Ubuntu CPI service returned unexpected HTTP status code 5.. while looking for snap "hello-world" in channel "edge" \[OOPS-[a-f0-9A-F]*\]`)
+	c.Assert(err, ErrorMatches, `Ubuntu CPI service returned unexpected HTTP status code 5.. while getting details for snap "hello-world" in channel "edge" \[OOPS-[a-f0-9A-F]*\]`)
 }
 
 /*
 acquired via
-curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://search.apps.ubuntu.com/api/v1/search?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&q=package_name%3A%22%22' | python -m json.tool | xsel -b
+
+http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/details/no:such:package X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha512,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
+
+on 2016-07-03
 */
 const MockNoDetailsJSON = `{
-    "_links": {
-        "curies": [
-            {
-                "href": "https://wiki.ubuntu.com/AppStore/Interfaces/ClickPackageIndex#reltype_{rel}",
-                "name": "clickindex",
-                "templated": true
-            }
-        ],
-        "first": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=package_name%3A%22%22&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
-        },
-        "last": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=package_name%3A%22%22&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
-        },
-        "self": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=package_name%3A%22%22&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
-        }
-    }
-}
-`
+    "errors": [
+        "No such package"
+    ],
+    "result": "error"
+}`
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.URL.Path, Equals, "/search")
+		c.Check(r.URL.Path, Equals, "/details/no-such-pkg")
 
 		q := r.URL.Query()
-		c.Check(q.Get("q"), Equals, "package_name:\"no-such-pkg\"")
-		c.Check(r.Header.Get("X-Ubuntu-Device-Channel"), Equals, "edge")
+		c.Check(q.Get("channel"), Equals, "edge")
 		w.WriteHeader(404)
 		io.WriteString(w, MockNoDetailsJSON)
 	}))
@@ -488,10 +498,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	searchURI, err := url.Parse(mockServer.URL + "/search")
+	detailsURI, err := url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		SearchURI: searchURI,
+		DetailsURI: detailsURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
 	c.Assert(repo, NotNil)
@@ -1224,10 +1234,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositorySuggestedCurrency(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	searchURI, err := url.Parse(mockServer.URL + "/search")
+	detailsURI, err := url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		SearchURI: searchURI,
+		DetailsURI: detailsURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
 	c.Assert(repo, NotNil)
@@ -1560,8 +1570,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuySuccess(c *C) {
 	searchServerCalled := false
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
-		q := r.URL.Query()
-		c.Check(q.Get("q"), Equals, "package_name:\"hello-world\"")
+		c.Check(r.URL.Path, Equals, "/hello-world")
 		w.Header().Set("Content-Type", "application/hal+json")
 		w.Header().Set("X-Suggested-Currency", "EUR")
 		w.WriteHeader(http.StatusOK)
@@ -1599,12 +1608,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuySuccess(c *C) {
 	c.Assert(mockPurchasesServer, NotNil)
 	defer mockPurchasesServer.Close()
 
-	searchURI, err := url.Parse(mockServer.URL)
+	detailsURI, err := url.Parse(mockServer.URL)
 	c.Assert(err, IsNil)
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		SearchURI:    searchURI,
+		DetailsURI:   detailsURI,
 		PurchasesURI: purchasesURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
@@ -1644,8 +1653,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailWrongPrice(c *C) {
 	searchServerCalled := false
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
-		q := r.URL.Query()
-		c.Check(q.Get("q"), Equals, "package_name:\"hello-world\"")
+		c.Check(r.URL.Path, Equals, "/hello-world")
 		w.Header().Set("Content-Type", "application/hal+json")
 		w.Header().Set("X-Suggested-Currency", "EUR")
 		w.WriteHeader(http.StatusOK)
@@ -1684,12 +1692,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailWrongPrice(c *C) {
 	c.Assert(mockPurchasesServer, NotNil)
 	defer mockPurchasesServer.Close()
 
-	searchURI, err := url.Parse(mockServer.URL)
+	detailsURI, err := url.Parse(mockServer.URL)
 	c.Assert(err, IsNil)
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		SearchURI:    searchURI,
+		DetailsURI:   detailsURI,
 		PurchasesURI: purchasesURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")
@@ -1724,8 +1732,9 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailNotFound(c *C) {
 	searchServerCalled := false
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/details/hello-world")
 		q := r.URL.Query()
-		c.Check(q.Get("q"), Equals, "package_name:\"hello-world\"")
+		c.Check(q.Get("channel"), Equals, "edge")
 		w.Header().Set("Content-Type", "application/hal+json")
 		w.Header().Set("X-Suggested-Currency", "EUR")
 		w.WriteHeader(http.StatusOK)
@@ -1764,12 +1773,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailNotFound(c *C) {
 	c.Assert(mockPurchasesServer, NotNil)
 	defer mockPurchasesServer.Close()
 
-	searchURI, err := url.Parse(mockServer.URL)
+	detailsURI, err := url.Parse(mockServer.URL + "/details/")
 	c.Assert(err, IsNil)
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 	cfg := SnapUbuntuStoreConfig{
-		SearchURI:    searchURI,
+		DetailsURI:   detailsURI,
 		PurchasesURI: purchasesURI,
 	}
 	repo := NewUbuntuStoreSnapRepository(&cfg, "")

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -205,6 +205,9 @@ http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/detai
 on 2016-07-03. Then, by hand:
  * set prices to {"EUR": 0.99, "USD": 1.23}.
 
+On Ubuntu, apt install httpie xsel (although you could get http from
+the http snap instead).
+
 */
 const MockDetailsJSON = `{
     "_links": {
@@ -477,6 +480,10 @@ acquired via
 http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/details/no:such:package X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha512,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
 
 on 2016-07-03
+
+On Ubuntu, apt install httpie xsel (although you could get http from
+the http snap instead).
+
 */
 const MockNoDetailsJSON = `{
     "errors": [

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -20,8 +20,10 @@ execute: |
     snap install $SNAP_NAME --devmode | grep -Pzq "$expected"
 
     echo "Install devmode snap without devmode option"
-    # XXX want to move this to a more verbose, user-friendly error soonest
-    expected="snap wants devmode"
+    # XXX want to move this to a more precise, verbose, user-friendly
+    # error (e.g. "snap asks for devmode but not provided nor
+    # overridden")
+    expected="snap not found"
     actual=$(snap install --channel beta $DEVMODE_SNAP 2>&1 && exit 1 || true)
     echo "$actual" | grep -Pzq "$expected"
 

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -20,7 +20,8 @@ execute: |
     snap install $SNAP_NAME --devmode | grep -Pzq "$expected"
 
     echo "Install devmode snap without devmode option"
-    expected="snap not found"
+    # XXX want to move this to a more verbose, user-friendly error soonest
+    expected="snap wants devmode"
     actual=$(snap install --channel beta $DEVMODE_SNAP 2>&1 && exit 1 || true)
     echo "$actual" | grep -Pzq "$expected"
 


### PR DESCRIPTION
This builds on #1482 so maybe [compare with that](https://github.com/chipaca/snappy/compare/new-details...new-search).