### PR TITLE
Add Priced status to go client definitions

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -76,6 +76,7 @@ const (
 	StatusInstalled = "installed"
 	StatusActive    = "active"
 	StatusRemoved   = "removed"
+	StatusPriced    = "priced"
 
 	TypeApp    = "app"
 	TypeKernel = "kernel"


### PR DESCRIPTION
"priced" as a status is actually "defined" & set in daemon/snap.go in mapRemote() and fits the snaps that are priced and have not been bought by the current user as set in store/store.go decorateOrders()