### PR TITLE
many: add support for classic confinement

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -81,6 +81,7 @@ const (
 
 	StrictConfinement  = "strict"
 	DevModeConfinement = "devmode"
+	ClassicConfinement = "classic"
 )
 
 type ResultInfo struct {

--- a/client/packages.go
+++ b/client/packages.go
@@ -47,6 +47,7 @@ type Snap struct {
 	Confinement   string        `json:"confinement"`
 	Private       bool          `json:"private"`
 	DevMode       bool          `json:"devmode"`
+	JailMode      bool          `json:"jailmode"`
 	TryMode       bool          `json:"trymode"`
 	Apps          []AppInfo     `json:"apps"`
 	Broken        string        `json:"broken"`

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -191,6 +191,7 @@ func sendSnapFile(snapPath string, snapFile *os.File, pw *io.PipeWriter, mw *mul
 		mw.WriteField("channel", action.Channel),
 		mw.WriteField("devmode", strconv.FormatBool(action.DevMode)),
 		mw.WriteField("jailmode", strconv.FormatBool(action.JailMode)),
+		mw.WriteField("classic", strconv.FormatBool(action.Classic)),
 		mw.WriteField("dangerous", strconv.FormatBool(action.Dangerous)),
 	}
 	for _, err := range errs {

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -35,6 +35,7 @@ type SnapOptions struct {
 	Revision         string `json:"revision,omitempty"`
 	DevMode          bool   `json:"devmode,omitempty"`
 	JailMode         bool   `json:"jailmode,omitempty"`
+	Classic          bool   `json:"classic,omitempty"`
 	Dangerous        bool   `json:"dangerous,omitempty"`
 	IgnoreValidation bool   `json:"ignore-validation,omitempty"`
 }

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -193,7 +193,7 @@ func (s *SnapSuite) TestListWithNotes(c *check.C) {
 {"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17, "trymode": true}
 ,{"name": "dm1", "status": "active", "version": "5", "revision":1, "devmode": true, "confinement": "devmode"}
 ,{"name": "dm2", "status": "active", "version": "5", "revision":1, "devmode": true, "confinement": "strict"}
-,{"name": "cf1", "status": "active", "version": "6", "revision":2, "confinement": "devmode"}
+,{"name": "cf1", "status": "active", "version": "6", "revision":2, "confinement": "devmode", "jailmode": true}
 ]}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -177,9 +177,12 @@ func runSnapConfine(info *snap.Info, securityTag, snapApp, command, hook string,
 
 	cmd := []string{
 		filepath.Join(dirs.LibExecDir, "snap-confine"),
-		securityTag,
-		filepath.Join(dirs.LibExecDir, "snap-exec"),
 	}
+	if info.NeedsClassic() {
+		cmd = append(cmd, "--classic")
+	}
+	cmd = append(cmd, securityTag)
+	cmd = append(cmd, filepath.Join(dirs.LibExecDir, "snap-exec"))
 
 	if command != "" {
 		cmd = append(cmd, "--command="+command)

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -342,11 +342,13 @@ func (mx *channelMixin) asksForChannel() bool {
 type modeMixin struct {
 	DevMode  bool `long:"devmode"`
 	JailMode bool `long:"jailmode"`
+	Classic  bool `long:"classic"`
 }
 
 var modeDescs = mixinDescs{
 	"devmode":  i18n.G("Request non-enforcing security"),
 	"jailmode": i18n.G("Override a snap's request for non-enforcing security"),
+	"classic":  i18n.G("Consent to use classic confinement"),
 }
 
 var errModeConflict = errors.New(i18n.G("cannot use devmode and jailmode flags together"))
@@ -474,6 +476,7 @@ func (x *cmdInstall) Execute([]string) error {
 		Channel:   x.Channel,
 		DevMode:   x.DevMode,
 		JailMode:  x.JailMode,
+		Classic:   x.Classic,
 		Revision:  x.Revision,
 		Dangerous: dangerous,
 	}

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -346,9 +346,9 @@ type modeMixin struct {
 }
 
 var modeDescs = mixinDescs{
-	"devmode":  i18n.G("Request non-enforcing security"),
-	"jailmode": i18n.G("Override a snap's request for non-enforcing security"),
-	"classic":  i18n.G("Consent to use classic confinement"),
+	"classic":  i18n.G("Put snap in classic mode and disable security confinement"),
+	"devmode":  i18n.G("Put snap in development mode and disable security confinement"),
+	"jailmode": i18n.G("Put snap in enforced confinement mode"),
 }
 
 var errModeConflict = errors.New(i18n.G("cannot use devmode and jailmode flags together"))

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -276,6 +276,31 @@ func (s *SnapOpSuite) TestInstallPathDevMode(c *check.C) {
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
 
+func (s *SnapOpSuite) TestInstallPathClassic(c *check.C) {
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps")
+		postData, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, check.IsNil)
+		c.Assert(string(postData), check.Matches, "(?s).*\r\nsnap-data\r\n.*")
+		c.Assert(string(postData), check.Matches, "(?s).*Content-Disposition: form-data; name=\"action\"\r\n\r\ninstall\r\n.*")
+		c.Assert(string(postData), check.Matches, "(?s).*Content-Disposition: form-data; name=\"classic\"\r\n\r\ntrue\r\n.*")
+	}
+
+	snapBody := []byte("snap-data")
+	s.RedirectClientToTestServer(s.srv.handle)
+	snapPath := filepath.Join(c.MkDir(), "foo.snap")
+	err := ioutil.WriteFile(snapPath, snapBody, 0644)
+	c.Assert(err, check.IsNil)
+
+	rest, err := snap.Parser().ParseArgs([]string{"install", "--classic", snapPath})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from 'bar' installed`)
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
 func (s *SnapOpSuite) TestInstallPathDangerous(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps")

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -207,6 +207,25 @@ func (s *SnapOpSuite) TestInstallDevMode(c *check.C) {
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
 
+func (s *SnapOpSuite) TestInstallClassic(c *check.C) {
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action":  "install",
+			"classic": true,
+		})
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser().ParseArgs([]string{"install", "--classic", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Matches, `(?sm).*foo 1.0 from 'bar' installed`)
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
 func (s *SnapOpSuite) TestInstallPath(c *check.C) {
 	s.srv.checker = func(r *http.Request) {
 		c.Check(r.URL.Path, check.Equals, "/v2/snaps")

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -55,6 +55,7 @@ type Notes struct {
 	Private  bool
 	DevMode  bool
 	JailMode bool
+	Classic  bool
 	TryMode  bool
 	Disabled bool
 	Broken   bool
@@ -62,7 +63,8 @@ type Notes struct {
 
 func NotesFromRef(ref *snap.Ref) *Notes {
 	return &Notes{
-		DevMode: ref.Confinement != client.StrictConfinement,
+		DevMode: ref.Confinement == client.DevModeConfinement,
+		Classic: ref.Confinement == client.ClassicConfinement,
 	}
 }
 
@@ -70,6 +72,7 @@ func NotesFromRemote(snap *client.Snap, resInfo *client.ResultInfo) *Notes {
 	notes := &Notes{
 		Private: snap.Private,
 		DevMode: snap.Confinement == client.DevModeConfinement,
+		Classic: snap.Confinement == client.ClassicConfinement,
 	}
 	if resInfo != nil {
 		notes.Price = getPriceString(snap.Prices, resInfo.SuggestedCurrency, snap.Status)
@@ -83,6 +86,7 @@ func NotesFromLocal(snap *client.Snap) *Notes {
 	return &Notes{
 		Private:  snap.Private,
 		DevMode:  snap.DevMode,
+		Classic:  snap.Confinement == client.ClassicConfinement,
 		JailMode: jailMode,
 		TryMode:  snap.TryMode,
 		Disabled: snap.Status != client.StatusActive,
@@ -94,6 +98,7 @@ func NotesFromInfo(info *snap.Info) *Notes {
 	return &Notes{
 		Private: info.Private,
 		DevMode: info.Confinement == client.DevModeConfinement,
+		Classic: info.Confinement == client.ClassicConfinement,
 		Broken:  info.Broken != "",
 	}
 }
@@ -119,6 +124,10 @@ func (n *Notes) String() string {
 
 	if n.JailMode {
 		ns = append(ns, "jailmode")
+	}
+
+	if n.Classic {
+		ns = append(ns, "classic")
 	}
 
 	if n.Private {

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -82,12 +82,11 @@ func NotesFromRemote(snap *client.Snap, resInfo *client.ResultInfo) *Notes {
 }
 
 func NotesFromLocal(snap *client.Snap) *Notes {
-	jailMode := snap.Confinement == client.DevModeConfinement && !snap.DevMode
 	return &Notes{
 		Private:  snap.Private,
-		DevMode:  snap.DevMode,
-		Classic:  !jailMode && snap.Confinement == client.ClassicConfinement,
-		JailMode: jailMode,
+		DevMode:  !snap.JailMode && (snap.DevMode || snap.Confinement == client.DevModeConfinement),
+		Classic:  !snap.JailMode && (snap.Confinement == client.ClassicConfinement),
+		JailMode: snap.JailMode,
 		TryMode:  snap.TryMode,
 		Disabled: snap.Status != client.StatusActive,
 		Broken:   snap.Broken != "",

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -86,7 +86,7 @@ func NotesFromLocal(snap *client.Snap) *Notes {
 	return &Notes{
 		Private:  snap.Private,
 		DevMode:  snap.DevMode,
-		Classic:  snap.Confinement == client.ClassicConfinement,
+		Classic:  !jailMode && snap.Confinement == client.ClassicConfinement,
 		JailMode: jailMode,
 		TryMode:  snap.TryMode,
 		Disabled: snap.Status != client.StatusActive,

--- a/cmd/snap/notes_test.go
+++ b/cmd/snap/notes_test.go
@@ -57,6 +57,12 @@ func (notesSuite) TestNotesJailMode(c *check.C) {
 	}).String(), check.Equals, "jailmode")
 }
 
+func (notesSuite) TestNotesClassic(c *check.C) {
+	c.Check((&snap.Notes{
+		Classic: true,
+	}).String(), check.Equals, "classic")
+}
+
 func (notesSuite) TestNotesTryMode(c *check.C) {
 	c.Check((&snap.Notes{
 		TryMode: true,

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1233,8 +1233,7 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	dangerousOK := isTrue(form, "dangerous")
-	devmode := isTrue(form, "devmode")
-	flags, err := modeFlags(devmode, isTrue(form, "jailmode"), isTrue(form, "classic"))
+	flags, err := modeFlags(isTrue(form, "devmode"), isTrue(form, "jailmode"), isTrue(form, "classic"))
 	if err != nil {
 		return BadRequest(err.Error())
 	}
@@ -1313,7 +1312,7 @@ out:
 		case asserts.ErrNotFound:
 			// with devmode we try to find assertions but it's ok
 			// if they are not there (implies --dangerous)
-			if !devmode {
+			if !isTrue(form, "devmode") {
 				msg := "cannot find signatures with metadata for snap"
 				if origPath != "" {
 					msg = fmt.Sprintf("%s %q", msg, origPath)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -804,7 +804,7 @@ func modeFlags(devMode, jailMode, classic bool) (snapstate.Flags, error) {
 	case devMode && classic:
 		return flags, errClassicDevmodeConflict
 	}
-	// NOTE: jailmode and classic are allowed together In that setting,
+	// NOTE: jailmode and classic are allowed together. In that setting,
 	// jailmode overrides classic and the app gets regular (non-classic)
 	// confinement.
 	flags.JailMode = jailMode

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -789,7 +789,7 @@ func withEnsureUbuntuCore(st *state.State, targetSnap string, userID int, instal
 	return []*state.TaskSet{ts}, nil
 }
 
-var errModeConflict = errors.New("cannot use devmode and jailmode flags together")
+var errDevJailModeConflict = errors.New("cannot use devmode and jailmode flags together")
 var errClassicDevmodeConflict = errors.New("cannot use classic and devmode flags together")
 var errNoJailMode = errors.New("this system cannot honour the jailmode flag")
 
@@ -800,7 +800,7 @@ func modeFlags(devMode, jailMode, classic bool) (snapstate.Flags, error) {
 	case jailMode && devModeOS:
 		return flags, errNoJailMode
 	case jailMode && devMode:
-		return flags, errModeConflict
+		return flags, errDevJailModeConflict
 	case devMode && classic:
 		return flags, errClassicDevmodeConflict
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -305,6 +305,7 @@ func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {
 			"resource":    "/v2/snaps/foo",
 			"private":     false,
 			"devmode":     false,
+			"jailmode":    false,
 			"confinement": snap.StrictConfinement,
 			"trymode":     false,
 			"apps":        []appJSON{},

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -400,7 +400,6 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"oldDefaultSnapCoreName",
 		"errModeConflict",
 		"errNoJailMode",
-		"errClassicJailmodeConflict",
 		"errClassicDevmodeConflict",
 		// snapInstruction vars:
 		"snapInstructionDispTable",

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -400,6 +400,8 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"oldDefaultSnapCoreName",
 		"errModeConflict",
 		"errNoJailMode",
+		"errClassicJailmodeConflict",
+		"errClassicDevmodeConflict",
 		// snapInstruction vars:
 		"snapInstructionDispTable",
 		"snapstateInstall",

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -399,7 +399,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"errNothingToInstall",
 		"defaultCoreSnapName",
 		"oldDefaultSnapCoreName",
-		"errModeConflict",
+		"errDevJailModeConflict",
 		"errNoJailMode",
 		"errClassicDevmodeConflict",
 		// snapInstruction vars:

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -167,6 +167,7 @@ func mapLocal(localSnap *snap.Info, snapst *snapstate.SnapState) map[string]inte
 		"confinement":    localSnap.Confinement,
 		"devmode":        snapst.DevMode,
 		"trymode":        snapst.TryMode,
+		"jailmode":       snapst.JailMode,
 		"private":        localSnap.Private,
 		"apps":           apps,
 		"broken":         localSnap.Broken,

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -145,7 +145,7 @@ func (b *Backend) combineSnippets(snapInfo *snap.Info, opts interfaces.Confineme
 
 func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippets map[string][][]byte, content map[string]*osutil.FileState) {
 	var policy []byte
-	if opts.Classic {
+	if opts.Classic && !opts.JailMode {
 		policy = classicTemplate
 	} else {
 		policy = defaultTemplate

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -346,7 +346,7 @@ var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// Classic confinement in JailMode uses enforcing apparmor.
 	opts:    interfaces.ConfinementOptions{Classic: true, JailMode: true},
 	snippet: "snippet",
-	content: "\n#classic" + commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
 }}
 
 func (s *backendSuite) TestCombineSnippets(c *C) {

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -195,6 +195,14 @@ var combineSnippetsScenarios = []combineSnippetsScenario{{
 	opts:    interfaces.ConfinementOptions{DevMode: true},
 	snippet: "snippet",
 	content: "@complain\ndefault\nsnippet\n",
+}, {
+	opts:    interfaces.ConfinementOptions{Classic: true},
+	snippet: "snippet",
+	content: "@unrestricted\ndefault\nsnippet\n",
+}, {
+	opts:    interfaces.ConfinementOptions{Classic: true, JailMode: true},
+	snippet: "snippet",
+	content: "default\nsnippet\n",
 }}
 
 func (s *backendSuite) TestCombineSnippets(c *C) {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -40,7 +40,7 @@ func confinementOptions(flags snapstate.Flags) interfaces.ConfinementOptions {
 	return interfaces.ConfinementOptions{
 		DevMode:  flags.DevMode,
 		JailMode: flags.JailMode,
-		// TODO: map Classic when it shows up in snapstate.Flags
+		Classic:  flags.Classic,
 	}
 }
 

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -113,8 +113,13 @@ func checkSnap(st *state.State, snapFilePath string, si *snap.SideInfo, curInfo 
 	if s.NeedsDevMode() && !flags.DevModeAllowed() {
 		return fmt.Errorf("snap %q requires devmode or confinement override", s.Name())
 	}
-	if s.NeedsClassic() && !flags.Classic {
-		return fmt.Errorf("snap %q requires consent to use classic confinement", s.Name())
+	if s.NeedsClassic() {
+		if !release.OnClassic {
+			return fmt.Errorf("snap %q requires classic confinement which is only available on classic systems")
+		}
+		if !flags.Classic {
+			return fmt.Errorf("snap %q requires consent to use classic confinement", s.Name())
+		}
 	}
 
 	// verify we have a valid architecture

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -115,7 +115,7 @@ func checkSnap(st *state.State, snapFilePath string, si *snap.SideInfo, curInfo 
 	}
 	if s.NeedsClassic() {
 		if !release.OnClassic {
-			return fmt.Errorf("snap %q requires classic confinement which is only available on classic systems")
+			return fmt.Errorf("snap %q requires classic confinement which is only available on classic systems", s.Name())
 		}
 		if !flags.Classic {
 			return fmt.Errorf("snap %q requires consent to use classic confinement", s.Name())

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -113,6 +113,9 @@ func checkSnap(st *state.State, snapFilePath string, si *snap.SideInfo, curInfo 
 	if s.NeedsDevMode() && !flags.DevModeAllowed() {
 		return fmt.Errorf("snap %q requires devmode or confinement override", s.Name())
 	}
+	if s.NeedsClassic() && !flags.Classic {
+		return fmt.Errorf("snap %q requires consent to use classic confinement", s.Name())
+	}
 
 	// verify we have a valid architecture
 	if !arch.IsSupportedArchitecture(s.Architectures) {

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -26,7 +26,7 @@ type Flags struct {
 	// JailMode is set when the user has requested confinement
 	// always be enforcing, even if the snap requests otherwise.
 	JailMode bool `json:"jailmode,omitempty"`
-	// Classic is set when the user has made consent to install a snap with
+	// Classic is set when the user has consented to install a snap with
 	// classic confinement and the snap declares that confinement.
 	Classic bool `json:"classic,omitempty"`
 	// TryMode is set for snaps installed to try directly from a local directory.

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -26,6 +26,9 @@ type Flags struct {
 	// JailMode is set when the user has requested confinement
 	// always be enforcing, even if the snap requests otherwise.
 	JailMode bool `json:"jailmode,omitempty"`
+	// Classic is set when the user has made consent to install a snap with
+	// classic confinement and the snap declares that confinement.
+	Classic bool `json:"classic,omitempty"`
 	// TryMode is set for snaps installed to try directly from a local directory.
 	TryMode bool `json:"trymode,omitempty"`
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -826,6 +826,8 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.DevMode = snapsup.DevMode
 	oldJailMode := snapst.JailMode
 	snapst.JailMode = snapsup.JailMode
+	oldClassic := snapst.Classic
+	snapst.Classic = snapsup.Classic
 
 	newInfo, err := readInfo(snapsup.Name(), cand)
 	if err != nil {
@@ -856,6 +858,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	t.Set("old-trymode", oldTryMode)
 	t.Set("old-devmode", oldDevMode)
 	t.Set("old-jailmode", oldJailMode)
+	t.Set("old-classic", oldClassic)
 	t.Set("old-channel", oldChannel)
 	t.Set("old-current", oldCurrent)
 	t.Set("old-candidate-index", oldCandidateIndex)
@@ -913,6 +916,11 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		return err
 	}
+	var oldClassic bool
+	err = t.Get("old-classic", &oldClassic)
+	if err != nil {
+		return err
+	}
 	var oldCurrent snap.Revision
 	err = t.Get("old-current", &oldCurrent)
 	if err != nil {
@@ -944,6 +952,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.TryMode = oldTryMode
 	snapst.DevMode = oldDevMode
 	snapst.JailMode = oldJailMode
+	snapst.Classic = oldClassic
 
 	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo)
 	if err != nil {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -31,11 +31,15 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 )
 
 func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup) (*state.TaskSet, error) {
+	if snapsup.Flags.Classic && !release.OnClassic {
+		return nil, fmt.Errorf("Classic confinement is only supported on classic systems")
+	}
 	if err := checkChangeConflict(st, snapsup.Name(), snapst); err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -38,7 +38,7 @@ import (
 
 func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup) (*state.TaskSet, error) {
 	if snapsup.Flags.Classic && !release.OnClassic {
-		return nil, fmt.Errorf("Classic confinement is only supported on classic systems")
+		return nil, fmt.Errorf("classic confinement is only supported on classic systems")
 	}
 	if err := checkChangeConflict(st, snapsup.Name(), snapst); err != nil {
 		return nil, err

--- a/snap/info.go
+++ b/snap/info.go
@@ -255,7 +255,7 @@ func (s *Info) XdgRuntimeDirs() string {
 	return filepath.Join(dirs.XdgRuntimeDirGlob, fmt.Sprintf("snap.%s", s.Name()))
 }
 
-// NeedsDevMode retursn whether the snap needs devmode.
+// NeedsDevMode returns whether the snap needs devmode.
 func (s *Info) NeedsDevMode() bool {
 	return s.Confinement == DevModeConfinement
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -260,6 +260,11 @@ func (s *Info) NeedsDevMode() bool {
 	return s.Confinement == DevModeConfinement
 }
 
+// NeedsClassic  returns whether the snap needs classic confinement consent.
+func (s *Info) NeedsClassic() bool {
+	return s.Confinement == ClassicConfinement
+}
+
 // DownloadInfo contains the information to download a snap.
 // It can be marshalled.
 type DownloadInfo struct {


### PR DESCRIPTION
This  branch adds support for "snap install --classic" throughout the stack.