### PR TITLE
Discard mount namespace on a content i/f plug connect/disconnect

### DIFF
--- a/overlord/snapstate/backend/ns.go
+++ b/overlord/snapstate/backend/ns.go
@@ -20,31 +20,9 @@
 package backend
 
 import (
-	"fmt"
-	"os/exec"
-	"path/filepath"
-
-	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap/discardns"
 )
 
-// mountNsPath returns path of the mount namespace file of a given snap
-func mountNsPath(snapName string) string {
-	// NOTE: This value has to be synchronized with snap-confine
-	return filepath.Join(dirs.SnapRunNsDir, fmt.Sprintf("%s.mnt", snapName))
-}
-
 func (b Backend) DiscardSnapNamespace(snapName string) error {
-	mntFile := mountNsPath(snapName)
-	// If there's a .mnt file that was created by snap-confine we should ask
-	// snap-confine to discard it appropriately.
-	if osutil.FileExists(mntFile) {
-		snapDiscardNs := filepath.Join(dirs.LibExecDir, "snap-discard-ns")
-		cmd := exec.Command(snapDiscardNs, snapName)
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("cannot discard preserved namespaces of snap %q: %s", snapName, osutil.OutputErr(output, err))
-		}
-	}
-	return nil
+	return discardns.DiscardSnapNamespace(snapName)
 }

--- a/overlord/snapstate/backend/ns_test.go
+++ b/overlord/snapstate/backend/ns_test.go
@@ -20,94 +20,35 @@
 package backend_test
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
-	"github.com/snapcore/snapd/progress"
-	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/snap/discardns"
 )
 
 type nsSuite struct {
-	be            backend.Backend
-	nullProgress  progress.NullProgress
-	oldLibExecDir string
+	be backend.Backend
 }
 
 var _ = Suite(&nsSuite{})
 
 func (s *nsSuite) SetUpTest(c *C) {
-	dirs.SetRootDir(c.MkDir())
-	// Mock enough bits so that we can observe calls to snap-discard-ns
-	s.oldLibExecDir = dirs.LibExecDir
 }
 
 func (s *nsSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("")
-	dirs.LibExecDir = s.oldLibExecDir
 }
 
-func (s *nsSuite) TestDiscardNamespaceMntFilePresent(c *C) {
-	// Mock the snap-discard-ns command
-	cmd := testutil.MockCommand(c, "snap-discard-ns", "")
-	dirs.LibExecDir = cmd.BinDir()
-	defer cmd.Restore()
+func (s *nsSuite) TestDiscardNamespaceInvokesDiscardNs(c *C) {
 
-	// the presence of the .mnt file is the trigger so create it now
-	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
+	var invoked bool
+	var invokedSnapName string
+	discardns.DiscardSnapNamespace = func(snapName string) error {
+		invoked = true
+		invokedSnapName = snapName
+		return nil
+	}
 
-	err := s.be.DiscardSnapNamespace("snap-name")
-	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{{"snap-discard-ns", "snap-name"}})
-}
-
-func (s *nsSuite) TestDiscardNamespaceMntFileAbsent(c *C) {
-	// Mock the snap-discard-ns command
-	cmd := testutil.MockCommand(c, "snap-discard-ns", "")
-	dirs.LibExecDir = cmd.BinDir()
-	defer cmd.Restore()
-
-	// don't create the .mnt file that triggers the discard operation
-
-	// ask the backend to discard the namespace
-	err := s.be.DiscardSnapNamespace("snap-name")
-	c.Assert(err, IsNil)
-	c.Check(cmd.Calls(), IsNil)
-}
-
-func (s *nsSuite) TestDiscardNamespaceFailure(c *C) {
-	// Mock the snap-discard-ns command, make it fail
-	cmd := testutil.MockCommand(c, "snap-discard-ns", "echo failure; exit 1;")
-	dirs.LibExecDir = cmd.BinDir()
-	defer cmd.Restore()
-
-	// the presence of the .mnt file is the trigger so create it now
-	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
-
-	// ask the backend to discard the namespace
-	err := s.be.DiscardSnapNamespace("snap-name")
-	c.Assert(err, ErrorMatches, `cannot discard preserved namespaces of snap "snap-name": failure`)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{{"snap-discard-ns", "snap-name"}})
-}
-
-func (s *nsSuite) TestDiscardNamespaceSilentFailure(c *C) {
-	// Mock the snap-discard-ns command, make it fail
-	cmd := testutil.MockCommand(c, "snap-discard-ns", "exit 1")
-	dirs.LibExecDir = cmd.BinDir()
-	defer cmd.Restore()
-
-	// the presence of the .mnt file is the trigger so create it now
-	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
-
-	// ask the backend to discard the namespace
-	err := s.be.DiscardSnapNamespace("snap-name")
-	c.Assert(err, ErrorMatches, `cannot discard preserved namespaces of snap "snap-name": exit status 1`)
-	c.Check(cmd.Calls(), DeepEquals, [][]string{{"snap-discard-ns", "snap-name"}})
+	s.be.DiscardSnapNamespace("snap-name")
+	c.Assert(invoked, Equals, true)
+	c.Assert(invokedSnapName, Equals, "snap-name")
 }

--- a/snap/discardns/discardns.go
+++ b/snap/discardns/discardns.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package discardns
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+// mountNsPath returns path of the mount namespace file of a given snap
+func mountNsPath(snapName string) string {
+	// NOTE: This value has to be synchronized with snap-confine
+	return filepath.Join(dirs.SnapRunNsDir, fmt.Sprintf("%s.mnt", snapName))
+}
+
+var DiscardSnapNamespace = func(snapName string) error {
+	mntFile := mountNsPath(snapName)
+	// If there's a .mnt file that was created by snap-confine we should ask
+	// snap-confine to discard it appropriately.
+	if osutil.FileExists(mntFile) {
+		snapDiscardNs := filepath.Join(dirs.LibExecDir, "snap-discard-ns")
+		cmd := exec.Command(snapDiscardNs, snapName)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("cannot discard preserved namespaces of snap %q: %s", snapName, osutil.OutputErr(output, err))
+		}
+	}
+	return nil
+}

--- a/snap/discardns/discardns_test.go
+++ b/snap/discardns/discardns_test.go
@@ -1,0 +1,112 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package discardns_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap/discardns"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type nsSuite struct {
+	nullProgress  progress.NullProgress
+	oldLibExecDir string
+}
+
+var _ = Suite(&nsSuite{})
+
+func (s *nsSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	// Mock enough bits so that we can observe calls to snap-discard-ns
+	s.oldLibExecDir = dirs.LibExecDir
+}
+
+func (s *nsSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+	dirs.LibExecDir = s.oldLibExecDir
+}
+
+func (s *nsSuite) TestDiscardNamespaceMntFilePresent(c *C) {
+	// Mock the snap-discard-ns command
+	cmd := testutil.MockCommand(c, "snap-discard-ns", "")
+	dirs.LibExecDir = cmd.BinDir()
+	defer cmd.Restore()
+
+	// the presence of the .mnt file is the trigger so create it now
+	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
+
+	err := discardns.DiscardSnapNamespace("snap-name")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{{"snap-discard-ns", "snap-name"}})
+}
+
+func (s *nsSuite) TestDiscardNamespaceMntFileAbsent(c *C) {
+	// Mock the snap-discard-ns command
+	cmd := testutil.MockCommand(c, "snap-discard-ns", "")
+	dirs.LibExecDir = cmd.BinDir()
+	defer cmd.Restore()
+
+	// don't create the .mnt file that triggers the discard operation
+
+	// ask to discard the namespace
+	err := discardns.DiscardSnapNamespace("snap-name")
+	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), IsNil)
+}
+
+func (s *nsSuite) TestDiscardNamespaceFailure(c *C) {
+	// Mock the snap-discard-ns command, make it fail
+	cmd := testutil.MockCommand(c, "snap-discard-ns", "echo failure; exit 1;")
+	dirs.LibExecDir = cmd.BinDir()
+	defer cmd.Restore()
+
+	// the presence of the .mnt file is the trigger so create it now
+	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
+
+	// ask to discard the namespace
+	err := discardns.DiscardSnapNamespace("snap-name")
+	c.Assert(err, ErrorMatches, `cannot discard preserved namespaces of snap "snap-name": failure`)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{{"snap-discard-ns", "snap-name"}})
+}
+
+func (s *nsSuite) TestDiscardNamespaceSilentFailure(c *C) {
+	// Mock the snap-discard-ns command, make it fail
+	cmd := testutil.MockCommand(c, "snap-discard-ns", "exit 1")
+	dirs.LibExecDir = cmd.BinDir()
+	defer cmd.Restore()
+
+	// the presence of the .mnt file is the trigger so create it now
+	c.Assert(os.MkdirAll(dirs.SnapRunNsDir, 0755), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapRunNsDir, "snap-name.mnt"), nil, 0644), IsNil)
+
+	// ask to discard the namespace
+	err := discardns.DiscardSnapNamespace("snap-name")
+	c.Assert(err, ErrorMatches, `cannot discard preserved namespaces of snap "snap-name": exit status 1`)
+	c.Check(cmd.Calls(), DeepEquals, [][]string{{"snap-discard-ns", "snap-name"}})
+}

--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -37,9 +37,33 @@ execute: |
     echo "Then the fstab files are removed"
     [ $(find /var/lib/snapd/mount -type f -name "*.fstab" | wc -l) -eq 0 ]
 
+    echo "And we cannot use the shared content"
+    test-snapd-content-plug.content-plug && ( echo "error: could still access shared content!"; exit 1 )
+
     echo "When the plug is reconnected"
     snap connect test-snapd-content-plug:shared-content-plug test-snapd-content-slot:shared-content-slot
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the fstab files are recreated"
     [ $(find /var/lib/snapd/mount -type f -name "*.fstab" | wc -l) -gt 0 ]
+
+    echo "And we can still use the shared content"
+    test-snapd-content-plug.content-plug | grep "Some shared content"
+
+    echo "Reinstalling consumer snap"
+    snap remove test-snapd-content-plug
+    snap install --edge test-snapd-content-plug
+
+    echo "and disconnecting its plug"
+    snap disconnect test-snapd-content-plug:shared-content-plug test-snapd-content-slot:shared-content-slot
+    snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
+
+    echo "prevents using the shared content"
+    test-snapd-content-plug.content-plug && ( echo "error: could still access shared content!"; exit 1 )
+
+    echo "And when the plug is reconnected"
+    snap connect test-snapd-content-plug:shared-content-plug test-snapd-content-slot:shared-content-slot
+    snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
+
+    echo "we can use the shared content"
+    test-snapd-content-plug.content-plug | grep "Some shared content"


### PR DESCRIPTION
The mount namespace will be discarded whenever a snap content plug
is connected/disconnected so that snap-confine generates or removes the
required bind mounts.

Previously, a bind mount would never be generated if a command was invoked from snap
declaring a content plug was installed prior to connecting the content plug.
Similarly, a content i/f related bind mount was not removed after disconnecting the
content plug.