### PR TITLE
snap, image: fix `snap download` and `snap prepare-image` running as user

### DIFF
--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -113,9 +113,8 @@ func (x *cmdDownload) Execute(args []string) error {
 	var authContext auth.AuthContext
 	var user *auth.UserState
 
-	cfg := &store.Config{
-		PartialDownloadsDir: "", //cwd
-	}
+	cfg := store.DefaultConfig()
+	cfg.PartialDownloadsDir = "" //cwd
 	sto := store.New(cfg, authContext)
 	// we always allow devmode for downloads
 	devMode := true

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -113,7 +113,10 @@ func (x *cmdDownload) Execute(args []string) error {
 	var authContext auth.AuthContext
 	var user *auth.UserState
 
-	sto := store.New(nil, authContext)
+	cfg := &store.Config{
+		PartialDownloadsDir: "", //cwd
+	}
+	sto := store.New(cfg, authContext)
 	// we always allow devmode for downloads
 	devMode := true
 

--- a/debian/snapd.dirs
+++ b/debian/snapd.dirs
@@ -1,5 +1,6 @@
 snap
-var/lib/snapd/snaps
+var/lib/snapd/auto-import
+var/lib/snapd/snaps/partial
 var/lib/snapd/lib/gl
 var/lib/snapd/desktop
 var/lib/snapd/environment

--- a/image/image.go
+++ b/image/image.go
@@ -123,7 +123,7 @@ func Prepare(opts *Options) error {
 		return err
 	}
 
-	sto := makeStore(model)
+	sto := makeStore(model, opts)
 
 	if err := downloadUnpackGadget(sto, model, opts, local); err != nil {
 		return err
@@ -461,10 +461,11 @@ func copyLocalSnapFile(snapPath, targetDir string, info *snap.Info) (dstPath str
 	return dst, osutil.CopyFile(snapPath, dst, 0)
 }
 
-func makeStore(model *asserts.Model) Store {
+func makeStore(model *asserts.Model, opts *Options) Store {
 	cfg := store.DefaultConfig()
 	cfg.Architecture = model.Architecture()
 	cfg.Series = model.Series()
 	cfg.StoreID = model.Store()
+	cfg.PartialDownloadsDir = filepath.Join(opts.RootDir, "partial")
 	return store.New(cfg, nil)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1106,7 +1106,13 @@ func (s *Store) Download(name string, downloadInfo *snap.DownloadInfo, pbar prog
 		logger.Noticef("Cannot download or apply deltas for %s: %v", name, err)
 	}
 
-	w, err := os.Create(filepath.Join(s.partialDownloadsDir, downloadInfo.Sha3_384+".snap"))
+	url := downloadInfo.AnonDownloadURL
+	if url == "" || hasStoreAuth(user) {
+		url = downloadInfo.DownloadURL
+	}
+
+	fn := name + "_" + filepath.Base(url) + ".partial"
+	w, err := os.Create(filepath.Join(s.partialDownloadsDir, fn))
 	if err != nil {
 		return "", err
 	}
@@ -1119,11 +1125,6 @@ func (s *Store) Download(name string, downloadInfo *snap.DownloadInfo, pbar prog
 			path = ""
 		}
 	}()
-
-	url := downloadInfo.AnonDownloadURL
-	if url == "" || hasStoreAuth(user) {
-		url = downloadInfo.DownloadURL
-	}
 
 	if err := download(name, url, user, s, w, pbar); err != nil {
 		return "", err

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -209,7 +209,9 @@ func createTestDevice() *auth.DeviceState {
 }
 
 func (t *remoteRepoTestSuite) SetUpTest(c *C) {
-	t.store = New(nil, nil)
+	cfg := DefaultConfig()
+	cfg.PartialDownloadsDir = c.MkDir()
+	t.store = New(cfg, nil)
 	t.origDownloadFunc = download
 	t.origBackoffs = downloadBackoffs
 	downloadBackoffs = []int{2, 5, 0}
@@ -496,7 +498,7 @@ func (t *remoteRepoTestSuite) TestDownloadWithDelta(c *C) {
 			downloadIndex++
 			return nil
 		}
-		applyDelta = func(name string, deltaPath string, deltaInfo *snap.DeltaInfo) (string, error) {
+		applyDelta = func(name, partialDownlodsDir, deltaPath string, deltaInfo *snap.DeltaInfo) (string, error) {
 			c.Check(deltaInfo, Equals, &testCase.info.Deltas[0])
 			w, err := ioutil.TempFile("", "")
 			defer w.Close()
@@ -659,7 +661,7 @@ func (t *remoteRepoTestSuite) TestApplyDelta(c *C) {
 		err = ioutil.WriteFile(currentSnapPath, nil, 0644)
 		c.Assert(err, IsNil)
 
-		snapPath, err := applyDelta(name, "/the/delta/path", &testCase.deltaInfo)
+		snapPath, err := applyDelta(name, dirs.SnapPartialBlobDir, "/the/delta/path", &testCase.deltaInfo)
 
 		c.Assert(os.Remove(currentSnapPath), IsNil)
 		if testCase.error == "" {

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -23,8 +23,8 @@ execute: |
     # have snap use the fakestore for assertions
     export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
 
-    echo Running prepare-image
-    snap prepare-image --channel edge --extra-snaps snapweb $TESTSLIB/assertions/developer1-pc.model $ROOT
+    echo Running prepare-image as user
+    su -l -c "snap prepare-image --channel edge --extra-snaps snapweb $TESTSLIB/assertions/developer1-pc.model $ROOT" test
 
     echo Verifying the result
     ls -lR $IMAGE

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -24,7 +24,7 @@ execute: |
     export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
 
     echo Running prepare-image as user
-    su -l -c "snap prepare-image --channel edge --extra-snaps snapweb $TESTSLIB/assertions/developer1-pc.model $ROOT" test
+    su -c "snap prepare-image --channel edge --extra-snaps snapweb $TESTSLIB/assertions/developer1-pc.model $ROOT" test
 
     echo Verifying the result
     ls -lR $IMAGE

--- a/tests/main/prepare-image-uboot/task.yaml
+++ b/tests/main/prepare-image-uboot/task.yaml
@@ -3,6 +3,8 @@ environment:
     ROOT: /tmp/root
     IMAGE: /tmp/root/image
     GADGET: /tmp/root/gadget
+prepare: |
+    mkdir -p $ROOT
 restore:
     rm -rf $ROOT
 execute: |

--- a/tests/main/prepare-image-uboot/task.yaml
+++ b/tests/main/prepare-image-uboot/task.yaml
@@ -5,6 +5,7 @@ environment:
     GADGET: /tmp/root/gadget
 prepare: |
     mkdir -p $ROOT
+    chown test:test $ROOT
 restore:
     rm -rf $ROOT
 execute: |

--- a/tests/main/prepare-image-uboot/task.yaml
+++ b/tests/main/prepare-image-uboot/task.yaml
@@ -26,8 +26,8 @@ execute: |
     echo The unverified model assertion will not be copied into the image
     export UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL=1
 
-    echo Running prepare-image
-    snap prepare-image --channel edge --extra-snaps snapweb model.assertion $ROOT
+    echo Running prepare-image as user
+    su -l -c "snap prepare-image --channel edge --extra-snaps snapweb model.assertion $ROOT" test
 
     echo Verifying the result
     ls -lR $IMAGE

--- a/tests/main/prepare-image-uboot/task.yaml
+++ b/tests/main/prepare-image-uboot/task.yaml
@@ -8,7 +8,7 @@ restore:
 execute: |
     # TODO: switch to a prebuilt properly signed model assertion once we can do that consistently
     echo Creating model assertion
-    cat > model.assertion <<EOF
+    cat > $ROOT/model.assertion <<EOF
     type: model
     series: 16
     authority-id: my-brand
@@ -27,7 +27,7 @@ execute: |
     export UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL=1
 
     echo Running prepare-image as user
-    su -l -c "snap prepare-image --channel edge --extra-snaps snapweb model.assertion $ROOT" test
+    su -l -c "snap prepare-image --channel edge --extra-snaps snapweb $ROOT/model.assertion $ROOT" test
 
     echo Verifying the result
     ls -lR $IMAGE

--- a/tests/main/prepare-image-uboot/task.yaml
+++ b/tests/main/prepare-image-uboot/task.yaml
@@ -30,7 +30,7 @@ execute: |
     export UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL=1
 
     echo Running prepare-image as user
-    su -l -c "snap prepare-image --channel edge --extra-snaps snapweb $ROOT/model.assertion $ROOT" test
+    su -c "snap prepare-image --channel edge --extra-snaps snapweb $ROOT/model.assertion $ROOT" test
 
     echo Verifying the result
     ls -lR $IMAGE

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -23,3 +23,7 @@ execute: |
     ls classic_*.snap
     verify_asserts classic_*.assert
 
+    echo "Snap download can download snaps as user"
+    su -l -c "snap download hello-world" test
+    ls /home/test/hello-world_*.snap
+    verify_asserts /home/test/hello-world_*.assert


### PR DESCRIPTION
Build on top of https://github.com/snapcore/snapd/pull/2202. It moves the "partialDir" to store.Store to avoid having to mutate the global dirs.

A alternative to this approach would be to drop the `partial/` dir altogether and just use "$targetFile.partial" instead, this would probably make the code slightly simpler, but iirc this was discussed before(?).
