### PR TITLE
snap-exec: add proper integration test for snap-exec

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -104,7 +104,7 @@ func snapExec(snapApp, revision, command string, args []string) error {
 		Revision: rev,
 	})
 	if err != nil {
-		return fmt.Errorf("cannot read info for %q", snapName, err)
+		return fmt.Errorf("cannot read info for %q: %s", snapName, err)
 	}
 
 	app := info.Apps[appName]
@@ -127,5 +127,6 @@ func snapExec(snapApp, revision, command string, args []string) error {
 	if err := syscallExec(fullCmd, fullCmdArgs, env); err != nil {
 		return fmt.Errorf("cannot exec %q: %s", fullCmd, err)
 	}
+	// this is never reached except in tests
 	return nil
 }

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -114,7 +114,7 @@ func snapExec(snapApp, revision, command string, args []string) error {
 
 	cmd, err := findCommand(app, command)
 	if err != nil {
-		return fmt.Errorf("cannot find command %q in app %q: %s", command, app, err)
+		return err
 	}
 
 	// build the evnironment from the yamle

--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -69,7 +69,7 @@ func run() error {
 	// confinement and (generally) can not talk to snapd
 	revision := os.Getenv("SNAP_REVISION")
 
-	return snapExec(snapApp, revision, opts.Command, args[1:])
+	return snapExec(snapApp, revision, opts.Command, args)
 }
 
 func findCommand(app *snap.AppInfo, command string) (string, error) {
@@ -96,7 +96,7 @@ func findCommand(app *snap.AppInfo, command string) (string, error) {
 func snapExec(snapApp, revision, command string, args []string) error {
 	rev, err := snap.ParseRevision(revision)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot parse revision %q: %s", revision, err)
 	}
 
 	snapName, appName := snap.SplitSnapApp(snapApp)
@@ -104,7 +104,7 @@ func snapExec(snapApp, revision, command string, args []string) error {
 		Revision: rev,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot read info for %q", snapName, err)
 	}
 
 	app := info.Apps[appName]
@@ -114,7 +114,7 @@ func snapExec(snapApp, revision, command string, args []string) error {
 
 	cmd, err := findCommand(app, command)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot find command %q in app %q: %s", command, app, err)
 	}
 
 	// build the evnironment from the yamle
@@ -124,5 +124,8 @@ func snapExec(snapApp, revision, command string, args []string) error {
 	fullCmd := filepath.Join(app.Snap.MountDir(), cmd)
 	fullCmdArgs := []string{fullCmd}
 	fullCmdArgs = append(fullCmdArgs, args...)
-	return syscallExec(fullCmd, fullCmdArgs, env)
+	if err := syscallExec(fullCmd, fullCmdArgs, env); err != nil {
+		return fmt.Errorf("cannot exec %q: %s", fullCmd, err)
+	}
+	return nil
 }

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -173,8 +173,9 @@ func (s *snapExecSuite) TestSnapExecRealIntegration(c *C) {
 	syscallExec = func(argv0 string, argv []string, env []string) error {
 		cmd := exec.Command(argv[0], argv[1:]...)
 		cmd.Env = env
-		cmd.Stdout = os.Stdout
-		return cmd.Run()
+		output, err := cmd.CombinedOutput()
+		c.Assert(output, HasLen, 0)
+		return err
 	}
 
 	// run it


### PR DESCRIPTION
It also fixes the error messages and fixes another off-by-one error that got overlooked in the previous fix. 