### PR TITLE
interfaces/seccomp: add support for classic confinement

### DIFF
--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -114,11 +114,11 @@ func (b *Backend) combineSnippets(snapInfo *snap.Info, opts interfaces.Confineme
 func addContent(securityTag string, opts interfaces.ConfinementOptions, snippets map[string][][]byte, content map[string]*osutil.FileState) {
 	var buffer bytes.Buffer
 	if opts.Classic && !opts.JailMode {
-		// Classic confinement doesn't generate a seccomp profile at all
-		return
+		// NOTE: This is understood by snap-confine
+		buffer.WriteString("@unrestricted\n")
 	}
 	if opts.DevMode && !opts.JailMode {
-		// NOTE: This is understood by ubuntu-core-launcher
+		// NOTE: This is understood by snap-confine
 		buffer.WriteString("@complain\n")
 	}
 

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -113,11 +113,14 @@ func (b *Backend) combineSnippets(snapInfo *snap.Info, opts interfaces.Confineme
 
 func addContent(securityTag string, opts interfaces.ConfinementOptions, snippets map[string][][]byte, content map[string]*osutil.FileState) {
 	var buffer bytes.Buffer
+	if opts.Classic && !opts.JailMode {
+		// Classic confinement doesn't generate a seccomp profile at all
+		return
+	}
 	if opts.DevMode && !opts.JailMode {
 		// NOTE: This is understood by ubuntu-core-launcher
 		buffer.WriteString("@complain\n")
 	}
-	// TODO: Add support for classic confinement later
 
 	buffer.Write(defaultTemplate)
 	for _, snippet := range snippets[securityTag] {

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -111,9 +111,14 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 		snapInfo := s.InstallSnap(c, opts, backendtest.SambaYamlV1, 0)
 		snapInfo = s.UpdateSnap(c, snapInfo, opts, backendtest.SambaYamlV1WithNmbd, 0)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.nmbd")
-		// file called "snap.sambda.nmbd" was created
 		_, err := os.Stat(profile)
-		c.Check(err, IsNil)
+		if !opts.Classic || opts.JailMode {
+			// file called "snap.sambda.nmbd" was created
+			c.Check(err, IsNil)
+		} else {
+			// Verify that the profile was *not* created
+			c.Check(os.IsNotExist(err), Equals, true)
+		}
 		s.RemoveSnap(c, snapInfo)
 	}
 }
@@ -124,9 +129,14 @@ func (s *backendSuite) TestUpdatingSnapToOneWithHooks(c *C) {
 		snapInfo = s.UpdateSnap(c, snapInfo, opts, backendtest.SambaYamlWithHook, 0)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.hook.configure")
 
-		// Verify that profile "snap.samba.hook.configure" was created.
 		_, err := os.Stat(profile)
-		c.Check(err, IsNil)
+		if !opts.Classic || opts.JailMode {
+			// Verify that profile "snap.samba.hook.configure" was created.
+			c.Check(err, IsNil)
+		} else {
+			// Verify that the profile was *not* created
+			c.Check(os.IsNotExist(err), Equals, true)
+		}
 		s.RemoveSnap(c, snapInfo)
 	}
 }

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -112,13 +112,8 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 		snapInfo = s.UpdateSnap(c, snapInfo, opts, backendtest.SambaYamlV1WithNmbd, 0)
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.nmbd")
 		_, err := os.Stat(profile)
-		if !opts.Classic || opts.JailMode {
-			// file called "snap.sambda.nmbd" was created
-			c.Check(err, IsNil)
-		} else {
-			// Verify that the profile was *not* created
-			c.Check(os.IsNotExist(err), Equals, true)
-		}
+		// file called "snap.sambda.nmbd" was created
+		c.Check(err, IsNil)
 		s.RemoveSnap(c, snapInfo)
 	}
 }
@@ -130,13 +125,8 @@ func (s *backendSuite) TestUpdatingSnapToOneWithHooks(c *C) {
 		profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.hook.configure")
 
 		_, err := os.Stat(profile)
-		if !opts.Classic || opts.JailMode {
-			// Verify that profile "snap.samba.hook.configure" was created.
-			c.Check(err, IsNil)
-		} else {
-			// Verify that the profile was *not* created
-			c.Check(os.IsNotExist(err), Equals, true)
-		}
+		// Verify that profile "snap.samba.hook.configure" was created.
+		c.Check(err, IsNil)
 		s.RemoveSnap(c, snapInfo)
 	}
 }


### PR DESCRIPTION
Snaps that have "confinement: classic" that are not installed in
JailMode simply don't get a seccomp profile.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>