### PR TITLE
osutil: do not error if the SUDO_USER can not be looked up

### DIFF
--- a/osutil/user.go
+++ b/osutil/user.go
@@ -83,6 +83,10 @@ func RealUser() (*user.User, error) {
 	}
 
 	real, err := user.Lookup(realName)
+	// can happen when sudo is used to enter a chroot (e.g. pbuilder)
+	if _, ok := err.(user.UnknownUserError); ok {
+		return cur, nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is not a real error, it may happen if e.g. sudo is used to enter
a chroot. This is what pbulider is doing and RealUser() breaks
building snapd with pbuilder (a very common use-case).