### PR TITLE
snap/snapenv: don't obscure HOME if snap uses classic confinement

### DIFF
--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -87,12 +87,18 @@ func basicEnv(info *snap.Info) map[string]string {
 // used by so many other modules, we run into circular dependencies if it's
 // somewhere more reasonable like the snappy module.
 func userEnv(info *snap.Info, home string) map[string]string {
-	return map[string]string{
-		"HOME":             info.UserDataDir(home),
+	result := map[string]string{
 		"SNAP_USER_COMMON": info.UserCommonDataDir(home),
 		"SNAP_USER_DATA":   info.UserDataDir(home),
 		"XDG_RUNTIME_DIR":  info.UserXdgRuntimeDir(os.Geteuid()),
 	}
+	if info.NeedsClassic() {
+		// Classic confinement allows snaps to see the real home
+		result["HOME"] = home
+	} else {
+		result["HOME"] = info.UserDataDir(home)
+	}
+	return result
 }
 
 // envMap creates a map from the given environment string list, e.g. the

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -92,9 +92,8 @@ func userEnv(info *snap.Info, home string) map[string]string {
 		"SNAP_USER_DATA":   info.UserDataDir(home),
 		"XDG_RUNTIME_DIR":  info.UserXdgRuntimeDir(os.Geteuid()),
 	}
-	if info.NeedsClassic() {
-		// Classic confinement allows snaps to see the real home
-	} else {
+	// Classic confinement allows snaps to see the real home
+	if !info.NeedsClassic() {
 		result["HOME"] = info.UserDataDir(home)
 	}
 	return result

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -92,7 +92,7 @@ func userEnv(info *snap.Info, home string) map[string]string {
 		"SNAP_USER_DATA":   info.UserDataDir(home),
 		"XDG_RUNTIME_DIR":  info.UserXdgRuntimeDir(os.Geteuid()),
 	}
-	// Classic confinement allows snaps to see the real home
+	// For non-classic snaps, we set HOME but on classic allow snaps to see real HOME
 	if !info.NeedsClassic() {
 		result["HOME"] = info.UserDataDir(home)
 	}

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -94,7 +94,6 @@ func userEnv(info *snap.Info, home string) map[string]string {
 	}
 	if info.NeedsClassic() {
 		// Classic confinement allows snaps to see the real home
-		result["HOME"] = home
 	} else {
 		result["HOME"] = info.UserDataDir(home)
 	}

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -95,7 +95,7 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 	env := userEnv(mockClassicSnapInfo, "/root")
 
 	c.Assert(env, DeepEquals, map[string]string{
-		"HOME":             "/root",
+		// NOTE HOME Is absent! we no longer override it
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
 		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", os.Geteuid()),

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -54,6 +54,14 @@ var mockSnapInfo = &snap.Info{
 		Revision: snap.R(17),
 	},
 }
+var mockClassicSnapInfo = &snap.Info{
+	SuggestedName: "foo",
+	Version:       "1.0",
+	SideInfo: snap.SideInfo{
+		Revision: snap.R(17),
+	},
+	Confinement: snap.ClassicConfinement,
+}
 
 func (ts *HTestSuite) TestBasic(c *C) {
 	env := basicEnv(mockSnapInfo)
@@ -77,6 +85,17 @@ func (ts *HTestSuite) TestUser(c *C) {
 
 	c.Assert(env, DeepEquals, map[string]string{
 		"HOME":             "/root/snap/foo/17",
+		"SNAP_USER_COMMON": "/root/snap/foo/common",
+		"SNAP_USER_DATA":   "/root/snap/foo/17",
+		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", os.Geteuid()),
+	})
+}
+
+func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
+	env := userEnv(mockClassicSnapInfo, "/root")
+
+	c.Assert(env, DeepEquals, map[string]string{
+		"HOME":             "/root",
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
 		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", os.Geteuid()),


### PR DESCRIPTION
This patch allows snaps using `confinement: classic` to see the real
value of the HOME environment variable. While all `$SNAP_` environment
variables are present and have their usual values it allows snaps to
migrate data from the home directory into the proper location.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>