### PR TITLE
overlord/snapstate: support revert flags

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -535,6 +535,7 @@ func (x *cmdDisable) Execute([]string) error {
 }
 
 type cmdRevert struct {
+	modeMixin
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>"`
 	} `positional-args:"yes"`
@@ -555,9 +556,14 @@ func (x *cmdRevert) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
+	if err := x.validateMode(); err != nil {
+		return err
+	}
+
 	cli := Client()
 	name := x.Positional.Snap
-	changeID, err := cli.Revert(name, nil)
+	opts := &client.SnapOptions{DevMode: x.DevMode, JailMode: x.JailMode}
+	changeID, err := cli.Revert(name, opts)
 	if err != nil {
 		return err
 	}
@@ -586,7 +592,5 @@ func init() {
 	addCommand("try", shortTryHelp, longTryHelp, func() flags.Commander { return &cmdTry{} })
 	addCommand("enable", shortEnableHelp, longEnableHelp, func() flags.Commander { return &cmdEnable{} })
 	addCommand("disable", shortDisableHelp, longDisableHelp, func() flags.Commander { return &cmdDisable{} })
-	// FIXME: make visible once everything has landed for revert
-	cmd := addCommand("revert", shortRevertHelp, longRevertHelp, func() flags.Commander { return &cmdRevert{} })
-	cmd.hidden = true
+	addCommand("revert", shortRevertHelp, longRevertHelp, func() flags.Commander { return &cmdRevert{} })
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -811,8 +811,13 @@ func snapRemove(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 }
 
 func snapRevert(inst *snapInstruction, st *state.State) (string, []*state.TaskSet, error) {
+	flags, err := modeFlags(inst.DevMode, inst.JailMode)
+	if err != nil {
+		return "", nil, err
+	}
+
 	// TODO: bail if revision is given (and != current), or revert to that revision?
-	ts, err := snapstate.Revert(st, inst.Snaps[0])
+	ts, err := snapstate.Revert(st, inst.Snaps[0], flags)
 	if err != nil {
 		return "", nil, err
 	}

--- a/overlord/boot/booted.go
+++ b/overlord/boot/booted.go
@@ -94,7 +94,7 @@ func UpdateRevisions(ovld *overlord.Overlord) error {
 		for snapName, snapState := range installed {
 			if name == snapName {
 				if rev != snapState.Current {
-					ts, err := snapstate.RevertToRevision(st, name, rev)
+					ts, err := snapstate.RevertToRevision(st, name, rev, snapstate.Flags(0))
 					if err != nil {
 						return err
 					}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -668,7 +668,7 @@ apps:
 	c.Assert(err, ErrorMatches, ".*no such file.*")
 
 	// now do the revert
-	ts, err := snapstate.Revert(st, "foo")
+	ts, err := snapstate.Revert(st, "foo", snapstate.Flags(0))
 	c.Assert(err, IsNil)
 	chg := st.NewChange("revert-snap", "...")
 	chg.AddAll(ts)

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -174,7 +174,7 @@ func (s *snapmgrTestSuite) TestRevertTasks(c *C) {
 		Current: snap.R(11),
 	})
 
-	ts, err := snapstate.Revert(s.state, "some-snap")
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags(0))
 	c.Assert(err, IsNil)
 
 	i := 0
@@ -298,7 +298,7 @@ func (s *snapmgrTestSuite) TestRevertCreatesNoGCTasks(c *C) {
 		Current: snap.R(2),
 	})
 
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R(4))
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R(4), snapstate.Flags(0))
 	c.Assert(err, IsNil)
 
 	// ensure that we do not run any form of garbage-collection
@@ -2131,7 +2131,7 @@ func (s *snapmgrTestSuite) TestRevertNoRevertAgain(c *C) {
 		Current:  snap.R(7),
 	})
 
-	ts, err := snapstate.Revert(s.state, "some-snap")
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags(0))
 	c.Assert(err, ErrorMatches, "no revision to revert to")
 	c.Assert(ts, IsNil)
 }
@@ -2151,7 +2151,7 @@ func (s *snapmgrTestSuite) TestRevertNothingToRevertTo(c *C) {
 		Current:  si.Revision,
 	})
 
-	ts, err := snapstate.Revert(s.state, "some-snap")
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags(0))
 	c.Assert(err, ErrorMatches, "no revision to revert to")
 	c.Assert(ts, IsNil)
 }
@@ -2175,7 +2175,7 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNoValidVersion(c *C) {
 		Current:  snap.R(77),
 	})
 
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R("99"))
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R("99"), snapstate.Flags(0))
 	c.Assert(err, ErrorMatches, `cannot find revision 99 for snap "some-snap"`)
 	c.Assert(ts, IsNil)
 }
@@ -2199,7 +2199,7 @@ func (s *snapmgrTestSuite) TestRevertToRevisionAlreadyCurrent(c *C) {
 		Current:  snap.R(77),
 	})
 
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R("77"))
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R("77"), snapstate.Flags(0))
 	c.Assert(err, ErrorMatches, `already on requested revision`)
 	c.Assert(ts, IsNil)
 }
@@ -2224,7 +2224,7 @@ func (s *snapmgrTestSuite) TestRevertRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap backwards")
-	ts, err := snapstate.Revert(s.state, "some-snap")
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags(0))
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2306,7 +2306,7 @@ func (s *snapmgrTestSuite) TestRevertWithLocalRevisionRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap backwards")
-	ts, err := snapstate.Revert(s.state, "some-snap")
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags(0))
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2346,7 +2346,7 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNewVersion(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap forward")
-	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R(7))
+	ts, err := snapstate.RevertToRevision(s.state, "some-snap", snap.R(7), snapstate.Flags(0))
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2419,7 +2419,7 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "revert a snap")
-	ts, err := snapstate.Revert(s.state, "some-snap")
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags(0))
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -2519,7 +2519,7 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 	})
 
 	chg := s.state.NewChange("revert", "install a revert")
-	ts, err := snapstate.Revert(s.state, "some-snap")
+	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags(0))
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -671,7 +671,7 @@ func Remove(s *state.State, name string, revision snap.Revision) (*state.TaskSet
 
 // Revert returns a set of tasks for reverting to the pervious version of the snap.
 // Note that the state must be locked by the caller.
-func Revert(s *state.State, name string) (*state.TaskSet, error) {
+func Revert(s *state.State, name string, flags Flags) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(s, name, &snapst)
 	if err != nil && err != state.ErrNoState {
@@ -683,10 +683,10 @@ func Revert(s *state.State, name string) (*state.TaskSet, error) {
 		return nil, fmt.Errorf("no revision to revert to")
 	}
 
-	return RevertToRevision(s, name, pi.Revision)
+	return RevertToRevision(s, name, pi.Revision, flags)
 }
 
-func RevertToRevision(s *state.State, name string, rev snap.Revision) (*state.TaskSet, error) {
+func RevertToRevision(s *state.State, name string, rev snap.Revision, flags Flags) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(s, name, &snapst)
 	if err != nil && err != state.ErrNoState {
@@ -706,6 +706,7 @@ func RevertToRevision(s *state.State, name string, rev snap.Revision) (*state.Ta
 	}
 	ss := &SnapSetup{
 		SideInfo: snapst.Sequence[i],
+		Flags:    SnapSetupFlags(flags),
 	}
 	return doInstall(s, &snapst, ss)
 }

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -38,8 +38,8 @@ execute: |
     echo "Then the old version is active"
     snap list | grep -Pq "test-snapd-tools +\d+\.\d+ "
 
-    echo "And the snap uses jailmode"
-    snap list|grep test-snapd-tools|grep -q jailmode
+    echo "And the snap runs confined"
+    snap list|grep test-snapd-tools|grep -q "-"
 
     echo "When the latest revision is installed again"
     snap remove --revision=$LATEST test-snapd-tools

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -30,12 +30,23 @@ execute: |
 
     echo "Then the new version is installed"
     snap list | grep -Pq "test-snapd-tools +\d+\.\d+\+fake1"
+    LATEST=$(readlink /snap/test-snapd-tools/current)
 
-    echo "When a revert is made"
-    snap revert --devmode test-snapd-tools
+    echo "When a revert is made without --devmode flag"
+    snap revert test-snapd-tools
 
     echo "Then the old version is active"
     snap list | grep -Pq "test-snapd-tools +\d+\.\d+ "
 
-    echo "And apparmor profile is in complain mode"
+    echo "And apparmor profile is in enforcing mode"
+    cat /sys/kernel/security/apparmor/profiles|grep test-snapd-tools|grep -q enforce
+
+    echo "When the latest revision is installed again"
+    snap remove --revision=$LATEST test-snapd-tools
+    snap refresh --devmode --edge test-snapd-tools
+
+    echo "And revert is made with --devmode flag"
+    snap revert --devmode test-snapd-tools
+
+    echo "Then apparmor profile is in complain mode"
     cat /sys/kernel/security/apparmor/profiles|grep test-snapd-tools|grep -q complain

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -38,8 +38,8 @@ execute: |
     echo "Then the old version is active"
     snap list | grep -Pq "test-snapd-tools +\d+\.\d+ "
 
-    echo "And apparmor profile is in enforcing mode"
-    cat /sys/kernel/security/apparmor/profiles|grep test-snapd-tools|grep -q enforce
+    echo "And the snap uses jailmode"
+    snap list|grep test-snapd-tools|grep -q jailmode
 
     echo "When the latest revision is installed again"
     snap remove --revision=$LATEST test-snapd-tools
@@ -48,5 +48,5 @@ execute: |
     echo "And revert is made with --devmode flag"
     snap revert --devmode test-snapd-tools
 
-    echo "Then apparmor profile is in complain mode"
-    cat /sys/kernel/security/apparmor/profiles|grep test-snapd-tools|grep -q complain
+    echo "Then snap uses devmode"
+    snap list|grep test-snapd-tools|grep -q devmode

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -1,0 +1,41 @@
+summary: Check that revert of a snap in devmode restores devmode
+
+environment:
+    STORE_TYPE/fake: fake
+    STORE_TYPE/staging: staging
+    STORE_TYPE/production: production
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+
+prepare: |
+    if [ "$STORE_TYPE" = "fake" ]; then
+        echo "Given a snap is installed"
+        snap install --devmode test-snapd-tools
+    fi
+
+    . $TESTSLIB/store.sh
+    setup_store $STORE_TYPE $BLOB_DIR
+
+    if [ "$STORE_TYPE" = "fake" ]; then
+        echo "And a new version of that snap put in the controlled store"
+        fakestore -dir $BLOB_DIR -make-refreshable test-snapd-tools
+    fi
+
+restore: |
+    . $TESTSLIB/store.sh
+    teardown_store $STORE_TYPE $BLOB_DIR
+
+execute: |
+    echo "When a refresh is made"
+    snap refresh --devmode --edge test-snapd-tools
+
+    echo "Then the new version is installed"
+    snap list | grep -Pq "test-snapd-tools +\d+\.\d+\+fake1"
+
+    echo "When a revert is made"
+    snap revert test-snapd-tools
+
+    echo "Then the old version is active"
+    snap list | grep -Pq "test-snapd-tools +\d+\.\d+ "
+
+    echo "And apparmor profile is in complain mode"
+    cat /sys/kernel/security/apparmor/profiles|grep test-snapd-tools|grep -q complain

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -32,7 +32,7 @@ execute: |
     snap list | grep -Pq "test-snapd-tools +\d+\.\d+\+fake1"
 
     echo "When a revert is made"
-    snap revert test-snapd-tools
+    snap revert --devmode test-snapd-tools
 
     echo "Then the old version is active"
     snap list | grep -Pq "test-snapd-tools +\d+\.\d+ "

--- a/tests/main/revert/task.yaml
+++ b/tests/main/revert/task.yaml
@@ -41,8 +41,8 @@ execute: |
     ls /snap/test-snapd-tools | grep -q current
     ls /var/snap/test-snapd-tools | grep -q current
 
-    echo "And apparmor profile is in enforcing mode"
-    cat /sys/kernel/security/apparmor/profiles|grep test-snapd-tools|grep -q enforce
+    echo "And the snap uses jailmode"
+    snap list|grep test-snapd-tools|grep -q jailmode
 
     echo "And a new revert fails"
     if snap revert test-snapd-tools; then

--- a/tests/main/revert/task.yaml
+++ b/tests/main/revert/task.yaml
@@ -41,8 +41,8 @@ execute: |
     ls /snap/test-snapd-tools | grep -q current
     ls /var/snap/test-snapd-tools | grep -q current
 
-    echo "And the snap uses jailmode"
-    snap list|grep test-snapd-tools|grep -q jailmode
+    echo "And the snap runs confined"
+    snap list|grep test-snapd-tools|grep -q "-"
 
     echo "And a new revert fails"
     if snap revert test-snapd-tools; then

--- a/tests/main/revert/task.yaml
+++ b/tests/main/revert/task.yaml
@@ -41,6 +41,9 @@ execute: |
     ls /snap/test-snapd-tools | grep -q current
     ls /var/snap/test-snapd-tools | grep -q current
 
+    echo "And apparmor profile is in enforcing mode"
+    cat /sys/kernel/security/apparmor/profiles|grep test-snapd-tools|grep -q enforce
+
     echo "And a new revert fails"
     if snap revert test-snapd-tools; then
         echo "A revert on an already reverted snap should fail"


### PR DESCRIPTION
Support flags with revert request. No flags are applied on revert unless explicitly requested.