### PR TITLE
client: existing JSON fixtures uses tabs for indentation

### DIFF
--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -60,7 +60,7 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
 		"result": [{
-                        "id": "funky-snap-id",
+			"id": "funky-snap-id",
 			"summary": "salutation snap",
 			"description": "hello-world",
 			"download-size": 22212,
@@ -72,8 +72,8 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 			"status": "available",
 			"type": "app",
 			"version": "1.0.18",
-                        "confinement": "strict",
-                        "private": true
+			"confinement": "strict",
+			"private": true
 		}],
 		"suggested-currency": "GBP"
 	}`
@@ -114,23 +114,23 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
 		"result": {
-                        "id": "funky-snap-id",
-                        "summary": "bla bla",
+			"id": "funky-snap-id",
+			"summary": "bla bla",
 			"description": "WebRTC Video chat server for Snappy",
 			"download-size": 6930947,
 			"icon": "/v2/icons/chatroom.ogra/icon",
 			"installed-size": 18976651,
-                        "install-date": "2016-01-02T15:04:05Z",
+			"install-date": "2016-01-02T15:04:05Z",
 			"name": "chatroom",
 			"developer": "ogra",
 			"resource": "/v2/snaps/chatroom.ogra",
 			"status": "active",
 			"type": "app",
 			"version": "0.1-8",
-                        "confinement": "strict",
-                        "private": true,
-                        "devmode": true,
-                        "trymode": true
+			"confinement": "strict",
+			"private": true,
+			"devmode": true,
+			"trymode": true
 		}
 	}`
 	pkg, _, err := cs.cli.Snap(pkgName)


### PR DESCRIPTION
A minor annoyance in an area I'm looking at.