### PR TITLE
osutil: fix create-user on classic

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1491,7 +1491,7 @@ func abortChange(c *Command, r *http.Request, user *auth.UserState) Response {
 var (
 	postCreateUserUcrednetGetUID = ucrednetGetUID
 	storeUserInfo                = store.UserInfo
-	osutilAddExtraUser           = osutil.AddExtraUser
+	osutilAddUser                = osutil.AddUser
 )
 
 func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -1526,7 +1526,13 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 	}
 
 	gecos := fmt.Sprintf("%s,%s", createData.Email, v.OpenIDIdentifier)
-	if err := osutilAddExtraUser(v.Username, v.SSHKeys, gecos, createData.Sudoer); err != nil {
+	opts := &osutil.AddUserOptions{
+		SSHKeys:    v.SSHKeys,
+		Gecos:      gecos,
+		Sudoer:     createData.Sudoer,
+		ExtraUsers: !release.OnClassic,
+	}
+	if err := osutilAddUser(v.Username, opts); err != nil {
 		return BadRequest("cannot create user %s: %s", v.Username, err)
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -396,7 +396,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"snapstateUpdateMany",
 		"snapstateRefreshCandidates",
 		"readSnapInfo",
-		"osutilAddExtraSudoUser",
+		"osutilAddUser",
 		"storeUserInfo",
 		"postCreateUserUcrednetGetUID",
 		"ensureStateSoon",
@@ -3289,11 +3289,11 @@ func (s *apiSuite) TestPostCreateUser(c *check.C) {
 			OpenIDIdentifier: "xxyyzz",
 		}, nil
 	}
-	osutilAddExtraUser = func(username string, sshKeys []string, gecos string, sudoer bool) error {
+	osutilAddUser = func(username string, opts *osutil.AddUserOptions) error {
 		c.Check(username, check.Equals, "karl")
-		c.Check(sshKeys, check.DeepEquals, []string{"ssh1", "ssh2"})
-		c.Check(gecos, check.Equals, "popper@lse.ac.uk,xxyyzz")
-		c.Check(sudoer, check.Equals, false)
+		c.Check(opts.SSHKeys, check.DeepEquals, []string{"ssh1", "ssh2"})
+		c.Check(opts.Gecos, check.Equals, "popper@lse.ac.uk,xxyyzz")
+		c.Check(opts.Sudoer, check.Equals, false)
 		return nil
 	}
 
@@ -3301,7 +3301,7 @@ func (s *apiSuite) TestPostCreateUser(c *check.C) {
 		return 0, nil
 	}
 	defer func() {
-		osutilAddExtraUser = osutil.AddExtraUser
+		osutilAddUser = osutil.AddUser
 		postCreateUserUcrednetGetUID = ucrednetGetUID
 	}()
 

--- a/release/release.go
+++ b/release/release.go
@@ -23,9 +23,9 @@ import (
 	"bufio"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/snapcore/snapd/osutil"
-	"unicode"
 )
 
 // Series holds the Ubuntu Core series for snapd to use.

--- a/spread.yaml
+++ b/spread.yaml
@@ -69,6 +69,7 @@ prepare: |
     dch -i "testing build"
 
     test -d /home/test || adduser --quiet --disabled-password --gecos '' test
+    echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
     chown test.test -R ..
     sudo -i -u test /bin/sh -c "cd $PWD && DEB_BUILD_OPTIONS='nocheck testkeys' dpkg-buildpackage -tc -b -Zgzip"
 

--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -1,0 +1,30 @@
+summary: Ensure create-user functionality 
+
+systems: [-ubuntu-core-16-64]
+
+environment:
+    USER_EMAIL: mvo@ubuntu.com
+    USER_NAME: mvo
+
+restore: |
+    userdel -r $USER_NAME
+    rm -rf /etc/sudoers.d/create-user-$USER_NAME
+
+execute: |
+    echo "snap create-user -- ensure failure when no email address provided"
+    expected="error: bad user result: cannot create user: 'email' field is empty"
+    snap create-user 2>&1 | grep -q "$expected"
+
+    echo "snap create-user -- ensure failure when run as non-root user without sudo"
+    expected="error: bad user result: access denied"
+    su - test /bin/sh -c "SNAP_REEXEC=0 snap create-user $USER_EMAIL 2>&1" | grep -q "$expected"
+
+    echo "snap create-user -- ensure success when run as non-root user with sudo"
+    expected="Created user \"$USER_NAME\" and imported SSH keys."
+    su - test /bin/sh -c "sudo SNAP_REEXEC=0 snap create-user --sudoer $USER_EMAIL 2>&1" | grep -q "$expected"
+
+    echo "ensure user exists in /etc/passwd"
+    grep -qE "^$USER_NAME:x:[0-9]+:[0-9]+:$USER_EMAIL" /etc/passwd
+
+    echo "ensure proper sudoers.d file"
+    grep -q "$USER_NAME ALL=(ALL) NOPASSWD:ALL" /etc/sudoers.d/create-user-$USER_NAME


### PR DESCRIPTION
This PR allows creating users on classic systems by removing '--extrausers' parameter from adduser command and adds a classic-specific test.

This is a continuation of [this PR](https://github.com/snapcore/snapd/pull/1663), which I closed because the underlying branch changed.

The change required a workaround in the 'release' package to remove its dependency on 'osutil.' This isn't the most elegant solution but was probably the simplest change to avoid an import cycle between the two packages -- I'd be open to other thoughts, though.

