### PR TITLE
tests: wait for file written instead of log entries in the writable-areas test

### DIFF
--- a/tests/main/writable-areas/task.yaml
+++ b/tests/main/writable-areas/task.yaml
@@ -19,14 +19,13 @@ execute: |
     #[ -f /root/snap/data-writer/common/from-app ]
 
     echo "Waiting for data writer service to finish..."
-    while ! journalctl --no-pager -u snap.data-writer.service.service | grep -q "Writing to SNAP_USER_DATA"; do
+    while [ ! -f /root/snap/data-writer/x1/from-service ]; do
        sleep 1
     done
 
     echo "Services can write to writable areas"
     [ -f /var/snap/data-writer/x1/from-service ]
     [ -f /var/snap/data-writer/common/from-service ]
-    [ -f /root/snap/data-writer/x1/from-service ]
     # TODO: As soon as `snap run` is used (which creates this directory),
     # uncomment the following line:
     #[ -f /root/snap/data-writer/common/from-service ]


### PR DESCRIPTION
We are getting this error eventually:
```
2016/10/19 12:49:53 WARNING: external:ubuntu-core-16-64 running late. Current output:
-----
mesg: ttyname failed: Inappropriate ioctl for device
+ snap install --dangerous data-writer_1.0_all.snap
data-writer 1.0 installed
+ echo 'Apps can write to writable areas'
Apps can write to writable areas
+ data-writer.app
Writing to SNAP_COMMON
Writing to SNAP_DATA
Writing to SNAP_USER_DATA
+ '[' -f /var/snap/data-writer/x1/from-app ']'
+ '[' -f /var/snap/data-writer/common/from-app ']'
+ '[' -f /root/snap/data-writer/x1/from-app ']'
+ echo 'Waiting for data writer service to finish...'
Waiting for data writer service to finish...
+ grep -q 'Writing to SNAP_USER_DATA'
+ journalctl --no-pager -u snap.data-writer.service.service
+ sleep 1
+ grep -q 'Writing to SNAP_USER_DATA'
+ journalctl --no-pager -u snap.data-writer.service.service
+ sleep 1
....
```
Instead of waiting for a log entry with these changes we wait for the last file to be written by the service before checking for the rest of them.