### PR TITLE
many: support interactive payments in snapd, filter from command line

### DIFF
--- a/client/buy.go
+++ b/client/buy.go
@@ -26,11 +26,7 @@ import (
 	"github.com/snapcore/snapd/store"
 )
 
-type BuyResult struct {
-	State string `json:"state"`
-}
-
-func (client *Client) Buy(opts *store.BuyOptions) (*BuyResult, error) {
+func (client *Client) Buy(opts *store.BuyOptions) (*store.BuyResult, error) {
 	if opts == nil {
 		opts = &store.BuyOptions{}
 	}
@@ -40,7 +36,7 @@ func (client *Client) Buy(opts *store.BuyOptions) (*BuyResult, error) {
 		return nil, err
 	}
 
-	var result BuyResult
+	var result store.BuyResult
 	_, err := client.doSync("POST", "/v2/buy", nil, nil, &body, &result)
 
 	if err != nil {

--- a/cmd/snap/cmd_buy_test.go
+++ b/cmd/snap/cmd_buy_test.go
@@ -306,6 +306,14 @@ const buyMethodsSelectPaymentMethodJson = `
         "requires-interaction": false
       },
       {
+        "backend-id": "credit_card",
+        "currencies": ["EUR"],
+        "description": "**** **** **** 3333 (exp 30/2027)",
+        "id": 345,
+        "preferred": false,
+        "requires-interaction": false
+      },
+      {
         "backend-id": "rest_paypal",
         "currencies": ["USD", "GBP", "EUR"],
         "description": "PayPal",
@@ -375,7 +383,7 @@ func (s *SnapSuite) TestBuySnapSelectPaymentMethod(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `  Selection  Description
   1          **** **** **** 1111 (exp 23/2020)
   2          **** **** **** 2222 (exp 23/2025)
-  3          PayPal
+  3          **** **** **** 3333 (exp 30/2027)
 Type a number to select payment method: Do you want to buy "hello" from "canonical" for 2.99GBP? (Y/n): hello bought
 `)
 	c.Check(s.Stderr(), check.Equals, "")
@@ -402,6 +410,14 @@ const buyMethodsSelectPaymentMethodWithDefaultJson = `
         "currencies": ["USD"],
         "description": "**** **** **** 2222 (exp 23/2025)",
         "id": 234,
+        "preferred": false,
+        "requires-interaction": false
+      },
+      {
+        "backend-id": "credit_card",
+        "currencies": ["USD"],
+        "description": "**** **** **** 3333 (exp 30/2027)",
+        "id": 345,
         "preferred": false,
         "requires-interaction": false
       },
@@ -475,7 +491,7 @@ func (s *SnapSuite) TestBuySnapSelectPaymentMethodWithDefault(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `   Selection  Description
 *  1          **** **** **** 1111 (exp 23/2020)
    2          **** **** **** 2222 (exp 23/2025)
-   3          PayPal
+   3          **** **** **** 3333 (exp 30/2027)
 Press <enter> to use your default[*], or type a number to select payment method: Do you want to buy "hello" from "canonical" for 2.99GBP? (Y/n): hello bought
 `)
 	c.Check(s.Stderr(), check.Equals, "")
@@ -545,7 +561,7 @@ func (s *SnapSuite) TestBuySnapFailsInvalidMethodID(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `  Selection  Description
   1          **** **** **** 1111 (exp 23/2020)
   2          **** **** **** 2222 (exp 23/2025)
-  3          PayPal
+  3          **** **** **** 3333 (exp 30/2027)
 Type a number to select payment method: `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -575,7 +591,7 @@ func (s *SnapSuite) TestBuySnapFailsEmptyMethodID(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `  Selection  Description
   1          **** **** **** 1111 (exp 23/2020)
   2          **** **** **** 2222 (exp 23/2025)
-  3          PayPal
+  3          **** **** **** 3333 (exp 30/2027)
 Type a number to select payment method: `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -605,7 +621,7 @@ func (s *SnapSuite) TestBuySnapFailsOutOfRangeMethodID(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `  Selection  Description
   1          **** **** **** 1111 (exp 23/2020)
   2          **** **** **** 2222 (exp 23/2025)
-  3          PayPal
+  3          **** **** **** 3333 (exp 30/2027)
 Type a number to select payment method: `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1466,10 +1466,9 @@ func postBuy(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot decode buy options from request body: %v", err)
 	}
 
-	opts.User = user
 	s := getStore(c)
 
-	buyResult, err := s.Buy(&opts)
+	buyResult, err := s.Buy(&opts, user)
 
 	switch err {
 	default:

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1457,10 +1457,6 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 	return SyncResponse(createResponseData, nil)
 }
 
-type buyResponseData struct {
-	State string `json:"state,omitempty"`
-}
-
 func postBuy(c *Command, r *http.Request, user *auth.UserState) Response {
 	var opts store.BuyOptions
 
@@ -1484,12 +1480,7 @@ func postBuy(c *Command, r *http.Request, user *auth.UserState) Response {
 		// continue
 	}
 
-	// TODO: Support purchasing redirects
-	if buyResult.State == "InProgress" {
-		return InternalError("payment backend %q is not yet supported", opts.BackendID)
-	}
-
-	return SyncResponse(buyResponseData{State: buyResult.State}, nil)
+	return SyncResponse(buyResult, nil)
 }
 
 func getPaymentMethods(c *Command, r *http.Request, user *auth.UserState) Response {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3128,7 +3128,7 @@ func (s *apiSuite) TestBuySnap(c *check.C) {
 
 	rsp := postBuy(buyCmd, req, user).(*resp)
 
-	expected := buyResponseData{
+	expected := &store.BuyResult{
 		State: "Complete",
 	}
 	c.Check(rsp.Status, check.Equals, http.StatusOK)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -107,8 +107,9 @@ func (s *apiSuite) Download(string, *snap.DownloadInfo, progress.Meter, *auth.Us
 	panic("Download not expected to be called")
 }
 
-func (s *apiSuite) Buy(options *store.BuyOptions) (*store.BuyResult, error) {
+func (s *apiSuite) Buy(options *store.BuyOptions, user *auth.UserState) (*store.BuyResult, error) {
 	s.buyOptions = options
+	s.user = user
 	return s.buyResult, s.err
 }
 
@@ -3141,8 +3142,8 @@ func (s *apiSuite) TestBuySnap(c *check.C) {
 		SnapName: "the snap name",
 		Price:    1.23,
 		Currency: "EUR",
-		User:     user,
 	})
+	c.Check(s.user, check.Equals, user)
 }
 
 func (s *apiSuite) TestBuyFailMissingParameter(c *check.C) {
@@ -3174,8 +3175,8 @@ func (s *apiSuite) TestBuyFailMissingParameter(c *check.C) {
 		SnapID:   "the-snap-id-1234abcd",
 		Price:    1.23,
 		Currency: "EUR",
-		User:     user,
 	})
+	c.Check(s.user, check.Equals, user)
 }
 
 func (s *apiSuite) TestIsTrue(c *check.C) {

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -34,7 +34,7 @@ type StoreService interface {
 	SuggestedCurrency() string
 
 	Download(string, *snap.DownloadInfo, progress.Meter, *auth.UserState) (string, error)
-	Buy(options *store.BuyOptions) (*store.BuyResult, error)
+	Buy(options *store.BuyOptions, user *auth.UserState) (*store.BuyResult, error)
 	PaymentMethods(*auth.UserState) (*store.PaymentInformation, error)
 }
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -180,7 +180,7 @@ func (f *fakeStore) Download(name string, snapInfo *snap.DownloadInfo, pb progre
 	return "downloaded-snap-path", nil
 }
 
-func (f *fakeStore) Buy(options *store.BuyOptions) (*store.BuyResult, error) {
+func (f *fakeStore) Buy(options *store.BuyOptions, user *auth.UserState) (*store.BuyResult, error) {
 	panic("Never expected fakeStore.Buy to be called")
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -1025,9 +1025,9 @@ type BuyOptions struct {
 // BuyResult holds information required to complete the purchase when state
 // is "InProgress", in which case it requires user interaction to complete.
 type BuyResult struct {
-	State      string
-	RedirectTo string
-	PartnerID  string
+	State      string `json:"state,omitempty"`
+	RedirectTo string `json:"redirect-to,omitempty"`
+	PartnerID  string `json:"partner-id,omitempty"`
 }
 
 // purchaseInstruction holds data sent to the store for purchases.
@@ -1114,9 +1114,14 @@ func (s *Store) Buy(options *BuyOptions) (*BuyResult, error) {
 			return nil, fmt.Errorf("cannot buy snap %q: payment cancelled", options.SnapName)
 		}
 
+		redirectTo := ""
+		if purchaseDetails.RedirectTo != "" {
+			redirectTo = fmt.Sprintf("%s://%s%s", s.purchasesURI.Scheme, s.purchasesURI.Host, purchaseDetails.RedirectTo)
+		}
+
 		return &BuyResult{
 			State:      purchaseDetails.State,
-			RedirectTo: purchaseDetails.RedirectTo,
+			RedirectTo: redirectTo,
 			PartnerID:  resp.Header.Get("X-Partner-Id"),
 		}, nil
 	case http.StatusBadRequest:

--- a/store/store.go
+++ b/store/store.go
@@ -1011,11 +1011,10 @@ func (s *Store) SuggestedCurrency() string {
 // BuyOptions specifies parameters for store purchases.
 type BuyOptions struct {
 	// Required
-	SnapID   string          `json:"snap-id"`
-	SnapName string          `json:"snap-name"`
-	Price    float64         `json:"price"`
-	Currency string          `json:"currency"` // ISO 4217 code as string
-	User     *auth.UserState `json:"-"`
+	SnapID   string  `json:"snap-id"`
+	SnapName string  `json:"snap-name"`
+	Price    float64 `json:"price"`
+	Currency string  `json:"currency"` // ISO 4217 code as string
 
 	// Optional
 	BackendID string `json:"backend-id"` // e.g. "credit_card", "paypal"
@@ -1058,7 +1057,7 @@ func buyOptionError(options *BuyOptions, message string) (*BuyResult, error) {
 
 // Buy sends a purchase request for the specified snap.
 // Returns the state of the purchase: Complete, Cancelled, InProgress or Pending.
-func (s *Store) Buy(options *BuyOptions) (*BuyResult, error) {
+func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, error) {
 	if options.SnapID == "" {
 		return buyOptionError(options, "snap ID missing")
 	}
@@ -1071,7 +1070,7 @@ func (s *Store) Buy(options *BuyOptions) (*BuyResult, error) {
 	if options.Currency == "" {
 		return buyOptionError(options, "currency missing")
 	}
-	if options.User == nil {
+	if user == nil {
 		return buyOptionError(options, "authentication credentials missing")
 	}
 
@@ -1095,7 +1094,7 @@ func (s *Store) Buy(options *BuyOptions) (*BuyResult, error) {
 		ContentType: "application/json",
 		Data:        jsonData,
 	}
-	resp, err := s.doRequest(s.client, reqOptions, options.User)
+	resp, err := s.doRequest(s.client, reqOptions, user)
 	if err != nil {
 		return nil, err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2038,11 +2038,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuySuccess(c *C) {
 		SnapName: snap.Name(),
 		Currency: repo.SuggestedCurrency(),
 		Price:    snap.Prices[repo.SuggestedCurrency()],
-		User:     t.user,
 
 		BackendID: "123",
 		MethodID:  234,
-	})
+	}, t.user)
 
 	c.Assert(result, NotNil)
 	c.Check(result.State, Equals, "Complete")
@@ -2117,11 +2116,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyInteractive(c *C) {
 		SnapName: snap.Name(),
 		Currency: repo.SuggestedCurrency(),
 		Price:    snap.Prices[repo.SuggestedCurrency()],
-		User:     t.user,
 
 		BackendID: "paypal_rest",
 		MethodID:  234,
-	})
+	}, t.user)
 
 	c.Assert(err, IsNil)
 	c.Assert(result, NotNil)
@@ -2173,11 +2171,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyRefreshesAuth(c *C) {
 		SnapName: "hello-world",
 		Currency: "EUR",
 		Price:    0.99,
-		User:     t.user,
 
 		BackendID: "123",
 		MethodID:  234,
-	})
+	}, t.user)
 
 	c.Assert(result, NotNil)
 	c.Check(result.State, Equals, "Complete")
@@ -2246,8 +2243,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailWrongPrice(c *C) {
 		SnapName: snap.Name(),
 		Price:    0.99,
 		Currency: "USD",
-		User:     t.user,
-	})
+	}, t.user)
 
 	c.Assert(result, IsNil)
 	c.Assert(err, NotNil)
@@ -2322,8 +2318,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailNotFound(c *C) {
 		SnapName: snap.Name(),
 		Price:    snap.Prices[repo.SuggestedCurrency()],
 		Currency: repo.SuggestedCurrency(),
-		User:     t.user,
-	})
+	}, t.user)
 	c.Assert(result, IsNil)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot buy snap \"hello-world\": server says not found (snap got removed?)")
@@ -2342,8 +2337,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailArgumentChecking(c *C) {
 		SnapName: "snap name",
 		Price:    1.0,
 		Currency: "USD",
-		User:     t.user,
-	})
+	}, t.user)
 	c.Assert(result, IsNil)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot buy snap \"snap name\": snap ID missing")
@@ -2353,8 +2347,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailArgumentChecking(c *C) {
 		SnapID:   "snap ID",
 		Price:    1.0,
 		Currency: "USD",
-		User:     t.user,
-	})
+	}, t.user)
 	c.Assert(result, IsNil)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot buy snap \"snap ID\": snap name missing")
@@ -2364,8 +2357,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailArgumentChecking(c *C) {
 		SnapID:   "snap ID",
 		SnapName: "snap name",
 		Currency: "USD",
-		User:     t.user,
-	})
+	}, t.user)
 	c.Assert(result, IsNil)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot buy snap \"snap name\": invalid expected price")
@@ -2375,8 +2367,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailArgumentChecking(c *C) {
 		SnapID:   "snap ID",
 		SnapName: "snap name",
 		Price:    1.0,
-		User:     t.user,
-	})
+	}, t.user)
 	c.Assert(result, IsNil)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot buy snap \"snap name\": currency missing")
@@ -2387,7 +2378,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailArgumentChecking(c *C) {
 		SnapName: "snap name",
 		Price:    1.0,
 		Currency: "USD",
-	})
+	}, nil)
 	c.Assert(result, IsNil)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot buy snap \"snap name\": authentication credentials missing")


### PR DESCRIPTION
- This branch moves the block in interactive payment methods from inside snapd to the snap command line client.
- The snap client now also filters out interactive payment methods, as they wouldn't work anyway.
- This allows GUI clients to start supporting interactive payments.
- The snapd store code now also builds the correct full URL (as reflected in the store tests).