### PR TITLE
asserts: add a key-proof assertion

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -65,6 +65,7 @@ var (
 var (
 	SerialProofType   = &AssertionType{"serial-proof", nil, assembleSerialProof, noAuthority}
 	SerialRequestType = &AssertionType{"serial-request", nil, assembleSerialRequest, noAuthority}
+	KeyProofType      = &AssertionType{"key-proof", nil, assembleKeyProof, noAuthority}
 )
 
 var typeRegistry = map[string]*AssertionType{
@@ -78,6 +79,7 @@ var typeRegistry = map[string]*AssertionType{
 	// no authority
 	SerialProofType.Name:   SerialProofType,
 	SerialRequestType.Name: SerialRequestType,
+	KeyProofType.Name:      KeyProofType,
 }
 
 // Type returns the AssertionType with name or nil

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -661,7 +661,7 @@ func (as *assertsSuite) TestWithAuthority(c *C) {
 		"model",
 		"serial",
 	}
-	c.Check(withAuthority, HasLen, asserts.NumAssertionType-2) // excluding serial-request, serial-proof
+	c.Check(withAuthority, HasLen, asserts.NumAssertionType-3) // excluding serial-request, serial-proof, key-proof
 	for _, name := range withAuthority {
 		typ := asserts.Type(name)
 		_, err := asserts.AssembleAndSignInTest(typ, nil, nil, testPrivKey1)


### PR DESCRIPTION
Add a no-authority key-proof assertion, signed by the key holder.  This
will be used to prove possession of an account key; the assertion will
only exist on the wire and will not be stored.

This assertion is somewhat like serial-request and serial-proof, but
isn't specific to device authentication.