### PR TITLE
overlord/state: prune old empty changes

### DIFF
--- a/overlord/state/change_test.go
+++ b/overlord/state/change_test.go
@@ -195,6 +195,7 @@ func (cs *changeSuite) TestCloseReadyOnExplicitStatus(c *C) {
 		c.Fatalf("Change should not be ready")
 	default:
 	}
+	c.Assert(chg.IsReady(), Equals, false)
 
 	chg.SetStatus(state.ErrorStatus)
 
@@ -203,6 +204,7 @@ func (cs *changeSuite) TestCloseReadyOnExplicitStatus(c *C) {
 	default:
 		c.Fatalf("Change should be ready")
 	}
+	c.Assert(chg.IsReady(), Equals, true)
 }
 
 func (cs *changeSuite) TestCloseReadyWhenTasksReady(c *C) {
@@ -221,6 +223,7 @@ func (cs *changeSuite) TestCloseReadyWhenTasksReady(c *C) {
 		c.Fatalf("Change should not be ready")
 	default:
 	}
+	c.Assert(chg.IsReady(), Equals, false)
 
 	t1.SetStatus(state.DoneStatus)
 
@@ -229,6 +232,7 @@ func (cs *changeSuite) TestCloseReadyWhenTasksReady(c *C) {
 		c.Fatalf("Change should not be ready")
 	default:
 	}
+	c.Assert(chg.IsReady(), Equals, false)
 
 	t2.SetStatus(state.DoneStatus)
 
@@ -237,6 +241,7 @@ func (cs *changeSuite) TestCloseReadyWhenTasksReady(c *C) {
 	default:
 		c.Fatalf("Change should be ready")
 	}
+	c.Assert(chg.IsReady(), Equals, true)
 }
 
 func (cs *changeSuite) TestIsClean(c *C) {

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -359,7 +359,10 @@ func (s *State) Prune(pruneWait, abortWait time.Duration) {
 		spawnTime := chg.SpawnTime()
 		readyTime := chg.ReadyTime()
 		if readyTime.IsZero() {
-			if spawnTime.Before(abortLimit) {
+			if spawnTime.Before(pruneLimit) && len(chg.Tasks()) == 0 {
+				chg.Abort()
+				delete(s.changes, chg.ID())
+			} else if spawnTime.Before(abortLimit) {
 				chg.Abort()
 			}
 			continue

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -201,9 +201,7 @@ func (r *TaskRunner) run(t *Task) {
 }
 
 func (r *TaskRunner) clean(t *Task) {
-	select {
-	case <-t.Change().Ready():
-	default:
+	if !t.Change().IsReady() {
 		// Whole Change is not ready so don't run cleanups yet.
 		return
 	}

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -614,17 +614,11 @@ func (ts *taskRunnerSuite) TestPrematureChangeReady(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	if chg.Status().Ready() {
+	if chg.IsReady() || chg.Status().Ready() {
 		c.Errorf("Change considered ready prematurely")
 	}
 
 	c.Assert(chg.Err(), IsNil)
-
-	select {
-	case <-chg.Ready():
-		c.Errorf("Change considered ready prematurely")
-	default:
-	}
 }
 
 func (ts *taskRunnerSuite) TestCleanup(c *C) {


### PR DESCRIPTION
Also adds Change.IsReady for convenience and clarity.