### PR TITLE
tests: add debug to all flaky expect tests

### DIFF
--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -7,10 +7,10 @@ restore: |
 
 execute: |
     echo "Checking missing email error"
-    expect -f missing_email_error.exp
+    expect -d -f missing_email_error.exp
 
     echo "Checking wrong password error"
-    expect -f unsuccessful_login.exp
+    expect -d -f unsuccessful_login.exp
 
     output=$(snap managed)
     if [ "$output" != "false" ]; then
@@ -20,7 +20,7 @@ execute: |
 
     if [[ $SPREAD_STORE_USER && $SPREAD_STORE_PASSWORD ]]; then
         echo "Checking successful login"
-        expect -f successful_login.exp
+        expect -d -f successful_login.exp
 
         output=$(snap managed)
         if [ "$output" != "system is managed" ]; then

--- a/tests/main/login/unsuccessful_login.exp
+++ b/tests/main/login/unsuccessful_login.exp
@@ -1,3 +1,5 @@
+set timeout 60
+
 spawn snap login someemail@testing.com
 
 expect "Password: "

--- a/tests/main/security-devpts/task.yaml
+++ b/tests/main/security-devpts/task.yaml
@@ -9,4 +9,4 @@ prepare: |
 
 execute: |
     echo "Then the pts device follows confinement rules"
-    expect -f pts.exp
+    expect -d -f pts.exp

--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -23,7 +23,7 @@ restore: |
 
 execute: |
     echo "When a temporary file is created by one snap"
-    expect -f tmp-create.exp
+    expect -d -f tmp-create.exp
 
     if [ -e /usr/lib/snapd/snap-discard-ns ]; then
         echo "Then that file is accessible from other calls of commands from the same snap"


### PR DESCRIPTION
A step towards making the expect tests more reliable. Hopefully this way we figure out why they sometimes fail.