### PR TITLE
tests: add a test for core about device initialization and device registration and auth

### DIFF
--- a/tests/main/ubuntu-core-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-device-reg/task.yaml
@@ -1,0 +1,19 @@
+summary: |
+    Ensure after device initialisation registration worked and
+    we have a serial and can acquire a session macaroon
+systems: [ubuntu-core-16-64]
+execute: |
+    echo "We have a model assertion"
+    snap known model|grep "brand-id: canonical"
+
+    echo "Wait for device initialisation to be done"
+    while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
+
+    echo "Check we have a serial"
+    snap known serial|grep "authority-id: canonical"
+    snap known serial|grep "brand-id: canonical"
+    snap known serial|grep "model: pc"
+
+    echo "Make sure we could acquire a session macaroon"
+    snap find pc
+    grep -qE '"session-macaroon":"[^"]' /var/lib/snapd/state.json


### PR DESCRIPTION
This adds an essential test about device initialisation obtaining a serial and snapd being able to acquire a session macaroon.