### PR TITLE
interfaces: builtin: Allow writing DHCP lease files to /run/NetworkManager/dhcp

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -74,7 +74,7 @@ network packet,
 /run/NetworkManager/{,**} r,
 
 # Allow writing dhcp lease files outside of the snap
-/run/NetworkManager/dhcp/ rw,
+/run/NetworkManager/dhcp/{,**} w,
 
 # Needed by the ifupdown plugin to check which interfaces can
 # be managed an which not.

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -73,7 +73,7 @@ network packet,
 # from netplan
 /run/NetworkManager/{,**} r,
 
-# Allow writing dhcp lease files outside of the snap
+# Allow writing dhcp files to a well-known system location
 /run/NetworkManager/dhcp/{,**} w,
 
 # Needed by the ifupdown plugin to check which interfaces can

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -74,7 +74,7 @@ network packet,
 /run/NetworkManager/{,**} r,
 
 # Allow writing dhcp lease files outside of the snap
-/run/NetworkManager/dhcp rw,
+/run/NetworkManager/dhcp/ rw,
 
 # Needed by the ifupdown plugin to check which interfaces can
 # be managed an which not.

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -73,6 +73,9 @@ network packet,
 # from netplan
 /run/NetworkManager/{,**} r,
 
+# Allow writing dhcp lease files outside of the snap
+/run/NetworkManager/dhcp rw,
+
 # Needed by the ifupdown plugin to check which interfaces can
 # be managed an which not.
 /etc/network/interfaces r,


### PR DESCRIPTION
This is needed to allow console-conf to properly detect that an
interface is configured with DHCP in certain cases where the
NetworkManager snap is installed and running on a device before
console-conf is run.