### PR TITLE
client,cmd/snap: cleanup cmd/snap test suite, add extra args test

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -129,6 +129,18 @@ var (
 	doTimeout = 5 * time.Second
 )
 
+// MockDoRetry mocks the delays used by the do retry loop.
+func MockDoRetry(retry, timeout time.Duration) (restore func()) {
+	oldRetry := doRetry
+	oldTimeout := doTimeout
+	doRetry = retry
+	doTimeout = timeout
+	return func() {
+		doRetry = oldRetry
+		doTimeout = oldTimeout
+	}
+}
+
 // do performs a request and decodes the resulting json into the given
 // value. It's low-level, for testing/experimenting only; you should
 // usually use a higher level interface that builds on this.

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -22,7 +22,6 @@ package client
 import (
 	"io"
 	"net/url"
-	"time"
 )
 
 // SetDoer sets the client's doer to the given one
@@ -33,18 +32,6 @@ func (client *Client) SetDoer(d doer) {
 // Do does do.
 func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}) error {
 	return client.do(method, path, query, nil, body, v)
-}
-
-// MockDoRetry mocks the delays used by the do retry loop.
-func MockDoRetry(retry, timeout time.Duration) (restore func()) {
-	oldRetry := doRetry
-	oldTimeout := doTimeout
-	doRetry = retry
-	doTimeout = timeout
-	return func() {
-		doRetry = oldRetry
-		doTimeout = oldTimeout
-	}
 }
 
 // expose parseError for testing

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -39,16 +39,14 @@ import (
 // Hook up check.v1 into the "go test" runner
 func Test(t *testing.T) { TestingT(t) }
 
-type SnapSuite struct {
+type BaseSnapSuite struct {
 	testutil.BaseTest
 	stdin  *bytes.Buffer
 	stdout *bytes.Buffer
 	stderr *bytes.Buffer
 }
 
-var _ = Suite(&SnapSuite{})
-
-func (s *SnapSuite) SetUpTest(c *C) {
+func (s *BaseSnapSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	s.stdin = bytes.NewBuffer(nil)
 	s.stdout = bytes.NewBuffer(nil)
@@ -58,27 +56,33 @@ func (s *SnapSuite) SetUpTest(c *C) {
 	snap.Stderr = s.stderr
 }
 
-func (s *SnapSuite) TearDownTest(c *C) {
+func (s *BaseSnapSuite) TearDownTest(c *C) {
 	snap.Stdin = os.Stdin
 	snap.Stdout = os.Stdout
 	snap.Stderr = os.Stderr
 	s.BaseTest.TearDownTest(c)
 }
 
-func (s *SnapSuite) Stdout() string {
+func (s *BaseSnapSuite) Stdout() string {
 	return s.stdout.String()
 }
 
-func (s *SnapSuite) Stderr() string {
+func (s *BaseSnapSuite) Stderr() string {
 	return s.stderr.String()
 }
 
-func (s *SnapSuite) RedirectClientToTestServer(handler func(http.ResponseWriter, *http.Request)) {
+func (s *BaseSnapSuite) RedirectClientToTestServer(handler func(http.ResponseWriter, *http.Request)) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	s.BaseTest.AddCleanup(func() { server.Close() })
 	snap.ClientConfig.BaseURL = server.URL
 	s.BaseTest.AddCleanup(func() { snap.ClientConfig.BaseURL = "" })
 }
+
+type SnapSuite struct {
+	BaseSnapSuite
+}
+
+var _ = Suite(&SnapSuite{})
 
 // DecodedRequestBody returns the JSON-decoded body of the request.
 func DecodedRequestBody(c *C, r *http.Request) map[string]interface{} {
@@ -122,4 +126,14 @@ func (s *SnapSuite) TestAccessDeniedHint(c *C) {
 
 	err := snap.RunMain()
 	c.Assert(err, ErrorMatches, `access denied \(snap login --help\)`)
+}
+
+func (s *SnapSuite) TestExtraArgs(c *C) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	os.Args = []string{"snap", "abort", "1", "xxx", "zzz"}
+
+	err := snap.RunMain()
+	c.Assert(err, ErrorMatches, `too many arguments for command`)
 }


### PR DESCRIPTION
This cleans up the cmd/snap test suite:

* don't run most test twice by fixing the suite inheritance
* don't make TestWait take a long time, by exposing and using mocking the client retry times

in the process also add a test about extra args checks