### PR TITLE
spread.yaml: run dmesg -c with sudo and log the id before running it

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -100,7 +100,8 @@ prepare-each: |
     journalctl --rotate
     sleep .1
     journalctl --vacuum-time=1ms
-    dmesg -c > /dev/null
+    id
+    sudo dmesg -c > /dev/null
 
 debug-each: |
     journalctl -u snapd


### PR DESCRIPTION
The autopkgtest runs still seem to fail on non-x86 arches. It would appear that this dmesg -c line is being run as a normal user instead of root. This adds an 'id' call as a sanity check, and uses sudo for the dmesg -c.