### PR TITLE
snap: switch the auto-import dir to /run/snapd/auto-import

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -123,7 +123,7 @@ func SetRootDir(rootdir string) {
 	SnapSocket = filepath.Join(rootdir, "/run/snapd-snap.socket")
 
 	SnapAssertsDBDir = filepath.Join(rootdir, snappyDir, "assertions")
-	SnapAssertsSpoolDir = filepath.Join(rootdir, snappyDir, "auto-import")
+	SnapAssertsSpoolDir = filepath.Join(rootdir, "run", "auto-import")
 
 	SnapStateFile = filepath.Join(rootdir, snappyDir, "state.json")
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -123,7 +123,7 @@ func SetRootDir(rootdir string) {
 	SnapSocket = filepath.Join(rootdir, "/run/snapd-snap.socket")
 
 	SnapAssertsDBDir = filepath.Join(rootdir, snappyDir, "assertions")
-	SnapAssertsSpoolDir = filepath.Join(rootdir, "run", "auto-import")
+	SnapAssertsSpoolDir = filepath.Join(rootdir, "run/snapd/auto-import")
 
 	SnapStateFile = filepath.Join(rootdir, snappyDir, "state.json")
 

--- a/tests/main/snap-auto-import-asserts-spools/task.yaml
+++ b/tests/main/snap-auto-import-asserts-spools/task.yaml
@@ -35,7 +35,7 @@ execute: |
 
     echo "`snap auto-import` spooled assertions if it can not talk to snapd"
     snap auto-import
-    ls /var/lib/snapd/auto-import
+    ls /run/snapd/auto-import
     umount /mnt
     systemctl start snapd.service snapd.socket
 
@@ -43,9 +43,9 @@ execute: |
     snap auto-import
     snap known account-key | grep "name: test-store"
 
-    nr=$(ls /var/lib/snapd/auto-import|wc -l)
+    nr=$(ls /run/snapd/auto-import|wc -l)
     if [ "$nr" != "0" ]; then
-        echo "Expected an empty /var/lib/snapd/auto-import got:"
-        ls /var/lib/snapd/auto-import
+        echo "Expected an empty /run/snapd/auto-import got:"
+        ls /run/snapd/auto-import
         exit 1
     fi


### PR DESCRIPTION
This avoids the a race at boot when /var/lib/snapd may not be available yet.