### PR TITLE
asserts: export DecodePublicKey

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -68,7 +68,7 @@ func (ak *AccountKey) publicKey() PublicKey {
 }
 
 func checkPublicKey(ab *assertionBase, keyIDName string) (PublicKey, error) {
-	pubKey, err := decodePublicKey(ab.Body())
+	pubKey, err := DecodePublicKey(ab.Body())
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -200,7 +200,7 @@ func RSAPublicKey(pubKey *rsa.PublicKey) PublicKey {
 	return newOpenPGPPubKey(intPubKey)
 }
 
-// DecodePublicKey deserializes a public key from a slice of bytes.
+// DecodePublicKey deserializes a public key.
 func DecodePublicKey(pubKey []byte) (PublicKey, error) {
 	pkt, err := decodeV1(pubKey, "public key")
 	if err != nil {

--- a/asserts/crypto.go
+++ b/asserts/crypto.go
@@ -200,7 +200,8 @@ func RSAPublicKey(pubKey *rsa.PublicKey) PublicKey {
 	return newOpenPGPPubKey(intPubKey)
 }
 
-func decodePublicKey(pubKey []byte) (PublicKey, error) {
+// DecodePublicKey deserializes a public key from a slice of bytes.
+func DecodePublicKey(pubKey []byte) (PublicKey, error) {
 	pkt, err := decodeV1(pubKey, "public key")
 	if err != nil {
 		return nil, err

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -177,7 +177,7 @@ func assembleSerial(assert assertionBase) (Assertion, error) {
 	if err != nil {
 		return nil, err
 	}
-	pubKey, err := decodePublicKey([]byte(encodedKey))
+	pubKey, err := DecodePublicKey([]byte(encodedKey))
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -241,7 +241,7 @@ func assembleSerialRequest(assert assertionBase) (Assertion, error) {
 	if err != nil {
 		return nil, err
 	}
-	pubKey, err := decodePublicKey([]byte(encodedKey))
+	pubKey, err := DecodePublicKey([]byte(encodedKey))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
snap-assertions-service wants to use this so that it can have an
endpoint that takes a serialized public key and returns its SHA3-384
fingerprint.  EncodePublicKey was already exported, so this makes sense
for symmetry too.