### PR TITLE
wrappers: ensure services have a valid SNAP_USER_DATA dir

### DIFF
--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -70,8 +70,9 @@ func snapDataDirs(snap *snap.Info) ([]string, error) {
 		return nil, err
 	}
 	// then root data
-	found = append(found, snap.RootUserDataDir())
-
+	if rootUserData, err := snap.UserDataDir("root"); err == nil {
+		found = append(found, rootUserData)
+	}
 	// then system data
 	found = append(found, snap.DataDir())
 
@@ -86,8 +87,9 @@ func snapCommonDataDirs(snap *snap.Info) ([]string, error) {
 		return nil, err
 	}
 	// then root common data
-	found = append(found, snap.RootCommonUserDataDir())
-
+	if rootCommonUserData, err := snap.CommonUserDataDir("root"); err == nil {
+		found = append(found, rootCommonUserData)
+	}
 	// then system data
 	found = append(found, snap.CommonDataDir())
 

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -65,10 +65,13 @@ func removeDirs(dirs []string) error {
 // snapDataDirs returns the list of data directories for the given snap version
 func snapDataDirs(snap *snap.Info) ([]string, error) {
 	// collect the directories, homes first
-	found, err := filepath.Glob(snap.DataHomeDir())
+	found, err := filepath.Glob(snap.DataHomeGlob())
 	if err != nil {
 		return nil, err
 	}
+	// then root data
+	found = append(found, snap.RootUserDataDir())
+
 	// then system data
 	found = append(found, snap.DataDir())
 
@@ -78,10 +81,13 @@ func snapDataDirs(snap *snap.Info) ([]string, error) {
 // snapCommonDataDirs returns the list of data directories common between versions of the given snap
 func snapCommonDataDirs(snap *snap.Info) ([]string, error) {
 	// collect the directories, homes first
-	found, err := filepath.Glob(snap.CommonDataHomeDir())
+	found, err := filepath.Glob(snap.CommonDataHomeGlob())
 	if err != nil {
 		return nil, err
 	}
+	// then root common data
+	found = append(found, snap.CommonRootUserDataDir())
+
 	// then system data
 	found = append(found, snap.CommonDataDir())
 

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -86,7 +86,7 @@ func snapCommonDataDirs(snap *snap.Info) ([]string, error) {
 		return nil, err
 	}
 	// then root common data
-	found = append(found, snap.CommonRootUserDataDir())
+	found = append(found, snap.RootCommonUserDataDir())
 
 	// then system data
 	found = append(found, snap.CommonDataDir())

--- a/snap/info.go
+++ b/snap/info.go
@@ -203,7 +203,7 @@ func (s *Info) CommonDataHomeGlob() string {
 }
 
 // RootCommonUserDataDir returns the user data dir for the root user
-func (s *Info) RootUserDataDir() string {
+func (s *Info) RootCommonUserDataDir() string {
 	return filepath.Join(dirs.GlobalRootDir, "/root/snap/", s.Name(), "common")
 }
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -192,6 +192,11 @@ func (s *Info) DataHomeDir() string {
 	return filepath.Join(dirs.SnapDataHomeGlob, s.Name(), s.Revision.String())
 }
 
+// RootUserDataDir returns the user data dir for the root user
+func (s *Info) RootUserDataDir() string {
+	return filepath.Join(dirs.GlobalRootDir, "/root/snap/", s.Name(), s.Revision.String())
+}
+
 // CommonDataHomeDir returns the per user data directory common across revisions of the snap.
 func (s *Info) CommonDataHomeDir() string {
 	return filepath.Join(dirs.SnapDataHomeGlob, s.Name(), "common")

--- a/snap/info.go
+++ b/snap/info.go
@@ -51,11 +51,11 @@ type PlaceInfo interface {
 	// CommonDataDir returns the data directory common across revisions of the snap.
 	CommonDataDir() string
 
-	// DataHomeDir returns the per user data directory of the snap.
-	DataHomeDir() string
+	// DataHomeGlob returns the per user data directory of the snap.
+	DataHomeGlob() string
 
-	// CommonDataHomeDir returns the per user data directory common across revisions of the snap.
-	CommonDataHomeDir() string
+	// CommonDataHomeGlob returns the per user data directory common across revisions of the snap.
+	CommonDataHomeGlob() string
 }
 
 // MinimalPlaceInfo returns a PlaceInfo with just the location information for a snap of the given name and revision.
@@ -187,8 +187,8 @@ func (s *Info) CommonDataDir() string {
 	return filepath.Join(dirs.SnapDataDir, s.Name(), "common")
 }
 
-// DataHomeDir returns the per user data directory of the snap.
-func (s *Info) DataHomeDir() string {
+// DataHomeGlob returns the per user data directory of the snap.
+func (s *Info) DataHomeGlob() string {
 	return filepath.Join(dirs.SnapDataHomeGlob, s.Name(), s.Revision.String())
 }
 
@@ -197,9 +197,14 @@ func (s *Info) RootUserDataDir() string {
 	return filepath.Join(dirs.GlobalRootDir, "/root/snap/", s.Name(), s.Revision.String())
 }
 
-// CommonDataHomeDir returns the per user data directory common across revisions of the snap.
-func (s *Info) CommonDataHomeDir() string {
+// CommonDataHomeGlob returns the per user data directory common across revisions of the snap.
+func (s *Info) CommonDataHomeGlob() string {
 	return filepath.Join(dirs.SnapDataHomeGlob, s.Name(), "common")
+}
+
+// RootCommonUserDataDir returns the user data dir for the root user
+func (s *Info) RootUserDataDir() string {
+	return filepath.Join(dirs.GlobalRootDir, "/root/snap/", s.Name(), "common")
 }
 
 // NeedsDevMode retursn whether the snap needs devmode.

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -191,7 +191,7 @@ Requires=snapd.frameworks.target{{ if .App.Socket }} {{.SocketFileName}}{{end}}
 X-Snappy=yes
 
 [Service]
-ExecPreStart=/bin/mkdir -p {{.App.Snap.RootUserDataDir}} {{.App.Snap.RootCommonUserDataDir}}
+ExecPreStart=/bin/mkdir -p {{.App.Snap.UserDataDir "root"}} {{.App.Snap.CommonUserDataDir "root"}}
 ExecStart={{.App.LauncherCommand}}
 Restart={{.Restart}}
 WorkingDirectory={{.App.Snap.DataDir}}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -191,6 +191,7 @@ Requires=snapd.frameworks.target{{ if .App.Socket }} {{.SocketFileName}}{{end}}
 X-Snappy=yes
 
 [Service]
+ExecPreStart=mkdir -p {{.App.Snap.RootUserDataDir}}
 ExecStart={{.App.LauncherCommand}}
 Restart={{.Restart}}
 WorkingDirectory={{.App.Snap.DataDir}}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -191,7 +191,7 @@ Requires=snapd.frameworks.target{{ if .App.Socket }} {{.SocketFileName}}{{end}}
 X-Snappy=yes
 
 [Service]
-ExecPreStart=mkdir -p {{.App.Snap.RootUserDataDir}} {{.App.Snap.RootCommonUserDataDir}}
+ExecPreStart=/bin/mkdir -p {{.App.Snap.RootUserDataDir}} {{.App.Snap.RootCommonUserDataDir}}
 ExecStart={{.App.LauncherCommand}}
 Restart={{.Restart}}
 WorkingDirectory={{.App.Snap.DataDir}}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -191,7 +191,7 @@ Requires=snapd.frameworks.target{{ if .App.Socket }} {{.SocketFileName}}{{end}}
 X-Snappy=yes
 
 [Service]
-ExecPreStart=mkdir -p {{.App.Snap.RootUserDataDir}}
+ExecPreStart=mkdir -p {{.App.Snap.RootUserDataDir}} {{.App.Snap.RootCommonUserDataDir}}
 ExecStart={{.App.LauncherCommand}}
 Restart={{.Restart}}
 WorkingDirectory={{.App.Snap.DataDir}}

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -42,7 +42,7 @@ Description=Service for snap application snap.app
 X-Snappy=yes
 
 [Service]
-ExecPreStart=mkdir -p /root/snap/snap/44 /root/snap/snap/common
+ExecPreStart=/bin/mkdir -p /root/snap/snap/44 /root/snap/snap/common
 ExecStart=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app /snap/snap/44/bin/start
 Restart=on-failure
 WorkingDirectory=/var/snap/snap/44
@@ -69,7 +69,7 @@ Description=Service for snap application xkcd-webserver.xkcd-webserver
 X-Snappy=yes
 
 [Service]
-ExecPreStart=mkdir -p /root/snap/xkcd-webserver/44 /root/snap/xkcd-webserver/common
+ExecPreStart=/bin/mkdir -p /root/snap/xkcd-webserver/44 /root/snap/xkcd-webserver/common
 ExecStart=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo start
 Restart=on-failure
 WorkingDirectory=/var/snap/xkcd-webserver/44

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -42,7 +42,7 @@ Description=Service for snap application snap.app
 X-Snappy=yes
 
 [Service]
-ExecPreStart=mkdir -p /root/snap/snap/44
+ExecPreStart=mkdir -p /root/snap/snap/44 /root/snap/snap/common
 ExecStart=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app /snap/snap/44/bin/start
 Restart=on-failure
 WorkingDirectory=/var/snap/snap/44
@@ -69,7 +69,7 @@ Description=Service for snap application xkcd-webserver.xkcd-webserver
 X-Snappy=yes
 
 [Service]
-ExecPreStart=mkdir -p /root/snap/xkcd-webserver/44
+ExecPreStart=mkdir -p /root/snap/xkcd-webserver/44 /root/snap/xkcd-webserver/common
 ExecStart=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo start
 Restart=on-failure
 WorkingDirectory=/var/snap/xkcd-webserver/44

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -42,6 +42,7 @@ Description=Service for snap application snap.app
 X-Snappy=yes
 
 [Service]
+ExecPreStart=mkdir -p /root/snap/snap/44
 ExecStart=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app /snap/snap/44/bin/start
 Restart=on-failure
 WorkingDirectory=/var/snap/snap/44
@@ -68,6 +69,7 @@ Description=Service for snap application xkcd-webserver.xkcd-webserver
 X-Snappy=yes
 
 [Service]
+ExecPreStart=mkdir -p /root/snap/xkcd-webserver/44
 ExecStart=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo start
 Restart=on-failure
 WorkingDirectory=/var/snap/xkcd-webserver/44


### PR DESCRIPTION
In the old world we created the SNAP_USER_DATA  and SNAP_COMMON_USER_DATA with ubuntu-core-launcher. This is not ideal for various reasons and got removed in snap-confine. In the future `snap run` will do the user dir creation. However this is not fully ready yet. So in the meantime we still want the data dirs created. For binaries we do this via the generated shell script wrapper. For services this is currently broken with snap-confine, so we need to fix it until snap run is ready.