### PR TITLE
client: only allow Dangerous option in InstallPath

### DIFF
--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -94,11 +94,11 @@ func (client *Client) Revert(name string, options *SnapOptions) (changeID string
 	return client.doSnapAction("revert", name, options)
 }
 
-var ErrNoDangerous = fmt.Errorf("dangerous option only valid when installing from a file")
+var ErrDangerousNotApplicable = fmt.Errorf("dangerous option only meaningful when installing from a local file")
 
 func (client *Client) doSnapAction(actionName string, snapName string, options *SnapOptions) (changeID string, err error) {
 	if options != nil && options.Dangerous {
-		return "", ErrNoDangerous
+		return "", ErrDangerousNotApplicable
 	}
 	action := actionData{
 		Action:      actionName,
@@ -168,7 +168,7 @@ func (client *Client) Try(path string, options *SnapOptions) (changeID string, e
 		options = &SnapOptions{}
 	}
 	if options.Dangerous {
-		return "", ErrNoDangerous
+		return "", ErrDangerousNotApplicable
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/client/snap_op.go
+++ b/client/snap_op.go
@@ -94,7 +94,12 @@ func (client *Client) Revert(name string, options *SnapOptions) (changeID string
 	return client.doSnapAction("revert", name, options)
 }
 
+var ErrNoDangerous = fmt.Errorf("dangerous option only valid when installing from a file")
+
 func (client *Client) doSnapAction(actionName string, snapName string, options *SnapOptions) (changeID string, err error) {
+	if options != nil && options.Dangerous {
+		return "", ErrNoDangerous
+	}
 	action := actionData{
 		Action:      actionName,
 		SnapOptions: options,
@@ -161,6 +166,9 @@ func (client *Client) InstallPath(path string, options *SnapOptions) (changeID s
 func (client *Client) Try(path string, options *SnapOptions) (changeID string, err error) {
 	if options == nil {
 		options = &SnapOptions{}
+	}
+	if options.Dangerous {
+		return "", ErrNoDangerous
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -227,7 +227,7 @@ func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
 
 	// Install does not (and gives us a clear error message)
 	_, err = cs.cli.Install("foo", &opts)
-	c.Assert(err, check.Equals, client.ErrNoDangerous)
+	c.Assert(err, check.Equals, client.ErrDangerousNotApplicable)
 
 	// nor does InstallMany (whether it fails because any option
 	// at all was provided, or because dangerous was provided, is
@@ -291,5 +291,5 @@ func (cs *clientSuite) TestClientOpTryModeDangerous(c *check.C) {
 	snapdir := filepath.Join(c.MkDir(), "/some/path")
 
 	_, err := cs.cli.Try(snapdir, &client.SnapOptions{Dangerous: true})
-	c.Assert(err, check.Equals, client.ErrNoDangerous)
+	c.Assert(err, check.Equals, client.ErrDangerousNotApplicable)
 }

--- a/client/snap_op_test.go
+++ b/client/snap_op_test.go
@@ -200,6 +200,42 @@ func (cs *clientSuite) TestClientOpInstallPath(c *check.C) {
 	c.Check(id, check.Equals, "66b3")
 }
 
+func (cs *clientSuite) TestClientOpInstallDangerous(c *check.C) {
+	cs.rsp = `{
+		"change": "66b3",
+		"status-code": 202,
+		"type": "async"
+	}`
+	bodyData := []byte("snap-data")
+
+	snap := filepath.Join(c.MkDir(), "foo.snap")
+	err := ioutil.WriteFile(snap, bodyData, 0644)
+	c.Assert(err, check.IsNil)
+
+	opts := client.SnapOptions{
+		Dangerous: true,
+	}
+
+	// InstallPath takes Dangerous
+	_, err = cs.cli.InstallPath(snap, &opts)
+	c.Assert(err, check.IsNil)
+
+	body, err := ioutil.ReadAll(cs.req.Body)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(string(body), check.Matches, "(?s).*Content-Disposition: form-data; name=\"dangerous\"\r\n\r\ntrue\r\n.*")
+
+	// Install does not (and gives us a clear error message)
+	_, err = cs.cli.Install("foo", &opts)
+	c.Assert(err, check.Equals, client.ErrNoDangerous)
+
+	// nor does InstallMany (whether it fails because any option
+	// at all was provided, or because dangerous was provided, is
+	// unimportant)
+	_, err = cs.cli.InstallMany([]string{"foo"}, &opts)
+	c.Assert(err, check.NotNil)
+}
+
 func formToMap(c *check.C, mr *multipart.Reader) map[string]string {
 	formData := map[string]string{}
 	for {
@@ -249,4 +285,11 @@ func (cs *clientSuite) TestClientOpTryMode(c *check.C) {
 		c.Assert(cs.req.Header.Get("Content-Type"), check.Matches, "multipart/form-data; boundary=.*")
 		c.Check(id, check.Equals, "66b3")
 	}
+}
+
+func (cs *clientSuite) TestClientOpTryModeDangerous(c *check.C) {
+	snapdir := filepath.Join(c.MkDir(), "/some/path")
+
+	_, err := cs.cli.Try(snapdir, &client.SnapOptions{Dangerous: true})
+	c.Assert(err, check.Equals, client.ErrNoDangerous)
 }

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/policy"
-	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -114,7 +113,7 @@ func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, 
 	}
 	if err := m.repo.AddSnap(snapInfo); err != nil {
 		if _, ok := err.(*interfaces.BadInterfacesError); ok {
-			logger.Noticef("%s", err)
+			task.Logf("%s", err)
 		} else {
 			return err
 		}


### PR DESCRIPTION
a silly little branch pulled from the more scary “no interface check on `--dangerous`” one.