### PR TITLE
asserts: make account-key's `until` optional to represent a never-expiring key

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -43,7 +43,7 @@ func (ak *AccountKey) Since() time.Time {
 	return ak.since
 }
 
-// Until returns the time when the account key stops being valid.
+// Until returns the time when the account key stops being valid. A zero time means the key is valid forever.
 func (ak *AccountKey) Until() time.Time {
 	return ak.until
 }
@@ -60,7 +60,11 @@ func (ak *AccountKey) PublicKeyFingerprint() string {
 
 // isKeyValidAt returns whether the account key is valid at 'when' time.
 func (ak *AccountKey) isKeyValidAt(when time.Time) bool {
-	return (when.After(ak.since) || when.Equal(ak.since)) && when.Before(ak.until)
+	valid := when.After(ak.since) || when.Equal(ak.since)
+	if valid && !ak.until.IsZero() {
+		valid = when.Before(ak.until)
+	}
+	return valid
 }
 
 // publicKey returns the underlying public key of the account key.
@@ -122,17 +126,20 @@ func assembleAccountKey(assert assertionBase) (Assertion, error) {
 	if err != nil {
 		return nil, err
 	}
-	until, err := checkRFC3339Date(assert.headers, "until")
+
+	until, err := checkRFC3339DateWithDefault(assert.headers, "until", time.Time{})
 	if err != nil {
 		return nil, err
 	}
-	if !until.After(since) {
-		return nil, fmt.Errorf("invalid 'since' and 'until' times (no gap after 'since' till 'until')")
+	if !until.IsZero() && until.Before(since) {
+		return nil, fmt.Errorf("'until' time cannot be before 'since' time")
 	}
+
 	pubk, err := checkPublicKey(&assert, "public-key-fingerprint", "public-key-id")
 	if err != nil {
 		return nil, err
 	}
+
 	// ignore extra headers for future compatibility
 	return &AccountKey{
 		assertionBase: assert,

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -122,6 +122,22 @@ func checkRFC3339Date(headers map[string]interface{}, name string) (time.Time, e
 	return date, nil
 }
 
+func checkRFC3339DateWithDefault(headers map[string]interface{}, name string, defl time.Time) (time.Time, error) {
+	value, ok := headers[name]
+	if !ok {
+		return defl, nil
+	}
+	dateStr, ok := value.(string)
+	if !ok {
+		return time.Time{}, fmt.Errorf("%q header must be a string", name)
+	}
+	date, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%q header is not a RFC3339 date: %v", name, err)
+	}
+	return date, nil
+}
+
 func checkUint(headers map[string]interface{}, name string, bitSize int) (uint64, error) {
 	valueStr, err := checkNotEmptyString(headers, name)
 	if err != nil {


### PR DESCRIPTION
This allows a key's lifetime to be open ended. It also allows a key to be effectively revoked by setting `until` to the same value as `since`.