### PR TITLE
many: various fixes around the `create-user` command

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1384,7 +1384,7 @@ func abortChange(c *Command, r *http.Request, user *auth.UserState) Response {
 var (
 	postCreateUserUcrednetGetUID = ucrednetGetUID
 	storeUserInfo                = store.UserInfo
-	osutilAddExtraUser           = osutil.AddExtraUser
+	osutilAddExtraSudoUser       = osutil.AddExtraSudoUser
 )
 
 func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -1418,7 +1418,7 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 	}
 
 	gecos := fmt.Sprintf("%s,%s", createData.EMail, v.OpenIDIdentifier)
-	if err := osutilAddExtraUser(v.Username, v.SSHKeys, gecos); err != nil {
+	if err := osutilAddExtraSudoUser(v.Username, v.SSHKeys, gecos); err != nil {
 		return BadRequest("cannot create user %s: %s", v.Username, err)
 	}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1414,7 +1414,8 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 		return BadRequest("cannot create user %q: %s", createData.EMail, err)
 	}
 
-	if err := osutilAddExtraUser(v.Username, v.SSHKeys); err != nil {
+	gecos := fmt.Sprintf("%s,%s", createData.EMail, v.OpenIDIdentifier)
+	if err := osutilAddExtraUser(v.Username, v.SSHKeys, gecos); err != nil {
 		return BadRequest("cannot create user %s: %s", v.Username, err)
 	}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1413,6 +1413,9 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 	if err != nil {
 		return BadRequest("cannot create user %q: %s", createData.EMail, err)
 	}
+	if len(v.SSHKeys) == 0 {
+		return BadRequest("cannot create user for %s: no ssh keys found", createData.EMail)
+	}
 
 	gecos := fmt.Sprintf("%s,%s", createData.EMail, v.OpenIDIdentifier)
 	if err := osutilAddExtraUser(v.Username, v.SSHKeys, gecos); err != nil {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3079,13 +3079,15 @@ func (s *apiSuite) TestPostCreateUser(c *check.C) {
 	storeUserInfo = func(user string) (*store.User, error) {
 		c.Check(user, check.Equals, "popper@lse.ac.uk")
 		return &store.User{
-			Username: "karl",
-			SSHKeys:  []string{"ssh1", "ssh2"},
+			Username:         "karl",
+			SSHKeys:          []string{"ssh1", "ssh2"},
+			OpenIDIdentifier: "xxyyzz",
 		}, nil
 	}
-	osutilAddExtraUser = func(username string, sshKeys []string) error {
+	osutilAddExtraUser = func(username string, sshKeys []string, gecos string) error {
 		c.Check(username, check.Equals, "karl")
 		c.Check(sshKeys, check.DeepEquals, []string{"ssh1", "ssh2"})
+		c.Check(gecos, check.Equals, "popper@lse.ac.uk,xxyyzz")
 		return nil
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -387,7 +387,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"snapstateTryPath",
 		"snapstateGet",
 		"readSnapInfo",
-		"osutilAddExtraUser",
+		"osutilAddExtraSudoUser",
 		"storeUserInfo",
 		"postCreateUserUcrednetGetUID",
 		"ensureStateSoon",
@@ -3109,7 +3109,7 @@ func (s *apiSuite) TestPostCreateUser(c *check.C) {
 			OpenIDIdentifier: "xxyyzz",
 		}, nil
 	}
-	osutilAddExtraUser = func(username string, sshKeys []string, gecos string) error {
+	osutilAddExtraSudoUser = func(username string, sshKeys []string, gecos string) error {
 		c.Check(username, check.Equals, "karl")
 		c.Check(sshKeys, check.DeepEquals, []string{"ssh1", "ssh2"})
 		c.Check(gecos, check.Equals, "popper@lse.ac.uk,xxyyzz")
@@ -3120,7 +3120,7 @@ func (s *apiSuite) TestPostCreateUser(c *check.C) {
 		return 0, nil
 	}
 	defer func() {
-		osutilAddExtraUser = osutil.AddExtraUser
+		osutilAddExtraSudoUser = osutil.AddExtraSudoUser
 		postCreateUserUcrednetGetUID = ucrednetGetUID
 	}()
 

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -34,8 +34,9 @@ var userLookup = user.Lookup
 
 func AddExtraSudoUser(name string, sshKeys []string, gecos string) error {
 	// we check the (user)name ourselfs, adduser is a bit too
-	// strict (i.e. no `.`)
-	validNames := regexp.MustCompile(`^[a-z][-a-z0-9_.]*$`)
+	// strict (i.e. no `.`) - this regexp is in sync with that SSO
+	// allows as valid usernames
+	validNames := regexp.MustCompile(`^[a-z0-9][-a-z0-9+.-_]*$`)
 	if !validNames.MatchString(name) {
 		return fmt.Errorf("cannot add user %q: name contains invalid charackters", name)
 	}

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -31,9 +31,7 @@ import (
 
 var userLookup = user.Lookup
 
-func AddExtraUser(name string, sshKeys []string) error {
-	// FIXME: put date/time/openid in there
-	gecos := "created by snapd"
+func AddExtraUser(name string, sshKeys []string, gecos string) error {
 	cmd := exec.Command("adduser", "--gecos", gecos, "--extrausers", "--disabled-password", name)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("adduser failed with %s: %s", err, output)

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -32,7 +32,7 @@ import (
 
 var userLookup = user.Lookup
 
-func AddExtraUser(name string, sshKeys []string, gecos string) error {
+func AddExtraSudoUser(name string, sshKeys []string, gecos string) error {
 	// we check the (user)name ourselfs, adduser is a bit too
 	// strict (i.e. no `.`)
 	validNames := regexp.MustCompile(`^[a-z][-a-z0-9_.]*$`)
@@ -40,7 +40,13 @@ func AddExtraUser(name string, sshKeys []string, gecos string) error {
 		return fmt.Errorf("cannot add user %q: name contains invalid charackters", name)
 	}
 
-	cmd := exec.Command("adduser", "--force-badname", "--gecos", gecos, "--extrausers", "--disabled-password", name)
+	cmd := exec.Command("adduser",
+		"--force-badname",
+		"--gecos", gecos,
+		"--extrausers",
+		"--disabled-password",
+		"--add_extra_groups", "sudo",
+		name)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("adduser failed with %s: %s", err, output)
 	}

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -52,9 +52,14 @@ func (s *createUserSuite) TestAddExtraUser(c *check.C) {
 	err := osutil.AddExtraUser("karl", []string{"ssh-key1", "ssh-key2"}, "my gecos")
 	c.Assert(err, check.IsNil)
 	c.Check(mc.Calls(), check.DeepEquals, [][]string{
-		{"adduser", "--gecos", "my gecos", "--extrausers", "--disabled-password", "karl"},
+		{"adduser", "--force-badname", "--gecos", "my gecos", "--extrausers", "--disabled-password", "karl"},
 	})
 	sshKeys, err := ioutil.ReadFile(filepath.Join(mockHome, ".ssh", "authorized_keys"))
 	c.Assert(err, check.IsNil)
 	c.Check(string(sshKeys), check.Equals, "ssh-key1\nssh-key2")
+}
+
+func (s *createUserSuite) TestAddExtraUserInvalid(c *check.C) {
+	err := osutil.AddExtraUser("k!", nil, "my gecos")
+	c.Assert(err, check.ErrorMatches, `cannot add user "k!": name contains invalid charackters`)
 }

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -49,10 +49,10 @@ func (s *createUserSuite) TestAddExtraUser(c *check.C) {
 	mc := testutil.MockCommand(c, "adduser", "true")
 	defer mc.Restore()
 
-	err := osutil.AddExtraUser("karl", []string{"ssh-key1", "ssh-key2"})
+	err := osutil.AddExtraUser("karl", []string{"ssh-key1", "ssh-key2"}, "my gecos")
 	c.Assert(err, check.IsNil)
 	c.Check(mc.Calls(), check.DeepEquals, [][]string{
-		{"adduser", "--gecos", "created by snapd", "--extrausers", "--disabled-password", "karl"},
+		{"adduser", "--gecos", "my gecos", "--extrausers", "--disabled-password", "karl"},
 	})
 	sshKeys, err := ioutil.ReadFile(filepath.Join(mockHome, ".ssh", "authorized_keys"))
 	c.Assert(err, check.IsNil)

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -37,7 +37,7 @@ type createUserSuite struct {
 
 var _ = check.Suite(&createUserSuite{})
 
-func (s *createUserSuite) TestAddExtraUser(c *check.C) {
+func (s *createUserSuite) TestAddExtraSudoUser(c *check.C) {
 	mockHome := c.MkDir()
 	restorer := osutil.MockUserLookup(func(string) (*user.User, error) {
 		return &user.User{
@@ -49,17 +49,17 @@ func (s *createUserSuite) TestAddExtraUser(c *check.C) {
 	mc := testutil.MockCommand(c, "adduser", "true")
 	defer mc.Restore()
 
-	err := osutil.AddExtraUser("karl", []string{"ssh-key1", "ssh-key2"}, "my gecos")
+	err := osutil.AddExtraSudoUser("karl", []string{"ssh-key1", "ssh-key2"}, "my gecos")
 	c.Assert(err, check.IsNil)
 	c.Check(mc.Calls(), check.DeepEquals, [][]string{
-		{"adduser", "--force-badname", "--gecos", "my gecos", "--extrausers", "--disabled-password", "karl"},
+		{"adduser", "--force-badname", "--gecos", "my gecos", "--extrausers", "--disabled-password", "--add_extra_groups", "sudo", "karl"},
 	})
 	sshKeys, err := ioutil.ReadFile(filepath.Join(mockHome, ".ssh", "authorized_keys"))
 	c.Assert(err, check.IsNil)
 	c.Check(string(sshKeys), check.Equals, "ssh-key1\nssh-key2")
 }
 
-func (s *createUserSuite) TestAddExtraUserInvalid(c *check.C) {
-	err := osutil.AddExtraUser("k!", nil, "my gecos")
+func (s *createUserSuite) TestAddExtraSudoUserInvalid(c *check.C) {
+	err := osutil.AddExtraSudoUser("k!", nil, "my gecos")
 	c.Assert(err, check.ErrorMatches, `cannot add user "k!": name contains invalid charackters`)
 }


### PR DESCRIPTION
A collection of fixes for the create-user command:   

Closes:   LP: #1603018,     LP: #1607129,     LP: #1607129
