### PR TITLE
client,cmd/snap: display os-release data only on classic

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -248,6 +248,7 @@ type ServerVersion struct {
 	Series      string
 	OSID        string
 	OSVersionID string
+	OnClassic   bool
 }
 
 func (client *Client) ServerVersion() (*ServerVersion, error) {
@@ -261,6 +262,7 @@ func (client *Client) ServerVersion() (*ServerVersion, error) {
 		Series:      sysInfo.Series,
 		OSID:        sysInfo.OSRelease.ID,
 		OSVersionID: sysInfo.OSRelease.VersionID,
+		OnClassic:   sysInfo.OnClassic,
 	}, nil
 }
 

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -117,7 +117,9 @@ func Parser() *flags.Parser {
 		fmt.Fprintf(w, "snap\t%s\n", cmd.Version)
 		fmt.Fprintf(w, "snapd\t%s\n", sv.Version)
 		fmt.Fprintf(w, "series\t%s\n", sv.Series)
-		fmt.Fprintf(w, "%s\t%s\n", sv.OSID, sv.OSVersionID)
+		if sv.OnClassic {
+			fmt.Fprintf(w, "%s\t%s\n", sv.OSID, sv.OSVersionID)
+		}
 		w.Flush()
 
 		os.Exit(0)

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -137,3 +137,38 @@ func (s *SnapSuite) TestExtraArgs(c *C) {
 	err := snap.RunMain()
 	c.Assert(err, ErrorMatches, `too many arguments for command`)
 }
+
+func (s *SnapSuite) TestVersionOnClassic(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"on-classic":true,"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89"}}`)
+	})
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"snap", "--version"}
+	err := snap.RunMain()
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Equals,
+		`snap    7.89
+snapd   7.89
+series  56
+ubuntu  12.34
+`)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestVersionOnAllSnap(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89"}}`)
+	})
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{"snap", "--version"}
+	err := snap.RunMain()
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Equals,
+		`snap    7.89
+snapd   7.89
+series  56
+`)
+	c.Assert(s.Stderr(), Equals, "")
+}


### PR DESCRIPTION
This patch changes "snap --version" so that ID and ID_VERSION from the
distribution is only displayed in classic environments.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>