### PR TITLE
client: add "Snap.Screenshots" to the client API

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -51,11 +51,18 @@ type Snap struct {
 	Apps          []AppInfo     `json:"apps"`
 	Broken        string        `json:"broken"`
 
-	Prices map[string]float64 `json:"prices"`
+	Prices      map[string]float64 `json:"prices"`
+	Screenshots []Screenshot       `json:"screenshots"`
 }
 
 type AppInfo struct {
 	Name string `json:"name"`
+}
+
+type Screenshot struct {
+	URL    string `json:"url"`
+	Width  int64  `json:"width,omitempty"`
+	Height int64  `json:"height,omitempty"`
 }
 
 // Statuses and types a snap may have.

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -141,10 +141,12 @@ func (cs *clientSuite) TestClientFindOne(c *check.C) {
 }
 
 const (
-	pkgName = "chatroom.ogra"
+	pkgName = "chatroom"
 )
 
 func (cs *clientSuite) TestClientSnap(c *check.C) {
+	// example data obtained via
+	// printf "GET /v2/find?name=test-snapd-tools HTTP/1.0\r\n\r\n" | nc -U -q 1 /run/snapd.socket|grep '{'|python3 -m json.tool
 	cs.rsp = `{
 		"type": "sync",
 		"result": {
@@ -164,7 +166,11 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 			"confinement": "strict",
 			"private": true,
 			"devmode": true,
-			"trymode": true
+			"trymode": true,
+                        "screenshots": [
+                            {"url":"http://example.com/shot1.png", "width":640, "height":480},
+                            {"url":"http://example.com/shot2.png"}
+                        ]
 		}
 	}`
 	pkg, _, err := cs.cli.Snap(pkgName)
@@ -188,5 +194,9 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 		Private:       true,
 		DevMode:       true,
 		TryMode:       true,
+		Screenshots: []client.Screenshot{
+			{URL: "http://example.com/shot1.png", Width: 640, Height: 480},
+			{URL: "http://example.com/shot2.png"},
+		},
 	})
 }


### PR DESCRIPTION
Adds client.Snap.Screenshots struct so that the client library can
access the screenshot data that the server sends.

LP: #1637399