### PR TITLE
interfaces/builtin: fix incorrect udev rule in i2c

### DIFF
--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -101,7 +101,7 @@ func (iface *I2cInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *int
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
 		const pathPrefix = "/dev/"
-		const udevRule string = `KERNEL="%s", TAG+="%s"`
+		const udevRule string = `KERNEL=="%s", TAG+="%s"`
 		for appName := range plug.Apps {
 			tag := udevSnapSecurityName(plug.Snap.Name(), appName)
 			tagSnippet.WriteString(fmt.Sprintf(udevRule, strings.TrimPrefix(path, pathPrefix), tag))

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -179,7 +179,7 @@ func (s *I2cInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
 }
 
 func (s *I2cInterfaceSuite) TestConnectedPlugUdevSnippets(c *C) {
-	expectedSnippet1 := []byte(`KERNEL="i2c-1", TAG+="snap_client-snap_app-accessing-1-port"
+	expectedSnippet1 := []byte(`KERNEL=="i2c-1", TAG+="snap_client-snap_app-accessing-1-port"
 `)
 
 	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityUDev)


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/snappy/+bug/1645961
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>