### PR TITLE
image: ensure local snaps are put last in seed.yaml 

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -248,21 +248,25 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 		DevMode:   false, // XXX: should this be true?
 	}
 
-	snaps := []string{}
-	// opts.Snaps need to be considered first to support local overrides
-	// of snaps mentioned in the model assertion whose fetching
-	// from the store will be then skipped
-	snaps = append(snaps, opts.Snaps...)
-	snaps = append(snaps, model.Gadget())
-	snaps = append(snaps, defaultCore)
-	snaps = append(snaps, model.Kernel())
-	snaps = append(snaps, model.RequiredSnaps()...)
-
 	for _, d := range []string{snapSeedDir, assertSeedDir} {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			return err
 		}
 	}
+
+	snaps := []string{}
+	// only add snaps if they are not overriden by a local snap
+	if local.Info(model.Gadget()) == nil {
+		snaps = append(snaps, model.Gadget())
+	}
+	if local.Info(defaultCore) == nil {
+		snaps = append(snaps, defaultCore)
+	}
+	if local.Info(model.Kernel()) == nil {
+		snaps = append(snaps, model.Kernel())
+	}
+	snaps = append(snaps, opts.Snaps...)
+	snaps = append(snaps, model.RequiredSnaps()...)
 
 	seen := make(map[string]bool)
 	downloadedSnapsInfo := map[string]*snap.Info{}

--- a/image/image.go
+++ b/image/image.go
@@ -267,7 +267,9 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 	snaps = append(snaps, local.PreferLocal(model.Kernel()))
 	snaps = append(snaps, local.PreferLocal(model.Gadget()))
 	// then required and the user requested stuff
-	snaps = append(snaps, model.RequiredSnaps()...)
+	for _, snapName := range model.RequiredSnaps() {
+		snaps = append(snaps, local.PreferLocal(snapName))
+	}
 	snaps = append(snaps, opts.Snaps...)
 
 	seen := make(map[string]bool)

--- a/image/image.go
+++ b/image/image.go
@@ -262,9 +262,11 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 	}
 
 	snaps := []string{}
-	snaps = append(snaps, local.PreferLocal(model.Gadget()))
+	// core,kernel,gadget first
 	snaps = append(snaps, local.PreferLocal(defaultCore))
 	snaps = append(snaps, local.PreferLocal(model.Kernel()))
+	snaps = append(snaps, local.PreferLocal(model.Gadget()))
+	// then required and the user requested stuff
 	snaps = append(snaps, model.RequiredSnaps()...)
 	snaps = append(snaps, opts.Snaps...)
 

--- a/image/image.go
+++ b/image/image.go
@@ -66,6 +66,13 @@ func (li *localInfos) Name(pathOrName string) string {
 	return pathOrName
 }
 
+func (li *localInfos) PreferLocal(name string) string {
+	if path := li.Path(name); path != "" {
+		return path
+	}
+	return name
+}
+
 func (li *localInfos) Path(name string) string {
 	return li.nameToPath[name]
 }
@@ -255,18 +262,11 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 	}
 
 	snaps := []string{}
-	// only add snaps if they are not overriden by a local snap
-	if local.Info(model.Gadget()) == nil {
-		snaps = append(snaps, model.Gadget())
-	}
-	if local.Info(defaultCore) == nil {
-		snaps = append(snaps, defaultCore)
-	}
-	if local.Info(model.Kernel()) == nil {
-		snaps = append(snaps, model.Kernel())
-	}
-	snaps = append(snaps, opts.Snaps...)
+	snaps = append(snaps, local.PreferLocal(model.Gadget()))
+	snaps = append(snaps, local.PreferLocal(defaultCore))
+	snaps = append(snaps, local.PreferLocal(model.Kernel()))
 	snaps = append(snaps, model.RequiredSnaps()...)
+	snaps = append(snaps, opts.Snaps...)
 
 	seen := make(map[string]bool)
 	downloadedSnapsInfo := map[string]*snap.Info{}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -442,7 +442,7 @@ func (s *imageSuite) TestBootstrapToRootDirLocalCore(c *C) {
 	c.Check(seed.Snaps, HasLen, 3)
 
 	// check the files are in place
-	for i, name := range []string{"ubuntu-core_x1.snap", "pc", "pc-kernel"} {
+	for i, name := range []string{"pc", "pc-kernel", "ubuntu-core_x1.snap"} {
 		unasserted := false
 		info := s.storeSnapInfo[name]
 		if info == nil {
@@ -560,7 +560,10 @@ func (s *imageSuite) TestBootstrapToRootDirDevmodeSnap(c *C) {
 	fn := filepath.Base(info.MountFile())
 	p := filepath.Join(rootdir, "var/lib/snapd/seed/snaps", fn)
 	c.Check(osutil.FileExists(p), Equals, true)
-	c.Check(seed.Snaps[0], DeepEquals, &snap.SeedSnap{
+
+	// ensure local snaps are put last in seed.yaml
+	last := len(seed.Snaps) - 1
+	c.Check(seed.Snaps[last], DeepEquals, &snap.SeedSnap{
 		Name:       "devmode-snap",
 		File:       fn,
 		DevMode:    true,

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -442,7 +442,7 @@ func (s *imageSuite) TestBootstrapToRootDirLocalCore(c *C) {
 	c.Check(seed.Snaps, HasLen, 3)
 
 	// check the files are in place
-	for i, name := range []string{"pc", "pc-kernel", "ubuntu-core_x1.snap"} {
+	for i, name := range []string{"pc", "ubuntu-core_x1.snap", "pc-kernel"} {
 		unasserted := false
 		info := s.storeSnapInfo[name]
 		if info == nil {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -358,7 +358,7 @@ func (s *imageSuite) TestBootstrapToRootDir(c *C) {
 	c.Check(seed.Snaps, HasLen, 3)
 
 	// check the files are in place
-	for i, name := range []string{"pc", "ubuntu-core", "pc-kernel"} {
+	for i, name := range []string{"ubuntu-core", "pc-kernel", "pc"} {
 		info := s.storeSnapInfo[name]
 		fn := filepath.Base(info.MountFile())
 		p := filepath.Join(rootdir, "var/lib/snapd/seed/snaps", fn)
@@ -442,7 +442,7 @@ func (s *imageSuite) TestBootstrapToRootDirLocalCore(c *C) {
 	c.Check(seed.Snaps, HasLen, 3)
 
 	// check the files are in place
-	for i, name := range []string{"pc", "ubuntu-core_x1.snap", "pc-kernel"} {
+	for i, name := range []string{"ubuntu-core_x1.snap", "pc-kernel", "pc"} {
 		unasserted := false
 		info := s.storeSnapInfo[name]
 		if info == nil {


### PR DESCRIPTION
This ensure that on firstboot the core snap is ready when e.g. the network connections are setup. This just unblocks snapweb starting in the image, there is a bigger problem here that we need to solve for out-of-oder installs.