### PR TITLE
camera interface improvements

### DIFF
--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -24,7 +24,8 @@ import (
 )
 
 const cameraConnectedPlugAppArmor = `
-/dev/video0 rw,
+# Until we have proper device assignment, allow access to all cameras
+/dev/video[0-9]* rw,
 
 # Allow detection of cameras. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -25,6 +25,11 @@ import (
 
 const cameraConnectedPlugAppArmor = `
 /dev/video0 rw,
+
+# Allow detection of cameras. Leaks plugged in USB device info
+/sys/bus/usb/devices/ r,
+/sys/devices/pci**/usb*/**/idVendor r,
+/sys/devices/pci**/usb*/**/idProduct r,
 `
 
 // NewCameraInterface returns a new "camera" interface.


### PR DESCRIPTION
- interfaces: allow detection of idProduct and idVendor of USB devices in camera interface
- interfaces: all access to /dev/video[0-9]* in camera interface (LP: #1600719)

This PR is prompted by using the camera interface with the chrome browser. With these changes, I can use google hangouts.

The change to `/dev/video[0-9]*` from `/dev/video0` is possibly contentious, however I was never clear on why only /dev/video0 was allowed-- it seemed an arbitrary limitation. I think the glob rule unblocks people now (indeed, I have two cameras but only one works, and it is /dev/video1) and leaves open the path forward when the core and/or gadget snap might auto-detect cameras via device introspection and hotplugging.