### PR TITLE
 image,overlord/boot,snap: metadata from asserts for image snaps

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -245,7 +245,7 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options) error {
 		fmt.Fprintf(Stdout, "Fetching %s\n", snapName)
 		fn, info, err := acquireSnap(sto, snapName, dlOpts, seen)
 		if err == errSeen {
-			fmt.Fprintf(Stdout, "... Already installed")
+			fmt.Fprintf(Stdout, "... already installed")
 			continue
 		}
 		if err != nil {
@@ -276,10 +276,11 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options) error {
 
 		// set seed.yaml
 		seedYaml.Snaps = append(seedYaml.Snaps, &snap.SeedSnap{
-			Name:    info.Name(),
-			SnapID:  info.SnapID,
-			Channel: info.Channel,
-			File:    filepath.Base(fn),
+			Name:       info.Name(),
+			SnapID:     info.SnapID,
+			Channel:    info.Channel,
+			File:       filepath.Base(fn),
+			Sideloaded: info.SnapID == "",
 		})
 	}
 

--- a/image/image.go
+++ b/image/image.go
@@ -20,6 +20,7 @@
 package image
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -63,6 +64,7 @@ func Prepare(opts *Options) error {
 
 	sto := makeStore(model)
 
+	// TODO: let opts.Snaps also override gadget with a local one
 	if err := downloadUnpackGadget(sto, model, opts); err != nil {
 		return err
 	}
@@ -109,7 +111,7 @@ func downloadUnpackGadget(sto Store, model *asserts.Model, opts *Options) error 
 		TargetDir: opts.GadgetUnpackDir,
 		Channel:   opts.Channel,
 	}
-	snapFn, _, err := acquireSnap(sto, model.Gadget(), dlOpts)
+	snapFn, _, err := acquireSnap(sto, model.Gadget(), dlOpts, nil)
 	if err != nil {
 		return err
 	}
@@ -119,9 +121,14 @@ func downloadUnpackGadget(sto Store, model *asserts.Model, opts *Options) error 
 	return snap.Unpack("*", opts.GadgetUnpackDir)
 }
 
-func acquireSnap(sto Store, snapName string, dlOpts *downloadOptions) (downloadedSnap string, info *snap.Info, err error) {
-	// FIXME: add support for sideloading snaps here
-	return downloadSnapWithSideInfo(sto, snapName, dlOpts)
+var errSeen = errors.New("already seen/installed")
+
+func acquireSnap(sto Store, snapName string, dlOpts *downloadOptions, seen map[string]bool) (downloadedSnap string, info *snap.Info, err error) {
+	if strings.HasSuffix(snapName, ".snap") && osutil.FileExists(snapName) {
+		// local snap to sideload
+		return copyLocalSnapFile(snapName, dlOpts.TargetDir)
+	}
+	return downloadSnapWithSideInfo(sto, snapName, dlOpts, seen)
 }
 
 type addingFetcher struct {
@@ -217,14 +224,14 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options) error {
 		Channel:   opts.Channel,
 	}
 
-	// FIXME: support sideloading snaps by copying the boostrap.snaps
-	//        first and keeping track of the already downloaded names
 	snaps := []string{}
 	snaps = append(snaps, opts.Snaps...)
 	snaps = append(snaps, model.Gadget())
 	snaps = append(snaps, defaultCore)
 	snaps = append(snaps, model.Kernel())
 	snaps = append(snaps, model.RequiredSnaps()...)
+
+	seen := make(map[string]bool)
 
 	for _, d := range []string{snapSeedDir, assertSeedDir} {
 		if err := os.MkdirAll(d, 0755); err != nil {
@@ -236,15 +243,23 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options) error {
 	var seedYaml snap.Seed
 	for _, snapName := range snaps {
 		fmt.Fprintf(Stdout, "Fetching %s\n", snapName)
-		fn, info, err := acquireSnap(sto, snapName, dlOpts)
+		fn, info, err := acquireSnap(sto, snapName, dlOpts, seen)
+		if err == errSeen {
+			fmt.Fprintf(Stdout, "... Already installed")
+			continue
+		}
 		if err != nil {
 			return err
 		}
 
-		// fetch the snap assertions too
-		err = fetchSnapAssertions(fn, info, f, db)
-		if err != nil {
-			return err
+		seen[info.Name()] = true
+
+		// if it comes from the store fetch the snap assertions too
+		if info.SnapID != "" {
+			err = fetchSnapAssertions(fn, info, f, db)
+			if err != nil {
+				return err
+			}
 		}
 
 		typ := info.Type
@@ -261,13 +276,10 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options) error {
 
 		// set seed.yaml
 		seedYaml.Snaps = append(seedYaml.Snaps, &snap.SeedSnap{
-			Name:        info.Name(),
-			SnapID:      info.SnapID,
-			Revision:    info.Revision,
-			Channel:     info.Channel,
-			DeveloperID: info.DeveloperID,
-			Developer:   info.Developer,
-			File:        filepath.Base(fn),
+			Name:    info.Name(),
+			SnapID:  info.SnapID,
+			Channel: info.Channel,
+			File:    filepath.Base(fn),
 		})
 	}
 
@@ -379,7 +391,7 @@ func copyLocalSnapFile(snapName, targetDir string) (copyiedSnapFn string, info *
 	if info.Revision.Unset() {
 		info.Revision = snap.R(-1)
 	}
-	dst := filepath.Join(targetDir, filepath.Dir(info.MountFile()))
+	dst := filepath.Join(targetDir, filepath.Base(info.MountFile()))
 
 	return dst, info, osutil.CopyFile(snapName, dst, 0)
 }
@@ -404,7 +416,7 @@ type Store interface {
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
 }
 
-func downloadSnapWithSideInfo(sto Store, name string, opts *downloadOptions) (targetPath string, info *snap.Info, err error) {
+func downloadSnapWithSideInfo(sto Store, name string, opts *downloadOptions, seen map[string]bool) (targetPath string, info *snap.Info, err error) {
 	if opts == nil {
 		opts = &downloadOptions{}
 	}
@@ -421,6 +433,9 @@ func downloadSnapWithSideInfo(sto Store, name string, opts *downloadOptions) (ta
 	snap, err := sto.Snap(name, opts.Channel, false, snap.R(0), nil)
 	if err != nil {
 		return "", nil, fmt.Errorf("cannot find snap %q: %s", name, err)
+	}
+	if seen[snap.Name()] {
+		return "", nil, errSeen
 	}
 	pb := progress.NewTextProgress()
 	tmpName, err := sto.Download(name, &snap.DownloadInfo, pb, nil)

--- a/snap/seed_yaml.go
+++ b/snap/seed_yaml.go
@@ -32,17 +32,21 @@ import (
 type SeedSnap struct {
 	// XXX: this will all go away once we have assertions
 	// yaml needs to be in sync with SideInfo
-	Name        string   `yaml:"name" json:"name"`
+	Name string `yaml:"name" json:"name"`
+
+	// XXX: these come from assertions now
 	SnapID      string   `yaml:"snap-id" json:"snap-id"`
 	Revision    Revision `yaml:"revision" json:"revision"`
 	Channel     string   `yaml:"channel,omitempty" json:"channel,omitempty"`
 	DeveloperID string   `yaml:"developer-id,omitempty" json:"developer-id,omitempty"`
 	Developer   string   `yaml:"developer,omitempty" json:"developer,omitempty"` // XXX: obsolete, will be retired after full backfilling of DeveloperID
-	Private     bool     `yaml:"private,omitempty" json:"private,omitempty"`
 
+	Private bool `yaml:"private,omitempty" json:"private,omitempty"`
 	// not in side-info
 	File    string `yaml:"file"`
 	DevMode bool   `yaml:"devmode"`
+
+	Sideloaded bool `yaml:"sideloaded"`
 }
 
 type Seed struct {

--- a/snap/seed_yaml_test.go
+++ b/snap/seed_yaml_test.go
@@ -40,6 +40,9 @@ snaps:
    revision: 31
    file: foo_1.0_all.snap
    devmode: true
+ - name: local
+   sideloaded: true
+   file: local.snap
 `)
 
 func (s *seedYamlTestSuite) TestSimple(c *C) {
@@ -49,7 +52,7 @@ func (s *seedYamlTestSuite) TestSimple(c *C) {
 
 	seed, err := snap.ReadSeedYaml(fn)
 	c.Assert(err, IsNil)
-	c.Assert(seed.Snaps, HasLen, 1)
+	c.Assert(seed.Snaps, HasLen, 2)
 	c.Assert(seed.Snaps[0], DeepEquals, &snap.SeedSnap{
 		File:     "foo_1.0_all.snap",
 		Name:     "foo",
@@ -57,6 +60,11 @@ func (s *seedYamlTestSuite) TestSimple(c *C) {
 		Channel:  "stable",
 		Revision: snap.R(31),
 		DevMode:  true,
+	})
+	c.Assert(seed.Snaps[1], DeepEquals, &snap.SeedSnap{
+		File:       "local.snap",
+		Name:       "local",
+		Sideloaded: true,
 	})
 }
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -93,7 +93,7 @@ setup_reflash_magic() {
 
         # teardown store
         teardown_store fake $STORE_DIR
-        
+
         # mount fresh image and add all our SPREAD_PROJECT data
         kpartx -avs $IMAGE_HOME/$IMAGE
         # FIXME: hardcoded mapper location, parse from kpartx
@@ -104,7 +104,14 @@ setup_reflash_magic() {
         # create test user home dir
         mkdir -p /mnt/user-data/test
         chown 1001:1001 /mnt/user-data/test
-        
+
+        # we do what sync-dirs is normally doing on boot, but because
+        # we have subdirs/files in /etc/systemd/system (created below)
+        # the writeable-path sync-boot won't work
+        mkdir -p /mnt/system-data/etc/systemd
+        (cd /tmp ; unsquashfs -v $IMAGE_HOME/ubuntu-core_*.snap etc/systemd/system)
+        cp -avr /tmp/squashfs-root/etc/systemd/system /mnt/system-data/etc/systemd/
+
         # FIXUP silly systemd
         mkdir -p /mnt/system-data/etc/systemd/system/snapd.service.d
         cat <<EOF > /mnt/system-data/etc/systemd/system/snapd.service.d/local.conf


### PR DESCRIPTION
This is really just https://github.com/snapcore/snapd/pull/1802 with a new u-d-f. Proposing to get spread results.