### PR TITLE
snap: set user variables even if HOME is unset (like with systemd services)

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -116,8 +116,19 @@ func getSnapInfo(snapName string, revision snap.Revision) (*snap.Info, error) {
 // returns the environment that is important for the later stages of execution
 // (like SNAP_REVISION that snap-exec requires to work)
 func snapExecEnv(info *snap.Info) []string {
+	home := os.Getenv("HOME")
+	// HOME is not set for systemd services, so pull it out of passwd
+	if home == "" {
+		user, err := user.Current()
+		if err == nil {
+			home = user.HomeDir
+		}
+	}
+
 	env := snapenv.Basic(info)
-	env = append(env, snapenv.User(info, os.Getenv("HOME"))...)
+	if home != "" {
+		env = append(env, snapenv.User(info, home)...)
+	}
 	return env
 }
 

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -73,6 +73,9 @@ func (s *SnapSuite) TestSnapRunSnapExecEnv(c *check.C) {
 	usr, err := user.Current()
 	c.Assert(err, check.IsNil)
 
+	homeEnv := os.Getenv("HOME")
+	defer os.Setenv("HOME", homeEnv)
+
 	for _, withHomeEnv := range []bool{true, false} {
 		if !withHomeEnv {
 			os.Setenv("HOME", "")

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -22,6 +22,7 @@ package main_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"os/user"
 	"path/filepath"
 	"sort"
@@ -72,20 +73,26 @@ func (s *SnapSuite) TestSnapRunSnapExecEnv(c *check.C) {
 	usr, err := user.Current()
 	c.Assert(err, check.IsNil)
 
-	env := snaprun.SnapExecEnv(info)
-	sort.Strings(env)
-	c.Check(env, check.DeepEquals, []string{
-		fmt.Sprintf("SNAP=%s/snapname/42", dirs.SnapMountDir),
-		fmt.Sprintf("SNAP_ARCH=%s", arch.UbuntuArchitecture()),
-		"SNAP_COMMON=/var/snap/snapname/common",
-		"SNAP_DATA=/var/snap/snapname/42",
-		"SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:",
-		"SNAP_NAME=snapname",
-		"SNAP_REVISION=42",
-		fmt.Sprintf("SNAP_USER_COMMON=%s/snap/snapname/common", usr.HomeDir),
-		fmt.Sprintf("SNAP_USER_DATA=%s/snap/snapname/42", usr.HomeDir),
-		"SNAP_VERSION=1.0",
-	})
+	for _, withHomeEnv := range []bool{true, false} {
+		if !withHomeEnv {
+			os.Setenv("HOME", "")
+		}
+
+		env := snaprun.SnapExecEnv(info)
+		sort.Strings(env)
+		c.Check(env, check.DeepEquals, []string{
+			fmt.Sprintf("SNAP=%s/snapname/42", dirs.SnapMountDir),
+			fmt.Sprintf("SNAP_ARCH=%s", arch.UbuntuArchitecture()),
+			"SNAP_COMMON=/var/snap/snapname/common",
+			"SNAP_DATA=/var/snap/snapname/42",
+			"SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:",
+			"SNAP_NAME=snapname",
+			"SNAP_REVISION=42",
+			fmt.Sprintf("SNAP_USER_COMMON=%s/snap/snapname/common", usr.HomeDir),
+			fmt.Sprintf("SNAP_USER_DATA=%s/snap/snapname/42", usr.HomeDir),
+			"SNAP_VERSION=1.0",
+		})
+	}
 }
 
 func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {


### PR DESCRIPTION
This fixes `snap run` when used with systemd services.