### PR TITLE
network-observe: add device read support

### DIFF
--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -85,6 +85,9 @@ network inet6 raw,
 
 # route
 /etc/networks r,
+
+# network devices
+/sys/devices/**/net/** r,
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/network-observe


### PR DESCRIPTION
I have an application that expects to be able to read network interface information from /sys/class/net, which contains symlinks to ../../devices/. The current network-observe interface lacks the ability, however, to read from the locations referenced by the symlinks. This addition to the interface profile has resolved the problem for me in all test cases I've thrown at it:

/sys/devices/**/net/** r

