### PR TITLE
tests: add udev rules spread test

### DIFF
--- a/tests/lib/snaps/modem-manager-consumer/bin/consumer
+++ b/tests/lib/snaps/modem-manager-consumer/bin/consumer
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "dummy"

--- a/tests/lib/snaps/modem-manager-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/modem-manager-consumer/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: modem-manager-consumer
+version: 1.0
+summary: Basic modem-manager consumer snap
+description: A basic snap declaring a plug on modem-manager
+
+apps:
+    modem-manager-consumer:
+        command: bin/consumer
+        slots: [modem-manager]

--- a/tests/main/interfaces-udev/task.yaml
+++ b/tests/main/interfaces-udev/task.yaml
@@ -1,0 +1,16 @@
+summary: Ensure that the udev interface backend works.
+
+execute: |
+    echo "Given a snap is installed"
+
+    echo "Then the udev rules files specific to it are created"
+
+    echo "And the udev rules are reloaded"
+
+    echo "======================================="
+
+    echo "When the snap is removed"
+
+    echo "Then the udev rules files are removed"
+
+    echo "And the udev rules are reloaded"

--- a/tests/main/interfaces-udev/task.yaml
+++ b/tests/main/interfaces-udev/task.yaml
@@ -1,16 +1,31 @@
 summary: Ensure that the udev interface backend works.
 
+details: |
+    This test checks that the udev rules file is created when a snap declaring
+    a dependency on an interface (being it a slot or a plug) and that concrete
+    dependency has a related udev snippet, then the udev rules files are created
+    on install and removed after it is uninstalled.
+
+    Currently the ony interface that declares a udev snippet is the modem-manager
+    interface for its slot. This test can be easily extended with variants when
+    more interfaces declare udev snippets.
+
+prepare: |
+    echo "Given a snap declaring a slot with associated udev rules is installed"
+    snapbuild $TESTSLIB/snaps/modem-manager-consumer .
+    snap install modem-manager-consumer_1.0_all.snap
+
+restore: |
+    rm -f modem-manager-consumer_1.0_all.snap
+
 execute: |
-    echo "Given a snap is installed"
-
     echo "Then the udev rules files specific to it are created"
-
-    echo "And the udev rules are reloaded"
+    test -f /etc/udev/rules.d/70-snap.modem-manager-consumer.rules
 
     echo "======================================="
 
     echo "When the snap is removed"
+    snap remove modem-manager-consumer
 
     echo "Then the udev rules files are removed"
-
-    echo "And the udev rules are reloaded"
+    ! test -f /etc/udev/rules.d/70-snap.modem-manager-consumer.rules

--- a/tests/main/interfaces-udev/task.yaml
+++ b/tests/main/interfaces-udev/task.yaml
@@ -21,6 +21,8 @@ restore: |
 execute: |
     echo "Then the udev rules files specific to it are created"
     test -f /etc/udev/rules.d/70-snap.modem-manager-consumer.rules
+    expected="ATTRS{idVendor}==\".*?\", ATTRS{idProduct}==\".*?\""
+    grep -Pq "$expected" /etc/udev/rules.d/70-snap.modem-manager-consumer.rules
 
     echo "======================================="
 


### PR DESCRIPTION
This test checks for the creation/removal of udev rules files. Currently the only interface that defines udev snippets is modem-manager for the slot, we use a test snap declaring a slot on that interface. 

Besides the rules file creation, an interface with udev snippets also triggers the reload of the udev files, this is not checked atm.