### PR TITLE
give a directory argument to update-desktop-database because the script

### DIFF
--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -171,7 +171,7 @@ func updateDesktopDatabase(desktopFiles []string) error {
 	}
 
 	if _, err := exec.LookPath("update-desktop-database"); err == nil {
-		if output, err := exec.Command("update-desktop-database").CombinedOutput(); err != nil {
+		if output, err := exec.Command("update-desktop-database", dirs.SnapDesktopFilesDir).CombinedOutput(); err != nil {
 			return fmt.Errorf("cannot update-desktop-database %q: %s", output, err)
 		}
 		logger.Debugf("update-desktop-database successful")

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -81,7 +81,7 @@ func (s *desktopSuite) TestAddPackageDesktopFiles(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, true)
 	c.Assert(s.mockUpdateDesktopDatabase.Calls(), DeepEquals, [][]string{
-		{"update-desktop-database"},
+		{"update-desktop-database", dirs.SnapDesktopFilesDir},
 	})
 }
 
@@ -99,7 +99,7 @@ func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, false)
 	c.Assert(s.mockUpdateDesktopDatabase.Calls(), DeepEquals, [][]string{
-		{"update-desktop-database"},
+		{"update-desktop-database", dirs.SnapDesktopFilesDir},
 	})
 }
 


### PR DESCRIPTION
is called in an environment where the xdg_data_dirs is not defined which
leads to the directory we are interested in to not be considered