### PR TITLE
docs/interfaces: change snappy command to snap

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -55,14 +55,14 @@ interface upon install:
     :log-observe         -
     -                    foo:log-observe
 
-You may manually connect using ``snappy connect``:
+You may manually connect using ``snap connect``:
 
     $ sudo snap connect foo:log-observe core:log-observe
     $ snap interfaces
     Slot                 Plug
     :log-observe         foo:log-observe
 
-and disconnect using ``snappy disconnect``:
+and disconnect using ``snap disconnect``:
 
     $ sudo snap disconnect foo:log-observe core:log-observe
     $ snap interfaces # shows they are disconnected


### PR DESCRIPTION
* Changes the `snappy` connect/disconnect commands to `snap`