### PR TITLE
tests: added spread find private test

### DIFF
--- a/tests/lib/snaps/test-snapd-private/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-private/meta/snap.yaml
@@ -1,0 +1,4 @@
+name: test-snapd-private
+version: 1.0
+summary: Basic snap to be published as private
+description: A basic buildable snap that is expected to be published in private mode

--- a/tests/main/find-private/successful_login.exp
+++ b/tests/main/find-private/successful_login.exp
@@ -1,0 +1,12 @@
+spawn snap login $env(SPREAD_STORE_USER)
+
+expect "Password: "
+send "$env(SPREAD_STORE_PASSWORD)\n"
+
+expect {
+    "Login successful" {
+        exit 0
+    } default {
+        exit 1
+    }
+}

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -6,17 +6,21 @@ details: |
     In order to do the full checks, it also needs the credentials of the owner of that
     snap set in the environment variables SPREAD_STORE_USER and SPREAD_STORE_PASSWORD, if
     they are not present then only the negative check (private snap does not show up in
-    the find results without the owner logged) is performed.
+    the find results without specifying private search or without the owner logged) is
+    performed.
 
 restore: |
     snap logout || true
 
 execute: |
-    echo "When a snap is private it doesn't show up in the find results without login"
+    echo "When a snap is private it doesn't show up in the find without login and without specifying private search"
+    ! snap find test-snapd-private | grep -q "test-snapd-private +\d+\.\d+"
+
+    echo "When a snap is private it doesn't show up in the find --private results without login"
     ! snap find test-snapd-private --private | grep -q "test-snapd-private +\d+\.\d+"
 
     echo "Given account store credentials are available"
-    if [[ $SPREAD_STORE_USER && $SPREAD_STORE_PASSWORD ]]; then
+    if [ -z "$SPREAD_STORE_USER" ] && [ -z "$SPREAD_STORE_PASSWORD" ]; then
         echo "And the user has logged in"
         expect -f successful_login.exp
 

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -1,0 +1,25 @@
+summary: Check that find works with private snaps.
+
+details: |
+    These tests rely on the existence of a snap in the production store set to private.
+
+    In order to do the full checks, it also needs the credentials of the owner of that
+    snap set in the environment variables SPREAD_STORE_USER and SPREAD_STORE_PASSWORD, if
+    they are not present then only the negative check (private snap does not show up in
+    the find results without the owner logged) is performed.
+
+restore: |
+    snap logout || true
+
+execute: |
+    echo "When a snap is private it doesn't show up in the find results without login"
+    ! snap find test-snapd-private | grep -q "test-snapd-private +\d+\.\d+"
+
+    echo "Given account store credentials are available"
+    if [[ $SPREAD_STORE_USER && $SPREAD_STORE_PASSWORD ]]; then
+        echo "And the user has logged in"
+        expect -f successful_login.exp
+
+        echo "Then a private snap belonging to that user shows up in the find results"
+        snap find test-snapd-private | grep -q "test-snapd-private +\d+\.\d+"
+    fi

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -13,7 +13,7 @@ restore: |
 
 execute: |
     echo "When a snap is private it doesn't show up in the find results without login"
-    ! snap find test-snapd-private | grep -q "test-snapd-private +\d+\.\d+"
+    ! snap find test-snapd-private --private | grep -q "test-snapd-private +\d+\.\d+"
 
     echo "Given account store credentials are available"
     if [[ $SPREAD_STORE_USER && $SPREAD_STORE_PASSWORD ]]; then
@@ -21,5 +21,5 @@ execute: |
         expect -f successful_login.exp
 
         echo "Then a private snap belonging to that user shows up in the find results"
-        snap find test-snapd-private | grep -q "test-snapd-private +\d+\.\d+"
+        snap find test-snapd-private --private | grep -q "test-snapd-private +\d+\.\d+"
     fi

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -20,7 +20,7 @@ execute: |
     ! snap find test-snapd-private --private | grep -q "test-snapd-private +\d+\.\d+"
 
     echo "Given account store credentials are available"
-    if [ -z "$SPREAD_STORE_USER" ] && [ -z "$SPREAD_STORE_PASSWORD" ]; then
+    if [ ! -z "$SPREAD_STORE_USER" ] && [ ! -z "$SPREAD_STORE_PASSWORD" ]; then
         echo "And the user has logged in"
         expect -f successful_login.exp
 


### PR DESCRIPTION
These tests require the `test-snapd-private` snap (snap.yaml file included in the PR) to be published as private in the production store.

The test that checks for the private snap showing up in the find list requires the credentials of the user that uploaded the snap in the environment variables `SPREAD_STORE_USER` and `SPREAD_STORE_PASSWORD`, if they are not set then the test won't be executed.