### PR TITLE
asserts,snap: validate attributes to a JSON-compatible type subset

### DIFF
--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -120,13 +120,7 @@ func matchList(context string, matcher attrMatcher, l []interface{}) error {
 
 func (matcher mapAttrMatcher) match(context string, v interface{}) error {
 	switch x := v.(type) {
-	case map[string]interface{}: // top level looks like this
-		for k, matcher1 := range matcher {
-			if err := matchEntry(context, k, matcher1, x[k]); err != nil {
-				return err
-			}
-		}
-	case map[interface{}]interface{}: // nested maps look like this
+	case map[string]interface{}: // maps in attributes look like this
 		for k, matcher1 := range matcher {
 			if err := matchEntry(context, k, matcher1, x[k]); err != nil {
 				return err
@@ -161,6 +155,8 @@ func (matcher regexpAttrMatcher) match(context string, v interface{}) error {
 		s = strconv.FormatBool(x)
 	case int:
 		s = strconv.Itoa(x)
+	case int64:
+		s = strconv.FormatInt(x, 10)
 	case []interface{}:
 		return matchList(context, matcher, x)
 	default:

--- a/snap/info.go
+++ b/snap/info.go
@@ -260,23 +260,25 @@ var _ PlaceInfo = (*Info)(nil)
 type PlugInfo struct {
 	Snap *Info
 
-	Name      string
-	Interface string
-	Attrs     map[string]interface{}
-	Label     string
-	Apps      map[string]*AppInfo
-	Hooks     map[string]*HookInfo
+	Name        string
+	Interface   string
+	Attrs       map[string]interface{}
+	StringAttrs map[string]interface{}
+	Label       string
+	Apps        map[string]*AppInfo
+	Hooks       map[string]*HookInfo
 }
 
 // SlotInfo provides information about a slot.
 type SlotInfo struct {
 	Snap *Info
 
-	Name      string
-	Interface string
-	Attrs     map[string]interface{}
-	Label     string
-	Apps      map[string]*AppInfo
+	Name        string
+	Interface   string
+	Attrs       map[string]interface{}
+	StringAttrs map[string]interface{}
+	Label       string
+	Apps        map[string]*AppInfo
 }
 
 // AppInfo provides information about a app.

--- a/snap/info.go
+++ b/snap/info.go
@@ -260,25 +260,23 @@ var _ PlaceInfo = (*Info)(nil)
 type PlugInfo struct {
 	Snap *Info
 
-	Name        string
-	Interface   string
-	Attrs       map[string]interface{}
-	StringAttrs map[string]interface{}
-	Label       string
-	Apps        map[string]*AppInfo
-	Hooks       map[string]*HookInfo
+	Name      string
+	Interface string
+	Attrs     map[string]interface{}
+	Label     string
+	Apps      map[string]*AppInfo
+	Hooks     map[string]*HookInfo
 }
 
 // SlotInfo provides information about a slot.
 type SlotInfo struct {
 	Snap *Info
 
-	Name        string
-	Interface   string
-	Attrs       map[string]interface{}
-	StringAttrs map[string]interface{}
-	Label       string
-	Apps        map[string]*AppInfo
+	Name      string
+	Interface string
+	Attrs     map[string]interface{}
+	Label     string
+	Apps      map[string]*AppInfo
 }
 
 // AppInfo provides information about a app.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -22,6 +22,7 @@ package snap
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -47,20 +48,6 @@ type snapYaml struct {
 	Slots            map[string]interface{} `yaml:"slots,omitempty"`
 	Apps             map[string]appYaml     `yaml:"apps,omitempty"`
 	Hooks            map[string]hookYaml    `yaml:"hooks,omitempty"`
-}
-
-type plugYaml struct {
-	Interface string                 `yaml:"interface"`
-	Attrs     map[string]interface{} `yaml:"attrs,omitempty"`
-	Apps      []string               `yaml:"apps,omitempty"`
-	Label     string                 `yaml:"label"`
-}
-
-type slotYaml struct {
-	Interface string                 `yaml:"interface"`
-	Attrs     map[string]interface{} `yaml:"attrs,omitempty"`
-	Apps      []string               `yaml:"apps,omitempty"`
-	Label     string                 `yaml:"label"`
 }
 
 type appYaml struct {
@@ -189,16 +176,17 @@ func setEnvironmentFromSnapYaml(y snapYaml, snap *Info) {
 
 func setPlugsFromSnapYaml(y snapYaml, snap *Info) error {
 	for name, data := range y.Plugs {
-		iface, label, attrs, err := convertToSlotOrPlugData("plug", name, data)
+		iface, label, attrs, strattrs, err := convertToSlotOrPlugData("plug", name, data)
 		if err != nil {
 			return err
 		}
 		snap.Plugs[name] = &PlugInfo{
-			Snap:      snap,
-			Name:      name,
-			Interface: iface,
-			Attrs:     attrs,
-			Label:     label,
+			Snap:        snap,
+			Name:        name,
+			Interface:   iface,
+			Attrs:       attrs,
+			StringAttrs: strattrs,
+			Label:       label,
 		}
 		if len(y.Apps) > 0 {
 			snap.Plugs[name].Apps = make(map[string]*AppInfo)
@@ -213,16 +201,17 @@ func setPlugsFromSnapYaml(y snapYaml, snap *Info) error {
 
 func setSlotsFromSnapYaml(y snapYaml, snap *Info) error {
 	for name, data := range y.Slots {
-		iface, label, attrs, err := convertToSlotOrPlugData("slot", name, data)
+		iface, label, attrs, strattrs, err := convertToSlotOrPlugData("slot", name, data)
 		if err != nil {
 			return err
 		}
 		snap.Slots[name] = &SlotInfo{
-			Snap:      snap,
-			Name:      name,
-			Interface: iface,
-			Attrs:     attrs,
-			Label:     label,
+			Snap:        snap,
+			Name:        name,
+			Interface:   iface,
+			Attrs:       attrs,
+			StringAttrs: strattrs,
+			Label:       label,
 		}
 		if len(y.Apps) > 0 {
 			snap.Slots[name].Apps = make(map[string]*AppInfo)
@@ -369,24 +358,24 @@ func bindUnboundSlots(slotNames []string, snap *Info) error {
 	return nil
 }
 
-func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, label string, attrs map[string]interface{}, err error) {
+func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, label string, attrs map[string]interface{}, strattrs map[string]interface{}, err error) {
 	iface = name
 	switch data.(type) {
 	case string:
-		return data.(string), "", nil, nil
+		return data.(string), "", nil, nil, nil
 	case nil:
-		return name, "", nil, nil
+		return name, "", nil, nil, nil
 	case map[interface{}]interface{}:
 		for keyData, valueData := range data.(map[interface{}]interface{}) {
 			key, ok := keyData.(string)
 			if !ok {
 				err := fmt.Errorf("%s %q has attribute that is not a string (found %T)",
 					plugOrSlot, name, keyData)
-				return "", "", nil, err
+				return "", "", nil, nil, err
 			}
 			if strings.HasPrefix(key, "$") {
 				err := fmt.Errorf("%s %q uses reserved attribute %q", plugOrSlot, name, key)
-				return "", "", nil, err
+				return "", "", nil, nil, err
 			}
 			switch key {
 			case "interface":
@@ -394,7 +383,7 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, 
 				if !ok {
 					err := fmt.Errorf("interface name on %s %q is not a string (found %T)",
 						plugOrSlot, name, valueData)
-					return "", "", nil, err
+					return "", "", nil, nil, err
 				}
 				iface = value
 			case "label":
@@ -402,19 +391,65 @@ func convertToSlotOrPlugData(plugOrSlot, name string, data interface{}) (iface, 
 				if !ok {
 					err := fmt.Errorf("label of %s %q is not a string (found %T)",
 						plugOrSlot, name, valueData)
-					return "", "", nil, err
+					return "", "", nil, nil, err
 				}
 				label = value
 			default:
 				if attrs == nil {
 					attrs = make(map[string]interface{})
+					strattrs = make(map[string]interface{})
+				}
+				strval, err := validateAttr(valueData)
+				if err != nil {
+					return "", "", nil, nil, fmt.Errorf("attribute of %s %q: %v", plugOrSlot, name, err)
 				}
 				attrs[key] = valueData
+				strattrs[key] = strval
 			}
 		}
-		return iface, label, attrs, nil
+		return iface, label, attrs, strattrs, nil
 	default:
 		err := fmt.Errorf("%s %q has malformed definition (found %T)", plugOrSlot, name, data)
-		return "", "", nil, err
+		return "", "", nil, nil, err
+	}
+}
+
+// validateAttr validates an attribute value and returns a version of it with scalars canonically turned into strings.
+func validateAttr(v interface{}) (interface{}, error) {
+	switch x := v.(type) {
+	case string:
+		return x, nil
+	case bool:
+		return strconv.FormatBool(x), nil
+	case int:
+		return strconv.Itoa(x), nil
+	case int64:
+		return strconv.FormatInt(x, 10), nil
+	case []interface{}:
+		sl := make([]interface{}, len(x))
+		for i, el := range x {
+			s, err := validateAttr(el)
+			if err != nil {
+				return nil, err
+			}
+			sl[i] = s
+		}
+		return sl, nil
+	case map[interface{}]interface{}:
+		sm := make(map[string]interface{}, len(x))
+		for k, item := range x {
+			kStr, ok := k.(string)
+			if !ok {
+				return nil, fmt.Errorf("not a string key in attribute map: %v", k)
+			}
+			s, err := validateAttr(item)
+			if err != nil {
+				return nil, err
+			}
+			sm[kStr] = s
+		}
+		return sm, nil
+	default:
+		return nil, fmt.Errorf("invalid attribute scalar: %v", v)
 	}
 }

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -155,11 +155,37 @@ plugs:
 	c.Check(info.Plugs, HasLen, 1)
 	c.Check(info.Slots, HasLen, 0)
 	c.Assert(info.Plugs["net"], DeepEquals, &snap.PlugInfo{
-		Snap:        info,
-		Name:        "net",
-		Interface:   "network-client",
-		Attrs:       map[string]interface{}{"ipv6-aware": true},
-		StringAttrs: map[string]interface{}{"ipv6-aware": "true"},
+		Snap:      info,
+		Name:      "net",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"ipv6-aware": true},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalStandalonePlugWithListAndMap(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    iface:
+        interface: complex
+        l: [1,2,3]
+        m:
+          a: A
+          b: B
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name(), Equals, "snap")
+	c.Check(info.Plugs, HasLen, 1)
+	c.Check(info.Slots, HasLen, 0)
+	c.Assert(info.Plugs["iface"], DeepEquals, &snap.PlugInfo{
+		Snap:      info,
+		Name:      "iface",
+		Interface: "complex",
+		Attrs: map[string]interface{}{
+			"l": []interface{}{1, 2, 3},
+			"m": map[string]interface{}{"a": "A", "b": "B"},
+		},
 	})
 }
 
@@ -180,11 +206,10 @@ plugs:
 	c.Check(info.Plugs, HasLen, 1)
 	c.Check(info.Slots, HasLen, 0)
 	c.Assert(info.Plugs["net"], DeepEquals, &snap.PlugInfo{
-		Snap:        info,
-		Name:        "net",
-		Interface:   "network-client",
-		Attrs:       map[string]interface{}{"attr": 2},
-		StringAttrs: map[string]interface{}{"attr": "2"},
+		Snap:      info,
+		Name:      "net",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"attr": 2},
 	})
 }
 
@@ -328,11 +353,10 @@ plugs:
 	c.Check(info.Slots, HasLen, 0)
 	c.Check(info.Apps, HasLen, 0)
 	c.Assert(info.Plugs["network-client"], DeepEquals, &snap.PlugInfo{
-		Snap:        info,
-		Name:        "network-client",
-		Interface:   "network-client",
-		Attrs:       map[string]interface{}{"ipv6-aware": true},
-		StringAttrs: map[string]interface{}{"ipv6-aware": "true"},
+		Snap:      info,
+		Name:      "network-client",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"ipv6-aware": true},
 	})
 }
 
@@ -413,6 +437,32 @@ plugs:
 	c.Assert(err, ErrorMatches, `plug "serial" uses reserved attribute "\$baud-rate"`)
 }
 
+func (s *YamlSuite) TestUnmarshalInvalidPlugAttribute(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    serial:
+        interface: serial-port
+        foo: null
+`))
+	c.Assert(err, ErrorMatches, `attribute "foo" of plug \"serial\": invalid attribute scalar:.*`)
+}
+
+func (s *YamlSuite) TestUnmarshalInvalidAttributeMapKey(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+plugs:
+    serial:
+        interface: serial-port
+        bar:
+          baz:
+          - 1: A
+`))
+	c.Assert(err, ErrorMatches, `attribute "bar" of plug \"serial\": non-string key in attribute map: 1`)
+}
+
 // Tests focusing on slots
 
 func (s *YamlSuite) TestUnmarshalStandaloneImplicitSlot(c *C) {
@@ -484,11 +534,36 @@ slots:
 	c.Check(info.Plugs, HasLen, 0)
 	c.Check(info.Slots, HasLen, 1)
 	c.Assert(info.Slots["net"], DeepEquals, &snap.SlotInfo{
-		Snap:        info,
-		Name:        "net",
-		Interface:   "network-client",
-		Attrs:       map[string]interface{}{"ipv6-aware": true},
-		StringAttrs: map[string]interface{}{"ipv6-aware": "true"},
+		Snap:      info,
+		Name:      "net",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"ipv6-aware": true},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalStandaloneSlotWithListAndMap(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    iface:
+        interface: complex
+        l: [1,2]
+        m:
+          a: "A"
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name(), Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	c.Assert(info.Slots["iface"], DeepEquals, &snap.SlotInfo{
+		Snap:      info,
+		Name:      "iface",
+		Interface: "complex",
+		Attrs: map[string]interface{}{
+			"l": []interface{}{1, 2},
+			"m": map[string]interface{}{"a": "A"},
+		},
 	})
 }
 
@@ -509,11 +584,10 @@ slots:
 	c.Check(info.Plugs, HasLen, 0)
 	c.Check(info.Slots, HasLen, 1)
 	c.Assert(info.Slots["net"], DeepEquals, &snap.SlotInfo{
-		Snap:        info,
-		Name:        "net",
-		Interface:   "network-client",
-		Attrs:       map[string]interface{}{"attr": 2},
-		StringAttrs: map[string]interface{}{"attr": "2"},
+		Snap:      info,
+		Name:      "net",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"attr": 2},
 	})
 }
 
@@ -618,11 +692,10 @@ slots:
 	c.Check(info.Slots, HasLen, 1)
 	c.Check(info.Apps, HasLen, 0)
 	c.Assert(info.Slots["network-client"], DeepEquals, &snap.SlotInfo{
-		Snap:        info,
-		Name:        "network-client",
-		Interface:   "network-client",
-		Attrs:       map[string]interface{}{"ipv6-aware": true},
-		StringAttrs: map[string]interface{}{"ipv6-aware": "true"},
+		Snap:      info,
+		Name:      "network-client",
+		Interface: "network-client",
+		Attrs:     map[string]interface{}{"ipv6-aware": true},
 	})
 }
 
@@ -702,6 +775,18 @@ slots:
         $baud-rate: [9600]
 `))
 	c.Assert(err, ErrorMatches, `slot "serial" uses reserved attribute "\$baud-rate"`)
+}
+
+func (s *YamlSuite) TestUnmarshalInvalidSlotAttribute(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    serial:
+        interface: serial-port
+        foo: null
+`))
+	c.Assert(err, ErrorMatches, `attribute "foo" of slot \"serial\": invalid attribute scalar:.*`)
 }
 
 func (s *YamlSuite) TestUnmarshalHook(c *C) {

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -155,10 +155,11 @@ plugs:
 	c.Check(info.Plugs, HasLen, 1)
 	c.Check(info.Slots, HasLen, 0)
 	c.Assert(info.Plugs["net"], DeepEquals, &snap.PlugInfo{
-		Snap:      info,
-		Name:      "net",
-		Interface: "network-client",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Snap:        info,
+		Name:        "net",
+		Interface:   "network-client",
+		Attrs:       map[string]interface{}{"ipv6-aware": true},
+		StringAttrs: map[string]interface{}{"ipv6-aware": "true"},
 	})
 }
 
@@ -179,10 +180,11 @@ plugs:
 	c.Check(info.Plugs, HasLen, 1)
 	c.Check(info.Slots, HasLen, 0)
 	c.Assert(info.Plugs["net"], DeepEquals, &snap.PlugInfo{
-		Snap:      info,
-		Name:      "net",
-		Interface: "network-client",
-		Attrs:     map[string]interface{}{"attr": 2},
+		Snap:        info,
+		Name:        "net",
+		Interface:   "network-client",
+		Attrs:       map[string]interface{}{"attr": 2},
+		StringAttrs: map[string]interface{}{"attr": "2"},
 	})
 }
 
@@ -326,10 +328,11 @@ plugs:
 	c.Check(info.Slots, HasLen, 0)
 	c.Check(info.Apps, HasLen, 0)
 	c.Assert(info.Plugs["network-client"], DeepEquals, &snap.PlugInfo{
-		Snap:      info,
-		Name:      "network-client",
-		Interface: "network-client",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Snap:        info,
+		Name:        "network-client",
+		Interface:   "network-client",
+		Attrs:       map[string]interface{}{"ipv6-aware": true},
+		StringAttrs: map[string]interface{}{"ipv6-aware": "true"},
 	})
 }
 
@@ -481,10 +484,11 @@ slots:
 	c.Check(info.Plugs, HasLen, 0)
 	c.Check(info.Slots, HasLen, 1)
 	c.Assert(info.Slots["net"], DeepEquals, &snap.SlotInfo{
-		Snap:      info,
-		Name:      "net",
-		Interface: "network-client",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Snap:        info,
+		Name:        "net",
+		Interface:   "network-client",
+		Attrs:       map[string]interface{}{"ipv6-aware": true},
+		StringAttrs: map[string]interface{}{"ipv6-aware": "true"},
 	})
 }
 
@@ -505,10 +509,11 @@ slots:
 	c.Check(info.Plugs, HasLen, 0)
 	c.Check(info.Slots, HasLen, 1)
 	c.Assert(info.Slots["net"], DeepEquals, &snap.SlotInfo{
-		Snap:      info,
-		Name:      "net",
-		Interface: "network-client",
-		Attrs:     map[string]interface{}{"attr": 2},
+		Snap:        info,
+		Name:        "net",
+		Interface:   "network-client",
+		Attrs:       map[string]interface{}{"attr": 2},
+		StringAttrs: map[string]interface{}{"attr": "2"},
 	})
 }
 
@@ -613,10 +618,11 @@ slots:
 	c.Check(info.Slots, HasLen, 1)
 	c.Check(info.Apps, HasLen, 0)
 	c.Assert(info.Slots["network-client"], DeepEquals, &snap.SlotInfo{
-		Snap:      info,
-		Name:      "network-client",
-		Interface: "network-client",
-		Attrs:     map[string]interface{}{"ipv6-aware": true},
+		Snap:        info,
+		Name:        "network-client",
+		Interface:   "network-client",
+		Attrs:       map[string]interface{}{"ipv6-aware": true},
+		StringAttrs: map[string]interface{}{"ipv6-aware": "true"},
 	})
 }
 


### PR DESCRIPTION
This adds early validation of plug/slot attribute values to make sure they belong to a limited set of types, in particular we need them to be JSON serialisable and also to make matching them via regexps not a too ambiguous.

Given the JSON-compatible constraint we can support only maps with string keys, so normalise early to that. 

Simplify correspondingly the asserts/ifacedecls.go code.