### PR TITLE
daemon: close the dup()ed file descriptor to not leak it

### DIFF
--- a/daemon/ucrednet.go
+++ b/daemon/ucrednet.go
@@ -80,6 +80,8 @@ func (wl *ucrednetListener) Accept() (net.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
+		// File() is a dup(); needs closing
+		defer f.Close()
 
 		ucred, err := getUcred(int(f.Fd()), sys.SOL_SOCKET, sys.SO_PEERCRED)
 		if err != nil {


### PR DESCRIPTION
[lp:1634885](https://bugs.launchpad.net/snappy/+bug/1634885)