### PR TITLE
snapstate/backend: add backend methods to manage aliases

### DIFF
--- a/overlord/snapstate/backend/aliases.go
+++ b/overlord/snapstate/backend/aliases.go
@@ -1,0 +1,123 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+// Alias represents a command alias with a name and its application target.
+type Alias struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
+}
+
+// MissingAliases returns the subset of aliases that are missing on disk.
+func (b Backend) MissingAliases(aliases []*Alias) ([]*Alias, error) {
+	var res []*Alias
+	for _, cand := range aliases {
+		_, err := os.Lstat(filepath.Join(dirs.SnapBinariesDir, cand.Name))
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, err
+			}
+			res = append(res, cand)
+		}
+	}
+	return res, nil
+}
+
+// MatchingAliases returns the subset of aliases that exist on disk and have the expected targets.
+func (b Backend) MatchingAliases(aliases []*Alias) ([]*Alias, error) {
+	var res []*Alias
+	for _, cand := range aliases {
+		fn := filepath.Join(dirs.SnapBinariesDir, cand.Name)
+		fileInfo, err := os.Lstat(fn)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, err
+			}
+			continue
+		}
+		if (fileInfo.Mode() & os.ModeSymlink) != 0 {
+			target, err := os.Readlink(fn)
+			if err != nil {
+				return nil, err
+			}
+			if target == cand.Target {
+				res = append(res, cand)
+			}
+		}
+	}
+	return res, nil
+}
+
+// UpdateAliases adds and removes the given aliases.
+func (b Backend) UpdateAliases(add []*Alias, remove []*Alias) error {
+	for _, alias := range add {
+		err := os.Symlink(alias.Target, filepath.Join(dirs.SnapBinariesDir, alias.Name))
+		if err != nil {
+			return fmt.Errorf("cannot create alias symlink: %v", err)
+		}
+	}
+
+	for _, alias := range remove {
+		err := os.Remove(filepath.Join(dirs.SnapBinariesDir, alias.Name))
+		if err != nil {
+			return fmt.Errorf("cannot remove alias symlink: %v", err)
+		}
+	}
+	return nil
+}
+
+// RemoveSnapAliases removes all the aliases targeting the given snap.
+func (b Backend) RemoveSnapAliases(snapName string) error {
+	cands, err := filepath.Glob(filepath.Join(dirs.SnapBinariesDir, "*"))
+	if err != nil {
+		return err
+	}
+	prefix := fmt.Sprintf("%s.", snapName)
+	var firstErr error
+	// best effort
+	for _, cand := range cands {
+		if osutil.IsSymlink(cand) {
+			target, err := os.Readlink(cand)
+			if err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			if target == snapName || strings.HasPrefix(target, prefix) {
+				err := os.Remove(cand)
+				if err != nil && firstErr == nil {
+					firstErr = fmt.Errorf("cannot remove alias symlink: %v", err)
+				}
+			}
+		}
+	}
+	return firstErr
+}

--- a/overlord/snapstate/backend/aliases_test.go
+++ b/overlord/snapstate/backend/aliases_test.go
@@ -1,0 +1,114 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package backend_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+)
+
+type aliasesSuite struct {
+	be backend.Backend
+}
+
+var _ = Suite(&aliasesSuite{})
+
+func (s *aliasesSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
+	c.Assert(err, IsNil)
+}
+
+func (s *aliasesSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+}
+
+func (s *aliasesSuite) TestMissingAliases(c *C) {
+	err := os.Symlink("x.foo", filepath.Join(dirs.SnapBinariesDir, "foo"))
+	c.Assert(err, IsNil)
+
+	aliases, err := s.be.MissingAliases([]*backend.Alias{{"a", "a"}, {"foo", "foo"}})
+	c.Assert(err, IsNil)
+	c.Check(aliases, DeepEquals, []*backend.Alias{{"a", "a"}})
+}
+
+func (s *aliasesSuite) TestMatchingAliases(c *C) {
+	err := os.Symlink("x.foo", filepath.Join(dirs.SnapBinariesDir, "foo"))
+	c.Assert(err, IsNil)
+	err = os.Symlink("y.bar", filepath.Join(dirs.SnapBinariesDir, "bar"))
+	c.Assert(err, IsNil)
+
+	aliases, err := s.be.MatchingAliases([]*backend.Alias{{"a", "a"}, {"foo", "x.foo"}, {"bar", "x.bar"}})
+	c.Assert(err, IsNil)
+	c.Check(aliases, DeepEquals, []*backend.Alias{{"foo", "x.foo"}})
+}
+
+func (s *aliasesSuite) TestUpdateAliasesAdd(c *C) {
+	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+
+	err := s.be.UpdateAliases(aliases, nil)
+	c.Assert(err, IsNil)
+
+	match, err := s.be.MatchingAliases(aliases)
+	c.Assert(err, IsNil)
+	c.Check(match, HasLen, len(aliases))
+}
+
+func (s *aliasesSuite) TestUpdateAliasesRemove(c *C) {
+	aliases := []*backend.Alias{{"foo", "x.foo"}, {"bar", "x.bar"}}
+
+	err := s.be.UpdateAliases(aliases, nil)
+	c.Assert(err, IsNil)
+
+	match, err := s.be.MatchingAliases(aliases)
+	c.Assert(err, IsNil)
+	c.Check(match, HasLen, len(aliases))
+
+	err = s.be.UpdateAliases(nil, aliases)
+	c.Assert(err, IsNil)
+
+	missing, err := s.be.MissingAliases(aliases)
+	c.Assert(err, IsNil)
+	c.Check(missing, HasLen, len(aliases))
+
+	match, err = s.be.MatchingAliases(aliases)
+	c.Assert(err, IsNil)
+	c.Check(match, HasLen, 0)
+}
+
+func (s *aliasesSuite) TestRemoveSnapAliases(c *C) {
+	aliases := []*backend.Alias{{"x", "x"}, {"bar", "x.bar"}, {"baz", "y.baz"}, {"y", "y"}}
+
+	err := s.be.UpdateAliases(aliases, nil)
+	c.Assert(err, IsNil)
+
+	err = s.be.RemoveSnapAliases("x")
+	c.Assert(err, IsNil)
+
+	match, err := s.be.MatchingAliases(aliases)
+	c.Assert(err, IsNil)
+	c.Check(match, DeepEquals, []*backend.Alias{{"baz", "y.baz"}, {"y", "y"}})
+}


### PR DESCRIPTION
This adds  methods to the snapstate backend to manage aliases:

* methods to verify how the aliases on disk match expectations
* a method to update (adding and/or removing) aliases
* a robust method (that considers only what is on disk) to remove the aliases for a given snap