### PR TITLE
Add Qt5 indicator support in unity7 interface

### DIFF
--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -308,11 +308,18 @@ dbus (send)
     member="New{AttentionIcon,Icon,OverlayIcon,Status,Title,ToolTip}"
     peer=(name=org.freedesktop.DBus, label=unconfined),
 
+dbus (send)
+    bus=session
+    path=/StatusNotifierItem/menu
+    interface=com.canonical.dbusmenu
+    member="{LayoutUpdated,ItemsPropertiesUpdated}"
+    peer=(name=org.freedesktop.DBus, label=unconfined),
+
 dbus (receive)
     bus=session
-    path=/StatusNotifierItem
-    interface=org.freedesktop.DBus.Properties
-    member=Get*
+    path=/StatusNotifierItem{,/menu}
+    interface={org.freedesktop.DBus.Properties,com.canonical.dbusmenu}
+    member={Get*,AboutTo*,Event*}
     peer=(label=unconfined),
 
 dbus (send)


### PR DESCRIPTION
Menus were blanked in Qt5 applications when running confined.
Adapt the unity7 interface to allow missing calls from sni-qt:
- some properties are still under the com.canonical namespaces
- some calls and signals are slightly different between KDE ones
  and ours (they mirror the appmenu ones)
- path is different (under /menu)

That fixes https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1600138