### PR TITLE
debian: drop hard xdelta dependency for now

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,6 @@ Depends: adduser,
          snap-confine (>= 1.0.43),
          squashfs-tools,
          systemd,
-         xdelta,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)


### PR DESCRIPTION
For now because we don't do deltas yet by default.

I also suspect xdelta itself is not an ideal choice and we will want to use xdelta3 anyway because xdelta has a 2gb filesize limit and we will have some work doing the MIR for this.