### PR TITLE
[WIP] Fix prefix search query; Fix empty query search; Find doc

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -185,7 +185,7 @@ func (client *Client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
 	}
 
 	if section != "" || (section == "" && query == ""){
-		q.Set("section", opts.Section)
+		q.Set("section", section)
 	}
 
 	return client.snapsFromPath("/v2/find", q)

--- a/client/packages.go
+++ b/client/packages.go
@@ -90,7 +90,10 @@ type ResultInfo struct {
 // FindOptions supports exactly one of the following options:
 // - Refresh: only return snaps that are refreshable
 // - Private: return snaps that are private
-// - Query: only return snaps that match the query string
+// - Query: only return snaps that match the query string.
+// The Prefix predicate can be used to specify that
+// a search action is limited to the snaps' name fields only. By default
+// the search is performed on all of the snaps' description fields.
 type FindOptions struct {
 	Refresh bool
 	Private bool
@@ -162,12 +165,16 @@ func (client *Client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
 		opts = &FindOptions{}
 	}
 
+	query := opts.Query
+	section := opts.Section
+
 	q := url.Values{}
 	if opts.Prefix {
-		q.Set("name", opts.Query+"*")
+		q.Set("name", query)
 	} else {
-		q.Set("q", opts.Query)
+		q.Set("q", query)
 	}
+
 	switch {
 	case opts.Refresh && opts.Private:
 		return nil, nil, fmt.Errorf("cannot specify refresh and private together")
@@ -176,7 +183,8 @@ func (client *Client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
 	case opts.Private:
 		q.Set("select", "private")
 	}
-	if opts.Section != "" {
+
+	if section != "" || (section == "" && query == ""){
 		q.Set("section", opts.Section)
 	}
 

--- a/client/packages.go
+++ b/client/packages.go
@@ -91,15 +91,15 @@ type ResultInfo struct {
 // - Refresh: only return snaps that are refreshable
 // - Private: return snaps that are private
 // - Query: only return snaps that match the query string.
-// The Prefix predicate can be used to specify that
-// a search action is limited to the snaps' name fields only. By default
+// The SearchNameOnly predicate can be used to specify that
+// a search action is restricted to the snaps' name fields only. By default
 // the search is performed on all of the snaps' description fields.
 type FindOptions struct {
-	Refresh bool
-	Private bool
-	Prefix  bool
-	Query   string
-	Section string
+	Refresh        bool
+	Private        bool
+	SearchNameOnly bool
+	Query          string
+	Section        string
 }
 
 var ErrNoSnapsInstalled = errors.New("no snaps installed")
@@ -169,8 +169,8 @@ func (client *Client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
 	section := opts.Section
 
 	q := url.Values{}
-	if opts.Prefix {
-		q.Set("name", query)
+	if opts.SearchNameOnly {
+		q.Set("name", query+"*")
 	} else {
 		q.Set("q", query)
 	}
@@ -184,7 +184,7 @@ func (client *Client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
 		q.Set("select", "private")
 	}
 
-	if section != "" || (section == "" && query == ""){
+	if section != "" || (section == "" && query == "") {
 		q.Set("section", section)
 	}
 

--- a/client/packages.go
+++ b/client/packages.go
@@ -165,14 +165,11 @@ func (client *Client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
 		opts = &FindOptions{}
 	}
 
-	query := opts.Query
-	section := opts.Section
-
 	q := url.Values{}
 	if opts.SearchNameOnly {
-		q.Set("name", query+"*")
+		q.Set("name", opts.Query+"*")
 	} else {
-		q.Set("q", query)
+		q.Set("q", opts.Query)
 	}
 
 	switch {
@@ -184,8 +181,8 @@ func (client *Client) Find(opts *FindOptions) ([]*Snap, *ResultInfo, error) {
 		q.Set("select", "private")
 	}
 
-	if section != "" || (section == "" && query == "") {
-		q.Set("section", section)
+	if opts.Section != "" {
+		q.Set("section", opts.Section)
 	}
 
 	return client.snapsFromPath("/v2/find", q)

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -151,10 +151,10 @@ func (cs *clientSuite) TestClientFilterSnaps(c *check.C) {
 	c.Check(cs.req.URL.RawQuery, check.Equals, "q=foo")
 }
 
-func (cs *clientSuite) TestClientFindPrefix(c *check.C) {
-	_, _, _ = cs.cli.Find(&client.FindOptions{Query: "foo", Prefix: true})
+func (cs *clientSuite) TestClientFindSearchNameOnly(c *check.C) {
+	_, _, _ = cs.cli.Find(&client.FindOptions{Query: "foo", SearchNameOnly: true})
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/find")
-	c.Check(cs.req.URL.RawQuery, check.Equals, "name=foo") // 2A is `*`
+	c.Check(cs.req.URL.RawQuery, check.Equals, "name=foo%2A") // 2A is `*`
 }
 
 func (cs *clientSuite) TestClientFindOne(c *check.C) {

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -43,7 +43,7 @@ func (cs *clientSuite) TestClientFindRefreshSetsQuery(c *check.C) {
 	c.Check(cs.req.Method, check.Equals, "GET")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/find")
 	c.Check(cs.req.URL.Query(), check.DeepEquals, url.Values{
-		"q": []string{""}, "section": []string{""}, "select": []string{"refresh"},
+		"q": []string{""}, "select": []string{"refresh"},
 	})
 }
 

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -43,7 +43,7 @@ func (cs *clientSuite) TestClientFindRefreshSetsQuery(c *check.C) {
 	c.Check(cs.req.Method, check.Equals, "GET")
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/find")
 	c.Check(cs.req.URL.Query(), check.DeepEquals, url.Values{
-		"q": []string{""}, "select": []string{"refresh"},
+		"q": []string{""}, "section": []string{""}, "select": []string{"refresh"},
 	})
 }
 
@@ -154,7 +154,7 @@ func (cs *clientSuite) TestClientFilterSnaps(c *check.C) {
 func (cs *clientSuite) TestClientFindPrefix(c *check.C) {
 	_, _, _ = cs.cli.Find(&client.FindOptions{Query: "foo", Prefix: true})
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/find")
-	c.Check(cs.req.URL.RawQuery, check.Equals, "name=foo%2A") // 2A is `*`
+	c.Check(cs.req.URL.RawQuery, check.Equals, "name=foo") // 2A is `*`
 }
 
 func (cs *clientSuite) TestClientFindOne(c *check.C) {


### PR DESCRIPTION
- Fix prefix search query: the '*' being appended is not necessary,
- Make the client go binding consistent with the find command regarding the empty search semantics,
- Complete the FindOptions docs and make it a tiny bit clearer,