### PR TITLE
tests: skip some tests on non-amd64 architectures

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -11,6 +11,7 @@ environment:
     SPREAD_STORE_PASSWORD: "$(HOST: echo $SPREAD_STORE_PASSWORD)"
     LANG: "$(echo ${LANG:-C.UTF-8})"
     LANGUAGE: "$(echo ${LANGUAGE:-en})"
+    KARCH: "$(uname -m)"
     # important to ensure adhoc and linode/qemu behave the same
     SUDO_USER: ""
     SUDO_UID: ""
@@ -62,7 +63,7 @@ exclude:
 
 prepare: |
     # this indicates that the server got reused, nothing to setup
-    [ "$REUSE_PROJECT" != 1 ] || exit 0
+    [ "${REUSE_PROJECT:-}" != 1 ] || exit 0
 
     # apt update is hanging on security.ubuntu.com with IPv6.
     sysctl -w net.ipv6.conf.all.disable_ipv6=1

--- a/tests/main/interfaces-bluez/task.yaml
+++ b/tests/main/interfaces-bluez/task.yaml
@@ -13,6 +13,11 @@ environment:
     SNAP_NAME: bluez
 
 execute: |
+    if [ "$KARCH" != "x86_64" ]; then
+        echo "Skipping for non amd64 architectures"
+        exit 0
+    fi
+
     echo "Installing bluez snap from the store ..."
     expected="(?s)$SNAP_NAME .* from 'canonical' installed\n"
     snap install $SNAP_NAME | grep -Pzq "$expected"

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -19,9 +19,6 @@ environment:
     TEST_FILE: /var/snap/test-snapd-cups-control-consumer/current/test_file.txt
 
 prepare: |
-    echo "Given a snap declaring a cups plug is installed"
-    snap install test-snapd-cups-control-consumer
-
     echo "And the pdf printer is available"
     apt install -y printer-driver-cups-pdf
 
@@ -31,6 +28,14 @@ restore: |
     rm -rf $HOME/PDF $TEST_FILE print.error
 
 execute: |
+    if [ "$KARCH" != "x86_64" ]; then
+        echo "Skipping for non amd64 architectures"
+        exit 0
+    fi
+
+    echo "Given a snap declaring a cups plug is installed"
+    snap install test-snapd-cups-control-consumer
+
     CONNECTED_PATTERN=":cups-control +test-snapd-cups-control-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +test-snapd-cups-control-consumer:cups-control"
 

--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -17,9 +17,6 @@ environment:
     MOUNT_POINT: /var/snap/test-snapd-fuse-consumer/current/mount_point
 
 prepare: |
-    echo "Given a snap declaring a fuse plug is installed"
-    snap install test-snapd-fuse-consumer
-
     echo "And a user writable mount point is created"
     mkdir -p $MOUNT_POINT
 
@@ -28,6 +25,14 @@ restore: |
     rm -rf $MOUNT_POINT fuse.error
 
 execute: |
+    if [ "$KARCH" != "x86_64" ]; then
+        echo "Skipping for non amd64 architectures"
+        exit 0
+    fi
+
+    echo "Given a snap declaring a fuse plug is installed"
+    snap install test-snapd-fuse-consumer
+
     CONNECTED_PATTERN=":fuse-support +test-snapd-fuse-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +test-snapd-fuse-consumer:fuse-support"
 

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -13,9 +13,6 @@ summary: |
     it without error while the plug is connected.
 
 prepare: |
-    echo "Given a snap declaring a plug on the upower-observe interface is installed"
-    snap install --edge test-snapd-upower-observe-consumer
-
     apt install -y upower
 
 restore: |
@@ -24,6 +21,14 @@ restore: |
     apt autoremove -y
 
 execute: |
+    if [ "$KARCH" != "x86_64" ]; then
+        echo "Skipping for non amd64 architectures"
+        exit 0
+    fi
+
+    echo "Given a snap declaring a plug on the upower-observe interface is installed"
+    snap install --edge test-snapd-upower-observe-consumer
+
     CONNECTED_PATTERN=":upower-observe +test-snapd-upower-observe-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +test-snapd-upower-observe-consumer:upower-observe"
 

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -6,6 +6,11 @@ restore: |
     snap logout || true
 
 execute: |
+    if [ "$KARCH" != "x86_64" ]; then
+        echo "Skipping for non amd64 architectures"
+        exit 0
+    fi
+
     echo "Checking missing email error"
     expect -f missing_email_error.exp
 

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -21,6 +21,11 @@ restore: |
     udevadm trigger
 
 execute: |
+    if [ "$KARCH" != "x86_64" ]; then
+        echo "Skipping for non amd64 architectures"
+        exit 0
+    fi
+
     echo "Given a snap is installed"
     snapbuild $TESTSLIB/snaps/test-snapd-tools .
     snap install --dangerous ./test-snapd-tools_1.0_all.snap

--- a/tests/main/server-snap/task.yaml
+++ b/tests/main/server-snap/task.yaml
@@ -14,7 +14,15 @@ environment:
 
 warn-timeout: 3m
 
-prepare: |
+restore: |
+    rm -f request.txt
+
+execute: |
+    if [ "$KARCH" != "x86_64" ]; then
+        echo "Skipping for non amd64 architectures"
+        exit 0
+    fi
+
     snap install $SNAP_NAME
     cat > request.txt <<EOF
     GET / HTTP/1.0
@@ -23,12 +31,10 @@ prepare: |
     echo "Wait for the service to be listening, limited to the task kill-timeout"
     while ! netstat -lnt | grep -Pq "tcp.*?:$PORT +.*?LISTEN\n*"; do sleep 0.5; done
 
-restore: |
-    rm -f request.txt
-
-execute: |
     response=$(nc -"$IP_VERSION" "$LOCALHOST" "$PORT" < request.txt)
 
     statusPattern="(?s)HTTP\/1\.0 200 OK\n*"
     echo "$response" | grep -Pzq "$statusPattern"
     echo "$response" | grep -Pzq "$TEXT"
+
+


### PR DESCRIPTION
This avoids errors during the autopkgtests that are run on all ubuntu arches, see e.g.:
https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-yakkety/yakkety/ppc64el/s/snapd/20160920_134059@/log.gz