### PR TITLE
spread.yaml: Ensure ubuntu user has passwordless sudo for autopkgtests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -56,6 +56,7 @@ backends:
                 FATAL "adhoc only works inside autopkgtest"
                 exit 1
             fi
+            echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/99-spread-users
             ADDRESS localhost:22
         discard: |
             echo "Discarding ad-hoc $SPREAD_SYSTEM"


### PR DESCRIPTION
Autopkgtests on armhf (and others) currently fail because many of the tests need sudo. It would normally be fine, since the tests/control file has needs-root specified, but spread conntects as the ubuntu user over ssh to localhost, but the ubuntu user can't be assured to have sudoers set up for it.