### PR TITLE
cmd/snap: generate account-key-request "since" header in UTC

### DIFF
--- a/cmd/snap/cmd_export_key.go
+++ b/cmd/snap/cmd_export_key.go
@@ -67,7 +67,7 @@ func (x *cmdExportKey) Execute(args []string) error {
 			"account-id":          x.Account,
 			"name":                keyName,
 			"public-key-sha3-384": pubKey.ID(),
-			"since":               time.Now().Format(time.RFC3339),
+			"since":               time.Now().UTC().Format(time.RFC3339),
 			// XXX: To support revocation, we need to check for matching known assertions and set a suitable revision if we find one.
 		}
 		body, err := asserts.EncodePublicKey(pubKey)

--- a/cmd/snap/cmd_export_key_test.go
+++ b/cmd/snap/cmd_export_key_test.go
@@ -20,6 +20,8 @@
 package main_test
 
 import (
+	"time"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -71,6 +73,11 @@ func (s *SnapKeysSuite) TestExportKeyAccount(c *C) {
 	c.Check(assertion.HeaderString("account-id"), Equals, "developer1")
 	c.Check(assertion.HeaderString("name"), Equals, "another")
 	c.Check(assertion.HeaderString("public-key-sha3-384"), Equals, "DVQf1U4mIsuzlQqAebjjTPYtYJ-GEhJy0REuj3zvpQYTZ7EJj7adBxIXLJ7Vmk3L")
+	since, err := time.Parse(time.RFC3339, assertion.HeaderString("since"))
+	c.Assert(err, IsNil)
+	zone, offset := since.Zone()
+	c.Check(zone, Equals, "UTC")
+	c.Check(offset, Equals, 0)
 	c.Check(s.Stderr(), Equals, "")
 	privKey, err := manager.Get(assertion.HeaderString("public-key-sha3-384"))
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The system design specification says "utc-datetime" for account-keys,
and it seems best to use a canonical form of the timestamp in the
assertion anyway.