### PR TITLE
interfaces/builtin: allow mmaping pulseaudio buffers

### DIFF
--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -27,7 +27,7 @@ import (
 )
 
 const pulseaudioConnectedPlugAppArmor = `
-/{run,dev}/shm/pulse-shm-* rwk,
+/{run,dev}/shm/pulse-shm-* rwkm,
 
 owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/snappy/+bug/1624963
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>