### PR TITLE
snap: relax auto-import test

### DIFF
--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -77,6 +77,9 @@ func (s *SnapSuite) TestAutoImportAssertsHappy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Check(s.Stdout(), Equals, "")
-	c.Check(s.Stderr(), Equals, fmt.Sprintf("imported %s\n", fakeAssertsFn))
+	// matches because we may get a:
+	//   "WARNING: cannot create syslog logger\n"
+	// in the output
+	c.Check(s.Stderr(), Matches, fmt.Sprintf("(?ms).*imported %s\n", fakeAssertsFn))
 	c.Check(n, Equals, total)
 }


### PR DESCRIPTION
The output on stderr may also contain a warni…ng that it couldn't create a logger. This fixes a fails to build from source in the PPA: https://launchpadlibrarian.net/288176526/buildlog_ubuntu-xenial-amd64.snapd_2.16+ppa25-1_BUILDING.txt.gz