### PR TITLE
interfaces: add hidraw-device interface

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -262,6 +262,24 @@ Can mount fuse filesystems (as root only).
 
 Can query hardware information from the system.
 
+### hidraw-device
+
+Provide access to devices with HIDRaw interfaces identfied by either device path
+or USB VID & PID.
+This is restricted because it provides privileged access to hardware devices.
+
+* Auto-Connect: no
+* Attributes:
+    * path (slot): path to hidraw device provided
+    * path (plug): path to requested hidraw device
+    * vendor-id (plug): the 16-bit USB vendor identifier
+    * product-id (plug): the 16-bit USB product identifier
+
+If identifying hidraw devices by VID & PID both vendor-id and product-id
+must be specified in the plug declaration.
+If identifying a hidraw device by path the plug and slot must have matching
+path attributes.
+
 * Auto-Connect: no
 
 ### kernel-module-control

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -29,6 +29,7 @@ var allInterfaces = []interfaces.Interface{
 	&BrowserSupportInterface{},
 	&ContentInterface{},
 	&GpioInterface{},
+	&HidrawDeviceInterface{},
 	&LocationControlInterface{},
 	&LocationObserveInterface{},
 	&MirInterface{},

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -36,6 +36,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.BluezInterface{})
 	c.Check(all, Contains, &builtin.BrowserSupportInterface{})
 	c.Check(all, Contains, &builtin.GpioInterface{})
+	c.Check(all, Contains, &builtin.HidrawDeviceInterface{})
 	c.Check(all, Contains, &builtin.LocationControlInterface{})
 	c.Check(all, Contains, &builtin.LocationObserveInterface{})
 	c.Check(all, Contains, &builtin.MirInterface{})

--- a/interfaces/builtin/hidraw_device.go
+++ b/interfaces/builtin/hidraw_device.go
@@ -48,9 +48,10 @@ var hidrawAllowedPathPattern = regexp.MustCompile(`^/dev/hidraw[0-9]{1,3}$`)
 // attribute of the udev rule is used to indicate that devices with these
 // parameters should be added to the apps device cgroup
 var udevVidPidFormat = regexp.MustCompile(`^[\da-fA-F]{4}$`)
-var udevHeader = `IMPORT{builtin}="usb_id"`
-var udevEntryPattern = `SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", ATTRS{idProduct}=="%s"`
-var udevEntryTagPattern = `, TAG+="%s"`
+
+const udevHeader string = `IMPORT{builtin}="usb_id"`
+const udevEntryPattern string = `SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", ATTRS{idProduct}=="%s"`
+const udevEntryTagPattern string = `, TAG+="%s"`
 
 // SanitizeSlot checks validity of the defined slot
 func (iface *HidrawDeviceInterface) SanitizeSlot(slot *interfaces.Slot) error {
@@ -95,7 +96,7 @@ func (iface *HidrawDeviceInterface) SanitizePlug(plug *interfaces.Plug) error {
 	switch len(plug.Attrs) {
 	case 1:
 		// In the case of one attribute it should be valid path attribute
-		// Check slot has a path attribute identify hidraw device
+		// Check the plug has a path attribute to identify the hidraw device
 		path, ok := plug.Attrs["path"].(string)
 		if !ok || path == "" {
 			return fmt.Errorf(`hidraw-device plug found one attribute but it was not "path"`)

--- a/interfaces/builtin/hidraw_device.go
+++ b/interfaces/builtin/hidraw_device.go
@@ -1,0 +1,227 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+// HidrawDeviceInterface is the type for serial port interfaces.
+type HidrawDeviceInterface struct{}
+
+// Name of the hidraw-device interface.
+func (iface *HidrawDeviceInterface) Name() string {
+	return "hidraw-device"
+}
+
+func (iface *HidrawDeviceInterface) String() string {
+	return iface.Name()
+}
+
+// Pattern to match allowed hidraw device nodes, path attributes will be
+// compared to this for validity
+var hidrawAllowedPathPattern = regexp.MustCompile(`^/dev/hidraw[0-9]{1,3}$`)
+
+// Strings used to build up udev snippet for VID+PID identified devices. The TAG
+// attribute of the udev rule is used to indicate that devices with these
+// parameters should be added to the apps device cgroup
+var udevVidPidFormat = regexp.MustCompile(`^[\da-fA-F]{4}$`)
+var udevHeader = `IMPORT{builtin}="usb_id"`
+var udevEntryPattern = `SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%s", ATTRS{idProduct}=="%s"`
+var udevEntryTagPattern = `, TAG+="%s"`
+
+// SanitizeSlot checks validity of the defined slot
+func (iface *HidrawDeviceInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	// Check slot is of right type
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("slot is not of interface %q", iface))
+	}
+
+	// Allow the core snap to create implicit hidraw-device slots with no
+	// attributes. These will be used to grant access based on Udev rules
+	if slot.Snap.Type == "os" && len(slot.Attrs) == 0 {
+		return nil
+	}
+
+	if len(slot.Attrs) > 1 {
+		return fmt.Errorf("hidraw-device slot definition has unexpected number of attributes")
+	}
+
+	// Check slot has a path attribute identify serial device
+	path, ok := slot.Attrs["path"].(string)
+	if !ok || path == "" {
+		return fmt.Errorf("hidraw-device slot must have a path attribute")
+	}
+
+	// Clean the path before checking it matches the pattern
+	path = filepath.Clean(path)
+
+	// Check the path attribute is in the allowable pattern
+	if !hidrawAllowedPathPattern.MatchString(path) {
+		return fmt.Errorf("hidraw-device path attribute must be a valid device node")
+	}
+
+	return nil
+}
+
+// SanitizePlug checks and possibly modifies a plug.
+func (iface *HidrawDeviceInterface) SanitizePlug(plug *interfaces.Plug) error {
+	if iface.Name() != plug.Interface {
+		panic(fmt.Sprintf("plug is not of interface %q", iface))
+	}
+
+	switch len(plug.Attrs) {
+	case 1:
+		// In the case of one attribute it should be valid path attribute
+		// Check slot has a path attribute identify hidraw device
+		path, ok := plug.Attrs["path"].(string)
+		if !ok || path == "" {
+			return fmt.Errorf(`hidraw-device plug found one attribute but it was not "path"`)
+		}
+
+		// Clean the path before checking it matches the pattern
+		path = filepath.Clean(path)
+
+		// Check the path attribute is in the allowable pattern
+		if !hidrawAllowedPathPattern.MatchString(path) {
+			return fmt.Errorf("hidraw-device path attribute must be a valid device node")
+		}
+	case 2:
+		// In the case of two attributes it should be valid vendor-id product-id pair
+		idVendor, vOk := plug.Attrs["vendor-id"].(string)
+		if !vOk {
+			return fmt.Errorf("hidraw-device plug failed to find vendor-id attribute")
+		}
+		if !udevVidPidFormat.MatchString(idVendor) {
+			return fmt.Errorf("hidraw-device vendor-id attribute not valid: %s", idVendor)
+		}
+
+		idProduct, pOk := plug.Attrs["product-id"].(string)
+		if !pOk {
+			return fmt.Errorf("hidraw-device plug failed to find product-id attribute")
+		}
+		if !udevVidPidFormat.MatchString(idProduct) {
+			return fmt.Errorf("hidraw-device product-id attribute not valid: %s", idProduct)
+		}
+	default:
+		return fmt.Errorf("hidraw-device plug definition has unexpected number of attributes")
+	}
+
+	return nil
+}
+
+// PermanentSlotSnippet returns snippets granted on install
+func (iface *HidrawDeviceInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedSlotSnippet no extra permissions granted on connection
+func (iface *HidrawDeviceInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// PermanentPlugSnippet no permissions provided to plug permanently
+func (iface *HidrawDeviceInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor, interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityUDev, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// ConnectedPlugSnippet returns security snippet specific to the plug
+func (iface *HidrawDeviceInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+
+	slotPath, slotOk := slot.Attrs["path"].(string)
+	if !slotOk || slotPath == "" {
+		// don't have path attribute so must be using Udev tagging
+
+		switch securitySystem {
+		case interfaces.SecurityAppArmor:
+			// Wildcarded apparmor snippet as the cgroup will restrict down to the
+			// specific device
+			return []byte("/dev/hidraw* rw,\n"), nil
+		case interfaces.SecurityUDev:
+			idVendor, vOk := plug.Attrs["vendor-id"].(string)
+			if !vOk {
+				return nil, fmt.Errorf("hidraw-device plug failed to find vendor-id attribute")
+			}
+			idProduct, pOk := plug.Attrs["product-id"].(string)
+			if !pOk {
+				return nil, fmt.Errorf("hidraw-device plug failed to find product-id attribute")
+			}
+			var udevSnippet bytes.Buffer
+			udevSnippet.WriteString(udevHeader + "\n")
+			for appName := range plug.Apps {
+				udevSnippet.WriteString(fmt.Sprintf(udevEntryPattern, idVendor, idProduct))
+				tag := fmt.Sprintf("snap_%s_%s", plug.Snap.Name(), appName)
+				udevSnippet.WriteString(fmt.Sprintf(udevEntryTagPattern, tag) + "\n")
+			}
+			return udevSnippet.Bytes(), nil
+		}
+	} else {
+		// use path attribute to generate specific device apparmor snippet
+		// no udev required for this
+		plugPath, plugOk := plug.Attrs["path"].(string)
+		if !plugOk || plugPath == "" {
+			return nil, fmt.Errorf("hidraw-device failed to get plug path attribute")
+		}
+		if plugPath != slotPath {
+			return nil, fmt.Errorf("hidraw-device slot and plug path attributes do not match")
+		}
+
+		cleanedPath := filepath.Clean(slotPath)
+
+		switch securitySystem {
+		case interfaces.SecurityAppArmor:
+			return []byte(fmt.Sprintf("%s rwk,\n", cleanedPath)), nil
+		case interfaces.SecurityUDev:
+			return nil, nil
+		}
+	}
+
+	switch securitySystem {
+	case interfaces.SecuritySecComp, interfaces.SecurityDBus, interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+// AutoConnect indicates whether this type of interface should allow autoconnect
+func (iface *HidrawDeviceInterface) AutoConnect() bool {
+	return false
+}

--- a/interfaces/builtin/hidraw_device_test.go
+++ b/interfaces/builtin/hidraw_device_test.go
@@ -1,0 +1,324 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type HidrawDeviceInterfaceSuite struct {
+	testutil.BaseTest
+	iface            interfaces.Interface
+	testSlot1        *interfaces.Slot
+	testSlot2        *interfaces.Slot
+	missingPathSlot  *interfaces.Slot
+	badPathSlot1     *interfaces.Slot
+	badPathSlot2     *interfaces.Slot
+	badPathSlot3     *interfaces.Slot
+	badInterfaceSlot *interfaces.Slot
+	udevPlug1        *interfaces.Plug
+	pathPlug1        *interfaces.Plug
+	pathPlug2        *interfaces.Plug
+	pathPlug3        *interfaces.Plug
+	pathPlug4        *interfaces.Plug
+	emptyBadPlug1    *interfaces.Plug
+	udevBadPlug1     *interfaces.Plug
+	udevBadPlug2     *interfaces.Plug
+	udevBadPlug3     *interfaces.Plug
+	udevBadPlug4     *interfaces.Plug
+	badInterfacePlug *interfaces.Plug
+	osSlot           *interfaces.Slot
+}
+
+var _ = Suite(&HidrawDeviceInterfaceSuite{
+	iface: &builtin.HidrawDeviceInterface{},
+})
+
+func (s *HidrawDeviceInterfaceSuite) SetUpTest(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: my-snap
+slots:
+    test-port-1:
+        interface: hidraw-device
+        path: /dev/hidraw0
+    test-port-2:
+        interface: hidraw-device
+        path: /dev/hidraw99
+    missing-path: hidraw-device
+    bad-path-1:
+        interface: hidraw-device
+        path: path
+    bad-path-2:
+        interface: hidraw-device
+        path: /dev/tty0
+    bad-path-3:
+        interface: hidraw-device
+        path: /dev/hidraw9271
+    bad-interface: other-interface
+plugs:
+    test-udev-1:
+        interface: hidraw-device
+        vendor-id: "0000"
+        product-id: "aaaa"
+    test-plug-1:
+        interface: hidraw-device
+        path: /dev/hidraw0
+    test-plug-2:
+        interface: hidraw-device
+        path: /dev/hidraw99
+    bad-empty-plug: hidraw-device
+    bad-udev-attrs-1:
+        interface: hidraw-device
+        product-id: "1111"
+    bad-udev-attrs-2:
+        interface: hidraw-device
+        vendor-id: "1111"
+    bad-udev-attrs-3:
+        interface: hidraw-device
+        product-id: "1"
+        vendor-id: "abcd"
+    bad-udev-attrs-4:
+        interface: hidraw-device
+        product-id: "1234"
+        vendor-id: "adc"
+    bad-interface: other-interface
+`))
+	c.Assert(err, IsNil)
+	// Slots
+	s.testSlot1 = &interfaces.Slot{SlotInfo: info.Slots["test-port-1"]}
+	s.testSlot2 = &interfaces.Slot{SlotInfo: info.Slots["test-port-2"]}
+	s.missingPathSlot = &interfaces.Slot{SlotInfo: info.Slots["missing-path"]}
+	s.badPathSlot1 = &interfaces.Slot{SlotInfo: info.Slots["bad-path-1"]}
+	s.badPathSlot2 = &interfaces.Slot{SlotInfo: info.Slots["bad-path-2"]}
+	s.badPathSlot3 = &interfaces.Slot{SlotInfo: info.Slots["bad-path-3"]}
+	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-interface"]}
+
+	// Plugs
+	s.udevPlug1 = &interfaces.Plug{PlugInfo: info.Plugs["test-udev-1"]}
+	s.pathPlug1 = &interfaces.Plug{PlugInfo: info.Plugs["test-plug-1"]}
+	s.pathPlug2 = &interfaces.Plug{PlugInfo: info.Plugs["test-plug-2"]}
+	s.emptyBadPlug1 = &interfaces.Plug{PlugInfo: info.Plugs["bad-empty-plug"]}
+	s.udevBadPlug1 = &interfaces.Plug{PlugInfo: info.Plugs["bad-udev-attrs-1"]}
+	s.udevBadPlug2 = &interfaces.Plug{PlugInfo: info.Plugs["bad-udev-attrs-2"]}
+	s.udevBadPlug3 = &interfaces.Plug{PlugInfo: info.Plugs["bad-udev-attrs-3"]}
+	s.udevBadPlug4 = &interfaces.Plug{PlugInfo: info.Plugs["bad-udev-attrs-4"]}
+	s.badInterfacePlug = &interfaces.Plug{PlugInfo: info.Plugs["bad-interface"]}
+
+	osInfo, osErr := snap.InfoFromSnapYaml([]byte(`
+name: my-core
+type: os
+slots:
+    slot: hidraw-device
+`))
+	c.Assert(osErr, IsNil)
+	s.osSlot = &interfaces.Slot{SlotInfo: osInfo.Slots["slot"]}
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "hidraw-device")
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestSanitizePathSlot(c *C) {
+	// Test good slot examples
+	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2} {
+		err := s.iface.SanitizeSlot(slot)
+		c.Assert(err, IsNil)
+	}
+
+	// Slots without the "path" attribute are rejected.
+	err := s.iface.SanitizeSlot(s.missingPathSlot)
+	c.Assert(err, ErrorMatches, "hidraw-device slot must have a path attribute")
+
+	// Slots with incorrect value of the "path" attribute are rejected.
+	for _, slot := range []*interfaces.Slot{s.badPathSlot1, s.badPathSlot2, s.badPathSlot3} {
+		err := s.iface.SanitizeSlot(slot)
+		c.Assert(err, ErrorMatches, "hidraw-device path attribute must be a valid device node")
+	}
+
+	// It is impossible to use "bool-file" interface to sanitize slots with other interfaces.
+	c.Assert(func() { s.iface.SanitizeSlot(s.badInterfaceSlot) }, PanicMatches, `slot is not of interface "hidraw-device"`)
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestSanitizeCoreSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.osSlot)
+	c.Assert(err, IsNil)
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestSanitizeGoodPlugs(c *C) {
+	for _, plug := range []*interfaces.Plug{s.udevPlug1, s.pathPlug1, s.pathPlug2} {
+		err := s.iface.SanitizePlug(plug)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestSanitizeBadPlugs(c *C) {
+	err := s.iface.SanitizePlug(s.udevBadPlug1)
+	c.Assert(err, ErrorMatches, `hidraw-device plug found one attribute but it was not "path"`)
+
+	err = s.iface.SanitizePlug(s.udevBadPlug2)
+	c.Assert(err, ErrorMatches, `hidraw-device plug found one attribute but it was not "path"`)
+
+	err = s.iface.SanitizePlug(s.udevBadPlug3)
+	c.Assert(err, ErrorMatches, `hidraw-device product-id attribute not valid: 1`)
+
+	err = s.iface.SanitizePlug(s.udevBadPlug4)
+	c.Assert(err, ErrorMatches, `hidraw-device vendor-id attribute not valid: adc`)
+
+	// It is impossible to use "bool-file" interface to sanitize plugs of different interface.
+	c.Assert(func() { s.iface.SanitizePlug(s.badInterfacePlug) }, PanicMatches, `plug is not of interface "hidraw-device"`)
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestConnectedPathPlugSnippetUnusedSecuritySystems(c *C) {
+	// No extra seccomp permissions for plug
+	snippet, err := s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra dbus permissions for plug
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra udev permissions for plug
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra mount permissions for plug
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityMount)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// Other security types are not recognized
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system`)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestConnectedUdevPlugSnippetGivesExtraPermissions(c *C) {
+	expectedPlugSnippet1 := []byte(`/dev/hidraw* rw,
+`)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.udevPlug1, s.osSlot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedPlugSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedPlugSnippet1, snippet))
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestPermanentPlugSnippetUnusedSecuritySystems(c *C) {
+	// No extra apparmor permissions for plug
+	snippet, err := s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra seccomp permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra dbus permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra udev permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra mount permissions for plug
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, interfaces.SecurityMount)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// Other security types are not recognized
+	snippet, err = s.iface.PermanentPlugSnippet(s.pathPlug1, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system`)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestConnectedEmptyPlugSnippetGivesExtraPermissions(c *C) {
+	// slot snippet 1
+	expectedPlugSnippet1 := []byte(`/dev/hidraw0 rwk,
+`)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedPlugSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedPlugSnippet1, snippet))
+	// slot snippet 2
+	expectedPlugSnippet2 := []byte(`/dev/hidraw99 rwk,
+`)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.pathPlug2, s.testSlot2, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedPlugSnippet2, Commentf("\nexpected:\n%s\nfound:\n%s", expectedPlugSnippet2, snippet))
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestConnectedSlotSnippetUnusedSecuritySystems(c *C) {
+	// No extra apparmor permissions for slot
+	snippet, err := s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra seccomp permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra dbus permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra udev permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// No extra mount permissions for slot
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, interfaces.SecurityMount)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	// Other security types are not recognized
+	snippet, err = s.iface.ConnectedSlotSnippet(s.pathPlug1, s.testSlot1, "foo")
+	c.Assert(err, ErrorMatches, `unknown security system`)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestPermanentSlotSnippetUnusedSecuritySystems(c *C) {
+	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2} {
+		// No extra apparmor permissions for slot
+		snippet, err := s.iface.PermanentSlotSnippet(slot, interfaces.SecurityAppArmor)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra seccomp permissions for slot
+		snippet, err = s.iface.PermanentSlotSnippet(slot, interfaces.SecuritySecComp)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra dbus permissions for slot
+		snippet, err = s.iface.PermanentSlotSnippet(slot, interfaces.SecurityDBus)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra udev permissions for slot
+		snippet, err = s.iface.PermanentSlotSnippet(slot, interfaces.SecurityUDev)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// No extra mount permissions for slot
+		snippet, err = s.iface.PermanentSlotSnippet(slot, interfaces.SecurityMount)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		// Other security types are not recognized
+		snippet, err = s.iface.PermanentSlotSnippet(slot, "foo")
+		c.Assert(err, ErrorMatches, `unknown security system`)
+		c.Assert(snippet, IsNil)
+	}
+}
+
+func (s *HidrawDeviceInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(), Equals, false)
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -33,6 +33,7 @@ var implicitSlots = []string{
 	"fuse-support",
 	"home",
 	"hardware-observe",
+	"hidraw-device",
 	"locale-control",
 	"log-observe",
 	"mount-observe",

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -42,7 +42,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 22)
+	c.Assert(info.Slots, HasLen, 23)
 }
 
 func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 32)
+	c.Assert(info.Slots, HasLen, 33)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
Allow access to /dev/hidraw* devices. Follows exactly same
pattern as serial-port interface with this PR landed:

https://github.com/snapcore/snapd/pull/1669

This may make these PRs good candidates to be reviewed together.