### PR TITLE
interfaces: bluez: add missing mount security snippet case

### DIFF
--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -210,7 +210,7 @@ func (iface *BluezInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *i
 		return snippet, nil
 	case interfaces.SecuritySecComp:
 		return bluezConnectedPlugSecComp, nil
-	case interfaces.SecurityUDev, interfaces.SecurityDBus:
+	case interfaces.SecurityUDev, interfaces.SecurityDBus, interfaces.SecurityMount:
 		return nil, nil
 	default:
 		return nil, interfaces.ErrUnknownSecurity


### PR DESCRIPTION
Without this not interface connection from a plug to a slot can be made.

This is relative critical as it prevents users from connecting plugs with the bluez interface and bluez snap becomes basically unusable.