### PR TITLE
ensure snapd.refresh.service waits for snapd.firstboot.services.

### DIFF
--- a/debian/snapd.refresh.service
+++ b/debian/snapd.refresh.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Automatically refresh installed snaps
-After=network.target
+After=network.target snapd.firstboot.service
 Documentation=man:snap(1)
 
 # FIXME: add auto-reboot on devices


### PR DESCRIPTION
If not we have a race and maybe refresh will create a state.json file and firstboot won't run anymore