### PR TITLE
Add /dev/uhid to bluetooth-control interface

### DIFF
--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -43,6 +43,8 @@ const bluetoothControlConnectedPlugAppArmor = `
 
   # Requires CONFIG_BT_VHCI to be loaded
   /dev/vhci                       rw,
+  # Requires CONFIG_UHID
+  /dev/uhid                       rw,
 `
 
 const bluetoothControlConnectedPlugSecComp = `


### PR DESCRIPTION
Some of the Bluetooth devices such as BT 4.0 keyboard require access
to the /dev/uhid. So far the bluetooth-control interface disallowed
it and this commit changes this state. RW rights are added to
AppArmor rules.