### PR TITLE
overlord/snapstate: use keyed fields on literals

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -291,7 +291,7 @@ func updateInfo(st *state.State, snapst *SnapState, channel string, userID int, 
 		return nil, fmt.Errorf("cannot get refresh information for snap %q: %s", curInfo.Name(), err)
 	}
 	if len(res) == 0 {
-		return nil, &snap.NoUpdateAvailableError{curInfo.Name()}
+		return nil, &snap.NoUpdateAvailableError{Snap: curInfo.Name()}
 	}
 	return res[0], nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -304,7 +304,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		return nil, err
 	}
 	if snapst.HasCurrent() {
-		return nil, &snap.AlreadyInstalledError{name}
+		return nil, &snap.AlreadyInstalledError{Snap: name}
 	}
 
 	snapInfo, err := snapInfo(st, name, channel, revision, userID, flags)
@@ -693,7 +693,7 @@ func Remove(st *state.State, name string, revision snap.Revision) (*state.TaskSe
 	}
 
 	if !snapst.HasCurrent() {
-		return nil, &snap.NotInstalledError{name, snap.R(0)}
+		return nil, &snap.NotInstalledError{Snap: name, Rev: snap.R(0)}
 	}
 
 	if err := checkChangeConflict(st, name, nil); err != nil {
@@ -720,7 +720,7 @@ func Remove(st *state.State, name string, revision snap.Revision) (*state.TaskSe
 		}
 
 		if !revisionInSequence(&snapst, revision) {
-			return nil, &snap.NotInstalledError{name, revision}
+			return nil, &snap.NotInstalledError{Snap: name, Rev: revision}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>