### PR TITLE
many: create auth.json for the freshly created user in `snap create-user`

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -303,7 +303,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	overlord := c.d.overlord
 	state := overlord.State()
 	state.Lock()
-	_, err = auth.NewUser(state, loginData.Username, macaroon, []string{discharge})
+	_, err = auth.NewUser(state, loginData.Username, macaroon, []string{discharge}, macaroon, []string{discharge})
 	state.Unlock()
 	if err != nil {
 		return InternalError("cannot persist authentication details: %v", err)
@@ -1726,7 +1726,7 @@ func addAuthUser(st *state.State, username string) error {
 	// store the freshly created user in the state so that snapd
 	// can be used without sudo
 	st.Lock()
-	_, err = auth.NewUser(st, username, string(macaB), nil)
+	_, err = auth.NewUser(st, username, string(macaB), nil, "", nil)
 	st.Unlock()
 	if err != nil {
 		return fmt.Errorf("cannot persist authentication details: %v", err)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3621,6 +3621,7 @@ func (s *apiSuite) TestPostCreateUser(c *check.C) {
 			Username: username,
 			Uid:      "1000",
 			Gid:      "1000",
+			HomeDir:  c.MkDir(),
 		}, nil
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -316,7 +316,7 @@ func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {
 func (s *apiSuite) TestSnapInfoWithAuth(c *check.C) {
 	state := snapCmd.d.overlord.State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -570,7 +570,7 @@ func (s *apiSuite) TestLogoutUser(c *check.C) {
 	d := s.daemon(c)
 	state := d.overlord.State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	state.Unlock()
 	c.Assert(err, check.IsNil)
 
@@ -725,7 +725,7 @@ func (s *apiSuite) TestUserFromRequestHeaderCorrectMissingUser(c *check.C) {
 func (s *apiSuite) TestUserFromRequestHeaderValidUser(c *check.C) {
 	state := snapCmd.d.overlord.State()
 	state.Lock()
-	expectedUser, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	expectedUser, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -743,7 +743,7 @@ func (s *apiSuite) TestUserFromRequestHeaderValidUser(c *check.C) {
 func (s *apiSuite) TestUserFromRequestHeaderValidUserMultipleDischarges(c *check.C) {
 	state := snapCmd.d.overlord.State()
 	state.Lock()
-	expectedUser, err := auth.NewUser(state, "username", "macaroon", []string{"discharge2", "discharge1"})
+	expectedUser, err := auth.NewUser(state, "username", "macaroon", []string{"discharge2", "discharge1"}, "macaroon", []string{"discharge"})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -1128,7 +1128,7 @@ func (s *apiSuite) TestSnapsStoreConfinement(c *check.C) {
 func (s *apiSuite) TestSnapsInfoStoreWithAuth(c *check.C) {
 	state := snapCmd.d.overlord.State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -1317,7 +1317,7 @@ func (s *apiSuite) TestPostSnapSetsUser(c *check.C) {
 
 	state := snapCmd.d.overlord.State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -3665,7 +3665,7 @@ func (s *apiSuite) TestBuySnap(c *check.C) {
 
 	state := snapCmd.d.overlord.State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -3703,7 +3703,7 @@ func (s *apiSuite) TestBuyFailMissingParameter(c *check.C) {
 
 	state := snapCmd.d.overlord.State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 
@@ -3778,7 +3778,7 @@ func (s *apiSuite) TestReadyToBuy(c *check.C) {
 
 		state := snapCmd.d.overlord.State()
 		state.Lock()
-		user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+		user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 		state.Unlock()
 		c.Check(err, check.IsNil)
 
@@ -3811,7 +3811,7 @@ func (s *apiSuite) TestPaymentMethods(c *check.C) {
 
 	state := snapCmd.d.overlord.State()
 	state.Lock()
-	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	state.Unlock()
 	c.Check(err, check.IsNil)
 

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -58,7 +58,7 @@ type UserState struct {
 }
 
 // NewUser tracks a new authenticated user and saves its details in the state
-func NewUser(st *state.State, username, macaroon string, discharges []string) (*UserState, error) {
+func NewUser(st *state.State, username, macaroon string, discharges []string, storeMacaroon string, storeDischarges []string) (*UserState, error) {
 	var authStateData AuthState
 
 	err := st.Get("auth", &authStateData)
@@ -69,14 +69,15 @@ func NewUser(st *state.State, username, macaroon string, discharges []string) (*
 	}
 
 	sort.Strings(discharges)
+	sort.Strings(storeDischarges)
 	authStateData.LastID++
 	authenticatedUser := UserState{
 		ID:              authStateData.LastID,
 		Username:        username,
 		Macaroon:        macaroon,
 		Discharges:      discharges,
-		StoreMacaroon:   macaroon,
-		StoreDischarges: discharges,
+		StoreMacaroon:   storeMacaroon,
+		StoreDischarges: storeDischarges,
 	}
 	authStateData.Users = append(authStateData.Users, authenticatedUser)
 

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -47,7 +47,7 @@ func (as *authSuite) SetUpTest(c *C) {
 
 func (as *authSuite) TestNewUser(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 
 	expected := &auth.UserState{
@@ -70,7 +70,7 @@ func (as *authSuite) TestNewUser(c *C) {
 
 func (as *authSuite) TestNewUserSortsDischarges(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge2", "discharge1"})
+	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge2", "discharge1"}, "macaroon", []string{"discharge2", "discharge1"})
 	as.state.Unlock()
 
 	expected := &auth.UserState{
@@ -93,13 +93,13 @@ func (as *authSuite) TestNewUserSortsDischarges(c *C) {
 
 func (as *authSuite) TestNewUserAddsToExistent(c *C) {
 	as.state.Lock()
-	firstUser, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	firstUser, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
 	// adding a new one
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "new_username", "new_macaroon", []string{"new_discharge"})
+	user, err := auth.NewUser(as.state, "new_username", "new_macaroon", []string{"new_discharge"}, "new_macaroon", []string{"new_discharge"})
 	as.state.Unlock()
 	expected := &auth.UserState{
 		ID:              2,
@@ -144,7 +144,7 @@ func (as *authSuite) TestCheckMacaroonInvalidAuth(c *C) {
 	c.Check(user, IsNil)
 
 	as.state.Lock()
-	_, err = auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	_, err = auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -158,7 +158,7 @@ func (as *authSuite) TestCheckMacaroonInvalidAuth(c *C) {
 
 func (as *authSuite) TestCheckMacaroonValidUser(c *C) {
 	as.state.Lock()
-	expectedUser, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	expectedUser, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -180,7 +180,7 @@ func (as *authSuite) TestUserForNoAuthInState(c *C) {
 
 func (as *authSuite) TestUserForNonExistent(c *C) {
 	as.state.Lock()
-	_, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	_, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -192,7 +192,7 @@ func (as *authSuite) TestUserForNonExistent(c *C) {
 
 func (as *authSuite) TestUser(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -205,7 +205,7 @@ func (as *authSuite) TestUser(c *C) {
 
 func (as *authSuite) TestUpdateUser(c *C) {
 	as.state.Lock()
-	user, _ := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	user, _ := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 
 	user.Username = "different"
@@ -225,7 +225,7 @@ func (as *authSuite) TestUpdateUser(c *C) {
 
 func (as *authSuite) TestUpdateUserInvalid(c *C) {
 	as.state.Lock()
-	_, _ = auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	_, _ = auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 
 	user := &auth.UserState{
@@ -242,7 +242,7 @@ func (as *authSuite) TestUpdateUserInvalid(c *C) {
 
 func (as *authSuite) TestRemove(c *C) {
 	as.state.Lock()
-	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	user, err := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 	c.Check(err, IsNil)
 
@@ -285,7 +285,7 @@ func (as *authSuite) TestSetDevice(c *C) {
 
 func (as *authSuite) TestAuthContextUpdateUserAuth(c *C) {
 	as.state.Lock()
-	user, _ := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	user, _ := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 
 	newDischarges := []string{"updated-discharge"}
@@ -305,7 +305,7 @@ func (as *authSuite) TestAuthContextUpdateUserAuth(c *C) {
 
 func (as *authSuite) TestAuthContextUpdateUserAuthOtherUpdate(c *C) {
 	as.state.Lock()
-	user, _ := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	user, _ := auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	otherUpdateUser := *user
 	otherUpdateUser.Macaroon = "macaroon2"
 	otherUpdateUser.StoreDischarges = []string{"other-discharges"}
@@ -337,7 +337,7 @@ func (as *authSuite) TestAuthContextUpdateUserAuthOtherUpdate(c *C) {
 
 func (as *authSuite) TestAuthContextUpdateUserAuthInvalid(c *C) {
 	as.state.Lock()
-	_, _ = auth.NewUser(as.state, "username", "macaroon", []string{"discharge"})
+	_, _ = auth.NewUser(as.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	as.state.Unlock()
 
 	user := &auth.UserState{

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -90,7 +90,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 
 	s.state.Lock()
 	snapstate.ReplaceStore(s.state, s.fakeStore)
-	s.user, err = auth.NewUser(s.state, "username", "macaroon", []string{"discharge"})
+	s.user, err = auth.NewUser(s.state, "username", "macaroon", []string{"discharge"}, "macaroon", []string{"discharge"})
 	c.Assert(err, IsNil)
 	s.state.Unlock()
 }

--- a/tests/main/ubuntu-core-create-user/task.yaml
+++ b/tests/main/ubuntu-core-create-user/task.yaml
@@ -20,6 +20,9 @@ execute: |
     echo "Ensure the user is a sudo user"
     sudo -u mvo sudo true
 
+    echo "Snaps can be installed without an extra `snap login` by the created user"
+    su -l -c "snap install test-snapd-tools" mvo
+
 
     echo "Adding invalid user"
     expected='error: bad user result: cannot create user "nosuchuser@example.com"'
@@ -31,3 +34,4 @@ execute: |
         echo "Unexpected output $output"
         exit 1
     fi
+


### PR DESCRIPTION
This is a straw-man branch to get early feedback on the approach and to allow discussion around the API. Quite a few unit tests are missing currently.

The branch will:
- create a local macaroon 
- put it into the users .snap/auth.json
- put it into the auth state
- change auth.NewUser() so that it takes a macaroon and a store macaroon

Things to consider:
- move client/login.go:storeAuthDataFilename() out so that it can be used in api.go
- move client/login.go:type user out so that it can be used in api.go
- change auth.NewUser() to take only the macaroon and set the storeMacaroon as an extra step(?)
