### PR TITLE
dirs,snap: define methods for SNAP_USER_DATA and SNAP_USER_COMMON

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -31,6 +31,7 @@ var (
 	SnapSnapsDir              string
 	SnapBlobDir               string
 	SnapDataDir               string
+	SnapDataHomeDir           string
 	SnapDataHomeGlob          string
 	SnapAppArmorDir           string
 	AppArmorCacheDir          string
@@ -83,6 +84,7 @@ func SetRootDir(rootdir string) {
 
 	SnapSnapsDir = filepath.Join(rootdir, "/snap")
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
+	SnapDataHomeDir = "snap"
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/snap/")
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	AppArmorCacheDir = filepath.Join(rootdir, "/var/cache/apparmor")

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -31,7 +31,6 @@ var (
 	SnapSnapsDir              string
 	SnapBlobDir               string
 	SnapDataDir               string
-	SnapDataHomeDir           string
 	SnapDataHomeGlob          string
 	SnapAppArmorDir           string
 	AppArmorCacheDir          string
@@ -84,7 +83,6 @@ func SetRootDir(rootdir string) {
 
 	SnapSnapsDir = filepath.Join(rootdir, "/snap")
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
-	SnapDataHomeDir = "snap"
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/snap/")
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	AppArmorCacheDir = filepath.Join(rootdir, "/var/cache/apparmor")

--- a/snap/info.go
+++ b/snap/info.go
@@ -189,12 +189,12 @@ func (s *Info) DataDir() string {
 
 // UserDataDir returns the user-specific data directory of the snap.
 func (s *Info) UserDataDir(home string) string {
-	return filepath.Join(home, dirs.SnapDataHomeDir, s.Name(), s.Revision.String())
+	return filepath.Join(home, "snap", s.Name(), s.Revision.String())
 }
 
 // UserCommonDataDir returns the user-specific data directory common across revision of the snap.
 func (s *Info) UserCommonDataDir(home string) string {
-	return filepath.Join(home, dirs.SnapDataHomeDir, s.Name(), "common")
+	return filepath.Join(home, "snap", s.Name(), "common")
 }
 
 // CommonDataDir returns the data directory common across revisions of the snap.

--- a/snap/info.go
+++ b/snap/info.go
@@ -187,6 +187,16 @@ func (s *Info) DataDir() string {
 	return filepath.Join(dirs.SnapDataDir, s.Name(), s.Revision.String())
 }
 
+// UserDataDir returns the user-specific data directory of the snap.
+func (s *Info) UserDataDir(home string) string {
+	return filepath.Join(home, dirs.SnapDataHomeDir, s.Name(), s.Revision.String())
+}
+
+// UserCommonDataDir returns the user-specific data directory common across revision of the snap.
+func (s *Info) UserCommonDataDir(home string) string {
+	return filepath.Join(home, dirs.SnapDataHomeDir, s.Name(), "common")
+}
+
 // CommonDataDir returns the data directory common across revisions of the snap.
 func (s *Info) CommonDataDir() string {
 	return filepath.Join(dirs.SnapDataDir, s.Name(), "common")

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -465,3 +465,19 @@ func verifyExplicitHook(c *C, info *snap.Info, hookName string, plugNames []stri
 		c.Check(info.Plugs[plugName], DeepEquals, plug)
 	}
 }
+
+func (s *infoSuite) TestDirAndFileMethods(c *C) {
+	dirs.SetRootDir("")
+	info := &snap.Info{SuggestedName: "name", SideInfo: snap.SideInfo{Revision: snap.R(1)}}
+	c.Check(info.MountDir(), Equals, fmt.Sprintf("%s/name/1", dirs.SnapSnapsDir))
+	// XXX: Note the lack of leading forward slash here
+	c.Check(info.MountFile(), Equals, "var/lib/snapd/snaps/name_1.snap")
+	c.Check(info.HooksDir(), Equals, fmt.Sprintf("%s/name/1/meta/hooks", dirs.SnapSnapsDir))
+	c.Check(info.DataDir(), Equals, "/var/snap/name/1")
+	c.Check(info.UserDataDir("/home/bob"), Equals, "/home/bob/snap/name/1")
+	c.Check(info.UserCommonDataDir("/home/bob"), Equals, "/home/bob/snap/name/common")
+	c.Check(info.CommonDataDir(), Equals, "/var/snap/name/common")
+	// XXX: Those are actually a globs, not directories
+	c.Check(info.DataHomeDir(), Equals, "/home/*/snap/name/1")
+	c.Check(info.CommonDataHomeDir(), Equals, "/home/*/snap/name/common")
+}

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -21,7 +21,6 @@ package snapenv
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/snap"
@@ -49,11 +48,8 @@ func Basic(info *snap.Info) []string {
 // used by so many other modules, we run into circular dependencies if it's
 // somewhere more reasonable like the snappy module.
 func User(info *snap.Info, home string) []string {
-	// FIXME: should go into PlacementInfo
-	userData := filepath.Join(home, info.MountDir())
-	userCommon := filepath.Clean(filepath.Join(userData, "..", "common"))
 	return []string{
-		fmt.Sprintf("SNAP_USER_COMMON=%s", userCommon),
-		fmt.Sprintf("SNAP_USER_DATA=%s", userData),
+		fmt.Sprintf("SNAP_USER_COMMON=%s", info.UserCommonDataDir(home)),
+		fmt.Sprintf("SNAP_USER_DATA=%s", info.UserDataDir(home)),
 	}
 }


### PR DESCRIPTION
This branch defines explicit methods for computing the two environment variables.

In the past they were derived from MountDir() which is undesirable should the mount directory move to another location.