### PR TITLE
Drop warning about 2.0 API being different - we're already 2.0!

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -2,9 +2,6 @@
 
 Version: v2pre0
 
-Note: The v2 API is going to be very different from the 1.0; right now, not
-so much.
-
 ## Versioning
 
 As the API evolves, some changes are deemed backwards-compatible (such


### PR DESCRIPTION
This documentation warning is confusing - it suggests there is a 2.0 version coming, when this is already a 2.0 version. I think this is a hangover from the old 1.0 doc?! If this is valid, perhaps we should rename to something like "This API is currently in progress and may change".