### PR TITLE
partition: ensure that snap_{kernel,core} is not overriden with an empty value

### DIFF
--- a/partition/bootloader.go
+++ b/partition/bootloader.go
@@ -139,7 +139,9 @@ func MarkBootSuccessful(bootloader Bootloader) error {
 		if err != nil {
 			return err
 		}
-
+		if value == "" {
+			continue
+		}
 		// FIXME: ugly string replace
 		newKey := strings.Replace(k, "_try_", "_", -1)
 		if err := bootloader.SetBootVar(newKey, value); err != nil {


### PR DESCRIPTION
When only a single component (core or kernel) is updated the
snap_try_{core,kernel} value is empty. Do not override the real
snap_{core,kernel} in this case.