### PR TITLE
tests: increase wait time for service to be up

### DIFF
--- a/tests/main/ubuntu-core-reboot/task.yaml
+++ b/tests/main/ubuntu-core-reboot/task.yaml
@@ -16,14 +16,14 @@ execute: |
     snap list | grep network-bind-consumer
 
     echo "Ensure the service is (still) running."
-    retries=10
+    retries=30
     while ! systemctl is-active snap.network-bind-consumer.network-consumer.service; do
         if [ $retries -eq 0 ]; then
             echo "Service did not activate."
             exit 1
         fi
         retries=$(( $retries - 1 ))
-        sleep 2
+        sleep 1
     done
 
     echo "Ensure apparmor profiles are (still) loaded."


### PR DESCRIPTION
On dragonboard, pi2 and 3 `tests/main/ubuntu-core-reboot` fails eventually because the test service is not up on time after the reboot, these changes increase the wait timeout.