### PR TITLE
store: resp.Body.Close() missing in ReadyToBuy

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1632,6 +1632,8 @@ func (s *Store) ReadyToBuy(user *auth.UserState) error {
 		return err
 	}
 
+	defer resp.Body.Close()
+
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var customer storeCustomer


### PR DESCRIPTION
Added missing resp.Body.Close() in ReadyToBuy, as otherwise we would leak fd.