### PR TITLE
interfaces: misc openstack snap enablement

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -152,6 +152,7 @@ var defaultTemplate = []byte(`
   /{,usr/}bin/rev ixr,
   /{,usr/}bin/rm ixr,
   /{,usr/}bin/rmdir ixr,
+  /{,usr/}bin/run-parts ixr,
   /{,usr/}bin/sed ixr,
   /{,usr/}bin/seq ixr,
   /{,usr/}bin/sha{1,224,256,384,512}sum ixr,
@@ -235,6 +236,7 @@ var defaultTemplate = []byte(`
   # match until AppArmor kernel var is available to solve this properly (see
   # LP: #1546825 for details)
   owner @{PROC}/@{pid}/cmdline r,
+  owner @{PROC}/@{pid}/comm r,
 
   # Miscellaneous accesses
   /dev/{,u}random w,

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -69,6 +69,7 @@ var allInterfaces = []interfaces.Interface{
 	NewNetworkObserveInterface(),
 	NewNetworkSetupObserveInterface(),
 	NewOpenglInterface(),
+	NewOpenvSwitchInterface(),
 	NewOpenvSwitchSupportInterface(),
 	NewOpticalDriveInterface(),
 	NewProcessControlInterface(),

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -69,6 +69,7 @@ var allInterfaces = []interfaces.Interface{
 	NewNetworkObserveInterface(),
 	NewNetworkSetupObserveInterface(),
 	NewOpenglInterface(),
+	NewOpenvSwitchSupportInterface(),
 	NewOpticalDriveInterface(),
 	NewProcessControlInterface(),
 	NewRawUsbInterface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -68,6 +68,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewNetworkInterface())
 	c.Check(all, DeepContains, builtin.NewNetworkObserveInterface())
 	c.Check(all, DeepContains, builtin.NewOpenglInterface())
+	c.Check(all, DeepContains, builtin.NewOpenvSwitchSupportInterface())
 	c.Check(all, DeepContains, builtin.NewOpticalDriveInterface())
 	c.Check(all, DeepContains, builtin.NewProcessControlInterface())
 	c.Check(all, DeepContains, builtin.NewRawUsbInterface())

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -68,6 +68,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, DeepContains, builtin.NewNetworkInterface())
 	c.Check(all, DeepContains, builtin.NewNetworkObserveInterface())
 	c.Check(all, DeepContains, builtin.NewOpenglInterface())
+	c.Check(all, DeepContains, builtin.NewOpenvSwitchInterface())
 	c.Check(all, DeepContains, builtin.NewOpenvSwitchSupportInterface())
 	c.Check(all, DeepContains, builtin.NewOpticalDriveInterface())
 	c.Check(all, DeepContains, builtin.NewProcessControlInterface())

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -376,6 +376,11 @@ slots:
     allow-installation:
       slot-snap-type:
         - core
+  openvswitch:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
   openvswitch-support:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -376,6 +376,11 @@ slots:
     allow-installation:
       slot-snap-type:
         - core
+  openvswitch-support:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
   optical-drive:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -23,6 +23,7 @@ import "github.com/snapcore/snapd/interfaces"
 
 const libvirtConnectedPlugAppArmor = `
 /run/libvirt/libvirt-sock rw,
+/etc/libvirt/* r,
 `
 
 const libvirtConnectedPlugSecComp = `
@@ -35,6 +36,8 @@ sendto
 sendmsg
 socket
 socketpair
+listen
+accept
 `
 
 func NewLibvirtInterface() interfaces.Interface {

--- a/interfaces/builtin/openvswitch.go
+++ b/interfaces/builtin/openvswitch.go
@@ -1,0 +1,46 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import "github.com/snapcore/snapd/interfaces"
+
+const openvswitchConnectedPlugAppArmor = `
+/run/openvswitch/db.sock rw,
+`
+
+const openvswitchConnectedPlugSecComp = `
+connect
+recv
+recvmsg
+send
+sendto
+sendmsg
+socket
+socketpair
+`
+
+func NewOpenvSwitchInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "openvswitch",
+		connectedPlugAppArmor: openvswitchConnectedPlugAppArmor,
+		connectedPlugSecComp:  openvswitchConnectedPlugSecComp,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/openvswitch_support.go
+++ b/interfaces/builtin/openvswitch_support.go
@@ -1,0 +1,37 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const openvswitchSupportConnectedPlugKmod = `
+openvswitch
+`
+
+// NewOpenvSwitchSupportInterface returns a new "openvswitch-support" interface.
+func NewOpenvSwitchSupportInterface() interfaces.Interface {
+	return &commonInterface{
+		name:              "openvswitch-support",
+		connectedPlugKMod: openvswitchSupportConnectedPlugKmod,
+		reservedForOS:     true,
+	}
+}

--- a/interfaces/builtin/openvswitch_support_test.go
+++ b/interfaces/builtin/openvswitch_support_test.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+)
+
+type OpenvSwitchSupportInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&OpenvSwitchSupportInterfaceSuite{
+	iface: builtin.NewOpenvSwitchSupportInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Name:      "openvswitch-support",
+			Interface: "openvswitch-support",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "openvswitch-support",
+			Interface: "openvswitch-support",
+		},
+	},
+})
+
+func (s *OpenvSwitchSupportInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "openvswitch-support")
+}
+
+func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "openvswitch-support",
+		Interface: "openvswitch-support",
+	}})
+	c.Assert(err, ErrorMatches, "openvswitch-support slots are reserved for the operating system snap")
+}
+
+func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "openvswitch-support"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "openvswitch-support"`)
+}
+
+func (s *OpenvSwitchSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for kmod
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityKMod)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}

--- a/interfaces/builtin/openvswitch_support_test.go
+++ b/interfaces/builtin/openvswitch_support_test.go
@@ -79,16 +79,8 @@ func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) 
 }
 
 func (s *OpenvSwitchSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	// connected plugs have a non-nil security snippet for seccomp
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
 	// connected plugs have a non-nil security snippet for kmod
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityKMod)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityKMod)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }

--- a/interfaces/builtin/openvswitch_test.go
+++ b/interfaces/builtin/openvswitch_test.go
@@ -1,0 +1,90 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+)
+
+type OpenvSwitchInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&OpenvSwitchInterfaceSuite{
+	iface: builtin.NewOpenvSwitchInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Name:      "openvswitch",
+			Interface: "openvswitch",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "openvswitch",
+			Interface: "openvswitch",
+		},
+	},
+})
+
+func (s *OpenvSwitchInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "openvswitch")
+}
+
+func (s *OpenvSwitchInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "openvswitch",
+		Interface: "openvswitch",
+	}})
+	c.Assert(err, ErrorMatches, "openvswitch slots are reserved for the operating system snap")
+}
+
+func (s *OpenvSwitchInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *OpenvSwitchInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "openvswitch"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "openvswitch"`)
+}
+
+func (s *OpenvSwitchInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -29,6 +29,9 @@ const processControlConnectedPlugAppArmor = `
 # all processes under root or processes running under the same UID otherwise.
 # Usage: reserved
 
+/{,usr/}bin/nice ixr,
+
+capability sys_resource,
 capability sys_nice,
 
 signal,

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -48,6 +48,7 @@ var implicitSlots = []string{
 	"network-observe",
 	"network-setup-observe",
 	"opengl",
+	"openvswitch-support",
 	"ppp",
 	"process-control",
 	"raw-usb",

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -72,6 +72,7 @@ var implicitClassicSlots = []string{
 	"modem-manager",
 	"network-manager",
 	"ofono",
+	"openvswitch",
 	"optical-drive",
 	"pulseaudio",
 	"screen-inhibit-control",


### PR DESCRIPTION
This pull request includes two new interfaces

1) openvswitch

Allow access to ovs socket on host OS to processes within a snap

2) openvswitch-support

Simple interface to ensure openvswitch kernel module is loaded for snaps that embed openvswitch

and a number of minor updates and fixes to a) support openvswitch in a snap and b) ensure that the libvirt interface works with libvirt-python which for some reason wants to listen on the socket as well.