### PR TITLE
tests: ensure that the XDG_ env contains at least XDG_RUNTIME_DIR

### DIFF
--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -25,6 +25,6 @@ execute: |
 
     echo "Enure that XDG environment variables are what we expect"
     egrep -q '^XDG_RUNTIME_DIR=/run/user/0/snap.test-snapd-tools$' xdg-vars.txt
-    test $(wc -l < xdg-vars.txt) -eq 2
+    test $(wc -l < xdg-vars.txt) -ge 1
 debug: |
     cat *-vars.txt


### PR DESCRIPTION
In the autopkgtest environment we only have a single XDG_ variable (XDG_RUNTIME_DIR) in the environment. In the spread tests on qemu/linode the environment is richer. For the purpose of our test we only care about XDG_RUNTIME_DIR. This fixes an autopkgtest failure.