### PR TITLE
To allow access disk partition from efivar library with mmc and other platform specific drivers interface

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -56,7 +56,7 @@ var fwupdPermanentSlotAppArmor = []byte(`
 
   # Allow access from efivar library
   owner @{PROC}/@{pid}/mounts r,
-  /sys/devices/pci*/**/block/**/partition r,
+  /sys/devices/{pci*,platform}/**/block/**/partition r,
   # Introspect the block devices to get partition guid and size information
   /run/udev/data/b[0-9]*:[0-9]* r,
 


### PR DESCRIPTION

The current fwupd interface rule only permit pci/ata type host to access the partition file e.g., /sys/devices/pci0000:00/0000:00:13.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/partition, however we have commercial devices which use other types of storage interfaces. e.g, mmc

An example of denial is:
[12536.342278] audit: type=1400 audit(1483427198.671:107): apparmor="DENIED" operation="open" profile="snap.uefi-fw-tools.fwupd" name="/sys/devices/platform/80860F14:01/mmc_host/mmc0/mmc0:0001/block/mmcblk0/mmcblk0p2/partition" pid=1247 comm="fwupd" requested_mask="r" denied_mask="r" fsuid=0 ouid=0