### PR TITLE
tests: debug zesty autopkgtest failures

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -45,11 +45,13 @@ prepare_classic() {
     if snap --version |MATCH unknown; then
         echo "Package build incorrect, 'snap --version' mentions 'unknown'"
         snap --version
+        apt-cache policy snapd
         exit 1
     fi
     if /usr/lib/snapd/snap-confine --version | MATCH unknown; then
         echo "Package build incorrect, 'snap-confine --version' mentions 'unknown'"
         /usr/lib/snapd/snap-confine --version
+        apt-cache policy snap-confine
         exit 1
     fi
 


### PR DESCRIPTION
Zesty autopkgtest-based tests are sometimes failing with snapd or snap-confine having `unknown` version (as reported by `snap --version`). This doesn't happen each time but the added `apt-cache policy` output should help us understand the issue.