### PR TITLE
debian: chmod created config files to 0644

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -10,6 +10,7 @@ cat <<EOF | sudo tee /etc/systemd/system/snapd.service.d/no-reexec.conf
 [Service]
 Environment=SNAP_REEXEC=0
 EOF
+chmod 0644 /etc/systemd/system/snapd.service.d/no-reexec.conf
 
 # required for the debian adt host
 if [ "$http_proxy" != "" ]; then
@@ -18,6 +19,7 @@ if [ "$http_proxy" != "" ]; then
 Environment=http_proxy=$http_proxy
 Environment=https_proxy=$http_proxy
 EOF
+chmod 0644 /etc/systemd/system/snapd.service.d/proxy.conf
 fi
 sudo systemctl daemon-reload
 


### PR DESCRIPTION
This is a shot in the dark, currently autopackage tests fail on yakkety
with systemd 230 and snapd > 2.0.2. One of the error messages found is
that systemd ignores the created environment files due to incorrect
permissions, presumably causing various other things to misbehave.

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1599799
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>