### PR TITLE
Return proper icon URL for non-installed snaps

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1897,6 +1897,12 @@ func (s *apiSuite) TestAppIconGetNoApp(c *check.C) {
 	c.Check(rec.Code, check.Equals, 404)
 }
 
+func (s *apiSuite) TestNotInstalledSnapIcon(c *check.C) {
+	info := &snap.Info{SuggestedName: "notInstalledSnap", IconURL: "icon.svg"}
+	iconfile := snapIcon(info)
+	c.Check(iconfile, testutil.Contains, "icon.svg")
+}
+
 func (s *apiSuite) TestInstallOnNonDevModeDistro(c *check.C) {
 	s.testInstall(c, &release.OS{ID: "ubuntu"}, snapstate.Flags(0), snap.R(0))
 }

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -38,7 +38,7 @@ func snapIcon(info *snap.Info) string {
 	// XXX: copy of snap.Snap.Icon which will go away
 	found, _ := filepath.Glob(filepath.Join(info.MountDir(), "meta", "gui", "icon.*"))
 	if len(found) == 0 {
-		return ""
+		return info.IconURL
 	}
 
 	return found[0]


### PR DESCRIPTION
Fix lp:1623589, returning the proper icon url for a given snap.