### PR TITLE
store: download deltas if explicitly enabled

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -234,6 +234,10 @@ type DownloadInfo struct {
 	Size     int64  `json:"size,omitempty"`
 	Sha3_384 string `json:"sha3-384,omitempty"`
 
+	// The server can include information about available deltas for a given
+	// snap at a specific revision during refresh. Currently during refresh the
+	// server will provide single matching deltas only, from the clients
+	// revision to the target revision when available, per requested format.
 	Deltas []DeltaInfo `json:"deltas,omitempty"`
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -1143,11 +1143,11 @@ func (s *Store) Download(name string, downloadInfo *snap.DownloadInfo, pbar prog
 				// Just log the error and continue with the normal non-delta
 				// download.
 				logger.Noticef("cannot download deltas for %s: %v", name, err)
+			} else {
+				// Currently even on successful delta downloads, continue with the
+				// normal full download.
+				logger.Debugf("successfully downloaded deltas for %s", name)
 			}
-
-			// Currently even on successful delta downloads, continue with the
-			// normal full download.
-			logger.Debugf("successfully downloaded deltas for %s", name)
 		}
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -1061,7 +1061,7 @@ func (s *Store) ListRefresh(installed []*RefreshCandidate, user *auth.UserState)
 		Data:        jsonData,
 	}
 
-	if os.Getenv("SNAPPY_USE_DELTAS_EXPERIMENTAL") == "1" {
+	if os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL") == "1" {
 		reqOptions.ExtraHeaders = map[string]string{
 			"X-Ubuntu-Delta-Formats": s.deltaFormat,
 		}
@@ -1133,7 +1133,7 @@ func (s *Store) Download(name string, downloadInfo *snap.DownloadInfo, pbar prog
 		}
 	}()
 
-	if os.Getenv("SNAPPY_USE_DELTAS_EXPERIMENTAL") == "1" && len(downloadInfo.Deltas) == 1 {
+	if os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL") == "1" && len(downloadInfo.Deltas) == 1 {
 		downloadDir, err := ioutil.TempDir("", name+"-deltas")
 		if err == nil {
 			defer os.RemoveAll(downloadDir)
@@ -1219,13 +1219,13 @@ var download = func(name, downloadURL string, user *auth.UserState, s *Store, w 
 func (s *Store) downloadDelta(name string, downloadDir string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState) (string, error) {
 
 	if len(downloadInfo.Deltas) != 1 {
-		return "", errors.New("store returned more than one delta")
+		return "", errors.New("store returned more than one download delta")
 	}
 
 	deltaInfo := downloadInfo.Deltas[0]
 
 	if deltaInfo.Format != s.deltaFormat {
-		return "", fmt.Errorf("store returned delta with format %q", deltaInfo.Format)
+		return "", fmt.Errorf("store returned a download delta with the wrong format (%q instead of the configured %s format)", deltaInfo.Format, s.deltaFormat)
 	}
 
 	deltaName := fmt.Sprintf("%s_%d_%d_delta.%s", name, deltaInfo.FromRevision, deltaInfo.ToRevision, deltaInfo.Format)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -447,9 +447,9 @@ var deltaTests = []struct {
 }}
 
 func (t *remoteRepoTestSuite) TestDownloadWithDeltas(c *C) {
-	origUseDeltas := os.Getenv("SNAPPY_USE_DELTAS_EXPERIMENTAL")
-	defer os.Setenv("SNAPPY_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
-	c.Assert(os.Setenv("SNAPPY_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
+	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
+	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
+	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
 
 	for _, testCase := range deltaTests {
 
@@ -531,9 +531,9 @@ var downloadDeltaTests = []struct {
 }}
 
 func (t *remoteRepoTestSuite) TestDownloadDelta(c *C) {
-	origUseDeltas := os.Getenv("SNAPPY_USE_DELTAS_EXPERIMENTAL")
-	defer os.Setenv("SNAPPY_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
-	c.Assert(os.Setenv("SNAPPY_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
+	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
+	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
+	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
 
 	for _, testCase := range downloadDeltaTests {
 		t.store.deltaFormat = testCase.format
@@ -1845,9 +1845,9 @@ var MockUpdatesWithDeltasJSON = `
 `
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *C) {
-	origUseDeltas := os.Getenv("SNAPPY_USE_DELTAS_EXPERIMENTAL")
-	defer os.Setenv("SNAPPY_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
-	c.Assert(os.Setenv("SNAPPY_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
+	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
+	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
+	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Header.Get("X-Ubuntu-Delta-Formats"), Equals, `xdelta`)
@@ -1920,9 +1920,9 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(c *C) {
 	// Verify the X-Delta-Format header is not set.
-	origUseDeltas := os.Getenv("SNAPPY_USE_DELTAS_EXPERIMENTAL")
-	defer os.Setenv("SNAPPY_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
-	c.Assert(os.Setenv("SNAPPY_USE_DELTAS_EXPERIMENTAL", "0"), IsNil)
+	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
+	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
+	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "0"), IsNil)
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Header.Get("X-Ubuntu-Delta-Formats"), Equals, ``)


### PR DESCRIPTION
This branch enables (via the SNAPPY_USE_DELTAS env var) the download of deltas associated with a store downloadInfo.

It is written to default back to the normal full download if there's an error, and in this branch, even when there is no error it doesn't actually do anything with the downloaded deltas anyway (other than log success and delete them again).

I'll have another branch soon which will actually use the downloaded deltas.

(Note: when running ./run-checks I see one unrelated test failure which passes if I run that test on its own - http://paste.ubuntu.com/23245672/ - is that a known flaky test? EDIT: confirmed that re-running ./run-checks and everything passed, so I'm assuming it's flaky).