### PR TITLE
spread.yaml: dump apparmor denials on spread failure

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -215,6 +215,7 @@ suites:
             fi
         restore-each: |
             $TESTSLIB/reset.sh --reuse-core
+
     tests/upgrade/:
         summary: Tests for snapd upgrade
         systems: [-ubuntu-core-16-64-fixme]

--- a/spread.yaml
+++ b/spread.yaml
@@ -93,9 +93,11 @@ prepare-each: |
     journalctl --rotate
     sleep .1
     journalctl --vacuum-time=1ms
+    dmesg -c > /dev/null
 
 debug-each: |
     journalctl -u snapd
+    dmesg | grep DENIED
 
 prepare: |
     # this indicates that the server got reused, nothing to setup
@@ -213,8 +215,6 @@ suites:
             fi
         restore-each: |
             $TESTSLIB/reset.sh --reuse-core
-        debug-each: |
-            dmesg | grep DENIED
     tests/upgrade/:
         summary: Tests for snapd upgrade
         systems: [-ubuntu-core-16-64-fixme]
@@ -222,5 +222,3 @@ suites:
             apt-get purge -y snapd || true
         restore-each: |
             $TESTSLIB/reset.sh
-        debug-each: |
-            dmesg | grep DENIED

--- a/spread.yaml
+++ b/spread.yaml
@@ -213,7 +213,8 @@ suites:
             fi
         restore-each: |
             $TESTSLIB/reset.sh --reuse-core
-
+        debug-each: |
+            dmesg | grep DENIED
     tests/upgrade/:
         summary: Tests for snapd upgrade
         systems: [-ubuntu-core-16-64-fixme]
@@ -221,3 +222,5 @@ suites:
             apt-get purge -y snapd || true
         restore-each: |
             $TESTSLIB/reset.sh
+        debug-each: |
+            dmesg | grep DENIED


### PR DESCRIPTION
We're facing an intermittent failure that manifests itself as a failure
to one of the mount operations in snap-confine. To debug the problem
we'd like to dump apparmor denials each time a spread test fails. This
is useful in travis, where the log is kept around and where we cannot
log in interactively to investigate.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>