### PR TITLE
store: fix unhandled error from io.Copy() in download()

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1387,12 +1387,16 @@ var download = func(name, sha3_384, downloadURL string, user *auth.UserState, s 
 	mw := io.MultiWriter(w, h, pbar)
 	_, err = io.Copy(mw, resp.Body)
 	pbar.Finished()
+	if err != nil {
+		return err
+	}
 
 	actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
 	if sha3_384 != "" && sha3_384 != actualSha3 {
 		return fmt.Errorf("sha3-384 mismatch downloading %s: got %s but expected %s", name, actualSha3, sha3_384)
 	}
-	return err
+
+	return nil
 }
 
 // downloadDelta downloads the delta for the preferred format, returning the path.


### PR DESCRIPTION
Thanks: Gustavo!

Testing this is tricky as I can not force an EOF (or similar error) from the httptest.Server, I only have a HttpResponseWriter to work with. Ideas very welcome.