### PR TITLE
snap: add new `snap prepare-image --devmode` option

### DIFF
--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -36,6 +36,7 @@ type cmdPrepareImage struct {
 
 	ExtraSnaps []string `long:"extra-snaps"`
 	Channel    string   `long:"channel"`
+	Devmode    bool     `long:"devmode"`
 }
 
 func init() {
@@ -47,6 +48,7 @@ func init() {
 		}, map[string]string{
 			"extra-snaps": "Extra snaps to be installed",
 			"channel":     "The channel to use",
+			"devmode":     "Allow devmode snaps",
 		}, []argDesc{
 			{
 				name: i18n.G("<model-assertion>"),
@@ -66,6 +68,7 @@ func (x *cmdPrepareImage) Execute(args []string) error {
 		RootDir:         filepath.Join(x.Positional.Rootdir, "image"),
 		GadgetUnpackDir: filepath.Join(x.Positional.Rootdir, "gadget"),
 		Channel:         x.Channel,
+		Devmode:         x.Devmode,
 		Snaps:           x.ExtraSnaps,
 	}
 

--- a/image/image.go
+++ b/image/image.go
@@ -51,6 +51,7 @@ type Options struct {
 	Snaps           []string
 	RootDir         string
 	Channel         string
+	Devmode         bool
 	ModelFile       string
 	GadgetUnpackDir string
 }
@@ -273,7 +274,7 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 	dlOpts := &DownloadOptions{
 		TargetDir: snapSeedDir,
 		Channel:   opts.Channel,
-		DevMode:   false, // XXX: should this be true?
+		DevMode:   opts.Devmode,
 	}
 
 	for _, d := range []string{snapSeedDir, assertSeedDir} {


### PR DESCRIPTION
Added the critical label because its an important feature for the team that works on personal images.

Strawman branch - if the direction is ok I will add more tests.

This unblocks the people from building personal images. The MIR snap currently requires to be run with devmode and `snap preapre-image` has currently no support for this.

This branch adds a global flag --devmode to `snap prepare-image`. Just like the existing --channel flag it allows a global setting that devmode snaps are ok (or not).