### PR TITLE
interfaces: apparmor support for classic confinement

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -145,7 +145,7 @@ func (b *Backend) combineSnippets(snapInfo *snap.Info, opts interfaces.Confineme
 
 func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippets map[string][][]byte, content map[string]*osutil.FileState) {
 	policy := defaultTemplate
-	if opts.DevMode && !opts.JailMode {
+	if (opts.DevMode || opts.Classic) && !opts.JailMode {
 		policy = attachPattern.ReplaceAll(policy, attachComplain)
 	}
 	// TODO: add support for opts.Classic later

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -319,19 +319,34 @@ const commonPrefix = `
 @{INSTALL_DIR}="/snap"`
 
 var combineSnippetsScenarios = []combineSnippetsScenario{{
+	// By default apparmor is enforcing mode.
 	opts:    interfaces.ConfinementOptions{},
 	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\n\n}\n",
 }, {
+	// Snippets are injected in the space between "{" and "}"
 	opts:    interfaces.ConfinementOptions{},
 	snippet: "snippet",
 	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
 }, {
-	opts:    interfaces.ConfinementOptions{DevMode: true},
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\n\n}\n",
-}, {
+	// DevMode switches apparmor to non-enforcing (complain) mode.
 	opts:    interfaces.ConfinementOptions{DevMode: true},
 	snippet: "snippet",
 	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
+}, {
+	// JailMode switches apparmor to enforcing mode even in the presence of DevMode.
+	opts:    interfaces.ConfinementOptions{DevMode: true},
+	snippet: "snippet",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
+}, {
+	// Classic confinement uses apparmor in complain mode by default.
+	opts:    interfaces.ConfinementOptions{Classic: true},
+	snippet: "snippet",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
+}, {
+	// Classic confinement in JailMode uses enforcing apparmor.
+	opts:    interfaces.ConfinementOptions{Classic: true, JailMode: true},
+	snippet: "snippet",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
 }}
 
 func (s *backendSuite) TestCombineSnippets(c *C) {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -319,35 +319,20 @@ const commonPrefix = `
 @{INSTALL_DIR}="/snap"`
 
 var combineSnippetsScenarios = []combineSnippetsScenario{{
-	opts: interfaces.ConfinementOptions{},
-	content: commonPrefix + `
-profile "snap.samba.smbd" (attach_disconnected) {
-
-}
-`,
+	opts:    interfaces.ConfinementOptions{},
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\n\n}\n",
 }, {
 	opts:    interfaces.ConfinementOptions{},
 	snippet: "snippet",
-	content: commonPrefix + `
-profile "snap.samba.smbd" (attach_disconnected) {
-snippet
-}
-`,
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
 }, {
-	opts: interfaces.ConfinementOptions{DevMode: true},
-	content: commonPrefix + `
-profile "snap.samba.smbd" (attach_disconnected,complain) {
-
-}
-`,
+	opts:    interfaces.ConfinementOptions{DevMode: true},
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\n\n}\n",
 }, {
 	opts:    interfaces.ConfinementOptions{DevMode: true},
 	snippet: "snippet",
-	content: commonPrefix + `
-profile "snap.samba.smbd" (attach_disconnected,complain) {
-snippet
-}
-`}}
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
+}}
 
 func (s *backendSuite) TestCombineSnippets(c *C) {
 	// NOTE: replace the real template with a shorter variant


### PR DESCRIPTION
This simple branch adds apparmor support for classic confinement. In classic confinement (when `interfaces.ConfinementOptions{Classic: true}`) apparmor is in non-enforcing mode. As with devmode, using `JailMode` flag forces the enforcing confinement.