### PR TITLE
tests: decrease the number of expected featured apps

### DIFF
--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -11,8 +11,8 @@ execute: |
         snap find
         exit 1
     fi
-    if [ $(snap find | wc -l) -lt 3 ]; then
-        echo "Found less than 3 featured apps, this seems bogus:"
+    if [ $(snap find | wc -l) -lt 2 ]; then
+        echo "Not found any featured app, this seems bogus:"
         snap find
         exit 1
     fi


### PR DESCRIPTION
On some archs (for instance arm64) there's only one featured app. For making sure that there's at least one of them the test currently checks if the number of lines of the output of snap find is less than 2, the first line is the header of the results.