### PR TITLE
snapstate: initial health checks draft

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -63,6 +63,9 @@ type managerBackend interface {
 	RemoveSnapCommonData(info *snap.Info) error
 	DiscardSnapNamespace(snapName string) error
 
+	// health check
+	HealthCheckStatic(name string, rev snap.Revision) error
+
 	// testing helpers
 	CurrentInfo(cur *snap.Info)
 	Candidate(sideInfo *snap.SideInfo)

--- a/overlord/snapstate/backend/health.go
+++ b/overlord/snapstate/backend/health.go
@@ -1,0 +1,43 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+)
+
+func (b Backend) HealthCheckStatic(snapName string, rev snap.Revision) error {
+	checker := filepath.Join(snap.MountDir(snapName, rev), "meta/checks/static-check")
+	if osutil.FileExists(checker) {
+		// FIXME: this is curently unconfined, we need
+		//   `snap run --health-check=static snap-name`
+		output, err := exec.Command(checker).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("static health check for %q failed: %s", snapName, osutil.OutputErr(output, err))
+		}
+	}
+
+	return nil
+}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -418,6 +418,17 @@ func (f *fakeSnappyBackend) DiscardSnapNamespace(snapName string) error {
 	return nil
 }
 
+func (f *fakeSnappyBackend) HealthCheckStatic(snapName string, rev snap.Revision) error {
+	// FIXME: update all tests
+	/*
+		f.ops = append(f.ops, fakeOp{
+			op:   "health-check-static",
+			name: snapName,
+		})
+	*/
+	return nil
+}
+
 func (f *fakeSnappyBackend) Candidate(sideInfo *snap.SideInfo) {
 	var sinfo snap.SideInfo
 	if sideInfo != nil {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -315,6 +315,9 @@ func Manager(s *state.State) (*SnapManager, error) {
 	runner.AddHandler("clear-snap", m.doClearSnapData, nil)
 	runner.AddHandler("discard-snap", m.doDiscardSnap, nil)
 
+	// health check
+	runner.AddHandler("health-check-static", m.doHealthCheckStatic, nil)
+
 	// test handlers
 	runner.AddHandler("fake-install-snap", func(t *state.Task, _ *tomb.Tomb) error {
 		return nil
@@ -560,6 +563,19 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 	Set(st, ss.Name(), snapst)
 	st.Unlock()
 	return nil
+}
+
+func (m *SnapManager) doHealthCheckStatic(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+
+	st.Lock()
+	ss, err := TaskSnapSetup(t)
+	st.Unlock()
+	if err != nil {
+		return err
+	}
+
+	return m.backend.HealthCheckStatic(ss.Name(), ss.Revision())
 }
 
 // Ensure implements StateManager.Ensure.

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -163,6 +163,7 @@ func verifyInstallUpdateTasks(c *C, opts, discards int, ts *state.TaskSet, st *s
 	}
 	expected = append(expected,
 		"run-hook",
+		"health-check-static",
 	)
 
 	c.Assert(kinds, DeepEquals, expected)
@@ -214,6 +215,7 @@ func (s *snapmgrTestSuite) TestRevertTasks(c *C) {
 		"link-snap",
 		"start-snap-services",
 		"run-hook",
+		"health-check-static",
 	})
 }
 
@@ -424,6 +426,7 @@ func (s *snapmgrTestSuite) TestRevertCreatesNoGCTasks(c *C) {
 		"link-snap",
 		"start-snap-services",
 		"run-hook",
+		"health-check-static",
 	})
 }
 
@@ -881,9 +884,9 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap" (42) from channel "some-channel"`)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-3]
+	linkTask := ta[len(ta)-4]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap" (42) available to the system`)
-	startTask := ta[len(ta)-2]
+	startTask := ta[len(ta)-3]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap" (42) services`)
 
 	// verify snap-setup in the task state
@@ -3898,13 +3901,13 @@ func (s *snapmgrTestSuite) TestUpdateTasksWithOldCurrent(c *C) {
 	var ss snapstate.SnapSetup
 	tasks := ts.Tasks()
 
-	i := len(tasks) - 6
+	i := len(tasks) - 7
 	c.Check(tasks[i].Kind(), Equals, "clear-snap")
 	err = tasks[i].Get("snap-setup", &ss)
 	c.Assert(err, IsNil)
 	c.Check(ss.Revision(), Equals, si3.Revision)
 
-	i = len(tasks) - 4
+	i = len(tasks) - 5
 	c.Check(tasks[i].Kind(), Equals, "clear-snap")
 	err = tasks[i].Get("snap-setup", &ss)
 	c.Assert(err, IsNil)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -179,6 +179,12 @@ func doInstall(s *state.State, snapst *SnapState, ss *SnapSetup) (*state.TaskSet
 	configSet.WaitAll(installSet)
 	installSet.AddAll(configSet)
 
+	// FIXME: move to a separate pkg?
+	healthCheck := s.NewTask("health-check-static", fmt.Sprintf("Static health check for %q", ss.Name()))
+	healthCheck.Set("snap-setup-task", prepare.ID())
+	healthCheck.WaitAll(configSet)
+	installSet.AddAll(state.NewTaskSet(healthCheck))
+
 	return installSet, nil
 }
 

--- a/tests/lib/snaps/test-snapd-service-v3-bad-health/bin/good
+++ b/tests/lib/snaps/test-snapd-service-v3-bad-health/bin/good
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "service v1"

--- a/tests/lib/snaps/test-snapd-service-v3-bad-health/meta/checks/static-check
+++ b/tests/lib/snaps/test-snapd-service-v3-bad-health/meta/checks/static-check
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "I don't feel well"
+exit 1

--- a/tests/lib/snaps/test-snapd-service-v3-bad-health/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service-v3-bad-health/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-service
+version: 3.0
+apps:
+ service:
+  command: bin/good
+  daemon: oneshot
+  restart-condition: never

--- a/tests/main/health-check-static/task.yaml
+++ b/tests/main/health-check-static/task.yaml
@@ -1,0 +1,45 @@
+summary: Run static health check
+details: |
+    When a snap is refreshed and the health check fails, the snap in reverted
+
+environment:
+    SNAP_NAME: test-snapd-service
+    SNAP_NAME_GOOD: ${SNAP_NAME}-v1-good
+    SNAP_NAME_BAD: ${SNAP_NAME}-v3-bad-health
+    SNAP_FILE_GOOD: ${SNAP_NAME}_1.0_all.snap
+    SNAP_FILE_BAD: ${SNAP_NAME}_3.0_all.snap
+    
+prepare: |
+    echo "Given a good (v1) and a bad health check (v3) snap"
+    snapbuild $TESTSLIB/snaps/$SNAP_NAME_GOOD .
+    snapbuild $TESTSLIB/snaps/$SNAP_NAME_BAD .
+
+debug: |
+    journalctl -u snap.test-snapd-service.service.service
+
+execute: |
+    wait_for_service_status() {
+        retries=0
+        while ! systemctl status snap.test-snapd-service.service.service|grep "$1"; do
+            # retry
+            retries=$((retries+1))
+            if [ $retries -gt 20 ]; then
+                echo 'expected "service v1" output did not appear in systemctl status snap.test-snapd-service.service.service'
+                exit 1
+            fi
+            sleep 1
+        done
+    }
+    echo "When we install v1"
+    snap install --dangerous ${SNAP_FILE_GOOD}
+    echo "The v1 service started correctly"
+    wait_for_service_status "Started Service for snap application test-snapd-service.service"
+    
+    echo "When we refresh to v3 with a broken health check"
+    if snap install --dangerous ${SNAP_FILE_BAD}; then
+       echo "The ${SNAP_FILE_BAD} snap should not install cleanly, test broken"
+       exit 1
+    fi
+    echo "Then v3 is rolled back and v1 is started again"
+    wait_for_service_status "Started Service for snap application test-snapd-service.service"
+    wait_for_service_status "service v1"


### PR DESCRIPTION
Tiny strawman branch for getting started with basic healthchecks, mostly to check what direction the first iteration of this should have.

Some questions/RFC:
- should we move health-checks into their own "healstate" manager? or do that later and keep in snapstate for now? or reuse hookmgr (similar to what configstate is doing)?
- run all checks in a single task?

