### PR TITLE
interface/builtin: add ptrace support to system-trace

### DIFF
--- a/interfaces/builtin/system_trace.go
+++ b/interfaces/builtin/system_trace.go
@@ -33,6 +33,9 @@ const systemTraceConnectedPlugAppArmor = `
   capability sys_admin,
   capability sys_resource,
 
+  # Enable ptrace from/to a peer in the same profile.
+  ptrace (trace, tracedby) peer=snap.@{SNAP_NAME}.**,
+
   # For kernel probes, etc
   /sys/kernel/debug/kprobes/ r,
   /sys/kernel/debug/kprobes/** r,

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type SystemTraceInterfaceSuite struct {
@@ -83,6 +84,7 @@ func (s *SystemTraceInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
+	c.Assert(string(snippet), testutil.Contains, `ptrace (trace, tracedby) peer=snap.@{SNAP_NAME}.**`)
 }
 
 func (s *SystemTraceInterfaceSuite) TestAutoConnect(c *C) {


### PR DESCRIPTION
[Disclaimer]
I am not sure if this is the right interface to add this rule.
Judging the interface documentation/description it seems to match, as this interface
is intended  to enable system level trace capabilities, being ptrace an interface
to observe and control a process. 

This commit adds an apparmor rule to allow
the usage of ptrace on a peer within the same profile.



