### PR TITLE
snapstate: use lanes when building a "refresh-many" change

### DIFF
--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -86,7 +86,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 }
 
 func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
-	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"some":"data"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0}`, patch.Level))
+	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"some":"data"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level))
 	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
 	c.Assert(err, IsNil)
 

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -185,7 +185,7 @@ func (s *snapmgrTestSuite) TestInstallTasks(c *C) {
 	c.Assert(err, IsNil)
 
 	verifyInstallUpdateTasks(c, 0, 0, ts, s.state)
-	c.Assert(s.state.NumTask(), Equals, len(ts.Tasks()))
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
 func (s *snapmgrTestSuite) TestRevertTasks(c *C) {
@@ -205,7 +205,7 @@ func (s *snapmgrTestSuite) TestRevertTasks(c *C) {
 	ts, err := snapstate.Revert(s.state, "some-snap", snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	c.Assert(s.state.NumTask(), Equals, len(ts.Tasks()))
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
 		"prepare-snap",
 		"stop-snap-services",
@@ -237,7 +237,7 @@ func (s *snapmgrTestSuite) TestUpdateCreatesGCTasks(c *C) {
 	c.Assert(err, IsNil)
 
 	verifyInstallUpdateTasks(c, unlinkBefore|cleanupAfter, 2, ts, s.state)
-	c.Assert(s.state.NumTask(), Equals, len(ts.Tasks()))
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
 func (s *snapmgrTestSuite) TestUpdateCreatesDiscardAfterCurrentTasks(c *C) {
@@ -260,7 +260,7 @@ func (s *snapmgrTestSuite) TestUpdateCreatesDiscardAfterCurrentTasks(c *C) {
 	c.Assert(err, IsNil)
 
 	verifyInstallUpdateTasks(c, unlinkBefore|cleanupAfter, 3, ts, s.state)
-	c.Assert(s.state.NumTask(), Equals, len(ts.Tasks()))
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
 func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
@@ -286,7 +286,7 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 
 	ts := tts[0]
 	verifyInstallUpdateTasks(c, unlinkBefore|cleanupAfter, 3, ts, s.state)
-	c.Assert(s.state.NumTask(), Equals, len(ts.Tasks()))
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 }
 
 func (s *snapmgrTestSuite) TestUpdateManyValidateRefreshes(c *C) {
@@ -377,7 +377,7 @@ func (s *snapmgrTestSuite) TestRevertCreatesNoGCTasks(c *C) {
 	c.Assert(err, IsNil)
 
 	// ensure that we do not run any form of garbage-collection
-	c.Assert(s.state.NumTask(), Equals, len(ts.Tasks()))
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
 		"prepare-snap",
 		"stop-snap-services",
@@ -406,7 +406,7 @@ func (s *snapmgrTestSuite) TestEnableTasks(c *C) {
 
 	i := 0
 	c.Assert(ts.Tasks(), HasLen, 3)
-	c.Assert(s.state.NumTask(), Equals, 3)
+	c.Assert(s.state.TaskCount(), Equals, 3)
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "prepare-snap")
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "link-snap")
@@ -431,7 +431,7 @@ func (s *snapmgrTestSuite) TestDisableTasks(c *C) {
 
 	i := 0
 	c.Assert(ts.Tasks(), HasLen, 2)
-	c.Assert(s.state.NumTask(), Equals, 2)
+	c.Assert(s.state.TaskCount(), Equals, 2)
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "stop-snap-services")
 	i++
 	c.Assert(ts.Tasks()[i].Kind(), Equals, "unlink-snap")
@@ -619,7 +619,7 @@ func (s *snapmgrTestSuite) TestUpdateTasks(c *C) {
 	ts, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 	verifyInstallUpdateTasks(c, unlinkBefore|cleanupAfter, 0, ts, s.state)
-	c.Assert(s.state.NumTask(), Equals, len(ts.Tasks()))
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 
 	c.Check(validateCalled, Equals, true)
 
@@ -715,7 +715,7 @@ func (s *snapmgrTestSuite) TestRemoveTasks(c *C) {
 	ts, err := snapstate.Remove(s.state, "foo", snap.R(0))
 	c.Assert(err, IsNil)
 
-	c.Assert(s.state.NumTask(), Equals, len(ts.Tasks()))
+	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
 		"stop-snap-services",
 		"unlink-snap",
@@ -3937,7 +3937,7 @@ func (s *snapmgrTestSuite) TestRemoveMany(c *C) {
 	c.Assert(tts, HasLen, 2)
 	c.Check(removed, DeepEquals, []string{"one", "two"})
 
-	c.Assert(s.state.NumTask(), Equals, 6*2)
+	c.Assert(s.state.TaskCount(), Equals, 6*2)
 	for _, ts := range tts {
 		c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
 			"stop-snap-services",

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -432,6 +432,8 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 			}
 			return nil, nil, err
 		}
+		ts.JoinLane(st.NewLane())
+
 		updated = append(updated, update.Name())
 		tasksets = append(tasksets, ts)
 	}

--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -123,6 +123,7 @@ type Change struct {
 	clean   bool
 	data    customData
 	taskIDs []string
+	lanes   int
 	ready   chan struct{}
 
 	spawnTime time.Time
@@ -150,6 +151,7 @@ type marshalledChange struct {
 	Clean   bool                        `json:"clean,omitempty"`
 	Data    map[string]*json.RawMessage `json:"data,omitempty"`
 	TaskIDs []string                    `json:"task-ids,omitempty"`
+	Lanes   int                         `json:"lanes,omitempty"`
 
 	SpawnTime time.Time  `json:"spawn-time"`
 	ReadyTime *time.Time `json:"ready-time,omitempty"`
@@ -170,6 +172,7 @@ func (c *Change) MarshalJSON() ([]byte, error) {
 		Clean:   c.clean,
 		Data:    c.data,
 		TaskIDs: c.taskIDs,
+		Lanes:   c.lanes,
 
 		SpawnTime: c.spawnTime,
 		ReadyTime: readyTime,
@@ -197,6 +200,7 @@ func (c *Change) UnmarshalJSON(data []byte) error {
 	}
 	c.data = custData
 	c.taskIDs = unmarshalled.TaskIDs
+	c.lanes = unmarshalled.Lanes
 	c.ready = make(chan struct{})
 	c.spawnTime = unmarshalled.SpawnTime
 	if unmarshalled.ReadyTime != nil {
@@ -467,21 +471,115 @@ func (c *Change) Tasks() []*Task {
 	return c.state.tasksIn(c.taskIDs)
 }
 
-// Abort flags the change for cancellation, whether in progress or not. Cancellation will proceed at the next ensure pass.
+// AddLane adds a new lane ID in the change.
+func (c *Change) AddLane() int {
+	c.state.writing()
+	c.lanes++
+	return c.lanes
+}
+
+// LaneCount returns the number of lane IDs registered with the change.
+// Registered lanes may not be used on tasks currently in the change.
+func (c *Change) LaneCount() int {
+	c.state.reading()
+	return c.lanes
+}
+
+// Abort flags the change for cancellation, whether in progress or not.
+// Cancellation will proceed at the next ensure pass.
 func (c *Change) Abort() {
 	c.state.writing()
+	tasks := make([]*Task, len(c.taskIDs))
+	for i, tid := range c.taskIDs {
+		tasks[i] = c.state.tasks[tid]
+	}
+	c.abortTasks(tasks)
+}
+
+// AbortLane aborts all tasks in the provided lanes and any tasks waiting on them,
+// except for tasks that are also in a healthy lane (not aborted, and not waiting
+// on aborted).
+func (c *Change) AbortLanes(lanes []int) {
+	c.state.writing()
+	var hasLive = make(map[int]bool)
+	var hasDead = make(map[int]bool)
+	var laneTasks []*Task
+NextChangeTask:
 	for _, tid := range c.taskIDs {
 		t := c.state.tasks[tid]
+
+		var live bool
+		switch t.Status() {
+		case DoStatus, DoingStatus, DoneStatus:
+			live = true
+		}
+
+		for _, tlane := range t.Lanes() {
+			for _, lane := range lanes {
+				if tlane == lane {
+					laneTasks = append(laneTasks, t)
+					continue NextChangeTask
+				}
+			}
+
+			// Track opinion about lanes not in the kill list.
+			// If the lane ends up being entirely live, we'll
+			// preserve this task alive too.
+			if live {
+				hasLive[tlane] = true
+			} else {
+				hasDead[tlane] = true
+			}
+		}
+	}
+
+	abortTasks := make([]*Task, 0, len(laneTasks))
+NextLaneTask:
+	for _, t := range laneTasks {
+		for _, tlane := range t.Lanes() {
+			if hasLive[tlane] && !hasDead[tlane] {
+				continue NextLaneTask
+			}
+		}
+		abortTasks = append(abortTasks, t)
+	}
+
+	if len(abortTasks) > 0 {
+		c.abortTasks(abortTasks)
+	}
+}
+
+func (c *Change) abortTasks(tasks []*Task) {
+	var lanes []int
+	for i := 0; i < len(tasks); i++ {
+		t := tasks[i]
+		changed := true
 		switch t.Status() {
 		case DoStatus:
 			// Still pending so don't even start.
 			t.SetStatus(HoldStatus)
-		case DoneStatus:
-			// Already done so undo it.
-			t.SetStatus(UndoStatus)
 		case DoingStatus:
 			// In progress so stop and undo it.
 			t.SetStatus(AbortStatus)
+		case DoneStatus:
+			// Already done so undo it.
+			t.SetStatus(UndoStatus)
+		default:
+			changed = false
 		}
+
+		if changed {
+			lanes = append(lanes, t.Lanes()...)
+		}
+
+		for _, halted := range t.HaltTasks() {
+			switch halted.Status() {
+			case DoStatus, DoingStatus, DoneStatus:
+				tasks = append(tasks, halted)
+			}
+		}
+	}
+	if len(lanes) > 0 {
+		c.AbortLanes(lanes)
 	}
 }

--- a/overlord/state/change.go
+++ b/overlord/state/change.go
@@ -471,20 +471,6 @@ func (c *Change) Tasks() []*Task {
 	return c.state.tasksIn(c.taskIDs)
 }
 
-// AddLane adds a new lane ID in the change.
-func (c *Change) AddLane() int {
-	c.state.writing()
-	c.lanes++
-	return c.lanes
-}
-
-// LaneCount returns the number of lane IDs registered with the change.
-// Registered lanes may not be used on tasks currently in the change.
-func (c *Change) LaneCount() int {
-	c.state.reading()
-	return c.lanes
-}
-
 // Abort flags the change for cancellation, whether in progress or not.
 // Cancellation will proceed at the next ensure pass.
 func (c *Change) Abort() {

--- a/overlord/state/change_test.go
+++ b/overlord/state/change_test.go
@@ -20,10 +20,13 @@
 package state_test
 
 import (
-	. "gopkg.in/check.v1"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/snapcore/snapd/overlord/state"
-	"time"
+
+	. "gopkg.in/check.v1"
 )
 
 type changeSuite struct{}
@@ -320,6 +323,7 @@ func (cs *changeSuite) TestMethodEntrance(c *C) {
 		func() { chg.AddTask(nil) },
 		func() { chg.AddAll(nil) },
 		func() { chg.UnmarshalJSON(nil) },
+		func() { chg.AddLane() },
 	}
 
 	reads := []func(){
@@ -331,6 +335,7 @@ func (cs *changeSuite) TestMethodEntrance(c *C) {
 		func() { chg.MarshalJSON() },
 		func() { chg.SpawnTime() },
 		func() { chg.ReadyTime() },
+		func() { chg.LaneCount() },
 	}
 
 	for i, f := range reads {
@@ -384,4 +389,207 @@ func (cs *changeSuite) TestAbort(c *C) {
 			c.Assert(t.Status(), Equals, s)
 		}
 	}
+}
+
+// Task wait order:
+//
+//             => t21 => t22
+//           /               \
+// t11 => t12                 => t41 => t42
+//           \               /
+//             => t31 => t32
+//
+// setup and result lines are <task>:<status>[:<lane>,...]
+//
+// "*" as task name means "all remaining".
+//
+var abortLanesTests = []struct {
+	setup  string
+	abort  []int
+	result string
+}{
+
+	// Some basics.
+	{
+		setup:  "*:do",
+		abort:  []int{},
+		result: "*:do",
+	}, {
+		setup:  "*:do",
+		abort:  []int{1},
+		result: "*:do",
+	}, {
+		setup:  "*:do",
+		abort:  []int{0},
+		result: "*:hold",
+	}, {
+		setup:  "t11:done t12:doing t22:do",
+		abort:  []int{0},
+		result: "t11:undo t12:abort t22:hold",
+	},
+
+	//                      => t21 (2) => t22 (2)
+	//                    /                       \
+	// t11 (1) => t12 (1)                           => t41 (4) => t42 (4)
+	//                    \                       /
+	//                      => t31 (3) => t32 (3)
+	{
+		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{0},
+		result: "*:do",
+	}, {
+		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{1},
+		result: "*:hold",
+	}, {
+		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{2},
+		result: "t21:hold t22:hold t41:hold t42:hold *:do",
+	}, {
+		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{3},
+		result: "t31:hold t32:hold t41:hold t42:hold *:do",
+	}, {
+		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{2, 3},
+		result: "t21:hold t22:hold t31:hold t32:hold t41:hold t42:hold *:do",
+	}, {
+		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{4},
+		result: "t41:hold t42:hold *:do",
+	}, {
+		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{5},
+		result: "*:do",
+	},
+
+	//                          => t21 (2) => t22 (2)
+	//                        /                       \
+	// t11 (2,3) => t12 (2,3)                           => t41 (4) => t42 (4)
+	//                        \                       /
+	//                          => t31 (3) => t32 (3)
+	{
+		setup:  "t11:do:2,3 t12:do:2,3 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{2},
+		result: "t21:hold t22:hold t41:hold t42:hold *:do",
+	}, {
+		setup:  "t11:do:2,3 t12:do:2,3 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{3},
+		result: "t31:hold t32:hold t41:hold t42:hold *:do",
+	}, {
+		setup:  "t11:do:2,3 t12:do:2,3 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{2, 3},
+		result: "*:hold",
+	}}
+
+func (ts *taskRunnerSuite) TestAbortLanes(c *C) {
+
+	names := strings.Fields("t11 t12 t21 t22 t31 t32 t41 t42")
+
+	for _, test := range abortLanesTests {
+		sb := &stateBackend{}
+		st := state.New(sb)
+		r := state.NewTaskRunner(st)
+		defer r.Stop()
+
+		st.Lock()
+		defer st.Unlock()
+
+		c.Assert(len(st.Tasks()), Equals, 0)
+
+		chg := st.NewChange("install", "...")
+		tasks := make(map[string]*state.Task)
+		for _, name := range names {
+			tasks[name] = st.NewTask("do", name)
+			chg.AddTask(tasks[name])
+		}
+		tasks["t12"].WaitFor(tasks["t11"])
+		tasks["t21"].WaitFor(tasks["t12"])
+		tasks["t22"].WaitFor(tasks["t21"])
+		tasks["t31"].WaitFor(tasks["t12"])
+		tasks["t32"].WaitFor(tasks["t31"])
+		tasks["t41"].WaitFor(tasks["t22"])
+		tasks["t41"].WaitFor(tasks["t32"])
+		tasks["t42"].WaitFor(tasks["t41"])
+
+		c.Logf("-----")
+		c.Logf("Testing setup: %s", test.setup)
+
+		statuses := make(map[string]state.Status)
+		for s := state.DefaultStatus; s <= state.ErrorStatus; s++ {
+			statuses[strings.ToLower(s.String())] = s
+		}
+
+		items := strings.Fields(test.setup)
+		seen := make(map[string]bool)
+		for i := 0; i < len(items); i++ {
+			item := items[i]
+			parts := strings.Split(item, ":")
+			if parts[0] == "*" {
+				for _, name := range names {
+					if !seen[name] {
+						parts[0] = name
+						items = append(items, strings.Join(parts, ":"))
+					}
+				}
+				continue
+			}
+			seen[parts[0]] = true
+			task := tasks[parts[0]]
+			task.SetStatus(statuses[parts[1]])
+			if len(parts) > 2 {
+				lanes := strings.Split(parts[2], ",")
+				for _, lane := range lanes {
+					n, err := strconv.Atoi(lane)
+					c.Assert(err, IsNil)
+					task.JoinLane(n)
+				}
+			}
+		}
+
+		c.Logf("Aborting with: %v", test.abort)
+
+		chg.AbortLanes(test.abort)
+
+		c.Logf("Expected result: %s", test.result)
+
+		seen = make(map[string]bool)
+		var expected = strings.Fields(test.result)
+		var obtained []string
+		for i := 0; i < len(expected); i++ {
+			item := expected[i]
+			parts := strings.Split(item, ":")
+			if parts[0] == "*" {
+				var expanded []string
+				for _, name := range names {
+					if !seen[name] {
+						parts[0] = name
+						expanded = append(expanded, strings.Join(parts, ":"))
+					}
+				}
+				expected = append(expected[:i], append(expanded, expected[i+1:]...)...)
+				i--
+				continue
+			}
+			name := parts[0]
+			seen[parts[0]] = true
+			obtained = append(obtained, name+":"+strings.ToLower(tasks[name].Status().String()))
+		}
+
+		c.Assert(strings.Join(obtained, " "), Equals, strings.Join(expected, " "), Commentf("setup: %s", test.setup))
+	}
+}
+
+func (cs *changeSuite) TestAddLane(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("install", "...")
+
+	c.Assert(chg.LaneCount(), Equals, 0)
+	c.Assert(chg.AddLane(), Equals, 1)
+	c.Assert(chg.LaneCount(), Equals, 1)
+	c.Assert(chg.AddLane(), Equals, 2)
+	c.Assert(chg.LaneCount(), Equals, 2)
 }

--- a/overlord/state/change_test.go
+++ b/overlord/state/change_test.go
@@ -323,7 +323,6 @@ func (cs *changeSuite) TestMethodEntrance(c *C) {
 		func() { chg.AddTask(nil) },
 		func() { chg.AddAll(nil) },
 		func() { chg.UnmarshalJSON(nil) },
-		func() { chg.AddLane() },
 	}
 
 	reads := []func(){
@@ -335,7 +334,6 @@ func (cs *changeSuite) TestMethodEntrance(c *C) {
 		func() { chg.MarshalJSON() },
 		func() { chg.SpawnTime() },
 		func() { chg.ReadyTime() },
-		func() { chg.LaneCount() },
 	}
 
 	for i, f := range reads {
@@ -590,18 +588,4 @@ func (ts *taskRunnerSuite) TestAbortLanes(c *C) {
 
 		c.Assert(strings.Join(obtained, " "), Equals, strings.Join(expected, " "), Commentf("setup: %s", test.setup))
 	}
-}
-
-func (cs *changeSuite) TestAddLane(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
-
-	chg := st.NewChange("install", "...")
-
-	c.Assert(chg.LaneCount(), Equals, 0)
-	c.Assert(chg.AddLane(), Equals, 1)
-	c.Assert(chg.LaneCount(), Equals, 1)
-	c.Assert(chg.AddLane(), Equals, 2)
-	c.Assert(chg.LaneCount(), Equals, 2)
 }

--- a/overlord/state/change_test.go
+++ b/overlord/state/change_test.go
@@ -480,7 +480,19 @@ var abortLanesTests = []struct {
 		setup:  "t11:do:2,3 t12:do:2,3 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
 		abort:  []int{2, 3},
 		result: "*:hold",
-	}}
+	},
+
+	//                      => t21 (1) => t22 (1)
+	//                    /                       \
+	// t11 (1) => t12 (1)                           => t41 (4) => t42 (4)
+	//                    \                       /
+	//                      => t31 (1) => t32 (1)
+	{
+		setup:  "t41:error:4 t42:do:4 *:do:1",
+		abort:  []int{1},
+		result: "t41:error *:hold",
+	},
+}
 
 func (ts *taskRunnerSuite) TestAbortLanes(c *C) {
 

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -334,8 +334,9 @@ func (s *State) Task(id string) *Task {
 	return t
 }
 
-// NumTask returns the number of tasks that currently exist in the state (both linked or not yet linked to changes), useful for sanity checking.
-func (s *State) NumTask() int {
+// TaskCount returns the number of tasks that currently exist in the state,
+// whether linked to a change or not.
+func (s *State) TaskCount() int {
 	s.reading()
 	return len(s.tasks)
 }

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -87,6 +87,7 @@ type State struct {
 
 	lastTaskId   int
 	lastChangeId int
+	lastLaneId   int
 
 	backend Backend
 	data    customData
@@ -146,6 +147,7 @@ type marshalledState struct {
 
 	LastChangeId int `json:"last-change-id"`
 	LastTaskId   int `json:"last-task-id"`
+	LastLaneId   int `json:"last-lane-id"`
 }
 
 // MarshalJSON makes State a json.Marshaller
@@ -158,6 +160,7 @@ func (s *State) MarshalJSON() ([]byte, error) {
 
 		LastTaskId:   s.lastTaskId,
 		LastChangeId: s.lastChangeId,
+		LastLaneId:   s.lastLaneId,
 	})
 }
 
@@ -174,6 +177,7 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	s.tasks = unmarshalled.Tasks
 	s.lastChangeId = unmarshalled.LastChangeId
 	s.lastTaskId = unmarshalled.LastTaskId
+	s.lastLaneId = unmarshalled.LastLaneId
 	// backlink state again
 	for _, t := range s.tasks {
 		t.state = s
@@ -281,6 +285,13 @@ func (s *State) NewChange(kind, summary string) *Change {
 	chg := newChange(s, id, kind, summary)
 	s.changes[id] = chg
 	return chg
+}
+
+// NewLane creates a new lane in the state.
+func (s *State) NewLane() int {
+	s.writing()
+	s.lastLaneId++
+	return s.lastLaneId
 }
 
 // Changes returns all changes currently known to the state.

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -647,6 +647,7 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.NewChange("install", "...") },
 		func() { st.NewTask("download", "...") },
 		func() { st.UnmarshalJSON(nil) },
+		func() { st.NewLane() },
 	}
 
 	reads := []func(){

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -659,7 +659,7 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.Task("foo") },
 		func() { st.MarshalJSON() },
 		func() { st.Prune(time.Hour, time.Hour) },
-		func() { st.NumTask() },
+		func() { st.TaskCount() },
 	}
 
 	for i, f := range reads {
@@ -737,7 +737,7 @@ func (ss *stateSuite) TestPrune(c *C) {
 	c.Assert(t3.Status(), Equals, state.DoStatus)
 	c.Assert(t4.Status(), Equals, state.DoStatus)
 
-	c.Check(st.NumTask(), Equals, 3)
+	c.Check(st.TaskCount(), Equals, 3)
 }
 
 func (ss *stateSuite) TestPruneEmptyChange(c *C) {

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -463,6 +463,13 @@ func (ts *TaskSet) AddAll(anotherTs *TaskSet) {
 	}
 }
 
+// JoinLane adds all the tasks in the current taskset to the given lane
+func (ts *TaskSet) JoinLane(lane int) {
+	for _, t := range ts.tasks {
+		t.JoinLane(lane)
+	}
+}
+
 // Tasks returns the tasks in the task set.
 func (ts TaskSet) Tasks() []*Task {
 	// Return something mutable, just like every other Tasks method.

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -48,6 +48,7 @@ type Task struct {
 	data      customData
 	waitTasks []string
 	haltTasks []string
+	lanes     []int
 	log       []string
 	change    string
 
@@ -79,6 +80,7 @@ type marshalledTask struct {
 	Data      map[string]*json.RawMessage `json:"data,omitempty"`
 	WaitTasks []string                    `json:"wait-tasks,omitempty"`
 	HaltTasks []string                    `json:"halt-tasks,omitempty"`
+	Lanes     []int                       `json:"lanes,omitempty"`
 	Log       []string                    `json:"log,omitempty"`
 	Change    string                      `json:"change"`
 
@@ -109,6 +111,7 @@ func (t *Task) MarshalJSON() ([]byte, error) {
 		Data:      t.data,
 		WaitTasks: t.waitTasks,
 		HaltTasks: t.haltTasks,
+		Lanes:     t.lanes,
 		Log:       t.log,
 		Change:    t.change,
 
@@ -142,6 +145,7 @@ func (t *Task) UnmarshalJSON(data []byte) error {
 	t.data = custData
 	t.waitTasks = unmarshalled.WaitTasks
 	t.haltTasks = unmarshalled.HaltTasks
+	t.lanes = unmarshalled.Lanes
 	t.log = unmarshalled.Log
 	t.change = unmarshalled.Change
 	t.spawnTime = unmarshalled.SpawnTime
@@ -381,6 +385,22 @@ func (t *Task) WaitTasks() []*Task {
 func (t *Task) HaltTasks() []*Task {
 	t.state.reading()
 	return t.state.tasksIn(t.haltTasks)
+}
+
+// Lanes returns the lanes the task is in.
+func (t *Task) Lanes() []int {
+	t.state.reading()
+	if len(t.lanes) == 0 {
+		return []int{0}
+	}
+	return t.lanes
+}
+
+// JoinLane registers the task in the provided lane. Tasks in different lanes
+// abort independently on errors. See Change.AbortLane for details.
+func (t *Task) JoinLane(lane int) {
+	t.state.writing()
+	t.lanes = append(t.lanes, lane)
 }
 
 // At schedules the task, if it's not ready, to happen no earlier than when, if when is the zero time any previous special scheduling is supressed.

--- a/overlord/state/task_test.go
+++ b/overlord/state/task_test.go
@@ -362,6 +362,7 @@ func (cs *taskSuite) TestMethodEntrance(c *C) {
 		func() { t1.Errorf("") },
 		func() { t1.UnmarshalJSON(nil) },
 		func() { t1.SetProgress("", 1, 1) },
+		func() { t1.JoinLane(1) },
 	}
 
 	reads := []func(){
@@ -375,6 +376,7 @@ func (cs *taskSuite) TestMethodEntrance(c *C) {
 		func() { t1.MarshalJSON() },
 		func() { t1.Progress() },
 		func() { t1.SetProgress("", 0, 1) },
+		func() { t1.Lanes() },
 	}
 
 	for i, f := range reads {
@@ -478,4 +480,18 @@ func (ts *taskSuite) TestTaskSetAddTaskAndAddAll(c *C) {
 	ts0.AddAll(state.NewTaskSet(t3, t4))
 
 	c.Check(ts0.Tasks(), DeepEquals, []*state.Task{t1, t2, t3, t4})
+}
+
+func (ts *taskSuite) TestLanes(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	t := st.NewTask("download", "1...")
+
+	c.Assert(t.Lanes(), DeepEquals, []int{0})
+	t.JoinLane(1)
+	c.Assert(t.Lanes(), DeepEquals, []int{1})
+	t.JoinLane(2)
+	c.Assert(t.Lanes(), DeepEquals, []int{1, 2})
 }

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -191,7 +191,7 @@ func (r *TaskRunner) run(t *Task) {
 				r.state.EnsureBefore(0)
 			}
 		default:
-			r.abortChange(t.Change())
+			r.abortLanes(t.Change(), t.Lanes())
 			t.SetStatus(ErrorStatus)
 			t.Errorf("%s", err)
 		}
@@ -234,8 +234,8 @@ func (r *TaskRunner) clean(t *Task) {
 	})
 }
 
-func (r *TaskRunner) abortChange(chg *Change) {
-	chg.Abort()
+func (r *TaskRunner) abortLanes(chg *Change, lanes []int) {
+	chg.AbortLanes(lanes)
 	ensureScheduled := false
 	for _, t := range chg.Tasks() {
 		status := t.Status()

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -22,6 +22,7 @@ package state_test
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -89,6 +90,7 @@ func ensureChange(c *C, r *state.TaskRunner, sb *stateBackend, chg *state.Change
 //     <task>:(do|undo)-block - block handler until task tomb dies
 //     <task>:(do|undo)-retry - return from handler with with state.Retry
 //     <task>:(do|undo)-error - return from handler with an error
+//     <task>:...:1,2         - one of the above, and add task to lanes 1 and 2
 //     chg:abort              - call abort on the change
 //
 // Task wait order: ( t11 | t12 ) => ( t21 ) => ( t31 | t32 )
@@ -127,12 +129,16 @@ var sequenceTests = []struct{ setup, result string }{{
 }, {
 	setup:  "t21:do-set-ready",
 	result: "t11:do t12:do t21:do t31:do t32:do",
-},
-	{
-		setup:  "t31:do-error t21:undo-set-ready",
-		result: "t11:do t12:do t21:do t31:do t31:do-error t32:do t32:undo t21:undo t11:undo",
-	},
-}
+}, {
+	setup:  "t31:do-error t21:undo-set-ready",
+	result: "t11:do t12:do t21:do t31:do t31:do-error t32:do t32:undo t21:undo t11:undo",
+}, {
+	setup:  "t11:was-done:1 t12:was-done:2 t21:was-done:1,2 t31:was-done:1 t32:do-error:2",
+	result: "t31:undo t32:do t32:do-error t21:undo t11:undo",
+}, {
+	setup:  "t11:was-done:1 t12:was-done:2 t21:was-done:2 t31:was-done:2 t32:do-error:2",
+	result: "t31:undo t32:do t32:do-error t21:undo",
+}}
 
 func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 	sb := &stateBackend{}
@@ -217,15 +223,23 @@ func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 			t.Set("undo-block", false)
 		}
 		for _, item := range strings.Fields(test.setup) {
-			if item == "chg:abort" {
+			parts := strings.Split(item, ":")
+			if parts[0] == "chg" && parts[1] == "abort" {
 				chg.Abort()
-				continue
-			}
-			kv := strings.Split(item, ":")
-			if strings.HasPrefix(kv[1], "was-") {
-				tasks[kv[0]].SetStatus(statuses[kv[1][4:]])
 			} else {
-				tasks[kv[0]].Set(kv[1], true)
+				if strings.HasPrefix(parts[1], "was-") {
+					tasks[parts[0]].SetStatus(statuses[parts[1][4:]])
+				} else {
+					tasks[parts[0]].Set(parts[1], true)
+				}
+			}
+			if len(parts) > 2 {
+				lanes := strings.Split(parts[2], ",")
+				for _, lane := range lanes {
+					n, err := strconv.Atoi(lane)
+					c.Assert(err, IsNil)
+					tasks[parts[0]].JoinLane(n)
+				}
 			}
 		}
 		st.Unlock()
@@ -271,41 +285,41 @@ func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 		}
 		// ... overwrite based on relevant setup
 		for _, item := range strings.Fields(test.setup) {
-			if item == "chg:abort" && strings.Contains(test.setup, "t12:was-doing") {
+			parts := strings.Split(item, ":")
+			if parts[0] == "chg" && parts[1] == "abort" && strings.Contains(test.setup, "t12:was-doing") {
 				// t12 has no undo so must hold if asked to abort when was doing.
 				finalStatus["t12"] = state.HoldStatus
 			}
-			kv := strings.Split(item, ":")
-			if !strings.HasPrefix(kv[1], "was-") {
+			if !strings.HasPrefix(parts[1], "was-") {
 				continue
 			}
-			switch strings.TrimPrefix(kv[1], "was-") {
+			switch strings.TrimPrefix(parts[1], "was-") {
 			case "do", "doing", "done":
-				finalStatus[kv[0]] = state.DoneStatus
+				finalStatus[parts[0]] = state.DoneStatus
 			case "abort", "undo", "undoing", "undone":
-				if kv[0] == "t12" {
-					finalStatus[kv[0]] = state.DoneStatus // no undo for t12
+				if parts[0] == "t12" {
+					finalStatus[parts[0]] = state.DoneStatus // no undo for t12
 				} else {
-					finalStatus[kv[0]] = state.UndoneStatus
+					finalStatus[parts[0]] = state.UndoneStatus
 				}
 			case "was-error":
-				finalStatus[kv[0]] = state.ErrorStatus
+				finalStatus[parts[0]] = state.ErrorStatus
 			case "was-hold":
-				finalStatus[kv[0]] = state.ErrorStatus
+				finalStatus[parts[0]] = state.ErrorStatus
 			}
 		}
 		// ... and overwrite based on events observed.
 		for _, ev := range events {
-			kv := strings.Split(ev, ":")
-			switch kv[1] {
+			parts := strings.Split(ev, ":")
+			switch parts[1] {
 			case "do":
-				finalStatus[kv[0]] = state.DoneStatus
+				finalStatus[parts[0]] = state.DoneStatus
 			case "undo":
-				finalStatus[kv[0]] = state.UndoneStatus
+				finalStatus[parts[0]] = state.UndoneStatus
 			case "do-error", "undo-error":
-				finalStatus[kv[0]] = state.ErrorStatus
+				finalStatus[parts[0]] = state.ErrorStatus
 			case "do-retry":
-				if kv[0] == "t12" && finalStatus["t11"] == state.ErrorStatus {
+				if parts[0] == "t12" && finalStatus["t11"] == state.ErrorStatus {
 					// t12 has no undo so must hold if asked to abort on retry.
 					finalStatus["t12"] = state.HoldStatus
 				}

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -1,0 +1,47 @@
+summary: Check that undo for snap refresh works
+
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+
+environment:
+    BLOB_DIR: $(pwd)/fake-store-blobdir
+    GOOD_SNAP: xkcd-webserver
+    BAD_SNAP: test-snapd-tools
+
+prepare: |
+    . $TESTSLIB/store.sh
+
+    echo "Given two snaps are installed"
+    for snap in $GOOD_SNAP $BAD_SNAP; do
+        snap install $snap
+    done
+
+    echo "And the daemon is configured to point to the fake store"
+    setup_store fake $BLOB_DIR
+
+restore: |
+    . $TESTSLIB/store.sh
+    teardown_store fake $BLOB_DIR
+
+execute: |
+    echo "When the store is configured to make them refreshable"
+    fakestore -make-refreshable $GOOD_SNAP,$BAD_SNAP -dir $BLOB_DIR
+
+    echo "When a snap is broken"
+    echo "i-am-broken-now" >> $BLOB_DIR/${BAD_SNAP}*fake1*.snap
+
+    echo "And a refresh is performed"
+    if snap refresh ; then
+        echo "snap refresh should fail but it did not, test is broken"
+        exit 1
+    fi
+
+    echo "Then the new version of the good snap got installed"
+    snap list | grep -Pq "${GOOD_SNAP}.*?fake1"
+
+    echo "But the bad snap did not get updated"
+    snap list | grep -P "${BAD_SNAP}"|grep -v "fake"
+
+    echo "Verify the snap change"
+    snap change 4 |grep "Undone.*Download snap \"${BAD_SNAP}\""
+    snap change 4 |grep "Done.*Download snap \"${GOOD_SNAP}\""
+    snap change 4 |grep "ERROR cannot verify snap \"test-snapd-tools\", no matching signatures found"


### PR DESCRIPTION
Build on top of #2241