### PR TITLE
overlord/assertstate,asserts/snapasserts: give snap assertions helpers a package, introduce ReconstructSideInfo

### DIFF
--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package snapasserts offers helpers to handle snap assertions and their checking.
+package snapasserts
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+)
+
+// CrossCheck tries to cross check the name, hash digest and size of a snap plus its metadata in a SideInfo with the relevant snap assertions in a database that should have been populated with them.
+func CrossCheck(name, snapSHA3_384 string, snapSize uint64, si *snap.SideInfo, db asserts.RODatabase) error {
+	// get relevant assertions and do cross checks
+	a, err := db.Find(asserts.SnapRevisionType, map[string]string{
+		"snap-sha3-384": snapSHA3_384,
+	})
+	if err != nil {
+		return fmt.Errorf("internal error: cannot find pre-populated snap-revision assertion for %q: %s", name, snapSHA3_384)
+	}
+	snapRev := a.(*asserts.SnapRevision)
+
+	if snapRev.SnapSize() != snapSize {
+		return fmt.Errorf("snap %q file does not have expected size according to signatures (download is broken or tampered): %d != %d", name, snapSize, snapRev.SnapSize())
+	}
+
+	snapID := si.SnapID
+
+	if snapRev.SnapID() != snapID || snapRev.SnapRevision() != si.Revision.N {
+		// we have at least 2 cases here, what's the best message?
+		// - an unsuccesufl MITM
+		// - broken store metadata resulting into broken assertions
+		//   (more likely if it is snap-revision not matching)
+		//   people would need to report this
+		return fmt.Errorf("snap %q does not have expected ID or revision according to assertions (metadata is broken or tampered): %s / %s != %d / %s", name, si.Revision, snapID, snapRev.SnapRevision(), snapRev.SnapID())
+	}
+
+	a, err = db.Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  release.Series,
+		"snap-id": snapID,
+	})
+	if err != nil {
+		return fmt.Errorf("internal error: cannot find pre-populated snap declaration for %q: %s", name, snapID)
+	}
+	snapDecl := a.(*asserts.SnapDeclaration)
+
+	if snapDecl.SnapName() == "" {
+		// TODO: trigger a global sanity check
+		// that will generate the changes to deal with this
+		return fmt.Errorf("cannot install snap %q with a revoked snap declaration", name)
+	}
+
+	if snapDecl.SnapName() != name {
+		// TODO: trigger a global sanity check
+		// that will generate the changes to deal with this
+		return fmt.Errorf("cannot install snap %q that is undergoing a rename to %q", name, snapDecl.SnapName())
+	}
+
+	return nil
+}

--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -17,7 +17,7 @@
  *
  */
 
-// Package snapasserts offers helpers to handle snap assertions and their checking.
+// Package snapasserts offers helpers to handle snap assertions and their checking for installation.
 package snapasserts
 
 import (
@@ -27,6 +27,23 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
+
+func findSnapDeclaration(snapID, name string, db asserts.RODatabase) (*asserts.SnapDeclaration, error) {
+	a, err := db.Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  release.Series,
+		"snap-id": snapID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("internal error: cannot find snap declaration for %q: %s", name, snapID)
+	}
+	snapDecl := a.(*asserts.SnapDeclaration)
+
+	if snapDecl.SnapName() == "" {
+		return nil, fmt.Errorf("cannot install snap %q with a revoked snap declaration", name)
+	}
+
+	return snapDecl, nil
+}
 
 // CrossCheck tries to cross check the name, hash digest and size of a snap plus its metadata in a SideInfo with the relevant snap assertions in a database that should have been populated with them.
 func CrossCheck(name, snapSHA3_384 string, snapSize uint64, si *snap.SideInfo, db asserts.RODatabase) error {
@@ -54,26 +71,92 @@ func CrossCheck(name, snapSHA3_384 string, snapSize uint64, si *snap.SideInfo, d
 		return fmt.Errorf("snap %q does not have expected ID or revision according to assertions (metadata is broken or tampered): %s / %s != %d / %s", name, si.Revision, snapID, snapRev.SnapRevision(), snapRev.SnapID())
 	}
 
-	a, err = db.Find(asserts.SnapDeclarationType, map[string]string{
-		"series":  release.Series,
-		"snap-id": snapID,
-	})
+	snapDecl, err := findSnapDeclaration(snapID, name, db)
 	if err != nil {
-		return fmt.Errorf("internal error: cannot find pre-populated snap declaration for %q: %s", name, snapID)
-	}
-	snapDecl := a.(*asserts.SnapDeclaration)
-
-	if snapDecl.SnapName() == "" {
-		// TODO: trigger a global sanity check
-		// that will generate the changes to deal with this
-		return fmt.Errorf("cannot install snap %q with a revoked snap declaration", name)
+		return err
 	}
 
 	if snapDecl.SnapName() != name {
-		// TODO: trigger a global sanity check
-		// that will generate the changes to deal with this
 		return fmt.Errorf("cannot install snap %q that is undergoing a rename to %q", name, snapDecl.SnapName())
 	}
 
 	return nil
+}
+
+// ReconstructSideInfoFlags represent the mode flags for ReconstructSideInfo.
+type ReconstructSideInfoFlags int
+
+const (
+	// AllowWithoutSignatures flags allowing extracting information from a snap for which signatures cannot be found.
+	AllowWithoutSignatures ReconstructSideInfoFlags = iota + 1
+)
+
+// ReconstructSideInfo tries to construct a SideInfo for the given snap using its digest to find the relevant snap assertions with the information in the given database. It will fail if it cannot find them, unless flags is AllowWithoutSignatures in which case it extracts unsafely just the name from the snap itself.
+func ReconstructSideInfo(snapPath string, flags ReconstructSideInfoFlags, db asserts.RODatabase) (*snap.SideInfo, error) {
+	snapSHA3_384, snapSize, err := asserts.SnapFileSHA3_384(snapPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// get relevant assertions and reconstruct metadata
+	a, err := db.Find(asserts.SnapRevisionType, map[string]string{
+		"snap-sha3-384": snapSHA3_384,
+	})
+	if err == asserts.ErrNotFound {
+		if flags == AllowWithoutSignatures {
+			// unsafe fallback mode
+			return unsafeReconstructSideInfo(snapPath)
+		}
+		return nil, fmt.Errorf("cannot find signatures with metadata for snap %q", snapPath)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	snapRev := a.(*asserts.SnapRevision)
+
+	if snapRev.SnapSize() != snapSize {
+		return nil, fmt.Errorf("snap %q does not have expected size according to signatures (broken or tampered): %d != %d", snapPath, snapSize, snapRev.SnapSize())
+	}
+
+	snapID := snapRev.SnapID()
+
+	snapDecl, err := findSnapDeclaration(snapID, snapPath, db)
+	if err != nil {
+		return nil, err
+	}
+
+	name := snapDecl.SnapName()
+
+	// TODO: once we are fully migrated to assertions this can
+	// be done dynamically later instead of statically here
+	a, err = db.Find(asserts.AccountType, map[string]string{
+		"account-id": snapRev.DeveloperID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("internal error: cannot find developer account for snap %q (%q): %s", name, snapPath, snapRev.DeveloperID())
+	}
+	devAcct := a.(*asserts.Account)
+
+	return &snap.SideInfo{
+		RealName:    name,
+		SnapID:      snapID,
+		Revision:    snap.R(snapRev.SnapRevision()),
+		DeveloperID: snapRev.DeveloperID(),
+		Developer:   devAcct.Username(),
+	}, nil
+}
+
+func unsafeReconstructSideInfo(snapPath string) (*snap.SideInfo, error) {
+	snapf, err := snap.Open(snapPath)
+	if err != nil {
+		return nil, err
+	}
+	info, err := snap.ReadInfoFromSnapFile(snapf, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &snap.SideInfo{
+		RealName: info.Name(),
+	}, nil
 }

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -1,0 +1,232 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapasserts_test
+
+import (
+	"crypto"
+	"fmt"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/sha3"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/snap"
+)
+
+func TestSnapasserts(t *testing.T) { TestingT(t) }
+
+type snapassertsSuite struct {
+	storeSigning *assertstest.StoreStack
+	dev1Acct     *asserts.Account
+
+	localDB *asserts.Database
+}
+
+var _ = Suite(&snapassertsSuite{})
+
+func (s *snapassertsSuite) SetUpTest(c *C) {
+	rootPrivKey, _ := assertstest.GenerateKey(1024)
+	storePrivKey, _ := assertstest.GenerateKey(752)
+	s.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+
+	s.dev1Acct = assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
+
+	localDB, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   s.storeSigning.Trusted,
+	})
+	c.Assert(err, IsNil)
+
+	s.localDB = localDB
+}
+
+func fakeSnap(rev int) []byte {
+	fake := fmt.Sprintf("hsqs________________%d", rev)
+	return []byte(fake)
+}
+
+func fakeHash(rev int) []byte {
+	h := sha3.Sum384(fakeSnap(rev))
+	return h[:]
+}
+
+func makeDigest(rev int) string {
+	d, err := asserts.EncodeDigest(crypto.SHA3_384, fakeHash(rev))
+	if err != nil {
+		panic(err)
+	}
+	return string(d)
+}
+
+func (s *snapassertsSuite) TestCrossCheckHappy(c *C) {
+	// add in prereqs assertions
+	err := s.localDB.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	headers := map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "snap-id-1",
+		"snap-name":    "foo",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(snapDecl)
+	c.Assert(err, IsNil)
+
+	digest := makeDigest(12)
+	size := uint64(len(fakeSnap(12)))
+	headers = map[string]interface{}{
+		"snap-id":       "snap-id-1",
+		"snap-sha3-384": digest,
+		"snap-size":     fmt.Sprintf("%d", size),
+		"snap-revision": "12",
+		"developer-id":  s.dev1Acct.AccountID(),
+		"timestamp":     time.Now().Format(time.RFC3339),
+	}
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(snapRev)
+	c.Assert(err, IsNil)
+
+	si := &snap.SideInfo{
+		SnapID:   "snap-id-1",
+		Revision: snap.R(12),
+	}
+
+	// everything cross checks
+	err = snapasserts.CrossCheck("foo", digest, size, si, s.localDB)
+	c.Check(err, IsNil)
+}
+
+func (s *snapassertsSuite) TestCrossCheckErrors(c *C) {
+	// add in prereqs assertions
+	err := s.localDB.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	headers := map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "snap-id-1",
+		"snap-name":    "foo",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(snapDecl)
+	c.Assert(err, IsNil)
+
+	digest := makeDigest(12)
+	size := uint64(len(fakeSnap(12)))
+	headers = map[string]interface{}{
+		"snap-id":       "snap-id-1",
+		"snap-sha3-384": digest,
+		"snap-size":     fmt.Sprintf("%d", size),
+		"snap-revision": "12",
+		"developer-id":  s.dev1Acct.AccountID(),
+		"timestamp":     time.Now().Format(time.RFC3339),
+	}
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(snapRev)
+	c.Assert(err, IsNil)
+
+	si := &snap.SideInfo{
+		SnapID:   "snap-id-1",
+		Revision: snap.R(12),
+	}
+
+	// different size
+	err = snapasserts.CrossCheck("foo", digest, size+1, si, s.localDB)
+	c.Check(err, ErrorMatches, fmt.Sprintf(`snap "foo" file does not have expected size according to signatures \(download is broken or tampered\): %d != %d`, size+1, size))
+
+	// mismatched revision vs what we got from store original info
+	err = snapasserts.CrossCheck("foo", digest, size, &snap.SideInfo{
+		SnapID:   "snap-id-1",
+		Revision: snap.R(21),
+	}, s.localDB)
+	c.Check(err, ErrorMatches, `snap "foo" does not have expected ID or revision according to assertions \(metadata is broken or tampered\): 21 / snap-id-1 != 12 / snap-id-1`)
+
+	// mismatched snap id vs what we got from store original info
+	err = snapasserts.CrossCheck("foo", digest, size, &snap.SideInfo{
+		SnapID:   "snap-id-other",
+		Revision: snap.R(12),
+	}, s.localDB)
+	c.Check(err, ErrorMatches, `snap "foo" does not have expected ID or revision according to assertions \(metadata is broken or tampered\): 12 / snap-id-other != 12 / snap-id-1`)
+
+	// changed name
+	err = snapasserts.CrossCheck("baz", digest, size, si, s.localDB)
+	c.Check(err, ErrorMatches, `cannot install snap "baz" that is undergoing a rename to "foo"`)
+
+}
+
+func (s *snapassertsSuite) TestCrossCheckRevokedSnapDecl(c *C) {
+	// add in prereqs assertions
+	err := s.localDB.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	// revoked snap declaration (snap-name=="") !
+	headers := map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "snap-id-1",
+		"snap-name":    "",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}
+	snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(snapDecl)
+	c.Assert(err, IsNil)
+
+	digest := makeDigest(12)
+	size := uint64(len(fakeSnap(12)))
+	headers = map[string]interface{}{
+		"snap-id":       "snap-id-1",
+		"snap-sha3-384": digest,
+		"snap-size":     fmt.Sprintf("%d", size),
+		"snap-revision": "12",
+		"developer-id":  s.dev1Acct.AccountID(),
+		"timestamp":     time.Now().Format(time.RFC3339),
+	}
+	snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.localDB.Add(snapRev)
+	c.Assert(err, IsNil)
+
+	si := &snap.SideInfo{
+		SnapID:   "snap-id-1",
+		Revision: snap.R(12),
+	}
+
+	err = snapasserts.CrossCheck("foo", digest, size, si, s.localDB)
+	c.Check(err, ErrorMatches, `cannot install snap "foo" with a revoked snap declaration`)
+}

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -216,6 +216,9 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 	db := DB(t.State())
 	err = snapasserts.CrossCheck(ss.Name(), sha3_384, snapSize, ss.SideInfo, db)
 	if err != nil {
+		// TODO: trigger a global sanity check
+		// that will generate the changes to deal with this
+		// for things like snap-decl revocation and renames?
 		return err
 	}
 

--- a/overlord/assertstate/export_test.go
+++ b/overlord/assertstate/export_test.go
@@ -21,6 +21,5 @@ package assertstate
 
 // expose for testing
 var (
-	Fetch          = fetch
-	CrossCheckSnap = crossCheckSnap
+	Fetch = fetch
 )


### PR DESCRIPTION
This introduces asserts/snapasserts that helps dealing with snap assertions for installation, assertstate.crossCheckSnap moves here as CrossCheck, and this also adds a function going from assertions to a SideInfo for the snap called ReconstructSideInfo.

ReconstructSideInfo can be passed a flag to allow an unsafe fallback mode where it opens the snap directly to read out its name.