### PR TITLE
snap: add `snap known --remote`

### DIFF
--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -63,6 +63,8 @@ func init() {
 
 var nl = []byte{'\n'}
 
+var storeNew = store.New
+
 func downloadAssertion(typeName string, headers map[string]string) ([]asserts.Assertion, error) {
 	var user *auth.UserState
 
@@ -82,7 +84,7 @@ func downloadAssertion(typeName string, headers map[string]string) ([]asserts.As
 		primaryKeys[i] = pk
 	}
 
-	sto := store.New(nil, authContext)
+	sto := storeNew(nil, authContext)
 	as, err := sto.Assertion(at, primaryKeys, user)
 	if err != nil {
 		return nil, err

--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -37,7 +37,7 @@ type cmdKnown struct {
 		HeaderFilters  []string `required:"0"`
 	} `positional-args:"true" required:"true"`
 
-	Store bool `long:"store"`
+	Remote bool `long:"remote"`
 }
 
 var shortKnownHelp = i18n.G("Shows known assertions of the provided type")
@@ -75,7 +75,11 @@ func downloadAssertion(typeName string, headers map[string]string) ([]asserts.As
 	}
 	primaryKeys := make([]string, len(at.PrimaryKey))
 	for i, k := range at.PrimaryKey {
-		primaryKeys[i] = headers[k]
+		pk, ok := headers[k]
+		if !ok {
+			return nil, fmt.Errorf("missing primary header %q to query remote assertion", k)
+		}
+		primaryKeys[i] = pk
 	}
 
 	sto := store.New(nil, authContext)
@@ -104,7 +108,7 @@ func (x *cmdKnown) Execute(args []string) error {
 
 	var assertions []asserts.Assertion
 	var err error
-	if x.Store {
+	if x.Remote {
 		assertions, err = downloadAssertion(x.KnownOptions.AssertTypeName, headers)
 	} else {
 		assertions, err = Client().Known(x.KnownOptions.AssertTypeName, headers)

--- a/cmd/snap/cmd_known_test.go
+++ b/cmd/snap/cmd_known_test.go
@@ -1,0 +1,90 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/store"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+// acquire example data via:
+// curl  -H "accept: application/x.ubuntu.assertion" https://assertions.ubuntu.com/v1/assertions/model/16/canonical/pi2
+const mockModelAssertion = `type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: pi99
+architecture: armhf
+gadget: pi99
+kernel: pi99-kernel
+timestamp: 2016-08-31T00:00:00.0Z
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLorsomethingthatlooksvaguelylikeasignature==
+`
+
+func (s *SnapSuite) TestKnownRemote(c *check.C) {
+	var server *httptest.Server
+
+	restorer := snap.MockStoreNew(func(cfg *store.Config, auth auth.AuthContext) *store.Store {
+		if cfg == nil {
+			cfg = store.DefaultConfig()
+		}
+		serverURL, err := url.Parse(server.URL + "/assertions/")
+		c.Assert(err, check.IsNil)
+		cfg.AssertionsURI = serverURL
+		return store.New(cfg, auth)
+	})
+	defer restorer()
+
+	n := 0
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/assertions/model/16/canonical/pi99")
+			fmt.Fprintln(w, mockModelAssertion)
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+		}
+
+		n++
+	}))
+
+	rest, err := snap.Parser().ParseArgs([]string{"known", "--remote", "model", "series=16", "brand-id=canonical", "model=pi99"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, mockModelAssertion)
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestKnownRemoteMissingPrimaryKey(c *check.C) {
+	_, err := snap.Parser().ParseArgs([]string{"known", "--remote", "model", "series=16", "brand-id=canonical"})
+	c.Assert(err, check.ErrorMatches, `missing primary header "model" to query remote assertion`)
+}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -22,6 +22,9 @@ package main
 import (
 	"os/user"
 	"time"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/store"
 )
 
 var RunMain = run
@@ -62,5 +65,13 @@ func MockUserCurrent(f func() (*user.User, error)) (restore func()) {
 	userCurrent = f
 	return func() {
 		userCurrent = userCurrentOrig
+	}
+}
+
+func MockStoreNew(f func(*store.Config, auth.AuthContext) *store.Store) (restore func()) {
+	storeNewOrig := storeNew
+	storeNew = f
+	return func() {
+		storeNew = storeNewOrig
 	}
 }

--- a/tests/main/known-remote/task.yaml
+++ b/tests/main/known-remote/task.yaml
@@ -1,7 +1,7 @@
 summary: Check snap known --store
 execute: |
     echo "Check getting assertion from the store"
-    output=$(snap known --store model series=16 brand-id=canonical model=pi2)
+    output=$(snap known --remote model series=16 brand-id=canonical model=pi2)
     echo $output |grep "type: model"
     echo $output |grep "series: 16"
     echo $output |grep "brand-id: canonical"

--- a/tests/main/known-store/task.yaml
+++ b/tests/main/known-store/task.yaml
@@ -1,0 +1,8 @@
+summary: Check snap known --store
+execute: |
+    echo "Check getting assertion from the store"
+    output=$(snap known --store model series=16 brand-id=canonical model=pi2)
+    echo $output |grep "type: model"
+    echo $output |grep "series: 16"
+    echo $output |grep "brand-id: canonical"
+    echo $output |grep "model: pi2"


### PR DESCRIPTION
Followup on https://github.com/snapcore/snapd/pull/1878

This adds a command to download assertions from the store via the existing `snap known` cli interface.