### PR TITLE
partition: clear snap_try_{kernel,core} on success

### DIFF
--- a/partition/bootloader.go
+++ b/partition/bootloader.go
@@ -107,8 +107,11 @@ func MarkBootSuccessful(bootloader Bootloader) error {
 		if err := bootloader.SetBootVar(newKey, value); err != nil {
 			return err
 		}
-
 		if err := bootloader.SetBootVar("snap_mode", modeSuccess); err != nil {
+			return err
+		}
+		// clear "snap_try_{core,kernel}"
+		if err := bootloader.SetBootVar(k, ""); err != nil {
 			return err
 		}
 	}

--- a/partition/bootloader_test.go
+++ b/partition/bootloader_test.go
@@ -85,10 +85,12 @@ func (s *PartitionTestSuite) TestMarkBootSuccessfulAllSnap(c *C) {
 	err := MarkBootSuccessful(b)
 	c.Assert(err, IsNil)
 	c.Assert(b.bootVars, DeepEquals, map[string]string{
+		// cleared
 		"snap_mode":       "",
-		"snap_try_kernel": "k1",
-		"snap_kernel":     "k1",
-		"snap_try_core":   "os1",
-		"snap_core":       "os1",
+		"snap_try_kernel": "",
+		"snap_try_core":   "",
+		// updated
+		"snap_kernel": "k1",
+		"snap_core":   "os1",
 	})
 }


### PR DESCRIPTION
Trivial branch, there is no need to keep the `snap_try_{kernel.core}` after `snap_{kernel,core}` got updated.