### PR TITLE
tests: account for different PWD handling on trusty.

### DIFF
--- a/tests/main/interfaces-locale-control/task.yaml
+++ b/tests/main/interfaces-locale-control/task.yaml
@@ -47,11 +47,11 @@ execute: |
     snap disconnect locale-control-consumer:locale-control ubuntu-core:locale-control
 
     echo "Then the snap is not able to read the locale configuration"
-    if su -l -c "locale-control-consumer.get LANG 2>${PWD}/locale-read.error" test; then
+    if su -l -c "locale-control-consumer.get LANG 2>locale-read.error" test; then
         echo "Expected permission error accessing locale configuration with disconnected plug"
         exit 1
     fi
-    grep -q "Permission denied" locale-read.error
+    grep -q "Permission denied" /home/test/locale-read.error
 
     echo "==================================="
 


### PR DESCRIPTION
On trusty, $(PWD) is evaluated after switching to user 'test'. With that, the resulting file is placed in /home/test and the subsequent grep fails for the file not being found. This change makes sure that (a.) the file is always placed in /home/test and (b.) subsequent grep uses an absolute path such that the file is found.