### PR TITLE
overlord: apply auto-aliases information from the snap-declaration on install or refresh

### DIFF
--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -500,3 +500,21 @@ func SnapDeclaration(s *state.State, snapID string) (*asserts.SnapDeclaration, e
 	}
 	return a.(*asserts.SnapDeclaration), nil
 }
+
+// AutoAliases returns the auto-aliases list for the given installed snap.
+func AutoAliases(s *state.State, info *snap.Info) ([]string, error) {
+	if info.SnapID == "" {
+		// without declaration
+		return nil, nil
+	}
+	decl, err := SnapDeclaration(s, info.SnapID)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: cannot find snap-declaration for installed snap %q: %v", info.Name(), err)
+	}
+	return decl.AutoAliases(), nil
+}
+
+func init() {
+	// hook retrieving auto-aliases into snapstate logic
+	snapstate.AutoAliases = AutoAliases
+}

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -560,7 +560,7 @@ func (s *assertMgrSuite) TestValidateSnapSnapDeclIsTooNewFirstInstall(c *C) {
 	c.Assert(chg.Err(), ErrorMatches, `(?s).*proposed "snap-declaration" assertion has format 999 but 0 is latest supported.*`)
 }
 
-func (s *assertMgrSuite) snapDecl(c *C, name string, control []interface{}) *asserts.SnapDeclaration {
+func (s *assertMgrSuite) snapDecl(c *C, name string, extraHeaders map[string]interface{}) *asserts.SnapDeclaration {
 	headers := map[string]interface{}{
 		"series":       "16",
 		"snap-id":      name + "-id",
@@ -568,8 +568,8 @@ func (s *assertMgrSuite) snapDecl(c *C, name string, control []interface{}) *ass
 		"publisher-id": s.dev1Acct.AccountID(),
 		"timestamp":    time.Now().Format(time.RFC3339),
 	}
-	if len(control) != 0 {
-		headers["refresh-control"] = control
+	for h, v := range extraHeaders {
+		headers[h] = v
 	}
 	decl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
 	c.Assert(err, IsNil)
@@ -736,7 +736,9 @@ func (s *assertMgrSuite) TestValidateRefreshesMissingValidation(c *C) {
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", []interface{}{"foo-id"})
+	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
+		"refresh-control": []interface{}{"foo-id"},
+	})
 	s.stateFromDecl(snapDeclFoo, snap.R(7))
 	s.stateFromDecl(snapDeclBar, snap.R(3))
 
@@ -763,8 +765,12 @@ func (s *assertMgrSuite) TestValidateRefreshesValidationOK(c *C) {
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", []interface{}{"foo-id"})
-	snapDeclBaz := s.snapDecl(c, "baz", []interface{}{"foo-id"})
+	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
+		"refresh-control": []interface{}{"foo-id"},
+	})
+	snapDeclBaz := s.snapDecl(c, "baz", map[string]interface{}{
+		"refresh-control": []interface{}{"foo-id"},
+	})
 	s.stateFromDecl(snapDeclFoo, snap.R(7))
 	s.stateFromDecl(snapDeclBar, snap.R(3))
 	s.stateFromDecl(snapDeclBaz, snap.R(1))
@@ -827,8 +833,12 @@ func (s *assertMgrSuite) TestValidateRefreshesRevokedValidation(c *C) {
 	defer s.state.Unlock()
 
 	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	snapDeclBar := s.snapDecl(c, "bar", []interface{}{"foo-id"})
-	snapDeclBaz := s.snapDecl(c, "baz", []interface{}{"foo-id"})
+	snapDeclBar := s.snapDecl(c, "bar", map[string]interface{}{
+		"refresh-control": []interface{}{"foo-id"},
+	})
+	snapDeclBaz := s.snapDecl(c, "baz", map[string]interface{}{
+		"refresh-control": []interface{}{"foo-id"},
+	})
 	s.stateFromDecl(snapDeclFoo, snap.R(7))
 	s.stateFromDecl(snapDeclBar, snap.R(3))
 	s.stateFromDecl(snapDeclBaz, snap.R(1))
@@ -932,4 +942,58 @@ func (s *assertMgrSuite) TestSnapDeclaration(c *C) {
 	snapDecl, err := assertstate.SnapDeclaration(s.state, "foo-id")
 	c.Assert(err, IsNil)
 	c.Check(snapDecl.SnapName(), Equals, "foo")
+}
+
+func (s *assertMgrSuite) TestAutoAliases(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a declaration in the system db
+	err := assertstate.Add(s.state, s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, s.dev1Acct)
+	c.Assert(err, IsNil)
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+	err = assertstate.Add(s.state, snapDeclFoo)
+	c.Assert(err, IsNil)
+
+	// not from the store
+	aliases, err := assertstate.AutoAliases(s.state, &snap.Info{SuggestedName: "local"})
+	c.Assert(err, IsNil)
+	c.Check(aliases, HasLen, 0)
+
+	// missing
+	_, err = assertstate.AutoAliases(s.state, &snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "baz",
+			SnapID:   "baz-id",
+		},
+	})
+	c.Check(err, ErrorMatches, `internal error: cannot find snap-declaration for installed snap "baz": assertion not found`)
+
+	// empty list
+	aliases, err = assertstate.AutoAliases(s.state, &snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "foo",
+			SnapID:   "foo-id",
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(aliases, HasLen, 0)
+
+	// some aliases
+	snapDeclFoo = s.snapDecl(c, "foo", map[string]interface{}{
+		"auto-aliases": []interface{}{"alias1", "alias2"},
+		"revision":     "1",
+	})
+	err = assertstate.Add(s.state, snapDeclFoo)
+	c.Assert(err, IsNil)
+	aliases, err = assertstate.AutoAliases(s.state, &snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "foo",
+			SnapID:   "foo-id",
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(aliases, DeepEquals, []string{"alias1", "alias2"})
 }

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -948,13 +948,10 @@ func (s *assertMgrSuite) TestAutoAliases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	// have a declaration in the system db
+	// prereqs for developer assertions in the system db
 	err := assertstate.Add(s.state, s.storeSigning.StoreAccountKey(""))
 	c.Assert(err, IsNil)
 	err = assertstate.Add(s.state, s.dev1Acct)
-	c.Assert(err, IsNil)
-	snapDeclFoo := s.snapDecl(c, "foo", nil)
-	err = assertstate.Add(s.state, snapDeclFoo)
 	c.Assert(err, IsNil)
 
 	// not from the store
@@ -972,6 +969,10 @@ func (s *assertMgrSuite) TestAutoAliases(c *C) {
 	c.Check(err, ErrorMatches, `internal error: cannot find snap-declaration for installed snap "baz": assertion not found`)
 
 	// empty list
+	// have a declaration in the system db
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+	err = assertstate.Add(s.state, snapDeclFoo)
+	c.Assert(err, IsNil)
 	aliases, err = assertstate.AutoAliases(s.state, &snap.Info{
 		SideInfo: snap.SideInfo{
 			RealName: "foo",

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -23,6 +23,7 @@ package overlord_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -74,8 +75,9 @@ type mgrsSuite struct {
 
 	o *overlord.Overlord
 
-	serveSnapPath string
-	serveRevision string
+	serveIDtoName map[string]string
+	serveSnapPath map[string]string
+	serveRevision map[string]string
 }
 
 var (
@@ -131,6 +133,10 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	st.Lock()
 	st.Set("seeded", true)
 	st.Unlock()
+
+	ms.serveIDtoName = make(map[string]string)
+	ms.serveSnapPath = make(map[string]string)
+	ms.serveRevision = make(map[string]string)
 }
 
 func (ms *mgrsSuite) TearDownTest(c *C) {
@@ -236,8 +242,13 @@ apps:
 	c.Assert(osutil.FileExists(mup), Equals, false)
 }
 
+func fakeSnapID(name string) string {
+	const suffix = "idididididididididididididididid"
+	return name + suffix[len(name)+1:]
+}
+
 const (
-	fooSearchHit = `{
+	searchHit = `{
 	"anon_download_url": "@URL@",
 	"architecture": [
 	    "all"
@@ -249,39 +260,52 @@ const (
 	"download_url": "@URL@",
 	"icon_url": "@ICON@",
 	"origin": "bar",
-	"package_name": "foo",
+	"package_name": "@NAME@",
 	"revision": @REVISION@,
-	"snap_id": "idididididididididididididididid",
+	"snap_id": "@SNAPID@",
 	"summary": "Foo",
 	"version": "@VERSION@"
 }`
-
-	fooSnapID = "idididididididididididididididid"
 )
 
-func (ms *mgrsSuite) prereqSnapAssertions(c *C) *asserts.SnapDeclaration {
-	headers := map[string]interface{}{
-		"series":       "16",
-		"snap-id":      fooSnapID,
-		"snap-name":    "foo",
-		"publisher-id": "devdevdev",
-		"timestamp":    time.Now().Format(time.RFC3339),
+var fooSnapID = fakeSnapID("foo")
+
+func (ms *mgrsSuite) prereqSnapAssertions(c *C, extraHeaders ...map[string]interface{}) *asserts.SnapDeclaration {
+	if len(extraHeaders) == 0 {
+		extraHeaders = []map[string]interface{}{{}}
 	}
-	snapDecl, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
-	c.Assert(err, IsNil)
-	err = ms.storeSigning.Add(snapDecl)
-	c.Assert(err, IsNil)
-	return snapDecl.(*asserts.SnapDeclaration)
+	var snapDecl *asserts.SnapDeclaration
+	for _, extraHeaders := range extraHeaders {
+		headers := map[string]interface{}{
+			"series":       "16",
+			"snap-name":    "foo",
+			"publisher-id": "devdevdev",
+			"timestamp":    time.Now().Format(time.RFC3339),
+		}
+		for h, v := range extraHeaders {
+			headers[h] = v
+		}
+		headers["snap-id"] = fakeSnapID(headers["snap-name"].(string))
+		a, err := ms.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+		c.Assert(err, IsNil)
+		err = ms.storeSigning.Add(a)
+		c.Assert(err, IsNil)
+		snapDecl = a.(*asserts.SnapDeclaration)
+	}
+	return snapDecl
 }
 
 func (ms *mgrsSuite) makeStoreTestSnap(c *C, snapYaml string, revno string) (path, digest string) {
+	info, err := snap.InfoFromSnapYaml([]byte(snapYaml))
+	c.Assert(err, IsNil)
+
 	snapPath := makeTestSnap(c, snapYaml)
 
 	snapDigest, size, err := asserts.SnapFileSHA3_384(snapPath)
 	c.Assert(err, IsNil)
 
 	headers := map[string]interface{}{
-		"snap-id":       fooSnapID,
+		"snap-id":       fakeSnapID(info.Name()),
 		"snap-sha3-384": snapDigest,
 		"snap-size":     fmt.Sprintf("%d", size),
 		"snap-revision": revno,
@@ -298,8 +322,8 @@ func (ms *mgrsSuite) makeStoreTestSnap(c *C, snapYaml string, revno string) (pat
 
 func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 	var baseURL string
-	fillHit := func() string {
-		snapf, err := snap.Open(ms.serveSnapPath)
+	fillHit := func(name string) string {
+		snapf, err := snap.Open(ms.serveSnapPath[name])
 		if err != nil {
 			panic(err)
 		}
@@ -307,16 +331,23 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 		if err != nil {
 			panic(err)
 		}
-		hit := strings.Replace(fooSearchHit, "@URL@", baseURL+"/snap", -1)
+		hit := strings.Replace(searchHit, "@URL@", baseURL+"/snap/"+name, -1)
+		hit = strings.Replace(hit, "@NAME@", name, -1)
+		hit = strings.Replace(hit, "@SNAPID@", fakeSnapID(name), -1)
 		hit = strings.Replace(hit, "@ICON@", baseURL+"/icon", -1)
 		hit = strings.Replace(hit, "@VERSION@", info.Version, -1)
-		hit = strings.Replace(hit, "@REVISION@", ms.serveRevision, -1)
+		hit = strings.Replace(hit, "@REVISION@", ms.serveRevision[name], -1)
 		return hit
 	}
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/assertions/") {
-			comps := strings.Split(r.URL.Path, "/")
+		comps := strings.Split(r.URL.Path, "/")
+		if len(comps) == 0 {
+			panic("unexpected url path: " + r.URL.Path)
+
+		}
+		switch comps[1] {
+		case "assertions":
 			ref := &asserts.Ref{
 				Type:       asserts.Type(comps[2]),
 				PrimaryKey: comps[3:],
@@ -335,23 +366,41 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 			w.WriteHeader(200)
 			w.Write(asserts.Encode(a))
 			return
-		}
-
-		switch r.URL.Path {
-		case "/details/foo":
+		case "details":
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, fillHit())
-		case "/metadata":
+			io.WriteString(w, fillHit(comps[2]))
+		case "metadata":
+			dec := json.NewDecoder(r.Body)
+			var input struct {
+				Snaps []struct {
+					SnapID   string `json:"snap_id"`
+					Revision int    `json:"revision"`
+				} `json:"snaps"`
+			}
+			err := dec.Decode(&input)
+			if err != nil {
+				panic(err)
+			}
+			var hits []json.RawMessage
+			for _, s := range input.Snaps {
+				name := ms.serveIDtoName[s.SnapID]
+				if snap.R(s.Revision) == snap.R(ms.serveRevision[name]) {
+					continue
+				}
+				hits = append(hits, json.RawMessage(fillHit(name)))
+			}
 			w.WriteHeader(http.StatusOK)
-			output := `{
-    "_embedded": {
-	    "clickindex:package": [@HIT@]
-    }
-}`
-			output = strings.Replace(output, "@HIT@", fillHit(), 1)
-			io.WriteString(w, output)
-		case "/snap":
-			snapR, err := os.Open(ms.serveSnapPath)
+			output, err := json.Marshal(map[string]interface{}{
+				"_embedded": map[string]interface{}{
+					"clickindex:package": hits,
+				},
+			})
+			if err != nil {
+				panic(err)
+			}
+			w.Write(output)
+		case "snap":
+			snapR, err := os.Open(ms.serveSnapPath[comps[2]])
 			if err != nil {
 				panic(err)
 			}
@@ -385,9 +434,19 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 	return mockServer
 }
 
-func (ms *mgrsSuite) serveSnap(snapPath string, revno string) {
-	ms.serveSnapPath = snapPath
-	ms.serveRevision = revno
+func (ms *mgrsSuite) serveSnap(snapPath, revno string) {
+	snapf, err := snap.Open(snapPath)
+	if err != nil {
+		panic(err)
+	}
+	info, err := snap.ReadInfoFromSnapFile(snapf, nil)
+	if err != nil {
+		panic(err)
+	}
+	name := info.Name()
+	ms.serveIDtoName[fakeSnapID(name)] = name
+	ms.serveSnapPath[name] = snapPath
+	ms.serveRevision[name] = revno
 }
 
 func (ms *mgrsSuite) TestHappyRemoteInstallAndUpgradeSvc(c *C) {
@@ -1090,7 +1149,6 @@ apps:
 	c.Check(osutil.IsSymlink(foo_Alias), Equals, false)
 
 	allAliases = nil
-
 	err = st.Get("aliases", &allAliases)
 	c.Assert(err, IsNil)
 	c.Check(allAliases, DeepEquals, map[string]map[string]string{
@@ -1098,6 +1156,173 @@ apps:
 			"foo_": "disabled",
 		},
 	})
+}
+
+func (ms *mgrsSuite) TestHappyRemoteInstallAutoAliases(c *C) {
+	ms.prereqSnapAssertions(c, map[string]interface{}{
+		"snap-name":    "foo",
+		"auto-aliases": []interface{}{"app1", "app2"},
+	})
+
+	snapYamlContent := `name: foo
+version: @VERSION@
+apps:
+ app1:
+  command: bin/app1
+  aliases: [app1]
+ app2:
+  command: bin/app2
+  aliases: [app2]
+`
+
+	ver := "1.0"
+	revno := "42"
+	snapPath, _ := ms.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
+	ms.serveSnap(snapPath, revno)
+
+	mockServer := ms.mockStore(c)
+	defer mockServer.Close()
+
+	st := ms.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	ts, err := snapstate.Install(st, "foo", "stable", snap.R(0), 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg := st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	st.Unlock()
+	err = ms.o.Settle()
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
+
+	var allAliases map[string]map[string]string
+	err = st.Get("aliases", &allAliases)
+	c.Assert(err, IsNil)
+	c.Check(allAliases, DeepEquals, map[string]map[string]string{
+		"foo": {
+			"app1": "auto",
+			"app2": "auto",
+		},
+	})
+
+	// check disk
+	app1Alias := filepath.Join(dirs.SnapBinariesDir, "app1")
+	dest, err := os.Readlink(app1Alias)
+	c.Assert(err, IsNil)
+	c.Check(dest, Equals, "foo.app1")
+
+	app2Alias := filepath.Join(dirs.SnapBinariesDir, "app2")
+	dest, err = os.Readlink(app2Alias)
+	c.Assert(err, IsNil)
+	c.Check(dest, Equals, "foo.app2")
+}
+
+func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateAutoAliases(c *C) {
+	ms.prereqSnapAssertions(c, map[string]interface{}{
+		"snap-name":    "foo",
+		"auto-aliases": []interface{}{"app1"},
+	})
+
+	fooYaml := `name: foo
+version: @VERSION@
+apps:
+ app1:
+  command: bin/app1
+  aliases: [app1]
+ app2:
+  command: bin/app2
+  aliases: [app2]
+`
+
+	fooPath, _ := ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
+	ms.serveSnap(fooPath, "10")
+
+	mockServer := ms.mockStore(c)
+	defer mockServer.Close()
+
+	st := ms.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	ts, err := snapstate.Install(st, "foo", "stable", snap.R(0), 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg := st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	st.Unlock()
+	err = ms.o.Settle()
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
+
+	info, err := snapstate.CurrentInfo(st, "foo")
+	c.Assert(err, IsNil)
+	c.Check(info.Revision, Equals, snap.R(10))
+	c.Check(info.Version, Equals, "1.0")
+
+	var allAliases map[string]map[string]string
+	err = st.Get("aliases", &allAliases)
+	c.Check(err, IsNil)
+	c.Check(allAliases, DeepEquals, map[string]map[string]string{
+		"foo": {
+			"app1": "auto",
+		},
+	})
+	app1Alias := filepath.Join(dirs.SnapBinariesDir, "app1")
+	dest, err := os.Readlink(app1Alias)
+	c.Assert(err, IsNil)
+	c.Check(dest, Equals, "foo.app1")
+
+	ms.prereqSnapAssertions(c, map[string]interface{}{
+		"snap-name":    "foo",
+		"auto-aliases": []interface{}{"app2"},
+		"revision":     "1",
+	})
+
+	// new foo version/revision
+	fooPath, _ = ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.5", -1), "15")
+	ms.serveSnap(fooPath, "15")
+
+	// refresh all
+	updated, tss, err := snapstate.UpdateMany(st, nil, 0)
+	c.Assert(err, IsNil)
+	c.Assert(updated, DeepEquals, []string{"foo"})
+	c.Assert(tss, HasLen, 1)
+	chg = st.NewChange("upgrade-snaps", "...")
+	chg.AddAll(tss[0])
+
+	st.Unlock()
+	err = ms.o.Settle()
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("upgrade-snap change failed with: %v", chg.Err()))
+
+	info, err = snapstate.CurrentInfo(st, "foo")
+	c.Assert(err, IsNil)
+	c.Check(info.Revision, Equals, snap.R(15))
+	c.Check(info.Version, Equals, "1.5")
+
+	allAliases = nil
+	err = st.Get("aliases", &allAliases)
+	c.Check(err, IsNil)
+	c.Check(allAliases, DeepEquals, map[string]map[string]string{
+		"foo": {
+			"app2": "auto",
+		},
+	})
+
+	c.Check(osutil.IsSymlink(app1Alias), Equals, false)
+
+	app2Alias := filepath.Join(dirs.SnapBinariesDir, "app2")
+	dest, err = os.Readlink(app2Alias)
+	c.Assert(err, IsNil)
+	c.Check(dest, Equals, "foo.app2")
 }
 
 type authContextSetupSuite struct {

--- a/overlord/snapstate/aliases.go
+++ b/overlord/snapstate/aliases.go
@@ -622,6 +622,7 @@ func (m *SnapManager) doSetAutoAliases(t *state.Task, _ *tomb.Tomb) error {
 			// not a known alias anymore or yet, skip
 			continue
 		}
+		// TODO: only mark/log conflict if this is an update instead of an install?
 		err := checkAliasConflict(st, snapName, alias)
 		if err != nil {
 			return err

--- a/overlord/snapstate/aliases.go
+++ b/overlord/snapstate/aliases.go
@@ -508,7 +508,7 @@ func checkAliasConflict(st *state.State, snapName, alias string) error {
 
 	// check against aliases
 	return checkAgainstEnabledAliases(st, func(otherAlias, otherSnap string) error {
-		if otherAlias == alias {
+		if otherAlias == alias && otherSnap != snapName {
 			return &aliasConflictError{
 				Alias:  alias,
 				Snap:   snapName,
@@ -517,4 +517,117 @@ func checkAliasConflict(st *state.State, snapName, alias string) error {
 		}
 		return nil
 	})
+}
+
+// AutoAliases allows to hook support for retrieving auto-aliases of a snap.
+var AutoAliases func(st *state.State, info *snap.Info) ([]string, error)
+
+// AutoAliasesDelta compares the alias statuses with the current snap
+// declaration for the installed snaps with the given names (or all if
+// names is empty) and returns new and retired auto-aliases by snap
+// name. It accounts for already set enabled/disabled statuses but
+// does not check for conflicts.
+func AutoAliasesDelta(st *state.State, names []string) (new map[string][]string, retired map[string][]string, err error) {
+	var snapStates map[string]*SnapState
+	if len(names) == 0 {
+		var err error
+		snapStates, err = All(st)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		snapStates = make(map[string]*SnapState, len(names))
+		for _, name := range names {
+			var snapst SnapState
+			err := Get(st, name, &snapst)
+			if err != nil {
+				return nil, nil, err
+			}
+			snapStates[name] = &snapst
+		}
+	}
+	var firstErr error
+	new = make(map[string][]string)
+	retired = make(map[string][]string)
+	for snapName, snapst := range snapStates {
+		aliasStatuses, err := getAliases(st, snapName)
+		if err != nil && err != state.ErrNoState {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		info, err := snapst.CurrentInfo()
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		autoAliases, err := AutoAliases(st, info)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		autoSet := make(map[string]bool, len(autoAliases))
+		for _, alias := range autoAliases {
+			autoSet[alias] = true
+			if aliasStatuses[alias] == "" { // not auto, or disabled, or enabled
+				new[snapName] = append(new[snapName], alias)
+			}
+		}
+		for alias, curStatus := range aliasStatuses {
+			if curStatus == "auto" && !autoSet[alias] {
+				retired[snapName] = append(retired[snapName], alias)
+			}
+		}
+	}
+	return new, retired, firstErr
+}
+
+func (m *SnapManager) doSetAutoAliases(t *state.Task, _ *tomb.Tomb) error {
+	st := t.State()
+	st.Lock()
+	defer st.Unlock()
+	snapsup, snapst, err := snapSetupAndState(t)
+	if err != nil {
+		return err
+	}
+	snapName := snapsup.Name()
+	curInfo, err := snapst.CurrentInfo()
+	if err != nil {
+		return err
+	}
+	aliasStatuses, err := getAliases(st, snapName)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	t.Set("old-aliases", aliasStatuses)
+	if aliasStatuses == nil {
+		aliasStatuses = make(map[string]string)
+	}
+	allNew, allRetired, err := AutoAliasesDelta(st, []string{snapName})
+	if err != nil {
+		return err
+	}
+	for _, alias := range allRetired[snapName] {
+		delete(aliasStatuses, alias)
+	}
+
+	for _, alias := range allNew[snapName] {
+		aliasApp := curInfo.Aliases[alias]
+		if aliasApp == nil {
+			// not a known alias anymore or yet, skip
+			continue
+		}
+		err := checkAliasConflict(st, snapName, alias)
+		if err != nil {
+			return err
+		}
+		aliasStatuses[alias] = "auto"
+	}
+	setAliases(st, snapName, aliasStatuses)
+	return nil
 }

--- a/overlord/snapstate/aliases_test.go
+++ b/overlord/snapstate/aliases_test.go
@@ -150,6 +150,106 @@ func (s *snapmgrTestSuite) TestAliasTasks(c *C) {
 	})
 }
 
+func (s *snapmgrTestSuite) TestDoSetupAliasesAuto(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		},
+		Current: snap.R(11),
+		Active:  true,
+	})
+	s.state.Set("aliases", map[string]map[string]string{
+		"alias-snap": {
+			"alias1": "auto",
+		},
+	})
+
+	t := s.state.NewTask("setup-aliases", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	})
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.snapmgr.Ensure()
+	s.snapmgr.Wait()
+
+	s.state.Lock()
+
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	expected := fakeOps{
+		{
+			op:      "update-aliases",
+			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+}
+
+func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAuto(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		},
+		Current: snap.R(11),
+		Active:  true,
+	})
+	s.state.Set("aliases", map[string]map[string]string{
+		"alias-snap": {
+			"alias1": "auto",
+		},
+	})
+
+	t := s.state.NewTask("setup-aliases", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
+	})
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(t)
+
+	terr := s.state.NewTask("error-trigger", "provoking total undo")
+	terr.WaitFor(t)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.snapmgr.Ensure()
+		s.snapmgr.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(t.Status(), Equals, state.UndoneStatus)
+	expected := fakeOps{
+		{
+			op:      "update-aliases",
+			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+		},
+		{
+			op:      "matching-aliases",
+			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+		},
+		{
+			op:        "update-aliases",
+			rmAliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+}
+
 func (s *snapmgrTestSuite) TestAliasRunThrough(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -310,6 +410,37 @@ func (s *snapmgrTestSuite) TestAliasAliasConflict(c *C) {
 	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1" for "alias-snap", already enabled for "other-snap".*`)
 }
 
+func (s *snapmgrTestSuite) TestAliasAutoAliasConflict(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "alias-snap", Revision: snap.R(11)},
+		},
+		Current: snap.R(11),
+		Active:  true,
+	})
+	s.state.Set("aliases", map[string]map[string]string{
+		"other-snap": {"alias1": "auto"},
+	})
+
+	chg := s.state.NewChange("alias", "enable an alias")
+	ts, err := snapstate.Alias(s.state, "alias-snap", []string{"alias1"})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.state.Unlock()
+
+	s.snapmgr.Ensure()
+	s.snapmgr.Wait()
+
+	s.state.Lock()
+
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1" for "alias-snap", already enabled for "other-snap".*`)
+}
+
 func (s *snapmgrTestSuite) TestAliasSnapCommandSpaceConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -383,7 +514,7 @@ func (s *snapmgrTestSuite) TestDoUndoClearAliases(c *C) {
 	defer s.state.Unlock()
 
 	s.state.Set("aliases", map[string]map[string]string{
-		"alias-snap": {"alias1": "enabled"},
+		"alias-snap": {"alias1": "enabled", "alias5": "auto"},
 		"other-snap": {"alias2": "enabled"},
 	})
 
@@ -414,7 +545,7 @@ func (s *snapmgrTestSuite) TestDoUndoClearAliases(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(allAliases, DeepEquals, map[string]map[string]string{
-		"alias-snap": {"alias1": "enabled"},
+		"alias-snap": {"alias1": "enabled", "alias5": "auto"},
 		"other-snap": {"alias2": "enabled"},
 	})
 }
@@ -425,13 +556,15 @@ func (s *snapmgrTestSuite) TestDoUndoClearAliasesConflict(c *C) {
 
 	s.state.Set("aliases", map[string]map[string]string{
 		"alias-snap": {
-			"alias1": "enabled",
-			"alias9": "enabled",
+			"alias1":  "enabled",
+			"alias5":  "auto",
+			"alias9":  "enabled",
+			"alias10": "auto",
 		},
 		"other-snap": {"alias2": "enabled"},
 	})
 
-	grabAlias9 := func(t *state.Task, _ *tomb.Tomb) error {
+	grabAlias9_10 := func(t *state.Task, _ *tomb.Tomb) error {
 		st := t.State()
 		st.Lock()
 		defer st.Unlock()
@@ -445,14 +578,15 @@ func (s *snapmgrTestSuite) TestDoUndoClearAliasesConflict(c *C) {
 
 		st.Set("aliases", map[string]map[string]string{
 			"other-snap": {
-				"alias2": "enabled",
-				"alias9": "enabled",
+				"alias2":  "enabled",
+				"alias9":  "enabled",
+				"alias10": "enabled",
 			},
 		})
 		return nil
 	}
 
-	s.snapmgr.AddAdhocTaskHandler("grab-alias9", grabAlias9, nil)
+	s.snapmgr.AddAdhocTaskHandler("grab-alias9_10", grabAlias9_10, nil)
 
 	t := s.state.NewTask("clear-aliases", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
@@ -461,12 +595,12 @@ func (s *snapmgrTestSuite) TestDoUndoClearAliasesConflict(c *C) {
 	chg := s.state.NewChange("dummy", "...")
 	chg.AddTask(t)
 
-	tgrab9 := s.state.NewTask("grab-alias9", "grab alias9 for other-snap")
-	tgrab9.WaitFor(t)
-	chg.AddTask(tgrab9)
+	tgrab9_10 := s.state.NewTask("grab-alias9_10", "grab alias9&alias10 for other-snap")
+	tgrab9_10.WaitFor(t)
+	chg.AddTask(tgrab9_10)
 
 	terr := s.state.NewTask("error-trigger", "provoking total undo")
-	terr.WaitFor(tgrab9)
+	terr.WaitFor(tgrab9_10)
 	chg.AddTask(terr)
 
 	s.state.Unlock()
@@ -485,15 +619,19 @@ func (s *snapmgrTestSuite) TestDoUndoClearAliasesConflict(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(allAliases, DeepEquals, map[string]map[string]string{
-		"alias-snap": {"alias1": "enabled"},
+		"alias-snap": {
+			"alias1": "enabled",
+			"alias5": "auto",
+		},
 		"other-snap": {
-			"alias2": "enabled",
-			"alias9": "enabled",
+			"alias2":  "enabled",
+			"alias9":  "enabled",
+			"alias10": "enabled",
 		},
 	})
 
-	c.Check(t.Log(), HasLen, 1)
-	c.Check(t.Log()[0], Matches, `.* ERROR cannot enable alias "alias9" for "alias-snap", already enabled for "other-snap"`)
+	c.Check(t.Log(), HasLen, 2)
+	c.Check(t.Log()[0]+t.Log()[1], Matches, `.* ERROR cannot enable alias "alias9" for "alias-snap", already enabled for "other-snap".*`)
 }
 
 var statusesMatrix = []struct {
@@ -505,9 +643,11 @@ var statusesMatrix = []struct {
 	{"", "alias", "enabled", "add"},
 	{"enabled", "alias", "enabled", "-"},
 	{"disabled", "alias", "enabled", "add"},
+	{"auto", "alias", "enabled", "-"},
 	{"", "unalias", "disabled", "-"},
 	{"enabled", "unalias", "disabled", "rm"},
 	{"disabled", "unalias", "disabled", "-"},
+	{"auto", "unalias", "disabled", "rm"},
 }
 
 func (s *snapmgrTestSuite) TestAliasMatrixRunThrough(c *C) {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -294,6 +294,14 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 apps:
   cmd1:
     aliases: [alias1, alias1.cmd1]
+  cmd2:
+    aliases: [alias2]
+  cmd3:
+    aliases: [alias3]
+  cmd4:
+    aliases: [alias4]
+  cmd5:
+    aliases: [alias5]
 `))
 		if err != nil {
 			panic(err)

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -67,9 +67,13 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	bs.snapmgr.AddForeignTaskHandlers(bs.fakeBackend)
 
 	snapstate.SetSnapManagerBackend(bs.snapmgr, bs.fakeBackend)
+	snapstate.AutoAliases = func(*state.State, *snap.Info) ([]string, error) {
+		return nil, nil
+	}
 }
 
 func (bs *bootedSuite) TearDownTest(c *C) {
+	snapstate.AutoAliases = nil
 	release.MockOnClassic(true)
 	dirs.SetRootDir("")
 	partition.ForceBootloader(nil)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -345,8 +345,8 @@ func Manager(st *state.State) (*SnapManager, error) {
 
 	// alias related
 	runner.AddHandler("alias", m.doAlias, m.undoAlias)
-	//TODO: unalias
 	runner.AddHandler("clear-aliases", m.doClearAliases, m.undoClearAliases)
+	runner.AddHandler("set-auto-aliases", m.doSetAutoAliases, m.undoClearAliases)
 	runner.AddHandler("setup-aliases", m.doSetupAliases, m.undoSetupAliases)
 	runner.AddHandler("remove-aliases", m.doRemoveAliases, m.doSetupAliases)
 

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -96,10 +96,15 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	s.user, err = auth.NewUser(s.state, "username", "email@test.com", "macaroon", []string{"discharge"})
 	c.Assert(err, IsNil)
 	s.state.Unlock()
+
+	snapstate.AutoAliases = func(*state.State, *snap.Info) ([]string, error) {
+		return nil, nil
+	}
 }
 
 func (s *snapmgrTestSuite) TearDownTest(c *C) {
 	snapstate.ValidateRefreshes = nil
+	snapstate.AutoAliases = nil
 	s.reset()
 }
 
@@ -149,6 +154,7 @@ func verifyInstallUpdateTasks(c *C, opts, discards int, ts *state.TaskSet, st *s
 		"copy-snap-data",
 		"setup-profiles",
 		"link-snap",
+		"set-auto-aliases",
 		"setup-aliases",
 		"start-snap-services",
 	)
@@ -215,6 +221,7 @@ func (s *snapmgrTestSuite) TestRevertTasks(c *C) {
 		"unlink-current-snap",
 		"setup-profiles",
 		"link-snap",
+		"set-auto-aliases",
 		"setup-aliases",
 		"start-snap-services",
 		"run-hook",
@@ -427,6 +434,7 @@ func (s *snapmgrTestSuite) TestRevertCreatesNoGCTasks(c *C) {
 		"unlink-current-snap",
 		"setup-profiles",
 		"link-snap",
+		"set-auto-aliases",
 		"setup-aliases",
 		"start-snap-services",
 		"run-hook",
@@ -908,7 +916,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Check(task.Summary(), Equals, `Download snap "some-snap" (42) from channel "some-channel"`)
 
 	// check link/start snap summary
-	linkTask := ta[len(ta)-4]
+	linkTask := ta[len(ta)-5]
 	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap" (42) available to the system`)
 	startTask := ta[len(ta)-2]
 	c.Check(startTask.Summary(), Equals, `Start snap "some-snap" (42) services`)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -126,6 +126,10 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup) (*state.T
 	prev = linkSnap
 
 	// setup aliases
+	setAutoAliases := st.NewTask("set-auto-aliases", fmt.Sprintf(i18n.G("Set auto-aliases for snap %q"), snapsup.Name()))
+	addTask(setAutoAliases)
+	prev = setAutoAliases
+
 	setupAliases := st.NewTask("setup-aliases", fmt.Sprintf(i18n.G("Setup snap %q aliases"), snapsup.Name()))
 	addTask(setupAliases)
 	prev = setupAliases

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -126,7 +126,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup) (*state.T
 	prev = linkSnap
 
 	// setup aliases
-	setAutoAliases := st.NewTask("set-auto-aliases", fmt.Sprintf(i18n.G("Set auto-aliases for snap %q"), snapsup.Name()))
+	setAutoAliases := st.NewTask("set-auto-aliases", fmt.Sprintf(i18n.G("Set automatic aliases for snap %q"), snapsup.Name()))
 	addTask(setAutoAliases)
 	prev = setAutoAliases
 


### PR DESCRIPTION
This first add support for the "auto" status of an alias through the pre-existing infrastructure,  then it adds support to apply auto-aliases information from the snap-declaration on install and refresh of a snap. It adds overlord integration tests in managers_test.go about this support.

later TODO:
* e2e spread test
* retire dropped auto-aliases earlier/together in refreshes to support transfers more gracefully
* apply changes to auto-aliases even if the snap doesn't have a new revision?