### PR TITLE
snapstate: avoid reboots if nothing in the boot setup has changed.

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -28,6 +28,7 @@ import (
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
@@ -953,7 +954,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		st.RequestRestart(state.RestartDaemon)
 		st.Lock()
 	}
-	if !release.OnClassic && (newInfo.Type == snap.TypeOS || newInfo.Type == snap.TypeKernel) {
+	if !release.OnClassic && boot.KernelOrOsRebootRequired(newInfo) {
 		t.Logf("Requested system restart.")
 		st.Unlock()
 		st.RequestRestart(state.RestartSystem)


### PR DESCRIPTION
Use helper boot.KernelOrOsRebootRequired() in doLinkSnap instead of a inferious manual version of it.

On firstboot the system will be in a state where snap_try_{kernel,os}/snap_{kernel,os} are exactly the same. In this case no forced reboot is needed.