### PR TITLE
store: switch device session to use device-session-request assertion

### DIFF
--- a/store/auth.go
+++ b/store/auth.go
@@ -267,12 +267,12 @@ func RequestStoreDeviceNonce() (string, error) {
 }
 
 // RequestDeviceSession requests a device session macaroon from the store.
-func RequestDeviceSession(serialAssertion, serialProof, previousSession string) (string, error) {
+func RequestDeviceSession(serialAssertion, sessionRequest, previousSession string) (string, error) {
 	const errorPrefix = "cannot get device session from store: "
 
 	data := map[string]string{
-		"serial-assertion": serialAssertion,
-		"serial-proof":     serialProof,
+		"serial-assertion":       serialAssertion,
+		"device-session-request": sessionRequest,
 	}
 	deviceJSONData, err := json.Marshal(data)
 	if err != nil {

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -333,7 +333,7 @@ func (s *authTestSuite) TestRequestDeviceSession(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		jsonReq, err := ioutil.ReadAll(r.Body)
 		c.Assert(err, IsNil)
-		c.Check(string(jsonReq), Equals, `{"serial-assertion":"serial-assertion","serial-proof":"serial-proof"}`)
+		c.Check(string(jsonReq), Equals, `{"device-session-request":"session-request","serial-assertion":"serial-assertion"}`)
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, "")
 
 		io.WriteString(w, mockStoreReturnMacaroon)
@@ -341,7 +341,7 @@ func (s *authTestSuite) TestRequestDeviceSession(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
 
-	macaroon, err := RequestDeviceSession("serial-assertion", "serial-proof", "")
+	macaroon, err := RequestDeviceSession("serial-assertion", "session-request", "")
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
@@ -350,7 +350,7 @@ func (s *authTestSuite) TestRequestDeviceSessionWithPreviousSession(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		jsonReq, err := ioutil.ReadAll(r.Body)
 		c.Assert(err, IsNil)
-		c.Check(string(jsonReq), Equals, `{"serial-assertion":"serial-assertion","serial-proof":"serial-proof"}`)
+		c.Check(string(jsonReq), Equals, `{"device-session-request":"session-request","serial-assertion":"serial-assertion"}`)
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="previous-session"`)
 
 		io.WriteString(w, mockStoreReturnMacaroon)
@@ -358,7 +358,7 @@ func (s *authTestSuite) TestRequestDeviceSessionWithPreviousSession(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
 
-	macaroon, err := RequestDeviceSession("serial-assertion", "serial-proof", "previous-session")
+	macaroon, err := RequestDeviceSession("serial-assertion", "session-request", "previous-session")
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
@@ -370,7 +370,7 @@ func (s *authTestSuite) TestRequestDeviceSessionMissingData(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
 
-	macaroon, err := RequestDeviceSession("serial-assertion", "serial-proof", "")
+	macaroon, err := RequestDeviceSession("serial-assertion", "session-request", "")
 	c.Assert(err, ErrorMatches, "cannot get device session from store: empty session returned")
 	c.Assert(macaroon, Equals, "")
 }
@@ -382,7 +382,7 @@ func (s *authTestSuite) TestRequestDeviceSessionError(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
 
-	macaroon, err := RequestDeviceSession("serial-assertion", "serial-proof", "")
+	macaroon, err := RequestDeviceSession("serial-assertion", "session-request", "")
 	c.Assert(err, ErrorMatches, "cannot get device session from store: store server returned status 500")
 	c.Assert(macaroon, Equals, "")
 }

--- a/store/store.go
+++ b/store/store.go
@@ -38,7 +38,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -414,22 +413,17 @@ func (s *Store) refreshDeviceSession() error {
 		return err
 	}
 
-	serialAssertion, err := s.authContext.Serial()
-	if err != nil {
-		return err
-	}
-
 	nonce, err := RequestStoreDeviceNonce()
 	if err != nil {
 		return err
 	}
 
-	serialProof, err := s.authContext.SerialProof(nonce)
+	sessionRequest, serialAssertion, err := s.authContext.DeviceSessionRequest(nonce)
 	if err != nil {
 		return err
 	}
 
-	session, err := RequestDeviceSession(string(serialAssertion), string(serialProof), device.SessionMacaroon)
+	session, err := RequestDeviceSession(string(serialAssertion), string(sessionRequest), device.SessionMacaroon)
 	if err != nil {
 		return err
 	}
@@ -534,11 +528,11 @@ func (s *Store) newRequest(reqOptions *requestOptions, user *auth.UserState) (*h
 		}
 		if device.SessionMacaroon == "" {
 			err = s.refreshDeviceSession()
-			if err == state.ErrNoState {
+			if err == auth.ErrNoSerial {
 				// missing serial assertion, log and continue without device authentication
 				logger.Debugf("cannot set device session: %v", err)
 			}
-			if err != nil && err != state.ErrNoState {
+			if err != nil && err != auth.ErrNoSerial {
 				return nil, err
 			}
 		}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -82,8 +82,12 @@ sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQ
 
 AXNpZw=`
 
-	exSerialProof = `type: serial-proof
+	exDeviceSessionRequest = `type: device-session-request
+brand-id: my-brand
+model: baz-3000
+serial: 9999
 nonce: @NONCE@
+timestamp: 2016-08-24T21:55:00Z
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
 AXNpZw=`
@@ -119,23 +123,25 @@ func (ac *testAuthContext) StoreID(fallback string) (string, error) {
 }
 
 func (ac *testAuthContext) Serial() ([]byte, error) {
-	a, err := asserts.Decode([]byte(exSerial))
-	if err != nil {
-		return nil, err
-	}
-	return asserts.Encode(a.(*asserts.Serial)), nil
+	panic("Serial is deprecated, it should not be called")
 }
 
 func (ac *testAuthContext) SerialProof(nonce string) ([]byte, error) {
-	a, err := asserts.Decode([]byte(strings.Replace(exSerialProof, "@NONCE@", nonce, 1)))
-	if err != nil {
-		return nil, err
-	}
-	return asserts.Encode(a.(*asserts.SerialProof)), nil
+	panic("SerialProof is deprecated, it should not be called")
 }
 
 func (ac *testAuthContext) DeviceSessionRequest(nonce string) ([]byte, []byte, error) {
-	panic("implement me")
+	serial, err := asserts.Decode([]byte(exSerial))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sessReq, err := asserts.Decode([]byte(strings.Replace(exDeviceSessionRequest, "@NONCE@", nonce, 1)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return asserts.Encode(sessReq.(*asserts.DeviceSessionRequest)), asserts.Encode(serial.(*asserts.Serial)), nil
 }
 
 func makeTestMacaroon() (*macaroon.Macaroon, error) {


### PR DESCRIPTION
Updates device session flow to use DeviceSessionRequest assertion when requesting a session to the store (instead of SerialProof).

NOTE: requires a production rollout of store services (SAS, SCA)