### PR TITLE
tests: reenable ubuntu-core tests on qemu

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -106,6 +106,7 @@ setup_reflash_magic() {
         echo "$want_pw" > /tmp/new-shadow
         tail -n +2 /etc/shadow >> /tmp/new-shadow
         cp -v /tmp/new-shadow $UNPACKD/etc/shadow
+        cp -v /etc/passwd $UNPACKD/etc/passwd
 
         # ensure spread -reuse works in the core image as well
         if [ -e /.spread.yaml ]; then
@@ -114,9 +115,12 @@ setup_reflash_magic() {
 
         # we need the test user in the image
         # see the comment in spread.yaml about 12345
+        sed -i "s/^test.*$//" $UNPACKD/etc/{shadow,passwd}
         chroot $UNPACKD addgroup --quiet --gid 12345 test
         chroot $UNPACKD adduser --quiet --no-create-home --uid 12345 --gid 12345 --disabled-password --gecos '' test
         echo 'test ALL=(ALL) NOPASSWD:ALL' >> $UNPACKD/etc/sudoers.d/99-test-user
+
+        echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> $UNPACKD/etc/sudoers.d/99-ubuntu-user
 
         # modify sshd so that we can connect as root
         sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' $UNPACKD/etc/ssh/sshd_config
@@ -252,7 +256,7 @@ prepare_all_snap() {
         snap changes || true
         sleep 1
     done
- 
+
     echo "Ensure fundamental snaps are still present"
     . $TESTSLIB/names.sh
     for name in $gadget_name $kernel_name $core_name; do

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -8,7 +8,7 @@ execute: |
     . "$TESTSLIB/names.sh"
 
     echo "List prints core snap version"
-    if [ "$SPREAD_BACKEND" == "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" == "ubuntu-core-16-64" ]; then
+    if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
         expected="^${core_name} +.*? +((\d{2}\.\d{2}\.\d+)|\w{12}) + x\d+ +- *"
     else

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -8,7 +8,7 @@ execute: |
     . "$TESTSLIB/names.sh"
 
     echo "List prints core snap version"
-    if [[ "$SPREAD_BACKEND" = "linode" ]] && [[ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]]; then
+    if [ "$SPREAD_BACKEND" == "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" == "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
         expected="^${core_name} +.*? +((\d{2}\.\d{2}\.\d+)|\w{12}) + x\d+ +- *"
     else

--- a/tests/main/ubuntu-core-reboot/task.yaml
+++ b/tests/main/ubuntu-core-reboot/task.yaml
@@ -23,7 +23,7 @@ execute: |
             exit 1
         fi
         retries=$(( $retries - 1 ))
-        sleep 0.5
+        sleep 1
     done
 
     echo "Ensure apparmor profiles are (still) loaded."


### PR DESCRIPTION
When executing the suite on the qemu backend, ubuntu-core-16-64 system, the tests were getting stuck in the reboot after reflashing. spread tried to reconnect with the configured user (ubuntu:ubuntu) but in the ubuntu-core system that user was not known, there was only an entry about it in /etc/shadow but none in /etc/passwd. There wasn't present either any info about the ubuntu user being a sudoer. The suite is working on linode for the ubuntu-core-16-64 system because we are connecting as root there.

These changes solve the issue and also fix the listing and ubuntu-core-reboot tests for this specific backend and system.