### PR TITLE
changed snapd to snap

### DIFF
--- a/docs/autoupdate.md
+++ b/docs/autoupdate.md
@@ -37,7 +37,7 @@ fly themselves); the `systemd` units still use this name.
 For more details of when it is to be triggered you could dig into the
 implementation, via
 
-    systemctl list-timers snapd.refresh.timer
+    systemctl list-timers snap.refresh.timer
 
 To check whether the update ran, run
 

--- a/docs/autoupdate.md
+++ b/docs/autoupdate.md
@@ -41,8 +41,8 @@ implementation, via
 
 To check whether the update ran, run
 
-    systemctl status -l snapd.refresh.service
+    systemctl status -l snap.refresh.service
 
 and to view any output from the command run
 
-    sudo journalctl -u snapd.refresh.service
+    sudo journalctl -u snap.refresh.service


### PR DESCRIPTION
https://github.com/snapcore/snapd/blob/master/docs/autoupdate.md, the command:

systemctl status -l snapd.refresh.service

is not right, and the correct one should be:

systemctl status -l snap.refresh.service

For the rest if the command, it is the same.