### PR TITLE
interfaces/builtin: allow network-manager to access netplan conf files

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -69,6 +69,10 @@ network packet,
 
 /run/udev/data/* r,
 
+# Allow access to configuration files generated on the fly
+# from netplan
+/run/NetworkManager/{,**} r,
+
 # Needed by the ifupdown plugin to check which interfaces can
 # be managed an which not.
 /etc/network/interfaces r,


### PR DESCRIPTION
Allow network-manager to access the configuration files netplan generated for it.