### PR TITLE
interfaces/builtin: tweak opengl interface

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -28,6 +28,7 @@ const openglConnectedPlugAppArmor = `
 # Usage: reserved
 
   # specific gl libs
+  /var/lib/snapd/lib/gl/ r,
   /var/lib/snapd/lib/gl/** rm,
 
   /dev/dri/card0 rw,


### PR DESCRIPTION
This patch extends the opengl interface to be able to enumerate files in
/var/lib/snapd/lib/gl.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>