### PR TITLE
tests: use the spread tests with the adhoc interface inside autopkgtest

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -26,5 +26,4 @@ sudo systemctl daemon-reload
 
 export GOPATH=/tmp/go
 go get -u github.com/snapcore/spread/cmd/spread
-sudo snap install spread
-spread -v adhoc:
+/tmp/go/bin/spread -v adhoc:

--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -24,29 +24,7 @@ sudo systemctl daemon-reload
 # ensure our PATH is right
 . /etc/profile.d/apps-bin-path.sh
 
-tmp="${ADT_ARTIFACTS}/build"
-mkdir -p "$tmp"
-export GOPATH="$tmp"
-mkdir -p "$GOPATH"/src/github.com/snapcore/snapd
-cp -R ./* "$GOPATH"/src/github.com/snapcore/snapd/
-mkdir -p "$GOPATH"/src/github.com/snapcore/snapd/integration-tests/data/output
-cp debian/tests/testconfig.json "$GOPATH"/src/github.com/snapcore/snapd/integration-tests/data/output/
-cd "$GOPATH"/src/github.com/snapcore/snapd
-
-# don't install deps nor compile binaries after reboot
-if [ -z "$ADT_REBOOT_MARK" ]; then
-    ./get-deps.sh
-    go test -tags classic -c ./integration-tests/tests
-
-    # ensure we have snapbuild available for the tests
-    go get ./tests/lib/snapbuild
-    sudo cp $GOPATH/bin/snapbuild /usr/local/bin
-fi
-
-SNAP_REEXEC=0 ./tests.test -check.vv
-
-if [ -e "${NEEDS_REBOOT}" ]; then
-    mark=$(cat "${NEEDS_REBOOT}")
-    echo "Rebooting..."
-    sudo /tmp/autopkgtest-reboot "$mark"
-fi
+export GOPATH=/tmp/go
+go get -u github.com/snapcore/spread/cmd/spread
+sudo snap install spread
+spread -v adhoc:

--- a/spread.yaml
+++ b/spread.yaml
@@ -31,6 +31,20 @@ backends:
                   image: ubuntu-16.04-64
                   username: ubuntu
                   password: ubuntu
+    adhoc:
+        allocate: |
+            echo "Allocating ad-hoc $SPREAD_SYSTEM"
+            if [ -z "$ADT_ARTIFACTS" ]; then
+                echo "out adhoc only works inside autopkgtest"
+                exit 1
+            fi
+            echo "localhost:22"
+        discard: |
+            echo "Discarding ad-hoc $SPREAD_SYSTEM"
+        systems:
+            - ubuntu-16.04-64:
+                  username: ubuntu
+                  password: ubuntu
 
 path: /home/gopath/src/github.com/snapcore/snapd
 

--- a/tests/main/server-snap/task.yaml
+++ b/tests/main/server-snap/task.yaml
@@ -5,10 +5,12 @@ environment:
     IP_VERSION/pythonServer: 4
     PORT/pythonServer: 80
     TEXT/pythonServer: XKCD rocks!
+    LOCALHOST/pythonServer: localhost
     SNAP_NAME/goServer: go-example-webserver
     IP_VERSION/goServer: 6
     PORT/goServer: 8081
     TEXT/goServer: Hello World
+    LOCALHOST/goServer: ip6-localhost
 
 warn-timeout: 3m
 
@@ -25,7 +27,7 @@ restore: |
     rm -f request.txt
 
 execute: |
-    response=$(nc -"$IP_VERSION" localhost "$PORT" < request.txt)
+    response=$(nc -"$IP_VERSION" "$LOCALHOST" "$PORT" < request.txt)
 
     statusPattern="(?s)HTTP\/1\.0 200 OK\n*"
     echo "$response" | grep -Pzq "$statusPattern"


### PR DESCRIPTION
This should fix the autopkgtest regression we had with 2.14{,.1}. 