### PR TITLE
overlord/snapstate, daemon: support for multi-snap refresh

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -651,13 +651,15 @@ type snapInstruction struct {
 	userID int
 }
 
-var snapstateInstall = snapstate.Install
-var snapstateUpdate = snapstate.Update
-var snapstateInstallPath = snapstate.InstallPath
-var snapstateTryPath = snapstate.TryPath
-var snapstateGet = snapstate.Get
-var snapstateUpdateMany = snapstate.UpdateMany
-var snapstateRefreshCandidates = snapstate.RefreshCandidates
+var (
+	snapstateGet               = snapstate.Get
+	snapstateInstall           = snapstate.Install
+	snapstateInstallPath       = snapstate.InstallPath
+	snapstateRefreshCandidates = snapstate.RefreshCandidates
+	snapstateTryPath           = snapstate.TryPath
+	snapstateUpdate            = snapstate.Update
+	snapstateUpdateMany        = snapstate.UpdateMany
+)
 
 func ensureStateSoonImpl(st *state.State) {
 	st.EnsureBefore(0)
@@ -730,7 +732,7 @@ func modeFlags(devMode, jailMode bool) (snapstate.Flags, error) {
 func snapUpdateMany(inst *snapInstruction, st *state.State) (msg string, updated []string, tasksets []*state.TaskSet, err error) {
 	// TODO: check inst flags and bail if any are given (-many
 	// doesn't take options)
-	updated, tts, err := snapstateUpdateMany(st, inst.Snaps, inst.userID)
+	updated, tasksets, err = snapstateUpdateMany(st, inst.Snaps, inst.userID)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -750,7 +752,7 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (msg string, updated
 		msg = fmt.Sprintf(i18n.G("Refresh snaps %s"), strings.Join(quoted, ", "))
 	}
 
-	return msg, updated, tts, nil
+	return msg, updated, tasksets, nil
 }
 
 func snapInstall(inst *snapInstruction, st *state.State) (string, []*state.TaskSet, error) {

--- a/daemon/api_mock_test.go
+++ b/daemon/api_mock_test.go
@@ -48,6 +48,7 @@ func (s *apiSuite) mockSnap(c *C, yamlText string) *snap.Info {
 			{
 				RealName: snapInfo.Name(),
 				Revision: snapInfo.Revision,
+				SnapID:   "ididid",
 			},
 		},
 		Current: snapInfo.Revision,

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -358,16 +358,25 @@ furthermore, `download-size` and `price` cannot occur in the output of `/v2/snap
 
 ### POST
 
-* Description: Install an uploaded snap to the system.
+* Description: Install, refresh, revert, remove snaps
 * Access: trusted
 * Operation: async
 * Return: background operation or standard error
 
 #### Input
 
-The snap to install must be provided as part of the body of a
-`multipart/form-data` request. The form should have one file
-named "snap".
+This endpoint accepts an `application/json` request specifying the
+kind of operation, optional flags and a list of snaps, or a
+`multipart/form-data` request with one file named "snap".
+
+#### Sample JSON input
+
+```javascript
+{
+  "action": "refresh",
+  "snaps": [...] // for refresh an empty or absent snaps field means "refresh all"
+}
+```
 
 ## /v2/snaps/[name]
 ### GET

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -251,9 +251,10 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 		Current: snap.R(1),
 	})
 
-	tts, err := snapstate.UpdateMany(s.state, nil, 0)
+	updates, tts, err := snapstate.UpdateMany(s.state, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(tts, HasLen, 1)
+	c.Check(updates, DeepEquals, []string{"some-snap"})
 
 	ts := tts[0]
 	i := verifyInstallUpdateTasks(c, true, ts, s.state)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -365,8 +365,12 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 
 		ts, err := doInstall(st, snapst, ss)
 		if err != nil {
-			// log?
-			continue
+			if len(names) == 0 {
+				// doing "refresh all", just skip this snap
+				logger.Noticef("cannot refresh snap %q: %v", update.Name(), err)
+				continue
+			}
+			return nil, nil, err
 		}
 		updated = append(updated, update.Name())
 		tasksets = append(tasksets, ts)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -250,7 +250,9 @@ func Install(s *state.State, name, channel string, userID int, flags Flags) (*st
 	return doInstall(s, &snapst, ss)
 }
 
-// like strings.Contains but assumes the list is sorted
+// contains determines whether the given string is contained in the
+// given list of strings, which must have been previously sorted using
+// sort.Strings.
 func contains(ns []string, n string) bool {
 	i := sort.SearchStrings(ns, n)
 	if i >= len(ns) {
@@ -260,7 +262,7 @@ func contains(ns []string, n string) bool {
 }
 
 // RefreshCandidates gets a list of candidates for update
-// (call it with the state lock held)
+// Note that the state must be locked by the caller.
 func RefreshCandidates(st *state.State, user *auth.UserState) ([]*snap.Info, error) {
 	updates, _, err := refreshCandidates(st, nil, user)
 	return updates, err
@@ -327,7 +329,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 
 // UpdateMany updates everything from the given list of names that the
 // store says is updateable. If the list is empty, update everything.
-// (state must be locked)
+// Note that the state must be locked by the caller.
 func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state.TaskSet, error) {
 	user, err := userFromUserID(st, userID)
 	if err != nil {
@@ -340,7 +342,7 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 	}
 
 	updated := make([]string, 0, len(updates))
-	tts := make([]*state.TaskSet, 0, len(updates))
+	tasksets := make([]*state.TaskSet, 0, len(updates))
 	for _, update := range updates {
 		snapst := stateByID[update.SnapID]
 		// XXX: this check goes away when update-to-local is done
@@ -362,10 +364,10 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 			continue
 		}
 		updated = append(updated, update.Name())
-		tts = append(tts, ts)
+		tasksets = append(tasksets, ts)
 	}
 
-	return updated, tts, nil
+	return updated, tasksets, nil
 }
 
 // Update initiates a change updating a snap.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -328,17 +328,18 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 // UpdateMany updates everything from the given list of names that the
 // store says is updateable. If the list is empty, update everything.
 // (state must be locked)
-func UpdateMany(st *state.State, names []string, userID int) ([]*state.TaskSet, error) {
+func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state.TaskSet, error) {
 	user, err := userFromUserID(st, userID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	updates, stateByID, err := refreshCandidates(st, names, user)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	updated := make([]string, 0, len(updates))
 	tts := make([]*state.TaskSet, 0, len(updates))
 	for _, update := range updates {
 		snapst := stateByID[update.SnapID]
@@ -360,10 +361,11 @@ func UpdateMany(st *state.State, names []string, userID int) ([]*state.TaskSet, 
 			// log?
 			continue
 		}
+		updated = append(updated, update.Name())
 		tts = append(tts, ts)
 	}
 
-	return tts, nil
+	return updated, tts, nil
 }
 
 // Update initiates a change updating a snap.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -280,7 +280,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 	candidatesInfo := make([]*store.RefreshCandidate, 0, len(snapStates))
 	for _, snapst := range snapStates {
 		if snapst.TryMode() || snapst.DevMode() {
-			// no automatic refreshes for trymode nor devmode
+			// no multi-refresh for trymode nor devmode
 			continue
 		}
 
@@ -293,6 +293,11 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 		snapInfo, err := snapst.CurrentInfo()
 		if err != nil {
 			// log something maybe?
+			continue
+		}
+
+		if snapInfo.SnapID == "" {
+			// no refresh for sideloaded
 			continue
 		}
 


### PR DESCRIPTION
This exposes multi-snap refresh (including all-snaps refresh) as a single operation in snapstate and exposes it to the REST API. Also moves the code for checking for updates to snapstate.

This does *not* switch the client to use this endpoint; that will follow.