### PR TITLE
overlord/snapstate: add Flags.EffectiveConfinement

### DIFF
--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -68,6 +68,8 @@ func (f Flags) EffectiveConfinement(confinementType snap.ConfinementType) snap.C
 		}
 		// unchanged, stays devmode
 	case snap.StrictConfinement:
+		// In case both jailmode and devmode are set in flags, look at jailmode
+		// first. This errs on the safer side of being strict.
 		if f.JailMode {
 			// jailmode flag overrides devmode flag
 			return snap.StrictConfinement

--- a/overlord/snapstate/flags_test.go
+++ b/overlord/snapstate/flags_test.go
@@ -1,0 +1,54 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/snap"
+)
+
+type flagsSuite struct{}
+
+var _ = Suite(&flagsSuite{})
+
+func (s *flagsSuite) TestEffectiveConfinement(c *C) {
+	f := snapstate.Flags{}
+	// In absence of jailmode or devmode flags, confinement is unchanged
+	c.Assert(f.EffectiveConfinement(snap.ClassicConfinement), Equals, snap.ClassicConfinement)
+	c.Assert(f.EffectiveConfinement(snap.DevmodeConfinement), Equals, snap.DevmodeConfinement)
+	c.Assert(f.EffectiveConfinement(snap.StrictConfinement), Equals, snap.StrictConfinement)
+	// When devmode flag is set it can override strict confinement
+	f = snapstate.Flags{DevMode: true}
+	c.Assert(f.EffectiveConfinement(snap.ClassicConfinement), Equals, snap.ClassicConfinement)
+	c.Assert(f.EffectiveConfinement(snap.DevmodeConfinement), Equals, snap.DevmodeConfinement)
+	c.Assert(f.EffectiveConfinement(snap.StrictConfinement), Equals, snap.DevmodeConfinement)
+	// When jailmode flag is set it can override devmode confinement
+	f = snapstate.Flags{JailMode: true}
+	c.Assert(f.EffectiveConfinement(snap.ClassicConfinement), Equals, snap.ClassicConfinement)
+	c.Assert(f.EffectiveConfinement(snap.DevmodeConfinement), Equals, snap.StrictConfinement)
+	c.Assert(f.EffectiveConfinement(snap.StrictConfinement), Equals, snap.StrictConfinement)
+	// When both devmode and jailmode flags are set then jailmode is the stronger one
+	f = snapstate.Flags{DevMode: true, JailMode: true}
+	c.Assert(f.EffectiveConfinement(snap.ClassicConfinement), Equals, snap.ClassicConfinement)
+	c.Assert(f.EffectiveConfinement(snap.DevmodeConfinement), Equals, snap.StrictConfinement)
+	c.Assert(f.EffectiveConfinement(snap.StrictConfinement), Equals, snap.StrictConfinement)
+}


### PR DESCRIPTION
This patch adds a helper function that returns the effective
confinement, given declared snap confinement and flags such as devmode
or jailmode.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>