### PR TITLE
debian: remove unneeded conflict against the "snappy" package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,7 +47,7 @@ Depends: adduser,
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
-Conflicts: snap (<< 2013-11-29-1ubuntu1), snappy
+Conflicts: snap (<< 2013-11-29-1ubuntu1)
 Built-Using: ${misc:Built-Using}
 Description: Tool to interact with Ubuntu Core Snappy.
  Manage an Ubuntu system with snappy.


### PR DESCRIPTION
We needed this conflict a long time ago when we had a conflicting `snappy` binary (and man-page iirc). But nowdays there are no conflicts anymore.

LP: #1574114