### PR TITLE
snap/implicit: don't restrict the camera iface to clasic

### DIFF
--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -53,11 +53,11 @@ var implicitSlots = []string{
 	"timezone-control",
 	"tpm",
 	"kernel-module-control",
+	"camera",
 }
 
 var implicitClassicSlots = []string{
 	"browser-support",
-	"camera",
 	"cups-control",
 	"gsettings",
 	"libvirt",


### PR DESCRIPTION
This patch changes implicitl slots so that the camera interface is
always added and not just on classic images.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>