### PR TITLE
tests: increase `expect` timeouts 

### DIFF
--- a/tests/main/security-devpts/pts.exp
+++ b/tests/main/security-devpts/pts.exp
@@ -1,6 +1,6 @@
 #!/usr/bin/expect -f
 
-set timeout 2
+set timeout 20
 
 spawn bash
 send "ls /dev/pts\n"

--- a/tests/main/security-private-tmp/tmp-create.exp
+++ b/tests/main/security-private-tmp/tmp-create.exp
@@ -1,6 +1,6 @@
 #!/usr/bin/expect -f
 
-set timeout 2
+set timeout 20
 
 spawn bash
 


### PR DESCRIPTION
to avoid failures in busy hosts that can not do an ls in 2s