### PR TITLE
store: refresh expired device sessions

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -385,17 +385,66 @@ func refreshMacaroon(user *auth.UserState) error {
 	return nil
 }
 
-// authenticateDevice will add the store expected Macaroon X-Device-Authorization header for device
-func (s *Store) authenticateDevice(r *http.Request) {
+// refreshUser will refresh user discharge macaroon and update state
+func (s *Store) refreshUser(user *auth.UserState) error {
+	err := refreshMacaroon(user)
+	if err != nil {
+		return err
+	}
+
 	if s.authContext != nil {
-		device, err := s.authContext.Device()
+		err = s.authContext.UpdateUser(user)
 		if err != nil {
-			logger.Debugf("cannot get device from state: %v", err)
-			return
+			return err
 		}
-		if device.SessionMacaroon != "" {
-			r.Header.Set("X-Device-Authorization", fmt.Sprintf(`Macaroon root="%s"`, device.SessionMacaroon))
-		}
+	}
+
+	return nil
+}
+
+// refreshDeviceSession will set or refresh the device session in the state
+func (s *Store) refreshDeviceSession() error {
+	if s.authContext == nil {
+		return fmt.Errorf("cannot get device from state: no authContext")
+	}
+
+	device, err := s.authContext.Device()
+	if err != nil {
+		return fmt.Errorf("cannot get device from state: %v", err)
+	}
+
+	nonce, err := RequestStoreDeviceNonce()
+	if err != nil {
+		return err
+	}
+
+	serialProof, err := s.authContext.SerialProof(nonce)
+	if err != nil {
+		return err
+	}
+
+	serialAssertion, err := s.authContext.Serial()
+	if err != nil {
+		return err
+	}
+
+	session, err := RequestDeviceSession(string(serialAssertion), string(serialProof), device.SessionMacaroon)
+	if err != nil {
+		return err
+	}
+
+	device.SessionMacaroon = session
+	err = s.authContext.UpdateDevice(device)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// authenticateDevice will add the store expected Macaroon X-Device-Authorization header for device
+func authenticateDevice(r *http.Request, device *auth.DeviceState) {
+	if device.SessionMacaroon != "" {
+		r.Header.Set("X-Device-Authorization", fmt.Sprintf(`Macaroon root="%s"`, device.SessionMacaroon))
 	}
 }
 
@@ -437,24 +486,26 @@ func (s *Store) doRequest(client *http.Client, reqOptions *requestOptions, user 
 
 	wwwAuth := resp.Header.Get("WWW-Authenticate")
 	if resp.StatusCode == 401 && user != nil && strings.Contains(wwwAuth, "needs_refresh=1") {
-		// close previous response, refresh and retry
+		// close previous response, refresh user and retry
 		resp.Body.Close()
-		err = refreshMacaroon(user)
+		err = s.refreshUser(user)
 		if err != nil {
 			return nil, err
 		}
-		if s.authContext != nil {
-			err = s.authContext.UpdateUser(user)
-			if err != nil {
-				return nil, err
-			}
-		}
-		req, err := s.newRequest(reqOptions, user)
+		// retry
+		return s.doRequest(client, reqOptions, user)
+
+	} else if resp.StatusCode == 401 && strings.Contains(wwwAuth, "refresh_device_session=1") {
+		// close previous response, refresh device session and retry
+		resp.Body.Close()
+		err = s.refreshDeviceSession()
 		if err != nil {
 			return nil, err
 		}
-		resp, err = client.Do(req)
+		// retry
+		return s.doRequest(client, reqOptions, user)
 	}
+
 	return resp, err
 }
 
@@ -470,7 +521,15 @@ func (s *Store) newRequest(reqOptions *requestOptions, user *auth.UserState) (*h
 		return nil, err
 	}
 
-	s.authenticateDevice(req)
+	if s.authContext != nil {
+		device, err := s.authContext.Device()
+		if err != nil {
+			return nil, err
+		}
+		// TODO: if device session is empty, request new session
+		authenticateDevice(req, device)
+	}
+
 	if user != nil {
 		authenticateUser(req, user)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -405,12 +405,12 @@ func (s *Store) refreshUser(user *auth.UserState) error {
 // refreshDeviceSession will set or refresh the device session in the state
 func (s *Store) refreshDeviceSession() error {
 	if s.authContext == nil {
-		return fmt.Errorf("cannot get device from state: no authContext")
+		return fmt.Errorf("internal error: no authContext")
 	}
 
 	device, err := s.authContext.Device()
 	if err != nil {
-		return fmt.Errorf("cannot get device from state: %v", err)
+		return err
 	}
 
 	serialAssertion, err := s.authContext.Serial()

--- a/store/store.go
+++ b/store/store.go
@@ -413,17 +413,17 @@ func (s *Store) refreshDeviceSession() error {
 		return fmt.Errorf("cannot get device from state: %v", err)
 	}
 
+	serialAssertion, err := s.authContext.Serial()
+	if err != nil {
+		return err
+	}
+
 	nonce, err := RequestStoreDeviceNonce()
 	if err != nil {
 		return err
 	}
 
 	serialProof, err := s.authContext.SerialProof(nonce)
-	if err != nil {
-		return err
-	}
-
-	serialAssertion, err := s.authContext.Serial()
 	if err != nil {
 		return err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -50,6 +50,7 @@ type remoteRepoTestSuite struct {
 	store  *Store
 	logbuf *bytes.Buffer
 	user   *auth.UserState
+	device *auth.DeviceState
 
 	origDownloadFunc func(string, string, *auth.UserState, *Store, io.Writer, progress.Meter) error
 }
@@ -58,18 +59,50 @@ func TestStore(t *testing.T) { TestingT(t) }
 
 var _ = Suite(&remoteRepoTestSuite{})
 
+const (
+	exSerial = `type: serial
+authority-id: my-brand
+brand-id: my-brand
+model: baz-3000
+serial: 9999
+device-key:
+    AcbBTQRWhcGAARAAtJGIguK7FhSyRxL/6jvdy0zAgGCjC1xVNFzeF76p5G8BXNEEHZUHK+z8Gr2J
+    inVrpvhJhllf5Ob2dIMH2YQbC9jE1kjbzvuauQGDqk6tNQm0i3KDeHCSPgVN+PFXPwKIiLrh66Po
+    AC7OfR1rFUgCqu0jch0H6Nue0ynvEPiY4dPeXq7mCdpDr5QIAM41L+3hg0OdzvO8HMIGZQpdF6jP
+    7fkkVMROYvHUOJ8kknpKE7FiaNNpH7jK1qNxOYhLeiioX0LYrdmTvdTWHrSKZc82ZmlDjpKc4hUx
+    VtTXMAysw7CzIdREPom/vJklnKLvZt+Wk5AEF5V5YKnuT3pY+fjVMZ56GtTEeO/Er/oLk/n2xUK5
+    fD5DAyW/9z0ygzwTbY5IuWXyDfYneL4nXwWOEgg37Z4+8mTH+ftTz2dl1x1KIlIR2xo0kxf9t8K+
+    jlr13vwF1+QReMCSUycUsZ2Eep5XhjI+LG7G1bMSGqodZTIOXLkIy6+3iJ8Z/feIHlJ0ELBDyFbl
+    Yy04Sf9LI148vJMsYenonkoWejWdMi8iCUTeaZydHJEUBU/RbNFLjCWa6NIUe9bfZgLiOOZkps54
+    +/AL078ri/tGjo/5UGvezSmwrEoWJyqrJt2M69N2oVDLJcHeo2bUYPtFC2Kfb2je58JrJ+llifdg
+    rAsxbnHXiXyVimUAEQEAAQ==
+device-key-sha3-384: EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
+timestamp: 2016-08-24T21:55:00Z
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw=`
+
+	exSerialProof = `type: serial-proof
+nonce: @NONCE@
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw=`
+)
+
 type testAuthContext struct {
-	c    *C
-	user *auth.UserState
+	c      *C
+	device *auth.DeviceState
+	user   *auth.UserState
 
 	storeID string
 }
 
 func (ac *testAuthContext) Device() (*auth.DeviceState, error) {
-	return createTestDevice(), nil
+	return ac.device, nil
 }
 
 func (ac *testAuthContext) UpdateDevice(d *auth.DeviceState) error {
+	ac.device = d
 	return nil
 }
 
@@ -86,11 +119,19 @@ func (ac *testAuthContext) StoreID(fallback string) (string, error) {
 }
 
 func (ac *testAuthContext) Serial() ([]byte, error) {
-	return nil, fmt.Errorf("no serial")
+	a, err := asserts.Decode([]byte(exSerial))
+	if err != nil {
+		return nil, err
+	}
+	return asserts.Encode(a.(*asserts.Serial)), nil
 }
 
 func (ac *testAuthContext) SerialProof(nonce string) ([]byte, error) {
-	return nil, fmt.Errorf("no key pair")
+	a, err := asserts.Decode([]byte(strings.Replace(exSerialProof, "@NONCE@", nonce, 1)))
+	if err != nil {
+		return nil, err
+	}
+	return asserts.Encode(a.(*asserts.SerialProof)), nil
 }
 
 func makeTestMacaroon() (*macaroon.Macaroon, error) {
@@ -168,6 +209,7 @@ func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	t.user, err = createTestUser(1, root, discharge)
 	c.Assert(err, IsNil)
+	t.device = createTestDevice()
 }
 
 func (t *remoteRepoTestSuite) TearDownTest(c *C) {
@@ -529,7 +571,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryStoreIDFromAuthContext(c 
 	cfg.Series = "21"
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "fallback"
-	repo := New(cfg, &testAuthContext{c: c, storeID: "my-brand-store-id"})
+	repo := New(cfg, &testAuthContext{c: c, device: t.device, storeID: "my-brand-store-id"})
 	c.Assert(repo, NotNil)
 
 	// the actual test
@@ -644,7 +686,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsSetsAuth(c *C) {
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		DetailsURI:   detailsURI,
 		PurchasesURI: purchasesURI,
@@ -697,7 +739,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsRefreshesAuth(c *C
 	defer mockServer.Close()
 	detailsURI, _ := url.Parse(mockServer.URL + "/details/")
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		DetailsURI:   detailsURI,
 		PurchasesURI: purchasesURI,
@@ -709,6 +751,63 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsRefreshesAuth(c *C
 	c.Assert(err, IsNil)
 	c.Check(refreshDischargeEndpointHit, Equals, true)
 	c.Assert(snap, NotNil)
+	c.Check(snap.MustBuy, Equals, false)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsRefreshesDeviceAuth(c *C) {
+	// mock purchases response
+	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, mockPurchaseJSON)
+	}))
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+	purchasesURI, _ := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
+
+	refreshSessionRequested := false
+	expiredAuth := fmt.Sprintf(`Macaroon root="%s"`, t.device.SessionMacaroon)
+	// mock store response
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		switch r.URL.Path {
+		case "/details/hello-world":
+			authorization := r.Header.Get("X-Device-Authorization")
+			if authorization == expiredAuth {
+				w.Header().Set("WWW-Authenticate", "Macaroon refresh_device_session=1")
+				w.WriteHeader(http.StatusUnauthorized)
+			} else {
+				c.Check(authorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
+				io.WriteString(w, MockDetailsJSON)
+			}
+		case "/identity/api/v1/nonces":
+			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
+		case "/identity/api/v1/sessions":
+			authorization := r.Header.Get("X-Device-Authorization")
+			c.Check(authorization, Equals, expiredAuth)
+			io.WriteString(w, `{"macaroon": "refreshed-session-macaroon"}`)
+			refreshSessionRequested = true
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
+	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+	detailsURI, _ := url.Parse(mockServer.URL + "/details/")
+
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
+	cfg := Config{
+		DetailsURI:   detailsURI,
+		PurchasesURI: purchasesURI,
+	}
+	repo := New(&cfg, authContext)
+	c.Assert(repo, NotNil)
+
+	snap, err := repo.Snap("hello-world", "edge", false, snap.R(0), t.user)
+	c.Assert(err, IsNil)
+	c.Assert(snap, NotNil)
+	c.Check(refreshSessionRequested, Equals, true)
 	c.Check(snap.MustBuy, Equals, false)
 }
 
@@ -1057,7 +1156,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindSetsAuth(c *C) {
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		SearchURI:    searchURI,
 		PurchasesURI: purchasesURI,
@@ -1119,7 +1218,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindRefreshesAuth(c *C) {
 		SearchURI:    searchURI,
 		PurchasesURI: purchasesURI,
 	}
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 
 	repo := New(&cfg, authContext)
 	c.Assert(repo, NotNil)
@@ -1127,6 +1226,71 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindRefreshesAuth(c *C) {
 	snaps, err := repo.Find(&Search{Query: "foo"}, t.user)
 	c.Assert(err, IsNil)
 	c.Check(refreshDischargeEndpointHit, Equals, true)
+	c.Assert(snaps, HasLen, 1)
+	c.Check(snaps[0].SnapID, Equals, helloWorldSnapID)
+	c.Check(snaps[0].Prices, DeepEquals, map[string]float64{"EUR": 2.99, "USD": 3.49})
+	c.Check(snaps[0].MustBuy, Equals, false)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreFindRefreshesDeviceAuth(c *C) {
+	// mock purchases response
+	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+		io.WriteString(w, mockPurchaseJSON)
+	}))
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
+	c.Assert(err, IsNil)
+
+	refreshSessionRequested := false
+	expiredAuth := fmt.Sprintf(`Macaroon root="%s"`, t.device.SessionMacaroon)
+	// mock store response
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		switch r.URL.Path {
+		case "/":
+			authorization := r.Header.Get("X-Device-Authorization")
+			if authorization == expiredAuth {
+				w.Header().Set("WWW-Authenticate", "Macaroon refresh_device_session=1")
+				w.WriteHeader(http.StatusUnauthorized)
+			} else {
+				c.Check(authorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
+				c.Check(r.URL.Query().Get("q"), Equals, "foo")
+				w.Header().Set("Content-Type", "application/hal+json")
+				w.WriteHeader(http.StatusOK)
+				io.WriteString(w, MockSearchJSON)
+			}
+		case "/identity/api/v1/nonces":
+			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
+		case "/identity/api/v1/sessions":
+			authorization := r.Header.Get("X-Device-Authorization")
+			c.Check(authorization, Equals, expiredAuth)
+			io.WriteString(w, `{"macaroon": "refreshed-session-macaroon"}`)
+			refreshSessionRequested = true
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
+	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+	searchURI, _ := url.Parse(mockServer.URL)
+
+	cfg := Config{
+		SearchURI:    searchURI,
+		PurchasesURI: purchasesURI,
+	}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
+
+	repo := New(&cfg, authContext)
+	c.Assert(repo, NotNil)
+
+	snaps, err := repo.Find(&Search{Query: "foo"}, t.user)
+	c.Assert(err, IsNil)
+	c.Check(refreshSessionRequested, Equals, true)
 	c.Assert(snaps, HasLen, 1)
 	c.Check(snaps[0].SnapID, Equals, helloWorldSnapID)
 	c.Check(snaps[0].Prices, DeepEquals, map[string]float64{"EUR": 2.99, "USD": 3.49})
@@ -1454,7 +1618,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdatesSetsAuth(c *C) {
 	bulkURI, err := url.Parse(mockServer.URL + "/updates/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		BulkURI: bulkURI,
 	}
@@ -1504,7 +1668,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdatesRefreshesAuth(c *C
 	defer mockServer.Close()
 	bulkURI, _ := url.Parse(mockServer.URL + "/updates/")
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		BulkURI: bulkURI,
 	}
@@ -1522,6 +1686,60 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdatesRefreshesAuth(c *C
 	}, t.user)
 	c.Assert(err, IsNil)
 	c.Check(refreshDischargeEndpointHit, Equals, true)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdatesRefreshesDeviceAuth(c *C) {
+	refreshSessionRequested := false
+	expiredAuth := fmt.Sprintf(`Macaroon root="%s"`, t.device.SessionMacaroon)
+	// mock store response
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		switch r.URL.Path {
+		case "/updates/":
+			authorization := r.Header.Get("X-Device-Authorization")
+			if authorization == expiredAuth {
+				w.Header().Set("WWW-Authenticate", "Macaroon refresh_device_session=1")
+				w.WriteHeader(http.StatusUnauthorized)
+			} else {
+				c.Check(authorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
+				io.WriteString(w, MockUpdatesJSON)
+			}
+		case "/identity/api/v1/nonces":
+			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
+		case "/identity/api/v1/sessions":
+			authorization := r.Header.Get("X-Device-Authorization")
+			c.Check(authorization, Equals, expiredAuth)
+			io.WriteString(w, `{"macaroon": "refreshed-session-macaroon"}`)
+			refreshSessionRequested = true
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
+	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+	bulkURI, _ := url.Parse(mockServer.URL + "/updates/")
+
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
+	cfg := Config{
+		BulkURI: bulkURI,
+	}
+	repo := New(&cfg, authContext)
+	c.Assert(repo, NotNil)
+
+	_, err := repo.ListRefresh([]*RefreshCandidate{
+		{
+			SnapID:   helloWorldSnapID,
+			Channel:  "stable",
+			Revision: snap.R(1),
+			Epoch:    "0",
+			DevMode:  false,
+		},
+	}, t.user)
+	c.Assert(err, IsNil)
+	c.Check(refreshSessionRequested, Equals, true)
 }
 
 func (t *remoteRepoTestSuite) TestStructFieldsSurvivesNoTag(c *C) {
@@ -1653,7 +1871,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionSetsAuth(c *C) {
 	assertionsURI, err := url.Parse(mockServer.URL + "/assertions/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		AssertionsURI: assertionsURI,
 	}
@@ -1696,7 +1914,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionRefreshesAuth(c 
 	defer mockServer.Close()
 	assertionsURI, _ := url.Parse(mockServer.URL + "/assertions/")
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		AssertionsURI: assertionsURI,
 	}
@@ -1705,6 +1923,52 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionRefreshesAuth(c 
 	_, err = repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, t.user)
 	c.Assert(err, IsNil)
 	c.Check(refreshDischargeEndpointHit, Equals, true)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionRefreshesDeviceAuth(c *C) {
+	refreshSessionRequested := false
+	expiredAuth := fmt.Sprintf(`Macaroon root="%s"`, t.device.SessionMacaroon)
+	// mock store response
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		switch r.URL.Path {
+		case "/assertions/snap-declaration/16/snapidfoo":
+			authorization := r.Header.Get("X-Device-Authorization")
+			if authorization == expiredAuth {
+				w.Header().Set("WWW-Authenticate", "Macaroon refresh_device_session=1")
+				w.WriteHeader(http.StatusUnauthorized)
+			} else {
+				c.Check(authorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
+				c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
+				io.WriteString(w, testAssertion)
+			}
+		case "/identity/api/v1/nonces":
+			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
+		case "/identity/api/v1/sessions":
+			authorization := r.Header.Get("X-Device-Authorization")
+			c.Check(authorization, Equals, expiredAuth)
+			io.WriteString(w, `{"macaroon": "refreshed-session-macaroon"}`)
+			refreshSessionRequested = true
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
+	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+	assertionsURI, _ := url.Parse(mockServer.URL + "/assertions/")
+
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
+	cfg := Config{
+		AssertionsURI: assertionsURI,
+	}
+	repo := New(&cfg, authContext)
+
+	_, err := repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, t.user)
+	c.Assert(err, IsNil)
+	c.Check(refreshSessionRequested, Equals, true)
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNotFound(c *C) {
@@ -1785,7 +2049,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecoratePurchases(c *C) {
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		PurchasesURI: purchasesURI,
 	}
@@ -1846,7 +2110,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecoratePurchasesRefreshesAuth(c *C
 	defer mockPurchasesServer.Close()
 	purchasesURI, _ := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		PurchasesURI: purchasesURI,
 	}
@@ -1873,6 +2137,74 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecoratePurchasesRefreshesAuth(c *C
 	err = repo.decoratePurchases(snaps, "edge", t.user)
 	c.Assert(err, IsNil)
 	c.Check(refreshDischargeEndpointHit, Equals, true)
+
+	c.Check(helloWorld.MustBuy, Equals, false)
+	c.Check(funkyApp.MustBuy, Equals, false)
+	c.Check(otherApp.MustBuy, Equals, true)
+	c.Check(otherApp2.MustBuy, Equals, false)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreDecoratePurchasesRefreshesDeviceAuth(c *C) {
+	refreshSessionRequested := false
+	expiredAuth := fmt.Sprintf(`Macaroon root="%s"`, t.device.SessionMacaroon)
+	// mock store response
+	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		switch r.URL.Path {
+		case "/dev/api/snap-purchases/":
+			authorization := r.Header.Get("X-Device-Authorization")
+			if authorization == expiredAuth {
+				w.Header().Set("WWW-Authenticate", "Macaroon refresh_device_session=1")
+				w.WriteHeader(http.StatusUnauthorized)
+			} else {
+				c.Check(authorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
+				io.WriteString(w, mockPurchasesJSON)
+			}
+		case "/identity/api/v1/nonces":
+			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
+		case "/identity/api/v1/sessions":
+			authorization := r.Header.Get("X-Device-Authorization")
+			c.Check(authorization, Equals, expiredAuth)
+			io.WriteString(w, `{"macaroon": "refreshed-session-macaroon"}`)
+			refreshSessionRequested = true
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+	MyAppsDeviceNonceAPI = mockPurchasesServer.URL + "/identity/api/v1/nonces"
+	MyAppsDeviceSessionAPI = mockPurchasesServer.URL + "/identity/api/v1/sessions"
+	purchasesURI, _ := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
+
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
+	cfg := Config{
+		PurchasesURI: purchasesURI,
+	}
+	repo := New(&cfg, authContext)
+	c.Assert(repo, NotNil)
+
+	helloWorld := &snap.Info{}
+	helloWorld.SnapID = helloWorldSnapID
+	helloWorld.Prices = map[string]float64{"USD": 1.23}
+
+	funkyApp := &snap.Info{}
+	funkyApp.SnapID = funkyAppSnapID
+	funkyApp.Prices = map[string]float64{"USD": 2.34}
+
+	otherApp := &snap.Info{}
+	otherApp.SnapID = "other"
+	otherApp.Prices = map[string]float64{"USD": 3.45}
+
+	otherApp2 := &snap.Info{}
+	otherApp2.SnapID = "other2"
+
+	snaps := []*snap.Info{helloWorld, funkyApp, otherApp, otherApp2}
+
+	err := repo.decoratePurchases(snaps, "edge", t.user)
+	c.Assert(err, IsNil)
+	c.Check(refreshSessionRequested, Equals, true)
 
 	c.Check(helloWorld.MustBuy, Equals, false)
 	c.Check(funkyApp.MustBuy, Equals, false)
@@ -2009,7 +2341,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreGetPurchasesSingle(c *C) {
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		PurchasesURI: purchasesURI,
 	}
@@ -2059,7 +2391,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreGetPurchasesSingleNotFound(c *C) {
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		PurchasesURI: purchasesURI,
 	}
@@ -2094,7 +2426,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreGetPurchasesTokenExpired(c *C) {
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		PurchasesURI: purchasesURI,
 	}
@@ -2185,7 +2517,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuySuccess(c *C) {
 	purchasesURI, err := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		DetailsURI:   detailsURI,
 		PurchasesURI: purchasesURI,
@@ -2344,6 +2676,63 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyRefreshesAuth(c *C) {
 	c.Assert(result, NotNil)
 	c.Check(result.State, Equals, "Complete")
 	c.Check(refreshDischargeEndpointHit, Equals, true)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreBuyRefreshesDeviceAuth(c *C) {
+	refreshSessionRequested := false
+	expiredAuth := fmt.Sprintf(`Macaroon root="%s"`, t.device.SessionMacaroon)
+	// mock store response
+	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		switch r.URL.Path {
+		case "/dev/api/snap-purchases/":
+			authorization := r.Header.Get("X-Device-Authorization")
+			if authorization == expiredAuth {
+				w.Header().Set("WWW-Authenticate", "Macaroon refresh_device_session=1")
+				w.WriteHeader(http.StatusUnauthorized)
+			} else {
+				c.Check(authorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
+				io.WriteString(w, mockSinglePurchaseJSON)
+			}
+		case "/identity/api/v1/nonces":
+			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
+		case "/identity/api/v1/sessions":
+			authorization := r.Header.Get("X-Device-Authorization")
+			c.Check(authorization, Equals, expiredAuth)
+			io.WriteString(w, `{"macaroon": "refreshed-session-macaroon"}`)
+			refreshSessionRequested = true
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+	MyAppsDeviceNonceAPI = mockPurchasesServer.URL + "/identity/api/v1/nonces"
+	MyAppsDeviceSessionAPI = mockPurchasesServer.URL + "/identity/api/v1/sessions"
+	purchasesURI, _ := url.Parse(mockPurchasesServer.URL + "/dev/api/snap-purchases/")
+
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
+	cfg := Config{
+		PurchasesURI: purchasesURI,
+	}
+	repo := New(&cfg, authContext)
+	c.Assert(repo, NotNil)
+
+	result, err := repo.Buy(&BuyOptions{
+		SnapID:   helloWorldSnapID,
+		SnapName: "hello-world",
+		Currency: "EUR",
+		Price:    0.99,
+
+		BackendID: "123",
+		MethodID:  234,
+	}, t.user)
+
+	c.Assert(err, IsNil)
+	c.Assert(result, NotNil)
+	c.Check(result.State, Equals, "Complete")
+	c.Check(refreshSessionRequested, Equals, true)
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailWrongPrice(c *C) {
@@ -2620,7 +3009,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStorePaymentMethods(c *C) {
 	paymentMethodsURI, err := url.Parse(mockPurchasesServer.URL + "/api/2.0/click/paymentmethods/")
 	c.Assert(err, IsNil)
 
-	authContext := &testAuthContext{c: c, user: t.user}
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 	cfg := Config{
 		PaymentMethodsURI: paymentMethodsURI,
 	}
@@ -2699,4 +3088,51 @@ func (t *remoteRepoTestSuite) TestUbuntuStorePaymentMethodsRefreshesAuth(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(result, NotNil)
 	c.Check(refreshDischargeEndpointHit, Equals, true)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStorePaymentMethodsRefreshesDeviceAuth(c *C) {
+	refreshSessionRequested := false
+	expiredAuth := fmt.Sprintf(`Macaroon root="%s"`, t.device.SessionMacaroon)
+	// mock store response
+	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		switch r.URL.Path {
+		case "/api/2.0/click/paymentmethods/":
+			authorization := r.Header.Get("X-Device-Authorization")
+			if authorization == expiredAuth {
+				w.Header().Set("WWW-Authenticate", "Macaroon refresh_device_session=1")
+				w.WriteHeader(http.StatusUnauthorized)
+			} else {
+				c.Check(authorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
+				io.WriteString(w, paymentMethodsJson)
+			}
+		case "/identity/api/v1/nonces":
+			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
+		case "/identity/api/v1/sessions":
+			authorization := r.Header.Get("X-Device-Authorization")
+			c.Check(authorization, Equals, expiredAuth)
+			io.WriteString(w, `{"macaroon": "refreshed-session-macaroon"}`)
+			refreshSessionRequested = true
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	c.Assert(mockPurchasesServer, NotNil)
+	defer mockPurchasesServer.Close()
+	MyAppsDeviceNonceAPI = mockPurchasesServer.URL + "/identity/api/v1/nonces"
+	MyAppsDeviceSessionAPI = mockPurchasesServer.URL + "/identity/api/v1/sessions"
+	paymentMethodsURI, _ := url.Parse(mockPurchasesServer.URL + "/api/2.0/click/paymentmethods/")
+
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
+	cfg := Config{
+		PaymentMethodsURI: paymentMethodsURI,
+	}
+	repo := New(&cfg, authContext)
+	c.Assert(repo, NotNil)
+
+	result, err := repo.PaymentMethods(t.user)
+	c.Assert(err, IsNil)
+	c.Assert(result, NotNil)
+	c.Check(refreshSessionRequested, Equals, true)
 }


### PR DESCRIPTION
Updates store requests to handle device sessions requiring refresh. This path won't be triggered until an initial device session is set (see TODO in l.521). To enable device sessions [1] we need to make sure device registration is plugged in and server-side endpoints are available.

[1] https://github.com/matiasb/snappy/compare/set-device-session...matiasb:enable-device-sessions?expand=1