### PR TITLE
snap: add `snap is-managed` for console-conf

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -321,6 +321,7 @@ type SysInfo struct {
 	Version   string    `json:"version,omitempty"`
 	OSRelease OSRelease `json:"os-release"`
 	OnClassic bool      `json:"on-classic"`
+	Managed   bool      `json:"managed"`
 }
 
 func (rsp *response) err() error {

--- a/cmd/snap/cmd_is_managed.go
+++ b/cmd/snap/cmd_is_managed.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/i18n"
+
+	"github.com/jessevdk/go-flags"
+)
+
+var shortIsManagedHelp = i18n.G("internal")
+var longIsManagedHelp = i18n.G(`
+internal
+`)
+
+type cmdIsManaged struct{}
+
+func init() {
+	cmd := addCommand("is-managed", shortIsManagedHelp, longIsManagedHelp, func() flags.Commander { return &cmdIsManaged{} }, nil, nil)
+	cmd.hidden = true
+}
+
+func (cmd cmdIsManaged) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	is, err := Client().SysInfo()
+	if err != nil {
+		return fmt.Errorf("cannot get system information: %s", err)
+	}
+
+	if is.Managed {
+		fmt.Fprintf(Stdout, "system is managed\n")
+		return nil
+	}
+
+	return fmt.Errorf("system is not managed")
+}

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -15,12 +15,14 @@ execute: |
     if [[ $SPREAD_STORE_USER && $SPREAD_STORE_PASSWORD ]]; then
         echo "Checking successful login"
         expect -f successful_login.exp
+
+        output=$(snap is-managed)
+        if [ "$output" != "system is managed" ]; then
+            echo "Unexpected output from 'snap is-managed'"
+            echo $output
+            exit 1
+        fi
+
         snap logout
     fi
 
-    output=$(snap is-managed)
-    if [ "$output" != "system is managed" ]; then
-        echo "Unexpected output from 'snap is-managed'"
-        echo $output
-        exit 1
-    fi

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -17,3 +17,10 @@ execute: |
         expect -f successful_login.exp
         snap logout
     fi
+
+    output=$(snap is-managed)
+    if [ "$output" != "system is managed" ]; then
+        echo "Unexpected output from 'snap is-managed'"
+        echo $output
+        exit 1
+    fi


### PR DESCRIPTION
For console-conf so that it can check this in its systemd job: https://github.com/CanonicalLtd/subiquity/pull/169