### PR TITLE
revert 'allow mmaping pulseaudio buffers'

### DIFF
--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -27,7 +27,7 @@ import (
 )
 
 const pulseaudioConnectedPlugAppArmor = `
-/{run,dev}/shm/pulse-shm-* rwkm,
+/{run,dev}/shm/pulse-shm-* rwk,
 
 owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,


### PR DESCRIPTION
From the apparmor.d man page: 'm - allow PROT_EXEC with mmap(2) calls' and
using this with 'w' should not be allowed by the policy. Pulseaudio was
confirmed to only use 'PROT_READ | PROT_WRITE' and not PROT_EXEC and this only
showed up on a non-Ubuntu kernel that did not have the required AppArmor
patches for snappy applied.