### PR TITLE
Enable SNAPPY_STORE_AUTH_DATA_FILENAME override for client auth data.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Before contributing you should sign [Canonical's contributor agreement](http://w
 
 Before merging any pull request to snappy's code base we need to verify that the code functionality and quality is not degraded by that addition. In order to do that there's a set of checks that we run for each PR, some of them using external services (TravisCI and Coveralls) and others using our own CI infrastructure (integration tests and autopkgtests). The checks based on external services are run for all the pull request. We are using the [GitHub Pull Request Builder Plugin](https://github.com/jenkinsci/ghprb-plugin/blob/master/README.md) for easing the management of PRs in relation with our internal infrastructure.
 
-Depending on the afiliation of the GitHub user submitting a PR, the following actions may happen after receiving it:
+Depending on the affiliation of the GitHub user submitting a PR, the following actions may happen after receiving it:
 
 * If the user belongs to the `ubuntu-core` organization or has been previously whitelisted, the internal downstream verification jobs will be triggered, their progress is reported in the PR's status section. Any of the users of the organization can retrigger the execution by posting a `retest this please` comment in the PR.
 * For user's outside the `ubuntu-core` organization, the internal checks won't be triggered by default and the [snappy-m-o](https://github.com/snappy-m-o) user, managed by the ghrbp plugin, will post a comment "Can one of the admins verify this patch?". After this, an `ubuntu-core` admin can post one of these comments:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To run the various tests that we have to ensure a high quality source just run:
 This will check if the source format is consistent, that it build, all tests
 work as expected and that "go vet" and "golint" have nothing to complain.
 
-You can run individual test with:
+You can run individual test for a sub-package by changing into that directory and:
 
     go test -check.f $testname
 

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -40,3 +40,4 @@ var ParseErrorInTest = parseError
 // expose read and write auth helpers for testing
 var TestWriteAuth = writeAuthData
 var TestReadAuth = readAuthData
+var TestStoreAuthFilename = storeAuthDataFilename

--- a/client/login.go
+++ b/client/login.go
@@ -79,6 +79,10 @@ func (client *Client) LoggedIn() bool {
 }
 
 func storeAuthDataFilename() string {
+	authFilename := os.Getenv("SNAPPY_STORE_AUTH_DATA_FILENAME")
+	if authFilename != "" {
+		return authFilename
+	}
 	homeDir, err := osutil.CurrentHomeDir()
 	if err != nil {
 		panic(err)

--- a/client/login_test.go
+++ b/client/login_test.go
@@ -139,3 +139,27 @@ func (cs *clientSuite) TestReadAuthData(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(readUser, check.DeepEquals, &authData)
 }
+
+func (cs *clientSuite) TestStoreAuthDataFilenameDefault(c *check.C) {
+	home := os.Getenv("HOME")
+	tmpdir := c.MkDir()
+	os.Setenv("HOME", tmpdir)
+	defer os.Setenv("HOME", home)
+
+	authFilename := client.TestStoreAuthFilename()
+
+	expectedFilename := filepath.Join(tmpdir, ".snap", "auth.json")
+	c.Check(authFilename, check.Equals, expectedFilename)
+}
+
+func (cs *clientSuite) TestStoreAuthDataFilenameViaEnv(c *check.C) {
+	authFilenameOrig := os.Getenv("SNAPPY_STORE_AUTH_DATA_FILENAME")
+	tmpdir := c.MkDir()
+	expectedAuthFilename := filepath.Join(tmpdir, "auth.json")
+	os.Setenv("SNAPPY_STORE_AUTH_DATA_FILENAME", expectedAuthFilename)
+	defer os.Setenv("SNAPPY_STORE_AUTH_DATA_FILENAME", authFilenameOrig)
+
+	authFilename := client.TestStoreAuthFilename()
+
+	c.Check(authFilename, check.Equals, expectedAuthFilename)
+}


### PR DESCRIPTION
If a service is running as root on a machine using credentials provided by a user and using the snapd client, currently the service would need to either override $HOME on every use of the client, or create/copy/symlink a single /.snap/auth.json , neither of which seem great (or maybe there's a better method?)

Anyway, this branch just allows an env var to be used with the client so that services can choose where they store the auth credentials.

Let me know if this isn't a good idea - I'm happy to look at better options :)