### PR TITLE
asserts: fix GPG key generation parameters

### DIFF
--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -159,7 +159,7 @@ var (
 	AppendEntry  = appendEntry
 )
 
-// GetGenerateParameters exposes getGenerateParameters for tests.
-func (gkm *GPGKeypairManager) GetGenerateParameters(passphrase string, name string) string {
-	return gkm.getGenerateParameters(passphrase, name)
+// ParametersForGenerate exposes parametersForGenerate for tests.
+func (gkm *GPGKeypairManager) ParametersForGenerate(passphrase string, name string) string {
+	return gkm.parametersForGenerate(passphrase, name)
 }

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -158,3 +158,8 @@ var (
 	ParseHeaders = parseHeaders
 	AppendEntry  = appendEntry
 )
+
+// GetGenerateParameters exposes getGenerateParameters for tests.
+func (gkm *GPGKeypairManager) GetGenerateParameters(passphrase string, name string) string {
+	return gkm.getGenerateParameters(passphrase, name)
+}

--- a/asserts/gpgkeypairmgr.go
+++ b/asserts/gpgkeypairmgr.go
@@ -269,7 +269,7 @@ Creation-Date: seconds=%d
 Preferences: SHA512
 `
 
-func (gkm *GPGKeypairManager) getGenerateParameters(passphrase string, name string) string {
+func (gkm *GPGKeypairManager) parametersForGenerate(passphrase string, name string) string {
 	fixedCreationTime := v1FixedTimestamp.Unix()
 	generateParams := fmt.Sprintf(generateTemplate, name, fixedCreationTime)
 	if passphrase != "" {
@@ -284,7 +284,7 @@ func (gkm *GPGKeypairManager) Generate(passphrase string, name string) error {
 	if err == nil {
 		return fmt.Errorf("key named %q already exists in GPG keyring", name)
 	}
-	generateParams := gkm.getGenerateParameters(passphrase, name)
+	generateParams := gkm.parametersForGenerate(passphrase, name)
 	_, err = gkm.gpg([]byte(generateParams), "--batch", "--gen-key")
 	if err != nil {
 		return err

--- a/asserts/gpgkeypairmgr.go
+++ b/asserts/gpgkeypairmgr.go
@@ -264,12 +264,19 @@ func (gkm *GPGKeypairManager) findByName(name string) (*gpgKeypairInfo, error) {
 var generateTemplate = `
 Key-Type: RSA
 Key-Length: 4096
-Subkey-Type: RSA
-Subkey-Length: 4096
 Name-Real: %s
-Creation-Date: %s
+Creation-Date: seconds=%d
 Preferences: SHA512
 `
+
+func (gkm *GPGKeypairManager) getGenerateParameters(passphrase string, name string) string {
+	fixedCreationTime := v1FixedTimestamp.Unix()
+	generateParams := fmt.Sprintf(generateTemplate, name, fixedCreationTime)
+	if passphrase != "" {
+		generateParams += "Passphrase: " + passphrase + "\n"
+	}
+	return generateParams
+}
 
 // Generate creates a new key with the given passphrase and name.
 func (gkm *GPGKeypairManager) Generate(passphrase string, name string) error {
@@ -277,11 +284,7 @@ func (gkm *GPGKeypairManager) Generate(passphrase string, name string) error {
 	if err == nil {
 		return fmt.Errorf("key named %q already exists in GPG keyring", name)
 	}
-	fixedCreationTime := v1FixedTimestamp.Format("20060102T030405")
-	generateParams := fmt.Sprintf(generateTemplate, name, fixedCreationTime)
-	if passphrase != "" {
-		generateParams += "Passphrase: " + passphrase + "\n"
-	}
+	generateParams := gkm.getGenerateParameters(passphrase, name)
 	_, err = gkm.gpg([]byte(generateParams), "--batch", "--gen-key")
 	if err != nil {
 		return err
@@ -295,11 +298,7 @@ func (gkm *GPGKeypairManager) Export(name string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	encoded, err := EncodePublicKey(keyInfo.pubKey)
-	if err != nil {
-		return nil, err
-	}
-	return encoded, nil
+	return EncodePublicKey(keyInfo.pubKey)
 }
 
 // Delete removes the named key pair from GnuPG's storage.

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -305,3 +305,27 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigningKeyTooShort(c *C) {
 	_, err = signDB.Sign(asserts.SnapBuildType, headers, nil, privk.PublicKey().ID())
 	c.Check(err, ErrorMatches, `cannot sign assertion: signing needs at least a 4096 bits key, got 2048`)
 }
+
+func (gkms *gpgKeypairMgrSuite) TestGetGenerateParameters(c *C) {
+	gpgKeypairMgr := gkms.keypairMgr.(*asserts.GPGKeypairManager)
+	baseParameters := `
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: test-key
+Creation-Date: seconds=1451606400
+Preferences: SHA512
+`
+
+	tests := []struct {
+		passphrase      string
+		extraParameters string
+	}{
+		{"", ""},
+		{"secret", "Passphrase: secret\n"},
+	}
+
+	for _, test := range tests {
+		parameters := gpgKeypairMgr.GetGenerateParameters(test.passphrase, "test-key")
+		c.Check(parameters, Equals, baseParameters+test.extraParameters)
+	}
+}

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -62,7 +62,7 @@ func (gkms *gpgKeypairMgrSuite) SetUpTest(c *C) {
 	gkms.importKey(assertstest.DevKey)
 }
 
-func (gkms *gpgKeypairMgrSuite) TearDowntest(c *C) {
+func (gkms *gpgKeypairMgrSuite) TearDownTest(c *C) {
 	os.Unsetenv("SNAP_GNUPG_HOME")
 }
 

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -306,7 +306,7 @@ func (gkms *gpgKeypairMgrSuite) TestUseInSigningKeyTooShort(c *C) {
 	c.Check(err, ErrorMatches, `cannot sign assertion: signing needs at least a 4096 bits key, got 2048`)
 }
 
-func (gkms *gpgKeypairMgrSuite) TestGetGenerateParameters(c *C) {
+func (gkms *gpgKeypairMgrSuite) TestParametersForGenerate(c *C) {
 	gpgKeypairMgr := gkms.keypairMgr.(*asserts.GPGKeypairManager)
 	baseParameters := `
 Key-Type: RSA
@@ -325,7 +325,7 @@ Preferences: SHA512
 	}
 
 	for _, test := range tests {
-		parameters := gpgKeypairMgr.GetGenerateParameters(test.passphrase, "test-key")
+		parameters := gpgKeypairMgr.ParametersForGenerate(test.passphrase, "test-key")
 		c.Check(parameters, Equals, baseParameters+test.extraParameters)
 	}
 }


### PR DESCRIPTION
The Creation-Date was off by twelve hours, and is easier to get right
using the seconds= form.  We must also avoid creating a subkey because
we only ever import the primary public key packet (snapd intentionally
does not have a full OpenPGP implementation).

An end-to-end test of this will come later when we have a command-line
tool that signs assertions that we can use from integration tests.
Generating keys in unit tests would be much too slow.