### PR TITLE
daemon: add users to the sysInfo data

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -374,9 +374,10 @@ type CreateUserResult struct {
 
 // createUserRequest holds the user creation request
 type CreateUserRequest struct {
-	Email  string `json:"email"`
-	Sudoer bool   `json:"sudoer"`
-	Known  bool   `json:"known"`
+	Email        string `json:"email"`
+	Sudoer       bool   `json:"sudoer"`
+	Known        bool   `json:"known"`
+	ForceManaged bool   `json:"force-managed"`
 }
 
 // CreateUser creates a user from the given mail address

--- a/cmd/snap/cmd_create_user.go
+++ b/cmd/snap/cmd_create_user.go
@@ -42,17 +42,19 @@ type cmdCreateUser struct {
 		Email string
 	} `positional-args:"yes"`
 
-	JSON   bool `long:"json"`
-	Sudoer bool `long:"sudoer"`
-	Known  bool `long:"known"`
+	JSON         bool `long:"json"`
+	Sudoer       bool `long:"sudoer"`
+	Known        bool `long:"known"`
+	ForceManaged bool `long:"force-managed"`
 }
 
 func init() {
 	addCommand("create-user", shortCreateUserHelp, longCreateUserHelp, func() flags.Commander { return &cmdCreateUser{} },
 		map[string]string{
-			"json":   i18n.G("Output results in JSON format"),
-			"sudoer": i18n.G("Grant sudo access to the created user"),
-			"known":  i18n.G("Use known assertions for user creation"),
+			"json":          i18n.G("Output results in JSON format"),
+			"sudoer":        i18n.G("Grant sudo access to the created user"),
+			"known":         i18n.G("Use known assertions for user creation"),
+			"force-managed": i18n.G("Force adding the user, even if the device is already managed"),
 		}, []argDesc{{
 			// TRANSLATORS: noun
 			name: i18n.G("<email>"),
@@ -69,9 +71,10 @@ func (x *cmdCreateUser) Execute(args []string) error {
 	cli := Client()
 
 	request := client.CreateUserRequest{
-		Email:  x.Positional.Email,
-		Sudoer: x.Sudoer,
-		Known:  x.Known,
+		Email:        x.Positional.Email,
+		Sudoer:       x.Sudoer,
+		Known:        x.Known,
+		ForceManaged: x.ForceManaged,
 	}
 
 	rsp, err := cli.CreateUser(&request)

--- a/cmd/snap/cmd_create_user_test.go
+++ b/cmd/snap/cmd_create_user_test.go
@@ -41,9 +41,10 @@ func makeCreateUserChecker(c *check.C, n *int, sudoer, known bool) func(w http.R
 			err := dec.Decode(&body)
 			c.Assert(err, check.IsNil)
 			c.Check(body, check.DeepEquals, map[string]interface{}{
-				"email":  "popper@lse.ac.uk",
-				"sudoer": sudoer,
-				"known":  known,
+				"email":         "popper@lse.ac.uk",
+				"sudoer":        sudoer,
+				"known":         known,
+				"force-managed": false,
 			})
 			fmt.Fprintln(w, `{"type": "sync", "result": {"username": "karl", "ssh-key-count": 1}}`)
 		default:

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -213,11 +213,17 @@ func tbd(c *Command, r *http.Request, user *auth.UserState) Response {
 }
 
 func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
+	st := c.d.overlord.State()
+	st.Lock()
+	userCount, _ := auth.UserCount(st)
+	st.Unlock()
+
 	m := map[string]interface{}{
 		"series":     release.Series,
 		"version":    c.d.Version,
 		"os-release": release.ReleaseInfo,
 		"on-classic": release.OnClassic,
+		"user-count": userCount,
 	}
 
 	// TODO: set the store-id here from the model information

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1679,6 +1679,42 @@ func getUserDetailsFromStore(email string) (string, *osutil.AddUserOptions, erro
 	return v.Username, opts, nil
 }
 
+func createAllKnownSystemUsers(st *state.State, createData *postUserCreateData) Response {
+	var createdUsers []createResponseData
+
+	st.Lock()
+	db := assertstate.DB(st)
+	assertions, err := db.FindMany(asserts.SystemUserType, nil)
+	st.Unlock()
+	if err != nil {
+		return BadRequest("cannot find system-user assertion: %s", err)
+	}
+	for _, as := range assertions {
+		email := as.(*asserts.SystemUser).Email()
+		// we need to use getUserDetailsFromAssertion as this verifies
+		// the assertion against the current brand/model/time
+		username, opts, err := getUserDetailsFromAssertion(st, email)
+		if err != nil {
+			logger.Debugf("ignoring system-user assertion for %q: %s", email, err)
+			continue
+		}
+		// FIXME: duplicated code
+		opts.Sudoer = createData.Sudoer
+		opts.ExtraUsers = !release.OnClassic
+
+		if err := osutilAddUser(username, opts); err != nil {
+			return InternalError("cannot add user %q: %s", username, err)
+		}
+		createdUsers = append(createdUsers, createResponseData{
+			Username:    username,
+			SSHKeys:     opts.SSHKeys,
+			SSHKeyCount: len(opts.SSHKeys),
+		})
+	}
+
+	return SyncResponse(createdUsers, nil)
+}
+
 func getUserDetailsFromAssertion(st *state.State, email string) (string, *osutil.AddUserOptions, error) {
 	errorPrefix := fmt.Sprintf("cannot add system-user %q: ", email)
 
@@ -1739,6 +1775,12 @@ type createResponseData struct {
 	SSHKeyCount int `json:"ssh-key-count"`
 }
 
+type postUserCreateData struct {
+	Email  string `json:"email"`
+	Sudoer bool   `json:"sudoer"`
+	Known  bool   `json:"known"`
+}
+
 func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	uid, err := postCreateUserUcrednetGetUID(r.RemoteAddr)
 	if err != nil {
@@ -1748,17 +1790,18 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 		return BadRequest("cannot use create-user as non-root")
 	}
 
-	var createData struct {
-		Email  string `json:"email"`
-		Sudoer bool   `json:"sudoer"`
-		Known  bool   `json:"known"`
-	}
+	var createData postUserCreateData
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&createData); err != nil {
 		return BadRequest("cannot decode create-user data from request body: %v", err)
 	}
 
+	// special case: the user requested the creation of all known
+	// system-users
+	if createData.Email == "" && createData.Known {
+		return createAllKnownSystemUsers(c.d.overlord.State(), &createData)
+	}
 	if createData.Email == "" {
 		return BadRequest("cannot create user: 'email' field is empty")
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3636,6 +3636,7 @@ func (s *apiSuite) TestStateChangeAbortIsReady(c *check.C) {
 }
 
 func (s *apiSuite) TestPostCreateUserNoSSHKeys(c *check.C) {
+	s.daemon(c)
 	storeUserInfo = func(user string) (*store.User, error) {
 		c.Check(user, check.Equals, "popper@lse.ac.uk")
 		return &store.User{
@@ -3661,6 +3662,8 @@ func (s *apiSuite) TestPostCreateUserNoSSHKeys(c *check.C) {
 }
 
 func (s *apiSuite) TestPostCreateUser(c *check.C) {
+	s.daemon(c)
+
 	storeUserInfo = func(user string) (*store.User, error) {
 		c.Check(user, check.Equals, "popper@lse.ac.uk")
 		return &store.User{
@@ -4086,6 +4089,105 @@ func (s *apiSuite) TestPostCreateUserFromAssertionAllKnown(c *check.C) {
 		{Username: "guy", SSHKeyCount: 0},
 	}
 
+	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	c.Check(rsp.Result, check.FitsTypeOf, expected)
+	c.Check(rsp.Result, check.DeepEquals, expected)
+}
+
+func (s *apiSuite) TestPostCreateUserFromAssertionAllKnownButOwnedErrors(c *check.C) {
+	restorer := s.makeSystemUsers(c, []map[string]interface{}{
+		{
+			// good user
+			"authority-id": "my-brand",
+			"brand-id":     "my-brand",
+			"email":        "foo@bar.com",
+			"series":       []interface{}{"16", "18"},
+			"models":       []interface{}{"my-model", "other-model"},
+			"name":         "Boring Guy",
+			"username":     "guy",
+			"password":     "$6$salt$hash",
+			"since":        time.Now().Format(time.RFC3339),
+			"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
+		},
+	})
+	defer restorer()
+
+	st := s.d.overlord.State()
+	st.Lock()
+	_, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
+	st.Unlock()
+	c.Check(err, check.IsNil)
+
+	postCreateUserUcrednetGetUID = func(string) (uint32, error) {
+		return 0, nil
+	}
+	defer func() {
+		postCreateUserUcrednetGetUID = ucrednetGetUID
+	}()
+
+	// do it!
+	buf := bytes.NewBufferString(`{"known":true}`)
+	req, err := http.NewRequest("POST", "/v2/create-user", buf)
+	c.Assert(err, check.IsNil)
+
+	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+
+	c.Check(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Message, check.Matches, `cannot create user: device already managed`)
+}
+
+func (s *apiSuite) TestPostCreateUserFromAssertionAllKnownButOwned(c *check.C) {
+	restorer := s.makeSystemUsers(c, []map[string]interface{}{
+		{
+			// good user
+			"authority-id": "my-brand",
+			"brand-id":     "my-brand",
+			"email":        "foo@bar.com",
+			"series":       []interface{}{"16", "18"},
+			"models":       []interface{}{"my-model", "other-model"},
+			"name":         "Boring Guy",
+			"username":     "guy",
+			"password":     "$6$salt$hash",
+			"since":        time.Now().Format(time.RFC3339),
+			"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
+		},
+	})
+	defer restorer()
+
+	st := s.d.overlord.State()
+	st.Lock()
+	_, err := auth.NewUser(st, "username", "email@test.com", "macaroon", []string{"discharge"})
+	st.Unlock()
+	c.Check(err, check.IsNil)
+
+	postCreateUserUcrednetGetUID = func(string) (uint32, error) {
+		return 0, nil
+	}
+	// mock the calls that create the user
+	osutilAddUser = func(username string, opts *osutil.AddUserOptions) error {
+		c.Check(username, check.Equals, "guy")
+		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
+		c.Check(opts.Sudoer, check.Equals, false)
+		c.Check(opts.Password, check.Equals, "$6$salt$hash")
+		return nil
+	}
+	defer func() {
+		osutilAddUser = osutil.AddUser
+		postCreateUserUcrednetGetUID = ucrednetGetUID
+	}()
+
+	// do it!
+	buf := bytes.NewBufferString(`{"known":true,"force-managed":true}`)
+	req, err := http.NewRequest("POST", "/v2/create-user", buf)
+	c.Assert(err, check.IsNil)
+
+	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
+
+	// note that we get a list here instead of a single
+	// createResponseData item
+	expected := []createResponseData{
+		{Username: "guy", SSHKeyCount: 0},
+	}
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -465,6 +465,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 			"version-id": "1.2",
 		},
 		"on-classic": true,
+		"user-count": float64(0),
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4080,6 +4080,8 @@ func (s *apiSuite) TestPostCreateUserFromAssertionAllKnown(c *check.C) {
 
 	rsp := postCreateUser(createUserCmd, req, nil).(*resp)
 
+	// note that we get a list here instead of a single
+	// createResponseData item
 	expected := []createResponseData{
 		{Username: "guy", SSHKeyCount: 0},
 	}

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -686,6 +686,28 @@ Generally the UUID of a background operation you are interested in.
 * Operation: sync
 * Return: an object with the created username and the ssh keys imported.
 
+#### Input
+
+A javascript object with the following keys:
+* email: the email of the user to create
+* sudoers: if true adds "sudo" access to the created user
+* known: use the local system-user assertions to create the user
+
+As a special case: if email is empty and known is set to true, the
+command will create users for all system-user assertions that are
+valid for this device.
+
+#### Output
+
+A javascript object with the following keys:
+* username: the username of the created user
+* ssh-keys: a list of strings with the ssh keys that got added
+* ssh-key-count: (deprecated) the number of ssh keys that got added
+
+As a special case: if the input email was empty and known set to true,
+multiple users can be created, so the return type is a list of the above
+objects.
+
 Sample input:
 
 ```javascript

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -111,6 +111,20 @@ func RemoveUser(st *state.State, userID int) error {
 	return fmt.Errorf("invalid user")
 }
 
+func UserCount(st *state.State) (int, error) {
+	var authStateData AuthState
+
+	err := st.Get("auth", &authStateData)
+	if err == state.ErrNoState {
+		return 0, nil
+	}
+	if err != nil {
+		return -1, err
+	}
+
+	return len(authStateData.Users), nil
+}
+
 // User returns a user from the state given its ID
 func User(st *state.State, id int) (*UserState, error) {
 	var authStateData AuthState


### PR DESCRIPTION
Based on https://github.com/snapcore/snapd/pull/2041

This is a strawman branch. For console-conf it would be desirable to to know if the device is owned or not (same for webdm I would presume). This branch adds the user count to the sysInfo data so that the frontends can work accordingly. 

Alternatively we could make it a "auth.Users()" call that returns more information. This way the frontends could display something like "This device is used by "mvo@ubuntu.com", "niemeyer@ubuntu.com"" or similar.

Or we do something else - its a strawman afterall :)