### PR TITLE
interfaces: add lxd-support interface

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -296,6 +296,14 @@ Can read system logs and set kernel log rate-limiting.
 
 * Auto-Connect: no
 
+### lxd-support
+Can access all resources and syscalls on the device for LXD to mediate access
+for its containers. This interface currently may only be used by the lxd snap
+from Canonical.
+
+* Auto-Connect: yes
+* Transitional: yes
+
 ### modem-manager
 
 Can access snaps providing the modem-manager interface which gives privileged

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -31,6 +31,7 @@ var allInterfaces = []interfaces.Interface{
 	&GpioInterface{},
 	&LocationControlInterface{},
 	&LocationObserveInterface{},
+	&LxdSupportInterface{},
 	&MirInterface{},
 	&ModemManagerInterface{},
 	&MprisInterface{},

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -38,6 +38,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.GpioInterface{})
 	c.Check(all, Contains, &builtin.LocationControlInterface{})
 	c.Check(all, Contains, &builtin.LocationObserveInterface{})
+	c.Check(all, Contains, &builtin.LxdSupportInterface{})
 	c.Check(all, Contains, &builtin.MirInterface{})
 	c.Check(all, Contains, &builtin.MprisInterface{})
 	c.Check(all, Contains, &builtin.SerialPortInterface{})

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -93,8 +93,12 @@ func (iface *LxdSupportInterface) ConnectedSlotSnippet(plug *interfaces.Plug, sl
 }
 
 func (iface *LxdSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if plug.Snap.Name() != "lxd" || plug.Snap.Developer != "canonical" {
-		return fmt.Errorf("lxd-support plug reserved for lxd snap from canonical")
+	snapName := plug.Snap.Name()
+	devName := plug.Snap.Developer
+	if snapName != "lxd" {
+		return fmt.Errorf("lxd-support plug reserved (snap name '%s' != 'lxd')", snapName)
+	} else if devName != "canonical" {
+		return fmt.Errorf("lxd-support plug reserved (developer name '%s' != 'canonical')", devName)
 	}
 	return nil
 }

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -1,0 +1,109 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const lxdSupportConnectedPlugAppArmor = `
+# Description: Can change to any apparmor profile (including unconfined) thus
+# giving access to all resources of the system so LXD may manage what to give
+# to its containers. This gives device ownership to connected snaps.
+@{PROC}/**/attr/current r,
+/usr/sbin/aa-exec ux,
+`
+
+const lxdSupportConnectedPlugSecComp = `
+# Description: Can access all syscalls of the system so LXD may manage what to
+# give to its containers, giving device ownership to connected snaps.
+@unrestricted
+`
+
+type LxdSupportInterface struct{}
+
+func (iface *LxdSupportInterface) Name() string {
+	return "lxd-support"
+}
+
+func (iface *LxdSupportInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityUDev,
+		interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *LxdSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		return []byte(lxdSupportConnectedPlugAppArmor), nil
+	case interfaces.SecuritySecComp:
+		return []byte(lxdSupportConnectedPlugSecComp), nil
+	case interfaces.SecurityDBus, interfaces.SecurityUDev,
+		interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *LxdSupportInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityUDev,
+		interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *LxdSupportInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityDBus, interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityUDev,
+		interfaces.SecurityMount:
+		return nil, nil
+	default:
+		return nil, interfaces.ErrUnknownSecurity
+	}
+}
+
+func (iface *LxdSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
+	if plug.Snap.Name() != "lxd" || plug.Snap.Developer != "canonical" {
+		return fmt.Errorf("lxd-support plug reserved for lxd snap from canonical")
+	}
+	return nil
+}
+
+func (iface *LxdSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	return nil
+}
+
+func (iface *LxdSupportInterface) AutoConnect() bool {
+	// since limited to lxd.canonical, we can auto-connect
+	return true
+}

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -79,7 +79,7 @@ func (s *LxdSupportInterfaceSuite) TestSanitizePlugNotLxdFromCanonical(c *C) {
 		Name:      "lxd-support",
 		Interface: "lxd-support",
 	}})
-	c.Assert(err, ErrorMatches, "lxd-support plug reserved for lxd snap from canonical")
+	c.Assert(err, ErrorMatches, "lxd-support plug reserved \\(snap name 'notlxd' != 'lxd'\\)")
 }
 
 func (s *LxdSupportInterfaceSuite) TestSanitizePlugLxdNotFromCanonical(c *C) {
@@ -91,7 +91,7 @@ func (s *LxdSupportInterfaceSuite) TestSanitizePlugLxdNotFromCanonical(c *C) {
 		Name:      "lxd-support",
 		Interface: "lxd-support",
 	}})
-	c.Assert(err, ErrorMatches, "lxd-support plug reserved for lxd snap from canonical")
+	c.Assert(err, ErrorMatches, "lxd-support plug reserved \\(developer name 'foo' != 'canonical'\\)")
 }
 
 func (s *LxdSupportInterfaceSuite) TestSanitizePlugNotLxdNotFromCanonical(c *C) {
@@ -103,7 +103,7 @@ func (s *LxdSupportInterfaceSuite) TestSanitizePlugNotLxdNotFromCanonical(c *C) 
 		Name:      "lxd-support",
 		Interface: "lxd-support",
 	}})
-	c.Assert(err, ErrorMatches, "lxd-support plug reserved for lxd snap from canonical")
+	c.Assert(err, ErrorMatches, "lxd-support plug reserved \\(snap name 'notlxd' != 'lxd'\\)")
 }
 
 func (s *LxdSupportInterfaceSuite) TestUnusedSecuritySystems(c *C) {

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -1,0 +1,172 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type LxdSupportInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&LxdSupportInterfaceSuite{
+	iface: &builtin.LxdSupportInterface{},
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Name:      "lxd-support",
+			Interface: "lxd-support",
+		},
+	},
+
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap: &snap.Info{
+				SuggestedName: "lxd",
+				SideInfo:      snap.SideInfo{Developer: "canonical"},
+			},
+			Name:      "lxd-support",
+			Interface: "lxd-support",
+		},
+	},
+})
+
+func (s *LxdSupportInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "lxd-support")
+}
+
+func (s *LxdSupportInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+}
+
+func (s *LxdSupportInterfaceSuite) TestSanitizePlugLxdFromCanonical(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *LxdSupportInterfaceSuite) TestSanitizePlugNotLxdFromCanonical(c *C) {
+	err := s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{
+		Snap: &snap.Info{
+			SuggestedName: "notlxd",
+			SideInfo:      snap.SideInfo{Developer: "canonical"},
+		},
+		Name:      "lxd-support",
+		Interface: "lxd-support",
+	}})
+	c.Assert(err, ErrorMatches, "lxd-support plug reserved for lxd snap from canonical")
+}
+
+func (s *LxdSupportInterfaceSuite) TestSanitizePlugLxdNotFromCanonical(c *C) {
+	err := s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{
+		Snap: &snap.Info{
+			SuggestedName: "lxd",
+			SideInfo:      snap.SideInfo{Developer: "foo"},
+		},
+		Name:      "lxd-support",
+		Interface: "lxd-support",
+	}})
+	c.Assert(err, ErrorMatches, "lxd-support plug reserved for lxd snap from canonical")
+}
+
+func (s *LxdSupportInterfaceSuite) TestSanitizePlugNotLxdNotFromCanonical(c *C) {
+	err := s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{
+		Snap: &snap.Info{
+			SuggestedName: "notlxd",
+			SideInfo:      snap.SideInfo{Developer: "foo"},
+		},
+		Name:      "lxd-support",
+		Interface: "lxd-support",
+	}})
+	c.Assert(err, ErrorMatches, "lxd-support plug reserved for lxd snap from canonical")
+}
+
+func (s *LxdSupportInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev}
+	for _, system := range systems {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *LxdSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *LxdSupportInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *LxdSupportInterfaceSuite) TestPermanentSlotPolicyAppArmor(c *C) {
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Check(string(snippet), testutil.Contains, "/usr/sbin/aa-exec ux,\n")
+}
+
+func (s *LxdSupportInterfaceSuite) TestPermanentSlotPolicySecComp(c *C) {
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Check(string(snippet), testutil.Contains, "@unrestricted\n")
+}
+
+func (s *LxdSupportInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(), Equals, true)
+}

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -115,7 +115,7 @@ func (s *LxdSupportInterfaceSuite) TestSanitizePlugLxdSideload(c *C) {
 		Name:      "lxd-support",
 		Interface: "lxd-support",
 	}})
-	c.Assert(err, ErrorMatches, "lxd-support plug reserved \\(developer name 'foo' != 'canonical'\\)")
+	c.Assert(err, ErrorMatches, "lxd-support plug reserved \\(developer name '' != 'canonical'\\)")
 }
 
 func (s *LxdSupportInterfaceSuite) TestUnusedSecuritySystems(c *C) {

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -106,6 +106,18 @@ func (s *LxdSupportInterfaceSuite) TestSanitizePlugNotLxdNotFromCanonical(c *C) 
 	c.Assert(err, ErrorMatches, "lxd-support plug reserved \\(snap name 'notlxd' != 'lxd'\\)")
 }
 
+func (s *LxdSupportInterfaceSuite) TestSanitizePlugLxdSideload(c *C) {
+	err := s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{
+		Snap: &snap.Info{
+			SuggestedName: "lxd",
+			SideInfo:      snap.SideInfo{Developer: ""},
+		},
+		Name:      "lxd-support",
+		Interface: "lxd-support",
+	}})
+	c.Assert(err, ErrorMatches, "lxd-support plug reserved \\(developer name 'foo' != 'canonical'\\)")
+}
+
 func (s *LxdSupportInterfaceSuite) TestUnusedSecuritySystems(c *C) {
 	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
 		interfaces.SecuritySecComp, interfaces.SecurityDBus,

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -35,6 +35,7 @@ var implicitSlots = []string{
 	"hardware-observe",
 	"locale-control",
 	"log-observe",
+	"lxd-support",
 	"mount-observe",
 	"network",
 	"network-bind",

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -42,7 +42,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOutsideClassic(c *C) {
 	c.Assert(info.Slots["network"].Interface, Equals, "network")
 	c.Assert(info.Slots["network"].Name, Equals, "network")
 	c.Assert(info.Slots["network"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 22)
+	c.Assert(info.Slots, HasLen, 23)
 }
 
 func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 32)
+	c.Assert(info.Slots, HasLen, 33)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
As discussed in https://github.com/snapcore/snapd/pull/1699, implement a transitional (essentially unconfined) lxd-support interface such that the plugging snap must be named 'lxd' and be from the 'canonical' developer. This also means that the interface will not connect if the snap is sideloaded. LXD developers should add 'plugs: [ lxd-support ]' to the snap and test by uploading to the store in a non-stable channel and 'snap install lxd --channel=...'. When assertions are fully in place for interface connections, we may consider changing this.

The check is implemented in SanitizePlug and it does not panic(). Instead the error is logged in syslog like so:

```
/usr/lib/snapd/snapd[3313]: handlers.go:98: snap "lxd" has bad plugs or slots: lxd-support (lxd-support plug reserved (developer name '' != 'canonical')
/usr/lib/snapd/snapd[3313]: handlers.go:98: snap "snap-lxd-test" has bad plugs or slots: lxd-support (lxd-support plug reserved (snap name 'snap-lxd-test' != 'lxd'))
```