### PR TITLE
overlord, daemon, progress: enable building snapd without CGO

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -43,7 +43,7 @@ import (
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -32,7 +32,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/notifications"
 	"github.com/snapcore/snapd/osutil"

--- a/i18n/dumb/dumb.go
+++ b/i18n/dumb/dumb.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,15 +17,8 @@
  *
  */
 
-package progress
+package i18n // import "github.com/snapcore/snapd/i18n/dumb"
 
-/*
-#include <unistd.h>
-*/
-import "C"
-
-// isatty is a wrapper around isatty(3).
-// Returns true if the specified fd is associated with a tty.
-func isatty(fd int) bool {
-	return C.isatty(C.int(fd)) == 1
+func G(s string) string {
+	return s
 }

--- a/overlord/configstate/tasksets.go
+++ b/overlord/configstate/tasksets.go
@@ -22,7 +22,7 @@ package configstate
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -40,7 +40,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -28,7 +28,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"

--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/overlord/configstate"
 )
 

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/overlord/configstate"
 )
 

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -24,7 +24,7 @@ package ifacestate
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backends"
 

--- a/overlord/patch/patch3.go
+++ b/overlord/patch/patch3.go
@@ -22,7 +22,7 @@ package patch
 import (
 	"fmt"
 
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/overlord/state"
 )
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -27,7 +27,7 @@ import (
 	"sort"
 
 	"github.com/snapcore/snapd/boot"
-	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -26,6 +26,7 @@ import (
 	"unicode"
 
 	"github.com/cheggaaa/pb"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Meter is an interface to show progress to the user
@@ -194,5 +195,5 @@ func MakeProgressBar() Meter {
 var attachedToTerminal = func() bool {
 	fd := int(os.Stdin.Fd())
 
-	return isatty(fd)
+	return terminal.IsTerminal(fd)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -43,7 +43,6 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -1296,7 +1295,7 @@ var download = func(name, sha3_384, downloadURL string, user *auth.UserState, s 
 	case http.StatusOK, http.StatusPartialContent:
 		break
 	case http.StatusUnauthorized:
-		return fmt.Errorf(i18n.G("cannot download non-free snap without purchase"))
+		return fmt.Errorf("cannot download non-free snap without purchase")
 	default:
 		return &ErrDownload{Code: resp.StatusCode, URL: resp.Request.URL}
 	}

--- a/tests/main/static/task.yaml
+++ b/tests/main/static/task.yaml
@@ -1,0 +1,5 @@
+summary: Check that snapd can be built without cgo
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+execute: |
+    CGO_ENABLED=0 go build -o snapd.static github.com/snapcore/snapd/cmd/snapd
+    ldd snapd.static && exit 1 || true


### PR DESCRIPTION
With these changes you can (but probably shouldn't) build snapd with `CGO_ENABLED=0`. This means we're only using cgo in snapd for the resolver. More study is required to determine whether we actually want to use the pure-go resolver, ignoring `nsswitch.conf`.