### PR TITLE
cmd/snap,overlord/hookstate: support hook data transfer.

### DIFF
--- a/overlord/hookstate/handler.go
+++ b/overlord/hookstate/handler.go
@@ -1,0 +1,113 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hookstate
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Handler is the interface a client must satify to handle hooks.
+type Handler interface {
+	// Before is called right before the hook is to be run.
+	Before() error
+
+	// Done is called right after the hook has finished successfully.
+	Done() error
+
+	// Error is called if the hook encounters an error while running.
+	Error(err error) error
+
+	// Get the data that this handler has associated with the given key.
+	Get(key string) (map[string]interface{}, error)
+
+	// Set the data that this handler has associated with the given key.
+	Set(key string, data map[string]interface{}) error
+}
+
+// HandlerCollection is responsible for keeping track of a set of handlers
+// accessed by unique ID.
+type HandlerCollection struct {
+	handlersMutex sync.RWMutex
+	handlers      map[int]Handler
+	lastID        int
+}
+
+// NewHandlerCollection returns a new HandlerCollection.
+func NewHandlerCollection() *HandlerCollection {
+	return &HandlerCollection{
+		handlers: make(map[int]Handler),
+	}
+}
+
+// HandlerCount returns the number of handlers in the collection.
+func (c *HandlerCollection) HandlerCount() int {
+	c.handlersMutex.RLock()
+	defer c.handlersMutex.RUnlock()
+
+	return len(c.handlers)
+}
+
+// GetHandlerData obtains the data that a specific handler has associated with
+// the given key.
+func (c *HandlerCollection) GetHandlerData(id int, key string) (map[string]interface{}, error) {
+	c.handlersMutex.RLock()
+	defer c.handlersMutex.RUnlock()
+
+	if handler, ok := c.handlers[id]; ok {
+		return handler.Get(key)
+	}
+
+	return nil, fmt.Errorf("no handler with ID %d", id)
+}
+
+// SetHandlerData sets the data that a specific handler has associated with the
+// given key.
+func (c *HandlerCollection) SetHandlerData(id int, key string, data map[string]interface{}) error {
+	c.handlersMutex.RLock()
+	defer c.handlersMutex.RUnlock()
+
+	if handler, ok := c.handlers[id]; ok {
+		return handler.Set(key, data)
+	}
+
+	return fmt.Errorf("no handler with ID %d", id)
+}
+
+// AddHandler adds a new handler to the collection. Returns the ID which can be
+// used to refer to this handler in the future.
+func (c *HandlerCollection) AddHandler(handler Handler) int {
+	c.handlersMutex.Lock()
+	defer c.handlersMutex.Unlock()
+
+	c.lastID++
+	c.handlers[c.lastID] = handler
+
+	return c.lastID
+}
+
+// RemoveHandler removes the handler with the specified ID. If no such handler
+// exists, this function does nothing.
+func (c *HandlerCollection) RemoveHandler(id int) {
+	c.handlersMutex.Lock()
+	defer c.handlersMutex.Unlock()
+
+	delete(c.handlers, id)
+}

--- a/overlord/hookstate/handler_test.go
+++ b/overlord/hookstate/handler_test.go
@@ -1,0 +1,104 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hookstate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/hookstate"
+)
+
+type handlerSuite struct {
+	collection *hookstate.HandlerCollection
+}
+
+var _ = Suite(&handlerSuite{})
+
+func (s *handlerSuite) SetUpTest(c *C) {
+	s.collection = hookstate.NewHandlerCollection()
+}
+
+func (s *handlerSuite) TestAddActiveHandler(c *C) {
+	mockHandler1 := hookstate.NewMockHandler()
+	mockHandler2 := hookstate.NewMockHandler()
+
+	c.Check(s.collection.HandlerCount(), Equals, 0)
+	s.collection.AddHandler(mockHandler1)
+	c.Check(s.collection.HandlerCount(), Equals, 1)
+	s.collection.AddHandler(mockHandler2)
+	c.Check(s.collection.HandlerCount(), Equals, 2)
+}
+
+func (s *handlerSuite) TestRemoveActiveHandler(c *C) {
+	mockHandler1 := hookstate.NewMockHandler()
+	mockHandler2 := hookstate.NewMockHandler()
+
+	handlerID1 := s.collection.AddHandler(mockHandler1)
+	handlerID2 := s.collection.AddHandler(mockHandler2)
+
+	s.collection.RemoveHandler(handlerID1)
+	s.collection.RemoveHandler(handlerID2)
+	c.Check(s.collection.HandlerCount(), Equals, 0)
+}
+
+func (s *handlerSuite) TestGetHandlerData(c *C) {
+	mockHandler1 := hookstate.NewMockHandler()
+	mockHandler2 := hookstate.NewMockHandler()
+
+	handlerID1 := s.collection.AddHandler(mockHandler1)
+	handlerID2 := s.collection.AddHandler(mockHandler2)
+
+	s.collection.GetHandlerData(handlerID1, "foo")
+	c.Check(mockHandler1.GetCalled, Equals, true)
+	c.Check(mockHandler1.Key, Equals, "foo")
+
+	s.collection.GetHandlerData(handlerID2, "bar")
+	c.Check(mockHandler2.GetCalled, Equals, true)
+	c.Check(mockHandler2.Key, Equals, "bar")
+}
+
+func (s *handlerSuite) TestGetHandlerDataWithoutHandlers(c *C) {
+	data, err := s.collection.GetHandlerData(1, "foo")
+	c.Check(data, IsNil)
+	c.Check(err, ErrorMatches, ".*no handler with ID 1.*")
+}
+
+func (s *handlerSuite) TestSetHandlerDataWithoutHandlers(c *C) {
+	err := s.collection.SetHandlerData(1, "foo", map[string]interface{}{"bar": nil})
+	c.Check(err, ErrorMatches, ".*no handler with ID 1.*")
+}
+
+func (s *handlerSuite) TestSetHandlerData(c *C) {
+	mockHandler1 := hookstate.NewMockHandler()
+	mockHandler2 := hookstate.NewMockHandler()
+
+	handlerID1 := s.collection.AddHandler(mockHandler1)
+	handlerID2 := s.collection.AddHandler(mockHandler2)
+
+	s.collection.SetHandlerData(handlerID1, "foo", map[string]interface{}{"bar": nil})
+	c.Check(mockHandler1.SetCalled, Equals, true)
+	c.Check(mockHandler1.Key, Equals, "foo")
+	c.Check(mockHandler1.Data, DeepEquals, map[string]interface{}{"bar": nil})
+
+	s.collection.SetHandlerData(handlerID2, "bar", map[string]interface{}{"baz": nil})
+	c.Check(mockHandler2.SetCalled, Equals, true)
+	c.Check(mockHandler2.Key, Equals, "bar")
+	c.Check(mockHandler2.Data, DeepEquals, map[string]interface{}{"baz": nil})
+}

--- a/overlord/hookstate/hookmgr_private_test.go
+++ b/overlord/hookstate/hookmgr_private_test.go
@@ -79,8 +79,8 @@ func (s *hookManagerSuite) TestRunHookInstruction(c *C) {
 }
 
 func (s *hookManagerSuite) TestHookSetupJsonMarshal(c *C) {
-	hookSetup := hookSetup{Snap: "snap-name", Revision: snap.R(1), Hook: "hook-name"}
-	out, err := json.Marshal(hookSetup)
+	setup := hookSetup{Snap: "snap-name", Revision: snap.R(1), Hook: "hook-name"}
+	out, err := json.Marshal(setup)
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "{\"snap\":\"snap-name\",\"revision\":\"1\",\"hook\":\"hook-name\"}")
 }

--- a/overlord/hookstate/hookmgr_test.go
+++ b/overlord/hookstate/hookmgr_test.go
@@ -206,12 +206,12 @@ func (s *hookManagerSuite) TestSetHookData(c *C) {
 func (s *hookManagerSuite) TestGetHookDataFailsWithoutActiveHook(c *C) {
 	data, err := s.manager.GetHookData(1, "foo")
 	c.Check(data, IsNil)
-	c.Check(err, ErrorMatches, ".*no hook with ID 1.*")
+	c.Check(err, ErrorMatches, ".*no handler with ID 1.*")
 }
 
 func (s *hookManagerSuite) TestSetHookDataFailsWithoutActiveHook(c *C) {
 	err := s.manager.SetHookData(1, "foo", map[string]interface{}{"bar": "baz"})
-	c.Check(err, ErrorMatches, ".*no hook with ID 1.*")
+	c.Check(err, ErrorMatches, ".*no handler with ID 1.*")
 }
 
 func (s *hookManagerSuite) TestHookTaskHandlerBeforeError(c *C) {

--- a/overlord/hookstate/hookmgr_test.go
+++ b/overlord/hookstate/hookmgr_test.go
@@ -20,7 +20,6 @@
 package hookstate_test
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestHookManager(t *testing.T) { TestingT(t) }
 type hookManagerSuite struct {
 	state       *state.State
 	manager     *hookstate.HookManager
-	mockHandler *mockHandler
+	mockHandler *hookstate.MockHandler
 	task        *state.Task
 	change      *state.Change
 	command     *testutil.MockCmd
@@ -67,6 +66,7 @@ func (s *hookManagerSuite) SetUpTest(c *C) {
 func (s *hookManagerSuite) TearDownTest(c *C) {
 	s.manager.Stop()
 	dirs.SetRootDir("")
+	s.command.Restore()
 }
 
 func (s *hookManagerSuite) TestSmoke(c *C) {
@@ -77,7 +77,7 @@ func (s *hookManagerSuite) TestSmoke(c *C) {
 func (s *hookManagerSuite) TestHookTask(c *C) {
 	// Register a handler generator for the "test-hook" hook
 	var calledContext *hookstate.Context
-	mockHandler := newMockHandler()
+	mockHandler := hookstate.NewMockHandler()
 	mockHandlerGenerator := func(context *hookstate.Context) hookstate.Handler {
 		calledContext = context
 		return mockHandler
@@ -97,12 +97,12 @@ func (s *hookManagerSuite) TestHookTask(c *C) {
 	c.Check(calledContext.HookName(), Equals, "test-hook")
 
 	c.Check(s.command.Calls(), DeepEquals, [][]string{[]string{
-		"snap", "run", "test-snap", "--hook", "test-hook", "-r", "1",
+		"snap", "run", "--hook", "test-hook", "-r", "1", "-i", "1", "test-snap",
 	}})
 
-	c.Check(mockHandler.beforeCalled, Equals, true)
-	c.Check(mockHandler.doneCalled, Equals, true)
-	c.Check(mockHandler.errorCalled, Equals, false)
+	c.Check(mockHandler.BeforeCalled, Equals, true)
+	c.Check(mockHandler.DoneCalled, Equals, true)
+	c.Check(mockHandler.ErrorCalled, Equals, false)
 
 	c.Check(s.task.Kind(), Equals, "run-hook")
 	c.Check(s.task.Status(), Equals, state.DoneStatus)
@@ -111,7 +111,7 @@ func (s *hookManagerSuite) TestHookTask(c *C) {
 
 func (s *hookManagerSuite) TestHookTaskHandlesHookError(c *C) {
 	// Register a handler generator for the "test-hook" hook
-	mockHandler := newMockHandler()
+	mockHandler := hookstate.NewMockHandler()
 	mockHandlerGenerator := func(context *hookstate.Context) hookstate.Handler {
 		return mockHandler
 	}
@@ -128,9 +128,9 @@ func (s *hookManagerSuite) TestHookTaskHandlesHookError(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	c.Check(mockHandler.beforeCalled, Equals, true)
-	c.Check(mockHandler.doneCalled, Equals, false)
-	c.Check(mockHandler.errorCalled, Equals, true)
+	c.Check(mockHandler.BeforeCalled, Equals, true)
+	c.Check(mockHandler.DoneCalled, Equals, false)
+	c.Check(mockHandler.ErrorCalled, Equals, true)
 
 	c.Check(s.task.Kind(), Equals, "run-hook")
 	c.Check(s.task.Status(), Equals, state.ErrorStatus)
@@ -140,22 +140,8 @@ func (s *hookManagerSuite) TestHookTaskHandlesHookError(c *C) {
 
 func (s *hookManagerSuite) TestHookTaskCanKillHook(c *C) {
 	// Register a handler generator for the "test-hook" hook
-	mockHandler := newMockHandler()
-	mockHandlerGenerator := func(context *hookstate.Context) hookstate.Handler {
-		return mockHandler
-	}
-
-	// Force the snap command to hang
-	s.command = testutil.MockCommand(c, "snap", "while true; do sleep 1; done")
-
-	s.manager.Register(regexp.MustCompile("test-hook"), mockHandlerGenerator)
-
-	s.manager.Ensure()
-	completed := make(chan struct{})
-	go func() {
-		s.manager.Wait()
-		close(completed)
-	}()
+	mockHandler := hookstate.NewMockHandler()
+	completed := s.runHangingHook(c, mockHandler)
 
 	// Abort the change, which should kill the hanging hook, and wait for the
 	// task to complete.
@@ -168,10 +154,10 @@ func (s *hookManagerSuite) TestHookTaskCanKillHook(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	c.Check(mockHandler.beforeCalled, Equals, true)
-	c.Check(mockHandler.doneCalled, Equals, false)
-	c.Check(mockHandler.errorCalled, Equals, true)
-	c.Check(mockHandler.err, ErrorMatches, ".*hook \"test-hook\" aborted.*")
+	c.Check(mockHandler.BeforeCalled, Equals, true)
+	c.Check(mockHandler.DoneCalled, Equals, false)
+	c.Check(mockHandler.ErrorCalled, Equals, true)
+	c.Check(mockHandler.Err, ErrorMatches, ".*hook \"test-hook\" aborted.*")
 
 	c.Check(s.task.Kind(), Equals, "run-hook")
 	c.Check(s.task.Status(), Equals, state.ErrorStatus)
@@ -179,10 +165,59 @@ func (s *hookManagerSuite) TestHookTaskCanKillHook(c *C) {
 	checkTaskLogContains(c, s.task, regexp.MustCompile(".*hook \"test-hook\" aborted.*"))
 }
 
+func (s *hookManagerSuite) TestGetHookData(c *C) {
+	// Register a handler generator for the "test-hook" hook
+	mockHandler := hookstate.NewMockHandler()
+	completed := s.runHangingHook(c, mockHandler)
+
+	data, err := s.manager.GetHookData(1, "gimme")
+	c.Check(err, IsNil)
+	c.Check(mockHandler.GetCalled, Equals, true)
+	c.Check(mockHandler.Key, Equals, "gimme")
+	c.Check(data, DeepEquals, map[string]interface{}{"foo": "bar"})
+
+	// Since we are using a hook that hangs, abort it and wait for it to exit.
+	s.state.Lock()
+	s.change.Abort()
+	s.state.Unlock()
+	s.manager.Ensure()
+	<-completed
+}
+
+func (s *hookManagerSuite) TestSetHookData(c *C) {
+	// Register a handler generator for the "test-hook" hook
+	mockHandler := hookstate.NewMockHandler()
+	completed := s.runHangingHook(c, mockHandler)
+
+	err := s.manager.SetHookData(1, "hereyago", map[string]interface{}{"foo": "bar"})
+	c.Check(err, IsNil)
+	c.Check(mockHandler.SetCalled, Equals, true)
+	c.Check(mockHandler.Key, Equals, "hereyago")
+	c.Check(mockHandler.Data, DeepEquals, map[string]interface{}{"foo": "bar"})
+
+	// Since we are using a hook that hangs, abort it and wait for it to exit.
+	s.state.Lock()
+	s.change.Abort()
+	s.state.Unlock()
+	s.manager.Ensure()
+	<-completed
+}
+
+func (s *hookManagerSuite) TestGetHookDataFailsWithoutActiveHook(c *C) {
+	data, err := s.manager.GetHookData(1, "foo")
+	c.Check(data, IsNil)
+	c.Check(err, ErrorMatches, ".*no hook with ID 1.*")
+}
+
+func (s *hookManagerSuite) TestSetHookDataFailsWithoutActiveHook(c *C) {
+	err := s.manager.SetHookData(1, "foo", map[string]interface{}{"bar": "baz"})
+	c.Check(err, ErrorMatches, ".*no hook with ID 1.*")
+}
+
 func (s *hookManagerSuite) TestHookTaskHandlerBeforeError(c *C) {
 	// Register a handler generator for the "test-hook" hook
-	mockHandler := newMockHandler()
-	mockHandler.beforeError = true
+	mockHandler := hookstate.NewMockHandler()
+	mockHandler.BeforeError = true
 	mockHandlerGenerator := func(context *hookstate.Context) hookstate.Handler {
 		return mockHandler
 	}
@@ -195,9 +230,9 @@ func (s *hookManagerSuite) TestHookTaskHandlerBeforeError(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	c.Check(mockHandler.beforeCalled, Equals, true)
-	c.Check(mockHandler.doneCalled, Equals, false)
-	c.Check(mockHandler.errorCalled, Equals, false)
+	c.Check(mockHandler.BeforeCalled, Equals, true)
+	c.Check(mockHandler.DoneCalled, Equals, false)
+	c.Check(mockHandler.ErrorCalled, Equals, false)
 
 	c.Check(s.task.Kind(), Equals, "run-hook")
 	c.Check(s.task.Status(), Equals, state.ErrorStatus)
@@ -207,8 +242,8 @@ func (s *hookManagerSuite) TestHookTaskHandlerBeforeError(c *C) {
 
 func (s *hookManagerSuite) TestHookTaskHandlerDoneError(c *C) {
 	// Register a handler generator for the "test-hook" hook
-	mockHandler := newMockHandler()
-	mockHandler.doneError = true
+	mockHandler := hookstate.NewMockHandler()
+	mockHandler.DoneError = true
 	mockHandlerGenerator := func(context *hookstate.Context) hookstate.Handler {
 		return mockHandler
 	}
@@ -221,9 +256,9 @@ func (s *hookManagerSuite) TestHookTaskHandlerDoneError(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	c.Check(mockHandler.beforeCalled, Equals, true)
-	c.Check(mockHandler.doneCalled, Equals, true)
-	c.Check(mockHandler.errorCalled, Equals, false)
+	c.Check(mockHandler.BeforeCalled, Equals, true)
+	c.Check(mockHandler.DoneCalled, Equals, true)
+	c.Check(mockHandler.ErrorCalled, Equals, false)
 
 	c.Check(s.task.Kind(), Equals, "run-hook")
 	c.Check(s.task.Status(), Equals, state.ErrorStatus)
@@ -233,8 +268,8 @@ func (s *hookManagerSuite) TestHookTaskHandlerDoneError(c *C) {
 
 func (s *hookManagerSuite) TestHookTaskHandlerErrorError(c *C) {
 	// Register a handler generator for the "test-hook" hook
-	mockHandler := newMockHandler()
-	mockHandler.errorError = true
+	mockHandler := hookstate.NewMockHandler()
+	mockHandler.ErrorError = true
 	mockHandlerGenerator := func(context *hookstate.Context) hookstate.Handler {
 		return mockHandler
 	}
@@ -250,9 +285,9 @@ func (s *hookManagerSuite) TestHookTaskHandlerErrorError(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	c.Check(mockHandler.beforeCalled, Equals, true)
-	c.Check(mockHandler.doneCalled, Equals, false)
-	c.Check(mockHandler.errorCalled, Equals, true)
+	c.Check(mockHandler.BeforeCalled, Equals, true)
+	c.Check(mockHandler.DoneCalled, Equals, false)
+	c.Check(mockHandler.ErrorCalled, Equals, true)
 
 	c.Check(s.task.Kind(), Equals, "run-hook")
 	c.Check(s.task.Status(), Equals, state.ErrorStatus)
@@ -277,7 +312,7 @@ func (s *hookManagerSuite) TestHookWithoutHandlerIsError(c *C) {
 
 func (s *hookManagerSuite) TestHookWithMultipleHandlersIsError(c *C) {
 	mockHandlerGenerator := func(context *hookstate.Context) hookstate.Handler {
-		return newMockHandler()
+		return hookstate.NewMockHandler()
 	}
 
 	// Register multiple times for this hook
@@ -297,6 +332,34 @@ func (s *hookManagerSuite) TestHookWithMultipleHandlersIsError(c *C) {
 	checkTaskLogContains(c, s.task, regexp.MustCompile(".*2 handlers registered for hook \"test-hook\".*"))
 }
 
+func (s *hookManagerSuite) runHangingHook(c *C, mockHandler *hookstate.MockHandler) chan struct{} {
+	// Register a handler generator for the "test-hook" hook
+	mockHandlerGenerator := func(context *hookstate.Context) hookstate.Handler {
+		return mockHandler
+	}
+
+	// Force the snap command to hang
+	s.command = testutil.MockCommand(c, "snap", "while true; do sleep 1; done")
+
+	s.manager.Register(regexp.MustCompile("test-hook"), mockHandlerGenerator)
+
+	s.manager.Ensure()
+	completed := make(chan struct{})
+	go func() {
+		s.manager.Wait()
+		close(completed)
+	}()
+
+	// Wait for the hook to actually be running
+	for {
+		if len(s.command.Calls()) > 0 {
+			break
+		}
+	}
+
+	return completed
+}
+
 func checkTaskLogContains(c *C, task *state.Task, pattern *regexp.Regexp) {
 	found := false
 	for _, message := range task.Log() {
@@ -306,55 +369,4 @@ func checkTaskLogContains(c *C, task *state.Task, pattern *regexp.Regexp) {
 	}
 
 	c.Check(found, Equals, true, Commentf("Expected to find regex %q in task log: %v", pattern, task.Log()))
-}
-
-type mockHandler struct {
-	beforeCalled bool
-	beforeError  bool
-
-	doneCalled bool
-	doneError  bool
-
-	errorCalled bool
-	errorError  bool
-	err         error
-}
-
-func newMockHandler() *mockHandler {
-	return &mockHandler{
-		beforeCalled: false,
-		beforeError:  false,
-
-		doneCalled: false,
-		doneError:  false,
-
-		errorCalled: false,
-		errorError:  false,
-		err:         nil,
-	}
-}
-
-func (h *mockHandler) Before() error {
-	h.beforeCalled = true
-	if h.beforeError {
-		return fmt.Errorf("before failed at user request")
-	}
-	return nil
-}
-
-func (h *mockHandler) Done() error {
-	h.doneCalled = true
-	if h.doneError {
-		return fmt.Errorf("done failed at user request")
-	}
-	return nil
-}
-
-func (h *mockHandler) Error(err error) error {
-	h.err = err
-	h.errorCalled = true
-	if h.errorError {
-		return fmt.Errorf("error failed at user request")
-	}
-	return nil
 }


### PR DESCRIPTION
Currently snapd supports running hooks as long as no information exchange is needed between the hook and its handler. This PR makes some more progress on LP: [#1586465](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1586465), making the first step toward supporting that information exchange by uniquely identifying hook instances and providing an internal API for communicating with handlers.