### PR TITLE
overlord/devicestate: set device registration URLs

### DIFF
--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -33,6 +33,14 @@ func MockKeyLength(n int) (restore func()) {
 	}
 }
 
+func MockRequestIDURL(url string) (restore func()) {
+	oldURL := requestIDURL
+	requestIDURL = url
+	return func() {
+		requestIDURL = oldURL
+	}
+}
+
 func MockSerialRequestURL(url string) (restore func()) {
 	oldURL := serialRequestURL
 	serialRequestURL = url


### PR DESCRIPTION
Updates device registration URLs, and updates the request-id request to be a POST.
(still needs some server-side changes to be rolled out)