### PR TITLE
snap, daemon, store: pass through screenshots from store

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1049,8 +1049,8 @@ func (s *apiSuite) TestFindScreenshotted(c *check.C) {
 	c.Check(snaps[0]["screenshots"], check.DeepEquals, []interface{}{
 		map[string]interface{}{
 			"url":    "http://example.com/screenshot.png",
-			"width":  800,
-			"height": 1280,
+			"width":  float64(800),
+			"height": float64(1280),
 		},
 		map[string]interface{}{
 			"url": "http://example.com/screenshot2.png",

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -167,13 +167,13 @@ func mapRemote(remoteSnap *snap.Info) map[string]interface{} {
 		confinement = snap.StrictConfinement
 	}
 
-	screenshots := make([]screenshotJSON, 0, len(remoteSnap.Screenshots))
-	for _, screenshot := range remoteSnap.Screenshots {
-		screenshots = append(screenshots, screenshotJSON{
+	screenshots := make([]screenshotJSON, len(remoteSnap.Screenshots))
+	for i, screenshot := range remoteSnap.Screenshots {
+		screenshots[i] = screenshotJSON{
 			URL:    screenshot.URL,
 			Width:  screenshot.Width,
 			Height: screenshot.Height,
-		})
+		}
 	}
 
 	result := map[string]interface{}{

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -113,6 +113,13 @@ type appJSON struct {
 	Name string `json:"name"`
 }
 
+// screenshotJSON contains the json for snap.ScreenshotInfo
+type screenshotJSON struct {
+	URL    string `json:"url"`
+	Width  int64  `json:"width,omitempty"`
+	Height int64  `json:"height,omitempty"`
+}
+
 func mapLocal(localSnap *snap.Info, snapst *snapstate.SnapState) map[string]interface{} {
 	status := "installed"
 	if snapst.Active && localSnap.Revision == snapst.Current {
@@ -160,6 +167,15 @@ func mapRemote(remoteSnap *snap.Info) map[string]interface{} {
 		confinement = snap.StrictConfinement
 	}
 
+	screenshots := make([]screenshotJSON, 0, len(remoteSnap.Screenshots))
+	for _, screenshot := range remoteSnap.Screenshots {
+		screenshots = append(screenshots, screenshotJSON{
+			URL:    screenshot.URL,
+			Width:  screenshot.Width,
+			Height: screenshot.Height,
+		})
+	}
+
 	result := map[string]interface{}{
 		"description":   remoteSnap.Description(),
 		"developer":     remoteSnap.Developer,
@@ -175,6 +191,10 @@ func mapRemote(remoteSnap *snap.Info) map[string]interface{} {
 		"channel":       remoteSnap.Channel,
 		"private":       remoteSnap.Private,
 		"confinement":   confinement,
+	}
+
+	if len(screenshots) > 0 {
+		result["screenshots"] = screenshots
 	}
 
 	if len(remoteSnap.Prices) > 0 {

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -246,6 +246,7 @@ Alter the collection searched:
       "name": "http",
       "resource": "/v2/snaps/http",
       "revision": 14,
+      "screenshots": [{url: "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/10/screenshot.png", width: 800, height: 1280}],
       "status": "available",
       "summary": "HTTPie in a snap",
       "type": "app",
@@ -269,6 +270,7 @@ Alter the collection searched:
 * `private`: true if this snap is only available to its author.
 * `resource`: HTTP resource for this snap.
 * `revision`: a number representing the revision.
+* `screenshots`: JSON array of the screenshots for this snap. Each screenshot has a `url` field for the image and optionally `width` and `height` (in pixels).
 * `status`: can be either `available`, or `priced` (i.e. needs to be bought to become available).
 * `summary`: one-line summary.
 * `type`: the type of snap; one of `app`, `kernel`, `gadget`, or `os`.
@@ -354,7 +356,7 @@ In addition to the fields described in `/v2/find`:
 * `status`: can be either `installed` or `active` (i.e. is current).
 * `trymode`: true if the app was installed in try mode.
 
-furthermore, `download-size` and `price` cannot occur in the output of `/v2/snaps`.
+furthermore, `download-size`, `screenshots` and `prices` cannot occur in the output of `/v2/snaps`.
 
 ### POST
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -145,6 +145,8 @@ type Info struct {
 	Prices  map[string]float64 `yaml:"prices,omitempty" json:"prices,omitempty"`
 	MustBuy bool
 	Broken  string
+
+	Screenshots []ScreenshotInfo
 }
 
 // Name returns the blessed name for the snap.
@@ -297,6 +299,15 @@ type AppInfo struct {
 	Slots map[string]*SlotInfo
 
 	Environment map[string]string
+}
+
+// ScreenshotInfo provides information about a screenshot.
+type ScreenshotInfo struct {
+	Snap *Info
+
+	URL    string
+	Width  int64
+	Height int64
 }
 
 // HookInfo provides information about a hook.

--- a/store/details.go
+++ b/store/details.go
@@ -41,6 +41,7 @@ type snapDetails struct {
 	Publisher        string             `json:"publisher,omitempty"`
 	RatingsAverage   float64            `json:"ratings_average,omitempty"`
 	Revision         int                `json:"revision"` // store revisions are ints starting at 1
+	ScreenshotURLs   []string           `json:"screenshot_urls,omitempty"`
 	SnapID           string             `json:"snap_id"`
 	SupportURL       string             `json:"support_url"`
 	Title            string             `json:"title"`

--- a/store/store.go
+++ b/store/store.go
@@ -110,6 +110,14 @@ func infoFromRemote(d snapDetails) *snap.Info {
 	}
 	info.Deltas = deltas
 
+	screenshots := make([]snap.ScreenshotInfo, 0, len(d.ScreenshotURLs))
+	for _, url := range d.ScreenshotURLs {
+		screenshots = append(screenshots, snap.ScreenshotInfo{
+			URL: url,
+		})
+	}
+	info.Screenshots = screenshots
+
 	return info
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -605,10 +605,11 @@ const (
 
 /* acquired via
 
-http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha3_384,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
+http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha3_384,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,screenshot_urls,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
 
 on 2016-07-03. Then, by hand:
  * set prices to {"EUR": 0.99, "USD": 1.23}.
+ * Screenshot URLS set manually.
 
 On Ubuntu, apt install httpie xsel (although you could get http from
 the http snap instead).
@@ -624,7 +625,7 @@ const MockDetailsJSON = `{
             }
         ],
         "self": {
-            "href": "https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cprivate%2Cconfinement&channel=edge"
+            "href": "https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cprivate%2Cconfinement&channel=edge"
         }
     },
     "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap",
@@ -647,6 +648,7 @@ const MockDetailsJSON = `{
     "publisher": "Canonical",
     "ratings_average": 0.0,
     "revision": 27,
+    "screenshot_urls": ["https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/screenshot.png"],
     "snap_id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
     "summary": "The 'hello-world' of snaps",
     "support_url": "mailto:snappy-devel@lists.ubuntu.com",
@@ -777,6 +779,11 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(result.Description(), Equals, "This is a simple hello world example.")
 	c.Check(result.Summary(), Equals, "The 'hello-world' of snaps")
 	c.Assert(result.Prices, DeepEquals, map[string]float64{"EUR": 0.99, "USD": 1.23})
+	c.Assert(result.Screenshots, DeepEquals, []snap.ScreenshotInfo{
+		snap.ScreenshotInfo{
+			URL: "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/screenshot.png",
+		},
+	})
 	c.Check(result.MustBuy, Equals, true)
 
 	// Make sure the epoch (currently not sent by the store) defaults to "0"
@@ -1010,7 +1017,8 @@ func (t *remoteRepoTestSuite) TestStructFields(c *C) {
 }
 
 /* acquired via:
-curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://search.apps.ubuntu.com/api/v1/search?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&q=hello' | python -m json.tool | xsel -b
+curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://search.apps.ubuntu.com/api/v1/search?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&q=hello' | python -m json.tool | xsel -b
+Screenshot URLS set manually.
 */
 const MockSearchJSON = `{
     "_embedded": {
@@ -1039,6 +1047,7 @@ const MockSearchJSON = `{
                 "publisher": "Canonical",
                 "ratings_average": 0.0,
                 "revision": 25,
+                "screenshot_urls": ["https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/screenshot.png"],
                 "snap_id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
                 "summary": "Hello world example",
                 "support_url": "mailto:snappy-devel@lists.ubuntu.com",
@@ -1056,13 +1065,13 @@ const MockSearchJSON = `{
             }
         ],
         "first": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
+            "href": "https://search.apps.ubuntu.com/api/v1/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
         },
         "last": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
+            "href": "https://search.apps.ubuntu.com/api/v1/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
         },
         "self": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
+            "href": "https://search.apps.ubuntu.com/api/v1/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
         }
     }
 }


### PR DESCRIPTION
This change allows the Snap store screenshots to be passed through to a snapd client [1].

Some thoughts on the changes:
- Even though the store only provides screenshot URLs I added support for more metadata (e.g. width, height). I've requested the store consider providing this [2].
- I wasn't sure if the screenshots should be in snap.Info or snap.DownloadInfo or snap.SideInfo
- The test is failing, but I can't work out why. It seems like it is succeeding but the check.DeepEquals is not working for some reason. I need a Go expert to tell me what I'm doing wrong...

```
api_test.go:1058:
    c.Check(snaps[0]["screenshots"], check.DeepEquals, []interface{}{
        map[string]interface{}{
            "url":    "http://example.com/screenshot.png",
            "width":  800,
            "height": 1280,
        },
        map[string]interface{}{
            "url": "http://example.com/screenshot2.png",
        },
    })
... obtained []interface {} = []interface {}{map[string]interface {}{"width":800, "height":1280, "url":"http://example.com/screenshot.png"}, map[string]interface {}{"url":"http://example.com/screenshot2.png"}}
... expected []interface {} = []interface {}{map[string]interface {}{"height":1280, "url":"http://example.com/screenshot.png", "width":800}, map[string]interface {}{"url":"http://example.com/screenshot2.png"}}
```

[1] https://bugs.launchpad.net/bugs/1603610
[2] https://bugs.launchpad.net/bugs/1625852