### PR TITLE
interfaces/apparmor: allow 'm' in default policy for snap-exec

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -185,6 +185,9 @@ var defaultTemplate = []byte(`
   /{,usr/}bin/zip ixr,
   /{,usr/}bin/zipgrep ixr,
 
+  # For snappy reexec on 4.8+ kernels
+  /usr/lib/snapd/snap-exec m,
+
   # For printing the cache (we don't allow updating the cache)
   /{,usr/}sbin/ldconfig{,.real} ixr,
 


### PR DESCRIPTION
4.8+ kernels have a semantic change where the location of the mmap check in
the binfmt_elf loader changed along with the cred that is used for the check.
As a result, when using snappy reexec on these kernels we must allow 'm' on
/usr/lib/snapd/snap-exec.

Bug: LP: #1626121