### PR TITLE
tests: add spread test for tried snaps removal

### DIFF
--- a/tests/main/try-non-fatal/task.yaml
+++ b/tests/main/try-non-fatal/task.yaml
@@ -2,9 +2,17 @@ summary: Checks that removing the base directory of a tried snap works.
 
 execute: |
     echo "Given a tried snap"
+    base_dir=$(mktemp -d)
+    cp -R $TESTSLIB/snaps/test-snapd-tools/* $base_dir
+    snap try $base_dir
 
     echo "Then it is listed as installed"
+    installed_pattern="(?s)Name +Version +Rev +Developer +Notes\n\
+    test-snapd-tools +.*?try"
+    snap list | grep -Pzq "$installed_pattern"
 
     echo "When its base directory is removed"
+    rm -rf $base_dir
 
     echo "Then the snap is no loger listed as installed"
+    ! snap list | grep -Pzq "$installed_pattern"

--- a/tests/main/try-non-fatal/task.yaml
+++ b/tests/main/try-non-fatal/task.yaml
@@ -1,0 +1,10 @@
+summary: Checks that removing the base directory of a tried snap works.
+
+execute: |
+    echo "Given a tried snap"
+
+    echo "Then it is listed as installed"
+
+    echo "When its base directory is removed"
+
+    echo "Then the snap is no loger listed as installed"


### PR DESCRIPTION
This test was manually performed in the 2.0.10 SRU, it verifies that a tried snap can be uninstalled by removing the base directory without errors.
