### PR TITLE
spread.yaml: don't assume LANG is set

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -9,7 +9,7 @@ environment:
     SNAP_REEXEC: 0
     SPREAD_STORE_USER: "$(HOST: echo $SPREAD_STORE_USER)"
     SPREAD_STORE_PASSWORD: "$(HOST: echo $SPREAD_STORE_PASSWORD)"
-    LANG: "$(echo $LANG)"
+    LANG: "$(echo ${LANG:-C.UTF-8})"
     # important to ensure adhoc and linode/qemu behave the same
     SUDO_USER: ""
     SUDO_UID: ""

--- a/spread.yaml
+++ b/spread.yaml
@@ -10,6 +10,7 @@ environment:
     SPREAD_STORE_USER: "$(HOST: echo $SPREAD_STORE_USER)"
     SPREAD_STORE_PASSWORD: "$(HOST: echo $SPREAD_STORE_PASSWORD)"
     LANG: "$(echo ${LANG:-C.UTF-8})"
+    LANGUAGE: "$(echo ${LANGUAGE:-en})"
     # important to ensure adhoc and linode/qemu behave the same
     SUDO_USER: ""
     SUDO_UID: ""

--- a/tests/lib/snaps/locale-control-consumer/bin/get
+++ b/tests/lib/snaps/locale-control-consumer/bin/get
@@ -4,11 +4,11 @@ import subprocess
 import sys
 
 def run(key):
+    prefix = key+'='
     with open('/etc/default/locale') as input_data:
         for line in input_data:
-            if key in line:
-                parts=line.split('=')
-                print(parts[1].replace('"', ''), end='')
+            if line.startswith(prefix):
+                print(line[len(prefix):].strip().strip('"'), end='')
 
 if __name__ == '__main__':
   sys.exit(run(sys.argv[1]))

--- a/tests/main/interfaces-locale-control/task.yaml
+++ b/tests/main/interfaces-locale-control/task.yaml
@@ -16,7 +16,11 @@ prepare: |
     echo "Given a snap declaring a plug on the locale-control interface is installed"
     snapbuild $TESTSLIB/snaps/locale-control-consumer .
     snap install --dangerous locale-control-consumer_1.0_all.snap
-    cp /etc/default/locale locale.back
+    mv /etc/default/locale locale.back
+    cat > /etc/default/locale <<EOF
+    LANG="$LANG"
+    LANGUAGE="$LANGUAGE"
+    EOF
 
 restore: |
     rm -f locale-control-consumer_1.0_all.snap locale-read.error locale-write.error


### PR DESCRIPTION
I *think* this'll get rid of the `/bin/bash: line 12: LANG: unbound variable` errors we're seeing. Can't see any where else this is used out of the blue.