### PR TITLE
osutil: check for nogrup instead of adm

### DIFF
--- a/osutil/group_linux_test.go
+++ b/osutil/group_linux_test.go
@@ -62,9 +62,9 @@ func getgrnamForking(name string) (grp Group, err error) {
 }
 
 func (s *groupTestSuite) TestGetgrnam(c *C) {
-	expected, err := getgrnamForking("adm")
+	expected, err := getgrnamForking("nogroup")
 	c.Assert(err, IsNil)
-	groups, err := Getgrnam("adm")
+	groups, err := Getgrnam("nogroup")
 	c.Assert(err, IsNil)
 	c.Assert(groups, DeepEquals, expected)
 }


### PR DESCRIPTION
This patch uses the "nogroup" which is present everywhere because the "adm" group doesn't exist universally and it tends to break unit tests.