### PR TITLE
packaging: make sure debhelper-generated snippet is invoked on postrm

### DIFF
--- a/debian/snapd.postrm
+++ b/debian/snapd.postrm
@@ -47,7 +47,7 @@ if [ "$1" = "purge" ]; then
                 fi
             done
         fi
-        
+
         echo "Removing $unit"
         rm -f "/etc/systemd/system/$unit"
         rm -f "/etc/systemd/system/multi-user.target.wants/$unit"
@@ -55,4 +55,19 @@ if [ "$1" = "purge" ]; then
 
     echo "Removing snapd state"
     rm -rf /var/lib/snapd
+
+    echo "Removing symlinks of systemd units"
+    systemd_symlinks="/etc/systemd/system/sockets.target.wants/snapd.socket \
+    /etc/systemd/system/timers.target.wants/snapd.refresh.timer \
+    /etc/systemd/system/multi-user.target.wants/snapd.firstboot.service \
+    /etc/systemd/system/multi-user.target.wants/snapd.refresh.timer \
+    /etc/systemd/system/multi-user.target.wants/snapd.service \
+    /etc/systemd/system/multi-user.target.wants/snapd.boot-ok.service"
+    for sym in ${systemd_symlinks}; do
+        if test -L $sym ; then
+            rm -rf $sym
+        fi
+    done
 fi
+
+#DEBHELPER#

--- a/debian/snapd.postrm
+++ b/debian/snapd.postrm
@@ -55,19 +55,6 @@ if [ "$1" = "purge" ]; then
 
     echo "Removing snapd state"
     rm -rf /var/lib/snapd
-
-    echo "Removing symlinks of systemd units"
-    systemd_symlinks="/etc/systemd/system/sockets.target.wants/snapd.socket \
-    /etc/systemd/system/timers.target.wants/snapd.refresh.timer \
-    /etc/systemd/system/multi-user.target.wants/snapd.firstboot.service \
-    /etc/systemd/system/multi-user.target.wants/snapd.refresh.timer \
-    /etc/systemd/system/multi-user.target.wants/snapd.service \
-    /etc/systemd/system/multi-user.target.wants/snapd.boot-ok.service"
-    for sym in ${systemd_symlinks}; do
-        if test -L $sym ; then
-            rm -rf $sym
-        fi
-    done
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Make sure debhelper-generated snippet is invoked on postrm to remove symlinks for systemd units on apt-get purge (fixes https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1622045)