### PR TITLE
Interfaces: hardware-observe

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -193,3 +193,10 @@ Can manage timeservers directly separate from config ubuntu-core.
 
 Usage: reserved
 Auto-Connect: no
+
+### hardware-observe
+
+Can query hardware information from the system.
+
+Usage: reserved
+Auto-Connect: no

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -36,6 +36,7 @@ var allInterfaces = []interfaces.Interface{
 	&SerialPortInterface{},
 	NewFirewallControlInterface(),
 	NewGsettingsInterface(),
+	NewHardwareObserveInterface(),
 	NewHomeInterface(),
 	NewLocaleControlInterface(),
 	NewLogObserveInterface(),

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -31,22 +31,13 @@ const hardwareObserveConnectedPlugAppArmor = `
 
 #include <abstractions/base>
 
-/etc/udev/udev.conf r,
-@{PROC}/*/stat r,
-/run/udev/data/* r,
-/sys/bus/ r,
-/sys/bus/**/ r,
-/sys/class/ r,
-/sys/class/*/ r,
-/sys/devices/** r,
-@{PROC}/*/mountinfo r,
-@{PROC}/swaps r,
-/sys/block/ r,
-/sys/devices/** r,
-/dev/bus/usb/ r,
-/dev/bus/usb/** r,
-/sys/bus/usb/devices/ r,
+# files in /sys pertaining to hardware
+/sys/{block,bus,class,devices}/{,**} r,
+
+# USB IDs
 /var/lib/usbutils/usb.ids r,
+
+# DMI tables
 /sys/firmware/dmi/tables/DMI r,
 /sys/firmware/dmi/tables/smbios_entry_point r,
 `

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -25,7 +25,8 @@ import (
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/log-observe
 const hardwareObserveConnectedPlugAppArmor = `
-# Description: Can read udevadm info
+# Description: This interface allows for getting hardware information
+# from the system, as is needed by checkbox on snappy.  This is reserved for OS snap.
 # Usage: reserved
 
 #include <abstractions/base>

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -34,9 +34,6 @@ const hardwareObserveConnectedPlugAppArmor = `
 # files in /sys pertaining to hardware
 /sys/{block,bus,class,devices}/{,**} r,
 
-# USB IDs
-/var/lib/usbutils/usb.ids r,
-
 # DMI tables
 /sys/firmware/dmi/tables/DMI r,
 /sys/firmware/dmi/tables/smbios_entry_point r,

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -46,6 +46,7 @@ const hardwareObserveConnectedPlugAppArmor = `
 /sys/block/ r,
 /sys/devices/** r,
 /dev/bus/usb/ r,
+/dev/bus/usb/** r,
 /sys/bus/usb/devices/ r,
 /var/lib/usbutils/usb.ids r,
 /sys/firmware/dmi/tables/DMI r,

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -26,7 +26,7 @@ import (
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/log-observe
 const hardwareObserveConnectedPlugAppArmor = `
 # Description: This interface allows for getting hardware information
-# from the system, as is needed by checkbox on snappy.  This is reserved for OS snap.
+# from the system.  This is reserved for OS snap.
 # Usage: reserved
 
 #include <abstractions/base>
@@ -50,8 +50,6 @@ const hardwareObserveConnectedPlugAppArmor = `
 /var/lib/usbutils/usb.ids r,
 /sys/firmware/dmi/tables/DMI r,
 /sys/firmware/dmi/tables/smbios_entry_point r,
-
-
 `
 
 // NewHardwareObserveInterface returns a new "hardware-observe" interface.

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -1,0 +1,65 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/log-observe
+const hardwareObserveConnectedPlugAppArmor = `
+# Description: Can read udevadm info
+# Usage: reserved
+
+#include <abstractions/base>
+
+/bin/udevadm ixr,
+/bin/lsblk ixr,
+/usr/sbin/dmidecode ixr,
+/usr/bin/lsusb ixr,
+/etc/udev/udev.conf r,
+@{PROC}/*/stat r,
+/run/udev/data/* r,
+/sys/bus/ r,
+/sys/bus/**/ r,
+/sys/class/ r,
+/sys/class/*/ r,
+/sys/devices/** r,
+@{PROC}/*/mountinfo r,
+@{PROC}/swaps r,
+/sys/block/ r,
+/sys/devices/** r,
+/dev/bus/usb/ r,
+/sys/bus/usb/devices/ r,
+/var/lib/usbutils/usb.ids r,
+/sys/firmware/dmi/tables/DMI r,
+/sys/firmware/dmi/tables/smbios_entry_point r,
+
+
+`
+
+// NewHardwareObserveInterface returns a new "hardware-observe" interface.
+func NewHardwareObserveInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "hardware-observe",
+		connectedPlugAppArmor: hardwareObserveConnectedPlugAppArmor,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -29,8 +29,6 @@ const hardwareObserveConnectedPlugAppArmor = `
 # from the system.  This is reserved for OS snap.
 # Usage: reserved
 
-#include <abstractions/base>
-
 # files in /sys pertaining to hardware
 /sys/{block,bus,class,devices}/{,**} r,
 

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -31,8 +31,6 @@ const hardwareObserveConnectedPlugAppArmor = `
 
 #include <abstractions/base>
 
-/bin/udevadm ixr,
-/bin/lsblk ixr,
 /etc/udev/udev.conf r,
 @{PROC}/*/stat r,
 /run/udev/data/* r,

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -33,8 +33,6 @@ const hardwareObserveConnectedPlugAppArmor = `
 
 /bin/udevadm ixr,
 /bin/lsblk ixr,
-/usr/sbin/dmidecode ixr,
-/usr/bin/lsusb ixr,
 /etc/udev/udev.conf r,
 @{PROC}/*/stat r,
 /run/udev/data/* r,

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -26,7 +26,7 @@ import (
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/log-observe
 const hardwareObserveConnectedPlugAppArmor = `
 # Description: This interface allows for getting hardware information
-# from the system.  This is reserved for OS snap.
+# from the system.  this is reserved because it allows reading potentially sensitive information.
 # Usage: reserved
 
 # files in /sys pertaining to hardware

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -1,0 +1,128 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+)
+
+type HardwareObserveInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&HardwareObserveInterfaceSuite{
+	iface: builtin.NewHardwareObserveInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Name:      "hardware-observe",
+			Interface: "hardware-observe",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "hardware-observe",
+			Interface: "hardware-observe",
+		},
+	},
+})
+
+func (s *HardwareObserveInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "hardware-observe")
+}
+
+func (s *HardwareObserveInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "hardware-observe",
+		Interface: "hardware-observe",
+	}})
+	c.Assert(err, ErrorMatches, "hardware-observe slots are reserved for the operating system snap")
+}
+
+func (s *HardwareObserveInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *HardwareObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "hardware-observe"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "hardware-observe"`)
+}
+
+func (s *HardwareObserveInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev}
+	for _, system := range systems {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *HardwareObserveInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *HardwareObserveInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(), Equals, false)
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -30,6 +30,7 @@ import (
 var implicitSlots = []string{
 	"firewall-control",
 	"home",
+	"hardware-observe",
 	"locale-control",
 	"log-observe",
 	"mount-observe",

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -42,7 +42,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 14)
+	c.Assert(info.Slots, HasLen, 15)
 }
 
 func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 24)
+	c.Assert(info.Slots, HasLen, 25)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
This adds an interface to pull some hardware information from the system, and is needed to be able to run checkbox on a snappy system without --devmode. 