### PR TITLE
tests: stop using hello-world.echo in the tests

### DIFF
--- a/tests/main/snap-run-symlink/task.yaml
+++ b/tests/main/snap-run-symlink/task.yaml
@@ -8,7 +8,6 @@ prepare: |
 
 environment:
     APP/helloworld: hello-world
-    APP/helloworldevil: hello-world.evil
 
 execute: |
     echo Testing that replacing the wrapper with a symlink works

--- a/tests/main/snap-run-symlink/task.yaml
+++ b/tests/main/snap-run-symlink/task.yaml
@@ -8,7 +8,7 @@ prepare: |
 
 environment:
     APP/helloworld: hello-world
-    APP/helloworldecho: hello-world.echo
+    APP/helloworldenv: hello-world.env
 
 execute: |
     echo Testing that replacing the wrapper with a symlink works

--- a/tests/main/snap-run-symlink/task.yaml
+++ b/tests/main/snap-run-symlink/task.yaml
@@ -8,7 +8,7 @@ prepare: |
 
 environment:
     APP/helloworld: hello-world
-    APP/helloworldenv: hello-world.env
+    APP/helloworldevil: hello-world.evil
 
 execute: |
     echo Testing that replacing the wrapper with a symlink works

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -11,7 +11,8 @@ execute: |
     snap install hello-world
 
     echo Sanity check install
-    hello-world.echo | grep Hello
+    hello-world | grep Hello
+    hello-world.env | grep SNAP_NAME=hello-world
 
     # setup not to reexec
     export SNAP_REEXEC=0
@@ -27,7 +28,7 @@ execute: |
     echo Sanity check already installed snaps after upgrade
     snap list | grep core
     snap list | grep hello-world
-    hello-world.echo | grep Hello
+    hello-world | grep Hello
     hello-world.env | grep SNAP_NAME=hello-world
     hello-world.evil && exit 1 || true
 


### PR DESCRIPTION
The `hello-world.echo` binary got dropped from the hello-world snap. 