### PR TITLE
many: implement 'snap aliases'

### DIFF
--- a/client/aliases.go
+++ b/client/aliases.go
@@ -67,3 +67,15 @@ func (client *Client) ResetAliases(snapName string, aliases []string) (changeID 
 		Aliases: aliases,
 	})
 }
+
+// AliasStatus represents the status of an alias.
+type AliasStatus struct {
+	App    string `json:"app,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// Aliases returns a map snap -> alias -> AliasStatus for all snaps and aliases in the system.
+func (client *Client) Aliases() (allStatuses map[string]map[string]AliasStatus, err error) {
+	_, err = client.doSync("GET", "/v2/aliases", nil, nil, nil, &allStatuses)
+	return
+}

--- a/cmd/snap/cmd_aliases.go
+++ b/cmd/snap/cmd_aliases.go
@@ -43,6 +43,10 @@ The aliases command lists all aliases available in the system and their status.
 $ snap aliases <snap>
 
 Lists only the aliases defined by the specified snap.
+
+An alias noted as undefined means it was explicitly enabled or disabled but is
+not defined in the current revision of the snap; possibly temporarely (e.g
+because of a revert), if not this can be cleared with snap alias --reset.
 `)
 
 func init() {

--- a/cmd/snap/cmd_aliases.go
+++ b/cmd/snap/cmd_aliases.go
@@ -1,0 +1,134 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+)
+
+type cmdAliases struct {
+	Positionals struct {
+		Snap installedSnapName `positional-arg-name:"<snap>"`
+	} `positional-args:"true"`
+}
+
+var shortAliasesHelp = i18n.G("Lists aliases in the system")
+var longAliasesHelp = i18n.G(`
+The aliases command lists all aliases available in the system and their status.
+
+$ snap aliases <snap>
+
+Lists only the aliases defined by the specified snap.
+`)
+
+func init() {
+	addCommand("aliases", shortAliasesHelp, longAliasesHelp, func() flags.Commander {
+		return &cmdAliases{}
+	}, nil, nil)
+}
+
+type aliasInfo struct {
+	Snap   string
+	App    string
+	Alias  string
+	Status string
+}
+
+type aliasInfos []*aliasInfo
+
+func (infos aliasInfos) Len() int      { return len(infos) }
+func (infos aliasInfos) Swap(i, j int) { infos[i], infos[j] = infos[j], infos[i] }
+func (infos aliasInfos) Less(i, j int) bool {
+	if infos[i].Snap < infos[j].Snap {
+		return true
+	}
+	if infos[i].Snap == infos[j].Snap {
+		if infos[i].App != "" {
+			if infos[j].App == "" {
+				return true
+			}
+			if infos[i].App < infos[j].App {
+				return true
+			}
+		}
+		if infos[i].App == infos[j].App {
+			if infos[i].Alias < infos[j].Alias {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (x *cmdAliases) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	allStatuses, err := Client().Aliases()
+	if err == nil {
+		w := tabWriter()
+		fmt.Fprintln(w, i18n.G("App\tAlias\tNotes"))
+		defer w.Flush()
+		var infos aliasInfos
+		filterSnap := string(x.Positionals.Snap)
+		if filterSnap != "" {
+			allStatuses = map[string]map[string]client.AliasStatus{
+				filterSnap: allStatuses[filterSnap],
+			}
+		}
+		for snapName, aliasStatuses := range allStatuses {
+			for alias, aliasStatus := range aliasStatuses {
+				infos = append(infos, &aliasInfo{
+					Snap:   snapName,
+					App:    aliasStatus.App,
+					Alias:  alias,
+					Status: aliasStatus.Status,
+				})
+			}
+		}
+		sort.Sort(infos)
+
+		for _, info := range infos {
+			var notes []string
+			app := info.App
+			if app == "" {
+				app = fmt.Sprintf("%s.???", info.Snap)
+				notes = append(notes, "undefined")
+			}
+			if info.Status != "" {
+				notes = append(notes, info.Status)
+			}
+			notesStr := strings.Join(notes, ",")
+			if notesStr == "" {
+				notesStr = "-"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\n", app, info.Alias, notesStr)
+		}
+	}
+	return err
+}

--- a/cmd/snap/cmd_aliases_test.go
+++ b/cmd/snap/cmd_aliases_test.go
@@ -39,6 +39,10 @@ $ snap aliases <snap>
 
 Lists only the aliases defined by the specified snap.
 
+An alias noted as undefined means it was explicitly enabled or disabled but is
+not defined in the current revision of the snap; possibly temporarely (e.g
+because of a revert), if not this can be cleared with snap alias --reset.
+
 Application Options:
       --version     Print the version and exit
 

--- a/cmd/snap/cmd_aliases_test.go
+++ b/cmd/snap/cmd_aliases_test.go
@@ -1,0 +1,165 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/client"
+	. "github.com/snapcore/snapd/cmd/snap"
+)
+
+func (s *SnapSuite) TestAliasesHelp(c *C) {
+	msg := `Usage:
+  snap.test [OPTIONS] aliases [<snap>]
+
+The aliases command lists all aliases available in the system and their status.
+
+$ snap aliases <snap>
+
+Lists only the aliases defined by the specified snap.
+
+Application Options:
+      --version     Print the version and exit
+
+Help Options:
+  -h, --help        Show this help message
+`
+	rest, err := Parser().ParseArgs([]string{"aliases", "--help"})
+	c.Assert(err.Error(), Equals, msg)
+	c.Assert(rest, DeepEquals, []string{})
+}
+
+func (s *SnapSuite) TestAliases(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v2/aliases")
+		body, err := ioutil.ReadAll(r.Body)
+		c.Check(err, IsNil)
+		c.Check(body, DeepEquals, []byte{})
+		EncodeResponseBody(c, w, map[string]interface{}{
+			"type": "sync",
+			"result": map[string]map[string]client.AliasStatus{
+				"foo": {
+					"foo0":      {App: "foo", Status: "auto"},
+					"foo_reset": {App: "foo.reset", Status: ""},
+				},
+				"bar": {
+					"bar_dump":   {App: "bar.dump", Status: "enabled"},
+					"bar_dump.1": {App: "", Status: "disabled"},
+				},
+			},
+		})
+	})
+	rest, err := Parser().ParseArgs([]string{"aliases"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	expectedStdout := "" +
+		"App        Alias       Notes\n" +
+		"bar.dump   bar_dump    enabled\n" +
+		"bar.???    bar_dump.1  undefined,disabled\n" +
+		"foo        foo0        auto\n" +
+		"foo.reset  foo_reset   -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestAliasesFilterSnap(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v2/aliases")
+		body, err := ioutil.ReadAll(r.Body)
+		c.Check(err, IsNil)
+		c.Check(body, DeepEquals, []byte{})
+		EncodeResponseBody(c, w, map[string]interface{}{
+			"type": "sync",
+			"result": map[string]map[string]client.AliasStatus{
+				"foo": {
+					"foo0":      {App: "foo", Status: "auto"},
+					"foo_reset": {App: "foo.reset", Status: ""},
+				},
+				"bar": {
+					"bar_dump":   {App: "bar.dump", Status: "enabled"},
+					"bar_dump.1": {App: "", Status: "disabled"},
+				},
+			},
+		})
+	})
+	rest, err := Parser().ParseArgs([]string{"aliases", "foo"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	expectedStdout := "" +
+		"App        Alias      Notes\n" +
+		"foo        foo0       auto\n" +
+		"foo.reset  foo_reset  -\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestAliasesNone(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v2/aliases")
+		body, err := ioutil.ReadAll(r.Body)
+		c.Check(err, IsNil)
+		c.Check(body, DeepEquals, []byte{})
+		EncodeResponseBody(c, w, map[string]interface{}{
+			"type":   "sync",
+			"result": map[string]map[string]client.AliasStatus{},
+		})
+	})
+	_, err := Parser().ParseArgs([]string{"aliases"})
+	c.Assert(err, IsNil)
+	expectedStdout := "" +
+		"App  Alias  Notes\n"
+	c.Assert(s.Stdout(), Equals, expectedStdout)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestAliasesSorting(c *C) {
+	tests := []struct {
+		snap1  string
+		app1   string
+		alias1 string
+		snap2  string
+		app2   string
+		alias2 string
+	}{
+		{"bar", "bar", "r", "baz", "baz", "z"},
+		{"bar", "bar", "bar0", "bar", "bar.app", "bapp"},
+		{"bar", "bar.app1", "bapp1", "bar", "bar.app2", "bapp2"},
+		{"bar", "bar", "bar0", "bar", "", "bapp"},
+		{"bar", "bar.app1", "appy", "bar", "", "appx"},
+		{"bar", "", "bapp1", "bar", "", "bapp2"},
+		{"bar", "bar.app1", "appx", "bar", "bar.app1", "appy"},
+	}
+
+	for _, test := range tests {
+		res := AliasInfoLess(test.snap1, test.alias1, test.app1, test.snap2, test.alias2, test.app2)
+		c.Check(res, Equals, true, Commentf("%v", test))
+
+		rres := AliasInfoLess(test.snap2, test.alias2, test.app2, test.snap1, test.alias1, test.app1)
+		c.Check(rres, Equals, false, Commentf("reversed %v", test))
+	}
+
+}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -86,3 +86,19 @@ func MockMountInfoPath(newMountInfoPath string) (restore func()) {
 }
 
 var AutoImportCandidates = autoImportCandidates
+
+func AliasInfoLess(snapName1, alias1, app1, snapName2, alias2, app2 string) bool {
+	x := aliasInfos{
+		&aliasInfo{
+			Snap:  snapName1,
+			Alias: alias1,
+			App:   app1,
+		},
+		&aliasInfo{
+			Snap:  snapName2,
+			Alias: alias2,
+			App:   app2,
+		},
+	}
+	return x.Less(0, 1)
+}

--- a/tests/main/alias/task.yaml
+++ b/tests/main/alias/task.yaml
@@ -9,8 +9,16 @@ execute: |
     aliases.cmd1|MATCH "ok command 1"
     aliases.cmd2|MATCH "ok command 2"
 
+    echo "Default statuses"
+    snap aliases|MATCH "aliases.cmd1 +alias1 +-"
+    snap aliases|MATCH "aliases.cmd2 +alias2 +-"
+
     echo "Enable aliases"
     snap alias aliases alias1 alias2
+
+    echo "Enabled statuses"
+    snap aliases|MATCH "aliases.cmd1 +alias1 +enabled"
+    snap aliases|MATCH "aliases.cmd2 +alias2 +enabled"
 
     echo "Test the aliases"
     test -h /snap/bin/alias1
@@ -20,6 +28,10 @@ execute: |
 
     echo "Disable an alias explicitly"
     snap unalias aliases alias2
+
+    echo "One disabled status"
+    snap aliases|MATCH "aliases.cmd1 +alias1 +enabled"
+    snap aliases|MATCH "aliases.cmd2 +alias2 +disabled"
 
     echo "One still works, one is not there"
     alias1|MATCH "ok command 1"
@@ -31,8 +43,16 @@ execute: |
     test -h /snap/bin/alias2
     alias2|MATCH "ok command 2"
 
+    echo "Both enabled again"
+    snap aliases|MATCH "aliases.cmd1 +alias1 +enabled"
+    snap aliases|MATCH "aliases.cmd2 +alias2 +enabled"
+
     echo "Reset the aliases to their automatic states (disabled)"
     snap alias --reset aliases alias1
+
+    echo "One default again"
+    snap aliases|MATCH "aliases.cmd1 +alias1 +-"
+    snap aliases|MATCH "aliases.cmd2 +alias2 +enabled"
 
     echo "Alias is gone"
     test ! -e /snap/bin/alias1
@@ -42,6 +62,10 @@ execute: |
     snap alias aliases alias1 alias2
     alias1|MATCH "ok command 1"
     alias2|MATCH "ok command 2"
+
+    echo "Both enabled again"
+    snap aliases|MATCH "aliases.cmd1 +alias1 +enabled"
+    snap aliases|MATCH "aliases.cmd2 +alias2 +enabled"
 
     echo "Removing the snap should remove the aliases"
     snap remove aliases


### PR DESCRIPTION
This implements `snap aliases [<snap>]` to list all aliases in the system and their status or all aliases for the given snap.