### PR TITLE
many: use snap-confine to save cost of repackaging core snap for testing

### DIFF
--- a/cmd/snap-confine/manpages/snap-confine.rst
+++ b/cmd/snap-confine/manpages/snap-confine.rst
@@ -120,6 +120,13 @@ This is only applicable when testing the program itself.
     feature that will be merged into snapd's snap-run command. The set of directories
     that can be created is confined with apparmor.
 
+`SNAP_CONFINE_TESTING`:
+    Internal variable that should not be relied upon.
+
+    If defined and set to `bind-packaged-over-core` it will bind-mount certain
+    executables from the packaged version of snapd over the currently executing
+    core snap. This is meant to accelerate testing of snapd.
+
 FILES
 =====
 

--- a/cmd/snap-confine/quirks.c
+++ b/cmd/snap-confine/quirks.c
@@ -39,7 +39,7 @@
  * (legacy).  The mount point does not depend on build-time configuration and
  * does not differ from distribution to distribution.
  **/
-static const char *sc_get_inner_core_mount_point()
+const char *sc_get_inner_core_mount_point()
 {
 	const char *core_path = "/snap/core/current/";
 	const char *ubuntu_core_path = "/snap/ubuntu-core/current/";

--- a/cmd/snap-confine/quirks.h
+++ b/cmd/snap-confine/quirks.h
@@ -27,4 +27,6 @@
  **/
 void sc_setup_quirks();
 
+const char *sc_get_inner_core_mount_point();
+
 #endif

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -187,6 +187,10 @@
     mount options=(rw bind) /dev/pts/ptmx/ -> /dev/ptmx/,
     mount options=(rw bind) /dev/pts/ptmx/ -> /dev/pts/ptmx/,
 
+    # SNAP_CONFINE_TESTING=bind-packaged-over-core
+    mount options=(rw bind) /var/lib/snapd/hostfs/usr/bin/snapctl -> /snap/{ubuntu-,}core/*/usr/bin/snapctl,
+    mount options=(rw bind) /var/lib/snapd/hostfs/usr/lib/snapd/snap-exec -> /snap/{ubuntu-,}core/*/usr/lib/snapd/snap-exec,
+
     # for running snaps on classic
     /snap/ r,
     /snap/** r,

--- a/spread.yaml
+++ b/spread.yaml
@@ -21,6 +21,11 @@ environment:
     CORE_CHANNEL: "$(HOST: echo ${SPREAD_CORE_CHANNEL:-edge})"
     # slight abuse
     GENERATE_14_04: "$(HOST: ./generate-packaging-dir ubuntu 14.04)"
+    # In classic systems this will cause snap-confine to bind mount snap-exec
+    # and snapctl from the system package (that we rebuild and reinstall) over
+    # to the snap execution environment. Note that *only* classic systems are
+    # supported this way.
+    SNAP_CONFINE_TESTING: bind-packaged-over-core
 
 backends:
     linode:

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -5,38 +5,11 @@ set -eux
 . $TESTSLIB/apt.sh
 
 update_core_snap_with_snap_exec_snapctl() {
-    # We want to use the in-tree snap-exec and snapctl, not the ones in the core
-    # snap. To accomplish that, we'll just unpack the core we just grabbed,
-    # shove the new snap-exec and snapctl in there, and repack it.
-
-    # First of all, unmount the core
-    core="$(readlink -f /snap/core/current || readlink -f /snap/ubuntu-core/current)"
-    snap="$(mount | grep " $core" | awk '{print $1}')"
-    umount --verbose "$core"
-
-    # Now unpack the core, inject the new snap-exec and snapctl into it, and
-    # repack it.
-    unsquashfs "$snap"
-    cp /usr/lib/snapd/snap-exec squashfs-root/usr/lib/snapd/
-    cp /usr/bin/snapctl squashfs-root/usr/bin/
-    mv "$snap" "${snap}.orig"
-    mksquashfs squashfs-root "$snap" -comp xz
-    rm -rf squashfs-root
-
-    # Now mount the new core snap
-    mount "$snap" "$core"
-
-    # Make sure we're running with the correct snap-exec
-    if ! cmp /usr/lib/snapd/snap-exec ${core}/usr/lib/snapd/snap-exec; then
-        echo "snap-exec in tree and snap-exec in core snap are unexpectedly not the same"
-        exit 1
-    fi
-
-    # Make sure we're running with the correct snapctl
-    if ! cmp /usr/bin/snapctl ${core}/usr/bin/snapctl; then
-        echo "snapctl in tree and snapctl in core snap are unexpectedly not the same"
-        exit 1
-    fi
+    # We want to use the in-tree snap-exec and snapctl, not the ones in the
+    # core snap. This is now managed internally with snap-confine with the
+    # environment variable SNAP_CONFINE_TESTING=bind-packaged-over-core
+    # which is set by the top-level spread.yaml file.
+    true
 }
 
 prepare_classic() {

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -1,13 +1,23 @@
 summary: inspect all the set environment variables prefixed with SNAP_ and XDG_
 prepare: |
-    snapbuild $TESTSLIB/snaps/test-snapd-tools .
-    snap install --dangerous test-snapd-tools_1.0_all.snap
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-tools
 restore: |
-    rm -f *.snap
+    rm -f *.vars.txt
 execute: |
-    echo "Collect SNAP and XDG environment variables"
-    test-snapd-tools.env | egrep '^SNAP_' | sort > snap-vars.txt 
-    test-snapd-tools.env | egrep '^XDG_' | sort > xdg-vars.txt 
+    echo "Collect SNAP environment variables set in the testbed"
+    env | egrep '^SNAP_' | sort > testbed-snap-vars.txt
+
+    echo "Collect SNAP and XDG environment variables as seen by apps"
+    test-snapd-tools.env | egrep '^SNAP_' | sort > snap-vars-unfiltered.txt
+    test-snapd-tools.env | egrep '^XDG_' | sort > xdg-vars.txt
+
+    echo "Filter out testbed variables from observed variables"
+    truncate -s 0 blacklist-vars.txt
+    for varname in $(cat testbed-snap-vars.txt | cut -d '=' -f 1); do
+        printf '^%s=.*$\n' "$varname" >> blacklist-vars.txt
+    done
+    grep -v -f blacklist-vars.txt snap-vars-unfiltered.txt > snap-vars.txt
 
     echo "Ensure that SNAP environment variables are what we expect"
     egrep -q '^SNAP_ARCH=(amd64|i386|arm64|armhf|ppc64el)$' snap-vars.txt
@@ -15,16 +25,21 @@ execute: |
     egrep -q '^SNAP_DATA=/var/snap/test-snapd-tools/x1$' snap-vars.txt
     egrep -q '^SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:$' snap-vars.txt
     egrep -q '^SNAP_NAME=test-snapd-tools$' snap-vars.txt
-    # XXX: probably not something we ought to test
-    # egrep -q '^SNAP_REEXEC=0$' snap-vars.txt
     egrep -q '^SNAP_REVISION=x1$' snap-vars.txt
     egrep -q '^SNAP_USER_COMMON=/root/snap/test-snapd-tools/common$' snap-vars.txt
     egrep -q '^SNAP_USER_DATA=/root/snap/test-snapd-tools/x1$' snap-vars.txt
     egrep -q '^SNAP_VERSION=1.0$' snap-vars.txt
-    test $(wc -l < snap-vars.txt) -eq 10
+    test $(wc -l < snap-vars.txt) -eq 9
+
+    egrep -q '^SNAP_REEXEC=0$' testbed-snap-vars.txt
+    egrep -q '^SNAP_CONFINE_TESTING=bind-packaged-over-core$' testbed-snap-vars.txt
+    test $(wc -l < testbed-snap-vars.txt) -eq 2
 
     echo "Enure that XDG environment variables are what we expect"
     egrep -q '^XDG_RUNTIME_DIR=/run/user/0/snap.test-snapd-tools$' xdg-vars.txt
     test $(wc -l < xdg-vars.txt) -ge 1
 debug: |
-    cat *-vars.txt
+    for fname in *-vars.txt; do
+        echo " == $fname == "
+        cat "$fname"
+    done


### PR DESCRIPTION
This is an idea picked up from #2528 but implemented more robustly inside snap-confine.

The main idea is that we don't need to repackage or really otherwise touch the core snap (or the ubuntu-core snap) when we do testing because we can ask snap-confine to bind mount `snapctl` and `snap-exec` from the system package over the version that snaps see while running.

When hacking on this I was thinking that, unless SNAP_REEXEC is enabled, this should in fact be the default. It would save us from having to release new core to get people that have new snapd from packages on their system. We had similar issues earlier AFAIK.

A quick rough look seems to indicate that this shaves 5 minutes off the spread run on Linode; from 34 minutes down to 29 minutes.