### PR TITLE
interfaces: remove LegacyAutoConnect() from the interfaces 

### DIFF
--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -157,9 +157,6 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		expected := autoconnect[iface.Name()]
 		comm := Commentf(iface.Name())
 
-		// cross-check with past behavior
-		c.Check(expected, Equals, iface.LegacyAutoConnect(), comm)
-
 		// check base declaration
 		cand := s.connectCand(c, iface.Name(), "", "")
 		err := cand.CheckAutoConnect()

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -88,7 +88,3 @@ func (s *BluetoothControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *BluetoothControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -240,10 +240,6 @@ func (iface *BluezInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *BluezInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *BluezInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -147,10 +147,6 @@ func (iface *BoolFileInterface) isGPIO(slot *interfaces.Slot) bool {
 	panic("slot is not sanitized")
 }
 
-func (iface *BoolFileInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 // AutoConnect returns whether plug and slot should be implicitly
 // auto-connected assuming they will be an unambiguous connection
 // candidate and declaration-based checks allow.

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -237,7 +237,3 @@ func (s *BoolFileInterfaceSuite) TestPermanentSlotSnippetPanicksOnUnsanitizedSlo
 		s.iface.PermanentSlotSnippet(s.missingPathSlot, interfaces.SecurityAppArmor)
 	}, PanicMatches, "slot is not sanitized")
 }
-
-func (s *BoolFileInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -260,10 +260,6 @@ func (iface *BrowserSupportInterface) PermanentPlugSnippet(plug *interfaces.Plug
 	return nil, nil
 }
 
-func (iface *BrowserSupportInterface) LegacyAutoConnect() bool {
-	return true
-}
-
 func (iface *BrowserSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -173,7 +173,3 @@ func (s *BrowserSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *BrowserSupportInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -39,7 +39,6 @@ type commonInterface struct {
 	connectedPlugSecComp   string
 	connectedPlugKMod      string
 	reservedForOS          bool
-	autoConnect            bool // OBSOLETE, only cross-check info atm
 	rejectAutoConnectPairs bool
 }
 
@@ -114,10 +113,6 @@ func (iface *commonInterface) PermanentSlotSnippet(slot *interfaces.Slot, securi
 // Slots don't get any per-connection security snippets.
 func (iface *commonInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
-}
-
-func (iface *commonInterface) LegacyAutoConnect() bool {
-	return iface.autoConnect
 }
 
 // AutoConnect returns whether plug and slot should be implicitly

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -153,10 +153,6 @@ func (iface *ContentInterface) PermanentPlugSnippet(plug *interfaces.Plug, secur
 	return nil, nil
 }
 
-func (iface *ContentInterface) LegacyAutoConnect() bool {
-	return true
-}
-
 func (iface *ContentInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	return plug.Attrs["content"] == slot.Attrs["content"]
 }

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -245,39 +245,3 @@ slots:
 	expected := "/var/snap/producer/common/export /var/snap/consumer/common/import none bind 0 0\n"
 	c.Assert(string(content), Equals, expected)
 }
-
-func (s *ContentSuite) TestLegacyAutoConnect(c *C) {
-	const plugSnapYaml = `name: content-slot-snap
-version: 1.0
-plugs:
- content-plug:
-  interface: content
-  content: cont1
-`
-	info := snaptest.MockInfo(c, plugSnapYaml, nil)
-	plug := &interfaces.Plug{PlugInfo: info.Plugs["content-plug"]}
-
-	const slotSnapYaml = `name: content-slot-snap
-version: 1.0
-slots:
- content-slot:
-  interface: content
-  content: cont1
-`
-	info = snaptest.MockInfo(c, slotSnapYaml, nil)
-	slot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
-
-	c.Check(s.iface.AutoConnect(plug, slot), Equals, true)
-
-	const otherSnapYaml = `name: content-other-snap
-version: 1.0
-slots:
- content-slot:
-  interface: content
-  content: cont2
-`
-	info = snaptest.MockInfo(c, otherSnapYaml, nil)
-	otherslot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
-
-	c.Check(s.iface.AutoConnect(plug, otherslot), Equals, false)
-}

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -39,6 +39,5 @@ func NewCupsControlInterface() interfaces.Interface {
 		connectedPlugAppArmor: cupsControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  cupsControlConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           false,
 	}
 }

--- a/interfaces/builtin/dcdbas_control_test.go
+++ b/interfaces/builtin/dcdbas_control_test.go
@@ -86,7 +86,3 @@ func (s *DcdbasControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 	c.Assert(string(snippet), testutil.Contains, `/dcdbas/smi_data`)
 }
-
-func (s *DcdbasControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -90,10 +90,6 @@ func (iface *DockerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *DockerInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *DockerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -575,10 +575,6 @@ func (iface *DockerSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *DockerSupportInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *DockerSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -72,10 +72,6 @@ func (s *DockerSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *DockerSupportInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}
-
 func (s *DockerSupportInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/docker_test.go
+++ b/interfaces/builtin/docker_test.go
@@ -70,10 +70,6 @@ func (s *DockerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *DockerInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}
-
 func (s *DockerInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -92,7 +92,3 @@ func (s *FirewallControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *FirewallControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/fuse_support.go
+++ b/interfaces/builtin/fuse_support.go
@@ -80,6 +80,5 @@ func NewFuseSupportInterface() interfaces.Interface {
 		connectedPlugAppArmor: fuseSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:  fuseSupportConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           false,
 	}
 }

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -88,7 +88,3 @@ func (s *FuseSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *FuseSupportInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -248,10 +248,6 @@ func (iface *FwupdInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *FwupdInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *FwupdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -147,10 +147,6 @@ func (iface *GpioInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *in
 	return rawSnippet, nil
 }
 
-func (iface *GpioInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *GpioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -62,6 +62,5 @@ func NewGsettingsInterface() interfaces.Interface {
 		connectedPlugAppArmor: gsettingsConnectedPlugAppArmor,
 		connectedPlugSecComp:  gsettingsConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/gsettings_test.go
+++ b/interfaces/builtin/gsettings_test.go
@@ -88,7 +88,3 @@ func (s *GsettingsInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *GsettingsInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -84,7 +84,3 @@ func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *HardwareObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -179,10 +179,6 @@ func (iface *HidrawInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *
 	return nil, nil
 }
 
-func (iface *HidrawInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *HidrawInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -21,7 +21,6 @@ package builtin
 
 import (
 	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/release"
 )
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/home
@@ -56,6 +55,5 @@ func NewHomeInterface() interfaces.Interface {
 		name: "home",
 		connectedPlugAppArmor: homeConnectedPlugAppArmor,
 		reservedForOS:         true,
-		autoConnect:           release.OnClassic,
 	}
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -84,9 +84,3 @@ func (s *HomeInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *HomeInterfaceSuite) TestAutoConnect(c *C) {
-	iface := builtin.NewHomeInterface()
-	// allow what declarations allowed
-	c.Check(iface.AutoConnect(nil, nil), Equals, true)
-}

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -49,6 +49,5 @@ func NewKernelModuleControlInterface() interfaces.Interface {
 		connectedPlugAppArmor: kernelModuleControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  kernelModuleControlConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           false,
 	}
 }

--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -43,7 +43,5 @@ func NewLibvirtInterface() interfaces.Interface {
 		connectedPlugAppArmor: libvirtConnectedPlugAppArmor,
 		connectedPlugSecComp:  libvirtConnectedPlugSecComp,
 		reservedForOS:         true,
-		// cannot auto-connect, it grants too much power
-		autoConnect: false,
 	}
 }

--- a/interfaces/builtin/libvirt_test.go
+++ b/interfaces/builtin/libvirt_test.go
@@ -64,7 +64,3 @@ func (s *LibvirtInterfaceSuite) TestSanitizePlug(c *C) {
 	err := s.iface.SanitizePlug(s.plug)
 	c.Assert(err, IsNil)
 }
-
-func (s *LibvirtInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -84,7 +84,3 @@ func (s *LocaleControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *LocaleControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -208,10 +208,6 @@ func (iface *LocationControlInterface) SanitizeSlot(slot *interfaces.Slot) error
 	return nil
 }
 
-func (iface *LocationControlInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *LocationControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -281,10 +281,6 @@ func (iface *LocationObserveInterface) SanitizeSlot(slot *interfaces.Slot) error
 	return nil
 }
 
-func (iface *LocationObserveInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *LocationObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -84,7 +84,3 @@ func (s *LogObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *LogObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -81,10 +81,6 @@ func (iface *LxdInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *LxdInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *LxdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -73,11 +73,6 @@ func (iface *LxdSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *LxdSupportInterface) LegacyAutoConnect() bool {
-	// since limited to lxd.canonical, we can auto-connect
-	return true
-}
-
 func (iface *LxdSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -93,10 +93,6 @@ func (s *LxdSupportInterfaceSuite) TestPermanentSlotPolicySecComp(c *C) {
 	c.Check(string(snippet), testutil.Contains, "@unrestricted\n")
 }
 
-func (s *LxdSupportInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}
-
 func (s *LxdSupportInterfaceSuite) TestAutoConnect(c *C) {
 	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)
 }

--- a/interfaces/builtin/lxd_test.go
+++ b/interfaces/builtin/lxd_test.go
@@ -92,10 +92,6 @@ func (s *LxdInterfaceSuite) TestConnectedPlugSnippetSecComp(c *C) {
 	c.Check(string(snippet), testutil.Contains, "shutdown\n")
 }
 
-func (s *LxdInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}
-
 func (s *LxdInterfaceSuite) TestAutoConnect(c *C) {
 	// allow what declarations allowed
 	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -137,10 +137,6 @@ func (iface *MirInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *MirInterface) LegacyAutoConnect() bool {
-	return true
-}
-
 func (iface *MirInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -72,7 +72,3 @@ func (s *MirInterfaceSuite) TestUsedSecuritySystems(c *C) {
 		}
 	}
 }
-
-func (s MirInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1209,10 +1209,6 @@ func (iface *ModemManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *ModemManagerInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *ModemManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -84,7 +84,3 @@ func (s *MountObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *MountObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -248,10 +248,6 @@ func (iface *MprisInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return err
 }
 
-func (iface *MprisInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *MprisInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/mpris_test.go
+++ b/interfaces/builtin/mpris_test.go
@@ -343,8 +343,3 @@ func (s *MprisInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *MprisInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	iface := &builtin.MprisInterface{}
-	c.Check(iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -69,6 +69,5 @@ func NewNetworkInterface() interfaces.Interface {
 		connectedPlugAppArmor: networkConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -99,6 +99,5 @@ func NewNetworkBindInterface() interfaces.Interface {
 		connectedPlugAppArmor: networkBindConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkBindConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -88,7 +88,3 @@ func (s *NetworkBindInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *NetworkBindInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -450,10 +450,6 @@ func (iface *NetworkManagerInterface) SanitizeSlot(slot *interfaces.Slot) error 
 	return nil
 }
 
-func (iface *NetworkManagerInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *NetworkManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -88,7 +88,3 @@ func (s *NetworkObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *NetworkObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -84,7 +84,3 @@ func (s *NetworkSetupObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *NetworkSetupObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -88,7 +88,3 @@ func (s *NetworkInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *NetworkInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -70,6 +70,5 @@ func NewOpenglInterface() interfaces.Interface {
 		connectedPlugAppArmor: openglConnectedPlugAppArmor,
 		connectedPlugSecComp:  openglConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -34,6 +34,5 @@ func NewOpticalDriveInterface() interfaces.Interface {
 		name: "optical-drive",
 		connectedPlugAppArmor: opticalDriveConnectedPlugAppArmor,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -86,10 +86,6 @@ func (iface *PppInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *PppInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *PppInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -87,7 +87,3 @@ func (s *ProcessControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *ProcessControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -160,10 +160,6 @@ func (iface *PulseAudioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *PulseAudioInterface) LegacyAutoConnect() bool {
-	return true
-}
-
 func (iface *PulseAudioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -84,7 +84,3 @@ func (s *RemovableMediaInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *RemovableMediaInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -79,6 +79,5 @@ func NewScreenInhibitControlInterface() interfaces.Interface {
 		connectedPlugAppArmor: screenInhibitControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  screenInhibitControlConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -88,7 +88,3 @@ func (s *ScreenInhibitControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *ScreenInhibitControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -179,10 +179,6 @@ func (iface *SerialPortInterface) ConnectedPlugSnippet(plug *interfaces.Plug, sl
 	return nil, nil
 }
 
-func (iface *SerialPortInterface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *SerialPortInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -54,6 +54,5 @@ func NewShutdownInterface() interfaces.Interface {
 		connectedPlugAppArmor: shutdownConnectedPlugAppArmor,
 		connectedPlugSecComp:  shutdownConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           false,
 	}
 }

--- a/interfaces/builtin/shutdown_test.go
+++ b/interfaces/builtin/shutdown_test.go
@@ -99,7 +99,3 @@ func (s *ShutdownInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(string(snippet), testutil.Contains, `recvfrom`)
 }
-
-func (s *ShutdownInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -55,6 +55,5 @@ func NewSnapdControlInterface() interfaces.Interface {
 		connectedPlugAppArmor: snapdControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  snapdControlConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -88,7 +88,3 @@ func (s *SnapdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *SnapdControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -88,7 +88,3 @@ func (s *SystemObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *SystemObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -84,7 +84,3 @@ func (s *SystemTraceInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *SystemTraceInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -79,6 +79,5 @@ func NewTimeControlInterface() interfaces.Interface {
 		connectedPlugAppArmor: timeControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  timeControlConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           false,
 	}
 }

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -88,7 +88,3 @@ func (s *TimeControlTestInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *TimeControlTestInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -89,7 +89,3 @@ func (s *TimeserverControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *TimeserverControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -89,7 +89,3 @@ func (s *TimezoneControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *TimezoneControlInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/tpm.go
+++ b/interfaces/builtin/tpm.go
@@ -33,6 +33,5 @@ func NewTpmInterface() interfaces.Interface {
 		name: "tpm",
 		connectedPlugAppArmor: tpmConnectedPlugAppArmor,
 		reservedForOS:         true,
-		autoConnect:           false,
 	}
 }

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -84,7 +84,3 @@ func (s *TpmInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *TpmInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -414,10 +414,6 @@ func (iface *UDisks2Interface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *UDisks2Interface) LegacyAutoConnect() bool {
-	return false
-}
-
 func (iface *UDisks2Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -249,7 +249,3 @@ func (s *UDisks2InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *UDisks2InterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, false)
-}

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -442,6 +442,5 @@ func NewUnity7Interface() interfaces.Interface {
 		connectedPlugAppArmor: unity7ConnectedPlugAppArmor,
 		connectedPlugSecComp:  unity7ConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -88,7 +88,3 @@ func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *Unity7InterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -88,6 +88,5 @@ func NewUPowerObserveInterface() interfaces.Interface {
 		connectedPlugAppArmor: upowerObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  upowerObserveConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -88,7 +88,3 @@ func (s *UPowerObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
-
-func (s *UPowerObserveInterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -58,6 +58,5 @@ func NewX11Interface() interfaces.Interface {
 		connectedPlugAppArmor: x11ConnectedPlugAppArmor,
 		connectedPlugSecComp:  x11ConnectedPlugSecComp,
 		reservedForOS:         true,
-		autoConnect:           true,
 	}
 }

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -90,10 +90,6 @@ func (s *X11InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-func (s *X11InterfaceSuite) TestLegacyAutoConnect(c *C) {
-	c.Check(s.iface.LegacyAutoConnect(), Equals, true)
-}
-
 // The getsockname system call is allowed
 func (s *X11InterfaceSuite) TestLP1574526(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -150,12 +150,6 @@ type Interface interface {
 	// doesn't recognize the security system.
 	ConnectedSlotSnippet(plug *Plug, slot *Slot, securitySystem SecuritySystem) ([]byte, error)
 
-	// LegacyAutoConnect is OBSOLETE, only used temporarily in tests
-	// to cross check with past behavior.
-	// It returned whether plugs and slots should be implicitly
-	// auto-connected when an unambiguous connection candidate is available.
-	LegacyAutoConnect() bool
-
 	// AutoConnect returns whether plug and slot should be
 	// implicitly auto-connected assuming they will be an
 	// unambiguous connection candidate and declaration-based checks

--- a/interfaces/testtype.go
+++ b/interfaces/testtype.go
@@ -112,10 +112,6 @@ func (t *TestInterface) PermanentSlotSnippet(slot *Slot, securitySystem Security
 	return nil, nil
 }
 
-func (t *TestInterface) LegacyAutoConnect() bool {
-	panic("no test should depend on this anymore")
-}
-
 // AutoConnect returns whether plug and slot should be implicitly
 // auto-connected assuming they will be an unambiguous connection
 // candidate.


### PR DESCRIPTION
Now that we have the base-declaration we don't need this anymore. As suggested by @jdstrand (thanks!).