### PR TITLE
overlord/ifacestate: don't setup jailmode snaps with devmode confinement

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -35,6 +35,15 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+// optsFromFlags returns interfaces.ConfinementOptions from snapstate.Flags.
+func optsFromFlags(flags snapstate.Flags) interfaces.ConfinementOptions {
+	return interfaces.ConfinementOptions{
+		DevMode:  flags.DevMode,
+		JailMode: flags.JailMode,
+		// TODO: map Classic when it shows up in snapstate.Flags
+	}
+}
+
 func (m *InterfaceManager) setupAffectedSnaps(task *state.Task, affectingSnap string, affectedSnaps []string) error {
 	st := task.State()
 
@@ -53,7 +62,7 @@ func (m *InterfaceManager) setupAffectedSnaps(task *state.Task, affectingSnap st
 			return err
 		}
 		snap.AddImplicitSlots(affectedSnapInfo)
-		opts := interfaces.ConfinementOptions{DevMode: snapst.DevModeAllowed()}
+		opts := optsFromFlags(snapst.Flags)
 		if err := setupSnapSecurity(task, affectedSnapInfo, opts, m.repo); err != nil {
 			return err
 		}
@@ -76,7 +85,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 		return err
 	}
 
-	opts := interfaces.ConfinementOptions{DevMode: snapsup.DevModeAllowed()}
+	opts := optsFromFlags(snapsup.Flags)
 	return m.setupProfilesForSnap(task, tomb, snapInfo, opts)
 }
 
@@ -196,7 +205,7 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 		if err != nil {
 			return err
 		}
-		opts := interfaces.ConfinementOptions{DevMode: snapst.DevModeAllowed()}
+		opts := optsFromFlags(snapst.Flags)
 		return m.setupProfilesForSnap(task, tomb, snapInfo, opts)
 	}
 }
@@ -345,11 +354,11 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	slotOpts := interfaces.ConfinementOptions{DevMode: slotSnapst.DevModeAllowed()}
+	slotOpts := optsFromFlags(slotSnapst.Flags)
 	if err := setupSnapSecurity(task, slot.Snap, slotOpts, m.repo); err != nil {
 		return err
 	}
-	plugOpts := interfaces.ConfinementOptions{DevMode: plugSnapst.DevModeAllowed()}
+	plugOpts := optsFromFlags(plugSnapst.Flags)
 	if err := setupSnapSecurity(task, plug.Snap, plugOpts, m.repo); err != nil {
 		return err
 	}
@@ -422,7 +431,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 		if err != nil {
 			return err
 		}
-		opts := interfaces.ConfinementOptions{DevMode: snapst.DevModeAllowed()}
+		opts := optsFromFlags(snapst.Flags)
 		if err := setupSnapSecurity(task, snapInfo, opts, m.repo); err != nil {
 			return &state.Retry{}
 		}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -35,8 +35,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// optsFromFlags returns interfaces.ConfinementOptions from snapstate.Flags.
-func optsFromFlags(flags snapstate.Flags) interfaces.ConfinementOptions {
+// confinementOptions returns interfaces.ConfinementOptions from snapstate.Flags.
+func confinementOptions(flags snapstate.Flags) interfaces.ConfinementOptions {
 	return interfaces.ConfinementOptions{
 		DevMode:  flags.DevMode,
 		JailMode: flags.JailMode,
@@ -62,7 +62,7 @@ func (m *InterfaceManager) setupAffectedSnaps(task *state.Task, affectingSnap st
 			return err
 		}
 		snap.AddImplicitSlots(affectedSnapInfo)
-		opts := optsFromFlags(snapst.Flags)
+		opts := confinementOptions(snapst.Flags)
 		if err := setupSnapSecurity(task, affectedSnapInfo, opts, m.repo); err != nil {
 			return err
 		}
@@ -85,7 +85,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 		return err
 	}
 
-	opts := optsFromFlags(snapsup.Flags)
+	opts := confinementOptions(snapsup.Flags)
 	return m.setupProfilesForSnap(task, tomb, snapInfo, opts)
 }
 
@@ -205,7 +205,7 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 		if err != nil {
 			return err
 		}
-		opts := optsFromFlags(snapst.Flags)
+		opts := confinementOptions(snapst.Flags)
 		return m.setupProfilesForSnap(task, tomb, snapInfo, opts)
 	}
 }
@@ -354,11 +354,11 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	slotOpts := optsFromFlags(slotSnapst.Flags)
+	slotOpts := confinementOptions(slotSnapst.Flags)
 	if err := setupSnapSecurity(task, slot.Snap, slotOpts, m.repo); err != nil {
 		return err
 	}
-	plugOpts := optsFromFlags(plugSnapst.Flags)
+	plugOpts := confinementOptions(plugSnapst.Flags)
 	if err := setupSnapSecurity(task, plug.Snap, plugOpts, m.repo); err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 		if err != nil {
 			return err
 		}
-		opts := optsFromFlags(snapst.Flags)
+		opts := confinementOptions(snapst.Flags)
 		if err := setupSnapSecurity(task, snapInfo, opts, m.repo); err != nil {
 			return &state.Retry{}
 		}

--- a/tests/lib/snaps/test-snapd-devmode/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-devmode/meta/snap.yaml
@@ -3,3 +3,6 @@ version: 1.0
 summary: Basic snap with devmode confinement
 description: A basic buildable snap that asks for devmode confinement
 confinement: devmode
+apps:
+    test-snapd-devmode:
+        command: /bin/bash

--- a/tests/main/regression-jailmode-1641885/task.yaml
+++ b/tests/main/regression-jailmode-1641885/task.yaml
@@ -20,6 +20,6 @@ restore: |
     rm -f ./test-snapd-devmode_1.0_all.snap
 debug: |
     echo "Apparmor profile (first 30 lines)"
-    head -n 30 /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.basic-devmode || true
+    head -n 30 /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode || true
     echo "Seccomp profile (first 30 lines)"
-    head -n 30 /var/lib/snapd/seccomp/profiles/snap.test-snapd-devmode.basic-devmode || true
+    head -n 30 /var/lib/snapd/seccomp/profiles/snap.test-snapd-devmode.test-snapd-devmode || true

--- a/tests/main/regression-jailmode-1641885/task.yaml
+++ b/tests/main/regression-jailmode-1641885/task.yaml
@@ -1,0 +1,25 @@
+summary: snaps installed with --jailmode are not in devmode
+details: |
+    Users found that a snap that uses "confinement: devmode", even when
+    installed with "snap install --jailmode" is effectively in devmode (the
+    apparmor profile is in complain mode) even if "snap list" reports it as
+    "jailmode".
+    This has been reported as https://bugs.launchpad.net/snappy/+bug/1641885
+prepare: |
+    snapbuild $TESTSLIB/snaps/test-snapd-devmode .
+    echo "Install a test snap that uses 'confinement: devmode' in jailmode"
+    snap install --jailmode --dangerous ./test-snapd-devmode_1.0_all.snap
+execute: |
+    echo "Ensure that the snap is installed in jailmode"
+    snap list | grep test-snapd-devmode | grep jailmode
+    echo "Ensure that the apparmor profile doesn't use the complain mode"
+    cat /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode | grep attach_disconnected | grep -v complain
+    echo "Ensure that the seccomp profile doesn't use the complain mode"
+    cat /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode | grep -v '@complain'
+restore: |
+    rm -f ./test-snapd-devmode_1.0_all.snap
+debug: |
+    echo "Apparmor profile (first 30 lines)"
+    head -n 30 /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.basic-devmode || true
+    echo "Seccomp profile (first 30 lines)"
+    head -n 30 /var/lib/snapd/seccomp/profiles/snap.test-snapd-devmode.basic-devmode || true


### PR DESCRIPTION
This branch picks ups where #2310 left off based on the new ConfinementOptions.

The bulk of the fix is described by one of the commit messages:

    This patch fixes a bug where "devmode" would be applied to any snap that
    was actually attempting to use "jailmode". The DevModeAllowed function
    was incorrectly used as the API for interface security setup was
    somewhat confusing earlier.
    
    The API was changed to much more friendly and effective
    ConfinementOptions earlier and now it's the time to use them correctly.
    Instead of calling DevModeAllowed the values from SnapState or SnapSetup
    (from Flags technically) are simply mapped to their ConfinementOption
    equivalents.
