### PR TITLE
tests: only stop a service if it is running or ok (eg. active (exited))

### DIFF
--- a/tests/lib/systemd.sh
+++ b/tests/lib/systemd.sh
@@ -9,7 +9,9 @@ systemd_create_and_start_unit() {
 
 # Use like systemd_stop_and_destroy_unit(fakestore)
 systemd_stop_and_destroy_unit() {
-    systemctl stop $1
+    if systemctl status "$1"; then
+        systemctl stop "$1"
+    fi
     rm -f /run/systemd/system/$1.service
     systemctl daemon-reload
 }


### PR DESCRIPTION
This will prevent errors on restore like:
```
2016/09/27 00:12:09 Error restoring linode:ubuntu-16.04-32:tests/main/refresh-all : 
-----
+ . /home/gopath/src/github.com/snapcore/snapd/tests/lib/store.sh
++ STORE_CONFIG=/etc/systemd/system/snapd.service.d/store.conf
+ teardown_store fake /home/gopath/src/github.com/snapcore/snapd/tests/main/refresh-all/fake-store-blobdir
+ local store_type=fake
+ local top_dir=/home/gopath/src/github.com/snapcore/snapd/tests/main/refresh-all/fake-store-blobdir
+ '[' fake = fake ']'
+ systemctl stop fakestore
Failed to stop fakestore.service: Unit fakestore.service not loaded.
-----
```