### PR TITLE
interfaces/builtin: allow bind in the network interface

### DIFF
--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -36,6 +36,7 @@ const networkConnectedPlugAppArmor = `
 const networkConnectedPlugSecComp = `
 # Description: Can access the network as a client.
 # Usage: common
+bind
 connect
 getpeername
 getsockname


### PR DESCRIPTION
One way to connect to things is to bind the address to the socket before
connect(). Any golang client that imports net/http does this [1], and so we
need to allow it.

[1]: https://github.com/golang/go/issues/16789

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>