### PR TITLE
tests: prevent timeout while waiting for log on systemctl status

### DIFF
--- a/tests/main/writable-areas/task.yaml
+++ b/tests/main/writable-areas/task.yaml
@@ -19,9 +19,7 @@ execute: |
     #[ -f /root/snap/data-writer/common/from-app ]
 
     echo "Waiting for data writer service to finish..."
-    unit="snap.data-writer.service.service"
-    while ! systemctl status $unit | grep -q "Writing to SNAP_USER_DATA"; do
-       systemctl status $unit || true
+    while ! journalctl --no-pager -u snap.data-writer.service.service | grep -q "Writing to SNAP_USER_DATA"; do
        sleep 1
     done
 


### PR DESCRIPTION
`tests/main/writable-areas` is giving timeouts on amd64 based images while waiting for a log output on `systemctl status` after the process has exited:
```
+ snap install --dangerous data-writer_1.0_all.snap

data-writer 1.0 installed
+ echo 'Apps can write to writable areas'
Apps can write to writable areas
+ data-writer.app
Writing to SNAP_COMMON
Writing to SNAP_DATA
Writing to SNAP_USER_DATA
+ '[' -f /var/snap/data-writer/x1/from-app ']'
+ '[' -f /var/snap/data-writer/common/from-app ']'
+ '[' -f /root/snap/data-writer/x1/from-app ']'
+ echo 'Waiting for data writer service to finish...'
Waiting for data writer service to finish...
+ unit=snap.data-writer.service.service
+ grep -q 'Writing to SNAP_USER_DATA'
+ systemctl status snap.data-writer.service.service
+ systemctl status snap.data-writer.service.service
● snap.data-writer.service.service - Service for snap application data-writer.service
   Loaded: loaded (/etc/systemd/system/snap.data-writer.service.service; enabled; vendor preset: enabled)
   Active: inactive (dead) since Wed 2016-09-28 07:49:00 UTC; 117ms ago
  Process: 9606 ExecStart=/usr/bin/snap run data-writer.service (code=exited, status=0/SUCCESS)
 Main PID: 9606 (code=exited, status=0/SUCCESS)
+ true
+ sleep 1
+ grep -q 'Writing to SNAP_USER_DATA'
+ systemctl status snap.data-writer.service.service
+ systemctl status snap.data-writer.service.service
● snap.data-writer.service.service - Service for snap application data-writer.service
  Loaded: loaded (/etc/systemd/system/snap.data-writer.service.service; enabled; vendor preset: enabled)
   Active: inactive (dead) since Wed 2016-09-28 07:49:00 UTC; 117ms ago
  Process: 9606 ExecStart=/usr/bin/snap run data-writer.service (code=exited, status=0/SUCCESS)
 Main PID: 9606 (code=exited, status=0/SUCCESS)
+ true
…...............
```

In this case after the process has exited the log entries are no longer available in `systemctl status` output. These changes make the test check the output of `journalctl` instead.