### PR TITLE
interfaces/apparmor: use distinct apparmor template for classic

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -144,7 +144,12 @@ func (b *Backend) combineSnippets(snapInfo *snap.Info, opts interfaces.Confineme
 }
 
 func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippets map[string][][]byte, content map[string]*osutil.FileState) {
-	policy := defaultTemplate
+	var policy []byte
+	if opts.Classic {
+		policy = classicTemplate
+	} else {
+		policy = defaultTemplate
+	}
 	if (opts.DevMode || opts.Classic) && !opts.JailMode {
 		policy = attachPattern.ReplaceAll(policy, attachComplain)
 	}

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -341,22 +341,29 @@ var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// Classic confinement uses apparmor in complain mode by default.
 	opts:    interfaces.ConfinementOptions{Classic: true},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
+	content: "\n(classic)" + commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
 }, {
 	// Classic confinement in JailMode uses enforcing apparmor.
 	opts:    interfaces.ConfinementOptions{Classic: true, JailMode: true},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
+	content: "\n(classic)" + commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
 }}
 
 func (s *backendSuite) TestCombineSnippets(c *C) {
 	// NOTE: replace the real template with a shorter variant
-	restore := apparmor.MockTemplate([]byte("\n" +
+	restoreTemplate := apparmor.MockTemplate([]byte("\n" +
 		"###VAR###\n" +
 		"###PROFILEATTACH### (attach_disconnected) {\n" +
 		"###SNIPPETS###\n" +
 		"}\n"))
-	defer restore()
+	defer restoreTemplate()
+	restoreClassicTemplate := apparmor.MockClassicTemplate([]byte("\n" +
+		"(classic)\n" +
+		"###VAR###\n" +
+		"###PROFILEATTACH### (attach_disconnected) {\n" +
+		"###SNIPPETS###\n" +
+		"}\n"))
+	defer restoreClassicTemplate()
 	for _, scenario := range combineSnippetsScenarios {
 		s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 			if scenario.snippet == "" {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -341,12 +341,12 @@ var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// Classic confinement uses apparmor in complain mode by default.
 	opts:    interfaces.ConfinementOptions{Classic: true},
 	snippet: "snippet",
-	content: "\n(classic)" + commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
+	content: "\n#classic" + commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
 }, {
 	// Classic confinement in JailMode uses enforcing apparmor.
 	opts:    interfaces.ConfinementOptions{Classic: true, JailMode: true},
 	snippet: "snippet",
-	content: "\n(classic)" + commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
+	content: "\n#classic" + commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
 }}
 
 func (s *backendSuite) TestCombineSnippets(c *C) {
@@ -358,7 +358,7 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 		"}\n"))
 	defer restoreTemplate()
 	restoreClassicTemplate := apparmor.MockClassicTemplate([]byte("\n" +
-		"(classic)\n" +
+		"#classic\n" +
 		"###VAR###\n" +
 		"###PROFILEATTACH### (attach_disconnected) {\n" +
 		"###SNIPPETS###\n" +

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -40,3 +40,10 @@ func MockTemplate(fakeTemplate []byte) (restore func()) {
 	defaultTemplate = fakeTemplate
 	return func() { defaultTemplate = orig }
 }
+
+// MockClassicTemplate replaces the classic apprmor template.
+func MockClassicTemplate(fakeTemplate []byte) (restore func()) {
+	orig := classicTemplate
+	classicTemplate = fakeTemplate
+	return func() { classicTemplate = orig }
+}

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -378,7 +378,7 @@ var classicTemplate = []byte(`
 ###VAR###
 
 ###PROFILEATTACH### (attach_disconnected) {
-  # set file rules so that exec() inherit our profile unless there is
+  # set file rules so that exec() inherits our profile unless there is
   # already a profile for it (eg, snap-confine)
   / rwkl,
   /** rwlkm,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -363,10 +363,15 @@ var defaultTemplate = []byte(`
 }
 `)
 
-// classicTemplate contains apparmor template used for snaps with classic confinement.
+// classicTemplate contains apparmor template used for snaps with classic
+// confinement. This template was Designed by jdstrand:
+// https://github.com/snapcore/snapd/pull/2366#discussion_r90101320
+//
+// The classic template intentionally provides no confinement and is used
+// simply to ensure that processes have the proper command-specific security
+// label instead of 'unconfined'.
 //
 // It can be overridden for testing using MockClassicTemplate().
-// Designed by jdstrand https://github.com/snapcore/snapd/pull/2366#discussion_r90101320
 var classicTemplate = []byte(`
 #include <tunables/global>
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -362,3 +362,35 @@ var defaultTemplate = []byte(`
 ###SNIPPETS###
 }
 `)
+
+// classicTemplate contains apparmor template used for snaps with classic confinement.
+//
+// It can be overridden for testing using MockClassicTemplate().
+// Designed by jdstrand https://github.com/snapcore/snapd/pull/2366#discussion_r90101320
+var classicTemplate = []byte(`
+#include <tunables/global>
+
+###VAR###
+
+###PROFILEATTACH### (attach_disconnected) {
+  # set file rules so that exec() inherit our profile unless there is
+  # already a profile for it (eg, snap-confine)
+  / rwkl,
+  /** rwlkm,
+  /** pix,
+
+  capability,
+  change_profile,
+  dbus,
+  network,
+  mount,
+  remount,
+  umount,
+  pivot_root,
+  ptrace,
+  signal,
+  unix,
+
+###SNIPPETS###
+}
+`)


### PR DESCRIPTION
This patch adds a distinct apparmor template used for snaps with classic
confinement as suggested by jdstrand.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>