### PR TITLE
Fix build failure on call to UbuntuArchitecture

### DIFF
--- a/cmd/snap/cmd_buy_test.go
+++ b/cmd/snap/cmd_buy_test.go
@@ -258,7 +258,7 @@ const loginJson = `
 `
 
 func archWithBrokenDevPtmx() error {
-	if ubunArch := arch.UbuntuArchitecture(); ubuArch == "ppc64el" || ubuArch == "powerpc" {
+	if ubuArch := arch.UbuntuArchitecture(); ubuArch == "ppc64el" || ubuArch == "powerpc" {
 		return fmt.Errorf("/dev/ptmx ioctl not working on %s", ubuArch)
 	}
 	return nil

--- a/cmd/snap/cmd_buy_test.go
+++ b/cmd/snap/cmd_buy_test.go
@@ -258,8 +258,8 @@ const loginJson = `
 `
 
 func archWithBrokenDevPtmx() error {
-	if arch.UbuntuArchitecture() == "ppc64el" || arch.UbuntuArchitecture() == "powerpc" {
-		return fmt.Errorf("/dev/ptmx ioctl not working on %s", arch.UbuntuArchitecture())
+	if ubunArch := arch.UbuntuArchitecture(); ubuArch == "ppc64el" || ubuArch == "powerpc" {
+		return fmt.Errorf("/dev/ptmx ioctl not working on %s", ubuArch)
 	}
 	return nil
 }

--- a/cmd/snap/cmd_buy_test.go
+++ b/cmd/snap/cmd_buy_test.go
@@ -259,7 +259,7 @@ const loginJson = `
 
 func archWithBrokenDevPtmx() error {
 	if arch.UbuntuArchitecture() == "ppc64el" || arch.UbuntuArchitecture() == "powerpc" {
-		return fmt.Errorf("/dev/ptmx ioctl not working on %s", arch.UbuntuArchitecture)
+		return fmt.Errorf("/dev/ptmx ioctl not working on %s", arch.UbuntuArchitecture())
 	}
 	return nil
 }


### PR DESCRIPTION
Fix for cmd/snap/cmd_buy_test.go:262: arg arch.UbuntuArchitecture in printf call is a function value, not a function call