### PR TITLE
interfaces/builtin: network-manager and bluez can change hostname

### DIFF
--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -86,6 +86,13 @@ var bluezPermanentSlotAppArmor = []byte(`
       bus=system
       path=/org/bluez{,/**}
       interface=org.freedesktop.DBus.**,
+
+  # Allow access to hostname system service
+  dbus (receive, send)
+      bus=system
+      path=/org/freedesktop/hostname1
+      interface=org.freedesktop.DBus.Properties
+      peer=(label=unconfined),
 `)
 
 var bluezConnectedPlugAppArmor = []byte(`

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -136,7 +136,7 @@ dbus (receive, send)
     interface=org.freedesktop.DBus.*,
 
 # Allow access to hostname system service
-dbus (send)
+dbus (receive, send)
     bus=system
     path=/org/freedesktop/hostname1
     interface=org.freedesktop.DBus.Properties

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -141,6 +141,12 @@ dbus (send)
     path=/org/freedesktop/hostname1
     interface=org.freedesktop.DBus.Properties
     peer=(label=unconfined),
+dbus(receive, send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.hostname1
+    member={Set,SetStatic}Hostname
+    peer=(label=unconfined),
 
 # Sleep monitor inside NetworkManager needs this
 dbus (send)
@@ -204,6 +210,7 @@ sendmmsg
 sendmsg
 sendto
 setsockopt
+sethostname
 shutdown
 socketpair
 socket


### PR DESCRIPTION
This allows access to hostnamed for both network-manager and bluez which was only partially possible until now. The policy changes are only on the slot side.

This fixes https://bugs.launchpad.net/snappy-hwe-snaps/+bug/1635607 where we have a seccomp denial of network-manager due to it not being allowed to change the hostname via hostnamed or sethostname which results in network outage.