### PR TITLE
introduce the "lxd" interface

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -296,6 +296,12 @@ Can read system logs and set kernel log rate-limiting.
 
 * Auto-Connect: no
 
+### lxd
+
+Can aa-exec in unconfined mode with no seccomp restrictions.
+
+* Auto-Connect: no
+
 ### modem-manager
 
 Can access snaps providing the modem-manager interface which gives privileged

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -65,6 +65,7 @@ var allInterfaces = []interfaces.Interface{
 	NewBluetoothControlInterface(),
 	NewKernelModuleControlInterface(),
 	NewFuseSupportInterface(),
+	NewLXDInterface(),
 }
 
 // Interfaces returns all of the built-in interfaces.

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+var lxdApparmorProfile = `
+  /proc/**/attr/current r,
+  /usr/sbin/aa-exec ux,
+`
+
+func NewLXDInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "lxd",
+		connectedPlugAppArmor: lxdApparmorProfile,
+		connectedPlugSecComp:  "@unrestricted",
+		reservedForOS:         true,
+		autoConnect:           false,
+	}
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -35,6 +35,7 @@ var implicitSlots = []string{
 	"hardware-observe",
 	"locale-control",
 	"log-observe",
+	"lxd",
 	"mount-observe",
 	"network",
 	"network-bind",

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -42,7 +42,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 22)
+	c.Assert(info.Slots, HasLen, 23)
 }
 
 func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 32)
+	c.Assert(info.Slots, HasLen, 33)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
The "lxd" interface is special: it is unconfined both in apparmor and in
seccomp. LXD is a bit of a special case, because it needs to do lots of
things (like load kernel modules, apparmor profiles, create cgroups,
manipulate namespaces, etc.), so we just leave it unconfined.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>