### PR TITLE
overlord/devstate: add DeviceManager which checks assertions

### DIFF
--- a/overlord/devstate/devstate.go
+++ b/overlord/devstate/devstate.go
@@ -1,0 +1,126 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package devstate implements the manager responsible for device
+// identity.
+package devstate
+
+import (
+	"fmt"
+
+	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// DeviceManager is responsible for the management of device identity in
+// the system state. It acquires and stores credentials and verifies
+// that the device's identity is valid when checked against the local
+// assertion database.
+type DeviceManager struct {
+	state     *state.State
+	runner    *state.TaskRunner
+	assertMgr *assertstate.AssertManager
+}
+
+// Manager returns a new DeviceManager.
+func Manager(s *state.State, assertMgr *assertstate.AssertManager) (*DeviceManager, error) {
+	runner := state.NewTaskRunner(s)
+	manager := &DeviceManager{
+		state:     s,
+		runner:    runner,
+		assertMgr: assertMgr,
+	}
+
+	runner.AddHandler("set-device-identity", manager.doSetDeviceIdentity, nil)
+
+	return manager, nil
+}
+
+// Ensure implements StateManager.Ensure.
+func (m *DeviceManager) Ensure() error {
+	m.runner.Ensure()
+	return nil
+}
+
+// Wait implements StateManager.Wait.
+func (m *DeviceManager) Wait() {
+	m.runner.Wait()
+}
+
+// Stop implements StateManager.Stop.
+func (m *DeviceManager) Stop() {
+	m.runner.Stop()
+}
+
+type deviceIdentity struct {
+	Brand  string `json:"brand"`
+	Model  string `json:"model"`
+	Serial string `json:"serial"`
+}
+
+// SetDeviceIdentity returns a set of tasks that changes the device's identity.
+func SetDeviceIdentity(s *state.State, brand string, model string, serial string) (*state.TaskSet, error) {
+	// TODO: Ask identity provider to give us the serial assertion
+	// and its dependencies, rather than failing if it's not already
+	// there.
+	task := s.NewTask("set-device-identity", fmt.Sprintf(i18n.G(`Set device identity to brand "%s", model "%s", serial "%s"`), brand, model, serial))
+	task.Set("device-identity", deviceIdentity{Brand: brand, Model: model, Serial: serial})
+	return state.NewTaskSet(task), nil
+}
+
+func (m *DeviceManager) doSetDeviceIdentity(task *state.Task, tomb *tomb.Tomb) error {
+	st := task.State()
+	st.Lock()
+	var identity deviceIdentity
+	err := task.Get("device-identity", &identity)
+	st.Unlock()
+
+	if err != nil {
+		return fmt.Errorf("cannot extract new device identity from task: %s", err)
+	}
+
+	assert, err := m.assertMgr.DB().Find(asserts.SerialType, map[string]string{"brand-id": identity.Brand, "model": identity.Model, "serial": identity.Serial})
+	if err == asserts.ErrNotFound {
+		return fmt.Errorf("no matching serial assertion")
+	} else if err != nil {
+		return err
+	}
+	err = m.assertMgr.DB().Check(assert)
+	if err != nil {
+		return err
+	}
+
+	st.Lock()
+	dev, err := auth.Device(st)
+	if err != nil {
+		st.Unlock()
+		return err
+	}
+	dev.Brand = identity.Brand
+	dev.Model = identity.Model
+	dev.Serial = identity.Serial
+	err = auth.SetDevice(st, dev)
+	st.Unlock()
+	return err
+}

--- a/overlord/devstate/devstate_test.go
+++ b/overlord/devstate/devstate_test.go
@@ -1,0 +1,171 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package devstate_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/asserts/systestkeys"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devstate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestDeviceManager(t *testing.T) { TestingT(t) }
+
+type deviceManagerSuite struct {
+	state     *state.State
+	manager   *devstate.DeviceManager
+	assertMgr *assertstate.AssertManager
+}
+
+var _ = Suite(&deviceManagerSuite{})
+
+func (s *deviceManagerSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	s.state = state.New(nil)
+
+	// Inject trusted assertions that we can chain from while we
+	// construct the AssertManager.
+	restore := sysdb.InjectTrusted([]asserts.Assertion{systestkeys.TestRootAccount, systestkeys.TestRootAccountKey})
+	assertMgr, err := assertstate.Manager(s.state)
+	restore()
+
+	c.Assert(err, IsNil)
+	s.assertMgr = assertMgr
+	manager, err := devstate.Manager(s.state, s.assertMgr)
+	c.Assert(err, IsNil)
+	s.manager = manager
+}
+
+func (s *deviceManagerSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+}
+
+func (s *deviceManagerSuite) TestSmoke(c *C) {
+	s.manager.Ensure()
+	s.manager.Wait()
+}
+
+// addSerialAssertion constructs a trustworthy serial assertion and adds
+// it to the database.
+func addSerialAssertion(assertMgr *assertstate.AssertManager, brand string, model string, serial string) (*asserts.Serial, error) {
+	rootPrivKey, _ := assertstest.ReadPrivKey(systestkeys.TestRootPrivKey)
+	assertMgr.DB().ImportKey("testrootorg", rootPrivKey)
+
+	devPrivKey, _ := assertstest.GenerateKey(512)
+	deviceKeyEncoded, err := asserts.EncodePublicKey(devPrivKey.PublicKey())
+	if err != nil {
+		return nil, err
+	}
+
+	// XXX: asserts doesn't check model consistency!
+	headers := map[string]string{
+		"authority-id": brand,
+		"brand-id":     brand,
+		"model":        model,
+		"serial":       serial,
+		"device-key":   string(deviceKeyEncoded),
+		"timestamp":    "2016-07-07T04:52:00Z",
+	}
+	serialAssertion, err := assertMgr.DB().Sign(asserts.SerialType, headers, []byte{}, rootPrivKey.PublicKey().ID())
+	if err != nil {
+		return nil, err
+	}
+	err = assertMgr.DB().Add(serialAssertion)
+	if err != nil {
+		return nil, err
+	}
+	return serialAssertion.(*asserts.Serial), nil
+}
+
+func (s *deviceManagerSuite) TestSetDeviceIdentityTask(c *C) {
+	_, err := addSerialAssertion(s.assertMgr, "testrootorg", "the-model", "the-serial")
+	c.Assert(err, IsNil)
+
+	// Create a task to set the identity.
+	s.state.Lock()
+	change := s.state.NewChange("kind", "summary")
+	ts, err := devstate.SetDeviceIdentity(s.state, "testrootorg", "the-model", "the-serial")
+	c.Assert(err, IsNil)
+	change.AddAll(ts)
+	s.state.Unlock()
+
+	s.manager.Ensure()
+	s.manager.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// The task has succeeded.
+	task := change.Tasks()[0]
+	c.Check(task.Kind(), Equals, "set-device-identity")
+	c.Check(task.Summary(), Equals, `Set device identity to brand "testrootorg", model "the-model", serial "the-serial"`)
+	c.Check(task.Status(), Equals, state.DoneStatus)
+	c.Check(change.Status(), Equals, state.DoneStatus)
+	c.Check(change.Err(), IsNil)
+
+	// The device identity is updated in state.
+	dev, err := auth.Device(s.state)
+	c.Check(err, IsNil)
+	c.Check(dev.Brand, Equals, "testrootorg")
+	c.Check(dev.Model, Equals, "the-model")
+	c.Check(dev.Serial, Equals, "the-serial")
+}
+
+func (s *deviceManagerSuite) TestSetDeviceIdentityTaskNoSerialAssertion(c *C) {
+	_, err := addSerialAssertion(s.assertMgr, "testrootorg", "the-model", "the-serial")
+	c.Assert(err, IsNil)
+
+	// Create a task to set the identity.
+	s.state.Lock()
+	change := s.state.NewChange("kind", "summary")
+	ts, err := devstate.SetDeviceIdentity(s.state, "testrootorg", "the-model", "wrong-serial")
+	c.Assert(err, IsNil)
+	change.AddAll(ts)
+	s.state.Unlock()
+
+	s.manager.Ensure()
+	s.manager.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// The task has failed.
+	task := change.Tasks()[0]
+	c.Check(task.Kind(), Equals, "set-device-identity")
+	c.Check(task.Status(), Equals, state.ErrorStatus)
+	c.Check(task.Log()[len(task.Log())-1], Matches, ".* ERROR no matching serial assertion")
+	c.Check(change.Status(), Equals, state.ErrorStatus)
+
+	// The device identity is unchanged in state.
+	dev, err := auth.Device(s.state)
+	c.Check(err, IsNil)
+	c.Check(dev.Brand, Equals, "")
+	c.Check(dev.Model, Equals, "")
+	c.Check(dev.Serial, Equals, "")
+}


### PR DESCRIPTION
This branch adds the start of a DeviceManager, so far with just a single task: setting the brand/model/serial in state if there is a matching serial assertion. The Change will grow more Tasks that tie together the other branches, eg. to ask the gadget snap to fill in missing assertions and to acquire store device credentials.

One major complication is that DeviceManager naturally depends on AssertManager, but the existing manager management in Overlord provides no facility for managers to reference each other. For now I just take the AssertManager as an argument to the constructor, but hopefully a better way can be devised.