### PR TITLE
interfaces/builtin: improve testability and add regression test for LP: #1625291

### DIFF
--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -22,3 +22,10 @@ package builtin
 func MprisGetName(iface *MprisInterface, attribs map[string]interface{}) (string, error) {
 	return iface.getName(attribs)
 }
+
+func MockGPIOExportToUserspace() (restore func()) {
+	reallyExportGPIOsToUserspace = false
+	return func() {
+		reallyExportGPIOsToUserspace = true
+	}
+}

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -100,7 +100,7 @@ func (s *GpioInterfaceSuite) TestName(c *C) {
 }
 
 func (s *GpioInterfaceSuite) TestSanitizeSlotGadgetSnap(c *C) {
-	// gpio slot on gadget accepeted
+	// gpio slot on gadget accepted
 	err := s.iface.SanitizeSlot(s.gadgetGpioSlot)
 	c.Assert(err, IsNil)
 
@@ -108,7 +108,7 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotGadgetSnap(c *C) {
 	err = s.iface.SanitizeSlot(s.gadgetMissingNumberSlot)
 	c.Assert(err, ErrorMatches, "gpio slot must have a number attribute")
 
-	// slots with number attribute that isnt a number
+	// slots with number attribute that isn't a number
 	err = s.iface.SanitizeSlot(s.gadgetBadNumberSlot)
 	c.Assert(err, ErrorMatches, "gpio slot number attribute must be an int")
 
@@ -117,7 +117,7 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotGadgetSnap(c *C) {
 }
 
 func (s *GpioInterfaceSuite) TestSanitizeSlotOsSnap(c *C) {
-	// gpio slot on OS accepeted
+	// gpio slot on OS accepted
 	err := s.iface.SanitizeSlot(s.osGpioSlot)
 	c.Assert(err, IsNil)
 }

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -132,6 +132,6 @@ func (s *GpioInterfaceSuite) TestSanitizePlug(c *C) {
 	err := s.iface.SanitizePlug(s.gadgetPlug)
 	c.Assert(err, IsNil)
 
-	// It is impossible to use "bool-file" interface to sanitize plugs of different interface.
+	// It is impossible to use "gpio" interface to sanitize plugs of different interface.
 	c.Assert(func() { s.iface.SanitizePlug(s.gadgetBadInterfacePlug) }, PanicMatches, `plug is not of interface "gpio"`)
 }

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -58,18 +58,19 @@ slots:
     bad-number:
         interface: gpio
         number: forty-two
-    bad-interface: other-interface
+    bad-interface-slot: other-interface
 plugs:
     plug: gpio
-    bad-interface: other-interface
+    bad-interface-plug: other-interface
 `))
 	c.Assert(gadgetErr, IsNil)
+	c.Assert(snap.Validate(gadgetInfo), IsNil)
 	s.gadgetGpioSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["my-pin"]}
 	s.gadgetMissingNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["missing-number"]}
 	s.gadgetBadNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-number"]}
-	s.gadgetBadInterfaceSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-interface"]}
+	s.gadgetBadInterfaceSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-interface-slot"]}
 	s.gadgetPlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["plug"]}
-	s.gadgetBadInterfacePlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["bad-interface"]}
+	s.gadgetBadInterfacePlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["bad-interface-plug"]}
 
 	osInfo, osErr := snap.InfoFromSnapYaml([]byte(`
 name: my-core


### PR DESCRIPTION
This branch changes the GPIO interface to make it testable by allowing to disable the GPIO setup side effects in tests. Subsequently a simple test case is constructed where a GPIO is exposed by the gadget snap (as a slot) and used by an application (through a plug). This ensures that ConnectedSlotSnippet method is really called.
