### PR TITLE
firstboot: change location of netplan config

### DIFF
--- a/firstboot/firstboot.go
+++ b/firstboot/firstboot.go
@@ -45,10 +45,12 @@ func StampFirstBoot() error {
 	return osutil.AtomicWriteFile(dirs.SnapFirstBootStamp, []byte{}, 0644, 0)
 }
 
-var netplanConfigFile = "/etc/netplan/00-initial-config.yaml"
+var netplanConfigFile = "/etc/netplan/00-snapd-config.yaml"
 var enableConfig = []string{"netplan", "apply"}
 
 var netplanConfigData = `
+# This is the initial network config written by 'snap firstboot'.
+# It can be overwritten by cloud-init or console-conf.
 network:
  version: 2
  ethernets:


### PR DESCRIPTION
For now, we are going to have snapd / console-conf / cloud-init
write their network config to the same location so let's use a
file name that makes a bit more sense.