### PR TITLE
daemon: add support for `snap create-user --known`

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -29,6 +29,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -1698,6 +1699,11 @@ func createAllKnownSystemUsers(st *state.State, createData *postUserCreateData) 
 			logger.Debugf("ignoring system-user assertion for %q: %s", email, err)
 			continue
 		}
+		// ignore already existing users
+		if _, err := user.Lookup(username); err == nil {
+			continue
+		}
+
 		// FIXME: duplicated code
 		opts.Sudoer = createData.Sudoer
 		opts.ExtraUsers = !release.OnClassic

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1679,6 +1679,42 @@ func getUserDetailsFromStore(email string) (string, *osutil.AddUserOptions, erro
 	return v.Username, opts, nil
 }
 
+func createAllKnownSystemUsers(st *state.State, createData *postUserCreateData) Response {
+	var createdUsers []createResponseData
+
+	st.Lock()
+	db := assertstate.DB(st)
+	assertions, err := db.FindMany(asserts.SystemUserType, nil)
+	st.Unlock()
+	if err != nil {
+		return BadRequest("cannot find system-user assertion: %s", err)
+	}
+	for _, as := range assertions {
+		email := as.(*asserts.SystemUser).Email()
+		// we need to use getUserDetailsFromAssertion as this verifies
+		// the assertion against the current brand/model/time
+		username, opts, err := getUserDetailsFromAssertion(st, email)
+		if err != nil {
+			logger.Debugf("ignoring system-user assertion for %q: %s", email, err)
+			continue
+		}
+		// FIXME: duplicated code
+		opts.Sudoer = createData.Sudoer
+		opts.ExtraUsers = !release.OnClassic
+
+		if err := osutilAddUser(username, opts); err != nil {
+			return InternalError("cannot add user %q: %s", username, err)
+		}
+		createdUsers = append(createdUsers, createResponseData{
+			Username:    username,
+			SSHKeys:     opts.SSHKeys,
+			SSHKeyCount: len(opts.SSHKeys),
+		})
+	}
+
+	return SyncResponse(createdUsers, nil)
+}
+
 func getUserDetailsFromAssertion(st *state.State, email string) (string, *osutil.AddUserOptions, error) {
 	errorPrefix := fmt.Sprintf("cannot add system-user %q: ", email)
 
@@ -1739,6 +1775,12 @@ type createResponseData struct {
 	SSHKeyCount int `json:"ssh-key-count"`
 }
 
+type postUserCreateData struct {
+	Email  string `json:"email"`
+	Sudoer bool   `json:"sudoer"`
+	Known  bool   `json:"known"`
+}
+
 func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	uid, err := postCreateUserUcrednetGetUID(r.RemoteAddr)
 	if err != nil {
@@ -1748,17 +1790,18 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 		return BadRequest("cannot use create-user as non-root")
 	}
 
-	var createData struct {
-		Email  string `json:"email"`
-		Sudoer bool   `json:"sudoer"`
-		Known  bool   `json:"known"`
-	}
+	var createData postUserCreateData
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&createData); err != nil {
 		return BadRequest("cannot decode create-user data from request body: %v", err)
 	}
 
+	// special case: the user requested the creation of all known
+	// system-users
+	if createData.Email == "" && createData.Known {
+		return createAllKnownSystemUsers(c.d.overlord.State(), &createData)
+	}
 	if createData.Email == "" {
 		return BadRequest("cannot create user: 'email' field is empty")
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4080,6 +4080,8 @@ func (s *apiSuite) TestPostCreateUserFromAssertionAllKnown(c *check.C) {
 
 	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
 
+	// note that we get a list here instead of a single
+	// createResponseData item
 	expected := []createResponseData{
 		{Username: "guy", SSHKeyCount: 0},
 	}

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -1,0 +1,73 @@
+# Snapd assertions
+
+A summary of the supported assertions of snapd.
+
+## Account
+
+Account holds an account assertion, which ties a name for an to its
+identifier and provides the authority's confidence in the name's
+validity.
+
+## AccountKey
+
+AccountKey holds an account-key assertion, asserting a public key
+belonging to the account.
+
+## Model
+
+Model holds a model assertion, which is a statement by a brand
+about the properties of a device model.
+
+## Serial
+
+Serial holds a serial assertion, which is a statement binding a
+device identity with the device public key.
+
+## SnapDeclaration
+
+SnapDeclaration holds a snap-declaration assertion, declaring a
+snap binding its identifying snap-id to a name, asserting its
+publisher and its other properties.
+
+## SnapBuild
+
+SnapBuild holds a snap-build assertion, asserting the properties of a snap
+at the time it was built by the developer.
+
+## SnapRevision
+
+SnapRevision holds a snap-revision assertion, which is a statement by the
+store acknowledging the receipt of a build of a snap and labeling it with a
+snap revision.
+
+## System-user
+
+SystemUser holds a system-user assertion which allows creating local
+system users.
+
+The system-user assertion has the following form:
+```
+type:           system-user
+authority-id:   account-id   // Owner of the key, must be the brand
+brand-id:       account-id   // Assertion will only work on models of this brand
+email:          string       // Email of user
+series:         list         // List of series which should accept this assertion
+models:         list         // Models which should accept this assertion
+name:           string       // Optional person’s name, for context and for gecos
+username:       string       // Local system username for the user
+password:       string       // Password for local system user, encoded and salted with
+                                an algorithm hard to brute-force ($6$rounds=...$...)
+ssh-keys:       list         // SSH keys to authorize for connection
+since:          utc-datetime
+until:          utc-datetime // Required!
+revision:       integer
+
+signature       authority-sig
+```
+
+## Validation
+
+Validation holds a validation assertion, describing that a combination of
+(snap-id, approved-snap-id, approved-revision) has been validated for
+the series, meaning updating to that revision of approved-snap-id
+has been approved by the owner of the gating snap with snap-id.

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -688,10 +688,11 @@ Generally the UUID of a background operation you are interested in.
 
 #### Input
 
-A javascript object with the following keys:
+A JSON object with the following keys:
 * email: the email of the user to create
 * sudoers: if true adds "sudo" access to the created user
 * known: use the local system-user assertions to create the user
+         (see assertions.md for details about the system-user assertion)
 
 As a special case: if email is empty and known is set to true, the
 command will create users for all system-user assertions that are
@@ -699,7 +700,7 @@ valid for this device.
 
 #### Output
 
-A javascript object with the following keys:
+A JSON object with the following keys:
 * username: the username of the created user
 * ssh-keys: a list of strings with the ssh keys that got added
 * ssh-key-count: (deprecated) the number of ssh keys that got added

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -686,6 +686,28 @@ Generally the UUID of a background operation you are interested in.
 * Operation: sync
 * Return: an object with the created username and the ssh keys imported.
 
+#### Input
+
+A javascript object with the following keys:
+* email: the email of the user to create
+* sudoers: if true adds "sudo" access to the created user
+* known: use the local system-user assertions to create the user
+
+As a special case: if email is empty and known is set to true, the
+command will create users for all system-user assertions that are
+valid for this device.
+
+#### Output
+
+A javascript object with the following keys:
+* username: the username of the created user
+* ssh-keys: a list of strings with the ssh keys that got added
+* ssh-key-count: (deprecated) the number of ssh keys that got added
+
+As a special case: if the input email was empty and known set to true,
+multiple users can be created, so the return type is a list of the above
+objects.
+
 Sample input:
 
 ```javascript


### PR DESCRIPTION
This branch adds support for creating users from all known and valid system-user assertions for the given device. The next branch will add a check for "owned" devices and adds `--force-managed`.