### PR TITLE
tests: allow-downgrades on upgrade test to prevent version errors

### DIFF
--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -21,7 +21,9 @@ execute: |
     cat /etc/environment
 
     echo Do upgrade
-    apt install -y ${SPREAD_PATH}/../snapd*.deb
+    # allow-downgrades prevents errors when new versions hit the archive, for instance,
+    # trying to install 2.11ubuntu1 over 2.11+0.16.04
+    apt install -y --allow-downgrades ${SPREAD_PATH}/../snapd*.deb
 
     snapdver=$(snap --version|grep "snapd ")
     [ "$snapdver" != "$prevsnapdver" ]


### PR DESCRIPTION
After building the deb from the branch, these changes prevent errors when new versions hit the archive, for instance trying to install 2.11ubuntu1 (built from branch) over 2.11+0.16.04 (from the archive).