### PR TITLE
snap: move/clarify Info.Broken

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -138,13 +138,15 @@ type Info struct {
 	// The information in all the remaining fields is not sourced from the snap blob itself.
 	SideInfo
 
+	// Broken marks if set whether the snap is broken and the reason.
+	Broken  string
+
 	// The information in these fields is ephemeral, available only from the store.
 	DownloadInfo
 
 	IconURL string
 	Prices  map[string]float64 `yaml:"prices,omitempty" json:"prices,omitempty"`
 	MustBuy bool
-	Broken  string
 }
 
 // Name returns the blessed name for the snap.

--- a/snap/info.go
+++ b/snap/info.go
@@ -139,7 +139,7 @@ type Info struct {
 	SideInfo
 
 	// Broken marks if set whether the snap is broken and the reason.
-	Broken  string
+	Broken string
 
 	// The information in these fields is ephemeral, available only from the store.
 	DownloadInfo


### PR DESCRIPTION
Move Info.Broken in the struct, it seemed like it came from the store, also add a doc comment for it.