### PR TITLE
Update documentation on testing snapd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ transfer it to the snappy system and then run:
 
     sudo systemctl stop snapd.service snapd.socket
     sudo /lib/systemd/systemd-activate -E SNAPD_DEBUG=1 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
+    or with systemd version >= 230
+    sudo systemd-socket-activate -E SNAPD_DEBUG=1 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
 
 This will stop the installed snapd and activate the new one. Once it's
 printed out something like `Listening on /run/snapd.socket as 3.` you


### PR DESCRIPTION
The documentation refers to systemd-activate which was renamed to
systemd-socket-activate in systemd 230.