### PR TITLE
interface/builtin: access system bus on screen-inhibit-control

### DIFF
--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -26,6 +26,7 @@ import (
 const screenInhibitControlConnectedPlugAppArmor = `
 # Description: Can inhibit and uninhibit screen savers in desktop sessions.
 #include <abstractions/dbus-session-strict>
+#include <abstractions/dbus-strict>
 
 # gnome-session
 dbus (send)


### PR DESCRIPTION
System bus access is needed to use the Unity screen blanking API.