### PR TITLE
overlord/snapstate: misc fixes/tweaks/cleanups

### DIFF
--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -115,6 +115,9 @@ func copySnapDataDirectory(oldPath, newPath string) (err error) {
 				return fmt.Errorf("cannot copy %q to %q: %v", oldPath, newPath, err)
 			}
 		}
+	} else if !os.IsNotExist(err) {
+		return err
 	}
+
 	return nil
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -45,6 +45,37 @@ type fakeOp struct {
 	old string
 }
 
+type fakeOps []fakeOp
+
+func (ops fakeOps) Ops() []string {
+	opsOps := make([]string, len(ops))
+	for i, op := range ops {
+		opsOps[i] = op.op
+	}
+
+	return opsOps
+}
+
+func (ops fakeOps) Count(op string) int {
+	n := 0
+	for i := range ops {
+		if ops[i].op == op {
+			n++
+		}
+	}
+	return n
+}
+
+func (ops fakeOps) First(op string) *fakeOp {
+	for i := range ops {
+		if ops[i].op == op {
+			return &ops[i]
+		}
+	}
+
+	return nil
+}
+
 type fakeDownload struct {
 	name     string
 	macaroon string
@@ -196,7 +227,7 @@ func (f *fakeStore) Assertion(*asserts.AssertionType, []string, *auth.UserState)
 }
 
 type fakeSnappyBackend struct {
-	ops []fakeOp
+	ops fakeOps
 
 	linkSnapFailTrigger     string
 	copySnapDataFailTrigger string

--- a/overlord/snapstate/download_snap_test.go
+++ b/overlord/snapstate/download_snap_test.go
@@ -88,7 +88,7 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatbility(c *C) {
 	s.snapmgr.Wait()
 
 	// the compat code called the store "Snap" endpoint
-	c.Assert(s.fakeBackend.ops, DeepEquals, []fakeOp{
+	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
 			op:    "storesvc-snap",
 			name:  "foo",
@@ -141,7 +141,7 @@ func (s *downloadSnapSuite) TestDoDownloadSnapNormal(c *C) {
 	s.snapmgr.Wait()
 
 	// only the download endpoint of the store was hit
-	c.Assert(s.fakeBackend.ops, DeepEquals, []fakeOp{
+	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
 			op:   "storesvc-download",
 			name: "foo",

--- a/overlord/snapstate/link_snap_test.go
+++ b/overlord/snapstate/link_snap_test.go
@@ -172,7 +172,7 @@ func (s *linkSnapSuite) TestDoLinkSnapTryToCleanupOnError(c *C) {
 	c.Assert(err, Equals, state.ErrNoState)
 
 	// tried to cleanup
-	c.Check(s.fakeBackend.ops, DeepEquals, []fakeOp{
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
 			op:    "candidate",
 			sinfo: *si,

--- a/overlord/snapstate/mount_snap_test.go
+++ b/overlord/snapstate/mount_snap_test.go
@@ -125,7 +125,7 @@ func (s *mountSnapSuite) TestDoUndoMountSnap(c *C) {
 	s.state.Lock()
 
 	// ensure undo was called the right way
-	c.Check(s.fakeBackend.ops, DeepEquals, []fakeOp{
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
 			op:  "current",
 			old: "/snap/core/1",

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -140,6 +140,15 @@ func verifyInstallUpdateTasks(c *C, curActive bool, ts *state.TaskSet, st *state
 	return n
 }
 
+func (s *snapmgrTestSuite) TestLastIndexFindsLast(c *C) {
+	snapst := &snapstate.SnapState{Sequence: []*snap.SideInfo{
+		{Revision: snap.R(7)},
+		{Revision: snap.R(11)},
+		{Revision: snap.R(11)},
+	}}
+	c.Check(snapst.LastIndex(snap.R(11)), Equals, 2)
+}
+
 func (s *snapmgrTestSuite) TestInstallTasks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -663,7 +672,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 		macaroon: s.user.Macaroon,
 		name:     "some-snap",
 	}})
-	c.Assert(s.fakeBackend.ops, DeepEquals, []fakeOp{
+	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
 			op:    "storesvc-snap",
 			name:  "some-snap",
@@ -796,7 +805,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op: "storesvc-list-refresh",
 			cand: store.RefreshCandidate{
@@ -952,7 +961,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op: "storesvc-list-refresh",
 			cand: store.RefreshCandidate{
@@ -1102,7 +1111,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op: "storesvc-list-refresh",
 			cand: store.RefreshCandidate{
@@ -1210,6 +1219,8 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 		macaroon: s.user.Macaroon,
 		name:     "some-snap",
 	}})
+	// friendlier failure first
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
 	// verify snaps in the system state
@@ -1626,7 +1637,7 @@ func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 	s.state.Lock()
 
 	c.Check(len(s.fakeBackend.ops), Equals, 7)
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op:   "stop-snap-services",
 			name: "/snap/some-snap/7",
@@ -1726,7 +1737,7 @@ func (s *snapmgrTestSuite) TestRemoveWithManyRevisionsRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op:   "stop-snap-services",
 			name: "/snap/some-snap/7",
@@ -1852,7 +1863,7 @@ func (s *snapmgrTestSuite) TestRemoveOneRevisionRunThrough(c *C) {
 	s.state.Lock()
 
 	c.Check(len(s.fakeBackend.ops), Equals, 2)
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op:   "remove-snap-data",
 			name: "/snap/some-snap/3",
@@ -1915,7 +1926,7 @@ func (s *snapmgrTestSuite) TestRemoveLastRevisionRunThrough(c *C) {
 	s.state.Lock()
 
 	c.Check(len(s.fakeBackend.ops), Equals, 4)
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op:   "remove-snap-data",
 			name: "/snap/some-snap/2",
@@ -2222,32 +2233,32 @@ func (s *snapmgrTestSuite) TestRevertRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	expected := []fakeOp{
-		fakeOp{
+	expected := fakeOps{
+		{
 			op:   "stop-snap-services",
 			name: "/snap/some-snap/7",
 		},
-		fakeOp{
+		{
 			op:   "unlink-snap",
 			name: "/snap/some-snap/7",
 		},
-		fakeOp{
+		{
 			op:    "setup-profiles:Doing",
 			name:  "some-snap",
 			revno: snap.R(2),
 		},
-		fakeOp{
+		{
 			op: "candidate",
 			sinfo: snap.SideInfo{
 				RealName: "some-snap",
 				Revision: snap.R(2),
 			},
 		},
-		fakeOp{
+		{
 			op:   "link-snap",
 			name: "/snap/some-snap/2",
 		},
-		fakeOp{
+		{
 			op:   "start-snap-services",
 			name: "/snap/some-snap/2",
 		},
@@ -2344,32 +2355,32 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNewVersion(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	expected := []fakeOp{
-		fakeOp{
+	expected := fakeOps{
+		{
 			op:   "stop-snap-services",
 			name: "/snap/some-snap/2",
 		},
-		fakeOp{
+		{
 			op:   "unlink-snap",
 			name: "/snap/some-snap/2",
 		},
-		fakeOp{
+		{
 			op:    "setup-profiles:Doing",
 			name:  "some-snap",
 			revno: snap.R(7),
 		},
-		fakeOp{
+		{
 			op: "candidate",
 			sinfo: snap.SideInfo{
 				RealName: "some-snap",
 				Revision: snap.R(7),
 			},
 		},
-		fakeOp{
+		{
 			op:   "link-snap",
 			name: "/snap/some-snap/7",
 		},
-		fakeOp{
+		{
 			op:   "start-snap-services",
 			name: "/snap/some-snap/7",
 		},
@@ -2424,7 +2435,7 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op:   "stop-snap-services",
 			name: "/snap/some-snap/2",
@@ -2519,7 +2530,7 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op:   "stop-snap-services",
 			name: "/snap/some-snap/2",
@@ -2622,20 +2633,19 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	c.Assert(s.fakeBackend.ops, HasLen, 3)
-	expected := []fakeOp{
-		fakeOp{
+	expected := fakeOps{
+		{
 			op: "candidate",
 			sinfo: snap.SideInfo{
 				RealName: "some-snap",
 				Revision: snap.R(7),
 			},
 		},
-		fakeOp{
+		{
 			op:   "link-snap",
 			name: "/snap/some-snap/7",
 		},
-		fakeOp{
+		{
 			op:   "start-snap-services",
 			name: "/snap/some-snap/7",
 		},
@@ -2674,8 +2684,7 @@ func (s *snapmgrTestSuite) TestDisableRunThrough(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	c.Assert(s.fakeBackend.ops, HasLen, 2)
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op:   "stop-snap-services",
 			name: "/snap/some-snap/7",
@@ -2730,7 +2739,7 @@ func (s *snapmgrTestSuite) TestUndoMountSnapFailsInCopyData(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	expected := []fakeOp{
+	expected := fakeOps{
 		{
 			op:    "storesvc-snap",
 			name:  "some-snap",

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -79,7 +79,7 @@ func doInstall(s *state.State, snapst *SnapState, ss *SnapSetup) (*state.TaskSet
 	}
 
 	// check if we already have the revision locally (alters tasks)
-	revisionIsLocal := snapst.findIndex(ss.Revision()) >= 0
+	revisionIsLocal := snapst.LastIndex(ss.Revision()) >= 0
 
 	var prepare, prev *state.Task
 	fromStore := false
@@ -150,7 +150,7 @@ func doInstall(s *state.State, snapst *SnapState, ss *SnapSetup) (*state.TaskSet
 	// Do not do that if we are reverting to a local revision
 	if snapst.HasCurrent() && !revisionIsLocal {
 		seq := snapst.Sequence
-		currentIndex := snapst.findIndex(snapst.Current)
+		currentIndex := snapst.LastIndex(snapst.Current)
 
 		// discard everything after "current" (we may have reverted to
 		// a previous versions earlier)
@@ -700,7 +700,7 @@ func RevertToRevision(s *state.State, name string, rev snap.Revision) (*state.Ta
 	if !snapst.Active {
 		return nil, fmt.Errorf("cannot revert inactive snaps")
 	}
-	i := snapst.findIndex(rev)
+	i := snapst.LastIndex(rev)
 	if i < 0 {
 		return nil, fmt.Errorf("cannot find revision %s for snap %q", rev, name)
 	}


### PR DESCRIPTION
overlord/snapstate: introduce `fakeOps` to have methods on `[]fakeOp` for easier-to-read tests. Rename `(*SnapState).findIndex` to `(*SnapState).LastIndex`.
overlord/snapstate/backend: fail data copy on unexpected copy error.