### PR TITLE
cmd/snap,image: teach snap download to download also assertions

### DIFF
--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -29,9 +29,8 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/image"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 )
@@ -56,47 +55,32 @@ func init() {
 	})
 }
 
-func fetchSnapAssertions(sto *store.Store, snapFn string) (string, error) {
-	// TODO: share some of this code
+func fetchSnapAssertions(sto *store.Store, snapPath string, snapInfo *snap.Info, dlOpts *image.DownloadOptions) error {
 	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
-		KeypairManager: asserts.NewMemoryKeypairManager(),
-		Backstore:      asserts.NewMemoryBackstore(),
-		Trusted:        sysdb.Trusted(),
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   sysdb.Trusted(),
 	})
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	assertsFn := snapFn + ".asserts"
+	assertsFn := filepath.Join(filepath.Dir(snapPath), filepath.Base(snapInfo.MountFile())+".asserts")
 	w, err := os.Create(assertsFn)
 	if err != nil {
-		return "", fmt.Errorf("cannot create assertions file: %s", err)
+		return fmt.Errorf("cannot create assertions file: %v", err)
 	}
 	defer w.Close()
 
 	encoder := asserts.NewEncoder(w)
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
-		return sto.Assertion(ref.Type, ref.PrimaryKey, nil)
+		return sto.Assertion(ref.Type, ref.PrimaryKey, dlOpts.User)
 	}
 	save := func(a asserts.Assertion) error {
 		return encoder.Encode(a)
 	}
 	f := asserts.NewFetcher(db, retrieve, save)
 
-	sha3_384, _, err := asserts.SnapFileSHA3_384(snapFn)
-	if err != nil {
-		return "", err
-	}
-	ref := &asserts.Ref{
-		Type:       asserts.SnapRevisionType,
-		PrimaryKey: []string{sha3_384},
-	}
-	if err := f.Fetch(ref); err != nil {
-		return "", fmt.Errorf("cannot fetch assertion %s: %s", ref, err)
-	}
-	// FIXME: cross check assertions here?
-
-	return assertsFn, nil
+	return image.FetchSnapAssertions(snapPath, snapInfo, f, db)
 }
 
 func (x *cmdDownload) Execute(args []string) error {
@@ -128,30 +112,25 @@ func (x *cmdDownload) Execute(args []string) error {
 	sto := store.New(nil, authContext)
 	// we always allow devmode for downloads
 	devMode := true
-	snap, err := sto.Snap(snapName, x.Channel, devMode, revision, user)
-	if err != nil {
-		return err
+
+	dlOpts := image.DownloadOptions{
+		TargetDir: "", // cwd
+		DevMode:   devMode,
+		Channel:   x.Channel,
+		User:      user,
 	}
 
 	fmt.Printf("Fetching snap %s\n", snapName)
-	pb := progress.NewTextProgress()
-	tmpName, err := sto.Download(snapName, &snap.DownloadInfo, pb, user)
+	snapPath, snapInfo, err := image.DownloadSnap(sto, snapName, revision, &dlOpts)
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmpName)
 
 	fmt.Printf("Fetching assertions for %s\n", snapName)
-	tmpAssertsFn, err := fetchSnapAssertions(sto, tmpName)
+	err = fetchSnapAssertions(sto, snapPath, snapInfo, &dlOpts)
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmpAssertsFn)
 
-	// copy files into the working directory
-	targetFn := filepath.Base(snap.MountFile())
-	if err := osutil.CopyFile(tmpAssertsFn, targetFn+".asserts", 0); err != nil {
-		return err
-	}
-	return osutil.CopyFile(tmpName, targetFn, 0)
+	return nil
 }

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -63,7 +63,7 @@ func fetchSnapAssertions(sto *store.Store, snapPath string, snapInfo *snap.Info,
 		return err
 	}
 
-	w, err := os.Create(snapPath+".assertions")
+	w, err := os.Create(snapPath + ".assertions")
 	if err != nil {
 		return fmt.Errorf("cannot create assertions file: %v", err)
 	}

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -1,0 +1,104 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package image
+
+// TODO: put these in appropriate package(s) once they are clarified a bit more
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+)
+
+// DownloadOptions carries options for downloading snaps plus assertions.
+type DownloadOptions struct {
+	TargetDir string
+	Channel   string
+	DevMode   bool
+	User      *auth.UserState
+}
+
+// A Store can find metadata on snaps, download snaps and fetch assertions.
+type Store interface {
+	Snap(name, channel string, devmode bool, revision snap.Revision, user *auth.UserState) (*snap.Info, error)
+	Download(name string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState) (path string, err error)
+
+	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
+}
+
+// DownloadSnap downloads the snap with the given name and optionally revision  using the provided store and options. It returns the final full path of the snap inside the opts.TargetDir and a snap.Info for the snap.
+func DownloadSnap(sto Store, name string, revision snap.Revision, opts *DownloadOptions) (targetPath string, info *snap.Info, err error) {
+	if opts == nil {
+		opts = &DownloadOptions{}
+	}
+
+	targetDir := opts.TargetDir
+	if targetDir == "" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return "", nil, err
+		}
+		targetDir = pwd
+	}
+
+	snap, err := sto.Snap(name, opts.Channel, opts.DevMode, revision, opts.User)
+	if err != nil {
+		return "", nil, fmt.Errorf("cannot find snap %q: %v", name, err)
+	}
+	pb := progress.NewTextProgress()
+	tmpName, err := sto.Download(name, &snap.DownloadInfo, pb, opts.User)
+	if err != nil {
+		return "", nil, err
+	}
+	defer os.Remove(tmpName)
+
+	baseName := filepath.Base(snap.MountFile())
+	targetPath = filepath.Join(targetDir, baseName)
+	if err := osutil.CopyFile(tmpName, targetPath, 0); err != nil {
+		return "", nil, err
+	}
+
+	return targetPath, snap, nil
+}
+
+// FetchSnapAssertions fetches and cross checks the snap assertions matching the given snap file using the provided asserts.Fetcher and assertion database.
+func FetchSnapAssertions(snapPath string, info *snap.Info, f *asserts.Fetcher, db asserts.RODatabase) error {
+	sha3_384, size, err := asserts.SnapFileSHA3_384(snapPath)
+	if err != nil {
+		return err
+	}
+	ref := &asserts.Ref{
+		Type:       asserts.SnapRevisionType,
+		PrimaryKey: []string{sha3_384},
+	}
+	if err := f.Fetch(ref); err != nil {
+		return fmt.Errorf("cannot fetch assertion %v: %v", ref, err)
+	}
+
+	// cross checks
+	return snapasserts.CrossCheck(info.Name(), sha3_384, size, &info.SideInfo, db)
+}

--- a/image/image.go
+++ b/image/image.go
@@ -29,15 +29,12 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/partition"
-	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/squashfs"
 	"github.com/snapcore/snapd/store"
@@ -160,7 +157,7 @@ func downloadUnpackGadget(sto Store, model *asserts.Model, opts *Options, local 
 		return fmt.Errorf("cannot create gadget unpack dir %q: %s", opts.GadgetUnpackDir, err)
 	}
 
-	dlOpts := &downloadOptions{
+	dlOpts := &DownloadOptions{
 		TargetDir: opts.GadgetUnpackDir,
 		Channel:   opts.Channel,
 	}
@@ -174,7 +171,7 @@ func downloadUnpackGadget(sto Store, model *asserts.Model, opts *Options, local 
 	return snap.Unpack("*", opts.GadgetUnpackDir)
 }
 
-func acquireSnap(sto Store, name string, dlOpts *downloadOptions, local *localInfos) (downloadedSnap string, info *snap.Info, err error) {
+func acquireSnap(sto Store, name string, dlOpts *DownloadOptions, local *localInfos) (downloadedSnap string, info *snap.Info, err error) {
 	if info := local.Info(name); info != nil {
 		// local snap to install (unasserted only for now)
 		p := local.Path(name)
@@ -184,7 +181,7 @@ func acquireSnap(sto Store, name string, dlOpts *downloadOptions, local *localIn
 		}
 		return dst, info, nil
 	}
-	return downloadSnapWithSideInfo(sto, name, dlOpts)
+	return DownloadSnap(sto, name, snap.R(0), dlOpts)
 }
 
 type addingFetcher struct {
@@ -214,24 +211,6 @@ func makeFetcher(sto Store, db *asserts.Database) *addingFetcher {
 
 }
 
-func fetchSnapAssertions(fn string, info *snap.Info, f *addingFetcher, db asserts.RODatabase) error {
-	// TODO: share some of this code
-	sha3_384, size, err := asserts.SnapFileSHA3_384(fn)
-	if err != nil {
-		return err
-	}
-	ref := &asserts.Ref{
-		Type:       asserts.SnapRevisionType,
-		PrimaryKey: []string{sha3_384},
-	}
-	if err := f.Fetch(ref); err != nil {
-		return fmt.Errorf("cannot fetch assertion %v: %s", ref, err)
-	}
-
-	// cross checks
-	return snapasserts.CrossCheck(info.Name(), sha3_384, size, &info.SideInfo, db)
-}
-
 // one and only core snap for now
 const defaultCore = "ubuntu-core"
 
@@ -250,9 +229,8 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 	// TODO: developer database in home or use snapd (but need
 	// a bit more API there, potential issues when crossing stores/series)
 	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
-		KeypairManager: asserts.NewMemoryKeypairManager(),
-		Backstore:      asserts.NewMemoryBackstore(),
-		Trusted:        sysdb.Trusted(),
+		Backstore: asserts.NewMemoryBackstore(),
+		Trusted:   sysdb.Trusted(),
 	})
 	if err != nil {
 		return err
@@ -275,9 +253,10 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 
 	snapSeedDir := filepath.Join(dirs.SnapSeedDir, "snaps")
 	assertSeedDir := filepath.Join(dirs.SnapSeedDir, "assertions")
-	dlOpts := &downloadOptions{
+	dlOpts := &DownloadOptions{
 		TargetDir: snapSeedDir,
 		Channel:   opts.Channel,
+		DevMode:   false, // XXX: should this be true?
 	}
 
 	snaps := []string{}
@@ -323,7 +302,7 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 		// TODO: support somehow including available assertions
 		// also for local snaps
 		if info.SnapID != "" {
-			err = fetchSnapAssertions(fn, info, f, db)
+			err = FetchSnapAssertions(fn, info, f.Fetcher, db)
 			if err != nil {
 				return err
 			}
@@ -453,56 +432,10 @@ func copyLocalSnapFile(snapPath, targetDir string, info *snap.Info) (dstPath str
 	return dst, osutil.CopyFile(snapPath, dst, 0)
 }
 
-type downloadOptions struct {
-	TargetDir string
-	Channel   string
-}
-
 func makeStore(model *asserts.Model) Store {
 	cfg := store.DefaultConfig()
 	cfg.Architecture = model.Architecture()
 	cfg.Series = model.Series()
 	cfg.StoreID = model.Store()
 	return store.New(cfg, nil)
-}
-
-type Store interface {
-	Snap(name, channel string, devmode bool, revision snap.Revision, user *auth.UserState) (*snap.Info, error)
-	Download(name string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState) (path string, err error)
-
-	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
-}
-
-func downloadSnapWithSideInfo(sto Store, name string, opts *downloadOptions) (targetPath string, info *snap.Info, err error) {
-	if opts == nil {
-		opts = &downloadOptions{}
-	}
-
-	targetDir := opts.TargetDir
-	if targetDir == "" {
-		pwd, err := os.Getwd()
-		if err != nil {
-			return "", nil, err
-		}
-		targetDir = pwd
-	}
-
-	snap, err := sto.Snap(name, opts.Channel, false, snap.R(0), nil)
-	if err != nil {
-		return "", nil, fmt.Errorf("cannot find snap %q: %s", name, err)
-	}
-	pb := progress.NewTextProgress()
-	tmpName, err := sto.Download(name, &snap.DownloadInfo, pb, nil)
-	if err != nil {
-		return "", nil, err
-	}
-	defer os.Remove(tmpName)
-
-	baseName := filepath.Base(snap.MountFile())
-	targetPath = filepath.Join(targetDir, baseName)
-	if err := osutil.CopyFile(tmpName, targetPath, 0); err != nil {
-		return "", nil, err
-	}
-
-	return targetPath, snap, nil
 }

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -11,15 +11,15 @@ execute: |
     echo "Snap download can download snaps"
     snap download hello-world
     ls hello-world_*.snap
-    verify_asserts hello-world_*.snap.asserts
+    verify_asserts hello-world_*.snap.assertions
 
     echo "Snap download understand --edge"
     snap download --edge test-snapd-tools
     ls test-snapd-tools_*.snap
-    verify_asserts test-snapd-tools_*.snap.asserts
+    verify_asserts test-snapd-tools_*.snap.assertions
 
     echo "Snap download downloads devmode snaps"
     snap download --beta classic
     ls classic_*.snap
-    verify_asserts classic_*.snap.asserts
+    verify_asserts classic_*.snap.assertions
 

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -2,14 +2,24 @@ summary: Check that snap download works
 restore: |
     rm -f *.snap
 execute: |
+    verify_asserts() {
+        fn="$1"
+        grep "type: account-key" "$fn"
+        grep "type: snap-declaration" "$fn"
+        grep "type: snap-revision" "$fn"
+    }
     echo "Snap download can download snaps"
     snap download hello-world
     ls hello-world_*.snap
+    verify_asserts hello-world_*.snap.asserts
 
     echo "Snap download understand --edge"
     snap download --edge test-snapd-tools
     ls test-snapd-tools_*.snap
+    verify_asserts test-snapd-tools_*.snap.asserts
 
     echo "Snap download downloads devmode snaps"
     snap download --beta classic
     ls classic_*.snap
+    verify_asserts classic_*.snap.asserts
+


### PR DESCRIPTION
This teaches 'snap download' to also download and checks assertions sharing code with prepare-image.