### PR TITLE
snap: show `snap --help` output when just running `snap`

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -280,7 +280,7 @@ func run() error {
 	_, err := parser.Parse()
 	if err != nil {
 		if e, ok := err.(*flags.Error); ok {
-			if e.Type == flags.ErrHelp {
+			if e.Type == flags.ErrHelp || e.Type == flags.ErrCommandRequired {
 				if parser.Command.Active != nil && parser.Command.Active.Name == "help" {
 					parser.Command.Active = nil
 				}


### PR DESCRIPTION
Trivial branch that addresses LP: #1611641. When running snap without further option `snap --help` is displayed instead of an error message.

LP: #1611641