### PR TITLE
client,daemon,cmd: add payment-declined error kind

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -296,6 +296,7 @@ const (
 	ErrorKindLoginRequired     = "login-required"
 	ErrorKindTermsNotAccepted  = "terms-not-accepted"
 	ErrorKindNoPaymentMethods  = "no-payment-methods"
+	ErrorKindPaymentDeclined   = "payment-declined"
 )
 
 // IsTwoFactorError returns whether the given error is due to problems

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -122,6 +122,13 @@ for %s. Press ctrl-c to cancel.`), snap.Name, snap.Developer, formatPrice(opts.P
 
 	_, err = cli.Buy(opts)
 	if err != nil {
+		if e, ok := err.(*client.Error); ok {
+			switch e.Kind {
+			case client.ErrorKindPaymentDeclined:
+				return fmt.Errorf(i18n.G(`Sorry, your payment method has been declined by the issuer. Please review your
+payment details at https://my.ubuntu.com/payment/edit and try again.`))
+			}
+		}
 		return err
 	}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1976,6 +1976,15 @@ func convertBuyError(err error) Response {
 			},
 			Status: http.StatusBadRequest,
 		}, nil)
+	case store.ErrPaymentDeclined:
+		return SyncResponse(&resp{
+			Type: ResponseTypeError,
+			Result: &errorResult{
+				Message: err.Error(),
+				Kind:    errorKindPaymentDeclined,
+			},
+			Status: http.StatusBadRequest,
+		}, nil)
 	default:
 		return InternalError("%v", err)
 	}

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -126,6 +126,7 @@ const (
 	errorKindInvalidAuthData   = errorKind("invalid-auth-data")
 	errorKindTermsNotAccepted  = errorKind("terms-not-accepted")
 	errorKindNoPaymentMethods  = errorKind("no-payment-methods")
+	errorKindPaymentDeclined   = errorKind("payment-declined")
 )
 
 type errorValue interface{}

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -122,6 +122,7 @@ kind               | value description
 `invalid-auth-data` | the authentication data provided failed to validate (e.g. a malformed email address). The `value` of the error is an object with a key per failed field and a list of the failures on each field.
 `terms-not-accepted` | the user has not accepted the store's terms of service.
 `no-payment-methods` | the user does not have a payment method registered to complete a purchase.
+`payment-declined` | the user's payment method was declined by the payment provider.
 
 ### Timestamps
 


### PR DESCRIPTION
- Also refactor and extend tests for api.go.
- Print error message from https://docs.google.com/document/d/1g6nWgl3bQARp8deSU3NAAJJAMS-PgpTFtglSQJjLFKM/edit#heading=h.njlagfhluwzl