### PR TITLE
store: request device session macaroon from store

### DIFF
--- a/store/auth.go
+++ b/store/auth.go
@@ -275,6 +275,9 @@ func RequestDeviceSession(serialAssertion, serialProof, previousSession string) 
 		"serial-proof":     serialProof,
 	}
 	deviceJSONData, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf(errorPrefix+"%v", err)
+	}
 
 	req, err := http.NewRequest("POST", MyAppsDeviceSessionAPI, bytes.NewReader(deviceJSONData))
 	if err != nil {

--- a/store/auth.go
+++ b/store/auth.go
@@ -35,7 +35,9 @@ var (
 	MyAppsMacaroonACLAPI = myappsAPIBase + "dev/api/acl/"
 	// MyAppsDeviceNonceAPI points to MyApps endpoint to get a nonce
 	MyAppsDeviceNonceAPI = myappsAPIBase + "identity/api/v1/nonces"
-	ubuntuoneAPIBase     = authURL()
+	// MyAppsDeviceSessionAPI points to MyApps endpoint to get a device session
+	MyAppsDeviceSessionAPI = myappsAPIBase + "identity/api/v1/sessions"
+	ubuntuoneAPIBase       = authURL()
 	// UbuntuoneLocation is the Ubuntuone location as defined in the store macaroon
 	UbuntuoneLocation = authLocation()
 	// UbuntuoneDischargeAPI points to SSO endpoint to discharge a macaroon
@@ -262,4 +264,50 @@ func RequestStoreDeviceNonce() (string, error) {
 		return "", fmt.Errorf(errorPrefix + "empty nonce returned")
 	}
 	return responseData.Nonce, nil
+}
+
+// RequestDeviceSession requests a device session macaroon from the store.
+func RequestDeviceSession(serialAssertion, serialProof, previousSession string) (string, error) {
+	const errorPrefix = "cannot get device session from store: "
+
+	data := map[string]string{
+		"serial-assertion": serialAssertion,
+		"serial-proof":     serialProof,
+	}
+	deviceJSONData, err := json.Marshal(data)
+
+	req, err := http.NewRequest("POST", MyAppsDeviceSessionAPI, bytes.NewReader(deviceJSONData))
+	if err != nil {
+		return "", fmt.Errorf(errorPrefix+"%v", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	if previousSession != "" {
+		req.Header.Set("X-Device-Authorization", fmt.Sprintf(`Macaroon root="%s"`, previousSession))
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf(errorPrefix+"%v", err)
+	}
+	defer resp.Body.Close()
+
+	// check return code, error on anything !200
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf(errorPrefix+"store server returned status %d", resp.StatusCode)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	var responseData struct {
+		Macaroon string `json:"macaroon"`
+	}
+	if err := dec.Decode(&responseData); err != nil {
+		return "", fmt.Errorf(errorPrefix+"%v", err)
+	}
+
+	if responseData.Macaroon == "" {
+		return "", fmt.Errorf(errorPrefix + "empty session returned")
+	}
+	return responseData.Macaroon, nil
 }

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -21,6 +21,7 @@ package store
 
 import (
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
@@ -326,4 +327,62 @@ func (s *authTestSuite) TestRequestStoreDeviceNonceError(c *C) {
 	nonce, err := RequestStoreDeviceNonce()
 	c.Assert(err, ErrorMatches, "cannot get nonce from store: store server returned status 500")
 	c.Assert(nonce, Equals, "")
+}
+
+func (s *authTestSuite) TestRequestDeviceSession(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		c.Check(string(jsonReq), Equals, `{"serial-assertion":"serial-assertion","serial-proof":"serial-proof"}`)
+		c.Check(r.Header.Get("X-Device-Authorization"), Equals, "")
+
+		io.WriteString(w, mockStoreReturnMacaroon)
+	}))
+	defer mockServer.Close()
+	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+
+	macaroon, err := RequestDeviceSession("serial-assertion", "serial-proof", "")
+	c.Assert(err, IsNil)
+	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
+}
+
+func (s *authTestSuite) TestRequestDeviceSessionWithPreviousSession(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		c.Check(string(jsonReq), Equals, `{"serial-assertion":"serial-assertion","serial-proof":"serial-proof"}`)
+		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="previous-session"`)
+
+		io.WriteString(w, mockStoreReturnMacaroon)
+	}))
+	defer mockServer.Close()
+	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+
+	macaroon, err := RequestDeviceSession("serial-assertion", "serial-proof", "previous-session")
+	c.Assert(err, IsNil)
+	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
+}
+
+func (s *authTestSuite) TestRequestDeviceSessionMissingData(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, mockStoreReturnNoMacaroon)
+	}))
+	defer mockServer.Close()
+	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+
+	macaroon, err := RequestDeviceSession("serial-assertion", "serial-proof", "")
+	c.Assert(err, ErrorMatches, "cannot get device session from store: empty session returned")
+	c.Assert(macaroon, Equals, "")
+}
+
+func (s *authTestSuite) TestRequestDeviceSessionError(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer mockServer.Close()
+	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+
+	macaroon, err := RequestDeviceSession("serial-assertion", "serial-proof", "")
+	c.Assert(err, ErrorMatches, "cannot get device session from store: store server returned status 500")
+	c.Assert(macaroon, Equals, "")
 }


### PR DESCRIPTION
Adds method to request a device session macaroon from the store, given serial and serial-proof assertions. If a previous session is passed, it will be refreshed.