### PR TITLE
tests: add -y flag to apt autoremove command in unity task restore

### DIFF
--- a/tests/main/unity/task.yaml
+++ b/tests/main/unity/task.yaml
@@ -11,7 +11,7 @@ prepare: |
 restore: |
     systemctl stop unity-app
     apt remove -y x11-utils xvfb unity
-    apt autoremove
+    apt autoremove -y
 
 execute: |
     echo "Given a unity snap is installed"


### PR DESCRIPTION
If executed without the `-y` flag, the `apt autoremove` call actually removes the packages, but the next restore steps (specifically those that reset the snap's state) are not executed. This leftover state can lead to failures depending on which tasks are executed immediately after the unity task, giving overall flaky results.