### PR TITLE
snap: use "SSO Password:" in the `snap login` prompt

### DIFF
--- a/client/login.go
+++ b/client/login.go
@@ -78,9 +78,13 @@ func (client *Client) Logout() error {
 	return removeAuthData()
 }
 
-// LoggedIn returns whether the client has authentication data available.
-func (client *Client) LoggedIn() bool {
-	return osutil.FileExists(storeAuthDataFilename(""))
+// LoggedInUser returns the logged in User or nil
+func (client *Client) LoggedInUser() *User {
+	u, err := readAuthData()
+	if err != nil {
+		return nil
+	}
+	return u
 }
 
 const authFileEnvKey = "SNAPPY_STORE_AUTH_DATA_FILENAME"

--- a/client/login_test.go
+++ b/client/login_test.go
@@ -41,7 +41,7 @@ func (cs *clientSuite) TestClientLogin(c *check.C) {
 	os.Setenv(client.TestAuthFileEnvKey, outfile)
 	defer os.Unsetenv(client.TestAuthFileEnvKey)
 
-	c.Assert(cs.cli.LoggedIn(), check.Equals, false)
+	c.Assert(cs.cli.LoggedInUser(), check.IsNil)
 
 	user, err := cs.cli.Login("username", "pass", "")
 	c.Check(err, check.IsNil)
@@ -50,7 +50,7 @@ func (cs *clientSuite) TestClientLogin(c *check.C) {
 		Macaroon:   "the-root-macaroon",
 		Discharges: []string{"discharge-macaroon"}})
 
-	c.Assert(cs.cli.LoggedIn(), check.Equals, true)
+	c.Assert(cs.cli.LoggedInUser(), check.Not(check.IsNil))
 
 	c.Check(osutil.FileExists(outfile), check.Equals, true)
 	content, err := ioutil.ReadFile(outfile)

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -65,7 +65,8 @@ func (x *cmdBuy) Execute(args []string) error {
 func buySnap(snapName, currency string) error {
 	cli := Client()
 
-	if !cli.LoggedIn() {
+	user := cli.LoggedInUser()
+	if user == nil {
 		return fmt.Errorf(i18n.G("You need to be logged in to purchase software. Please run 'snap login' and try again."))
 	}
 
@@ -116,7 +117,7 @@ Once completed, return here and run 'snap buy %s' again.`), snap.Name)
 for %s. Press ctrl-c to cancel.`), snap.Name, snap.Developer, formatPrice(opts.Price, opts.Currency))
 	fmt.Fprint(Stdout, "\n")
 
-	err = requestLogin("")
+	err = requestLogin(user.Email)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_buy_test.go
+++ b/cmd/snap/cmd_buy_test.go
@@ -311,7 +311,7 @@ func (s *BuySnapSuite) TestBuySnapSuccess(c *check.C) {
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `Please re-enter your Ubuntu One password to purchase "hello" from "canonical"
 for 2.99GBP. Press ctrl-c to cancel.
-Store password: 
+Password of "hello@mail.com": 
 Thanks for purchasing "hello". You may now install it on any of your devices
 with 'snap install hello'.
 `)
@@ -378,7 +378,7 @@ payment details at https://my.ubuntu.com/payment/edit and try again.`)
 	c.Check(rest, check.DeepEquals, []string{"hello"})
 	c.Check(s.Stdout(), check.Equals, `Please re-enter your Ubuntu One password to purchase "hello" from "canonical"
 for 2.99GBP. Press ctrl-c to cancel.
-Store password: 
+Password of "hello@mail.com": 
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_buy_test.go
+++ b/cmd/snap/cmd_buy_test.go
@@ -311,7 +311,7 @@ func (s *BuySnapSuite) TestBuySnapSuccess(c *check.C) {
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `Please re-enter your Ubuntu One password to purchase "hello" from "canonical"
 for 2.99GBP. Press ctrl-c to cancel.
-Password: 
+SSO Password: 
 Thanks for purchasing "hello". You may now install it on any of your devices
 with 'snap install hello'.
 `)
@@ -378,7 +378,7 @@ payment details at https://my.ubuntu.com/payment/edit and try again.`)
 	c.Check(rest, check.DeepEquals, []string{"hello"})
 	c.Check(s.Stdout(), check.Equals, `Please re-enter your Ubuntu One password to purchase "hello" from "canonical"
 for 2.99GBP. Press ctrl-c to cancel.
-Password: 
+SSO Password: 
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_buy_test.go
+++ b/cmd/snap/cmd_buy_test.go
@@ -311,7 +311,7 @@ func (s *BuySnapSuite) TestBuySnapSuccess(c *check.C) {
 	c.Check(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `Please re-enter your Ubuntu One password to purchase "hello" from "canonical"
 for 2.99GBP. Press ctrl-c to cancel.
-SSO Password: 
+Store password: 
 Thanks for purchasing "hello". You may now install it on any of your devices
 with 'snap install hello'.
 `)
@@ -378,7 +378,7 @@ payment details at https://my.ubuntu.com/payment/edit and try again.`)
 	c.Check(rest, check.DeepEquals, []string{"hello"})
 	c.Check(s.Stdout(), check.Equals, `Please re-enter your Ubuntu One password to purchase "hello" from "canonical"
 for 2.99GBP. Press ctrl-c to cancel.
-SSO Password: 
+Store password: 
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -92,7 +92,7 @@ func requestLoginWith2faRetry(email, password string) error {
 }
 
 func requestLogin(email string) error {
-	fmt.Fprint(Stdout, i18n.G("SSO Password: "))
+	fmt.Fprint(Stdout, i18n.G("Store password: "))
 	password, err := terminal.ReadPassword(Terminal)
 	fmt.Fprint(Stdout, "\n")
 	if err != nil {

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -92,7 +92,7 @@ func requestLoginWith2faRetry(email, password string) error {
 }
 
 func requestLogin(email string) error {
-	fmt.Fprint(Stdout, i18n.G("Password: "))
+	fmt.Fprint(Stdout, i18n.G("SSO Password: "))
 	password, err := terminal.ReadPassword(Terminal)
 	fmt.Fprint(Stdout, "\n")
 	if err != nil {

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -92,7 +92,7 @@ func requestLoginWith2faRetry(email, password string) error {
 }
 
 func requestLogin(email string) error {
-	fmt.Fprint(Stdout, i18n.G("Store password: "))
+	fmt.Fprint(Stdout, fmt.Sprintf(i18n.G("Password of %q: "), email))
 	password, err := terminal.ReadPassword(Terminal)
 	fmt.Fprint(Stdout, "\n")
 	if err != nil {

--- a/tests/main/login/successful_login.exp
+++ b/tests/main/login/successful_login.exp
@@ -1,6 +1,6 @@
 spawn snap login $env(SPREAD_STORE_USER)
 
-expect "SSO Password: "
+expect "Store password: "
 send "$env(SPREAD_STORE_PASSWORD)\n"
 
 expect {

--- a/tests/main/login/successful_login.exp
+++ b/tests/main/login/successful_login.exp
@@ -1,6 +1,6 @@
 spawn snap login $env(SPREAD_STORE_USER)
 
-expect "Store password: "
+expect "Password of "
 send "$env(SPREAD_STORE_PASSWORD)\n"
 
 expect {

--- a/tests/main/login/successful_login.exp
+++ b/tests/main/login/successful_login.exp
@@ -1,6 +1,6 @@
 spawn snap login $env(SPREAD_STORE_USER)
 
-expect "Password: "
+expect "SSO Password: "
 send "$env(SPREAD_STORE_PASSWORD)\n"
 
 expect {

--- a/tests/main/login/unsuccessful_login.exp
+++ b/tests/main/login/unsuccessful_login.exp
@@ -1,6 +1,6 @@
 spawn snap login someemail@testing.com
 
-expect "Store password: "
+expect "Password of "
 send "wrong-password\n"
 
 expect {

--- a/tests/main/login/unsuccessful_login.exp
+++ b/tests/main/login/unsuccessful_login.exp
@@ -1,6 +1,6 @@
 spawn snap login someemail@testing.com
 
-expect "SSO Password: "
+expect "Store password: "
 send "wrong-password\n"
 
 expect {

--- a/tests/main/login/unsuccessful_login.exp
+++ b/tests/main/login/unsuccessful_login.exp
@@ -1,6 +1,6 @@
 spawn snap login someemail@testing.com
 
-expect "Password: "
+expect "SSO Password: "
 send "wrong-password\n"
 
 expect {


### PR DESCRIPTION
This avoids potential confusion with the sudo password prompt when
`sudo snap login` is run.

LP: #1637299