### PR TITLE
client, cmd/snap: better errors for empty snap list result

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -20,6 +20,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -88,12 +89,18 @@ type FindOptions struct {
 	Query   string
 }
 
+var ErrNoSnapsInstalled = errors.New("no snaps installed")
+
 // List returns the list of all snaps installed on the system
 // with names in the given list; if the list is empty, all snaps.
 func (client *Client) List(names []string) ([]*Snap, error) {
 	snaps, _, err := client.snapsFromPath("/v2/snaps", nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(snaps) == 0 {
+		return nil, ErrNoSnapsInstalled
 	}
 
 	if len(names) == 0 {

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -66,6 +66,18 @@ func (cs *clientSuite) TestClientSnapsInvalidSnapsJSON(c *check.C) {
 	c.Check(err, check.ErrorMatches, `.*cannot unmarshal.*`)
 }
 
+func (cs *clientSuite) TestClientNoSnaps(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"result": [],
+		"suggested-currency": "GBP"
+	}`
+	_, err := cs.cli.List(nil)
+	c.Check(err, check.Equals, client.ErrNoSnapsInstalled)
+	_, err = cs.cli.List([]string{"foo"})
+	c.Check(err, check.Equals, client.ErrNoSnapsInstalled)
+}
+
 func (cs *clientSuite) TestClientSnaps(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",

--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"text/tabwriter"
@@ -62,10 +63,13 @@ func listSnaps(names []string) error {
 	cli := Client()
 	snaps, err := cli.List(names)
 	if err != nil {
+		if err == client.ErrNoSnapsInstalled {
+			fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet. Try 'snap install hello-world'."))
+			return nil
+		}
 		return err
 	} else if len(snaps) == 0 {
-		fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet. Try 'snap install hello-world'."))
-		return nil
+		return errors.New(i18n.G("no matching snaps installed"))
 	}
 	sort.Sort(snapsByName(snaps))
 

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -73,6 +73,45 @@ func (s *SnapSuite) TestListEmpty(c *check.C) {
 	c.Check(s.Stderr(), check.Matches, "No snaps are installed yet. Try 'snap install hello-world'.\n")
 }
 
+func (s *SnapSuite) TestListEmptyWithQuery(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			fmt.Fprintln(w, `{"type": "sync", "result": []}`)
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser().ParseArgs([]string{"list", "quux"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Matches, "No snaps are installed yet. Try 'snap install hello-world'.\n")
+}
+
+func (s *SnapSuite) TestListWithNoMatchingQuery(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17}]}`)
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+		}
+
+		n++
+	})
+	_, err := snap.Parser().ParseArgs([]string{"list", "quux"})
+	c.Assert(err, check.ErrorMatches, "no matching snaps installed")
+}
+
 func (s *SnapSuite) TestListWithQuery(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
this makes `client.List` return an error (`client.ErrNoSnapsInstalled`) when no snaps installed, as opposed to returning an empty list when snaps are installed but no snaps match.

This enables `snap list` to print the suggestion to install a snap, or an error informing about the match failing, as appropriate. The latter is an error instead of a message to align with the behaviour of `snap find`.

This fixes [lp:1607717](https://bugs.launchpad.net/snapcraft/+bug/1607717).