### PR TITLE
debian: add missing ca-certificates dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,6 +39,7 @@ Description: snappy development go packages.
 Package: snapd
 Architecture: any
 Depends: adduser,
+         ca-certificates,
          gnupg1 | gnupg,
          snap-confine (>= 1.0.43),
          squashfs-tools,


### PR DESCRIPTION
LP: #1635016