### PR TITLE
many: start services only after the snap is fully ready (link-snap was run)

### DIFF
--- a/overlord/patch/patch.go
+++ b/overlord/patch/patch.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Level is the current implemented patch level of the state format and content.
-var Level = 2
+var Level = 3
 
 // patches maps from patch level L to the function that moves from L-1 to L.
 var patches = make(map[int]func(s *state.State) error)

--- a/overlord/patch/patch3.go
+++ b/overlord/patch/patch3.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package patch
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func init() {
+	patches[3] = patch3
+}
+
+func activeStatus(status state.Status) bool {
+	switch status {
+	case state.DoStatus, state.DoingStatus, state.UndoStatus, state.UndoingStatus:
+		return true
+	}
+	return false
+}
+
+// patch3:
+// - migrates pending tasks and add {start,stop}-snap-services tasks
+func patch3(s *state.State) error {
+
+	// migrate all pending tasks and insert "{start,stop}-snap-server"
+	for _, t := range s.Tasks() {
+		if t.Kind() == "link-snap" && activeStatus(t.Status()) {
+			startSnapServices := s.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap services")))
+			startSnapServices.Set("snap-setup-task", t.ID())
+			startSnapServices.WaitFor(t)
+
+			chg := t.Change()
+			chg.AddTask(startSnapServices)
+		}
+
+		if t.Kind() == "unlink-snap" && activeStatus(t.Status()) {
+			stopSnapServices := s.NewTask("stop-snap-services", fmt.Sprintf(i18n.G("Stop snap  services")))
+			stopSnapServices.Set("snap-setup-task", t.ID())
+			t.WaitFor(stopSnapServices)
+
+			chg := t.Change()
+			chg.AddTask(stopSnapServices)
+		}
+	}
+
+	return nil
+}

--- a/overlord/patch/patch3_test.go
+++ b/overlord/patch/patch3_test.go
@@ -82,6 +82,16 @@ var statePatch3JSON = []byte(`
 				"3"
 			],
 			"change": "1"
+		},
+		"4": {
+			"id": "4",
+			"kind": "unlink-current-snap",
+			"summary": "meep",
+			"status": 2,
+			"halt-tasks": [
+				"3"
+			],
+			"change": "1"
 		}
 	}
 }
@@ -108,7 +118,7 @@ func (s *patch3Suite) TestPatch3(c *C) {
 
 	// our mocks are correct
 	st.Lock()
-	c.Assert(st.Tasks(), HasLen, 3)
+	c.Assert(st.Tasks(), HasLen, 4)
 	st.Unlock()
 
 	// go from patch level 2 -> 3
@@ -119,17 +129,21 @@ func (s *patch3Suite) TestPatch3(c *C) {
 	defer st.Unlock()
 
 	// we got two more tasks
-	c.Assert(st.Tasks(), HasLen, 5)
+	c.Assert(st.Tasks(), HasLen, 7)
 	for _, t := range st.Tasks() {
 		switch t.Kind() {
 		case "start-snap-services":
 			ht := t.WaitTasks()
 			c.Check(ht, HasLen, 1)
 			c.Check(ht[0].Kind(), Equals, "link-snap")
-		case "stop-snap-services":
-			ht := t.HaltTasks()
+		case "unlink-snap":
+			ht := t.WaitTasks()
 			c.Check(ht, HasLen, 1)
-			c.Check(ht[0].Kind(), Equals, "unlink-snap")
+			c.Check(ht[0].Kind(), Equals, "stop-snap-services")
+		case "unlink-current-snap":
+			ht := t.WaitTasks()
+			c.Check(ht, HasLen, 1)
+			c.Check(ht[0].Kind(), Equals, "stop-snap-services")
 		}
 	}
 }

--- a/overlord/patch/patch3_test.go
+++ b/overlord/patch/patch3_test.go
@@ -1,0 +1,135 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package patch_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/patch"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type patch3Suite struct{}
+
+var _ = Suite(&patch3Suite{})
+
+var statePatch3JSON = []byte(`
+{
+        "last-task-id": 999,
+        "last-change-id": 99,
+
+	"data": {
+		"patch-level": 2
+	},
+        "changes": {
+		"1": {
+			"id": "1",
+			"kind": "some-change",
+			"summary": "summary-1",
+			"status": 0,
+			"task-ids": ["1"]
+		}
+        },
+	"tasks": {
+		"1": {
+			"id": "1",
+			"kind": "link-snap",
+			"summary": "meep",
+			"status": 2,
+			"halt-tasks": [
+				"7"
+			],
+			"change": "1"
+		},
+		"2": {
+			"id": "2",
+			"kind": "unlink-snap",
+			"summary": "meep",
+			"status": 2,
+			"halt-tasks": [
+				"3"
+			],
+			"change": "1"
+		},
+		"3": {
+			"id": "3",
+			"kind": "unrelated",
+			"summary": "meep",
+			"status": 4,
+			"halt-tasks": [
+				"3"
+			],
+			"change": "1"
+		}
+	}
+}
+`)
+
+func (s *patch3Suite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+
+	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(dirs.SnapStateFile, statePatch3JSON, 0644)
+	c.Assert(err, IsNil)
+}
+
+func (s *patch3Suite) TestPatch3(c *C) {
+	restorer := patch.MockLevel(3)
+	defer restorer()
+
+	r, err := os.Open(dirs.SnapStateFile)
+	c.Assert(err, IsNil)
+	defer r.Close()
+	st, err := state.ReadState(nil, r)
+	c.Assert(err, IsNil)
+
+	// our mocks are correct
+	st.Lock()
+	c.Assert(st.Tasks(), HasLen, 3)
+	st.Unlock()
+
+	// go from patch level 2 -> 3
+	err = patch.Apply(st)
+	c.Assert(err, IsNil)
+
+	st.Lock()
+	defer st.Unlock()
+
+	// we got two more tasks
+	c.Assert(st.Tasks(), HasLen, 5)
+	for _, t := range st.Tasks() {
+		switch t.Kind() {
+		case "start-snap-services":
+			ht := t.WaitTasks()
+			c.Check(ht, HasLen, 1)
+			c.Check(ht[0].Kind(), Equals, "link-snap")
+		case "stop-snap-services":
+			ht := t.HaltTasks()
+			c.Check(ht, HasLen, 1)
+			c.Check(ht[0].Kind(), Equals, "unlink-snap")
+		}
+	}
+}

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -48,6 +48,7 @@ type managerBackend interface {
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 	LinkSnap(info *snap.Info) error
 	StartSnapServices(info *snap.Info, meter progress.Meter) error
+	StopSnapServices(info *snap.Info, meter progress.Meter) error
 
 	// the undoers for install
 	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, meter progress.Meter) error

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -47,6 +47,8 @@ type managerBackend interface {
 	SetupSnap(snapFilePath string, si *snap.SideInfo, meter progress.Meter) error
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 	LinkSnap(info *snap.Info) error
+	StartSnapServices(info *snap.Info, meter progress.Meter) error
+
 	// the undoers for install
 	UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, meter progress.Meter) error
 	UndoCopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -70,6 +70,10 @@ func (b Backend) LinkSnap(info *snap.Info) error {
 	return updateCurrentSymlinks(info)
 }
 
+func (b Backend) StartSnapServices(info *snap.Info, meter progress.Meter) error {
+	return wrappers.StartSnapServices(info, meter)
+}
+
 func generateWrappers(s *snap.Info) error {
 	// add the CLI apps from the snap.yaml
 	if err := wrappers.AddSnapBinaries(s); err != nil {

--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -74,6 +74,10 @@ func (b Backend) StartSnapServices(info *snap.Info, meter progress.Meter) error 
 	return wrappers.StartSnapServices(info, meter)
 }
 
+func (b Backend) StopSnapServices(info *snap.Info, meter progress.Meter) error {
+	return wrappers.StopSnapServices(info, meter)
+}
+
 func generateWrappers(s *snap.Info) error {
 	// add the CLI apps from the snap.yaml
 	if err := wrappers.AddSnapBinaries(s); err != nil {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -300,6 +300,14 @@ func (f *fakeSnappyBackend) StartSnapServices(info *snap.Info, meter progress.Me
 	return nil
 }
 
+func (f *fakeSnappyBackend) StopSnapServices(info *snap.Info, meter progress.Meter) error {
+	f.ops = append(f.ops, fakeOp{
+		op:   "stop-snap-services",
+		name: info.MountDir(),
+	})
+	return nil
+}
+
 func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, p progress.Meter) error {
 	p.Notify("setup-snap")
 	f.ops = append(f.ops, fakeOp{

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -292,6 +292,14 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info) error {
 	return nil
 }
 
+func (f *fakeSnappyBackend) StartSnapServices(info *snap.Info, meter progress.Meter) error {
+	f.ops = append(f.ops, fakeOp{
+		op:   "start-services-snap",
+		name: info.MountDir(),
+	})
+	return nil
+}
+
 func (f *fakeSnappyBackend) UndoSetupSnap(s snap.PlaceInfo, typ snap.Type, p progress.Meter) error {
 	p.Notify("setup-snap")
 	f.ops = append(f.ops, fakeOp{

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -294,7 +294,7 @@ func (f *fakeSnappyBackend) LinkSnap(info *snap.Info) error {
 
 func (f *fakeSnappyBackend) StartSnapServices(info *snap.Info, meter progress.Meter) error {
 	f.ops = append(f.ops, fakeOp{
-		op:   "start-services-snap",
+		op:   "start-snap-services",
 		name: info.MountDir(),
 	})
 	return nil

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -364,7 +364,7 @@ func Manager(s *state.State) (*SnapManager, error) {
 	runner.AddHandler("unlink-current-snap", m.doUnlinkCurrentSnap, m.undoUnlinkCurrentSnap)
 	runner.AddHandler("copy-snap-data", m.doCopySnapData, m.undoCopySnapData)
 	runner.AddHandler("link-snap", m.doLinkSnap, m.undoLinkSnap)
-	runner.AddHandler("start-services-snap", m.doStartServicesSnap, m.undoStartServicesSnap)
+	runner.AddHandler("start-snap-services", m.doStartSnapServices, m.undoStartSnapServices)
 	// FIXME: port to native tasks and rename
 	//runner.AddHandler("garbage-collect", m.doGarbageCollect, nil)
 
@@ -773,7 +773,7 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	// mark as active again
 	Set(st, ss.Name(), snapst)
 
-	// FIXME: would be good to undo in undoStartServicesSnap
+	// FIXME: would be good to undo in undoStartSnapServices
 	//        however in order to start the old service again
 	//        we need "current" to point to the previous version
 	//        of the snap and that is happening here.
@@ -1024,7 +1024,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) doStartServicesSnap(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doStartSnapServices(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1045,7 +1045,7 @@ func (m *SnapManager) doStartServicesSnap(t *state.Task, _ *tomb.Tomb) error {
 	return err
 }
 
-func (m *SnapManager) undoStartServicesSnap(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) undoStartSnapServices(t *state.Task, _ *tomb.Tomb) error {
 	// nothing needs to be done here, m.backend.UnlinkSnap() in
 	// undoLinkSnap will stop all the services
 	return nil

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -134,7 +134,7 @@ func verifyInstallUpdateTasks(c *C, curActive bool, ts *state.TaskSet, st *state
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "link-snap")
 	i++
-	c.Assert(ts.Tasks()[i].Kind(), Equals, "start-services-snap")
+	c.Assert(ts.Tasks()[i].Kind(), Equals, "start-snap-services")
 	return n
 }
 
@@ -177,7 +177,7 @@ func (s *snapmgrTestSuite) TestRevertTasks(c *C) {
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "link-snap")
 	i++
-	c.Assert(ts.Tasks()[i].Kind(), Equals, "start-services-snap")
+	c.Assert(ts.Tasks()[i].Kind(), Equals, "start-snap-services")
 }
 
 func (s *snapmgrTestSuite) TestUpdateCreatesGCTasks(c *C) {
@@ -300,7 +300,7 @@ func (s *snapmgrTestSuite) TestRevertCreatesNoGCTasks(c *C) {
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "link-snap")
 	i++
-	c.Assert(ts.Tasks()[i].Kind(), Equals, "start-services-snap")
+	c.Assert(ts.Tasks()[i].Kind(), Equals, "start-snap-services")
 }
 
 func (s *snapmgrTestSuite) TestEnableTasks(c *C) {
@@ -703,7 +703,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 			name: "/snap/some-snap/42",
 		},
 		{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/42",
 		},
 	})
@@ -846,7 +846,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 			name: "/snap/some-snap/11",
 		},
 		{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/11",
 		},
 	}
@@ -1016,7 +1016,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 			name: "/snap/some-snap/7",
 		},
 		{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/7",
 		},
 		{
@@ -1144,7 +1144,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 			name: "/snap/some-snap/11",
 		},
 		{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/11",
 		},
 		// undoing everything from here down...
@@ -1167,7 +1167,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 			name: "/snap/some-snap/7",
 		},
 		{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/7",
 		},
 		{
@@ -1337,7 +1337,7 @@ version: 1.0`)
 	})
 	c.Check(s.fakeBackend.ops[5].op, Equals, "link-snap")
 	c.Check(s.fakeBackend.ops[5].name, Equals, "/snap/mock/x1")
-	c.Check(s.fakeBackend.ops[6].op, Equals, "start-services-snap")
+	c.Check(s.fakeBackend.ops[6].op, Equals, "start-snap-services")
 	c.Check(s.fakeBackend.ops[6].name, Equals, "/snap/mock/x1")
 
 	// verify snapSetup info
@@ -1422,7 +1422,7 @@ version: 1.0`)
 	})
 	c.Check(s.fakeBackend.ops[6].op, Equals, "link-snap")
 	c.Check(s.fakeBackend.ops[6].name, Equals, "/snap/mock/x3")
-	c.Check(s.fakeBackend.ops[7].op, Equals, "start-services-snap")
+	c.Check(s.fakeBackend.ops[7].op, Equals, "start-snap-services")
 	c.Check(s.fakeBackend.ops[7].name, Equals, "/snap/mock/x3")
 
 	// verify snapSetup info
@@ -1543,7 +1543,7 @@ version: 1.0`)
 	c.Check(s.fakeBackend.ops[4].sinfo, DeepEquals, *si)
 	c.Check(s.fakeBackend.ops[5].op, Equals, "link-snap")
 	c.Check(s.fakeBackend.ops[5].name, Equals, "/snap/some-snap/42")
-	c.Check(s.fakeBackend.ops[6].op, Equals, "start-services-snap")
+	c.Check(s.fakeBackend.ops[6].op, Equals, "start-snap-services")
 	c.Check(s.fakeBackend.ops[6].name, Equals, "/snap/some-snap/42")
 
 	// verify snapSetup info
@@ -2038,7 +2038,7 @@ func (s *snapmgrTestSuite) TestUpdateDoesGC(c *C) {
 		name: "/snap/some-snap/11",
 	})
 	c.Assert(ops[len(ops)-5], DeepEquals, fakeOp{
-		op:   "start-services-snap",
+		op:   "start-snap-services",
 		name: "/snap/some-snap/11",
 	})
 	c.Assert(ops[len(ops)-4], DeepEquals, fakeOp{
@@ -2206,7 +2206,7 @@ func (s *snapmgrTestSuite) TestRevertRunThrough(c *C) {
 			name: "/snap/some-snap/2",
 		},
 		fakeOp{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/2",
 		},
 	}
@@ -2324,7 +2324,7 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNewVersion(c *C) {
 			name: "/snap/some-snap/7",
 		},
 		fakeOp{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/7",
 		},
 	}
@@ -2400,7 +2400,7 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 			name: "/snap/some-snap/1",
 		},
 		{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/1",
 		},
 		// undoing everything from here down...
@@ -2418,7 +2418,7 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 			name: "/snap/some-snap/2",
 		},
 		{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/2",
 		},
 	}
@@ -2501,7 +2501,7 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 			name: "/snap/some-snap/2",
 		},
 		{
-			op:   "start-services-snap",
+			op:   "start-snap-services",
 			name: "/snap/some-snap/2",
 		},
 	}

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -116,7 +116,7 @@ func verifyInstallUpdateTasks(c *C, curActive bool, ts *state.TaskSet, st *state
 	i := 0
 	n := 7
 	if curActive {
-		n++
+		n += 2
 	}
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "download-snap")
 	i++
@@ -125,6 +125,8 @@ func verifyInstallUpdateTasks(c *C, curActive bool, ts *state.TaskSet, st *state
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "mount-snap")
 	i++
 	if curActive {
+		c.Assert(ts.Tasks()[i].Kind(), Equals, "stop-snap-services")
+		i++
 		c.Assert(ts.Tasks()[i].Kind(), Equals, "unlink-current-snap")
 		i++
 	}
@@ -167,9 +169,11 @@ func (s *snapmgrTestSuite) TestRevertTasks(c *C) {
 	c.Assert(err, IsNil)
 
 	i := 0
-	c.Assert(ts.Tasks(), HasLen, 5)
-	c.Assert(s.state.NumTask(), Equals, 5)
+	c.Assert(ts.Tasks(), HasLen, 6)
+	c.Assert(s.state.NumTask(), Equals, 6)
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "prepare-snap")
+	i++
+	c.Assert(ts.Tasks()[i].Kind(), Equals, "stop-snap-services")
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "unlink-current-snap")
 	i++
@@ -290,9 +294,11 @@ func (s *snapmgrTestSuite) TestRevertCreatesNoGCTasks(c *C) {
 
 	// ensure that we do not run any form of garbage-collection
 	i := 0
-	c.Assert(ts.Tasks(), HasLen, 5)
-	c.Assert(s.state.NumTask(), Equals, 5)
+	c.Assert(ts.Tasks(), HasLen, 6)
+	c.Assert(s.state.NumTask(), Equals, 6)
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "prepare-snap")
+	i++
+	c.Assert(ts.Tasks()[i].Kind(), Equals, "stop-snap-services")
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "unlink-current-snap")
 	i++

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -319,11 +319,13 @@ func (s *snapmgrTestSuite) TestEnableTasks(c *C) {
 	c.Assert(err, IsNil)
 
 	i := 0
-	c.Assert(ts.Tasks(), HasLen, 2)
-	c.Assert(s.state.NumTask(), Equals, 2)
+	c.Assert(ts.Tasks(), HasLen, 3)
+	c.Assert(s.state.NumTask(), Equals, 3)
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "prepare-snap")
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "link-snap")
+	i++
+	c.Assert(ts.Tasks()[i].Kind(), Equals, "start-snap-services")
 }
 
 func (s *snapmgrTestSuite) TestDisableTasks(c *C) {
@@ -2614,7 +2616,7 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	c.Assert(s.fakeBackend.ops, HasLen, 2)
+	c.Assert(s.fakeBackend.ops, HasLen, 3)
 	expected := []fakeOp{
 		fakeOp{
 			op: "candidate",
@@ -2625,6 +2627,10 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 		},
 		fakeOp{
 			op:   "link-snap",
+			name: "/snap/some-snap/7",
+		},
+		fakeOp{
+			op:   "start-snap-services",
 			name: "/snap/some-snap/7",
 		},
 	}

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -1149,6 +1149,10 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 		},
 		// undoing everything from here down...
 		{
+			op:   "stop-snap-services",
+			name: "/snap/some-snap/11",
+		},
+		{
 			op:   "unlink-snap",
 			name: "/snap/some-snap/11",
 		},
@@ -2404,6 +2408,10 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 			name: "/snap/some-snap/1",
 		},
 		// undoing everything from here down...
+		{
+			op:   "stop-snap-services",
+			name: "/snap/some-snap/1",
+		},
 		{
 			op:   "unlink-snap",
 			name: "/snap/some-snap/1",

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -136,10 +136,15 @@ func doInstall(s *state.State, snapst *SnapState, ss *SnapSetup) (*state.TaskSet
 	// finalize (wrappers+current symlink)
 	linkSnap := s.NewTask("link-snap", fmt.Sprintf(i18n.G("Make snap %q%s available to the system"), ss.Name(), revisionStr))
 	addTask(linkSnap)
+	prev = linkSnap
+
+	// run new serices
+	runServicesSnap := s.NewTask("start-services-snap", fmt.Sprintf(i18n.G("Start snap %q%s services"), ss.Name(), revisionStr))
+	addTask(runServicesSnap)
+	prev = runServicesSnap
 
 	// Do not do that if we are reverting to a local revision
 	if snapst.HasCurrent() && !revisionIsLocal {
-		prev := linkSnap
 		seq := snapst.Sequence
 		currentIndex := snapst.findIndex(snapst.Current)
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -139,9 +139,9 @@ func doInstall(s *state.State, snapst *SnapState, ss *SnapSetup) (*state.TaskSet
 	prev = linkSnap
 
 	// run new serices
-	runServicesSnap := s.NewTask("start-services-snap", fmt.Sprintf(i18n.G("Start snap %q%s services"), ss.Name(), revisionStr))
-	addTask(runServicesSnap)
-	prev = runServicesSnap
+	startSnapServices := s.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q%s services"), ss.Name(), revisionStr))
+	addTask(startSnapServices)
+	prev = startSnapServices
 
 	// Do not do that if we are reverting to a local revision
 	if snapst.HasCurrent() && !revisionIsLocal {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -479,7 +479,11 @@ func Enable(s *state.State, name string) (*state.TaskSet, error) {
 	linkSnap.Set("snap-setup", &ss)
 	linkSnap.WaitFor(prepareSnap)
 
-	return state.NewTaskSet(prepareSnap, linkSnap), nil
+	startSnapServices := s.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q (%s) services"), ss.Name(), snapst.Current))
+	startSnapServices.Set("snap-setup", &ss)
+	startSnapServices.WaitFor(linkSnap)
+
+	return state.NewTaskSet(prepareSnap, linkSnap, startSnapServices), nil
 }
 
 // Disable sets a snap to the inactive state

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -116,6 +116,10 @@ func doInstall(s *state.State, snapst *SnapState, ss *SnapSetup) (*state.TaskSet
 
 	if snapst.Active {
 		// unlink-current-snap (will stop services for copy-data)
+		stop := s.NewTask("stop-snap-services", fmt.Sprintf(i18n.G("Stop snap %q services"), ss.Name()))
+		addTask(stop)
+		prev = stop
+
 		unlink := s.NewTask("unlink-current-snap", fmt.Sprintf(i18n.G("Make current revision for snap %q unavailable"), ss.Name()))
 		addTask(unlink)
 		prev = unlink

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -175,7 +175,7 @@ func StopSnapServices(s *snap.Info, inter interacter) error {
 
 }
 
-// RemoveSnapServices stops and removes service units for the applications from the snap which are services.
+// RemoveSnapServices disables and removes service units for the applications from the snap which are services.
 func RemoveSnapServices(s *snap.Info, inter interacter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -108,7 +108,11 @@ func (s *servicesTestSuite) TestRemoveSnapPackageFallbackToKill(c *C) {
 
 	var sysdLog [][]string
 	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
-		sysdLog = append(sysdLog, cmd)
+		// filter out the "systemctl show" that
+		// StopSnapServicesGenerates
+		if cmd[0] != "show" {
+			sysdLog = append(sysdLog, cmd)
+		}
 		return []byte("ActiveState=active\n"), nil
 	}
 


### PR DESCRIPTION
This is a prerequisite branch for moving to symlinks (instead of wrappers). To do that, we need to start the service only after the snap is fully finalized (and arguable it is already a bug that a service starts before the snap is considered fully ready).