### PR TITLE
interfaces/builtin: allow getsockopt for connected x11 plugs

### DIFF
--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -44,6 +44,7 @@ const x11ConnectedPlugSecComp = `
 
 getpeername
 getsockname
+getsockopt
 recvfrom
 recvmsg
 shutdown


### PR DESCRIPTION
This patch fixes the x11 interface to allow snaps having a connected x11
plug to use the getsockopt system call.

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1604839
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>