### PR TITLE
store: send correct JSON type of string for expected payment amount

### DIFF
--- a/store/errors.go
+++ b/store/errors.go
@@ -55,6 +55,9 @@ var (
 
 	// ErrNoPaymentMethods is returned when the user has no valid payment methods associated with their account.
 	ErrNoPaymentMethods = errors.New("no payment methods")
+
+	// ErrPaymentDeclined is returned when the user's payment method was declined by the upstream payment provider.
+	ErrPaymentDeclined = errors.New("payment declined")
 )
 
 // ErrDownload represents a download error

--- a/store/store.go
+++ b/store/store.go
@@ -1334,9 +1334,9 @@ type BuyResult struct {
 
 // orderInstruction holds data sent to the store for orders.
 type orderInstruction struct {
-	SnapID   string  `json:"snap_id"`
-	Amount   float64 `json:"amount,omitempty"`
-	Currency string  `json:"currency,omitempty"`
+	SnapID   string `json:"snap_id"`
+	Amount   string `json:"amount,omitempty"`
+	Currency string `json:"currency,omitempty"`
 }
 
 type storeError struct {
@@ -1397,7 +1397,7 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 
 	instruction := orderInstruction{
 		SnapID:   options.SnapID,
-		Amount:   options.Price,
+		Amount:   fmt.Sprintf("%.2f", options.Price),
 		Currency: options.Currency,
 	}
 
@@ -1446,6 +1446,14 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 	case http.StatusNotFound:
 		// Likely because snap ID doesn't exist.
 		return nil, fmt.Errorf("cannot buy snap %q: server says not found (snap got removed?)", options.SnapName)
+	case http.StatusPaymentRequired:
+		// Payment failed for some reason.
+		var errorInfo storeErrors
+		dec := json.NewDecoder(resp.Body)
+		if err := dec.Decode(&errorInfo); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("cannot buy snap %q: payment failed: %v", options.SnapName, errorInfo.Error())
 	case http.StatusUnauthorized:
 		// TODO handle token expiry and refresh
 		return nil, ErrInvalidCredentials

--- a/store/store.go
+++ b/store/store.go
@@ -1448,12 +1448,7 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 		return nil, fmt.Errorf("cannot buy snap %q: server says not found (snap got removed?)", options.SnapName)
 	case http.StatusPaymentRequired:
 		// Payment failed for some reason.
-		var errorInfo storeErrors
-		dec := json.NewDecoder(resp.Body)
-		if err := dec.Decode(&errorInfo); err != nil {
-			return nil, err
-		}
-		return nil, fmt.Errorf("cannot buy snap %q: payment failed: %v", options.SnapName, errorInfo.Error())
+		return nil, ErrPaymentDeclined
 	case http.StatusUnauthorized:
 		// TODO handle token expiry and refresh
 		return nil, ErrInvalidCredentials

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2675,7 +2675,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuySuccess(c *C) {
 			c.Check(r.URL.Path, Equals, ordersPath)
 			jsonReq, err := ioutil.ReadAll(r.Body)
 			c.Assert(err, IsNil)
-			c.Check(string(jsonReq), Equals, `{"snap_id":"`+helloWorldSnapID+`","amount":0.99,"currency":"EUR"}`)
+			c.Check(string(jsonReq), Equals, `{"snap_id":"`+helloWorldSnapID+`","amount":"0.99","currency":"EUR"}`)
 			io.WriteString(w, mockOrderResponseJSON)
 			purchaseServerPostCalled = true
 		default:
@@ -2760,7 +2760,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailWrongPrice(c *C) {
 			c.Check(r.URL.Path, Equals, ordersPath)
 			jsonReq, err := ioutil.ReadAll(r.Body)
 			c.Assert(err, IsNil)
-			c.Check(string(jsonReq), Equals, "{\"snap_id\":\""+helloWorldSnapID+"\",\"amount\":0.99,\"currency\":\"USD\"}")
+			c.Check(string(jsonReq), Equals, `{"snap_id":"`+helloWorldSnapID+`","amount":"0.99","currency":"USD"}`)
 			w.WriteHeader(http.StatusBadRequest)
 			io.WriteString(w, `
 {
@@ -2854,7 +2854,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailNotFound(c *C) {
 			c.Check(r.URL.Path, Equals, ordersPath)
 			jsonReq, err := ioutil.ReadAll(r.Body)
 			c.Assert(err, IsNil)
-			c.Check(string(jsonReq), Equals, "{\"snap_id\":\"invalid snap ID\",\"amount\":0.99,\"currency\":\"EUR\"}")
+			c.Check(string(jsonReq), Equals, `{"snap_id":"invalid snap ID","amount":"0.99","currency":"EUR"}`)
 			w.WriteHeader(http.StatusNotFound)
 			io.WriteString(w, "{\"error_message\":\"Not found\"}")
 			purchaseServerPostCalled = true

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2683,7 +2683,7 @@ var buyTests = []struct {
 		buyStatus:         http.StatusPaymentRequired,
 		buyErrorCode:      "request-failed",
 		buyErrorMessage:   "Purchase failed",
-		expectedError:     "cannot buy snap \"hello-world\": payment failed: store reported an error: Purchase failed",
+		expectedError:     "payment declined",
 	},
 }
 


### PR DESCRIPTION
- The new store API takes the price as a string, so convert the float price.
- We avoid taking a string for the price on the snapd API, as the price is still a float in the store index API, and the existing properties on snaps from /v2/find, etc.
- Also handle one of the expected HTTP codes, 402, which appears to mean payment failed for unspecified reason.
- Refactor store.Buy tests into a table.