### PR TITLE
tests: update custom core snap with the freshly build snap-confine

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -134,6 +134,7 @@ setup_reflash_magic() {
         #        the image
         # unpack our freshly build snapd into the new core snap
         dpkg-deb -x ${SPREAD_PATH}/../snapd_*.deb $UNPACKD
+        dpkg-deb -x ${SPREAD_PATH}/../snap-confine_*.deb $UNPACKD
 
         # add a gpio slot
         cat >> $UNPACKD/meta/snap.yaml <<-EOF


### PR DESCRIPTION
This should fix the test errors that @jdstrand saw in https://github.com/snapcore/snapd/pull/2450