### PR TITLE
snap,store: capture newest digest from the store, make it DownloadInfo only

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -110,8 +110,6 @@ type SideInfo struct {
 	Developer         string   `yaml:"developer,omitempty" json:"developer,omitempty"` // XXX: obsolete, will be retired after full backfilling of DeveloperID
 	EditedSummary     string   `yaml:"summary,omitempty" json:"summary,omitempty"`
 	EditedDescription string   `yaml:"description,omitempty" json:"description,omitempty"`
-	Size              int64    `yaml:"size,omitempty" json:"size,omitempty"`
-	Sha512            string   `yaml:"sha512,omitempty" json:"sha512,omitempty"`
 	Private           bool     `yaml:"private,omitempty" json:"private,omitempty"`
 }
 
@@ -228,6 +226,9 @@ func (s *Info) NeedsDevMode() bool {
 type DownloadInfo struct {
 	AnonDownloadURL string `json:"anon-download-url,omitempty"`
 	DownloadURL     string `json:"download-url,omitempty"`
+
+	Size     int64  `json:"size,omitempty"`
+	Sha3_384 string `json:"sha3-384,omitempty"`
 }
 
 // sanity check that Info is a PlaceInfo

--- a/store/details.go
+++ b/store/details.go
@@ -25,26 +25,26 @@ import (
 
 // snapDetails encapsulates the data sent to us from the store as JSON.
 type snapDetails struct {
-	AnonDownloadURL string             `json:"anon_download_url,omitempty"`
-	Architectures   []string           `json:"architecture"`
-	Channel         string             `json:"channel,omitempty"`
-	DownloadSha512  string             `json:"download_sha512,omitempty"`
-	Summary         string             `json:"summary,omitempty"`
-	Description     string             `json:"description,omitempty"`
-	DownloadSize    int64              `json:"binary_filesize,omitempty"`
-	DownloadURL     string             `json:"download_url,omitempty"`
-	IconURL         string             `json:"icon_url"`
-	LastUpdated     string             `json:"last_updated,omitempty"`
-	Name            string             `json:"package_name"`
-	Prices          map[string]float64 `json:"prices,omitempty"`
-	Publisher       string             `json:"publisher,omitempty"`
-	RatingsAverage  float64            `json:"ratings_average,omitempty"`
-	Revision        int                `json:"revision"` // store revisions are ints starting at 1
-	SnapID          string             `json:"snap_id"`
-	SupportURL      string             `json:"support_url"`
-	Title           string             `json:"title"`
-	Type            snap.Type          `json:"content,omitempty"`
-	Version         string             `json:"version"`
+	AnonDownloadURL  string             `json:"anon_download_url,omitempty"`
+	Architectures    []string           `json:"architecture"`
+	Channel          string             `json:"channel,omitempty"`
+	DownloadSha3_384 string             `json:"download_sha3_384,omitempty"`
+	Summary          string             `json:"summary,omitempty"`
+	Description      string             `json:"description,omitempty"`
+	DownloadSize     int64              `json:"binary_filesize,omitempty"`
+	DownloadURL      string             `json:"download_url,omitempty"`
+	IconURL          string             `json:"icon_url"`
+	LastUpdated      string             `json:"last_updated,omitempty"`
+	Name             string             `json:"package_name"`
+	Prices           map[string]float64 `json:"prices,omitempty"`
+	Publisher        string             `json:"publisher,omitempty"`
+	RatingsAverage   float64            `json:"ratings_average,omitempty"`
+	Revision         int                `json:"revision"` // store revisions are ints starting at 1
+	SnapID           string             `json:"snap_id"`
+	SupportURL       string             `json:"support_url"`
+	Title            string             `json:"title"`
+	Type             snap.Type          `json:"content,omitempty"`
+	Version          string             `json:"version"`
 
 	// FIXME: the store should return "developer" to us instead of
 	//        origin

--- a/store/store.go
+++ b/store/store.go
@@ -87,7 +87,7 @@ func infoFromRemote(d snapDetails) *snap.Info {
 	info.DeveloperID = d.DeveloperID
 	info.Developer = d.Developer // XXX: obsolete, will be retired after full backfilling of DeveloperID
 	info.Channel = d.Channel
-	info.Sha512 = d.DownloadSha512
+	info.Sha3_384 = d.DownloadSha3_384
 	info.Size = d.DownloadSize
 	info.IconURL = d.IconURL
 	info.AnonDownloadURL = d.AnonDownloadURL

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -347,7 +347,7 @@ const (
 
 /* acquired via
 
-http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha512,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
+http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha3_384,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
 
 on 2016-07-03. Then, by hand:
  * set prices to {"EUR": 0.99, "USD": 1.23}.
@@ -366,10 +366,10 @@ const MockDetailsJSON = `{
             }
         ],
         "self": {
-            "href": "https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cprivate%2Cconfinement&channel=edge"
+            "href": "https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cprivate%2Cconfinement&channel=edge"
         }
     },
-    "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_26.snap",
+    "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap",
     "architecture": [
         "all"
     ],
@@ -379,22 +379,23 @@ const MockDetailsJSON = `{
     "content": "application",
     "description": "This is a simple hello world example.",
     "developer_id": "canonical",
-    "download_sha512": "345f33c06373f799b64c497a778ef58931810dd7ae85279d6917d8b4f43d38abaf37e68239cb85914db276cb566a0ef83ea02b6f2fd064b54f9f2508fa4ca1f1",
-    "download_url": "https://public.apps.ubuntu.com/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_26.snap",
+    "download_sha3_384": "eed62063c04a8c3819eb71ce7d929cc8d743b43be9e7d86b397b6d61b66b0c3a684f3148a9dbe5821360ae32105c1bd9",
+    "download_url": "https://public.apps.ubuntu.com/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap",
     "icon_url": "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
-    "last_updated": "2016-05-31T07:02:32.586839Z",
+    "last_updated": "2016-07-12T16:37:23.960632Z",
     "origin": "canonical",
     "package_name": "hello-world",
     "prices": {"EUR": 0.99, "USD": 1.23},
     "publisher": "Canonical",
     "ratings_average": 0.0,
-    "revision": 26,
+    "revision": 27,
     "snap_id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
-    "summary": "Hello world example",
+    "summary": "The 'hello-world' of snaps",
     "support_url": "mailto:snappy-devel@lists.ubuntu.com",
     "title": "hello-world",
-    "version": "6.1"
-}`
+    "version": "6.3"
+}
+`
 
 const mockPurchasesJSON = `[
   {
@@ -504,15 +505,15 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 	c.Check(result.Architectures, DeepEquals, []string{"all"})
-	c.Check(result.Revision, Equals, snap.R(26))
+	c.Check(result.Revision, Equals, snap.R(27))
 	c.Check(result.SnapID, Equals, helloWorldSnapID)
 	c.Check(result.Developer, Equals, "canonical")
-	c.Check(result.Version, Equals, "6.1")
-	c.Check(result.Sha512, Matches, `[[:xdigit:]]{128}`)
+	c.Check(result.Version, Equals, "6.3")
+	c.Check(result.Sha3_384, Matches, `[[:xdigit:]]{96}`)
 	c.Check(result.Size, Equals, int64(20480))
 	c.Check(result.Channel, Equals, "edge")
 	c.Check(result.Description(), Equals, "This is a simple hello world example.")
-	c.Check(result.Summary(), Equals, "Hello world example")
+	c.Check(result.Summary(), Equals, "The 'hello-world' of snaps")
 	c.Assert(result.Prices, DeepEquals, map[string]float64{"EUR": 0.99, "USD": 1.23})
 	c.Check(result.MustBuy, Equals, true)
 
@@ -616,7 +617,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRevision(c *C) {
 	result, err := repo.Snap("hello-world", "edge", true, snap.R(26), t.user)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
-	c.Check(result.Revision, DeepEquals, snap.R(26))
+	c.Check(result.Revision, DeepEquals, snap.R(27))
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsDevmode(c *C) {


### PR DESCRIPTION
Given that now size/digest are in the snap-revision assertion for store installed snaps, move this information and size to just DownloadInfo, is still useful in some testing contexts/for completeness.