### PR TITLE
snapstate, devicestate: do not remove seed

### DIFF
--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -60,7 +60,7 @@ func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 	tsAll := []*state.TaskSet{}
 	for i, sn := range seed.Snaps {
 
-		flags := snapstate.Flags{}
+		flags := snapstate.Flags{KeepSnapPath: true}
 		if sn.DevMode {
 			flags.DevMode = true
 		}

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -32,6 +32,9 @@ type Flags struct {
 	// Revert flags the SnapSetup as coming from a revert
 	Revert bool `json:"revert,omitempty"`
 
+	// KeepSnapPath is used via InstallPath to flag that the file passed in is not temporary and should not be removed
+	KeepSnapPath bool `json:"keep-snap-path,omitempty"`
+
 	// IgnoreValidation is set when the user requested as one-off
 	// to ignore refresh control validation.
 	IgnoreValidation bool `json:"ignore-validation,omitempty"`

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -671,14 +671,10 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	t.Set("snap-type", newInfo.Type)
 	t.State().Unlock()
 
-	// cleanup the downloaded snap after it got installed
-	// in backend.SetupSnap.
-	//
-	// Note that we always remove the file because the
-	// way sideloading works currently is to always create
-	// a temporary file (see daemon/api.go:sideloadSnap()
-	if err := os.Remove(ss.SnapPath); err != nil {
-		logger.Noticef("Failed to cleanup %q: %s", err)
+	if !ss.Flags.KeepSnapPath {
+		if err := os.Remove(ss.SnapPath); err != nil {
+			logger.Noticef("Failed to cleanup %q: %s", err)
+		}
 	}
 
 	return nil

--- a/tests/main/firstboot-snaps/task.yaml
+++ b/tests/main/firstboot-snaps/task.yaml
@@ -1,0 +1,40 @@
+summary: Check that firstboot snaps are installed
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+environment:
+    SEED_DIR: /var/lib/snapd/seed
+prepare: |
+    snapbuild $TESTSLIB/snaps/basic .
+
+    systemctl stop snapd.service snapd.socket
+    rm -f /var/lib/snapd/state.json
+    mkdir -p $SEED_DIR/snaps
+    mkdir -p $SEED_DIR/assertions
+    cat > $SEED_DIR/seed.yaml <<EOF
+    snaps:
+      - name: basic
+        unasserted: true
+        file: basic.snap
+    EOF
+    # pretend to be not classic :)
+    mv /var/lib/dpkg/status /var/lib/dpkg/status.save
+
+    echo Copy the needed snaps to $SEED_DIR/snaps
+    cp ./basic_1.0_all.snap $SEED_DIR/snaps/basic.snap
+restore: |
+    rm -r $SEED_DIR
+    mv /var/lib/dpkg/status.save /var/lib/dpkg/status
+    systemctl start snapd.socket snapd.service
+execute: |
+    echo "Start the daemon with an empty state, this will make it import "
+    echo "assertions from the $SEED_DIR/assertions subdirectory."
+    systemctl start snapd.socket snapd.service
+
+    echo "Wait for Seed change to be finished"
+    for i in `seq 60`; do
+        if snap list 2>/dev/null | grep -q ^basic; then
+            break
+        fi
+    done
+
+    snap list | grep ^basic
+    test -f $SEED_DIR/snaps/basic.snap

--- a/tests/main/ubuntu-core-custom-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg/task.yaml
@@ -17,8 +17,6 @@ prepare: |
     cp prepare-device squashfs-root/meta/hooks
     mksquashfs squashfs-root pc_x1.snap -comp xz
     rm -rf squashfs-root
-    # XXX these should not have been deleted
-    cp /var/lib/snapd/snaps/*.snap /var/lib/snapd/seed/snaps
     cp pc_x1.snap /var/lib/snapd/seed/snaps/
     mv /var/lib/snapd/seed/assertions/model model.bak
     cp /var/lib/snapd/seed/seed.yaml seed.yaml.bak
@@ -42,8 +40,7 @@ restore: |
     rm -rf /var/lib/snapd/assertions/*
     rm -rf /var/lib/snapd/device
     rm -rf /var/lib/snapd/state.json
-    # XXX these should not have been deleted
-    cp /var/lib/snapd/snaps/*.snap /var/lib/snapd/seed/snaps
+    rm /var/lib/snapd/seed/snaps/pc_x1.snap
     cp seed.yaml.bak /var/lib/snapd/seed/seed.yaml
     rm /var/lib/snapd/seed/assertions/developer1.account
     rm /var/lib/snapd/seed/assertions/developer1.account-key


### PR DESCRIPTION
* overlord/snapstate: introduce `Keep` flag to skip removing a snap on install.
* overlord/devicestate: use `Keep` to not remove seed snaps on install.
