### PR TITLE
interfaces/builtin: add iio interface

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -34,6 +34,7 @@ var allInterfaces = []interfaces.Interface{
 	&GpioInterface{},
 	&HidrawInterface{},
 	&I2cInterface{},
+	&IioInterface{},
 	&LocationControlInterface{},
 	&LocationObserveInterface{},
 	&LxdInterface{},

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -42,6 +42,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.GpioInterface{})
 	c.Check(all, Contains, &builtin.HidrawInterface{})
 	c.Check(all, Contains, &builtin.I2cInterface{})
+	c.Check(all, Contains, &builtin.IioInterface{})
 	c.Check(all, Contains, &builtin.LocationControlInterface{})
 	c.Check(all, Contains, &builtin.LocationObserveInterface{})
 	c.Check(all, Contains, &builtin.LxdSupportInterface{})

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -266,6 +266,12 @@ slots:
         - gadget
         - core
     deny-auto-connection: true
+  iio:
+    allow-installation:
+      slot-snap-type:
+        - gadget
+        - core
+    deny-auto-connection: true
   kernel-module-control:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -354,6 +354,7 @@ var (
 		"gpio":             {"core", "gadget"},
 		"hidraw":           {"core", "gadget"},
 		"i2c":              {"core", "gadget"},
+                "iio":              {"core", "gadget"},
 		"location-control": {"app"},
 		"location-observe": {"app"},
 		"lxd-support":      {"core"},

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -354,7 +354,7 @@ var (
 		"gpio":             {"core", "gadget"},
 		"hidraw":           {"core", "gadget"},
 		"i2c":              {"core", "gadget"},
-                "iio":              {"core", "gadget"},
+		"iio":              {"core", "gadget"},
 		"location-control": {"app"},
 		"location-observe": {"app"},
 		"lxd-support":      {"core"},

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -43,7 +43,7 @@ func (iface *IioInterface) String() string {
 // Pattern to match allowed iio device nodes. It is gonna be used to check the
 // validity of the path attributes in case the udev is not used for
 // identification
-var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio-device[0-9]")
+var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio:device[0-9]")
 
 // Check validity of the defined slot
 func (iface *IioInterface) SanitizeSlot(slot *interfaces.Slot) error {

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -43,7 +43,7 @@ func (iface *IioInterface) String() string {
 // Pattern to match allowed iio device nodes. It is gonna be used to check the
 // validity of the path attributes in case the udev is not used for
 // identification
-var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio:device[0-9]")
+var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio:device[0-9]+$")
 
 // Check validity of the defined slot
 func (iface *IioInterface) SanitizeSlot(slot *interfaces.Slot) error {
@@ -101,7 +101,7 @@ func (iface *IioInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *int
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
 		const pathPrefix = "/dev/"
-		const udevRule string = `KERNEL="%s", TAG+="%s"`
+		const udevRule string = `KERNEL=="%s", TAG+="%s"`
 		for appName := range plug.Apps {
 			tag := udevSnapSecurityName(plug.Snap.Name(), appName)
 			tagSnippet.WriteString(fmt.Sprintf(udevRule, strings.TrimPrefix(path, pathPrefix), tag))
@@ -120,10 +120,6 @@ func (iface *IioInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *int
 // No permissions granted to plug permanently
 func (iface *IioInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
-}
-
-func (iface *IioInterface) LegacyAutoConnect() bool {
-	return false
 }
 
 func (iface *IioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -22,10 +22,11 @@ package builtin
 import (
 	"bytes"
 	"fmt"
-	"github.com/snapcore/snapd/interfaces"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/snapcore/snapd/interfaces"
 )
 
 var iioConnectedPlugAppArmor = []byte(`
@@ -47,7 +48,7 @@ func (iface *IioInterface) String() string {
 	return iface.Name()
 }
 
-// Pattern to match allowed iio device nodes. It is gonna be used to check the
+// Pattern to match allowed iio device nodes. It is going to be used to check the
 // validity of the path attributes in case the udev is not used for
 // identification
 var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio:device[0-9]+$")
@@ -60,7 +61,7 @@ func (iface *IioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 
 	// Creation of the slot of this type
-	// is allowed only by a gadget snap
+	// is allowed only by a gadget or os snap
 	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
 		return fmt.Errorf("%s slots only allowed on gadget or core snaps", iface.Name())
 	}
@@ -117,7 +118,7 @@ func (iface *IioInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *int
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
 		const pathPrefix = "/dev/"
-		const udevRule string = `KERNEL=="%s", TAG+="%s"`
+		const udevRule = `KERNEL=="%s", TAG+="%s"`
 		for appName := range plug.Apps {
 			tag := udevSnapSecurityName(plug.Snap.Name(), appName)
 			tagSnippet.WriteString(fmt.Sprintf(udevRule, strings.TrimPrefix(path, pathPrefix), tag))

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -1,0 +1,132 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/snapcore/snapd/interfaces"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// The type for iio interface
+type IioInterface struct{}
+
+// Getter for the name of the iio interface
+func (iface *IioInterface) Name() string {
+	return "iio"
+}
+
+func (iface *IioInterface) String() string {
+	return iface.Name()
+}
+
+// Pattern to match allowed iio device nodes. It is gonna be used to check the
+// validity of the path attributes in case the udev is not used for
+// identification
+var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio-device[0-9]+$")
+
+// Check validity of the defined slot
+func (iface *IioInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	// Does it have right type?
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("slot is not of interface %q", iface))
+	}
+
+	// Creation of the slot of this type
+	// is allowed only by a gadget snap
+	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
+		return fmt.Errorf("%s slots only allowed on gadget or core snaps", iface.Name())
+	}
+
+	// Validate the path
+	path, ok := slot.Attrs["path"].(string)
+	if !ok || path == "" {
+		return fmt.Errorf("%s slot must have a path attribute", iface.Name())
+	}
+
+	path = filepath.Clean(path)
+
+	if !iioControlDeviceNodePattern.MatchString(path) {
+		return fmt.Errorf("%s path attribute must be a valid device node", iface.Name())
+	}
+
+	return nil
+}
+
+// Checks and possibly modifies a plug
+func (iface *IioInterface) SanitizePlug(plug *interfaces.Plug) error {
+	if iface.Name() != plug.Interface {
+		panic(fmt.Sprintf("plug is not of interface %q", iface))
+	}
+	// Currently nothing is checked on the plug side
+	return nil
+}
+
+// Returns snippet granted on install
+func (iface *IioInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+// Getter for the security snippet specific to the plug
+func (iface *IioInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	path, pathOk := slot.Attrs["path"].(string)
+	if !pathOk {
+		return nil, nil
+	}
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		cleanedPath := filepath.Clean(path)
+		return []byte(fmt.Sprintf("%s rw,\n", cleanedPath)), nil
+
+	case interfaces.SecurityUDev:
+		var tagSnippet bytes.Buffer
+		const pathPrefix = "/dev/"
+		const udevRule string = `KERNEL="%s", TAG+="%s"`
+		for appName := range plug.Apps {
+			tag := udevSnapSecurityName(plug.Snap.Name(), appName)
+			tagSnippet.WriteString(fmt.Sprintf(udevRule, strings.TrimPrefix(path, pathPrefix), tag))
+			tagSnippet.WriteString("\n")
+		}
+		return tagSnippet.Bytes(), nil
+	}
+	return nil, nil
+}
+
+// No extra permissions granted on connection
+func (iface *IioInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+// No permissions granted to plug permanently
+func (iface *IioInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+func (iface *IioInterface) LegacyAutoConnect() bool {
+	return false
+}
+
+func (iface *IioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+	// Allow what is allowed in the declarations
+	return true
+}

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -43,7 +43,7 @@ func (iface *IioInterface) String() string {
 // Pattern to match allowed iio device nodes. It is gonna be used to check the
 // validity of the path attributes in case the udev is not used for
 // identification
-var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio-device[0-9]+$")
+var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio-device[0-9]")
 
 // Check validity of the defined slot
 func (iface *IioInterface) SanitizeSlot(slot *interfaces.Slot) error {

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -33,7 +33,8 @@ var iioConnectedPlugAppArmor = []byte(`
 # Description: Give access to a specific IIO device on the system.
 
 ###IIO_DEVICE_PATH### rw,
-/sys/bus/iio/devices/###IIO_DEVICE_NAME###/{,**} rw,
+/sys/bus/iio/devices/###IIO_DEVICE_NAME###/ r,
+/sys/bus/iio/devices/###IIO_DEVICE_NAME###/** rwk,
 `)
 
 // The type for iio interface

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -46,6 +46,7 @@ type IioInterfaceSuite struct {
 	testUdevBadValue5     *interfaces.Slot
 	testUdevBadValue6     *interfaces.Slot
 	testUdevBadValue7     *interfaces.Slot
+	testUdevBadValue8     *interfaces.Slot
 	testUdevBadInterface1 *interfaces.Slot
 
 	// Consuming Snap
@@ -81,7 +82,7 @@ slots:
     path: /dev/iio:device2
   test-udev-3:
     interface: iio
-    path: /dev/iio:device0
+    path: /dev/iio:device10000
   test-udev-bad-value-1:
     interface: iio
     path: /dev/iio
@@ -99,8 +100,11 @@ slots:
     path: /dev/iio:devicefoo
   test-udev-bad-value-6:
     interface: iio
-    path: ""
+    path: /dev/iio-device0
   test-udev-bad-value-7:
+    interface: iio
+    path: ""
+  test-udev-bad-value-8:
     interface: iio
   test-udev-bad-interface-1:
     interface: other-interface
@@ -115,6 +119,7 @@ slots:
 	s.testUdevBadValue5 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-5"]}
 	s.testUdevBadValue6 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-6"]}
 	s.testUdevBadValue7 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-7"]}
+	s.testUdevBadValue8 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-8"]}
 	s.testUdevBadInterface1 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-interface-1"]}
 
 	// Snap Consumers
@@ -153,16 +158,19 @@ func (s *IioInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
 	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
 
 	err = s.iface.SanitizeSlot(s.testUdevBadValue6)
-	c.Assert(err, ErrorMatches, "iio slot must have a path attribute")
+	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
 
 	err = s.iface.SanitizeSlot(s.testUdevBadValue7)
+	c.Assert(err, ErrorMatches, "iio slot must have a path attribute")
+
+	err = s.iface.SanitizeSlot(s.testUdevBadValue8)
 	c.Assert(err, ErrorMatches, "iio slot must have a path attribute")
 
 	c.Assert(func() { s.iface.SanitizeSlot(s.testUdevBadInterface1) }, PanicMatches, `slot is not of interface "iio"`)
 }
 
 func (s *IioInterfaceSuite) TestConnectedPlugUdevSnippets(c *C) {
-	expectedSnippet1 := []byte(`KERNEL="iio:device1", TAG+="snap_client-snap_app-accessing-1-port"
+	expectedSnippet1 := []byte(`KERNEL=="iio:device1", TAG+="snap_client-snap_app-accessing-1-port"
 `)
 
 	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityUDev)

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -179,7 +179,11 @@ func (s *IioInterfaceSuite) TestConnectedPlugUdevSnippets(c *C) {
 }
 
 func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
-	expectedSnippet1 := []byte(`/dev/iio:device1 rw,
+	expectedSnippet1 := []byte(`
+# Description: Give access to a specific IIO device on the system.
+
+/dev/iio:device1 rw,
+/sys/bus/iio/devices/iio:device1/{,**} rw,
 `)
 	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -183,7 +183,8 @@ func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 # Description: Give access to a specific IIO device on the system.
 
 /dev/iio:device1 rw,
-/sys/bus/iio/devices/iio:device1/{,**} rw,
+/sys/bus/iio/devices/iio:device1/ r,
+/sys/bus/iio/devices/iio:device1/** rwk,
 `)
 	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -1,0 +1,184 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type IioInterfaceSuite struct {
+	testutil.BaseTest
+	iface interfaces.Interface
+
+	// OS Snap
+	testSlot1 *interfaces.Slot
+
+	// Gadget Snap
+	testUdev1             *interfaces.Slot
+	testUdev2             *interfaces.Slot
+	testUdev3             *interfaces.Slot
+	testUdevBadValue1     *interfaces.Slot
+	testUdevBadValue2     *interfaces.Slot
+	testUdevBadValue3     *interfaces.Slot
+	testUdevBadValue4     *interfaces.Slot
+	testUdevBadValue5     *interfaces.Slot
+	testUdevBadValue6     *interfaces.Slot
+	testUdevBadValue7     *interfaces.Slot
+	testUdevBadInterface1 *interfaces.Slot
+
+	// Consuming Snap
+	testPlugPort1 *interfaces.Plug
+}
+
+var _ = Suite(&IioInterfaceSuite{
+	iface: &builtin.IioInterface{},
+})
+
+func (s *IioInterfaceSuite) SetUpTest(c *C) {
+	// Mock for OS Snap
+	osSnapInfo := snaptest.MockInfo(c, `
+name: ubuntu-core
+type: os
+slots:
+  test-port-1:
+    interface: iio
+    path: /dev/iio:device0
+`, nil)
+	s.testSlot1 = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["test-port-1"]}
+
+	// Mock for Gadget Snap
+	gadgetSnapInfo := snaptest.MockInfo(c, `
+name: some-device
+type: gadget
+slots:
+  test-udev-1:
+    interface: iio
+    path: /dev/iio:device1
+  test-udev-2:
+    interface: iio
+    path: /dev/iio:device2
+  test-udev-3:
+    interface: iio
+    path: /dev/iio:device0
+  test-udev-bad-value-1:
+    interface: iio
+    path: /dev/iio
+  test-udev-bad-value-2:
+    interface: iio
+    path: /dev/iio:devicea
+  test-udev-bad-value-3:
+    interface: iio
+    path: /dev/iio:device2a
+  test-udev-bad-value-4:
+    interface: iio
+    path: /dev/foo-0
+  test-udev-bad-value-5:
+    interface: iio
+    path: /dev/iio:devicefoo
+  test-udev-bad-value-6:
+    interface: iio
+    path: ""
+  test-udev-bad-value-7:
+    interface: iio
+  test-udev-bad-interface-1:
+    interface: other-interface
+`, nil)
+	s.testUdev1 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-1"]}
+	s.testUdev2 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-2"]}
+	s.testUdev3 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-3"]}
+	s.testUdevBadValue1 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-1"]}
+	s.testUdevBadValue2 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-2"]}
+	s.testUdevBadValue3 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-3"]}
+	s.testUdevBadValue4 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-4"]}
+	s.testUdevBadValue5 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-5"]}
+	s.testUdevBadValue6 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-6"]}
+	s.testUdevBadValue7 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-value-7"]}
+	s.testUdevBadInterface1 = &interfaces.Slot{SlotInfo: gadgetSnapInfo.Slots["test-udev-bad-interface-1"]}
+
+	// Snap Consumers
+	consumingSnapInfo := snaptest.MockInfo(c, `
+name: client-snap
+plugs:
+  plug-for-port-1:
+    interface: iio
+apps:
+  app-accessing-1-port:
+    command: foo
+    plugs: [iio]
+`, nil)
+	s.testPlugPort1 = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["plug-for-port-1"]}
+}
+
+func (s *IioInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "iio")
+}
+
+func (s *IioInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
+
+	err := s.iface.SanitizeSlot(s.testUdevBadValue1)
+	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
+
+	err = s.iface.SanitizeSlot(s.testUdevBadValue2)
+	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
+
+	err = s.iface.SanitizeSlot(s.testUdevBadValue3)
+	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
+
+	err = s.iface.SanitizeSlot(s.testUdevBadValue4)
+	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
+
+	err = s.iface.SanitizeSlot(s.testUdevBadValue5)
+	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
+
+	err = s.iface.SanitizeSlot(s.testUdevBadValue6)
+	c.Assert(err, ErrorMatches, "iio slot must have a path attribute")
+
+	err = s.iface.SanitizeSlot(s.testUdevBadValue7)
+	c.Assert(err, ErrorMatches, "iio slot must have a path attribute")
+
+	c.Assert(func() { s.iface.SanitizeSlot(s.testUdevBadInterface1) }, PanicMatches, `slot is not of interface "iio"`)
+}
+
+func (s *IioInterfaceSuite) TestConnectedPlugUdevSnippets(c *C) {
+	expectedSnippet1 := []byte(`KERNEL="iio:device1", TAG+="snap_client-snap_app-accessing-1-port"
+`)
+
+	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, snippet))
+}
+
+func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
+	expectedSnippet1 := []byte(`/dev/iio:device1 rw,
+`)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, DeepEquals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, snippet))
+
+}
+
+func (s *IioInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)
+}

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -135,13 +135,16 @@ setup_reflash_magic() {
         # unpack our freshly build snapd into the new core snap
         dpkg-deb -x ${SPREAD_PATH}/../snapd_*.deb $UNPACKD
 
-        # add a gpio slot
+        # add gpio and iio slots
         cat >> $UNPACKD/meta/snap.yaml <<-EOF
 slots:
     gpio-pin:
         interface: gpio
         number: 100
         direction: out
+    iio0:
+        interface: iio
+        path: /dev/iio:device0
 EOF
 
         # build new core snap for the image
@@ -211,6 +214,7 @@ EOF
 StartLimitInterval=0
 [Service]
 Environment=SNAPD_DEBUG_HTTP=7 SNAP_REEXEC=0
+ExecPreStart=/bin/touch /dev/iio:device0
 EOF
         mkdir -p /mnt/system-data/etc/systemd/system/snapd.socket.d
         cat <<EOF > /mnt/system-data/etc/systemd/system/snapd.socket.d/local.conf

--- a/tests/lib/snaps/iio-consumer/bin/read
+++ b/tests/lib/snaps/iio-consumer/bin/read
@@ -1,0 +1,2 @@
+#!/bin/sh
+cat /dev/iio:device0

--- a/tests/lib/snaps/iio-consumer/bin/write
+++ b/tests/lib/snaps/iio-consumer/bin/write
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo $1 > /dev/iio:device0

--- a/tests/lib/snaps/iio-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/iio-consumer/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: iio-consumer
+version: 1.0
+summary: Basic iio consumer snap
+description: A basic snap declaring a plug on a iio slot
+
+apps:
+  read:
+    command: bin/read
+    plugs: [iio]
+  write:
+    command: bin/write
+    plugs: [iio]

--- a/tests/main/interfaces-iio/task.yaml
+++ b/tests/main/interfaces-iio/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that IIO device nodes are accessible through an interface
 
 details: |
-    This test makes sure that the a snap using the IIO interface can access
+    This test makes sure that a snap using the IIO interface can access
     devices nodes exposed by a slot properly.
 
     It modifies the core snap to provide a iio slot. The actual iio device

--- a/tests/main/interfaces-iio/task.yaml
+++ b/tests/main/interfaces-iio/task.yaml
@@ -1,0 +1,47 @@
+summary: Check that IIO device nodes are accessible through an interface
+
+details: |
+    This test makes sure that the a snap using the IIO interface can access
+    devices nodes exposed by a slot properly.
+
+    It modifies the core snap to provide a iio slot. The actual iio device
+    node is served as a plain file with static text content. The test expects
+    that, after a snap declared a iio plug is installed and connected, it can
+    access the node and read/write its content.
+
+systems: [ubuntu-core-16-64]
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    # Mock IIO device node and give it some content we can verify
+    # the test snap can read.
+    echo "iio-0" > /dev/iio:device0
+
+    echo "Given a snap declaring a plug on iio is installed"
+    . $TESTSLIB/snaps.sh
+    install_local iio-consumer
+
+    echo "And the iio plug is connected"
+    . "$TESTSLIB/names.sh"
+    snap connect iio-consumer:iio ${core_name}:iio0
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    rm /dev/iio:device0
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    test "`/snap/bin/iio-consumer.read`" = "iio-0"
+
+    /snap/bin/iio-consumer.write "hello"
+    test "`/snap/bin/iio-consumer.read`" = "hello"


### PR DESCRIPTION
Implement IIO interface. Actual work is based on top of https://github.com/snapcore/snapd/pull/2397 but fixes certain problems of it and adds proper testing.

The interface itself is suposed to work similar as the i2c or the gpio one. The slot side will be declared with a path to the IIO node like

```
slots:
  iio-device0:
    interface: iio
    path: /dev/iio:device0
```

More information about the IIO kernel interface can be found on https://events.linuxfoundation.org/sites/events/files/slides/lceu15_baluta.pdf or https://archive.fosdem.org/2012/schedule/event/693/127_iio-a-new-subsystem.pdf