### PR TITLE
tests: increase timeout for key generation in create-key test

### DIFF
--- a/tests/main/create-key/successful_default.exp
+++ b/tests/main/create-key/successful_default.exp
@@ -1,3 +1,5 @@
+set timeout 60
+
 spawn snap create-key
 
 expect "Passphrase: "

--- a/tests/main/create-key/successful_non_default.exp
+++ b/tests/main/create-key/successful_non_default.exp
@@ -1,3 +1,5 @@
+set timeout 60
+
 spawn snap create-key another
 
 expect "Passphrase: "

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -34,10 +34,10 @@ prepare: |
 
 execute: |
     echo "Checking passphrase mismatch error"
-    expect -f passphrase_mismatch.exp
+    expect -d -f passphrase_mismatch.exp
 
     echo "Checking successful default key pair generation"
-    expect -f successful_default.exp
+    expect -d -f successful_default.exp
 
     echo "Checking successful non-default key pair generation"
-    expect -f successful_non_default.exp
+    expect -d -f successful_non_default.exp


### PR DESCRIPTION
Also add debug output so that we have a better idea what is going wrong if this fails.