### PR TITLE
Clean mount namespace when mount changes

### DIFF
--- a/overlord/snapstate/backend/ns.go
+++ b/overlord/snapstate/backend/ns.go
@@ -34,7 +34,7 @@ func mountNsPath(snapName string) string {
 	return filepath.Join(dirs.SnapRunNsDir, fmt.Sprintf("%s.mnt", snapName))
 }
 
-func (b Backend) DiscardSnapNamespace(snapName string) error {
+func DiscardSnapNamespace(snapName string) error {
 	mntFile := mountNsPath(snapName)
 	// If there's a .mnt file that was created by snap-confine we should ask
 	// snap-confine to discard it appropriately.
@@ -47,4 +47,8 @@ func (b Backend) DiscardSnapNamespace(snapName string) error {
 		}
 	}
 	return nil
+}
+
+func (b Backend) DiscardSnapNamespace(snapName string) error {
+	return DiscardSnapNamespace(snapName)
 }


### PR DESCRIPTION
Otherwise you disconnect a content interface but if the mount namespace for the
snap had already been created it still has access to it.

LP: #1649331

Not sure importing snapcore/snapd/overlord/snapstate/backend is a very good idea, maybe i can move the DiscardSnapNamespace function somewhere else? It's not really dependent on the backend itself.