### PR TITLE
interfaces: add screen-inhibit-control interface (LP: #1604880)

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -183,6 +183,12 @@ and media application. Recording not supported but will be in a future release.
 
 * Auto-Connect: yes
 
+### screen-inhibit-control
+
+Can access desktop session manager screen inhibit and uninhibit functionality.
+
+* Auto-Connect: yes
+
 ### unity7
 
 Can access Unity7. Unity 7 runs on X and requires access to various DBus

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -51,6 +51,7 @@ var allInterfaces = []interfaces.Interface{
 	NewNetworkControlInterface(),
 	NewNetworkObserveInterface(),
 	NewProcessControlInterface(),
+	NewScreenInhibitControlInterface(),
 	NewSnapdControlInterface(),
 	NewSystemObserveInterface(),
 	NewSystemTraceInterface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -54,6 +54,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewNetworkControlInterface())
 	c.Check(all, DeepContains, builtin.NewNetworkObserveInterface())
 	c.Check(all, DeepContains, builtin.NewProcessControlInterface())
+	c.Check(all, DeepContains, builtin.NewScreenInhibitControlInterface())
 	c.Check(all, DeepContains, builtin.NewSnapdControlInterface())
 	c.Check(all, DeepContains, builtin.NewSystemObserveInterface())
 	c.Check(all, DeepContains, builtin.NewSystemTraceInterface())

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const screenInhibitControlConnectedPlugAppArmor = `
+# Description: Can inhibit and uninhibit screen savers in desktop sessions.
+#include <abstractions/dbus-session-strict>
+
+# gnome-session
+dbus (send)
+    bus=session
+    path=/org/gnome/SessionManager
+    interface=org.gnome.SessionManager
+    member={Inhibit,Uninhibit}
+    peer=(label=unconfined),
+
+# unity screen API
+dbus (send)
+    bus=system
+    interface="org.freedesktop.DBus.Introspectable"
+    path="/com/canonical/Unity/Screen"
+    member="Introspect"
+    peer=(label=unconfined),
+dbus (send)
+    bus=system
+    interface="com.canonical.Unity.Screen"
+    path="/com/canonical/Unity/Screen"
+    member={keepDisplayOn,removeDisplayOnRequest}
+    peer=(label=unconfined),
+
+# freedesktop.org ScreenSaver
+dbus (send)
+    bus=session
+    path=/Screensaver
+    interface=org.freedesktop.ScreenSaver
+    member=org.freedesktop.ScreenSaver.{Inhibit,UnInhibit}
+    peer=(label=unconfined),
+`
+
+const screenInhibitControlConnectedPlugSecComp = `
+# Description: Can inhibit and uninhibit screen savers in desktop sessions.
+# dbus
+connect
+getsockname
+recvmsg
+send
+sendto
+sendmsg
+socket
+`
+
+// NewScreenInhibitControlInterface returns a new "screen-inhibit-control" interface.
+func NewScreenInhibitControlInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "screen-inhibit-control",
+		connectedPlugAppArmor: screenInhibitControlConnectedPlugAppArmor,
+		connectedPlugSecComp:  screenInhibitControlConnectedPlugSecComp,
+		reservedForOS:         true,
+		autoConnect:           true,
+	}
+}

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -63,6 +63,7 @@ const screenInhibitControlConnectedPlugSecComp = `
 # dbus
 connect
 getsockname
+recvfrom
 recvmsg
 send
 sendto

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -1,0 +1,132 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+)
+
+type ScreenInhibitControlInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&ScreenInhibitControlInterfaceSuite{
+	iface: builtin.NewScreenInhibitControlInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "ubuntu-core", Type: snap.TypeOS},
+			Name:      "screen-inhibit-control",
+			Interface: "screen-inhibit-control",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "screen-inhibit-control",
+			Interface: "screen-inhibit-control",
+		},
+	},
+})
+
+func (s *ScreenInhibitControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "screen-inhibit-control")
+}
+
+func (s *ScreenInhibitControlInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "screen-inhibit-control",
+		Interface: "screen-inhibit-control",
+	}})
+	c.Assert(err, ErrorMatches, "screen-inhibit-control slots are reserved for the operating system snap")
+}
+
+func (s *ScreenInhibitControlInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *ScreenInhibitControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "screen-inhibit-control"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "screen-inhibit-control"`)
+}
+
+func (s *ScreenInhibitControlInterfaceSuite) TestUnusedSecuritySystems(c *C) {
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
+		interfaces.SecuritySecComp, interfaces.SecurityDBus,
+		interfaces.SecurityUDev}
+	for _, system := range systems {
+		snippet, err := s.iface.PermanentPlugSnippet(s.plug, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+		snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+		c.Assert(err, IsNil)
+		c.Assert(snippet, IsNil)
+	}
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *ScreenInhibitControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *ScreenInhibitControlInterfaceSuite) TestUnexpectedSecuritySystems(c *C) {
+	snippet, err := s.iface.PermanentPlugSnippet(s.plug, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, "foo")
+	c.Assert(err, Equals, interfaces.ErrUnknownSecurity)
+	c.Assert(snippet, IsNil)
+}
+
+func (s *ScreenInhibitControlInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(), Equals, true)
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -62,6 +62,7 @@ var implicitClassicSlots = []string{
 	"network-manager",
 	"optical-drive",
 	"pulseaudio",
+	"screen-inhibit-control",
 	"unity7",
 	"x11",
 }

--- a/snap/implicit_test.go
+++ b/snap/implicit_test.go
@@ -56,7 +56,7 @@ func (s *InfoSnapYamlTestSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	c.Assert(info.Slots["unity7"].Interface, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Name, Equals, "unity7")
 	c.Assert(info.Slots["unity7"].Snap, Equals, info)
-	c.Assert(info.Slots, HasLen, 33)
+	c.Assert(info.Slots, HasLen, 34)
 }
 
 func (s *InfoSnapYamlTestSuite) TestImplicitSlotsAreRealInterfaces(c *C) {


### PR DESCRIPTION
This currently implements inhibit/uninhibit for gnome, unity screen and freedesktop.org (kde).