### PR TITLE
boot: use `cp -aLv` instead of `cp -a` (no symlinks on vfat)

### DIFF
--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -52,7 +52,7 @@ func RemoveKernelAssets(s snap.PlaceInfo, inter progress.Meter) error {
 }
 
 func copyAll(src, dst string) error {
-	if output, err := exec.Command("cp", "-a", src, dst).CombinedOutput(); err != nil {
+	if output, err := exec.Command("cp", "-aLv", src, dst).CombinedOutput(); err != nil {
 		return fmt.Errorf("cannot copy %q -> %q: %s (%s)", src, dst, err, output)
 	}
 	return nil


### PR DESCRIPTION
There are no symlinks on vfat, so we must ensure that we
always follow symlinks when copying.