### PR TITLE
tests: fix create-key/snap-sign test isolation

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -14,6 +14,7 @@ reset_classic() {
         exit 1
     fi
 
+    rm -rf /root/.snap/gnupg
     rm -f /tmp/ubuntu-core*
 
     if [ "$1" = "--reuse-core" ]; then

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -2,9 +2,6 @@ summary: Checks for snap create-key
 
 systems: [-ubuntu-core-16-64]
 
-restore: |
-    rm -rf $HOME/.snap/gnupg
-
 prepare: |
     echo "setup fake gpg pinentry environment"
     cat > /tmp/pinentry-fake <<'EOF'
@@ -33,9 +30,6 @@ prepare: |
     echo pinentry-program /tmp/pinentry-fake > /root/.snap/gnupg/gpg-agent.conf
 
 execute: |
-    # Test is broken: http://paste.ubuntu.com/23217619/
-    exit 0
-
     echo "Checking passphrase mismatch error"
     expect -d -f passphrase_mismatch.exp
 


### PR DESCRIPTION
The create-key and snap-sign tests both ran "snap create-key", but only
the create-key test declared a restore script that removed
/root/.snap/gnupg afterwards (although in all-snaps mode
tests/lib/reset.sh would remove that, since it removes all of
/root/.snap).  If snap-sign was run before create-key on the same
worker, create-key would therefore fail.

Extending reset_classic to remove /root/.snap/gnupg fixes this isolation
error, and makes it harder to make the same mistake in future.  It
should now also be safe to re-enable the create-key test, so I've done
so.