### PR TITLE
interfaces: add system-trace interface LP: #1600085

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -187,6 +187,15 @@ with trusted apps.
 Usage: reserved
 Auto-Connect: no
 
+### system-trace
+
+Can use kernel tracing facilities. This is restricted because it gives
+privileged access to all processes on the system and should only be used with
+trusted apps.
+
+Usage: reserved
+Auto-Connect: no
+
 ### timeserver-control
 
 Can manage timeservers directly separate from config ubuntu-core.

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -47,6 +47,7 @@ var allInterfaces = []interfaces.Interface{
 	NewNetworkObserveInterface(),
 	NewSnapdControlInterface(),
 	NewSystemObserveInterface(),
+	NewSystemTraceInterface(),
 	NewTimeserverControlInterface(),
 	NewTimezoneControlInterface(),
 	NewUnity7Interface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -50,6 +50,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewNetworkObserveInterface())
 	c.Check(all, DeepContains, builtin.NewSnapdControlInterface())
 	c.Check(all, DeepContains, builtin.NewSystemObserveInterface())
+	c.Check(all, DeepContains, builtin.NewSystemTraceInterface())
 	c.Check(all, DeepContains, builtin.NewTimeserverControlInterface())
 	c.Check(all, DeepContains, builtin.NewTimezoneControlInterface())
 	c.Check(all, DeepContains, builtin.NewUnity7Interface())

--- a/interfaces/builtin/system_trace.go
+++ b/interfaces/builtin/system_trace.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const systemTraceConnectedPlugAppArmor = `
+# Description: Can use kernel tracing facilities. This is restricted because it
+# gives privileged access to all processes on the system and should only be
+# used with trusted apps.
+# Usage: reserved
+
+  # For the bpf() syscall and manipulating bpf map types
+  capability sys_admin,
+  capability sys_resource,
+
+  # For kernel probes, etc
+  /sys/kernel/debug/tracing/ r,
+  /sys/kernel/debug/tracing/** rw,
+
+  # Access to kernel headers required for iovisor/bcc. This is typically
+  # detected with 'ls -l /lib/modules/$(uname -r)/build/' which is a symlink
+  # to /usr/src on Ubuntu and so only /usr/src is needed.
+  /usr/src/ r,
+  /usr/src/** r,
+`
+
+const systemTraceConnectedPlugSecComp = `
+# Description: Can use kernel tracing facilities. This is restricted because it
+# gives privileged access to all processes on the system and should only be
+# used with trusted apps.
+# Usage: reserved
+
+bpf
+perf_event_open
+`
+// NewSystemTraceInterface returns a new "system-trace" interface.
+func NewSystemTraceInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "system-trace",
+		connectedPlugAppArmor: systemTraceConnectedPlugAppArmor,
+		connectedPlugSecComp: systemTraceConnectedPlugSecComp,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/system_trace.go
+++ b/interfaces/builtin/system_trace.go
@@ -34,6 +34,9 @@ const systemTraceConnectedPlugAppArmor = `
   capability sys_resource,
 
   # For kernel probes, etc
+  /sys/kernel/debug/kprobes/ r,
+  /sys/kernel/debug/kprobes/** r,
+
   /sys/kernel/debug/tracing/ r,
   /sys/kernel/debug/tracing/** rw,
 

--- a/interfaces/builtin/system_trace.go
+++ b/interfaces/builtin/system_trace.go
@@ -56,12 +56,13 @@ const systemTraceConnectedPlugSecComp = `
 bpf
 perf_event_open
 `
+
 // NewSystemTraceInterface returns a new "system-trace" interface.
 func NewSystemTraceInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "system-trace",
 		connectedPlugAppArmor: systemTraceConnectedPlugAppArmor,
-		connectedPlugSecComp: systemTraceConnectedPlugSecComp,
+		connectedPlugSecComp:  systemTraceConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -1,0 +1,128 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+)
+
+type SystemTraceInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&SystemTraceInterfaceSuite{
+	iface: builtin.NewSystemTraceInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Name:      "system-trace",
+			Interface: "system-trace",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "system-trace",
+			Interface: "system-trace",
+		},
+	},
+})
+
+func (s *SystemTraceInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "system-trace")
+}
+
+func (s *SystemTraceInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "system-trace",
+		Interface: "system-trace",
+	}})
+	c.Assert(err, ErrorMatches, "system-trace slots are reserved for the operating system snap")
+}
+
+func (s *SystemTraceInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *SystemTraceInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "system-trace"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "system-trace"`)
+}
+
+func (s *SystemTraceInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev}
+	for _, system := range systems {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *SystemTraceInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *SystemTraceInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *SystemTraceInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(), Equals, false)
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -41,6 +41,7 @@ var implicitSlots = []string{
 	"ppp",
 	"snapd-control",
 	"system-observe",
+	"system-trace",
 	"timeserver-control",
 	"timezone-control",
 }

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -42,7 +42,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 16)
+	c.Assert(info.Slots, HasLen, 17)
 }
 
 func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 26)
+	c.Assert(info.Slots, HasLen, 27)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -42,7 +42,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 15)
+	c.Assert(info.Slots, HasLen, 16)
 }
 
 func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 25)
+	c.Assert(info.Slots, HasLen, 26)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
This interface is in support of BPF/bcc and is a privileged interface that should only be manually connected. It allows using the kernel debug functionality for setting kernel probes and traces and also provides CAP_SYS_ADMIN and CAP_SYS_RESOURCE that are needed for bpf() syscall and manipulating bpf map types.

The BPF Compiler Collection (BCC) was tested to work when using 'plugs: [ mount-observe, system-observe, system-trace ]' when snap-confine is modified to mount /usr/src (this will be handled in snap-confine). See https://bugs.launchpad.net/snappy/+bug/1600085 for details on obtaining the snap (you'll also need the patch attached to the bug to make the snap work).