### PR TITLE
fix vet error

### DIFF
--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -549,11 +549,11 @@ func (s *RepositorySuite) TestConnectSucceedsWhenIdenticalConnectExists(c *C) {
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
 		Plugs: []*Plug{{
 			PlugInfo:    s.plug.PlugInfo,
-			Connections: []SlotRef{{s.slot.Snap.Name(), s.slot.Name}},
+			Connections: []SlotRef{{Snap: s.slot.Snap.Name(), Name: s.slot.Name}},
 		}},
 		Slots: []*Slot{{
 			SlotInfo:    s.slot.SlotInfo,
-			Connections: []PlugRef{{s.plug.Snap.Name(), s.plug.Name}},
+			Connections: []PlugRef{{Snap: s.plug.Snap.Name(), Name: s.plug.Name}},
 		}},
 	})
 }
@@ -714,11 +714,11 @@ func (s *RepositorySuite) TestInterfacesSmokeTest(c *C) {
 	c.Assert(ifaces, DeepEquals, &Interfaces{
 		Plugs: []*Plug{{
 			PlugInfo:    s.plug.PlugInfo,
-			Connections: []SlotRef{{s.slot.Snap.Name(), s.slot.Name}},
+			Connections: []SlotRef{{Snap: s.slot.Snap.Name(), Name: s.slot.Name}},
 		}},
 		Slots: []*Slot{{
 			SlotInfo:    s.slot.SlotInfo,
-			Connections: []PlugRef{{s.plug.Snap.Name(), s.plug.Name}},
+			Connections: []PlugRef{{Snap: s.plug.Snap.Name(), Name: s.plug.Name}},
 		}},
 	})
 	// After disconnecting the connections become empty

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -1565,7 +1565,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 
 	// verify snapSetup info
 	tasks := ts.Tasks()
-	revnos := []snap.Revision{{7}, {3}, {5}}
+	revnos := []snap.Revision{{N: 7}, {N: 3}, {N: 5}}
 	whichRevno := 0
 	for _, t := range tasks {
 		ss, err := snapstate.TaskSnapSetup(t)


### PR DESCRIPTION
name struct fields to suppress a vet error which makes ./run-checks fail