### PR TITLE
patch: fix patch4 transition

### DIFF
--- a/overlord/patch/patch4.go
+++ b/overlord/patch/patch4.go
@@ -206,7 +206,7 @@ func (p4 patch4T) mangle(task *state.Task) error {
 	}
 
 	var hadCandidate bool
-	if err := p4.get(task, "had-candidate", &hadCandidate); err != nil {
+	if err := p4.getMaybe(task, "had-candidate", &hadCandidate); err != nil && err != state.ErrNoState {
 		return err
 	}
 
@@ -245,6 +245,11 @@ func (p4 patch4T) addRevertFlag(task *state.Task) error {
 func patch4(s *state.State) error {
 	p4 := patch4T{}
 	for _, change := range s.Changes() {
+		// change is full done, take it easy
+		if change.Status().Ready() {
+			continue
+		}
+
 		if change.Kind() != "revert-snap" {
 			continue
 		}
@@ -256,6 +261,11 @@ func patch4(s *state.State) error {
 	}
 
 	for _, task := range s.Tasks() {
+		// change is full done, take it easy
+		if task.Change().Status().Ready() {
+			continue
+		}
+
 		switch task.Kind() {
 		case "link-snap":
 			if err := p4.mangle(task); err != nil {


### PR DESCRIPTION
This deals with some more cases that may happen when going from
patch level 3 to 4:
- skip change that are already done and not migrate them.
- do not assume that "had-candidate" is set, it may e.g. not be
  set yet (because the task has not run yet)