### PR TITLE
client, cmd: change buy command to match UX document

### DIFF
--- a/client/buy.go
+++ b/client/buy.go
@@ -56,3 +56,9 @@ func (client *Client) PaymentMethods() (*store.PaymentInformation, error) {
 
 	return &result, nil
 }
+
+func (client *Client) ReadyToBuy() error {
+	var result bool
+	_, err := client.doSync("GET", "/v2/buy/ready", nil, nil, nil, &result)
+	return err
+}

--- a/client/client.go
+++ b/client/client.go
@@ -294,6 +294,8 @@ const (
 	ErrorKindTwoFactorRequired = "two-factor-required"
 	ErrorKindTwoFactorFailed   = "two-factor-failed"
 	ErrorKindLoginRequired     = "login-required"
+	ErrorKindTermsNotAccepted  = "terms-not-accepted"
+	ErrorKindNoPaymentMethods  = "no-payment-methods"
 )
 
 // IsTwoFactorError returns whether the given error is due to problems


### PR DESCRIPTION
- Helpful error messages for no payment method / not accepted TOS.
- New messages when purchase is successful.
- No-longer expose payment methods to the user.
- Use new /v2/buy/ready endpoint for pre-flight check instead of /v2/buy/methods.