### PR TITLE
interfaces/builtin/mir: allow client access to /dev/shm/

### DIFF
--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -69,6 +69,7 @@ var mirConnectedPlugAppArmor = []byte(`
 # Description: Permit clients to use Mir
 # Usage: common
 unix (receive, send) type=seqpacket addr=none peer=(label=###SLOT_SECURITY_TAGS###),
+/{dev,run}/shm/\#* rw,
 /run/mir_socket rw,
 /run/user/[0-9]*/mir_socket rw,
 `)


### PR DESCRIPTION
Mir clients that request cpu renderable surfaces need read/write permissions
to /dev/shm entries