### PR TITLE
Do not install a snap again if it is already valid

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -52,7 +52,6 @@ func New(snapPath string) *Snap {
 	return &Snap{path: snapPath}
 }
 
-// Install just copies the blob into place (unless it is used in the tests)
 func (s *Snap) Install(targetPath, mountDir string) error {
 
 	// ensure mount-point and blob target dir.
@@ -72,8 +71,9 @@ func (s *Snap) Install(targetPath, mountDir string) error {
 		}
 	}
 
-	// nothing to do, happens on e.g. first-boot
-	if s.path == targetPath {
+	// nothing to do, happens on e.g. first-boot when we already
+	// booted with the OS snap but its also in the seed.yaml
+	if s.path == targetPath || osutil.FilesAreEqual(s.path, targetPath) {
 		return nil
 	}
 


### PR DESCRIPTION
On firstboot we may call snap.Install() for the core/kernel snap
that is in the seed/snaps directory so that it gets copied to
the snaps directory. We do not need to copy in this case because
the files are already identical. The copy is actually harmful
because the system will continue to read from the squashfs
ubuntu-core file while it is being copied which leads to errors
during the boot process.