### PR TITLE
many: use snap.ConfinementType rather than bool devmode

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -65,7 +65,7 @@ func (b *Backend) Name() string {
 //
 // This method should be called after changing plug, slots, connections between
 // them or application present in the snap.
-func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, confinement snap.ConfinementType, repo *interfaces.Repository) error {
 	snapName := snapInfo.Name()
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapName, interfaces.SecurityAppArmor)
@@ -73,7 +73,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repo
 		return fmt.Errorf("cannot obtain security snippets for snap %q: %s", snapName, err)
 	}
 	// Get the files that this snap should have
-	content, err := b.combineSnippets(snapInfo, devMode, snippets)
+	content, err := b.combineSnippets(snapInfo, confinement, snippets)
 	if err != nil {
 		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapName, err)
 	}
@@ -125,29 +125,30 @@ var (
 // combineSnippets combines security snippets collected from all the interfaces
 // affecting a given snap into a content map applicable to EnsureDirState. The
 // backend delegates writing those files to higher layers.
-func (b *Backend) combineSnippets(snapInfo *snap.Info, devMode bool, snippets map[string][][]byte) (content map[string]*osutil.FileState, err error) {
+func (b *Backend) combineSnippets(snapInfo *snap.Info, confinement snap.ConfinementType, snippets map[string][][]byte) (content map[string]*osutil.FileState, err error) {
 	for _, appInfo := range snapInfo.Apps {
 		if content == nil {
 			content = make(map[string]*osutil.FileState)
 		}
-		addContent(appInfo.SecurityTag(), snapInfo, devMode, snippets, content)
+		addContent(appInfo.SecurityTag(), snapInfo, confinement, snippets, content)
 	}
 
 	for _, hookInfo := range snapInfo.Hooks {
 		if content == nil {
 			content = make(map[string]*osutil.FileState)
 		}
-		addContent(hookInfo.SecurityTag(), snapInfo, devMode, snippets, content)
+		addContent(hookInfo.SecurityTag(), snapInfo, confinement, snippets, content)
 	}
 
 	return content, nil
 }
 
-func addContent(securityTag string, snapInfo *snap.Info, devMode bool, snippets map[string][][]byte, content map[string]*osutil.FileState) {
+func addContent(securityTag string, snapInfo *snap.Info, confinement snap.ConfinementType, snippets map[string][][]byte, content map[string]*osutil.FileState) {
 	policy := defaultTemplate
-	if devMode {
+	if confinement == snap.DevmodeConfinement {
 		policy = attachPattern.ReplaceAll(policy, attachComplain)
 	}
+	// TODO: add support for snap.ClassicConfinement later
 	policy = templatePattern.ReplaceAllFunc(policy, func(placeholder []byte) []byte {
 		switch {
 		case bytes.Equal(placeholder, placeholderVar):

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -31,12 +31,13 @@ type SecurityBackend interface {
 	Name() string
 
 	// Setup creates and loads security artefacts specific to a given snap.
-	// The snap can be in developer mode to make security violations non-fatal
-	// to the offending application process.
+	// The snap can be in one of three kids onf confinement (strict mode,
+	// developer mode or classic mode). In the last two security violations
+	// are non-fatal to the offending application process.
 	//
 	// This method should be called after changing plug, slots, connections
 	// between them or application present in the snap.
-	Setup(snapInfo *snap.Info, devMode bool, repo *Repository) error
+	Setup(snapInfo *snap.Info, confinement snap.ConfinementType, repo *Repository) error
 
 	// Remove removes and unloads security artefacts of a given snap.
 	//

--- a/interfaces/backendtest/backendtest.go
+++ b/interfaces/backendtest/backendtest.go
@@ -143,19 +143,19 @@ slots:
 // Support code for tests
 
 // InstallSnap "installs" a snap from YAML.
-func (s *BackendSuite) InstallSnap(c *C, devMode bool, snapYaml string, revision int) *snap.Info {
+func (s *BackendSuite) InstallSnap(c *C, confinement snap.ConfinementType, snapYaml string, revision int) *snap.Info {
 	snapInfo := snaptest.MockInfo(c, snapYaml, &snap.SideInfo{
 		Revision:  snap.R(revision),
 		Developer: "acme",
 	})
 	s.addPlugsSlots(c, snapInfo)
-	err := s.Backend.Setup(snapInfo, devMode, s.Repo)
+	err := s.Backend.Setup(snapInfo, confinement, s.Repo)
 	c.Assert(err, IsNil)
 	return snapInfo
 }
 
 // UpdateSnap "updates" an existing snap from YAML.
-func (s *BackendSuite) UpdateSnap(c *C, oldSnapInfo *snap.Info, devMode bool, snapYaml string, revision int) *snap.Info {
+func (s *BackendSuite) UpdateSnap(c *C, oldSnapInfo *snap.Info, confinement snap.ConfinementType, snapYaml string, revision int) *snap.Info {
 	newSnapInfo := snaptest.MockInfo(c, snapYaml, &snap.SideInfo{
 		Revision:  snap.R(revision),
 		Developer: "acme",
@@ -163,7 +163,7 @@ func (s *BackendSuite) UpdateSnap(c *C, oldSnapInfo *snap.Info, devMode bool, sn
 	c.Assert(newSnapInfo.Name(), Equals, oldSnapInfo.Name())
 	s.removePlugsSlots(c, oldSnapInfo)
 	s.addPlugsSlots(c, newSnapInfo)
-	err := s.Backend.Setup(newSnapInfo, devMode, s.Repo)
+	err := s.Backend.Setup(newSnapInfo, confinement, s.Repo)
 	c.Assert(err, IsNil)
 	return newSnapInfo
 }

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -48,8 +48,8 @@ func (b *Backend) Name() string {
 
 // Setup creates dbus configuration files specific to a given snap.
 //
-// DBus has no concept of a complain mode so devMode is not supported
-func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repository) error {
+// DBus has no concept of a complain mode so confinment type is ignored.
+func (b *Backend) Setup(snapInfo *snap.Info, confinement snap.ConfinementType, repo *interfaces.Repository) error {
 	snapName := snapInfo.Name()
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityDBus)

--- a/interfaces/dbus/backend_test.go
+++ b/interfaces/dbus/backend_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backendtest"
 	"github.com/snapcore/snapd/interfaces/dbus"
+	"github.com/snapcore/snapd/snap"
 )
 
 type backendSuite struct {
@@ -62,8 +63,8 @@ func (s *backendSuite) TestInstallingSnapWritesConfigFiles(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("<policy/>"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.smbd.conf")
 		// file called "snap.sambda.smbd.conf" was created
 		_, err := os.Stat(profile)
@@ -80,8 +81,8 @@ func (s *backendSuite) TestInstallingSnapWithHookWritesConfigFiles(c *C) {
 	s.Iface.PermanentPlugSnippetCallback = func(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("<policy/>"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.HookYaml, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.HookYaml, 0)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.foo.hook.configure.conf")
 
 		// Verify that "snap.foo.hook.configure.conf" was created
@@ -96,8 +97,8 @@ func (s *backendSuite) TestRemovingSnapRemovesConfigFiles(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("<policy/>"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		s.RemoveSnap(c, snapInfo)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.smbd.conf")
 		// file called "snap.sambda.smbd.conf" was removed
@@ -114,8 +115,8 @@ func (s *backendSuite) TestRemovingSnapWithHookRemovesConfigFiles(c *C) {
 	s.Iface.PermanentPlugSnippetCallback = func(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("<policy/>"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.HookYaml, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.HookYaml, 0)
 		s.RemoveSnap(c, snapInfo)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.foo.hook.configure.conf")
 
@@ -130,9 +131,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("<policy/>"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1WithNmbd, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1WithNmbd, 0)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.nmbd.conf")
 		// file called "snap.sambda.nmbd.conf" was created
 		_, err := os.Stat(profile)
@@ -149,9 +150,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreHooks(c *C) {
 	s.Iface.PermanentPlugSnippetCallback = func(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("<policy/>"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlWithHook, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlWithHook, 0)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.hook.configure.conf")
 
 		// Verify that "snap.samba.hook.configure.conf" was created
@@ -166,9 +167,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerApps(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("<policy/>"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1WithNmbd, 0)
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1WithNmbd, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1, 0)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.nmbd.conf")
 		// file called "snap.sambda.nmbd.conf" was removed
 		_, err := os.Stat(profile)
@@ -185,9 +186,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerHooks(c *C) {
 	s.Iface.PermanentPlugSnippetCallback = func(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("<policy/>"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlWithHook, 0)
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlWithHook, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1, 0)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.hook.configure.conf")
 
 		// Verify that "snap.samba.hook.configure.conf" was removed
@@ -204,8 +205,8 @@ func (s *backendSuite) TestCombineSnippetsWithActualSnippets(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("<policy>...</policy>"), nil
 	}
-	for _, devMode := range []bool{false, true} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.smbd.conf")
 		data, err := ioutil.ReadFile(profile)
 		c.Assert(err, IsNil)
@@ -217,8 +218,8 @@ func (s *backendSuite) TestCombineSnippetsWithActualSnippets(c *C) {
 }
 
 func (s *backendSuite) TestCombineSnippetsWithoutAnySnippets(c *C) {
-	for _, devMode := range []bool{false, true} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		profile := filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.smbd.conf")
 		_, err := os.Stat(profile)
 		// Without any snippets, there the .conf file is not created.
@@ -244,7 +245,7 @@ func (s *backendSuite) TestAppBoundIfaces(c *C) {
 	}
 	// Install a snap with two apps, only one of which needs a .conf file
 	// because the interface is app-bound.
-	snapInfo := s.InstallSnap(c, false, sambaYamlWithIfaceBoundToNmbd, 0)
+	snapInfo := s.InstallSnap(c, snap.StrictConfinement, sambaYamlWithIfaceBoundToNmbd, 0)
 	defer s.RemoveSnap(c, snapInfo)
 	// Check that only one of the .conf files is actually created
 	_, err := os.Stat(filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.smbd.conf"))

--- a/interfaces/kmod/backend.go
+++ b/interfaces/kmod/backend.go
@@ -61,7 +61,7 @@ func (b *Backend) Name() string {
 // using /sbin/modprobe. The devMode is ignored.
 //
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
-func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, confinement snap.ConfinementType, repo *interfaces.Repository) error {
 	snapName := snapInfo.Name()
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityKMod)

--- a/interfaces/kmod/backend_test.go
+++ b/interfaces/kmod/backend_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/backendtest"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
 
 func Test(t *testing.T) {
@@ -91,9 +92,9 @@ func (s *backendSuite) TestInstallingSnapCreatesModulesConf(c *C) {
 	path := filepath.Join(dirs.SnapKModModulesDir, "snap.samba.conf")
 	c.Assert(osutil.FileExists(path), Equals, false)
 
-	for _, devMode := range []bool{true, false} {
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
 		s.modprobeCmd.ForgetCalls()
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 
 		c.Assert(osutil.FileExists(path), Equals, true)
 		modfile, err := ioutil.ReadFile(path)
@@ -120,8 +121,8 @@ func (s *backendSuite) TestRemovingSnapRemovesModulesConf(c *C) {
 	path := filepath.Join(dirs.SnapKModModulesDir, "snap.samba.conf")
 	c.Assert(osutil.FileExists(path), Equals, false)
 
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		c.Assert(osutil.FileExists(path), Equals, true)
 		s.RemoveSnap(c, snapInfo)
 		c.Assert(osutil.FileExists(path), Equals, false)
@@ -136,10 +137,10 @@ func (s *backendSuite) TestSecurityIsStable(c *C) {
 		}
 		return nil, nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		s.modprobeCmd.ForgetCalls()
-		err := s.Backend.Setup(snapInfo, devMode, s.Repo)
+		err := s.Backend.Setup(snapInfo, confinement, s.Repo)
 		c.Assert(err, IsNil)
 		// modules conf is not re-loaded when nothing changes
 		c.Check(s.modprobeCmd.Calls(), HasLen, 0)

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -49,7 +49,7 @@ func (b *Backend) Name() string {
 }
 
 // Setup creates mount mount profile files specific to a given snap.
-func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, confinement snap.ConfinementType, repo *interfaces.Repository) error {
 	snapName := snapInfo.Name()
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityMount)

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/backendtest"
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 )
 
 func Test(t *testing.T) {
@@ -130,8 +131,8 @@ func (s *backendSuite) TestSetupSetsupSimple(c *C) {
 		return []byte(fsEntryIF2), nil
 	}
 
-	// devMode is irrelevant for this security backend
-	s.InstallSnap(c, false, mockSnapYaml, 0)
+	// confinement type is irrelevant for this security backend
+	s.InstallSnap(c, snap.StrictConfinement, mockSnapYaml, 0)
 
 	// ensure both security snippets for iface/iface2 are combined
 	expected := strings.Split(fmt.Sprintf("%s\n%s\n", fsEntryIF1, fsEntryIF2), "\n")
@@ -157,7 +158,7 @@ func (s *backendSuite) TestSetupSetsupWithoutDir(c *C) {
 
 	// Ensure that backend.Setup() creates the required dir on demand
 	os.Remove(dirs.SnapMountPolicyDir)
-	s.InstallSnap(c, false, mockSnapYaml, 0)
+	s.InstallSnap(c, snap.StrictConfinement, mockSnapYaml, 0)
 
 	for _, binary := range []string{"app1", "app2", "hook.configure"} {
 		fn := filepath.Join(dirs.SnapMountPolicyDir, fmt.Sprintf("snap.snap-name.%s.fstab", binary))

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -57,7 +57,7 @@ func (b *Backend) Name() string {
 //
 // This method should be called after changing plug, slots, connections between
 // them or application present in the snap.
-func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, confinement snap.ConfinementType, repo *interfaces.Repository) error {
 	snapName := snapInfo.Name()
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecuritySecComp)
@@ -65,7 +65,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repo
 		return fmt.Errorf("cannot obtain security snippets for snap %q: %s", snapName, err)
 	}
 	// Get the files that this snap should have
-	content, err := b.combineSnippets(snapInfo, devMode, snippets)
+	content, err := b.combineSnippets(snapInfo, confinement, snippets)
 	if err != nil {
 		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapName, err)
 	}
@@ -93,30 +93,31 @@ func (b *Backend) Remove(snapName string) error {
 
 // combineSnippets combines security snippets collected from all the interfaces
 // affecting a given snap into a content map applicable to EnsureDirState.
-func (b *Backend) combineSnippets(snapInfo *snap.Info, devMode bool, snippets map[string][][]byte) (content map[string]*osutil.FileState, err error) {
+func (b *Backend) combineSnippets(snapInfo *snap.Info, confinement snap.ConfinementType, snippets map[string][][]byte) (content map[string]*osutil.FileState, err error) {
 	for _, appInfo := range snapInfo.Apps {
 		if content == nil {
 			content = make(map[string]*osutil.FileState)
 		}
-		addContent(appInfo.SecurityTag(), devMode, snippets, content)
+		addContent(appInfo.SecurityTag(), confinement, snippets, content)
 	}
 
 	for _, hookInfo := range snapInfo.Hooks {
 		if content == nil {
 			content = make(map[string]*osutil.FileState)
 		}
-		addContent(hookInfo.SecurityTag(), devMode, snippets, content)
+		addContent(hookInfo.SecurityTag(), confinement, snippets, content)
 	}
 
 	return content, nil
 }
 
-func addContent(securityTag string, devMode bool, snippets map[string][][]byte, content map[string]*osutil.FileState) {
+func addContent(securityTag string, confinement snap.ConfinementType, snippets map[string][][]byte, content map[string]*osutil.FileState) {
 	var buffer bytes.Buffer
-	if devMode {
+	if confinement == snap.DevmodeConfinement {
 		// NOTE: This is understood by ubuntu-core-launcher
 		buffer.WriteString("@complain\n")
 	}
+	// TODO: Add support for classic confinement later
 
 	buffer.Write(defaultTemplate)
 	for _, snippet := range snippets[securityTag] {

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backendtest"
 	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -60,8 +61,7 @@ func (s *backendSuite) TestName(c *C) {
 }
 
 func (s *backendSuite) TestInstallingSnapWritesProfiles(c *C) {
-	devMode := false
-	s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	s.InstallSnap(c, snap.StrictConfinement, backendtest.SambaYamlV1, 0)
 	profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.smbd")
 	// file called "snap.sambda.smbd" was created
 	_, err := os.Stat(profile)
@@ -69,8 +69,7 @@ func (s *backendSuite) TestInstallingSnapWritesProfiles(c *C) {
 }
 
 func (s *backendSuite) TestInstallingSnapWritesHookProfiles(c *C) {
-	devMode := false
-	s.InstallSnap(c, devMode, backendtest.HookYaml, 0)
+	s.InstallSnap(c, snap.StrictConfinement, backendtest.HookYaml, 0)
 	profile := filepath.Join(dirs.SnapSeccompDir, "snap.foo.hook.configure")
 
 	// Verify that profile named "snap.foo.hook.configure" was created.
@@ -79,8 +78,8 @@ func (s *backendSuite) TestInstallingSnapWritesHookProfiles(c *C) {
 }
 
 func (s *backendSuite) TestRemovingSnapRemovesProfiles(c *C) {
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		s.RemoveSnap(c, snapInfo)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.smbd")
 		// file called "snap.sambda.smbd" was removed
@@ -90,8 +89,8 @@ func (s *backendSuite) TestRemovingSnapRemovesProfiles(c *C) {
 }
 
 func (s *backendSuite) TestRemovingSnapRemovesHookProfiles(c *C) {
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.HookYaml, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.HookYaml, 0)
 		s.RemoveSnap(c, snapInfo)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.foo.hook.configure")
 
@@ -102,9 +101,9 @@ func (s *backendSuite) TestRemovingSnapRemovesHookProfiles(c *C) {
 }
 
 func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1WithNmbd, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1WithNmbd, 0)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.nmbd")
 		// file called "snap.sambda.nmbd" was created
 		_, err := os.Stat(profile)
@@ -114,9 +113,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 }
 
 func (s *backendSuite) TestUpdatingSnapToOneWithHooks(c *C) {
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlWithHook, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlWithHook, 0)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.hook.configure")
 
 		// Verify that profile "snap.samba.hook.configure" was created.
@@ -127,9 +126,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithHooks(c *C) {
 }
 
 func (s *backendSuite) TestUpdatingSnapToOneWithFewerApps(c *C) {
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1WithNmbd, 0)
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1WithNmbd, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1, 0)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.nmbd")
 		// file called "snap.sambda.nmbd" was removed
 		_, err := os.Stat(profile)
@@ -139,9 +138,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerApps(c *C) {
 }
 
 func (s *backendSuite) TestUpdatingSnapToOneWithNoHooks(c *C) {
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlWithHook, 0)
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlWithHook, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1, 0)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.hook.configure")
 
 		// Verify that profile snap.samba.hook.configure was removed.
@@ -154,7 +153,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithNoHooks(c *C) {
 func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 	snapInfo := snaptest.MockInfo(c, backendtest.SambaYamlV1, nil)
 	// NOTE: we don't call seccomp.MockTemplate()
-	err := s.Backend.Setup(snapInfo, false, s.Repo)
+	err := s.Backend.Setup(snapInfo, snap.StrictConfinement, s.Repo)
 	c.Assert(err, IsNil)
 	profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.smbd")
 	data, err := ioutil.ReadFile(profile)
@@ -171,23 +170,25 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 }
 
 type combineSnippetsScenario struct {
-	devMode bool
-	snippet string
-	content string
+	confinement snap.ConfinementType
+	snippet     string
+	content     string
 }
 
 var combineSnippetsScenarios = []combineSnippetsScenario{{
-	content: "default\n",
+	confinement: snap.StrictConfinement,
+	content:     "default\n",
 }, {
-	snippet: "snippet",
-	content: "default\nsnippet\n",
+	confinement: snap.StrictConfinement,
+	snippet:     "snippet",
+	content:     "default\nsnippet\n",
 }, {
-	devMode: true,
-	content: "@complain\ndefault\n",
+	confinement: snap.DevmodeConfinement,
+	content:     "@complain\ndefault\n",
 }, {
-	devMode: true,
-	snippet: "snippet",
-	content: "@complain\ndefault\nsnippet\n",
+	confinement: snap.DevmodeConfinement,
+	snippet:     "snippet",
+	content:     "@complain\ndefault\nsnippet\n",
 }}
 
 func (s *backendSuite) TestCombineSnippets(c *C) {
@@ -201,7 +202,7 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 			}
 			return []byte(scenario.snippet), nil
 		}
-		snapInfo := s.InstallSnap(c, scenario.devMode, backendtest.SambaYamlV1, 0)
+		snapInfo := s.InstallSnap(c, scenario.confinement, backendtest.SambaYamlV1, 0)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.smbd")
 		data, err := ioutil.ReadFile(profile)
 		c.Assert(err, IsNil)

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -63,7 +63,7 @@ func disableRemovedServices(systemd sysd.Systemd, dir, glob string, content map[
 	return nil
 }
 
-func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, confinement snap.ConfinementType, repo *interfaces.Repository) error {
 	snapName := snapInfo.Name()
 	rawSnippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecuritySystemd)
 	if err != nil {

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/backendtest"
 	"github.com/snapcore/snapd/interfaces/systemd"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 
 	sysd "github.com/snapcore/snapd/systemd"
@@ -148,7 +149,6 @@ func (s *backendSuite) TestRenderSnippet(c *C) {
 }
 
 func (s *backendSuite) TestInstallingSnapWritesStartsServices(c *C) {
-	devMode := false
 	prevctlCmd := sysd.SystemctlCmd
 	var sysdLog [][]string
 	sysd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
@@ -161,7 +161,7 @@ func (s *backendSuite) TestInstallingSnapWritesStartsServices(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte(`{"services": {"snap.samba.interface.foo.service": {"exec-start": "/bin/true"}}}`), nil
 	}
-	s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 1)
+	s.InstallSnap(c, snap.StrictConfinement, backendtest.SambaYamlV1, 1)
 	service := filepath.Join(dirs.SnapServicesDir, "snap.samba.interface.foo.service")
 	// the service file was created
 	_, err := os.Stat(service)
@@ -181,8 +181,8 @@ func (s *backendSuite) TestRemovingSnapRemovesAndStopsServices(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte(`{"services": {"snap.samba.interface.foo.service": {"exec-start": "/bin/true"}}}`), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 1)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 1)
 		s.systemctlCmd.ForgetCalls()
 		s.RemoveSnap(c, snapInfo)
 		service := filepath.Join(dirs.SnapServicesDir, "snap.samba.interface.foo.service")
@@ -202,11 +202,10 @@ func (s *backendSuite) TestRemovingSnapRemovesAndStopsServices(c *C) {
 }
 
 func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
-	devMode := false
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte(`{"services": {"snap.samba.interface.foo.service": {"exec-start": "/bin/true"}, "snap.samba.interface.bar.service": {"exec-start": "/bin/false"}}}`), nil
 	}
-	snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 1)
+	snapInfo := s.InstallSnap(c, snap.StrictConfinement, backendtest.SambaYamlV1, 1)
 	s.systemctlCmd.ForgetCalls()
 	serviceFoo := filepath.Join(dirs.SnapServicesDir, "snap.samba.interface.foo.service")
 	serviceBar := filepath.Join(dirs.SnapServicesDir, "snap.samba.interface.bar.service")
@@ -221,7 +220,7 @@ func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 		return []byte(`{"services": {"snap.samba.interface.foo.service": {"exec-start": "/bin/true"}}}`), nil
 	}
 	// Update over to the same snap to regenerate security
-	s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1, 0)
+	s.UpdateSnap(c, snapInfo, snap.StrictConfinement, backendtest.SambaYamlV1, 0)
 	// The bar service should have been stopped
 	calls := s.systemctlCmd.Calls()
 	c.Check(calls[0], DeepEquals, []string{"systemctl", "--root", dirs.GlobalRootDir, "--now", "disable", "snap.samba.interface.bar.service"})

--- a/interfaces/testbackend.go
+++ b/interfaces/testbackend.go
@@ -30,7 +30,7 @@ type TestSecurityBackend struct {
 	// RemoveCalls stores information about all calls to Remove
 	RemoveCalls []string
 	// SetupCallback is an callback that is optionally called in Setup
-	SetupCallback func(snapInfo *snap.Info, developerMode bool, repo *Repository) error
+	SetupCallback func(snapInfo *snap.Info, confinement snap.ConfinementType, repo *Repository) error
 	// RemoveCallback is a callback that is optionally called in Remove
 	RemoveCallback func(snapName string) error
 }
@@ -39,8 +39,8 @@ type TestSecurityBackend struct {
 type TestSetupCall struct {
 	// SnapInfo is a copy of the snapInfo argument to a particular call to Setup
 	SnapInfo *snap.Info
-	// DevMode is a copy of the developerMode argument to a particular call to Setup
-	DevMode bool
+	// Confinement is a copy of the confinement argument to a particular call to Setup
+	Confinement snap.ConfinementType
 }
 
 // Name returns the name of the security backend.
@@ -49,12 +49,12 @@ func (b *TestSecurityBackend) Name() string {
 }
 
 // Setup records information about the call and calls the setup callback if one is defined.
-func (b *TestSecurityBackend) Setup(snapInfo *snap.Info, devMode bool, repo *Repository) error {
-	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SnapInfo: snapInfo, DevMode: devMode})
+func (b *TestSecurityBackend) Setup(snapInfo *snap.Info, confinement snap.ConfinementType, repo *Repository) error {
+	b.SetupCalls = append(b.SetupCalls, TestSetupCall{SnapInfo: snapInfo, Confinement: confinement})
 	if b.SetupCallback == nil {
 		return nil
 	}
-	return b.SetupCallback(snapInfo, devMode, repo)
+	return b.SetupCallback(snapInfo, confinement, repo)
 }
 
 // Remove records information about the call and calls the remove callback if one is defined

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -54,10 +54,10 @@ func snapRulesFilePath(snapName string) string {
 // Setup creates udev rules specific to a given snap.
 // If any of the rules are changed or removed then udev database is reloaded.
 //
-// Since udev has no concept of a complain mode, devMode is ignored.
+// Udev has no concept of a complain mode so confinment type is ignored.
 //
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
-func (b *Backend) Setup(snapInfo *snap.Info, devMode bool, repo *interfaces.Repository) error {
+func (b *Backend) Setup(snapInfo *snap.Info, confinement snap.ConfinementType, repo *interfaces.Repository) error {
 	snapName := snapInfo.Name()
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityUDev)
 	if err != nil {

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -80,9 +80,9 @@ func (s *backendSuite) TestInstallingSnapWritesAndLoadsRules(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{true, false} {
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
 		s.udevadmCmd.ForgetCalls()
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
 		// file called "70-snap.sambda.rules" was created
 		_, err := os.Stat(fname)
@@ -104,9 +104,9 @@ func (s *backendSuite) TestInstallingSnapWithHookWritesAndLoadsRules(c *C) {
 	s.Iface.PermanentPlugSnippetCallback = func(slot *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{true, false} {
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
 		s.udevadmCmd.ForgetCalls()
-		snapInfo := s.InstallSnap(c, devMode, backendtest.HookYaml, 0)
+		snapInfo := s.InstallSnap(c, confinement, backendtest.HookYaml, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.foo.rules")
 
 		// Verify that "70-snap.foo.rules" was created.
@@ -127,10 +127,10 @@ func (s *backendSuite) TestSecurityIsStable(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		s.udevadmCmd.ForgetCalls()
-		err := s.Backend.Setup(snapInfo, devMode, s.Repo)
+		err := s.Backend.Setup(snapInfo, confinement, s.Repo)
 		c.Assert(err, IsNil)
 		// rules are not re-loaded when nothing changes
 		c.Check(s.udevadmCmd.Calls(), HasLen, 0)
@@ -143,8 +143,8 @@ func (s *backendSuite) TestRemovingSnapRemovesAndReloadsRules(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		s.udevadmCmd.ForgetCalls()
 		s.RemoveSnap(c, snapInfo)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
@@ -164,10 +164,10 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return createSnippetForApps(slot.Apps), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		s.udevadmCmd.ForgetCalls()
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1WithNmbd, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1WithNmbd, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
 		// file called "70-snap.sambda.rules" was created
 		_, err := os.Stat(fname)
@@ -189,10 +189,10 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreHooks(c *C) {
 	s.Iface.PermanentPlugSnippetCallback = func(slot *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		s.udevadmCmd.ForgetCalls()
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlWithHook, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlWithHook, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
 
 		// Verify that "70-snap.samba.rules" was created
@@ -213,10 +213,10 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerApps(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return createSnippetForApps(slot.Apps), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1WithNmbd, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1WithNmbd, 0)
 		s.udevadmCmd.ForgetCalls()
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
 		// file called "70-snap.sambda.rules" still exists
 		_, err := os.Stat(fname)
@@ -238,10 +238,10 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerHooks(c *C) {
 	s.Iface.PermanentPlugSnippetCallback = func(slot *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlWithHook, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlWithHook, 0)
 		s.udevadmCmd.ForgetCalls()
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
 		// file called "70-snap.sambda.rules" still exists
 		_, err := os.Stat(fname)
@@ -260,8 +260,8 @@ func (s *backendSuite) TestCombineSnippetsWithActualSnippets(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{false, true} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
 		data, err := ioutil.ReadFile(fname)
 		c.Assert(err, IsNil)
@@ -277,8 +277,8 @@ func (s *backendSuite) TestCombineSnippetsWithActualSnippetsWhenPlugNoApps(c *C)
 	s.Iface.PermanentPlugSnippetCallback = func(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{false, true} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.PlugNoAppsYaml, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.PlugNoAppsYaml, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.foo.rules")
 		data, err := ioutil.ReadFile(fname)
 		c.Assert(err, IsNil)
@@ -294,8 +294,8 @@ func (s *backendSuite) TestCombineSnippetsWithActualSnippetsWhenSlotNoApps(c *C)
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{false, true} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SlotNoAppsYaml, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SlotNoAppsYaml, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.foo.rules")
 		data, err := ioutil.ReadFile(fname)
 		c.Assert(err, IsNil)
@@ -307,8 +307,8 @@ func (s *backendSuite) TestCombineSnippetsWithActualSnippetsWhenSlotNoApps(c *C)
 }
 
 func (s *backendSuite) TestCombineSnippetsWithoutAnySnippets(c *C) {
-	for _, devMode := range []bool{false, true} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
 		_, err := os.Stat(fname)
 		// Without any snippets, there the .rules file is not created.
@@ -322,10 +322,10 @@ func (s *backendSuite) TestUpdatingSnapToOneWithoutSlots(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1, 0)
 		s.udevadmCmd.ForgetCalls()
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1NoSlot, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1NoSlot, 0)
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
 		// file called "70-snap.sambda.rules" was removed
 		_, err := os.Stat(fname)
@@ -344,15 +344,15 @@ func (s *backendSuite) TestUpdatingSnapWithoutSlotsToOneWithoutSlots(c *C) {
 	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 		return []byte("dummy"), nil
 	}
-	for _, devMode := range []bool{true, false} {
-		snapInfo := s.InstallSnap(c, devMode, backendtest.SambaYamlV1NoSlot, 0)
+	for _, confinement := range []snap.ConfinementType{snap.DevmodeConfinement, snap.StrictConfinement} {
+		snapInfo := s.InstallSnap(c, confinement, backendtest.SambaYamlV1NoSlot, 0)
 		// file called "70-snap.sambda.rules" does not exist
 		fname := filepath.Join(dirs.SnapUdevRulesDir, "70-snap.samba.rules")
 		_, err := os.Stat(fname)
 		c.Check(os.IsNotExist(err), Equals, true)
 		s.udevadmCmd.ForgetCalls()
 
-		snapInfo = s.UpdateSnap(c, snapInfo, devMode, backendtest.SambaYamlV1WithNmbdNoSlot, 0)
+		snapInfo = s.UpdateSnap(c, snapInfo, confinement, backendtest.SambaYamlV1WithNmbdNoSlot, 0)
 		// file called "70-snap.sambda.rules" still does not exist
 		_, err = os.Stat(fname)
 		c.Check(os.IsNotExist(err), Equals, true)

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -53,7 +53,13 @@ func (m *InterfaceManager) setupAffectedSnaps(task *state.Task, affectingSnap st
 			return err
 		}
 		snap.AddImplicitSlots(affectedSnapInfo)
-		if err := setupSnapSecurity(task, affectedSnapInfo, snapst.DevModeAllowed(), m.repo); err != nil {
+		var confinement snap.ConfinementType
+		if snapst.DevModeAllowed() {
+			confinement = snap.DevmodeConfinement
+		} else {
+			confinement = snap.StrictConfinement
+		}
+		if err := setupSnapSecurity(task, affectedSnapInfo, confinement, m.repo); err != nil {
 			return err
 		}
 	}
@@ -74,10 +80,16 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 	if err != nil {
 		return err
 	}
-	return m.setupProfilesForSnap(task, tomb, snapInfo, ss.DevModeAllowed())
+	var confinement snap.ConfinementType
+	if ss.DevModeAllowed() {
+		confinement = snap.DevmodeConfinement
+	} else {
+		confinement = snap.StrictConfinement
+	}
+	return m.setupProfilesForSnap(task, tomb, snapInfo, confinement)
 }
 
-func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, snapInfo *snap.Info, devModeAllowed bool) error {
+func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, snapInfo *snap.Info, confinement snap.ConfinementType) error {
 	snap.AddImplicitSlots(snapInfo)
 	snapName := snapInfo.Name()
 
@@ -115,7 +127,7 @@ func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, 
 	if err := m.autoConnect(task, snapName, nil); err != nil {
 		return err
 	}
-	if err := setupSnapSecurity(task, snapInfo, devModeAllowed, m.repo); err != nil {
+	if err := setupSnapSecurity(task, snapInfo, confinement, m.repo); err != nil {
 		return err
 	}
 
@@ -193,7 +205,13 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 		if err != nil {
 			return err
 		}
-		return m.setupProfilesForSnap(task, tomb, snapInfo, snapst.DevMode)
+		var confinement snap.ConfinementType
+		if snapst.DevModeAllowed() {
+			confinement = snap.DevmodeConfinement
+		} else {
+			confinement = snap.StrictConfinement
+		}
+		return m.setupProfilesForSnap(task, tomb, snapInfo, confinement)
 	}
 }
 
@@ -341,10 +359,22 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	if err := setupSnapSecurity(task, slot.Snap, slotSnapst.DevModeAllowed(), m.repo); err != nil {
+	var slotConfinement snap.ConfinementType
+	if slotSnapst.DevModeAllowed() {
+		slotConfinement = snap.DevmodeConfinement
+	} else {
+		slotConfinement = snap.StrictConfinement
+	}
+	if err := setupSnapSecurity(task, slot.Snap, slotConfinement, m.repo); err != nil {
 		return err
 	}
-	if err := setupSnapSecurity(task, plug.Snap, plugSnapst.DevModeAllowed(), m.repo); err != nil {
+	var plugConfinement snap.ConfinementType
+	if plugSnapst.DevModeAllowed() {
+		plugConfinement = snap.DevmodeConfinement
+	} else {
+		plugConfinement = snap.StrictConfinement
+	}
+	if err := setupSnapSecurity(task, plug.Snap, plugConfinement, m.repo); err != nil {
 		return err
 	}
 
@@ -416,7 +446,13 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 		if err != nil {
 			return err
 		}
-		if err := setupSnapSecurity(task, snapInfo, snapst.DevModeAllowed(), m.repo); err != nil {
+		var confinement snap.ConfinementType
+		if snapst.DevModeAllowed() {
+			confinement = snap.DevmodeConfinement
+		} else {
+			confinement = snap.StrictConfinement
+		}
+		if err := setupSnapSecurity(task, snapInfo, confinement, m.repo); err != nil {
 			return &state.Retry{}
 		}
 	}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -105,13 +105,13 @@ func (m *InterfaceManager) reloadConnections(snapName string) error {
 	return nil
 }
 
-func setupSnapSecurity(task *state.Task, snapInfo *snap.Info, devMode bool, repo *interfaces.Repository) error {
+func setupSnapSecurity(task *state.Task, snapInfo *snap.Info, confinement snap.ConfinementType, repo *interfaces.Repository) error {
 	st := task.State()
 	snapName := snapInfo.Name()
 
 	for _, backend := range backends.All {
 		st.Unlock()
-		err := backend.Setup(snapInfo, devMode, repo)
+		err := backend.Setup(snapInfo, confinement, repo)
 		st.Lock()
 		if err != nil {
 			task.Errorf("cannot setup %s for snap %q: %s", backend.Name(), snapName, err)

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -449,8 +449,8 @@ func (s *interfaceManagerSuite) testDisconnect(c *C, plugSnap, plugName, slotSna
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Name(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.Name(), Equals, "producer")
 
-	c.Check(s.secBackend.SetupCalls[0].DevMode, Equals, false)
-	c.Check(s.secBackend.SetupCalls[1].DevMode, Equals, false)
+	c.Check(s.secBackend.SetupCalls[0].Confinement, Equals, snap.StrictConfinement)
+	c.Check(s.secBackend.SetupCalls[1].Confinement, Equals, snap.StrictConfinement)
 }
 
 func (s *interfaceManagerSuite) mockIface(c *C, iface interfaces.Interface) {
@@ -930,11 +930,11 @@ func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 	// Ensure that the task succeeded.
 	c.Check(change.Status(), Equals, state.DoneStatus)
 
-	// The snap was setup with DevMode equal to true.
+	// The snap was setup with DevmodeConfinement
 	c.Assert(s.secBackend.SetupCalls, HasLen, 1)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Name(), Equals, "snap")
-	c.Check(s.secBackend.SetupCalls[0].DevMode, Equals, true)
+	c.Check(s.secBackend.SetupCalls[0].Confinement, Equals, snap.DevmodeConfinement)
 }
 
 // setup-profiles uses the new snap.Info when setting up security for the new
@@ -1217,8 +1217,8 @@ func (s *interfaceManagerSuite) TestConnectSetsUpSecurity(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Name(), Equals, "producer")
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.Name(), Equals, "consumer")
 
-	c.Check(s.secBackend.SetupCalls[0].DevMode, Equals, false)
-	c.Check(s.secBackend.SetupCalls[1].DevMode, Equals, false)
+	c.Check(s.secBackend.SetupCalls[0].Confinement, Equals, snap.StrictConfinement)
+	c.Check(s.secBackend.SetupCalls[1].Confinement, Equals, snap.StrictConfinement)
 }
 
 func (s *interfaceManagerSuite) TestDisconnectSetsUpSecurity(c *C) {
@@ -1262,8 +1262,8 @@ func (s *interfaceManagerSuite) TestDisconnectSetsUpSecurity(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Name(), Equals, "consumer")
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.Name(), Equals, "producer")
 
-	c.Check(s.secBackend.SetupCalls[0].DevMode, Equals, false)
-	c.Check(s.secBackend.SetupCalls[1].DevMode, Equals, false)
+	c.Check(s.secBackend.SetupCalls[0].Confinement, Equals, snap.StrictConfinement)
+	c.Check(s.secBackend.SetupCalls[1].Confinement, Equals, snap.StrictConfinement)
 }
 
 func (s *interfaceManagerSuite) TestDisconnectTracksConnectionsInState(c *C) {
@@ -1384,9 +1384,9 @@ func (s *interfaceManagerSuite) TestSetupProfilesDevModeMultiple(c *C) {
 	c.Assert(s.secBackend.SetupCalls, HasLen, 2)
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Name(), Equals, siC.Name())
-	c.Check(s.secBackend.SetupCalls[0].DevMode, Equals, true)
+	c.Check(s.secBackend.SetupCalls[0].Confinement, Equals, snap.DevmodeConfinement)
 	c.Check(s.secBackend.SetupCalls[1].SnapInfo.Name(), Equals, siP.Name())
-	c.Check(s.secBackend.SetupCalls[1].DevMode, Equals, false)
+	c.Check(s.secBackend.SetupCalls[1].Confinement, Equals, snap.StrictConfinement)
 }
 
 func (s *interfaceManagerSuite) TestCheckInterfacesDeny(c *C) {
@@ -1524,5 +1524,5 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	c.Assert(s.secBackend.RemoveCalls, HasLen, 0)
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Name(), Equals, snapInfo.Name())
 	c.Check(s.secBackend.SetupCalls[0].SnapInfo.Revision, Equals, snapInfo.Revision)
-	c.Check(s.secBackend.SetupCalls[0].DevMode, Equals, false)
+	c.Check(s.secBackend.SetupCalls[0].Confinement, Equals, snap.StrictConfinement)
 }


### PR DESCRIPTION
This large patch semi-mechanically changes all of devMode bool flag to
snap.ConfinementType with values such as DevmodeConfinement (old true)
and StrictConfinement (old false).

The intent is to have more than two states (so that we can have classic
confinement later) and so that the effective confinement is conveyed,
regardless of flags such as devmode and jailmode elsewhere.

The code in the interface manager is kept as-is (same logic as before,
just trivial adjustments to let it compile) so that a subsequent branch
can use EffectiveConfinement and fix the jailmode bug neatly.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>