### PR TITLE
client, cmd/snap: use the new multi-refresh endpoint

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -107,7 +107,7 @@ func wait(client *client.Client, id string) (*client.Change, error) {
 				return chg, errors.New(chg.Err)
 			}
 
-			return nil, fmt.Errorf("change finished in status %q with no error message", chg.Status)
+			return nil, fmt.Errorf(i18n.G("change finished in status %q with no error message"), chg.Status)
 		}
 
 		// note this very purposely is not a ticker; we want
@@ -254,7 +254,7 @@ type modeMixin struct {
 	JailMode bool `long:"jailmode" description:"Override a snap's request for non-enforcing security"`
 }
 
-var errModeConflict = errors.New("cannot use devmode and jailmode flags together")
+var errModeConflict = errors.New(i18n.G("cannot use devmode and jailmode flags together"))
 
 func (mx modeMixin) validateMode() error {
 	if mx.DevMode && mx.JailMode {
@@ -350,6 +350,8 @@ func refreshMany(snaps []string) error {
 		return showDone(upgraded, "upgrade")
 	}
 
+	fmt.Fprintln(Stderr, i18n.G("All snaps up-to-date."))
+
 	return nil
 }
 
@@ -407,7 +409,7 @@ func (x *cmdRefresh) Execute([]string) error {
 
 	if x.List {
 		if x.asksForMode() || x.asksForChannel() {
-			return errors.New("--list does not take mode nor channel flags")
+			return errors.New(i18n.G("--list does not take mode nor channel flags"))
 		}
 
 		return listRefresh()
@@ -421,7 +423,7 @@ func (x *cmdRefresh) Execute([]string) error {
 	}
 
 	if x.asksForMode() || x.asksForChannel() {
-		return errors.New("a snap name is needed to specify mode or channel flags")
+		return errors.New(i18n.G("a single snap name is needed to specify mode or channel flags"))
 	}
 
 	return refreshMany(x.Positional.Snaps)

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -325,36 +325,32 @@ type cmdRefresh struct {
 
 	List       bool `long:"list" description:"show available snaps for refresh"`
 	Positional struct {
-		Snap string `positional-arg-name:"<snap>"`
+		Snaps []string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes"`
 }
 
-func refreshAll() error {
-	// FIXME: move this to snapd instead and have a new refresh-all endpoint
+func refreshMany(snaps []string) error {
 	cli := Client()
-	updates, _, err := cli.Find(&client.FindOptions{Refresh: true})
+	changeID, err := cli.RefreshMany(snaps, nil)
 	if err != nil {
-		return fmt.Errorf("cannot list updates: %s", err)
-	}
-	// nothing to update/list
-	if len(updates) == 0 {
-		fmt.Fprintln(Stderr, i18n.G("All snaps up-to-date."))
-		return nil
+		return err
 	}
 
-	names := make([]string, len(updates))
-	for i, update := range updates {
-		changeID, err := cli.Refresh(update.Name, &client.SnapOptions{Channel: update.Channel})
-		if err != nil {
-			return err
-		}
-		if _, err := wait(cli, changeID); err != nil {
-			return err
-		}
-		names[i] = update.Name
+	chg, err := wait(cli, changeID)
+	if err != nil {
+		return err
 	}
 
-	return showDone(names, "upgrade")
+	var upgraded []string
+	if err := chg.Get("snap-names", &upgraded); err != nil && err != client.ErrNoData {
+		return err
+	}
+
+	if len(upgraded) > 0 {
+		return showDone(upgraded, "upgrade")
+	}
+
+	return nil
 }
 
 func refreshOne(name string, opts *client.SnapOptions) error {
@@ -416,19 +412,19 @@ func (x *cmdRefresh) Execute([]string) error {
 
 		return listRefresh()
 	}
-	if x.Positional.Snap == "" {
-		if x.asksForMode() || x.asksForChannel() {
-			return errors.New("a snap name is needed to specify mode or channel flags")
-		}
-
-		return refreshAll()
+	if len(x.Positional.Snaps) == 1 {
+		return refreshOne(x.Positional.Snaps[0], &client.SnapOptions{
+			Channel:  x.Channel,
+			DevMode:  x.DevMode,
+			JailMode: x.JailMode,
+		})
 	}
 
-	return refreshOne(x.Positional.Snap, &client.SnapOptions{
-		Channel:  x.Channel,
-		DevMode:  x.DevMode,
-		JailMode: x.JailMode,
-	})
+	if x.asksForMode() || x.asksForChannel() {
+		return errors.New("a snap name is needed to specify mode or channel flags")
+	}
+
+	return refreshMany(x.Positional.Snaps)
 }
 
 type cmdTry struct {

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -171,7 +171,6 @@ func (s *SnapOpSuite) TestInstall(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":  "install",
-			"name":    "foo",
 			"channel": "chan",
 		})
 		s.srv.channel = "chan"
@@ -192,7 +191,6 @@ func (s *SnapOpSuite) TestInstallDevMode(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":  "install",
-			"name":    "foo",
 			"devmode": true,
 			"channel": "chan",
 		})
@@ -264,7 +262,6 @@ func (s *SnapOpSuite) TestRevert(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action": "revert",
-			"name":   "foo",
 		})
 	}
 
@@ -316,7 +313,6 @@ func (s *SnapOpSuite) TestRefreshOne(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action": "refresh",
-			"name":   "one",
 		})
 	}
 	_, err := snap.Parser().ParseArgs([]string{"refresh", "one"})
@@ -330,7 +326,6 @@ func (s *SnapOpSuite) TestRefreshOneSwitchChannel(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":  "refresh",
-			"name":    "one",
 			"channel": "beta",
 		})
 	}
@@ -345,7 +340,6 @@ func (s *SnapOpSuite) TestRefreshOneDevmode(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":  "refresh",
-			"name":    "one",
 			"devmode": true,
 		})
 	}
@@ -360,7 +354,6 @@ func (s *SnapOpSuite) TestRefreshOneJailmode(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":   "refresh",
-			"name":     "one",
 			"jailmode": true,
 		})
 	}
@@ -447,7 +440,6 @@ func (s *SnapOpSuite) TestInstallFromChannel(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action":  "install",
-			"name":    "foo",
 			"channel": "edge",
 		})
 		s.srv.channel = "edge"
@@ -469,7 +461,6 @@ func (s *SnapOpSuite) TestEnable(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action": "enable",
-			"name":   "foo",
 		})
 	}
 
@@ -489,7 +480,6 @@ func (s *SnapOpSuite) TestDisable(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action": "disable",
-			"name":   "foo",
 		})
 	}
 
@@ -509,7 +499,6 @@ func (s *SnapOpSuite) TestRemove(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
 		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
 			"action": "remove",
-			"name":   "foo",
 		})
 	}
 

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -376,13 +376,19 @@ func (s *SnapOpSuite) TestRefreshOneChanErr(c *check.C) {
 func (s *SnapOpSuite) TestRefreshAllChannel(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser().ParseArgs([]string{"refresh", "--beta"})
-	c.Assert(err, check.ErrorMatches, `a snap name is needed to specify mode or channel flags`)
+	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
+}
+
+func (s *SnapOpSuite) TestRefreshManyChannel(c *check.C) {
+	s.RedirectClientToTestServer(nil)
+	_, err := snap.Parser().ParseArgs([]string{"refresh", "--beta", "one", "two"})
+	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
 }
 
 func (s *SnapOpSuite) TestRefreshAllModeFlags(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser().ParseArgs([]string{"refresh", "--devmode"})
-	c.Assert(err, check.ErrorMatches, `a snap name is needed to specify mode or channel flags`)
+	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
 }
 
 func (s *SnapOpSuite) runTryTest(c *check.C, devmode bool) {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -651,13 +651,15 @@ type snapInstruction struct {
 	userID int
 }
 
-var snapstateInstall = snapstate.Install
-var snapstateUpdate = snapstate.Update
-var snapstateInstallPath = snapstate.InstallPath
-var snapstateTryPath = snapstate.TryPath
-var snapstateGet = snapstate.Get
-var snapstateUpdateMany = snapstate.UpdateMany
-var snapstateRefreshCandidates = snapstate.RefreshCandidates
+var (
+	snapstateGet               = snapstate.Get
+	snapstateInstall           = snapstate.Install
+	snapstateInstallPath       = snapstate.InstallPath
+	snapstateRefreshCandidates = snapstate.RefreshCandidates
+	snapstateTryPath           = snapstate.TryPath
+	snapstateUpdate            = snapstate.Update
+	snapstateUpdateMany        = snapstate.UpdateMany
+)
 
 func ensureStateSoonImpl(st *state.State) {
 	st.EnsureBefore(0)
@@ -730,7 +732,7 @@ func modeFlags(devMode, jailMode bool) (snapstate.Flags, error) {
 func snapUpdateMany(inst *snapInstruction, st *state.State) (msg string, updated []string, tasksets []*state.TaskSet, err error) {
 	// TODO: check inst flags and bail if any are given (-many
 	// doesn't take options)
-	updated, tts, err := snapstateUpdateMany(st, inst.Snaps, inst.userID)
+	updated, tasksets, err = snapstateUpdateMany(st, inst.Snaps, inst.userID)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -750,7 +752,7 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (msg string, updated
 		msg = fmt.Sprintf(i18n.G("Refresh snaps %s"), strings.Join(quoted, ", "))
 	}
 
-	return msg, updated, tts, nil
+	return msg, updated, tasksets, nil
 }
 
 func snapInstall(inst *snapInstruction, st *state.State) (string, []*state.TaskSet, error) {

--- a/daemon/api_mock_test.go
+++ b/daemon/api_mock_test.go
@@ -48,6 +48,7 @@ func (s *apiSuite) mockSnap(c *C, yamlText string) *snap.Info {
 			{
 				RealName: snapInfo.Name(),
 				Revision: snapInfo.Revision,
+				SnapID:   "ididid",
 			},
 		},
 		Current: snapInfo.Revision,

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -358,16 +358,25 @@ furthermore, `download-size` and `price` cannot occur in the output of `/v2/snap
 
 ### POST
 
-* Description: Install an uploaded snap to the system.
+* Description: Install, refresh, revert, remove snaps
 * Access: trusted
 * Operation: async
 * Return: background operation or standard error
 
 #### Input
 
-The snap to install must be provided as part of the body of a
-`multipart/form-data` request. The form should have one file
-named "snap".
+This endpoint accepts an `application/json` request specifying the
+kind of operation, optional flags and a list of snaps, or a
+`multipart/form-data` request with one file named "snap".
+
+#### Sample JSON input
+
+```javascript
+{
+  "action": "refresh",
+  "snaps": [...] // for refresh an empty or absent snaps field means "refresh all"
+}
+```
 
 ## /v2/snaps/[name]
 ### GET

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -251,9 +251,10 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 		Current: snap.R(1),
 	})
 
-	tts, err := snapstate.UpdateMany(s.state, nil, 0)
+	updates, tts, err := snapstate.UpdateMany(s.state, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(tts, HasLen, 1)
+	c.Check(updates, DeepEquals, []string{"some-snap"})
 
 	ts := tts[0]
 	i := verifyInstallUpdateTasks(c, true, ts, s.state)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -365,8 +365,12 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 
 		ts, err := doInstall(st, snapst, ss)
 		if err != nil {
-			// log?
-			continue
+			if len(names) == 0 {
+				// doing "refresh all", just skip this snap
+				logger.Noticef("cannot refresh snap %q: %v", update.Name(), err)
+				continue
+			}
+			return nil, nil, err
 		}
 		updated = append(updated, update.Name())
 		tasksets = append(tasksets, ts)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -250,7 +250,9 @@ func Install(s *state.State, name, channel string, userID int, flags Flags) (*st
 	return doInstall(s, &snapst, ss)
 }
 
-// like strings.Contains but assumes the list is sorted
+// contains determines whether the given string is contained in the
+// given list of strings, which must have been previously sorted using
+// sort.Strings.
 func contains(ns []string, n string) bool {
 	i := sort.SearchStrings(ns, n)
 	if i >= len(ns) {
@@ -260,7 +262,7 @@ func contains(ns []string, n string) bool {
 }
 
 // RefreshCandidates gets a list of candidates for update
-// (call it with the state lock held)
+// Note that the state must be locked by the caller.
 func RefreshCandidates(st *state.State, user *auth.UserState) ([]*snap.Info, error) {
 	updates, _, err := refreshCandidates(st, nil, user)
 	return updates, err
@@ -327,7 +329,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 
 // UpdateMany updates everything from the given list of names that the
 // store says is updateable. If the list is empty, update everything.
-// (state must be locked)
+// Note that the state must be locked by the caller.
 func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state.TaskSet, error) {
 	user, err := userFromUserID(st, userID)
 	if err != nil {
@@ -340,7 +342,7 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 	}
 
 	updated := make([]string, 0, len(updates))
-	tts := make([]*state.TaskSet, 0, len(updates))
+	tasksets := make([]*state.TaskSet, 0, len(updates))
 	for _, update := range updates {
 		snapst := stateByID[update.SnapID]
 		// XXX: this check goes away when update-to-local is done
@@ -362,10 +364,10 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 			continue
 		}
 		updated = append(updated, update.Name())
-		tts = append(tts, ts)
+		tasksets = append(tasksets, ts)
 	}
 
-	return updated, tts, nil
+	return updated, tasksets, nil
 }
 
 // Update initiates a change updating a snap.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -328,17 +328,18 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 // UpdateMany updates everything from the given list of names that the
 // store says is updateable. If the list is empty, update everything.
 // (state must be locked)
-func UpdateMany(st *state.State, names []string, userID int) ([]*state.TaskSet, error) {
+func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state.TaskSet, error) {
 	user, err := userFromUserID(st, userID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	updates, stateByID, err := refreshCandidates(st, names, user)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	updated := make([]string, 0, len(updates))
 	tts := make([]*state.TaskSet, 0, len(updates))
 	for _, update := range updates {
 		snapst := stateByID[update.SnapID]
@@ -360,10 +361,11 @@ func UpdateMany(st *state.State, names []string, userID int) ([]*state.TaskSet, 
 			// log?
 			continue
 		}
+		updated = append(updated, update.Name())
 		tts = append(tts, ts)
 	}
 
-	return tts, nil
+	return updated, tts, nil
 }
 
 // Update initiates a change updating a snap.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -280,7 +280,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 	candidatesInfo := make([]*store.RefreshCandidate, 0, len(snapStates))
 	for _, snapst := range snapStates {
 		if snapst.TryMode() || snapst.DevMode() {
-			// no automatic refreshes for trymode nor devmode
+			// no multi-refresh for trymode nor devmode
 			continue
 		}
 
@@ -293,6 +293,11 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 		snapInfo, err := snapst.CurrentInfo()
 		if err != nil {
 			// log something maybe?
+			continue
+		}
+
+		if snapInfo.SnapID == "" {
+			// no refresh for sideloaded
 			continue
 		}
 


### PR DESCRIPTION
This builds on #1615 so [compare with that](https://github.com/chipaca/snappy/compare/refresh-all...chipaca:refresh-all-client).

multi-refresh does not currently offer a way to show errors beyond the catastrophic. That is, if the actual update fails it'll show an error, but if you ask it to update snaps you don't have installed, or for which there aren't updates, nothing is printed. 