### PR TITLE
Wrapper: create $SNAP_USER_COMMON (LP:#1611063)

### DIFF
--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -49,6 +49,9 @@ set -e
 if [ ! -d "$SNAP_USER_DATA" ]; then
    mkdir -p "$SNAP_USER_DATA"
 fi
+if [ ! -d "$SNAP_USER_COMMON" ]; then
+   mkdir -p "$SNAP_USER_COMMON"
+fi
 export HOME="$SNAP_USER_DATA"
 
 # Snap name is: {{.App.Snap.Name}}

--- a/wrappers/binaries_gen_test.go
+++ b/wrappers/binaries_gen_test.go
@@ -52,6 +52,9 @@ export SNAP_USER_DATA="$HOME/snap/pastebinit/44"
 if [ ! -d "$SNAP_USER_DATA" ]; then
    mkdir -p "$SNAP_USER_DATA"
 fi
+if [ ! -d "$SNAP_USER_COMMON" ]; then
+   mkdir -p "$SNAP_USER_COMMON"
+fi
 export HOME="$SNAP_USER_DATA"
 
 # Snap name is: pastebinit


### PR DESCRIPTION
As reported in the bug [LP: #1611063][1], the `$SNAP_USER_COMMON` directory isn't being created.
Furthermore, that directory can't be created by the application (permission denied).
Since this apparently hasn't been fixed yet, I made this pull request.

I added some lines to `wrappers/binaries.go` so that the generated wrapper scripts create that directory (just like `$SNAP_USER_DATA`).
I also added that to `wrappers/binaries_gen_test.go`.

**I didn't compile and test this**, so you should double-check this.
However, I added those lines directly to one of the scripts in my `/snap/bin/` directory. Running that script did indeed create the directory `~/snap/$SNAP/common/`.

More tests are probably needed too, especially to check that this directory is indeed being created.

[1]: https://bugs.launchpad.net/snappy/+bug/1611063 "Launchpad - Bug #1611063 - can't mkdir SNAP_USER_COMMON directory"