### PR TITLE
spread.yaml, tests: replace hello-world with test-snapd-tools

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -73,10 +73,10 @@ suites:
             # Snapshot the state including core.
             if [ ! -f $SPREAD_PATH/snapd-state.tar.gz ]; then
                 ! snap list | grep core || exit 1
-                snap install hello-world
+                snap install test-snapd-tools
                 snap list | grep core
-                snap remove hello-world
-                rmdir /snap/hello-world # Should be done by snapd.
+                snap remove test-snapd-tools
+                rmdir /snap/test-snapd-tools # Should be done by snapd.
 
                 systemctl stop snapd.service snapd.socket
                 systemctl daemon-reload

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -24,7 +24,9 @@ setup_fake_store(){
 
 setup_staging_store(){
     echo "Given ubuntu-core snap is available before switching to staging"
-    snap install hello-world
+    if ! snap list | grep -q ubuntu-core; then
+        snap install ubuntu-core
+    fi
 
     echo "And snapd is configured to use the staging store"
     configure_store_backend search.apps.staging.ubuntu.com/api/v1/

--- a/tests/main/abort/task.yaml
+++ b/tests/main/abort/task.yaml
@@ -1,7 +1,7 @@
 summary: Check change abort
 
 environment:
-    SNAP_NAME: hello-world
+    SNAP_NAME: test-snapd-tools
 
 execute: |
     echo "Abort with invalid id"

--- a/tests/main/auth-errors/task.yaml
+++ b/tests/main/auth-errors/task.yaml
@@ -9,7 +9,7 @@ restore: |
 
 execute: |
     echo "An unauthenticated user cannot install snaps"
-    if sudo -i -u test /bin/sh -c "snap install hello-world 2>${PWD}/install.output"; then
+    if sudo -i -u test /bin/sh -c "snap install test-snapd-tools 2>${PWD}/install.output"; then
         echo "Expected error installing snap from unauthenticated account"
         exit 1
     fi

--- a/tests/main/cmdline/task.yaml
+++ b/tests/main/cmdline/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that cmdline for channel shortcuts work
 execute: |
     echo Conflicting channel commandline errors correctly
-    if snap install --beta --edge hello-world 2>err.msg; then
+    if snap install --beta --edge test-snapd-tools 2>err.msg; then
         echo "Expected failure when --beta --edge is given at the same time"
         exit 1
     fi

--- a/tests/main/enable-disable/task.yaml
+++ b/tests/main/enable-disable/task.yaml
@@ -1,20 +1,19 @@
 summary: Check that enable/disable works
 
 execute: |
-    echo "Install hello-world and ensure it runs"
-    snap install hello-world
-    hello-world|grep "Hello World"
-    echo "Disable hello-world and ensure it is listed as disabled"
-    snap disable hello-world|grep disabled
+    echo "Install test-snapd-tools and ensure it runs"
+    snap install test-snapd-tools
+    test-snapd-tools.echo Hello|grep Hello
+    echo "Disable test-snapd-tools and ensure it is listed as disabled"
+    snap disable test-snapd-tools|grep disabled
 
-    echo "Ensure the hello-world command is no longer there"
-    if ls /snap/bin/hello-world*; then
-        echo "hello-world binaries are not disabled"
+    echo "Ensure the test-snapd-tools command is no longer there"
+    if ls /snap/bin/test-snapd-tools*; then
+        echo "test-snapd-tools binaries are not disabled"
         exit 1
     fi
 
-    echo "Enable hello-world again and ensure it is no longer listed as disabled"
-    snap enable hello-world|grep -v disabled
-    echo "Ensure hello-world runs normally after it was enabled"
-    hello-world|grep "Hello World"
-
+    echo "Enable test-snapd-tools again and ensure it is no longer listed as disabled"
+    snap enable test-snapd-tools|grep -v disabled
+    echo "Ensure test-snapd-tools runs normally after it was enabled"
+    test-snapd-tools.echo Hello |grep Hello

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -1,21 +1,11 @@
 summary: Checks for cli errors installing snaps
+
 environment:
-    SIDELOAD_SNAP_NAME: test-snapd-tools
-    STORE_SNAP_NAME: hello-world
-    SNAP_FILE: "./$[SIDELOAD_SNAP_NAME]_1.0_all.snap"
+    SNAP_NAME: test-snapd-tools
 
 prepare: |
     echo "Given a snap with a failing command is installed"
-    snapbuild $TESTSLIB/snaps/$SIDELOAD_SNAP_NAME .
-    snap install $SNAP_FILE
-
-    echo "And a snap from the store is installed"
-    snap install $STORE_SNAP_NAME
-
-restore: |
-    snap remove $SIDELOAD_SNAP_NAME
-    snap remove $STORE_SNAP_NAME
-    rm -f $SNAP_FILE
+    snap install $SNAP_NAME
 
 execute: |
     echo "Install unexisting snap prints error"
@@ -35,7 +25,7 @@ execute: |
     echo "============================================"
 
     echo "Install points to login when not authenticated"
-    if sudo -i -u test /bin/sh -c "snap install hello-world 2>${PWD}/install.output"; then
+    if sudo -i -u test /bin/sh -c "snap install $SNAP_NAME 2>${PWD}/install.output"; then
         echo "Unauthenticated install should fail"
         exit 1
     fi
@@ -52,7 +42,7 @@ execute: |
     echo "============================================"
 
     echo "Install a snap already installed fails"
-    if snap install $STORE_SNAP_NAME; then
+    if snap install $SNAP_NAME; then
         echo "Trying to install an already installed snap should fail"
         exit 1
     fi

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -1,7 +1,7 @@
 summary: Checks for special cases of snap install from the store
 
 environment:
-    SNAP_NAME: hello-world
+    SNAP_NAME: test-snapd-tools
     DEVMODE_SNAP: devmode-world
 
 execute: |

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -1,7 +1,7 @@
 summary: Check snap listings
 
 prepare: |
-    snap install hello-world
+    snap install test-snapd-tools
 
 execute: |
     echo "List prints core snap version"
@@ -9,5 +9,5 @@ execute: |
     snap list | grep -Pq "$expected"
 
     echo "List prints installed snap version"
-    expected="^hello-world +(\\d+)(\\.\\d+)* +[0-9]+ +\\S+ +- *"
+    expected="^test-snapd-tools +(\\d+)(\\.\\d+)* +[0-9]+ +\\S+ +- *"
     snap list | grep -Pq "$expected"

--- a/tests/main/op-remove-retry/task.yaml
+++ b/tests/main/op-remove-retry/task.yaml
@@ -39,4 +39,4 @@ execute: |
     wait_for_remove_state Done
 
     echo "And the snap is removed"
-    ! snap list | grep -q test-snapd-tools
+    while snap list | grep -q test-snapd-tools; do sleep 1; done

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -12,7 +12,7 @@ prepare: |
     . $TESTSLIB/store.sh
 
     echo "Given two snaps are installed"
-    for snap in hello-world xkcd-webserver; do
+    for snap in test-snapd-tools xkcd-webserver; do
         snap install $snap
     done
 
@@ -25,12 +25,12 @@ restore: |
 
 execute: |
     echo "When the store is configured to make them refreshable"
-    fakestore -make-refreshable hello-world,xkcd-webserver -blobdir $BLOB_DIR
+    fakestore -make-refreshable test-snapd-tools,xkcd-webserver -blobdir $BLOB_DIR
 
     echo "And a refresh is performed"
     snap refresh
 
     echo "Then the new versions are installed"
-    for snap in hello-world xkcd-webserver; do
+    for snap in test-snapd-tools xkcd-webserver; do
         snap list | grep -Pq "$snap.*?fake1"
     done

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -7,7 +7,7 @@ details: |
     directory
 
 environment:
-    SNAP_NAME: hello-world
+    SNAP_NAME: test-snapd-tools
     CONFIG_DIR: /etc/systemd/system/snapd.service.d
     STORE_CONFIG: $[CONFIG_DIR]/fakestore.conf
     BLOB_DIR: $(mktemp -d)

--- a/tests/main/remove-errors/task.yaml
+++ b/tests/main/remove-errors/task.yaml
@@ -2,14 +2,14 @@ summary: Check remove command errors
 
 execute: |
     echo "An error is returned when trying to remove an non installed snap"
-    if snap remove hello-world; then
+    if snap remove test-snapd-tools; then
         echo "An error is expected when trying to remove a non installed snap"
         exit 1
     fi
     echo "================================"
 
     echo "Given ubuntu-core is installed"
-    snap install hello-world
+    snap install test-snapd-tools
 
     echo "An error is returned whrn trying to remove ubuntu-core"
     if snap remove ubuntu-core; then

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -5,7 +5,7 @@ execute: |
     ( snap find 2>&1 || echo FAILED ) | grep -Pzq "(?ms)empty query.*FAILED"
 
     echo "Exact matches"
-    for snapName in hello-world xkcd-webserver
+    for snapName in test-snapd-tools xkcd-webserver
     do
         expected="(?s)Name +Version +Developer +Notes +Summary *\n\
     (.*?\n)?\
@@ -17,6 +17,6 @@ execute: |
     echo "Partial terms work too"
     expected="(?s)Name +Version +Developer +Notes +Summary *\n\
     (.*?\n)?\
-    hello-world +.*? *\n\
+    test-snapd-tools +.*? *\n\
     .*"
-    snap find hello- | grep -Pzq "$expected"
+    snap find test-snapd- | grep -Pzq "$expected"

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that upgrade works
 restore: |
     sed -i -e '/SNAP_REEXEC=0/d' /etc/environment
+    rm -f /var/tmp/myevil.txt
 execute: |
     echo Install previous version...
     apt install -y snapd
@@ -30,7 +31,8 @@ execute: |
     snap list | grep test-snapd-tools
     test-snapd-tools.echo Hello | grep Hello
     test-snapd-tools.env | grep SNAP_NAME=test-snapd-tools
-    test-snapd-tools.echo Hello > /var/tmp/myevil.txt && exit 1 || true
+    echo Hello > /var/tmp/myevil.txt
+    test-snapd-tools.cat /var/tmp/myevil.txt && exit 1 || true
 
     echo Check migrating to types in state
     coreType=$(jq -r '.data.snaps["ubuntu-core"].type' /var/lib/snapd/state.json)

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -8,10 +8,10 @@ execute: |
     prevsnapdver=$(snap --version|grep "snapd ")
 
     echo Install a snap with it
-    snap install hello-world
+    snap install test-snapd-tools
 
     echo Sanity check install
-    hello-world.echo | grep Hello
+    test-snapd-tools.echo Hello | grep Hello
 
     # setup not to reexec
     export SNAP_REEXEC=0
@@ -26,13 +26,13 @@ execute: |
 
     echo Sanity check already installed snaps after upgrade
     snap list | grep core
-    snap list | grep hello-world
-    hello-world.echo | grep Hello
-    hello-world.env | grep SNAP_NAME=hello-world
-    hello-world.evil && exit 1 || true
+    snap list | grep test-snapd-tools
+    test-snapd-tools.echo Hello | grep Hello
+    test-snapd-tools.env | grep SNAP_NAME=test-snapd-tools
+    test-snapd-tools.echo Hello > /var/tmp/myevil.txt && exit 1 || true
 
     echo Check migrating to types in state
     coreType=$(jq -r '.data.snaps["ubuntu-core"].type' /var/lib/snapd/state.json)
-    helloType=$(jq -r '.data.snaps["hello-world"].type' /var/lib/snapd/state.json)
+    testSnapType=$(jq -r '.data.snaps["test-snapd-tools"].type' /var/lib/snapd/state.json)
     [ "$coreType" = "os" ]
-    [ "$helloType" = "app" ]
+    [ "$testSnapType" = "app" ]


### PR DESCRIPTION
Requires #1539, the fakestore change in #1535 and the latest version of test-snapd-tools (including the `env` command) uploaded to the production store for all the spread tests to pass.