### PR TITLE
many: setup snapd macaroon for local users

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -298,13 +298,11 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	overlord := c.d.overlord
 	state := overlord.State()
 	state.Lock()
-	// TODO Look at the error and fail if there's an attempt to authenticate with invalid data.
-	localUser, _ := UserFromRequest(state, r)
-	if localUser != nil {
+	if user != nil {
 		// local user logged-in, set its store macaroons
-		localUser.StoreMacaroon = macaroon
-		localUser.StoreDischarges = []string{discharge}
-		err := auth.UpdateUser(state, localUser)
+		user.StoreMacaroon = macaroon
+		user.StoreDischarges = []string{discharge}
+		err := auth.UpdateUser(state, user)
 		if err != nil {
 			return InternalError("cannot persist authentication details: %v", err)
 		}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -306,10 +306,10 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	} else {
 		_, err = auth.NewUser(state, loginData.Username, loginData.Email, macaroon, []string{discharge})
 	}
+	state.Unlock()
 	if err != nil {
 		return InternalError("cannot persist authentication details: %v", err)
 	}
-	state.Unlock()
 
 	result := loginResponseData{
 		Macaroon:   macaroon,

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -302,15 +302,12 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		// local user logged-in, set its store macaroons
 		user.StoreMacaroon = macaroon
 		user.StoreDischarges = []string{discharge}
-		err := auth.UpdateUser(state, user)
-		if err != nil {
-			return InternalError("cannot persist authentication details: %v", err)
-		}
+		err = auth.UpdateUser(state, user)
 	} else {
 		_, err = auth.NewUser(state, loginData.Username, loginData.Email, macaroon, []string{discharge})
-		if err != nil {
-			return InternalError("cannot persist authentication details: %v", err)
-		}
+	}
+	if err != nil {
+		return InternalError("cannot persist authentication details: %v", err)
 	}
 	state.Unlock()
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3730,7 +3730,7 @@ func (s *apiSuite) TestPostCreateUserNoSSHKeys(c *check.C) {
 }
 
 func (s *apiSuite) TestPostCreateUser(c *check.C) {
-	s.daemon(c)
+	d := s.daemon(c)
 
 	storeUserInfo = func(user string) (*store.User, error) {
 		c.Check(user, check.Equals, "popper@lse.ac.uk")
@@ -4253,9 +4253,20 @@ func (s *apiSuite) TestPostCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		return nil
 	}
+
+	userLookup = func(username string) (*user.User, error) {
+		return &user.User{
+			Username: username,
+			Uid:      "1000",
+			Gid:      "1000",
+			HomeDir:  c.MkDir(),
+		}, nil
+	}
+
 	defer func() {
 		osutilAddUser = osutil.AddUser
 		postCreateUserUcrednetGetUID = ucrednetGetUID
+		userLookup = user.Lookup
 	}()
 
 	// do it!

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -20,10 +20,14 @@
 package auth
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
 	"sort"
+
+	"gopkg.in/macaroon.v1"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/state"
@@ -31,9 +35,10 @@ import (
 
 // AuthState represents current authenticated users as tracked in state
 type AuthState struct {
-	LastID int          `json:"last-id"`
-	Users  []UserState  `json:"users"`
-	Device *DeviceState `json:"device,omitempty"`
+	LastID      int          `json:"last-id"`
+	Users       []UserState  `json:"users"`
+	Device      *DeviceState `json:"device,omitempty"`
+	MacaroonKey []byte       `json:"macaroon-key,omitempty"`
 }
 
 // DeviceState represents the device's identity and store credentials
@@ -58,6 +63,54 @@ type UserState struct {
 	StoreDischarges []string `json:"store-discharges,omitempty"`
 }
 
+// MacaroonSerialize returns a store-compatible serialized representation of the given macaroon
+func MacaroonSerialize(m *macaroon.Macaroon) (string, error) {
+	marshalled, err := m.MarshalBinary()
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(marshalled)
+	return encoded, nil
+}
+
+// MacaroonDeserialize returns a deserialized macaroon from a given store-compatible serialization
+func MacaroonDeserialize(serializedMacaroon string) (*macaroon.Macaroon, error) {
+	var m macaroon.Macaroon
+	decoded, err := base64.RawURLEncoding.DecodeString(serializedMacaroon)
+	if err != nil {
+		return nil, err
+	}
+	err = m.UnmarshalBinary(decoded)
+	if err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// generateMacaroonKey generates a random key to sign snapd macaroons
+func generateMacaroonKey() ([]byte, error) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// newUserMacaroon returns a snapd macaroon for the given username
+func newUserMacaroon(macaroonKey []byte, username string) (string, error) {
+	userMacaroon, err := macaroon.New(macaroonKey, username, "snapd")
+	if err != nil {
+		return "", fmt.Errorf("cannot create macaroon for snapd user: %s", err)
+	}
+
+	serializedMacaroon, err := MacaroonSerialize(userMacaroon)
+	if err != nil {
+		return "", fmt.Errorf("cannot serialize macaroon for snapd user: %s", err)
+	}
+
+	return serializedMacaroon, nil
+}
+
 // NewUser tracks a new authenticated user and saves its details in the state
 func NewUser(st *state.State, username, email, macaroon string, discharges []string) (*UserState, error) {
 	var authStateData AuthState
@@ -69,14 +122,29 @@ func NewUser(st *state.State, username, email, macaroon string, discharges []str
 		return nil, err
 	}
 
+	if authStateData.MacaroonKey == nil {
+		authStateData.MacaroonKey, err = generateMacaroonKey()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	localMacaroon := macaroon
+	if username != "" {
+		localMacaroon, err = newUserMacaroon(authStateData.MacaroonKey, username)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	sort.Strings(discharges)
 	authStateData.LastID++
 	authenticatedUser := UserState{
 		ID:              authStateData.LastID,
 		Username:        username,
 		Email:           email,
-		Macaroon:        macaroon,
-		Discharges:      discharges,
+		Macaroon:        localMacaroon,
+		Discharges:      nil,
 		StoreMacaroon:   macaroon,
 		StoreDischarges: discharges,
 	}

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -771,7 +771,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	// ensure all our tasks ran
 	c.Assert(chg.Err(), IsNil)
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{{
-		macaroon: s.user.Macaroon,
+		macaroon: s.user.StoreMacaroon,
 		name:     "some-snap",
 	}})
 	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
@@ -985,7 +985,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 
 	// ensure all our tasks ran
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{{
-		macaroon: s.user.Macaroon,
+		macaroon: s.user.StoreMacaroon,
 		name:     "some-snap",
 	}})
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
@@ -1163,7 +1163,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 
 	// ensure all our tasks ran
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{{
-		macaroon: s.user.Macaroon,
+		macaroon: s.user.StoreMacaroon,
 		name:     "some-snap",
 	}})
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
@@ -1328,7 +1328,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 
 	// ensure all our tasks ran
 	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{{
-		macaroon: s.user.Macaroon,
+		macaroon: s.user.StoreMacaroon,
 		name:     "some-snap",
 	}})
 	// friendlier failure first

--- a/store/auth.go
+++ b/store/auth.go
@@ -21,7 +21,6 @@ package store
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -62,30 +61,6 @@ func httpStatusCodeSuccess(httpStatusCode int) bool {
 // returns true if the http status code is in the "client-error" range (4xx)
 func httpStatusCodeClientError(httpStatusCode int) bool {
 	return httpStatusCode/100 == 4
-}
-
-// MacaroonSerialize returns a store-compatible serialized representation of the given macaroon
-func MacaroonSerialize(m *macaroon.Macaroon) (string, error) {
-	marshalled, err := m.MarshalBinary()
-	if err != nil {
-		return "", err
-	}
-	encoded := base64.RawURLEncoding.EncodeToString(marshalled)
-	return encoded, nil
-}
-
-// MacaroonDeserialize returns a deserialized macaroon from a given store-compatible serialization
-func MacaroonDeserialize(serializedMacaroon string) (*macaroon.Macaroon, error) {
-	var m macaroon.Macaroon
-	decoded, err := base64.RawURLEncoding.DecodeString(serializedMacaroon)
-	if err != nil {
-		return nil, err
-	}
-	err = m.UnmarshalBinary(decoded)
-	if err != nil {
-		return nil, err
-	}
-	return &m, nil
 }
 
 // loginCaveatID returns the 3rd party caveat from the macaroon to be discharged by Ubuntuone

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -230,47 +230,6 @@ func (s *authTestSuite) TestRefreshDischargeMacaroonError(c *C) {
 	c.Assert(discharge, Equals, "")
 }
 
-func (s *authTestSuite) TestMacaroonSerialize(c *C) {
-	m, err := makeTestMacaroon()
-	c.Check(err, IsNil)
-
-	serialized, err := MacaroonSerialize(m)
-	c.Check(err, IsNil)
-
-	deserialized, err := MacaroonDeserialize(serialized)
-	c.Check(err, IsNil)
-	c.Check(deserialized, DeepEquals, m)
-}
-
-func (s *authTestSuite) TestMacaroonSerializeDeserializeStoreMacaroon(c *C) {
-	// sample serialized macaroon using store server setup.
-	serialized := `MDAxNmxvY2F0aW9uIGxvY2F0aW9uCjAwMTdpZGVudGlmaWVyIHNvbWUgaWQKMDAwZmNpZCBjYXZlYXQKMDAxOWNpZCAzcmQgcGFydHkgY2F2ZWF0CjAwNTF2aWQgcyvpXSVlMnj9wYw5b-WPCLjTnO_8lVzBrRr8tJfu9tOhPORbsEOFyBwPOM_YiiXJ_qh-Pp8HY0HsUueCUY4dxONLIxPWTdMzCjAwMTJjbCByZW1vdGUuY29tCjAwMmZzaWduYXR1cmUgcm_Gdz75wUCWF9KGXZQEANhwfvBcLNt9xXGfAmxurPMK`
-
-	deserialized, err := MacaroonDeserialize(serialized)
-	c.Check(err, IsNil)
-
-	// expected json serialization of the above macaroon
-	jsonData := []byte(`{"caveats":[{"cid":"caveat"},{"cid":"3rd party caveat","vid":"cyvpXSVlMnj9wYw5b-WPCLjTnO_8lVzBrRr8tJfu9tOhPORbsEOFyBwPOM_YiiXJ_qh-Pp8HY0HsUueCUY4dxONLIxPWTdMz","cl":"remote.com"}],"location":"location","identifier":"some id","signature":"726fc6773ef9c1409617d2865d940400d8707ef05c2cdb7dc5719f026c6eacf3"}`)
-
-	var expected macaroon.Macaroon
-	err = expected.UnmarshalJSON(jsonData)
-	c.Check(err, IsNil)
-	c.Check(deserialized, DeepEquals, &expected)
-
-	// reserializing the macaroon should give us the same original store serialization
-	reserialized, err := MacaroonSerialize(deserialized)
-	c.Check(err, IsNil)
-	c.Check(reserialized, Equals, serialized)
-}
-
-func (s *authTestSuite) TestMacaroonDeserializeInvalidData(c *C) {
-	serialized := "invalid-macaroon-data"
-
-	deserialized, err := MacaroonDeserialize(serialized)
-	c.Check(deserialized, IsNil)
-	c.Check(err, NotNil)
-}
-
 func (s *authTestSuite) TestLoginCaveatIDReturnCaveatID(c *C) {
 	m, err := macaroon.New([]byte("secret"), "some-id", "location")
 	c.Check(err, IsNil)

--- a/store/store.go
+++ b/store/store.go
@@ -388,7 +388,7 @@ func LoginUser(username, password, otp string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	deserializedMacaroon, err := MacaroonDeserialize(macaroon)
+	deserializedMacaroon, err := auth.MacaroonDeserialize(macaroon)
 	if err != nil {
 		return "", "", err
 	}
@@ -413,7 +413,7 @@ func authenticateUser(r *http.Request, user *auth.UserState) {
 	fmt.Fprintf(&buf, `Macaroon root="%s"`, user.StoreMacaroon)
 
 	// deserialize root macaroon (we need its signature to do the discharge binding)
-	root, err := MacaroonDeserialize(user.StoreMacaroon)
+	root, err := auth.MacaroonDeserialize(user.StoreMacaroon)
 	if err != nil {
 		logger.Debugf("cannot deserialize root macaroon: %v", err)
 		return
@@ -421,14 +421,14 @@ func authenticateUser(r *http.Request, user *auth.UserState) {
 
 	for _, d := range user.StoreDischarges {
 		// prepare discharge for request
-		discharge, err := MacaroonDeserialize(d)
+		discharge, err := auth.MacaroonDeserialize(d)
 		if err != nil {
 			logger.Debugf("cannot deserialize discharge macaroon: %v", err)
 			return
 		}
 		discharge.Bind(root.Signature())
 
-		serializedDischarge, err := MacaroonSerialize(discharge)
+		serializedDischarge, err := auth.MacaroonSerialize(discharge)
 		if err != nil {
 			logger.Debugf("cannot re-serialize discharge macaroon: %v", err)
 			return
@@ -442,7 +442,7 @@ func authenticateUser(r *http.Request, user *auth.UserState) {
 func refreshDischarges(user *auth.UserState) ([]string, error) {
 	newDischarges := make([]string, len(user.StoreDischarges))
 	for i, d := range user.StoreDischarges {
-		discharge, err := MacaroonDeserialize(d)
+		discharge, err := auth.MacaroonDeserialize(d)
 		if err != nil {
 			return nil, err
 		}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -176,15 +176,15 @@ func makeTestRefreshDischargeResponse() (string, error) {
 		return "", err
 	}
 
-	return MacaroonSerialize(m)
+	return auth.MacaroonSerialize(m)
 }
 
 func createTestUser(userID int, root, discharge *macaroon.Macaroon) (*auth.UserState, error) {
-	serializedMacaroon, err := MacaroonSerialize(root)
+	serializedMacaroon, err := auth.MacaroonSerialize(root)
 	if err != nil {
 		return nil, err
 	}
-	serializedDischarge, err := MacaroonSerialize(discharge)
+	serializedDischarge, err := auth.MacaroonSerialize(discharge)
 	if err != nil {
 		return nil, err
 	}
@@ -243,15 +243,15 @@ func (t *remoteRepoTestSuite) TearDownSuite(c *C) {
 func (t *remoteRepoTestSuite) expectedAuthorization(c *C, user *auth.UserState) string {
 	var buf bytes.Buffer
 
-	root, err := MacaroonDeserialize(user.StoreMacaroon)
+	root, err := auth.MacaroonDeserialize(user.StoreMacaroon)
 	c.Assert(err, IsNil)
-	discharge, err := MacaroonDeserialize(user.StoreDischarges[0])
+	discharge, err := auth.MacaroonDeserialize(user.StoreDischarges[0])
 	c.Assert(err, IsNil)
 	discharge.Bind(root.Signature())
 
-	serializedMacaroon, err := MacaroonSerialize(root)
+	serializedMacaroon, err := auth.MacaroonSerialize(root)
 	c.Assert(err, IsNil)
-	serializedDischarge, err := MacaroonSerialize(discharge)
+	serializedDischarge, err := auth.MacaroonSerialize(discharge)
 	c.Assert(err, IsNil)
 
 	fmt.Fprintf(&buf, `Macaroon root="%s", discharge="%s"`, serializedMacaroon, serializedDischarge)
@@ -839,7 +839,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 func (t *remoteRepoTestSuite) TestLoginUser(c *C) {
 	macaroon, err := makeTestMacaroon()
 	c.Assert(err, IsNil)
-	serializedMacaroon, err := MacaroonSerialize(macaroon)
+	serializedMacaroon, err := auth.MacaroonSerialize(macaroon)
 	c.Assert(err, IsNil)
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -851,7 +851,7 @@ func (t *remoteRepoTestSuite) TestLoginUser(c *C) {
 
 	discharge, err := makeTestDischarge()
 	c.Assert(err, IsNil)
-	serializedDischarge, err := MacaroonSerialize(discharge)
+	serializedDischarge, err := auth.MacaroonSerialize(discharge)
 	c.Assert(err, IsNil)
 	mockSSOServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -887,7 +887,7 @@ func (t *remoteRepoTestSuite) TestLoginUserMyAppsError(c *C) {
 func (t *remoteRepoTestSuite) TestLoginUserSSOError(c *C) {
 	macaroon, err := makeTestMacaroon()
 	c.Assert(err, IsNil)
-	serializedMacaroon, err := MacaroonSerialize(macaroon)
+	serializedMacaroon, err := auth.MacaroonSerialize(macaroon)
 	c.Assert(err, IsNil)
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Setup local users in the AuthState, issuing a snapd macaroon. If a local user logs in to the store, update its store macaroons.
Moved MacaroonSerialize/MacaroonDeserialize from store/auth to overlord/auth.
Next step: do snapd macaroons verification.