### PR TITLE
snap: ensure that plug and slot names are unique

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -91,6 +91,21 @@ func Validate(info *Info) error {
 			return err
 		}
 	}
+
+	// ensure that plug and slot have unique names
+	if err := plugsSlotsUniqueNames(info); err != nil {
+		return err
+	}
+	return nil
+}
+
+func plugsSlotsUniqueNames(info *Info) error {
+	// we could choose the smaller collection if we wanted to optimize this check
+	for plugName := range info.Plugs {
+		if info.Slots[plugName] != nil {
+			return fmt.Errorf("cannot have plug and slot with the same name: %q", plugName)
+		}
+	}
 	return nil
 }
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -242,3 +242,15 @@ hooks:
 	err = Validate(info)
 	c.Check(err, ErrorMatches, `invalid hook name: "123abc"`)
 }
+
+func (s *ValidateSuite) TestPlugSlotNamesUnique(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: snap
+plugs:
+ foo:
+slots:
+ foo:
+`))
+	c.Assert(err, IsNil)
+	err = Validate(info)
+	c.Check(err, ErrorMatches, `cannot have plug and slot with the same name: "foo"`)
+}


### PR DESCRIPTION
This branch extended snap validation to ensure that plug and slot names are unique within one snap so that a given name is always uniquely identifying a plug or a slot but not both.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>