### PR TITLE
asserts: add an account-key-request assertion

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -63,8 +63,9 @@ var (
 
 // Assertion types without a definite authority set (on the wire and/or self-signed).
 var (
-	SerialProofType   = &AssertionType{"serial-proof", nil, assembleSerialProof, noAuthority}
-	SerialRequestType = &AssertionType{"serial-request", nil, assembleSerialRequest, noAuthority}
+	SerialProofType       = &AssertionType{"serial-proof", nil, assembleSerialProof, noAuthority}
+	SerialRequestType     = &AssertionType{"serial-request", nil, assembleSerialRequest, noAuthority}
+	AccountKeyRequestType = &AssertionType{"account-key-request", nil, assembleAccountKeyRequest, noAuthority}
 )
 
 var typeRegistry = map[string]*AssertionType{
@@ -76,8 +77,9 @@ var typeRegistry = map[string]*AssertionType{
 	SnapBuildType.Name:       SnapBuildType,
 	SnapRevisionType.Name:    SnapRevisionType,
 	// no authority
-	SerialProofType.Name:   SerialProofType,
-	SerialRequestType.Name: SerialRequestType,
+	SerialProofType.Name:       SerialProofType,
+	SerialRequestType.Name:     SerialRequestType,
+	AccountKeyRequestType.Name: AccountKeyRequestType,
 }
 
 // Type returns the AssertionType with name or nil

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -661,7 +661,7 @@ func (as *assertsSuite) TestWithAuthority(c *C) {
 		"model",
 		"serial",
 	}
-	c.Check(withAuthority, HasLen, asserts.NumAssertionType-2) // excluding serial-request, serial-proof
+	c.Check(withAuthority, HasLen, asserts.NumAssertionType-3) // excluding serial-request, serial-proof, account-key-request
 	for _, name := range withAuthority {
 		typ := asserts.Type(name)
 		_, err := asserts.AssembleAndSignInTest(typ, nil, nil, testPrivKey1)


### PR DESCRIPTION
Add a no-authority account-key-request assertion, signed by the key holder.
This will be used to prove that the key holder wishes to create a matching
account-key assertion.