### PR TITLE
debian: only install share/locale if available (missing on powerpc)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -130,7 +130,9 @@ override_dh_install:
 	install --mode=0644 data/completion/snap -D debian/snapd/usr/share/bash-completion/completions/snap
 	# i18n stuff
 	mkdir -p debian/snapd/usr/share
-	cp -R share/locale debian/snapd/usr/share
+	if [ -d share/locale ]; then \
+		cp -R share/locale debian/snapd/usr/share; \
+	fi
 	# etc/profile.d contains the PATH extension for snap packages
 	mkdir -p debian/snapd/etc
 	cp -R etc/profile.d debian/snapd/etc


### PR DESCRIPTION
This fixes a FTBFS on powerpc