### PR TITLE
tests: use beta u-d-f in test by default 

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -33,7 +33,7 @@ setup_reflash_magic() {
         apt install -y ${SPREAD_PATH}/../snapd_*.deb
         
         snap install --edge ubuntu-core
-        snap install --edge --devmode ubuntu-device-flash
+        snap install --beta --devmode ubuntu-device-flash
 
         # needs to be under /home because ubuntu-device-flash
         # uses snap-confine and that will hide parts of the hostfs


### PR DESCRIPTION
This allows to put something else into the "--edge" channel for u-d-f. Like a new version that will use a model assertion.