### PR TITLE
Introduce a simple key-value store for user-specific data

### DIFF
--- a/overlord/userdata/userdata.go
+++ b/overlord/userdata/userdata.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package userdata
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// UserData acts as a key-value store for a specific user
+type UserData struct {
+	user  *auth.UserState
+	state *state.State
+}
+
+// New returns a store for the user which is persisted using the provided state
+func New(u *auth.UserState, s *state.State) *UserData {
+	return &UserData{
+		user:  u,
+		state: s,
+	}
+}
+
+func (ud *UserData) keyForData(key string) string {
+	return fmt.Sprintf("user-%d-%s", ud.user.ID, key)
+}
+
+// Get retrieves a value for the user
+func (ud *UserData) Get(key string, value interface{}) error {
+	return ud.state.Get(ud.keyForData(key), value)
+}
+
+// Set stores a value for the user
+func (ud *UserData) Set(key string, value interface{}) {
+	ud.state.Set(ud.keyForData(key), value)
+}

--- a/overlord/userdata/userdata_test.go
+++ b/overlord/userdata/userdata_test.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package userdata_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/userdata"
+)
+
+func TestOverlord(t *testing.T) { TestingT(t) }
+
+type userDataSuite struct {
+	ud *userdata.UserData
+	u  *auth.UserState
+	s  *state.State
+}
+
+var _ = Suite(&userDataSuite{})
+
+const userID = 7
+
+func (s *userDataSuite) SetUpTest(c *C) {
+	s.u = &auth.UserState{ID: userID}
+	s.s = state.New(nil)
+	s.ud = userdata.New(s.u, s.s)
+	s.s.Lock()
+}
+
+func (s *userDataSuite) TearDownTest(c *C) {
+	s.s.Unlock()
+}
+
+func (s *userDataSuite) TestGetUnsetKey(c *C) {
+	var value string
+	err := s.ud.Get("foo", &value)
+	c.Assert(err, NotNil)
+}
+
+func (s *userDataSuite) TestGet(c *C) {
+	s.s.Set("user-7-foo", "bar")
+
+	var value string
+	err := s.ud.Get("foo", &value)
+
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "bar")
+}
+
+func (s *userDataSuite) TestSet(c *C) {
+	s.ud.Set("foo", "bar")
+
+	var value string
+	err := s.s.Get("user-7-foo", &value)
+
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, "bar")
+}


### PR DESCRIPTION
We've identified a need to persist an authorised user's preferred currency for paid snaps.

Snap listings from the store contain a `preferred-currency` field but relying solely on this can be problematic for certain countries, eg: those with multiple currencies in circulation. Currently `snap find` makes use of this field but __snapweb__ has no concept of paid snaps yet and the two use cases must be consistent.

This proposed first step towards solving that need is a naive key-value store built on top of the existing `state` package which can store an arbitrary value for a given user.

For simplicities sake each value is stored under a fresh entry in the `state` with the name of the entry being associated with the user's ID, eg: a key named `foo` for a user with ID `7` will be stored under `user-7-foo`. The assumption is that the provided value can be marshalled/unmarshalled to/from JSON trivially.

A next step from here would be something like a `CurrencyManager` which would use this mechanism to track the preferred currency, falling back to `suggested-currency` if it has not already been set and we could finish off with an `/v2/currency` API endpoint to get and set the value.