### PR TITLE
interfaces/apparmor: allow reading /etc/environment

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -86,6 +86,7 @@ var defaultTemplate = []byte(`
   /etc/libnl-3/{classid,pktloc} r,      # apps that use libnl
   /var/lib/extrausers/{passwd,group} r,
   /etc/profile r,
+  /etc/environment r,
   /usr/share/terminfo/** r,
   /etc/inputrc r,
   # Common utilities for shell scripts


### PR DESCRIPTION
This patch adjusts the default apparmor template to allow snap
applications to read /etc/environment.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>