### PR TITLE
daemon: fix login API to return local macaroons

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -304,7 +304,7 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		user.StoreDischarges = []string{discharge}
 		err = auth.UpdateUser(state, user)
 	} else {
-		_, err = auth.NewUser(state, loginData.Username, loginData.Email, macaroon, []string{discharge})
+		user, err = auth.NewUser(state, loginData.Username, loginData.Email, macaroon, []string{discharge})
 	}
 	state.Unlock()
 	if err != nil {
@@ -312,8 +312,8 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	result := loginResponseData{
-		Macaroon:   macaroon,
-		Discharges: []string{discharge},
+		Macaroon:   user.Macaroon,
+		Discharges: user.Discharges,
 	}
 	return SyncResponse(result, nil)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -536,19 +536,20 @@ func (s *apiSuite) TestLoginUser(c *check.C) {
 
 	rsp := loginUser(loginCmd, req, nil).(*resp)
 
+	state.Lock()
+	user, err := auth.User(state, 1)
+	state.Unlock()
+	c.Check(err, check.IsNil)
+
 	expected := loginResponseData{
-		Macaroon:   serializedMacaroon,
-		Discharges: []string{"the-discharge-macaroon-serialized-data"},
+		Macaroon:   user.Macaroon,
+		Discharges: user.Discharges,
 	}
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Assert(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 
-	state.Lock()
-	user, err := auth.User(state, 1)
-	state.Unlock()
-	c.Check(err, check.IsNil)
 	c.Check(user.ID, check.Equals, 1)
 	c.Check(user.Username, check.Equals, "")
 	c.Check(user.Email, check.Equals, "email@.com")
@@ -583,19 +584,20 @@ func (s *apiSuite) TestLoginUserWithUsername(c *check.C) {
 
 	rsp := loginUser(loginCmd, req, nil).(*resp)
 
+	state.Lock()
+	user, err := auth.User(state, 1)
+	state.Unlock()
+	c.Check(err, check.IsNil)
+
 	expected := loginResponseData{
-		Macaroon:   serializedMacaroon,
-		Discharges: []string{"the-discharge-macaroon-serialized-data"},
+		Macaroon:   user.Macaroon,
+		Discharges: user.Discharges,
 	}
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Assert(rsp.Result, check.FitsTypeOf, expected)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 
-	state.Lock()
-	user, err := auth.User(state, 1)
-	state.Unlock()
-	c.Check(err, check.IsNil)
 	c.Check(user.ID, check.Equals, 1)
 	c.Check(user.Username, check.Equals, "username")
 	c.Check(user.Email, check.Equals, "email@.com")
@@ -638,8 +640,8 @@ func (s *apiSuite) TestLoginUserWithExistentLocalUser(c *check.C) {
 	rsp := loginUser(loginCmd, req, localUser).(*resp)
 
 	expected := loginResponseData{
-		Macaroon:   serializedMacaroon,
-		Discharges: []string{"the-discharge-macaroon-serialized-data"},
+		Macaroon:   localUser.Macaroon,
+		Discharges: localUser.Discharges,
 	}
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)


### PR DESCRIPTION
Updates LoginUser to return the user local macaroons instead of store ones.