### PR TITLE
asserts,many: start supporting structured headers using the new parseHeaders

### DIFF
--- a/asserts/account.go
+++ b/asserts/account.go
@@ -38,17 +38,17 @@ type Account struct {
 
 // AccountID returns the account-id of the account.
 func (acc *Account) AccountID() string {
-	return acc.Header("account-id")
+	return acc.HeaderString("account-id")
 }
 
 // Username returns the user name for the account.
 func (acc *Account) Username() string {
-	return acc.Header("username")
+	return acc.HeaderString("username")
 }
 
 // DisplayName returns the human-friendly name for the account.
 func (acc *Account) DisplayName() string {
-	return acc.Header("display-name")
+	return acc.HeaderString("display-name")
 }
 
 // IsCertified returns true if the authority has confidence in the account's name.
@@ -73,12 +73,12 @@ func (acc *Account) checkConsistency(db RODatabase, acck *AccountKey) error {
 var _ consistencyChecker = (*Account)(nil)
 
 func assembleAccount(assert assertionBase) (Assertion, error) {
-	_, err := checkNotEmpty(assert.headers, "display-name")
+	_, err := checkNotEmptyString(assert.headers, "display-name")
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = checkNotEmpty(assert.headers, "validation")
+	_, err = checkNotEmptyString(assert.headers, "validation")
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +88,8 @@ func assembleAccount(assert assertionBase) (Assertion, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO: username is optional (atm) but if it's there it must be a string
 
 	return &Account{
 		assertionBase: assert,

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -35,7 +35,7 @@ type AccountKey struct {
 
 // AccountID returns the account-id of this account-key.
 func (ak *AccountKey) AccountID() string {
-	return ak.Header("account-id")
+	return ak.HeaderString("account-id")
 }
 
 // Since returns the time when the account key starts being valid.
@@ -73,14 +73,14 @@ func checkPublicKey(ab *assertionBase, fingerprintName, keyIDName string) (Publi
 	if err != nil {
 		return nil, err
 	}
-	fp, err := checkNotEmpty(ab.headers, fingerprintName)
+	fp, err := checkNotEmptyString(ab.headers, fingerprintName)
 	if err != nil {
 		return nil, err
 	}
 	if fp != pubKey.Fingerprint() {
 		return nil, fmt.Errorf("public key does not match provided fingerprint")
 	}
-	keyID, err := checkNotEmpty(ab.headers, keyIDName)
+	keyID, err := checkNotEmptyString(ab.headers, keyIDName)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -209,7 +209,7 @@ func (aks *accountKeySuite) openDB(c *C) *asserts.Database {
 func (aks *accountKeySuite) prereqAccount(c *C, db *asserts.Database) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"display-name": "Acct1",
 		"account-id":   "acc-id1",
@@ -227,7 +227,7 @@ func (aks *accountKeySuite) prereqAccount(c *C, db *asserts.Database) {
 func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id":           "canonical",
 		"account-id":             "acc-id1",
 		"public-key-id":          aks.keyid,
@@ -249,7 +249,7 @@ func (aks *accountKeySuite) TestAccountKeyCheck(c *C) {
 func (aks *accountKeySuite) TestAccountKeyCheckNoAccount(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id":           "canonical",
 		"account-id":             "acc-id1",
 		"public-key-id":          aks.keyid,
@@ -273,7 +273,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckUntrustedAuthority(c *C) {
 	storeDB := assertstest.NewSigningDB("canonical", trustedKey)
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"account-id":             "acc-id1",
 		"public-key-id":          aks.keyid,
 		"public-key-fingerprint": aks.fp,
@@ -290,7 +290,7 @@ func (aks *accountKeySuite) TestAccountKeyCheckUntrustedAuthority(c *C) {
 func (aks *accountKeySuite) TestAccountKeyAddAndFind(c *C) {
 	trustedKey := testPrivKey0
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id":           "canonical",
 		"account-id":             "acc-id1",
 		"public-key-id":          aks.keyid,

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -24,11 +24,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"regexp"
 	"sort"
 	"strconv"
-	"strings"
-	"unicode/utf8"
 )
 
 // AssertionType describes a known assertion type with its name and metadata.
@@ -80,10 +77,13 @@ type Assertion interface {
 	AuthorityID() string
 
 	// Header retrieves the header with name
-	Header(name string) string
+	Header(name string) interface{}
 
 	// Headers returns the complete headers
-	Headers() map[string]string
+	Headers() map[string]interface{}
+
+	// HeaderString retrieves the string value of header with name or ""
+	HeaderString(name string) string
 
 	// Body returns the body of this assertion
 	Body() []byte
@@ -97,7 +97,7 @@ const MediaType = "application/x.ubuntu.assertion"
 
 // assertionBase is the concrete base to hold representation data for actual assertions.
 type assertionBase struct {
-	headers map[string]string
+	headers map[string]interface{}
 	body    []byte
 	// parsed revision
 	revision int
@@ -107,9 +107,15 @@ type assertionBase struct {
 	signature []byte
 }
 
+// HeaderString retrieves the string value of header with name or ""
+func (ab *assertionBase) HeaderString(name string) string {
+	s, _ := ab.headers[name].(string)
+	return s
+}
+
 // Type returns the assertion type.
 func (ab *assertionBase) Type() *AssertionType {
-	return Type(ab.headers["type"])
+	return Type(ab.HeaderString("type"))
 }
 
 // Revision returns the assertion revision.
@@ -119,21 +125,21 @@ func (ab *assertionBase) Revision() int {
 
 // AuthorityID returns the authority-id a.k.a the signer id of the assertion.
 func (ab *assertionBase) AuthorityID() string {
-	return ab.headers["authority-id"]
+	return ab.HeaderString("authority-id")
 }
 
 // Header returns the value of an header by name.
-func (ab *assertionBase) Header(name string) string {
-	return ab.headers[name]
+func (ab *assertionBase) Header(name string) interface{} {
+	v := ab.headers[name]
+	if v == nil {
+		return nil
+	}
+	return copyHeader(v)
 }
 
 // Headers returns the complete headers.
-func (ab *assertionBase) Headers() map[string]string {
-	res := make(map[string]string, len(ab.headers))
-	for name, v := range ab.headers {
-		res[name] = v
-	}
-	return res
+func (ab *assertionBase) Headers() map[string]interface{} {
+	return copyHeaders(ab.headers)
 }
 
 // Body returns the body of the assertion.
@@ -149,71 +155,6 @@ func (ab *assertionBase) Signature() (content, signature []byte) {
 // sanity check
 var _ Assertion = (*assertionBase)(nil)
 
-var (
-	nl   = []byte("\n")
-	nlnl = []byte("\n\n")
-
-	// for basic sanity checking of header names
-	headerNameSanity = regexp.MustCompile("^[a-z][a-z0-9-]*[a-z0-9]$")
-)
-
-func parseHeadersNaive(head []byte) (map[string]string, error) {
-	if !utf8.Valid(head) {
-		return nil, fmt.Errorf("header is not utf8")
-	}
-	headers := make(map[string]string)
-	lines := strings.Split(string(head), "\n")
-	for i := 0; i < len(lines); {
-		entry := lines[i]
-		i++
-		nameValueSplit := strings.Index(entry, ":")
-		if nameValueSplit == -1 {
-			return nil, fmt.Errorf("header entry missing ':' separator: %q", entry)
-		}
-		name := entry[:nameValueSplit]
-		if !headerNameSanity.MatchString(name) {
-			return nil, fmt.Errorf("invalid header name: %q", name)
-		}
-
-		afterSplit := nameValueSplit + 1
-		if afterSplit == len(entry) {
-			// multiline value
-			size := 0
-			j := i
-			for j < len(lines) {
-				iline := lines[j]
-				if len(iline) == 0 || iline[0] != ' ' {
-					break
-				}
-				size += len(iline)
-				j++
-			}
-			if j == i {
-				return nil, fmt.Errorf("empty multiline header value: %q", entry)
-			}
-
-			valueBuf := bytes.NewBuffer(make([]byte, 0, size-1))
-			valueBuf.WriteString(lines[i][1:])
-			i++
-			for i < j {
-				valueBuf.WriteByte('\n')
-				valueBuf.WriteString(lines[i][1:])
-				i++
-			}
-
-			headers[name] = valueBuf.String()
-			continue
-		}
-
-		if entry[afterSplit] != ' ' {
-			return nil, fmt.Errorf("header entry should have a space or newline (multiline) before value: %q", entry)
-		}
-
-		headers[name] = entry[afterSplit+1:]
-	}
-	return headers, nil
-}
-
 // Decode parses a serialized assertion.
 //
 // The expected serialisation format looks like:
@@ -228,11 +169,25 @@ func parseHeadersNaive(head []byte) (map[string]string, error) {
 //
 // A header entry for a single line value (no '\n' in it) looks like:
 //
-//   NAME ": " VALUE
+//   NAME ": " SIMPLEVALUE
 //
-// A header entry for a multiline value (a value with '\n's in it) looks like:
+// The format supports multiline text values (with '\n's in them) and
+// lists possibly nested with string scalars in them.
 //
-//   NAME ":\n"  1-space indented VALUE
+// For those a header entry looks like:
+//
+//   NAME ":\n" MULTI(baseindent)
+//
+// where MULTI can be
+//
+// * (baseindent + 4)-space indented value (multiline text)
+// * entries of a list each of the form:
+//
+//   " "*baseindent "  -"  ( " " SIMPLEVALUE | "\n" MULTI )
+//
+// baseindent starts at 0 and then grows with nesting matching the
+// previous level introduction (the " "*baseindent " -" bit)
+// length minus 1.
 //
 // The following headers are mandatory:
 //
@@ -242,13 +197,12 @@ func parseHeadersNaive(head []byte) (map[string]string, error) {
 // Further for a given assertion type all the primary key headers
 // must be non empty and must not contain '/'.
 //
-// The following headers expect integer values and if omitted
-// otherwise are assumed to be 0:
+// The following headers expect string representing integer values and
+// if omitted otherwise are assumed to be 0:
 //
 //   revision (a positive int)
 //   body-length (expected to be equal to the length of BODY)
 //
-// Typically list values in headers are expected to be comma separated.
 // Times are expected to be in the RFC3339 format: "2006-01-02T15:04:05Z07:00".
 func Decode(serializedAssertion []byte) (Assertion, error) {
 	// copy to get an independent backstorage that can't be mutated later
@@ -273,12 +227,12 @@ func Decode(serializedAssertion []byte) (Assertion, error) {
 		head = content[:headersBodySplit]
 	}
 
-	headers, err := parseHeadersNaive(head)
+	headers, err := parseHeaders(head)
 	if err != nil {
 		return nil, fmt.Errorf("parsing assertion headers: %v", err)
 	}
 
-	return Assemble(headers, body, content, signature)
+	return assemble(headers, body, content, signature)
 }
 
 // Maximum assertion component sizes.
@@ -389,7 +343,7 @@ func (d *Decoder) Decode() (Assertion, error) {
 	}
 
 	headLen := len(headAndSep) - len(nlnl)
-	headers, err := parseHeadersNaive(headAndSep[:headLen])
+	headers, err := parseHeaders(headAndSep[:headLen])
 	if err != nil {
 		return nil, fmt.Errorf("parsing assertion headers: %v", err)
 	}
@@ -452,10 +406,10 @@ func (d *Decoder) Decode() (Assertion, error) {
 	finalSig := make([]byte, len(sig))
 	copy(finalSig, sig)
 
-	return Assemble(headers, finalBody, finalContent, finalSig)
+	return assemble(headers, finalBody, finalContent, finalSig)
 }
 
-func checkRevision(headers map[string]string) (int, error) {
+func checkRevision(headers map[string]interface{}) (int, error) {
 	revision, err := checkInteger(headers, "revision", 0)
 	if err != nil {
 		return -1, err
@@ -467,7 +421,16 @@ func checkRevision(headers map[string]string) (int, error) {
 }
 
 // Assemble assembles an assertion from its components.
-func Assemble(headers map[string]string, body, content, signature []byte) (Assertion, error) {
+func Assemble(headers map[string]interface{}, body, content, signature []byte) (Assertion, error) {
+	err := checkHeaders(headers)
+	if err != nil {
+		return nil, err
+	}
+	return assemble(headers, body, content, signature)
+}
+
+// assemble is the internal variant of Assemble, assumes headers are already checked for supported types
+func assemble(headers map[string]interface{}, body, content, signature []byte) (Assertion, error) {
 	length, err := checkInteger(headers, "body-length", 0)
 	if err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)
@@ -476,11 +439,11 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 		return nil, fmt.Errorf("assertion body length and declared body-length don't match: %v != %v", len(body), length)
 	}
 
-	if _, err := checkNotEmpty(headers, "authority-id"); err != nil {
+	if _, err := checkNotEmptyString(headers, "authority-id"); err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)
 	}
 
-	typ, err := checkNotEmpty(headers, "type")
+	typ, err := checkNotEmptyString(headers, "type")
 	if err != nil {
 		return nil, fmt.Errorf("assertion: %v", err)
 	}
@@ -517,37 +480,29 @@ func Assemble(headers map[string]string, body, content, signature []byte) (Asser
 	return assert, nil
 }
 
-func writeHeader(buf *bytes.Buffer, headers map[string]string, name string) {
-	buf.WriteByte('\n')
-	buf.WriteString(name)
-	value := headers[name]
-	if strings.IndexRune(value, '\n') != -1 {
-		// multiline value => quote by 1-space indenting
-		buf.WriteString(":\n ")
-		value = strings.Replace(value, "\n", "\n ", -1)
-	} else {
-		buf.WriteString(": ")
-	}
-	buf.WriteString(value)
+func writeHeader(buf *bytes.Buffer, headers map[string]interface{}, name string) {
+	appendEntry(buf, fmt.Sprintf("%s:", name), headers[name], 0)
 }
 
-func assembleAndSign(assertType *AssertionType, headers map[string]string, body []byte, privKey PrivateKey) (Assertion, error) {
+func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, body []byte, privKey PrivateKey) (Assertion, error) {
 	err := checkAssertType(assertType)
 	if err != nil {
 		return nil, err
 	}
 
-	finalHeaders := make(map[string]string, len(headers))
-	for name, value := range headers {
-		finalHeaders[name] = value
+	err = checkHeaders(headers)
+	if err != nil {
+		return nil, err
 	}
+
+	finalHeaders := copyHeaders(headers)
 	bodyLength := len(body)
 	finalBody := make([]byte, bodyLength)
 	copy(finalBody, body)
 	finalHeaders["type"] = assertType.Name
 	finalHeaders["body-length"] = strconv.Itoa(bodyLength)
 
-	if _, err := checkNotEmpty(finalHeaders, "authority-id"); err != nil {
+	if _, err := checkNotEmptyString(finalHeaders, "authority-id"); err != nil {
 		return nil, err
 	}
 

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -523,18 +523,17 @@ func (as *assertsSuite) TestAssembleRoundtrip(c *C) {
 }
 
 func (as *assertsSuite) TestAssembleHeadersCheck(c *C) {
-	encoded := []byte("type: test-only\n" +
+	cont := []byte("type: test-only\n" +
 		"authority-id: auth-id2\n" +
 		"primary-key: abc\n" +
-		"revision: 5" +
-		"\n\n" +
-		"openpgp c2ln")
-	a, err := asserts.Decode(encoded)
-	c.Assert(err, IsNil)
-	cont, sig := a.Signature()
+		"revision: 5")
+	headers := map[string]interface{}{
+		"type":         "test-only",
+		"authority-id": "auth-id2",
+		"primary-key":  "abc",
+		"revision":     5, // must be a string actually!
+	}
 
-	h := a.Headers()
-	h["revision"] = 5
-	_, err = asserts.Assemble(h, nil, cont, sig)
+	_, err := asserts.Assemble(headers, nil, cont, nil)
 	c.Check(err, ErrorMatches, `header "revision": header values must be strings or nested lists with strings as the only scalars: 5`)
 }

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -165,8 +165,10 @@ func (as *assertsSuite) TestDecodeInvalid(c *C) {
 		{"type: test-only\n", "", `assertion: "type" header is mandatory`},
 		{"type: test-only\n", "type: unknown\n", `unknown assertion type: "unknown"`},
 		{"revision: 0\n", "revision: Z\n", `assertion: "revision" header is not an integer: Z`},
+		{"revision: 0\n", "revision:\n  - 1\n", `assertion: "revision" header is not an integer: \[1\]`},
 		{"revision: 0\n", "revision: -10\n", "assertion: revision should be positive: -10"},
 		{"primary-key: abc\n", "", `assertion test-only: "primary-key" header is mandatory`},
+		{"primary-key: abc\n", "primary-key:\n  - abc\n", `assertion test-only: "primary-key" header must be a string`},
 		{"primary-key: abc\n", "primary-key: a/c\n", `assertion test-only: "primary-key" primary key header cannot contain '/'`},
 	}
 

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -295,7 +295,7 @@ func (db *Database) Add(assert Assertion) error {
 	for i, k := range assertType.PrimaryKey {
 		keyVal := assert.HeaderString(k)
 		if keyVal == "" {
-			return fmt.Errorf("missing primary key header: %v", k)
+			return fmt.Errorf("missing or non-string primary key header: %v", k)
 		}
 		keyValues[i] = keyVal
 	}

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -218,8 +218,8 @@ func (db *Database) PublicKey(authorityID string, keyID string) (PublicKey, erro
 
 // Sign assembles an assertion with the provided information and signs it
 // with the private key from `headers["authority-id"]` that has the provided key id.
-func (db *Database) Sign(assertType *AssertionType, headers map[string]string, body []byte, keyID string) (Assertion, error) {
-	authorityID, err := checkNotEmpty(headers, "authority-id")
+func (db *Database) Sign(assertType *AssertionType, headers map[string]interface{}, body []byte, keyID string) (Assertion, error) {
+	authorityID, err := checkNotEmptyString(headers, "authority-id")
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func (db *Database) Add(assert Assertion) error {
 
 	keyValues := make([]string, len(assertType.PrimaryKey))
 	for i, k := range assertType.PrimaryKey {
-		keyVal := assert.Header(k)
+		keyVal := assert.HeaderString(k)
 		if keyVal == "" {
 			return fmt.Errorf("missing primary key header: %v", k)
 		}

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -60,7 +60,7 @@ func (opens *openSuite) TestOpenDatabasePanicOnUnsetBackstores(c *C) {
 }
 
 func (opens *openSuite) TestOpenDatabaseTrustedAccount(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"account-id":   "trusted",
 		"display-name": "Trusted",
@@ -93,7 +93,7 @@ func (opens *openSuite) TestOpenDatabaseTrustedAccount(c *C) {
 }
 
 func (opens *openSuite) TestOpenDatabaseTrustedWrongType(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
@@ -208,7 +208,7 @@ func (chks *checkSuite) SetUpTest(c *C) {
 	chks.bs, err = asserts.OpenFSBackstore(topDir)
 	c.Assert(err, IsNil)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "0",
 	}
@@ -319,7 +319,7 @@ func (safs *signAddFindSuite) SetUpTest(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSign(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -331,7 +331,7 @@ func (safs *signAddFindSuite) TestSign(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignEmptyKeyID(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -341,7 +341,7 @@ func (safs *signAddFindSuite) TestSignEmptyKeyID(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignMissingAuthorityId(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"primary-key": "a",
 	}
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
@@ -350,7 +350,7 @@ func (safs *signAddFindSuite) TestSignMissingAuthorityId(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignMissingPrimaryKey(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 	}
 	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
@@ -359,7 +359,7 @@ func (safs *signAddFindSuite) TestSignMissingPrimaryKey(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignPrimaryKeyWithSlash(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "baz/9000",
 	}
@@ -369,7 +369,7 @@ func (safs *signAddFindSuite) TestSignPrimaryKeyWithSlash(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignNoPrivateKey(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -379,7 +379,7 @@ func (safs *signAddFindSuite) TestSignNoPrivateKey(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignUnknownType(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 	}
 	a1, err := safs.signingDB.Sign(&asserts.AssertionType{Name: "xyz", PrimaryKey: nil}, headers, nil, safs.signingKeyID)
@@ -388,7 +388,7 @@ func (safs *signAddFindSuite) TestSignUnknownType(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignNonPredefinedType(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 	}
 	a1, err := safs.signingDB.Sign(&asserts.AssertionType{Name: "test-only", PrimaryKey: nil}, headers, nil, safs.signingKeyID)
@@ -397,7 +397,7 @@ func (safs *signAddFindSuite) TestSignNonPredefinedType(c *C) {
 }
 
 func (safs *signAddFindSuite) TestSignBadRevision(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"revision":     "zzz",
@@ -407,8 +407,19 @@ func (safs *signAddFindSuite) TestSignBadRevision(c *C) {
 	c.Check(a1, IsNil)
 }
 
+func (safs *signAddFindSuite) TestSignHeadersCheck(c *C) {
+	headers := map[string]interface{}{
+		"authority-id": "canonical",
+		"primary-key":  "a",
+		"extra":        []interface{}{1, 2},
+	}
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
+	c.Check(err, ErrorMatches, `header "extra": header values must be strings or nested lists with strings as the only scalars: 1`)
+	c.Check(a1, IsNil)
+}
+
 func (safs *signAddFindSuite) TestSignAssemblerError(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"count":        "zzz",
@@ -419,7 +430,7 @@ func (safs *signAddFindSuite) TestSignAssemblerError(c *C) {
 }
 
 func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -455,7 +466,7 @@ func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 }
 
 func (safs *signAddFindSuite) TestFindNotFound(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 	}
@@ -487,7 +498,7 @@ func (safs *signAddFindSuite) TestFindPrimaryLeftOut(c *C) {
 }
 
 func (safs *signAddFindSuite) TestFindMany(c *C) {
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "a",
 		"other":        "other-x",
@@ -497,7 +508,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	err = safs.db.Add(aa)
 	c.Assert(err, IsNil)
 
-	headers = map[string]string{
+	headers = map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "b",
 		"other":        "other-y",
@@ -507,7 +518,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	err = safs.db.Add(ab)
 	c.Assert(err, IsNil)
 
-	headers = map[string]string{
+	headers = map[string]interface{}{
 		"authority-id": "canonical",
 		"primary-key":  "c",
 		"other":        "other-x",
@@ -522,7 +533,7 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 	})
 	c.Assert(err, IsNil)
 	c.Assert(res, HasLen, 2)
-	primKeys := []string{res[0].Header("primary-key"), res[1].Header("primary-key")}
+	primKeys := []string{res[0].HeaderString("primary-key"), res[1].HeaderString("primary-key")}
 	sort.Strings(primKeys)
 	c.Check(primKeys, DeepEquals, []string{"a", "c"})
 
@@ -555,11 +566,11 @@ func (safs *signAddFindSuite) TestFindMany(c *C) {
 func (safs *signAddFindSuite) TestFindFindsTrustedAccountKeys(c *C) {
 	pk1 := testPrivKey1
 
-	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]string{
+	acct1 := assertstest.NewAccount(safs.signingDB, "acc-id1", map[string]interface{}{
 		"authority-id": "canonical",
 	}, safs.signingKeyID)
 
-	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]string{
+	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]interface{}{
 		"authority-id": "canonical",
 	}, pk1.PublicKey(), safs.signingKeyID)
 
@@ -591,7 +602,7 @@ func (safs *signAddFindSuite) TestDontLetAddConfusinglyAssertionClashingWithTrus
 	c.Assert(err, IsNil)
 
 	now := time.Now().UTC()
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id":           "canonical",
 		"account-id":             "canonical",
 		"public-key-id":          safs.signingKeyID,
@@ -707,7 +718,7 @@ ZF5jSvRDLgI=`
 	c.Assert(err, IsNil)
 
 	// prereq Account assertion
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "can0nical",
 		"account-id":   "developer1",
 		"display-name": "Dev 1",

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -37,42 +37,42 @@ type Model struct {
 
 // BrandID returns the brand identifier. Same as the authority id.
 func (mod *Model) BrandID() string {
-	return mod.Header("brand-id")
+	return mod.HeaderString("brand-id")
 }
 
 // Model returns the model name identifier.
 func (mod *Model) Model() string {
-	return mod.Header("model")
+	return mod.HeaderString("model")
 }
 
 // Series returns the series of the core software the model uses.
 func (mod *Model) Series() string {
-	return mod.Header("series")
+	return mod.HeaderString("series")
 }
 
 // Core returns the core snap the model uses.
 func (mod *Model) Core() string {
-	return mod.Header("core")
+	return mod.HeaderString("core")
 }
 
 // Architecture returns the archicteture the model is based on.
 func (mod *Model) Architecture() string {
-	return mod.Header("architecture")
+	return mod.HeaderString("architecture")
 }
 
 // Gadget returns the gadget snap the model uses.
 func (mod *Model) Gadget() string {
-	return mod.Header("gadget")
+	return mod.HeaderString("gadget")
 }
 
 // Kernel returns the kernel snap the model uses.
 func (mod *Model) Kernel() string {
-	return mod.Header("kernel")
+	return mod.HeaderString("kernel")
 }
 
 // Store returns the snap store the model uses.
 func (mod *Model) Store() string {
-	return mod.Header("store")
+	return mod.HeaderString("store")
 }
 
 // AllowedModes returns which ones of the "classic" and "developer" modes are allowed for the model.
@@ -88,7 +88,7 @@ func (mod *Model) RequiredSnaps() []string {
 // Class returns which class the model belongs to defining policies for
 // additional software installation.
 func (mod *Model) Class() string {
-	return mod.Header("class")
+	return mod.HeaderString("class")
 }
 
 // Timestamp returns the time when the model assertion was issued.
@@ -113,7 +113,7 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 	}
 
 	for _, mandatory := range modelMandatory {
-		if _, err := checkNotEmpty(assert.headers, mandatory); err != nil {
+		if _, err := checkNotEmptyString(assert.headers, mandatory); err != nil {
 			return nil, err
 		}
 	}
@@ -144,18 +144,18 @@ type Serial struct {
 
 // BrandID returns the brand identifier of the device.
 func (ser *Serial) BrandID() string {
-	return ser.Header("brand-id")
+	return ser.HeaderString("brand-id")
 }
 
 // Model returns the model name identifier of the device.
 func (ser *Serial) Model() string {
-	return ser.Header("model")
+	return ser.HeaderString("model")
 }
 
 // Serial returns the serial identifier of the device, together with
 // brand id and model they form the unique identifier of the device.
 func (ser *Serial) Serial() string {
-	return ser.Header("serial")
+	return ser.HeaderString("serial")
 }
 
 // DeviceKey returns the public key of the device.
@@ -173,7 +173,7 @@ func (ser *Serial) Timestamp() time.Time {
 func assembleSerial(assert assertionBase) (Assertion, error) {
 	// TODO: authority-id can only == canonical or brand-id
 
-	encodedKey, err := checkNotEmpty(assert.headers, "device-key")
+	encodedKey, err := checkNotEmptyString(assert.headers, "device-key")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -179,7 +179,7 @@ const serialExample = "type: serial\n" +
 	"brand-id: brand-id1\n" +
 	"model: baz-3000\n" +
 	"serial: 2700\n" +
-	"device-key:\n DEVICEKEY\n" +
+	"device-key:\n    DEVICEKEY\n" +
 	"TSLINE" +
 	"body-length: 2\n\n" +
 	"HW" +
@@ -188,7 +188,7 @@ const serialExample = "type: serial\n" +
 
 func (ss *serialSuite) TestDecodeOK(c *C) {
 	encoded := strings.Replace(serialExample, "TSLINE", ss.tsLine, 1)
-	encoded = strings.Replace(encoded, "DEVICEKEY", strings.Replace(ss.encodedDevKey, "\n", "\n ", -1), 1)
+	encoded = strings.Replace(encoded, "DEVICEKEY", strings.Replace(ss.encodedDevKey, "\n", "\n    ", -1), 1)
 	a, err := asserts.Decode([]byte(encoded))
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.SerialType)
@@ -218,14 +218,14 @@ func (ss *serialSuite) TestDecodeInvalid(c *C) {
 		{ss.tsLine, "", `"timestamp" header is mandatory`},
 		{ss.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{ss.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},
-		{"device-key:\n DEVICEKEY\n", "", `"device-key" header is mandatory`},
-		{"device-key:\n DEVICEKEY\n", "device-key: \n", `"device-key" header should not be empty`},
-		{"device-key:\n DEVICEKEY\n", "device-key: openpgp ZZZ\n", `public key: could not decode base64 data:.*`},
+		{"device-key:\n    DEVICEKEY\n", "", `"device-key" header is mandatory`},
+		{"device-key:\n    DEVICEKEY\n", "device-key: \n", `"device-key" header should not be empty`},
+		{"device-key:\n    DEVICEKEY\n", "device-key: openpgp ZZZ\n", `public key: could not decode base64 data:.*`},
 	}
 
 	for _, test := range invalidTests {
 		invalid := strings.Replace(encoded, test.original, test.invalid, 1)
-		invalid = strings.Replace(invalid, "DEVICEKEY", strings.Replace(ss.encodedDevKey, "\n", "\n ", -1), 1)
+		invalid = strings.Replace(invalid, "DEVICEKEY", strings.Replace(ss.encodedDevKey, "\n", "\n    ", -1), 1)
 
 		_, err := asserts.Decode([]byte(invalid))
 		c.Check(err, ErrorMatches, serialErrPrefix+test.expectedErr)

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -58,7 +58,7 @@ func EncoderAppend(enc *Encoder, encoded []byte) error {
 func BootstrapAccountForTest(authorityID string) *Account {
 	return &Account{
 		assertionBase: assertionBase{
-			headers: map[string]string{
+			headers: map[string]interface{}{
 				"type":         "account",
 				"authority-id": authorityID,
 				"account-id":   authorityID,
@@ -72,7 +72,7 @@ func BootstrapAccountForTest(authorityID string) *Account {
 func makeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, validYears int) *AccountKey {
 	return &AccountKey{
 		assertionBase: assertionBase{
-			headers: map[string]string{
+			headers: map[string]interface{}{
 				"type":          "account-key",
 				"authority-id":  authorityID,
 				"account-id":    authorityID,
@@ -144,4 +144,5 @@ func MockRunGPG(mock func(prev GPGRunner, homedir string, input []byte, args ...
 // Headers helpers to test
 var (
 	ParseHeaders = parseHeaders
+	AppendEntry  = appendEntry
 )

--- a/asserts/fsbackstore.go
+++ b/asserts/fsbackstore.go
@@ -87,7 +87,7 @@ func (fsbs *filesystemBackstore) Put(assertType *AssertionType, assert Assertion
 
 	primaryPath := make([]string, len(assertType.PrimaryKey))
 	for i, k := range assertType.PrimaryKey {
-		primaryPath[i] = assert.Header(k)
+		primaryPath[i] = assert.HeaderString(k)
 	}
 
 	diskPrimaryPath := buildDiskPrimaryPath(primaryPath)

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -80,7 +80,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigning(c *C) {
 	devKey, err := gkms.keypairMgr.Get("dev1", assertstest.DevKeyID)
 	c.Assert(err, IsNil)
 
-	devAcct := assertstest.NewAccount(store, "devel1", map[string]string{
+	devAcct := assertstest.NewAccount(store, "devel1", map[string]interface{}{
 		"account-id": "dev1-id",
 	}, "")
 	devAccKey := assertstest.NewAccountKey(store, devAcct, nil, devKey.PublicKey(), "")
@@ -105,7 +105,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigning(c *C) {
 	err = checkDB.Add(devAccKey)
 	c.Assert(err, IsNil)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "dev1-id",
 		"series":       "16",
 		"snap-id":      "snap-id-1",
@@ -241,7 +241,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigningBrokenSignature(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "dev1-id",
 		"series":       "16",
 		"snap-id":      "snap-id-1",
@@ -299,7 +299,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigningFailure(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": "dev1-id",
 		"series":       "16",
 		"snap-id":      "snap-id-1",

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -87,7 +87,7 @@ func checkInteger(headers map[string]interface{}, name string, defl int) (int, e
 	}
 	s, ok := value.(string)
 	if !ok {
-		return -1, fmt.Errorf("%q header must be a string representing an integer", name)
+		return -1, fmt.Errorf("%q header is not an integer: %v", name, value)
 	}
 	m, err := strconv.Atoi(s)
 	if err != nil {

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -28,27 +28,31 @@ import (
 
 // common checks used when decoding/assembling assertions
 
-func checkExists(headers map[string]string, name string) (string, error) {
+func checkExistsString(headers map[string]interface{}, name string) (string, error) {
 	value, ok := headers[name]
 	if !ok {
 		return "", fmt.Errorf("%q header is mandatory", name)
 	}
-	return value, nil
+	s, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("%q header must be a string", name)
+	}
+	return s, nil
 }
 
-func checkNotEmpty(headers map[string]string, name string) (string, error) {
-	value, err := checkExists(headers, name)
+func checkNotEmptyString(headers map[string]interface{}, name string) (string, error) {
+	s, err := checkExistsString(headers, name)
 	if err != nil {
 		return "", err
 	}
-	if len(value) == 0 {
+	if len(s) == 0 {
 		return "", fmt.Errorf("%q header should not be empty", name)
 	}
-	return value, nil
+	return s, nil
 }
 
-func checkPrimaryKey(headers map[string]string, primKey string) (string, error) {
-	value, err := checkNotEmpty(headers, primKey)
+func checkPrimaryKey(headers map[string]interface{}, primKey string) (string, error) {
+	value, err := checkNotEmptyString(headers, primKey)
 	if err != nil {
 		return "", err
 	}
@@ -76,20 +80,24 @@ func checkAssertType(assertType *AssertionType) error {
 }
 
 // use 'defl' default if missing
-func checkInteger(headers map[string]string, name string, defl int) (int, error) {
-	valueStr, ok := headers[name]
+func checkInteger(headers map[string]interface{}, name string, defl int) (int, error) {
+	value, ok := headers[name]
 	if !ok {
 		return defl, nil
 	}
-	value, err := strconv.Atoi(valueStr)
-	if err != nil {
-		return -1, fmt.Errorf("%q header is not an integer: %v", name, valueStr)
+	s, ok := value.(string)
+	if !ok {
+		return -1, fmt.Errorf("%q header must be a string representing an integer", name)
 	}
-	return value, nil
+	m, err := strconv.Atoi(s)
+	if err != nil {
+		return -1, fmt.Errorf("%q header is not an integer: %v", name, s)
+	}
+	return m, nil
 }
 
-func checkRFC3339Date(headers map[string]string, name string) (time.Time, error) {
-	dateStr, err := checkNotEmpty(headers, name)
+func checkRFC3339Date(headers map[string]interface{}, name string) (time.Time, error) {
+	dateStr, err := checkNotEmptyString(headers, name)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -100,8 +108,8 @@ func checkRFC3339Date(headers map[string]string, name string) (time.Time, error)
 	return date, nil
 }
 
-func checkUint(headers map[string]string, name string, bitSize int) (uint64, error) {
-	valueStr, err := checkNotEmpty(headers, name)
+func checkUint(headers map[string]interface{}, name string, bitSize int) (uint64, error) {
+	valueStr, err := checkNotEmptyString(headers, name)
 	if err != nil {
 		return 0, err
 	}

--- a/asserts/headers.go
+++ b/asserts/headers.go
@@ -106,6 +106,7 @@ func parseEntry(consumedByIntro int, first int, lines []string, baseIndent int) 
 			// list
 			return parseList(i, lines, baseIndent)
 		}
+		// TODO: support maps
 
 		return parseMultilineText(i, lines, baseIndent)
 	}
@@ -185,6 +186,7 @@ func checkHeader(v interface{}) error {
 			}
 		}
 		return nil
+	// TODO: support maps
 	default:
 		return fmt.Errorf("header values must be strings or nested lists with strings as the only scalars: %v", v)
 	}
@@ -258,5 +260,8 @@ func appendEntry(buf *bytes.Buffer, intro string, v interface{}, baseIndent int)
 		for _, elem := range x {
 			appendEntry(buf, pfx, elem, baseIndent+len(listPrefix)-1)
 		}
+	// TODO: support maps
+	default:
+		panic(fmt.Sprintf("internal error: encountered unexpected value type formatting headers: %v", v))
 	}
 }

--- a/asserts/membackstore.go
+++ b/asserts/membackstore.go
@@ -128,7 +128,7 @@ func (mbs *memoryBackstore) Put(assertType *AssertionType, assert Assertion) err
 	internalKey := make([]string, 1+len(assertType.PrimaryKey))
 	internalKey[0] = assertType.Name
 	for i, name := range assertType.PrimaryKey {
-		internalKey[1+i] = assert.Header(name)
+		internalKey[1+i] = assert.HeaderString(name)
 	}
 
 	err := mbs.top.put(internalKey, assert)

--- a/asserts/membackstore_test.go
+++ b/asserts/membackstore_test.go
@@ -102,7 +102,7 @@ func (mbss *memBackstoreSuite) TestSearch(c *C) {
 
 	found := map[string]asserts.Assertion{}
 	cb := func(a asserts.Assertion) {
-		found[a.Header("primary-key")] = a
+		found[a.HeaderString("primary-key")] = a
 	}
 	err = mbss.bs.Search(asserts.TestOnlyType, nil, cb)
 	c.Assert(err, IsNil)
@@ -161,7 +161,7 @@ func (mbss *memBackstoreSuite) TestSearch2Levels(c *C) {
 
 	found := map[string]asserts.Assertion{}
 	cb := func(a asserts.Assertion) {
-		found[a.Header("pk1")+":"+a.Header("pk2")] = a
+		found[a.HeaderString("pk1")+":"+a.HeaderString("pk2")] = a
 	}
 	err = mbss.bs.Search(asserts.TestOnly2Type, map[string]string{
 		"pk2": "x",

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -36,22 +36,22 @@ type SnapDeclaration struct {
 
 // Series returns the series for which the snap is being declared.
 func (snapdcl *SnapDeclaration) Series() string {
-	return snapdcl.Header("series")
+	return snapdcl.HeaderString("series")
 }
 
 // SnapID returns the snap id of the declared snap.
 func (snapdcl *SnapDeclaration) SnapID() string {
-	return snapdcl.Header("snap-id")
+	return snapdcl.HeaderString("snap-id")
 }
 
 // SnapName returns the declared snap name.
 func (snapdcl *SnapDeclaration) SnapName() string {
-	return snapdcl.Header("snap-name")
+	return snapdcl.HeaderString("snap-name")
 }
 
 // PublisherID returns the identifier of the publisher of the declared snap.
 func (snapdcl *SnapDeclaration) PublisherID() string {
-	return snapdcl.Header("publisher-id")
+	return snapdcl.HeaderString("publisher-id")
 }
 
 // Timestamp returns the time when the snap-declaration was issued.
@@ -80,12 +80,12 @@ func (snapdcl *SnapDeclaration) checkConsistency(db RODatabase, acck *AccountKey
 var _ consistencyChecker = (*SnapDeclaration)(nil)
 
 func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
-	_, err := checkExists(assert.headers, "snap-name")
+	_, err := checkExistsString(assert.headers, "snap-name")
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = checkNotEmpty(assert.headers, "publisher-id")
+	_, err = checkNotEmptyString(assert.headers, "publisher-id")
 	if err != nil {
 		return nil, err
 	}
@@ -111,18 +111,18 @@ type SnapBuild struct {
 
 // Series returns the series for which the snap was built.
 func (snapbld *SnapBuild) Series() string {
-	return snapbld.Header("series")
+	return snapbld.HeaderString("series")
 }
 
 // SnapID returns the snap id of the snap.
 func (snapbld *SnapBuild) SnapID() string {
-	return snapbld.Header("snap-id")
+	return snapbld.HeaderString("snap-id")
 }
 
 // SnapDigest returns the digest of the snap. The digest is prefixed with the
 // algorithm used to generate it.
 func (snapbld *SnapBuild) SnapDigest() string {
-	return snapbld.Header("snap-digest")
+	return snapbld.HeaderString("snap-digest")
 }
 
 // SnapSize returns the size of the snap.
@@ -132,7 +132,7 @@ func (snapbld *SnapBuild) SnapSize() uint64 {
 
 // Grade returns the grade of the snap: devel|stable
 func (snapbld *SnapBuild) Grade() string {
-	return snapbld.Header("grade")
+	return snapbld.HeaderString("grade")
 }
 
 // Timestamp returns the time when the snap-build assertion was created.
@@ -143,7 +143,7 @@ func (snapbld *SnapBuild) Timestamp() time.Time {
 func assembleSnapBuild(assert assertionBase) (Assertion, error) {
 	// TODO: more parsing/checking of snap-digest
 
-	_, err := checkNotEmpty(assert.headers, "grade")
+	_, err := checkNotEmptyString(assert.headers, "grade")
 	if err != nil {
 		return nil, err
 	}
@@ -178,18 +178,18 @@ type SnapRevision struct {
 // Series returns the series of the snap submitted to and acknowledged by the
 // store.
 func (snaprev *SnapRevision) Series() string {
-	return snaprev.Header("series")
+	return snaprev.HeaderString("series")
 }
 
 // SnapID returns the snap id of the snap.
 func (snaprev *SnapRevision) SnapID() string {
-	return snaprev.Header("snap-id")
+	return snaprev.HeaderString("snap-id")
 }
 
 // SnapDigest returns the digest of the snap submitted to and acknowledged by
 // the store. The digest is prefixed with the algorithm used to generate it.
 func (snaprev *SnapRevision) SnapDigest() string {
-	return snaprev.Header("snap-digest")
+	return snaprev.HeaderString("snap-digest")
 }
 
 // SnapSize returns the size in bytes of the snap submitted to the store.
@@ -205,7 +205,7 @@ func (snaprev *SnapRevision) SnapRevision() uint64 {
 // DeveloperID returns the id of the developer that submitted this build of the
 // snap.
 func (snaprev *SnapRevision) DeveloperID() string {
-	return snaprev.Header("developer-id")
+	return snaprev.HeaderString("developer-id")
 }
 
 // Timestamp returns the time when the snap-revision was issued.
@@ -257,7 +257,7 @@ func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
-	_, err = checkNotEmpty(assert.headers, "developer-id")
+	_, err = checkNotEmptyString(assert.headers, "developer-id")
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -123,7 +123,7 @@ func (sds *snapDeclSuite) TestDecodeInvalid(c *C) {
 }
 
 func prereqDevAccount(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {
-	dev1Acct := assertstest.NewAccount(storeDB, "developer1", map[string]string{
+	dev1Acct := assertstest.NewAccount(storeDB, "developer1", map[string]interface{}{
 		"account-id": "dev-id1",
 	}, "")
 	err := db.Add(dev1Acct)
@@ -135,7 +135,7 @@ func (sds *snapDeclSuite) TestSnapDeclarationCheck(c *C) {
 
 	prereqDevAccount(c, storeDB, db)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -155,7 +155,7 @@ func (sds *snapDeclSuite) TestSnapDeclarationCheckUntrustedAuthority(c *C) {
 
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -173,7 +173,7 @@ func (sds *snapDeclSuite) TestSnapDeclarationCheckUntrustedAuthority(c *C) {
 func (sds *snapDeclSuite) TestSnapDeclarationCheckMissingPublisherAccount(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -302,7 +302,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheck(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 	devDB := setup3rdPartySigning(c, "devel1", storeDB, db)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"authority-id": devDB.AuthorityID,
 		"series":       "16",
 		"snap-id":      "snap-id-1",
@@ -322,7 +322,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 	devDB := setup3rdPartySigning(c, "devel1", storeDB, db)
 
-	headers := map[string]string{
+	headers := map[string]interface{}{
 		"series":      "16",
 		"snap-id":     "snap-id-1",
 		"snap-digest": "sha256 ...",
@@ -364,8 +364,8 @@ func (srs *snapRevSuite) makeValidEncoded() string {
 		"openpgp c2ln"
 }
 
-func (srs *snapRevSuite) makeHeaders(overrides map[string]string) map[string]string {
-	headers := map[string]string{
+func (srs *snapRevSuite) makeHeaders(overrides map[string]interface{}) map[string]interface{} {
+	headers := map[string]interface{}{
 		"authority-id":  "canonical",
 		"series":        "16",
 		"snap-id":       "snap-id-1",
@@ -435,7 +435,7 @@ func (srs *snapRevSuite) TestDecodeInvalid(c *C) {
 }
 
 func prereqSnapDecl(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {
-	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]string{
+	snapDecl, err := storeDB.Sign(asserts.SnapDeclarationType, map[string]interface{}{
 		"series":       "16",
 		"snap-id":      "snap-id-1",
 		"snap-name":    "foo",
@@ -465,7 +465,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheck(c *C) {
 func (srs *snapRevSuite) TestSnapRevisionCheckInconsistentTimestamp(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 
-	headers := srs.makeHeaders(map[string]string{
+	headers := srs.makeHeaders(map[string]interface{}{
 		"timestamp": "2013-01-01T14:00:00Z",
 	})
 	snapRev, err := storeDB.Sign(asserts.SnapRevisionType, headers, nil, "")
@@ -526,8 +526,8 @@ func (srs *snapRevSuite) TestPrimaryKey(c *C) {
 
 	_, err = db.Find(asserts.SnapRevisionType, map[string]string{
 		"series":      "16",
-		"snap-id":     headers["snap-id"],
-		"snap-digest": headers["snap-digest"],
+		"snap-id":     headers["snap-id"].(string),
+		"snap-digest": headers["snap-digest"].(string),
 	})
 	c.Assert(err, IsNil)
 }

--- a/asserts/sysdb/sysdb_test.go
+++ b/asserts/sysdb/sysdb_test.go
@@ -50,13 +50,13 @@ func (sdbs *sysDBSuite) SetUpTest(c *C) {
 
 	signingDB := assertstest.NewSigningDB("can0nical", pk)
 
-	trustedAcct := assertstest.NewAccount(signingDB, "can0nical", map[string]string{
+	trustedAcct := assertstest.NewAccount(signingDB, "can0nical", map[string]interface{}{
 		"account-id": "can0nical",
 		"validation": "certified",
 		"timestamp":  "2015-11-20T15:04:00Z",
 	}, "")
 
-	trustedAccKey := assertstest.NewAccountKey(signingDB, trustedAcct, map[string]string{
+	trustedAccKey := assertstest.NewAccountKey(signingDB, trustedAcct, map[string]interface{}{
 		"account-id": "can0nical",
 		"since":      "2015-11-20T15:04:00Z",
 		"until":      "2500-11-20T15:04:00Z",

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2624,7 +2624,7 @@ func (s *apiSuite) TestAssertsFindManyAll(c *check.C) {
 	// add store key
 	err := d.overlord.AssertManager().DB().Add(s.storeSigning.StoreAccountKey(""))
 	c.Assert(err, check.IsNil)
-	acct := assertstest.NewAccount(s.storeSigning, "developer1", map[string]string{
+	acct := assertstest.NewAccount(s.storeSigning, "developer1", map[string]interface{}{
 		"account-id": "developer1-id",
 	}, "")
 	err = d.overlord.AssertManager().DB().Add(acct)


### PR DESCRIPTION
This starts supporting the new structured headers using the new parseHeaders.

It also switches most handling of assertion headers from map[string]string to map[string]interface{} (except when querying for now).

Notice that primary keys are expected to stay/must be strings.

It fixes and adapts tests.
