### PR TITLE
many: introduce snap refresh --ignore-validation <snap> to override refresh validation

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -31,11 +31,12 @@ import (
 )
 
 type SnapOptions struct {
-	Channel   string `json:"channel,omitempty"`
-	Revision  string `json:"revision,omitempty"`
-	DevMode   bool   `json:"devmode,omitempty"`
-	JailMode  bool   `json:"jailmode,omitempty"`
-	Dangerous bool   `json:"dangerous,omitempty"`
+	Channel          string `json:"channel,omitempty"`
+	Revision         string `json:"revision,omitempty"`
+	DevMode          bool   `json:"devmode,omitempty"`
+	JailMode         bool   `json:"jailmode,omitempty"`
+	Dangerous        bool   `json:"dangerous,omitempty"`
+	IgnoreValidation bool   `json:"ignore-validation,omitempty"`
 }
 
 type actionData struct {

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -386,6 +386,20 @@ func (s *SnapOpSuite) TestRefreshOneJailmode(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
+func (s *SnapOpSuite) TestRefreshOneIgnoreValidation(c *check.C) {
+	s.RedirectClientToTestServer(s.srv.handle)
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/one")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":            "refresh",
+			"ignore-validation": true,
+		})
+	}
+	_, err := snap.Parser().ParseArgs([]string{"refresh", "--ignore-validation", "one"})
+	c.Assert(err, check.IsNil)
+}
+
 func (s *SnapOpSuite) TestRefreshOneModeErr(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser().ParseArgs([]string{"refresh", "--jailmode", "--devmode", "one"})
@@ -408,6 +422,12 @@ func (s *SnapOpSuite) TestRefreshManyChannel(c *check.C) {
 	s.RedirectClientToTestServer(nil)
 	_, err := snap.Parser().ParseArgs([]string{"refresh", "--beta", "one", "two"})
 	c.Assert(err, check.ErrorMatches, `a single snap name is needed to specify mode or channel flags`)
+}
+
+func (s *SnapOpSuite) TestRefreshManyIgnoreValidation(c *check.C) {
+	s.RedirectClientToTestServer(nil)
+	_, err := snap.Parser().ParseArgs([]string{"refresh", "--ignore-validation", "one", "two"})
+	c.Assert(err, check.ErrorMatches, `a single snap name must be specified when ignoring validation`)
 }
 
 func (s *SnapOpSuite) TestRefreshAllModeFlags(c *check.C) {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -633,11 +633,12 @@ func (*licenseData) Error() string {
 
 type snapInstruction struct {
 	progress.NullProgress
-	Action   string        `json:"action"`
-	Channel  string        `json:"channel"`
-	Revision snap.Revision `json:"revision"`
-	DevMode  bool          `json:"devmode"`
-	JailMode bool          `json:"jailmode"`
+	Action           string        `json:"action"`
+	Channel          string        `json:"channel"`
+	Revision         snap.Revision `json:"revision"`
+	DevMode          bool          `json:"devmode"`
+	JailMode         bool          `json:"jailmode"`
+	IgnoreValidation bool          `json:"ignore-validation"`
 	// dropping support temporarely until flag confusion is sorted,
 	// this isn't supported by client atm anyway
 	LeaveOld bool         `json:"temp-dropped-leave-old"`
@@ -811,6 +812,9 @@ func snapUpdate(inst *snapInstruction, st *state.State) (string, []*state.TaskSe
 	flags, err := modeFlags(inst.DevMode, inst.JailMode)
 	if err != nil {
 		return "", nil, err
+	}
+	if inst.IgnoreValidation {
+		flags |= snapstate.IgnoreValidation
 	}
 
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -37,6 +37,7 @@ import (
 // Flags are used to pass additional flags to operations and to keep track of snap modes.
 type Flags int
 
+// Flags that will be stored in SnapState.
 const (
 	// DevMode switches confinement to non-enforcing mode.
 	DevMode = 1 << iota
@@ -46,6 +47,15 @@ const (
 	// JailMode is set when the user has requested confinement
 	// always be enforcing, even if the snap requests otherwise.
 	JailMode
+
+	// TODO: migrate away from this bit flags based approach in API and state
+)
+
+// Flags affecting operations but not stored in state.
+const (
+	// IgnoreValidation is set when the user requested as one-off
+	// to ignore refresh control validation.
+	IgnoreValidation = 0x10000
 )
 
 func (f Flags) DevModeAllowed() bool {
@@ -60,6 +70,10 @@ func (f Flags) JailMode() bool {
 	return f&JailMode != 0
 }
 
+func (f Flags) IgnoreValidation() bool {
+	return f&IgnoreValidation != 0
+}
+
 func doInstall(s *state.State, snapst *SnapState, ss *SnapSetup) (*state.TaskSet, error) {
 	if err := checkChangeConflict(s, ss.Name(), snapst); err != nil {
 		return nil, err
@@ -68,6 +82,9 @@ func doInstall(s *state.State, snapst *SnapState, ss *SnapSetup) (*state.TaskSet
 	if ss.SnapPath == "" && ss.Channel == "" {
 		ss.Channel = "stable"
 	}
+
+	// clear out IgnoreValidation
+	ss.Flags &= ^IgnoreValidation
 
 	revisionStr := ""
 	if ss.SideInfo != nil {
@@ -480,7 +497,7 @@ func infoForUpdate(s *state.State, snapst *SnapState, name, channel string, revi
 		if err != nil {
 			return nil, err
 		}
-		if ValidateRefreshes != nil {
+		if ValidateRefreshes != nil && !flags.IgnoreValidation() {
 			_, err := ValidateRefreshes(s, []*snap.Info{info}, userID)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This introduces a refresh flag --ignore-validation to override refresh control validation on a one-off basis.