### PR TITLE
interfaces/builtin: updates to dcdbas-control interface

### DIFF
--- a/interfaces/builtin/dcdbas_control.go
+++ b/interfaces/builtin/dcdbas_control.go
@@ -45,6 +45,22 @@ const dcdbasControlConnectedPlugAppArmor = `
 /sys/devices/platform/dcdbas/host_control_action rw,
 /sys/devices/platform/dcdbas/host_control_smi_type rw,
 /sys/devices/platform/dcdbas/host_control_on_shutdown rw,
+
+# additional devices required by dchbas library
+/dev/EsmBASDev r,
+/dev/port r,
+/dev/mem r,
+/dev/char/mem/smbios r,
+/dev/char/mem/pir r,
+/dev/char/mem/rci r,
+/proc/bus/pci r,
+`
+
+var dcdbasControlConnectedPlugSecComp = `
+# Description: Allow use of iopl system call.
+
+# Change IO privilege level
+iopl
 `
 
 // NewHardwareObserveInterface returns a new "dcdbas-control" interface.
@@ -52,6 +68,7 @@ func NewDcdbasControlInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "dcdbas-control",
 		connectedPlugAppArmor: dcdbasControlConnectedPlugAppArmor,
+		connectedPlugSecComp:  dcdbasControlConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/dcdbas_control_test.go
+++ b/interfaces/builtin/dcdbas_control_test.go
@@ -85,4 +85,10 @@ func (s *DcdbasControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 	c.Assert(string(snippet), testutil.Contains, `/dcdbas/smi_data`)
+
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	c.Assert(string(snippet), testutil.Contains, `iopl`)
 }


### PR DESCRIPTION
Added additional /dev and /proc nodes to the interface.
Also added the iopl (set IO privilege) system call to
the interface's ConnectedPlugSecComp.