### PR TITLE
interfaces/builtin: implement systemd-control

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -223,3 +223,10 @@ Allow to manage the kernel side Bluetooth stack.
 
 Usage: reserved
 Auto-Connect: no
+
+### systemd-control
+
+Allow to manage systemd (services, system reboot/halt/shutdown)
+
+Usage: reserved
+Auto-Connect: no

--- a/integration-tests/manual-tests.md
+++ b/integration-tests/manual-tests.md
@@ -198,3 +198,59 @@ $ snap remove bluez
    and verify it actually passes. If some of the tests fail
    there will be a problem with the particular kernel used on
    the device.
+
+# Test systemd-control interface
+
+1. Create a simple example snap which uses the systemd-control
+   interface:
+
+```yaml
+name: systemd-control-example
+version: 1
+summary: Simple snap to demonstrate systemd-control interface use
+description: |
+  Simple snap that ships a small script which utilises the systemd-control
+  interface to talk with systemd.
+confinement: strict
+apps:
+  status:
+    command: bin/system-status
+    plugs: [systemd-control]
+parts:
+  system-status:
+    plugin: copy
+    files:
+      system-status: bin/system-status
+```
+
+The system-status script has the following content
+
+```
+#!/bin/sh
+/bin/systemctl status --no-pager
+```
+
+2. Install the snap and connect its plug 
+
+```
+$ snap install systemd-control-example
+$ snap connect systemd-control-example:systemd-control ubuntu-core:systemd-control
+```
+
+3. Run the status app from the snap
+
+```
+$ systemd-control-example.status
+● nirvana
+    State: degraded
+     Jobs: 0 queued
+   Failed: 1 units
+    Since: Do 2016-08-04 09:16:07 CEST; 1 day 4h ago
+   CGroup: /
+           ├─3743 /sbin/cgmanager -m name=systemd
+           ├─init.scope
+           │ └─1 /sbin/init splash
+...
+```
+
+Verify the command prints out the current system status.

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -59,6 +59,7 @@ var allInterfaces = []interfaces.Interface{
 	NewOpticalDriveInterface(),
 	NewCameraInterface(),
 	NewBluetoothControlInterface(),
+	NewSystemdControlInterface(),
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/systemd_control.go
+++ b/interfaces/builtin/systemd_control.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const systemdControlConnectedPlugAppArmor = `
+# Description: Can manage systemd.
+# Usage: reserved
+
+# FIXME: Decide if we want to allow snaps to reuse the systemctl command from
+# the core snap or if every snap should ship its own.
+
+# Allow to use the systemctl command from the core snap
+/bin/systemctl ix,
+# Those are just symlinks to the systemctl command
+/bin/reboot ix,
+/bin/halt ix,
+/bin/shutdown ix,
+
+# As systemctl uses dbus we need to allow dbus communication
+# with the systemd daemon here
+#include <abstractions/dbus-strict>
+
+dbus (send)
+    bus=system
+    peer=(name=org.freedesktop.systemd1, label=unconfined),
+
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/systemd1{,/**}
+    interface=org.freedesktop.DBus.*
+    peer=(label=unconfined),
+
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/systemd1{,/**}
+    interface=org.freedesktop.systemd1.*
+    peer=(label=unconfined),
+
+# systemctl reads cgroup information for status reports
+/sys/fs/cgroup/systemd{,/**} r,
+
+# Need by systemctl to read cmdline each process in the status
+# report is executed with
+/proc/*/cmdline r,
+`
+
+const systemdControlConnectedPlugSeccomp = `
+# Description: Can manage systemd.
+# Usage: reserved
+
+# systemctl needs those
+getsockopt
+setsockopt
+
+# dbus
+connect
+getsockname
+recvmsg
+send
+sendto
+sendmsg
+socket
+`
+
+// NewSystemdControlInterface returns a new "systemd-control" interface.
+func NewSystemdControlInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "systemd-control",
+		connectedPlugAppArmor: systemdControlConnectedPlugAppArmor,
+		connectedPlugSecComp:  systemdControlConnectedPlugSeccomp,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/systemd_control_test.go
+++ b/interfaces/builtin/systemd_control_test.go
@@ -1,0 +1,135 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+)
+
+type SystemdControlInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&SystemdControlInterfaceSuite{
+	iface: builtin.NewSystemdControlInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Name:      "systemd-control",
+			Interface: "systemd-control",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "systemd-control",
+			Interface: "systemd-control",
+		},
+	},
+})
+
+func (s *SystemdControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "systemd-control")
+}
+
+func (s *SystemdControlInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "systemd-control",
+		Interface: "systemd-control",
+	}})
+	c.Assert(err, ErrorMatches, "systemd-control slots are reserved for the operating system snap")
+}
+
+func (s *SystemdControlInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *SystemdControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "systemd-control"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "systemd-control"`)
+}
+
+func (s *SystemdControlInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev}
+	for _, system := range systems {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityMount)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *SystemdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *SystemdControlInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *SystemdControlInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(), Equals, false)
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -46,6 +46,7 @@ var implicitSlots = []string{
 	"system-trace",
 	"timeserver-control",
 	"timezone-control",
+	"systemd-control",
 }
 
 var implicitClassicSlots = []string{

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -42,7 +42,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 18)
+	c.Assert(info.Slots, HasLen, 19)
 }
 
 func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 28)
+	c.Assert(info.Slots, HasLen, 29)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
Add a new interface which allows snaps to control systemd through the
systemctl command shipped in the core snap.

We still have decide if we want the snaps to allow using the systemctl binary from the core snap or have to ship their own. In the currently implementation I allow them to execute the one from the core snap as that way we have at least for Ubuntu all-snap systems the possibility to make sure both sides agree on the same API rather than running into API conflicts.