### PR TITLE
snap: provide friendlier `snap find` message when no snaps are found

### DIFF
--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -125,7 +125,8 @@ func findSnaps(opts *client.FindOptions) error {
 
 	if len(snaps) == 0 {
 		// TRANSLATORS: the %q is the (quoted) query the user entered
-		return fmt.Errorf(i18n.G("no snaps found for %q"), opts.Query)
+		fmt.Fprintf(Stderr, i18n.G("The search %q returned 0 snaps\n"), opts.Query)
+		return nil
 	}
 
 	w := tabWriter()


### PR DESCRIPTION
One thing to argue about is if we should return exit status 0 or 1.

LP: #1606053