### PR TITLE
tests: do not leave "squashfs-root" around

### DIFF
--- a/tests/main/snap-run-hook/task.yaml
+++ b/tests/main/snap-run-hook/task.yaml
@@ -45,6 +45,9 @@ restore: |
     mount "$snap" "$core"
     systemctl start snapd.service
 
+    # do not leave a mess around
+    rm -rf squashfs-root
+
 execute: |
     # Note that `snap run` doesn't exit non-zero if the hook is missing, so we
     # check the output instead.


### PR DESCRIPTION
This should fix the spurious spread failures we saw recently