### PR TITLE
release: Remove "UBUNTU_CODENAME" from the test data

### DIFF
--- a/release/release_test.go
+++ b/release/release_test.go
@@ -55,7 +55,6 @@ VERSION_ID="18.09"
 HOME_URL="http://www.ubuntu.com/"
 SUPPORT_URL="http://help.ubuntu.com/"
 BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
-UBUNTU_CODENAME=awesome
 `
 	err := ioutil.WriteFile(mockOSRelease, []byte(s), 0644)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
We don't use it anymore and it is deprecated in favour of upstreams
VERSION_CODENAME.

LP: #1598212