### PR TITLE
tests: parameterize core channel with env var

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -16,6 +16,7 @@ environment:
     SUDO_UID: ""
     TRUST_TEST_KEYS: "true"
     MANAGED_DEVICE: "false"
+    CORE_CHANNEL: "$(HOST: echo ${SPREAD_CORE_CHANNEL:-edge})"
 
 backends:
     linode:

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -83,7 +83,7 @@ setup_reflash_magic() {
         apt_install_local ${SPREAD_PATH}/../snapd_*.deb
         apt-get clean
 
-        snap install --edge core
+        snap install --${CORE_CHANNEL} core
 
         # install ubuntu-image
         snap install --devmode --edge ubuntu-image


### PR DESCRIPTION
This will make it easier to run the suite when a new core snap is promoted to the different channels.