### PR TITLE
asserts: introduce auto-aliases header in snap-declaration

### DIFF
--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -145,7 +145,7 @@ func checkOptionalSystemUserAuthority(headers map[string]interface{}, brandID st
 			return nil, nil
 		}
 	case []interface{}:
-		lst, err := checkStringListInMap(headers, name, fmt.Sprintf("%q header", name), validAccountID)
+		lst, err := checkStringListMatches(headers, name, validAccountID)
 		if err == nil {
 			return lst, nil
 		}

--- a/asserts/header_checks.go
+++ b/asserts/header_checks.go
@@ -209,7 +209,11 @@ func checkStringListInMap(m map[string]interface{}, name, what string, pattern *
 }
 
 func checkStringList(headers map[string]interface{}, name string) ([]string, error) {
-	return checkStringListInMap(headers, name, fmt.Sprintf("%q header", name), anyString)
+	return checkStringListMatches(headers, name, anyString)
+}
+
+func checkStringListMatches(headers map[string]interface{}, name string, pattern *regexp.Regexp) ([]string, error) {
+	return checkStringListInMap(headers, name, fmt.Sprintf("%q header", name), pattern)
 }
 
 func checkStringMatches(headers map[string]interface{}, name string, pattern *regexp.Regexp) (string, error) {

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"crypto"
 	"fmt"
+	"regexp"
 	"time"
 
 	_ "golang.org/x/crypto/sha3" // expected for digests
@@ -39,6 +40,7 @@ type SnapDeclaration struct {
 	refreshControl []string
 	plugRules      map[string]*PlugRule
 	slotRules      map[string]*SlotRule
+	topCommands    []string
 	timestamp      time.Time
 }
 
@@ -82,6 +84,11 @@ func (snapdcl *SnapDeclaration) SlotRule(interfaceName string) *SlotRule {
 	return snapdcl.slotRules[interfaceName]
 }
 
+// TopCommands returns the optional top-level commands granted to this snap.
+func (snapdcl *SnapDeclaration) TopCommands() []string {
+	return snapdcl.topCommands
+}
+
 // Implement further consistency checks.
 func (snapdcl *SnapDeclaration) checkConsistency(db RODatabase, acck *AccountKey) error {
 	if !db.IsTrustedAccount(snapdcl.AuthorityID()) {
@@ -109,6 +116,8 @@ func (snapdcl *SnapDeclaration) Prerequisites() []*Ref {
 		{Type: AccountType, PrimaryKey: []string{snapdcl.PublisherID()}},
 	}
 }
+
+var validAppCommand = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$")
 
 func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
 	_, err := checkExistsString(assert.headers, "snap-name")
@@ -165,11 +174,17 @@ func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
 		}
 	}
 
+	topCommands, err := checkStringListMatches(assert.headers, "top-commands", validAppCommand)
+	if err != nil {
+		return nil, err
+	}
+
 	return &SnapDeclaration{
 		assertionBase:  assert,
 		refreshControl: refControl,
 		plugRules:      plugRules,
 		slotRules:      slotRules,
+		topCommands:    topCommands,
 		timestamp:      timestamp,
 	}, nil
 }

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -40,7 +40,7 @@ type SnapDeclaration struct {
 	refreshControl []string
 	plugRules      map[string]*PlugRule
 	slotRules      map[string]*SlotRule
-	topCommands    []string
+	autoAliases    []string
 	timestamp      time.Time
 }
 
@@ -84,9 +84,9 @@ func (snapdcl *SnapDeclaration) SlotRule(interfaceName string) *SlotRule {
 	return snapdcl.slotRules[interfaceName]
 }
 
-// TopCommands returns the optional top-level commands granted to this snap.
-func (snapdcl *SnapDeclaration) TopCommands() []string {
-	return snapdcl.topCommands
+// AutoAliases returns the optional auto-aliases granted to this snap.
+func (snapdcl *SnapDeclaration) AutoAliases() []string {
+	return snapdcl.autoAliases
 }
 
 // Implement further consistency checks.
@@ -117,7 +117,7 @@ func (snapdcl *SnapDeclaration) Prerequisites() []*Ref {
 	}
 }
 
-var validAppCommand = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$")
+var validAlias = regexp.MustCompile("^[a-zA-Z0-9][-_.a-zA-Z0-9]*$")
 
 func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
 	_, err := checkExistsString(assert.headers, "snap-name")
@@ -174,7 +174,7 @@ func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
 		}
 	}
 
-	topCommands, err := checkStringListMatches(assert.headers, "top-commands", validAppCommand)
+	autoAliases, err := checkStringListMatches(assert.headers, "auto-aliases", validAlias)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
 		refreshControl: refControl,
 		plugRules:      plugRules,
 		slotRules:      slotRules,
-		topCommands:    topCommands,
+		autoAliases:    autoAliases,
 		timestamp:      timestamp,
 	}, nil
 }

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -60,6 +60,7 @@ func (sds *snapDeclSuite) TestDecodeOK(c *C) {
 		"snap-name: first\n" +
 		"publisher-id: dev-id1\n" +
 		"refresh-control:\n  - foo\n  - bar\n" +
+		"top-commands:\n  - cmd1\n  - cmd2\n" +
 		sds.tsLine +
 		"body-length: 0\n" +
 		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
@@ -76,6 +77,7 @@ func (sds *snapDeclSuite) TestDecodeOK(c *C) {
 	c.Check(snapDecl.SnapName(), Equals, "first")
 	c.Check(snapDecl.PublisherID(), Equals, "dev-id1")
 	c.Check(snapDecl.RefreshControl(), DeepEquals, []string{"foo", "bar"})
+	c.Check(snapDecl.TopCommands(), DeepEquals, []string{"cmd1", "cmd2"})
 }
 
 func (sds *snapDeclSuite) TestEmptySnapName(c *C) {
@@ -96,7 +98,7 @@ func (sds *snapDeclSuite) TestEmptySnapName(c *C) {
 	c.Check(snapDecl.SnapName(), Equals, "")
 }
 
-func (sds *snapDeclSuite) TestMissingRefreshControl(c *C) {
+func (sds *snapDeclSuite) TestMissingRefreshControlTopCommands(c *C) {
 	encoded := "type: snap-declaration\n" +
 		"authority-id: canonical\n" +
 		"series: 16\n" +
@@ -112,6 +114,7 @@ func (sds *snapDeclSuite) TestMissingRefreshControl(c *C) {
 	c.Assert(err, IsNil)
 	snapDecl := a.(*asserts.SnapDeclaration)
 	c.Check(snapDecl.RefreshControl(), HasLen, 0)
+	c.Check(snapDecl.TopCommands(), HasLen, 0)
 }
 
 const (
@@ -126,6 +129,7 @@ func (sds *snapDeclSuite) TestDecodeInvalid(c *C) {
 		"snap-name: first\n" +
 		"publisher-id: dev-id1\n" +
 		"refresh-control:\n  - foo\n  - bar\n" +
+		"top-commands:\n  - cmd1\n  - cmd2\n" +
 		"plugs:\n  interface1: true\n" +
 		"slots:\n  interface2: true\n" +
 		sds.tsLine +
@@ -148,6 +152,9 @@ func (sds *snapDeclSuite) TestDecodeInvalid(c *C) {
 		{"plugs:\n  interface1: true\n", "plugs:\n  intf1:\n    foo: bar\n", `plug rule for interface "intf1" must specify at least one of.*`},
 		{"slots:\n  interface2: true\n", "slots: \n", `"slots" header must be a map`},
 		{"slots:\n  interface2: true\n", "slots:\n  intf1:\n    foo: bar\n", `slot rule for interface "intf1" must specify at least one of.*`},
+		{"top-commands:\n  - cmd1\n  - cmd2\n", "top-commands: cmd0\n", `"top-commands" header must be a list of strings`},
+		{"top-commands:\n  - cmd1\n  - cmd2\n", "top-commands:\n  -\n    - nested\n", `"top-commands" header must be a list of strings`},
+		{"top-commands:\n  - cmd1\n  - cmd2\n", "top-commands:\n  - cmd_1\n  - cmd_2\n", `"top-commands" header contains an invalid element: "cmd_1"`},
 		{sds.tsLine, "", `"timestamp" header is mandatory`},
 		{sds.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{sds.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -60,7 +60,7 @@ func (sds *snapDeclSuite) TestDecodeOK(c *C) {
 		"snap-name: first\n" +
 		"publisher-id: dev-id1\n" +
 		"refresh-control:\n  - foo\n  - bar\n" +
-		"top-commands:\n  - cmd1\n  - cmd2\n" +
+		"auto-aliases:\n  - cmd1\n  - cmd_2\n  - Cmd-3\n  - CMD.4\n" +
 		sds.tsLine +
 		"body-length: 0\n" +
 		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
@@ -77,7 +77,7 @@ func (sds *snapDeclSuite) TestDecodeOK(c *C) {
 	c.Check(snapDecl.SnapName(), Equals, "first")
 	c.Check(snapDecl.PublisherID(), Equals, "dev-id1")
 	c.Check(snapDecl.RefreshControl(), DeepEquals, []string{"foo", "bar"})
-	c.Check(snapDecl.TopCommands(), DeepEquals, []string{"cmd1", "cmd2"})
+	c.Check(snapDecl.AutoAliases(), DeepEquals, []string{"cmd1", "cmd_2", "Cmd-3", "CMD.4"})
 }
 
 func (sds *snapDeclSuite) TestEmptySnapName(c *C) {
@@ -98,7 +98,7 @@ func (sds *snapDeclSuite) TestEmptySnapName(c *C) {
 	c.Check(snapDecl.SnapName(), Equals, "")
 }
 
-func (sds *snapDeclSuite) TestMissingRefreshControlTopCommands(c *C) {
+func (sds *snapDeclSuite) TestMissingRefreshControlAutoAliases(c *C) {
 	encoded := "type: snap-declaration\n" +
 		"authority-id: canonical\n" +
 		"series: 16\n" +
@@ -114,7 +114,7 @@ func (sds *snapDeclSuite) TestMissingRefreshControlTopCommands(c *C) {
 	c.Assert(err, IsNil)
 	snapDecl := a.(*asserts.SnapDeclaration)
 	c.Check(snapDecl.RefreshControl(), HasLen, 0)
-	c.Check(snapDecl.TopCommands(), HasLen, 0)
+	c.Check(snapDecl.AutoAliases(), HasLen, 0)
 }
 
 const (
@@ -129,7 +129,7 @@ func (sds *snapDeclSuite) TestDecodeInvalid(c *C) {
 		"snap-name: first\n" +
 		"publisher-id: dev-id1\n" +
 		"refresh-control:\n  - foo\n  - bar\n" +
-		"top-commands:\n  - cmd1\n  - cmd2\n" +
+		"auto-aliases:\n  - cmd1\n  - cmd2\n" +
 		"plugs:\n  interface1: true\n" +
 		"slots:\n  interface2: true\n" +
 		sds.tsLine +
@@ -152,9 +152,9 @@ func (sds *snapDeclSuite) TestDecodeInvalid(c *C) {
 		{"plugs:\n  interface1: true\n", "plugs:\n  intf1:\n    foo: bar\n", `plug rule for interface "intf1" must specify at least one of.*`},
 		{"slots:\n  interface2: true\n", "slots: \n", `"slots" header must be a map`},
 		{"slots:\n  interface2: true\n", "slots:\n  intf1:\n    foo: bar\n", `slot rule for interface "intf1" must specify at least one of.*`},
-		{"top-commands:\n  - cmd1\n  - cmd2\n", "top-commands: cmd0\n", `"top-commands" header must be a list of strings`},
-		{"top-commands:\n  - cmd1\n  - cmd2\n", "top-commands:\n  -\n    - nested\n", `"top-commands" header must be a list of strings`},
-		{"top-commands:\n  - cmd1\n  - cmd2\n", "top-commands:\n  - cmd_1\n  - cmd_2\n", `"top-commands" header contains an invalid element: "cmd_1"`},
+		{"auto-aliases:\n  - cmd1\n  - cmd2\n", "auto-aliases: cmd0\n", `"auto-aliases" header must be a list of strings`},
+		{"auto-aliases:\n  - cmd1\n  - cmd2\n", "auto-aliases:\n  -\n    - nested\n", `"auto-aliases" header must be a list of strings`},
+		{"auto-aliases:\n  - cmd1\n  - cmd2\n", "auto-aliases:\n  - _cmd-1\n  - cmd2\n", `"auto-aliases" header contains an invalid element: "_cmd-1"`},
 		{sds.tsLine, "", `"timestamp" header is mandatory`},
 		{sds.tsLine, "timestamp: \n", `"timestamp" header should not be empty`},
 		{sds.tsLine, "timestamp: 12:30\n", `"timestamp" header is not a RFC3339 date: .*`},


### PR DESCRIPTION
This introduces a auto-aliases header in snap-declaration meant to be used to grant automatically enabled aliases to a snap.