### PR TITLE
interfaces: miscellaneous policy updates (LP: #1639988, 1614269, 1639614, 1605216, 1629996, et al)

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -237,7 +237,7 @@ var defaultTemplate = []byte(`
   owner @{PROC}/@{pid}/cmdline r,
 
   # Miscellaneous accesses
-  /dev/random w,
+  /dev/{,u}random w,
   /etc/machine-id r,
   /etc/mime.types r,
   @{PROC}/ r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -237,6 +237,7 @@ var defaultTemplate = []byte(`
   owner @{PROC}/@{pid}/cmdline r,
 
   # Miscellaneous accesses
+  /dev/random w,
   /etc/machine-id r,
   /etc/mime.types r,
   @{PROC}/ r,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -137,6 +137,7 @@ unix (bind)
      addr="@[0-9A-F]*._service_*",
 
 # Policy needed only when using the chrome/chromium setuid sandbox
+capability sys_ptrace,
 ptrace (trace) peer=snap.@{SNAP_NAME}.**,
 unix (receive, send) peer=(label=snap.@{SNAP_NAME}.**),
 

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -29,6 +29,8 @@ const cupsControlConnectedPlugAppArmor = `
 `
 
 const cupsControlConnectedPlugSecComp = `
+recvfrom
+sendto
 setsockopt
 `
 

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -69,6 +69,7 @@ capability,
 /dev/mapper/docker* rw,
 /dev/loop-control r,
 /dev/loop[0-9]* rw,
+/sys/devices/virtual/block/dm-[0-9]*/** r,
 mount,
 umount,
 

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -45,6 +45,14 @@ capability sys_rawio,
 # util-linux
 /{,usr/}bin/lscpu ixr,
 @{PROC}/bus/pci/devices r,
+
+# lsusb
+# Note: lsusb and its database have to be shipped in the snap if not on classic
+/{,usr/}bin/lsusb ixr,
+/var/lib/usbutils/usb.ids r,
+/dev/ r,
+/dev/bus/usb/{,**/} r,
+/etc/udev/udev.conf r,
 `
 
 // NewHardwareObserveInterface returns a new "hardware-observe" interface.

--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -29,6 +29,9 @@ const mountObserveConnectedPlugAppArmor = `
 # it gives privileged read access to mount arguments and should only be used
 # with trusted apps.
 # Usage: reserved
+
+/{,usr/}bin/df ixr,
+
 # Needed by 'df'. This is an information leak
 @{PROC}/mounts r,
 owner @{PROC}/@{pid}/mounts r,

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -59,6 +59,13 @@ deny ptrace (trace),
 @{PROC}/*/{,task/*/}stat r,
 @{PROC}/*/{,task/*/}statm r,
 @{PROC}/*/{,task/*/}status r,
+
+dbus (send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.DBus.Properties
+    member=Get{,All}
+    peer=(label=unconfined),
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/system-observe
@@ -74,6 +81,16 @@ const systemObserveConnectedPlugSecComp = `
 # Note: may uncomment once ubuntu-core-launcher understands @deny rules and
 # if/when we conditionally deny this in the future.
 #@deny ptrace
+
+# for connecting to /org/freedesktop/hostname1 over DBus
+connect
+getsockname
+recvfrom
+recvmsg
+send
+sendto
+sendmsg
+socket
 `
 
 // NewSystemObserveInterface returns a new "system-observe" interface.

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -409,7 +409,7 @@ dbus (receive)
 
 # Lttng tracing is very noisy and should not be allowed by confined apps. Can
 # safely deny. LP: #1260491
-deny /{,var/}run/shm/lttng-ust-* r,
+deny /{,var/}{dev,run}/shm/lttng-ust-* r,
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/unity7

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -305,28 +305,28 @@ dbus (send)
 
 dbus (send)
     bus=session
-    path=/StatusNotifierWatcher
+    path=/{StatusNotifierWatcher,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierWatcher
     member=RegisterStatusNotifierItem
-    peer=(name=org.kde.StatusNotifierWatcher, label=unconfined),
+    peer=(label=unconfined),
 
 dbus (send)
     bus=session
-    path=/StatusNotifierItem
+    path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierItem
     member="New{AttentionIcon,Icon,OverlayIcon,Status,Title,ToolTip}"
     peer=(name=org.freedesktop.DBus, label=unconfined),
 
 dbus (send)
     bus=session
-    path=/StatusNotifierItem/menu
+    path=/{StatusNotifierItem/menu,org/ayatana/NotificationItem/*/Menu}
     interface=com.canonical.dbusmenu
     member="{LayoutUpdated,ItemsPropertiesUpdated}"
     peer=(name=org.freedesktop.DBus, label=unconfined),
 
 dbus (receive)
     bus=session
-    path=/StatusNotifierItem{,/menu}
+    path=/{StatusNotifierItem,StatusNotifierItem/menu,org/ayatana/NotificationItem/**}
     interface={org.freedesktop.DBus.Properties,com.canonical.dbusmenu}
     member={Get*,AboutTo*,Event*}
     peer=(label=unconfined),
@@ -344,6 +344,13 @@ dbus (receive)
     interface=org.freedesktop.Notifications
     member=NotificationClosed
     peer=(label=unconfined),
+
+dbus (send)
+    bus=session
+    path=/org/ayatana/NotificationItem/*
+    interface=org.kde.StatusNotifierItem
+    member=XAyatanaNew*
+    peer=(name=org.freedesktop.DBus, label=unconfined),
 
 # unity launcher
 dbus (send)

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -264,6 +264,7 @@ open
 
 openat
 pause
+personality
 pipe
 pipe2
 poll


### PR DESCRIPTION
- interfaces: allow write to /dev/(u)random by default (LP: #1629996)
- interfaces: allow recvfrom and sendto in cups-control (LP: #1605216)
- interfaces: also deny /dev/shm/lttng-ust-* (LP: #1639614)
- interfaces: allow 'df' in mount-observe
- interfaces: allow lsusb to work with hardware-observe
- interfaces: allow docker-support read to /sys/devices/virtual/block/dm-[0-9]*
- interfaces: allow use of personality syscall by default (LP: #1614269)
- interfaces: allow 'capability sys_ptrace' with 'allow-sandbox: true'
- interfaces: update unity7 for libappindicator (LP: #1639988)
- interfaces: allow Get/GetAll to /org/freedesktop/hostname1 in system-observe