### PR TITLE
overlord/auth: add Device/SetDevice to persist device identity in state

### DIFF
--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -160,21 +160,6 @@ func SetDevice(st *state.State, device *DeviceState) error {
 	return nil
 }
 
-// SetDeviceIdentity sets the device's identity as used for communication with the store.
-func SetDeviceIdentity(st *state.State, brand string, model string, serial string) error {
-	device, err := Device(st)
-	if err != nil {
-		return err
-	}
-
-	device.Brand = brand
-	device.Model = model
-	device.Serial = serial
-	SetDevice(st, device)
-
-	return nil
-}
-
 var ErrInvalidAuth = fmt.Errorf("invalid authentication")
 
 // CheckMacaroon returns the UserState for the given macaroon/discharges credentials

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -34,8 +34,16 @@ import (
 
 // AuthState represents current authenticated users as tracked in state
 type AuthState struct {
-	LastID int         `json:"last-id"`
-	Users  []UserState `json:"users"`
+	LastID int          `json:"last-id"`
+	Users  []UserState  `json:"users"`
+	Device *DeviceState `json:"device,omitempty"`
+}
+
+// DeviceState represents the device's identity and store credentials
+type DeviceState struct {
+	Brand  string `json:"brand,omitempty"`
+	Model  string `json:"model,omitempty"`
+	Serial string `json:"serial,omitempty"`
 }
 
 // UserState represents an authenticated user
@@ -115,6 +123,56 @@ func User(st *state.State, id int) (*UserState, error) {
 		}
 	}
 	return nil, fmt.Errorf("invalid user")
+}
+
+// Device returns the device details from the state.
+func Device(st *state.State) (*DeviceState, error) {
+	var authStateData AuthState
+
+	err := st.Get("auth", &authStateData)
+	if err == state.ErrNoState {
+		return &DeviceState{}, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	if authStateData.Device == nil {
+		return &DeviceState{}, nil
+	}
+
+	return authStateData.Device, nil
+}
+
+// SetDevice updates the device details in the state.
+func SetDevice(st *state.State, device *DeviceState) error {
+	var authStateData AuthState
+
+	err := st.Get("auth", &authStateData)
+	if err == state.ErrNoState {
+		authStateData = AuthState{}
+	} else if err != nil {
+		return err
+	}
+
+	authStateData.Device = device
+	st.Set("auth", authStateData)
+
+	return nil
+}
+
+// SetDeviceIdentity sets the device's identity as used for communication with the store.
+func SetDeviceIdentity(st *state.State, brand string, model string, serial string) error {
+	device, err := Device(st)
+	if err != nil {
+		return err
+	}
+
+	device.Brand = brand
+	device.Model = model
+	device.Serial = serial
+	SetDevice(st, device)
+
+	return nil
 }
 
 var ErrInvalidAuth = fmt.Errorf("invalid authentication")

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -316,21 +316,6 @@ func (as *authSuite) TestSetDevice(c *C) {
 	c.Check(device, DeepEquals, &auth.DeviceState{Brand: "some-brand"})
 }
 
-func (as *authSuite) TestSetDeviceIdentity(c *C) {
-	as.state.Lock()
-	err := auth.SetDeviceIdentity(as.state, "the-brand", "the-model", "the-serial")
-	c.Check(err, IsNil)
-	device, err := auth.Device(as.state)
-	as.state.Unlock()
-	expected := &auth.DeviceState{
-		Brand:  "the-brand",
-		Model:  "the-model",
-		Serial: "the-serial",
-	}
-	c.Check(err, IsNil)
-	c.Check(device, DeepEquals, expected)
-}
-
 func (as *authSuite) TestGetAuthenticatorFromUser(c *C) {
 	as.state.Lock()
 	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -300,6 +300,37 @@ func (as *authSuite) TestLoginCaveatIDMacaroonMissingCaveat(c *C) {
 	c.Check(caveat, Equals, "")
 }
 
+func (as *authSuite) TestSetDevice(c *C) {
+	as.state.Lock()
+	device, err := auth.Device(as.state)
+	as.state.Unlock()
+	c.Check(err, IsNil)
+	c.Check(device, DeepEquals, &auth.DeviceState{})
+
+	as.state.Lock()
+	err = auth.SetDevice(as.state, &auth.DeviceState{Brand: "some-brand"})
+	c.Check(err, IsNil)
+	device, err = auth.Device(as.state)
+	as.state.Unlock()
+	c.Check(err, IsNil)
+	c.Check(device, DeepEquals, &auth.DeviceState{Brand: "some-brand"})
+}
+
+func (as *authSuite) TestSetDeviceIdentity(c *C) {
+	as.state.Lock()
+	err := auth.SetDeviceIdentity(as.state, "the-brand", "the-model", "the-serial")
+	c.Check(err, IsNil)
+	device, err := auth.Device(as.state)
+	as.state.Unlock()
+	expected := &auth.DeviceState{
+		Brand:  "the-brand",
+		Model:  "the-model",
+		Serial: "the-serial",
+	}
+	c.Check(err, IsNil)
+	c.Check(device, DeepEquals, expected)
+}
+
 func (as *authSuite) TestGetAuthenticatorFromUser(c *C) {
 	as.state.Lock()
 	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})


### PR DESCRIPTION
The brand, model and serial in state will be used to look up the device's serial assertion.

The SetDeviceIdentity helper might be better as a method on DeviceState, but I don't like the idea of encouraging code to get into the habit of using SetDevice directly. Objects like UserState tend to be held around even when the state is unlocked, and it's easy to accidentally clobber concurrent changes to unrelated fields in that situation.