### PR TITLE
interfaces,overlord/ifacestate: initial cleaning up of no arg AutoConnect related bits

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -153,12 +153,12 @@ To test the `snapd` REST API daemon on a snappy system you need to
 transfer it to the snappy system and then run:
 
     sudo systemctl stop snapd.service snapd.socket
-    sudo /lib/systemd/systemd-activate -E SNAPD_DEBUG=1 -E SNAP_REEXEC=0 -E SNAPD_DEBUG_HTTP3 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
+    sudo /lib/systemd/systemd-activate -E SNAPD_DEBUG=1 -E SNAP_REEXEC=0 -E SNAPD_DEBUG_HTTP=3 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
 
 or with systemd version >= 230
 
     sudo systemctl stop snapd.service snapd.socket
-    sudo systemd-socket-activate -E SNAPD_DEBUG=1 -E SNAP_REEXEC=0 -E SNAPD_DEBUG_HTTP3 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
+    sudo systemd-socket-activate -E SNAPD_DEBUG=1 -E SNAP_REEXEC=0 -E SNAPD_DEBUG_HTTP=3 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
 
 This will stop the installed snapd and activate the new one. Once it's
 printed out something like `Listening on /run/snapd.socket as 3.` you

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -118,17 +118,39 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		"snapd-control": true,
 	}
 
+	// these simply auto-connect, anything else doesn't
+	autoconnect := map[string]bool{
+		"browser-support":        true,
+		"mir":                    true,
+		"pulseaudio":             true,
+		"gsettings":              true,
+		"network":                true,
+		"network-bind":           true,
+		"screen-inhibit-control": true,
+		"unity7":                 true,
+		"upower-observe":         true,
+		"x11":                    true,
+		"opengl":                 true,
+		"optical-drive":          true,
+	}
+
 	for _, iface := range all {
 		if snowflakes[iface.Name()] {
 			continue
 		}
-		expected := iface.LegacyAutoConnect()
+		expected := autoconnect[iface.Name()]
+		comm := Commentf(iface.Name())
+
+		// cross-check with past behavior
+		c.Check(expected, Equals, iface.LegacyAutoConnect(), comm)
+
+		// check base declaration
 		cand := s.connectCand(c, iface.Name(), "", "")
 		err := cand.CheckAutoConnect()
 		if expected {
-			c.Check(err, IsNil, Commentf(iface.Name()))
+			c.Check(err, IsNil, comm)
 		} else {
-			c.Check(err, NotNil, Commentf(iface.Name()))
+			c.Check(err, NotNil, comm)
 		}
 	}
 }

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -133,7 +133,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 	}
 }
 
-func (s *baseDeclSuite) TestAutoConnectPair(c *C) {
+func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *C) {
 	all := builtin.Interfaces()
 
 	// these have more complex or in flux policies and have their
@@ -148,12 +148,12 @@ func (s *baseDeclSuite) TestAutoConnectPair(c *C) {
 		if snowflakes[iface.Name()] {
 			continue
 		}
-		c.Check(iface.AutoConnectPair(nil, nil), Equals, true)
+		c.Check(iface.AutoConnect(nil, nil), Equals, true)
 	}
 }
 
-func (s *baseDeclSuite) TestInterimAutoConnectHome(c *C) {
-	// home will be controlled by AutoConnectPair(plug, slot) until
+func (s *baseDeclSuite) TestInterimAutoConnectionHome(c *C) {
+	// home will be controlled by AutoConnect(plug, slot) until
 	// we have on-classic support in decls
 	// to stop it from working on non-classic
 	cand := s.connectCand(c, "home", "", "")
@@ -161,22 +161,22 @@ func (s *baseDeclSuite) TestInterimAutoConnectHome(c *C) {
 	c.Check(err, IsNil)
 }
 
-func (s *baseDeclSuite) TestInterimAutoConnectSnapdControl(c *C) {
+func (s *baseDeclSuite) TestInterimAutoConnectionSnapdControl(c *C) {
 	// snapd-control is auto-connect until we have snap declaration editing
 	cand := s.connectCand(c, "snapd-control", "", "")
 	err := cand.CheckAutoConnect()
 	c.Check(err, IsNil)
 }
 
-func (s *baseDeclSuite) TestAutoConnectContent(c *C) {
-	// content will also depend for now AutoConnectPair(plug, slot)
+func (s *baseDeclSuite) TestAutoConnectionContent(c *C) {
+	// content will also depend for now AutoConnect(plug, slot)
 	// random snaps cannot connect with content
 	cand := s.connectCand(c, "content", "", "")
 	err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 }
 
-func (s *baseDeclSuite) TestAutoConnectLxdSupport(c *C) {
+func (s *baseDeclSuite) TestAutoConnectionLxdSupport(c *C) {
 	cand := s.connectCand(c, "lxd-support", "", "")
 	err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -122,7 +122,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		if snowflakes[iface.Name()] {
 			continue
 		}
-		expected := iface.AutoConnect()
+		expected := iface.LegacyAutoConnect()
 		cand := s.connectCand(c, iface.Name(), "", "")
 		err := cand.CheckAutoConnect()
 		if expected {
@@ -169,7 +169,7 @@ func (s *baseDeclSuite) TestInterimAutoConnectSnapdControl(c *C) {
 }
 
 func (s *baseDeclSuite) TestAutoConnectContent(c *C) {
-	// content will also depend for now AutoConnect(plug, slot)
+	// content will also depend for now AutoConnectPair(plug, slot)
 	// random snaps cannot connect with content
 	cand := s.connectCand(c, "content", "", "")
 	err := cand.CheckAutoConnect()

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -121,17 +121,17 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 	// these simply auto-connect, anything else doesn't
 	autoconnect := map[string]bool{
 		"browser-support":        true,
-		"mir":                    true,
-		"pulseaudio":             true,
 		"gsettings":              true,
+		"mir":                    true,
 		"network":                true,
 		"network-bind":           true,
+		"opengl":                 true,
+		"optical-drive":          true,
+		"pulseaudio":             true,
 		"screen-inhibit-control": true,
 		"unity7":                 true,
 		"upower-observe":         true,
 		"x11":                    true,
-		"opengl":                 true,
-		"optical-drive":          true,
 	}
 
 	for _, iface := range all {

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -90,5 +90,5 @@ func (s *BluetoothControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *BluetoothControlInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -89,6 +89,6 @@ func (s *BluetoothControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *BluetoothControlInterfaceSuite) TestAutoConnect(c *C) {
+func (s *BluetoothControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -233,7 +233,7 @@ func (iface *BluezInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *BluezInterface) AutoConnect() bool {
+func (iface *BluezInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -237,7 +237,7 @@ func (iface *BluezInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *BluezInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *BluezInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -151,11 +151,11 @@ func (iface *BoolFileInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-// AutoConnectPair returns whether plug and slot should be implicitly
+// AutoConnect returns whether plug and slot should be implicitly
 // auto-connected assuming they will be an unambiguous connection
 // candidate and declaration-based checks allow.
 //
 // By default we allow what declarations allowed.
-func (iface *BoolFileInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *BoolFileInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -147,11 +147,7 @@ func (iface *BoolFileInterface) isGPIO(slot *interfaces.Slot) bool {
 	panic("slot is not sanitized")
 }
 
-// AutoConnect returns true if plugs and slots should be implicitly
-// auto-connected when an unambiguous connection candidate is available.
-//
-// This interface does not auto-connect.
-func (iface *BoolFileInterface) AutoConnect() bool {
+func (iface *BoolFileInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -238,6 +238,6 @@ func (s *BoolFileInterfaceSuite) TestPermanentSlotSnippetPanicksOnUnsanitizedSlo
 	}, PanicMatches, "slot is not sanitized")
 }
 
-func (s *BoolFileInterfaceSuite) TestAutoConnect(c *C) {
+func (s *BoolFileInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -239,5 +239,5 @@ func (s *BoolFileInterfaceSuite) TestPermanentSlotSnippetPanicksOnUnsanitizedSlo
 }
 
 func (s *BoolFileInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -260,7 +260,7 @@ func (iface *BrowserSupportInterface) PermanentPlugSnippet(plug *interfaces.Plug
 	return nil, nil
 }
 
-func (iface *BrowserSupportInterface) AutoConnect() bool {
+func (iface *BrowserSupportInterface) LegacyAutoConnect() bool {
 	return true
 }
 

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -264,6 +264,6 @@ func (iface *BrowserSupportInterface) LegacyAutoConnect() bool {
 	return true
 }
 
-func (iface *BrowserSupportInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *BrowserSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -174,6 +174,6 @@ func (s *BrowserSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *BrowserSupportInterfaceSuite) TestAutoConnect(c *C) {
+func (s *BrowserSupportInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -175,5 +175,5 @@ func (s *BrowserSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *BrowserSupportInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -39,7 +39,7 @@ type commonInterface struct {
 	connectedPlugSecComp   string
 	connectedPlugKMod      string
 	reservedForOS          bool
-	autoConnect            bool
+	autoConnect            bool // OBSOLETE, only cross-check info atm
 	rejectAutoConnectPairs bool
 }
 
@@ -120,11 +120,11 @@ func (iface *commonInterface) LegacyAutoConnect() bool {
 	return iface.autoConnect
 }
 
-// AutoConnectPair returns whether plug and slot should be implicitly
+// AutoConnect returns whether plug and slot should be implicitly
 // auto-connected assuming they will be an unambiguous connection
 // candidate and declaration-based checks allow.
 //
 // By default we allow what declarations allowed.
-func (iface *commonInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *commonInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return !iface.rejectAutoConnectPairs
 }

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -116,9 +116,7 @@ func (iface *commonInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *
 	return nil, nil
 }
 
-// AutoConnect returns true if plugs and slots should be implicitly
-// auto-connected when an unambiguous connection candidate is available.
-func (iface *commonInterface) AutoConnect() bool {
+func (iface *commonInterface) LegacyAutoConnect() bool {
 	return iface.autoConnect
 }
 

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -153,7 +153,7 @@ func (iface *ContentInterface) PermanentPlugSnippet(plug *interfaces.Plug, secur
 	return nil, nil
 }
 
-func (iface *ContentInterface) AutoConnect() bool {
+func (iface *ContentInterface) LegacyAutoConnect() bool {
 	return true
 }
 

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -157,6 +157,6 @@ func (iface *ContentInterface) LegacyAutoConnect() bool {
 	return true
 }
 
-func (iface *ContentInterface) AutoConnectPair(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (iface *ContentInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	return plug.Attrs["content"] == slot.Attrs["content"]
 }

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -246,7 +246,7 @@ slots:
 	c.Assert(string(content), Equals, expected)
 }
 
-func (s *ContentSuite) TestAutoConnectPair(c *C) {
+func (s *ContentSuite) TestLegacyAutoConnect(c *C) {
 	const plugSnapYaml = `name: content-slot-snap
 version: 1.0
 plugs:
@@ -267,7 +267,7 @@ slots:
 	info = snaptest.MockInfo(c, slotSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
 
-	c.Check(s.iface.AutoConnectPair(plug, slot), Equals, true)
+	c.Check(s.iface.AutoConnect(plug, slot), Equals, true)
 
 	const otherSnapYaml = `name: content-other-snap
 version: 1.0
@@ -279,5 +279,5 @@ slots:
 	info = snaptest.MockInfo(c, otherSnapYaml, nil)
 	otherslot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
 
-	c.Check(s.iface.AutoConnectPair(plug, otherslot), Equals, false)
+	c.Check(s.iface.AutoConnect(plug, otherslot), Equals, false)
 }

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -94,7 +94,7 @@ func (iface *DockerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *DockerInterface) AutoConnect() bool {
+func (iface *DockerInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -98,7 +98,7 @@ func (iface *DockerInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *DockerInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *DockerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -584,7 +584,7 @@ func (iface *DockerSupportInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *DockerSupportInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *DockerSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -580,7 +580,7 @@ func (iface *DockerSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *DockerSupportInterface) AutoConnect() bool {
+func (iface *DockerSupportInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -72,7 +72,7 @@ func (s *DockerSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *DockerSupportInterfaceSuite) TestAutoConnect(c *C) {
+func (s *DockerSupportInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }
 

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -73,7 +73,7 @@ func (s *DockerSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *DockerSupportInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }
 
 func (s *DockerSupportInterfaceSuite) TestConnectedPlugSnippet(c *C) {

--- a/interfaces/builtin/docker_test.go
+++ b/interfaces/builtin/docker_test.go
@@ -71,7 +71,7 @@ func (s *DockerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *DockerInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }
 
 func (s *DockerInterfaceSuite) TestConnectedPlugSnippet(c *C) {

--- a/interfaces/builtin/docker_test.go
+++ b/interfaces/builtin/docker_test.go
@@ -70,7 +70,7 @@ func (s *DockerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *DockerInterfaceSuite) TestAutoConnect(c *C) {
+func (s *DockerInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }
 

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -94,5 +94,5 @@ func (s *FirewallControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *FirewallControlInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -93,6 +93,6 @@ func (s *FirewallControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *FirewallControlInterfaceSuite) TestAutoConnect(c *C) {
+func (s *FirewallControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -90,5 +90,5 @@ func (s *FuseSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *FuseSupportInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -89,6 +89,6 @@ func (s *FuseSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *FuseSupportInterfaceSuite) TestAutoConnect(c *C) {
+func (s *FuseSupportInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -248,8 +248,7 @@ func (iface *FwupdInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-// AutoConnect returns whether interface should be auto-connected by default
-func (iface *FwupdInterface) AutoConnect() bool {
+func (iface *FwupdInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -252,7 +252,7 @@ func (iface *FwupdInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *FwupdInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *FwupdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -135,8 +135,7 @@ func (iface *GpioInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *in
 	return nil, nil
 }
 
-// AutoConnect returns whether interface should be auto-connected by default
-func (iface *GpioInterface) AutoConnect() bool {
+func (iface *GpioInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -139,7 +139,7 @@ func (iface *GpioInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *GpioInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *GpioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/gsettings_test.go
+++ b/interfaces/builtin/gsettings_test.go
@@ -89,6 +89,6 @@ func (s *GsettingsInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *GsettingsInterfaceSuite) TestAutoConnect(c *C) {
+func (s *GsettingsInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/gsettings_test.go
+++ b/interfaces/builtin/gsettings_test.go
@@ -90,5 +90,5 @@ func (s *GsettingsInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *GsettingsInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -85,6 +85,6 @@ func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *HardwareObserveInterfaceSuite) TestAutoConnect(c *C) {
+func (s *HardwareObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -86,5 +86,5 @@ func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *HardwareObserveInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -179,8 +179,7 @@ func (iface *HidrawInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *
 	return nil, nil
 }
 
-// AutoConnect indicates whether this type of interface should allow autoconnect
-func (iface *HidrawInterface) AutoConnect() bool {
+func (iface *HidrawInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -183,7 +183,7 @@ func (iface *HidrawInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *HidrawInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *HidrawInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -91,7 +91,7 @@ func (s *HomeInterfaceSuite) TestAutoConnectOnClassic(c *C) {
 	defer restore()
 	iface := builtin.NewHomeInterface()
 	c.Check(iface.LegacyAutoConnect(), Equals, true)
-	c.Check(iface.AutoConnectPair(nil, nil), Equals, true)
+	c.Check(iface.AutoConnect(nil, nil), Equals, true)
 }
 
 func (s *HomeInterfaceSuite) TestAutoConnectOnCore(c *C) {
@@ -99,5 +99,5 @@ func (s *HomeInterfaceSuite) TestAutoConnectOnCore(c *C) {
 	defer restore()
 	iface := builtin.NewHomeInterface()
 	c.Check(iface.LegacyAutoConnect(), Equals, false)
-	c.Check(iface.AutoConnectPair(nil, nil), Equals, false)
+	c.Check(iface.AutoConnect(nil, nil), Equals, false)
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -90,7 +90,7 @@ func (s *HomeInterfaceSuite) TestAutoConnectOnClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 	iface := builtin.NewHomeInterface()
-	c.Check(iface.AutoConnect(), Equals, true)
+	c.Check(iface.LegacyAutoConnect(), Equals, true)
 	c.Check(iface.AutoConnectPair(nil, nil), Equals, true)
 }
 
@@ -98,6 +98,6 @@ func (s *HomeInterfaceSuite) TestAutoConnectOnCore(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 	iface := builtin.NewHomeInterface()
-	c.Check(iface.AutoConnect(), Equals, false)
+	c.Check(iface.LegacyAutoConnect(), Equals, false)
 	c.Check(iface.AutoConnectPair(nil, nil), Equals, false)
 }

--- a/interfaces/builtin/libvirt_test.go
+++ b/interfaces/builtin/libvirt_test.go
@@ -65,6 +65,6 @@ func (s *LibvirtInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *LibvirtInterfaceSuite) TestAutoConnect(c *C) {
+func (s *LibvirtInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/libvirt_test.go
+++ b/interfaces/builtin/libvirt_test.go
@@ -66,5 +66,5 @@ func (s *LibvirtInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *LibvirtInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -86,5 +86,5 @@ func (s *LocaleControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *LocaleControlInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -85,6 +85,6 @@ func (s *LocaleControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *LocaleControlInterfaceSuite) TestAutoConnect(c *C) {
+func (s *LocaleControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -196,7 +196,7 @@ func (iface *LocationControlInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *LocationControlInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *LocationControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -192,7 +192,7 @@ func (iface *LocationControlInterface) SanitizeSlot(slot *interfaces.Slot) error
 	return nil
 }
 
-func (iface *LocationControlInterface) AutoConnect() bool {
+func (iface *LocationControlInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -281,7 +281,7 @@ func (iface *LocationObserveInterface) SanitizeSlot(slot *interfaces.Slot) error
 	return nil
 }
 
-func (iface *LocationObserveInterface) AutoConnect() bool {
+func (iface *LocationObserveInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -285,7 +285,7 @@ func (iface *LocationObserveInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *LocationObserveInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *LocationObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -86,5 +86,5 @@ func (s *LogObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *LogObserveInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -85,6 +85,6 @@ func (s *LogObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *LogObserveInterfaceSuite) TestAutoConnect(c *C) {
+func (s *LogObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -82,7 +82,7 @@ func (iface *LxdSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *LxdSupportInterface) AutoConnect() bool {
+func (iface *LxdSupportInterface) LegacyAutoConnect() bool {
 	// since limited to lxd.canonical, we can auto-connect
 	return true
 }

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -87,7 +87,7 @@ func (iface *LxdSupportInterface) LegacyAutoConnect() bool {
 	return true
 }
 
-func (iface *LxdSupportInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *LxdSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -142,7 +142,7 @@ func (s *LxdSupportInterfaceSuite) TestPermanentSlotPolicySecComp(c *C) {
 }
 
 func (s *LxdSupportInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }
 
 func (s *LxdSupportInterfaceSuite) TestAutoConnectPair(c *C) {

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -141,10 +141,10 @@ func (s *LxdSupportInterfaceSuite) TestPermanentSlotPolicySecComp(c *C) {
 	c.Check(string(snippet), testutil.Contains, "@unrestricted\n")
 }
 
-func (s *LxdSupportInterfaceSuite) TestAutoConnect(c *C) {
+func (s *LxdSupportInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }
 
-func (s *LxdSupportInterfaceSuite) TestAutoConnectPair(c *C) {
-	c.Check(s.iface.AutoConnectPair(nil, nil), Equals, true)
+func (s *LxdSupportInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)
 }

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -140,6 +140,6 @@ func (iface *MirInterface) LegacyAutoConnect() bool {
 	return true
 }
 
-func (iface *MirInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *MirInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -136,7 +136,7 @@ func (iface *MirInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *MirInterface) AutoConnect() bool {
+func (iface *MirInterface) LegacyAutoConnect() bool {
 	return true
 }
 

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -73,6 +73,6 @@ func (s *MirInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	}
 }
 
-func (s MirInterfaceSuite) TestAutoConnect(c *C) {
+func (s MirInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -74,5 +74,5 @@ func (s *MirInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s MirInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1213,7 +1213,7 @@ func (iface *ModemManagerInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *ModemManagerInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *ModemManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1209,7 +1209,7 @@ func (iface *ModemManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *ModemManagerInterface) AutoConnect() bool {
+func (iface *ModemManagerInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -86,5 +86,5 @@ func (s *MountObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *MountObserveInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -85,6 +85,6 @@ func (s *MountObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *MountObserveInterfaceSuite) TestAutoConnect(c *C) {
+func (s *MountObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -252,7 +252,7 @@ func (iface *MprisInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *MprisInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *MprisInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -248,7 +248,7 @@ func (iface *MprisInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return err
 }
 
-func (iface *MprisInterface) AutoConnect() bool {
+func (iface *MprisInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/mpris_test.go
+++ b/interfaces/builtin/mpris_test.go
@@ -344,7 +344,7 @@ func (s *MprisInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *MprisInterfaceSuite) TestAutoConnect(c *C) {
+func (s *MprisInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	iface := &builtin.MprisInterface{}
 	c.Check(iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/mpris_test.go
+++ b/interfaces/builtin/mpris_test.go
@@ -346,5 +346,5 @@ func (s *MprisInterfaceSuite) TestUsedSecuritySystems(c *C) {
 
 func (s *MprisInterfaceSuite) TestAutoConnect(c *C) {
 	iface := &builtin.MprisInterface{}
-	c.Check(iface.AutoConnect(), Equals, false)
+	c.Check(iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -89,6 +89,6 @@ func (s *NetworkBindInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *NetworkBindInterfaceSuite) TestAutoConnect(c *C) {
+func (s *NetworkBindInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -90,5 +90,5 @@ func (s *NetworkBindInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *NetworkBindInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -446,7 +446,7 @@ func (iface *NetworkManagerInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *NetworkManagerInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *NetworkManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -442,7 +442,7 @@ func (iface *NetworkManagerInterface) SanitizeSlot(slot *interfaces.Slot) error 
 	return nil
 }
 
-func (iface *NetworkManagerInterface) AutoConnect() bool {
+func (iface *NetworkManagerInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -89,6 +89,6 @@ func (s *NetworkObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *NetworkObserveInterfaceSuite) TestAutoConnect(c *C) {
+func (s *NetworkObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -90,5 +90,5 @@ func (s *NetworkObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *NetworkObserveInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -86,5 +86,5 @@ func (s *NetworkSetupObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *NetworkSetupObserveInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -85,6 +85,6 @@ func (s *NetworkSetupObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *NetworkSetupObserveInterfaceSuite) TestAutoConnect(c *C) {
+func (s *NetworkSetupObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -89,6 +89,6 @@ func (s *NetworkInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *NetworkInterfaceSuite) TestAutoConnect(c *C) {
+func (s *NetworkInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -90,5 +90,5 @@ func (s *NetworkInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *NetworkInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -90,7 +90,7 @@ func (iface *PppInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *PppInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *PppInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -86,7 +86,7 @@ func (iface *PppInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *PppInterface) AutoConnect() bool {
+func (iface *PppInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -88,6 +88,6 @@ func (s *ProcessControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *ProcessControlInterfaceSuite) TestAutoConnect(c *C) {
+func (s *ProcessControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -89,5 +89,5 @@ func (s *ProcessControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *ProcessControlInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -160,7 +160,7 @@ func (iface *PulseAudioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *PulseAudioInterface) AutoConnect() bool {
+func (iface *PulseAudioInterface) LegacyAutoConnect() bool {
 	return true
 }
 

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -164,6 +164,6 @@ func (iface *PulseAudioInterface) LegacyAutoConnect() bool {
 	return true
 }
 
-func (iface *PulseAudioInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *PulseAudioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -86,5 +86,5 @@ func (s *RemovableMediaInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *RemovableMediaInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -85,6 +85,6 @@ func (s *RemovableMediaInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *RemovableMediaInterfaceSuite) TestAutoConnect(c *C) {
+func (s *RemovableMediaInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -89,6 +89,6 @@ func (s *ScreenInhibitControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *ScreenInhibitControlInterfaceSuite) TestAutoConnect(c *C) {
+func (s *ScreenInhibitControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -90,5 +90,5 @@ func (s *ScreenInhibitControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *ScreenInhibitControlInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -183,7 +183,7 @@ func (iface *SerialPortInterface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *SerialPortInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *SerialPortInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -179,8 +179,7 @@ func (iface *SerialPortInterface) ConnectedPlugSnippet(plug *interfaces.Plug, sl
 	return nil, nil
 }
 
-// AutoConnect indicates whether this type of interface should allow autoconnect
-func (iface *SerialPortInterface) AutoConnect() bool {
+func (iface *SerialPortInterface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -182,7 +182,6 @@ func (iface *SerialPortInterface) ConnectedPlugSnippet(plug *interfaces.Plug, sl
 // AutoConnect indicates whether this type of interface should allow autoconnect
 func (iface *SerialPortInterface) AutoConnect() bool {
 	return false
-
 }
 
 func (iface *SerialPortInterface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -89,6 +89,6 @@ func (s *SnapdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *SnapdControlInterfaceSuite) TestAutoConnect(c *C) {
+func (s *SnapdControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -90,5 +90,5 @@ func (s *SnapdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *SnapdControlInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -90,5 +90,5 @@ func (s *SystemObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *SystemObserveInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -89,6 +89,6 @@ func (s *SystemObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *SystemObserveInterfaceSuite) TestAutoConnect(c *C) {
+func (s *SystemObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -85,6 +85,6 @@ func (s *SystemTraceInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *SystemTraceInterfaceSuite) TestAutoConnect(c *C) {
+func (s *SystemTraceInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -86,5 +86,5 @@ func (s *SystemTraceInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *SystemTraceInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -90,5 +90,5 @@ func (s *TimeControlTestInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *TimeControlTestInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -89,6 +89,6 @@ func (s *TimeControlTestInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *TimeControlTestInterfaceSuite) TestAutoConnect(c *C) {
+func (s *TimeControlTestInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -91,5 +91,5 @@ func (s *TimeserverControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *TimeserverControlInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -90,6 +90,6 @@ func (s *TimeserverControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *TimeserverControlInterfaceSuite) TestAutoConnect(c *C) {
+func (s *TimeserverControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -90,6 +90,6 @@ func (s *TimezoneControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *TimezoneControlInterfaceSuite) TestAutoConnect(c *C) {
+func (s *TimezoneControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -91,5 +91,5 @@ func (s *TimezoneControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *TimezoneControlInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -85,6 +85,6 @@ func (s *TpmInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *TpmInterfaceSuite) TestAutoConnect(c *C) {
+func (s *TpmInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -86,5 +86,5 @@ func (s *TpmInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *TpmInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -414,7 +414,7 @@ func (iface *UDisks2Interface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *UDisks2Interface) AutoConnect() bool {
+func (iface *UDisks2Interface) LegacyAutoConnect() bool {
 	return false
 }
 

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -418,7 +418,7 @@ func (iface *UDisks2Interface) LegacyAutoConnect() bool {
 	return false
 }
 
-func (iface *UDisks2Interface) AutoConnectPair(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *UDisks2Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -251,5 +251,5 @@ func (s *UDisks2InterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, false)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -250,6 +250,6 @@ func (s *UDisks2InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *UDisks2InterfaceSuite) TestAutoConnect(c *C) {
+func (s *UDisks2InterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
 }

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -89,6 +89,6 @@ func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *Unity7InterfaceSuite) TestAutoConnect(c *C) {
+func (s *Unity7InterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -90,5 +90,5 @@ func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *Unity7InterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -90,5 +90,5 @@ func (s *UPowerObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *UPowerObserveInterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -89,6 +89,6 @@ func (s *UPowerObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *UPowerObserveInterfaceSuite) TestAutoConnect(c *C) {
+func (s *UPowerObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -91,7 +91,7 @@ func (s *X11InterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *X11InterfaceSuite) TestAutoConnect(c *C) {
-	c.Check(s.iface.AutoConnect(), Equals, true)
+	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }
 
 // The getsockname system call is allowed

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -90,7 +90,7 @@ func (s *X11InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *X11InterfaceSuite) TestAutoConnect(c *C) {
+func (s *X11InterfaceSuite) TestLegacyAutoConnect(c *C) {
 	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
 }
 

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -150,11 +150,11 @@ type Interface interface {
 	// doesn't recognize the security system.
 	ConnectedSlotSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
-	// AutoConnect returns whether plugs and slots should be implicitly
-	// auto-connected when an unambiguous connection candidate is available in
-	// the OS snap.
-	// TODO: make this completely obsolete
-	AutoConnect() bool
+	// LegacyAutoConnect is OBSOLETE, only used temporarily in tests
+	// to cross check with past behavior.
+	// It returned whether plugs and slots should be implicitly
+	// auto-connected when an unambiguous connection candidate is available.
+	LegacyAutoConnect() bool
 
 	// AutoConnectPair returns whether plug and slot should be
 	// implicitly auto-connected assuming they will be an

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -156,11 +156,11 @@ type Interface interface {
 	// auto-connected when an unambiguous connection candidate is available.
 	LegacyAutoConnect() bool
 
-	// AutoConnectPair returns whether plug and slot should be
+	// AutoConnect returns whether plug and slot should be
 	// implicitly auto-connected assuming they will be an
 	// unambiguous connection candidate and declaration-based checks
 	// allow.
-	AutoConnectPair(plug *Plug, slot *Slot) bool
+	AutoConnect(plug *Plug, slot *Slot) bool
 }
 
 // SecuritySystem is a name of a security system.

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -803,25 +803,19 @@ func (r *Repository) AutoConnectCandidates(plugSnapName, plugName string, policy
 	var candidates []*Slot
 	for _, slotsForSnap := range r.slots {
 		for _, slot := range slotsForSnap {
-			if r.isAutoConnectCandidate(plug, slot, policyCheck) {
+			if slot.Interface != plug.Interface {
+				continue
+			}
+
+			// declaration based checks disallow
+			if !policyCheck(plug, slot) {
+				continue
+			}
+
+			if r.ifaces[plug.Interface].AutoConnect(plug, slot) {
 				candidates = append(candidates, slot)
 			}
 		}
 	}
 	return candidates
-}
-
-// isAutoConnectCandidate returns true if the plug is a candidate to
-// automatically connect to the given slot.
-func (r *Repository) isAutoConnectCandidate(plug *Plug, slot *Slot, policyCheck func(*Plug, *Slot) bool) bool {
-	if slot.Interface != plug.Interface {
-		return false
-	}
-
-	// declaration based checks disallow
-	if !policyCheck(plug, slot) {
-		return false
-	}
-
-	return r.ifaces[plug.Interface].AutoConnect(plug, slot)
 }

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -760,7 +760,7 @@ func (r *Repository) AutoConnectBlacklist(snapName string) map[string]bool {
 		// XXX: what do about this? it's mostly an optimisation,
 		// anyway this is logic is probably already doing the wrong
 		// thing in some corner cases
-		if !iface.AutoConnect() {
+		if !iface.LegacyAutoConnect() {
 			continue
 		}
 		if len(r.plugSlots[plug]) != 0 {

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -745,35 +745,6 @@ func (r *Repository) RemoveSnap(snapName string) error {
 	return nil
 }
 
-// AutoConnectBlacklist returns plug names that should not be auto-connected.
-//
-// Plug is blacklisted if it has no connections despite using an auto-connected
-// interface. That implies it was manually disconnected.
-func (r *Repository) AutoConnectBlacklist(snapName string) map[string]bool {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	var blacklist map[string]bool
-
-	for plugName, plug := range r.plugs[snapName] {
-		iface := r.ifaces[plug.Interface]
-		// XXX: what do about this? it's mostly an optimisation,
-		// anyway this is logic is probably already doing the wrong
-		// thing in some corner cases
-		if !iface.LegacyAutoConnect() {
-			continue
-		}
-		if len(r.plugSlots[plug]) != 0 {
-			continue
-		}
-		if blacklist == nil {
-			blacklist = make(map[string]bool)
-		}
-		blacklist[plugName] = true
-	}
-	return blacklist
-}
-
 // DisconnectSnap disconnects all the connections to and from a given snap.
 //
 // The return value is a list of names that were affected.

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -823,5 +823,5 @@ func (r *Repository) isAutoConnectCandidate(plug *Plug, slot *Slot, policyCheck 
 		return false
 	}
 
-	return r.ifaces[plug.Interface].AutoConnectPair(plug, slot)
+	return r.ifaces[plug.Interface].AutoConnect(plug, slot)
 }

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1376,7 +1376,7 @@ func contentPolicyCheck(plug *Plug, slot *Slot) bool {
 	return plug.Snap.Developer == slot.Snap.Developer
 }
 
-func contentAutoConnectPair(plug *Plug, slot *Slot) bool {
+func contentAutoConnect(plug *Plug, slot *Slot) bool {
 	return plug.Attrs["content"] == slot.Attrs["content"]
 }
 
@@ -1384,7 +1384,7 @@ func contentAutoConnectPair(plug *Plug, slot *Slot) bool {
 // is a content plug and one a content slot
 func makeContentConnectionTestSnaps(c *C, plugContentToken, slotContentToken string) (*Repository, *snap.Info, *snap.Info) {
 	repo := NewRepository()
-	err := repo.AddInterface(&TestInterface{InterfaceName: "content", AutoConnectPairCallback: contentAutoConnectPair})
+	err := repo.AddInterface(&TestInterface{InterfaceName: "content", AutoConnectCallback: contentAutoConnect})
 
 	plugSnap := snaptest.MockInfo(c, fmt.Sprintf(`
 name: content-plug-snap

--- a/interfaces/testtype.go
+++ b/interfaces/testtype.go
@@ -28,11 +28,8 @@ import (
 type TestInterface struct {
 	// InterfaceName is the name of this interface
 	InterfaceName string
-	// AutoConnectFlag indicates whether plugs and slots should be implicitly
-	// auto-connected.
-	AutoConnectFlag bool
-	// confirm given pairs to auto-connect.
-	AutoConnectPairHook func(*Plug, *Slot) bool
+	// AutoConnectPairCallback is the callback invoked inside AutoConnectPair
+	AutoConnectPairCallback func(*Plug, *Slot) bool
 	// SanitizePlugCallback is the callback invoked inside SanitizePlug()
 	SanitizePlugCallback func(plug *Plug) error
 	// SanitizeSlotCallback is the callback invoked inside SanitizeSlot()
@@ -115,19 +112,16 @@ func (t *TestInterface) PermanentSlotSnippet(slot *Slot, securitySystem Security
 	return nil, nil
 }
 
-// AutoConnect returns whether plugs and slots should be implicitly
-// auto-connected when an unambiguous connection candidate is available in
-// the OS snap.
-func (t *TestInterface) AutoConnect() bool {
-	return t.AutoConnectFlag
+func (t *TestInterface) LegacyAutoConnect() bool {
+	panic("no test should depend on this anymore")
 }
 
 // AutoConnectPair returns whether plug and slot should be implicitly
 // auto-connected assuming they will be an unambiguous connection
 // candidate.
 func (t *TestInterface) AutoConnectPair(plug *Plug, slot *Slot) bool {
-	if t.AutoConnectPairHook != nil {
-		return t.AutoConnectPairHook(plug, slot)
+	if t.AutoConnectPairCallback != nil {
+		return t.AutoConnectPairCallback(plug, slot)
 	}
 	return true
 }

--- a/interfaces/testtype.go
+++ b/interfaces/testtype.go
@@ -28,8 +28,8 @@ import (
 type TestInterface struct {
 	// InterfaceName is the name of this interface
 	InterfaceName string
-	// AutoConnectPairCallback is the callback invoked inside AutoConnectPair
-	AutoConnectPairCallback func(*Plug, *Slot) bool
+	// AutoConnectCallback is the callback invoked inside AutoConnect
+	AutoConnectCallback func(*Plug, *Slot) bool
 	// SanitizePlugCallback is the callback invoked inside SanitizePlug()
 	SanitizePlugCallback func(plug *Plug) error
 	// SanitizeSlotCallback is the callback invoked inside SanitizeSlot()
@@ -116,12 +116,12 @@ func (t *TestInterface) LegacyAutoConnect() bool {
 	panic("no test should depend on this anymore")
 }
 
-// AutoConnectPair returns whether plug and slot should be implicitly
+// AutoConnect returns whether plug and slot should be implicitly
 // auto-connected assuming they will be an unambiguous connection
 // candidate.
-func (t *TestInterface) AutoConnectPair(plug *Plug, slot *Slot) bool {
-	if t.AutoConnectPairCallback != nil {
-		return t.AutoConnectPairCallback(plug, slot)
+func (t *TestInterface) AutoConnect(plug *Plug, slot *Slot) bool {
+	if t.AutoConnectCallback != nil {
+		return t.AutoConnectCallback(plug, slot)
 	}
 	return true
 }

--- a/interfaces/testtype_test.go
+++ b/interfaces/testtype_test.go
@@ -149,8 +149,10 @@ func (s *TestInterfaceSuite) TestSlotSnippet(c *C) {
 	c.Assert(snippet, IsNil)
 }
 
-func (s *TestInterfaceSuite) TestAutoConnect(c *C) {
-	c.Assert(s.iface.AutoConnect(), Equals, false)
-	iface := &TestInterface{AutoConnectFlag: true}
-	c.Assert(iface.AutoConnect(), Equals, true)
+func (s *TestInterfaceSuite) TestAutoConnectPair(c *C) {
+	c.Check(s.iface.AutoConnectPair(nil, nil), Equals, true)
+
+	iface := &TestInterface{AutoConnectPairCallback: func(*Plug, *Slot) bool { return false }}
+
+	c.Check(iface.AutoConnectPair(nil, nil), Equals, false)
 }

--- a/interfaces/testtype_test.go
+++ b/interfaces/testtype_test.go
@@ -149,10 +149,10 @@ func (s *TestInterfaceSuite) TestSlotSnippet(c *C) {
 	c.Assert(snippet, IsNil)
 }
 
-func (s *TestInterfaceSuite) TestAutoConnectPair(c *C) {
-	c.Check(s.iface.AutoConnectPair(nil, nil), Equals, true)
+func (s *TestInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)
 
-	iface := &TestInterface{AutoConnectPairCallback: func(*Plug, *Slot) bool { return false }}
+	iface := &TestInterface{AutoConnectCallback: func(*Plug, *Slot) bool { return false }}
 
-	c.Check(iface.AutoConnectPair(nil, nil), Equals, false)
+	c.Check(iface.AutoConnect(nil, nil), Equals, false)
 }

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -87,7 +87,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	// - restore connections based on what is kept in the state
 	//   - if a connection cannot be restored then remove it from the state
 	// - setup the security of all the affected snaps
-	blacklist := m.repo.AutoConnectBlacklist(snapName)
+	//blacklist := m.repo.AutoConnectBlacklist(snapName)
 	affectedSnaps, err := m.repo.DisconnectSnap(snapName)
 	if err != nil {
 		return err
@@ -107,7 +107,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	if err := m.reloadConnections(snapName); err != nil {
 		return err
 	}
-	if err := m.autoConnect(task, snapName, blacklist); err != nil {
+	if err := m.autoConnect(task, snapName, nil); err != nil {
 		return err
 	}
 	if err := setupSnapSecurity(task, snapInfo, ss.DevModeAllowed(), m.repo); err != nil {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -106,6 +106,8 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	if err := m.reloadConnections(snapName); err != nil {
 		return err
 	}
+	// FIXME: here we should not reconnect auto-connect plug/slot
+	// pairs that were explicitly disconnected by the user
 	if err := m.autoConnect(task, snapName, nil); err != nil {
 		return err
 	}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -87,7 +87,6 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, _ *tomb.Tomb) error
 	// - restore connections based on what is kept in the state
 	//   - if a connection cannot be restored then remove it from the state
 	// - setup the security of all the affected snaps
-	//blacklist := m.repo.AutoConnectBlacklist(snapName)
 	affectedSnaps, err := m.repo.DisconnectSnap(snapName)
 	if err != nil {
 		return err

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -620,6 +620,7 @@ slots:
 // The setup-profiles task will not auto-connect an plug that was previously
 // explicitly disconnected by the user.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsDisconnect(c *C) {
+	c.Skip("feature disabled until redesign/reimpl")
 	// Add an OS snap as well as a sample snap with a "network" plug.
 	// The plug is normally auto-connected.
 	s.mockSnap(c, osSnapYaml)


### PR DESCRIPTION
This cleans up and renames various things.

Interface.AutoConnect => Interface.LegacyAutoConnect (use only in tests for cross-checking with the past)
Interface.AutoConnectPair => InterfaceAutoConnect

and attendant names, comments etc changes

In the process, as discussed, the blacklist logic to honor disconnected auto-connect plug/slots is dropped to be fixed later with a less guessing involving approach.