### PR TITLE
cmd/snap: generate account-key revocation requests

### DIFF
--- a/cmd/snap/cmd_export_key_test.go
+++ b/cmd/snap/cmd_export_key_test.go
@@ -20,12 +20,19 @@
 package main_test
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"time"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/store"
+
 	snap "github.com/snapcore/snapd/cmd/snap"
 )
 
@@ -83,4 +90,78 @@ func (s *SnapKeysSuite) TestExportKeyAccount(c *C) {
 	c.Assert(err, IsNil)
 	err = asserts.SignatureCheck(assertion, privKey.PublicKey())
 	c.Assert(err, IsNil)
+}
+
+func (s *SnapKeysSuite) TestExportKeyRevoke(c *C) {
+	rootPrivKey, _ := assertstest.GenerateKey(1024)
+	storePrivKey, _ := assertstest.GenerateKey(752)
+	storeSigning := assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+	trustedRestorer := sysdb.InjectTrusted(storeSigning.Trusted)
+	defer trustedRestorer()
+	manager := asserts.NewGPGKeypairManager()
+	privKey, err := manager.Get("DVQf1U4mIsuzlQqAebjjTPYtYJ-GEhJy0REuj3zvpQYTZ7EJj7adBxIXLJ7Vmk3L")
+	c.Assert(err, IsNil)
+	devAcct := assertstest.NewAccount(storeSigning, "developer1", map[string]interface{}{
+		"account-id": "developer1",
+	}, "")
+	devKey := assertstest.NewAccountKey(storeSigning, devAcct, map[string]interface{}{
+		"name": "another",
+	}, privKey.PublicKey(), "")
+
+	var server *httptest.Server
+
+	restorer := snap.MockStoreNew(func(cfg *store.Config, auth auth.AuthContext) *store.Store {
+		if cfg == nil {
+			cfg = store.DefaultConfig()
+		}
+		serverURL, err := url.Parse(server.URL + "/assertions/")
+		c.Assert(err, IsNil)
+		cfg.AssertionsURI = serverURL
+		return store.New(cfg, auth)
+	})
+	defer restorer()
+
+	n := 0
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/assertions/account-key/"+privKey.PublicKey().ID())
+			w.Write(asserts.Encode(devKey))
+		case 1:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/assertions/account/developer1")
+			w.Write(asserts.Encode(devAcct))
+		case 2:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/assertions/account-key/"+storePrivKey.PublicKey().ID())
+			w.Write(asserts.Encode(storeSigning.StoreAccountKey("")))
+		case 3:
+			c.Check(r.Method, Equals, "GET")
+			c.Check(r.URL.Path, Equals, "/assertions/account-key/"+rootPrivKey.PublicKey().ID())
+			w.Write(asserts.Encode(storeSigning.TrustedKey))
+		default:
+			c.Fatalf("expected to get 4 requests, now on %d: %v", n+1, r)
+		}
+
+		n++
+	}))
+
+	rest, err := snap.Parser().ParseArgs([]string{"export-key", "another", "--account=developer1", "--revoke"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	assertion, err := asserts.Decode(s.stdout.Bytes())
+	c.Assert(err, IsNil)
+	c.Check(assertion.Type(), Equals, asserts.AccountKeyRequestType)
+	c.Check(assertion.Revision(), Equals, 1)
+	c.Check(assertion.HeaderString("account-id"), Equals, "developer1")
+	c.Check(assertion.HeaderString("name"), Equals, "another")
+	c.Check(assertion.HeaderString("public-key-sha3-384"), Equals, "DVQf1U4mIsuzlQqAebjjTPYtYJ-GEhJy0REuj3zvpQYTZ7EJj7adBxIXLJ7Vmk3L")
+	since, err := time.Parse(time.RFC3339, assertion.HeaderString("since"))
+	c.Assert(err, IsNil)
+	zone, offset := since.Zone()
+	c.Check(zone, Equals, "UTC")
+	c.Check(offset, Equals, 0)
+	c.Check(assertion.HeaderString("until"), Equals, assertion.HeaderString("since"))
+	c.Check(s.Stderr(), Equals, "")
 }

--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/store"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -62,8 +61,6 @@ func init() {
 }
 
 var nl = []byte{'\n'}
-
-var storeNew = store.New
 
 func downloadAssertion(typeName string, headers map[string]string) ([]asserts.Assertion, error) {
 	var user *auth.UserState

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/store"
 
 	"github.com/jessevdk/go-flags"
 )
@@ -215,6 +216,8 @@ var ClientConfig client.Config
 func Client() *client.Client {
 	return client.New(&ClientConfig)
 }
+
+var storeNew = store.New
 
 func init() {
 	err := logger.SimpleSetup()


### PR DESCRIPTION
Add "snap export-key --account=<account-id> --revoke" to generate an
account-key revocation request, which is formatted as an
account-key-request with since == until.  We consult the store to
determine the necessary revision of the new account-key-request
assertion.

Note that the client may not yet always respond to revoked assertions
correctly, e.g. by removing packages signed by a revoked key, but it
will at least refuse to accept the revoked key for signing future
assertions.
