### PR TITLE
debian: wrap-and-sort

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,26 +21,34 @@ Vcs-Git: https://github.com/snapcore/snapd.git
 
 Package: golang-github-ubuntu-core-snappy-dev
 Architecture: all
-Depends: ${misc:Depends}, golang-github-snapcore-snapd-dev
+Depends: golang-github-snapcore-snapd-dev, ${misc:Depends}
 Section: oldlibs
 Description: transitional dummy package
  This is a transitional dummy package. It can safely be removed.
 
 Package: golang-github-snapcore-snapd-dev
 Architecture: all
-Breaks: golang-snappy-dev (<< 1.7.3+20160303ubuntu4), golang-github-ubuntu-core-snappy-dev (<< 2.0.6)
-Replaces: golang-snappy-dev (<< 1.7.3+20160303ubuntu4), golang-github-ubuntu-core-snappy-dev (<< 2.0.6)
+Breaks: golang-github-ubuntu-core-snappy-dev (<< 2.0.6),
+        golang-snappy-dev (<< 1.7.3+20160303ubuntu4)
+Replaces: golang-github-ubuntu-core-snappy-dev (<< 2.0.6),
+          golang-snappy-dev (<< 1.7.3+20160303ubuntu4)
 Depends: ${misc:Depends}
 Description: snappy development go packages.
  Use these to use the snappy API.
 
 Package: snapd
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser,
- squashfs-tools, gnupg1 | gnupg, systemd, snap-confine (>= 1.0.43), xdelta
+Depends: adduser,
+         gnupg1 | gnupg,
+         snap-confine (>= 1.0.43),
+         squashfs-tools,
+         systemd,
+         xdelta,
+         ${misc:Depends},
+         ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
-Conflicts: snappy, snap (<< 2013-11-29-1ubuntu1)
+Conflicts: snap (<< 2013-11-29-1ubuntu1), snappy
 Built-Using: ${misc:Built-Using}
 Description: Tool to interact with Ubuntu Core Snappy.
  Manage an Ubuntu system with snappy.
@@ -54,14 +62,14 @@ Description: transitional dummy package
 
 Package: ubuntu-snappy-cli
 Architecture: all
-Depends: snapd,  ${misc:Depends}
+Depends: snapd, ${misc:Depends}
 Section: oldlibs
 Description: transitional dummy package
  This is a transitional dummy package. It can safely be removed.
 
 Package: ubuntu-core-snapd-units
 Architecture: all
-Depends: snapd,  ${misc:Depends}
+Depends: snapd, ${misc:Depends}
 Section: oldlibs
 Description: transitional dummy package
  This is a transitional dummy package. It can safely be removed.

--- a/debian/snapd.dirs
+++ b/debian/snapd.dirs
@@ -1,9 +1,9 @@
 snap
+usr/lib/snapd
 var/lib/snapd/auto-import
-var/lib/snapd/snaps/partial
-var/lib/snapd/lib/gl
 var/lib/snapd/desktop
 var/lib/snapd/environment
 var/lib/snapd/firstboot
-usr/lib/snapd
+var/lib/snapd/lib/gl
+var/lib/snapd/snaps/partial
 var/snap

--- a/debian/snapd.maintscript
+++ b/debian/snapd.maintscript
@@ -1,5 +1,4 @@
-
+# keep mount point busy
 # we used to ship a custom grub config that is no longer needed
 rm_conffile /etc/grub.d/09_snappy 1.7.3ubuntu1
-# keep mount point busy
 rm_conffile /etc/ld.so.conf.d/snappy.conf 2.0.7~

--- a/debian/ubuntu-snappy-cli.dirs
+++ b/debian/ubuntu-snappy-cli.dirs
@@ -1,2 +1,2 @@
-var/lib/snapd/snaps
 usr/lib/snapd
+var/lib/snapd/snaps


### PR DESCRIPTION
This patch just runs `wrap-and-sort` in anticipation of further packaging changes.