### PR TITLE
interface: network_manager: enable resolvconf

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -75,6 +75,9 @@ network packet,
 # Needed for systemd's dhcp implementation
 /etc/machine-id r,
 
+# Needed to use resolvconf from core
+/sbin/resolvconf ixr,
+
 #include <abstractions/nameservice>
 
 # DBus accesses


### PR DESCRIPTION
Allow NetworkManager to launch resolvconf from core.  Resolves:

https://bugs.launchpad.net/snappy-hwe-snaps/+bug/1602356