### PR TITLE
many: removed authenticator, store gets a user instead

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -217,10 +217,10 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	if err != nil {
 		return InternalError(err.Error())
 	}
-	macaroon, err := auth.MacaroonDeserialize(serializedMacaroon)
+	macaroon, err := store.MacaroonDeserialize(serializedMacaroon)
 
 	// get SSO 3rd party caveat, and request discharge
-	loginCaveat, err := auth.LoginCaveatID(macaroon)
+	loginCaveat, err := store.LoginCaveatID(macaroon)
 	if err != nil {
 		return InternalError(err.Error())
 	}
@@ -390,7 +390,7 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	store := getStore(c)
-	found, err := store.Find(query.Get("q"), query.Get("channel"), user.Authenticator())
+	found, err := store.Find(query.Get("q"), query.Get("channel"), user)
 	if err != nil {
 		return InternalError("%v", err)
 	}
@@ -463,7 +463,7 @@ func storeUpdates(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	store := getStore(c)
-	updates, err := store.ListRefresh(candidatesInfo, user.Authenticator())
+	updates, err := store.ListRefresh(candidatesInfo, user)
 	if err != nil {
 		return InternalError("cannot list updates: %v", err)
 	}
@@ -1334,7 +1334,7 @@ func postBuy(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot decode buy options from request body: %v", err)
 	}
 
-	opts.Auther = user.Authenticator()
+	opts.User = user
 	s := getStore(c)
 
 	buyResult, err := s.Buy(&opts)

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -20,16 +20,12 @@
 package auth_test
 
 import (
-	"fmt"
-	"net/http"
 	"testing"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v1"
 
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/store"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -230,91 +226,6 @@ func (as *authSuite) TestRemove(c *C) {
 	c.Assert(err, ErrorMatches, "invalid user")
 }
 
-func (as *authSuite) makeTestMacaroon() (*macaroon.Macaroon, error) {
-	m, err := macaroon.New([]byte("secret"), "some-id", "location")
-	if err != nil {
-		return nil, err
-	}
-	err = m.AddFirstPartyCaveat("first-party-caveat")
-	if err != nil {
-		return nil, err
-	}
-	err = m.AddThirdPartyCaveat([]byte("shared-key"), "third-party-caveat", store.UbuntuoneLocation)
-	if err != nil {
-		return nil, err
-	}
-
-	return m, nil
-}
-
-func (as *authSuite) makeTestDischarge() (*macaroon.Macaroon, error) {
-	m, err := macaroon.New([]byte("shared-key"), "third-party-caveat", store.UbuntuoneLocation)
-	if err != nil {
-		return nil, err
-	}
-
-	return m, nil
-}
-
-func (as *authSuite) TestMacaroonSerialize(c *C) {
-	m, err := as.makeTestMacaroon()
-	c.Check(err, IsNil)
-
-	serialized, err := auth.MacaroonSerialize(m)
-	c.Check(err, IsNil)
-
-	deserialized, err := auth.MacaroonDeserialize(serialized)
-	c.Check(err, IsNil)
-	c.Check(deserialized, DeepEquals, m)
-}
-
-func (as *authSuite) TestMacaroonSerializeDeserializeStoreMacaroon(c *C) {
-	// sample serialized macaroon using store server setup.
-	serialized := `MDAxNmxvY2F0aW9uIGxvY2F0aW9uCjAwMTdpZGVudGlmaWVyIHNvbWUgaWQKMDAwZmNpZCBjYXZlYXQKMDAxOWNpZCAzcmQgcGFydHkgY2F2ZWF0CjAwNTF2aWQgcyvpXSVlMnj9wYw5b-WPCLjTnO_8lVzBrRr8tJfu9tOhPORbsEOFyBwPOM_YiiXJ_qh-Pp8HY0HsUueCUY4dxONLIxPWTdMzCjAwMTJjbCByZW1vdGUuY29tCjAwMmZzaWduYXR1cmUgcm_Gdz75wUCWF9KGXZQEANhwfvBcLNt9xXGfAmxurPMK`
-
-	deserialized, err := auth.MacaroonDeserialize(serialized)
-	c.Check(err, IsNil)
-
-	// expected json serialization of the above macaroon
-	jsonData := []byte(`{"caveats":[{"cid":"caveat"},{"cid":"3rd party caveat","vid":"cyvpXSVlMnj9wYw5b-WPCLjTnO_8lVzBrRr8tJfu9tOhPORbsEOFyBwPOM_YiiXJ_qh-Pp8HY0HsUueCUY4dxONLIxPWTdMz","cl":"remote.com"}],"location":"location","identifier":"some id","signature":"726fc6773ef9c1409617d2865d940400d8707ef05c2cdb7dc5719f026c6eacf3"}`)
-
-	var expected macaroon.Macaroon
-	err = expected.UnmarshalJSON(jsonData)
-	c.Check(err, IsNil)
-	c.Check(deserialized, DeepEquals, &expected)
-
-	// reserializing the macaroon should give us the same original store serialization
-	reserialized, err := auth.MacaroonSerialize(deserialized)
-	c.Check(err, IsNil)
-	c.Check(reserialized, Equals, serialized)
-}
-
-func (as *authSuite) TestMacaroonDeserializeInvalidData(c *C) {
-	serialized := "invalid-macaroon-data"
-
-	deserialized, err := auth.MacaroonDeserialize(serialized)
-	c.Check(deserialized, IsNil)
-	c.Check(err, NotNil)
-}
-
-func (as *authSuite) TestLoginCaveatIDReturnCaveatID(c *C) {
-	m, err := as.makeTestMacaroon()
-	c.Check(err, IsNil)
-
-	caveat, err := auth.LoginCaveatID(m)
-	c.Check(err, IsNil)
-	c.Check(caveat, Equals, "third-party-caveat")
-}
-
-func (as *authSuite) TestLoginCaveatIDMacaroonMissingCaveat(c *C) {
-	m, err := macaroon.New([]byte("secret"), "some-id", "location")
-	c.Check(err, IsNil)
-
-	caveat, err := auth.LoginCaveatID(m)
-	c.Check(err, NotNil)
-	c.Check(caveat, Equals, "")
-}
-
 func (as *authSuite) TestSetDevice(c *C) {
 	as.state.Lock()
 	device, err := auth.Device(as.state)
@@ -329,52 +240,4 @@ func (as *authSuite) TestSetDevice(c *C) {
 	as.state.Unlock()
 	c.Check(err, IsNil)
 	c.Check(device, DeepEquals, &auth.DeviceState{Brand: "some-brand"})
-}
-
-func (as *authSuite) TestGetAuthenticatorFromUser(c *C) {
-	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
-	as.state.Unlock()
-	c.Check(err, IsNil)
-
-	authenticator, ok := user.Authenticator().(*auth.MacaroonAuthenticator)
-	c.Assert(ok, Equals, true)
-	c.Check(authenticator.Macaroon, Equals, user.Macaroon)
-	c.Check(authenticator.Discharges, DeepEquals, user.Discharges)
-}
-
-func (as *authSuite) TestGetAuthenticatorFromNilUser(c *C) {
-	// just check we don't blow up, really
-	user := (*auth.UserState)(nil)
-	c.Check(user.Authenticator(), IsNil)
-}
-
-func (as *authSuite) TestAuthenticatorSetHeaders(c *C) {
-	root, err := as.makeTestMacaroon()
-	c.Check(err, IsNil)
-	discharge, err := as.makeTestDischarge()
-	c.Check(err, IsNil)
-
-	serializedMacaroon, err := auth.MacaroonSerialize(root)
-	c.Check(err, IsNil)
-	serializedDischarge, err := auth.MacaroonSerialize(discharge)
-	c.Check(err, IsNil)
-
-	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", serializedMacaroon, []string{serializedDischarge})
-	as.state.Unlock()
-	c.Check(err, IsNil)
-
-	req, _ := http.NewRequest("GET", "http://example.com", nil)
-	authenticator := user.Authenticator()
-	authenticator.Authenticate(req)
-
-	// discharge macaroon should be bound to the root macaroon
-	discharge.Bind(root.Signature())
-	serializedPreparedDischarge, err := auth.MacaroonSerialize(discharge)
-	c.Check(err, IsNil)
-
-	authorization := req.Header.Get("Authorization")
-	expected := fmt.Sprintf(`Macaroon root="%s", discharge="%s"`, serializedMacaroon, serializedPreparedDischarge)
-	c.Check(authorization, Equals, expected)
 }

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -20,6 +20,7 @@
 package snapstate
 
 import (
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
@@ -27,12 +28,12 @@ import (
 
 // A StoreService can find, list available updates and download snaps.
 type StoreService interface {
-	Snap(name, channel string, devmode bool, auther store.Authenticator) (*snap.Info, error)
-	Find(query, channel string, auther store.Authenticator) ([]*snap.Info, error)
-	ListRefresh([]*store.RefreshCandidate, store.Authenticator) ([]*snap.Info, error)
+	Snap(name, channel string, devmode bool, user *auth.UserState) (*snap.Info, error)
+	Find(query, channel string, user *auth.UserState) ([]*snap.Info, error)
+	ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error)
 	SuggestedCurrency() string
 
-	Download(string, *snap.DownloadInfo, progress.Meter, store.Authenticator) (string, error)
+	Download(string, *snap.DownloadInfo, progress.Meter, *auth.UserState) (string, error)
 	Buy(options *store.BuyOptions) (*store.BuyResult, error)
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -54,7 +54,7 @@ type fakeStore struct {
 	fakeTotalProgress   int
 }
 
-func (f *fakeStore) Snap(name, channel string, devmode bool, auther store.Authenticator) (*snap.Info, error) {
+func (f *fakeStore) Snap(name, channel string, devmode bool, user *auth.UserState) (*snap.Info, error) {
 	revno := snap.R(11)
 	if channel == "channel-for-7" {
 		revno.N = 7
@@ -77,11 +77,11 @@ func (f *fakeStore) Snap(name, channel string, devmode bool, auther store.Authen
 	return info, nil
 }
 
-func (f *fakeStore) Find(query, channel string, auther store.Authenticator) ([]*snap.Info, error) {
+func (f *fakeStore) Find(query, channel string, user *auth.UserState) ([]*snap.Info, error) {
 	panic("Find called")
 }
 
-func (f *fakeStore) ListRefresh([]*store.RefreshCandidate, store.Authenticator) ([]*snap.Info, error) {
+func (f *fakeStore) ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error) {
 	panic("ListRefresh called")
 }
 
@@ -89,10 +89,10 @@ func (f *fakeStore) SuggestedCurrency() string {
 	return "XTS"
 }
 
-func (f *fakeStore) Download(name string, snapInfo *snap.DownloadInfo, pb progress.Meter, auther store.Authenticator) (string, error) {
+func (f *fakeStore) Download(name string, snapInfo *snap.DownloadInfo, pb progress.Meter, user *auth.UserState) (string, error) {
 	var macaroon string
-	if auther != nil {
-		macaroon = auther.(*auth.MacaroonAuthenticator).Macaroon
+	if user != nil {
+		macaroon = user.StoreMacaroon
 	}
 	f.downloads = append(f.downloads, fakeDownload{
 		macaroon: macaroon,

--- a/store/store.go
+++ b/store/store.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -284,15 +285,46 @@ func NewUbuntuStoreSnapRepository(cfg *SnapUbuntuStoreConfig, storeID string) *S
 	}
 }
 
+// authenticate will add the store expected Authorization header for macaroons
+func authenticate(r *http.Request, user *auth.UserState) {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, `Macaroon root="%s"`, user.StoreMacaroon)
+
+	// deserialize root macaroon (we need its signature to do the discharge binding)
+	root, err := MacaroonDeserialize(user.StoreMacaroon)
+	if err != nil {
+		logger.Debugf("cannot deserialize root macaroon: %v", err)
+		return
+	}
+
+	for _, d := range user.StoreDischarges {
+		// prepare discharge for request
+		discharge, err := MacaroonDeserialize(d)
+		if err != nil {
+			logger.Debugf("cannot deserialize discharge macaroon: %v", err)
+			return
+		}
+		discharge.Bind(root.Signature())
+
+		serializedDischarge, err := MacaroonSerialize(discharge)
+		if err != nil {
+			logger.Debugf("cannot re-serialize discharge macaroon: %v", err)
+			return
+		}
+		fmt.Fprintf(&buf, `, discharge="%s"`, serializedDischarge)
+	}
+	r.Header.Set("Authorization", buf.String())
+}
+
 // build a new http.Request with headers for the store
-func (s *SnapUbuntuStoreRepository) newRequest(method, urlStr string, body io.Reader, auther Authenticator) (*http.Request, error) {
+func (s *SnapUbuntuStoreRepository) newRequest(method, urlStr string, body io.Reader, user *auth.UserState) (*http.Request, error) {
 	req, err := http.NewRequest(method, urlStr, body)
 	if err != nil {
 		return nil, err
 	}
 
-	if auther != nil {
-		auther.Authenticate(req)
+	if user != nil {
+		authenticate(req, user)
 	}
 
 	req.Header.Set("User-Agent", userAgent)
@@ -309,9 +341,9 @@ func (s *SnapUbuntuStoreRepository) newRequest(method, urlStr string, body io.Re
 }
 
 // small helper that sets the correct http headers for the ubuntu store
-func (s *SnapUbuntuStoreRepository) setUbuntuStoreHeaders(req *http.Request, channel string, devmode bool, auther Authenticator) {
-	if auther != nil {
-		auther.Authenticate(req)
+func (s *SnapUbuntuStoreRepository) setUbuntuStoreHeaders(req *http.Request, channel string, devmode bool, user *auth.UserState) {
+	if user != nil {
+		authenticate(req, user)
 	}
 
 	req.Header.Set("User-Agent", userAgent)
@@ -386,8 +418,8 @@ type purchase struct {
 	RedirectTo      string `json:"redirect_to,omitempty"`
 }
 
-func (s *SnapUbuntuStoreRepository) getPurchasesFromURL(url *url.URL, channel string, auther Authenticator) ([]*purchase, error) {
-	if auther == nil {
+func (s *SnapUbuntuStoreRepository) getPurchasesFromURL(url *url.URL, channel string, user *auth.UserState) ([]*purchase, error) {
+	if user == nil {
 		return nil, fmt.Errorf("cannot obtain known purchases from store: no authentication credentials provided")
 	}
 
@@ -396,7 +428,7 @@ func (s *SnapUbuntuStoreRepository) getPurchasesFromURL(url *url.URL, channel st
 		return nil, err
 	}
 
-	s.setUbuntuStoreHeaders(req, channel, false, auther)
+	s.setUbuntuStoreHeaders(req, channel, false, user)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -441,11 +473,11 @@ func hasPriced(snaps []*snap.Info) bool {
 }
 
 // decorateAllPurchases sets the MustBuy property of each snap in the given list according to the user's known purchases.
-func (s *SnapUbuntuStoreRepository) decoratePurchases(snaps []*snap.Info, channel string, auther Authenticator) error {
+func (s *SnapUbuntuStoreRepository) decoratePurchases(snaps []*snap.Info, channel string, user *auth.UserState) error {
 	// Mark every non-free snap as must buy until we know better.
 	setMustBuy(snaps)
 
-	if auther == nil {
+	if user == nil {
 		return nil
 	}
 
@@ -470,7 +502,7 @@ func (s *SnapUbuntuStoreRepository) decoratePurchases(snaps []*snap.Info, channe
 		purchasesURL = s.purchasesURI
 	}
 
-	purchases, err := s.getPurchasesFromURL(purchasesURL, channel, auther)
+	purchases, err := s.getPurchasesFromURL(purchasesURL, channel, user)
 	if err != nil {
 		return err
 	}
@@ -509,7 +541,7 @@ func mustBuy(prices map[string]float64, purchases []*purchase) bool {
 }
 
 // Snap returns the snap.Info for the store hosted snap with the given name or an error.
-func (s *SnapUbuntuStoreRepository) Snap(name, channel string, devmode bool, auther Authenticator) (*snap.Info, error) {
+func (s *SnapUbuntuStoreRepository) Snap(name, channel string, devmode bool, user *auth.UserState) (*snap.Info, error) {
 	u, err := s.detailsURI.Parse(name)
 	if err != nil {
 		return nil, err
@@ -530,7 +562,7 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string, devmode bool, aut
 
 	u.RawQuery = query.Encode()
 
-	req, err := s.newRequest("GET", u.String(), nil, auther)
+	req, err := s.newRequest("GET", u.String(), nil, user)
 	if err != nil {
 		return nil, err
 	}
@@ -564,7 +596,7 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string, devmode bool, aut
 
 	info := infoFromRemote(remote)
 
-	err = s.decoratePurchases([]*snap.Info{info}, channel, auther)
+	err = s.decoratePurchases([]*snap.Info{info}, channel, user)
 	if err != nil {
 		logger.Noticef("cannot get user purchases: %v", err)
 	}
@@ -576,7 +608,7 @@ func (s *SnapUbuntuStoreRepository) Snap(name, channel string, devmode bool, aut
 
 // Find finds  (installable) snaps from the store, matching the
 // given search term.
-func (s *SnapUbuntuStoreRepository) Find(searchTerm string, channel string, auther Authenticator) ([]*snap.Info, error) {
+func (s *SnapUbuntuStoreRepository) Find(searchTerm string, channel string, user *auth.UserState) ([]*snap.Info, error) {
 	if channel == "" {
 		channel = "stable"
 	}
@@ -588,7 +620,7 @@ func (s *SnapUbuntuStoreRepository) Find(searchTerm string, channel string, auth
 	q.Set("confinement", "strict")
 	u.RawQuery = q.Encode()
 
-	req, err := s.newRequest("GET", u.String(), nil, auther)
+	req, err := s.newRequest("GET", u.String(), nil, user)
 	if err != nil {
 		return nil, err
 	}
@@ -619,7 +651,7 @@ func (s *SnapUbuntuStoreRepository) Find(searchTerm string, channel string, auth
 		snaps[i] = infoFromRemote(pkg)
 	}
 
-	err = s.decoratePurchases(snaps, channel, auther)
+	err = s.decoratePurchases(snaps, channel, user)
 	if err != nil {
 		logger.Noticef("cannot get user purchases: %v", err)
 	}
@@ -662,7 +694,7 @@ type metadataWrapper struct {
 }
 
 // ListRefresh returns the available updates for a list of snap identified by fullname with channel.
-func (s *SnapUbuntuStoreRepository) ListRefresh(installed []*RefreshCandidate, auther Authenticator) (snaps []*snap.Info, err error) {
+func (s *SnapUbuntuStoreRepository) ListRefresh(installed []*RefreshCandidate, user *auth.UserState) (snaps []*snap.Info, err error) {
 
 	candidateMap := map[string]*RefreshCandidate{}
 	currentSnaps := make([]currentSnapJson, 0, len(installed))
@@ -706,7 +738,7 @@ func (s *SnapUbuntuStoreRepository) ListRefresh(installed []*RefreshCandidate, a
 		return nil, err
 	}
 
-	s.setUbuntuStoreHeaders(req, "", false, auther)
+	s.setUbuntuStoreHeaders(req, "", false, user)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -755,7 +787,7 @@ func findRev(needle snap.Revision, haystack []snap.Revision) bool {
 // filename.
 // The file is saved in temporary storage, and should be removed
 // after use to prevent the disk from running out of space.
-func (s *SnapUbuntuStoreRepository) Download(name string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, auther Authenticator) (path string, err error) {
+func (s *SnapUbuntuStoreRepository) Download(name string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState) (path string, err error) {
 	w, err := ioutil.TempFile("", name)
 	if err != nil {
 		return "", err
@@ -771,7 +803,7 @@ func (s *SnapUbuntuStoreRepository) Download(name string, downloadInfo *snap.Dow
 	}()
 
 	url := downloadInfo.AnonDownloadURL
-	if url == "" || auther != nil {
+	if url == "" || user != nil {
 		url = downloadInfo.DownloadURL
 	}
 
@@ -779,7 +811,7 @@ func (s *SnapUbuntuStoreRepository) Download(name string, downloadInfo *snap.Dow
 	if err != nil {
 		return "", err
 	}
-	s.setUbuntuStoreHeaders(req, "", false, auther)
+	s.setUbuntuStoreHeaders(req, "", false, user)
 
 	if err := download(name, w, req, pbar); err != nil {
 		return "", err
@@ -822,7 +854,7 @@ type assertionSvcError struct {
 }
 
 // Assertion retrivies the assertion for the given type and primary key.
-func (s *SnapUbuntuStoreRepository) Assertion(assertType *asserts.AssertionType, primaryKey []string, auther Authenticator) (asserts.Assertion, error) {
+func (s *SnapUbuntuStoreRepository) Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error) {
 	url, err := s.assertionsURI.Parse(path.Join(assertType.Name, path.Join(primaryKey...)))
 	if err != nil {
 		return nil, err
@@ -833,8 +865,8 @@ func (s *SnapUbuntuStoreRepository) Assertion(assertType *asserts.AssertionType,
 		return nil, err
 	}
 
-	if auther != nil {
-		auther.Authenticate(req)
+	if user != nil {
+		authenticate(req, user)
 	}
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", asserts.MediaType)
@@ -879,12 +911,12 @@ func (s *SnapUbuntuStoreRepository) SuggestedCurrency() string {
 // BuyOptions specifies parameters for store purchases.
 type BuyOptions struct {
 	// Required
-	SnapID   string        `json:"snap-id"`
-	SnapName string        `json:"snap-name"`
-	Channel  string        `json:"channel"`
-	Price    float64       `json:"price"`
-	Currency string        `json:"currency"` // ISO 4217 code as string
-	Auther   Authenticator `json:"-"`
+	SnapID   string          `json:"snap-id"`
+	SnapName string          `json:"snap-name"`
+	Channel  string          `json:"channel"`
+	Price    float64         `json:"price"`
+	Currency string          `json:"currency"` // ISO 4217 code as string
+	User     *auth.UserState `json:"-"`
 
 	// Optional
 	BackendID string `json:"backend-id"` // e.g. "credit_card", "paypal"
@@ -943,7 +975,7 @@ func (s *SnapUbuntuStoreRepository) Buy(options *BuyOptions) (*BuyResult, error)
 	if options.Currency == "" {
 		return buyOptionError(options, "currency missing")
 	}
-	if options.Auther == nil {
+	if options.User == nil {
 		return buyOptionError(options, "authentication credentials missing")
 	}
 
@@ -965,7 +997,7 @@ func (s *SnapUbuntuStoreRepository) Buy(options *BuyOptions) (*BuyResult, error)
 		return nil, err
 	}
 
-	s.setUbuntuStoreHeaders(req, options.Channel, false, options.Auther)
+	s.setUbuntuStoreHeaders(req, options.Channel, false, options.User)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := s.client.Do(req)


### PR DESCRIPTION
Refactoring store authentication. Store methods will get a UserState instance instead of an Authenticator (and then authentication is really handled by the store).