### PR TITLE
spread: disable re-exec to always test development tree.

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -6,6 +6,7 @@ environment:
     GOPATH: /home/gopath
     PATH: /home/gopath/bin:/snap/bin:$PATH
     TESTSLIB: $[PROJECT_PATH]/tests/lib
+    SNAP_REEXEC: 0
 
 backends:
     linode:
@@ -59,7 +60,7 @@ prepare: |
     [Unit]
     StartLimitInterval=0
     [Service]
-    Environment=SNAPD_DEBUG_HTTP=7
+    Environment=SNAPD_DEBUG_HTTP=7 SNAP_REEXEC=0
     EOF
 
     # Build snapbuild.

--- a/tests/main/snap-run-symlink-error/task.yaml
+++ b/tests/main/snap-run-symlink-error/task.yaml
@@ -9,8 +9,6 @@ restore: |
     rm -f /etc/systemd/system/multi-user.target.wants/snap-*.mount
     systemctl start snapd
 execute: |
-    # FIXME: remove "SNAP_REEXEC" once we have `snap run` inside the os snap
-    export SNAP_REEXEC=0
     echo Setting up incorrect symlink for snap run
     mkdir -p /snap/bin
     ln -s /usr/bin/snap /snap/bin/xxx

--- a/tests/main/snap-run-symlink/task.yaml
+++ b/tests/main/snap-run-symlink/task.yaml
@@ -19,8 +19,7 @@ execute: |
     rm /snap/bin/$APP
     ln -s /usr/bin/snap /snap/bin/$APP
 
-    # FIXME: remove "SNAP_REEXEC" once we have `snap run` inside the os snap
-    SNAP_REEXEC=0 $APP $SNAP/bin/cat
-    SNAP_REEXEC=0 $APP $SNAP/bin/cat > new.txt 2>&1 
+    $APP $SNAP/bin/cat
+    $APP $SNAP/bin/cat > new.txt 2>&1 
 
     diff -u orig.txt new.txt

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -1,6 +1,5 @@
 summary: Check that upgrade works
 restore: |
-    sed -i -e '/SNAP_REEXEC=0/d' /etc/environment
     rm -f /var/tmp/myevil.txt
 execute: |
     echo Install previous version...
@@ -14,11 +13,6 @@ execute: |
     echo Sanity check install
     test-snapd-tools.echo Hello | grep Hello
     test-snapd-tools.env | grep SNAP_NAME=test-snapd-tools
-
-    # setup not to reexec
-    export SNAP_REEXEC=0
-    grep SNAP_REEXEC /etc/environment || echo "SNAP_REEXEC=0">>/etc/environment
-    cat /etc/environment
 
     echo Do upgrade
     # allow-downgrades prevents errors when new versions hit the archive, for instance,


### PR DESCRIPTION
This PR simply sets `SNAP_REEXEC=0` for both daemon and client within spread.yaml