### PR TITLE
cmd/snap-confine/tests: fix stale path after move to snapd

### DIFF
--- a/cmd/snap-confine/tests/Makefile.am
+++ b/cmd/snap-confine/tests/Makefile.am
@@ -29,7 +29,7 @@ TESTS += $(all_tests)
 endif
 endif
 
-check: ../src/snap-confine
+check: ../snap-confine
 
 .PHONY: check-syntax
 check-syntax:

--- a/cmd/snap-confine/tests/common.sh
+++ b/cmd/snap-confine/tests/common.sh
@@ -30,7 +30,7 @@ set_thread_area
 EOF
 }
 
-L="$(pwd)/../src/snap-confine"
+L="$(pwd)/../snap-confine"
 export L
 
 TMP="$(mktemp -d)"


### PR DESCRIPTION
This patch adjusts paths used in older tests of snap-confine to be
compatible with the tree layout after the merge into snapd.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>