### PR TITLE
store: change retry loops

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2125,7 +2125,7 @@ func (t *remoteRepoTestSuite) TestListRefresh500(c *C) {
 }
 
 func (t *remoteRepoTestSuite) TestListRefresh500DurationExceeded(c *C) {
-	MockDefaultRetryStrategy(&t.BaseTest, retry.LimitCount(6, retry.LimitTime(1*time.Second,
+	MockDefaultRetryStrategy(&t.BaseTest, retry.LimitCount(5, retry.LimitTime(1*time.Second,
 		retry.Exponential{
 			Initial: 10 * time.Millisecond,
 			Factor:  1.67,
@@ -2160,7 +2160,7 @@ func (t *remoteRepoTestSuite) TestListRefresh500DurationExceeded(c *C) {
 		},
 	}, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/updates/"`)
-	c.Assert(n, Equals, 1)
+	c.Assert(n, Equals, 2)
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c *C) {


### PR DESCRIPTION
This PR changes the loops to rely only on attempt.Next() when deciding whether to retry (continue) the loop. The loops are "inifinite" and they stop iterating (i.e. return from the method) either when server call was succesfull or the number of retries has been exceeded. I had to remove the panic("unreachable") as the code is now really unreachable and 'go vet' catches it and also guarantees any "break" statement in these loop wouldn't go unnoticed.