### PR TITLE
snap-exec: add support for commands with internal args in snap-exec

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -127,10 +127,16 @@ func snapExecApp(snapApp, revision, command string, args []string) error {
 		return fmt.Errorf("cannot find app %q in %q", appName, snapName)
 	}
 
-	cmd, err := findCommand(app, command)
+	cmdAndArgs, err := findCommand(app, command)
 	if err != nil {
 		return err
 	}
+	// strings.Split() is ok here because we validate all app fields
+	// and the whitelist is pretty strict (see
+	// snap/validate.go:appContentWhitelist)
+	cmdArgv := strings.Split(cmdAndArgs, " ")
+	cmd := cmdArgv[0]
+	cmdArgs := cmdArgv[1:]
 
 	// build the environment from the yaml
 	env := append(os.Environ(), app.Env()...)
@@ -139,8 +145,10 @@ func snapExecApp(snapApp, revision, command string, args []string) error {
 	fullCmd := filepath.Join(app.Snap.MountDir(), cmd)
 	if command == "shell" {
 		fullCmd = "/bin/bash"
+		cmdArgs = nil
 	}
 	fullCmdArgs := []string{fullCmd}
+	fullCmdArgs = append(fullCmdArgs, cmdArgs...)
 	fullCmdArgs = append(fullCmdArgs, args...)
 	if err := syscallExec(fullCmd, fullCmdArgs, env); err != nil {
 		return fmt.Errorf("cannot exec %q: %s", fullCmd, err)

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -58,7 +58,7 @@ var mockYaml = []byte(`name: snapname
 version: 1.0
 apps:
  app:
-  command: run-app
+  command: run-app cmd-arg1
   stop-command: stop-app
   post-stop-command: post-stop-app
   environment:
@@ -100,7 +100,7 @@ func (s *snapExecSuite) TestFindCommand(c *C) {
 		cmd      string
 		expected string
 	}{
-		{cmd: "", expected: "run-app"},
+		{cmd: "", expected: `run-app cmd-arg1`},
 		{cmd: "stop", expected: "stop-app"},
 		{cmd: "post-stop", expected: "post-stop-app"},
 	} {
@@ -231,6 +231,7 @@ func (s *snapExecSuite) TestSnapExecAppRealIntegration(c *C) {
 	output, err := ioutil.ReadFile(canaryFile)
 	c.Assert(err, IsNil)
 	c.Assert(string(output), Equals, `run-app
+cmd-arg1
 foo
 --bar=baz
 foobar


### PR DESCRIPTION
This adds support for snap.yaml fragments like this:
```
apps:
 app:
  command: bin/write-data from-app
```
via snap-exec. This is something we need for the snap-run3 branch, we have one internal test that uses this style of commands and there may be commands like this in the wild as well.