### PR TITLE
interface: add new interfaces.all.SecurityBackends

### DIFF
--- a/interfaces/all/all.go
+++ b/interfaces/all/all.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package all
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/dbus"
+	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/release"
+)
+
+// append when a new security backend is added
+var SecurityBackends = []interfaces.SecurityBackend{
+	&seccomp.Backend{},
+	&dbus.Backend{},
+	&udev.Backend{},
+	&mount.Backend{},
+}
+
+func init() {
+	if !release.ReleaseInfo.ForceDevMode() {
+		SecurityBackends = append(SecurityBackends, &apparmor.Backend{})
+	}
+}

--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -17,7 +17,7 @@
  *
  */
 
-package all
+package backends
 
 import (
 	"github.com/snapcore/snapd/interfaces"
@@ -30,7 +30,7 @@ import (
 )
 
 // append when a new security backend is added
-var SecurityBackends = []interfaces.SecurityBackend{
+var All = []interfaces.SecurityBackend{
 	&seccomp.Backend{},
 	&dbus.Backend{},
 	&udev.Backend{},
@@ -39,6 +39,6 @@ var SecurityBackends = []interfaces.SecurityBackend{
 
 func init() {
 	if !release.ReleaseInfo.ForceDevMode() {
-		SecurityBackends = append(SecurityBackends, &apparmor.Backend{})
+		All = append(All, &apparmor.Backend{})
 	}
 }

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -225,7 +225,7 @@ func (iface *BluezInterface) PermanentSlotSnippet(slot *interfaces.Slot, securit
 		return bluezPermanentSlotSecComp, nil
 	case interfaces.SecurityDBus:
 		return bluezPermanentSlotDBus, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -162,7 +162,7 @@ func (iface *LocationControlInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 		return locationControlConnectedPlugDBus, nil
 	case interfaces.SecuritySecComp:
 		return locationControlConnectedPlugSecComp, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -177,7 +177,7 @@ func (iface *LocationControlInterface) PermanentSlotSnippet(slot *interfaces.Slo
 		return locationControlPermanentSlotDBus, nil
 	case interfaces.SecuritySecComp:
 		return locationControlPermanentSlotSecComp, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -248,7 +248,7 @@ func (iface *LocationObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 		return locationObserveConnectedPlugDBus, nil
 	case interfaces.SecuritySecComp:
 		return locationObserveConnectedPlugSecComp, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -263,7 +263,7 @@ func (iface *LocationObserveInterface) PermanentSlotSnippet(slot *interfaces.Slo
 		return locationObservePermanentSlotDBus, nil
 	case interfaces.SecuritySecComp:
 		return locationObservePermanentSlotSecComp, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1149,7 +1149,7 @@ func (iface *ModemManagerInterface) Name() string {
 
 func (iface *ModemManagerInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev:
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -1174,7 +1174,7 @@ func (iface *ModemManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, 
 		return snippet, nil
 	case interfaces.SecuritySecComp:
 		return modemManagerConnectedPlugSecComp, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -1191,6 +1191,8 @@ func (iface *ModemManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, 
 		return modemManagerPermanentSlotUdev, nil
 	case interfaces.SecurityDBus:
 		return modemManagerPermanentSlotDBus, nil
+	case interfaces.SecurityMount:
+		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
 	}
@@ -1203,7 +1205,7 @@ func (iface *ModemManagerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, 
 		new := plugAppLabelExpr(plug)
 		snippet := bytes.Replace(modemManagerConnectedSlotAppArmor, old, new, -1)
 		return snippet, nil
-	case interfaces.SecurityDBus, interfaces.SecuritySecComp, interfaces.SecurityUDev:
+	case interfaces.SecurityDBus, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -179,7 +179,7 @@ func (iface *MprisInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *i
 		return nil, nil
 	case interfaces.SecuritySecComp:
 		return mprisConnectedPlugSecComp, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -200,7 +200,7 @@ func (iface *MprisInterface) PermanentSlotSnippet(slot *interfaces.Slot, securit
 		return nil, nil
 	case interfaces.SecuritySecComp:
 		return mprisPermanentSlotSecComp, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -402,7 +402,7 @@ func (iface *NetworkManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug
 		return snippet, nil
 	case interfaces.SecuritySecComp:
 		return networkManagerConnectedPlugSecComp, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -415,7 +415,7 @@ func (iface *NetworkManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot
 		return networkManagerPermanentSlotAppArmor, nil
 	case interfaces.SecuritySecComp:
 		return networkManagerPermanentSlotSecComp, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	case interfaces.SecurityDBus:
 		return networkManagerPermanentSlotDBus, nil

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -56,7 +56,7 @@ func (iface *PppInterface) Name() string {
 
 func (iface *PppInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev:
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -71,7 +71,7 @@ func (iface *PppInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *int
 		return pppConnectedPlugAppArmor, nil
 	case interfaces.SecuritySecComp:
 		return nil, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -84,7 +84,7 @@ func (iface *PppInterface) PermanentSlotSnippet(slot *interfaces.Slot, securityS
 		return nil, nil
 	case interfaces.SecuritySecComp:
 		return nil, nil
-	case interfaces.SecurityUDev:
+	case interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	case interfaces.SecurityDBus:
 		return nil, nil
@@ -95,7 +95,7 @@ func (iface *PppInterface) PermanentSlotSnippet(slot *interfaces.Slot, securityS
 
 func (iface *PppInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev:
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -80,7 +80,7 @@ func (iface *SerialPortInterface) PermanentSlotSnippet(slot *interfaces.Slot, se
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		return []byte(fmt.Sprintf("\n%s rwk,\n", iface.path(slot))), nil
-	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -90,7 +90,7 @@ func (iface *SerialPortInterface) PermanentSlotSnippet(slot *interfaces.Slot, se
 // ConnectedSlotSnippet no extra permissions granted on connection
 func (iface *SerialPortInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -100,7 +100,7 @@ func (iface *SerialPortInterface) ConnectedSlotSnippet(plug *interfaces.Plug, sl
 // PermanentPlugSnippet no permissions provided to plug permanently
 func (iface *SerialPortInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -112,7 +112,7 @@ func (iface *SerialPortInterface) ConnectedPlugSnippet(plug *interfaces.Plug, sl
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		return []byte(fmt.Sprintf("%s rwk,\n", iface.path(slot))), nil
-	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev:
+	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -16,24 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-// -*- Mode: Go; indent-tabs-mode: t -*-
-
-/*
- * Copyright (C) 2016 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
 
 package ifacestate
 

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/all"
+	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -108,7 +108,7 @@ func setupSnapSecurity(task *state.Task, snapInfo *snap.Info, repo *interfaces.R
 		task.Errorf("cannot get state of snap %q: %s", snapName, err)
 		return err
 	}
-	for _, backend := range all.SecurityBackends {
+	for _, backend := range backends.All {
 		st.Unlock()
 		err := backend.Setup(snapInfo, snapState.DevMode(), repo)
 		st.Lock()
@@ -122,7 +122,7 @@ func setupSnapSecurity(task *state.Task, snapInfo *snap.Info, repo *interfaces.R
 
 func removeSnapSecurity(task *state.Task, snapName string) error {
 	st := task.State()
-	for _, backend := range all.SecurityBackends {
+	for _, backend := range backends.All {
 		st.Unlock()
 		err := backend.Remove(snapName)
 		st.Lock()

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -16,6 +16,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 package ifacestate
 
@@ -24,15 +42,11 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/all"
 	"github.com/snapcore/snapd/interfaces/builtin"
-	"github.com/snapcore/snapd/interfaces/dbus"
-	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -112,7 +126,7 @@ func setupSnapSecurity(task *state.Task, snapInfo *snap.Info, repo *interfaces.R
 		task.Errorf("cannot get state of snap %q: %s", snapName, err)
 		return err
 	}
-	for _, backend := range securityBackends {
+	for _, backend := range all.SecurityBackends {
 		st.Unlock()
 		err := backend.Setup(snapInfo, snapState.DevMode(), repo)
 		st.Lock()
@@ -126,7 +140,7 @@ func setupSnapSecurity(task *state.Task, snapInfo *snap.Info, repo *interfaces.R
 
 func removeSnapSecurity(task *state.Task, snapName string) error {
 	st := task.State()
-	for _, backend := range securityBackends {
+	for _, backend := range all.SecurityBackends {
 		st.Unlock()
 		err := backend.Remove(snapName)
 		st.Lock()
@@ -219,14 +233,4 @@ func getConns(st *state.State) (map[string]connState, error) {
 
 func setConns(st *state.State, conns map[string]connState) {
 	st.Set("conns", conns)
-}
-
-var securityBackends = []interfaces.SecurityBackend{
-	&seccomp.Backend{}, &dbus.Backend{}, &udev.Backend{},
-}
-
-func init() {
-	if !release.ReleaseInfo.ForceDevMode() {
-		securityBackends = append(securityBackends, &apparmor.Backend{})
-	}
 }

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/all"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -117,7 +118,7 @@ func (m *InterfaceManager) Repository() *interfaces.Repository {
 //
 // This function is public because it is referenced in the daemon
 func MockSecurityBackends(backends []interfaces.SecurityBackend) func() {
-	old := securityBackends
-	securityBackends = backends
-	return func() { securityBackends = old }
+	old := all.SecurityBackends
+	all.SecurityBackends = backends
+	return func() { all.SecurityBackends = old }
 }

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/all"
+	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -117,8 +117,8 @@ func (m *InterfaceManager) Repository() *interfaces.Repository {
 // MockSecurityBackends mocks the list of security backends that are used for setting up security.
 //
 // This function is public because it is referenced in the daemon
-func MockSecurityBackends(backends []interfaces.SecurityBackend) func() {
-	old := all.SecurityBackends
-	all.SecurityBackends = backends
-	return func() { all.SecurityBackends = old }
+func MockSecurityBackends(be []interfaces.SecurityBackend) func() {
+	old := backends.All
+	backends.All = be
+	return func() { backends.All = old }
 }


### PR DESCRIPTION
So that the repository of all the backends is close to were backends are defined.

Also add the mount backend to the various new interfaces.