### PR TITLE
interfaces: add stub selinux backend

### DIFF
--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -154,6 +154,8 @@ const (
 	SecurityUDev SecuritySystem = "udev"
 	// SecurityMount identifies the mount security system.
 	SecurityMount SecuritySystem = "mount"
+	// SecuritySELinux identifies the selinux security system.
+	SecuritySELinux SecuritySystem = "selinux"
 )
 
 var (

--- a/interfaces/selinux/backend.go
+++ b/interfaces/selinux/backend.go
@@ -1,0 +1,48 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package selinux implements integration between snapd and snap-confine around
+// selinux.
+//
+// NOTE: This is currently in very early stages. Expect things to fail and to
+// be insecure.
+package selinux
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/snap"
+)
+
+// Backend is responsible for maintaining apparmor profiles for ubuntu-core-launcher.
+type Backend struct{}
+
+// Name returns the name of the backend.
+func (b *Backend) Name() string {
+	return "selinux"
+}
+
+// Setup does nothing yet.
+func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repository) error {
+	return nil
+}
+
+// Remove does nothing yet.
+func (b *Backend) Remove(snapName string) error {
+	return nil
+}

--- a/interfaces/selinux/backend_test.go
+++ b/interfaces/selinux/backend_test.go
@@ -1,0 +1,33 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package selinux_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/backendtest"
+	_ "github.com/snapcore/snapd/interfaces/selinux"
+)
+
+type backendSuite struct {
+	backendtest.BackendSuite
+}
+
+var _ = Suite(&backendSuite{})


### PR DESCRIPTION
This branch adds a new backend and security system identifier for selinux.

Currently there is no selinux support but this will make some collaboration easier.