### PR TITLE
interfaces: ppp: load needed kernel module

### DIFF
--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -43,6 +43,13 @@ capability setgid,
 capability setuid,
 `)
 
+// ppp_generic creates /dev/ppp. Other ppp modules will be automatically loaded
+// by the kernel on different ioctl calls for this device. Note also that
+// in many cases ppp_generic is statically linked into the kernel (CONFIG_PPP=y)
+var pppConnectedPlugKmod = []byte(`
+ppp_generic
+`)
+
 type PppInterface struct{}
 
 func (iface *PppInterface) Name() string {
@@ -57,6 +64,8 @@ func (iface *PppInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *int
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		return pppConnectedPlugAppArmor, nil
+	case interfaces.SecurityKMod:
+		return pppConnectedPlugKmod, nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/ppp_test.go
+++ b/interfaces/builtin/ppp_test.go
@@ -57,11 +57,11 @@ func (s *PppInterfaceSuite) TestName(c *C) {
 
 func (s *PppInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
-		interfaces.SecuritySecComp}
+		interfaces.SecuritySecComp, interfaces.SecurityKMod}
 	for _, system := range systems {
 		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
 		c.Assert(err, IsNil)
-		if system == interfaces.SecurityAppArmor {
+		if system == interfaces.SecurityAppArmor || system == interfaces.SecurityKMod {
 			c.Assert(snippet, Not(IsNil))
 		} else {
 			c.Assert(snippet, IsNil)


### PR DESCRIPTION
Make sure to load ppp_generic on connection if not statically linked
into the kernel, so /dev/ppp is available.