### PR TITLE
firstboot: only configure en* and eth* interfaces by default

### DIFF
--- a/firstboot/firstboot.go
+++ b/firstboot/firstboot.go
@@ -56,7 +56,7 @@ network:
  ethernets:
    all:
     match:
-     name: "*"
+     name: "en*"
     dhcp4: true
 `
 

--- a/firstboot/firstboot.go
+++ b/firstboot/firstboot.go
@@ -52,16 +52,16 @@ var netplanConfigData = `
 # This is the initial network config written by 'snap firstboot'.
 # It can be overwritten by cloud-init or console-conf.
 network:
- version: 2
- ethernets:
-   all-en:
-    match:
-     name: "en*"
-    dhcp4: true
-   all-eth:
-    match:
-     name: "eth*"
-    dhcp4: true
+    version: 2
+    ethernets:
+        all-en:
+            match:
+                name: "en*"
+            dhcp4: true
+        all-eth:
+            match:
+                name: "eth*"
+            dhcp4: true
 `
 
 // InitialNetworkConfig writes and applies a netplan config that

--- a/firstboot/firstboot.go
+++ b/firstboot/firstboot.go
@@ -54,9 +54,13 @@ var netplanConfigData = `
 network:
  version: 2
  ethernets:
-   all:
+   all-en:
     match:
      name: "en*"
+    dhcp4: true
+   all-eth:
+    match:
+     name: "eth*"
     dhcp4: true
 `
 


### PR DESCRIPTION
As reported by https://bugs.launchpad.net/ubuntu/+source/nplan/+bug/1618522 we
need to match with name="en*" to avoid configuring wifi devices by mistake.