### PR TITLE
tests: increase wait time for service to be up

### DIFF
--- a/tests/main/ubuntu-core-reboot/task.yaml
+++ b/tests/main/ubuntu-core-reboot/task.yaml
@@ -23,7 +23,7 @@ execute: |
             exit 1
         fi
         retries=$(( $retries - 1 ))
-        sleep 1
+        sleep 2
     done
 
     echo "Ensure apparmor profiles are (still) loaded."


### PR DESCRIPTION
In dragonboard `tests/main/ubuntu-core-reboot` was failing because the network-bind-consumer service wasn't up after reboot before the test stopped checking for it.