### PR TITLE
tests: make debug-each succeed if DENIED doesn't match

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -133,7 +133,7 @@ prepare-each: |
 
 debug-each: |
     journalctl -u snapd
-    dmesg | grep DENIED
+    dmesg | grep DENIED || true
 
 prepare: |
     # this indicates that the server got reused, nothing to setup


### PR DESCRIPTION
When a test fails and the debug section is invoked we try to match dmesg
for DENIED (apparmor denials typically) but this is not guaranteed to
happen. With this patch we at least won't see the "Error debugging
..." messages anymore.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>