### PR TITLE
osutil: support both "nobody" and "nogroup" for grpnam tests

### DIFF
--- a/osutil/group_linux_test.go
+++ b/osutil/group_linux_test.go
@@ -62,9 +62,17 @@ func getgrnamForking(name string) (grp Group, err error) {
 }
 
 func (s *groupTestSuite) TestGetgrnam(c *C) {
-	expected, err := getgrnamForking("nogroup")
-	c.Assert(err, IsNil)
-	groups, err := Getgrnam("nogroup")
+	// figure out whether we want "nobody" or "nogroup" or just bail
+	name := "nogroup"
+	expected, err := getgrnamForking(name)
+	if err != nil {
+		name = "nobody"
+		expected, err = getgrnamForking(name)
+		if err != nil {
+			c.Skip("unable to find an innocuous group name to use")
+		}
+	}
+	groups, err := Getgrnam(name)
 	c.Assert(err, IsNil)
 	c.Assert(groups, DeepEquals, expected)
 }


### PR DESCRIPTION
fixes [lp:1606961](https://bugs.launchpad.net/snappy/+bug/1606961).