### PR TITLE
cmd: enable SNAP_REEXEC only if it is set to SNAP_REEXEC=1

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -55,7 +55,7 @@ func ExecInCoreSnap() {
 		return
 	}
 
-	if os.Getenv(key) == "0" {
+	if os.Getenv(key) != "1" {
 		return
 	}
 


### PR DESCRIPTION
Given that we agreed to use the SRU process during the last sprint I would like to suggest that we disable the re-exec feature for now by default. 

This will fix the most recent issue with snapd and ubuntu-core from edge (https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1617890).

It also ensures that when we SRU 2.13 people actually use 2.13. Right now the 2.13 SRU re-execs to the version in ubuntu-core (which is 2.12 in stable) so we get less value out of the xenial-proposed testing than we could and should.

Other ideas are welcome of course!