### PR TITLE
interfaces: add unconfined access to modem-manager

### DIFF
--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -63,6 +63,19 @@ dbus (send)
 dbus (bind)
     bus=system
     name="org.freedesktop.ModemManager1",
+
+# Allow traffic to/from our path and interface with any method for unconfined
+# clients to talk to our modem-manager services.
+dbus (receive, send)
+    bus=system
+    path=/org/freedesktop/ModemManager1{,/**}
+    interface=org.freedesktop.ModemManager1*
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=system
+    path=/org/freedesktop/ModemManager1{,/**}
+    interface=org.freedesktop.DBus.*
+    peer=(label=unconfined),
 `)
 
 var modemManagerConnectedSlotAppArmor = []byte(`
@@ -94,7 +107,27 @@ var modemManagerConnectedPlugAppArmor = []byte(`
 dbus (receive, send)
     bus=system
     path=/org/freedesktop/ModemManager1{,/**}
+    interface=org.freedesktop.ModemManager1*
     peer=(label=###SLOT_SECURITY_TAGS###),
+dbus (receive, send)
+    bus=system
+    path=/org/freedesktop/ModemManager1{,/**}
+    interface=org.freedesktop.DBus.*
+    peer=(label=###SLOT_SECURITY_TAGS###),
+`)
+
+var modemManagerConnectedPlugAppArmorClassic = []byte(`
+# Allow access to the unconfined ModemManager service on classic.
+dbus (receive, send)
+    bus=system
+    path=/org/freedesktop/ModemManager1{,/**}
+    interface=org.freedesktop.ModemManager1*
+    peer=(label=unconfined),
+dbus (receive, send)
+    bus=system
+    path=/org/freedesktop/ModemManager1{,/**}
+    interface=org.freedesktop.DBus.*
+    peer=(label=unconfined),
 `)
 
 var modemManagerPermanentSlotSecComp = []byte(`
@@ -142,14 +175,16 @@ socket
 `)
 
 var modemManagerPermanentSlotDBus = []byte(`
-<!-- DBus policy for ModemManager (upstream version 1.4.0)
-  - TODO change to polkit one when we enable it -->
-<policy context="default">
-    <allow send_destination="org.freedesktop.ModemManager1"/>
-</policy>
-
 <policy user="root">
     <allow own="org.freedesktop.ModemManager1"/>
+    <allow send_destination="org.freedesktop.ModemManager1"/>
+</policy>
+`)
+
+var modemManagerConnectedPlugDBus = []byte(`
+<policy context="default">
+    <deny own="org.freedesktop.ModemManager1"/>
+    <deny send_destination="org.freedesktop.ModemManager1"/>
 </policy>
 `)
 
@@ -1157,18 +1192,15 @@ func (iface *ModemManagerInterface) PermanentPlugSnippet(plug *interfaces.Plug, 
 func (iface *ModemManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityDBus:
-		return nil, nil
+		return []byte(modemManagerConnectedPlugDBus), nil
 	case interfaces.SecurityAppArmor:
 		old := []byte("###SLOT_SECURITY_TAGS###")
-		var new []byte
+		new := slotAppLabelExpr(slot)
+		snippet := bytes.Replace([]byte(modemManagerConnectedPlugAppArmor), old, new, -1)
 		if release.OnClassic {
-			// If we're running on classic ModemManager will be part
-			// of the OS snap and will run unconfined.
-			new = []byte("unconfined")
-		} else {
-			new = slotAppLabelExpr(slot)
+			// Let confined apps access unconfined ofono on classic
+			snippet = append(snippet, modemManagerConnectedPlugAppArmorClassic...)
 		}
-		snippet := bytes.Replace(modemManagerConnectedPlugAppArmor, old, new, -1)
 		return snippet, nil
 	case interfaces.SecuritySecComp:
 		return modemManagerConnectedPlugSecComp, nil

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -121,9 +121,8 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c 
 }
 
 func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippedUsesUnconfinedLabelOnClassic(c *C) {
-	slot := &interfaces.Slot{}
 	release.OnClassic = true
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(string(snippet), testutil.Contains, "peer=(label=unconfined),")
 }
@@ -141,11 +140,25 @@ func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	}
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, IsNil)
+	c.Assert(snippet, Not(IsNil))
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityUDev)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *ModemManagerInterfaceSuite) TestPermanentSlotDBus(c *C) {
+	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, "allow own=\"org.freedesktop.ModemManager1\"")
+	c.Assert(string(snippet), testutil.Contains, "allow send_destination=\"org.freedesktop.ModemManager1\"")
+}
+
+func (s *ModemManagerInterfaceSuite) TestConnectedPlugDBus(c *C) {
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, "deny own=\"org.freedesktop.ModemManager1\"")
+	c.Assert(string(snippet), testutil.Contains, "deny send_destination=\"org.freedesktop.ModemManager1\"")
 }

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -120,7 +120,14 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c 
 	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.modem-manager.app"),`)
 }
 
-func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippedUsesUnconfinedLabelOnClassic(c *C) {
+func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabelNot(c *C) {
+	release.OnClassic = false
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), Not(testutil.Contains), "peer=(label=unconfined),")
+}
+
+func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabelOnClassic(c *C) {
 	release.OnClassic = true
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Let unconfined apps access modem-manager DBus interface, and also let
the plug access modem-manager in classic.