### PR TITLE
interfaces/builtin: fix resolvconf permissions for network-manager interface

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -81,9 +81,10 @@ network packet,
 
 # Needed to use resolvconf from core
 /sbin/resolvconf ixr,
-/run/resolvconf** rw,
-/etc/resolvconf/** rw,
-/etc/resolvconf/update.d/* ix,
+/run/resolvconf/{,**} r,
+/run/resolvconf/** w,
+/etc/resolvconf/{,**} r,
+/etc/resolvconf/** w,
 /lib/resolvconf/* ix,
 # Required by resolvconf
 /bin/run-parts ixr,

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -81,6 +81,12 @@ network packet,
 
 # Needed to use resolvconf from core
 /sbin/resolvconf ixr,
+/run/resolvconf** rw,
+/etc/resolvconf/** rw,
+/etc/resolvconf/update.d/* ix,
+/lib/resolvconf/* ix,
+# Required by resolvconf
+/bin/run-parts ixr,
 
 #include <abstractions/nameservice>
 

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -41,11 +41,6 @@ var pppConnectedPlugAppArmor = []byte(`
 @{PROC}/@{pid}/loginuid r,
 capability setgid,
 capability setuid,
-/sbin/resolvconf rix,
-/run/resolvconf** rw,
-/etc/resolvconf/** rw,
-/etc/resolvconf/update.d/* ix,
-/lib/resolvconf/* ix,
 `)
 
 type PppInterface struct{}


### PR DESCRIPTION
Execute permissions for resolvconf where recently added but it was missed that resolvconf needs more permissions in order to place certain files in the right directions. This was only tested in a scenario where the ppp plug of the network-manager snap was connected and the ppp interface allowed doing this.

This PR moves the resolvconf permissions properly into the permanent slot side of the network-manager interface and removes them from the ppp interface.