### PR TITLE
tests: fix mkversions.sh failure on zesty

### DIFF
--- a/mkversion.sh
+++ b/mkversion.sh
@@ -4,12 +4,12 @@ set -e
 # debugging if anything fails is tricky as dh-golang eats up all output
 # uncomment the lines below to get a useful trace if you have to touch
 # this again (my advice is: DON'T)
-#set -x
-#logfile=/tmp/mkversions.log
-#exec >> $logfile 2>&1
-#echo "env: $(set)"
-#echo "mkversion.sh run from: $0"
-#echo "pwd: $(pwd)"
+set -x
+logfile=/tmp/mkversions.log
+exec >> $logfile 2>&1
+echo "env: $(set)"
+echo "mkversion.sh run from: $0"
+echo "pwd: $(pwd)"
 
 # we have two directories we need to care about:
 # - our toplevel pkg builddir which is where "mkversion.sh" is located

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -4,12 +4,12 @@ set -e
 # debugging if anything fails is tricky as dh-golang eats up all output
 # uncomment the lines below to get a useful trace if you have to touch
 # this again (my advice is: DON'T)
-set -x
-logfile=/tmp/mkversions.log
-exec >> $logfile 2>&1
-echo "env: $(set)"
-echo "mkversion.sh run from: $0"
-echo "pwd: $(pwd)"
+#set -x
+#logfile=/tmp/mkversions.log
+#exec >> $logfile 2>&1
+#echo "env: $(set)"
+#echo "mkversion.sh run from: $0"
+#echo "pwd: $(pwd)"
 
 # we have two directories we need to care about:
 # - our toplevel pkg builddir which is where "mkversion.sh" is located

--- a/spread.yaml
+++ b/spread.yaml
@@ -263,6 +263,8 @@ prepare: |
     echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
     chown test.test -R ..
     su -l -c "cd $PWD && DEB_BUILD_OPTIONS='nocheck testkeys' dpkg-buildpackage -tc -b -Zgzip" test
+    # put our debs to a safe place
+    cp ../*.deb $GOPATH
 
     # Build snapbuild.
     apt-get install -y git

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -40,13 +40,12 @@ update_core_snap_with_snap_exec_snapctl() {
 }
 
 prepare_classic() {
-    apt_install_local ${SPREAD_PATH}/../snap-confine*.deb ${SPREAD_PATH}/../ubuntu-core-launcher_*.deb
-    apt_install_local ${SPREAD_PATH}/../snapd_*.deb
+    apt_install_local ${GOPATH}/snap-confine*.deb ${GOPATH}/ubuntu-core-launcher_*.deb
+    apt_install_local ${GOPATH}/snapd_*.deb
     if snap --version |MATCH unknown; then
         echo "Package build incorrect, 'snap --version' mentions 'unknown'"
         snap --version
         apt-cache policy snapd
-        cat /tmp/mkversions.log
         exit 1
     fi
     if /usr/lib/snapd/snap-confine --version | MATCH unknown; then
@@ -95,7 +94,7 @@ prepare_classic() {
 setup_reflash_magic() {
         # install the stuff we need
         apt-get install -y kpartx busybox-static
-        apt_install_local ${SPREAD_PATH}/../snapd_*.deb ${SPREAD_PATH}/../snap-confine_*.deb ${SPREAD_PATH}/../ubuntu-core-launcher_*.deb
+        apt_install_local ${GOPATH}/snapd_*.deb ${GOPATH}/snap-confine_*.deb ${GOPATH}/ubuntu-core-launcher_*.deb
         apt-get clean
 
         snap install --${CORE_CHANNEL} core

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -46,6 +46,7 @@ prepare_classic() {
         echo "Package build incorrect, 'snap --version' mentions 'unknown'"
         snap --version
         apt-cache policy snapd
+        cat /tmp/mkversions.log
         exit 1
     fi
     if /usr/lib/snapd/snap-confine --version | MATCH unknown; then

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -23,11 +23,11 @@ execute: |
     # trying to install 2.11ubuntu1 over 2.11+0.16.04
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         # apt_install_local uses dpkg directly which happily downgrades
-        apt_install_local ${SPREAD_PATH}/../snap-confine*.deb ${SPREAD_PATH}/../ubuntu-core-launcher*.deb ${SPREAD_PATH}/../snapd*.deb
+        apt_install_local ${GOPATH}/snap-confine*.deb ${GOPATH}/ubuntu-core-launcher*.deb ${GOPATH}/snapd*.deb
     else
         # not using apt_install_local here as this will not have
         # --allow-downgrades
-        apt install -y --allow-downgrades ${SPREAD_PATH}/../snapd*.deb ${SPREAD_PATH}/../snap-confine*.deb ${SPREAD_PATH}/../ubuntu-core-launcher*.deb
+        apt install -y --allow-downgrades ${GOPATH}/snapd*.deb ${GOPATH}/snap-confine*.deb ${GOPATH}/ubuntu-core-launcher*.deb
     fi
 
     snapdver=$(snap --version|grep "snapd ")


### PR DESCRIPTION
During package builds we overwrite the generated deb packages in the gccgo test. This is wrong and causes a autopkgtest failure on zesty. This branch fixes this.