### PR TITLE
osutil: call sync after cp if requested. overlord/snapstate/backend: switch to use osutil instead of another buggy call to cp

### DIFF
--- a/osutil/cp.go
+++ b/osutil/cp.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // CopyFlag is used to tweak the behaviour of CopyFile
@@ -136,8 +137,8 @@ func runCmd(cmd *exec.Cmd, errdesc string) error {
 	return nil
 }
 
-func runSync() error {
-	return runCmd(exec.Command("sync"), "sync")
+func runSync(args ...string) error {
+	return runCmd(exec.Command("sync", args...), "sync")
 }
 
 func runCpPreserveAll(path, dest, errdesc string) error {
@@ -147,7 +148,10 @@ func runCpPreserveAll(path, dest, errdesc string) error {
 // CopySpecialFile is used to copy all the things that are not files
 // (like device nodes, named pipes etc)
 func CopySpecialFile(path, dest string) error {
-	return runCpPreserveAll(path, dest, "copy device node")
+	if err := runCpPreserveAll(path, dest, "copy device node"); err != nil {
+		return err
+	}
+	return runSync(filepath.Dir(dest))
 }
 
 // ErrCopySpecialFile is returned if a special file copy fails

--- a/osutil/cp.go
+++ b/osutil/cp.go
@@ -20,6 +20,7 @@
 package osutil
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -63,7 +64,14 @@ func CopyFile(src, dst string, flags CopyFlag) (err error) {
 		// Our native copy code does not preserve all attributes
 		// (yet). If the user needs this functionatlity we just
 		// fallback to use the system's "cp" binary to do the copy.
-		return runCpPreserveAll(src, dst)
+		err := runCpPreserveAll(src, dst, "copy all")
+		if err != nil {
+			return err
+		}
+		if flags&CopyFlagSync != 0 {
+			return runSync()
+		}
+		return nil
 	}
 
 	fin, err := openfile(src, os.O_RDONLY, 0)
@@ -109,16 +117,18 @@ func CopyFile(src, dst string, flags CopyFlag) (err error) {
 	return nil
 }
 
-func runCpPreserveAll(path, dest string) error {
-	cmd := exec.Command("cp", "-av", path, dest)
+func runCmd(cmd *exec.Cmd, errdesc string) error {
 	if output, err := cmd.CombinedOutput(); err != nil {
+		output = bytes.TrimSpace(output)
 		if exitCode, err := ExitCode(err); err == nil {
 			return &ErrCopySpecialFile{
+				desc:     errdesc,
 				exitCode: exitCode,
 				output:   output,
 			}
 		}
 		return &ErrCopySpecialFile{
+			desc:   errdesc,
 			err:    err,
 			output: output,
 		}
@@ -127,14 +137,23 @@ func runCpPreserveAll(path, dest string) error {
 	return nil
 }
 
+func runSync() error {
+	return runCmd(exec.Command("sync"), "sync")
+}
+
+func runCpPreserveAll(path, dest, errdesc string) error {
+	return runCmd(exec.Command("cp", "-av", path, dest), errdesc)
+}
+
 // CopySpecialFile is used to copy all the things that are not files
 // (like device nodes, named pipes etc)
 func CopySpecialFile(path, dest string) error {
-	return runCpPreserveAll(path, dest)
+	return runCpPreserveAll(path, dest, "copy device node")
 }
 
 // ErrCopySpecialFile is returned if a special file copy fails
 type ErrCopySpecialFile struct {
+	desc     string
 	exitCode int
 	output   []byte
 	err      error
@@ -142,8 +161,8 @@ type ErrCopySpecialFile struct {
 
 func (e ErrCopySpecialFile) Error() string {
 	if e.err == nil {
-		return fmt.Sprintf("failed to copy device node: %q (%v)", e.output, e.exitCode)
+		return fmt.Sprintf("failed to %s: %q (%v)", e.desc, e.output, e.exitCode)
 	}
 
-	return fmt.Sprintf("failed to copy device node: %q (%v)", e.output, e.err)
+	return fmt.Sprintf("failed to %s: %q (%v)", e.desc, e.output, e.err)
 }

--- a/osutil/cp.go
+++ b/osutil/cp.go
@@ -64,8 +64,7 @@ func CopyFile(src, dst string, flags CopyFlag) (err error) {
 		// Our native copy code does not preserve all attributes
 		// (yet). If the user needs this functionatlity we just
 		// fallback to use the system's "cp" binary to do the copy.
-		err := runCpPreserveAll(src, dst, "copy all")
-		if err != nil {
+		if err := runCpPreserveAll(src, dst, "copy all"); err != nil {
 			return err
 		}
 		if flags&CopyFlagSync != 0 {

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 
 	. "gopkg.in/check.v1"
 
@@ -370,7 +371,11 @@ exit 3
 	defer os.Setenv("PATH", oldPATH)
 	os.Setenv("PATH", fakeBinDir+":"+oldPATH)
 
+	q := func(s string) string {
+		return regexp.QuoteMeta(strconv.Quote(s))
+	}
+
 	// copy data will fail
 	err = s.be.CopySnapData(v2, v1, &s.nullProgress)
-	c.Assert(err, ErrorMatches, regexp.QuoteMeta(fmt.Sprintf("cannot copy %s to %s: cp: boom", v1.DataDir(), v2.DataDir())))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot copy %s to %s: .*: "cp: boom" \(3\)`, q(v1.DataDir()), q(v2.DataDir())))
 }

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -20,12 +20,11 @@
 package backend
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -112,14 +111,9 @@ func copySnapData(oldSnap, newSnap *snap.Info) (err error) {
 func copySnapDataDirectory(oldPath, newPath string) (err error) {
 	if _, err := os.Stat(oldPath); err == nil {
 		if _, err := os.Stat(newPath); err != nil {
-			// there is no golang "CopyFile"
-			cmd := exec.Command("cp", "-a", oldPath, newPath)
-			if output, err := cmd.CombinedOutput(); err != nil {
-				output = bytes.TrimSpace(output)
-				if len(output) > 0 {
-					err = fmt.Errorf("%s", output)
-				}
-				return fmt.Errorf("cannot copy %s to %s: %v", oldPath, newPath, err)
+			err := osutil.CopyFile(oldPath, newPath, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
+			if err != nil {
+				return fmt.Errorf("cannot copy %q to %q: %v", oldPath, newPath, err)
 			}
 		}
 	}

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -111,8 +111,7 @@ func copySnapData(oldSnap, newSnap *snap.Info) (err error) {
 func copySnapDataDirectory(oldPath, newPath string) (err error) {
 	if _, err := os.Stat(oldPath); err == nil {
 		if _, err := os.Stat(newPath); err != nil {
-			err := osutil.CopyFile(oldPath, newPath, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync)
-			if err != nil {
+			if err := osutil.CopyFile(oldPath, newPath, osutil.CopyFlagPreserveAll|osutil.CopyFlagSync); err != nil {
 				return fmt.Errorf("cannot copy %q to %q: %v", oldPath, newPath, err)
 			}
 		}

--- a/testutil/exec_test.go
+++ b/testutil/exec_test.go
@@ -40,3 +40,14 @@ func (s *mockCommandSuite) TestMockCommand(c *C) {
 		{"cmd", "second-run", "--arg1", "arg2", "a %s"},
 	})
 }
+
+func (s *mockCommandSuite) TestMockCommandAlso(c *C) {
+	mock := MockCommand(c, "fst", "")
+	also := mock.Also("snd", "")
+	defer mock.Restore()
+
+	c.Assert(exec.Command("fst").Run(), IsNil)
+	c.Assert(exec.Command("snd").Run(), IsNil)
+	c.Check(mock.Calls(), DeepEquals, [][]string{{"fst"}, {"snd"}})
+	c.Check(mock.Calls(), DeepEquals, also.Calls())
+}


### PR DESCRIPTION
split and filled out from #1834 for your reviewing pleasure.