### PR TITLE
cmd/snap: mock terminal.ReadPassword instead of using /dev/ptmx

### DIFF
--- a/cmd/snap/cmd_buy_test.go
+++ b/cmd/snap/cmd_buy_test.go
@@ -26,7 +26,6 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/arch"
 	snap "github.com/snapcore/snapd/cmd/snap"
 )
 
@@ -257,18 +256,7 @@ const loginJson = `
 }
 `
 
-func archWithBrokenDevPtmx() error {
-	if ubuArch := arch.UbuntuArchitecture(); ubuArch == "ppc64el" || ubuArch == "powerpc" {
-		return fmt.Errorf("/dev/ptmx ioctl not working on %s", ubuArch)
-	}
-	return nil
-}
-
 func (s *BuySnapSuite) TestBuySnapSuccess(c *check.C) {
-	if err := archWithBrokenDevPtmx(); err != nil {
-		c.Skip(err.Error())
-	}
-
 	mockServer := &buyTestMockSnapServer{
 		ExpectedMethods: expectedMethods{
 			"GET": &expectedMethod{
@@ -304,7 +292,7 @@ func (s *BuySnapSuite) TestBuySnapSuccess(c *check.C) {
 	s.RedirectClientToTestServer(mockServer.serveHttp)
 
 	// Confirm the purchase.
-	fmt.Fprint(s.term, "the password\n")
+	s.password = "the password"
 
 	rest, err := snap.Parser().ParseArgs([]string{"buy", "hello"})
 	c.Check(err, check.IsNil)
@@ -330,10 +318,6 @@ const buySnapPaymentDeclinedJson = `
 `
 
 func (s *BuySnapSuite) TestBuySnapPaymentDeclined(c *check.C) {
-	if err := archWithBrokenDevPtmx(); err != nil {
-		c.Skip(err.Error())
-	}
-
 	mockServer := &buyTestMockSnapServer{
 		ExpectedMethods: expectedMethods{
 			"GET": &expectedMethod{
@@ -369,7 +353,7 @@ func (s *BuySnapSuite) TestBuySnapPaymentDeclined(c *check.C) {
 	s.RedirectClientToTestServer(mockServer.serveHttp)
 
 	// Confirm the purchase.
-	fmt.Fprint(s.term, "the password\n")
+	s.password = "the password"
 
 	rest, err := snap.Parser().ParseArgs([]string{"buy", "hello"})
 	c.Assert(err, check.NotNil)

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/jessevdk/go-flags"
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
@@ -62,8 +61,6 @@ func init() {
 		}})
 }
 
-var ReadPasswordFunc = terminal.ReadPassword
-
 func requestLoginWith2faRetry(email, password string) error {
 	var otp []byte
 	var err error
@@ -96,7 +93,7 @@ func requestLoginWith2faRetry(email, password string) error {
 
 func requestLogin(email string) error {
 	fmt.Fprint(Stdout, fmt.Sprintf(i18n.G("Password of %q: "), email))
-	password, err := ReadPasswordFunc(Terminal)
+	password, err := ReadPassword(0)
 	fmt.Fprint(Stdout, "\n")
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -62,6 +62,8 @@ func init() {
 		}})
 }
 
+var ReadPasswordFunc = terminal.ReadPassword
+
 func requestLoginWith2faRetry(email, password string) error {
 	var otp []byte
 	var err error
@@ -94,7 +96,7 @@ func requestLoginWith2faRetry(email, password string) error {
 
 func requestLogin(email string) error {
 	fmt.Fprint(Stdout, fmt.Sprintf(i18n.G("Password of %q: "), email))
-	password, err := terminal.ReadPassword(Terminal)
+	password, err := ReadPasswordFunc(Terminal)
 	fmt.Fprint(Stdout, "\n")
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_login_test.go
+++ b/cmd/snap/cmd_login_test.go
@@ -49,15 +49,11 @@ func makeLoginTestServer(c *C, n *int) func(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *SnapSuite) TestLoginSimple(c *C) {
-	if err := archWithBrokenDevPtmx(); err != nil {
-		c.Skip(err.Error())
-	}
-
 	n := 0
 	s.RedirectClientToTestServer(makeLoginTestServer(c, &n))
 
 	// send the password
-	fmt.Fprint(s.term, "some-password\n")
+	s.password = "some-password\n"
 	rest, err := snap.Parser().ParseArgs([]string{"login", "foo@example.com"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
@@ -69,17 +65,13 @@ Login successful
 }
 
 func (s *SnapSuite) TestLoginAskEmail(c *C) {
-	if err := archWithBrokenDevPtmx(); err != nil {
-		c.Skip(err.Error())
-	}
-
 	n := 0
 	s.RedirectClientToTestServer(makeLoginTestServer(c, &n))
 
 	// send the email
 	fmt.Fprint(s.stdin, "foo@example.com\n")
 	// send the password
-	fmt.Fprint(s.term, "some-password\n")
+	s.password = "some-password"
 
 	rest, err := snap.Parser().ParseArgs([]string{"login"})
 	c.Assert(err, IsNil)

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -36,14 +36,16 @@ import (
 	"github.com/snapcore/snapd/osutil"
 
 	"github.com/jessevdk/go-flags"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Standard streams, redirected for testing.
 var (
-	Stdin    io.Reader = os.Stdin
-	Stdout   io.Writer = os.Stdout
-	Stderr   io.Writer = os.Stderr
-	Terminal int       = 0
+	Stdin        io.Reader = os.Stdin
+	Stdout       io.Writer = os.Stdout
+	Stderr       io.Writer = os.Stderr
+	ReadPassword           = terminal.ReadPassword
 )
 
 type options struct {

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -31,6 +31,8 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"golang.org/x/crypto/ssh/terminal"
+
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
@@ -42,18 +44,18 @@ import (
 // Hook up check.v1 into the "go test" runner
 func Test(t *testing.T) { TestingT(t) }
 
-func openPty() (*os.File, error) {
-	return os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
-}
-
 type BaseSnapSuite struct {
 	testutil.BaseTest
-	stdin  *bytes.Buffer
-	stdout *bytes.Buffer
-	stderr *bytes.Buffer
-	term   *os.File
+	stdin    *bytes.Buffer
+	stdout   *bytes.Buffer
+	stderr   *bytes.Buffer
+	password string
 
 	AuthFile string
+}
+
+func (s *BaseSnapSuite) readPassword(fd int) ([]byte, error) {
+	return []byte(s.password), nil
 }
 
 func (s *BaseSnapSuite) SetUpTest(c *C) {
@@ -61,15 +63,12 @@ func (s *BaseSnapSuite) SetUpTest(c *C) {
 	s.stdin = bytes.NewBuffer(nil)
 	s.stdout = bytes.NewBuffer(nil)
 	s.stderr = bytes.NewBuffer(nil)
-
-	pty, err := openPty()
-	c.Assert(err, IsNil)
-	s.term = pty
+	s.password = ""
 
 	snap.Stdin = s.stdin
 	snap.Stdout = s.stdout
 	snap.Stderr = s.stderr
-	snap.Terminal = int(s.term.Fd())
+	snap.ReadPasswordFunc = s.readPassword
 	s.AuthFile = filepath.Join(c.MkDir(), "json")
 	os.Setenv(TestAuthFileEnvKey, s.AuthFile)
 }
@@ -78,9 +77,7 @@ func (s *BaseSnapSuite) TearDownTest(c *C) {
 	snap.Stdin = os.Stdin
 	snap.Stdout = os.Stdout
 	snap.Stderr = os.Stderr
-	snap.Terminal = 0
-
-	s.term.Close()
+	snap.ReadPasswordFunc = terminal.ReadPassword
 
 	c.Assert(s.AuthFile == "", Equals, false)
 	err := os.Unsetenv(TestAuthFileEnvKey)

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -68,7 +68,7 @@ func (s *BaseSnapSuite) SetUpTest(c *C) {
 	snap.Stdin = s.stdin
 	snap.Stdout = s.stdout
 	snap.Stderr = s.stderr
-	snap.ReadPasswordFunc = s.readPassword
+	snap.ReadPassword = s.readPassword
 	s.AuthFile = filepath.Join(c.MkDir(), "json")
 	os.Setenv(TestAuthFileEnvKey, s.AuthFile)
 }
@@ -77,7 +77,7 @@ func (s *BaseSnapSuite) TearDownTest(c *C) {
 	snap.Stdin = os.Stdin
 	snap.Stdout = os.Stdout
 	snap.Stderr = os.Stderr
-	snap.ReadPasswordFunc = terminal.ReadPassword
+	snap.ReadPassword = terminal.ReadPassword
 
 	c.Assert(s.AuthFile == "", Equals, false)
 	err := os.Unsetenv(TestAuthFileEnvKey)


### PR DESCRIPTION
- Should be more reliable.
- Will work on ppc64el and powerpc.