### PR TITLE
snapstate: fix hanging `snap remove` if a try mount dir is no longer mounted

### DIFF
--- a/osutil/mount.go
+++ b/osutil/mount.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package osutil
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+var mountInfoPath = "/proc/self/mountinfo"
+
+// FIXME: this needs a test
+func IsMounted(baseDir string) (bool, error) {
+	f, err := os.Open(mountInfoPath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		l := strings.Fields(scanner.Text())
+		if len(l) == 0 {
+			continue
+		}
+		mountPoint := l[4]
+		if baseDir == mountPoint {
+			return true, nil
+		}
+	}
+
+	return false, scanner.Err()
+}

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -62,12 +62,18 @@ func removeMountUnit(baseDir string, meter progress.Meter) error {
 		// use umount -l (lazy) to ensure that even busy mount points
 		// can be unmounted.
 		// note that the long option --lazy is not supported on trusty.
-		if output, err := exec.Command("umount", "-l", baseDir).CombinedOutput(); err != nil {
-			return osutil.OutputErr(output, err)
-		}
-
-		if err := sysd.Stop(filepath.Base(unit), time.Duration(1*time.Second)); err != nil {
+		isMounted, err := osutil.IsMounted(baseDir)
+		if err != nil {
 			return err
+		}
+		if isMounted {
+			if output, err := exec.Command("umount", "-l", baseDir).CombinedOutput(); err != nil {
+				return osutil.OutputErr(output, err)
+			}
+
+			if err := sysd.Stop(filepath.Base(unit), time.Duration(1*time.Second)); err != nil {
+				return err
+			}
 		}
 		if err := sysd.Disable(filepath.Base(unit)); err != nil {
 			return err

--- a/tests/main/snap-remove-not-mounted/task.yaml
+++ b/tests/main/snap-remove-not-mounted/task.yaml
@@ -1,0 +1,13 @@
+summary: Ensure remove with unmounted base dir works
+
+execute: |
+    cp -ar $TESTSLIB/snaps/test-snapd-tools /tmp
+    snap try /tmp/test-snapd-tools
+
+    # simulate what happens if someone "snap try /tmp/something" and then
+    # reboots: the dir is gone and nothing can be mounted anymore
+    rm -rf /tmp/test-snapd-tools
+    umount /snap/test-snapd-tools/x1
+
+    # ensure removal still works
+    snap remove test-snapd-tools


### PR DESCRIPTION
One unit test missing, but pushing out for test data from spread and so that we can work on this after the freeze. It fixes a real bug.