### PR TITLE
snap/squashfs: fix test not to hardcode snap size

### DIFF
--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -90,7 +90,9 @@ func (s *SquashfsTestSuite) TestHashFile(c *C) {
 	snap := makeSnap(c, "name: test", "")
 	size, digest, err := snap.HashDigest(crypto.SHA256)
 	c.Assert(err, IsNil)
-	c.Check(size, Equals, uint64(4096))
+	fileInfo, err := os.Stat(snap.Path())
+	c.Assert(err, IsNil)
+	c.Check(int64(size), Equals, fileInfo.Size())
 	c.Check(digest, HasLen, crypto.SHA256.Size())
 }
 


### PR DESCRIPTION
It turns out that mksquashfs on some distributions is patched to have a
different block size to what we assumed when we wrote the test on
Ubuntu. Instead of being very specific about it, let's just compare the
size of hashed data with the size of the file on disk.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>