### PR TITLE
tests: add new SNAP_IGNORE_SUDO_USER and set it for the spread tests

### DIFF
--- a/osutil/user.go
+++ b/osutil/user.go
@@ -119,6 +119,14 @@ func RealUser() (*user.User, error) {
 		return nil, err
 	}
 
+	// allow overriding the SUDO_USER detection for the integration
+	// tests to ensure we do not get inconsitent result for
+	// the regular runs (which uses root) and the adhoc runs (which
+	// use sudo -i)
+	if os.Getenv("SNAP_IGNORE_SUDO_USER") == "1" {
+		return cur, nil
+	}
+
 	realName := os.Getenv("SUDO_USER")
 	if realName == "" {
 		// not sudo; current is correct

--- a/spread.yaml
+++ b/spread.yaml
@@ -10,6 +10,7 @@ environment:
     SPREAD_STORE_USER: "$(HOST: echo $SPREAD_STORE_USER)"
     SPREAD_STORE_PASSWORD: "$(HOST: echo $SPREAD_STORE_PASSWORD)"
     LANG: "$(echo $LANG)"
+    SNAP_IGNORE_SUDO_USER: 1
 
 backends:
     linode:


### PR DESCRIPTION
This works around the problem that the adhoc tests use sudo now which always sets SUDO_USER. This is then used inside snapd to go from the /root to the sudo users directory. However some tests need to setup things inside $HOME and the sudo behaviour makes it inconsistent between the linode/qemu backend (which uses root) and the adhoc backend (which uses sudo). Ideally we fix that in spread but that will need approval from Gustavo first.