### PR TITLE
interfaces/hardware-observe.go: re-add /run/udev/data

### DIFF
--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -39,6 +39,9 @@ capability sys_rawio,
 /sys/firmware/dmi/tables/DMI r,
 /sys/firmware/dmi/tables/smbios_entry_point r,
 
+# Needed for udevadm
+/run/udev/data/** r,
+
 # util-linux
 /{,usr/}bin/lscpu ixr,
 @{PROC}/bus/pci/devices r,


### PR DESCRIPTION
This was in initially but was incorrectly removed