### PR TITLE
interfaces: add /proc/version_signature to appamor template

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -207,6 +207,7 @@ var defaultTemplate = []byte(`
   owner @{PROC}/@{pid}/cmdline r,
 
   # Miscellaneous accesses
+  @{PROC}/version_signature r,
   /etc/machine-id r,
   /etc/mime.types r,
   @{PROC}/ r,


### PR DESCRIPTION
Allow access to /proc/version_signature to be able to easily read kernel version
and build number.

Signed-off-by: Chris J Arges <chris.j.arges@canonical.com>