### PR TITLE
snap: disable support for socket activation

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -326,10 +326,6 @@ type AppInfo struct {
 	PostStopCommand string
 	RestartCond     systemd.RestartCondition
 
-	Socket       bool
-	SocketMode   string
-	ListenStream string
-
 	// TODO: this should go away once we have more plumbing and can change
 	// things vs refactor
 	// https://github.com/snapcore/snapd/pull/794#discussion_r58688496

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -65,10 +65,6 @@ type appYaml struct {
 	BusName string `yaml:"bus-name,omitempty"`
 
 	Environment map[string]string `yaml:"environment,omitempty"`
-
-	Socket       bool   `yaml:"socket,omitempty"`
-	ListenStream string `yaml:"listen-stream,omitempty"`
-	SocketMode   string `yaml:"socket-mode,omitempty"`
 }
 
 type hookYaml struct {
@@ -230,9 +226,6 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) {
 			StopCommand:     yApp.StopCommand,
 			PostStopCommand: yApp.PostStopCommand,
 			RestartCond:     yApp.RestartCond,
-			Socket:          yApp.Socket,
-			SocketMode:      yApp.SocketMode,
-			ListenStream:    yApp.ListenStream,
 			BusName:         yApp.BusName,
 			Environment:     yApp.Environment,
 		}

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1330,10 +1330,7 @@ apps:
    stop-command: stop-cmd
    post-stop-command: post-stop-cmd
    restart-condition: on-abnormal
-   socket-mode: socket_mode
-   listen-stream: listen_stream
    bus-name: busName
-   socket: yes
 `)
 	info, err := snap.InfoFromSnapYaml(y)
 	c.Assert(err, IsNil)
@@ -1347,9 +1344,6 @@ apps:
 			StopTimeout:     timeout.Timeout(25 * time.Second),
 			StopCommand:     "stop-cmd",
 			PostStopCommand: "post-stop-cmd",
-			Socket:          true,
-			SocketMode:      "socket_mode",
-			ListenStream:    "listen_stream",
 			BusName:         "busName",
 		},
 	})

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -141,8 +141,6 @@ func ValidateApp(app *AppInfo) error {
 		"command":           app.Command,
 		"stop-command":      app.StopCommand,
 		"post-stop-command": app.PostStopCommand,
-		"socket-mode":       app.SocketMode,
-		"listen-stream":     app.ListenStream,
 		"bus-name":          app.BusName,
 	}
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -143,8 +143,6 @@ func (s *ValidateSuite) TestAppWhitelistIllegal(c *C) {
 	c.Check(ValidateApp(&AppInfo{Name: "foo", Command: "foo\n"}), NotNil)
 	c.Check(ValidateApp(&AppInfo{Name: "foo", StopCommand: "foo\n"}), NotNil)
 	c.Check(ValidateApp(&AppInfo{Name: "foo", PostStopCommand: "foo\n"}), NotNil)
-	c.Check(ValidateApp(&AppInfo{Name: "foo", SocketMode: "foo\n"}), NotNil)
-	c.Check(ValidateApp(&AppInfo{Name: "foo", ListenStream: "foo\n"}), NotNil)
 	c.Check(ValidateApp(&AppInfo{Name: "foo", BusName: "foo\n"}), NotNil)
 }
 

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -27,7 +27,6 @@ import (
 var (
 	// services
 	GenerateSnapServiceFile = generateSnapServiceFile
-	GenerateSnapSocketFile  = generateSnapSocketFile
 
 	// desktop
 	SanitizeDesktopFile = sanitizeDesktopFile

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -58,20 +58,6 @@ func generateSnapServiceFile(app *snap.AppInfo) (string, error) {
 	return genServiceFile(app), nil
 }
 
-func generateSnapSocketFile(app *snap.AppInfo) (string, error) {
-	if err := snap.ValidateApp(app); err != nil {
-		return "", err
-	}
-
-	// lp: #1515709, systemd will default to 0666 if no socket mode
-	// is specified
-	if app.SocketMode == "" {
-		app.SocketMode = "0660"
-	}
-
-	return genSocketFile(app), nil
-}
-
 // StartSnapServices starts service units for the applications from the snap which are services.
 func StartSnapServices(s *snap.Info, inter interacter) error {
 	for _, app := range s.Apps {
@@ -91,18 +77,6 @@ func StartSnapServices(s *snap.Info, inter interacter) error {
 
 		if err := sysd.Start(serviceName); err != nil {
 			return err
-		}
-
-		if app.Socket {
-			socketName := filepath.Base(app.ServiceSocketFile())
-			// enable the socket
-			if err := sysd.Enable(socketName); err != nil {
-				return err
-			}
-
-			if err := sysd.Start(socketName); err != nil {
-				return err
-			}
 		}
 	}
 
@@ -124,18 +98,6 @@ func AddSnapServices(s *snap.Info, inter interacter) error {
 		os.MkdirAll(filepath.Dir(svcFilePath), 0755)
 		if err := osutil.AtomicWriteFile(svcFilePath, []byte(content), 0644, 0); err != nil {
 			return err
-		}
-		// Generate systemd socket file if needed
-		if app.Socket {
-			content, err := generateSnapSocketFile(app)
-			if err != nil {
-				return err
-			}
-			svcSocketFilePath := app.ServiceSocketFile()
-			os.MkdirAll(filepath.Dir(svcSocketFilePath), 0755)
-			if err := osutil.AtomicWriteFile(svcSocketFilePath, []byte(content), 0644, 0); err != nil {
-				return err
-			}
 		}
 	}
 
@@ -227,10 +189,10 @@ WorkingDirectory={{.App.Snap.DataDir}}
 {{if .StopTimeout}}TimeoutStopSec={{.StopTimeout.Seconds}}{{end}}
 Type={{.App.Daemon}}
 {{if .App.BusName}}BusName={{.App.BusName}}{{end}}
-{{if not .App.Socket}}
+
 [Install]
 WantedBy={{.ServicesTarget}}
-{{end}}`
+`
 	var templateOut bytes.Buffer
 	t := template.Must(template.New("service-wrapper").Parse(serviceTemplate))
 
@@ -266,47 +228,6 @@ WantedBy={{.ServicesTarget}}
 
 		// systemd runs as PID 1 so %h will not work.
 		Home: "/root",
-	}
-
-	if err := t.Execute(&templateOut, wrapperData); err != nil {
-		// this can never happen, except we forget a variable
-		logger.Panicf("Unable to execute template: %v", err)
-	}
-
-	return templateOut.String()
-}
-
-func genSocketFile(appInfo *snap.AppInfo) string {
-	socketTemplate := `[Unit]
-# Auto-generated, DO NO EDIT
-Description=Socket for snap application {{.App.Snap.Name}}.{{.App.Name}}
-Requires={{.MountUnit}}
-Wants={{.PrerequisiteTarget}}
-After={{.MountUnit}} {{.PrerequisiteTarget}}
-X-Snappy=yes
-
-[Socket]
-ListenStream={{.App.ListenStream}}
-{{if .App.SocketMode}}SocketMode={{.App.SocketMode}}{{end}}
-
-[Install]
-WantedBy={{.SocketsTarget}}
-`
-	var templateOut bytes.Buffer
-	t := template.Must(template.New("socket-wrapper").Parse(socketTemplate))
-
-	wrapperData := struct {
-		App                *snap.AppInfo
-		ServiceFileName    string
-		PrerequisiteTarget string
-		SocketsTarget      string
-		MountUnit          string
-	}{
-		App:                appInfo,
-		ServiceFileName:    filepath.Base(appInfo.ServiceFile()),
-		SocketsTarget:      systemd.SocketsTarget,
-		PrerequisiteTarget: systemd.PrerequisiteTarget,
-		MountUnit:          filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir())),
 	}
 
 	if err := t.Execute(&templateOut, wrapperData); err != nil {

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -79,7 +79,6 @@ TimeoutStopSec=30
 Type=%s
 %s
 `
-	expectedSocketUsingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "simple", "")
 	expectedTypeForkingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, "forking\n", "\n[Install]\nWantedBy=multi-user.target")
 )
 
@@ -195,46 +194,4 @@ apps:
 	c.Assert(err, IsNil)
 
 	c.Assert(wrapperText, Equals, expectedDbusService)
-}
-
-func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileWithSocket(c *C) {
-	service := &snap.AppInfo{
-		Snap: &snap.Info{
-			SideInfo: snap.SideInfo{
-				RealName: "xkcd-webserver",
-				Revision: snap.R(44),
-			},
-			Version: "0.3.4",
-		},
-		Name:            "xkcd-webserver",
-		Command:         "bin/foo start",
-		StopCommand:     "bin/foo stop",
-		PostStopCommand: "bin/foo post-stop",
-		StopTimeout:     timeout.DefaultTimeout,
-		Socket:          true,
-		Daemon:          "simple",
-	}
-
-	generatedWrapper, err := wrappers.GenerateSnapServiceFile(service)
-	c.Assert(err, IsNil)
-	c.Assert(generatedWrapper, Equals, expectedSocketUsingWrapper)
-}
-
-func (s *servicesWrapperGenSuite) TestGenerateSnapSocketFileMode(c *C) {
-	srv := &snap.AppInfo{
-		Name: "foo",
-		Snap: &snap.Info{},
-	}
-
-	// no socket mode means 0660
-	content, err := wrappers.GenerateSnapSocketFile(srv)
-	c.Assert(err, IsNil)
-	c.Assert(content, Matches, "(?ms).*SocketMode=0660")
-
-	// SocketMode itself is honored
-	srv.SocketMode = "0600"
-	content, err = wrappers.GenerateSnapSocketFile(srv)
-	c.Assert(err, IsNil)
-	c.Assert(content, Matches, "(?ms).*SocketMode=0600")
-
 }

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -197,63 +197,6 @@ apps:
 	c.Assert(wrapperText, Equals, expectedDbusService)
 }
 
-func (s *servicesWrapperGenSuite) TestGenerateSnapSocketFile(c *C) {
-	service := &snap.AppInfo{
-		Snap: &snap.Info{
-			SideInfo: snap.SideInfo{
-				RealName: "xkcd-webserver",
-				Revision: snap.R(44),
-			},
-			Version: "0.3.4",
-		},
-		Name:         "xkcd-webserver",
-		Command:      "bin/foo start",
-		Socket:       true,
-		ListenStream: "/var/run/docker.sock",
-		SocketMode:   "0660",
-		Daemon:       "simple",
-	}
-
-	content, err := wrappers.GenerateSnapSocketFile(service)
-	c.Assert(err, IsNil)
-	c.Assert(content, Equals, `[Unit]
-# Auto-generated, DO NO EDIT
-Description=Socket for snap application xkcd-webserver.xkcd-webserver
-Requires=snap-xkcd\x2dwebserver-44.mount
-Wants=network-online.target
-After=snap-xkcd\x2dwebserver-44.mount network-online.target
-X-Snappy=yes
-
-[Socket]
-ListenStream=/var/run/docker.sock
-SocketMode=0660
-
-[Install]
-WantedBy=sockets.target
-`)
-}
-
-func (s *servicesWrapperGenSuite) TestGenerateSnapSocketFileIllegalChars(c *C) {
-	service := &snap.AppInfo{
-		Snap: &snap.Info{
-			SideInfo: snap.SideInfo{
-				RealName: "xkcd-webserver",
-				Revision: snap.R(44),
-			},
-			Version: "0.3.4",
-		},
-		Name:         "xkcd-webserver",
-		Command:      "bin/foo start",
-		Socket:       true,
-		ListenStream: "/var/run/docker!sock",
-		SocketMode:   "0660",
-		Daemon:       "simple",
-	}
-
-	_, err := wrappers.GenerateSnapSocketFile(service)
-	c.Assert(err, NotNil)
-}
-
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileWithSocket(c *C) {
 	service := &snap.AppInfo{
 		Snap: &snap.Info{


### PR DESCRIPTION
Removed support or ListeanStream, Socket and SocketMode options of snap.yaml (socket-based activation). 