### PR TITLE
asserts: support checking account-key-request assertions

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -222,12 +222,6 @@ func (akr *AccountKeyRequest) signKey() PublicKey {
 	return akr.pubKey
 }
 
-// isValidAt returns whether the assertion is valid at a given time, in combination with other checks.
-func (akr *AccountKeyRequest) isValidAt(when time.Time) bool {
-	// account-key-request assertions are valid regardless of time.
-	return true
-}
-
 // Implement further consistency checks.
 func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) error {
 	_, err := db.Find(AccountType, map[string]string{

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -212,7 +212,7 @@ func (akr *AccountKeyRequest) Until() time.Time {
 	return akr.until
 }
 
-// PublicKey returns the underlying public key ID of the requested account key.
+// PublicKeyID returns the underlying public key ID of the requested account key.
 func (akr *AccountKeyRequest) PublicKeyID() string {
 	return akr.pubKey.ID()
 }

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -212,8 +212,8 @@ func (akr *AccountKeyRequest) Until() time.Time {
 	return akr.until
 }
 
-// PublicKey returns the underlying public key of the requested account key.
-func (akr *AccountKeyRequest) PublicKey() PublicKey {
+// signKey returns the underlying public key of the requested account key.
+func (akr *AccountKeyRequest) signKey() PublicKey {
 	return akr.pubKey
 }
 

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -232,7 +232,10 @@ func (akr *AccountKeyRequest) noAuthorityCheckConsistency(db RODatabase) error {
 }
 
 // sanity
-var _ noAuthorityConsistencyChecker = (*AccountKeyRequest)(nil)
+var (
+	_ noAuthorityConsistencyChecker = (*AccountKeyRequest)(nil)
+	_ selfSignedAssertion           = (*AccountKeyRequest)(nil)
+)
 
 // Prerequisites returns references to this account-key-request's prerequisite assertions.
 func (akr *AccountKeyRequest) Prerequisites() []*Ref {

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -222,8 +222,14 @@ func (akr *AccountKeyRequest) signKey() PublicKey {
 	return akr.pubKey
 }
 
+// isValidAt returns whether the assertion is valid at a given time, in combination with other checks.
+func (akr *AccountKeyRequest) isValidAt(when time.Time) bool {
+	// account-key-request assertions are valid regardless of time.
+	return true
+}
+
 // Implement further consistency checks.
-func (akr *AccountKeyRequest) noAuthorityCheckConsistency(db RODatabase) error {
+func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) error {
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": akr.AccountID(),
 	})
@@ -238,8 +244,8 @@ func (akr *AccountKeyRequest) noAuthorityCheckConsistency(db RODatabase) error {
 
 // sanity
 var (
-	_ noAuthorityConsistencyChecker = (*AccountKeyRequest)(nil)
-	_ selfSignedAssertion           = (*AccountKeyRequest)(nil)
+	_ consistencyChecker = (*AccountKeyRequest)(nil)
+	_ customSigner       = (*AccountKeyRequest)(nil)
 )
 
 // Prerequisites returns references to this account-key-request's prerequisite assertions.

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -212,6 +212,11 @@ func (akr *AccountKeyRequest) Until() time.Time {
 	return akr.until
 }
 
+// PublicKey returns the underlying public key ID of the requested account key.
+func (akr *AccountKeyRequest) PublicKeyID() string {
+	return akr.pubKey.ID()
+}
+
 // signKey returns the underlying public key of the requested account key.
 func (akr *AccountKeyRequest) signKey() PublicKey {
 	return akr.pubKey

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -218,7 +218,7 @@ func (akr *AccountKeyRequest) signKey() PublicKey {
 }
 
 // Implement further consistency checks.
-func (akr *AccountKeyRequest) noAuthorityCheckConsistency(db RODatabase, signingKey PublicKey) error {
+func (akr *AccountKeyRequest) noAuthorityCheckConsistency(db RODatabase) error {
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": akr.AccountID(),
 	})

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -218,7 +218,7 @@ func (akr *AccountKeyRequest) PublicKey() PublicKey {
 }
 
 // Implement further consistency checks.
-func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (akr *AccountKeyRequest) noAuthorityCheckConsistency(db RODatabase, signingKey PublicKey) error {
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": akr.AccountID(),
 	})
@@ -232,7 +232,7 @@ func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) 
 }
 
 // sanity
-var _ consistencyChecker = (*AccountKeyRequest)(nil)
+var _ noAuthorityConsistencyChecker = (*AccountKeyRequest)(nil)
 
 // Prerequisites returns references to this account-key-request's prerequisite assertions.
 func (akr *AccountKeyRequest) Prerequisites() []*Ref {

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -635,6 +635,7 @@ func (aks *accountKeySuite) TestAccountKeyRequestHappy(c *C) {
 
 	c.Check(akr2.AccountID(), Equals, "acc-id1")
 	c.Check(akr2.Name(), Equals, "default")
+	c.Check(akr2.PublicKeyID(), Equals, aks.keyID)
 	c.Check(akr2.Since(), Equals, aks.since)
 }
 

--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -630,12 +630,11 @@ func (aks *accountKeySuite) TestAccountKeyRequestHappy(c *C) {
 	db := aks.openDB(c)
 	aks.prereqAccount(c, db)
 
-	err = db.NoAuthorityCheck(akr2, akr2.PublicKey())
+	err = db.Check(akr2)
 	c.Check(err, IsNil)
 
 	c.Check(akr2.AccountID(), Equals, "acc-id1")
 	c.Check(akr2.Name(), Equals, "default")
-	c.Check(akr2.PublicKey().ID(), Equals, aks.keyID)
 	c.Check(akr2.Since(), Equals, aks.since)
 }
 
@@ -669,7 +668,7 @@ func (aks *accountKeySuite) TestAccountKeyRequestUntil(c *C) {
 		c.Assert(err, IsNil)
 		akr2 := a.(*asserts.AccountKeyRequest)
 		c.Check(akr2.Until(), Equals, test.until)
-		err = db.NoAuthorityCheck(akr2, akr2.PublicKey())
+		err = db.Check(akr2)
 		c.Check(err, IsNil)
 	}
 }
@@ -801,6 +800,6 @@ func (aks *accountKeySuite) TestAccountKeyRequestNoAccount(c *C) {
 
 	db := aks.openDB(c)
 
-	err = db.NoAuthorityCheck(akr, akr.(*asserts.AccountKeyRequest).PublicKey())
+	err = db.Check(akr)
 	c.Assert(err, ErrorMatches, `account-key-request assertion for "acc-id1" does not have a matching account assertion`)
 }

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -151,6 +151,12 @@ type Assertion interface {
 	Ref() *Ref
 }
 
+// selfSignedAssertion represents an assertion that contains its own signing key.
+type selfSignedAssertion interface {
+	// signKey returns the public key material for the key that signed this assertion.  See also SignKeyID.
+	signKey() PublicKey
+}
+
 // MediaType is the media type for encoded assertions on the wire.
 const MediaType = "application/x.ubuntu.assertion"
 

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -67,7 +67,7 @@ var (
 	DeviceSessionRequestType = &AssertionType{"device-session-request", []string{"brand-id", "model", "serial"}, assembleDeviceSessionRequest, noAuthority}
 	SerialProofType          = &AssertionType{"serial-proof", nil, assembleSerialProof, noAuthority}
 	SerialRequestType        = &AssertionType{"serial-request", nil, assembleSerialRequest, noAuthority}
-	AccountKeyRequestType    = &AssertionType{"account-key-request", nil, assembleAccountKeyRequest, noAuthority}
+	AccountKeyRequestType    = &AssertionType{"account-key-request", []string{"public-key-sha3-384"}, assembleAccountKeyRequest, noAuthority}
 )
 
 var typeRegistry = map[string]*AssertionType{

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -28,7 +28,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 	"unicode/utf8"
 )
 
@@ -156,9 +155,6 @@ type Assertion interface {
 type customSigner interface {
 	// signKey returns the public key material for the key that signed this assertion.  See also SignKeyID.
 	signKey() PublicKey
-
-	// isValidAt returns whether the assertion is valid at a given time, in combination with other checks.
-	isValidAt(when time.Time) bool
 }
 
 // MediaType is the media type for encoded assertions on the wire.

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 )
 
@@ -151,10 +152,13 @@ type Assertion interface {
 	Ref() *Ref
 }
 
-// selfSignedAssertion represents an assertion that contains its own signing key.
-type selfSignedAssertion interface {
+// customSigner represents an assertion with special arrangements for its signing key (e.g. self-signed), rather than the usual case where an assertion is signed by its authority.
+type customSigner interface {
 	// signKey returns the public key material for the key that signed this assertion.  See also SignKeyID.
 	signKey() PublicKey
+
+	// isValidAt returns whether the assertion is valid at a given time, in combination with other checks.
+	isValidAt(when time.Time) bool
 }
 
 // MediaType is the media type for encoded assertions on the wire.

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -415,11 +415,13 @@ func CheckSigningKeyIsNotExpired(assert Assertion, signingKey *AccountKey, roDB 
 	if signingKey != nil {
 		valid = signingKey.isKeyValidAt(checkTime)
 	} else {
-		custom, ok := assert.(customSigner)
-		if !ok {
+		_, ok := assert.(*AccountKeyRequest)
+		if ok {
+			// account-key-request assertions are special, and are valid regardless of time.
+			valid = true
+		} else {
 			panic(fmt.Errorf("cannot check no-authority assertion type %q", assert.Type().Name))
 		}
-		valid = custom.isValidAt(checkTime)
 	}
 	if !valid {
 		return fmt.Errorf("assertion is signed with expired public key %q from %q", assert.SignKeyID(), assert.AuthorityID())
@@ -464,11 +466,13 @@ func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey
 		if signingKey != nil {
 			valid = signingKey.isKeyValidAt(checkTime)
 		} else {
-			custom, ok := assert.(customSigner)
-			if !ok {
+			_, ok := assert.(*AccountKeyRequest)
+			if ok {
+				// account-key-request assertions are special, and are valid regardless of time.
+				valid = true
+			} else {
 				panic(fmt.Errorf("cannot check no-authority assertion type %q", assert.Type().Name))
 			}
-			valid = custom.isValidAt(checkTime)
 		}
 		if !valid {
 			return fmt.Errorf("%s assertion timestamp outside of signing key validity", assert.Type().Name)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -280,7 +280,6 @@ func (db *Database) Check(assert Assertion) error {
 		if assert.AuthorityID() != "" {
 			return fmt.Errorf("internal error: %q assertion cannot have authority-id set", typ.Name)
 		}
-		accKey = nil
 	}
 
 	for _, checker := range db.checkers {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -140,7 +140,6 @@ type Database struct {
 	trusted             Backstore
 	backstores          []Backstore
 	checkers            []Checker
-	noAuthorityCheckers []NoAuthorityChecker
 }
 
 // OpenDatabase opens the assertion database based on the configuration.
@@ -184,9 +183,6 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 	dbCheckers := make([]Checker, len(checkers))
 	copy(dbCheckers, checkers)
 
-	dbNoAuthorityCheckers := make([]NoAuthorityChecker, len(noAuthorityCheckers))
-	copy(dbNoAuthorityCheckers, noAuthorityCheckers)
-
 	return &Database{
 		bs:         bs,
 		keypairMgr: keypairMgr,
@@ -196,7 +192,6 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 		// general backstore!
 		backstores:          []Backstore{trustedBackstore, bs},
 		checkers:            dbCheckers,
-		noAuthorityCheckers: dbNoAuthorityCheckers,
 	}, nil
 }
 
@@ -293,7 +288,7 @@ func (db *Database) Check(assert Assertion) error {
 			return fmt.Errorf("internal error: %q assertion cannot have authority-id set", typ.Name)
 		}
 
-		for _, checker := range db.noAuthorityCheckers {
+		for _, checker := range noAuthorityCheckers {
 			err := checker(assert, db)
 			if err != nil {
 				return err

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -122,6 +122,8 @@ type RODatabase interface {
 	FindMany(assertionType *AssertionType, headers map[string]string) ([]Assertion, error)
 	// Check tests whether the assertion is properly signed and consistent with all the stored knowledge.
 	Check(assert Assertion) error
+	// NoAuthorityCheck tests whether a no-authority assertion is properly signed and consistent with all the stored knowledge.
+	NoAuthorityCheck(assert Assertion, pubKey PublicKey) error
 }
 
 // A Checker defines a check on an assertion considering aspects such as

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -486,7 +486,7 @@ var DefaultCheckers = []Checker{
 func NoAuthorityCheckSignature(assert Assertion, roDB RODatabase, checkTime time.Time) error {
 	selfSigned, ok := assert.(selfSignedAssertion)
 	if !ok {
-		return fmt.Errorf("cannot check non-self-signed assertion type %q", assert.Type().Name)
+		panic(fmt.Errorf("cannot check non-self-signed assertion type %q", assert.Type().Name))
 	}
 	signingKey := selfSigned.signKey()
 	content, encSig := assert.Signature()


### PR DESCRIPTION
account-key-request assertions lack an authority-id and are self-signed,
but we want to be able to add them to the database anyway as a record of
the request that caused us to create an account-key.  Add a customSigner
interface and teach the checking code to use it where necessary.