### PR TITLE
many: use unique plug/slot names in tests

### DIFF
--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -152,7 +152,7 @@ func (s *kernelOSSuite) TestSetNextBootOnClassic(c *C) {
 	defer restore()
 
 	// Create a fake OS snap that we try to update
-	snapInfo := snaptest.MockSnap(c, "type: os", &snap.SideInfo{Revision: snap.R(42)})
+	snapInfo := snaptest.MockSnap(c, "name: os\ntype: os", &snap.SideInfo{Revision: snap.R(42)})
 	err := boot.SetNextBoot(snapInfo)
 	c.Assert(err, IsNil)
 

--- a/interfaces/backendtest/backendtest.go
+++ b/interfaces/backendtest/backendtest.go
@@ -58,7 +58,8 @@ developer: acme
 apps:
     smbd:
 slots:
-    iface:
+    slot:
+        interface: iface
 `
 const SambaYamlV1WithNmbd = `
 name: samba
@@ -68,7 +69,8 @@ apps:
     smbd:
     nmbd:
 slots:
-    iface:
+    slot:
+        interface: iface
 `
 const SambaYamlV1NoSlot = `
 name: samba
@@ -92,7 +94,8 @@ developer: acme
 apps:
     smbd:
 slots:
-    iface:
+    slot:
+        interface: iface
 `
 const SambaYamlWithHook = `
 name: samba
@@ -101,9 +104,13 @@ apps:
     nmbd:
 hooks:
     apply-config:
-        plugs: [iface]
+        plugs: [plug]
 slots:
-    iface:
+    slot:
+        interface: iface
+plugs:
+    plug:
+        interface: iface
 `
 const HookYaml = `
 name: foo
@@ -112,21 +119,24 @@ developer: acme
 hooks:
     apply-config:
 plugs:
-    iface:
+    plug:
+        interface: iface
 `
 const PlugNoAppsYaml = `
 name: foo
 version: 1
 developer: acme
 plugs:
-    iface:
+    plug:
+        interface: iface
 `
 const SlotNoAppsYaml = `
 name: foo
 version: 1
 developer: acme
 slots:
-    iface:
+    slots:
+        interface: iface
 `
 
 // Support code for tests

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -70,10 +70,10 @@ slots:
     parent-dir-path:
         interface: bool-file
         path: "/sys/class/gpio/../value"
-    bad-interface: other-interface
+    bad-interface-slot: other-interface
 plugs:
     plug: bool-file
-    bad-interface: other-interface
+    bad-interface-plug: other-interface
 `))
 	c.Assert(err, IsNil)
 	s.gpioSlot = &interfaces.Slot{SlotInfo: info.Slots["gpio"]}
@@ -81,9 +81,9 @@ plugs:
 	s.missingPathSlot = &interfaces.Slot{SlotInfo: info.Slots["missing-path"]}
 	s.badPathSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-path"]}
 	s.parentDirPathSlot = &interfaces.Slot{SlotInfo: info.Slots["parent-dir-path"]}
-	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-interface"]}
+	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-interface-slot"]}
 	s.plug = &interfaces.Plug{PlugInfo: info.Plugs["plug"]}
-	s.badInterfacePlug = &interfaces.Plug{PlugInfo: info.Plugs["bad-interface"]}
+	s.badInterfacePlug = &interfaces.Plug{PlugInfo: info.Plugs["bad-interface-plug"]}
 }
 
 func (s *BoolFileInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -58,18 +58,18 @@ slots:
     bad-number:
         interface: gpio
         number: forty-two
-    bad-interface: other-interface
+    bad-interface-slot: other-interface
 plugs:
     plug: gpio
-    bad-interface: other-interface
+    bad-interface-plug: other-interface
 `))
 	c.Assert(gadgetErr, IsNil)
 	s.gadgetGpioSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["my-pin"]}
 	s.gadgetMissingNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["missing-number"]}
 	s.gadgetBadNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-number"]}
-	s.gadgetBadInterfaceSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-interface"]}
+	s.gadgetBadInterfaceSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-interface-slot"]}
 	s.gadgetPlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["plug"]}
-	s.gadgetBadInterfacePlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["bad-interface"]}
+	s.gadgetBadInterfacePlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["bad-interface-plug"]}
 
 	osInfo, osErr := snap.InfoFromSnapYaml([]byte(`
 name: my-core

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -100,10 +100,17 @@ apps:
     app2:
 hooks:
     apply-config:
-        plugs: [iface, iface2]
+        plugs: [iface-plug, iface2-plug]
+plugs:
+    iface-plug:
+        interface: iface
+    iface2-plug:
+        interface: iface2
 slots:
-    iface:
-    iface2:
+    iface-slot:
+        interface: iface
+    iface2-slot:
+        interface: iface2
 `
 
 func (s *backendSuite) TestSetupSetsupSimple(c *C) {

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -967,21 +967,21 @@ apps:
     daemon:
        command: foo --daemon
        plugs: [network, network-bind]
-       slots: [foo-socket]
+       slots: [foo-socket-slot]
     foo:
        command: fooctl
-       plugs: [foo-socket]
+       plugs: [foo-socket-plug]
 hooks:
     test-hook:
-       plugs: [foo-socket]
+       plugs: [foo-socket-plug]
 plugs:
-    foo-socket:
+    foo-socket-plug:
         interface: socket
         # $protocol: foo
     logging:
         interface: syslog
 slots:
-    foo-socket:
+    foo-socket-slot:
         interface: socket
         path: $SNAP_DATA/socket
         protocol: foo
@@ -1008,9 +1008,9 @@ slots:
 	hook := info.Hooks["test-hook"]
 	plug1 := info.Plugs["network"]
 	plug2 := info.Plugs["network-bind"]
-	plug3 := info.Plugs["foo-socket"]
+	plug3 := info.Plugs["foo-socket-plug"]
 	plug4 := info.Plugs["logging"]
-	slot1 := info.Slots["foo-socket"]
+	slot1 := info.Slots["foo-socket-slot"]
 	slot2 := info.Slots["tracing"]
 
 	// app1 ("daemon") has three plugs ("network", "network-bind", "logging")
@@ -1072,7 +1072,7 @@ slots:
 
 	c.Assert(plug3, Not(IsNil))
 	c.Check(plug3.Snap, Equals, info)
-	c.Check(plug3.Name, Equals, "foo-socket")
+	c.Check(plug3.Name, Equals, "foo-socket-plug")
 	c.Check(plug3.Interface, Equals, "socket")
 	c.Check(plug3.Attrs, HasLen, 0)
 	c.Check(plug3.Label, Equals, "")
@@ -1093,7 +1093,7 @@ slots:
 
 	c.Assert(slot1, Not(IsNil))
 	c.Check(slot1.Snap, Equals, info)
-	c.Check(slot1.Name, Equals, "foo-socket")
+	c.Check(slot1.Name, Equals, "foo-socket-slot")
 	c.Check(slot1.Interface, Equals, "socket")
 	c.Check(slot1.Attrs, DeepEquals, map[string]interface{}{
 		"protocol": "foo", "path": "$SNAP_DATA/socket"})


### PR DESCRIPTION
This branch contains fixes that show up once validation is turned on across all test code that just wants to use use a bit of (hopefully valid) snap yaml. I will follow up with a set of changes to switch all of the test code to use something new from snappiest that validates the input YAML.