### PR TITLE
client, cmd, daemon, osutil: support --yaml and --sudoer flags for create-user

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -350,7 +350,7 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 // CreateUserResult holds the result of a user creation
 type CreateUserResult struct {
 	Username    string `json:"username" yaml:"username"`
-	SshKeyCount int    `json:"ssh_key_count" yaml:"ssh_key_count"`
+	SSHKeyCount int    `json:"ssh-key-count" yaml:"ssh-key-count"`
 }
 
 // createUserRequest holds the user creation request

--- a/client/client.go
+++ b/client/client.go
@@ -349,8 +349,8 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 
 // CreateUserResult holds the result of a user creation
 type CreateUserResult struct {
-	Username    string `json:"username" yaml:"username"`
-	SSHKeyCount int    `json:"ssh-key-count" yaml:"ssh-key-count"`
+	Username    string `json:"username"`
+	SSHKeyCount int    `json:"ssh-key-count"`
 }
 
 // createUserRequest holds the user creation request

--- a/client/client.go
+++ b/client/client.go
@@ -349,7 +349,8 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 
 // CreateUserResult holds the result of a user creation
 type CreateUserResult struct {
-	Username string `json:"username"`
+	Username    string `json:"username" yaml:"username"`
+	SshKeyCount int    `json:"ssh_key_count" yaml:"ssh_key_count"`
 }
 
 // createUserRequest holds the user creation request
@@ -358,7 +359,7 @@ type createUserRequest struct {
 }
 
 // CreateUser creates a user from the given mail address
-func (client *Client) CreateUser(mail string) (*CreateUserResult, error) {
+func (client *Client) CreateUser(mail string, sudoer bool) (*CreateUserResult, error) {
 	var createResult CreateUserResult
 	b, err := json.Marshal(createUserRequest{
 		EMail: mail,

--- a/client/client.go
+++ b/client/client.go
@@ -355,14 +355,16 @@ type CreateUserResult struct {
 
 // createUserRequest holds the user creation request
 type createUserRequest struct {
-	EMail string `json:"email"`
+	EMail  string `json:"email"`
+	Sudoer bool   `json:"sudoer"`
 }
 
 // CreateUser creates a user from the given mail address
 func (client *Client) CreateUser(mail string, sudoer bool) (*CreateUserResult, error) {
 	var createResult CreateUserResult
 	b, err := json.Marshal(createUserRequest{
-		EMail: mail,
+		EMail:  mail,
+		Sudoer: sudoer,
 	})
 	if err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -354,18 +354,15 @@ type CreateUserResult struct {
 }
 
 // createUserRequest holds the user creation request
-type createUserRequest struct {
-	EMail  string `json:"email"`
+type CreateUserRequest struct {
+	Email  string `json:"email"`
 	Sudoer bool   `json:"sudoer"`
 }
 
 // CreateUser creates a user from the given mail address
-func (client *Client) CreateUser(mail string, sudoer bool) (*CreateUserResult, error) {
+func (client *Client) CreateUser(request *CreateUserRequest) (*CreateUserResult, error) {
 	var createResult CreateUserResult
-	b, err := json.Marshal(createUserRequest{
-		EMail:  mail,
-		Sudoer: sudoer,
-	})
+	b, err := json.Marshal(request)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -282,15 +282,17 @@ func (cs *clientSuite) TestClientCreateUser(c *check.C) {
 	cs.rsp = `{
 		"type": "sync",
 		"result": {
-                        "username": "karl"
+                        "username": "karl",
+                        "ssh_key_count": 1
 		}
 	}`
-	rsp, err := cs.cli.CreateUser("popper@lse.ac.uk")
+	rsp, err := cs.cli.CreateUser("popper@lse.ac.uk", true)
 	c.Assert(cs.req.Method, check.Equals, "POST")
 	c.Assert(cs.req.URL.Path, check.Equals, "/v2/create-user")
 	c.Assert(err, check.IsNil)
 	c.Assert(rsp, check.DeepEquals, &client.CreateUserResult{
-		Username: "karl",
+		Username:    "karl",
+		SshKeyCount: 1,
 	})
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -283,7 +283,7 @@ func (cs *clientSuite) TestClientCreateUser(c *check.C) {
 		"type": "sync",
 		"result": {
                         "username": "karl",
-                        "ssh_key_count": 1
+                        "ssh-key-count": 1
 		}
 	}`
 	rsp, err := cs.cli.CreateUser(&client.CreateUserRequest{Email: "popper@lse.ac.uk", Sudoer: true})
@@ -292,7 +292,7 @@ func (cs *clientSuite) TestClientCreateUser(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rsp, check.DeepEquals, &client.CreateUserResult{
 		Username:    "karl",
-		SshKeyCount: 1,
+		SSHKeyCount: 1,
 	})
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -286,7 +286,7 @@ func (cs *clientSuite) TestClientCreateUser(c *check.C) {
                         "ssh_key_count": 1
 		}
 	}`
-	rsp, err := cs.cli.CreateUser("popper@lse.ac.uk", true)
+	rsp, err := cs.cli.CreateUser(&client.CreateUserRequest{Email: "popper@lse.ac.uk", Sudoer: true})
 	c.Assert(cs.req.Method, check.Equals, "POST")
 	c.Assert(cs.req.URL.Path, check.Equals, "/v2/create-user")
 	c.Assert(err, check.IsNil)

--- a/cmd/snap/cmd_create_user.go
+++ b/cmd/snap/cmd_create_user.go
@@ -20,13 +20,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 
 	"github.com/jessevdk/go-flags"
-	"gopkg.in/yaml.v2"
 )
 
 var shortCreateUserHelp = i18n.G("Creates a local system user")
@@ -38,7 +38,7 @@ An account can be setup at https://login.ubuntu.com.
 `)
 
 type cmdCreateUser struct {
-	Yaml       bool `long:"yaml" description:"output results in YAML format"`
+	JSON       bool `long:"json" description:"output results in JSON format"`
 	Sudoer     bool `long:"sudoer" description:"grant sudo access to the created user"`
 	Positional struct {
 		Email string `positional-arg-name:"email"`
@@ -65,8 +65,8 @@ func (x *cmdCreateUser) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	if x.Yaml {
-		y, err := yaml.Marshal(rsp)
+	if x.JSON {
+		y, err := json.Marshal(rsp)
 		if err != nil {
 			return nil
 		}

--- a/cmd/snap/cmd_create_user.go
+++ b/cmd/snap/cmd_create_user.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 
 	"github.com/jessevdk/go-flags"
+	"gopkg.in/yaml.v2"
 )
 
 var shortCreateUserHelp = i18n.G("Creates a local system user")
@@ -36,6 +37,8 @@ An account can be setup at https://login.ubuntu.com.
 `)
 
 type cmdCreateUser struct {
+	Yaml       bool `long:"yaml" description:"output results in YAML format"`
+	Sudoer     bool `long:"sudoer" description:"make the created user a sudoer"`
 	Positional struct {
 		EMail string `positional-arg-name:"email"`
 	} `positional-args:"yes"`
@@ -51,11 +54,19 @@ func (x *cmdCreateUser) Execute(args []string) error {
 	}
 
 	cli := Client()
-	rsp, err := cli.CreateUser(x.Positional.EMail)
+	rsp, err := cli.CreateUser(x.Positional.EMail, x.Sudoer)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(Stdout, i18n.G("Created user %q\n"), rsp.Username)
+	if x.Yaml {
+		y, err := yaml.Marshal(rsp)
+		if err != nil {
+			return nil
+		}
+		fmt.Fprintf(Stdout, "%s\n", y)
+	} else {
+		fmt.Fprintf(Stdout, i18n.G("Created user %q\n"), rsp.Username)
+	}
 
 	return nil
 }

--- a/cmd/snap/cmd_create_user.go
+++ b/cmd/snap/cmd_create_user.go
@@ -22,6 +22,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 
 	"github.com/jessevdk/go-flags"
@@ -40,7 +41,7 @@ type cmdCreateUser struct {
 	Yaml       bool `long:"yaml" description:"output results in YAML format"`
 	Sudoer     bool `long:"sudoer" description:"make the created user a sudoer"`
 	Positional struct {
-		EMail string `positional-arg-name:"email"`
+		Email string `positional-arg-name:"email"`
 	} `positional-args:"yes"`
 }
 
@@ -54,7 +55,13 @@ func (x *cmdCreateUser) Execute(args []string) error {
 	}
 
 	cli := Client()
-	rsp, err := cli.CreateUser(x.Positional.EMail, x.Sudoer)
+
+	request := client.CreateUserRequest{
+		Email:  x.Positional.Email,
+		Sudoer: x.Sudoer,
+	}
+
+	rsp, err := cli.CreateUser(&request)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_create_user.go
+++ b/cmd/snap/cmd_create_user.go
@@ -39,7 +39,7 @@ An account can be setup at https://login.ubuntu.com.
 
 type cmdCreateUser struct {
 	Yaml       bool `long:"yaml" description:"output results in YAML format"`
-	Sudoer     bool `long:"sudoer" description:"make the created user a sudoer"`
+	Sudoer     bool `long:"sudoer" description:"grant sudo access to the created user"`
 	Positional struct {
 		Email string `positional-arg-name:"email"`
 	} `positional-args:"yes"`
@@ -72,7 +72,7 @@ func (x *cmdCreateUser) Execute(args []string) error {
 		}
 		fmt.Fprintf(Stdout, "%s\n", y)
 	} else {
-		fmt.Fprintf(Stdout, i18n.G("Created user %q\n"), rsp.Username)
+		fmt.Fprintf(Stdout, i18n.G("Created user %q and imported SSH keys.\n"), rsp.Username)
 	}
 
 	return nil

--- a/cmd/snap/cmd_create_user_test.go
+++ b/cmd/snap/cmd_create_user_test.go
@@ -25,7 +25,9 @@ import (
 	"net/http"
 
 	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 
+	"github.com/snapcore/snapd/client"
 	snap "github.com/snapcore/snapd/cmd/snap"
 )
 
@@ -33,19 +35,20 @@ func (s *SnapSuite) TestCreateUser(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch n {
-		case 0:
+		case 0, 1:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v2/create-user")
-			var body map[string]string
+			var body map[string]interface{}
 			dec := json.NewDecoder(r.Body)
 			err := dec.Decode(&body)
 			c.Assert(err, check.IsNil)
-			c.Check(body, check.DeepEquals, map[string]string{
-				"email": "popper@lse.ac.uk",
+			c.Check(body, check.DeepEquals, map[string]interface{}{
+				"email":  "popper@lse.ac.uk",
+				"sudoer": false,
 			})
-			fmt.Fprintln(w, `{"type": "sync", "result": {"username": "karl"}}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"username": "karl", "ssh_key_count": 1}}`)
 		default:
-			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+			c.Fatalf("expected to get 2 requests, now on %d", n+1)
 		}
 
 		n++
@@ -56,5 +59,21 @@ func (s *SnapSuite) TestCreateUser(c *check.C) {
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(n, check.Equals, 1)
 	c.Assert(s.Stdout(), check.Equals, `Created user "karl"`+"\n")
+	c.Assert(s.Stderr(), check.Equals, "")
+
+	s.stdout.Reset()
+
+	expectedResponse := &client.CreateUserResult{
+		Username:    "karl",
+		SshKeyCount: 1,
+	}
+	actualResponse := &client.CreateUserResult{}
+
+	rest, err = snap.Parser().ParseArgs([]string{"create-user", "--yaml", "popper@lse.ac.uk"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.DeepEquals, []string{})
+	c.Check(n, check.Equals, 2)
+	yaml.Unmarshal(s.stdout.Bytes(), actualResponse)
+	c.Assert(actualResponse, check.DeepEquals, expectedResponse)
 	c.Assert(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_create_user_test.go
+++ b/cmd/snap/cmd_create_user_test.go
@@ -58,7 +58,7 @@ func (s *SnapSuite) TestCreateUser(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(n, check.Equals, 1)
-	c.Assert(s.Stdout(), check.Equals, `Created user "karl"`+"\n")
+	c.Assert(s.Stdout(), check.Equals, `Created user "karl" and imported SSH keys.`+"\n")
 	c.Assert(s.Stderr(), check.Equals, "")
 
 	s.stdout.Reset()

--- a/cmd/snap/cmd_create_user_test.go
+++ b/cmd/snap/cmd_create_user_test.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 
 	"gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/client"
 	snap "github.com/snapcore/snapd/cmd/snap"
@@ -69,11 +68,11 @@ func (s *SnapSuite) TestCreateUser(c *check.C) {
 	}
 	actualResponse := &client.CreateUserResult{}
 
-	rest, err = snap.Parser().ParseArgs([]string{"create-user", "--yaml", "popper@lse.ac.uk"})
+	rest, err = snap.Parser().ParseArgs([]string{"create-user", "--json", "popper@lse.ac.uk"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(n, check.Equals, 2)
-	yaml.Unmarshal(s.stdout.Bytes(), actualResponse)
+	json.Unmarshal(s.stdout.Bytes(), actualResponse)
 	c.Assert(actualResponse, check.DeepEquals, expectedResponse)
 	c.Assert(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_create_user_test.go
+++ b/cmd/snap/cmd_create_user_test.go
@@ -46,7 +46,7 @@ func (s *SnapSuite) TestCreateUser(c *check.C) {
 				"email":  "popper@lse.ac.uk",
 				"sudoer": false,
 			})
-			fmt.Fprintln(w, `{"type": "sync", "result": {"username": "karl", "ssh_key_count": 1}}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": {"username": "karl", "ssh-key-count": 1}}`)
 		default:
 			c.Fatalf("expected to get 2 requests, now on %d", n+1)
 		}
@@ -65,7 +65,7 @@ func (s *SnapSuite) TestCreateUser(c *check.C) {
 
 	expectedResponse := &client.CreateUserResult{
 		Username:    "karl",
-		SshKeyCount: 1,
+		SSHKeyCount: 1,
 	}
 	actualResponse := &client.CreateUserResult{}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1428,7 +1428,7 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 	}
 
 	var createData struct {
-		EMail  string `json:"email"`
+		Email  string `json:"email"`
 		Sudoer bool   `json:"sudoer"`
 	}
 
@@ -1437,29 +1437,29 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 		return BadRequest("cannot decode create-user data from request body: %v", err)
 	}
 
-	if createData.EMail == "" {
+	if createData.Email == "" {
 		return BadRequest("cannot create user: 'email' field is empty")
 	}
 
-	v, err := storeUserInfo(createData.EMail)
+	v, err := storeUserInfo(createData.Email)
 	if err != nil {
-		return BadRequest("cannot create user %q: %s", createData.EMail, err)
+		return BadRequest("cannot create user %q: %s", createData.Email, err)
 	}
 	if len(v.SSHKeys) == 0 {
-		return BadRequest("cannot create user for %s: no ssh keys found", createData.EMail)
+		return BadRequest("cannot create user for %s: no ssh keys found", createData.Email)
 	}
 
-	gecos := fmt.Sprintf("%s,%s", createData.EMail, v.OpenIDIdentifier)
+	gecos := fmt.Sprintf("%s,%s", createData.Email, v.OpenIDIdentifier)
 	if err := osutilAddExtraUser(v.Username, v.SSHKeys, gecos, createData.Sudoer); err != nil {
 		return BadRequest("cannot create user %s: %s", v.Username, err)
 	}
 
 	var createResponseData struct {
 		Username    string `json:"username"`
-		SshKeyCount int    `json:"ssh_key_count"`
+		SSHKeyCount int    `json:"ssh-key-count"`
 	}
 	createResponseData.Username = v.Username
-	createResponseData.SshKeyCount = len(v.SSHKeys)
+	createResponseData.SSHKeyCount = len(v.SSHKeys)
 
 	return SyncResponse(createResponseData, nil)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3111,10 +3111,11 @@ func (s *apiSuite) TestPostCreateUser(c *check.C) {
 			OpenIDIdentifier: "xxyyzz",
 		}, nil
 	}
-	osutilAddExtraSudoUser = func(username string, sshKeys []string, gecos string) error {
+	osutilAddExtraUser = func(username string, sshKeys []string, gecos string, sudoer bool) error {
 		c.Check(username, check.Equals, "karl")
 		c.Check(sshKeys, check.DeepEquals, []string{"ssh1", "ssh2"})
 		c.Check(gecos, check.Equals, "popper@lse.ac.uk,xxyyzz")
+		c.Check(sudoer, check.Equals, false)
 		return nil
 	}
 
@@ -3122,7 +3123,7 @@ func (s *apiSuite) TestPostCreateUser(c *check.C) {
 		return 0, nil
 	}
 	defer func() {
-		osutilAddExtraSudoUser = osutil.AddExtraSudoUser
+		osutilAddExtraUser = osutil.AddExtraUser
 		postCreateUserUcrednetGetUID = ucrednetGetUID
 	}()
 

--- a/integration-tests/tests/create_user_test.go
+++ b/integration-tests/tests/create_user_test.go
@@ -36,7 +36,7 @@ type createUserSuite struct {
 func (s *createUserSuite) TestCreateUserCreatesUser(c *check.C) {
 	createOutput := cli.ExecCommand(c, "sudo", "snap", "create-user", "mvo@ubuntu.com")
 
-	expected := `Created user "mvo"\n`
+	expected := `Created user "mvo" and imported SSH keys.\n`
 	c.Assert(createOutput, check.Matches, expected)
 
 	// file exists and has a size greater than zero

--- a/integration-tests/tests/create_user_test.go
+++ b/integration-tests/tests/create_user_test.go
@@ -34,7 +34,7 @@ type createUserSuite struct {
 }
 
 func (s *createUserSuite) TestCreateUserCreatesUser(c *check.C) {
-	createOutput := cli.ExecCommand(c, "sudo", "snap", "create-user", "mvo@ubuntu.com")
+	createOutput := cli.ExecCommand(c, "sudo", "snap", "create-user", "--sudoer", "mvo@ubuntu.com")
 
 	expected := `Created user "mvo" and imported SSH keys.\n`
 	c.Assert(createOutput, check.Matches, expected)

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -41,7 +41,7 @@ var sudoersTemplate = `
 %[1]s ALL=(ALL) NOPASSWD:ALL
 `
 
-func AddExtraSudoUser(name string, sshKeys []string, gecos string) error {
+func AddExtraUser(name string, sshKeys []string, gecos string, sudoer bool) error {
 	// we check the (user)name ourselves, adduser is a bit too
 	// strict (i.e. no `.`) - this regexp is in sync with that SSO
 	// allows as valid usernames
@@ -60,10 +60,12 @@ func AddExtraSudoUser(name string, sshKeys []string, gecos string) error {
 		return fmt.Errorf("adduser failed with %s: %s", err, output)
 	}
 
-	// Must escape "." as files containing it are ignored in sudoers.d.
-	sudoersFile := filepath.Join(sudoersDotD, "create-user-"+strings.Replace(name, ".", "%2E", -1))
-	if err := AtomicWriteFile(sudoersFile, []byte(fmt.Sprintf(sudoersTemplate, name)), 0400, 0); err != nil {
-		return fmt.Errorf("cannot create file under sudoers.d: %s", err)
+	if sudoer {
+		// Must escape "." as files containing it are ignored in sudoers.d.
+		sudoersFile := filepath.Join(sudoersDotD, "create-user-"+strings.Replace(name, ".", "%2E", -1))
+		if err := AtomicWriteFile(sudoersFile, []byte(fmt.Sprintf(sudoersTemplate, name)), 0400, 0); err != nil {
+			return fmt.Errorf("cannot create file under sudoers.d: %s", err)
+		}
 	}
 
 	u, err := userLookup(name)


### PR DESCRIPTION
This adds an option for structured output and another to control whether the added user is a sudoer or not to the create-user command.

It's based on #1651 so the diff will get easier to read when that's merged :-) 