### PR TITLE
snap: switch to the new agreed regexp for snap names

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -25,13 +25,13 @@ import (
 )
 
 // Regular expression describing correct identifiers.
-var validName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
+var validSnapName = regexp.MustCompile("^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$")
 var validEpoch = regexp.MustCompile("^(?:0|[1-9][0-9]*[*]?)$")
 var validHookName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
 
 // ValidateName checks if a string can be used as a snap name.
 func ValidateName(name string) error {
-	valid := validName.MatchString(name)
+	valid := validSnapName.MatchString(name)
 	if !valid {
 		return fmt.Errorf("invalid snap name: %q", name)
 	}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -36,6 +36,7 @@ func (s *ValidateSuite) TestValidateName(c *C) {
 		"a", "aa", "aaa", "aaaa",
 		"a-a", "aa-a", "a-aa", "a-b-c",
 		"a0", "a-0", "a-0a",
+		"01game", "1-or-2",
 	}
 	for _, name := range validNames {
 		err := ValidateName(name)


### PR DESCRIPTION
This also add some examples to tests that now are valid (and weren't before).