### PR TITLE
interfaces: allow read of /etc/ld.so.preload by default for armhf on series 16

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -39,6 +39,10 @@ var defaultTemplate = []byte(`
   #include <abstractions/consoles>
   #include <abstractions/openssl>
 
+  # While in later versions of the base abstraction, include this explicitly
+  # for series 16 and cross-distro
+  /etc/ld.so.preload r,
+
   # for python apps/services
   #include <abstractions/python>
   /usr/bin/python{,2,2.[0-9]*,3,3.[0-9]*} ixr,


### PR DESCRIPTION
This rule is in later versions of the base abstraction but we should include it
in the default policy for systems that don't have newer AppArmor. This can be
dropped in series 18. (LP: #1627813)