### PR TITLE
many: introduce an assertion format iteration concept, refuse to add unsupported assertion

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -101,6 +101,14 @@ func init() {
 	maxSupportedFormat[SnapDeclarationType.Name] = 0
 }
 
+func MockMaxSupportedFormat(assertType *AssertionType, maxFormat int) (restore func()) {
+	prev := maxSupportedFormat[assertType.Name]
+	maxSupportedFormat[assertType.Name] = maxFormat
+	return func() {
+		maxSupportedFormat[assertType.Name] = prev
+	}
+}
+
 // Type returns the AssertionType with name or nil
 func Type(name string) *AssertionType {
 	return typeRegistry[name]

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -49,6 +49,11 @@ type AssertionType struct {
 	flags     typeFlags
 }
 
+// MaxSupportedFormat returns the maximum supported format iteration for the type.
+func (at *AssertionType) MaxSupportedFormat() int {
+	return maxSupportedFormat[at.Name]
+}
+
 // Understood assertion types.
 var (
 	AccountType         = &AssertionType{"account", []string{"account-id"}, assembleAccount, 0}
@@ -87,6 +92,13 @@ var typeRegistry = map[string]*AssertionType{
 	DeviceSessionRequestType.Name: DeviceSessionRequestType,
 	SerialRequestType.Name:        SerialRequestType,
 	AccountKeyRequestType.Name:    AccountKeyRequestType,
+}
+
+var maxSupportedFormat = map[string]int{}
+
+func init() {
+	// register maxSupportedFormats while breaking initialisation loop
+	maxSupportedFormat[SnapDeclarationType.Name] = 0
 }
 
 // Type returns the AssertionType with name or nil
@@ -139,6 +151,12 @@ func (ref *Ref) Resolve(find func(assertType *AssertionType, headers map[string]
 type Assertion interface {
 	// Type returns the type of this assertion
 	Type() *AssertionType
+	// Format returns the format iteration of this assertion
+	Format() int
+	// SupportedFormat() returns whether the assertion uses a supported
+	// format iteration. If false the assertion might have been only
+	// partially parsed.
+	SupportedFormat() bool
 	// Revision returns the revision of this assertion
 	Revision() int
 	// AuthorityID returns the authority that signed this assertion
@@ -182,6 +200,8 @@ const MediaType = "application/x.ubuntu.assertion"
 type assertionBase struct {
 	headers map[string]interface{}
 	body    []byte
+	// parsed format iteration
+	format int
 	// parsed revision
 	revision int
 	// preserved content
@@ -199,6 +219,18 @@ func (ab *assertionBase) HeaderString(name string) string {
 // Type returns the assertion type.
 func (ab *assertionBase) Type() *AssertionType {
 	return Type(ab.HeaderString("type"))
+}
+
+// Format returns the assertion format iteration.
+func (ab *assertionBase) Format() int {
+	return ab.format
+}
+
+// SupportedFormat() returns whether the assertion uses a supported
+// format iteration. If false the assertion might have been only
+// partially parsed.
+func (ab *assertionBase) SupportedFormat() bool {
+	return ab.format <= maxSupportedFormat[ab.HeaderString("type")]
 }
 
 // Revision returns the assertion revision.
@@ -515,15 +547,23 @@ func (d *Decoder) Decode() (Assertion, error) {
 	return assemble(headers, finalBody, finalContent, finalSig)
 }
 
-func checkRevision(headers map[string]interface{}) (int, error) {
-	revision, err := checkIntWithDefault(headers, "revision", 0)
+func checkIteration(headers map[string]interface{}, name string) (int, error) {
+	iternum, err := checkIntWithDefault(headers, name, 0)
 	if err != nil {
 		return -1, err
 	}
-	if revision < 0 {
-		return -1, fmt.Errorf("revision should be positive: %v", revision)
+	if iternum < 0 {
+		return -1, fmt.Errorf("%s should be positive: %v", name, iternum)
 	}
-	return revision, nil
+	return iternum, nil
+}
+
+func checkFormat(headers map[string]interface{}) (int, error) {
+	return checkIteration(headers, "format")
+}
+
+func checkRevision(headers map[string]interface{}) (int, error) {
+	return checkIteration(headers, "revision")
 }
 
 // Assemble assembles an assertion from its components.
@@ -573,6 +613,11 @@ func assemble(headers map[string]interface{}, body, content, signature []byte) (
 		}
 	}
 
+	formatnum, err := checkFormat(headers)
+	if err != nil {
+		return nil, fmt.Errorf("assertion: %v", err)
+	}
+
 	for _, primKey := range assertType.PrimaryKey {
 		if _, err := checkPrimaryKey(headers, primKey); err != nil {
 			return nil, fmt.Errorf("assertion %s: %v", assertType.Name, err)
@@ -591,6 +636,7 @@ func assemble(headers map[string]interface{}, body, content, signature []byte) (
 	assert, err := assertType.assembler(assertionBase{
 		headers:   headers,
 		body:      body,
+		format:    formatnum,
 		revision:  revision,
 		content:   content,
 		signature: signature,
@@ -643,6 +689,11 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 		}
 	}
 
+	formatnum, err := checkFormat(finalHeaders)
+	if err != nil {
+		return nil, err
+	}
+
 	revision, err := checkRevision(finalHeaders)
 	if err != nil {
 		return nil, err
@@ -650,6 +701,12 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 
 	buf := bytes.NewBufferString("type: ")
 	buf.WriteString(assertType.Name)
+
+	if formatnum > 0 {
+		writeHeader(buf, finalHeaders, "format")
+	} else {
+		delete(finalHeaders, "format")
+	}
 
 	if withAuthority {
 		writeHeader(buf, finalHeaders, "authority-id")
@@ -662,6 +719,7 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 	}
 	written := map[string]bool{
 		"type":              true,
+		"format":            true,
 		"authority-id":      true,
 		"revision":          true,
 		"body-length":       true,
@@ -716,6 +774,7 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 	assert, err := assertType.assembler(assertionBase{
 		headers:   finalHeaders,
 		body:      finalBody,
+		format:    formatnum,
 		revision:  revision,
 		content:   content,
 		signature: signature,

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -702,6 +702,10 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 		return nil, err
 	}
 
+	if formatnum > assertType.MaxSupportedFormat() {
+		return nil, fmt.Errorf("cannot sign %q assertion with format %d higher than max supported format %d", assertType.Name, formatnum, assertType.MaxSupportedFormat())
+	}
+
 	revision, err := checkRevision(finalHeaders)
 	if err != nil {
 		return nil, err

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -161,7 +161,7 @@ type Assertion interface {
 	Type() *AssertionType
 	// Format returns the format iteration of this assertion
 	Format() int
-	// SupportedFormat() returns whether the assertion uses a supported
+	// SupportedFormat returns whether the assertion uses a supported
 	// format iteration. If false the assertion might have been only
 	// partially parsed.
 	SupportedFormat() bool
@@ -234,7 +234,7 @@ func (ab *assertionBase) Format() int {
 	return ab.format
 }
 
-// SupportedFormat() returns whether the assertion uses a supported
+// SupportedFormat returns whether the assertion uses a supported
 // format iteration. If false the assertion might have been only
 // partially parsed.
 func (ab *assertionBase) SupportedFormat() bool {

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -405,6 +405,17 @@ func (safs *signAddFindSuite) TestSignBadRevision(c *C) {
 	c.Check(a1, IsNil)
 }
 
+func (safs *signAddFindSuite) TestSignBadFormat(c *C) {
+	headers := map[string]interface{}{
+		"authority-id": "canonical",
+		"primary-key":  "a",
+		"format":       "zzz",
+	}
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
+	c.Assert(err, ErrorMatches, `"format" header is not an integer: zzz`)
+	c.Check(a1, IsNil)
+}
+
 func (safs *signAddFindSuite) TestSignHeadersCheck(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "canonical",

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -142,6 +142,7 @@ var TestOnlyNoAuthorityPKType = &AssertionType{"test-only-no-authority-pk", []st
 
 func init() {
 	typeRegistry[TestOnlyType.Name] = TestOnlyType
+	maxSupportedFormat[TestOnlyType.Name] = 1
 	typeRegistry[TestOnly2Type.Name] = TestOnly2Type
 	typeRegistry[TestOnlyNoAuthorityType.Name] = TestOnlyNoAuthorityType
 	typeRegistry[TestOnlyNoAuthorityPKType.Name] = TestOnlyNoAuthorityPKType

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -121,46 +121,51 @@ func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
-	refControl, err := checkStringList(assert.headers, "refresh-control")
-	if err != nil {
-		return nil, err
-	}
-
-	var plugRules map[string]*PlugRule
-	plugs, err := checkMap(assert.headers, "plugs")
-	if err != nil {
-		return nil, err
-	}
-	if plugs != nil {
-		plugRules = make(map[string]*PlugRule, len(plugs))
-		for iface, rule := range plugs {
-			plugRule, err := compilePlugRule(iface, rule)
-			if err != nil {
-				return nil, err
-			}
-			plugRules[iface] = plugRule
-		}
-	}
-
-	var slotRules map[string]*SlotRule
-	slots, err := checkMap(assert.headers, "slots")
-	if err != nil {
-		return nil, err
-	}
-	if slots != nil {
-		slotRules = make(map[string]*SlotRule, len(slots))
-		for iface, rule := range slots {
-			slotRule, err := compileSlotRule(iface, rule)
-			if err != nil {
-				return nil, err
-			}
-			slotRules[iface] = slotRule
-		}
-	}
-
 	timestamp, err := checkRFC3339Date(assert.headers, "timestamp")
 	if err != nil {
 		return nil, err
+	}
+
+	var refControl []string
+	var plugRules map[string]*PlugRule
+	var slotRules map[string]*SlotRule
+
+	// guard evolvable complex parts
+	if assert.SupportedFormat() {
+		refControl, err = checkStringList(assert.headers, "refresh-control")
+		if err != nil {
+			return nil, err
+		}
+
+		plugs, err := checkMap(assert.headers, "plugs")
+		if err != nil {
+			return nil, err
+		}
+		if plugs != nil {
+			plugRules = make(map[string]*PlugRule, len(plugs))
+			for iface, rule := range plugs {
+				plugRule, err := compilePlugRule(iface, rule)
+				if err != nil {
+					return nil, err
+				}
+				plugRules[iface] = plugRule
+			}
+		}
+
+		slots, err := checkMap(assert.headers, "slots")
+		if err != nil {
+			return nil, err
+		}
+		if slots != nil {
+			slotRules = make(map[string]*SlotRule, len(slots))
+			for iface, rule := range slots {
+				slotRule, err := compileSlotRule(iface, rule)
+				if err != nil {
+					return nil, err
+				}
+				slotRules[iface] = slotRule
+			}
+		}
 	}
 
 	return &SnapDeclaration{

--- a/interfaces/policy/policy.go
+++ b/interfaces/policy/policy.go
@@ -90,6 +90,7 @@ func (ic *InstallCandidate) checkPlug(plug *snap.PlugInfo) error {
 	return nil
 }
 
+// Check checks whether the installation is allowed.
 func (ic *InstallCandidate) Check() error {
 	if ic.BaseDeclaration == nil {
 		return fmt.Errorf("internal error: improperly initialized InstallCandidate")
@@ -244,7 +245,7 @@ func (connc *ConnectCandidate) Check() error {
 	return connc.check("connection")
 }
 
-// Check checks whether the connection is allowed to auto-connect.
+// CheckAutoConnect checks whether the connection is allowed to auto-connect.
 func (connc *ConnectCandidate) CheckAutoConnect() error {
 	return connc.check("auto-connection")
 }

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -125,6 +125,9 @@ func NewBatch() *Batch {
 
 // Add one assertion to the batch.
 func (b *Batch) Add(a asserts.Assertion) error {
+	if !a.SupportedFormat() {
+		return &asserts.UnsupportedFormatError{Ref: a.Ref(), Format: a.Format()}
+	}
 	if err := b.bs.Put(a.Type(), a); err != nil {
 		// TODO: do we need to ignore UnsupportedFormatError here sometimes? not for the current use cases at least
 		if revErr, ok := err.(*asserts.RevisionError); ok {

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -129,7 +129,6 @@ func (b *Batch) Add(a asserts.Assertion) error {
 		return &asserts.UnsupportedFormatError{Ref: a.Ref(), Format: a.Format()}
 	}
 	if err := b.bs.Put(a.Type(), a); err != nil {
-		// TODO: do we need to ignore UnsupportedFormatError here sometimes? not for the current use cases at least
 		if revErr, ok := err.(*asserts.RevisionError); ok {
 			if revErr.Current >= a.Revision() {
 				// we already got something more recent

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -476,6 +476,58 @@ func (s *assertMgrSuite) TestValidateSnapCrossCheckFail(c *C) {
 	c.Assert(chg.Err(), ErrorMatches, `(?s).*cannot install snap "f" that is undergoing a rename to "foo".*`)
 }
 
+func (s *assertMgrSuite) TestValidateSnapSnapDeclIsTooNewFirsInstall(c *C) {
+	s.prereqSnapAssertions(c, 10)
+
+	tempdir := c.MkDir()
+	snapPath := filepath.Join(tempdir, "foo.snap")
+	err := ioutil.WriteFile(snapPath, fakeSnap(10), 0644)
+	c.Assert(err, IsNil)
+
+	// update snap decl with one that is too new
+	(func() {
+		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 999)
+		defer restore()
+		headers := map[string]interface{}{
+			"format":       "999",
+			"revision":     "1",
+			"series":       "16",
+			"snap-id":      "snap-id-1",
+			"snap-name":    "foo",
+			"publisher-id": s.dev1Acct.AccountID(),
+			"timestamp":    time.Now().Format(time.RFC3339),
+		}
+		snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+		c.Assert(err, IsNil)
+		err = s.storeSigning.Add(snapDecl)
+		c.Assert(err, IsNil)
+	})()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("install", "...")
+	t := s.state.NewTask("validate-snap", "Fetch and check snap assertions")
+	ss := snapstate.SnapSetup{
+		SnapPath: snapPath,
+		UserID:   0,
+		SideInfo: &snap.SideInfo{
+			RealName: "foo",
+			SnapID:   "snap-id-1",
+			Revision: snap.R(10),
+		},
+	}
+	t.Set("snap-setup", ss)
+	chg.AddTask(t)
+
+	s.state.Unlock()
+	defer s.mgr.Stop()
+	s.settle()
+	s.state.Lock()
+
+	c.Assert(chg.Err(), ErrorMatches, `(?s).*snap-declaration .* assertion format is too new for this snapd, upgrade snapd/core snap\n.*`)
+}
+
 func (s *assertMgrSuite) snapDecl(c *C, name string, control []interface{}) *asserts.SnapDeclaration {
 	headers := map[string]interface{}{
 		"series":       "16",
@@ -575,6 +627,40 @@ func (s *assertMgrSuite) TestRefreshSnapDeclarations(c *C) {
 	})
 	c.Assert(err, IsNil)
 	c.Check(a.(*asserts.Account).DisplayName(), Equals, "Dev 1 edited display-name")
+
+	// change snap decl to something that has a too new format
+
+	(func() {
+		restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 999)
+		defer restore()
+
+		headers := map[string]interface{}{
+			"format":       "999",
+			"series":       "16",
+			"snap-id":      "foo-id",
+			"snap-name":    "foo",
+			"publisher-id": s.dev1Acct.AccountID(),
+			"timestamp":    time.Now().Format(time.RFC3339),
+			"revision":     "2",
+		}
+
+		snapDeclFoo2, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+		c.Assert(err, IsNil)
+		err = s.storeSigning.Add(snapDeclFoo2)
+		c.Assert(err, IsNil)
+	})()
+
+	// no error, kept the old one
+	err = assertstate.RefreshSnapDeclarations(s.state, 0)
+	c.Assert(err, IsNil)
+
+	a, err = assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  "16",
+		"snap-id": "foo-id",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.SnapDeclaration).SnapName(), Equals, "fo-o")
+	c.Check(a.(*asserts.SnapDeclaration).Revision(), Equals, 1)
 }
 
 func (s *assertMgrSuite) TestValidateRefreshesNothing(c *C) {

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -525,7 +525,7 @@ func (s *assertMgrSuite) TestValidateSnapSnapDeclIsTooNewFirsInstall(c *C) {
 	s.settle()
 	s.state.Lock()
 
-	c.Assert(chg.Err(), ErrorMatches, `(?s).*snap-declaration .* assertion format is too new for this snapd, upgrade snapd/core snap\n.*`)
+	c.Assert(chg.Err(), ErrorMatches, `(?s).*proposed "snap-declaration" assertion has format 999 but 0 is latest supported.*`)
 }
 
 func (s *assertMgrSuite) snapDecl(c *C, name string, control []interface{}) *asserts.SnapDeclaration {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -740,7 +740,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 	if errAcctKey == nil {
 		err := assertstate.Add(st, a)
 		if err != nil {
-			if _, ok := err.(*asserts.RevisionError); !ok {
+			if !asserts.IsKeptCurrent(err) {
 				return err
 			}
 		}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -740,7 +740,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 	if errAcctKey == nil {
 		err := assertstate.Add(st, a)
 		if err != nil {
-			if !asserts.IsKeptCurrent(err) {
+			if !asserts.IsUnaccceptedUpdate(err) {
 				return err
 			}
 		}


### PR DESCRIPTION
* support a concept of assertion format iteration on all assertions, in snap-declaration do only a best effort assembling if the format is too new
* refuse to add assertions to a db with not yet supported formats, though ignore this selectively (on assertion refreshes atm)
* refuse to sign assertions with an unsupported format iteration, it's not possible to fully validate them while assembling them