### PR TITLE
boot: add support for "devmode: {true,false}" in seed.yaml

### DIFF
--- a/overlord/boot/export_test.go
+++ b/overlord/boot/export_test.go
@@ -20,6 +20,6 @@
 package boot
 
 var (
-	PopulateStateFromInstalled = populateStateFromInstalled
-	NameAndRevnoFromSnap       = nameAndRevnoFromSnap
+	PopulateStateFromSeed = populateStateFromSeed
+	NameAndRevnoFromSnap  = nameAndRevnoFromSnap
 )

--- a/snap/seed_yaml.go
+++ b/snap/seed_yaml.go
@@ -41,7 +41,8 @@ type SeedSnap struct {
 	Private     bool     `yaml:"private,omitempty" json:"private,omitempty"`
 
 	// not in side-info
-	File string `yaml:"file"`
+	File    string `yaml:"file"`
+	DevMode bool   `yaml:"devmode"`
 }
 
 type Seed struct {

--- a/snap/seed_yaml_test.go
+++ b/snap/seed_yaml_test.go
@@ -39,6 +39,7 @@ snaps:
    channel: stable
    revision: 31
    file: foo_1.0_all.snap
+   devmode: true
 `)
 
 func (s *seedYamlTestSuite) TestSimple(c *C) {
@@ -55,6 +56,7 @@ func (s *seedYamlTestSuite) TestSimple(c *C) {
 		SnapID:   "snapidsnapidsnapid",
 		Channel:  "stable",
 		Revision: snap.R(31),
+		DevMode:  true,
 	})
 }
 


### PR DESCRIPTION
This allows to have a `devmode` flag in seed.yaml that is honored on firstboot install to allow to install devmode snaps via seed.yaml.