### PR TITLE
many: avoid snap.InfoFromSnapYaml in tests

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/backendtest"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -284,10 +284,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerHooks(c *C) {
 }
 
 func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
-	snapInfo, err := snap.InfoFromSnapYaml([]byte(backendtest.SambaYamlV1))
-	c.Assert(err, IsNil)
+	snapInfo := snaptest.MockInfo(c, backendtest.SambaYamlV1, nil)
 	// NOTE: we don't call apparmor.MockTemplate()
-	err = s.Backend.Setup(snapInfo, false, s.Repo)
+	err := s.Backend.Setup(snapInfo, false, s.Repo)
 	c.Assert(err, IsNil)
 	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 	data, err := ioutil.ReadFile(profile)

--- a/interfaces/backendtest/backendtest.go
+++ b/interfaces/backendtest/backendtest.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 type BackendSuite struct {
@@ -143,30 +144,26 @@ slots:
 
 // InstallSnap "installs" a snap from YAML.
 func (s *BackendSuite) InstallSnap(c *C, devMode bool, snapYaml string, revision int) *snap.Info {
-	snapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
-	c.Assert(err, IsNil)
-	// this won't come from snap.yaml
-	snapInfo.Revision = snap.R(revision)
-	snapInfo.Developer = "acme"
-
+	snapInfo := snaptest.MockInfo(c, snapYaml, &snap.SideInfo{
+		Revision:  snap.R(revision),
+		Developer: "acme",
+	})
 	s.addPlugsSlots(c, snapInfo)
-	err = s.Backend.Setup(snapInfo, devMode, s.Repo)
+	err := s.Backend.Setup(snapInfo, devMode, s.Repo)
 	c.Assert(err, IsNil)
 	return snapInfo
 }
 
 // UpdateSnap "updates" an existing snap from YAML.
 func (s *BackendSuite) UpdateSnap(c *C, oldSnapInfo *snap.Info, devMode bool, snapYaml string, revision int) *snap.Info {
-	newSnapInfo, err := snap.InfoFromSnapYaml([]byte(snapYaml))
-	c.Assert(err, IsNil)
-	// this won't come from snap.yaml
-	newSnapInfo.Revision = snap.R(revision)
-	newSnapInfo.Developer = "acme"
-
+	newSnapInfo := snaptest.MockInfo(c, snapYaml, &snap.SideInfo{
+		Revision:  snap.R(revision),
+		Developer: "acme",
+	})
 	c.Assert(newSnapInfo.Name(), Equals, oldSnapInfo.Name())
 	s.removePlugsSlots(c, oldSnapInfo)
 	s.addPlugsSlots(c, newSnapInfo)
-	err = s.Backend.Setup(newSnapInfo, devMode, s.Repo)
+	err := s.Backend.Setup(newSnapInfo, devMode, s.Repo)
 	c.Assert(err, IsNil)
 	return newSnapInfo
 }

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -54,7 +55,7 @@ var _ = Suite(&BoolFileInterfaceSuite{
 })
 
 func (s *BoolFileInterfaceSuite) SetUpTest(c *C) {
-	info, err := snap.InfoFromSnapYaml([]byte(`
+	info := snaptest.MockInfo(c, `
 name: ubuntu-core
 slots:
     gpio:
@@ -74,8 +75,7 @@ slots:
 plugs:
     plug: bool-file
     bad-interface-plug: other-interface
-`))
-	c.Assert(err, IsNil)
+`, &snap.SideInfo{})
 	s.gpioSlot = &interfaces.Slot{SlotInfo: info.Slots["gpio"]}
 	s.ledSlot = &interfaces.Slot{SlotInfo: info.Slots["led"]}
 	s.missingPathSlot = &interfaces.Slot{SlotInfo: info.Slots["missing-path"]}

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -67,36 +68,32 @@ func (s *BrowserSupportInterfaceSuite) TestSanitizePlugNoAttrib(c *C) {
 }
 
 func (s *BrowserSupportInterfaceSuite) TestSanitizePlugWithAttrib(c *C) {
-	var mockSnapYaml = []byte(`name: browser-support-plug-snap
+	const mockSnapYaml = `name: browser-support-plug-snap
 version: 1.0
 plugs:
  browser-support-plug:
   interface: browser-support
   allow-sandbox: true
-`)
-
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["browser-support-plug"]}
-	err = s.iface.SanitizePlug(plug)
+	err := s.iface.SanitizePlug(plug)
 	c.Assert(err, IsNil)
 }
 
 func (s *BrowserSupportInterfaceSuite) TestSanitizePlugWithBadAttrib(c *C) {
-	var mockSnapYaml = []byte(`name: browser-support-plug-snap
+	const mockSnapYaml = `name: browser-support-plug-snap
 version: 1.0
 plugs:
  browser-support-plug:
   interface: browser-support
   allow-sandbox: bad
-`)
-
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["browser-support-plug"]}
-	err = s.iface.SanitizePlug(plug)
+	err := s.iface.SanitizePlug(plug)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "browser-support plug requires bool with 'allow-sandbox'")
 }
@@ -115,17 +112,15 @@ func (s *BrowserSupportInterfaceSuite) TestConnectedPlugSnippetWithoutAttrib(c *
 }
 
 func (s *BrowserSupportInterfaceSuite) TestConnectedPlugSnippetWithAttribFalse(c *C) {
-	var mockSnapYaml = []byte(`name: browser-support-plug-snap
+	const mockSnapYaml = `name: browser-support-plug-snap
 version: 1.0
 plugs:
  browser-support-plug:
   interface: browser-support
   allow-sandbox: false
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
-
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["browser-support-plug"]}
 
 	snippet, err := s.iface.ConnectedPlugSnippet(plug, s.slot, interfaces.SecurityAppArmor)
@@ -141,17 +136,14 @@ plugs:
 }
 
 func (s *BrowserSupportInterfaceSuite) TestConnectedPlugSnippetWithAttribTrue(c *C) {
-	var mockSnapYaml = []byte(`name: browser-support-plug-snap
+	const mockSnapYaml = `name: browser-support-plug-snap
 version: 1.0
 plugs:
  browser-support-plug:
   interface: browser-support
   allow-sandbox: true
-`)
-
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
-
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["browser-support-plug"]}
 
 	snippet, err := s.iface.ConnectedPlugSnippet(plug, s.slot, interfaces.SecurityAppArmor)

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -46,7 +46,7 @@ var _ = Suite(&GpioInterfaceSuite{
 })
 
 func (s *GpioInterfaceSuite) SetUpTest(c *C) {
-	gadgetInfo, gadgetErr := snap.InfoFromSnapYaml([]byte(`
+	gadgetInfo := snaptest.MockInfo(c, `
 name: my-device
 type: gadget
 slots:
@@ -62,8 +62,7 @@ slots:
 plugs:
     plug: gpio
     bad-interface-plug: other-interface
-`))
-	c.Assert(gadgetErr, IsNil)
+`, nil)
 	s.gadgetGpioSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["my-pin"]}
 	s.gadgetMissingNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["missing-number"]}
 	s.gadgetBadNumberSlot = &interfaces.Slot{SlotInfo: gadgetInfo.Slots["bad-number"]}
@@ -71,7 +70,7 @@ plugs:
 	s.gadgetPlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["plug"]}
 	s.gadgetBadInterfacePlug = &interfaces.Plug{PlugInfo: gadgetInfo.Plugs["bad-interface-plug"]}
 
-	osInfo, osErr := snap.InfoFromSnapYaml([]byte(`
+	osInfo := snaptest.MockInfo(c, `
 name: my-core
 type: os
 slots:
@@ -79,19 +78,17 @@ slots:
         interface: gpio
         number: 777
         direction: out
-`))
-	c.Assert(osErr, IsNil)
+`, nil)
 	s.osGpioSlot = &interfaces.Slot{SlotInfo: osInfo.Slots["my-pin"]}
 
-	appInfo, appErr := snap.InfoFromSnapYaml([]byte(`
+	appInfo := snaptest.MockInfo(c, `
 name: my-app
 slots:
     my-pin:
         interface: gpio
         number: 154
         direction: out
-`))
-	c.Assert(appErr, IsNil)
+`, nil)
 	s.appGpioSlot = &interfaces.Slot{SlotInfo: appInfo.Slots["my-pin"]}
 }
 

--- a/interfaces/builtin/hidraw_test.go
+++ b/interfaces/builtin/hidraw_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -58,7 +58,7 @@ var _ = Suite(&HidrawInterfaceSuite{
 })
 
 func (s *HidrawInterfaceSuite) SetUpTest(c *C) {
-	osSnapInfo, err := snap.InfoFromSnapYaml([]byte(`
+	osSnapInfo := snaptest.MockInfo(c, `
 name: ubuntu-core
 type: os
 slots:
@@ -79,8 +79,7 @@ slots:
         interface: hidraw
         path: /dev/hidraw9271
     bad-interface: other-interface
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	s.testSlot1 = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["test-port-1"]}
 	s.testSlot2 = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["test-port-2"]}
 	s.missingPathSlot = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["missing-path"]}
@@ -89,7 +88,7 @@ slots:
 	s.badPathSlot3 = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["bad-path-3"]}
 	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["bad-interface"]}
 
-	gadgetSnapInfo, err := snap.InfoFromSnapYaml([]byte(`
+	gadgetSnapInfo := snaptest.MockInfo(c, `
 name: some-device
 type: gadget
 slots:
@@ -118,15 +117,14 @@ slots:
       usb-vendor: 0x789a
       usb-product: 0x4321
       path: /dev/my-device
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	s.testUdev1 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-1"]}
 	s.testUdev2 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-2"]}
 	s.testUdevBadValue1 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-1"]}
 	s.testUdevBadValue2 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-2"]}
 	s.testUdevBadValue3 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-3"]}
 
-	consumingSnapInfo, err := snap.InfoFromSnapYaml([]byte(`
+	consumingSnapInfo := snaptest.MockInfo(c, `
 name: client-snap
 plugs:
     plug-for-device-1:
@@ -141,8 +139,7 @@ apps:
     app-accessing-2-devices:
         command: bar
         plugs: [plug-for-device-1, plug-for-device-2]
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	s.testPlugPort1 = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["plug-for-device-1"]}
 	s.testPlugPort2 = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["plug-for-device-2"]}
 }

--- a/interfaces/builtin/mpris_test.go
+++ b/interfaces/builtin/mpris_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -58,17 +59,14 @@ func (s *MprisInterfaceSuite) TestName(c *C) {
 }
 
 func (s *MprisInterfaceSuite) TestGetName(c *C) {
-	var mockSnapYaml = []byte(`name: mpris-client
+	const mockSnapYaml = `name: mpris-client
 version: 1.0
 slots:
  mpris-slot:
   interface: mpris
   name: foo
-`)
-
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
-
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
 	iface := &builtin.MprisInterface{}
 	name, err := builtin.MprisGetName(iface, slot.Attrs)
@@ -77,16 +75,13 @@ slots:
 }
 
 func (s *MprisInterfaceSuite) TestGetNameMissing(c *C) {
-	var mockSnapYaml = []byte(`name: mpris-client
+	const mockSnapYaml = `name: mpris-client
 version: 1.0
 slots:
  mpris-slot:
   interface: mpris
-`)
-
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
-
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
 	iface := &builtin.MprisInterface{}
 	name, err := builtin.MprisGetName(iface, slot.Attrs)
@@ -94,17 +89,14 @@ slots:
 	c.Assert(name, Equals, "@{SNAP_NAME}")
 }
 func (s *MprisInterfaceSuite) TestGetNameBadDot(c *C) {
-	var mockSnapYaml = []byte(`name: mpris-client
+	const mockSnapYaml = `name: mpris-client
 version: 1.0
 slots:
  mpris-slot:
   interface: mpris
   name: foo.bar
-`)
-
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
-
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
 	iface := &builtin.MprisInterface{}
 	name, err := builtin.MprisGetName(iface, slot.Attrs)
@@ -114,18 +106,15 @@ slots:
 }
 
 func (s *MprisInterfaceSuite) TestGetNameBadList(c *C) {
-	var mockSnapYaml = []byte(`name: mpris-client
+	const mockSnapYaml = `name: mpris-client
 version: 1.0
 slots:
  mpris-slot:
   interface: mpris
   name:
   - foo
-`)
-
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
-
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
 	iface := &builtin.MprisInterface{}
 	name, err := builtin.MprisGetName(iface, slot.Attrs)
@@ -135,17 +124,14 @@ slots:
 }
 
 func (s *MprisInterfaceSuite) TestGetNameUnknownAttribute(c *C) {
-	var mockSnapYaml = []byte(`name: mpris-client
+	const mockSnapYaml = `name: mpris-client
 version: 1.0
 slots:
  mpris-slot:
   interface: mpris
   unknown: foo
-`)
-
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
-
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
 	iface := &builtin.MprisInterface{}
 	name, err := builtin.MprisGetName(iface, slot.Attrs)
@@ -292,17 +278,14 @@ func (s *MprisInterfaceSuite) TestPermanentSlotAppArmor(c *C) {
 }
 
 func (s *MprisInterfaceSuite) TestPermanentSlotAppArmorWithName(c *C) {
-	var mockSnapYaml = []byte(`name: mpris-client
+	const mockSnapYaml = `name: mpris-client
 version: 1.0
 slots:
  mpris-slot:
   interface: mpris
   name: foo
-`)
-
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
-
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
 	iface := &builtin.MprisInterface{}
 	snippet, err := iface.PermanentSlotSnippet(slot, interfaces.SecurityAppArmor)

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -60,7 +60,7 @@ var _ = Suite(&SerialPortInterfaceSuite{
 })
 
 func (s *SerialPortInterfaceSuite) SetUpTest(c *C) {
-	osSnapInfo, err := snap.InfoFromSnapYaml([]byte(`
+	osSnapInfo := snaptest.MockInfo(c, `
 name: ubuntu-core
 type: os
 slots:
@@ -87,8 +87,7 @@ slots:
         interface: serial-port
         path: /dev/ttyUSB9271
     bad-interface: other-interface
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	s.testSlot1 = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["test-port-1"]}
 	s.testSlot2 = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["test-port-2"]}
 	s.testSlot3 = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["test-port-3"]}
@@ -99,7 +98,7 @@ slots:
 	s.badPathSlot3 = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["bad-path-3"]}
 	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["bad-interface"]}
 
-	gadgetSnapInfo, err := snap.InfoFromSnapYaml([]byte(`
+	gadgetSnapInfo := snaptest.MockInfo(c, `
 name: some-device
 type: gadget
 slots:
@@ -128,15 +127,14 @@ slots:
       usb-vendor: 0x789a
       usb-product: 0x4321
       path: /dev/my-device
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	s.testUdev1 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-1"]}
 	s.testUdev2 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-2"]}
 	s.testUdevBadValue1 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-1"]}
 	s.testUdevBadValue2 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-2"]}
 	s.testUdevBadValue3 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-3"]}
 
-	consumingSnapInfo, err := snap.InfoFromSnapYaml([]byte(`
+	consumingSnapInfo := snaptest.MockInfo(c, `
 name: client-snap
 plugs:
     plug-for-port-1:
@@ -151,8 +149,7 @@ apps:
     app-accessing-2-ports:
         command: bar
         plugs: [plug-for-port-1, plug-for-port-2]
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	s.testPlugPort1 = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["plug-for-port-1"]}
 	s.testPlugPort2 = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["plug-for-port-2"]}
 }

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -45,7 +46,7 @@ var _ = Suite(&RepositorySuite{
 })
 
 func (s *RepositorySuite) SetUpTest(c *C) {
-	consumer, err := snap.InfoFromSnapYaml([]byte(`
+	consumer := snaptest.MockInfo(c, `
 name: consumer
 apps:
     app:
@@ -56,10 +57,9 @@ plugs:
         interface: interface
         label: label
         attr: value
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	s.plug = &Plug{PlugInfo: consumer.Plugs["plug"]}
-	producer, err := snap.InfoFromSnapYaml([]byte(`
+	producer := snaptest.MockInfo(c, `
 name: producer
 apps:
     app:
@@ -70,20 +70,18 @@ slots:
         interface: interface
         label: label
         attr: value
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	s.slot = &Slot{SlotInfo: producer.Slots["slot"]}
 	s.emptyRepo = NewRepository()
 	s.testRepo = NewRepository()
-	err = s.testRepo.AddInterface(s.iface)
+	err := s.testRepo.AddInterface(s.iface)
 	c.Assert(err, IsNil)
 }
 
 func addPlugsSlots(c *C, repo *Repository, yamls ...string) []*snap.Info {
 	result := make([]*snap.Info, len(yamls))
 	for i, yaml := range yamls {
-		info, err := snap.InfoFromSnapYaml([]byte(yaml))
-		c.Assert(err, IsNil)
+		info := snaptest.MockInfo(c, yaml, nil)
 		result[i] = info
 		for _, plugInfo := range info.Plugs {
 			err := repo.AddPlug(&Plug{PlugInfo: plugInfo})
@@ -928,21 +926,19 @@ func (s *RepositorySuite) TestAutoConnectBlacklist(c *C) {
 	c.Assert(err, IsNil)
 
 	// Add a pair of snaps with plugs/slots using those two interfaces
-	consumer, err := snap.InfoFromSnapYaml([]byte(`
+	consumer := snaptest.MockInfo(c, `
 name: consumer
 plugs:
     auto:
     manual:
-`))
-	c.Assert(err, IsNil)
-	producer, err := snap.InfoFromSnapYaml([]byte(`
+`, nil)
+	producer := snaptest.MockInfo(c, `
 name: producer
 type: os
 slots:
     auto:
     manual:
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	err = repo.AddSnap(producer)
 	c.Assert(err, IsNil)
 	err = repo.AddSnap(consumer)
@@ -997,7 +993,7 @@ func (s *AddRemoveSuite) TestAddSnapComplexErrorHandling(c *C) {
 		SanitizePlugCallback: func(plug *Plug) error { return fmt.Errorf("plug is invalid") },
 		SanitizeSlotCallback: func(slot *Slot) error { return fmt.Errorf("slot is invalid") },
 	})
-	snapInfo, err := snap.InfoFromSnapYaml([]byte(`
+	snapInfo := snaptest.MockInfo(c, `
 name: complex
 plugs:
     invalid-plug-iface:
@@ -1005,8 +1001,7 @@ plugs:
 slots:
     invalid-slot-iface:
     unknown-slot-iface:
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	err = s.repo.AddSnap(snapInfo)
 	c.Check(err, ErrorMatches,
 		`snap "complex" has bad plugs or slots: invalid-plug-iface \(plug is invalid\); invalid-slot-iface \(slot is invalid\); unknown-plug-iface, unknown-slot-iface \(unknown interface\)`)
@@ -1031,8 +1026,7 @@ apps:
 `
 
 func (s *AddRemoveSuite) addSnap(c *C, yaml string) (*snap.Info, error) {
-	snapInfo, err := snap.InfoFromSnapYaml([]byte(yaml))
-	c.Assert(err, IsNil)
+	snapInfo := snaptest.MockInfo(c, yaml, nil)
 	return snapInfo, s.repo.AddSnap(snapInfo)
 }
 
@@ -1115,24 +1109,23 @@ func (s *DisconnectSnapSuite) SetUpTest(c *C) {
 	err = s.repo.AddInterface(&TestInterface{InterfaceName: "iface-b"})
 	c.Assert(err, IsNil)
 
-	s.s1, err = snap.InfoFromSnapYaml([]byte(`
+	s.s1 = snaptest.MockInfo(c, `
 name: s1
 plugs:
     iface-a:
 slots:
     iface-b:
-`))
-	c.Assert(err, IsNil)
+`, nil)
 	err = s.repo.AddSnap(s.s1)
 	c.Assert(err, IsNil)
 
-	s.s2, err = snap.InfoFromSnapYaml([]byte(`
+	s.s2 = snaptest.MockInfo(c, `
 name: s2
 plugs:
     iface-b:
 slots:
     iface-a:
-`))
+`, nil)
 	c.Assert(err, IsNil)
 	err = s.repo.AddSnap(s.s2)
 	c.Assert(err, IsNil)
@@ -1184,22 +1177,20 @@ func makeContentConnectionTestSnaps(c *C, plugContentToken, slotContentToken str
 	repo := NewRepository()
 	err := repo.AddInterface(&TestInterface{InterfaceName: "content", AutoConnectFlag: true})
 
-	plugSnap, err := snap.InfoFromSnapYaml([]byte(fmt.Sprintf(`
+	plugSnap := snaptest.MockInfo(c, fmt.Sprintf(`
 name: content-plug-snap
 plugs:
   import-content:
     interface: content
     content: %s
-`, plugContentToken)))
-	c.Assert(err, IsNil)
-	slotSnap, err := snap.InfoFromSnapYaml([]byte(fmt.Sprintf(`
+`, plugContentToken), nil)
+	slotSnap := snaptest.MockInfo(c, fmt.Sprintf(`
 name: content-slot-snap
 slots:
   exported-content:
     interface: content
     content: %s
-`, slotContentToken)))
-	c.Assert(err, IsNil)
+`, slotContentToken), nil)
 
 	err = repo.AddSnap(plugSnap)
 	c.Assert(err, IsNil)
@@ -1248,16 +1239,17 @@ func makeLivepatchConnectionTestSnaps(c *C, name, developer string) (*Repository
 	err = repo.AddInterface(&TestInterface{InterfaceName: "non-restricted", AutoConnectFlag: true})
 	c.Assert(err, IsNil)
 
-	plugSnap, err := snap.InfoFromSnapYaml([]byte(fmt.Sprintf(`
+	plugSnap := snaptest.MockInfo(c, fmt.Sprintf(`
 name: %s
 plugs:
   restricted:
     interface: restricted
   non-restricted:
     interface: non-restricted
-`, name)))
-	c.Assert(err, IsNil)
-	slotSnap, err := snap.InfoFromSnapYaml([]byte(`
+`, name), &snap.SideInfo{
+		DeveloperID: developer,
+	})
+	slotSnap := snaptest.MockInfo(c, `
 name: ubuntu-core
 type: os
 slots:
@@ -1265,12 +1257,9 @@ slots:
     interface: restricted
   non-restricted:
     interface: non-restricted
-`))
-	c.Assert(err, IsNil)
-
-	plugSnap.DeveloperID = developer
-	slotSnap.DeveloperID = "canonical"
-	slotSnap.Type = snap.TypeOS
+`, &snap.SideInfo{
+		DeveloperID: "canonical",
+	})
 
 	err = repo.AddSnap(plugSnap)
 	c.Assert(err, IsNil)

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backendtest"
 	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -152,10 +152,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithNoHooks(c *C) {
 }
 
 func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
-	snapInfo, err := snap.InfoFromSnapYaml([]byte(backendtest.SambaYamlV1))
-	c.Assert(err, IsNil)
+	snapInfo := snaptest.MockInfo(c, backendtest.SambaYamlV1, nil)
 	// NOTE: we don't call seccomp.MockTemplate()
-	err = s.Backend.Setup(snapInfo, false, s.Repo)
+	err := s.Backend.Setup(snapInfo, false, s.Repo)
 	c.Assert(err, IsNil)
 	profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.smbd")
 	data, err := ioutil.ReadFile(profile)

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -55,7 +55,7 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	return snapInfo
 }
 
-// MockInfo parses the give snap.yaml text and returns a validated snap.Info object with included the option sideInfo.
+// MockInfo parses the given snap.yaml text and returns a validated snap.Info object including the optional SideInfo.
 //
 // The result is just kept in memory, there is nothing kept on disk. If that is
 // desired please use MockSnap instead.

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -55,6 +55,23 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	return snapInfo
 }
 
+// MockInfo parses snap.yaml and returns a validated snap.Info object.
+//
+// The result is just kept in memory, there is nothing kept on disk. If that is
+// desired please use MockSnap instead.
+func MockInfo(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
+	if sideInfo == nil {
+		sideInfo = &snap.SideInfo{}
+	}
+
+	snapInfo, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	c.Assert(err, check.IsNil)
+	snapInfo.SideInfo = *sideInfo
+	err = snap.Validate(snapInfo)
+	c.Assert(err, check.IsNil)
+	return snapInfo
+}
+
 // PopulateDir populates the directory with files specified as pairs of relative file path and its content. Useful to add extra files to a snap.
 func PopulateDir(dir string, files [][]string) {
 	for _, filenameAndContent := range files {

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -55,7 +55,7 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	return snapInfo
 }
 
-// MockInfo parses snap.yaml and returns a validated snap.Info object.
+// MockInfo parses the give snap.yaml text and returns a validated snap.Info object with included the option sideInfo.
 //
 // The result is just kept in memory, there is nothing kept on disk. If that is
 // desired please use MockSnap instead.

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -21,6 +21,7 @@ package snaptest_test
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -68,6 +69,20 @@ func (s *snapTestSuite) TestMockSnap(c *C) {
 
 	c.Check(string(cont), Equals, sampleYaml)
 
+	// More
+	c.Check(snapInfo.Apps["app"].Command, Equals, "foo")
+	c.Check(snapInfo.Plugs["network"].Interface, Equals, "network")
+}
+
+func (s *snapTestSuite) TestMockInfo(c *C) {
+	snapInfo := snaptest.MockInfo(c, sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
+	// Data from YAML is used
+	c.Check(snapInfo.Name(), Equals, "sample")
+	// Data from SideInfo is used
+	c.Check(snapInfo.Revision, Equals, snap.R(42))
+	// The YAML is *not* placed on disk
+	_, err := os.Stat(filepath.Join(dirs.SnapMountDir, "sample", "42", "meta", "snap.yaml"))
+	c.Assert(os.IsNotExist(err), Equals, true)
 	// More
 	c.Check(snapInfo.Apps["app"].Command, Equals, "foo")
 	c.Check(snapInfo.Plugs["network"].Interface, Equals, "network")


### PR DESCRIPTION
This branch switches all of the interface/ code from snap.InfoFromSnapYaml, which does no validation, to the new snaptest.MockInfo (similar to the existing MockSnap). This ensures that YAML data in tests is accurately testing how the system would behave in a given situation by preventing invalid YAML to silently cause issues.