### PR TITLE
overlord/hookstate: use snap run posix parameters.

### DIFF
--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -73,7 +73,7 @@ func (sto *fakeStore) pokeStateLock() {
 
 func (sto *fakeStore) Assertion(assertType *asserts.AssertionType, key []string, _ *auth.UserState) (asserts.Assertion, error) {
 	sto.pokeStateLock()
-	ref := &asserts.Ref{assertType, key}
+	ref := &asserts.Ref{Type: assertType, PrimaryKey: key}
 	a, err := ref.Resolve(sto.db.Find)
 	if err != nil {
 		return nil, fmt.Errorf("simulated remote assertion retrieve: %s", err)

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -179,7 +179,7 @@ func (m *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 }
 
 func runHookAndWait(snapName string, revision snap.Revision, hookName string, tomb *tomb.Tomb) ([]byte, error) {
-	command := exec.Command("snap", "run", snapName, "--hook", hookName, "-r", revision.String())
+	command := exec.Command("snap", "run", "--hook", hookName, "-r", revision.String(), snapName)
 
 	// Make sure we can obtain stdout and stderror. Same buffer so they're
 	// combined.

--- a/overlord/hookstate/hookmgr_test.go
+++ b/overlord/hookstate/hookmgr_test.go
@@ -97,7 +97,7 @@ func (s *hookManagerSuite) TestHookTask(c *C) {
 	c.Check(calledContext.HookName(), Equals, "test-hook")
 
 	c.Check(s.command.Calls(), DeepEquals, [][]string{[]string{
-		"snap", "run", "test-snap", "--hook", "test-hook", "-r", "1",
+		"snap", "run", "--hook", "test-hook", "-r", "1", "test-snap",
 	}})
 
 	c.Check(mockHandler.beforeCalled, Equals, true)


### PR DESCRIPTION
The gift that keeps on giving. Now that we're actually making hooks these issues are finally surfacing.