### PR TITLE
interfaces/builtin: fix pulseaudio apparmor rules

### DIFF
--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -31,7 +31,8 @@ const pulseaudioConnectedPlugAppArmor = `
 
 owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,
-owner /run/user/[0-9]*/{,pulse/} rw,
+owner /run/user/[0-9]*/ r,
+owner /run/user/[0-9]*/pulse/ rw,
 `
 
 const pulseaudioConnectedPlugAppArmorDesktop = `
@@ -97,7 +98,8 @@ owner /{,var/}run/pulse/** rwk,
 /usr/share/applications/ r,
 
 owner /run/pulse/native/ rwk,
-owner /run/user/[0-9]*/{,pulse/} rw,
+owner /run/user/[0-9]*/ r,
+owner /run/user/[0-9]*/pulse/ rw,
 `
 
 const pulseaudioPermanentSlotSecComp = `

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -31,6 +31,7 @@ const pulseaudioConnectedPlugAppArmor = `
 
 owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,
+owner /run/user/[0-9]*/{,pulse/} rw,
 `
 
 const pulseaudioConnectedPlugAppArmorDesktop = `
@@ -92,6 +93,11 @@ owner /{,var/}run/pulse/** rwk,
 
 # Shared memory based communication with clients
 /{run,dev}/shm/pulse-shm-* rwk,
+
+/usr/share/applications/ r,
+
+owner /run/pulse/native/ rwk,
+owner /run/user/[0-9]*/{,pulse/} rw,
 `
 
 const pulseaudioPermanentSlotSecComp = `


### PR DESCRIPTION
The pulseaudio snap run on the kvm revealed that the pactl tries to
access several locations which were not described by the AppArmor
rules. This commit makes them accessible so that the pactl tool
can be executed.

In particular the locations in question were:
 - /run/user/${USERID}
 - /run/user/${USERID}/pulse
 - /usr/share/applications