### PR TITLE
snap: abort install with ctrl+c

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -391,7 +391,6 @@ func setupAbortHandler(changeId string) {
 		if err != nil {
 			fmt.Fprintf(Stderr, err.Error()+"\n")
 		}
-		os.Exit(1)
 	}()
 }
 

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -22,9 +22,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -23,8 +23,11 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"os"
+	"os/signal"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/jessevdk/go-flags"
@@ -377,6 +380,21 @@ type cmdInstall struct {
 	} `positional-args:"yes" required:"yes"`
 }
 
+func setupAbortHandler(changeId string) {
+	// Intercept sigint
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, syscall.SIGINT)
+	go func() {
+		<-c
+		cli := Client()
+		_, err := cli.Abort(changeId)
+		if err != nil {
+			fmt.Fprintf(Stderr, err.Error()+"\n")
+		}
+		os.Exit(1)
+	}()
+}
+
 func (x *cmdInstall) installOne(name string, opts *client.SnapOptions) error {
 	var err error
 	var installFromFile bool
@@ -396,6 +414,8 @@ func (x *cmdInstall) installOne(name string, opts *client.SnapOptions) error {
 	if err != nil {
 		return err
 	}
+
+	setupAbortHandler(changeID)
 
 	chg, err := wait(cli, changeID)
 	if err != nil {
@@ -428,6 +448,8 @@ func (x *cmdInstall) installMany(names []string, opts *client.SnapOptions) error
 	if err != nil {
 		return err
 	}
+
+	setupAbortHandler(changeID)
 
 	chg, err := wait(cli, changeID)
 	if err != nil {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -105,7 +105,7 @@ func (s *apiBaseSuite) SuggestedCurrency() string {
 	return s.suggestedCurrency
 }
 
-func (s *apiBaseSuite) Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, context.Context) error {
+func (s *apiBaseSuite) Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error {
 	panic("Download not expected to be called")
 }
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -39,6 +39,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/context"
 	"gopkg.in/check.v1"
 	"gopkg.in/macaroon.v1"
 
@@ -104,7 +105,7 @@ func (s *apiBaseSuite) SuggestedCurrency() string {
 	return s.suggestedCurrency
 }
 
-func (s *apiBaseSuite) Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error {
+func (s *apiBaseSuite) Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, context.Context) error {
 	panic("Download not expected to be called")
 }
 

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -31,6 +31,8 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
+
+	"golang.org/x/net/context"
 )
 
 // DownloadOptions carries options for downloading snaps plus assertions.
@@ -44,7 +46,7 @@ type DownloadOptions struct {
 // A Store can find metadata on snaps, download snaps and fetch assertions.
 type Store interface {
 	Snap(name, channel string, devmode bool, revision snap.Revision, user *auth.UserState) (*snap.Info, error)
-	Download(name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState) error
+	Download(name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState, ctx context.Context) error
 
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
 }
@@ -73,7 +75,7 @@ func DownloadSnap(sto Store, name string, revision snap.Revision, opts *Download
 	targetFn = filepath.Join(targetDir, baseName)
 
 	pb := progress.NewTextProgress()
-	if err = sto.Download(name, targetFn, &snap.DownloadInfo, pb, opts.User); err != nil {
+	if err = sto.Download(name, targetFn, &snap.DownloadInfo, pb, opts.User, nil); err != nil {
 		return "", nil, err
 	}
 

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -75,7 +75,7 @@ func DownloadSnap(sto Store, name string, revision snap.Revision, opts *Download
 	targetFn = filepath.Join(targetDir, baseName)
 
 	pb := progress.NewTextProgress()
-	if err = sto.Download(nil, name, targetFn, &snap.DownloadInfo, pb, opts.User); err != nil {
+	if err = sto.Download(context.TODO(), name, targetFn, &snap.DownloadInfo, pb, opts.User); err != nil {
 		return "", nil, err
 	}
 

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -46,7 +46,7 @@ type DownloadOptions struct {
 // A Store can find metadata on snaps, download snaps and fetch assertions.
 type Store interface {
 	Snap(name, channel string, devmode bool, revision snap.Revision, user *auth.UserState) (*snap.Info, error)
-	Download(name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState, ctx context.Context) error
+	Download(ctx context.Context, name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState) error
 
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
 }
@@ -75,7 +75,7 @@ func DownloadSnap(sto Store, name string, revision snap.Revision, opts *Download
 	targetFn = filepath.Join(targetDir, baseName)
 
 	pb := progress.NewTextProgress()
-	if err = sto.Download(name, targetFn, &snap.DownloadInfo, pb, opts.User, nil); err != nil {
+	if err = sto.Download(nil, name, targetFn, &snap.DownloadInfo, pb, opts.User); err != nil {
 		return "", nil, err
 	}
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -146,7 +146,7 @@ func (s *imageSuite) Snap(name, channel string, devmode bool, revision snap.Revi
 	return s.storeSnapInfo[name], nil
 }
 
-func (s *imageSuite) Download(name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState, ctx context.Context) error {
+func (s *imageSuite) Download(ctx context.Context, name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState) error {
 	return osutil.CopyFile(s.downloadedSnaps[name], targetFn, 0)
 }
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -145,7 +146,7 @@ func (s *imageSuite) Snap(name, channel string, devmode bool, revision snap.Revi
 	return s.storeSnapInfo[name], nil
 }
 
-func (s *imageSuite) Download(name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState) error {
+func (s *imageSuite) Download(name, targetFn string, downloadInfo *snap.DownloadInfo, pbar progress.Meter, user *auth.UserState, ctx context.Context) error {
 	return osutil.CopyFile(s.downloadedSnaps[name], targetFn, 0)
 }
 

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -95,7 +95,7 @@ func (sto *fakeStore) ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([
 	panic("fakeStore.ListRefresh not expected")
 }
 
-func (sto *fakeStore) Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, context.Context) error {
+func (sto *fakeStore) Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error {
 	panic("fakeStore.Download not expected")
 }
 

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"golang.org/x/crypto/sha3"
+	"golang.org/x/net/context"
 
 	. "gopkg.in/check.v1"
 
@@ -94,7 +95,7 @@ func (sto *fakeStore) ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([
 	panic("fakeStore.ListRefresh not expected")
 }
 
-func (sto *fakeStore) Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error {
+func (sto *fakeStore) Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, context.Context) error {
 	panic("fakeStore.Download not expected")
 }
 

--- a/overlord/devicestate/devicemgr_test.go
+++ b/overlord/devicestate/devicemgr_test.go
@@ -103,7 +103,7 @@ func (sto *fakeStore) ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([
 	panic("fakeStore.ListRefresh not expected")
 }
 
-func (sto *fakeStore) Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, context.Context) error {
+func (sto *fakeStore) Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error {
 	panic("fakeStore.Download not expected")
 }
 

--- a/overlord/devicestate/devicemgr_test.go
+++ b/overlord/devicestate/devicemgr_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
 	. "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 	"gopkg.in/yaml.v2"
@@ -102,7 +103,7 @@ func (sto *fakeStore) ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([
 	panic("fakeStore.ListRefresh not expected")
 }
 
-func (sto *fakeStore) Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error {
+func (sto *fakeStore) Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, context.Context) error {
 	panic("fakeStore.Download not expected")
 }
 

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -35,7 +35,7 @@ type StoreService interface {
 	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 	ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error)
 	Sections(user *auth.UserState) ([]string, error)
-	Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, context.Context) error
+	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error
 
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
 

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -25,6 +25,8 @@ import (
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
+
+	"golang.org/x/net/context"
 )
 
 // A StoreService can find, list available updates and download snaps.
@@ -33,7 +35,7 @@ type StoreService interface {
 	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 	ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error)
 	Sections(user *auth.UserState) ([]string, error)
-	Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error
+	Download(string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState, context.Context) error
 
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -201,7 +201,7 @@ func (f *fakeStore) SuggestedCurrency() string {
 	return "XTS"
 }
 
-func (f *fakeStore) Download(name, targetFn string, snapInfo *snap.DownloadInfo, pb progress.Meter, user *auth.UserState, ctx context.Context) error {
+func (f *fakeStore) Download(ctx context.Context, name, targetFn string, snapInfo *snap.DownloadInfo, pb progress.Meter, user *auth.UserState) error {
 	f.pokeStateLock()
 
 	var macaroon string

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -199,7 +201,7 @@ func (f *fakeStore) SuggestedCurrency() string {
 	return "XTS"
 }
 
-func (f *fakeStore) Download(name, targetFn string, snapInfo *snap.DownloadInfo, pb progress.Meter, user *auth.UserState) error {
+func (f *fakeStore) Download(name, targetFn string, snapInfo *snap.DownloadInfo, pb progress.Meter, user *auth.UserState, ctx context.Context) error {
 	f.pokeStateLock()
 
 	var macaroon string

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -424,10 +424,10 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		if err != nil {
 			return err
 		}
-		err = theStore.Download(snapsup.Name(), targetFn, &storeInfo.DownloadInfo, meter, user, tomb.Context(nil))
+		err = theStore.Download(tomb.Context(nil), snapsup.Name(), targetFn, &storeInfo.DownloadInfo, meter, user)
 		snapsup.SideInfo = &storeInfo.SideInfo
 	} else {
-		err = theStore.Download(snapsup.Name(), targetFn, snapsup.DownloadInfo, meter, user, tomb.Context(nil))
+		err = theStore.Download(tomb.Context(nil), snapsup.Name(), targetFn, snapsup.DownloadInfo, meter, user)
 	}
 	if err != nil {
 		return err

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -395,7 +395,7 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) doDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	snapsup, err := TaskSnapSetup(t)
@@ -424,10 +424,10 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 		if err != nil {
 			return err
 		}
-		err = theStore.Download(snapsup.Name(), targetFn, &storeInfo.DownloadInfo, meter, user, t.Context())
+		err = theStore.Download(snapsup.Name(), targetFn, &storeInfo.DownloadInfo, meter, user, tomb.Context(nil))
 		snapsup.SideInfo = &storeInfo.SideInfo
 	} else {
-		err = theStore.Download(snapsup.Name(), targetFn, snapsup.DownloadInfo, meter, user, t.Context())
+		err = theStore.Download(snapsup.Name(), targetFn, snapsup.DownloadInfo, meter, user, tomb.Context(nil))
 	}
 	if err != nil {
 		return err

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -424,10 +424,10 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 		if err != nil {
 			return err
 		}
-		err = theStore.Download(snapsup.Name(), targetFn, &storeInfo.DownloadInfo, meter, user, nil)
+		err = theStore.Download(snapsup.Name(), targetFn, &storeInfo.DownloadInfo, meter, user, t.Context())
 		snapsup.SideInfo = &storeInfo.SideInfo
 	} else {
-		err = theStore.Download(snapsup.Name(), targetFn, snapsup.DownloadInfo, meter, user, nil)
+		err = theStore.Download(snapsup.Name(), targetFn, snapsup.DownloadInfo, meter, user, t.Context())
 	}
 	if err != nil {
 		return err

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -424,10 +424,10 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, _ *tomb.Tomb) error {
 		if err != nil {
 			return err
 		}
-		err = theStore.Download(snapsup.Name(), targetFn, &storeInfo.DownloadInfo, meter, user)
+		err = theStore.Download(snapsup.Name(), targetFn, &storeInfo.DownloadInfo, meter, user, nil)
 		snapsup.SideInfo = &storeInfo.SideInfo
 	} else {
-		err = theStore.Download(snapsup.Name(), targetFn, snapsup.DownloadInfo, meter, user)
+		err = theStore.Download(snapsup.Name(), targetFn, snapsup.DownloadInfo, meter, user, nil)
 	}
 	if err != nil {
 		return err

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/snapcore/snapd/logger"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 type progress struct {
@@ -58,13 +56,9 @@ type Task struct {
 	readyTime time.Time
 
 	atTime time.Time
-
-	context context.Context
-	cancel  context.CancelFunc
 }
 
 func newTask(state *State, id, kind, summary string) *Task {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &Task{
 		state:   state,
 		id:      id,
@@ -73,8 +67,6 @@ func newTask(state *State, id, kind, summary string) *Task {
 		data:    make(customData),
 
 		spawnTime: timeNow(),
-		context:   ctx,
-		cancel:    cancel,
 	}
 }
 
@@ -190,11 +182,6 @@ func (t *Task) Status() Status {
 	return t.status
 }
 
-// Context return the context for this task.
-func (t *Task) Context() context.Context {
-	return t.context
-}
-
 // SetStatus sets the task status, overriding the default behavior (see Status method).
 func (t *Task) SetStatus(new Status) {
 	t.state.writing()
@@ -202,9 +189,6 @@ func (t *Task) SetStatus(new Status) {
 	t.status = new
 	if !old.Ready() && new.Ready() {
 		t.readyTime = timeNow()
-	}
-	if new == AbortStatus && t.context != nil {
-		t.cancel()
 	}
 	chg := t.Change()
 	if chg != nil {

--- a/overlord/state/task.go
+++ b/overlord/state/task.go
@@ -190,6 +190,11 @@ func (t *Task) Status() Status {
 	return t.status
 }
 
+// Context return the context for this task.
+func (t *Task) Context() context.Context {
+	return t.context
+}
+
 // SetStatus sets the task status, overriding the default behavior (see Status method).
 func (t *Task) SetStatus(new Status) {
 	t.state.writing()

--- a/store/store.go
+++ b/store/store.go
@@ -1415,6 +1415,10 @@ var download = func(ctx context.Context, name, sha3_384, downloadURL string, use
 	_, err = io.Copy(mw, resp.Body)
 	pbar.Finished()
 
+	if cancelled(ctx) {
+		return fmt.Errorf("The download has been cancelled: %s", ctx.Err())
+	}
+
 	actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
 	if sha3_384 != "" && sha3_384 != actualSha3 {
 		return fmt.Errorf("sha3-384 mismatch downloading %s: got %s but expected %s", name, actualSha3, sha3_384)

--- a/store/store.go
+++ b/store/store.go
@@ -611,7 +611,7 @@ func cancelled(ctx context.Context) bool {
 }
 
 // retryRequest uses defaultRetryStrategy to call doRequest with retry
-	func (s *Store) retryRequest(ctx context.Context, client *http.Client, reqOptions *requestOptions, user *auth.UserState) (resp *http.Response, err error) {
+func (s *Store) retryRequest(ctx context.Context, client *http.Client, reqOptions *requestOptions, user *auth.UserState) (resp *http.Response, err error) {
 	var attempt *retry.Attempt
 	startTime := time.Now()
 	for attempt = retry.Start(defaultRetryStrategy, nil); attempt.Next(); {

--- a/store/store.go
+++ b/store/store.go
@@ -1362,6 +1362,10 @@ var download = func(ctx context.Context, name, sha3_384, downloadURL string, use
 			return fmt.Errorf("The download has been cancelled: %s", ctx.Err())
 		}
 		resp, err = s.doRequest(ctx, newHTTPClient(nil), reqOptions, user)
+
+		if ctx != nil && cancelled(ctx) {
+			return fmt.Errorf("The download has been cancelled: %s", ctx.Err())
+		}
 		if err != nil {
 			if shouldRetryError(attempt, err) {
 				continue

--- a/store/store.go
+++ b/store/store.go
@@ -619,7 +619,7 @@ func (s *Store) retryRequest(ctx context.Context, client *http.Client, reqOption
 			delta := time.Since(startTime) / time.Millisecond
 			logger.Debugf("Retyring %s, attempt %d, delta time=%v ms", reqOptions.URL, attempt.Count(), delta)
 		}
-		if ctx != nil && cancelled(ctx) {
+		if cancelled(ctx) {
 			return nil, ctx.Err()
 		}
 
@@ -835,7 +835,7 @@ func (s *Store) decorateOrders(snaps []*snap.Info, channel string, user *auth.Us
 		URL:    s.ordersURI,
 		Accept: jsonContentType,
 	}
-	resp, err := s.doRequest(nil, s.client, reqOptions, user)
+	resp, err := s.doRequest(context.TODO(), s.client, reqOptions, user)
 	if err != nil {
 		return err
 	}
@@ -908,7 +908,7 @@ func (s *Store) fakeChannels(snapID string, user *auth.UserState) (map[string]*s
 		Data:        jsonData,
 	}
 
-	resp, err := s.retryRequest(nil, s.client, reqOptions, user)
+	resp, err := s.retryRequest(context.TODO(), s.client, reqOptions, user)
 	if err != nil {
 		return nil, err
 	}
@@ -969,7 +969,7 @@ func (s *Store) Snap(name, channel string, devmode bool, revision snap.Revision,
 		Accept: halJsonContentType,
 	}
 
-	resp, err := s.retryRequest(nil, s.client, reqOptions, user)
+	resp, err := s.retryRequest(context.TODO(), s.client, reqOptions, user)
 	if err != nil {
 		return nil, err
 	}
@@ -1074,7 +1074,7 @@ func (s *Store) Find(search *Search, user *auth.UserState) ([]*snap.Info, error)
 		URL:    &u,
 		Accept: halJsonContentType,
 	}
-	resp, err := s.retryRequest(nil, s.client, reqOptions, user)
+	resp, err := s.retryRequest(context.TODO(), s.client, reqOptions, user)
 	if err != nil {
 		return nil, err
 	}
@@ -1125,7 +1125,7 @@ func (s *Store) Sections(user *auth.UserState) ([]string, error) {
 		Accept: halJsonContentType,
 	}
 
-	resp, err := s.retryRequest(nil, s.client, reqOptions, user)
+	resp, err := s.retryRequest(context.TODO(), s.client, reqOptions, user)
 	if err != nil {
 		return nil, err
 	}
@@ -1240,7 +1240,7 @@ func (s *Store) ListRefresh(installed []*RefreshCandidate, user *auth.UserState)
 		}
 	}
 
-	resp, err := s.retryRequest(nil, s.client, reqOptions, user)
+	resp, err := s.retryRequest(context.TODO(), s.client, reqOptions, user)
 	if err != nil {
 		return nil, err
 	}
@@ -1374,12 +1374,12 @@ var download = func(ctx context.Context, name, sha3_384, downloadURL string, use
 
 	var resp *http.Response
 	for attempt := retry.Start(defaultRetryStrategy, nil); attempt.Next(); {
-		if ctx != nil && cancelled(ctx) {
+		if cancelled(ctx) {
 			return fmt.Errorf("The download has been cancelled: %s", ctx.Err())
 		}
 		resp, err = s.doRequest(ctx, newHTTPClient(nil), reqOptions, user)
 
-		if ctx != nil && cancelled(ctx) {
+		if cancelled(ctx) {
 			return fmt.Errorf("The download has been cancelled: %s", ctx.Err())
 		}
 		if err != nil {
@@ -1440,7 +1440,7 @@ func (s *Store) downloadDelta(deltaName string, downloadInfo *snap.DownloadInfo,
 		url = deltaInfo.DownloadURL
 	}
 
-	return download(nil, deltaName, deltaInfo.Sha3_384, url, user, s, w, 0, pbar)
+	return download(context.TODO(), deltaName, deltaInfo.Sha3_384, url, user, s, w, 0, pbar)
 }
 
 // applyDelta generates a target snap from a previously downloaded snap and a downloaded delta.
@@ -1541,7 +1541,7 @@ func (s *Store) Assertion(assertType *asserts.AssertionType, primaryKey []string
 		URL:    u,
 		Accept: asserts.MediaType,
 	}
-	resp, err := s.retryRequest(nil, s.client, reqOptions, user)
+	resp, err := s.retryRequest(context.TODO(), s.client, reqOptions, user)
 	if err != nil {
 		return nil, err
 	}
@@ -1663,7 +1663,7 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 		ContentType: jsonContentType,
 		Data:        jsonData,
 	}
-	resp, err := s.retryRequest(nil, s.client, reqOptions, user)
+	resp, err := s.retryRequest(context.TODO(), s.client, reqOptions, user)
 	if err != nil {
 		return nil, err
 	}
@@ -1732,7 +1732,7 @@ func (s *Store) ReadyToBuy(user *auth.UserState) error {
 		Accept: jsonContentType,
 	}
 
-	resp, err := s.retryRequest(nil, s.client, reqOptions, user)
+	resp, err := s.retryRequest(context.TODO(), s.client, reqOptions, user)
 	if err != nil {
 		return err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -1359,7 +1359,7 @@ var download = func(ctx context.Context, name, sha3_384, downloadURL string, use
 	var resp *http.Response
 	for attempt := retry.Start(defaultRetryStrategy, nil); attempt.Next(); {
 		if ctx != nil && cancelled(ctx) {
-			return ctx.Err()
+			return fmt.Errorf("The download has been cancelled: %s", ctx.Err())
 		}
 		resp, err = s.doRequest(ctx, newHTTPClient(nil), reqOptions, user)
 		if err != nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -36,6 +36,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
 	. "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v1"
 	"gopkg.in/retry.v1"
@@ -60,7 +61,7 @@ type remoteRepoTestSuite struct {
 	localUser *auth.UserState
 	device    *auth.DeviceState
 
-	origDownloadFunc func(string, string, string, *auth.UserState, *Store, io.ReadWriteSeeker, int64, progress.Meter) error
+	origDownloadFunc func(string, string, string, *auth.UserState, *Store, io.ReadWriteSeeker, int64, progress.Meter, context.Context) error
 	mockXDelta       *testutil.MockCmd
 }
 
@@ -265,7 +266,7 @@ func (t *remoteRepoTestSuite) expectedAuthorization(c *C, user *auth.UserState) 
 
 func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
+	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
 		c.Check(url, Equals, "anon-url")
 		w.Write([]byte("I was downloaded"))
 		return nil
@@ -277,7 +278,7 @@ func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, nil)
+	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, nil, nil)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -289,7 +290,7 @@ func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 	partialContentStr := "partial content "
 
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
+	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
 		c.Check(resume, Equals, int64(len(partialContentStr)))
 		c.Check(url, Equals, "anon-url")
 		w.Write([]byte("was downloaded"))
@@ -306,7 +307,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 	err := ioutil.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
 	c.Assert(err, IsNil)
 
-	err = t.store.Download("foo", targetFn, &snap.DownloadInfo, nil, nil)
+	err = t.store.Download("foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(targetFn)
@@ -315,7 +316,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 }
 
 func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
+	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
 		// check user is pass and auth url is used
 		c.Check(user, Equals, t.user)
 		c.Check(url, Equals, "AUTH-URL")
@@ -330,7 +331,7 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, t.user)
+	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, t.user, nil)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -340,7 +341,7 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 }
 
 func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
+	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
 		c.Check(url, Equals, "anon-url")
 
 		w.Write([]byte("I was downloaded"))
@@ -353,7 +354,7 @@ func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, t.localUser)
+	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, t.localUser, nil)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -364,7 +365,7 @@ func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
 
 func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
 	var tmpfile *os.File
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
+	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
 		tmpfile = w.(*os.File)
 		return fmt.Errorf("uh, it failed")
 	}
@@ -375,7 +376,7 @@ func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 	// simulate a failed download
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, nil)
+	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, nil, nil)
 	c.Assert(err, ErrorMatches, "uh, it failed")
 	// ... and ensure that the tempfile is removed
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
@@ -383,7 +384,7 @@ func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
 
 func (t *remoteRepoTestSuite) TestDownloadSyncFails(c *C) {
 	var tmpfile *os.File
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
+	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
 		tmpfile = w.(*os.File)
 		w.Write([]byte("sync will fail"))
 		err := tmpfile.Close()
@@ -398,7 +399,7 @@ func (t *remoteRepoTestSuite) TestDownloadSyncFails(c *C) {
 
 	// simulate a failed sync
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, nil)
+	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, nil, nil)
 	c.Assert(err, ErrorMatches, "fsync:.*")
 	// ... and ensure that the tempfile is removed
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
@@ -417,7 +418,7 @@ func (t *remoteRepoTestSuite) TestActualDownload(c *C) {
 	var buf SillyBuffer
 	// keep tests happy
 	sha3 := ""
-	err := download("foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil)
+	err := download("foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil, nil)
 	c.Assert(err, IsNil)
 	c.Check(buf.String(), Equals, "response-data")
 	c.Check(n, Equals, 1)
@@ -440,7 +441,7 @@ func (t *remoteRepoTestSuite) TestActualDownloadNonPurchased401(c *C) {
 
 	theStore := New(&Config{}, nil)
 	var buf bytes.Buffer
-	err := download("foo", "sha3", mockServer.URL, nil, theStore, nopeSeeker{&buf}, -1, nil)
+	err := download("foo", "sha3", mockServer.URL, nil, theStore, nopeSeeker{&buf}, -1, nil, nil)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot download non-free snap without purchase")
 	c.Check(n, Equals, 1)
@@ -457,7 +458,7 @@ func (t *remoteRepoTestSuite) TestActualDownload404(c *C) {
 
 	theStore := New(&Config{}, nil)
 	var buf SillyBuffer
-	err := download("foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil)
+	err := download("foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, FitsTypeOf, &ErrDownload{})
 	c.Check(err.(*ErrDownload).Code, Equals, http.StatusNotFound)
@@ -475,7 +476,7 @@ func (t *remoteRepoTestSuite) TestActualDownload500(c *C) {
 
 	theStore := New(&Config{}, nil)
 	var buf SillyBuffer
-	err := download("foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil)
+	err := download("foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, FitsTypeOf, &ErrDownload{})
 	c.Check(err.(*ErrDownload).Code, Equals, http.StatusInternalServerError)
@@ -543,7 +544,7 @@ func (t *remoteRepoTestSuite) TestActualDownloadResume(c *C) {
 	h := crypto.SHA3_384.New()
 	h.Write([]byte("some data"))
 	sha3 := fmt.Sprintf("%x", h.Sum(nil))
-	err := download("foo", sha3, mockServer.URL, nil, theStore, buf, int64(len("some ")), nil)
+	err := download("foo", sha3, mockServer.URL, nil, theStore, buf, int64(len("some ")), nil, nil)
 	c.Check(err, IsNil)
 	c.Check(buf.String(), Equals, "some data")
 	c.Check(n, Equals, 1)
@@ -608,7 +609,7 @@ func (t *remoteRepoTestSuite) TestDownloadWithDelta(c *C) {
 
 	for _, testCase := range deltaTests {
 		downloadIndex := 0
-		download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
+		download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
 			if testCase.downloads[downloadIndex].error {
 				downloadIndex++
 				return errors.New("Bang")
@@ -626,7 +627,7 @@ func (t *remoteRepoTestSuite) TestDownloadWithDelta(c *C) {
 		}
 
 		path := filepath.Join(c.MkDir(), "subdir", "downloaded-file")
-		err := t.store.Download("foo", path, &testCase.info, nil, nil)
+		err := t.store.Download("foo", path, &testCase.info, nil, nil, nil)
 
 		c.Assert(err, IsNil)
 		defer os.Remove(path)
@@ -717,7 +718,7 @@ func (t *remoteRepoTestSuite) TestDownloadDelta(c *C) {
 
 	for _, testCase := range downloadDeltaTests {
 		t.store.deltaFormat = testCase.format
-		download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
+		download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
 			expectedUser := t.user
 			if testCase.useLocalUser {
 				expectedUser = t.localUser
@@ -841,7 +842,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAuth(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -872,7 +873,7 @@ func (t *remoteRepoTestSuite) TestDoRequestDoesNotSetAuthForLocalOnlyUser(c *C) 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, reqOptions, t.localUser)
+	response, err := repo.doRequest(repo.client, nil, reqOptions, t.localUser)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -906,7 +907,7 @@ func (t *remoteRepoTestSuite) TestDoRequestAuthNoSerial(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -952,7 +953,7 @@ func (t *remoteRepoTestSuite) TestDoRequestRefreshesAuth(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1013,7 +1014,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1050,7 +1051,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 		},
 	}
 
-	response, err := repo.doRequest(repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -3607,6 +3608,6 @@ func (t *remoteRepoTestSuite) TestDoRequestSetRangeHeaderOnRedirect(c *C) {
 	}
 
 	sto := New(&Config{}, nil)
-	_, err = sto.doRequest(sto.client, reqOptions, t.user)
+	_, err = sto.doRequest(sto.client, nil, reqOptions, t.user)
 	c.Assert(err, IsNil)
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -452,10 +452,10 @@ func (t *remoteRepoTestSuite) TestDownloadCancellation(c *C) {
 		close(result)
 	}()
 
-	<- syncCh
+	<-syncCh
 	cancel()
 
-	err := <- result
+	err := <-result
 	c.Check(n, Equals, 1)
 	c.Assert(err, Equals, "The download has been cancelled: context canceled")
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3644,6 +3644,6 @@ func (t *remoteRepoTestSuite) TestDoRequestSetRangeHeaderOnRedirect(c *C) {
 	}
 
 	sto := New(&Config{}, nil)
-	_, err = sto.doRequest(nil, sto.client, reqOptions, t.user)
+	_, err = sto.doRequest(context.TODO(), sto.client, reqOptions, t.user)
 	c.Assert(err, IsNil)
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -278,7 +278,7 @@ func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, nil)
+	err := t.store.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, nil)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -307,7 +307,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 	err := ioutil.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
 	c.Assert(err, IsNil)
 
-	err = t.store.Download(nil, "foo", targetFn, &snap.DownloadInfo, nil, nil)
+	err = t.store.Download(context.TODO(), "foo", targetFn, &snap.DownloadInfo, nil, nil)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(targetFn)
@@ -331,7 +331,7 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, t.user)
+	err := t.store.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, t.user)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -354,7 +354,7 @@ func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, t.localUser)
+	err := t.store.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, t.localUser)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -376,7 +376,7 @@ func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 	// simulate a failed download
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, nil)
+	err := t.store.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, nil)
 	c.Assert(err, ErrorMatches, "uh, it failed")
 	// ... and ensure that the tempfile is removed
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
@@ -399,7 +399,7 @@ func (t *remoteRepoTestSuite) TestDownloadSyncFails(c *C) {
 
 	// simulate a failed sync
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, nil)
+	err := t.store.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, nil)
 	c.Assert(err, ErrorMatches, "fsync:.*")
 	// ... and ensure that the tempfile is removed
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
@@ -418,7 +418,7 @@ func (t *remoteRepoTestSuite) TestActualDownload(c *C) {
 	var buf SillyBuffer
 	// keep tests happy
 	sha3 := ""
-	err := download(nil, "foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil)
+	err := download(context.TODO(), "foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil)
 	c.Assert(err, IsNil)
 	c.Check(buf.String(), Equals, "response-data")
 	c.Check(n, Equals, 1)
@@ -477,7 +477,7 @@ func (t *remoteRepoTestSuite) TestActualDownloadNonPurchased401(c *C) {
 
 	theStore := New(&Config{}, nil)
 	var buf bytes.Buffer
-	err := download(nil, "foo", "sha3", mockServer.URL, nil, theStore, nopeSeeker{&buf}, -1, nil)
+	err := download(context.TODO(), "foo", "sha3", mockServer.URL, nil, theStore, nopeSeeker{&buf}, -1, nil)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot download non-free snap without purchase")
 	c.Check(n, Equals, 1)
@@ -494,7 +494,7 @@ func (t *remoteRepoTestSuite) TestActualDownload404(c *C) {
 
 	theStore := New(&Config{}, nil)
 	var buf SillyBuffer
-	err := download(nil, "foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil)
+	err := download(context.TODO(), "foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, FitsTypeOf, &ErrDownload{})
 	c.Check(err.(*ErrDownload).Code, Equals, http.StatusNotFound)
@@ -512,7 +512,7 @@ func (t *remoteRepoTestSuite) TestActualDownload500(c *C) {
 
 	theStore := New(&Config{}, nil)
 	var buf SillyBuffer
-	err := download(nil, "foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil)
+	err := download(context.TODO(), "foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, FitsTypeOf, &ErrDownload{})
 	c.Check(err.(*ErrDownload).Code, Equals, http.StatusInternalServerError)
@@ -580,7 +580,7 @@ func (t *remoteRepoTestSuite) TestActualDownloadResume(c *C) {
 	h := crypto.SHA3_384.New()
 	h.Write([]byte("some data"))
 	sha3 := fmt.Sprintf("%x", h.Sum(nil))
-	err := download(nil, "foo", sha3, mockServer.URL, nil, theStore, buf, int64(len("some ")), nil)
+	err := download(context.TODO(), "foo", sha3, mockServer.URL, nil, theStore, buf, int64(len("some ")), nil)
 	c.Check(err, IsNil)
 	c.Check(buf.String(), Equals, "some data")
 	c.Check(n, Equals, 1)
@@ -663,7 +663,7 @@ func (t *remoteRepoTestSuite) TestDownloadWithDelta(c *C) {
 		}
 
 		path := filepath.Join(c.MkDir(), "subdir", "downloaded-file")
-		err := t.store.Download(nil, "foo", path, &testCase.info, nil, nil)
+		err := t.store.Download(context.TODO(), "foo", path, &testCase.info, nil, nil)
 
 		c.Assert(err, IsNil)
 		defer os.Remove(path)
@@ -878,7 +878,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAuth(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -909,7 +909,7 @@ func (t *remoteRepoTestSuite) TestDoRequestDoesNotSetAuthForLocalOnlyUser(c *C) 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(nil, repo.client, reqOptions, t.localUser)
+	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, t.localUser)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -943,7 +943,7 @@ func (t *remoteRepoTestSuite) TestDoRequestAuthNoSerial(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -989,7 +989,7 @@ func (t *remoteRepoTestSuite) TestDoRequestRefreshesAuth(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1050,7 +1050,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1087,7 +1087,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 		},
 	}
 
-	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
+	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -61,7 +61,7 @@ type remoteRepoTestSuite struct {
 	localUser *auth.UserState
 	device    *auth.DeviceState
 
-	origDownloadFunc func(string, string, string, *auth.UserState, *Store, io.ReadWriteSeeker, int64, progress.Meter, context.Context) error
+	origDownloadFunc func(context.Context, string, string, string, *auth.UserState, *Store, io.ReadWriteSeeker, int64, progress.Meter) error
 	mockXDelta       *testutil.MockCmd
 }
 
@@ -266,7 +266,7 @@ func (t *remoteRepoTestSuite) expectedAuthorization(c *C, user *auth.UserState) 
 
 func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
+	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		c.Check(url, Equals, "anon-url")
 		w.Write([]byte("I was downloaded"))
 		return nil
@@ -278,7 +278,7 @@ func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, nil, nil)
+	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, nil)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -290,7 +290,7 @@ func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 	partialContentStr := "partial content "
 
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
+	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		c.Check(resume, Equals, int64(len(partialContentStr)))
 		c.Check(url, Equals, "anon-url")
 		w.Write([]byte("was downloaded"))
@@ -307,7 +307,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 	err := ioutil.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
 	c.Assert(err, IsNil)
 
-	err = t.store.Download("foo", targetFn, &snap.DownloadInfo, nil, nil, nil)
+	err = t.store.Download(nil, "foo", targetFn, &snap.DownloadInfo, nil, nil)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(targetFn)
@@ -316,7 +316,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 }
 
 func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
+	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		// check user is pass and auth url is used
 		c.Check(user, Equals, t.user)
 		c.Check(url, Equals, "AUTH-URL")
@@ -331,7 +331,7 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, t.user, nil)
+	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, t.user)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -341,7 +341,7 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 }
 
 func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
+	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		c.Check(url, Equals, "anon-url")
 
 		w.Write([]byte("I was downloaded"))
@@ -354,7 +354,7 @@ func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, t.localUser, nil)
+	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, t.localUser)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -365,7 +365,7 @@ func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
 
 func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
 	var tmpfile *os.File
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
+	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		tmpfile = w.(*os.File)
 		return fmt.Errorf("uh, it failed")
 	}
@@ -376,7 +376,7 @@ func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
 	snap.DownloadURL = "AUTH-URL"
 	// simulate a failed download
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, nil, nil)
+	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, nil)
 	c.Assert(err, ErrorMatches, "uh, it failed")
 	// ... and ensure that the tempfile is removed
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
@@ -384,7 +384,7 @@ func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
 
 func (t *remoteRepoTestSuite) TestDownloadSyncFails(c *C) {
 	var tmpfile *os.File
-	download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
+	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		tmpfile = w.(*os.File)
 		w.Write([]byte("sync will fail"))
 		err := tmpfile.Close()
@@ -399,7 +399,7 @@ func (t *remoteRepoTestSuite) TestDownloadSyncFails(c *C) {
 
 	// simulate a failed sync
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := t.store.Download("foo", path, &snap.DownloadInfo, nil, nil, nil)
+	err := t.store.Download(nil, "foo", path, &snap.DownloadInfo, nil, nil)
 	c.Assert(err, ErrorMatches, "fsync:.*")
 	// ... and ensure that the tempfile is removed
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
@@ -418,7 +418,7 @@ func (t *remoteRepoTestSuite) TestActualDownload(c *C) {
 	var buf SillyBuffer
 	// keep tests happy
 	sha3 := ""
-	err := download("foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil, nil)
+	err := download(nil, "foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil)
 	c.Assert(err, IsNil)
 	c.Check(buf.String(), Equals, "response-data")
 	c.Check(n, Equals, 1)
@@ -441,7 +441,7 @@ func (t *remoteRepoTestSuite) TestActualDownloadNonPurchased401(c *C) {
 
 	theStore := New(&Config{}, nil)
 	var buf bytes.Buffer
-	err := download("foo", "sha3", mockServer.URL, nil, theStore, nopeSeeker{&buf}, -1, nil, nil)
+	err := download(nil, "foo", "sha3", mockServer.URL, nil, theStore, nopeSeeker{&buf}, -1, nil)
 	c.Assert(err, NotNil)
 	c.Check(err.Error(), Equals, "cannot download non-free snap without purchase")
 	c.Check(n, Equals, 1)
@@ -458,7 +458,7 @@ func (t *remoteRepoTestSuite) TestActualDownload404(c *C) {
 
 	theStore := New(&Config{}, nil)
 	var buf SillyBuffer
-	err := download("foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil, nil)
+	err := download(nil, "foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, FitsTypeOf, &ErrDownload{})
 	c.Check(err.(*ErrDownload).Code, Equals, http.StatusNotFound)
@@ -476,7 +476,7 @@ func (t *remoteRepoTestSuite) TestActualDownload500(c *C) {
 
 	theStore := New(&Config{}, nil)
 	var buf SillyBuffer
-	err := download("foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil, nil)
+	err := download(nil, "foo", "sha3", mockServer.URL, nil, theStore, &buf, 0, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, FitsTypeOf, &ErrDownload{})
 	c.Check(err.(*ErrDownload).Code, Equals, http.StatusInternalServerError)
@@ -544,7 +544,7 @@ func (t *remoteRepoTestSuite) TestActualDownloadResume(c *C) {
 	h := crypto.SHA3_384.New()
 	h.Write([]byte("some data"))
 	sha3 := fmt.Sprintf("%x", h.Sum(nil))
-	err := download("foo", sha3, mockServer.URL, nil, theStore, buf, int64(len("some ")), nil, nil)
+	err := download(nil, "foo", sha3, mockServer.URL, nil, theStore, buf, int64(len("some ")), nil)
 	c.Check(err, IsNil)
 	c.Check(buf.String(), Equals, "some data")
 	c.Check(n, Equals, 1)
@@ -609,7 +609,7 @@ func (t *remoteRepoTestSuite) TestDownloadWithDelta(c *C) {
 
 	for _, testCase := range deltaTests {
 		downloadIndex := 0
-		download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
+		download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 			if testCase.downloads[downloadIndex].error {
 				downloadIndex++
 				return errors.New("Bang")
@@ -627,7 +627,7 @@ func (t *remoteRepoTestSuite) TestDownloadWithDelta(c *C) {
 		}
 
 		path := filepath.Join(c.MkDir(), "subdir", "downloaded-file")
-		err := t.store.Download("foo", path, &testCase.info, nil, nil, nil)
+		err := t.store.Download(nil, "foo", path, &testCase.info, nil, nil)
 
 		c.Assert(err, IsNil)
 		defer os.Remove(path)
@@ -718,7 +718,7 @@ func (t *remoteRepoTestSuite) TestDownloadDelta(c *C) {
 
 	for _, testCase := range downloadDeltaTests {
 		t.store.deltaFormat = testCase.format
-		download = func(name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter, ctx context.Context) error {
+		download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 			expectedUser := t.user
 			if testCase.useLocalUser {
 				expectedUser = t.localUser
@@ -842,7 +842,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAuth(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
+	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -873,7 +873,7 @@ func (t *remoteRepoTestSuite) TestDoRequestDoesNotSetAuthForLocalOnlyUser(c *C) 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, nil, reqOptions, t.localUser)
+	response, err := repo.doRequest(nil, repo.client, reqOptions, t.localUser)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -907,7 +907,7 @@ func (t *remoteRepoTestSuite) TestDoRequestAuthNoSerial(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
+	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -953,7 +953,7 @@ func (t *remoteRepoTestSuite) TestDoRequestRefreshesAuth(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
+	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1014,7 +1014,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
+	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1051,7 +1051,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 		},
 	}
 
-	response, err := repo.doRequest(repo.client, nil, reqOptions, t.user)
+	response, err := repo.doRequest(nil, repo.client, reqOptions, t.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -3608,6 +3608,6 @@ func (t *remoteRepoTestSuite) TestDoRequestSetRangeHeaderOnRedirect(c *C) {
 	}
 
 	sto := New(&Config{}, nil)
-	_, err = sto.doRequest(sto.client, nil, reqOptions, t.user)
+	_, err = sto.doRequest(nil, sto.client, reqOptions, t.user)
 	c.Assert(err, IsNil)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
+			"path": "context",
+			"revision": ""
+		},
+		{
 			"checksumSHA1": "f4UJKXymPS31lDRMfsmPA4PvwVw=",
 			"path": "github.com/cheggaaa/pb",
 			"revision": "6e9d17711bb763b26b68b3931d47f24c1323abab",
@@ -106,10 +110,10 @@
 			"revisionTime": "2016-10-25T18:07:18Z"
 		},
 		{
-			"checksumSHA1": "WiyCOMvfzRdymImAJ3ME6aoYUdM=",
+			"checksumSHA1": "RDshSIhn01+axeOW8yQ9TR88cZQ=",
 			"path": "gopkg.in/tomb.v2",
-			"revision": "14b3d72120e8d10ea6e6b7f87f7175734b1faab8",
-			"revisionTime": "2014-06-26T14:46:23Z"
+			"revision": "9dde971544235898fc9720ed594059f79fd3273c",
+			"revisionTime": "2016-11-14T17:47:44Z"
 		},
 		{
 			"checksumSHA1": "hiOUviIMDKo7y918uBiEhfJyOkk=",


### PR DESCRIPTION
Abort snap install via ctrl+c. Includes update to the latest tomb package.

LP: #1592074