### PR TITLE
tests: add missing quotes in security-device-cgroups/task.yaml 

### DIFF
--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -29,7 +29,7 @@ execute: |
     ! udevadm info $UDEVADM_PATH | grep -Pq "E: TAGS=.*?snap_test-snapd-tools_env"
 
     echo "And the device is not shown in the snap device list"
-    ! grep -q $DEVICE_ID /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    ! grep -q "$DEVICE_ID" /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
 
     echo "================================================="
 


### PR DESCRIPTION
I wonder how this every worked :/ $DEVICE_ID contains spaces, it looks like `c 1:11 rwm`.