### PR TITLE
overlord/snapstate: skip removing the snap on install if it's in the seed dir

### DIFF
--- a/tests/main/firstboot-snaps/task.yaml
+++ b/tests/main/firstboot-snaps/task.yaml
@@ -1,0 +1,40 @@
+summary: Check that firstboot snaps are installed
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+environment:
+    SEED_DIR: /var/lib/snapd/seed
+prepare: |
+    snapbuild $TESTSLIB/snaps/basic .
+
+    systemctl stop snapd.service snapd.socket
+    rm -f /var/lib/snapd/state.json
+    mkdir -p $SEED_DIR/snaps
+    mkdir -p $SEED_DIR/assertions
+    cat > $SEED_DIR/seed.yaml <<EOF
+    snaps:
+      - name: basic
+        unasserted: true
+        file: basic.snap
+    EOF
+    # pretend to be not classic :)
+    mv /var/lib/dpkg/status /var/lib/dpkg/status.save
+
+    echo Copy the needed snaps to $SEED_DIR/snaps
+    cp ./basic_1.0_all.snap $SEED_DIR/snaps/basic.snap
+restore: |
+    rm -r $SEED_DIR
+    mv /var/lib/dpkg/status.save /var/lib/dpkg/status
+    systemctl start snapd.socket snapd.service
+execute: |
+    echo "Start the daemon with an empty state, this will make it import "
+    echo "assertions from the $SEED_DIR/assertions subdirectory."
+    systemctl start snapd.socket snapd.service
+
+    echo "Wait for Seed change to be finished"
+    for i in `seq 60`; do
+        if snap list 2>/dev/null | grep -q ^basic; then
+            break
+        fi
+    done
+
+    snap list | grep ^basic
+    test -f $SEED_DIR/snaps/basic.snap


### PR DESCRIPTION
not the prettiest way of doing this, but small and dumb. We want to rework this cleanup in at least two separate dimensions anyway...