### PR TITLE
many: respect dirs.SnapSnapsDir in tests

### DIFF
--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -145,7 +145,7 @@ func (s *snapExecSuite) TestSnapExecAppIntegration(c *C) {
 	// launch and verify its run the right way
 	err := snapExecApp("snapname.app", "42", "stop", []string{"arg1", "arg2"})
 	c.Assert(err, IsNil)
-	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/42/stop-app", dirs.SnapSnapsDir))
+	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/42/stop-app", dirs.SnapMountDir))
 	c.Check(execArgs, DeepEquals, []string{execArgv0, "arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "LD_LIBRARY_PATH=/some/path\n")
 }
@@ -167,7 +167,7 @@ func (s *snapExecSuite) TestSnapExecHookIntegration(c *C) {
 	// launch and verify it ran correctly
 	err := snapExecHook("snapname", "42", "apply-config")
 	c.Assert(err, IsNil)
-	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/42/meta/hooks/apply-config", dirs.SnapSnapsDir))
+	c.Check(execArgv0, Equals, fmt.Sprintf("%s/snapname/42/meta/hooks/apply-config", dirs.SnapMountDir))
 	c.Check(execArgs, DeepEquals, []string{execArgv0})
 }
 

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -76,7 +76,7 @@ func (s *SnapSuite) TestSnapRunSnapExecEnv(c *check.C) {
 	sort.Strings(env)
 	c.Check(env, check.DeepEquals, []string{
 		"PATH=${PATH}:/usr/lib/snapd",
-		"SNAP=/snap/snapname/42",
+		fmt.Sprintf("SNAP=%s/snapname/42", dirs.SnapSnapsDir),
 		fmt.Sprintf("SNAP_ARCH=%s", arch.UbuntuArchitecture()),
 		"SNAP_COMMON=/var/snap/snapname/common",
 		"SNAP_DATA=/var/snap/snapname/42",
@@ -179,8 +179,8 @@ func (s *SnapSuite) TestSnapRunCreateDataDirs(c *check.C) {
 
 	err = snaprun.CreateUserDataDirs(info)
 	c.Assert(err, check.IsNil)
-	c.Check(osutil.FileExists(filepath.Join(fakeHome, "/snap/snapname/42")), check.Equals, true)
-	c.Check(osutil.FileExists(filepath.Join(fakeHome, "/snap/snapname/common")), check.Equals, true)
+	c.Check(osutil.FileExists(filepath.Join(fakeHome, fmt.Sprintf("%s/snapname/42", dirs.SnapSnapsDir))), check.Equals, true)
+	c.Check(osutil.FileExists(filepath.Join(fakeHome, fmt.Sprintf("%s/snapname/common", dirs.SnapSnapsDir))), check.Equals, true)
 }
 
 func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -179,8 +179,8 @@ func (s *SnapSuite) TestSnapRunCreateDataDirs(c *check.C) {
 
 	err = snaprun.CreateUserDataDirs(info)
 	c.Assert(err, check.IsNil)
-	c.Check(osutil.FileExists(filepath.Join(fakeHome, fmt.Sprintf("%s/snapname/42", dirs.SnapSnapsDir))), check.Equals, true)
-	c.Check(osutil.FileExists(filepath.Join(fakeHome, fmt.Sprintf("%s/snapname/common", dirs.SnapSnapsDir))), check.Equals, true)
+	c.Check(osutil.FileExists(filepath.Join(fakeHome, "/snap/snapname/42")), check.Equals, true)
+	c.Check(osutil.FileExists(filepath.Join(fakeHome, "/snap/snapname/common")), check.Equals, true)
 }
 
 func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -76,7 +76,7 @@ func (s *SnapSuite) TestSnapRunSnapExecEnv(c *check.C) {
 	sort.Strings(env)
 	c.Check(env, check.DeepEquals, []string{
 		"PATH=${PATH}:/usr/lib/snapd",
-		fmt.Sprintf("SNAP=%s/snapname/42", dirs.SnapSnapsDir),
+		fmt.Sprintf("SNAP=%s/snapname/42", dirs.SnapMountDir),
 		fmt.Sprintf("SNAP_ARCH=%s", arch.UbuntuArchitecture()),
 		"SNAP_COMMON=/var/snap/snapname/common",
 		"SNAP_DATA=/var/snap/snapname/42",

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1132,7 +1132,7 @@ func iconGet(st *state.State, name string) Response {
 	}
 
 	path := filepath.Clean(snapIcon(info))
-	if !strings.HasPrefix(path, dirs.SnapSnapsDir) {
+	if !strings.HasPrefix(path, dirs.SnapMountDir) {
 		// XXX: how could this happen?
 		return BadRequest("requested icon is not in snap path")
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -144,7 +144,7 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 	dirs.SetRootDir(c.MkDir())
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, check.IsNil)
-	c.Assert(os.MkdirAll(dirs.SnapSnapsDir, 0755), check.IsNil)
+	c.Assert(os.MkdirAll(dirs.SnapMountDir, 0755), check.IsNil)
 
 	s.rsnaps = nil
 	s.suggestedCurrency = ""
@@ -246,7 +246,7 @@ type: gadget
 gadget: {store: {id: %q}}
 `, store)
 	snaptest.MockSnap(c, yamlText, &snap.SideInfo{Revision: snap.R(1)})
-	c.Assert(os.Symlink("1", filepath.Join(dirs.SnapSnapsDir, "test", "current")), check.IsNil)
+	c.Assert(os.Symlink("1", filepath.Join(dirs.SnapMountDir, "test", "current")), check.IsNil)
 }
 
 func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -28,7 +28,7 @@ import (
 var (
 	GlobalRootDir string
 
-	SnapSnapsDir              string
+	SnapMountDir              string
 	SnapBlobDir               string
 	SnapDataDir               string
 	SnapDataHomeGlob          string
@@ -81,7 +81,7 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	SnapSnapsDir = filepath.Join(rootdir, "/snap")
+	SnapMountDir = filepath.Join(rootdir, "/snap")
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/snap/")
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
@@ -106,7 +106,7 @@ func SetRootDir(rootdir string) {
 	// snapd.firstboot.service to match
 	SnapFirstBootStamp = filepath.Join(rootdir, snappyDir, "firstboot", "stamp")
 
-	SnapBinariesDir = filepath.Join(SnapSnapsDir, "bin")
+	SnapBinariesDir = filepath.Join(SnapMountDir, "bin")
 	SnapServicesDir = filepath.Join(rootdir, "/etc/systemd/system")
 	SnapBusPolicyDir = filepath.Join(rootdir, "/etc/dbus-1/system.d")
 

--- a/integration-tests/testutils/refresh/refresh.go
+++ b/integration-tests/testutils/refresh/refresh.go
@@ -96,12 +96,12 @@ func copySnap(c *check.C, snap, targetDir string) {
 	// check for sideloaded snaps
 	// XXX: simplify this down to consider only the name (and not origin)
 	// in the directory once everything is moved to that
-	baseDir := filepath.Join(dirs.SnapSnapsDir, snap)
+	baseDir := filepath.Join(dirs.SnapMountDir, snap)
 	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
 		snapName := strings.Split(snap, ".")[0]
-		baseDir = filepath.Join(dirs.SnapSnapsDir, snapName)
+		baseDir = filepath.Join(dirs.SnapMountDir, snapName)
 		if _, err := os.Stat(baseDir); os.IsNotExist(err) {
-			baseDir = filepath.Join(dirs.SnapSnapsDir, snapName+".sideload")
+			baseDir = filepath.Join(dirs.SnapMountDir, snapName+".sideload")
 			_, err = os.Stat(baseDir)
 			c.Assert(err, check.IsNil,
 				check.Commentf("%s not found from it's original source not sideloaded", snap))

--- a/overlord/boot/firstboot_test.go
+++ b/overlord/boot/firstboot_test.go
@@ -114,7 +114,7 @@ snaps:
 	c.Assert(err, IsNil)
 
 	// and check the snap got correctly installed
-	c.Check(osutil.FileExists(filepath.Join(dirs.SnapSnapsDir, "foo", "128", "meta", "snap.yaml")), Equals, true)
+	c.Check(osutil.FileExists(filepath.Join(dirs.SnapMountDir, "foo", "128", "meta", "snap.yaml")), Equals, true)
 
 	// verify
 	r, err := os.Open(dirs.SnapStateFile)

--- a/snap/info.go
+++ b/snap/info.go
@@ -65,7 +65,7 @@ func MinimalPlaceInfo(name string, revision Revision) PlaceInfo {
 
 // MountDir returns the base directory where it gets mounted of the snap with the given name and revision.
 func MountDir(name string, revision Revision) string {
-	return filepath.Join(dirs.SnapSnapsDir, name, revision.String())
+	return filepath.Join(dirs.SnapMountDir, name, revision.String())
 }
 
 // SecurityTag returns the snap-specific security tag.

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -107,9 +107,9 @@ apps:
 	info.Revision = snap.R(42)
 
 	c.Check(info.Apps["bar"].LauncherCommand(), Equals,
-		fmt.Sprintf("/usr/bin/ubuntu-core-launcher snap.foo.bar snap.foo.bar %s/foo/42/bar-bin -x", dirs.SnapSnapsDir))
+		fmt.Sprintf("/usr/bin/ubuntu-core-launcher snap.foo.bar snap.foo.bar %s/foo/42/bar-bin -x", dirs.SnapMountDir))
 	c.Check(info.Apps["foo"].LauncherCommand(), Equals,
-		fmt.Sprintf("/usr/bin/ubuntu-core-launcher snap.foo.foo snap.foo.foo %s/foo/42/foo-bin", dirs.SnapSnapsDir))
+		fmt.Sprintf("/usr/bin/ubuntu-core-launcher snap.foo.foo snap.foo.foo %s/foo/42/foo-bin", dirs.SnapMountDir))
 }
 
 const sampleYaml = `
@@ -471,9 +471,9 @@ func verifyExplicitHook(c *C, info *snap.Info, hookName string, plugNames []stri
 func (s *infoSuite) TestDirAndFileMethods(c *C) {
 	dirs.SetRootDir("")
 	info := &snap.Info{SuggestedName: "name", SideInfo: snap.SideInfo{Revision: snap.R(1)}}
-	c.Check(info.MountDir(), Equals, fmt.Sprintf("%s/name/1", dirs.SnapSnapsDir))
+	c.Check(info.MountDir(), Equals, fmt.Sprintf("%s/name/1", dirs.SnapMountDir))
 	c.Check(info.MountFile(), Equals, "/var/lib/snapd/snaps/name_1.snap")
-	c.Check(info.HooksDir(), Equals, fmt.Sprintf("%s/name/1/meta/hooks", dirs.SnapSnapsDir))
+	c.Check(info.HooksDir(), Equals, fmt.Sprintf("%s/name/1/meta/hooks", dirs.SnapMountDir))
 	c.Check(info.DataDir(), Equals, "/var/snap/name/1")
 	c.Check(info.UserDataDir("/home/bob"), Equals, "/home/bob/snap/name/1")
 	c.Check(info.UserCommonDataDir("/home/bob"), Equals, "/home/bob/snap/name/common")

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -106,8 +106,10 @@ apps:
 	c.Assert(err, IsNil)
 	info.Revision = snap.R(42)
 
-	c.Check(info.Apps["bar"].LauncherCommand(), Equals, "/usr/bin/ubuntu-core-launcher snap.foo.bar snap.foo.bar /snap/foo/42/bar-bin -x")
-	c.Check(info.Apps["foo"].LauncherCommand(), Equals, "/usr/bin/ubuntu-core-launcher snap.foo.foo snap.foo.foo /snap/foo/42/foo-bin")
+	c.Check(info.Apps["bar"].LauncherCommand(), Equals,
+		fmt.Sprintf("/usr/bin/ubuntu-core-launcher snap.foo.bar snap.foo.bar %s/foo/42/bar-bin -x", dirs.SnapSnapsDir))
+	c.Check(info.Apps["foo"].LauncherCommand(), Equals,
+		fmt.Sprintf("/usr/bin/ubuntu-core-launcher snap.foo.foo snap.foo.foo %s/foo/42/foo-bin", dirs.SnapSnapsDir))
 }
 
 const sampleYaml = `

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -27,6 +27,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -49,7 +50,7 @@ func (ts *HTestSuite) TestBasic(c *C) {
 	sort.Strings(env)
 
 	c.Assert(env, DeepEquals, []string{
-		"SNAP=/snap/foo/17",
+		fmt.Sprintf("SNAP=%s/foo/17", dirs.SnapSnapsDir),
 		fmt.Sprintf("SNAP_ARCH=%s", arch.UbuntuArchitecture()),
 		"SNAP_COMMON=/var/snap/foo/common",
 		"SNAP_DATA=/var/snap/foo/17",

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -50,7 +50,7 @@ func (ts *HTestSuite) TestBasic(c *C) {
 	sort.Strings(env)
 
 	c.Assert(env, DeepEquals, []string{
-		fmt.Sprintf("SNAP=%s/foo/17", dirs.SnapSnapsDir),
+		fmt.Sprintf("SNAP=%s/foo/17", dirs.SnapMountDir),
 		fmt.Sprintf("SNAP_ARCH=%s", arch.UbuntuArchitecture()),
 		"SNAP_COMMON=/var/snap/foo/common",
 		"SNAP_DATA=/var/snap/foo/17",

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -63,7 +63,7 @@ func (s *snapTestSuite) TestMockSnap(c *C) {
 	// Data from SideInfo is used
 	c.Check(snapInfo.Revision, Equals, snap.R(42))
 	// The YAML is placed on disk
-	cont, err := ioutil.ReadFile(filepath.Join(dirs.SnapSnapsDir, "sample", "42", "meta", "snap.yaml"))
+	cont, err := ioutil.ReadFile(filepath.Join(dirs.SnapMountDir, "sample", "42", "meta", "snap.yaml"))
 	c.Assert(err, IsNil)
 
 	c.Check(string(cont), Equals, sampleYaml)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -138,7 +138,7 @@ func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 	t.store = New(nil, "", nil)
 	t.origDownloadFunc = download
 	dirs.SetRootDir(c.MkDir())
-	c.Assert(os.MkdirAll(dirs.SnapSnapsDir, 0755), IsNil)
+	c.Assert(os.MkdirAll(dirs.SnapMountDir, 0755), IsNil)
 
 	t.logbuf = bytes.NewBuffer(nil)
 	l, err := logger.NewConsoleLog(t.logbuf, logger.DefaultFlags)

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -139,7 +139,7 @@ type info struct {
 }
 
 func copySnap(snapName, targetDir string) (*info, error) {
-	baseDir := filepath.Join(dirs.SnapSnapsDir, snapName)
+	baseDir := filepath.Join(dirs.SnapMountDir, snapName)
 	if _, err := os.Stat(baseDir); err != nil {
 		return nil, err
 	}

--- a/wrappers/binaries_gen_test.go
+++ b/wrappers/binaries_gen_test.go
@@ -71,7 +71,7 @@ func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
 		Command: "bin/pastebinit",
 	}
 
-	expected := fmt.Sprintf(expectedWrapper, arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
+	expected := fmt.Sprintf(expectedWrapper, arch.UbuntuArchitecture(), dirs.SnapMountDir)
 
 	generatedWrapper, err := wrappers.GenerateSnapBinaryWrapper(binary)
 	c.Assert(err, IsNil)

--- a/wrappers/binaries_gen_test.go
+++ b/wrappers/binaries_gen_test.go
@@ -25,6 +25,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/wrappers"
 )
@@ -37,7 +38,7 @@ const expectedWrapper = `#!/bin/sh
 set -e
 
 # snap info
-export SNAP="/snap/pastebinit/44"
+export SNAP="%[2]s/pastebinit/44"
 export SNAP_COMMON="/var/snap/pastebinit/common"
 export SNAP_DATA="/var/snap/pastebinit/44"
 export SNAP_NAME="pastebinit"
@@ -56,7 +57,7 @@ export HOME="$SNAP_USER_DATA"
 # Snap name is: pastebinit
 # App name is: pastebinit
 
-exec /usr/bin/ubuntu-core-launcher snap.pastebinit.pastebinit snap.pastebinit.pastebinit /snap/pastebinit/44/bin/pastebinit "$@"
+exec /usr/bin/ubuntu-core-launcher snap.pastebinit.pastebinit snap.pastebinit.pastebinit %[2]s/pastebinit/44/bin/pastebinit "$@"
 `
 
 func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
@@ -70,7 +71,7 @@ func (s *binariesWrapperGenSuite) TestSnappyGenerateSnapBinaryWrapper(c *C) {
 		Command: "bin/pastebinit",
 	}
 
-	expected := fmt.Sprintf(expectedWrapper, arch.UbuntuArchitecture())
+	expected := fmt.Sprintf(expectedWrapper, arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
 
 	generatedWrapper, err := wrappers.GenerateSnapBinaryWrapper(binary)
 	c.Assert(err, IsNil)

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -71,14 +71,14 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	err := wrappers.AddSnapBinaries(info)
 	c.Assert(err, IsNil)
 
-	wrapper := fmt.Sprintf("%s/bin/hello-snap.hello", dirs.SnapSnapsDir)
+	wrapper := fmt.Sprintf("%s/bin/hello-snap.hello", dirs.SnapMountDir)
 
 	content, err := ioutil.ReadFile(wrapper)
 	c.Assert(err, IsNil)
 
 	needle := fmt.Sprintf(`
 exec /usr/bin/ubuntu-core-launcher snap.hello-snap.hello snap.hello-snap.hello %s/hello-snap/11/bin/hello "$@"
-`, dirs.SnapSnapsDir)
+`, dirs.SnapMountDir)
 
 	c.Assert(string(content), Matches, "(?ms).*"+regexp.QuoteMeta(needle)+".*")
 

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -22,7 +22,6 @@ package wrappers_test
 import (
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -72,14 +71,14 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	err := wrappers.AddSnapBinaries(info)
 	c.Assert(err, IsNil)
 
-	wrapper := filepath.Join(s.tempdir, "/snap/bin/hello-snap.hello")
+	wrapper := fmt.Sprintf("%s/bin/hello-snap.hello", dirs.SnapSnapsDir)
 
 	content, err := ioutil.ReadFile(wrapper)
 	c.Assert(err, IsNil)
 
 	needle := fmt.Sprintf(`
-exec /usr/bin/ubuntu-core-launcher snap.hello-snap.hello snap.hello-snap.hello %s/snap/hello-snap/11/bin/hello "$@"
-`, s.tempdir)
+exec /usr/bin/ubuntu-core-launcher snap.hello-snap.hello snap.hello-snap.hello %s/hello-snap/11/bin/hello "$@"
+`, dirs.SnapSnapsDir)
 
 	c.Assert(string(content), Matches, "(?ms).*"+regexp.QuoteMeta(needle)+".*")
 

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -20,6 +20,7 @@
 package wrappers_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -120,11 +121,11 @@ Icon=${SNAP}/meep
 # the empty line above is fine`)
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(string(e), Equals, `[Desktop Entry]
+	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 Name=foo
-Icon=/snap/foo/12/meep
+Icon=%s/foo/12/meep
 
-# the empty line above is fine`)
+# the empty line above is fine`, dirs.SnapSnapsDir))
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExec(c *C) {
@@ -180,9 +181,9 @@ Exec=snap.app %U
 `)
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(string(e), Equals, `[Desktop Entry]
+	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 Name=foo
-Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop /snap/bin/snap.app %U`)
+Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app %%U`, dirs.SnapSnapsDir))
 }
 
 // we do not support TryExec (even if its a valid line), this test ensures
@@ -253,7 +254,7 @@ apps:
 
 	newl, err := wrappers.RewriteExecLine(snap, "foo.desktop", "Exec=snap.app")
 	c.Assert(err, IsNil)
-	c.Assert(newl, Equals, "Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop /snap/bin/snap.app")
+	c.Assert(newl, Equals, fmt.Sprintf("Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app", dirs.SnapSnapsDir))
 }
 
 func (s *sanitizeDesktopFileSuite) TestTrimLang(c *C) {

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -125,7 +125,7 @@ Icon=${SNAP}/meep
 Name=foo
 Icon=%s/foo/12/meep
 
-# the empty line above is fine`, dirs.SnapSnapsDir))
+# the empty line above is fine`, dirs.SnapMountDir))
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExec(c *C) {
@@ -183,7 +183,7 @@ Exec=snap.app %U
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 Name=foo
-Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app %%U`, dirs.SnapSnapsDir))
+Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app %%U`, dirs.SnapMountDir))
 }
 
 // we do not support TryExec (even if its a valid line), this test ensures
@@ -254,7 +254,7 @@ apps:
 
 	newl, err := wrappers.RewriteExecLine(snap, "foo.desktop", "Exec=snap.app")
 	c.Assert(err, IsNil)
-	c.Assert(newl, Equals, fmt.Sprintf("Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app", dirs.SnapSnapsDir))
+	c.Assert(newl, Equals, fmt.Sprintf("Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app", dirs.SnapMountDir))
 }
 
 func (s *sanitizeDesktopFileSuite) TestTrimLang(c *C) {

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -25,6 +25,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timeout"
@@ -42,12 +43,12 @@ Description=Service for snap application snap.app
 X-Snappy=yes
 
 [Service]
-ExecStart=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app /snap/snap/44/bin/start
+ExecStart=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app %[4]s/snap/44/bin/start
 Restart=on-failure
 WorkingDirectory=/var/snap/snap/44
-Environment="SNAP=/snap/snap/44" "SNAP_COMMON=/var/snap/snap/common" "SNAP_DATA=/var/snap/snap/44" "SNAP_NAME=snap" "SNAP_VERSION=1.0" "SNAP_REVISION=44" "SNAP_ARCH=%[3]s" "SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:" "SNAP_USER_COMMON=/root/snap/snap/common" "SNAP_USER_DATA=/root/snap/snap/44"
-ExecStop=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app /snap/snap/44/bin/stop
-ExecStopPost=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app /snap/snap/44/bin/stop --post
+Environment="SNAP=%[4]s/snap/44" "SNAP_COMMON=/var/snap/snap/common" "SNAP_DATA=/var/snap/snap/44" "SNAP_NAME=snap" "SNAP_VERSION=1.0" "SNAP_REVISION=44" "SNAP_ARCH=%[3]s" "SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:" "SNAP_USER_COMMON=/root/snap/snap/common" "SNAP_USER_DATA=/root/snap/snap/44"
+ExecStop=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app %[4]s/snap/44/bin/stop
+ExecStopPost=/usr/bin/ubuntu-core-launcher snap.snap.app snap.snap.app %[4]s/snap/44/bin/stop --post
 TimeoutStopSec=10
 %[2]s
 
@@ -56,8 +57,8 @@ WantedBy=multi-user.target
 `
 
 var (
-	expectedAppService  = fmt.Sprintf(expectedServiceFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=simple\n", arch.UbuntuArchitecture())
-	expectedDbusService = fmt.Sprintf(expectedServiceFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=dbus\nBusName=foo.bar.baz", arch.UbuntuArchitecture())
+	expectedAppService  = fmt.Sprintf(expectedServiceFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=simple\n", arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
+	expectedDbusService = fmt.Sprintf(expectedServiceFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=dbus\nBusName=foo.bar.baz", arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
 )
 
 var (
@@ -68,20 +69,20 @@ Description=Service for snap application xkcd-webserver.xkcd-webserver
 X-Snappy=yes
 
 [Service]
-ExecStart=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo start
+ExecStart=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver %[4]s/xkcd-webserver/44/bin/foo start
 Restart=on-failure
 WorkingDirectory=/var/snap/xkcd-webserver/44
-Environment="SNAP=/snap/xkcd-webserver/44" "SNAP_COMMON=/var/snap/xkcd-webserver/common" "SNAP_DATA=/var/snap/xkcd-webserver/44" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_REVISION=44" "SNAP_ARCH=%[3]s" "SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:" "SNAP_USER_COMMON=/root/snap/xkcd-webserver/common" "SNAP_USER_DATA=/root/snap/xkcd-webserver/44"
-ExecStop=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo stop
-ExecStopPost=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver /snap/xkcd-webserver/44/bin/foo post-stop
+Environment="SNAP=%[4]s/xkcd-webserver/44" "SNAP_COMMON=/var/snap/xkcd-webserver/common" "SNAP_DATA=/var/snap/xkcd-webserver/44" "SNAP_NAME=xkcd-webserver" "SNAP_VERSION=0.3.4" "SNAP_REVISION=44" "SNAP_ARCH=%[3]s" "SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:" "SNAP_USER_COMMON=/root/snap/xkcd-webserver/common" "SNAP_USER_DATA=/root/snap/xkcd-webserver/44"
+ExecStop=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver %[4]s/xkcd-webserver/44/bin/foo stop
+ExecStopPost=/usr/bin/ubuntu-core-launcher snap.xkcd-webserver.xkcd-webserver snap.xkcd-webserver.xkcd-webserver %[4]s/xkcd-webserver/44/bin/foo post-stop
 TimeoutStopSec=30
 %[2]s
 
 [Install]
 WantedBy=multi-user.target
 `
-	expectedSocketUsingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "After=snapd.frameworks.target snap.xkcd-webserver.xkcd-webserver.socket\nRequires=snapd.frameworks.target snap.xkcd-webserver.xkcd-webserver.socket", "Type=simple\n", arch.UbuntuArchitecture())
-	expectedTypeForkingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=forking\n", arch.UbuntuArchitecture())
+	expectedSocketUsingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "After=snapd.frameworks.target snap.xkcd-webserver.xkcd-webserver.socket\nRequires=snapd.frameworks.target snap.xkcd-webserver.xkcd-webserver.socket", "Type=simple\n", arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
+	expectedTypeForkingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=forking\n", arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
 )
 
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFile(c *C) {

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -57,8 +57,8 @@ WantedBy=multi-user.target
 `
 
 var (
-	expectedAppService  = fmt.Sprintf(expectedServiceFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=simple\n", arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
-	expectedDbusService = fmt.Sprintf(expectedServiceFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=dbus\nBusName=foo.bar.baz", arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
+	expectedAppService  = fmt.Sprintf(expectedServiceFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=simple\n", arch.UbuntuArchitecture(), dirs.SnapMountDir)
+	expectedDbusService = fmt.Sprintf(expectedServiceFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=dbus\nBusName=foo.bar.baz", arch.UbuntuArchitecture(), dirs.SnapMountDir)
 )
 
 var (
@@ -81,8 +81,8 @@ TimeoutStopSec=30
 [Install]
 WantedBy=multi-user.target
 `
-	expectedSocketUsingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "After=snapd.frameworks.target snap.xkcd-webserver.xkcd-webserver.socket\nRequires=snapd.frameworks.target snap.xkcd-webserver.xkcd-webserver.socket", "Type=simple\n", arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
-	expectedTypeForkingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=forking\n", arch.UbuntuArchitecture(), dirs.SnapSnapsDir)
+	expectedSocketUsingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "After=snapd.frameworks.target snap.xkcd-webserver.xkcd-webserver.socket\nRequires=snapd.frameworks.target snap.xkcd-webserver.xkcd-webserver.socket", "Type=simple\n", arch.UbuntuArchitecture(), dirs.SnapMountDir)
+	expectedTypeForkingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "After=snapd.frameworks.target\nRequires=snapd.frameworks.target", "Type=forking\n", arch.UbuntuArchitecture(), dirs.SnapMountDir)
 )
 
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFile(c *C) {


### PR DESCRIPTION
This branch fixes some of the tests so that `dirs.SnapSnapsDir` can be changed without failures.