### PR TITLE
overlord/ifacestate: setup profiles is its own undo task

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -60,7 +60,7 @@ func Manager(s *state.State, extra []interfaces.Interface) (*InterfaceManager, e
 
 	runner.AddHandler("connect", m.doConnect, nil)
 	runner.AddHandler("disconnect", m.doDisconnect, nil)
-	runner.AddHandler("setup-profiles", m.doSetupProfiles, m.doRemoveProfiles)
+	runner.AddHandler("setup-profiles", m.doSetupProfiles, m.doSetupProfiles)
 	runner.AddHandler("remove-profiles", m.doRemoveProfiles, m.doSetupProfiles)
 	runner.AddHandler("discard-conns", m.doDiscardConns, m.undoDiscardConns)
 	return m, nil


### PR DESCRIPTION
The setup-security task sets up security for the current revision of the
given snap. If that task is undone the undo handler was removing
security entirely. Instead the undo handler should restore whatever was
there before (perhaps nothing on fresh install, perhaps the old security
before the refresh).

Fixes: https://bugs.launchpad.net/snappy/+bug/1637981
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>