### PR TITLE
store: don't discard error body from request device session call

### DIFF
--- a/store/auth.go
+++ b/store/auth.go
@@ -24,6 +24,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 
 	"gopkg.in/macaroon.v1"
@@ -298,9 +300,8 @@ func RequestDeviceSession(serialAssertion, sessionRequest, previousSession strin
 
 	// check return code, error on anything !200
 	if resp.StatusCode != 200 {
-		body := make([]byte, 1e6)
-		n, _ := resp.Body.Read(body) // do our best to read the body
-		return "", fmt.Errorf(errorPrefix+"store server returned status %d and body %q", resp.StatusCode, body[:n])
+		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 1e6)) // do our best to read the body
+		return "", fmt.Errorf(errorPrefix+"store server returned status %d and body %q", resp.StatusCode, body)
 	}
 
 	dec := json.NewDecoder(resp.Body)

--- a/store/auth.go
+++ b/store/auth.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"gopkg.in/macaroon.v1"
@@ -298,7 +299,8 @@ func RequestDeviceSession(serialAssertion, sessionRequest, previousSession strin
 
 	// check return code, error on anything !200
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf(errorPrefix+"store server returned status %d", resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body) // do our best to read the body
+		return "", fmt.Errorf(errorPrefix+"store server returned status %d and body %q", resp.StatusCode, body)
 	}
 
 	dec := json.NewDecoder(resp.Body)

--- a/store/auth.go
+++ b/store/auth.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"gopkg.in/macaroon.v1"
@@ -299,8 +298,9 @@ func RequestDeviceSession(serialAssertion, sessionRequest, previousSession strin
 
 	// check return code, error on anything !200
 	if resp.StatusCode != 200 {
-		body, _ := ioutil.ReadAll(resp.Body) // do our best to read the body
-		return "", fmt.Errorf(errorPrefix+"store server returned status %d and body %q", resp.StatusCode, body)
+		body := make([]byte, 1e6)
+		n, _ := resp.Body.Read(body) // do our best to read the body
+		return "", fmt.Errorf(errorPrefix+"store server returned status %d and body %q", resp.StatusCode, body[:n])
 	}
 
 	dec := json.NewDecoder(resp.Body)

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -378,11 +378,12 @@ func (s *authTestSuite) TestRequestDeviceSessionMissingData(c *C) {
 func (s *authTestSuite) TestRequestDeviceSessionError(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
+		w.Write([]byte("error body"))
 	}))
 	defer mockServer.Close()
 	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
 
 	macaroon, err := RequestDeviceSession("serial-assertion", "session-request", "")
-	c.Assert(err, ErrorMatches, "cannot get device session from store: store server returned status 500")
+	c.Assert(err, ErrorMatches, `cannot get device session from store: store server returned status 500 and body "error body"`)
 	c.Assert(macaroon, Equals, "")
 }


### PR DESCRIPTION
I'm sure this could be improved by attempting to parse the error but this is better than discarding it and losing all context.