### PR TITLE
interfaces/bulitin: allow fwupdmgr refresh on fwupd plug

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -91,6 +91,9 @@ var fwupdConnectedPlugAppArmor = []byte(`
 # privileged access to the fwupd service.
 # Usage: reserved
 
+  # Allow fwupdmgr refresh
+  capability net_admin,
+
   #Can access the network
   #include <abstractions/nameservice>
   #include <abstractions/ssl_certs>
@@ -182,6 +185,8 @@ getsockopt
 recvfrom
 recvmsg
 sendmsg
+# Allow fwupdmgr refresh
+sendmmsg
 sendto
 setsockopt
 `)


### PR DESCRIPTION
```
Need additional privileges to access LVFS server using fwupdmgr refresh, the denied log were:

Oct 28 12:06:53 localhost kernel: [ 167.065734] audit: type=1400 audit(1477656413.664:56): apparmor="DENIED" operation="capable" profile="snap.uefi-fw-tools.fwupdmgr" pid=1396 comm="pool" capability=12 capname="net_admin"
Oct 28 12:06:53 localhost kernel: [ 167.071627] audit: type=1326 audit(1477656413.672:57): auid=1000 uid=0 gid=0 ses=1 pid=1396 comm="pool" exe="/snap/uefi-fw-tools/1/bin/fwupdmgr" sig=31 arch=c000003e syscall=307 compat=0 ip=0x7f9e14cd5e2e code=0x0
```
