### PR TITLE
tests: prevent restore error on test failure

### DIFF
--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -32,7 +32,7 @@ restore: |
     systemctl stop $SERVICE_NAME
     rm -f network-control-consumer_1.0_all.snap net-query.output net-command.output $SERVICE_FILE
     . $TESTSLIB/network.sh
-    arp -d $ARP_ENTRY_ADDR -i $(get_default_iface)
+    arp -d $ARP_ENTRY_ADDR -i $(get_default_iface) || true
 
 execute: |
     CONNECTED_PATTERN=":network-control +network-control-consumer"


### PR DESCRIPTION
If the test fails and the arp entry is not created the restore step would fail, this change prevents it.