### PR TITLE
cmd/snap-confine: allow content interface mounts

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -195,10 +195,10 @@
 
     # Support mount profiles via the content interface. This should correspond
     # to permutations of $SNAP, $SNAP_DATA and $SNAP_COMMON for both reading
-    # and writing.
-    mount options=(bind) /snap/*/** -> /snap/*/*/**,
-    mount options=(bind) /snap/*/** -> /var/snap/*/*/**,
-    mount options=(bind) /var/snap/*/** -> /snap/*/*/**,
+    # and writing except for cases where a writable location is bind mounted to
+    # read-only location ($SNAP).
+    mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
+    mount options=(ro bind) /snap/*/** -> /var/snap/*/*/**,
     mount options=(bind) /var/snap/*/** -> /var/snap/*/*/**,
     # But we don't want anyone to touch /snap/bin
     audit deny mount /snap/bin/** -> /**,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -200,7 +200,7 @@
     mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
     mount options=(ro bind) /snap/*/** -> /var/snap/*/*/**,
     mount options=(rw bind) /var/snap/*/** -> /var/snap/*/*/**,
-    mount options=(rw bind) /var/snap/*/** -> /var/snap/*/*/**,
+    mount options=(ro bind) /var/snap/*/** -> /var/snap/*/*/**,
     # But we don't want anyone to touch /snap/bin
     audit deny mount /snap/bin/** -> /**,
     audit deny mount /** -> /snap/bin/**,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -199,7 +199,8 @@
     # read-only location ($SNAP).
     mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
     mount options=(ro bind) /snap/*/** -> /var/snap/*/*/**,
-    mount options=(bind) /var/snap/*/** -> /var/snap/*/*/**,
+    mount options=(rw bind) /var/snap/*/** -> /var/snap/*/*/**,
+    mount options=(rw bind) /var/snap/*/** -> /var/snap/*/*/**,
     # But we don't want anyone to touch /snap/bin
     audit deny mount /snap/bin/** -> /**,
     audit deny mount /** -> /snap/bin/**,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -193,9 +193,13 @@
     # NOTE: at this stage the /snap directory is stable as we have called
     # pivot_root already.
 
-    # Support mount profiles via the content interface
-    mount options=(rw bind) /snap/*/** -> /snap/*/*/**,
-    mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
+    # Support mount profiles via the content interface. This should correspond
+    # to permutations of $SNAP, $SNAP_DATA and $SNAP_COMMON for both reading
+    # and writing.
+    mount options=(bind) /snap/*/** -> /snap/*/*/**,
+    mount options=(bind) /snap/*/** -> /var/snap/*/*/**,
+    mount options=(bind) /var/snap/*/** -> /snap/*/*/**,
+    mount options=(bind) /var/snap/*/** -> /var/snap/*/*/**,
     # But we don't want anyone to touch /snap/bin
     audit deny mount /snap/bin/** -> /**,
     audit deny mount /** -> /snap/bin/**,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -196,6 +196,15 @@
     # Support mount profiles via the content interface. This should correspond
     # to permutations of $SNAP -> $SNAP for reading and $SNAP_{DATA,COMMON} ->
     # $SNAP_{DATA,COMMON} for both reading and writing.
+    #
+    # Note that:
+    #   /snap/*/*/**
+    # is meant to mean:
+    #   /snap/$SNAP_NAME/$SNAP_REVISION/and-any-subdirectory
+    # but:
+    #   /var/snap/*/**
+    # is meant to mean:
+    #   /var/snap/$SNAP_NAME/$SNAP_REVISION/
     mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
     mount options=(ro bind) /snap/*/** -> /var/snap/*/**,
     mount options=(rw bind) /var/snap/*/** -> /var/snap/*/**,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -197,9 +197,9 @@
     # to permutations of $SNAP -> $SNAP for reading and $SNAP_{DATA,COMMON} ->
     # $SNAP_{DATA,COMMON} for both reading and writing.
     mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
-    mount options=(ro bind) /snap/*/** -> /var/snap/*/*/**,
-    mount options=(rw bind) /var/snap/*/** -> /var/snap/*/*/**,
-    mount options=(ro bind) /var/snap/*/** -> /var/snap/*/*/**,
+    mount options=(ro bind) /snap/*/** -> /var/snap/*/**,
+    mount options=(rw bind) /var/snap/*/** -> /var/snap/*/**,
+    mount options=(ro bind) /var/snap/*/** -> /var/snap/*/**,
     # But we don't want anyone to touch /snap/bin
     audit deny mount /snap/bin/** -> /**,
     audit deny mount /** -> /snap/bin/**,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -194,9 +194,8 @@
     # pivot_root already.
 
     # Support mount profiles via the content interface. This should correspond
-    # to permutations of $SNAP, $SNAP_DATA and $SNAP_COMMON for both reading
-    # and writing except for cases where a writable location is bind mounted to
-    # read-only location ($SNAP).
+    # to permutations of $SNAP -> $SNAP for reading and $SNAP_{DATA,COMMON} ->
+    # $SNAP_{DATA,COMMON} for both reading and writing.
     mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
     mount options=(ro bind) /snap/*/** -> /var/snap/*/*/**,
     mount options=(rw bind) /var/snap/*/** -> /var/snap/*/*/**,

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -135,6 +135,19 @@ func mountEntry(plug *interfaces.Plug, slot *interfaces.Slot, relSrc string, mnt
 
 func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		var snippet []byte = nil
+		if len(iface.path(slot, "write")) > 0 {
+			snippet = []byte(fmt.Sprintf(`
+# In addition to the bind mount, add an AppArmor rule so that
+# snaps may directly access the slot implementation's files. Due
+# to a limitation in the kernel's LSM hooks for AF_UNIX, this rule
+# is needed for using named sockets within the exported
+# directory.
+/var/snap/%s/%s/** mrwklix,
+`, slot.Snap.Name, slot.Snap.Revision))
+		}
+		return snippet, nil
 	case interfaces.SecurityMount:
 		contentSnippet := bytes.NewBuffer(nil)
 		for _, r := range iface.path(slot, "read") {

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -145,7 +145,7 @@ func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot 
 # is needed for using named sockets within the exported
 # directory.
 /var/snap/%s/%s/** mrwklix,
-`, slot.Snap.Name, slot.Snap.Revision)
+`, slot.Snap.Name(), slot.Snap.Revision)
 		}
 		if len(iface.path(slot, "read")) > 0 {
 			fmt.Fprintf(contentSnippet, `
@@ -153,7 +153,7 @@ func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot 
 # snaps may directly access the slot implementation's files
 # read-only.
 /var/snap/%s/%s/** mrkix,
-`, slot.Snap.Name, slot.Snap.Revision)
+`, slot.Snap.Name(), slot.Snap.Revision)
 		}
 		return contentSnippet.Bytes(), nil
 	case interfaces.SecurityMount:

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -141,10 +141,10 @@ func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot 
 		writePaths := iface.path(slot, "write")
 		if len(writePaths) > 0 {
 			fmt.Fprintf(contentSnippet, `
-# In addition to the bind mount, add an AppArmor rule so that
+# In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files. Due
-# to a limitation in the kernel's LSM hooks for AF_UNIX, this rule
-# is needed for using named sockets within the exported
+# to a limitation in the kernel's LSM hooks for AF_UNIX, these
+# are needed for using named sockets within the exported
 # directory.
 `)
 			for _, w := range writePaths {
@@ -156,7 +156,7 @@ func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot 
 		readPaths := iface.path(slot, "read")
 		if len(readPaths) > 0 {
 			fmt.Fprintf(contentSnippet, `
-# In addition to the bind mount, add an AppArmor rule so that
+# In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files
 # read-only.
 `)

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -134,16 +134,15 @@ func mountEntry(plug *interfaces.Plug, slot *interfaces.Slot, relSrc string, mnt
 }
 
 func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	contentSnippet := bytes.NewBuffer(nil)
-	for _, r := range iface.path(slot, "read") {
-		fmt.Fprintln(contentSnippet, mountEntry(plug, slot, r, ",ro"))
-	}
-	for _, w := range iface.path(slot, "write") {
-		fmt.Fprintln(contentSnippet, mountEntry(plug, slot, w, ""))
-	}
-
 	switch securitySystem {
 	case interfaces.SecurityMount:
+		contentSnippet := bytes.NewBuffer(nil)
+		for _, r := range iface.path(slot, "read") {
+			fmt.Fprintln(contentSnippet, mountEntry(plug, slot, r, ",ro"))
+		}
+		for _, w := range iface.path(slot, "write") {
+			fmt.Fprintln(contentSnippet, mountEntry(plug, slot, w, ""))
+		}
 		return contentSnippet.Bytes(), nil
 	}
 	return nil, nil

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -203,7 +203,7 @@ slots:
 # In addition to the bind mount, add an AppArmor rule so that
 # snaps may directly access the slot implementation's files
 # read-only.
-/var/snap/producer/5/** mrkix,
+/snap/producer/5/export/** mrkix,
 `
 	c.Assert(string(content), Equals, expected)
 }
@@ -239,7 +239,7 @@ slots:
 # to a limitation in the kernel's LSM hooks for AF_UNIX, this rule
 # is needed for using named sockets within the exported
 # directory.
-/var/snap/producer/5/** mrwklix,
+/var/snap/producer/5/export/** mrwklix,
 `
 	c.Assert(string(content), Equals, expected)
 }
@@ -275,7 +275,7 @@ slots:
 # to a limitation in the kernel's LSM hooks for AF_UNIX, this rule
 # is needed for using named sockets within the exported
 # directory.
-/var/snap/producer/5/** mrwklix,
+/var/snap/producer/common/export/** mrwklix,
 `
 	c.Assert(string(content), Equals, expected)
 }

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -196,6 +196,16 @@ slots:
 	c.Assert(err, IsNil)
 	expected := "/snap/producer/5/export /snap/consumer/7/import none bind,ro 0 0\n"
 	c.Assert(string(content), Equals, expected)
+
+	content, err = s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	expected = `
+# In addition to the bind mount, add an AppArmor rule so that
+# snaps may directly access the slot implementation's files
+# read-only.
+/var/snap/producer/5/** mrkix,
+`
+	c.Assert(string(content), Equals, expected)
 }
 
 // Check that sharing of writable data is possible
@@ -220,6 +230,18 @@ slots:
 	c.Assert(err, IsNil)
 	expected := "/var/snap/producer/5/export /var/snap/consumer/7/import none bind 0 0\n"
 	c.Assert(string(content), Equals, expected)
+
+	content, err = s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	expected = `
+# In addition to the bind mount, add an AppArmor rule so that
+# snaps may directly access the slot implementation's files. Due
+# to a limitation in the kernel's LSM hooks for AF_UNIX, this rule
+# is needed for using named sockets within the exported
+# directory.
+/var/snap/producer/5/** mrwklix,
+`
+	c.Assert(string(content), Equals, expected)
 }
 
 // Check that sharing of writable common data is possible
@@ -243,5 +265,17 @@ slots:
 	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityMount)
 	c.Assert(err, IsNil)
 	expected := "/var/snap/producer/common/export /var/snap/consumer/common/import none bind 0 0\n"
+	c.Assert(string(content), Equals, expected)
+
+	content, err = s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	expected = `
+# In addition to the bind mount, add an AppArmor rule so that
+# snaps may directly access the slot implementation's files. Due
+# to a limitation in the kernel's LSM hooks for AF_UNIX, this rule
+# is needed for using named sockets within the exported
+# directory.
+/var/snap/producer/5/** mrwklix,
+`
 	c.Assert(string(content), Equals, expected)
 }

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -200,7 +200,7 @@ slots:
 	content, err = s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	expected = `
-# In addition to the bind mount, add an AppArmor rule so that
+# In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files
 # read-only.
 /snap/producer/5/export/** mrkix,
@@ -234,10 +234,10 @@ slots:
 	content, err = s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	expected = `
-# In addition to the bind mount, add an AppArmor rule so that
+# In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files. Due
-# to a limitation in the kernel's LSM hooks for AF_UNIX, this rule
-# is needed for using named sockets within the exported
+# to a limitation in the kernel's LSM hooks for AF_UNIX, these
+# are needed for using named sockets within the exported
 # directory.
 /var/snap/producer/5/export/** mrwklix,
 `
@@ -270,10 +270,10 @@ slots:
 	content, err = s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	expected = `
-# In addition to the bind mount, add an AppArmor rule so that
+# In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files. Due
-# to a limitation in the kernel's LSM hooks for AF_UNIX, this rule
-# is needed for using named sockets within the exported
+# to a limitation in the kernel's LSM hooks for AF_UNIX, these
+# are needed for using named sockets within the exported
 # directory.
 /var/snap/producer/common/export/** mrwklix,
 `


### PR DESCRIPTION
This branch fixes writable content sharing, there are two parts to this:

The confinement profile for `snap-confine` is changed to allow to perform more of the actions
that that the content interface allows to express. This specifically allows $SNAP_DATA,
$SNAP_COMMON and $SNAP to be shared as long as both source and destination share
permissions (can be both read or both written). In addition, a snap developer can choose to share
a naturally writable location in a read only way (e.g. a read-only view of $SNAP_DATA)

The generated apparmor profile is changed to work around Linux Security Modules design where
bind mounting a socket doesn't change how apparmor interprets the path (apparmor still sees
the original path).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>