### PR TITLE
interfaces/sytemd: enable/disable generated service units

### DIFF
--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -122,8 +122,8 @@ func (iface *GpioInterface) ConnectedSlotRichSnippet(plug *interfaces.Plug, slot
 				serviceName: systemd.Service{
 					Type:            "oneshot",
 					RemainAfterExit: true,
-					ExecStart:       fmt.Sprintf("/bin/sh -c 'echo %d > /sys/class/gpio/export'", gpioNum),
-					ExecStop:        fmt.Sprintf("/bin/sh -c 'echo %d > /sys/class/gpio/unexport'", gpioNum),
+					ExecStart:       fmt.Sprintf("/bin/sh -c 'test ! -e /sys/class/gpio/gpio%d && echo %d > /sys/class/gpio/export'", gpioNum, gpioNum),
+					ExecStop:        fmt.Sprintf("/bin/sh -c 'test -e /sys/class/gpio/gpio%d && echo %d > /sys/class/gpio/unexport'", gpioNum, gpioNum),
 				},
 			},
 		}

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -122,8 +122,8 @@ func (iface *GpioInterface) ConnectedSlotRichSnippet(plug *interfaces.Plug, slot
 				serviceName: systemd.Service{
 					Type:            "oneshot",
 					RemainAfterExit: true,
-					ExecStart:       fmt.Sprintf("/bin/sh -c 'test ! -e /sys/class/gpio/gpio%d && echo %d > /sys/class/gpio/export'", gpioNum, gpioNum),
-					ExecStop:        fmt.Sprintf("/bin/sh -c 'test -e /sys/class/gpio/gpio%d && echo %d > /sys/class/gpio/unexport'", gpioNum, gpioNum),
+					ExecStart:       fmt.Sprintf("/bin/sh -c 'test -e /sys/class/gpio/gpio%d || echo %d > /sys/class/gpio/export'", gpioNum, gpioNum),
+					ExecStop:        fmt.Sprintf("/bin/sh -c 'test ! -e /sys/class/gpio/gpio%d || echo %d > /sys/class/gpio/unexport'", gpioNum, gpioNum),
 				},
 			},
 		}

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -146,8 +146,8 @@ func (s *GpioInterfaceSuite) TestConnectedSlotSnippet(c *C) {
 			"snap.my-device.interface.gpio-100.service": map[string]interface{}{
 				"type":              "oneshot",
 				"remain-after-exit": true,
-				"exec-start":        `/bin/sh -c 'test ! -e /sys/class/gpio/gpio100 && echo 100 > /sys/class/gpio/export'`,
-				"exec-stop":         `/bin/sh -c 'test -e /sys/class/gpio/gpio100 && echo 100 > /sys/class/gpio/unexport'`,
+				"exec-start":        `/bin/sh -c 'test -e /sys/class/gpio/gpio100 || echo 100 > /sys/class/gpio/export'`,
+				"exec-stop":         `/bin/sh -c 'test ! -e /sys/class/gpio/gpio100 || echo 100 > /sys/class/gpio/unexport'`,
 			},
 		},
 	})

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -146,8 +146,8 @@ func (s *GpioInterfaceSuite) TestConnectedSlotSnippet(c *C) {
 			"snap.my-device.interface.gpio-100.service": map[string]interface{}{
 				"type":              "oneshot",
 				"remain-after-exit": true,
-				"exec-start":        `/bin/sh -c 'echo 100 > /sys/class/gpio/export'`,
-				"exec-stop":         `/bin/sh -c 'echo 100 > /sys/class/gpio/unexport'`,
+				"exec-start":        `/bin/sh -c 'test ! -e /sys/class/gpio/gpio100 && echo 100 > /sys/class/gpio/export'`,
+				"exec-stop":         `/bin/sh -c 'test -e /sys/class/gpio/gpio100 && echo 100 > /sys/class/gpio/unexport'`,
 			},
 		},
 	})

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -113,11 +113,13 @@ func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repo
 			logger.Noticef("cannot reload systemd state: %s", err)
 		}
 	}
-	// Start and enable any new services
+	// Start and enable or restart any new or changed services
 	for _, service := range changed {
 		if err := systemd.Enable(service); err != nil {
 			logger.Noticef("cannot enable service %q: %s", service, err)
 		}
+		// If we have a new service here which isn't started yet the restart
+		// operation will start it.
 		if err := systemd.Restart(service, 10*time.Second); err != nil {
 			logger.Noticef("cannot restart service %q: %s", service, err)
 		}

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/systemd"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/testutil"
+
+	sysd "github.com/snapcore/snapd/systemd"
 )
 
 type backendSuite struct {
@@ -147,6 +149,15 @@ func (s *backendSuite) TestRenderSnippet(c *C) {
 
 func (s *backendSuite) TestInstallingSnapWritesStartsServices(c *C) {
 	devMode := false
+	prevctlCmd := sysd.SystemctlCmd
+	var sysdLog [][]string
+	sysd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+		sysdLog = append(sysdLog, cmd)
+		if cmd[0] == "show" {
+			return []byte("ActiveState=inactive\n"), nil
+		}
+		return []byte{}, nil
+	}
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte(`{"services": {"snap.samba.interface.foo.service": {"exec-start": "/bin/true"}}}`), nil
 	}
@@ -156,10 +167,14 @@ func (s *backendSuite) TestInstallingSnapWritesStartsServices(c *C) {
 	_, err := os.Stat(service)
 	c.Check(err, IsNil)
 	// the service was also started (whee)
-	c.Check(s.systemctlCmd.Calls(), DeepEquals, [][]string{
-		{"systemctl", "daemon-reload"},
-		{"systemctl", "--root", dirs.GlobalRootDir, "--now", "enable", "snap.samba.interface.foo.service"},
+	c.Check(sysdLog, DeepEquals, [][]string{
+		{"daemon-reload"},
+		{"--root", dirs.GlobalRootDir, "enable", "snap.samba.interface.foo.service"},
+		{"stop", "snap.samba.interface.foo.service"},
+		{"show", "--property=ActiveState", "snap.samba.interface.foo.service"},
+		{"start", "snap.samba.interface.foo.service"},
 	})
+	sysd.SystemctlCmd = prevctlCmd
 }
 
 func (s *backendSuite) TestRemovingSnapRemovesAndStopsServices(c *C) {
@@ -209,8 +224,8 @@ func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 	s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1, 0)
 	// The bar service should have been stopped
 	calls := s.systemctlCmd.Calls()
-	c.Check(calls[0], DeepEquals, []string{"systemctl", "daemon-reload"})
-	c.Check(calls[1], DeepEquals, []string{"systemctl", "--root", dirs.GlobalRootDir, "--now", "disable", "snap.samba.interface.bar.service"})
+	c.Check(calls[0], DeepEquals, []string{"systemctl", "--root", dirs.GlobalRootDir, "--now", "disable", "snap.samba.interface.bar.service"})
+	c.Check(calls[1], DeepEquals, []string{"systemctl", "daemon-reload"})
 	for i, call := range calls {
 		if i > 1 {
 			c.Check(call, DeepEquals, []string{"systemctl", "show", "--property=ActiveState", "snap.samba.interface.bar.service"})

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -139,7 +139,7 @@ func (s *backendSuite) TestRenderSnippet(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(content, DeepEquals, map[string]*osutil.FileState{
 		"foo.service": &osutil.FileState{
-			Content: []byte("[Service]\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n"),
+			Content: []byte("[Service]\nExecStart=/bin/true\n\n[Install]\nWantedBy=multi-user.target\n"),
 			Mode:    0644,
 		},
 	})
@@ -158,8 +158,7 @@ func (s *backendSuite) TestInstallingSnapWritesStartsServices(c *C) {
 	// the service was also started (whee)
 	c.Check(s.systemctlCmd.Calls(), DeepEquals, [][]string{
 		{"systemctl", "daemon-reload"},
-		{"systemctl", "--root", dirs.GlobalRootDir, "enable", "snap.samba.interface.foo.service"},
-		{"systemctl", "start", "snap.samba.interface.foo.service"},
+		{"systemctl", "--root", dirs.GlobalRootDir, "--now", "enable", "snap.samba.interface.foo.service"},
 	})
 }
 
@@ -177,10 +176,9 @@ func (s *backendSuite) TestRemovingSnapRemovesAndStopsServices(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// the service was stopped
 		calls := s.systemctlCmd.Calls()
-		c.Check(calls[0], DeepEquals, []string{"systemctl", "--root", dirs.GlobalRootDir, "disable", "snap.samba.interface.foo.service"})
-		c.Check(calls[1], DeepEquals, []string{"systemctl", "stop", "snap.samba.interface.foo.service"})
+		c.Check(calls[0], DeepEquals, []string{"systemctl", "--root", dirs.GlobalRootDir, "--now", "disable", "snap.samba.interface.foo.service"})
 		for i, call := range calls {
-			if i > 1 && i < len(calls)-2 {
+			if i > 0 && i < len(calls)-1 {
 				c.Check(call, DeepEquals, []string{"systemctl", "show", "--property=ActiveState", "snap.samba.interface.foo.service"})
 			}
 		}
@@ -212,10 +210,9 @@ func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 	// The bar service should have been stopped
 	calls := s.systemctlCmd.Calls()
 	c.Check(calls[0], DeepEquals, []string{"systemctl", "daemon-reload"})
-	c.Check(calls[1], DeepEquals, []string{"systemctl", "--root", dirs.GlobalRootDir, "disable", "snap.samba.interface.bar.service"})
-	c.Check(calls[2], DeepEquals, []string{"systemctl", "stop", "snap.samba.interface.bar.service"})
+	c.Check(calls[1], DeepEquals, []string{"systemctl", "--root", dirs.GlobalRootDir, "--now", "disable", "snap.samba.interface.bar.service"})
 	for i, call := range calls {
-		if i > 2 {
+		if i > 1 {
 			c.Check(call, DeepEquals, []string{"systemctl", "show", "--property=ActiveState", "snap.samba.interface.bar.service"})
 		}
 	}

--- a/interfaces/systemd/snippet.go
+++ b/interfaces/systemd/snippet.go
@@ -59,5 +59,6 @@ func (s *Service) String() string {
 	if s.ExecStop != "" {
 		fmt.Fprintf(&buf, "ExecStop=%s\n", s.ExecStop)
 	}
+	fmt.Fprintf(&buf, "[Install]\nWantedBy=multi-user.target\n")
 	return buf.String()
 }

--- a/interfaces/systemd/snippet.go
+++ b/interfaces/systemd/snippet.go
@@ -43,7 +43,7 @@ func (s *Service) String() string {
 	var buf bytes.Buffer
 	if s.Description != "" {
 		buf.WriteString("[Unit]\n")
-		fmt.Fprintf(&buf, "Description=%s\n", s.Description)
+		fmt.Fprintf(&buf, "Description=%s\n\n", s.Description)
 	}
 	buf.WriteString("[Service]\n")
 	if s.Type != "" {
@@ -59,6 +59,6 @@ func (s *Service) String() string {
 	if s.ExecStop != "" {
 		fmt.Fprintf(&buf, "ExecStop=%s\n", s.ExecStop)
 	}
-	fmt.Fprintf(&buf, "[Install]\nWantedBy=multi-user.target\n")
+	fmt.Fprintf(&buf, "\n[Install]\nWantedBy=multi-user.target\n")
 	return buf.String()
 }

--- a/interfaces/systemd/snippet_test.go
+++ b/interfaces/systemd/snippet_test.go
@@ -31,15 +31,15 @@ var _ = Suite(&snippetSuite{})
 
 func (s *snippetSuite) TestString(c *C) {
 	service1 := systemd.Service{ExecStart: "/bin/true"}
-	c.Assert(service1.String(), Equals, "[Service]\nExecStart=/bin/true\n")
+	c.Assert(service1.String(), Equals, "[Service]\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n")
 	service2 := systemd.Service{Type: "oneshot"}
-	c.Assert(service2.String(), Equals, "[Service]\nType=oneshot\n")
+	c.Assert(service2.String(), Equals, "[Service]\nType=oneshot\n[Install]\nWantedBy=multi-user.target\n")
 	service3 := systemd.Service{RemainAfterExit: true}
-	c.Assert(service3.String(), Equals, "[Service]\nRemainAfterExit=yes\n")
+	c.Assert(service3.String(), Equals, "[Service]\nRemainAfterExit=yes\n[Install]\nWantedBy=multi-user.target\n")
 	service4 := systemd.Service{RemainAfterExit: false}
-	c.Assert(service4.String(), Equals, "[Service]\n")
+	c.Assert(service4.String(), Equals, "[Service]\n[Install]\nWantedBy=multi-user.target\n")
 	service5 := systemd.Service{ExecStop: "/bin/true"}
-	c.Assert(service5.String(), Equals, "[Service]\nExecStop=/bin/true\n")
+	c.Assert(service5.String(), Equals, "[Service]\nExecStop=/bin/true\n[Install]\nWantedBy=multi-user.target\n")
 	service6 := systemd.Service{Description: "ohai"}
-	c.Assert(service6.String(), Equals, "[Unit]\nDescription=ohai\n[Service]\n")
+	c.Assert(service6.String(), Equals, "[Unit]\nDescription=ohai\n[Service]\n[Install]\nWantedBy=multi-user.target\n")
 }

--- a/interfaces/systemd/snippet_test.go
+++ b/interfaces/systemd/snippet_test.go
@@ -31,15 +31,15 @@ var _ = Suite(&snippetSuite{})
 
 func (s *snippetSuite) TestString(c *C) {
 	service1 := systemd.Service{ExecStart: "/bin/true"}
-	c.Assert(service1.String(), Equals, "[Service]\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service1.String(), Equals, "[Service]\nExecStart=/bin/true\n\n[Install]\nWantedBy=multi-user.target\n")
 	service2 := systemd.Service{Type: "oneshot"}
-	c.Assert(service2.String(), Equals, "[Service]\nType=oneshot\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service2.String(), Equals, "[Service]\nType=oneshot\n\n[Install]\nWantedBy=multi-user.target\n")
 	service3 := systemd.Service{RemainAfterExit: true}
-	c.Assert(service3.String(), Equals, "[Service]\nRemainAfterExit=yes\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service3.String(), Equals, "[Service]\nRemainAfterExit=yes\n\n[Install]\nWantedBy=multi-user.target\n")
 	service4 := systemd.Service{RemainAfterExit: false}
-	c.Assert(service4.String(), Equals, "[Service]\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service4.String(), Equals, "[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
 	service5 := systemd.Service{ExecStop: "/bin/true"}
-	c.Assert(service5.String(), Equals, "[Service]\nExecStop=/bin/true\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service5.String(), Equals, "[Service]\nExecStop=/bin/true\n\n[Install]\nWantedBy=multi-user.target\n")
 	service6 := systemd.Service{Description: "ohai"}
-	c.Assert(service6.String(), Equals, "[Unit]\nDescription=ohai\n[Service]\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service6.String(), Equals, "[Unit]\nDescription=ohai\n\n[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -86,7 +86,9 @@ var JournalctlCmd = jctl
 type Systemd interface {
 	DaemonReload() error
 	Enable(service string) error
+	EnableNow(service string) error
 	Disable(service string) error
+	DisableNow(service string) error
 	Start(service string) error
 	Stop(service string, timeout time.Duration) error
 	Kill(service, signal string) error
@@ -184,9 +186,21 @@ func (s *systemd) Enable(serviceName string) error {
 	return err
 }
 
+// Enable the given service and start it
+func (s *systemd) EnableNow(serviceName string) error {
+	_, err := SystemctlCmd("--root", s.rootDir, "--now", "enable", serviceName)
+	return err
+}
+
 // Disable the given service
 func (s *systemd) Disable(serviceName string) error {
 	_, err := SystemctlCmd("--root", s.rootDir, "disable", serviceName)
+	return err
+}
+
+// Disable the given service and stop it
+func (s *systemd) DisableNow(serviceName string) error {
+	_, err := SystemctlCmd("--root", s.rootDir, "--now", "disable", serviceName)
 	return err
 }
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -191,11 +191,22 @@ func (s *SystemdTestSuite) TestDisable(c *C) {
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "disable", "foo"}})
 }
 
+func (s *SystemdTestSuite) TestDisableNow(c *C) {
+	err := New("xyzzy", s.rep).DisableNow("foo")
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "--now", "disable", "foo"}})
+}
+
 func (s *SystemdTestSuite) TestEnable(c *C) {
 	err := New("xyzzy", s.rep).Enable("foo")
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "enable", "foo"}})
+}
 
+func (s *SystemdTestSuite) TestEnableNow(c *C) {
+	err := New("xyzzy", s.rep).Enable("foo")
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "--now", "enable", "foo"}})
 }
 
 func (s *SystemdTestSuite) TestRestart(c *C) {

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -204,7 +204,7 @@ func (s *SystemdTestSuite) TestEnable(c *C) {
 }
 
 func (s *SystemdTestSuite) TestEnableNow(c *C) {
-	err := New("xyzzy", s.rep).Enable("foo")
+	err := New("xyzzy", s.rep).EnableNow("foo")
 	c.Assert(err, IsNil)
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "--now", "enable", "foo"}})
 }


### PR DESCRIPTION
The systemd backend was not enabling/disabling the unit it generates which led to a not working GPIO interface after the reboot of a device. Each unit now gets

```
[Install]
WantedBy=multi-user.target
```

and is properly enabled/disabled.
