### PR TITLE
interfaces: add repo.ResolveConnect that handles name resolution

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -282,7 +282,7 @@ func (r *Repository) ResolveConnect(plugSnapName, plugName, slotSnapName, slotNa
 	// Ensure that such plug exists
 	plug := r.plugs[plugSnapName][plugName]
 	if plug == nil {
-		return ref, fmt.Errorf("cannot resolve connection, plug %q from snap %q, no such plug", plugName, plugSnapName)
+		return ref, fmt.Errorf("snap %q has no plug named %q", plugSnapName, plugName)
 	}
 
 	if slotSnapName == "" {
@@ -309,23 +309,23 @@ func (r *Repository) ResolveConnect(plugSnapName, plugName, slotSnapName, slotNa
 		}
 		switch len(candidates) {
 		case 0:
-			return ref, fmt.Errorf("cannot resolve connection, slot name is empty and there are no valid candidates")
+			return ref, fmt.Errorf("snap %q has no %q interface slots", slotSnapName, plug.Interface)
 		case 1:
 			slotName = candidates[0]
 		default:
-			return ref, fmt.Errorf("cannot resolve connection, more than one slot is a valid candidate")
+			sort.Strings(candidates)
+			return ref, fmt.Errorf("snap %q has multiple %q interface slots: %s", slotSnapName, plug.Interface, strings.Join(candidates, ", "))
 		}
 	}
 
 	// Ensure that such slot exists
 	slot := r.slots[slotSnapName][slotName]
 	if slot == nil {
-		return ref, fmt.Errorf("cannot resolve connection, slot %q from snap %q, no such slot", slotName, slotSnapName)
+		return ref, fmt.Errorf("snap %q has no slot named %q", slotSnapName, slotName)
 	}
 	// Ensure that plug and slot are compatible
-	// XXX: should we do this or should this be only done in Connect?
 	if slot.Interface != plug.Interface {
-		return ref, fmt.Errorf(`cannot resolve connection, plug "%s:%s" (interface %q) to "%s:%s" (interface %q)`,
+		return ref, fmt.Errorf("cannot connect %s:%s (%q interface) to %s:%s (%q interface)",
 			plugSnapName, plugName, plug.Interface, slotSnapName, slotName, slot.Interface)
 	}
 	ref = ConnRef{PlugRef: plug.Ref(), SlotRef: slot.Ref()}

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -267,20 +267,22 @@ func (r *Repository) RemoveSlot(snapName, slotName string) error {
 
 // ResolveConnect resolves potentially missing plug or slot names and returns a
 // fully populated connection reference.
-func (r *Repository) ResolveConnect(plugSnapName, plugName, slotSnapName, slotName string) (*ConnRef, error) {
+func (r *Repository) ResolveConnect(plugSnapName, plugName, slotSnapName, slotName string) (ConnRef, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
+	ref := ConnRef{}
+
 	if plugSnapName == "" {
-		return nil, fmt.Errorf("cannot resolve connection, plug snap name is empty")
+		return ref, fmt.Errorf("cannot resolve connection, plug snap name is empty")
 	}
 	if plugName == "" {
-		return nil, fmt.Errorf("cannot resolve connection, plug name is empty")
+		return ref, fmt.Errorf("cannot resolve connection, plug name is empty")
 	}
 	// Ensure that such plug exists
 	plug := r.plugs[plugSnapName][plugName]
 	if plug == nil {
-		return nil, fmt.Errorf("cannot resolve connection, plug %q from snap %q, no such plug", plugName, plugSnapName)
+		return ref, fmt.Errorf("cannot resolve connection, plug %q from snap %q, no such plug", plugName, plugSnapName)
 	}
 
 	if slotSnapName == "" {
@@ -293,7 +295,7 @@ func (r *Repository) ResolveConnect(plugSnapName, plugName, slotSnapName, slotNa
 		default:
 			// XXX: perhaps this should not be an error and instead it should
 			// silently assume "core" now?
-			return nil, fmt.Errorf("cannot resolve connection, slot snap name is empty")
+			return ref, fmt.Errorf("cannot resolve connection, slot snap name is empty")
 		}
 	}
 	if slotName == "" {
@@ -307,27 +309,27 @@ func (r *Repository) ResolveConnect(plugSnapName, plugName, slotSnapName, slotNa
 		}
 		switch len(candidates) {
 		case 0:
-			return nil, fmt.Errorf("cannot resolve connection, slot name is empty and there are no valid candidates")
+			return ref, fmt.Errorf("cannot resolve connection, slot name is empty and there are no valid candidates")
 		case 1:
 			slotName = candidates[0]
 		default:
-			return nil, fmt.Errorf("cannot resolve connection, more than one slot is a valid candidate")
+			return ref, fmt.Errorf("cannot resolve connection, more than one slot is a valid candidate")
 		}
 	}
 
 	// Ensure that such slot exists
 	slot := r.slots[slotSnapName][slotName]
 	if slot == nil {
-		return nil, fmt.Errorf("cannot resolve connection, slot %q from snap %q, no such slot", slotName, slotSnapName)
+		return ref, fmt.Errorf("cannot resolve connection, slot %q from snap %q, no such slot", slotName, slotSnapName)
 	}
 	// Ensure that plug and slot are compatible
 	// XXX: should we do this or should this be only done in Connect?
 	if slot.Interface != plug.Interface {
-		return nil, fmt.Errorf(`cannot resolve connection, plug "%s:%s" (interface %q) to "%s:%s" (interface %q)`,
+		return ref, fmt.Errorf(`cannot resolve connection, plug "%s:%s" (interface %q) to "%s:%s" (interface %q)`,
 			plugSnapName, plugName, plug.Interface, slotSnapName, slotName, slot.Interface)
 	}
-	conn := &ConnRef{PlugRef: plug.Ref(), SlotRef: slot.Ref()}
-	return conn, nil
+	ref = ConnRef{PlugRef: plug.Ref(), SlotRef: slot.Ref()}
+	return ref, nil
 }
 
 // Connect establishes a connection between a plug and a slot.

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -265,6 +265,71 @@ func (r *Repository) RemoveSlot(snapName, slotName string) error {
 	return nil
 }
 
+// ResolveConnect resolves potentially missing plug or slot names and returns a
+// fully populated connection reference.
+func (r *Repository) ResolveConnect(plugSnapName, plugName, slotSnapName, slotName string) (*ConnRef, error) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if plugSnapName == "" {
+		return nil, fmt.Errorf("cannot resolve connection, plug snap name is empty")
+	}
+	if plugName == "" {
+		return nil, fmt.Errorf("cannot resolve connection, plug name is empty")
+	}
+	// Ensure that such plug exists
+	plug := r.plugs[plugSnapName][plugName]
+	if plug == nil {
+		return nil, fmt.Errorf("cannot resolve connection, plug %q from snap %q, no such plug", plugName, plugSnapName)
+	}
+
+	if slotSnapName == "" {
+		// Use the core snap if the slot-side snap name is empty
+		switch {
+		case r.slots["core"] != nil:
+			slotSnapName = "core"
+		case r.slots["ubuntu-core"] != nil:
+			slotSnapName = "ubuntu-core"
+		default:
+			// XXX: perhaps this should not be an error and instead it should
+			// silently assume "core" now?
+			return nil, fmt.Errorf("cannot resolve connection, slot snap name is empty")
+		}
+	}
+	if slotName == "" {
+		// Find the unambiguous slot that satisfies plug requirements
+		var candidates []string
+		for candidateSlotName, candidateSlot := range r.slots[slotSnapName] {
+			// TODO: use some smarter matching (e.g. against $attrs)
+			if candidateSlot.Interface == plug.Interface {
+				candidates = append(candidates, candidateSlotName)
+			}
+		}
+		switch len(candidates) {
+		case 0:
+			return nil, fmt.Errorf("cannot resolve connection, slot name is empty and there are no valid candidates")
+		case 1:
+			slotName = candidates[0]
+		default:
+			return nil, fmt.Errorf("cannot resolve connection, more than one slot is a valid candidate")
+		}
+	}
+
+	// Ensure that such slot exists
+	slot := r.slots[slotSnapName][slotName]
+	if slot == nil {
+		return nil, fmt.Errorf("cannot resolve connection, slot %q from snap %q, no such slot", slotName, slotSnapName)
+	}
+	// Ensure that plug and slot are compatible
+	// XXX: should we do this or should this be only done in Connect?
+	if slot.Interface != plug.Interface {
+		return nil, fmt.Errorf(`cannot resolve connection, plug "%s:%s" (interface %q) to "%s:%s" (interface %q)`,
+			plugSnapName, plugName, plug.Interface, slotSnapName, slotName, slot.Interface)
+	}
+	conn := &ConnRef{PlugRef: plug.Ref(), SlotRef: slot.Ref()}
+	return conn, nil
+}
+
 // Connect establishes a connection between a plug and a slot.
 // The plug and the slot must have the same interface.
 func (r *Repository) Connect(plugSnapName, plugName, slotSnapName, slotName string) error {

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -522,7 +522,7 @@ func (s *RepositorySuite) TestResolveConnectExplicit(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "producer", "slot")
 	c.Check(err, IsNil)
-	c.Check(conn, DeepEquals, &ConnRef{
+	c.Check(conn, Equals, ConnRef{
 		PlugRef: PlugRef{Snap: "consumer", Name: "plug"},
 		SlotRef: SlotRef{Snap: "producer", Name: "slot"},
 	})
@@ -541,7 +541,7 @@ slots:
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "", "slot")
 	c.Check(err, IsNil)
-	c.Check(conn, DeepEquals, &ConnRef{
+	c.Check(conn, Equals, ConnRef{
 		PlugRef: PlugRef{Snap: "consumer", Name: "plug"},
 		SlotRef: SlotRef{Snap: "core", Name: "slot"},
 	})
@@ -560,7 +560,7 @@ slots:
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "", "slot")
 	c.Check(err, IsNil)
-	c.Check(conn, DeepEquals, &ConnRef{
+	c.Check(conn, Equals, ConnRef{
 		PlugRef: PlugRef{Snap: "consumer", Name: "plug"},
 		SlotRef: SlotRef{Snap: "ubuntu-core", Name: "slot"},
 	})
@@ -604,7 +604,7 @@ slots:
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "", "")
 	c.Check(err, ErrorMatches, "cannot resolve connection, slot name is empty and there are no valid candidates")
-	c.Check(conn, IsNil)
+	c.Check(conn, Equals, ConnRef{})
 }
 
 // ResolveConnect detects ambiguities when slot snap name is empty
@@ -623,28 +623,28 @@ slots:
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "", "")
 	c.Check(err, ErrorMatches, "cannot resolve connection, more than one slot is a valid candidate")
-	c.Check(conn, IsNil)
+	c.Check(conn, Equals, ConnRef{})
 }
 
 // Pug snap name cannot be empty
 func (s *RepositorySuite) TestResolveConnectEmptyPlugSnapName(c *C) {
 	conn, err := s.testRepo.ResolveConnect("", "plug", "producer", "slot")
 	c.Check(err, ErrorMatches, "cannot resolve connection, plug snap name is empty")
-	c.Check(conn, IsNil)
+	c.Check(conn, Equals, ConnRef{})
 }
 
 // Plug name cannot be empty
 func (s *RepositorySuite) TestResolveConnectEmptyPlugName(c *C) {
 	conn, err := s.testRepo.ResolveConnect("consumer", "", "producer", "slot")
 	c.Check(err, ErrorMatches, "cannot resolve connection, plug name is empty")
-	c.Check(conn, IsNil)
+	c.Check(conn, Equals, ConnRef{})
 }
 
 // Plug must exist
 func (s *RepositorySuite) TestResolveNoSuchPlug(c *C) {
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "consumer", "slot")
 	c.Check(err, ErrorMatches, `cannot resolve connection, plug "plug" from snap "consumer", no such plug`)
-	c.Check(conn, IsNil)
+	c.Check(conn, Equals, ConnRef{})
 }
 
 // Slot snap name cannot be empty if there's no core snap around
@@ -652,7 +652,7 @@ func (s *RepositorySuite) TestResolveConnectEmptySlotSnapName(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "", "slot")
 	c.Check(err, ErrorMatches, "cannot resolve connection, slot snap name is empty")
-	c.Check(conn, IsNil)
+	c.Check(conn, Equals, ConnRef{})
 }
 
 // Slot name cannot be empty if there's no core snap around
@@ -660,7 +660,7 @@ func (s *RepositorySuite) TestResolveConnectEmptySlotName(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "producer", "")
 	c.Check(err, ErrorMatches, "cannot resolve connection, slot name is empty and there are no valid candidates")
-	c.Check(conn, IsNil)
+	c.Check(conn, Equals, ConnRef{})
 }
 
 // Slot must exists
@@ -668,7 +668,7 @@ func (s *RepositorySuite) TestResolveNoSuchSlot(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "producer", "slot")
 	c.Check(err, ErrorMatches, `cannot resolve connection, slot "slot" from snap "producer", no such slot`)
-	c.Check(conn, IsNil)
+	c.Check(conn, Equals, ConnRef{})
 }
 
 // Plug and slot must have matching types
@@ -686,7 +686,7 @@ func (s *RepositorySuite) TestResolveIncompatibleTypes(c *C) {
 	// Connecting a plug to an incompatible slot fails with an appropriate error
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "producer", "slot")
 	c.Check(err, ErrorMatches, `cannot resolve connection, plug "consumer:plug" \(interface "other-interface"\) to "producer:slot" \(interface "interface"\)`)
-	c.Check(conn, IsNil)
+	c.Check(conn, Equals, ConnRef{})
 }
 
 // Tests for Repository.Connect()

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -603,7 +603,7 @@ slots:
 	c.Assert(s.testRepo.AddSnap(coreSnap), IsNil)
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "", "")
-	c.Check(err, ErrorMatches, "cannot resolve connection, slot name is empty and there are no valid candidates")
+	c.Check(err, ErrorMatches, `snap "core" has no "interface" interface slots`)
 	c.Check(conn, Equals, ConnRef{})
 }
 
@@ -622,7 +622,7 @@ slots:
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "", "")
-	c.Check(err, ErrorMatches, "cannot resolve connection, more than one slot is a valid candidate")
+	c.Check(err, ErrorMatches, `snap "core" has multiple "interface" interface slots: slot-a, slot-b`)
 	c.Check(conn, Equals, ConnRef{})
 }
 
@@ -643,7 +643,7 @@ func (s *RepositorySuite) TestResolveConnectEmptyPlugName(c *C) {
 // Plug must exist
 func (s *RepositorySuite) TestResolveNoSuchPlug(c *C) {
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "consumer", "slot")
-	c.Check(err, ErrorMatches, `cannot resolve connection, plug "plug" from snap "consumer", no such plug`)
+	c.Check(err, ErrorMatches, `snap "consumer" has no plug named "plug"`)
 	c.Check(conn, Equals, ConnRef{})
 }
 
@@ -659,7 +659,7 @@ func (s *RepositorySuite) TestResolveConnectEmptySlotSnapName(c *C) {
 func (s *RepositorySuite) TestResolveConnectEmptySlotName(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "producer", "")
-	c.Check(err, ErrorMatches, "cannot resolve connection, slot name is empty and there are no valid candidates")
+	c.Check(err, ErrorMatches, `snap "producer" has no "interface" interface slots`)
 	c.Check(conn, Equals, ConnRef{})
 }
 
@@ -667,7 +667,7 @@ func (s *RepositorySuite) TestResolveConnectEmptySlotName(c *C) {
 func (s *RepositorySuite) TestResolveNoSuchSlot(c *C) {
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "producer", "slot")
-	c.Check(err, ErrorMatches, `cannot resolve connection, slot "slot" from snap "producer", no such slot`)
+	c.Check(err, ErrorMatches, `snap "producer" has no slot named "slot"`)
 	c.Check(conn, Equals, ConnRef{})
 }
 
@@ -685,7 +685,8 @@ func (s *RepositorySuite) TestResolveIncompatibleTypes(c *C) {
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
 	// Connecting a plug to an incompatible slot fails with an appropriate error
 	conn, err := s.testRepo.ResolveConnect("consumer", "plug", "producer", "slot")
-	c.Check(err, ErrorMatches, `cannot resolve connection, plug "consumer:plug" \(interface "other-interface"\) to "producer:slot" \(interface "interface"\)`)
+	c.Check(err, ErrorMatches,
+		`cannot connect consumer:plug \("other-interface" interface\) to producer:slot \("interface" interface\)`)
 	c.Check(conn, Equals, ConnRef{})
 }
 


### PR DESCRIPTION
This patch adds a new helper method that behaves like Repository.Connect
except that it doesn't really do the connection, just resolves the names
and handles various implicit convenience behaviors.

Subsequent patches will change Connect to take ConnRef instead, so this
logic can stay in one place and that other bits (e.g. assertion checks)
can use ResolveConnect.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>