### PR TITLE
daemon,store: move store login user logic to store

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -250,18 +250,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		}, nil)
 	}
 
-	serializedMacaroon, err := store.RequestStoreMacaroon()
-	if err != nil {
-		return InternalError(err.Error())
-	}
-	macaroon, err := store.MacaroonDeserialize(serializedMacaroon)
-
-	// get SSO 3rd party caveat, and request discharge
-	loginCaveat, err := store.LoginCaveatID(macaroon)
-	if err != nil {
-		return InternalError(err.Error())
-	}
-	discharge, err := store.DischargeAuthCaveat(loginCaveat, loginData.Username, loginData.Password, loginData.Otp)
+	macaroon, discharge, err := store.LoginUser(loginData.Username, loginData.Password, loginData.Otp)
 	switch err {
 	case store.ErrAuthenticationNeeds2fa:
 		return SyncResponse(&resp{
@@ -301,14 +290,14 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	overlord := c.d.overlord
 	state := overlord.State()
 	state.Lock()
-	_, err = auth.NewUser(state, loginData.Username, serializedMacaroon, []string{discharge})
+	_, err = auth.NewUser(state, loginData.Username, macaroon, []string{discharge})
 	state.Unlock()
 	if err != nil {
 		return InternalError("cannot persist authentication details: %v", err)
 	}
 
 	result := loginResponseData{
-		Macaroon:   serializedMacaroon,
+		Macaroon:   macaroon,
 		Discharges: []string{discharge},
 	}
 	return SyncResponse(result, nil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -600,7 +600,7 @@ func (s *apiSuite) TestLoginUserMyAppsError(c *check.C) {
 	rsp := loginUser(snapCmd, req, nil).(*resp)
 
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Status, check.Equals, http.StatusInternalServerError)
+	c.Check(rsp.Status, check.Equals, http.StatusUnauthorized)
 	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "cannot get snap access permission")
 }
 

--- a/store/auth.go
+++ b/store/auth.go
@@ -88,8 +88,8 @@ func MacaroonDeserialize(serializedMacaroon string) (*macaroon.Macaroon, error) 
 	return &m, nil
 }
 
-// LoginCaveatID returns the 3rd party caveat from the macaroon to be discharged by Ubuntuone
-func LoginCaveatID(m *macaroon.Macaroon) (string, error) {
+// loginCaveatID returns the 3rd party caveat from the macaroon to be discharged by Ubuntuone
+func loginCaveatID(m *macaroon.Macaroon) (string, error) {
 	caveatID := ""
 	for _, caveat := range m.Caveats() {
 		if caveat.Location == UbuntuoneLocation {
@@ -103,8 +103,8 @@ func LoginCaveatID(m *macaroon.Macaroon) (string, error) {
 	return caveatID, nil
 }
 
-// RequestStoreMacaroon requests a macaroon for accessing package data from the ubuntu store.
-func RequestStoreMacaroon() (string, error) {
+// requestStoreMacaroon requests a macaroon for accessing package data from the ubuntu store.
+func requestStoreMacaroon() (string, error) {
 	const errorPrefix = "cannot get snap access permission from store: "
 
 	data := map[string]interface{}{
@@ -209,8 +209,8 @@ func requestDischargeMacaroon(endpoint string, data map[string]string) (string, 
 	return responseData.Macaroon, nil
 }
 
-// DischargeAuthCaveat returns a macaroon with the store auth caveat discharged.
-func DischargeAuthCaveat(caveat, username, password, otp string) (string, error) {
+// dischargeAuthCaveat returns a macaroon with the store auth caveat discharged.
+func dischargeAuthCaveat(caveat, username, password, otp string) (string, error) {
 	data := map[string]string{
 		"email":     username,
 		"password":  password,
@@ -223,8 +223,8 @@ func DischargeAuthCaveat(caveat, username, password, otp string) (string, error)
 	return requestDischargeMacaroon(UbuntuoneDischargeAPI, data)
 }
 
-// RefreshDischargeMacaroon returns a soft-refreshed discharge macaroon.
-func RefreshDischargeMacaroon(discharge string) (string, error) {
+// refreshDischargeMacaroon returns a soft-refreshed discharge macaroon.
+func refreshDischargeMacaroon(discharge string) (string, error) {
 	data := map[string]string{
 		"discharge_macaroon": discharge,
 	}
@@ -232,8 +232,8 @@ func RefreshDischargeMacaroon(discharge string) (string, error) {
 	return requestDischargeMacaroon(UbuntuoneRefreshDischargeAPI, data)
 }
 
-// RequestStoreDeviceNonce requests a nonce for device authentication against the store.
-func RequestStoreDeviceNonce() (string, error) {
+// requestStoreDeviceNonce requests a nonce for device authentication against the store.
+func requestStoreDeviceNonce() (string, error) {
 	const errorPrefix = "cannot get nonce from store: "
 
 	req, err := http.NewRequest("POST", MyAppsDeviceNonceAPI, nil)
@@ -268,8 +268,8 @@ func RequestStoreDeviceNonce() (string, error) {
 	return responseData.Nonce, nil
 }
 
-// RequestDeviceSession requests a device session macaroon from the store.
-func RequestDeviceSession(serialAssertion, sessionRequest, previousSession string) (string, error) {
+// requestDeviceSession requests a device session macaroon from the store.
+func requestDeviceSession(serialAssertion, sessionRequest, previousSession string) (string, error) {
 	const errorPrefix = "cannot get device session from store: "
 
 	data := map[string]string{

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -77,7 +77,7 @@ func (s *authTestSuite) TestRequestStoreMacaroon(c *C) {
 	defer mockServer.Close()
 	MyAppsMacaroonACLAPI = mockServer.URL + "/acl/"
 
-	macaroon, err := RequestStoreMacaroon()
+	macaroon, err := requestStoreMacaroon()
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
@@ -89,7 +89,7 @@ func (s *authTestSuite) TestRequestStoreMacaroonMissingData(c *C) {
 	defer mockServer.Close()
 	MyAppsMacaroonACLAPI = mockServer.URL + "/acl/"
 
-	macaroon, err := RequestStoreMacaroon()
+	macaroon, err := requestStoreMacaroon()
 	c.Assert(err, ErrorMatches, "cannot get snap access permission from store: empty macaroon returned")
 	c.Assert(macaroon, Equals, "")
 }
@@ -101,7 +101,7 @@ func (s *authTestSuite) TestRequestStoreMacaroonError(c *C) {
 	defer mockServer.Close()
 	MyAppsMacaroonACLAPI = mockServer.URL + "/acl/"
 
-	macaroon, err := RequestStoreMacaroon()
+	macaroon, err := requestStoreMacaroon()
 	c.Assert(err, ErrorMatches, "cannot get snap access permission from store: store server returned status 500")
 	c.Assert(macaroon, Equals, "")
 }
@@ -113,7 +113,7 @@ func (s *authTestSuite) TestDischargeAuthCaveat(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("third-party-caveat", "guy@example.com", "passwd", "")
+	discharge, err := dischargeAuthCaveat("third-party-caveat", "guy@example.com", "passwd", "")
 	c.Assert(err, IsNil)
 	c.Assert(discharge, Equals, "the-discharge-macaroon-serialized-data")
 }
@@ -126,7 +126,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatNeeds2fa(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
+	discharge, err := dischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
 	c.Assert(err, Equals, ErrAuthenticationNeeds2fa)
 	c.Assert(discharge, Equals, "")
 }
@@ -139,7 +139,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatFails2fa(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
+	discharge, err := dischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
 	c.Assert(err, Equals, Err2faFailed)
 	c.Assert(discharge, Equals, "")
 }
@@ -152,7 +152,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatInvalidLogin(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
+	discharge, err := dischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
 	c.Assert(err, ErrorMatches, "cannot authenticate to snap store: Provided email/password is not correct.")
 	c.Assert(discharge, Equals, "")
 }
@@ -164,7 +164,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatMissingData(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
+	discharge, err := dischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
 	c.Assert(err, ErrorMatches, "cannot authenticate to snap store: empty macaroon returned")
 	c.Assert(discharge, Equals, "")
 }
@@ -176,7 +176,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatError(c *C) {
 	defer mockServer.Close()
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
-	discharge, err := DischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
+	discharge, err := dischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
 	c.Assert(err, ErrorMatches, "cannot authenticate to snap store: server returned status 500")
 	c.Assert(discharge, Equals, "")
 }
@@ -188,7 +188,7 @@ func (s *authTestSuite) TestRefreshDischargeMacaroon(c *C) {
 	defer mockServer.Close()
 	UbuntuoneRefreshDischargeAPI = mockServer.URL + "/tokens/refresh"
 
-	discharge, err := RefreshDischargeMacaroon("soft-expired-serialized-discharge-macaroon")
+	discharge, err := refreshDischargeMacaroon("soft-expired-serialized-discharge-macaroon")
 	c.Assert(err, IsNil)
 	c.Assert(discharge, Equals, "the-discharge-macaroon-serialized-data")
 }
@@ -201,7 +201,7 @@ func (s *authTestSuite) TestRefreshDischargeMacaroonInvalidLogin(c *C) {
 	defer mockServer.Close()
 	UbuntuoneRefreshDischargeAPI = mockServer.URL + "/tokens/refresh"
 
-	discharge, err := RefreshDischargeMacaroon("soft-expired-serialized-discharge-macaroon")
+	discharge, err := refreshDischargeMacaroon("soft-expired-serialized-discharge-macaroon")
 	c.Assert(err, ErrorMatches, "cannot authenticate to snap store: Provided email/password is not correct.")
 	c.Assert(discharge, Equals, "")
 }
@@ -213,7 +213,7 @@ func (s *authTestSuite) TestRefreshDischargeMacaroonMissingData(c *C) {
 	defer mockServer.Close()
 	UbuntuoneRefreshDischargeAPI = mockServer.URL + "/tokens/refresh"
 
-	discharge, err := RefreshDischargeMacaroon("soft-expired-serialized-discharge-macaroon")
+	discharge, err := refreshDischargeMacaroon("soft-expired-serialized-discharge-macaroon")
 	c.Assert(err, ErrorMatches, "cannot authenticate to snap store: empty macaroon returned")
 	c.Assert(discharge, Equals, "")
 }
@@ -225,7 +225,7 @@ func (s *authTestSuite) TestRefreshDischargeMacaroonError(c *C) {
 	defer mockServer.Close()
 	UbuntuoneRefreshDischargeAPI = mockServer.URL + "/tokens/refresh"
 
-	discharge, err := RefreshDischargeMacaroon("soft-expired-serialized-discharge-macaroon")
+	discharge, err := refreshDischargeMacaroon("soft-expired-serialized-discharge-macaroon")
 	c.Assert(err, ErrorMatches, "cannot authenticate to snap store: server returned status 500")
 	c.Assert(discharge, Equals, "")
 }
@@ -277,7 +277,7 @@ func (s *authTestSuite) TestLoginCaveatIDReturnCaveatID(c *C) {
 	err = m.AddThirdPartyCaveat([]byte("shared-key"), "third-party-caveat", UbuntuoneLocation)
 	c.Check(err, IsNil)
 
-	caveat, err := LoginCaveatID(m)
+	caveat, err := loginCaveatID(m)
 	c.Check(err, IsNil)
 	c.Check(caveat, Equals, "third-party-caveat")
 }
@@ -288,7 +288,7 @@ func (s *authTestSuite) TestLoginCaveatIDMacaroonMissingCaveat(c *C) {
 	err = m.AddThirdPartyCaveat([]byte("shared-key"), "third-party-caveat", "other-location")
 	c.Check(err, IsNil)
 
-	caveat, err := LoginCaveatID(m)
+	caveat, err := loginCaveatID(m)
 	c.Check(err, NotNil)
 	c.Check(caveat, Equals, "")
 }
@@ -300,7 +300,7 @@ func (s *authTestSuite) TestRequestStoreDeviceNonce(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
 
-	nonce, err := RequestStoreDeviceNonce()
+	nonce, err := requestStoreDeviceNonce()
 	c.Assert(err, IsNil)
 	c.Assert(nonce, Equals, "the-nonce")
 }
@@ -312,7 +312,7 @@ func (s *authTestSuite) TestRequestStoreDeviceNonceEmptyResponse(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
 
-	nonce, err := RequestStoreDeviceNonce()
+	nonce, err := requestStoreDeviceNonce()
 	c.Assert(err, ErrorMatches, "cannot get nonce from store: empty nonce returned")
 	c.Assert(nonce, Equals, "")
 }
@@ -324,7 +324,7 @@ func (s *authTestSuite) TestRequestStoreDeviceNonceError(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
 
-	nonce, err := RequestStoreDeviceNonce()
+	nonce, err := requestStoreDeviceNonce()
 	c.Assert(err, ErrorMatches, "cannot get nonce from store: store server returned status 500")
 	c.Assert(nonce, Equals, "")
 }
@@ -341,7 +341,7 @@ func (s *authTestSuite) TestRequestDeviceSession(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
 
-	macaroon, err := RequestDeviceSession("serial-assertion", "session-request", "")
+	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "")
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
@@ -358,7 +358,7 @@ func (s *authTestSuite) TestRequestDeviceSessionWithPreviousSession(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
 
-	macaroon, err := RequestDeviceSession("serial-assertion", "session-request", "previous-session")
+	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "previous-session")
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
@@ -370,7 +370,7 @@ func (s *authTestSuite) TestRequestDeviceSessionMissingData(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
 
-	macaroon, err := RequestDeviceSession("serial-assertion", "session-request", "")
+	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "")
 	c.Assert(err, ErrorMatches, "cannot get device session from store: empty session returned")
 	c.Assert(macaroon, Equals, "")
 }
@@ -383,7 +383,7 @@ func (s *authTestSuite) TestRequestDeviceSessionError(c *C) {
 	defer mockServer.Close()
 	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
 
-	macaroon, err := RequestDeviceSession("serial-assertion", "session-request", "")
+	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "")
 	c.Assert(err, ErrorMatches, `cannot get device session from store: store server returned status 500 and body "error body"`)
 	c.Assert(macaroon, Equals, "")
 }


### PR DESCRIPTION
Isolate store login logic (ie. getting root and discharge macaroons flow) in the store package. Make store interaction functions private to store package.