### PR TITLE
debian: use a packaging branch for 14.04

### DIFF
--- a/generate-packaging-dir
+++ b/generate-packaging-dir
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+ID="$1"
+VERSION_ID="$2"
+
+DST="debian-$ID-$VERSION_ID"
+rm -rf $DST
+mkdir -p "$DST"
+
+git ls-tree "$ID"/"$VERSION_ID" debian/ | while read line ; do
+    file=$(basename $(echo $line | cut -d " " -f4))
+    hash=$(echo $line | cut -d " " -f3)
+    type=$(echo $line | cut -d " " -f2)
+    # FIXME: deal with subdirs
+    if [ "$type" = "blob" ]; then
+        git cat-file -p $hash > "$DST/$file"
+    fi
+done

--- a/generate-packaging-dir
+++ b/generate-packaging-dir
@@ -9,6 +9,9 @@ DST="debian-$ID-$VERSION_ID"
 rm -rf $DST
 mkdir -p "$DST"
 
+git remote add upstream https://github.com/snapcore/snapd
+git fetch upstream
+
 git ls-tree "$ID"/"$VERSION_ID" debian/ | while read line ; do
     file=$(basename $(echo $line | cut -d " " -f4))
     hash=$(echo $line | cut -d " " -f3)

--- a/generate-packaging-dir
+++ b/generate-packaging-dir
@@ -9,10 +9,12 @@ DST="debian-$ID-$VERSION_ID"
 rm -rf $DST
 mkdir -p "$DST"
 
-git remote add upstream https://github.com/snapcore/snapd
+if ! git remote | grep upstream; then
+    git remote add upstream https://github.com/snapcore/snapd
+fi
 git fetch upstream
 
-git ls-tree "$ID"/"$VERSION_ID" debian/ | while read line ; do
+git ls-tree upstream/"$ID"/"$VERSION_ID" debian/ | while read line ; do
     file=$(basename $(echo $line | cut -d " " -f4))
     hash=$(echo $line | cut -d " " -f3)
     type=$(echo $line | cut -d " " -f2)

--- a/run-checks
+++ b/run-checks
@@ -142,6 +142,9 @@ if [ "$SPREAD" = 1 ]; then
     ( cd $TMP_SPREAD && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
     spread -v linode:
+
+    # cleanup the debian-ubuntu-14.04
+    rm -rf debian-ubuntu-14.04
 fi
 
 if [ "$DEPRECATED" = 1 ]; then

--- a/spread.yaml
+++ b/spread.yaml
@@ -186,11 +186,7 @@ prepare: |
          add-apt-repository ppa:snappy-dev/image
          apt-get update
          apt-get install -y --install-recommends linux-generic-lts-xenial
-         apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-lite
-
-         # FIXME: why is this needed? the path is set in the environment
-         #        already and this works in qemu?
-         export PATH=$PATH:/usr/lib/go-1.6/bin
+         apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-litedp
     fi
 
     apt-get purge -y snapd snap-confine ubuntu-core-launcher

--- a/spread.yaml
+++ b/spread.yaml
@@ -170,6 +170,16 @@ prepare: |
     apt-get install -y software-properties-common
 
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
+         if [ ! -d debian-ubuntu-14.04 ]; then
+             echo "no debian-ubuntu-14.04/ directory "
+             echo "broken test setup"
+             exit 1
+         fi
+
+         # 14.04 has its own packaging
+         rm -rf debian
+         mv debian-ubuntu-14.04 debian
+
          echo 'deb http://archive.ubuntu.com/ubuntu/ trusty-proposed main universe' >> /etc/apt/sources.list
          apt-get update
 
@@ -177,10 +187,6 @@ prepare: |
          apt-get update
          apt-get install -y --install-recommends linux-generic-lts-xenial
          apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd
-
-         # 14.04 has its own packaging
-         rm -rf debian
-         mv debian-ubuntu-14.04 debian
 
          # FIXME: why is this needed? the path is set in the environment
          #        already and this works in qemu?

--- a/spread.yaml
+++ b/spread.yaml
@@ -186,7 +186,7 @@ prepare: |
          add-apt-repository ppa:snappy-dev/image
          apt-get update
          apt-get install -y --install-recommends linux-generic-lts-xenial
-         apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-litedp
+         apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-lite util-linux
     fi
 
     apt-get purge -y snapd snap-confine ubuntu-core-launcher

--- a/spread.yaml
+++ b/spread.yaml
@@ -19,6 +19,9 @@ environment:
     TRUST_TEST_KEYS: "true"
     MANAGED_DEVICE: "false"
     CORE_CHANNEL: "$(HOST: echo ${SPREAD_CORE_CHANNEL:-edge})"
+    # slight abuse
+    GENERATE_14_04: "$(HOST: ./generate-packaging-dir ubuntu 14.04)"
+    GENERATE_16_04: "$(HOST: ./generate-packaging-dir ubuntu 16.04)"
 
 backends:
     linode:
@@ -179,6 +182,23 @@ prepare: |
     apt-get update
     # utilities
     apt-get install -y curl devscripts expect gdebi-core jq rng-tools git
+
+
+    # apply the right packaging delta, only 14.04 is special for now
+    . /etc/os-release
+    if [ "$ID" = "ubuntu" ]; then
+        case "$VERSION_ID" in
+        14.04)
+            mv debian-$ID-$VERSION_ID debian
+            ;;
+        *)
+            mv debian-ubuntu-16.04 debian
+            ;;
+        esac
+    else
+        echo "unknown distro ID $ID, please update the spread tests"
+        exit 1
+    fi
 
     # in 16.04: apt build-dep -y ./
     apt-get install -y $(gdebi --quiet --apt-line ./debian/control)

--- a/spread.yaml
+++ b/spread.yaml
@@ -21,13 +21,14 @@ environment:
     CORE_CHANNEL: "$(HOST: echo ${SPREAD_CORE_CHANNEL:-edge})"
     # slight abuse
     GENERATE_14_04: "$(HOST: ./generate-packaging-dir ubuntu 14.04)"
-    GENERATE_16_04: "$(HOST: ./generate-packaging-dir ubuntu 16.04)"
 
 backends:
     linode:
         key: "$(HOST: echo $SPREAD_LINODE_KEY)"
         halt-timeout: 2h
         systems:
+            - ubuntu-14.04-64:
+                kernel: GRUB 2
             - ubuntu-16.04-64:
                 kernel: GRUB 2
                 workers: 2
@@ -176,29 +177,16 @@ prepare: |
          apt-get update
          apt-get install -y --install-recommends linux-generic-lts-xenial
          apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd
+
+         # 14.04 has its own packaging
+         rm -rf debian
+         mv debian-ubuntu-14.04 debian
     fi
 
     apt-get purge -y snapd snap-confine ubuntu-core-launcher
     apt-get update
     # utilities
     apt-get install -y curl devscripts expect gdebi-core jq rng-tools git
-
-
-    # apply the right packaging delta, only 14.04 is special for now
-    . /etc/os-release
-    if [ "$ID" = "ubuntu" ]; then
-        case "$VERSION_ID" in
-        14.04)
-            mv debian-$ID-$VERSION_ID debian
-            ;;
-        *)
-            mv debian-ubuntu-16.04 debian
-            ;;
-        esac
-    else
-        echo "unknown distro ID $ID, please update the spread tests"
-        exit 1
-    fi
 
     # in 16.04: apt build-dep -y ./
     apt-get install -y $(gdebi --quiet --apt-line ./debian/control)

--- a/spread.yaml
+++ b/spread.yaml
@@ -181,6 +181,10 @@ prepare: |
          # 14.04 has its own packaging
          rm -rf debian
          mv debian-ubuntu-14.04 debian
+
+         # FIXME: why is this needed? the path is set in the environment
+         #        already and this works in qemu?
+         export PATH=$PATH:/usr/lib/go-1.6/bin
     fi
 
     apt-get purge -y snapd snap-confine ubuntu-core-launcher

--- a/spread.yaml
+++ b/spread.yaml
@@ -186,7 +186,7 @@ prepare: |
          add-apt-repository ppa:snappy-dev/image
          apt-get update
          apt-get install -y --install-recommends linux-generic-lts-xenial
-         apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd
+         apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-lite
 
          # FIXME: why is this needed? the path is set in the environment
          #        already and this works in qemu?

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -23,8 +23,7 @@ execute: |
     # trying to install 2.11ubuntu1 over 2.11+0.16.04
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         # apt_install_local uses dpkg directly which happily downgrades
-        apt_install_local ${SPREAD_PATH}/../snap-confine*.deb ${SPREAD_PATH}/../ubuntu-core-launcher*.deb
-        apt_install_local ${SPREAD_PATH}/../snapd*.deb
+        apt_install_local ${SPREAD_PATH}/../snap-confine*.deb ${SPREAD_PATH}/../ubuntu-core-launcher*.deb ${SPREAD_PATH}/../snapd*.deb
     else
         # not using apt_install_local here as this will not have
         # --allow-downgrades


### PR DESCRIPTION
This is a shortcut to make 14.04 work today.

The idea is that we have a ubuntu/14.04 packaigng branch in snapcore/snapd that contains the changes required for 14.04. We will need to keep it updated from master.

Originally I wanted to go all the way to packaging branches and remove the debian dir entirely. The generate-packaging-dir script is written in a way to make this easy. *But* this would break autopkgtest testing and it seems that is a bit of a harsh trade-off. While autopkgtest is slightly annoying sometimes it provides valuable data for regressions, especially on zesty (where we discovered a change in the "nc" behaviour because of our zesty autopkgtest or a change in systemctl because of a yakkety test).

The 14.04-64 qemu target works with this branch.:
```
$ spread -v -debug qemu:ubuntu-14.04-64
...
2016/12/15 12:58:06 Restoring project on qemu:ubuntu-14.04-64...
2016/12/15 12:58:06 Discarding qemu:ubuntu-14.04-64...
2016/12/15 12:58:06 Successful tasks: 107
``` 