### PR TITLE
interfaces: add uefi-manager interface

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -223,3 +223,10 @@ Allow to manage the kernel side Bluetooth stack.
 
 Usage: reserved
 Auto-Connect: no
+
+### uefi-manager
+
+Allow to update UEFI capsule format firmware.
+
+Usage: reserved
+Auto-Connect: no

--- a/integration-tests/manual-tests.md
+++ b/integration-tests/manual-tests.md
@@ -198,3 +198,21 @@ $ snap remove bluez
    and verify it actually passes. If some of the tests fail
    there will be a problem with the particular kernel used on
    the device.
+
+# Test uefi-manager interface
+
+1. Ensure your BIOS support UEFI firmware upgrading via UEFI capsule format
+
+2. Install the uefi-fw-tools snap from the store
+
+3. Ensure the 'uefi-manager' interface is connected
+
+4. Get available UEFI firmware from the server
+
+ $ uefi-fw-tools.fwupdmgr refresh
+
+5. Download firmware
+
+ $ uefi-fw-tools.fwupdmgr update
+
+6. Reboot and ensure it start the upgrading process.

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -34,6 +34,7 @@ var allInterfaces = []interfaces.Interface{
 	&NetworkManagerInterface{},
 	&PppInterface{},
 	&SerialPortInterface{},
+	&UefiManagerInterface{},
 	NewFirewallControlInterface(),
 	NewGsettingsInterface(),
 	NewHardwareObserveInterface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -38,6 +38,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.LocationObserveInterface{})
 	c.Check(all, Contains, &builtin.MprisInterface{})
 	c.Check(all, Contains, &builtin.SerialPortInterface{})
+	c.Check(all, Contains, &builtin.UefiManagerInterface{})
 	c.Check(all, DeepContains, builtin.NewFirewallControlInterface())
 	c.Check(all, DeepContains, builtin.NewGsettingsInterface())
 	c.Check(all, DeepContains, builtin.NewHomeInterface())

--- a/interfaces/builtin/uefi_manager.go
+++ b/interfaces/builtin/uefi_manager.go
@@ -1,0 +1,190 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"bytes"
+	"github.com/snapcore/snapd/interfaces"
+)
+
+var uefiManagerPermanentSlotAppArmor = []byte(`
+# Description: Allow operating as the uefiManager service. Reserved because this
+#  gives privileged access to the system.
+# Usage: reserved
+
+  capability sys_admin,
+  capability linux_immutable,
+
+  # File accesses
+  /sys/firmware/efi/                    r,
+  /sys/firmware/efi/fw_platform_size    r,
+  /sys/firmware/efi/esrt/entries/       r,
+  /sys/firmware/efi/esrt/entries/**     r,
+  /sys/firmware/efi/efivars/            r,
+  /sys/firmware/efi/efivars/**          rw,
+  /sys/devices/virtual/dmi/             r,
+  /sys/devices/virtual/dmi/**           r,
+  /usr/bin/gpg                          ix,
+  /boot/efi/EFI/ubuntu/fw/              rw,
+  /boot/efi/EFI/ubuntu/fw/**            rw,
+  @{PROC}/@{pid}/mounts                 r,
+  /sys/devices/**/partition             r,
+  /dev/sd[a-z]*                         r,
+
+  # DBus accesses
+  #include <abstractions/dbus-strict>
+  dbus (send)
+     bus=system
+     path=/org/freedesktop/DBus
+     interface=org.freedesktop.DBus
+     member={Request,Release}Name
+     peer=(name=org.freedesktop.DBus),
+
+  dbus (receive, send)
+    bus=system
+    path=/org/freedesktop/DBus
+    interface=org.freedesktop.DBus
+    member=GetConnectionUnixUser
+    peer=(label=unconfined),
+
+  # Allow binding the service to the requested connection name
+  dbus (bind)
+      bus=system
+      name="org.freedesktop.fwupd",
+
+  # Allow traffic to/from uefiManager interface with any method
+  dbus (receive, send)
+      bus=system
+      path=/
+      interface=org.freedesktop.fwupd,
+
+  dbus (receive, send)
+      bus=system
+      path=/org/freedesktop/fwupd{,/**}
+      interface=org.freedesktop.fwupd,
+
+  # Allow traffic to/from org.freedesktop.DBus for uefiManager service
+  dbus (receive, send)
+      bus=system
+      path=/
+      interface=org.freedesktop.DBus.**,
+
+  dbus (receive, send)
+      bus=system
+      path=/org/freedesktop/fwupd{,/**}
+      interface=org.freedesktop.DBus.**,
+`)
+
+var uefiManagerConnectedPlugAppArmor = []byte(`
+# Description: Allow using uefiManager service. Reserved because this gives
+#  privileged access to the uefiManager service.
+# Usage: reserved
+
+  # DBus accesses
+  #include <abstractions/dbus-strict>
+
+  # Allow access to uefiManager service
+  dbus (receive, send)
+      bus=system
+      path=/
+      interface=org.freedesktop.fwupd
+      peer=(label=###SLOT_SECURITY_TAGS###),
+
+  dbus (receive, send)
+      bus=system
+      path=/
+      interface=org.freedesktop.DBus.Properties
+      peer=(label=###SLOT_SECURITY_TAGS###),
+`)
+
+var uefiManagerPermanentSlotDBus = []byte(`
+<policy user="root">
+    <allow own="org.freedesktop.fwupd"/>
+</policy>
+<policy context="default">
+    <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.fwupd"/>
+    <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.DBus.Peer"/>
+</policy>
+`)
+
+type UefiManagerInterface struct{}
+
+func (iface *UefiManagerInterface) Name() string {
+	return "uefi-manager"
+}
+
+func (iface *UefiManagerInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecurityDBus, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *UefiManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		old := []byte("###SLOT_SECURITY_TAGS###")
+		new := slotAppLabelExpr(slot)
+		snippet := bytes.Replace(uefiManagerConnectedPlugAppArmor, old, new, -1)
+		return snippet, nil
+	case interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityDBus, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *UefiManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		return uefiManagerPermanentSlotAppArmor, nil
+	case interfaces.SecurityDBus:
+		return uefiManagerPermanentSlotDBus, nil
+	case interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *UefiManagerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *UefiManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
+	return nil
+}
+
+func (iface *UefiManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	return nil
+}
+
+func (iface *UefiManagerInterface) AutoConnect() bool {
+	return false
+}

--- a/interfaces/builtin/uefi_manager_test.go
+++ b/interfaces/builtin/uefi_manager_test.go
@@ -1,0 +1,171 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type UefiManagerInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&UefiManagerInterfaceSuite{
+	iface: &builtin.UefiManagerInterface{},
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "uefi-fw-tools"},
+			Name:      "uefi-manager",
+			Interface: "uefi-manager",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "uefi-fw-tools"},
+			Name:      "fwupdmgr",
+			Interface: "uefi-manager",
+		},
+	},
+})
+
+func (s *UefiManagerInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "uefi-manager")
+}
+
+// The label glob when all apps are bound to the uefi-manager slot
+func (s *UefiManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
+	app1 := &snap.AppInfo{Name: "app1"}
+	app2 := &snap.AppInfo{Name: "app2"}
+	slot := &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap: &snap.Info{
+				SuggestedName: "uefi-fw-tools",
+				Apps:          map[string]*snap.AppInfo{"app1": app1, "app2": app2},
+			},
+			Name:      "uefi-manager",
+			Interface: "uefi-manager",
+			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
+		},
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.uefi-fw-tools.*"),`)
+}
+
+// The label uses alternation when some, but not all, apps is bound to the uefi-manager slot
+func (s *UefiManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c *C) {
+	app1 := &snap.AppInfo{Name: "app1"}
+	app2 := &snap.AppInfo{Name: "app2"}
+	app3 := &snap.AppInfo{Name: "app3"}
+	slot := &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap: &snap.Info{
+				SuggestedName: "uefi-fw-tools",
+				Apps:          map[string]*snap.AppInfo{"app1": app1, "app2": app2, "app3": app3},
+			},
+			Name:      "uefi-manager",
+			Interface: "uefi-manager",
+			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
+		},
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.uefi-fw-tools.{app1,app2}"),`)
+}
+
+// The label uses short form when exactly one app is bound to the uefi-manager slot
+func (s *UefiManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c *C) {
+	app := &snap.AppInfo{Name: "app"}
+	slot := &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap: &snap.Info{
+				SuggestedName: "uefi-fw-tools",
+				Apps:          map[string]*snap.AppInfo{"app": app},
+			},
+			Name:      "uefi-manager",
+			Interface: "uefi-manager",
+			Apps:      map[string]*snap.AppInfo{"app": app},
+		},
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.uefi-fw-tools.app"),`)
+}
+
+func (s *UefiManagerInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev}
+	for _, system := range systems {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *UefiManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *UefiManagerInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}


### PR DESCRIPTION
An interface that allows UEFI firmware upgrading via UEFI capsule format.