### PR TITLE
partition: Revert "clear snap_try_{kernel,core} on success"

### DIFF
--- a/partition/bootloader.go
+++ b/partition/bootloader.go
@@ -145,11 +145,8 @@ func MarkBootSuccessful(bootloader Bootloader) error {
 		if err := bootloader.SetBootVar(newKey, value); err != nil {
 			return err
 		}
+
 		if err := bootloader.SetBootVar("snap_mode", modeSuccess); err != nil {
-			return err
-		}
-		// clear "snap_try_{core,kernel}"
-		if err := bootloader.SetBootVar(k, ""); err != nil {
 			return err
 		}
 	}

--- a/partition/bootloader_test.go
+++ b/partition/bootloader_test.go
@@ -86,10 +86,9 @@ func (s *PartitionTestSuite) TestForceBootloader(c *C) {
 
 func (s *PartitionTestSuite) TestMarkBootSuccessfulAllSnap(c *C) {
 	expected := map[string]string{
-		// cleared
 		"snap_mode":       "",
-		"snap_try_kernel": "",
-		"snap_try_core":   "",
+		"snap_try_kernel": "k1",
+		"snap_try_core":   "os1",
 		// updated
 		"snap_kernel": "k1",
 		"snap_core":   "os1",


### PR DESCRIPTION
This reverts commit e570e7ad1f09e9ff2edb2cf5d5ebbfd16a1c4e22.

This fixes the issues that in "try" mode the bootloader will try to boot from the kernel/core in the snap_try_{kernel,core} variable and this is empty now.