### PR TITLE
interfaces: add fwupd interface

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -264,6 +264,12 @@ Can mount fuse filesystems (as root only).
 
 * Auto-Connect: no
 
+### fwupd
+
+Can access snaps providing the fwupd interface which gives privileged access to update UEFI capsule format firmware.
+
+* Auto-Connect: no
+
 ### hardware-observe
 
 Can query hardware information from the system.

--- a/integration-tests/manual-tests.md
+++ b/integration-tests/manual-tests.md
@@ -263,3 +263,25 @@ $ snap remove bluez
       lid-is-closed:   no
       lid-is-present:  no
       critical-action: HybridSleep
+
+# Test fwupd interface with uefi-fw-tools
+
+1. Ensure your BIOS support UEFI firmware upgrading via UEFI capsule format
+2. Install the uefi-fw-tools snap from the store
+3. Ensure the 'fwupd' interface is connected
+
+ $ sudo snap connect uefi-fw-tools:fwupdmgr uefi-fw-tools:fwupd
+
+4. Check if the device support UEFI firmware updates
+
+ $ sudo uefi-fw-tools.fwupdmgr get-devices
+
+5. Get available UEFI firmware from the server
+
+ $ sudo uefi-fw-tools.fwupdmgr refresh
+
+6. Download firmware
+
+ $ sudo uefi-fw-tools.fwupdmgr update
+
+7. Reboot and ensure it start the upgrading process

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -39,6 +39,7 @@ var allInterfaces = []interfaces.Interface{
 	&PppInterface{},
 	&SerialPortInterface{},
 	&PulseAudioInterface{},
+	&FwupdInterface{},
 	NewFirewallControlInterface(),
 	NewGsettingsInterface(),
 	NewHardwareObserveInterface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -43,6 +43,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.MprisInterface{})
 	c.Check(all, Contains, &builtin.SerialPortInterface{})
 	c.Check(all, Contains, &builtin.PulseAudioInterface{})
+	c.Check(all, Contains, &builtin.FwupdInterface{})
 	c.Check(all, DeepContains, builtin.NewFirewallControlInterface())
 	c.Check(all, DeepContains, builtin.NewGsettingsInterface())
 	c.Check(all, DeepContains, builtin.NewHomeInterface())

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -1,0 +1,229 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"bytes"
+	"github.com/snapcore/snapd/interfaces"
+)
+
+var fwupdPermanentSlotAppArmor = []byte(`
+# Description: Allow operating as the fwupd service. Reserved because this
+#  gives privileged access to the system.
+# Usage: reserved
+
+  # Allow read/write access for old efivars sysfs interface
+  capability sys_admin,
+
+  # File accesses
+  # Allow access for EFI System Resource Table in the UEFI 2.5+ specification
+  /sys/firmware/efi/esrt/entries/ r,
+  /sys/firmware/efi/esrt/entries/** r,
+
+  # Allow fwupd to access system information
+  /sys/devices/virtual/dmi/id/product_name r,
+  /sys/devices/virtual/dmi/id/sys_vendor r,
+
+  # File accesses
+  # Allow read access for efivarfs filesystem
+  /sys/firmware/efi/efivars/ r,
+  /sys/firmware/efi/efivars/** r,
+
+  # DBus accesses
+  #include <abstractions/dbus-strict>
+  dbus (send)
+      bus=system
+      path=/org/freedesktop/DBus
+      interface=org.freedesktop.DBus
+      member={Request,Release}Name
+      peer=(name=org.freedesktop.DBus),
+
+  dbus (receive, send)
+      bus=system
+      path=/org/freedesktop/DBus
+      interface=org.freedesktop.DBus
+      member=GetConnectionUnixUser
+      peer=(label=unconfined),
+
+  # Allow binding the service to the requested connection name
+  dbus (bind)
+      bus=system
+      name="org.freedesktop.fwupd",
+`)
+
+var fwupdConnectedPlugAppArmor = []byte(`
+# Description: Allow using fwupd service. Reserved because this gives
+#  privileged access to the fwupd service.
+# Usage: reserved
+
+  # DBus accesses
+  #include <abstractions/dbus-strict>
+
+  # Allow access to fwupd service
+  dbus (receive, send)
+      bus=system
+      path=/
+      interface=org.freedesktop.fwupd
+      peer=(label=###SLOT_SECURITY_TAGS###),
+
+  dbus (receive, send)
+      bus=system
+      path=/
+      interface=org.freedesktop.DBus.Properties
+      peer=(label=###SLOT_SECURITY_TAGS###),
+`)
+
+var fwupdConnectedSlotAppArmor = []byte(`
+# Description: Allow firmware update from fwupd service. Reserved because this gives
+#  privileged access to the system.
+# Usage: reserved
+
+  # Allow libfwup to access efivarfs with immutable flag
+  capability linux_immutable,
+
+  # File accesses
+  # Allow write access for efivarfs filesystem
+  /sys/firmware/efi/efivars/** rw,
+
+  # Allow write access for efi firmware updater
+  /boot/efi/EFI/ubuntu/fw/** rw,
+  # Allow access from efivar library
+  @{PROC}/@{pid}/mounts r,
+  /sys/devices/**/partition r,
+  /dev/sd[a-z]* r,
+  # Allow access UEFI firmware platform size
+  /sys/firmware/efi/ r,
+  /sys/firmware/efi/fw_platform_size r,
+
+  # Allow traffic to/from org.freedesktop.DBus for fwupd service
+  dbus (receive, send)
+      bus=system
+      path=/
+      interface=org.freedesktop.DBus.**
+      peer=(label=###PLUG_SECURITY_TAGS###),
+
+  dbus (receive, send)
+      bus=system
+      path=/org/freedesktop/fwupd{,/**}
+      interface=org.freedesktop.DBus.**
+      peer=(label=###PLUG_SECURITY_TAGS###),
+
+  # Allow traffic to/from fwupd interface with any method
+  dbus (receive, send)
+      bus=system
+      path=/
+      interface=org.freedesktop.fwupd
+      peer=(label=###PLUG_SECURITY_TAGS###),
+
+  dbus (receive, send)
+      bus=system
+      path=/org/freedesktop/fwupd{,/**}
+      interface=org.freedesktop.fwupd
+      peer=(label=###PLUG_SECURITY_TAGS###),
+`)
+
+var fwupdPermanentSlotDBus = []byte(`
+<policy user="root">
+    <allow own="org.freedesktop.fwupd"/>
+</policy>
+<policy context="default">
+    <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.fwupd"/>
+    <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.freedesktop.fwupd" send_interface="org.freedesktop.DBus.Peer"/>
+</policy>
+`)
+
+// FwupdInterface type
+type FwupdInterface struct{}
+
+// Name of the FwupdInterface
+func (iface *FwupdInterface) Name() string {
+	return "fwupd"
+}
+
+// PermanentPlugSnippet - no slot snippets provided
+func (iface *FwupdInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecurityDBus, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedPlugSnippet returns security snippets for plug at connection
+func (iface *FwupdInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		old := []byte("###SLOT_SECURITY_TAGS###")
+		new := slotAppLabelExpr(slot)
+		snippet := bytes.Replace(fwupdConnectedPlugAppArmor, old, new, -1)
+		return snippet, nil
+	case interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityDBus, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// PermanentSlotSnippet returns security snippets for slot at install
+func (iface *FwupdInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		return fwupdPermanentSlotAppArmor, nil
+	case interfaces.SecurityDBus:
+		return fwupdPermanentSlotDBus, nil
+	case interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedSlotSnippet returns security snippets for slot at connection
+func (iface *FwupdInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		old := []byte("###PLUG_SECURITY_TAGS###")
+		new := plugAppLabelExpr(plug)
+		snippet := bytes.Replace(fwupdConnectedSlotAppArmor, old, new, -1)
+		return snippet, nil
+	case interfaces.SecurityDBus, interfaces.SecuritySecComp, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// SanitizePlug checks the plug definition is valid
+func (iface *FwupdInterface) SanitizePlug(plug *interfaces.Plug) error {
+	return nil
+}
+
+// SanitizeSlot checks the slot definition is valid
+func (iface *FwupdInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	return nil
+}
+
+// AutoConnect returns whether interface should be auto-connected by default
+func (iface *FwupdInterface) AutoConnect() bool {
+	return false
+}

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -56,10 +56,8 @@ var fwupdPermanentSlotAppArmor = []byte(`
   # Allow access from efivar library
   owner @{PROC}/@{pid}/mounts r,
   /sys/devices/pci*/**/block/**/partition r,
-  # The efivar library need ESP partition GUID,offset,size
-  #/dev/sd[a-z]* r,
-  # Get data from udev with modified efivar library
-  /run/udev/data/b* r,
+  # Introspect the block devices to get partition guid and size information
+  /run/udev/data/b[0-9]*:[0-9]* r,
 
   # Allow access UEFI firmware platform size
   /sys/firmware/efi/ r,
@@ -85,14 +83,6 @@ var fwupdPermanentSlotAppArmor = []byte(`
   dbus (bind)
       bus=system
       name="org.freedesktop.fwupd",
-
-  # Allow unconfined to talk to us. The API for unconfined will be limited
-  # with DBus policy, below.
-  dbus (receive, send)
-      bus=system
-      path=/
-      interface=org.freedesktop.DBus*
-      peer=(label=unconfined),
 `)
 
 var fwupdConnectedPlugAppArmor = []byte(`

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -1,0 +1,177 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type FwupdInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&FwupdInterfaceSuite{
+	iface: &builtin.FwupdInterface{},
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "uefi-fw-tools"},
+			Name:      "fwupd",
+			Interface: "fwupd",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "uefi-fw-tools"},
+			Name:      "fwupdmgr",
+			Interface: "fwupd",
+		},
+	},
+})
+
+func (s *FwupdInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "fwupd")
+}
+
+// The label glob when all apps are bound to the fwupd slot
+func (s *FwupdInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
+	app1 := &snap.AppInfo{Name: "app1"}
+	app2 := &snap.AppInfo{Name: "app2"}
+	slot := &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap: &snap.Info{
+				SuggestedName: "uefi-fw-tools",
+				Apps:          map[string]*snap.AppInfo{"app1": app1, "app2": app2},
+			},
+			Name:      "fwupd",
+			Interface: "fwupd",
+			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
+		},
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.uefi-fw-tools.*"),`)
+}
+
+// The label uses alternation when some, but not all, apps is bound to the fwupd slot
+func (s *FwupdInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c *C) {
+	app1 := &snap.AppInfo{Name: "app1"}
+	app2 := &snap.AppInfo{Name: "app2"}
+	app3 := &snap.AppInfo{Name: "app3"}
+	slot := &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap: &snap.Info{
+				SuggestedName: "uefi-fw-tools",
+				Apps:          map[string]*snap.AppInfo{"app1": app1, "app2": app2, "app3": app3},
+			},
+			Name:      "fwupd",
+			Interface: "fwupd",
+			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
+		},
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.uefi-fw-tools.{app1,app2}"),`)
+}
+
+// The label uses short form when exactly one app is bound to the fwupd slot
+func (s *FwupdInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c *C) {
+	app := &snap.AppInfo{Name: "app"}
+	slot := &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap: &snap.Info{
+				SuggestedName: "uefi-fw-tools",
+				Apps:          map[string]*snap.AppInfo{"app": app},
+			},
+			Name:      "fwupd",
+			Interface: "fwupd",
+			Apps:      map[string]*snap.AppInfo{"app": app},
+		},
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.uefi-fw-tools.app"),`)
+}
+
+func (s *FwupdInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	for _, system := range [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev, interfaces.SecurityMount} {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+
+	for _, system := range [...]interfaces.SecuritySystem{interfaces.SecuritySecComp,
+		interfaces.SecurityUDev, interfaces.SecurityMount} {
+		snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+
+	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *FwupdInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *FwupdInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -125,8 +125,8 @@ func (s *FwupdInterfaceSuite) TestUnusedSecuritySystems(c *C) {
 		c.Assert(snippet, IsNil)
 	}
 
-	for _, system := range [...]interfaces.SecuritySystem{interfaces.SecuritySecComp,
-		interfaces.SecurityUDev, interfaces.SecurityMount} {
+	for _, system := range [...]interfaces.SecuritySystem{interfaces.SecurityUDev,
+		interfaces.SecurityMount} {
 		snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, IsNil)
@@ -138,7 +138,10 @@ func (s *FwupdInterfaceSuite) TestUnusedSecuritySystems(c *C) {
 		c.Assert(snippet, IsNil)
 	}
 
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
@@ -153,10 +156,16 @@ func (s *FwupdInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
 	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }


### PR DESCRIPTION
An interface that allows fwupd upgrading UEFI firmware via UEFI capsule format.