### PR TITLE
asserts: add serial-proof device assertion

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -63,6 +63,7 @@ var (
 
 // Assertion types without a definite authority set (on the wire and/or self-signed).
 var (
+	SerialProofType   = &AssertionType{"serial-proof", nil, assembleSerialProof, noAuthority}
 	SerialRequestType = &AssertionType{"serial-request", nil, assembleSerialRequest, noAuthority}
 )
 
@@ -75,6 +76,7 @@ var typeRegistry = map[string]*AssertionType{
 	SnapBuildType.Name:       SnapBuildType,
 	SnapRevisionType.Name:    SnapRevisionType,
 	// no authority
+	SerialProofType.Name:   SerialProofType,
 	SerialRequestType.Name: SerialRequestType,
 }
 

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -635,7 +635,7 @@ func (as *assertsSuite) TestWithAuthority(c *C) {
 		"model",
 		"serial",
 	}
-	c.Check(withAuthority, HasLen, asserts.NumAssertionType-1) // excluding serial-request
+	c.Check(withAuthority, HasLen, asserts.NumAssertionType-2) // excluding serial-request, serial-proof
 	for _, name := range withAuthority {
 		typ := asserts.Type(name)
 		_, err := asserts.AssembleAndSignInTest(typ, nil, nil, testPrivKey1)

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -200,6 +200,11 @@ type SerialProof struct {
 	assertionBase
 }
 
+// Nonce returns the nonce obtained from store and to be presented when requesting a device session.
+func (sproof *SerialProof) Nonce() string {
+	return sproof.HeaderString("nonce")
+}
+
 func assembleSerialProof(assert assertionBase) (Assertion, error) {
 	_, err := checkNotEmptyString(assert.headers, "nonce")
 	if err != nil {

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -195,6 +195,22 @@ func assembleSerial(assert assertionBase) (Assertion, error) {
 	}, nil
 }
 
+// SerialProof holds a serial-proof assertion, which is a self-signed request to prove device owns device key.
+type SerialProof struct {
+	assertionBase
+}
+
+func assembleSerialProof(assert assertionBase) (Assertion, error) {
+	_, err := checkNotEmptyString(assert.headers, "nonce")
+	if err != nil {
+		return nil, err
+	}
+
+	return &SerialProof{
+		assertionBase: assert,
+	}, nil
+}
+
 // SerialRequest holds a serial-request assertion, which is a self-signed request to obtain a full device identity bound to the device public key.
 type SerialRequest struct {
 	assertionBase

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -330,16 +330,14 @@ func (ss *serialSuite) TestSerialProofHappy(c *C) {
 	err = asserts.SignatureCheck(sproof2, ss.deviceKey.PublicKey())
 	c.Check(err, IsNil)
 
-	c.Check(sproof2.HeaderString("nonce"), Equals, "NONCE")
+	c.Check(sproof2.Nonce(), Equals, "NONCE")
 }
 
 func (ss *serialSuite) TestSerialProofDecodeInvalid(c *C) {
 	encoded := "type: serial-proof\n" +
 		"nonce: NONCE\n" +
-		"body-length: 2\n" +
+		"body-length: 0\n" +
 		"sign-key-sha3-384: " + ss.deviceKey.PublicKey().ID() + "\n\n" +
-		"HW" +
-		"\n\n" +
 		"AXNpZw=="
 
 	invalidTests := []struct{ original, invalid, expectedErr string }{


### PR DESCRIPTION
Add self-signed serial-proof assertion, used to request a device session against the store (for which serial-assertion and serial-proof will be required).