### PR TITLE
docs/interfaces: Add empty line after lxd-support title

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -297,6 +297,7 @@ Can read system logs and set kernel log rate-limiting.
 * Auto-Connect: no
 
 ### lxd-support
+
 Can access all resources and syscalls on the device for LXD to mediate
 access for its containers. This interface currently may only be
 established with the upstream LXD project.


### PR DESCRIPTION
docs/interfaces: Add empty line after lxd-support title for consistency and doc parsing.