### PR TITLE
snap-confine,debian: disable XDG_RUNTIME_DIR support, package snap-confine

### DIFF
--- a/cmd/snap-confine/error.h
+++ b/cmd/snap-confine/error.h
@@ -71,7 +71,7 @@ struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
  * The error domain acts as a namespace for error codes.
  * No change of ownership takes place.
  **/
-__attribute__ ((warn_unused_result, nonnull, returns_nonnull))
+__attribute__ ((warn_unused_result, returns_nonnull))
 const char *sc_error_domain(struct sc_error *err);
 
 /**
@@ -84,7 +84,7 @@ const char *sc_error_domain(struct sc_error *err);
  * can rely on programmatically. This can be used to return an error message
  * without having to allocate a distinct code for each one.
  **/
-__attribute__ ((warn_unused_result, nonnull))
+__attribute__ ((warn_unused_result))
 int sc_error_code(struct sc_error *err);
 
 /**
@@ -93,7 +93,7 @@ int sc_error_code(struct sc_error *err);
  * The error message is bound to the life-cycle of the error object.
  * No change of ownership takes place.
  **/
-__attribute__ ((warn_unused_result, nonnull, returns_nonnull))
+__attribute__ ((warn_unused_result, returns_nonnull))
 const char *sc_error_msg(struct sc_error *err);
 
 /**
@@ -142,7 +142,7 @@ void sc_error_forward(struct sc_error **recipient, struct sc_error *error);
  * It is okay to match a NULL error, the function simply returns false in that
  * case. The domain cannot be NULL though.
  **/
-__attribute__ ((warn_unused_result, nonnull(2)))
+__attribute__ ((warn_unused_result))
 bool sc_error_match(struct sc_error *error, const char *domain, int code);
 
 #endif

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -127,7 +127,9 @@ int main(int argc, char **argv)
 	}
 	// Ensure that the user data path exists.
 	setup_user_data();
+#if 0
 	setup_user_xdg_runtime_dir();
+#endif
 
 	// https://wiki.ubuntu.com/SecurityTeam/Specifications/SnappyConfinement
 	sc_maybe_aa_change_onexec(&apparmor, security_tag);

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,13 @@ Source: snapd
 Section: devel
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Build-Depends: bash-completion,
+Build-Depends: autoconf,
+               automake,
+               autotools-dev,
+               bash-completion,
                debhelper (>= 9),
+               dh-apparmor,
+               dh-autoreconf,
                dh-golang (>=1.7),
                dh-systemd,
                fakeroot,
@@ -11,9 +16,17 @@ Build-Depends: bash-completion,
                gnupg2,
                golang-any (>=2:1.6) | golang-1.6,
                golang-github-gosexy-gettext-dev,
+               indent,
+               libapparmor-dev,
+               libglib2.0-dev,
+               libseccomp-dev,
+               libudev-dev,
+               pkg-config,
                python3,
+               python3-docutils,
                python3-markdown,
-               squashfs-tools
+               squashfs-tools,
+               udev
 Standards-Version: 3.9.7
 Homepage: https://github.com/snapcore/snapd
 Vcs-Browser: https://github.com/snapcore/snapd
@@ -39,15 +52,21 @@ Description: snappy development go packages.
 Package: snapd
 Architecture: any
 Depends: adduser,
+         apparmor (>= 2.10.95-0ubuntu2.2),
          gnupg1 | gnupg,
-         snap-confine (>= 1.0.43),
          squashfs-tools,
          systemd,
          ${misc:Depends},
          ${shlibs:Depends}
-Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
-Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)
-Conflicts: snap (<< 2013-11-29-1ubuntu1)
+Replaces: snap-confine,
+          ubuntu-core-launcher,
+          ubuntu-snappy (<< 1.9),
+          ubuntu-snappy-cli (<< 1.9)
+Breaks: snap-confine,
+        ubuntu-core-launcher,
+        ubuntu-snappy (<< 1.9),
+        ubuntu-snappy-cli (<< 1.9)
+Conflicts: snap (<< 2013-11-29-1ubuntu1), snap-confine, ubuntu-core-launcher
 Built-Using: ${misc:Built-Using}
 Description: Tool to interact with Ubuntu Core Snappy.
  Install, configure, refresh and remove snap packages. Snaps are

--- a/debian/golang-github-snapcore-snapd-dev.install
+++ b/debian/golang-github-snapcore-snapd-dev.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/share/gocode/src/*

--- a/debian/rules
+++ b/debian/rules
@@ -47,8 +47,30 @@ ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
 	TAGS=-tags withtestkeys
 endif
 
+# export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+# DPKG_EXPORT_BUILDFLAGS = 1
+# include /usr/share/dpkg/buildflags.mk
+
+# Currently, we enable confinement for Ubuntu only, not for derivatives,
+# because derivatives may have different kernels that don't support all the
+# required confinement features and we don't to mislead anyone about the
+# security of the system.  Discuss a proper approach to this for downstreams
+# if and when they approach us
+ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
+    VENDOR_ARGS=--enable-nvidia-ubuntu
+else
+    VENDOR_ARGS=--disable-apparmor
+endif
+
 %:
 	dh $@ --buildsystem=golang --with=golang --fail-missing --with systemd --builddirectory=_build
+
+override_dh_fixperms:
+	dh_fixperms -Xusr/lib/snapd/snap-confine
+
+override_dh_installdeb:
+	dh_apparmor --profile-name=usr.lib.snapd.snap-confine -psnapd
+	dh_installdeb
 
 override_dh_clean:
 ifneq (,$(TEST_GITHUB_AUTOPKGTEST))
@@ -63,12 +85,18 @@ ifneq (,$(TEST_GITHUB_AUTOPKGTEST))
         )
 endif
 	dh_clean
+	# XXX: hacky
+	$(MAKE) -C cmd clean || true
 
 override_dh_auto_build:
+	# Build golang bits
 	mkdir -p _build/src/$(DH_GOPKG)/cmd/snap/test-data
 	cp -a cmd/snap/test-data/*.gpg _build/src/$(DH_GOPKG)/cmd/snap/test-data/
 	dh_auto_build -- $(BUILDFLAGS) $(TAGS) $(GCCGOFLAGS)
-
+	# Build C bits, sadly manually
+	cd cmd && ( autoreconf -i -f )
+	cd cmd && ( ./configure --prefix=/usr --libexecdir=/usr/lib/snapd $(VENDOR_ARGS))
+	$(MAKE) -C cmd all
 
 override_dh_auto_test:
 	dh_auto_test -- $(GCCGOFLAGS)
@@ -133,15 +161,12 @@ override_dh_install:
 	rm -f ${CURDIR}/debian/tmp/usr/bin/snappy
 	# install dev package files
 	mkdir -p debian/golang-github-snapcore-snapd-dev/usr/share
+	rm -rf debian/tmp/usr/share/gocode/src/github.com/snapcore/snapd/cmd/snap-confine
 	cp -R debian/tmp/usr/share/gocode debian/golang-github-snapcore-snapd-dev/usr/share
 	# install udev stuff, must be installed before 80-udisks
 	install debian/snapd.autoimport.udev -D debian/snapd/lib/udev/rules.d/66-snapd-autoimport.rules
 
-	# install binaries and needed files
-	install debian/tmp/usr/bin/snap -D debian/snapd/usr/bin/snap
-	install debian/tmp/usr/bin/snapctl -D debian/snapd/usr/bin/snapctl
-	install debian/tmp/usr/bin/snapd -D debian/snapd/usr/lib/snapd
-	install debian/tmp/usr/bin/snap-exec -D debian/snapd/usr/lib/snapd
+	# install bash completion files
 	install --mode=0644 data/completion/snap -D debian/snapd/usr/share/bash-completion/completions/snap
 	# i18n stuff
 	mkdir -p debian/snapd/usr/share
@@ -165,6 +190,8 @@ ifeq ($(RELEASE),trusty)
 	dh_link debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.service debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/multi-user.target.wants/snapd.service
 	dh_link debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/snapd.autoimport.service debian/snapd/$(SYSTEMD_UNITS_DESTDIR)/multi-user.target.wants/snapd.autoimport.service
 endif
+	$(MAKE) -C cmd install DESTDIR=$(CURDIR)/debian/tmp
+	dh_install
 
 override_dh_auto_install: snap.8
 	dh_auto_install -O--buildsystem=golang

--- a/debian/rules
+++ b/debian/rules
@@ -86,7 +86,7 @@ ifneq (,$(TEST_GITHUB_AUTOPKGTEST))
 endif
 	dh_clean
 	# XXX: hacky
-	$(MAKE) -C cmd clean || true
+	$(MAKE) -C cmd distclean || true
 
 override_dh_auto_build:
 	# Build golang bits

--- a/debian/snapd.dirs
+++ b/debian/snapd.dirs
@@ -6,4 +6,5 @@ var/lib/snapd/environment
 var/lib/snapd/firstboot
 var/lib/snapd/lib/gl
 var/lib/snapd/snaps/partial
+var/lib/snapd/void
 var/snap

--- a/debian/snapd.install
+++ b/debian/snapd.install
@@ -1,0 +1,12 @@
+etc/apparmor.d/usr.lib.snapd.snap-confine
+lib/udev/rules.d/80-snappy-assign.rules
+lib/udev/snappy-app-dev
+usr/bin/snap
+usr/bin/snap-exec /usr/lib/snapd/
+usr/bin/snapctl
+usr/bin/snapd /usr/lib/snapd/
+usr/bin/ubuntu-core-launcher
+usr/lib/snapd/snap-confine
+usr/lib/snapd/snap-discard-ns
+usr/share/man/man1/*
+usr/share/man/man5/*


### PR DESCRIPTION
NOTE: this is a test pull request, don't really land this yet.