### PR TITLE
asserts,client: switch snap-build and snap-revision to be indexed by snap-sha3-384

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -46,8 +46,8 @@ var (
 	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel}
 	SerialType          = &AssertionType{"serial", []string{"brand-id", "model", "serial"}, assembleSerial}
 	SnapDeclarationType = &AssertionType{"snap-declaration", []string{"series", "snap-id"}, assembleSnapDeclaration}
-	SnapBuildType       = &AssertionType{"snap-build", []string{"series", "snap-id", "snap-digest"}, assembleSnapBuild}
-	SnapRevisionType    = &AssertionType{"snap-revision", []string{"series", "snap-id", "snap-digest"}, assembleSnapRevision}
+	SnapBuildType       = &AssertionType{"snap-build", []string{"snap-sha3-384"}, assembleSnapBuild}
+	SnapRevisionType    = &AssertionType{"snap-revision", []string{"snap-sha3-384"}, assembleSnapRevision}
 
 // ...
 )

--- a/asserts/digest.go
+++ b/asserts/digest.go
@@ -25,17 +25,19 @@ import (
 	"fmt"
 )
 
-// EncodeDigest encodes a hash algorithm and a digest to be put in an assertion header.
+// EncodeDigest encodes the digest from hash algorithm to be put in an assertion header.
 func EncodeDigest(hash crypto.Hash, hashDigest []byte) (string, error) {
 	algo := ""
 	switch hash {
 	case crypto.SHA512:
 		algo = "sha512"
+	case crypto.SHA3_384:
+		algo = "sha3-384"
 	default:
 		return "", fmt.Errorf("unsupported hash")
 	}
 	if len(hashDigest) != hash.Size() {
 		return "", fmt.Errorf("hash digest by %s should be %d bytes", algo, hash.Size())
 	}
-	return fmt.Sprintf("%s-%s", algo, base64.RawURLEncoding.EncodeToString(hashDigest)), nil
+	return base64.RawURLEncoding.EncodeToString(hashDigest), nil
 }

--- a/asserts/digest_test.go
+++ b/asserts/digest_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto"
 	_ "crypto/sha256"
 	"encoding/base64"
-	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -41,10 +40,17 @@ func (eds *encodeDigestSuite) TestEncodeDigestOK(c *C) {
 	encoded, err := asserts.EncodeDigest(crypto.SHA512, digest)
 	c.Assert(err, IsNil)
 
-	c.Check(strings.HasPrefix(encoded, "sha512-"), Equals, true)
-	decoded, err := base64.RawURLEncoding.DecodeString(encoded[len("sha512-"):])
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
 	c.Assert(err, IsNil)
 	c.Check(decoded, DeepEquals, digest)
+
+	// sha3-384
+	b, err := base64.RawURLEncoding.DecodeString(blobSHA3_384)
+	c.Assert(err, IsNil)
+	encoded, err = asserts.EncodeDigest(crypto.SHA3_384, b)
+	c.Assert(err, IsNil)
+	c.Check(encoded, Equals, blobSHA3_384)
+
 }
 
 func (eds *encodeDigestSuite) TestEncodeDigestErrors(c *C) {
@@ -53,4 +59,7 @@ func (eds *encodeDigestSuite) TestEncodeDigestErrors(c *C) {
 
 	_, err = asserts.EncodeDigest(crypto.SHA512, []byte{1, 2})
 	c.Check(err, ErrorMatches, "hash digest by sha512 should be 64 bytes")
+
+	_, err = asserts.EncodeDigest(crypto.SHA3_384, []byte{1, 2})
+	c.Check(err, ErrorMatches, "hash digest by sha3-384 should be 48 bytes")
 }

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -106,13 +106,12 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigning(c *C) {
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
-		"authority-id": "dev1-id",
-		"series":       "16",
-		"snap-id":      "snap-id-1",
-		"snap-digest":  "sha512-...",
-		"grade":        "devel",
-		"snap-size":    "1025",
-		"timestamp":    time.Now().Format(time.RFC3339),
+		"authority-id":  "dev1-id",
+		"snap-sha3-384": blobSHA3_384,
+		"snap-id":       "snap-id-1",
+		"grade":         "devel",
+		"snap-size":     "1025",
+		"timestamp":     time.Now().Format(time.RFC3339),
 	}
 	snapBuild, err := signDB.Sign(asserts.SnapBuildType, headers, nil, assertstest.DevKeyID)
 	c.Assert(err, IsNil)
@@ -242,13 +241,12 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigningBrokenSignature(c *C) {
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
-		"authority-id": "dev1-id",
-		"series":       "16",
-		"snap-id":      "snap-id-1",
-		"snap-digest":  "sha512-...",
-		"grade":        "devel",
-		"snap-size":    "1025",
-		"timestamp":    time.Now().Format(time.RFC3339),
+		"authority-id":  "dev1-id",
+		"snap-sha3-384": blobSHA3_384,
+		"snap-id":       "snap-id-1",
+		"grade":         "devel",
+		"snap-size":     "1025",
+		"timestamp":     time.Now().Format(time.RFC3339),
 	}
 
 	tests := []struct {
@@ -300,13 +298,12 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigningFailure(c *C) {
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
-		"authority-id": "dev1-id",
-		"series":       "16",
-		"snap-id":      "snap-id-1",
-		"snap-digest":  "sha512-...",
-		"grade":        "devel",
-		"snap-size":    "1025",
-		"timestamp":    time.Now().Format(time.RFC3339),
+		"authority-id":  "dev1-id",
+		"snap-sha3-384": blobSHA3_384,
+		"snap-id":       "snap-id-1",
+		"grade":         "devel",
+		"snap-size":     "1025",
+		"timestamp":     time.Now().Format(time.RFC3339),
 	}
 
 	_, err = signDB.Sign(asserts.SnapBuildType, headers, nil, assertstest.DevKeyID)

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -20,6 +20,8 @@
 package asserts
 
 import (
+	"crypto"
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
@@ -119,4 +121,20 @@ func checkUint(headers map[string]interface{}, name string, bitSize int) (uint64
 		return 0, fmt.Errorf("%q header is not an unsigned integer: %v", name, valueStr)
 	}
 	return value, nil
+}
+
+func checkDigest(headers map[string]interface{}, name string, h crypto.Hash) ([]byte, error) {
+	digestStr, err := checkNotEmptyString(headers, name)
+	if err != nil {
+		return nil, err
+	}
+	b, err := base64.RawURLEncoding.DecodeString(digestStr)
+	if err != nil {
+		return nil, fmt.Errorf("%q header cannot be decoded: %v", name, err)
+	}
+	if len(b) != h.Size() {
+		return nil, fmt.Errorf("%q header does not have the expected bit length: %d", name, len(b)*8)
+	}
+
+	return b, nil
 }

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -20,8 +20,13 @@
 package asserts
 
 import (
+	"crypto"
 	"fmt"
 	"time"
+
+	_ "golang.org/x/crypto/sha3" // expected for digests
+
+	"github.com/snapcore/snapd/release"
 )
 
 // TODO: adjust to new designs!
@@ -109,20 +114,14 @@ type SnapBuild struct {
 	timestamp time.Time
 }
 
-// Series returns the series for which the snap was built.
-func (snapbld *SnapBuild) Series() string {
-	return snapbld.HeaderString("series")
+// SnapSHA3_384 returns the SHA3-384 digest of the snap.
+func (snapbld *SnapBuild) SnapSHA3_384() string {
+	return snapbld.HeaderString("snap-sha3-384")
 }
 
 // SnapID returns the snap id of the snap.
 func (snapbld *SnapBuild) SnapID() string {
 	return snapbld.HeaderString("snap-id")
-}
-
-// SnapDigest returns the digest of the snap. The digest is prefixed with the
-// algorithm used to generate it.
-func (snapbld *SnapBuild) SnapDigest() string {
-	return snapbld.HeaderString("snap-digest")
 }
 
 // SnapSize returns the size of the snap.
@@ -141,9 +140,17 @@ func (snapbld *SnapBuild) Timestamp() time.Time {
 }
 
 func assembleSnapBuild(assert assertionBase) (Assertion, error) {
-	// TODO: more parsing/checking of snap-digest
+	_, err := checkDigest(assert.headers, "snap-sha3-384", crypto.SHA3_384)
+	if err != nil {
+		return nil, err
+	}
 
-	_, err := checkNotEmptyString(assert.headers, "grade")
+	_, err = checkNotEmptyString(assert.headers, "snap-id")
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = checkNotEmptyString(assert.headers, "grade")
 	if err != nil {
 		return nil, err
 	}
@@ -175,21 +182,14 @@ type SnapRevision struct {
 	timestamp    time.Time
 }
 
-// Series returns the series of the snap submitted to and acknowledged by the
-// store.
-func (snaprev *SnapRevision) Series() string {
-	return snaprev.HeaderString("series")
+// SnapSHA3_384 returns the SHA3-384 digest of the snap.
+func (snaprev *SnapRevision) SnapSHA3_384() string {
+	return snaprev.HeaderString("snap-sha3-384")
 }
 
 // SnapID returns the snap id of the snap.
 func (snaprev *SnapRevision) SnapID() string {
 	return snaprev.HeaderString("snap-id")
-}
-
-// SnapDigest returns the digest of the snap submitted to and acknowledged by
-// the store. The digest is prefixed with the algorithm used to generate it.
-func (snaprev *SnapRevision) SnapDigest() string {
-	return snaprev.HeaderString("snap-digest")
 }
 
 // SnapSize returns the size in bytes of the snap submitted to the store.
@@ -229,7 +229,7 @@ func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) e
 		return err
 	}
 	_, err = db.Find(SnapDeclarationType, map[string]string{
-		"series":  snaprev.Series(),
+		"series":  release.Series,
 		"snap-id": snaprev.SnapID(),
 	})
 	if err == ErrNotFound {
@@ -245,7 +245,15 @@ func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) e
 var _ consistencyChecker = (*SnapRevision)(nil)
 
 func assembleSnapRevision(assert assertionBase) (Assertion, error) {
-	// TODO: more parsing/checking of snap-digest
+	_, err := checkDigest(assert.headers, "snap-sha3-384", crypto.SHA3_384)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = checkNotEmptyString(assert.headers, "snap-id")
+	if err != nil {
+		return nil, err
+	}
 
 	snapSize, err := checkUint(assert.headers, "snap-size", 64)
 	if err != nil {

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -229,6 +229,7 @@ func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) e
 		return err
 	}
 	_, err = db.Find(SnapDeclarationType, map[string]string{
+		// XXX: mediate getting current series through some context object? this gets the job done for now
 		"series":  release.Series,
 		"snap-id": snaprev.SnapID(),
 	})

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -230,11 +230,11 @@ const (
 )
 
 func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
-	hh := "snap-sha3-384: " + blobSHA3_384 + "\n"
+	digestHdr := "snap-sha3-384: " + blobSHA3_384 + "\n"
 
 	encoded := "type: snap-build\n" +
 		"authority-id: dev-id1\n" +
-		hh +
+		digestHdr +
 		"grade: stable\n" +
 		"snap-id: snap-id-1\n" +
 		"snap-size: 10000\n" +
@@ -246,9 +246,9 @@ func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
-		{hh, "", `"snap-sha3-384" header is mandatory`},
-		{hh, "snap-sha3-384: \n", `"snap-sha3-384" header should not be empty`},
-		{hh, "snap-sha3-384: #\n", `"snap-sha3-384" header cannot be decoded:.*`},
+		{digestHdr, "", `"snap-sha3-384" header is mandatory`},
+		{digestHdr, "snap-sha3-384: \n", `"snap-sha3-384" header should not be empty`},
+		{digestHdr, "snap-sha3-384: #\n", `"snap-sha3-384" header cannot be decoded:.*`},
 		{"snap-size: 10000\n", "", `"snap-size" header is mandatory`},
 		{"snap-size: 10000\n", "snap-size: -1\n", `"snap-size" header is not an unsigned integer: -1`},
 		{"snap-size: 10000\n", "snap-size: zzz\n", `"snap-size" header is not an unsigned integer: zzz`},
@@ -403,14 +403,14 @@ const (
 func (srs *snapRevSuite) TestDecodeInvalid(c *C) {
 	encoded := srs.makeValidEncoded()
 
-	hh := "snap-sha3-384: " + blobSHA3_384 + "\n"
+	digestHdr := "snap-sha3-384: " + blobSHA3_384 + "\n"
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
-		{hh, "", `"snap-sha3-384" header is mandatory`},
-		{hh, "snap-sha3-384: \n", `"snap-sha3-384" header should not be empty`},
-		{hh, "snap-sha3-384: #\n", `"snap-sha3-384" header cannot be decoded:.*`},
-		{hh, "snap-sha3-384: eHl6\n", `"snap-sha3-384" header does not have the expected bit length: 24`},
+		{digestHdr, "", `"snap-sha3-384" header is mandatory`},
+		{digestHdr, "snap-sha3-384: \n", `"snap-sha3-384" header should not be empty`},
+		{digestHdr, "snap-sha3-384: #\n", `"snap-sha3-384" header cannot be decoded:.*`},
+		{digestHdr, "snap-sha3-384: eHl6\n", `"snap-sha3-384" header does not have the expected bit length: 24`},
 		{"snap-size: 123\n", "", `"snap-size" header is mandatory`},
 		{"snap-size: 123\n", "snap-size: \n", `"snap-size" header should not be empty`},
 		{"snap-size: 123\n", "snap-size: -1\n", `"snap-size" header is not an unsigned integer: -1`},

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -198,13 +198,16 @@ func (sbs *snapBuildSuite) SetUpSuite(c *C) {
 	sbs.tsLine = "timestamp: " + sbs.ts.Format(time.RFC3339) + "\n"
 }
 
+const (
+	blobSHA3_384 = "QlqR0uAWEAWF5Nwnzj5kqmmwFslYPu1IL16MKtLKhwhv0kpBv5wKZ_axf_nf_2cL"
+)
+
 func (sbs *snapBuildSuite) TestDecodeOK(c *C) {
 	encoded := "type: snap-build\n" +
 		"authority-id: dev-id1\n" +
-		"series: 16\n" +
-		"snap-id: snap-id-1\n" +
-		"snap-digest: sha256 ...\n" +
+		"snap-sha3-384: " + blobSHA3_384 + "\n" +
 		"grade: stable\n" +
+		"snap-id: snap-id-1\n" +
 		"snap-size: 10000\n" +
 		sbs.tsLine +
 		"body-length: 0" +
@@ -216,9 +219,8 @@ func (sbs *snapBuildSuite) TestDecodeOK(c *C) {
 	snapBuild := a.(*asserts.SnapBuild)
 	c.Check(snapBuild.AuthorityID(), Equals, "dev-id1")
 	c.Check(snapBuild.Timestamp(), Equals, sbs.ts)
-	c.Check(snapBuild.Series(), Equals, "16")
 	c.Check(snapBuild.SnapID(), Equals, "snap-id-1")
-	c.Check(snapBuild.SnapDigest(), Equals, "sha256 ...")
+	c.Check(snapBuild.SnapSHA3_384(), Equals, blobSHA3_384)
 	c.Check(snapBuild.SnapSize(), Equals, uint64(10000))
 	c.Check(snapBuild.Grade(), Equals, "stable")
 }
@@ -228,12 +230,13 @@ const (
 )
 
 func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
+	hh := "snap-sha3-384: " + blobSHA3_384 + "\n"
+
 	encoded := "type: snap-build\n" +
 		"authority-id: dev-id1\n" +
-		"series: 16\n" +
-		"snap-id: snap-id-1\n" +
-		"snap-digest: sha256 ...\n" +
+		hh +
 		"grade: stable\n" +
+		"snap-id: snap-id-1\n" +
 		"snap-size: 10000\n" +
 		sbs.tsLine +
 		"body-length: 0" +
@@ -241,12 +244,11 @@ func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
 		"openpgp c2ln"
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{
-		{"series: 16\n", "", `"series" header is mandatory`},
-		{"series: 16\n", "series: \n", `"series" header should not be empty`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
-		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
-		{"snap-digest: sha256 ...\n", "snap-digest: \n", `"snap-digest" header should not be empty`},
+		{hh, "", `"snap-sha3-384" header is mandatory`},
+		{hh, "snap-sha3-384: \n", `"snap-sha3-384" header should not be empty`},
+		{hh, "snap-sha3-384: #\n", `"snap-sha3-384" header cannot be decoded:.*`},
 		{"snap-size: 10000\n", "", `"snap-size" header is mandatory`},
 		{"snap-size: 10000\n", "snap-size: -1\n", `"snap-size" header is not an unsigned integer: -1`},
 		{"snap-size: 10000\n", "snap-size: zzz\n", `"snap-size" header is not an unsigned integer: zzz`},
@@ -303,13 +305,12 @@ func (sbs *snapBuildSuite) TestSnapBuildCheck(c *C) {
 	devDB := setup3rdPartySigning(c, "devel1", storeDB, db)
 
 	headers := map[string]interface{}{
-		"authority-id": devDB.AuthorityID,
-		"series":       "16",
-		"snap-id":      "snap-id-1",
-		"snap-digest":  "sha256 ...",
-		"grade":        "devel",
-		"snap-size":    "1025",
-		"timestamp":    time.Now().Format(time.RFC3339),
+		"authority-id":  devDB.AuthorityID,
+		"snap-sha3-384": blobSHA3_384,
+		"snap-id":       "snap-id-1",
+		"grade":         "devel",
+		"snap-size":     "1025",
+		"timestamp":     time.Now().Format(time.RFC3339),
 	}
 	snapBuild, err := devDB.Sign(asserts.SnapBuildType, headers, nil, "")
 	c.Assert(err, IsNil)
@@ -323,12 +324,11 @@ func (sbs *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 	devDB := setup3rdPartySigning(c, "devel1", storeDB, db)
 
 	headers := map[string]interface{}{
-		"series":      "16",
-		"snap-id":     "snap-id-1",
-		"snap-digest": "sha256 ...",
-		"grade":       "devel",
-		"snap-size":   "1025",
-		"timestamp":   "2013-01-01T14:00:00Z",
+		"snap-sha3-384": blobSHA3_384,
+		"snap-id":       "snap-id-1",
+		"grade":         "devel",
+		"snap-size":     "1025",
+		"timestamp":     "2013-01-01T14:00:00Z",
 	}
 	snapBuild, err := devDB.Sign(asserts.SnapBuildType, headers, nil, "")
 	c.Assert(err, IsNil)
@@ -351,9 +351,8 @@ func (srs *snapRevSuite) SetUpSuite(c *C) {
 func (srs *snapRevSuite) makeValidEncoded() string {
 	return "type: snap-revision\n" +
 		"authority-id: store-id1\n" +
-		"series: 16\n" +
+		"snap-sha3-384: " + blobSHA3_384 + "\n" +
 		"snap-id: snap-id-1\n" +
-		"snap-digest: sha256 ...\n" +
 		"snap-size: 123\n" +
 		"snap-revision: 1\n" +
 		"developer-id: dev-id1\n" +
@@ -367,9 +366,8 @@ func (srs *snapRevSuite) makeValidEncoded() string {
 func (srs *snapRevSuite) makeHeaders(overrides map[string]interface{}) map[string]interface{} {
 	headers := map[string]interface{}{
 		"authority-id":  "canonical",
-		"series":        "16",
+		"snap-sha3-384": blobSHA3_384,
 		"snap-id":       "snap-id-1",
-		"snap-digest":   "sha256 ...",
 		"snap-size":     "123",
 		"snap-revision": "1",
 		"developer-id":  "dev-id1",
@@ -390,9 +388,8 @@ func (srs *snapRevSuite) TestDecodeOK(c *C) {
 	snapRev := a.(*asserts.SnapRevision)
 	c.Check(snapRev.AuthorityID(), Equals, "store-id1")
 	c.Check(snapRev.Timestamp(), Equals, srs.ts)
-	c.Check(snapRev.Series(), Equals, "16")
 	c.Check(snapRev.SnapID(), Equals, "snap-id-1")
-	c.Check(snapRev.SnapDigest(), Equals, "sha256 ...")
+	c.Check(snapRev.SnapSHA3_384(), Equals, blobSHA3_384)
 	c.Check(snapRev.SnapSize(), Equals, uint64(123))
 	c.Check(snapRev.SnapRevision(), Equals, uint64(1))
 	c.Check(snapRev.DeveloperID(), Equals, "dev-id1")
@@ -405,13 +402,15 @@ const (
 
 func (srs *snapRevSuite) TestDecodeInvalid(c *C) {
 	encoded := srs.makeValidEncoded()
+
+	hh := "snap-sha3-384: " + blobSHA3_384 + "\n"
 	invalidTests := []struct{ original, invalid, expectedErr string }{
-		{"series: 16\n", "", `"series" header is mandatory`},
-		{"series: 16\n", "series: \n", `"series" header should not be empty`},
 		{"snap-id: snap-id-1\n", "", `"snap-id" header is mandatory`},
 		{"snap-id: snap-id-1\n", "snap-id: \n", `"snap-id" header should not be empty`},
-		{"snap-digest: sha256 ...\n", "", `"snap-digest" header is mandatory`},
-		{"snap-digest: sha256 ...\n", "snap-digest: \n", `"snap-digest" header should not be empty`},
+		{hh, "", `"snap-sha3-384" header is mandatory`},
+		{hh, "snap-sha3-384: \n", `"snap-sha3-384" header should not be empty`},
+		{hh, "snap-sha3-384: #\n", `"snap-sha3-384" header cannot be decoded:.*`},
+		{hh, "snap-sha3-384: eHl6\n", `"snap-sha3-384" header does not have the expected bit length: 24`},
 		{"snap-size: 123\n", "", `"snap-size" header is mandatory`},
 		{"snap-size: 123\n", "snap-size: \n", `"snap-size" header should not be empty`},
 		{"snap-size: 123\n", "snap-size: -1\n", `"snap-size" header is not an unsigned integer: -1`},
@@ -525,9 +524,7 @@ func (srs *snapRevSuite) TestPrimaryKey(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = db.Find(asserts.SnapRevisionType, map[string]string{
-		"series":      "16",
-		"snap-id":     headers["snap-id"].(string),
-		"snap-digest": headers["snap-digest"].(string),
+		"snap-sha3-384": headers["snap-sha3-384"].(string),
 	})
 	c.Assert(err, IsNil)
 }

--- a/client/asserts_test.go
+++ b/client/asserts_test.go
@@ -53,15 +53,15 @@ func (cs *clientSuite) TestClientAssertsCallsEndpoint(c *C) {
 
 func (cs *clientSuite) TestClientAssertsCallsEndpointWithFilter(c *C) {
 	_, _ = cs.cli.Known("snap-revision", map[string]string{
-		"snap-id":     "snap-id-1",
-		"snap-digest": "sha256 digest...",
+		"snap-id":       "snap-id-1",
+		"snap-sha3-384": "sha3-384...",
 	})
 	u, err := url.ParseRequestURI(cs.req.URL.String())
 	c.Assert(err, IsNil)
 	c.Check(u.Path, Equals, "/v2/assertions/snap-revision")
 	c.Check(u.Query(), DeepEquals, url.Values{
-		"snap-digest": []string{"sha256 digest..."},
-		"snap-id":     []string{"snap-id-1"},
+		"snap-sha3-384": []string{"sha3-384..."},
+		"snap-id":       []string{"snap-id-1"},
 	})
 }
 
@@ -91,9 +91,8 @@ func (cs *clientSuite) TestClientAsserts(c *C) {
 	cs.header.Add("X-Ubuntu-Assertions-Count", "2")
 	cs.rsp = `type: snap-revision
 authority-id: store-id1
-series: 16
+snap-sha3-384: P1wNUk5O_5tO5spqOLlqUuAk7gkNYezIMHp5N9hMUg1a6YEjNeaCc4T0BaYz7IWs
 snap-id: snap-id-1
-snap-digest: sha256 ...
 snap-size: 123
 snap-revision: 1
 developer-id: dev-id1
@@ -105,9 +104,8 @@ openpgp ...
 
 type: snap-revision
 authority-id: store-id1
-series: 16
+snap-sha3-384: 0Yt6-GXQeTZWUAHo1IKDpS9kqO6zMaizY6vGEfGM-aSfpghPKir1Ic7teQ5Zadaj
 snap-id: snap-id-2
-snap-digest: sha256 ...
 snap-size: 456
 snap-revision: 1
 developer-id: dev-id1


### PR DESCRIPTION
This also drop series and snap-digest from them.