### PR TITLE
snapstate: use umount --lazy when removing the mount units

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -59,8 +59,10 @@ import (
 type mgrsSuite struct {
 	tempdir string
 
-	aa         *testutil.MockCmd
-	udev       *testutil.MockCmd
+	aa     *testutil.MockCmd
+	udev   *testutil.MockCmd
+	umount *testutil.MockCmd
+
 	prevctlCmd func(...string) ([]byte, error)
 
 	storeSigning   *assertstest.StoreStack
@@ -100,6 +102,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	}
 	ms.aa = testutil.MockCommand(c, "apparmor_parser", "")
 	ms.udev = testutil.MockCommand(c, "udevadm", "")
+	ms.umount = testutil.MockCommand(c, "umount", "")
 
 	ms.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
 	ms.restoreTrusted = sysdb.InjectTrusted(ms.storeSigning.Trusted)
@@ -116,6 +119,7 @@ func (ms *mgrsSuite) TearDownTest(c *C) {
 	systemd.SystemctlCmd = ms.prevctlCmd
 	ms.udev.Restore()
 	ms.aa.Restore()
+	ms.umount.Restore()
 }
 
 func makeTestSnap(c *C, snapYamlContent string) string {

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -33,13 +33,12 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/testutil"
-
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func TestOverlord(t *testing.T) { TestingT(t) }

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -21,6 +21,7 @@ package backend
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -58,6 +59,12 @@ func removeMountUnit(baseDir string, meter progress.Meter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, meter)
 	unit := systemd.MountUnitPath(dirs.StripRootDir(baseDir), "mount")
 	if osutil.FileExists(unit) {
+		// use umount --lazy to ensure that even busy mount points
+		// can be unmounted
+		if output, err := exec.Command("umount", "--lazy", baseDir).CombinedOutput(); err != nil {
+			return osutil.OutputErr(output, err)
+		}
+
 		if err := sysd.Stop(filepath.Base(unit), time.Duration(1*time.Second)); err != nil {
 			return err
 		}

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -32,11 +32,13 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type mountunitSuite struct {
 	nullProgress progress.NullProgress
 	prevctlCmd   func(...string) ([]byte, error)
+	umount       *testutil.MockCmd
 }
 
 var _ = Suite(&mountunitSuite{})
@@ -51,11 +53,13 @@ func (s *mountunitSuite) SetUpTest(c *C) {
 	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
 	}
+	s.umount = testutil.MockCommand(c, "umount", "")
 }
 
 func (s *mountunitSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 	systemd.SystemctlCmd = s.prevctlCmd
+	s.umount.Restore()
 }
 
 func (s *mountunitSuite) TestAddMountUnit(c *C) {

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -35,12 +35,14 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type setupSuite struct {
 	be           backend.Backend
 	nullProgress progress.NullProgress
 	prevctlCmd   func(...string) ([]byte, error)
+	umount       *testutil.MockCmd
 }
 
 var _ = Suite(&setupSuite{})
@@ -55,12 +57,14 @@ func (s *setupSuite) SetUpTest(c *C) {
 	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
 	}
+	s.umount = testutil.MockCommand(c, "umount", "")
 }
 
 func (s *setupSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 	partition.ForceBootloader(nil)
 	systemd.SystemctlCmd = s.prevctlCmd
+	s.umount.Restore()
 }
 
 func (s *setupSuite) TestSetupDoUndoSimple(c *C) {

--- a/tests/main/op-remove-retry/task.yaml
+++ b/tests/main/op-remove-retry/task.yaml
@@ -1,4 +1,4 @@
-summary: Check that a remove operation is retried if the mount point is busy.
+summary: Check that a remove operation is working even if the mount point is busy.
 
 restore: |
     rm -f test-snapd-tools_1.0_all.snap
@@ -27,16 +27,12 @@ execute: |
     echo "When we try to remove the snap"
     snap remove test-snapd-tools &
 
-    echo "Then it fails and retries to remove"
-    snap list | grep -q test-snapd-tools
-    wait_for_remove_state Doing
-
-    echo "When the mount point is no longer busy"
-    systemctl stop unmount-blocker
-    wait_for_service unmount-blocker inactive
-
     echo "Then the remove retry succeeds"
     wait_for_remove_state Done
 
     echo "And the snap is removed"
     while snap list | grep -q test-snapd-tools; do sleep 1; done
+
+    # cleanup umount blocker
+    systemctl stop unmount-blocker
+    wait_for_service unmount-blocker inactive


### PR DESCRIPTION
This avoid hangs when the mount points of the snaps are busy. Needs proper unit test, but keen to see integration test output too.