### PR TITLE
systemd: correct the mount arguments when mounting with squashfuse

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -441,9 +441,8 @@ func (s *systemd) WriteMountUnitFile(name, what, where, fstype string) (string, 
 	if osutil.IsDirectory(what) {
 		extra = "Options=bind\n"
 		fstype = "none"
-	}
-
-	if fstype == "squashfs" && useFuse() {
+	} else if fstype == "squashfs" && useFuse() {
+		extra = "Options=ro,allow_other\n"
 		fstype = "fuse.squashfuse"
 	}
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -381,6 +381,7 @@ Description=Mount unit for foo
 What=%s
 Where=/apps/foo/1.0
 Type=fuse.squashfuse
+Options=ro,allow_other
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The "allow_other" mount option must be specified when mounting snaps
with the squashfuse filesystem in order for non-root users to make use
of the mount point. Without the "allow_other" mount option, non-root
users will not be able to run snap commands due to EACESS being returned
for all filesystem accesses:

  ubuntu@yakkety:~$ ls -al /snap/hello-world
  ls: cannot access '/snap/hello-world/27': Permission denied
  total 8
  drwxr-xr-x 3 root root 4096 Oct 5 21:09 .
  drwxr-xr-x 5 root root 4096 Oct 5 21:09 ..
  d????????? ? ? ? ? ? 27
  lrwxrwxrwx 1 root root 2 Oct 5 21:09 current -> 27

This patch also explicitly adds the "ro" mount option when squashfuse is
in use. This is done because, without the "ro" mount option, "rw"
incorrectly shows up in the mount table even though the squashfuse mount
point is read-only. Explicitly specifying the "ro" mount option prevents
any possible confusion.

Fixes: https://bugs.launchpad.net/snappy/+bug/1630789
Signed-off-by: Tyler Hicks tyhicks@canonical.com
