### PR TITLE
image: drop support for UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -32,7 +32,6 @@ import (
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/partition"
 	"github.com/snapcore/snapd/snap"
@@ -252,12 +251,7 @@ func bootstrapToRootDir(sto Store, model *asserts.Model, opts *Options, local *l
 	f := makeFetcher(sto, &DownloadOptions{}, db)
 
 	if err := f.Save(model); err != nil {
-		if !osutil.GetenvBool("UBUNTU_IMAGE_SKIP_COPY_UNVERIFIED_MODEL") {
-			return fmt.Errorf("cannot fetch and check prerequisites for the model assertion: %v", err)
-		} else {
-			logger.Noticef("Cannot fetch and check prerequisites for the model assertion, it will not be copied into the image: %v", err)
-			f.addedRefs = nil
-		}
+		return fmt.Errorf("cannot fetch and check prerequisites for the model assertion: %v", err)
 	}
 
 	// put snaps in place


### PR DESCRIPTION
It is no longer working and its easy enough to create your
own model assertion, e.g. http://snapcraft.io/docs/core/images

LP: #1635335
LP: #1636764