### PR TITLE
interfaces/builtin: allow /dev/vhci on bluetooth-control

### DIFF
--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -40,6 +40,10 @@ const bluetoothControlConnectedPlugAppArmor = `
   /sys/class/bluetooth/           r,
   /sys/devices/**/bluetooth/      rw,
   /sys/devices/**/bluetooth/**    rw,
+
+  # Requires CONFIG_BT_VHCI to be loaded
+  /dev/vhci                       r,
+
 `
 
 const bluetoothControlConnectedPlugSecComp = `


### PR DESCRIPTION
This is needed for the bluez self-tests, and without access, many of the tests are failing