### PR TITLE
snap: add support for classic confinement

### DIFF
--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1390,7 +1390,7 @@ apps:
 }
 
 // classic confinement
-func (s *YamlSuite ) TestClassicConfinement(c *C) {
+func (s *YamlSuite) TestClassicConfinement(c *C) {
 	y := []byte(`
 name: foo
 confinement: classic

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1388,3 +1388,14 @@ apps:
 		"k2": "v2",
 	})
 }
+
+// classic confinement
+func (s *YamlSuite ) TestClassicConfinement(c *C) {
+	y := []byte(`
+name: foo
+confinement: classic
+`)
+	info, err := snap.InfoFromSnapYaml(y)
+	c.Assert(err, IsNil)
+	c.Assert(info.Confinement, Equals, snap.ClassicConfinement)
+}

--- a/snap/types.go
+++ b/snap/types.go
@@ -81,6 +81,7 @@ type ConfinementType string
 // The various confinement types we support
 const (
 	DevmodeConfinement ConfinementType = "devmode"
+	ClassicConfinement ConfinementType = "classic"
 	StrictConfinement  ConfinementType = "strict"
 )
 
@@ -106,7 +107,7 @@ func (confinementType *ConfinementType) UnmarshalYAML(unmarshal func(interface{}
 
 func (confinementType *ConfinementType) fromString(str string) error {
 	c := ConfinementType(str)
-	if c != DevmodeConfinement && c != StrictConfinement {
+	if c != DevmodeConfinement && c != ClassicConfinement && c != StrictConfinement {
 		return fmt.Errorf("invalid confinement type: %q", str)
 	}
 


### PR DESCRIPTION
This patch adds support for the "classic" confinement for the `meta/snap.yaml` parser.