### PR TITLE
dirs,snap: handle empty root directory in SetRootDir

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -69,9 +69,6 @@ var (
 func init() {
 	// init the global directories at startup
 	root := os.Getenv("SNAPPY_GLOBAL_ROOT")
-	if root == "" {
-		root = "/"
-	}
 
 	SetRootDir(root)
 }
@@ -79,6 +76,9 @@ func init() {
 // SetRootDir allows settings a new global root directory, this is useful
 // for e.g. chroot operations
 func SetRootDir(rootdir string) {
+	if rootdir == "" {
+		rootdir = "/"
+	}
 	GlobalRootDir = rootdir
 
 	SnapSnapsDir = filepath.Join(rootdir, "/snap")

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -470,8 +470,7 @@ func (s *infoSuite) TestDirAndFileMethods(c *C) {
 	dirs.SetRootDir("")
 	info := &snap.Info{SuggestedName: "name", SideInfo: snap.SideInfo{Revision: snap.R(1)}}
 	c.Check(info.MountDir(), Equals, fmt.Sprintf("%s/name/1", dirs.SnapSnapsDir))
-	// XXX: Note the lack of leading forward slash here
-	c.Check(info.MountFile(), Equals, "var/lib/snapd/snaps/name_1.snap")
+	c.Check(info.MountFile(), Equals, "/var/lib/snapd/snaps/name_1.snap")
 	c.Check(info.HooksDir(), Equals, fmt.Sprintf("%s/name/1/meta/hooks", dirs.SnapSnapsDir))
 	c.Check(info.DataDir(), Equals, "/var/snap/name/1")
 	c.Check(info.UserDataDir("/home/bob"), Equals, "/home/bob/snap/name/1")


### PR DESCRIPTION
This patch moves the check for empty ("") root directory from the init()
function to the SetRootDirs itself. Without it some of the directories
would oddly become relative which could cause issues in case if snapd
ever used this in production.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>