### PR TITLE
wrappers: add new X-Snap-Exec=$snap.$app support to .desktop files

### DIFF
--- a/docs/meta.md
+++ b/docs/meta.md
@@ -90,8 +90,12 @@ Desktop Entry Specification version 1.1 with some exceptions listed
 below. If there is a line with an unknown key or an unofficial key
 that line is silently removed from the desktop file on install.
 
-Only `Exec=` lines that start with `Exec=$snap.$app` are valid, but
-arguments may be passed. E.g. for a snap like:
+It is possible to specific the application to launch via the
+`X-Snap-Exec=` line or via the traditional `Exec=` line.
+
+Only `X-Snap-Exec=` or `Exec=` lines that start with `X-Snap-Exec=` or
+`Exec=$snap.$app` are valid, but arguments may be passed. E.g. for a
+snap like:
 ```
 name: http
 version: 1.0
@@ -109,6 +113,9 @@ Exec=http.GET %U
 
 The `Exec=` line is valid because it starts with `Exec=http.GET` (the
 snap is called "http" and the app is called "GET").
+
+The `X-Snap-Exec=` line is useful when the `Exec=` line is used by
+e.g. autotools or similar.
 
 
 ### Unsupported desktop keys

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -277,3 +277,25 @@ func (s *sanitizeDesktopFileSuite) TestTrimLang(c *C) {
 		c.Assert(wrappers.TrimLang(t.in), Equals, t.out)
 	}
 }
+
+func (s *sanitizeDesktopFileSuite) TestSanitizeXSnapExec(c *C) {
+	snap, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+version: 1.0
+apps:
+ app:
+  command: cmd
+`))
+	c.Assert(err, IsNil)
+	desktopContent := []byte(`[Desktop Entry]
+Name=foo
+Exec=upstream-exec-line
+X-Snap-Exec=snap.app %U
+`)
+
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
+	c.Assert(string(e), Equals, `[Desktop Entry]
+Name=foo
+X-Snap-Exec=snap.app %U
+Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop /snap/bin/snap.app %U`)
+}


### PR DESCRIPTION
Strawman branch based on feedback from seb128 about the challenges of upstream packaging of gtk apps.

This allows upstreams to have a desktop file that contains
both the traditional Exec= line as well as a snap specific way
to start the app. This should make it easy to use the upstream
desktop file directly in meta/gui/.

This allows to write:
```
[Desktop Entry]
Name=Something
Exec=/usr/bin/non-snap-way to-start-the-thing
X-Snap-Exec=snap.app that-starts-the-thing
```