### PR TITLE
interfaces/builtin: add missing rule to allow run-parts to execute all resolvconf scripts

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -88,6 +88,7 @@ network packet,
 /lib/resolvconf/* ix,
 # Required by resolvconf
 /bin/run-parts ixr,
+/etc/resolvconf/update.d/* ix,
 
 #include <abstractions/nameservice>
 

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -84,7 +84,6 @@ network packet,
 /run/resolvconf/{,**} r,
 /run/resolvconf/** w,
 /etc/resolvconf/{,**} r,
-/etc/resolvconf/** w,
 /lib/resolvconf/* ix,
 # Required by resolvconf
 /bin/run-parts ixr,


### PR DESCRIPTION
This was missed in the previous PR https://github.com/snapcore/snapd/pull/1995