### PR TITLE
interfaces: add process-control interface (LP: #1598225)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -200,3 +200,10 @@ Can query hardware information from the system.
 
 Usage: reserved
 Auto-Connect: no
+
+### process-control
+
+Can manage processes via signals and nice.
+
+Usage: reserved
+Auto-Connect: no

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -45,6 +45,7 @@ var allInterfaces = []interfaces.Interface{
 	NewNetworkBindInterface(),
 	NewNetworkControlInterface(),
 	NewNetworkObserveInterface(),
+	NewProcessControlInterface(),
 	NewSnapdControlInterface(),
 	NewSystemObserveInterface(),
 	NewTimeserverControlInterface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -48,6 +48,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewNetworkBindInterface())
 	c.Check(all, DeepContains, builtin.NewNetworkControlInterface())
 	c.Check(all, DeepContains, builtin.NewNetworkObserveInterface())
+	c.Check(all, DeepContains, builtin.NewProcessControlInterface())
 	c.Check(all, DeepContains, builtin.NewSnapdControlInterface())
 	c.Check(all, DeepContains, builtin.NewSystemObserveInterface())
 	c.Check(all, DeepContains, builtin.NewTimeserverControlInterface())

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -1,0 +1,54 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const processControlConnectedPlugAppArmor = `
+# Description: This interface allows for controlling other processes via
+# signals and nice. This is reserved because it grants privileged access to
+# all processes under root or processes running under the same UID otherwise.
+# Usage: reserved
+
+capability sys_nice,
+
+signal,
+`
+
+const processControlConnectedPlugSecComp = `
+# Description: This interface allows for controlling other processes via
+# signals and nice. This is reserved because it grants privileged access to
+# all processes under root or processes running under the same UID otherwise.
+# Usage: reserved
+
+setpriority
+`
+
+// NewProcessControlInterface returns a new "process-control" interface.
+func NewProcessControlInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "process-control",
+		connectedPlugAppArmor: processControlConnectedPlugAppArmor,
+		connectedPlugSecComp:  processControlConnectedPlugSecComp,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -1,0 +1,134 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+)
+
+type ProcessControlInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&ProcessControlInterfaceSuite{
+	iface: builtin.NewProcessControlInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Name:      "process-control",
+			Interface: "process-control",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "process-control",
+			Interface: "process-control",
+		},
+	},
+})
+
+func (s *ProcessControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "process-control")
+}
+
+func (s *ProcessControlInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "process-control",
+		Interface: "process-control",
+	}})
+	c.Assert(err, ErrorMatches, "process-control slots are reserved for the operating system snap")
+}
+
+func (s *ProcessControlInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *ProcessControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "process-control"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "process-control"`)
+}
+
+func (s *ProcessControlInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev, interfaces.SecurityMount}
+	for _, system := range systems {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityMount)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *ProcessControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *ProcessControlInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *ProcessControlInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(), Equals, false)
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -39,6 +39,7 @@ var implicitSlots = []string{
 	"network-control",
 	"network-observe",
 	"ppp",
+	"process-control",
 	"snapd-control",
 	"system-observe",
 	"timeserver-control",

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -42,7 +42,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 15)
+	c.Assert(info.Slots, HasLen, 16)
 }
 
 func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 25)
+	c.Assert(info.Slots, HasLen, 26)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
This interface is a privileged interface (thus does not auto-connect) and allows sending signals to other processes and setting their nice value. This is particularly useful for management snaps or snaps like htop, but it can also be temporarily used by snaps requiring setpriority (eg, electron, chrome, firefox) while recent versions of snap-confine with seccomp arg filtering are not available.