### PR TITLE
tests: add test for auto-mount assertion import

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -49,6 +49,7 @@ reset_all_snap() {
 
     # ensure we have the same state as initially
     systemctl stop snapd.service snapd.socket
+    rm -rf /var/lib/snapd/*
     $(cd / && tar xzf $SPREAD_PATH/snapd-state.tar.gz)
     rm -rf /root/.snap
     systemctl start snapd.service snapd.socket

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -10,16 +10,16 @@ prepare: |
     snap known account-key | grep -v "account-id: testrootorg"
     
     echo "Create a ramdisk with the developer1.account assertion"
-    mkfs.vfat /dev/ram0
+    mkfs.ext4 /dev/ram0
     mount /dev/ram0 /mnt
     cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
     umount /mnt
 
     echo "Create new block device to trigger auto-import mount"
-    dmsetup create dm-ram0 --table '0 65536 linear /dev/ram0 0'
+    dmsetup -v --noudevsync --noudevrules create dm-ram0 --table '0 65536 linear /dev/ram0 0'
 
 restore: |
-    dmsetup remove dm-ram0
+    dmsetup -v --noudevsync --noudevrules  remove dm-ram0 
 
 execute: |
     echo "The auto-mount magic has given us the assertion"

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -3,6 +3,9 @@ summary: Check that `snap auto-import` works as expected
 systems: [ubuntu-core-16-64,ubuntu-core-16-arm-32,ubuntu-core-16-arm-64]
 
 prepare: |
+    echo "Install dmsetup"
+    snap install --devmode --edge dmsetup
+
     echo "Ensure the developer1.account is not already added"
     snap known account-key | grep -v "account-id: testrootorg"
     

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -6,16 +6,16 @@ prepare: |
     echo "Install dmsetup"
     snap install --devmode --edge dmsetup
 
-    echo "Ensure the developer1.account is not already added"
-    output=$(snap known account | grep "account-id: developer1" | wc -l)
+    echo "Ensure the testrootorg-store.account-key is not already added"
+    output=$(snap known account-key | grep "name: test-store"|wc -l)
     if [ "$output" != "0" ]; then
-        echo "developer1.account assertion already part of the system"
-        exit 1
+            echo " testrootorg-store.account-key is already added"
+            exit 1
     fi
-    echo "Create a ramdisk with the developer1.account assertion"
-    mkfs.ext4 /dev/ram0
+    echo "Create a ramdisk with the testrootorg-store.account-key assertion"
+    mkfs.vfat /dev/ram0
     mount /dev/ram0 /mnt
-    cp $TESTSLIB/assertions/developer1.account /mnt/auto-import.assert
+    cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
     umount /mnt
 
     echo "Create new block device to trigger auto-import mount"
@@ -24,6 +24,10 @@ prepare: |
 restore: |
     dmsetup -v --noudevsync --noudevrules  remove dm-ram0 
 
+debug: |
+    tail -n 20 /var/log/syslog
+
 execute: |
     echo "The auto-mount magic has given us the assertion"
-    snap known account | grep "account-id: developer1"
+    snap known account-key | grep "name: test-store"
+

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -1,0 +1,23 @@
+summary: Check that `snap auto-import` works as expected
+
+systems: [ubuntu-core-16-64,ubuntu-core-16-arm-32,ubuntu-core-16-arm-64]
+
+prepare: |
+    echo "Ensure the developer1.account is not already added"
+    snap known account-key | grep -v "account-id: testrootorg"
+    
+    echo "Create a ramdisk with the developer1.account assertion"
+    mkfs.vfat /dev/ram0
+    mount /dev/ram0 /mnt
+    cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
+    umount /mnt
+
+    echo "Create new block device to trigger auto-import mount"
+    dmsetup create dm-ram0 --table '0 65536 linear /dev/ram0 0'
+
+restore: |
+    dmsetup remove dm-ram0
+
+execute: |
+    echo "The auto-mount magic has given us the assertion"
+    snap known account-key | grep "account-id: testrootorg"

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -7,12 +7,15 @@ prepare: |
     snap install --devmode --edge dmsetup
 
     echo "Ensure the developer1.account is not already added"
-    snap known account-key | grep -v "account-id: testrootorg"
-    
+    output=$(snap known account | grep "account-id: developer1" | wc -l)
+    if [ "$output" != "0" ]; then
+        echo "developer1.account assertion already part of the system"
+        exit 1
+    fi
     echo "Create a ramdisk with the developer1.account assertion"
     mkfs.ext4 /dev/ram0
     mount /dev/ram0 /mnt
-    cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
+    cp $TESTSLIB/assertions/developer1.account /mnt/auto-import.assert
     umount /mnt
 
     echo "Create new block device to trigger auto-import mount"
@@ -23,4 +26,4 @@ restore: |
 
 execute: |
     echo "The auto-mount magic has given us the assertion"
-    snap known account-key | grep "account-id: testrootorg"
+    snap known account | grep "account-id: developer1"


### PR DESCRIPTION
This tests that the *automatic* mount/import of new block devices works.