### PR TITLE
progress: use New64 and fix output newline

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -100,12 +100,10 @@ func NewTextProgress() *TextProgress {
 
 // Start starts showing progress
 func (t *TextProgress) Start(label string, total float64) {
-	// TODO go to New64 once we update the pb package.
-	t.pbar = pb.New(0)
+	t.pbar = pb.New64(0)
 	t.pbar.Total = int64(total)
 	t.pbar.ShowSpeed = true
 	t.pbar.Units = pb.U_BYTES
-	t.pbar.NotPrint = true
 	t.pbar.Prefix(label)
 	t.pbar.Start()
 }
@@ -123,7 +121,11 @@ func (t *TextProgress) SetTotal(total float64) {
 // Finished stops displaying the progress
 func (t *TextProgress) Finished() {
 	if t.pbar != nil {
+		// workaround silly pb that always does a fmt.Println() on
+		// finish (unless NotPrint is set)
+		t.pbar.NotPrint = true
 		t.pbar.Finish()
+		t.pbar.NotPrint = false
 	}
 	fmt.Printf("\r\033[K")
 }


### PR DESCRIPTION
This also fixes missing progress in master. The `NotPrint` prevents any prints which is what we want for "Finish()" only. On Finish() it usually prints a final \n. However LP: #1584590 ask for the progress line to be replaced with a summary what happend. E.g. line:
`foo [====.....] 100/200kb `
becomes (when finished)
`foo installed`
and for that we need to tell pb to not do the final newline.