### PR TITLE
tests: disable prepare-image-grub test in autopkgtest

### DIFF
--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -1,5 +1,6 @@
 summary: Check that prepare-image works for grub-systems
 systems: [-ubuntu-core-16-64]
+backends: [-autopkgtest]
 # TODO: use the real stores with proper assertions fully as well once possible
 environment:
     ROOT: /tmp/root


### PR DESCRIPTION
This  tests works fine in qemu/autopkgtest but fails in the real autopkgtest environment for unknown reasons. Not worth the trouble given that we already test this in spread and given how impossible^Wdifficult it is to debug using autopkgtest that only happen on the actual infrastructure.