### PR TITLE
cmd/snap-confine: don't use __attribute__((nonull))

### DIFF
--- a/cmd/snap-confine/error.h
+++ b/cmd/snap-confine/error.h
@@ -71,7 +71,7 @@ struct sc_error *sc_error_init_from_errno(int errno_copy, const char *msgfmt,
  * The error domain acts as a namespace for error codes.
  * No change of ownership takes place.
  **/
-__attribute__ ((warn_unused_result, nonnull, returns_nonnull))
+__attribute__ ((warn_unused_result, returns_nonnull))
 const char *sc_error_domain(struct sc_error *err);
 
 /**
@@ -84,7 +84,7 @@ const char *sc_error_domain(struct sc_error *err);
  * can rely on programmatically. This can be used to return an error message
  * without having to allocate a distinct code for each one.
  **/
-__attribute__ ((warn_unused_result, nonnull))
+__attribute__ ((warn_unused_result))
 int sc_error_code(struct sc_error *err);
 
 /**
@@ -93,7 +93,7 @@ int sc_error_code(struct sc_error *err);
  * The error message is bound to the life-cycle of the error object.
  * No change of ownership takes place.
  **/
-__attribute__ ((warn_unused_result, nonnull, returns_nonnull))
+__attribute__ ((warn_unused_result, returns_nonnull))
 const char *sc_error_msg(struct sc_error *err);
 
 /**
@@ -142,7 +142,7 @@ void sc_error_forward(struct sc_error **recipient, struct sc_error *error);
  * It is okay to match a NULL error, the function simply returns false in that
  * case. The domain cannot be NULL though.
  **/
-__attribute__ ((warn_unused_result, nonnull(2)))
+__attribute__ ((warn_unused_result))
 bool sc_error_match(struct sc_error *error, const char *domain, int code);
 
 #endif


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>