### PR TITLE
interfaces: snippet creation for snaps without apps

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -471,9 +471,14 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 			return nil, err
 		}
 		if snippet != nil {
-			for appName := range slot.Apps {
-				securityTag := snap.AppSecurityTag(snapName, appName)
+			if len(slot.Apps) == 0 {
+				securityTag := snap.AppSecurityTag(snapName, snapName)
 				snippets[securityTag] = append(snippets[securityTag], snippet)
+			} else {
+				for appName := range slot.Apps {
+					securityTag := snap.AppSecurityTag(snapName, appName)
+					snippets[securityTag] = append(snippets[securityTag], snippet)
+				}
 			}
 		}
 		// Add connection-specific snippet specific to each plug
@@ -485,9 +490,14 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 			if snippet == nil {
 				continue
 			}
-			for appName := range slot.Apps {
-				securityTag := snap.AppSecurityTag(snapName, appName)
+			if len(slot.Apps) == 0 {
+				securityTag := snap.AppSecurityTag(snapName, snapName)
 				snippets[securityTag] = append(snippets[securityTag], snippet)
+			} else {
+				for appName := range slot.Apps {
+					securityTag := snap.AppSecurityTag(snapName, appName)
+					snippets[securityTag] = append(snippets[securityTag], snippet)
+				}
 			}
 		}
 	}
@@ -500,9 +510,14 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 			return nil, err
 		}
 		if snippet != nil {
-			for appName := range plug.Apps {
-				securityTag := snap.AppSecurityTag(snapName, appName)
+			if len(plug.Apps) == 0 {
+				securityTag := snap.AppSecurityTag(snapName, snapName)
 				snippets[securityTag] = append(snippets[securityTag], snippet)
+			} else {
+				for appName := range plug.Apps {
+					securityTag := snap.AppSecurityTag(snapName, appName)
+					snippets[securityTag] = append(snippets[securityTag], snippet)
+				}
 			}
 			for hookName := range plug.Hooks {
 				securityTag := snap.HookSecurityTag(snapName, hookName)
@@ -518,9 +533,14 @@ func (r *Repository) securitySnippetsForSnap(snapName string, securitySystem Sec
 			if snippet == nil {
 				continue
 			}
-			for appName := range plug.Apps {
-				securityTag := snap.AppSecurityTag(snapName, appName)
+			if len(plug.Apps) == 0 {
+				securityTag := snap.AppSecurityTag(snapName, snapName)
 				snippets[securityTag] = append(snippets[securityTag], snippet)
+			} else {
+				for appName := range plug.Apps {
+					securityTag := snap.AppSecurityTag(snapName, appName)
+					snippets[securityTag] = append(snippets[securityTag], snippet)
+				}
 			}
 			for hookName := range plug.Hooks {
 				securityTag := snap.HookSecurityTag(snapName, hookName)


### PR DESCRIPTION
There are situations where snaps may declare slots without
having them assigned to any app. A hardware resource slot
on a gadget or core snap for example. This allows for security
snippets to be created in these situations.