### PR TITLE
overlord,store: clean up serial-proof plumbing code

### DIFF
--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -222,9 +222,6 @@ type DeviceAssertions interface {
 
 	// DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the device serial assertion.
 	DeviceSessionRequest(nonce string) (*asserts.DeviceSessionRequest, *asserts.Serial, error)
-
-	// SerialProof produces a serial-proof with the given nonce. (DEPRECATED)
-	SerialProof(nonce string) (*asserts.SerialProof, error)
 }
 
 var (
@@ -241,9 +238,6 @@ type AuthContext interface {
 	UpdateUserAuth(user *UserState, discharges []string) (actual *UserState, err error)
 
 	StoreID(fallback string) (string, error)
-
-	Serial() ([]byte, error)                  // DEPRECATED
-	SerialProof(nonce string) ([]byte, error) // DEPRECATED
 
 	DeviceSessionRequest(nonce string) (devSessionRequest []byte, serial []byte, err error)
 }
@@ -329,30 +323,6 @@ func (ac *authContext) StoreID(fallback string) (string, error) {
 		return storeID, nil
 	}
 	return fallback, nil
-}
-
-// Serial returns the encoded device serial assertion.
-func (ac *authContext) Serial() ([]byte, error) {
-	if ac.deviceAsserts == nil {
-		return nil, state.ErrNoState
-	}
-	serial, err := ac.deviceAsserts.Serial()
-	if err != nil {
-		return nil, err
-	}
-	return asserts.Encode(serial), nil
-}
-
-// SerialProof produces a serial-proof with the given nonce.
-func (ac *authContext) SerialProof(nonce string) ([]byte, error) {
-	if ac.deviceAsserts == nil {
-		return nil, state.ErrNoState
-	}
-	proof, err := ac.deviceAsserts.SerialProof(nonce)
-	if err != nil {
-		return nil, err
-	}
-	return asserts.Encode(proof), nil
 }
 
 // DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the encoded device serial assertion. It returns ErrNoSerial if the device serial is not yet initialized.

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -492,26 +492,6 @@ func (m *DeviceManager) DeviceSessionRequest(nonce string) (*asserts.DeviceSessi
 
 }
 
-// SerialProof produces a serial-proof with the given nonce. (DEPRECATED)
-func (m *DeviceManager) SerialProof(nonce string) (*asserts.SerialProof, error) {
-	m.state.Lock()
-	defer m.state.Unlock()
-
-	privKey, err := m.keyPair()
-	if err != nil {
-		return nil, err
-	}
-
-	a, err := asserts.SignWithoutAuthority(asserts.SerialProofType, map[string]interface{}{
-		"nonce": nonce,
-	}, nil, privKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return a.(*asserts.SerialProof), err
-}
-
 // Model returns the device model assertion.
 func Model(st *state.State) (*asserts.Model, error) {
 	device, err := auth.Device(st)

--- a/overlord/devicestate/devicemgr_test.go
+++ b/overlord/devicestate/devicemgr_test.go
@@ -547,28 +547,6 @@ func (s *deviceMgrSuite) TestDeviceAssertionsModelAndSerial(c *C) {
 	c.Check(ser.Serial(), Equals, "8989")
 }
 
-func (s *deviceMgrSuite) TestDeviceAssertionsSerialProof(c *C) {
-	// nothing there
-	_, err := s.mgr.SerialProof("NONCE-1")
-	c.Check(err, Equals, state.ErrNoState)
-
-	s.state.Lock()
-	privKey, _ := assertstest.GenerateKey(1024)
-	// setup state as done by first-boot/Ensure/doGenerateDeviceKey
-	auth.SetDevice(s.state, &auth.DeviceState{
-		KeyID: privKey.PublicKey().ID(),
-	})
-	s.mgr.KeypairManager().Put(privKey)
-	s.state.Unlock()
-
-	serialProof, err := s.mgr.SerialProof("NONCE-1")
-	c.Assert(err, IsNil)
-
-	// correctly signed with device key
-	err = asserts.SignatureCheck(serialProof, privKey.PublicKey())
-	c.Check(err, IsNil)
-}
-
 func (s *deviceMgrSuite) TestDeviceAssertionsDeviceSessionRequest(c *C) {
 	// nothing there
 	_, _, err := s.mgr.DeviceSessionRequest("NONCE-1")

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -930,32 +930,6 @@ func (s *authContextSetupSuite) TearDownTest(c *C) {
 	s.restoreTrusted()
 }
 
-func (s *authContextSetupSuite) TestSerial(c *C) {
-	st := s.o.State()
-	st.Lock()
-	defer st.Unlock()
-
-	st.Unlock()
-	encSerial, err := s.ac.Serial()
-	st.Lock()
-	c.Check(err, Equals, state.ErrNoState)
-
-	// setup serial in system state
-	auth.SetDevice(st, &auth.DeviceState{
-		Brand:  s.serial.BrandID(),
-		Model:  s.serial.Model(),
-		Serial: s.serial.Serial(),
-	})
-	err = assertstate.Add(st, s.serial)
-	c.Assert(err, IsNil)
-
-	st.Unlock()
-	encSerial, err = s.ac.Serial()
-	st.Lock()
-	c.Assert(err, IsNil)
-	c.Check(encSerial, DeepEquals, asserts.Encode(s.serial))
-}
-
 func (s *authContextSetupSuite) TestStoreID(c *C) {
 	st := s.o.State()
 	st.Lock()
@@ -981,32 +955,6 @@ func (s *authContextSetupSuite) TestStoreID(c *C) {
 	st.Lock()
 	c.Assert(err, IsNil)
 	c.Check(storeID, Equals, "my-brand-store-id")
-}
-
-func (s *authContextSetupSuite) TestSerialProof(c *C) {
-	st := s.o.State()
-	st.Lock()
-	defer st.Unlock()
-
-	st.Unlock()
-	_, err := s.ac.SerialProof("NONCE")
-	st.Lock()
-	c.Check(err, Equals, state.ErrNoState)
-
-	// setup state as done by first-boot/Ensure/doGenerateDeviceKey
-	auth.SetDevice(st, &auth.DeviceState{
-		KeyID: deviceKey.PublicKey().ID(),
-	})
-	kpMgr, err := asserts.OpenFSKeypairManager(dirs.SnapDeviceDir)
-	c.Assert(err, IsNil)
-	err = kpMgr.Put(deviceKey)
-	c.Assert(err, IsNil)
-
-	st.Unlock()
-	proof, err := s.ac.SerialProof("NONCE")
-	st.Lock()
-	c.Assert(err, IsNil)
-	c.Check(bytes.HasPrefix(proof, []byte("type: serial-proof\n")), Equals, true)
 }
 
 func (s *authContextSetupSuite) TestDeviceSessionRequest(c *C) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -128,14 +128,6 @@ func (ac *testAuthContext) StoreID(fallback string) (string, error) {
 	return fallback, nil
 }
 
-func (ac *testAuthContext) Serial() ([]byte, error) {
-	panic("Serial is deprecated, it should not be called")
-}
-
-func (ac *testAuthContext) SerialProof(nonce string) ([]byte, error) {
-	panic("SerialProof is deprecated, it should not be called")
-}
-
 func (ac *testAuthContext) DeviceSessionRequest(nonce string) ([]byte, []byte, error) {
 	serial, err := asserts.Decode([]byte(exSerial))
 	if err != nil {


### PR DESCRIPTION
This starts cleaning up code involving serial-proof, starting from the now unused intermediate plumbing code.