### PR TITLE
tests: skip tests that use expect when expect is not working (like on ppc64el)

### DIFF
--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -6,6 +6,12 @@ restore: |
     snap logout || true
 
 execute: |
+    # expect does not work on some hardware in autopkgtest like ppc64el
+    echo "Check if expect is working at all"
+    if ! expect -f works.exp; then
+        echo "SKIP: expect broken in this environment"
+    fi
+
     echo "Checking missing email error"
     expect -f missing_email_error.exp
 

--- a/tests/main/login/works.exp
+++ b/tests/main/login/works.exp
@@ -1,0 +1,9 @@
+spawn echo "hello"
+
+expect {
+    "hello" {
+        exit 0
+    } default {
+        exit 1
+    }
+}

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -30,6 +30,12 @@ prepare: |
     echo pinentry-program /tmp/pinentry-fake > /root/.snap/gnupg/gpg-agent.conf
 
 execute: |
+    # expect does not work on some hardware in autopkgtest like ppc64el
+    echo "Check if expect is working at all"
+    if ! expect -f works.exp; then
+        echo "SKIP: expect broken in this environment"
+    fi
+
     echo "Creating a new key without a password"
     expect -f create-key.exp
 

--- a/tests/main/snap-sign/works.exp
+++ b/tests/main/snap-sign/works.exp
@@ -1,0 +1,1 @@
+../login/works.exp


### PR DESCRIPTION
We see failures on ppc64el that result from expect not working (https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-xenial/xenial/ppc64el/s/snapd/20161020_171527_4f30c@/log.gz) with `error: inappropriate ioctl for device`. This skips expect tests when expect is not working.
