### PR TITLE
spread: improve qemu ubuntu-14.04-{32,64} support

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -202,9 +202,6 @@ prepare: |
         if [ -d /etc/apt/apt.conf.d ] && [ -n "${APT_PROXY:-}" ]; then
             printf 'Acquire::http::Proxy "%s";\n' "$APT_PROXY" > /etc/apt/apt.conf.d/99proxy
         fi
-        # XXX: This seems to be required on 14.04. Otherwise package build
-        # fails with unmet dependency on "build-essential:native"
-        apt-get install -y build-essential
     fi
 
     # apt update is hanging on security.ubuntu.com with IPv6.
@@ -232,6 +229,10 @@ prepare: |
          apt-get update
          apt-get install -y --install-recommends linux-generic-lts-xenial
          apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-lite util-linux
+
+         # XXX: This seems to be required on 14.04. Otherwise package build
+         # fails with unmet dependency on "build-essential:native"
+         apt-get install -y build-essential
     fi
 
     apt-get purge -y snapd snap-confine ubuntu-core-launcher

--- a/spread.yaml
+++ b/spread.yaml
@@ -47,6 +47,9 @@ backends:
         environment:
             APT_PROXY: "$(HOST: echo $APT_PROXY)"
         systems:
+            - ubuntu-14.04-32:
+                username: ubuntu
+                password: ubuntu
             - ubuntu-14.04-64:
                 username: ubuntu
                 password: ubuntu

--- a/spread.yaml
+++ b/spread.yaml
@@ -145,7 +145,7 @@ prepare-each: |
     # or --vacuum-time.
     # TODO: Find a way to clean out systemd logs on
     # systemd 204.
-    if [ "$SPREAD_SYSTEM" != "ubuntu-14.04-64" ]; then
+    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
         journalctl --rotate
         sleep .1
         journalctl --vacuum-time=1ms

--- a/spread.yaml
+++ b/spread.yaml
@@ -202,6 +202,9 @@ prepare: |
         if [ -d /etc/apt/apt.conf.d ] && [ -n "${APT_PROXY:-}" ]; then
             printf 'Acquire::http::Proxy "%s";\n' "$APT_PROXY" > /etc/apt/apt.conf.d/99proxy
         fi
+        # XXX: This seems to be required on 14.04. Otherwise package build
+        # fails with unmet dependency on "build-essential:native"
+        apt-get install -y build-essential
     fi
 
     # apt update is hanging on security.ubuntu.com with IPv6.

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -23,14 +23,14 @@ prepare: |
     snap install test-snapd-cups-control-consumer
 
     echo "And the pdf printer is available"
-    if [ "$SPREAD_SYSTEM" = "ubuntu-14.04-64" ]; then
+    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         apt-get install -y cups-pdf
     else
         apt-get install -y printer-driver-cups-pdf
     fi
 
 restore: |
-    if [ "$SPREAD_SYSTEM" = "ubuntu-14.04-64" ]; then
+    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         apt-get remove -y cups-pdf
     else
         apt-get remove -y printer-driver-cups-pdf

--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the fuse-support interface works.
 
 # no support for fuse on 14.04
-systems: [-ubuntu-14.04-64]
+systems: [-ubuntu-14.04-64, -ubuntu-14.04-32]
 
 details: |
     The fuse-support interface allows a snap to manage FUSE file systems.


### PR DESCRIPTION
This branch makes it possible to run qemu tests on ubuntu-14.04-32 and fixes some oddities.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>