### PR TITLE
tests: add http_proxy to /etc/environment in the autopkgtest environment

### DIFF
--- a/debian/tests/integrationtests
+++ b/debian/tests/integrationtests
@@ -16,6 +16,9 @@ if [ "$http_proxy" != "" ]; then
 Environment=http_proxy=$http_proxy
 Environment=https_proxy=$http_proxy
 EOF
+
+    # ensure environment is updated
+    echo "http_proxy=$http_proxy" >> /etc/environment
 fi
 systemctl daemon-reload
 


### PR DESCRIPTION
This should unblock another autopkgtest issue, it seems that the network environment is timing out in the tests when the fake store falls back to the real store.

We can wait with the merge until the autopkgtest in yakkety run happend.