### PR TITLE
interface: add usb device support to serial-port

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -354,12 +354,21 @@ Can manage processes via signals and nice.
 
 ### serial-port
 
-Can access serial ports. This is restricted because it provides privileged
-access to configure serial port hardware.
+Provide access to serial ports identfied by either device path or USB VID & PID.
+This is restricted because it provides privileged access to configure serial
+port hardware.
 
 * Auto-Connect: no
 * Attributes:
-    * path (slot): path to serial device
+    * path (slot): path to serial device provided
+    * path (plug): path to requested serial device
+    * vendor-id (plug): the 16-bit USB vendor identifier
+    * product-id (plug): the 16-bit USB product identifier
+
+If identifying serial port devices by VID & PID both vendor-id and product-id
+must be specified in the plug declaration.
+If identifying a serial port by device path the plug and slot must have matching
+path attributes.
 
 ### snapd-control
 

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -41,13 +42,27 @@ func (iface *SerialPortInterface) String() string {
 
 // Pattern to match allowed serial device nodes, path attributes will be
 // compared to this for validity
-var serialAllowedPathPattern = regexp.MustCompile("^/dev/tty[A-Z]{1,3}[0-9]{1,3}$")
+var serialAllowedPathPattern = regexp.MustCompile(`^/dev/tty[A-Z]{1,3}[0-9]{1,3}$`)
+
+// Strings used to build up udev snippet for VID+PID identified devices. The TAG
+// attribute of the udev rule is used to indicate that devices with these
+// parameters should be added to the apps device cgroup
+var udevVidPidFormat = regexp.MustCompile(`^[\da-fA-F]{4}$`)
+var udevHeader = `IMPORT{builtin}="usb_id"`
+var udevEntryPattern = `SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", ATTRS{idProduct}=="%s"`
+var udevEntryTagPattern = `, TAG+="%s"`
 
 // SanitizeSlot checks validity of the defined slot
 func (iface *SerialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Check slot is of right type
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
+	}
+
+	// Allow the core snap to create implicits serial-port slots with no
+	// attributes. These will be used to grant access based on Udev rules
+	if slot.Snap.Type == "os" && len(slot.Attrs) == 0 {
+		return nil
 	}
 
 	// Check slot has a path attribute identify serial device
@@ -67,20 +82,42 @@ func (iface *SerialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // SanitizePlug checks and possibly modifies a plug.
-func (iface *SerialPortInterface) SanitizePlug(slot *interfaces.Plug) error {
-	if iface.Name() != slot.Interface {
+func (iface *SerialPortInterface) SanitizePlug(plug *interfaces.Plug) error {
+	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
-	// NOTE: currently we don't check anything on the plug side.
+
+	if len(plug.Attrs) == 0 {
+		return nil
+	}
+
+	if len(plug.Attrs) != 2 {
+		return fmt.Errorf("serial-port plug definition has unexpected number of attributes")
+	}
+
+	idVendor, vOk := plug.Attrs["vendor-id"].(string)
+	if !vOk {
+		return fmt.Errorf("serial-port plug failed to find vendor-id attribute")
+	}
+	if !udevVidPidFormat.MatchString(idVendor) {
+		return fmt.Errorf("serial-port vendor-id attribute not valid: %s", idVendor)
+	}
+
+	idProduct, pOk := plug.Attrs["product-id"].(string)
+	if !pOk {
+		return fmt.Errorf("serial-port plug failed to find product-id attribute")
+	}
+	if !udevVidPidFormat.MatchString(idProduct) {
+		return fmt.Errorf("serial-port product-id attribute not valid: %s", idProduct)
+	}
+
 	return nil
 }
 
 // PermanentSlotSnippet returns snippets granted on install
 func (iface *SerialPortInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(fmt.Sprintf("\n%s rwk,\n", iface.path(slot))), nil
-	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
@@ -109,21 +146,54 @@ func (iface *SerialPortInterface) PermanentPlugSnippet(plug *interfaces.Plug, se
 
 // ConnectedPlugSnippet returns security snippet specific to the plug
 func (iface *SerialPortInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+
+	path, ok := slot.Attrs["path"].(string)
+	if !ok || path == "" {
+		// don't have path attribute so must be using Udev tagging
+
+		switch securitySystem {
+		case interfaces.SecurityAppArmor:
+			// Wildcarded apparmor snippet as the cgroup will restrict down to the
+			// specific device
+			return []byte("/dev/tty* rw,\n"), nil
+		case interfaces.SecurityUDev:
+			idVendor, vOk := plug.Attrs["vendor-id"].(string)
+			if !vOk {
+				return nil, fmt.Errorf("serial-port plug failed to find vendor-id attribute")
+			}
+			idProduct, pOk := plug.Attrs["product-id"].(string)
+			if !pOk {
+				return nil, fmt.Errorf("serial-port plug failed to find product-id attribute")
+			}
+			var udevSnippet bytes.Buffer
+			udevSnippet.WriteString(udevHeader + "\n")
+			for appName := range plug.Apps {
+				udevSnippet.WriteString(fmt.Sprintf(udevEntryPattern, idVendor, idProduct))
+				tag := fmt.Sprintf("snap_%s_%s", plug.Snap.Name(), appName)
+				udevSnippet.WriteString(fmt.Sprintf(udevEntryTagPattern, tag) + "\n")
+			}
+			return udevSnippet.Bytes(), nil
+		}
+	} else {
+		// use path attribute to generate specific device apparmor snippet
+		// no udev required for this
+
+		cleanedPath := filepath.Clean(path)
+
+		switch securitySystem {
+		case interfaces.SecurityAppArmor:
+			return []byte(fmt.Sprintf("%s rwk,\n", cleanedPath)), nil
+		case interfaces.SecurityUDev:
+			return nil, nil
+		}
+	}
+
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(fmt.Sprintf("%s rwk,\n", iface.path(slot))), nil
-	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
+	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity
 	}
-}
-
-func (iface *SerialPortInterface) path(slot *interfaces.Slot) string {
-	if path, ok := slot.Attrs["path"].(string); ok {
-		return filepath.Clean(path)
-	}
-	panic("slot is not sanitized")
 }
 
 // AutoConnect indicates whether this type of interface should allow autoconnect

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -48,9 +48,10 @@ var serialAllowedPathPattern = regexp.MustCompile(`^/dev/tty[A-Z]{1,3}[0-9]{1,3}
 // attribute of the udev rule is used to indicate that devices with these
 // parameters should be added to the apps device cgroup
 var udevVidPidFormat = regexp.MustCompile(`^[\da-fA-F]{4}$`)
-var udevHeader = `IMPORT{builtin}="usb_id"`
-var udevEntryPattern = `SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", ATTRS{idProduct}=="%s"`
-var udevEntryTagPattern = `, TAG+="%s"`
+
+const udevHeader string = `IMPORT{builtin}="usb_id"`
+const udevEntryPattern string = `SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", ATTRS{idProduct}=="%s"`
+const udevEntryTagPattern string = `, TAG+="%s"`
 
 // SanitizeSlot checks validity of the defined slot
 func (iface *SerialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
@@ -95,7 +96,7 @@ func (iface *SerialPortInterface) SanitizePlug(plug *interfaces.Plug) error {
 	switch len(plug.Attrs) {
 	case 1:
 		// In the case of one attribute it should be valid path attribute
-		// Check slot has a path attribute identify serial device
+		// Check the plug has a path attribute to identify the serial device
 		path, ok := plug.Attrs["path"].(string)
 		if !ok || path == "" {
 			return fmt.Errorf(`serial-port plug found one attribute but it was not "path"`)

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -40,13 +40,17 @@ type SerialPortInterfaceSuite struct {
 	badPathSlot2     *interfaces.Slot
 	badPathSlot3     *interfaces.Slot
 	badInterfaceSlot *interfaces.Slot
-	plug             *interfaces.Plug
 	udevPlug1        *interfaces.Plug
-	badInterfacePlug *interfaces.Plug
+	pathPlug1        *interfaces.Plug
+	pathPlug2        *interfaces.Plug
+	pathPlug3        *interfaces.Plug
+	pathPlug4        *interfaces.Plug
+	emptyBadPlug1    *interfaces.Plug
 	udevBadPlug1     *interfaces.Plug
 	udevBadPlug2     *interfaces.Plug
 	udevBadPlug3     *interfaces.Plug
 	udevBadPlug4     *interfaces.Plug
+	badInterfacePlug *interfaces.Plug
 	osSlot           *interfaces.Slot
 }
 
@@ -82,11 +86,23 @@ slots:
         path: /dev/ttyUSB9271
     bad-interface: other-interface
 plugs:
-    plug: serial-port
     test-udev-1:
         interface: serial-port
         vendor-id: "0000"
         product-id: "aaaa"
+    test-plug-1:
+        interface: serial-port
+        path: /dev/ttyS0
+    test-plug-2:
+        interface: serial-port
+        path: /dev/ttyAMA2
+    test-plug-3:
+        interface: serial-port
+        path: /dev/ttyUSB927
+    test-plug-4:
+        interface: serial-port
+        path: /dev/ttyS42
+    bad-empty-plug: serial-port
     bad-udev-attrs-1:
         interface: serial-port
         product-id: "1111"
@@ -104,6 +120,7 @@ plugs:
     bad-interface: other-interface
 `))
 	c.Assert(err, IsNil)
+	// Slots
 	s.testSlot1 = &interfaces.Slot{SlotInfo: info.Slots["test-port-1"]}
 	s.testSlot2 = &interfaces.Slot{SlotInfo: info.Slots["test-port-2"]}
 	s.testSlot3 = &interfaces.Slot{SlotInfo: info.Slots["test-port-3"]}
@@ -113,8 +130,14 @@ plugs:
 	s.badPathSlot2 = &interfaces.Slot{SlotInfo: info.Slots["bad-path-2"]}
 	s.badPathSlot3 = &interfaces.Slot{SlotInfo: info.Slots["bad-path-3"]}
 	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-interface"]}
-	s.plug = &interfaces.Plug{PlugInfo: info.Plugs["plug"]}
+
+	// Plugs
 	s.udevPlug1 = &interfaces.Plug{PlugInfo: info.Plugs["test-udev-1"]}
+	s.pathPlug1 = &interfaces.Plug{PlugInfo: info.Plugs["test-plug-1"]}
+	s.pathPlug2 = &interfaces.Plug{PlugInfo: info.Plugs["test-plug-2"]}
+	s.pathPlug3 = &interfaces.Plug{PlugInfo: info.Plugs["test-plug-3"]}
+	s.pathPlug4 = &interfaces.Plug{PlugInfo: info.Plugs["test-plug-4"]}
+	s.emptyBadPlug1 = &interfaces.Plug{PlugInfo: info.Plugs["bad-empty-plug"]}
 	s.udevBadPlug1 = &interfaces.Plug{PlugInfo: info.Plugs["bad-udev-attrs-1"]}
 	s.udevBadPlug2 = &interfaces.Plug{PlugInfo: info.Plugs["bad-udev-attrs-2"]}
 	s.udevBadPlug3 = &interfaces.Plug{PlugInfo: info.Plugs["bad-udev-attrs-3"]}
@@ -144,7 +167,7 @@ func (s *SerialPortInterfaceSuite) TestSanitizePathSlot(c *C) {
 
 	// Slots without the "path" attribute are rejected.
 	err := s.iface.SanitizeSlot(s.missingPathSlot)
-	c.Assert(err, ErrorMatches, "serial-port slot must have a path attribute")
+	c.Assert(err, ErrorMatches, `serial-port slot does not have "path" attribute`)
 
 	// Slots with incorrect value of the "path" attribute are rejected.
 	for _, slot := range []*interfaces.Slot{s.badPathSlot1, s.badPathSlot2, s.badPathSlot3} {
@@ -162,16 +185,18 @@ func (s *SerialPortInterfaceSuite) TestSanitizeCoreSlot(c *C) {
 }
 
 func (s *SerialPortInterfaceSuite) TestSanitizeGoodPlugs(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	for _, plug := range []*interfaces.Plug{s.udevPlug1, s.pathPlug1, s.pathPlug2, s.pathPlug3, s.pathPlug4} {
+		err := s.iface.SanitizePlug(plug)
+		c.Assert(err, IsNil)
+	}
 }
 
 func (s *SerialPortInterfaceSuite) TestSanitizeBadPlugs(c *C) {
 	err := s.iface.SanitizePlug(s.udevBadPlug1)
-	c.Assert(err, ErrorMatches, `serial-port plug definition has unexpected number of attributes`)
+	c.Assert(err, ErrorMatches, `serial-port plug found one attribute but it was not "path"`)
 
 	err = s.iface.SanitizePlug(s.udevBadPlug2)
-	c.Assert(err, ErrorMatches, `serial-port plug definition has unexpected number of attributes`)
+	c.Assert(err, ErrorMatches, `serial-port plug found one attribute but it was not "path"`)
 
 	err = s.iface.SanitizePlug(s.udevBadPlug3)
 	c.Assert(err, ErrorMatches, `serial-port product-id attribute not valid: 1`)
@@ -183,29 +208,27 @@ func (s *SerialPortInterfaceSuite) TestSanitizeBadPlugs(c *C) {
 	c.Assert(func() { s.iface.SanitizePlug(s.badInterfacePlug) }, PanicMatches, `plug is not of interface "serial-port"`)
 }
 
-func (s *SerialPortInterfaceSuite) TestConnectedEmptyPlugSnippetUnusedSecuritySystems(c *C) {
-	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2, s.testSlot3, s.testSlot4} {
-		// No extra seccomp permissions for plug
-		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecuritySecComp)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra dbus permissions for plug
-		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityDBus)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra udev permissions for plug
-		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityUDev)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra mount permissions for plug
-		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityMount)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// Other security types are not recognized
-		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, slot, "foo")
-		c.Assert(err, ErrorMatches, `unknown security system`)
-		c.Assert(snippet, IsNil)
-	}
+func (s *SerialPortInterfaceSuite) TestConnectedPathPlugSnippetUnusedSecuritySystems(c *C) {
+	// No extra seccomp permissions for plug
+	snippet, err := s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra dbus permissions for plug
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra udev permissions for plug
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra mount permissions for plug
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityMount)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// Other security types are not recognized
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system`)
+	c.Assert(snippet, IsNil)
 }
 
 func (s *SerialPortInterfaceSuite) TestConnectedUdevPlugSnippetGivesExtraPermissions(c *C) {
@@ -218,27 +241,27 @@ func (s *SerialPortInterfaceSuite) TestConnectedUdevPlugSnippetGivesExtraPermiss
 
 func (s *SerialPortInterfaceSuite) TestPermanentPlugSnippetUnusedSecuritySystems(c *C) {
 	// No extra apparmor permissions for plug
-	snippet, err := s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	// No extra seccomp permissions for plug
-	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecuritySecComp)
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	// No extra dbus permissions for plug
-	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityDBus)
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	// No extra udev permissions for plug
-	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityUDev)
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecurityUDev)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	// No extra mount permissions for plug
-	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityMount)
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecurityMount)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	// Other security types are not recognized
-	snippet, err = s.iface.PermanentPlugSnippet(s.plug, "foo")
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, "foo")
 	c.Assert(err, ErrorMatches, `unknown security system`)
 	c.Assert(snippet, IsNil)
 }
@@ -247,56 +270,54 @@ func (s *SerialPortInterfaceSuite) TestConnectedEmptyPlugSnippetGivesExtraPermis
 	// slot snippet 1
 	expectedPlugSnippet1 := []byte(`/dev/ttyS0 rwk,
 `)
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.testSlot1, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, expectedPlugSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedPlugSnippet1, snippet))
 	// slot snippet 2
 	expectedPlugSnippet2 := []byte(`/dev/ttyAMA2 rwk,
 `)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.testSlot2, interfaces.SecurityAppArmor)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug2, s.testSlot2, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, expectedPlugSnippet2, Commentf("\nexpected:\n%s\nfound:\n%s", expectedPlugSnippet2, snippet))
 	// slot snippet 3
 	expectedPlugSnippet3 := []byte(`/dev/ttyUSB927 rwk,
 `)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.testSlot3, interfaces.SecurityAppArmor)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug3, s.testSlot3, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, expectedPlugSnippet3, Commentf("\nexpected:\n%s\nfound:\n%s", expectedPlugSnippet3, snippet))
 	// slot snippet 4
 	expectedPlugSnippet4 := []byte(`/dev/ttyS42 rwk,
 `)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.testSlot4, interfaces.SecurityAppArmor)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug4, s.testSlot4, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, expectedPlugSnippet4, Commentf("\nexpected:\n%s\nfound:\n%s", expectedPlugSnippet4, snippet))
 }
 
 func (s *SerialPortInterfaceSuite) TestConnectedSlotSnippetUnusedSecuritySystems(c *C) {
-	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2, s.testSlot3, s.testSlot4} {
-		// No extra apparmor permissions for slot
-		snippet, err := s.iface.ConnectedSlotSnippet(s.plug, slot, interfaces.SecurityAppArmor)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra seccomp permissions for slot
-		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, slot, interfaces.SecuritySecComp)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra dbus permissions for slot
-		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, slot, interfaces.SecurityDBus)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra udev permissions for slot
-		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, slot, interfaces.SecurityUDev)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// No extra mount permissions for slot
-		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, slot, interfaces.SecurityMount)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, IsNil)
-		// Other security types are not recognized
-		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, slot, "foo")
-		c.Assert(err, ErrorMatches, `unknown security system`)
-		c.Assert(snippet, IsNil)
-	}
+	// No extra apparmor permissions for slot
+	snippet, err := s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra seccomp permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra dbus permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra udev permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra mount permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityMount)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// Other security types are not recognized
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system`)
+	c.Assert(snippet, IsNil)
 }
 
 func (s *SerialPortInterfaceSuite) TestPermanentSlotSnippetUnusedSecuritySystems(c *C) {

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -44,6 +44,7 @@ var implicitSlots = []string{
 	"opengl",
 	"ppp",
 	"process-control",
+	"serial-port",
 	"snapd-control",
 	"system-observe",
 	"system-trace",

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -42,7 +42,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 23)
+	c.Assert(info.Slots, HasLen, 24)
 }
 
 func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 33)
+	c.Assert(info.Slots, HasLen, 34)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
Now allow serial-ports to be used in two ways:

1. A fixed "path: /dev/tty.." attribute defined on the slot with no attributes expected on the plug
2. A implicit slot with no attributes declared by the core snap, which may be connected to by a plug with VID & PID attributes. These will be used to create a UDev rule with a TAG that will cause snap-confine to set up cgroups such that only matching devices will be accessible.
