### PR TITLE
many: add `snap download` command that downloads into /var/lib/snapd/download

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -73,6 +73,11 @@ func (client *Client) Revert(name string, options *SnapOptions) (changeID string
 	return client.doSnapAction("revert", name, options)
 }
 
+// Download downloads the given snap file
+func (client *Client) Download(name string, options *SnapOptions) (changeID string, err error) {
+	return client.doSnapAction("download", name, options)
+}
+
 func (client *Client) doSnapAction(actionName string, snapName string, options *SnapOptions) (changeID string, err error) {
 	action := actionData{
 		Action:      actionName,

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -522,3 +522,23 @@ func (s *SnapOpSuite) TestRemove(c *check.C) {
 	// ensure that the fake server api was actually hit
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
+
+func (s *SnapOpSuite) TestDownload(c *check.C) {
+	s.srv.total = 3
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":  "download",
+			"name":    "foo",
+			"channel": "chan",
+		})
+		s.srv.channel = "chan"
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser().ParseArgs([]string{"download", "--channel", "chan", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -388,6 +388,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"snapstateInstallPath",
 		"snapstateTryPath",
 		"snapstateGet",
+		"snapstateDownload",
 		"readSnapInfo",
 		"osutilAddExtraSudoUser",
 		"storeUserInfo",

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -30,6 +30,7 @@ var (
 
 	SnapSnapsDir              string
 	SnapBlobDir               string
+	SnapDownloadDir           string
 	SnapDataDir               string
 	SnapDataHomeGlob          string
 	SnapAppArmorDir           string
@@ -90,6 +91,7 @@ func SetRootDir(rootdir string) {
 	SnapMountPolicyDir = filepath.Join(rootdir, snappyDir, "mount")
 	SnapMetaDir = filepath.Join(rootdir, snappyDir, "meta")
 	SnapBlobDir = filepath.Join(rootdir, snappyDir, "snaps")
+	SnapDownloadDir = filepath.Join(rootdir, snappyDir, "download")
 	SnapDesktopFilesDir = filepath.Join(rootdir, snappyDir, "desktop", "applications")
 	// keep in sync with the debian/ubuntu-snappy.snapd.socket file:
 	SnapdSocket = filepath.Join(rootdir, "/run/snapd.socket")

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
@@ -509,7 +510,17 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	ss.SnapPath = downloadedSnapFile
+	// used by snapstate.Downlaod()
+	if ss.SnapPath != "" {
+		if err := osutil.CopyFile(downloadedSnapFile, ss.SnapPath, 0); err != nil {
+			return err
+		}
+		if err := os.Remove(downloadedSnapFile); err != nil {
+			return err
+		}
+	} else {
+		ss.SnapPath = downloadedSnapFile
+	}
 	// update the snap setup for the follow up tasks
 	st.Lock()
 	t.Set("snap-setup", ss)

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -1,0 +1,18 @@
+summary: Check that that snap download works
+
+execute: |
+    echo When running `snap download`
+    snap download test-snapd-tools
+    echo A single snap is downloaded into /var/lib/snapd/download
+    ls /var/lib/snapd/download/test-snapd-tools_[0-9]*.snap
+    output=$(ls /var/lib/snapd/download/|wc -l)
+    if [ "$output" != "1" ]; then
+        echo "Multiple files in /var/lib/snapd/download"
+        ls /var/lib/snapd/download
+        exit 1
+    fi
+    echo And the snap looks valid
+    if ! file /var/lib/snapd/download/test-snapd-tools_[0-9]*.snap|grep Squashfs; then
+        echo "Downloaded snap not a squashfs file"
+        exit 1
+    fi


### PR DESCRIPTION
This is an initial and minimal implementation for `snap download`. It will download the given snap to  `/var/lib/snapd/download`. This is enough for me to continue with the spread image test plan (that involves downloading and modifying the ubuntu-core image. Some unit tests missing because I want to check the direction.

However its probably not yet good enough for end-user consumption. I'm keen to hear what we should support. Client selected output dir for download? Client selected target file? Json output so that it can be controlled from scripts? Or YAGNI and add all this once we have use-cases?
