### PR TITLE
interfaces: add lscpu to apparmor template.

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -172,6 +172,10 @@ var defaultTemplate = []byte(`
   /{,usr/}bin/zip ixr,
   /{,usr/}bin/zipgrep ixr,
 
+  # util-linux
+  /{,usr/}bin/lscpu ixr,
+  @{PROC}/bus/pci/devices r,
+
   # uptime
   /{,usr/}bin/uptime ixr,
   @{PROC}/uptime r,


### PR DESCRIPTION
Allow usage of lscpu. In addition allow read of /proc/bus/pci/devices as it is
used by lscpu.

Signed-off-by: Chris J Arges <chris.j.arges@canonical.com>