### PR TITLE
interfaces/builtin: add gpio interface

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -28,6 +28,7 @@ var allInterfaces = []interfaces.Interface{
 	&BluezInterface{},
 	&BrowserSupportInterface{},
 	&ContentInterface{},
+	&GpioInterface{},
 	&LocationControlInterface{},
 	&LocationObserveInterface{},
 	&ModemManagerInterface{},

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -35,6 +35,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.BoolFileInterface{})
 	c.Check(all, Contains, &builtin.BluezInterface{})
 	c.Check(all, Contains, &builtin.BrowserSupportInterface{})
+	c.Check(all, Contains, &builtin.GpioInterface{})
 	c.Check(all, Contains, &builtin.LocationControlInterface{})
 	c.Check(all, Contains, &builtin.LocationObserveInterface{})
 	c.Check(all, Contains, &builtin.MprisInterface{})

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -126,19 +126,15 @@ func (iface *GpioInterface) PermanentSlotSnippet(slot *interfaces.Slot, security
 func (iface *GpioInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	// We need to export the GPIO so that it becomes as entry in sysfs
 	// available and we can assign it to a connecting plug.
-	numAttr, ok := slot.Attrs["number"]
+	numInt, ok := slot.Attrs["number"].(int)
 	if !ok {
-		return nil, fmt.Errorf("Failed to get number attribute")
-	}
-	numInt, ok := numAttr.(int)
-	if !ok {
-		return nil, fmt.Errorf("Number attribute not an int")
+		return nil, fmt.Errorf("gpio slot has invalid number attribute")
 	}
 	numBytes := []byte(strconv.Itoa(numInt))
 
 	// Check if the gpio symlink is present, if not it needs exporting. Attempting
 	// to export a gpio again will cause an error on the Write() call
-	if _, err := os.Stat(fmt.Sprint(gpioSysfsGpioBase, numAttr)); os.IsNotExist(err) {
+	if _, err := os.Stat(fmt.Sprint(gpioSysfsGpioBase, numInt)); os.IsNotExist(err) {
 		fileExport, err := os.OpenFile(gpioSysfsExport, os.O_WRONLY, 0200)
 		if err != nil {
 			return nil, err

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -1,0 +1,164 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+var gpioSysfsGpioBase = "/sys/class/gpio/gpio"
+var gpioSysfsExport = "/sys/class/gpio/export"
+
+// GpioInterface type
+type GpioInterface struct{}
+
+// String returns the same value as Name().
+func (iface *GpioInterface) String() string {
+	return iface.Name()
+}
+
+// Name of the GpioInterface
+func (iface *GpioInterface) Name() string {
+	return "gpio"
+}
+
+// SanitizeSlot checks the slot definition is valid
+func (iface *GpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	// Paranoid check this right interface type
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("slot is not of interface %q", iface))
+	}
+
+	// We will only allow creation of this type of slot by a gadget or OS snap
+	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
+		return fmt.Errorf("gpio slots only allowed on gadget or os snaps")
+	}
+
+	// Must have a GPIO number
+	number, ok := slot.Attrs["number"]
+	if !ok {
+		return fmt.Errorf("gpio slot must have a number attribute")
+	}
+
+	// Valid values of number
+	switch t := number.(type) {
+	case int:
+		break
+	default:
+		_ = t
+		return fmt.Errorf("gpio slot number attribute must be an int")
+	}
+
+	// Must have a direction
+	direction, ok := slot.Attrs["direction"].(string)
+	if !ok {
+		return fmt.Errorf("gpio slot must have a direction attribute")
+	}
+
+	// Valid values of direction
+	if !(direction == "out" || direction == "in") {
+		return fmt.Errorf("gpio slot direction attribute must be in or out")
+	}
+
+	// Slot is good
+	return nil
+}
+
+// PermanentPlugSnippet returns security snippets for plug at install
+func (iface *GpioInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedPlugSnippet returns security snippets for plug at connection
+func (iface *GpioInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	case interfaces.SecurityAppArmor:
+		path := fmt.Sprint(gpioSysfsGpioBase, slot.Attrs["number"])
+		// Entries in /sys/class/gpio for single GPIO's are just symlinks
+		// to their correct device part in the sysfs tree. As AppArmor
+		// does not handle symlinks we need to dereference the GPIO
+		// path and add the correct absolute path to the AppArmor snippet.
+		dereferencedPath, err := evalSymlinks(path)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(fmt.Sprintf("%s/value rwk,\n", dereferencedPath)), nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *GpioInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *GpioInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	// We need to export the GPIO so that it becomes as entry in sysfs
+	// availalbe and we can assign it to a connecting plug.
+	number := []byte(strconv.Itoa(slot.Attrs["number"].(int)))
+	fileExport, err := os.OpenFile(gpioSysfsExport, os.O_WRONLY, 0200)
+	defer fileExport.Close()
+	if err != nil {
+		return nil, err
+	}
+	fileExport.Write(number)
+
+	directionPath := filepath.Join(fmt.Sprint(gpioSysfsGpioBase, slot.Attrs["number"]), "direction")
+	fileDirection, err := os.OpenFile(directionPath, os.O_WRONLY, 0200)
+	defer fileDirection.Close()
+	if err != nil {
+		return nil, err
+	}
+	fileDirection.WriteString(slot.Attrs["direction"].(string))
+
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	case interfaces.SecurityAppArmor:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *GpioInterface) SanitizePlug(plug *interfaces.Plug) error {
+	return nil
+}
+
+func (iface *GpioInterface) AutoConnect() bool {
+	return false
+}

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -53,7 +53,7 @@ func (iface *GpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 	// We will only allow creation of this type of slot by a gadget or OS snap
 	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
-		return fmt.Errorf("gpio slots only allowed on gadget or os snaps")
+		return fmt.Errorf("gpio slots only allowed on gadget or core snaps")
 	}
 
 	// Must have a GPIO number
@@ -63,11 +63,7 @@ func (iface *GpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 
 	// Valid values of number
-	switch t := number.(type) {
-	case int:
-		break
-	default:
-		_ = t
+	if _, ok := number.(int); !ok {
 		return fmt.Errorf("gpio slot number attribute must be an int")
 	}
 

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -106,17 +106,14 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotGadgetSnap(c *C) {
 
 	// slots without number attribute are rejected
 	err = s.iface.SanitizeSlot(s.gadgetMissingNumberSlot)
-	c.Assert(err, ErrorMatches,
-		"gpio slot must have a number attribute")
+	c.Assert(err, ErrorMatches, "gpio slot must have a number attribute")
 
 	// slots with number attribute that isnt a number
 	err = s.iface.SanitizeSlot(s.gadgetBadNumberSlot)
-	c.Assert(err, ErrorMatches,
-		"gpio slot number attribute must be an int")
+	c.Assert(err, ErrorMatches, "gpio slot number attribute must be an int")
 
 	// Must be right interface type
-	c.Assert(func() { s.iface.SanitizeSlot(s.gadgetBadInterfaceSlot) }, PanicMatches,
-		`slot is not of interface "gpio"`)
+	c.Assert(func() { s.iface.SanitizeSlot(s.gadgetBadInterfaceSlot) }, PanicMatches, `slot is not of interface "gpio"`)
 }
 
 func (s *GpioInterfaceSuite) TestSanitizeSlotOsSnap(c *C) {
@@ -128,8 +125,7 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotOsSnap(c *C) {
 func (s *GpioInterfaceSuite) TestSanitizeSlotAppSnap(c *C) {
 	// gpio slot not accepted on app snap
 	err := s.iface.SanitizeSlot(s.appGpioSlot)
-	c.Assert(err, ErrorMatches,
-		"gpio slots only allowed on gadget or core snaps")
+	c.Assert(err, ErrorMatches, "gpio slots only allowed on gadget or core snaps")
 }
 
 func (s *GpioInterfaceSuite) TestSanitizePlug(c *C) {
@@ -137,6 +133,5 @@ func (s *GpioInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 
 	// It is impossible to use "bool-file" interface to sanitize plugs of different interface.
-	c.Assert(func() { s.iface.SanitizePlug(s.gadgetBadInterfacePlug) }, PanicMatches,
-		`plug is not of interface "gpio"`)
+	c.Assert(func() { s.iface.SanitizePlug(s.gadgetBadInterfacePlug) }, PanicMatches, `plug is not of interface "gpio"`)
 }

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -1,0 +1,157 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type GpioInterfaceSuite struct {
+	testutil.BaseTest
+	iface                      interfaces.Interface
+	gadgetGpioSlot             *interfaces.Slot
+	gadgetMissingNumberSlot    *interfaces.Slot
+	gadgetMissingDirectionSlot *interfaces.Slot
+	gadgetBadDirectionSlot     *interfaces.Slot
+	gadgetBadNumberSlot        *interfaces.Slot
+	gadgetBadInterfaceSlot     *interfaces.Slot
+	gadgetPlug                 *interfaces.Plug
+	gadgetBadInterfacePlug     *interfaces.Plug
+	osGpioSlot                 *interfaces.Slot
+	appGpioSlot                *interfaces.Slot
+}
+
+var _ = Suite(&GpioInterfaceSuite{
+	iface: &builtin.GpioInterface{},
+})
+
+func (s *GpioInterfaceSuite) SetUpTest(c *C) {
+	gadgetInfo, gadgetErr := snap.InfoFromSnapYaml([]byte(`
+name: my-device
+type: gadget
+slots:
+    my-pin:
+        interface: gpio
+        number: 100
+        direction: out
+    missing-number:
+        interface: gpio
+        direction: in
+    missing-direction:
+        interface: gpio
+        number: 7
+    bad-direction:
+        interface: gpio
+        direction: up
+        number: 399
+    bad-number:
+        interface: gpio
+        direction: in
+        number: forty-two
+    bad-interface: other-interface
+plugs:
+    plug: gpio
+    bad-interface: other-interface
+`))
+	c.Assert(gadgetErr, IsNil)
+	s.gadgetGpioSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["my-pin"]}
+	s.gadgetMissingNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["missing-number"]}
+	s.gadgetMissingDirectionSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["missing-direction"]}
+	s.gadgetBadDirectionSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-direction"]}
+	s.gadgetBadNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-number"]}
+	s.gadgetBadInterfaceSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-interface"]}
+	s.gadgetPlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["plug"]}
+	s.gadgetBadInterfacePlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["bad-interface"]}
+
+	osInfo, osErr := snap.InfoFromSnapYaml([]byte(`
+name: my-core
+type: os
+slots:
+    my-pin:
+        interface: gpio
+        number: 777
+        direction: out
+`))
+	c.Assert(osErr, IsNil)
+	s.osGpioSlot = &interfaces.Slot{SlotInfo: osInfo.Slots["my-pin"]}
+
+	appInfo, appErr := snap.InfoFromSnapYaml([]byte(`
+name: my-app
+slots:
+    my-pin:
+        interface: gpio
+        number: 154
+        direction: out
+`))
+	c.Assert(appErr, IsNil)
+	s.appGpioSlot = &interfaces.Slot{SlotInfo: appInfo.Slots["my-pin"]}
+}
+
+func (s *GpioInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "gpio")
+}
+
+func (s *GpioInterfaceSuite) TestSanitizeSlotGadgetSnap(c *C) {
+	// gpio slot on gadget accepeted
+	err := s.iface.SanitizeSlot(s.gadgetGpioSlot)
+	c.Assert(err, IsNil)
+
+	// slots without number attribute are rejected
+	err = s.iface.SanitizeSlot(s.gadgetMissingNumberSlot)
+	c.Assert(err, ErrorMatches,
+		"gpio slot must have a number attribute")
+
+	// slots without direction attribute are rejected
+	err = s.iface.SanitizeSlot(s.gadgetMissingDirectionSlot)
+	c.Assert(err, ErrorMatches,
+		"gpio slot must have a direction attribute")
+
+	// slots with direction that isnt in or out
+	err = s.iface.SanitizeSlot(s.gadgetBadDirectionSlot)
+	c.Assert(err, ErrorMatches,
+		"gpio slot direction attribute must be in or out")
+
+	// slots with number attribute that isnt a number
+	err = s.iface.SanitizeSlot(s.gadgetBadNumberSlot)
+	c.Assert(err, ErrorMatches,
+		"gpio slot number attribute must be an int")
+
+	// Must be right interface type
+	c.Assert(func() { s.iface.SanitizeSlot(s.gadgetBadInterfaceSlot) }, PanicMatches,
+		`slot is not of interface "gpio"`)
+}
+
+func (s *GpioInterfaceSuite) TestSanitizeSlotOsSnap(c *C) {
+	// gpio slot on OS accepeted
+	err := s.iface.SanitizeSlot(s.osGpioSlot)
+	c.Assert(err, IsNil)
+}
+
+func (s *GpioInterfaceSuite) TestSanitizeSlotAppSnap(c *C) {
+	// gpio slot not accepted on app snap
+	err := s.iface.SanitizeSlot(s.appGpioSlot)
+	c.Assert(err, ErrorMatches,
+		"gpio slots only allowed on gadget or os snaps")
+}

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -30,17 +30,15 @@ import (
 
 type GpioInterfaceSuite struct {
 	testutil.BaseTest
-	iface                      interfaces.Interface
-	gadgetGpioSlot             *interfaces.Slot
-	gadgetMissingNumberSlot    *interfaces.Slot
-	gadgetMissingDirectionSlot *interfaces.Slot
-	gadgetBadDirectionSlot     *interfaces.Slot
-	gadgetBadNumberSlot        *interfaces.Slot
-	gadgetBadInterfaceSlot     *interfaces.Slot
-	gadgetPlug                 *interfaces.Plug
-	gadgetBadInterfacePlug     *interfaces.Plug
-	osGpioSlot                 *interfaces.Slot
-	appGpioSlot                *interfaces.Slot
+	iface                   interfaces.Interface
+	gadgetGpioSlot          *interfaces.Slot
+	gadgetMissingNumberSlot *interfaces.Slot
+	gadgetBadNumberSlot     *interfaces.Slot
+	gadgetBadInterfaceSlot  *interfaces.Slot
+	gadgetPlug              *interfaces.Plug
+	gadgetBadInterfacePlug  *interfaces.Plug
+	osGpioSlot              *interfaces.Slot
+	appGpioSlot             *interfaces.Slot
 }
 
 var _ = Suite(&GpioInterfaceSuite{
@@ -55,20 +53,10 @@ slots:
     my-pin:
         interface: gpio
         number: 100
-        direction: out
     missing-number:
         interface: gpio
-        direction: in
-    missing-direction:
-        interface: gpio
-        number: 7
-    bad-direction:
-        interface: gpio
-        direction: up
-        number: 399
     bad-number:
         interface: gpio
-        direction: in
         number: forty-two
     bad-interface: other-interface
 plugs:
@@ -78,8 +66,6 @@ plugs:
 	c.Assert(gadgetErr, IsNil)
 	s.gadgetGpioSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["my-pin"]}
 	s.gadgetMissingNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["missing-number"]}
-	s.gadgetMissingDirectionSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["missing-direction"]}
-	s.gadgetBadDirectionSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-direction"]}
 	s.gadgetBadNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-number"]}
 	s.gadgetBadInterfaceSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-interface"]}
 	s.gadgetPlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["plug"]}
@@ -123,16 +109,6 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotGadgetSnap(c *C) {
 	c.Assert(err, ErrorMatches,
 		"gpio slot must have a number attribute")
 
-	// slots without direction attribute are rejected
-	err = s.iface.SanitizeSlot(s.gadgetMissingDirectionSlot)
-	c.Assert(err, ErrorMatches,
-		"gpio slot must have a direction attribute")
-
-	// slots with direction that isnt in or out
-	err = s.iface.SanitizeSlot(s.gadgetBadDirectionSlot)
-	c.Assert(err, ErrorMatches,
-		"gpio slot direction attribute must be in or out")
-
 	// slots with number attribute that isnt a number
 	err = s.iface.SanitizeSlot(s.gadgetBadNumberSlot)
 	c.Assert(err, ErrorMatches,
@@ -154,4 +130,13 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotAppSnap(c *C) {
 	err := s.iface.SanitizeSlot(s.appGpioSlot)
 	c.Assert(err, ErrorMatches,
 		"gpio slots only allowed on gadget or core snaps")
+}
+
+func (s *GpioInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.gadgetPlug)
+	c.Assert(err, IsNil)
+
+	// It is impossible to use "bool-file" interface to sanitize plugs of different interface.
+	c.Assert(func() { s.iface.SanitizePlug(s.gadgetBadInterfacePlug) }, PanicMatches,
+		`plug is not of interface "gpio"`)
 }

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -153,5 +153,5 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotAppSnap(c *C) {
 	// gpio slot not accepted on app snap
 	err := s.iface.SanitizeSlot(s.appGpioSlot)
 	c.Assert(err, ErrorMatches,
-		"gpio slots only allowed on gadget or os snaps")
+		"gpio slots only allowed on gadget or core snaps")
 }


### PR DESCRIPTION
Requires the slot to declare gpio number and direction.
Only allowed on gadget or OS snap.
Exports the gpio and sets direction.

The ideal would be for the app developer to not need to know the gpio number (and hence the sysfs path) that they will connect to at build time. This would require some mapping of the gpio to a predictable location or some method of passing the information to the plug side at connection time. For now however, this just provides an apparmor snippet allowing access to the value file.