### PR TITLE
asserts: don't have Add/Check panic in the face of unsupported no-authority assertions

### DIFF
--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -474,6 +474,17 @@ func (safs *signAddFindSuite) TestAddNoAuthorityNoPrimaryKey(c *C) {
 	c.Assert(err, ErrorMatches, `internal error: assertion type "test-only-no-authority" has no primary key`)
 }
 
+func (safs *signAddFindSuite) TestAddNoAuthorityButPrimaryKey(c *C) {
+	headers := map[string]interface{}{
+		"pk": "primary",
+	}
+	a, err := asserts.SignWithoutAuthority(asserts.TestOnlyNoAuthorityPKType, headers, nil, testPrivKey0)
+	c.Assert(err, IsNil)
+
+	err = safs.db.Add(a)
+	c.Assert(err, ErrorMatches, `cannot check no-authority assertion type "test-only-no-authority-pk"`)
+}
+
 func (safs *signAddFindSuite) TestFindNotFound(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "canonical",

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -121,19 +121,30 @@ type TestOnlyNoAuthority struct {
 	assertionBase
 }
 
-func assembleTestOnlyFreeestanding(assert assertionBase) (Assertion, error) {
+func assembleTestOnlyNoAuthority(assert assertionBase) (Assertion, error) {
 	if _, err := checkNotEmptyString(assert.headers, "hdr"); err != nil {
 		return nil, err
 	}
 	return &TestOnlyNoAuthority{assert}, nil
 }
 
-var TestOnlyNoAuthorityType = &AssertionType{"test-only-no-authority", nil, assembleTestOnlyFreeestanding, noAuthority}
+var TestOnlyNoAuthorityType = &AssertionType{"test-only-no-authority", nil, assembleTestOnlyNoAuthority, noAuthority}
+
+type TestOnlyNoAuthorityPK struct {
+	assertionBase
+}
+
+func assembleTestOnlyNoAuthorityPK(assert assertionBase) (Assertion, error) {
+	return &TestOnlyNoAuthorityPK{assert}, nil
+}
+
+var TestOnlyNoAuthorityPKType = &AssertionType{"test-only-no-authority-pk", []string{"pk"}, assembleTestOnlyNoAuthorityPK, noAuthority}
 
 func init() {
 	typeRegistry[TestOnlyType.Name] = TestOnlyType
 	typeRegistry[TestOnly2Type.Name] = TestOnly2Type
 	typeRegistry[TestOnlyNoAuthorityType.Name] = TestOnlyNoAuthorityType
+	typeRegistry[TestOnlyNoAuthorityPKType.Name] = TestOnlyNoAuthorityPKType
 }
 
 // AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests


### PR DESCRIPTION
Database.Add and Check must not panic. We don't fully control what is fed to 'snap ack' or we might receive in general as input in some circumstances and it doesn't make sense to make this other layers' problem.

Also in doubt of what behavior we want in the future simplify further. It's really not possible anyway to add more special assertions without rethinking/attacking all checks holistically.