### PR TITLE
store : add requestOptions.ExtraHeaders so that individual requests can customise headers.

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -230,7 +230,7 @@ type DownloadInfo struct {
 	Size     int64  `json:"size,omitempty"`
 	Sha3_384 string `json:"sha3-384,omitempty"`
 
-	Deltas []DeltaInfo
+	Deltas []DeltaInfo `json:"deltas,omitempty"`
 }
 
 // DeltaInfo contains the information to download a delta


### PR DESCRIPTION
One thing I wasn't happy with, with a branch I landed yesterday, was that I didn't have a way to add the X-Ubuntu-Delta-Formats header only for the one ListRefresh function, but instead had to either (1) add the header for all requests (when the env var was set), or (2) update the requestOptions adding another struct field which would only be used on ListRefresh (which seems to be what's been done for requestOptions.ContentType)

I went with (1) yesterday, with the intention of doing this PR here. I'd personally like to add another commit removing requestOptions.Accept and requestOptions.ContentType, instead using ExtraHeaders in the corresponding calls. Let me know - I'll have it staged ready for commit :) (Edit: here's the diff - http://paste.ubuntu.com/23210243/ )