### PR TITLE
Add /dev/net/tun device to network-control apparmor rules.

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -114,6 +114,9 @@ capability setuid,
 
 # route
 /etc/networks r,
+
+# TUN/TAP
+/dev/net/tun rw,
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/network-control


### PR DESCRIPTION
Followup from discussion on snapcraft... @jdstrand @jamiedbennett PTAL, thanks.