### PR TITLE
many: move network initialization to a separate service.

### DIFF
--- a/cmd/snap/cmd_init_network.go
+++ b/cmd/snap/cmd_init_network.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,29 +17,29 @@
  *
  */
 
-package firstboot
+package main
 
 import (
-	"os"
-	"path/filepath"
+	"github.com/jessevdk/go-flags"
 
-	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/boot"
 )
 
-func HasRun() bool {
-	return osutil.FileExists(dirs.SnapFirstBootStamp)
+type cmdInternalInitNetwork struct{}
+
+func init() {
+	cmd := addCommand("init-network",
+		"internal",
+		"internal", func() flags.Commander {
+			return &cmdInternalInitNetwork{}
+		})
+	cmd.hidden = true
 }
 
-func StampFirstBoot() error {
-	// filepath.Dir instead of firstbootDir directly to ease testing
-	stampDir := filepath.Dir(dirs.SnapFirstBootStamp)
-
-	if _, err := os.Stat(stampDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(stampDir, 0755); err != nil {
-			return err
-		}
+func (x *cmdInternalInitNetwork) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
 	}
 
-	return osutil.AtomicWriteFile(dirs.SnapFirstBootStamp, []byte{}, 0644, 0)
+	return boot.InitialNetworkConfig()
 }

--- a/debian/rules
+++ b/debian/rules
@@ -42,6 +42,10 @@ override_dh_systemd_enable:
 	dh_systemd_enable \
 		-pubuntu-core-snapd-units \
 		snapd.firstboot.service
+	# enable the init-network service
+	dh_systemd_enable \
+		-pubuntu-core-snapd-units \
+		snapd.initnetwork.service
 	# we want the auto-update timer enabled by default
 	dh_systemd_enable \
 		-psnapd \

--- a/debian/snapd.initnetwork.service
+++ b/debian/snapd.initnetwork.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Apply default network configuration if none exists
+After=local-fs.target
+Before=network-pre.target snapd.service
+DefaultDependencies=false
+ConditionPathExistsGlob=!/etc/netplan/*.yaml
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/snap init-network
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/ubuntu-core-snapd-units.install
+++ b/debian/ubuntu-core-snapd-units.install
@@ -1,2 +1,3 @@
 debian/snapd.boot-ok.service /lib/systemd/system/
 debian/snapd.firstboot.service /lib/systemd/system/
+debian/snapd.initnetwork.service /lib/systemd/system/

--- a/overlord/boot/firstboot.go
+++ b/overlord/boot/firstboot.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/firstboot"
-	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -213,9 +212,6 @@ func importAssertionsFromSeed(st *state.State) error {
 func FirstBoot() error {
 	if firstboot.HasRun() {
 		return ErrNotFirstBoot
-	}
-	if err := firstboot.InitialNetworkConfig(); err != nil {
-		logger.Noticef("Failed during inital network configuration: %s", err)
 	}
 
 	// snappy will be in a very unhappy state if this happens,

--- a/overlord/boot/network.go
+++ b/overlord/boot/network.go
@@ -1,0 +1,49 @@
+package boot
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+var netplanConfigFile = "/run/netplan/00-initial-config.yaml"
+var enableConfig = []string{"netplan", "apply"}
+
+var netplanConfigData = `
+network:
+ version: 2
+ ethernets:
+   all:
+    match:
+     name: "*"
+    dhcp4: true
+`
+
+var osRemove = os.Remove
+
+// InitialNetworkConfig writes and applies a netplan config that
+// enables dhcp on all wired interfaces. In the long run this should
+// be run as part of the config-changed hook and read the snap's
+// config to determine the netplan config to write.
+func InitialNetworkConfig() error {
+	if err := os.MkdirAll(filepath.Dir(netplanConfigFile), 0755); err != nil {
+		return err
+	}
+	if err := osutil.AtomicWriteFile(netplanConfigFile, []byte(netplanConfigData), 0644, 0); err != nil {
+		return err
+	}
+
+	enable := exec.Command(enableConfig[0], enableConfig[1:]...)
+	enable.Stdout = os.Stdout
+	enable.Stderr = os.Stderr
+	if err := enable.Run(); err != nil {
+		return err
+	}
+	if err := osRemove(netplanConfigFile); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/overlord/boot/network_test.go
+++ b/overlord/boot/network_test.go
@@ -17,31 +17,28 @@
  *
  */
 
-package firstboot
+package boot
 
 import (
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"testing"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 )
 
-func TestStore(t *testing.T) { TestingT(t) }
-
-type FirstBootTestSuite struct {
+type InitialNetworkConfigTestSuite struct {
 	netplanConfigFile string
 	enableConfig      []string
 	removedFiles      []string
 }
 
-var _ = Suite(&FirstBootTestSuite{})
+var _ = Suite(&InitialNetworkConfigTestSuite{})
 
-func (s *FirstBootTestSuite) SetUpTest(c *C) {
+func (s *InitialNetworkConfigTestSuite) SetUpTest(c *C) {
 	tempdir := c.MkDir()
 	dirs.SetRootDir(tempdir)
 
@@ -52,13 +49,13 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	osRemove = func(name string) error { s.removedFiles = append(s.removedFiles, name); return nil }
 }
 
-func (s *FirstBootTestSuite) TearDownTest(c *C) {
+func (s *InitialNetworkConfigTestSuite) TearDownTest(c *C) {
 	netplanConfigFile = s.netplanConfigFile
 	enableConfig = s.enableConfig
 	osRemove = os.Remove
 }
 
-func (s *FirstBootTestSuite) TestInitialNetworkConfig(c *C) {
+func (s *InitialNetworkConfigTestSuite) TestInitialNetworkConfig(c *C) {
 	c.Check(InitialNetworkConfig(), IsNil)
 	bs, err := ioutil.ReadFile(netplanConfigFile)
 	c.Assert(err, IsNil)
@@ -66,14 +63,14 @@ func (s *FirstBootTestSuite) TestInitialNetworkConfig(c *C) {
 	c.Assert(s.removedFiles, DeepEquals, []string{netplanConfigFile})
 }
 
-func (s *FirstBootTestSuite) TestInitialNetworkConfigBadPath(c *C) {
+func (s *InitialNetworkConfigTestSuite) TestInitialNetworkConfigBadPath(c *C) {
 	netplanConfigFile = "/no/such/thing"
 	err := InitialNetworkConfig()
 	c.Check(err, NotNil)
 	c.Check(os.IsPermission(err), Equals, true)
 }
 
-func (s *FirstBootTestSuite) TestInitialNetworkConfigEnableFails(c *C) {
+func (s *InitialNetworkConfigTestSuite) TestInitialNetworkConfigEnableFails(c *C) {
 	enableConfig = []string{"/bin/false"}
 	err := InitialNetworkConfig()
 	c.Check(err, NotNil)


### PR DESCRIPTION
The default netplan config written by firstboot does not interact well with any
other config that gets written. So it should only be used if there is not any
other network config (thanks ConditionPathExistsGlob=!/etc/netplan/*.yaml) and
should not persist on the disk (so just write it to /run/netplan/ and delete it
immediately after use).

This all sounds great, but it doesn't work :/ (network doesn't come up on first
boot). Maybe one of you can see why -- it's time for my weekend.