### PR TITLE
interfaces: modem-manager: ignore camera

### DIFF
--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -797,6 +797,9 @@ ATTRS{idVendor}=="0216", ATTRS{idProduct}=="0051", ENV{ID_MM_DEVICE_IGNORE}="1"
 # Bluegiga BLE112B
 ATTRS{idVendor}=="2458", ATTRS{idProduct}=="0001", ENV{ID_MM_DEVICE_IGNORE}="1"
 
+# Analog Devices BLIP camera
+ATTRS{idVendor}=="064b", ATTRS{idProduct}=="7823", ENV{ID_MM_DEVICE_IGNORE}="1"
+
 # MediaTek GPS chip (HOLUX M-1200E, GlobalTop Gms-d1, etc)
 ATTRS{idVendor}=="0e8d", ATTRS{idProduct}=="3329", ENV{ID_MM_DEVICE_IGNORE}="1"
 


### PR DESCRIPTION
Ignore BLIP camera by using udev rules.