### PR TITLE
interfaces: add new boot-config interface

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -50,6 +50,7 @@ var allInterfaces = []interfaces.Interface{
 	NewAlsaInterface(),
 	NewAvahiObserveInterface(),
 	NewBluetoothControlInterface(),
+	NewBootConfigInterface(),
 	NewCameraInterface(),
 	NewCupsControlInterface(),
 	NewDcdbasControlInterface(),

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -178,6 +178,12 @@ slots:
         - core
         - gadget
     deny-auto-connection: true
+  boot-config:
+    allow-installation:
+      slot-snap-type:
+        - gadget
+    deny-connection: true
+    deny-auto-connection: true
   browser-support:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -155,7 +155,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 			continue
 		}
 		expected := autoconnect[iface.Name()]
-		comm := Commentf(iface.Name())
+		comm := Commentf("%s: %v", iface.Name(), expected)
 
 		// check base declaration
 		cand := s.connectCand(c, iface.Name(), "", "")
@@ -347,6 +347,7 @@ var (
 		// other
 		"bluez":            {"app"},
 		"bool-file":        {"core", "gadget"},
+		"boot-config":      {"gadget"},
 		"browser-support":  {"core"},
 		"content":          {"app", "gadget"},
 		"docker-support":   {"core"},
@@ -467,6 +468,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 	// case-by-case basis
 	noconnect := map[string]bool{
 		"bluez":            true,
+		"boot-config":      true,
 		"docker":           true,
 		"fwupd":            true,
 		"location-control": true,

--- a/interfaces/builtin/bootconfig.go
+++ b/interfaces/builtin/bootconfig.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const bootConfigConnectedPlugAppArmor = `
+# Description: Can access boot config files amd brick the system
+# Usage: reserved (very much so!)
+
+# Allow read/write access to the pi2 boot config.txt
+owner /boot/uboot/config.txt rwk,
+`
+
+func NewBootConfigInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "boot-config",
+		connectedPlugAppArmor: bootConfigConnectedPlugAppArmor,
+	}
+}

--- a/interfaces/builtin/bootconfig_test.go
+++ b/interfaces/builtin/bootconfig_test.go
@@ -1,0 +1,74 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type bootConfigInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&bootConfigInterfaceSuite{
+	iface: builtin.NewBootConfigInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "pi2", Type: snap.TypeGadget},
+			Name:      "boot-config",
+			Interface: "boot-config",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "boot-config",
+			Interface: "boot-config",
+		},
+	},
+})
+
+func (s *bootConfigInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "boot-config")
+}
+
+func (s *bootConfigInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, "/boot/uboot/config.txt")
+}
+
+func (s *bootConfigInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+}
+
+func (s *bootConfigInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
This is a new boot-config interfaces that allows tweaking of the /boot/uboot/config.txt file. We need to be very careful with this interface as it can potentially brick the device. 

The idea is that the pi2/pi3 gadget snaps get a `slots: ["boot-config"]` and a `meta/hooks/configure` that is very carefully written by us to allow modifying a whitelist of keys in the config.txt file, e.g. `hdmi_{width,height}` for now. With that, `snap set rpi2.config.hdmi_width NNN` will be possible.

This makes progress towards: https://bugs.launchpad.net/snappy/+bug/1587137