### PR TITLE
overlord/devicestate: recover/mark as seeded devices that were first booted with the old external approach

### DIFF
--- a/overlord/devicestate/devicemgr_test.go
+++ b/overlord/devicestate/devicemgr_test.go
@@ -21,11 +21,13 @@ package devicestate_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -235,6 +237,20 @@ func (s *deviceMgrSuite) setupGadget(c *C, snapYaml string) {
 		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfoGadget},
 		Current:  sideInfoGadget.Revision,
+	})
+}
+
+func (s *deviceMgrSuite) setupCore(c *C, name, snapYaml string) {
+	sideInfoCore := &snap.SideInfo{
+		RealName: name,
+		Revision: snap.R(3),
+	}
+	snaptest.MockSnap(c, snapYaml, sideInfoCore)
+	snapstate.Set(s.state, name, &snapstate.SnapState{
+		SnapType: "os",
+		Active:   true,
+		Sequence: []*snap.SideInfo{sideInfoCore},
+		Current:  sideInfoCore.Revision,
 	})
 }
 
@@ -824,6 +840,104 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureSeedYamlHappy(c *C) {
 	defer s.state.Unlock()
 
 	c.Check(s.state.Changes(), HasLen, 1)
+}
+
+func (s *deviceMgrSuite) TestDeviceManagerEnsureSeedYamlRecover(c *C) {
+	release.OnClassic = false
+
+	restore := devicestate.MockPopulateStateFromSeed(func(*state.State) (ts []*state.TaskSet, err error) {
+		return nil, errors.New("should not be called")
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setupCore(c, "ubuntu-core", `
+name: ubuntu-core
+type: os
+version: ubuntu-core
+`)
+
+	// have a model assertion
+	model, err := s.storeSigning.Sign(asserts.ModelType, map[string]interface{}{
+		"series":       "16",
+		"brand-id":     "canonical",
+		"model":        "pc",
+		"gadget":       "pc",
+		"kernel":       "kernel",
+		"architecture": "amd64",
+		"timestamp":    time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, model)
+	c.Assert(err, IsNil)
+
+	// have a serial assertion
+	devKey, _ := assertstest.GenerateKey(752)
+	encDevKey, err := asserts.EncodePublicKey(devKey.PublicKey())
+	keyID := devKey.PublicKey().ID()
+	c.Assert(err, IsNil)
+	serial, err := s.storeSigning.Sign(asserts.SerialType, map[string]interface{}{
+		"brand-id":            "canonical",
+		"model":               "pc",
+		"serial":              "8989",
+		"device-key":          string(encDevKey),
+		"device-key-sha3-384": keyID,
+		"timestamp":           time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, serial)
+	c.Assert(err, IsNil)
+
+	// forgotten key id and serial
+	auth.SetDevice(s.state, &auth.DeviceState{
+		Brand: "canonical",
+		Model: "pc",
+	})
+	// put key on disk
+	err = s.mgr.KeypairManager().Put(devKey)
+	c.Assert(err, IsNil)
+	// extra unused stuff
+	junk1 := filepath.Join(dirs.SnapDeviceDir, "private-keys-v1", "junkjunk1")
+	err = ioutil.WriteFile(junk1, nil, 0644)
+	c.Assert(err, IsNil)
+	junk2 := filepath.Join(dirs.SnapDeviceDir, "private-keys-v1", "junkjunk2")
+	err = ioutil.WriteFile(junk2, nil, 0644)
+	c.Assert(err, IsNil)
+	// double check
+	pat := filepath.Join(dirs.SnapDeviceDir, "private-keys-v1", "*")
+	onDisk, err := filepath.Glob(pat)
+	c.Assert(err, IsNil)
+	c.Check(onDisk, HasLen, 3)
+
+	s.state.Unlock()
+	err = s.mgr.EnsureSeedYaml()
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	c.Check(s.state.Changes(), HasLen, 0)
+
+	var seeded bool
+	err = s.state.Get("seeded", &seeded)
+	c.Assert(err, IsNil)
+	c.Check(seeded, Equals, true)
+
+	device, err := auth.Device(s.state)
+	c.Assert(err, IsNil)
+	c.Check(device, DeepEquals, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc",
+		KeyID:  keyID,
+		Serial: "8989",
+	})
+	// key is still there
+	_, err = s.mgr.KeypairManager().Get(keyID)
+	c.Assert(err, IsNil)
+	onDisk, err = filepath.Glob(pat)
+	c.Assert(err, IsNil)
+	// junk was removed
+	c.Check(onDisk, HasLen, 1)
 }
 
 func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkSkippedOnClassic(c *C) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -74,11 +74,13 @@ func (m *DeviceManager) EnsureSeedYaml() error {
 	return m.ensureSeedYaml()
 }
 
+var PopulateStateFromSeedImpl = populateStateFromSeedImpl
+
 func MockPopulateStateFromSeed(f func(*state.State) ([]*state.TaskSet, error)) (restore func()) {
-	old := PopulateStateFromSeed
-	PopulateStateFromSeed = f
+	old := populateStateFromSeed
+	populateStateFromSeed = f
 	return func() {
-		PopulateStateFromSeed = old
+		populateStateFromSeed = old
 	}
 }
 

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -107,7 +107,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedErrorsOnState(c *C) {
 	defer st.Unlock()
 	st.Set("seeded", true)
 
-	_, err := devicestate.PopulateStateFromSeed(st)
+	_, err := devicestate.PopulateStateFromSeedImpl(st)
 	c.Assert(err, ErrorMatches, "cannot populate state: already seeded")
 }
 
@@ -188,7 +188,7 @@ snaps:
 	st := s.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	tsAll, err := devicestate.PopulateStateFromSeed(st)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(st)
 	c.Assert(err, IsNil)
 
 	// the last task of the last taskset must be mark-seeded
@@ -355,7 +355,7 @@ snaps:
 	st.Lock()
 	defer st.Unlock()
 
-	tsAll, err := devicestate.PopulateStateFromSeed(st)
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(st)
 	chg := st.NewChange("run-it", "run the populate from seed changes")
 	for _, ts := range tsAll {
 		chg.AddAll(ts)


### PR DESCRIPTION
This also tries to recover key-id/serial from a present serial assertion.