### PR TITLE
many: support snapctl -h

### DIFF
--- a/cmd/snapctl/main.go
+++ b/cmd/snapctl/main.go
@@ -47,13 +47,8 @@ func main() {
 func run() (stdout, stderr []byte, err error) {
 	cli := client.New(&clientConfig)
 
-	context := os.Getenv("SNAP_CONTEXT")
-	if context == "" {
-		return nil, nil, fmt.Errorf("snapctl requires SNAP_CONTEXT environment variable")
-	}
-
 	return cli.RunSnapctl(&client.SnapCtlOptions{
-		ContextID: context,
+		ContextID: os.Getenv("SNAP_CONTEXT"),
 		Args:      os.Args[1:],
 	})
 }

--- a/cmd/snapctl/main_test.go
+++ b/cmd/snapctl/main_test.go
@@ -96,8 +96,13 @@ func (s *snapctlSuite) TestSnapctlWithArgs(c *C) {
 	c.Check(string(stderr), Equals, "test stderr")
 }
 
-func (s *snapctlSuite) TestSnapctlWithoutContextShouldError(c *C) {
+func (s *snapctlSuite) TestSnapctlHelp(c *C) {
 	os.Unsetenv("SNAP_CONTEXT")
+	s.expectedContextID = ""
+
+	os.Args = []string{"snapctl", "-h"}
+	s.expectedArgs = []string{"-h"}
+
 	_, _, err := run()
-	c.Check(err, ErrorMatches, ".*requires SNAP_CONTEXT.*")
+	c.Check(err, IsNil)
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
@@ -1676,24 +1677,20 @@ func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot decode snapctl request: %s", err)
 	}
 
-	if snapctlOptions.ContextID == "" {
-		return BadRequest("snapctl cannot run without context ID")
-	}
-
 	if len(snapctlOptions.Args) == 0 {
 		return BadRequest("snapctl cannot run without args")
 	}
 
 	// Right now snapctl is only used for hooks. If at some point it grows
 	// beyond that, this probably shouldn't go straight to the HookManager.
-	context, err := c.d.overlord.HookManager().Context(snapctlOptions.ContextID)
-	if err != nil {
-		return BadRequest("cannot run snapctl: %s", err)
-	}
-
+	context, _ := c.d.overlord.HookManager().Context(snapctlOptions.ContextID)
 	stdout, stderr, err := ctlcmd.Run(context, snapctlOptions.Args)
 	if err != nil {
-		return BadRequest("error running snapctl: %s", err)
+		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
+			stdout = []byte(e.Error())
+		} else {
+			return BadRequest("error running snapctl: %s", err)
+		}
 	}
 
 	result := map[string]string{

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -22,7 +22,8 @@ top-level attribute `hooks` in `snap.yaml` to request plugs, like so:
 		  plugs: [network] # Or any other plugs required by this hook
 
 Note that hooks will be called with no parameters. If they need more information
-from snapd they can utilize the `snapctl` command.
+from snapd (or need to provide information to snapd) they can utilize the
+`snapctl` command (for more information on `snapctl`, see `snapctl -h`).
 
 
 ## Supported Hooks

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -23,12 +23,12 @@ import "fmt"
 
 func AddMockCommand(name string) *MockCommand {
 	mockCommand := NewMockCommand()
-	addCommand(name, func() command { return mockCommand })
+	addCommand(name, "", "", func() command { return mockCommand })
 	return mockCommand
 }
 
 func RemoveCommand(name string) {
-	delete(commandGenerators, name)
+	delete(commands, name)
 }
 
 type MockCommand struct {

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -19,15 +19,29 @@
 
 package ctlcmd
 
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/i18n"
+)
+
 type setCommand struct {
 	baseCommand
 }
 
+var shortSetHelp = i18n.G("Set snap configuration")
+var longSetHelp = i18n.G(`
+The set command is currently only a placeholder.`)
+
 func init() {
-	addCommand("set", func() command { return &setCommand{} })
+	addCommand("set", shortSetHelp, longSetHelp, func() command { return &setCommand{} })
 }
 
 func (s *setCommand) Execute(args []string) error {
+	if s.context() == nil {
+		return fmt.Errorf("cannot set without a context")
+	}
+
 	// TODO: Talk to the handler to take care of the set request.
 	return nil
 }

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -20,8 +20,6 @@
 package ctlcmd_test
 
 import (
-	"testing"
-
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
@@ -31,15 +29,13 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-type ctlcmdSuite struct {
+type setSuite struct {
 	mockContext *hookstate.Context
 }
 
-var _ = Suite(&ctlcmdSuite{})
+var _ = Suite(&setSuite{})
 
-func (s *ctlcmdSuite) SetUpTest(c *C) {
+func (s *setSuite) SetUpTest(c *C) {
 	handler := hooktest.NewMockHandler()
 
 	state := state.New(nil)
@@ -54,23 +50,14 @@ func (s *ctlcmdSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *ctlcmdSuite) TestNonExistingCommand(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"foo"})
+func (s *setSuite) TestCommand(c *C) {
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "foo=bar"})
+	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
-	c.Check(err, ErrorMatches, ".*[Uu]nknown command.*")
 }
 
-func (s *ctlcmdSuite) TestCommandOutput(c *C) {
-	mockCommand := ctlcmd.AddMockCommand("mock")
-	defer ctlcmd.RemoveCommand("mock")
-
-	mockCommand.FakeStdout = "test stdout"
-	mockCommand.FakeStderr = "test stderr"
-
-	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"mock", "foo"})
-	c.Check(err, IsNil)
-	c.Check(string(stdout), Equals, "test stdout")
-	c.Check(string(stderr), Equals, "test stderr")
-	c.Check(mockCommand.Args, DeepEquals, []string{"foo"})
+func (s *setSuite) TestCommandWithoutContext(c *C) {
+	_, _, err := ctlcmd.Run(nil, []string{"set", "foo=bar"})
+	c.Check(err, ErrorMatches, ".*cannot set without a context.*")
 }

--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -52,19 +52,24 @@ restore: |
     systemctl start snapd.service
 
 execute: |
+    echo "Verify that snapctl -h runs without a context"
+
+    if ! snapctl -h; then
+        echo "Expected snapctl -h to be successful"
+    fi
+
     echo "Run the hook that calls snapctl"
 
-    # This context is enough to hit the API, but the hook will fail since this
-    # context is obviously invalid. That failure still means we're correctly
-    # hitting the API, though, which is all we care about here.
-    export SNAP_CONTEXT="foo"
+    # The snapctl usage in the hook is invalid and will cause a failure. That
+    # failure still means we're correctly hitting the API, though, which is all
+    # we care about here.
     if output="$(snap run --hook=apply-config snapctl-hooks 2>&1 >/dev/null)"; then
         echo "Expected the hook to fail"
         exit 1
     fi
 
-    if [[ ! "$output" =~ .*"no context for ID: \"foo\"".* ]]; then
-        echo "Expected failure to be due to missing context, but it was \"$output\""
+    if [[ ! "$output" =~ .*"unknown flag".*bar.* ]]; then
+        echo "Expected failure to be due to unknown flag, but it was \"$output\""
         exit 1
     fi
 


### PR DESCRIPTION
This makes the tool much easier to discover (and document). It requires that the API accepts a missing context, however, which means the commands need to verify its presence before using it.