### PR TITLE
client, cmd/snap, daemon: add is-managed command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -454,3 +454,13 @@ func (client *Client) CreateUsers(options []*CreateUserOptions) ([]*CreateUserRe
 	}
 	return results, nil
 }
+
+func (client *Client) IsManaged() (bool, error) {
+	var result bool
+
+	if _, err := client.doSync("GET", "/v2/is-managed", nil, nil, nil, &result); err != nil {
+		return false, err
+	}
+
+	return result, nil
+}

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -80,6 +80,7 @@ func autoImportFromAllMounts() error {
 		if err := ackFile(cand); err != nil {
 			logger.Noticef("error: cannot import %s: %s", cand, err)
 		} else {
+			added += 1
 			logger.Noticef("imported %s", cand)
 		}
 	}

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
@@ -83,13 +84,22 @@ func autoImportFromAllMounts() error {
 		}
 	}
 
-	// FIXME: once we have a way to know if a device is owned,
-	//        no longer call this unconditionally
 	if added > 0 {
-		// FIXME: run `snap create-users --known`
+		cli := Client()
+		isManaged, err := cli.IsManaged()
+		if err != nil {
+			logger.Noticef("error calling IsManaged: %v", err)
+		} else if !isManaged {
+			options := client.CreateUserOptions{
+				Sudoer: true,
+				Known:  true,
+			}
+
+			_, err = cli.CreateUsers([]*client.CreateUserOptions{&options})
+		}
 	}
 
-	return nil
+	return err
 }
 
 func tryMount(deviceName string) (string, error) {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -77,6 +77,7 @@ var api = []*Command{
 	eventsCmd,
 	stateChangeCmd,
 	stateChangesCmd,
+	isManagedCmd,
 	createUserCmd,
 	buyCmd,
 	readyToBuyCmd,
@@ -176,7 +177,7 @@ var (
 		GET:    getChanges,
 	}
 
-	createUserCmd = &Command{
+	isManagedCmd = &Command{
 		Path:   "/v2/is-managed",
 		UserOK: true,
 		GET:    getIsManaged,
@@ -1730,6 +1731,10 @@ func createAllKnownSystemUsers(st *state.State, createData *postUserCreateData) 
 
 		if err := osutilAddUser(username, opts); err != nil {
 			return InternalError("cannot add user %q: %s", username, err)
+		}
+
+		if err := setupLocalUser(st, username, email); err != nil {
+			return InternalError("%s", err)
 		}
 		createdUsers = append(createdUsers, createResponseData{
 			Username: username,

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -177,6 +177,12 @@ var (
 	}
 
 	createUserCmd = &Command{
+		Path:   "/v2/is-managed",
+		UserOK: true,
+		GET:    getIsManaged,
+	}
+
+	createUserCmd = &Command{
 		Path:   "/v2/create-user",
 		UserOK: false,
 		POST:   postCreateUser,
@@ -1904,6 +1910,18 @@ func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response 
 		Username: username,
 		SSHKeys:  opts.SSHKeys,
 	}, nil)
+}
+
+func getIsManaged(c *Command, r *http.Request, user *auth.UserState) Response {
+	st := c.d.overlord.State()
+	st.Lock()
+	userCount, err := auth.UserCount(st)
+	st.Unlock()
+	if err != nil {
+		return InternalError("cannot get user count: %s", err)
+	}
+
+	return SyncResponse(userCount > 0, nil)
 }
 
 func convertBuyError(err error) Response {


### PR DESCRIPTION
Also call create-user --known when importing assertions on an un-managed device.

Also also call setupLocalUser when creating users from all known assertions.