### PR TITLE
debian: fix Pre-Depends on dpkg

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -109,6 +109,6 @@ Description: Support executable to apply confinement for snappy apps
 Package: ubuntu-core-launcher
 Architecture: any
 Depends: snap-confine (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}
-Pre-Depends: dpkg (>= 1.17.14)
+Pre-Depends: dpkg (>= 1.15.7.2)
 Description: Launcher for ubuntu-core (snappy) apps
  This package contains the launcher for launching snappy applications


### PR DESCRIPTION
We only use rm_conffile from the maintscript helper so it is
sufficient to pre-depend on 1.15.7.2 instead of 1.17.4
(see `man dpkg-maintscript-helper`).