### PR TITLE
tests: port refresh-all-undo to MATCH

### DIFF
--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -36,12 +36,12 @@ execute: |
     fi
 
     echo "Then the new version of the good snap got installed"
-    snap list | grep -Pq "${GOOD_SNAP}.*?fake1"
+    snap list | MATCH -E "${GOOD_SNAP}.*?fake1"
 
     echo "But the bad snap did not get updated"
-    snap list | grep -P "${BAD_SNAP}"|grep -v "fake"
+    snap list | MATCH -E "${BAD_SNAP}"| MATCH -v "fake"
 
     echo "Verify the snap change"
-    snap change 4 |grep "Undone.*Download snap \"${BAD_SNAP}\""
-    snap change 4 |grep "Done.*Download snap \"${GOOD_SNAP}\""
-    snap change 4 |grep "ERROR cannot verify snap \"test-snapd-tools\", no matching signatures found"
+    snap change 4 | MATCH "Undone.*Download snap \"${BAD_SNAP}\""
+    snap change 4 | MATCH "Done.*Download snap \"${GOOD_SNAP}\""
+    snap change 4 | MATCH "ERROR cannot verify snap \"test-snapd-tools\", no matching signatures found"


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>