### PR TITLE
overlord/snapstate: apply flags (devmode) on revert

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -686,6 +686,8 @@ func Revert(s *state.State, name string) (*state.TaskSet, error) {
 	return RevertToRevision(s, name, pi.Revision)
 }
 
+// RevertToRevision returns a set of tasks for reverting to the given version of the snap.
+// Note that the state must be locked by the caller.
 func RevertToRevision(s *state.State, name string, rev snap.Revision) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(s, name, &snapst)
@@ -706,6 +708,7 @@ func RevertToRevision(s *state.State, name string, rev snap.Revision) (*state.Ta
 	}
 	ss := &SnapSetup{
 		SideInfo: snapst.Sequence[i],
+		Flags:    SnapSetupFlags(snapst.Flags),
 	}
 	return doInstall(s, &snapst, ss)
 }

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -1,0 +1,41 @@
+summary: Check that revert of a snap in devmode restores devmode
+
+environment:
+    STORE_TYPE/fake: fake
+    STORE_TYPE/staging: staging
+    STORE_TYPE/production: production
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+
+prepare: |
+    if [ "$STORE_TYPE" = "fake" ]; then
+        echo "Given a snap is installed"
+        snap install --devmode test-snapd-tools
+    fi
+
+    . $TESTSLIB/store.sh
+    setup_store $STORE_TYPE $BLOB_DIR
+
+    if [ "$STORE_TYPE" = "fake" ]; then
+        echo "And a new version of that snap put in the controlled store"
+        fakestore -dir $BLOB_DIR -make-refreshable test-snapd-tools
+    fi
+
+restore: |
+    . $TESTSLIB/store.sh
+    teardown_store $STORE_TYPE $BLOB_DIR
+
+execute: |
+    echo "When a refresh is made"
+    snap refresh --devmode --edge test-snapd-tools
+
+    echo "Then the new version is installed"
+    snap list | grep -Pq "test-snapd-tools +\d+\.\d+\+fake1"
+
+    echo "When a revert is made"
+    snap revert test-snapd-tools
+
+    echo "Then the old version is active"
+    snap list | grep -Pq "test-snapd-tools +\d+\.\d+ "
+
+    echo "And apparmor profile is in complain mode"
+    cat /sys/kernel/security/apparmor/profiles|grep test-snapd-tools|grep -q complain


### PR DESCRIPTION
Apply flags on revert to restore apparmor profile in complain mode if devmode was in use for given snap (fixes https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1620560).