### PR TITLE
interfaces/builtin/mir: allow slot to make recvfrom syscalls

### DIFF
--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -57,6 +57,7 @@ open
 getsockopt
 recvmsg
 sendmsg
+recvfrom
 `)
 
 var mirConnectedSlotAppArmor = []byte(`


### PR DESCRIPTION
A mir server needs to make recvfrom syscalls as the input stack expects
ack messages from the client