### PR TITLE
many: refresh all snap decls

### DIFF
--- a/asserts/fetcher.go
+++ b/asserts/fetcher.go
@@ -31,8 +31,17 @@ const (
 	fetchSaved
 )
 
-// Fetcher helps fetching assertions and their prerequisites.
-type Fetcher struct {
+// A Fetcher helps fetching assertions and their prerequisites.
+type Fetcher interface {
+	// Fetch retrieves the assertion indicated by ref then its prerequisites
+	// recursively, along the way saving prerequisites before dependent assertions.
+	Fetch(*Ref) error
+	// Save retrieves the prerequisites of the assertion recursively,
+	// along the way saving them, and finally saves the assertion.
+	Save(Assertion) error
+}
+
+type fetcher struct {
 	db       RODatabase
 	retrieve func(*Ref) (Assertion, error)
 	save     func(Assertion) error
@@ -41,8 +50,8 @@ type Fetcher struct {
 }
 
 // NewFetcher creates a Fetcher which will use trustedDB to determine trusted assertions, will fetch assertions following prerequisites using retrieve, and then will pass them to save, saving prerequisites before dependent assertions.
-func NewFetcher(trustedDB RODatabase, retrieve func(*Ref) (Assertion, error), save func(Assertion) error) *Fetcher {
-	return &Fetcher{
+func NewFetcher(trustedDB RODatabase, retrieve func(*Ref) (Assertion, error), save func(Assertion) error) Fetcher {
+	return &fetcher{
 		db:       trustedDB,
 		retrieve: retrieve,
 		save:     save,
@@ -50,7 +59,7 @@ func NewFetcher(trustedDB RODatabase, retrieve func(*Ref) (Assertion, error), sa
 	}
 }
 
-func (f *Fetcher) chase(ref *Ref, a Assertion) error {
+func (f *fetcher) chase(ref *Ref, a Assertion) error {
 	// check if ref points to a trusted assertion, in which case
 	// there is nothing to do
 	_, err := ref.Resolve(f.db.FindTrusted)
@@ -92,12 +101,12 @@ func (f *Fetcher) chase(ref *Ref, a Assertion) error {
 
 // Fetch retrieves the assertion indicated by ref then its prerequisites
 // recursively, along the way saving prerequisites before dependent assertions.
-func (f *Fetcher) Fetch(ref *Ref) error {
+func (f *fetcher) Fetch(ref *Ref) error {
 	return f.chase(ref, nil)
 }
 
 // fetchAccountKey behaves like Fetch for the account-key with the given key id.
-func (f *Fetcher) fetchAccountKey(keyID string) error {
+func (f *fetcher) fetchAccountKey(keyID string) error {
 	keyRef := &Ref{
 		Type:       AccountKeyType,
 		PrimaryKey: []string{keyID},
@@ -107,6 +116,6 @@ func (f *Fetcher) fetchAccountKey(keyID string) error {
 
 // Save retrieves the prerequisites of the assertion recursively,
 // along the way saving them, and finally saves the assertion.
-func (f *Fetcher) Save(a Assertion) error {
+func (f *fetcher) Save(a Assertion) error {
 	return f.chase(a.Ref(), a)
 }

--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -126,3 +126,14 @@ func DeriveSideInfo(snapPath string, db asserts.RODatabase) (*snap.SideInfo, err
 		Developer:   devAcct.Username(),
 	}, nil
 }
+
+// FetchSnapAssertions fetches the assertions matching the snap file digest using the given fetcher.
+func FetchSnapAssertions(f asserts.Fetcher, snapSHA3_384 string) error {
+	// for now starting from the snap-revision will get us all other relevant assertions
+	ref := &asserts.Ref{
+		Type:       asserts.SnapRevisionType,
+		PrimaryKey: []string{snapSHA3_384},
+	}
+
+	return f.Fetch(ref)
+}

--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -137,3 +137,13 @@ func FetchSnapAssertions(f asserts.Fetcher, snapSHA3_384 string) error {
 
 	return f.Fetch(ref)
 }
+
+// FetchSnapDeclaration fetches the snap declaration and its prerequisites for the given snap id using the given fetcher.
+func FetchSnapDeclaration(f asserts.Fetcher, snapID string) error {
+	ref := &asserts.Ref{
+		Type:       asserts.SnapDeclarationType,
+		PrimaryKey: []string{release.Series, snapID},
+	}
+
+	return f.Fetch(ref)
+}

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -80,7 +80,7 @@ func fetchSnapAssertions(sto *store.Store, snapPath string, snapInfo *snap.Info,
 	}
 	f := image.StoreAssertionFetcher(sto, dlOpts, db, save)
 
-	return image.FetchSnapAssertions(snapPath, snapInfo, f, db)
+	return image.FetchAndCheckSnapAssertions(snapPath, snapInfo, f, db)
 }
 
 func (x *cmdDownload) Execute(args []string) error {

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -85,7 +85,7 @@ func DownloadSnap(sto Store, name string, revision snap.Revision, opts *Download
 	return targetPath, snap, nil
 }
 
-// StoreAssertionFetcher creates an asserts.Fetcher for assertions against the given store using dlOpts for authorization, the fetcher will save assertions in the given database and after that also call save for each of them.
+// StoreAssertionFetcher creates an asserts.Fetcher for assertions against the given store using dlOpts for authorization, the fetcher will add assertions in the given database and after that also call save for each of them.
 func StoreAssertionFetcher(sto Store, dlOpts *DownloadOptions, db *asserts.Database, save func(asserts.Assertion) error) asserts.Fetcher {
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		return sto.Assertion(ref.Type, ref.PrimaryKey, dlOpts.User)

--- a/image/image.go
+++ b/image/image.go
@@ -185,7 +185,7 @@ func acquireSnap(sto Store, name string, dlOpts *DownloadOptions, local *localIn
 }
 
 type addingFetcher struct {
-	*asserts.Fetcher
+	asserts.Fetcher
 	addedRefs []*asserts.Ref
 }
 
@@ -291,7 +291,7 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 		// TODO: support somehow including available assertions
 		// also for local snaps
 		if info.SnapID != "" {
-			err = FetchSnapAssertions(fn, info, f.Fetcher, db)
+			err = FetchAndCheckSnapAssertions(fn, info, f, db)
 			if err != nil {
 				return err
 			}

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -24,6 +24,7 @@ package assertstate
 
 import (
 	"fmt"
+	"strings"
 
 	"gopkg.in/tomb.v2"
 
@@ -112,30 +113,18 @@ func userFromUserID(st *state.State, userID int) (*auth.UserState, error) {
 	return auth.User(st, userID)
 }
 
-type assertionNotFoundError struct {
-	ref *asserts.Ref
+type fetcher struct {
+	db *asserts.Database
+	asserts.Fetcher
+	fetched []asserts.Assertion
 }
 
-func (e *assertionNotFoundError) Error() string {
-	return fmt.Sprintf("%s %v not found", e.ref.Type.Name, e.ref.PrimaryKey)
-}
-
-// fetch fetches or updates the referenced assertion and all its prerequisites from the store and adds them to the system assertion database. It does not fail if required assertions were already present.
-func fetch(s *state.State, ref *asserts.Ref, userID int) error {
-	// TODO: once we have a bulk assertion retrieval endpoint this approach will change
-
-	user, err := userFromUserID(s, userID)
-	if err != nil {
-		return err
-	}
-
+// newFetches creates a fetcher used to retrieve assertions from the store and later commit them to the system database in one go.
+func newFetcher(s *state.State, user *auth.UserState) *fetcher {
 	db := cachedDB(s)
 	sto := snapstate.Store(s)
 
-	s.Unlock()
-	defer s.Lock()
-
-	got := []asserts.Assertion{}
+	f := &fetcher{db: db}
 
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		// TODO: ignore errors if already in db?
@@ -143,21 +132,32 @@ func fetch(s *state.State, ref *asserts.Ref, userID int) error {
 	}
 
 	save := func(a asserts.Assertion) error {
-		got = append(got, a)
+		f.fetched = append(f.fetched, a)
 		return nil
 	}
 
-	f := asserts.NewFetcher(db, retrieve, save)
+	f.Fetcher = asserts.NewFetcher(db, retrieve, save)
 
-	if err := f.Fetch(ref); err != nil {
-		return err
+	return f
+}
+
+type commitError struct {
+	errs []error
+}
+
+func (e *commitError) Error() string {
+	l := []string{""}
+	for _, e := range e.errs {
+		l = append(l, e.Error())
 	}
+	return fmt.Sprintf("cannot add some assertions to the system database:%s", strings.Join(l, "\n - "))
+}
 
-	s.Lock()
-	defer s.Unlock()
-
-	for _, a := range got {
-		err := db.Add(a)
+// commit does a best effort of adding all the fetched assertions to the system database.
+func (f *fetcher) commit() error {
+	var errs []error
+	for _, a := range f.fetched {
+		err := f.db.Add(a)
 		if revErr, ok := err.(*asserts.RevisionError); ok {
 			if revErr.Current >= a.Revision() {
 				// be idempotent
@@ -165,15 +165,37 @@ func fetch(s *state.State, ref *asserts.Ref, userID int) error {
 				continue
 			}
 		}
-		// TODO: trigger w. caller a global sanity check if a is revoked
-		// (but try to save as much possible still),
-		// or err is a check error
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-
+	if len(errs) != 0 {
+		return &commitError{errs: errs}
+	}
 	return nil
+}
+
+func doFetch(s *state.State, userID int, fetching func(asserts.Fetcher) error) error {
+	// TODO: once we have a bulk assertion retrieval endpoint this approach will change
+
+	user, err := userFromUserID(s, userID)
+	if err != nil {
+		return err
+	}
+
+	f := newFetcher(s, user)
+
+	s.Unlock()
+	err = fetching(f)
+	s.Lock()
+	if err != nil {
+		return err
+	}
+
+	// TODO: trigger w. caller a global sanity check if a is revoked
+	// (but try to save as much possible still),
+	// or err is a check error
+	return f.commit()
 }
 
 // doValidateSnap fetches the relevant assertions for the snap being installed and cross checks them with the snap.
@@ -191,13 +213,9 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// for now starting from the snap-revision will get us all other relevant assertions
-	ref := &asserts.Ref{
-		Type:       asserts.SnapRevisionType,
-		PrimaryKey: []string{sha3_384},
-	}
-
-	err = fetch(t.State(), ref, ss.UserID)
+	err = doFetch(t.State(), ss.UserID, func(f asserts.Fetcher) error {
+		return snapasserts.FetchSnapAssertions(f, sha3_384)
+	})
 	if notFound, ok := err.(*store.AssertionNotFoundError); ok {
 		if notFound.Ref.Type == asserts.SnapRevisionType {
 			return fmt.Errorf("cannot verify snap %q, no matching signatures found", ss.Name())

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -374,3 +374,110 @@ func (s *assertMgrSuite) TestValidateSnapCrossCheckFail(c *C) {
 
 	c.Assert(chg.Err(), ErrorMatches, `(?s).*cannot install snap "f" that is undergoing a rename to "foo".*`)
 }
+
+func (s *assertMgrSuite) TestRefreshSnapDeclarations(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	err := s.storeSigning.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	headers := map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "foo-id",
+		"snap-name":    "foo",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}
+	snapDeclFoo, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(snapDeclFoo)
+	c.Assert(err, IsNil)
+
+	headers = map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "bar-id",
+		"snap-name":    "bar",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}
+	snapDeclBar, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(snapDeclBar)
+	c.Assert(err, IsNil)
+
+	snapstate.Set(s.state, "foo", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "foo", SnapID: "foo-id", Revision: snap.R(7)},
+		},
+		Current: snap.R(7),
+	})
+	snapstate.Set(s.state, "bar", &snapstate.SnapState{
+		Active: false,
+		Sequence: []*snap.SideInfo{
+			{RealName: "bar", SnapID: "bar-id", Revision: snap.R(3)},
+		},
+		Current: snap.R(3),
+	})
+	snapstate.Set(s.state, "local", &snapstate.SnapState{
+		Active: false,
+		Sequence: []*snap.SideInfo{
+			{RealName: "local", Revision: snap.R(-1)},
+		},
+		Current: snap.R(-1),
+	})
+
+	// previous state
+	err = assertstate.Add(s.state, s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, s.dev1Acct)
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, snapDeclFoo)
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, snapDeclBar)
+	c.Assert(err, IsNil)
+
+	// one changed assertion
+	headers = map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "foo-id",
+		"snap-name":    "fo-o",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+		"revision":     "1",
+	}
+	snapDeclFoo1, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(snapDeclFoo1)
+	c.Assert(err, IsNil)
+
+	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	c.Assert(err, IsNil)
+
+	a, err := assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  "16",
+		"snap-id": "foo-id",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.SnapDeclaration).SnapName(), Equals, "fo-o")
+
+	// another one
+	// one changed assertion
+	headers = s.dev1Acct.Headers()
+	headers["display-name"] = "Dev 1 edited display-name"
+	headers["revision"] = "1"
+	dev1Acct1, err := s.storeSigning.Sign(asserts.AccountType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(dev1Acct1)
+	c.Assert(err, IsNil)
+
+	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	c.Assert(err, IsNil)
+
+	a, err = assertstate.DB(s.state).Find(asserts.AccountType, map[string]string{
+		"account-id": s.dev1Acct.AccountID(),
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.Account).DisplayName(), Equals, "Dev 1 edited display-name")
+}

--- a/overlord/assertstate/export_test.go
+++ b/overlord/assertstate/export_test.go
@@ -21,5 +21,5 @@ package assertstate
 
 // expose for testing
 var (
-	Fetch = fetch
+	DoFetch = doFetch
 )

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/asserts/systestkeys"
 	"github.com/snapcore/snapd/dirs"
@@ -85,7 +86,7 @@ func writeAssert(a asserts.Assertion, targetDir string) error {
 	return ioutil.WriteFile(filepath.Join(targetDir, "asserts", fn), asserts.Encode(a), 0644)
 }
 
-func makeFakeRefreshForSnap(snap, targetDir string, db *asserts.Database, f *asserts.Fetcher) error {
+func makeFakeRefreshForSnap(snap, targetDir string, db *asserts.Database, f asserts.Fetcher) error {
 	// make a fake update snap in /var/tmp (which is not a tempfs)
 	fakeUpdateDir, err := ioutil.TempDir("/var/tmp", "snap-build-")
 	if err != nil {
@@ -198,11 +199,8 @@ func buildSnap(snapDir, targetDir string) (*info, error) {
 	return &info{digest: newDigest, size: size}, nil
 }
 
-func copySnapAsserts(info *info, f *asserts.Fetcher) error {
-	return f.Fetch(&asserts.Ref{
-		Type:       asserts.SnapRevisionType,
-		PrimaryKey: []string{info.digest},
-	})
+func copySnapAsserts(info *info, f asserts.Fetcher) error {
+	return snapasserts.FetchSnapAssertions(f, info.digest)
 }
 
 func makeNewSnapRevision(orig, new *info, targetDir string, db *asserts.Database) error {

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -52,8 +52,6 @@ setup_store(){
     local store_type=$1
     local top_dir=$2
     if [ "$store_type" = "fake" ]; then
-        setup_fake_store $top_dir
-    elif [ "$store_type" = "fake-w-assert-fallback" ]; then
         setup_fake_store $top_dir -assert-fallback
     else
         if [ "$store_type" = "staging" ]; then

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -10,7 +10,7 @@ environment:
     UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_SNAPS: 1
 prepare: |
     . $TESTSLIB/store.sh
-    setup_store fake-w-assert-fallback $STORE_DIR
+    setup_store fake $STORE_DIR
 restore: |
     . $TESTSLIB/store.sh
     teardown_store fake $STORE_DIR

--- a/tests/main/refresh-devmode/task.yaml
+++ b/tests/main/refresh-devmode/task.yaml
@@ -14,7 +14,7 @@ environment:
     SNAP_VERSION_PATTERN: \d+\.\d+\+fake1
     BLOB_DIR: $(pwd)/fake-store-blobdir
     STORE_TYPE/fake: fake
-    STORE_TYPE/staging: staging
+#    STORE_TYPE/staging: staging
     STORE_TYPE/production: production
 
 prepare: |

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -13,7 +13,7 @@ environment:
     SNAP_NAME: test-snapd-tools
     SNAP_VERSION_PATTERN: \d+\.\d+\+fake1
     BLOB_DIR: $(pwd)/fake-store-blobdir
-    STORE_TYPE/fake: fake-w-assert-fallback
+    STORE_TYPE/fake: fake
 #    STORE_TYPE/staging: staging
     STORE_TYPE/production: production
 

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -13,7 +13,7 @@ environment:
     SNAP_NAME: test-snapd-tools
     SNAP_VERSION_PATTERN: \d+\.\d+\+fake1
     BLOB_DIR: $(pwd)/fake-store-blobdir
-    STORE_TYPE/fake: fake-w-asset-fallback
+    STORE_TYPE/fake: fake-w-assert-fallback
 #    STORE_TYPE/staging: staging
     STORE_TYPE/production: production
 

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -13,8 +13,8 @@ environment:
     SNAP_NAME: test-snapd-tools
     SNAP_VERSION_PATTERN: \d+\.\d+\+fake1
     BLOB_DIR: $(pwd)/fake-store-blobdir
-    STORE_TYPE/fake: fake
-    STORE_TYPE/staging: staging
+    STORE_TYPE/fake: fake-w-asset-fallback
+#    STORE_TYPE/staging: staging
     STORE_TYPE/production: production
 
 prepare: |

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -2,7 +2,7 @@ summary: Check that revert of a snap in devmode restores devmode
 systems: [-ubuntu-core-16-64]
 environment:
     STORE_TYPE/fake: fake
-    STORE_TYPE/staging: staging
+#    STORE_TYPE/staging: staging
     STORE_TYPE/production: production
     BLOB_DIR: $(pwd)/fake-store-blobdir
 

--- a/tests/main/revert/task.yaml
+++ b/tests/main/revert/task.yaml
@@ -2,7 +2,7 @@ summary: Check that revert works.
 systems: [-ubuntu-core-16-64]
 environment:
     STORE_TYPE/fake: fake
-    STORE_TYPE/staging: staging
+#    STORE_TYPE/staging: staging
     STORE_TYPE/production: production
     BLOB_DIR: $(pwd)/fake-store-blobdir
 


### PR DESCRIPTION
This improve organisation around asserts.Fetcher usages. It introduces assertstate.RefreshSnapDeclarations and use it just before all refreshes. 
As the comments explain that is a prerequisite to have up-to-date information to enforce refresh-control. 