### PR TITLE
misc: fix crash when $v is not set (set -u)

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -7,12 +7,12 @@ if which git >/dev/null; then
     o=git
 fi
 
-if [ -z "$v" ]; then
+if [ -z "${v:-}" ]; then
     v="$(dpkg-parsechangelog --show-field Version)"
     o=debian/changelog
 fi
 
-if [ -z "$v" ]; then
+if [ -z "${v:-}" ]; then
     exit 1
 fi
 


### PR DESCRIPTION
This fixes a FTBFS in the PPA and is important for the 2.19 release.