### PR TITLE
debian: update dependency of ubuntu-core-launcher to snap-confine

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Description: snappy development go packages.
 Package: snapd
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, adduser,
- squashfs-tools, gnupg1 | gnupg, systemd, snap-confine (>= 1.0.43), xdelta
+ squashfs-tools, gnupg1 | gnupg, systemd, ubuntu-core-launcher (>= 1.0.43), xdelta
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
 Conflicts: snappy, snap (<< 2013-11-29-1ubuntu1)

--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Description: snappy development go packages.
 Package: snapd
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, adduser,
- squashfs-tools, gnupg1 | gnupg, systemd, ubuntu-core-launcher (>= 1.0.23), xdelta
+ squashfs-tools, gnupg1 | gnupg, systemd, snap-confine (>= 1.0.43), xdelta
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
 Conflicts: snappy, snap (<< 2013-11-29-1ubuntu1)


### PR DESCRIPTION
This fixes LP: #1634236 (https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1634236)