### PR TITLE
tests: ensure SUDO_{USER,GID} is unset in the spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -10,6 +10,9 @@ environment:
     SPREAD_STORE_USER: "$(HOST: echo $SPREAD_STORE_USER)"
     SPREAD_STORE_PASSWORD: "$(HOST: echo $SPREAD_STORE_PASSWORD)"
     LANG: "$(echo $LANG)"
+    # important to ensure adhoc and linode/qemu behave the same
+    SUDO_USER: ""
+    SUDO_UID: ""
 
 backends:
     linode:


### PR DESCRIPTION
The adhoc interface is now using sudo -i to run code. This is nice, however it also means that the environment in the adhoc interface is different from the environment in linode/qemu. Specifically it contains now the SUDO_USER (and friends environment).

Our code looks at SUDO_USER and will use that user to find the homedir. We do certain setup in $HOME in the tests, e.g. the gpg-agent configuration. So this unsets SUDO_USER for the spread tests to unbreak the adhoc tests.