### PR TITLE
tests: add env command to test-snapd-tools

### DIFF
--- a/tests/lib/snaps/test-snapd-tools/bin/env
+++ b/tests/lib/snaps/test-snapd-tools/bin/env
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/bin/env

--- a/tests/lib/snaps/test-snapd-tools/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-tools/meta/snap.yaml
@@ -1,15 +1,17 @@
 name: test-snapd-tools
 version: 1.0
 apps:
- echo:
-  command: bin/echo
- success:
-  command: bin/success
- fail:
-  command: bin/fail
- block:
-  command: bin/block
- cat:
-  command: bin/cat
- head:
-  command: bin/head
+    echo:
+        command: bin/echo
+    success:
+        command: bin/success
+    fail:
+        command: bin/fail
+    block:
+        command: bin/block
+    cat:
+        command: bin/cat
+    head:
+        command: bin/head
+    env:
+        command: bin/env


### PR DESCRIPTION
With this addition we can replace hello-world with test-snapd-tools in the tests (once it is uploaded to the store), all the hello-world commands used in the tests are currently ported except `evil`, which can be replaced with `test-snapd-tools.echo "Hello" > /var/tmp/myevil.txt`.