### PR TITLE
squashfs: do not install a snap if its already exists and is valid

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -62,6 +62,9 @@ func (s *Snap) Install(targetPath, mountDir string) error {
 		}
 	}
 
+	// dst file
+	dst := filepath.Join(targetPath, filepath.Base(s.path))
+
 	// This is required so that the tests can simulate a mounted
 	// snap when we "install" a squashfs snap in the tests.
 	// We can not mount it for real in the tests, so we just unpack
@@ -73,12 +76,12 @@ func (s *Snap) Install(targetPath, mountDir string) error {
 	}
 
 	// nothing to do, happens on e.g. first-boot
-	if s.path == targetPath {
+	if s.path == dst || osutil.FilesAreEqual(s.path, dst) {
 		return nil
 	}
 
 	// FIXME: cp.CopyFile() has no preserve attribute flag yet
-	return runCommand("cp", "-a", s.path, targetPath)
+	return runCommand("cp", "-a", s.path, dst)
 }
 
 var runCommandWithOutput = func(args ...string) ([]byte, error) {

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -33,6 +33,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/testutil"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -78,6 +79,30 @@ func makeSnap(c *C, manifest, data string) *Snap {
 func (s *SquashfsTestSuite) SetUpTest(c *C) {
 	err := os.Chdir(c.MkDir())
 	c.Assert(err, IsNil)
+}
+
+func (s *SquashfsTestSuite) TestInstallSimple(c *C) {
+	snap := makeSnap(c, "name: test", "")
+	targetPath := c.MkDir()
+	mountDir := c.MkDir()
+	err := snap.Install(targetPath, mountDir)
+	c.Assert(err, IsNil)
+	dst := filepath.Join(targetPath, filepath.Base(snap.Path()))
+	c.Check(osutil.FileExists(dst), Equals, true)
+}
+
+func (s *SquashfsTestSuite) TestInstallNotCopyTwice(c *C) {
+	snap := makeSnap(c, "name: test2", "")
+	targetPath := c.MkDir()
+	mountDir := c.MkDir()
+	err := snap.Install(targetPath, mountDir)
+	c.Assert(err, IsNil)
+
+	cmd := testutil.MockCommand(c, "cp", "")
+	defer cmd.Restore()
+	err = snap.Install(targetPath, mountDir)
+	c.Assert(err, IsNil)
+	c.Assert(cmd.Calls(), HasLen, 0)
 }
 
 func (s *SquashfsTestSuite) TestPath(c *C) {


### PR DESCRIPTION
On firstboot we may call snap.Install() but there is a valid
snap already in the right place. Do not override the valid
snap in this case to avoid confusing squashfs errors.