### PR TITLE
cmd/snap,tests: alias support in snap run

### DIFF
--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -34,6 +34,7 @@ var (
 	SnapRunApp         = snapRunApp
 	SnapRunHook        = snapRunHook
 	Wait               = wait
+	ResolveApp         = resolveApp
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -215,19 +215,36 @@ func init() {
 	}
 }
 
+func resolveApp(snapApp string) (string, error) {
+	target, err := os.Readlink(filepath.Join(dirs.SnapBinariesDir, snapApp))
+	if err != nil {
+		return "", err
+	}
+	if filepath.Base(target) == target { // alias pointing to an app command in /snap/bin
+		return target, nil
+	}
+	return snapApp, nil
+}
+
 func main() {
 	cmd.ExecInCoreSnap()
 
 	// magic \o/
 	snapApp := filepath.Base(os.Args[0])
 	if osutil.IsSymlink(filepath.Join(dirs.SnapBinariesDir, snapApp)) {
+		var err error
+		snapApp, err = resolveApp(snapApp)
+		if err != nil {
+			fmt.Fprintf(Stderr, i18n.G("cannot resolve snap app %q: %v"), snapApp, err)
+			os.Exit(46)
+		}
 		cmd := &cmdRun{}
 		args := []string{snapApp}
 		args = append(args, os.Args[1:]...)
 		// this will call syscall.Exec() so it does not return
 		// *unless* there is an error, i.e. we setup a wrong
 		// symlink (or syscall.Exec() fails for strange reasons)
-		err := cmd.Execute(args)
+		err = cmd.Execute(args)
 		fmt.Fprintf(Stderr, i18n.G("internal error, please report: running %q failed: %v\n"), snapApp, err)
 		os.Exit(46)
 	}

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -32,6 +32,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/cmd"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/testutil"
 
@@ -223,4 +224,43 @@ func (s *SnapSuite) TestUnknownCommand(c *C) {
 
 	err := snap.RunMain()
 	c.Assert(err, ErrorMatches, `unknown command "unknowncmd", see "snap --help"`)
+}
+
+func (s *SnapSuite) TestResolveApp(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+
+	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
+	c.Assert(err, IsNil)
+
+	// "wrapper" symlinks
+	err = os.Symlink("/usr/bin/snap", filepath.Join(dirs.SnapBinariesDir, "foo"))
+	c.Assert(err, IsNil)
+	err = os.Symlink("/usr/bin/snap", filepath.Join(dirs.SnapBinariesDir, "foo.bar"))
+	c.Assert(err, IsNil)
+
+	// alias symlinks
+	err = os.Symlink("foo", filepath.Join(dirs.SnapBinariesDir, "foo_"))
+	c.Assert(err, IsNil)
+	err = os.Symlink("foo.bar", filepath.Join(dirs.SnapBinariesDir, "foo_bar-1"))
+	c.Assert(err, IsNil)
+
+	snapApp, err := snap.ResolveApp("foo")
+	c.Assert(err, IsNil)
+	c.Check(snapApp, Equals, "foo")
+
+	snapApp, err = snap.ResolveApp("foo.bar")
+	c.Assert(err, IsNil)
+	c.Check(snapApp, Equals, "foo.bar")
+
+	snapApp, err = snap.ResolveApp("foo_")
+	c.Assert(err, IsNil)
+	c.Check(snapApp, Equals, "foo")
+
+	snapApp, err = snap.ResolveApp("foo_bar-1")
+	c.Assert(err, IsNil)
+	c.Check(snapApp, Equals, "foo.bar")
+
+	_, err = snap.ResolveApp("baz")
+	c.Check(err, NotNil)
 }

--- a/tests/main/snap-run-alias/task.yaml
+++ b/tests/main/snap-run-alias/task.yaml
@@ -1,0 +1,33 @@
+summary: Check that alias symlinks work correctly
+
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+
+prepare: |
+    echo Ensure we have a os snap with snap run
+    $TESTSLIB/reset.sh
+    snap install --channel=beta core
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-tools
+
+restore:
+    rm -f /snap/bin/test_echo
+    rm -f /snap/bin/test_cat
+
+environment:
+    APP/testsnapdtoolsecho: test-snapd-tools.echo
+    APP/testsnapdtoolscat: test-snapd-tools.cat
+    ALIAS/testsnapdtoolsecho: test_echo
+    ALIAS/testsnapdtoolscat: test_cat
+    SNAP: /snap/test-snapd-tools/current
+
+execute: |
+    echo Testing that creating an alias symlinks works
+    $APP $SNAP/bin/cat
+    $APP $SNAP/bin/cat > orig.txt 2>&1
+
+    ln -s $APP /snap/bin/$ALIAS
+
+    $ALIAS $SNAP/bin/cat
+    $ALIAS $SNAP/bin/cat > new.txt 2>&1
+
+    diff -u orig.txt new.txt


### PR DESCRIPTION
The testing and the spread test are in the style of the previous "snap run" spread tests.