### PR TITLE
snap: stop using ubuntu-core-launcher, use snap-confine

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -177,7 +177,7 @@ func runSnapConfine(info *snap.Info, securityTag, snapApp, command, hook string,
 	}
 
 	cmd := []string{
-		"/usr/bin/snap-confine",
+		"/usr/lib/snapd/snap-confine",
 		securityTag,
 		"/usr/lib/snapd/snap-exec",
 	}

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -177,8 +177,7 @@ func runSnapConfine(info *snap.Info, securityTag, snapApp, command, hook string,
 	}
 
 	cmd := []string{
-		"/usr/bin/ubuntu-core-launcher",
-		securityTag,
+		"/usr/bin/snap-confine",
 		securityTag,
 		"/usr/lib/snapd/snap-exec",
 	}

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -28,10 +28,12 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapenv"
+	"path/filepath"
 )
 
 var (
@@ -177,9 +179,9 @@ func runSnapConfine(info *snap.Info, securityTag, snapApp, command, hook string,
 	}
 
 	cmd := []string{
-		"/usr/lib/snapd/snap-confine",
+		filepath.Join(dirs.LibExecDir, "snap-confine"),
 		securityTag,
-		"/usr/lib/snapd/snap-exec",
+		filepath.Join(dirs.LibExecDir, "snap-exec"),
 	}
 
 	if command != "" {

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -91,10 +91,9 @@ func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {
 	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
-	c.Check(execArg0, check.Equals, "/usr/bin/ubuntu-core-launcher")
+	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/ubuntu-core-launcher",
-		"snap.snapname.app",
+		"/usr/bin/snap-confine",
 		"snap.snapname.app",
 		"/usr/lib/snapd/snap-exec",
 		"snapname.app",
@@ -129,10 +128,9 @@ func (s *SnapSuite) TestSnapRunAppWithCommandIntegration(c *check.C) {
 	// and run it!
 	err := snaprun.SnapRunApp("snapname.app", "my-command", []string{"arg1", "arg2"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, "/usr/bin/ubuntu-core-launcher")
+	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/ubuntu-core-launcher",
-		"snap.snapname.app",
+		"/usr/bin/snap-confine",
 		"snap.snapname.app",
 		"/usr/lib/snapd/snap-exec",
 		"--command=my-command", "snapname.app",
@@ -184,10 +182,9 @@ func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {
 	// Run a hook from the active revision
 	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "snapname"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, "/usr/bin/ubuntu-core-launcher")
+	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/ubuntu-core-launcher",
-		"snap.snapname.hook.configure",
+		"/usr/bin/snap-confine",
 		"snap.snapname.hook.configure",
 		"/usr/lib/snapd/snap-exec",
 		"--hook=configure", "snapname"})
@@ -221,10 +218,9 @@ func (s *SnapSuite) TestSnapRunHookUnsetRevisionIntegration(c *check.C) {
 	// Specifically pass "unset" which would use the active version.
 	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=unset", "snapname"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, "/usr/bin/ubuntu-core-launcher")
+	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/ubuntu-core-launcher",
-		"snap.snapname.hook.configure",
+		"/usr/bin/snap-confine",
 		"snap.snapname.hook.configure",
 		"/usr/lib/snapd/snap-exec",
 		"--hook=configure", "snapname"})
@@ -262,10 +258,9 @@ func (s *SnapSuite) TestSnapRunHookSpecificRevisionIntegration(c *check.C) {
 	// Run a hook on revision 41
 	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=41", "snapname"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, "/usr/bin/ubuntu-core-launcher")
+	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/ubuntu-core-launcher",
-		"snap.snapname.hook.configure",
+		"/usr/bin/snap-confine",
 		"snap.snapname.hook.configure",
 		"/usr/lib/snapd/snap-exec",
 		"--hook=configure", "snapname"})

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -91,13 +91,12 @@ func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {
 	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
-	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/snap-confine",
+		filepath.Join(dirs.LibExecDir, "snap-confine"),
 		"snap.snapname.app",
-		"/usr/lib/snapd/snap-exec",
-		"snapname.app",
-		"--arg1", "arg2"})
+		filepath.Join(dirs.LibExecDir, "snap-exec"),
+		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
 }
 
@@ -128,13 +127,12 @@ func (s *SnapSuite) TestSnapRunAppWithCommandIntegration(c *check.C) {
 	// and run it!
 	err := snaprun.SnapRunApp("snapname.app", "my-command", []string{"arg1", "arg2"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/snap-confine",
+		filepath.Join(dirs.LibExecDir, "snap-confine"),
 		"snap.snapname.app",
-		"/usr/lib/snapd/snap-exec",
-		"--command=my-command", "snapname.app",
-		"arg1", "arg2"})
+		filepath.Join(dirs.LibExecDir, "snap-exec"),
+		"--command=my-command", "snapname.app", "arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
 }
 
@@ -182,11 +180,11 @@ func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {
 	// Run a hook from the active revision
 	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "snapname"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/snap-confine",
+		filepath.Join(dirs.LibExecDir, "snap-confine"),
 		"snap.snapname.hook.configure",
-		"/usr/lib/snapd/snap-exec",
+		filepath.Join(dirs.LibExecDir, "snap-exec"),
 		"--hook=configure", "snapname"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
 }
@@ -218,11 +216,11 @@ func (s *SnapSuite) TestSnapRunHookUnsetRevisionIntegration(c *check.C) {
 	// Specifically pass "unset" which would use the active version.
 	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=unset", "snapname"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/snap-confine",
+		filepath.Join(dirs.LibExecDir, "snap-confine"),
 		"snap.snapname.hook.configure",
-		"/usr/lib/snapd/snap-exec",
+		filepath.Join(dirs.LibExecDir, "snap-exec"),
 		"--hook=configure", "snapname"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
 }
@@ -258,11 +256,11 @@ func (s *SnapSuite) TestSnapRunHookSpecificRevisionIntegration(c *check.C) {
 	// Run a hook on revision 41
 	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=41", "snapname"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, "/usr/bin/snap-confine")
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		"/usr/bin/snap-confine",
+		filepath.Join(dirs.LibExecDir, "snap-confine"),
 		"snap.snapname.hook.configure",
-		"/usr/lib/snapd/snap-exec",
+		filepath.Join(dirs.LibExecDir, "snap-exec"),
 		"--hook=configure", "snapname"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=41")
 }

--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Description: snappy development go packages.
 Package: snapd
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, adduser,
- squashfs-tools, gnupg1 | gnupg, systemd, ubuntu-core-launcher (>= 1.0.23), xdelta
+ squashfs-tools, gnupg1 | gnupg, systemd, snap-confine (>= 1.0.43), xdelta
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
 Conflicts: snappy, snap (<< 2013-11-29-1ubuntu1)


### PR DESCRIPTION
Just fixing the path on @mvo5's #2165.