### PR TITLE
removing circular dependency between snapstate and hookstate

### DIFF
--- a/overlord/configstate/config/configmgr.go
+++ b/overlord/configstate/config/configmgr.go
@@ -19,12 +19,13 @@
 
 // Package configstate implements the manager and state aspects responsible for
 // the configuration of snaps.
-package configstate
+package config
 
 import (
 	"regexp"
 
-	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/hookstate/hook"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -35,12 +36,12 @@ type ConfigManager struct {
 }
 
 // Manager returns a new ConfigManager.
-func Manager(s *state.State, hookManager *hookstate.HookManager) (*ConfigManager, error) {
+func Manager(s *state.State, hookManager *hook.HookManager) (*ConfigManager, error) {
 	manager := &ConfigManager{
 		state: s,
 	}
 
-	hookManager.Register(regexp.MustCompile("^configure$"), newConfigureHandler)
+	hookManager.Register(regexp.MustCompile("^configure$"), configstate.NewConfigureHandler)
 
 	return manager, nil
 }

--- a/overlord/configstate/export_test.go
+++ b/overlord/configstate/export_test.go
@@ -19,4 +19,4 @@
 
 package configstate
 
-var NewConfigureHandler = newConfigureHandler
+//var NewConfigureHandler = NewConfigureHandler

--- a/overlord/configstate/handler.go
+++ b/overlord/configstate/handler.go
@@ -51,7 +51,7 @@ func ContextTransaction(context *hookstate.Context) *Transaction {
 	return transaction
 }
 
-func newConfigureHandler(context *hookstate.Context) hookstate.Handler {
+func NewConfigureHandler(context *hookstate.Context) hookstate.Handler {
 	return &configureHandler{context: context}
 }
 

--- a/overlord/configstate/tasksets.go
+++ b/overlord/configstate/tasksets.go
@@ -24,13 +24,8 @@ import (
 
 	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/overlord/hookstate"
-	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 )
-
-func init() {
-	snapstate.Configure = Configure
-}
 
 // Configure returns a taskset to apply the given configuration patch.
 func Configure(s *state.State, snapName string, patch map[string]interface{}) *state.TaskSet {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/hook"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/partition"
@@ -63,7 +64,7 @@ type DeviceManager struct {
 }
 
 // Manager returns a new device manager.
-func Manager(s *state.State, hookManager *hookstate.HookManager) (*DeviceManager, error) {
+func Manager(s *state.State, hookManager *hook.HookManager) (*DeviceManager, error) {
 	runner := state.NewTaskRunner(s)
 
 	keypairMgr, err := asserts.OpenFSKeypairManager(dirs.SnapDeviceDir)

--- a/overlord/devicestate/devicemgr_test.go
+++ b/overlord/devicestate/devicemgr_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/hookstate/hook"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/partition"
@@ -60,7 +61,7 @@ func TestDeviceManager(t *testing.T) { TestingT(t) }
 
 type deviceMgrSuite struct {
 	state   *state.State
-	hookMgr *hookstate.HookManager
+	hookMgr *hook.HookManager
 	mgr     *devicestate.DeviceManager
 	db      *asserts.Database
 
@@ -144,7 +145,7 @@ func (s *deviceMgrSuite) SetUpTest(c *C) {
 	err = db.Add(s.storeSigning.StoreAccountKey(""))
 	c.Assert(err, IsNil)
 
-	hookMgr, err := hookstate.Manager(s.state)
+	hookMgr, err := hook.Manager(s.state)
 	c.Assert(err, IsNil)
 	mgr, err := devicestate.Manager(s.state, hookMgr)
 	c.Assert(err, IsNil)
@@ -536,7 +537,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyPrepareDeviceHook(c *C) 
 	mockServer := s.mockServer(c, "REQID-1")
 	defer mockServer.Close()
 
-	r2 := hookstate.MockRunHook(func(ctx *hookstate.Context, _ *tomb.Tomb) ([]byte, error) {
+	r2 := hook.MockRunHook(func(ctx *hookstate.Context, _ *tomb.Tomb) ([]byte, error) {
 		c.Assert(ctx.HookName(), Equals, "prepare-device")
 
 		// snapctl set the registration params

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -88,6 +88,10 @@ func (c *Context) Handler() Handler {
 	return c.handler
 }
 
+func (c *Context) SetHandler(handler Handler) {
+	c.handler = handler
+}
+
 // Lock acquires the lock for this context (required for Set/Get, Cache/Cached),
 // and OnDone/Done).
 func (c *Context) Lock() {

--- a/overlord/hookstate/hook/hookmgr.go
+++ b/overlord/hookstate/hook/hookmgr.go
@@ -19,7 +19,7 @@
 
 // Package hookstate implements the manager and state aspects responsible for
 // the running of hooks.
-package hookstate
+package hook
 
 import (
 	"bytes"
@@ -32,6 +32,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -43,33 +44,10 @@ import (
 type HookManager struct {
 	state      *state.State
 	runner     *state.TaskRunner
-	repository *repository
+	repository *hookstate.Repository
 
 	contextsMutex sync.RWMutex
-	contexts      map[string]*Context
-}
-
-// Handler is the interface a client must satify to handle hooks.
-type Handler interface {
-	// Before is called right before the hook is to be run.
-	Before() error
-
-	// Done is called right after the hook has finished successfully.
-	Done() error
-
-	// Error is called if the hook encounters an error while running.
-	Error(err error) error
-}
-
-// HandlerGenerator is the function signature required to register for hooks.
-type HandlerGenerator func(*Context) Handler
-
-// HookSetup is a reference to a hook within a specific snap.
-type HookSetup struct {
-	Snap     string        `json:"snap"`
-	Revision snap.Revision `json:"revision"`
-	Hook     string        `json:"hook"`
-	Optional bool          `json:"optional,omitempty"`
+	contexts      map[string]*hookstate.Context
 }
 
 // Manager returns a new HookManager.
@@ -78,8 +56,8 @@ func Manager(s *state.State) (*HookManager, error) {
 	manager := &HookManager{
 		state:      s,
 		runner:     runner,
-		repository: newRepository(),
-		contexts:   make(map[string]*Context),
+		repository: hookstate.NewRepository(),
+		contexts:   make(map[string]*hookstate.Context),
 	}
 
 	runner.AddHandler("run-hook", manager.doRunHook, nil)
@@ -87,23 +65,10 @@ func Manager(s *state.State) (*HookManager, error) {
 	return manager, nil
 }
 
-// HookTask returns a task that will run the specified hook. Note that the
-// initial context must properly marshal and unmarshal with encoding/json.
-func HookTask(st *state.State, summary string, setup *HookSetup, contextData map[string]interface{}) *state.Task {
-	task := st.NewTask("run-hook", summary)
-	task.Set("hook-setup", setup)
-
-	// Initial data for Context.Get/Set.
-	if len(contextData) > 0 {
-		task.Set("hook-context", contextData)
-	}
-	return task
-}
-
 // Register registers a function to create Handler values whenever hooks
 // matching the provided pattern are run.
-func (m *HookManager) Register(pattern *regexp.Regexp, generator HandlerGenerator) {
-	m.repository.addHandlerGenerator(pattern, generator)
+func (m *HookManager) Register(pattern *regexp.Regexp, generator hookstate.HandlerGenerator) {
+	m.repository.AddHandlerGenerator(pattern, generator)
 }
 
 // Ensure implements StateManager.Ensure.
@@ -123,7 +88,7 @@ func (m *HookManager) Stop() {
 }
 
 // Context obtains the context for the given context ID.
-func (m *HookManager) Context(contextID string) (*Context, error) {
+func (m *HookManager) Context(contextID string) (*hookstate.Context, error) {
 	m.contextsMutex.RLock()
 	defer m.contextsMutex.RUnlock()
 
@@ -135,8 +100,8 @@ func (m *HookManager) Context(contextID string) (*Context, error) {
 	return context, nil
 }
 
-func hookSetup(task *state.Task) (*HookSetup, *snapstate.SnapState, error) {
-	var hooksup HookSetup
+func hookSetup(task *state.Task) (*hookstate.HookSetup, *snapstate.SnapState, error) {
+	var hooksup hookstate.HookSetup
 	err := task.Get("hook-setup", &hooksup)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot extract hook setup from task: %s", err)
@@ -176,7 +141,7 @@ func (m *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		return fmt.Errorf("snap %q has no %q hook", hooksup.Snap, hooksup.Hook)
 	}
 
-	context, err := NewContext(task, hooksup, nil)
+	context, err := hookstate.NewContext(task, hooksup, nil)
 	if err != nil {
 		return err
 	}
@@ -184,7 +149,7 @@ func (m *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	// Obtain a handler for this hook. The repository returns a list since it's
 	// possible for regular expressions to overlap, but multiple handlers is an
 	// error (as is no handler).
-	handlers := m.repository.generateHandlers(context)
+	handlers := m.repository.GenerateHandlers(context)
 	handlersCount := len(handlers)
 	if handlersCount == 0 {
 		return fmt.Errorf("internal error: no registered handlers for hook %q", hooksup.Hook)
@@ -193,7 +158,7 @@ func (m *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 		return fmt.Errorf("internal error: %d handlers registered for hook %q, expected 1", handlersCount, hooksup.Hook)
 	}
 
-	context.handler = handlers[0]
+	context.SetHandler(handlers[0])
 
 	contextID := context.ID()
 	m.contextsMutex.Lock()
@@ -235,14 +200,14 @@ func (m *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
-func runHookImpl(c *Context, tomb *tomb.Tomb) ([]byte, error) {
+func runHookImpl(c *hookstate.Context, tomb *tomb.Tomb) ([]byte, error) {
 	return runHookAndWait(c.SnapName(), c.SnapRevision(), c.HookName(), c.ID(), tomb)
 }
 
 var runHook = runHookImpl
 
 // MockRunHook mocks the actual invocation of hooks for tests.
-func MockRunHook(hookInvoke func(c *Context, tomb *tomb.Tomb) ([]byte, error)) (restore func()) {
+func MockRunHook(hookInvoke func(c *hookstate.Context, tomb *tomb.Tomb) ([]byte, error)) (restore func()) {
 	oldRunHook := runHook
 	runHook = hookInvoke
 	return func() {

--- a/overlord/hookstate/hook/hookmgr_test.go
+++ b/overlord/hookstate/hook/hookmgr_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package hookstate_test
+package hook_test
 
 import (
 	"encoding/json"
@@ -28,6 +28,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/hook"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -40,7 +41,7 @@ func TestHookManager(t *testing.T) { TestingT(t) }
 
 type hookManagerSuite struct {
 	state       *state.State
-	manager     *hookstate.HookManager
+	manager     *hook.HookManager
 	context     *hookstate.Context
 	mockHandler *hooktest.MockHandler
 	task        *state.Task
@@ -62,7 +63,7 @@ var snapContents = ""
 func (s *hookManagerSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.state = state.New(nil)
-	manager, err := hookstate.Manager(s.state)
+	manager, err := hook.Manager(s.state)
 	c.Assert(err, IsNil)
 	s.manager = manager
 

--- a/overlord/hookstate/repository.go
+++ b/overlord/hookstate/repository.go
@@ -26,7 +26,7 @@ import (
 
 // repository stores all registered handler generators, and generates registered
 // handlers.
-type repository struct {
+type Repository struct {
 	mutex      sync.RWMutex
 	generators []patternGeneratorPair
 }
@@ -39,12 +39,12 @@ type patternGeneratorPair struct {
 }
 
 // NewRepository creates an empty handler generator repository.
-func newRepository() *repository {
-	return &repository{}
+func NewRepository() *Repository {
+	return &Repository{}
 }
 
 // AddHandler adds the provided handler generator to the repository.
-func (r *repository) addHandlerGenerator(pattern *regexp.Regexp, generator HandlerGenerator) {
+func (r *Repository) AddHandlerGenerator(pattern *regexp.Regexp, generator HandlerGenerator) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -57,7 +57,7 @@ func (r *repository) addHandlerGenerator(pattern *regexp.Regexp, generator Handl
 // GenerateHandlers calls the handler generators whose patterns match the
 // hook name contained within the provided context, and returns the resulting
 // handlers.
-func (r *repository) generateHandlers(context *Context) []Handler {
+func (r *Repository) GenerateHandlers(context *Context) []Handler {
 	hookName := context.HookName()
 	var handlers []Handler
 
@@ -71,4 +71,19 @@ func (r *repository) generateHandlers(context *Context) []Handler {
 	}
 
 	return handlers
+}
+
+// HandlerGenerator is the function signature required to register for hooks.
+type HandlerGenerator func(*Context) Handler
+
+// Handler is the interface a client must satify to handle hooks.
+type Handler interface {
+	// Before is called right before the hook is to be run.
+	Before() error
+
+	// Done is called right after the hook has finished successfully.
+	Done() error
+
+	// Error is called if the hook encounters an error while running.
+	Error(err error) error
 }

--- a/overlord/hookstate/repository_test.go
+++ b/overlord/hookstate/repository_test.go
@@ -34,7 +34,7 @@ type repositorySuite struct{}
 var _ = Suite(&repositorySuite{})
 
 func (s *repositorySuite) TestAddHandlerGenerator(c *C) {
-	repository := newRepository()
+	repository := NewRepository()
 
 	var calledContext *Context
 	mockHandlerGenerator := func(context *Context) Handler {
@@ -43,7 +43,7 @@ func (s *repositorySuite) TestAddHandlerGenerator(c *C) {
 	}
 
 	// Verify that a handler generator can be added to the repository
-	repository.addHandlerGenerator(regexp.MustCompile("test-hook"), mockHandlerGenerator)
+	repository.AddHandlerGenerator(regexp.MustCompile("test-hook"), mockHandlerGenerator)
 
 	state := state.New(nil)
 	state.Lock()
@@ -55,15 +55,15 @@ func (s *repositorySuite) TestAddHandlerGenerator(c *C) {
 	c.Assert(context, NotNil)
 
 	// Verify that the handler can be generated
-	handlers := repository.generateHandlers(context)
+	handlers := repository.GenerateHandlers(context)
 	c.Check(handlers, HasLen, 1)
 	c.Check(calledContext, DeepEquals, context)
 
 	// Add another handler
-	repository.addHandlerGenerator(regexp.MustCompile(".*-hook"), mockHandlerGenerator)
+	repository.AddHandlerGenerator(regexp.MustCompile(".*-hook"), mockHandlerGenerator)
 
 	// Verify that two handlers are generated for the test-hook, now
-	handlers = repository.generateHandlers(context)
+	handlers = repository.GenerateHandlers(context)
 	c.Check(handlers, HasLen, 2)
 	c.Check(calledContext, DeepEquals, context)
 }

--- a/overlord/hookstate/task.go
+++ b/overlord/hookstate/task.go
@@ -1,0 +1,27 @@
+package hookstate
+
+import (
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+// HookSetup is a reference to a hook within a specific snap.
+type HookSetup struct {
+	Snap     string        `json:"snap"`
+	Revision snap.Revision `json:"revision"`
+	Hook     string        `json:"hook"`
+	Optional bool          `json:"optional,omitempty"`
+}
+
+// HookTask returns a task that will run the specified hook. Note that the
+// initial context must properly marshal and unmarshal with encoding/json.
+func HookTask(st *state.State, summary string, setup *HookSetup, contextData map[string]interface{}) *state.Task {
+	task := st.NewTask("run-hook", summary)
+	task.Set("hook-setup", setup)
+
+	// Initial data for Context.Get/Set.
+	if len(contextData) > 0 {
+		task.Set("hook-context", contextData)
+	}
+	return task
+}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -35,9 +35,9 @@ import (
 
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
-	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/hook"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -68,8 +68,8 @@ type Overlord struct {
 	snapMgr   *snapstate.SnapManager
 	assertMgr *assertstate.AssertManager
 	ifaceMgr  *ifacestate.InterfaceManager
-	hookMgr   *hookstate.HookManager
-	configMgr *configstate.ConfigManager
+	hookMgr   *hook.HookManager
+	configMgr *config.ConfigManager
 	deviceMgr *devicestate.DeviceManager
 }
 
@@ -93,7 +93,7 @@ func New() (*Overlord, error) {
 
 	o.stateEng = NewStateEngine(s)
 
-	hookMgr, err := hookstate.Manager(s)
+	hookMgr, err := hook.Manager(s)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func New() (*Overlord, error) {
 	o.ifaceMgr = ifaceMgr
 	o.stateEng.AddManager(o.ifaceMgr)
 
-	configMgr, err := configstate.Manager(s, hookMgr)
+	configMgr, err := config.Manager(s, hookMgr)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func (o *Overlord) InterfaceManager() *ifacestate.InterfaceManager {
 
 // HookManager returns the hook manager responsible for running hooks under the
 // overlord.
-func (o *Overlord) HookManager() *hookstate.HookManager {
+func (o *Overlord) HookManager() *hook.HookManager {
 	return o.hookMgr
 }
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -183,15 +184,11 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup) (*state.T
 	}
 
 	installSet := state.NewTaskSet(tasks...)
-	configSet := Configure(st, snapsup.Name(), defaults)
+	configSet := configstate.Configure(st, snapsup.Name(), defaults)
 	configSet.WaitAll(installSet)
 	installSet.AddAll(configSet)
 
 	return installSet, nil
-}
-
-var Configure = func(st *state.State, snapName string, patch map[string]interface{}) *state.TaskSet {
-	panic("internal error: snapstate.Configure is unset")
 }
 
 func checkChangeConflict(st *state.State, snapName string, snapst *SnapState) error {


### PR DESCRIPTION
After looking at snapstate installation code I have realised that we are not calling Configure directly because we would have circular dependency otherwise.

In an attempt to understand the code I have tried to refactor it a little so we do not need this "late binbing" by moving config and hook managers one package below as they depend on snapstate. This allowed snapstate to use the code from configsstate and hookstate directly.
https://github.com/snapcore/snapd/blob/master/overlord/snapstate/snapstate.go#L194

Sorry if I missed something, but that seemed a logical thing to do.