### PR TITLE
snap: run all tests with gpg2

### DIFF
--- a/cmd/snap/cmd_delete_key_test.go
+++ b/cmd/snap/cmd_delete_key_test.go
@@ -25,7 +25,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	snap "github.com/snapcore/snapd/cmd/snap"
-	"github.com/snapcore/snapd/release"
 )
 
 func (s *SnapKeysSuite) TestDeleteKeyRequiresName(c *C) {
@@ -45,11 +44,6 @@ func (s *SnapKeysSuite) TestDeleteKeyNonexistent(c *C) {
 }
 
 func (s *SnapKeysSuite) TestDeleteKey(c *C) {
-	// FIXME: remove once xenials gpg2 is fixed
-	if s.GnupgCmd == "/usr/bin/gpg2" && release.ReleaseInfo.VersionID == "16.04" {
-		c.Skip("gpg2 delete broken on xenial")
-	}
-
 	rest, err := snap.Parser().ParseArgs([]string{"delete-key", "another"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})

--- a/cmd/snap/cmd_keys_test.go
+++ b/cmd/snap/cmd_keys_test.go
@@ -21,6 +21,7 @@ package main_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -41,6 +42,22 @@ type SnapKeysSuite struct {
 //        switching to gpg2 fully. Once this is resolved we should switch.
 var _ = Suite(&SnapKeysSuite{GnupgCmd: "/usr/bin/gpg"})
 
+var fakePinentryData = []byte(`#!/bin/sh
+set -e
+echo "OK Pleased to meet you"
+while true; do
+  read line
+  case $line in
+  BYE)
+    exit 0
+  ;;
+  *)
+    echo "OK I agree to everything"
+    ;;
+esac
+done
+`)
+
 func (s *SnapKeysSuite) SetUpTest(c *C) {
 	s.BaseSnapSuite.SetUpTest(c)
 
@@ -51,6 +68,13 @@ func (s *SnapKeysSuite) SetUpTest(c *C) {
 		err = ioutil.WriteFile(filepath.Join(tempdir, fileName), data, 0644)
 		c.Assert(err, IsNil)
 	}
+	fakePinentryFn := filepath.Join(tempdir, "pinentry-fake")
+	err := ioutil.WriteFile(fakePinentryFn, fakePinentryData, 0755)
+	c.Assert(err, IsNil)
+	gpgAgentConfFn := filepath.Join(tempdir, "gpg-agent.conf")
+	err = ioutil.WriteFile(gpgAgentConfFn, []byte(fmt.Sprintf(`pinentry-program %s`, fakePinentryFn)), 0644)
+	c.Assert(err, IsNil)
+
 	os.Setenv("SNAP_GNUPG_HOME", tempdir)
 	os.Setenv("SNAP_GNUPG_CMD", s.GnupgCmd)
 }


### PR DESCRIPTION
Re-enable the delete key unit test via a with custom pinentry.