### PR TITLE
interfaces: add ConfinementOptions type

### DIFF
--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -23,6 +23,47 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+// ConfinementOptions describe confinement configuration.
+//
+// The confinement system controls the initial layout of the mount namespace as
+// well as the set of actions a process is allowed to perform. Confinement is
+// initially defined by the ConfinementType declared by the snap. It can be
+// either "strict", "devmode" or "classic".
+//
+// The "strict" type uses mount layout that puts the base snap as the root
+// filesystem and provides strong isolation from the system and from other
+// snaps. Violations cause permission errors or mandatory process termination.
+//
+// The "devmode" type uses the same mount layout as "strict" but switches
+// confinement to non-enforcing mode whenever possible. Violations that would
+// result in permission error or process termination are instead permitted. A
+// diagnostic message is logged when this occurs.
+//
+// The "classic" type uses mount layout that is identical to the runtime of the
+// classic system snapd runs in, in other words there is no "chroot". Most of
+// the confinement is lifted, specifically there's no seccomp filter being
+// applied and apparmor is using complain mode by default.
+//
+// The three types defined above map to some combinations of the three flags
+// defined below.
+//
+// The DevMode flag attempts to switch all confinement facilities into
+// non-enforcing mode even if the snap requested otherwise.
+//
+// The JailMode flag attempts to switch all confinement facilities into
+// enforcing mode even if the snap requested otherwise.
+//
+// The Classic flag switches the layout of the mount namespace so that there's
+// no "chroot" to the core snap.
+type ConfinementOptions struct {
+	// DevMode flag switches confinement to non-enforcing mode.
+	DevMode bool
+	// JailMode flag switches confinement to enforcing mode.
+	JailMode bool
+	// Classic flag switches the core snap "chroot" off.
+	Classic bool
+}
+
 // SecurityBackend abstracts interactions between the interface system and the
 // needs of a particular security system.
 type SecurityBackend interface {

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -30,7 +30,7 @@ import (
 // initially defined by the ConfinementType declared by the snap. It can be
 // either "strict", "devmode" or "classic".
 //
-// The "strict" type uses mount layout that puts the base snap as the root
+// The "strict" type uses mount layout that puts the core snap as the root
 // filesystem and provides strong isolation from the system and from other
 // snaps. Violations cause permission errors or mandatory process termination.
 //


### PR DESCRIPTION
This type encodes all of the configuration knobs that the confinement
system understands. It is meant to replace all use of ConfinementType
inside the interfaces package.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>