### PR TITLE
interfaces/builtin: allow writing on /dev/vhci in bluetooth-control

### DIFF
--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -42,7 +42,7 @@ const bluetoothControlConnectedPlugAppArmor = `
   /sys/devices/**/bluetooth/**    rw,
 
   # Requires CONFIG_BT_VHCI to be loaded
-  /dev/vhci                       r,
+  /dev/vhci                       rw,
 
 `
 


### PR DESCRIPTION
Sorry, had been a bit quick to assume w wasn't needed!  I've tested this on my system and can verify that the bluez self-tests that had been failing now run