### PR TITLE
osutil: fix build on armhf (arm in go-arch) and powerpc (ppc in go-arch)

### DIFF
--- a/osutil/chattr_32.go
+++ b/osutil/chattr_32.go
@@ -1,5 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-// +build armhf 386
+// +build arm 386 ppc
 
 /*
  * Copyright (C) 2016 Canonical Ltd


### PR DESCRIPTION
Trivial fix because we can't agree on architecture names.