### PR TITLE
snap: support assertion references in `snap prepare-image`

### DIFF
--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -26,12 +26,13 @@ import (
 
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/image"
+	"github.com/snapcore/snapd/osutil"
 )
 
 type cmdPrepareImage struct {
 	Positional struct {
-		ModelAssertionFn string `positional-arg-name:"model-assertion" description:"the model assertion name"`
-		Rootdir          string `long:"root-dir" description:"the output directory" `
+		ModelAssertion string `positional-arg-name:"model-assertion" description:"the model assertion name"`
+		Rootdir        string `long:"root-dir" description:"the output directory" `
 	} `positional-args:"yes" required:"yes"`
 
 	ExtraSnaps []string `long:"extra-snaps" description:"extra snaps to be installed"`
@@ -49,8 +50,17 @@ func init() {
 }
 
 func (x *cmdPrepareImage) Execute(args []string) error {
+	var modelFile, modelRef string
+
+	if osutil.FileExists(x.Positional.ModelAssertion) {
+		modelFile = x.Positional.ModelAssertion
+	} else {
+		modelRef = x.Positional.ModelAssertion
+	}
+
 	opts := &image.Options{
-		ModelFile: x.Positional.ModelAssertionFn,
+		ModelFile: modelFile,
+		ModelRef:  modelRef,
 
 		RootDir:         filepath.Join(x.Positional.Rootdir, "image"),
 		GadgetUnpackDir: filepath.Join(x.Positional.Rootdir, "gadget"),

--- a/image/export_test.go
+++ b/image/export_test.go
@@ -21,7 +21,7 @@ package image
 
 var (
 	LocalSnaps           = localSnaps
-	DecodeModelAssertion = decodeModelAssertion
+	ModelAssertion       = modelAssertion
 	DownloadUnpackGadget = downloadUnpackGadget
 	BootstrapToRootDir   = bootstrapToRootDir
 )

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -177,15 +177,15 @@ confinement: devmode
 `
 
 func (s *imageSuite) TestMissingModelAssertions(c *C) {
-	_, err := image.DecodeModelAssertion(&image.Options{})
-	c.Assert(err, ErrorMatches, "cannot read model assertion: open : no such file or directory")
+	_, err := image.ModelAssertion(&image.Options{})
+	c.Assert(err, ErrorMatches, "need either a model file or a model reference")
 }
 
 func (s *imageSuite) TestIncorrectModelAssertions(c *C) {
 	fn := filepath.Join(c.MkDir(), "broken-model.assertion")
 	err := ioutil.WriteFile(fn, nil, 0644)
 	c.Assert(err, IsNil)
-	_, err = image.DecodeModelAssertion(&image.Options{
+	_, err = image.ModelAssertion(&image.Options{
 		ModelFile: fn,
 	})
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot decode model assertion "%s": assertion content/signature separator not found`, fn))
@@ -208,10 +208,10 @@ AXNpZw==
 	err := ioutil.WriteFile(fn, differentAssertion, 0644)
 	c.Assert(err, IsNil)
 
-	_, err = image.DecodeModelAssertion(&image.Options{
+	_, err = image.ModelAssertion(&image.Options{
 		ModelFile: fn,
 	})
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`assertion in "%s" is not a model assertion`, fn))
+	c.Assert(err, ErrorMatches, `assertion "snap-declaration \[16 snap-id-1\]" is not a model assertion`)
 }
 
 func (s *imageSuite) TestModelAssertionReservedHeaders(c *C) {
@@ -241,19 +241,19 @@ AXNpZw==
 		fn := filepath.Join(c.MkDir(), "model.assertion")
 		err := ioutil.WriteFile(fn, []byte(tweaked), 0644)
 		c.Assert(err, IsNil)
-		_, err = image.DecodeModelAssertion(&image.Options{
+		_, err = image.ModelAssertion(&image.Options{
 			ModelFile: fn,
 		})
 		c.Check(err, ErrorMatches, fmt.Sprintf("model assertion cannot have reserved/unsupported header %q set", rsvd))
 	}
 }
 
-func (s *imageSuite) TestHappyDecodeModelAssertion(c *C) {
+func (s *imageSuite) TestHappyModelAssertion(c *C) {
 	fn := filepath.Join(c.MkDir(), "model.assertion")
 	err := ioutil.WriteFile(fn, asserts.Encode(s.model), 0644)
 	c.Assert(err, IsNil)
 
-	a, err := image.DecodeModelAssertion(&image.Options{
+	a, err := image.ModelAssertion(&image.Options{
 		ModelFile: fn,
 	})
 	c.Assert(err, IsNil)

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -76,31 +76,6 @@ setup_reflash_magic() {
         # build new core snap for the image
         snapbuild $UNPACKD $IMAGE_HOME
 
-        # FIXME: fetch directly once its in the assertion service
-        cat > $IMAGE_HOME/pc.model <<EOF
-type: model
-authority-id: canonical
-series: 16
-brand-id: canonical
-model: pc
-architecture: amd64
-gadget: pc
-kernel: pc-kernel
-timestamp: 2016-08-31T00:00:00.0Z
-sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
-
-AcLBXAQAAQoABgUCV8lRDQAKCRDgT5vottzAEg9GEACsSb+qXB34mwESsd7ns6VpM9BfAOOSstwB
-KJlWOlcJ39M7is/fO+dxRH4XsI7Td6BI1WEf5188sJuld8APUsTPn8tPYN3JB5CJ8Edkr6p78YUW
-f3Wo26USAE32ewjq9kHo6uBqIr4VixjTXfGUeDXc7tvKcduIMokSKjDLRHJRur1NC8LjkBn2ZPi8
-9d0BpJzr5y8wK0yFEyAhaS8H8LvL7VMjKG7/BkZcQ0a3jv69qh9jdmxnKDN2zcd1btRR1Giew3gw
-VJ8lNtfxQSWi+nYNEuzDqwKdffo9sVyCzBC+vEH3xYYk8NpRx2QgCSzDCPMoxaJgLwhAeWz6mHQp
-8EaGOsMZm7c85BXUcdJGEhZ5MpNGSzCb/ifgOKBB6zYzekiQh4TVLgi9Uk/acsLH75vNrI8Kwyl+
-r4Pahf///LbeWNwcEonaSV48S5fg3QqxEQeb42xcp6wPfRr7LN1LvQ9kRQTt42GDAlIva5HKlo0T
-cUb5A4zz3IlBn/KQ4BS/2sBcixrH97tHInef4oA8IrBiBDGnIv/s4qyZ+gB5fX8Ohnn/a5bUgU5u
-GmwRQ12Ix54YGJrzZocu1AiQINij4s6ZSoJAEJobI9VBK8WnV8PRmra6UJonV+qrJOiSKTJVCkAF
-+RFartQL+pjF/H29FsyBkIEcPwhTslxWKUWajHsExw==
-EOF
-
         # FIXME: how to test store updated of ubuntu-core with sideloaded snap?
         IMAGE=all-snap-amd64.img
 
@@ -110,7 +85,7 @@ EOF
         # when the snap uses confinement.
         cp /usr/bin/snap $IMAGE_HOME
         export UBUNTU_IMAGE_SNAP_CMD=$IMAGE_HOME/snap
-        /snap/bin/ubuntu-image -w $IMAGE_HOME $IMAGE_HOME/pc.model --channel edge --extra-snaps $IMAGE_HOME/ubuntu-core_*.snap  --output $IMAGE_HOME/$IMAGE
+        /snap/bin/ubuntu-image -w $IMAGE_HOME 16/canonical/pc-amd64 --channel edge --extra-snaps $IMAGE_HOME/ubuntu-core_*.snap  --output $IMAGE_HOME/$IMAGE
 
         # mount fresh image and add all our SPREAD_PROJECT data
         kpartx -avs $IMAGE_HOME/$IMAGE


### PR DESCRIPTION
This allows to run:
```
snap prepare-image 16/canonical/pc-amd64 ./image-dir
```
instead of having to have the model assertion file.

Branch needs some more unit  tests, but I want an ok for the general direction. I assume `ubuntu-image` may add some sugar to it so that the user does not have to type `ubuntu-image 16/canonical/pc-amd64` but instead maybe just `pc-amd64` and the rest is implicit. But that should not concern prepare-image :)