### PR TITLE
many: obtain installed snaps developer/publisher username through assertions

### DIFF
--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -108,22 +108,10 @@ func DeriveSideInfo(snapPath string, db asserts.RODatabase) (*snap.SideInfo, err
 
 	name := snapDecl.SnapName()
 
-	// TODO: once we are fully migrated to assertions this can
-	// be done dynamically later instead of statically here
-	a, err = db.Find(asserts.AccountType, map[string]string{
-		"account-id": snapRev.DeveloperID(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("internal error: cannot find developer account for snap %q (%q): %s", name, snapPath, snapRev.DeveloperID())
-	}
-	devAcct := a.(*asserts.Account)
-
 	return &snap.SideInfo{
-		RealName:    name,
-		SnapID:      snapID,
-		Revision:    snap.R(snapRev.SnapRevision()),
-		DeveloperID: snapRev.DeveloperID(),
-		Developer:   devAcct.Username(),
+		RealName: name,
+		SnapID:   snapID,
+		Revision: snap.R(snapRev.SnapRevision()),
 	}, nil
 }
 

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -234,12 +234,10 @@ func (s *snapassertsSuite) TestDeriveSideInfoHappy(c *C) {
 	si, err := snapasserts.DeriveSideInfo(snapPath, s.localDB)
 	c.Assert(err, IsNil)
 	c.Check(si, DeepEquals, &snap.SideInfo{
-		RealName:    "foo",
-		SnapID:      "snap-id-1",
-		Revision:    snap.R(42),
-		Channel:     "",
-		DeveloperID: s.dev1Acct.AccountID(),
-		Developer:   "developer1",
+		RealName: "foo",
+		SnapID:   "snap-id-1",
+		Revision: snap.R(42),
+		Channel:  "",
 	})
 }
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -414,7 +414,7 @@ func getSnapInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	vars := muxVars(r)
 	name := vars["name"]
 
-	localSnap, active, err := localSnapInfo(c.d.overlord.State(), name)
+	about, err := localSnapInfo(c.d.overlord.State(), name)
 	if err != nil {
 		if err == errNoSnap {
 			return NotFound("cannot find %q snap", name)
@@ -433,7 +433,7 @@ func getSnapInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("cannot build URL for %q snap: %v", name, err)
 	}
 
-	result := webify(mapLocal(localSnap, active), url.String())
+	result := webify(mapLocal(about), url.String())
 
 	return SyncResponse(result, nil)
 }
@@ -686,7 +686,7 @@ func getSnapsInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 			continue
 		}
 
-		data, err := json.Marshal(webify(mapLocal(x.info, x.snapst), url.String()))
+		data, err := json.Marshal(webify(mapLocal(x), url.String()))
 		if err != nil {
 			return InternalError("cannot serialize snap %q revision %s: %v", name, rev, err)
 		}
@@ -1386,7 +1386,7 @@ func unsafeReadSnapInfoImpl(snapPath string) (*snap.Info, error) {
 var unsafeReadSnapInfo = unsafeReadSnapInfoImpl
 
 func iconGet(st *state.State, name string) Response {
-	info, _, err := localSnapInfo(st, name)
+	about, err := localSnapInfo(st, name)
 	if err != nil {
 		if err == errNoSnap {
 			return NotFound("cannot find snap %q", name)
@@ -1394,7 +1394,7 @@ func iconGet(st *state.State, name string) Response {
 		return InternalError("%v", err)
 	}
 
-	path := filepath.Clean(snapIcon(info))
+	path := filepath.Clean(snapIcon(about.info))
 	if !strings.HasPrefix(path, dirs.SnapMountDir) {
 		// XXX: how could this happen?
 		return BadRequest("requested icon is not in snap path")

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"bytes"
+	"crypto"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,6 +40,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/sha3"
 	"golang.org/x/net/context"
 	"gopkg.in/check.v1"
 	"gopkg.in/macaroon.v1"
@@ -77,6 +79,7 @@ type apiBaseSuite struct {
 	buyResult         *store.BuyResult
 	storeSigning      *assertstest.StoreStack
 	restoreRelease    func()
+	trustedRestorer   func()
 }
 
 func (s *apiBaseSuite) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
@@ -145,6 +148,11 @@ func (s *apiBaseSuite) TearDownSuite(c *check.C) {
 	s.restoreRelease()
 }
 
+var (
+	rootPrivKey, _  = assertstest.GenerateKey(1024)
+	storePrivKey, _ = assertstest.GenerateKey(752)
+)
+
 func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	dirs.SetRootDir(c.MkDir())
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
@@ -164,12 +172,13 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 
 	s.buyOptions = nil
 	s.buyResult = nil
-	rootPrivKey, _ := assertstest.GenerateKey(1024)
-	storePrivKey, _ := assertstest.GenerateKey(752)
+
 	s.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+	s.trustedRestorer = sysdb.InjectTrusted(s.storeSigning.Trusted)
 }
 
 func (s *apiBaseSuite) TearDownTest(c *check.C) {
+	s.trustedRestorer()
 	s.d = nil
 	s.restoreBackends()
 	snapstateInstall = snapstate.Install
@@ -203,13 +212,13 @@ func (s *apiBaseSuite) mkInstalled(c *check.C, name, developer, version string, 
 }
 
 func (s *apiBaseSuite) mkInstalledInState(c *check.C, daemon *Daemon, name, developer, version string, revision snap.Revision, active bool, extraYaml string) *snap.Info {
+	snapID := name + "-id"
 	// Collect arguments into a snap.SideInfo structure
 	sideInfo := &snap.SideInfo{
-		SnapID:    "funky-snap-id",
-		RealName:  name,
-		Developer: developer,
-		Revision:  revision,
-		Channel:   "stable",
+		SnapID:   snapID,
+		RealName: name,
+		Revision: revision,
+		Channel:  "stable",
 	}
 
 	// Collect other arguments into a yaml string
@@ -232,6 +241,47 @@ version: %s
 		st := daemon.overlord.State()
 		st.Lock()
 		defer st.Unlock()
+
+		err := assertstate.Add(st, s.storeSigning.StoreAccountKey(""))
+		if _, ok := err.(*asserts.RevisionError); !ok {
+			c.Assert(err, check.IsNil)
+		}
+
+		devAcct := assertstest.NewAccount(s.storeSigning, developer, map[string]interface{}{
+			"account-id": developer + "-id",
+		}, "")
+		err = assertstate.Add(st, devAcct)
+		if _, ok := err.(*asserts.RevisionError); !ok {
+			c.Assert(err, check.IsNil)
+		}
+
+		snapDecl, err := s.storeSigning.Sign(asserts.SnapDeclarationType, map[string]interface{}{
+			"series":       "16",
+			"snap-id":      snapID,
+			"snap-name":    name,
+			"publisher-id": devAcct.AccountID(),
+			"timestamp":    time.Now().Format(time.RFC3339),
+		}, nil, "")
+		c.Assert(err, check.IsNil)
+		err = assertstate.Add(st, snapDecl)
+		if _, ok := err.(*asserts.RevisionError); !ok {
+			c.Assert(err, check.IsNil)
+		}
+
+		h := sha3.Sum384([]byte(fmt.Sprintf("%s%s", name, revision)))
+		dgst, err := asserts.EncodeDigest(crypto.SHA3_384, h[:])
+		c.Assert(err, check.IsNil)
+		snapRev, err := s.storeSigning.Sign(asserts.SnapRevisionType, map[string]interface{}{
+			"snap-sha3-384": string(dgst),
+			"snap-size":     "999",
+			"snap-id":       snapID,
+			"snap-revision": fmt.Sprintf("%s", revision),
+			"developer-id":  devAcct.AccountID(),
+			"timestamp":     time.Now().Format(time.RFC3339),
+		}, nil, "")
+		c.Assert(err, check.IsNil)
+		err = assertstate.Add(st, snapRev)
+		c.Assert(err, check.IsNil)
 
 		var snapst snapstate.SnapState
 		snapstate.Get(st, name, &snapst)
@@ -292,7 +342,7 @@ func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {
 		Type:   ResponseTypeSync,
 		Status: http.StatusOK,
 		Result: map[string]interface{}{
-			"id":          "funky-snap-id",
+			"id":          "foo-id",
 			"name":        "foo",
 			"revision":    snap.R(10),
 			"version":     "v1",
@@ -981,9 +1031,9 @@ func (s *apiSuite) TestSnapsInfoOnlyLocal(c *check.C) {
 
 	s.rsnaps = []*snap.Info{{
 		SideInfo: snap.SideInfo{
-			RealName:  "store",
-			Developer: "foo",
+			RealName: "store",
 		},
+		Publisher: "foo",
 	}}
 	s.mkInstalledInState(c, d, "local", "foo", "v1", snap.R(10), true, "")
 
@@ -1035,9 +1085,9 @@ func (s *apiSuite) TestFind(c *check.C) {
 
 	s.rsnaps = []*snap.Info{{
 		SideInfo: snap.SideInfo{
-			RealName:  "store",
-			Developer: "foo",
+			RealName: "store",
 		},
+		Publisher: "foo",
 	}}
 
 	req, err := http.NewRequest("GET", "/v2/find?q=hi", nil)
@@ -1063,9 +1113,9 @@ func (s *apiSuite) TestFindRefreshes(c *check.C) {
 
 	s.rsnaps = []*snap.Info{{
 		SideInfo: snap.SideInfo{
-			RealName:  "store",
-			Developer: "foo",
+			RealName: "store",
 		},
+		Publisher: "foo",
 	}}
 	s.mockSnap(c, "name: store\nversion: 1.0")
 
@@ -1085,9 +1135,9 @@ func (s *apiSuite) TestFindRefreshSideloaded(c *check.C) {
 
 	s.rsnaps = []*snap.Info{{
 		SideInfo: snap.SideInfo{
-			RealName:  "store",
-			Developer: "foo",
+			RealName: "store",
 		},
+		Publisher: "foo",
 	}}
 
 	s.mockSnap(c, "name: store\nversion: 1.0")
@@ -1167,9 +1217,9 @@ func (s *apiSuite) TestFindOne(c *check.C) {
 
 	s.rsnaps = []*snap.Info{{
 		SideInfo: snap.SideInfo{
-			RealName:  "store",
-			Developer: "foo",
+			RealName: "store",
 		},
+		Publisher: "foo",
 		Channels: map[string]*snap.ChannelSnapInfo{
 			"stable": {
 				Revision: snap.R(42),
@@ -1215,9 +1265,9 @@ func (s *apiSuite) TestFindPriced(c *check.C) {
 		},
 		MustBuy: true,
 		SideInfo: snap.SideInfo{
-			RealName:  "banana",
-			Developer: "foo",
+			RealName: "banana",
 		},
+		Publisher: "foo",
 	}}
 
 	req, err := http.NewRequest("GET", "/v2/find?q=banana&channel=stable", nil)
@@ -1255,9 +1305,9 @@ func (s *apiSuite) TestFindScreenshotted(c *check.C) {
 		},
 		MustBuy: true,
 		SideInfo: snap.SideInfo{
-			RealName:  "test-screenshot",
-			Developer: "foo",
+			RealName: "test-screenshot",
 		},
+		Publisher: "foo",
 	}}
 
 	req, err := http.NewRequest("GET", "/v2/find?q=test-screenshot", nil)
@@ -1288,9 +1338,9 @@ func (s *apiSuite) TestSnapsInfoOnlyStore(c *check.C) {
 
 	s.rsnaps = []*snap.Info{{
 		SideInfo: snap.SideInfo{
-			RealName:  "store",
-			Developer: "foo",
+			RealName: "store",
 		},
+		Publisher: "foo",
 	}}
 	s.mkInstalledInState(c, d, "local", "foo", "v1", snap.R(10), true, "")
 
@@ -1374,9 +1424,9 @@ func (s *apiSuite) TestSnapsInfoLocalAndStore(c *check.C) {
 	s.rsnaps = []*snap.Info{{
 		Version: "v42",
 		SideInfo: snap.SideInfo{
-			RealName:  "remote",
-			Developer: "foo",
+			RealName: "remote",
 		},
+		Publisher: "foo",
 	}}
 	s.mkInstalledInState(c, d, "local", "foo", "v1", snap.R(10), true, "")
 
@@ -1414,9 +1464,9 @@ func (s *apiSuite) TestSnapsInfoDefaultSources(c *check.C) {
 
 	s.rsnaps = []*snap.Info{{
 		SideInfo: snap.SideInfo{
-			RealName:  "remote",
-			Developer: "foo",
+			RealName: "remote",
 		},
+		Publisher: "foo",
 	}}
 	s.mkInstalledInState(c, d, "local", "foo", "v1", snap.R(10), true, "")
 
@@ -1433,9 +1483,9 @@ func (s *apiSuite) TestSnapsInfoDefaultSources(c *check.C) {
 func (s *apiSuite) TestSnapsInfoUnknownSource(c *check.C) {
 	s.rsnaps = []*snap.Info{{
 		SideInfo: snap.SideInfo{
-			RealName:  "remote",
-			Developer: "foo",
+			RealName: "remote",
 		},
+		Publisher: "foo",
 	}}
 	s.mkInstalled(c, "local", "foo", "v1", snap.R(10), true, "")
 
@@ -1735,9 +1785,6 @@ func (s *apiSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
 }
 
 func (s *apiSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
-	restore := sysdb.InjectTrusted(s.storeSigning.Trusted)
-	defer restore()
-
 	d := newTestDaemon(c)
 	d.overlord.Loop()
 	defer d.overlord.Stop()
@@ -1785,11 +1832,9 @@ func (s *apiSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
 	snapstateInstallPath = func(s *state.State, si *snap.SideInfo, path, channel string, flags snapstate.Flags) (*state.TaskSet, error) {
 		c.Check(flags, check.Equals, snapstate.Flags{RemoveSnapPath: true})
 		c.Check(si, check.DeepEquals, &snap.SideInfo{
-			RealName:    "x",
-			SnapID:      "x-id",
-			Revision:    snap.R(41),
-			DeveloperID: dev1Acct.AccountID(),
-			Developer:   "devel1",
+			RealName: "x",
+			SnapID:   "x-id",
+			Revision: snap.R(41),
 		})
 
 		return state.NewTaskSet(), nil
@@ -3360,8 +3405,6 @@ func assertAdd(st *state.State, a asserts.Assertion) {
 
 func (s *apiSuite) TestAssertOK(c *check.C) {
 	// Setup
-	restore := sysdb.InjectTrusted(s.storeSigning.Trusted)
-	defer restore()
 	d := s.daemon(c)
 	st := d.overlord.State()
 	// add store key
@@ -3387,8 +3430,6 @@ func (s *apiSuite) TestAssertOK(c *check.C) {
 
 func (s *apiSuite) TestAssertStreamOK(c *check.C) {
 	// Setup
-	restore := sysdb.InjectTrusted(s.storeSigning.Trusted)
-	defer restore()
 	d := s.daemon(c)
 	st := d.overlord.State()
 
@@ -3447,8 +3488,6 @@ func (s *apiSuite) TestAssertError(c *check.C) {
 
 func (s *apiSuite) TestAssertsFindManyAll(c *check.C) {
 	// Setup
-	restore := sysdb.InjectTrusted(s.storeSigning.Trusted)
-	defer restore()
 	d := s.daemon(c)
 	// add store key
 	st := d.overlord.State()
@@ -3489,8 +3528,6 @@ func (s *apiSuite) TestAssertsFindManyAll(c *check.C) {
 
 func (s *apiSuite) TestAssertsFindManyFilter(c *check.C) {
 	// Setup
-	restore := sysdb.InjectTrusted(s.storeSigning.Trusted)
-	defer restore()
 	d := s.daemon(c)
 	// add store key
 	st := d.overlord.State()
@@ -3519,8 +3556,6 @@ func (s *apiSuite) TestAssertsFindManyFilter(c *check.C) {
 
 func (s *apiSuite) TestAssertsFindManyNoResults(c *check.C) {
 	// Setup
-	restore := sysdb.InjectTrusted(s.storeSigning.Trusted)
-	defer restore()
 	d := s.daemon(c)
 	// add store key
 	st := d.overlord.State()
@@ -4080,13 +4115,11 @@ var _ = check.Suite(&postCreateUserSuite{})
 type postCreateUserSuite struct {
 	apiBaseSuite
 
-	mockUserHome    string
-	trustedRestorer func()
+	mockUserHome string
 }
 
 func (s *postCreateUserSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
-	s.trustedRestorer = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
 	s.daemon(c)
 	postCreateUserUcrednetGetUID = func(string) (uint32, error) {
@@ -4099,7 +4132,6 @@ func (s *postCreateUserSuite) SetUpTest(c *check.C) {
 func (s *postCreateUserSuite) TearDownTest(c *check.C) {
 	s.apiBaseSuite.TearDownTest(c)
 
-	s.trustedRestorer()
 	postCreateUserUcrednetGetUID = ucrednetGetUID
 	userLookup = user.Lookup
 	osutilAddUser = osutil.AddUser
@@ -4199,11 +4231,10 @@ func (s *postCreateUserSuite) TestGetUserDetailsFromAssertionModelNotFound(c *ch
 	c.Check(err, check.ErrorMatches, `cannot add system-user "foo@example.com": cannot get model assertion: no state entry for key`)
 }
 
-func (s *postCreateUserSuite) setupSigner(accountID string) *assertstest.SigningDB {
+func (s *postCreateUserSuite) setupSigner(accountID string, signerPrivKey asserts.PrivateKey) *assertstest.SigningDB {
 	st := s.d.overlord.State()
 
 	// create fake brand signature
-	signerPrivKey, _ := assertstest.GenerateKey(752)
 	signerSigning := assertstest.NewSigningDB(accountID, signerPrivKey)
 
 	signerAcct := assertstest.NewAccount(s.storeSigning, accountID, map[string]interface{}{
@@ -4220,14 +4251,20 @@ func (s *postCreateUserSuite) setupSigner(accountID string) *assertstest.Signing
 	return signerSigning
 }
 
+var (
+	brandPrivKey, _   = assertstest.GenerateKey(752)
+	partnerPrivKey, _ = assertstest.GenerateKey(752)
+	unknownPrivKey, _ = assertstest.GenerateKey(752)
+)
+
 func (s *postCreateUserSuite) makeSystemUsers(c *check.C, systemUsers []map[string]interface{}) {
 	st := s.d.overlord.State()
 
 	assertAdd(st, s.storeSigning.StoreAccountKey(""))
 
-	brandSigning := s.setupSigner("my-brand")
-	partnerSigning := s.setupSigner("partner")
-	unknownSigning := s.setupSigner("unknown")
+	brandSigning := s.setupSigner("my-brand", brandPrivKey)
+	partnerSigning := s.setupSigner("partner", partnerPrivKey)
+	unknownSigning := s.setupSigner("unknown", unknownPrivKey)
 
 	signers := map[string]*assertstest.SigningDB{
 		"my-brand": brandSigning,

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -54,31 +55,53 @@ func snapDate(info *snap.Info) time.Time {
 	return st.ModTime()
 }
 
+func publisherName(st *state.State, info *snap.Info) (string, error) {
+	publisher := ""
+	if info.SnapID != "" {
+		pubAcct, err := assertstate.Publisher(st, info.SnapID)
+		if err != nil {
+			return "", fmt.Errorf("cannot find publisher details: %v", err)
+		}
+		publisher = pubAcct.Username()
+	}
+	return publisher, nil
+}
+
+type aboutSnap struct {
+	info      *snap.Info
+	snapst    *snapstate.SnapState
+	publisher string
+}
+
 // localSnapInfo returns the information about the current snap for the given name plus the SnapState with the active flag and other snap revisions.
-func localSnapInfo(st *state.State, name string) (*snap.Info, *snapstate.SnapState, error) {
+func localSnapInfo(st *state.State, name string) (aboutSnap, error) {
 	st.Lock()
 	defer st.Unlock()
 
 	var snapst snapstate.SnapState
 	err := snapstate.Get(st, name, &snapst)
 	if err != nil && err != state.ErrNoState {
-		return nil, nil, fmt.Errorf("cannot consult state: %v", err)
+		return aboutSnap{}, fmt.Errorf("cannot consult state: %v", err)
 	}
 
 	info, err := snapst.CurrentInfo()
 	if err == snapstate.ErrNoCurrent {
-		return nil, nil, errNoSnap
+		return aboutSnap{}, errNoSnap
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot read snap details: %v", err)
+		return aboutSnap{}, fmt.Errorf("cannot read snap details: %v", err)
 	}
 
-	return info, &snapst, nil
-}
+	publisher, err := publisherName(st, info)
+	if err != nil {
+		return aboutSnap{}, err
+	}
 
-type aboutSnap struct {
-	info   *snap.Info
-	snapst *snapstate.SnapState
+	return aboutSnap{
+		info:      info,
+		snapst:    &snapst,
+		publisher: publisher,
+	}, nil
 }
 
 // allLocalSnapInfos returns the information about the all current snaps and their SnapStates.
@@ -94,8 +117,9 @@ func allLocalSnapInfos(st *state.State, all bool) ([]aboutSnap, error) {
 
 	var firstErr error
 	for _, snapst := range snapStates {
-		var infos []*snap.Info
+		var aboutThis []aboutSnap
 		var info *snap.Info
+		var publisher string
 		var err error
 		if all {
 			for _, seq := range snapst.Sequence {
@@ -103,11 +127,16 @@ func allLocalSnapInfos(st *state.State, all bool) ([]aboutSnap, error) {
 				if err != nil {
 					break
 				}
-				infos = append(infos, info)
+				publisher, err = publisherName(st, info)
+				aboutThis = append(aboutThis, aboutSnap{info, snapst, publisher})
 			}
 		} else {
 			info, err = snapst.CurrentInfo()
-			infos = append(infos, info)
+			if err == nil {
+				var publisher string
+				publisher, err = publisherName(st, info)
+				aboutThis = append(aboutThis, aboutSnap{info, snapst, publisher})
+			}
 		}
 
 		if err != nil {
@@ -117,9 +146,7 @@ func allLocalSnapInfos(st *state.State, all bool) ([]aboutSnap, error) {
 			}
 			continue
 		}
-		for _, info := range infos {
-			about = append(about, aboutSnap{info, snapst})
-		}
+		about = append(about, aboutThis...)
 	}
 
 	return about, firstErr
@@ -139,7 +166,8 @@ type screenshotJSON struct {
 	Height int64  `json:"height,omitempty"`
 }
 
-func mapLocal(localSnap *snap.Info, snapst *snapstate.SnapState) map[string]interface{} {
+func mapLocal(about aboutSnap) map[string]interface{} {
+	localSnap, snapst := about.info, about.snapst
 	status := "installed"
 	if snapst.Active && localSnap.Revision == snapst.Current {
 		status = "active"
@@ -156,7 +184,7 @@ func mapLocal(localSnap *snap.Info, snapst *snapstate.SnapState) map[string]inte
 
 	return map[string]interface{}{
 		"description":    localSnap.Description(),
-		"developer":      localSnap.Developer,
+		"developer":      about.publisher,
 		"icon":           snapIcon(localSnap),
 		"id":             localSnap.SnapID,
 		"install-date":   snapDate(localSnap),
@@ -200,7 +228,7 @@ func mapRemote(remoteSnap *snap.Info) map[string]interface{} {
 
 	result := map[string]interface{}{
 		"description":   remoteSnap.Description(),
-		"developer":     remoteSnap.Developer,
+		"developer":     remoteSnap.Publisher,
 		"download-size": remoteSnap.Size,
 		"icon":          snapIcon(remoteSnap),
 		"id":            remoteSnap.SnapID,

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -56,15 +56,15 @@ func snapDate(info *snap.Info) time.Time {
 }
 
 func publisherName(st *state.State, info *snap.Info) (string, error) {
-	publisher := ""
-	if info.SnapID != "" {
-		pubAcct, err := assertstate.Publisher(st, info.SnapID)
-		if err != nil {
-			return "", fmt.Errorf("cannot find publisher details: %v", err)
-		}
-		publisher = pubAcct.Username()
+	if info.SnapID == "" {
+		return "", nil
 	}
-	return publisher, nil
+
+	pubAcct, err := assertstate.Publisher(st, info.SnapID)
+	if err != nil {
+		return "", fmt.Errorf("cannot find publisher details: %v", err)
+	}
+	return pubAcct.Username(), nil
 }
 
 type aboutSnap struct {

--- a/interfaces/backendtest/backendtest.go
+++ b/interfaces/backendtest/backendtest.go
@@ -145,8 +145,7 @@ slots:
 // InstallSnap "installs" a snap from YAML.
 func (s *BackendSuite) InstallSnap(c *C, opts interfaces.ConfinementOptions, snapYaml string, revision int) *snap.Info {
 	snapInfo := snaptest.MockInfo(c, snapYaml, &snap.SideInfo{
-		Revision:  snap.R(revision),
-		Developer: "acme",
+		Revision: snap.R(revision),
 	})
 	s.addPlugsSlots(c, snapInfo)
 	err := s.Backend.Setup(snapInfo, opts, s.Repo)
@@ -157,8 +156,7 @@ func (s *BackendSuite) InstallSnap(c *C, opts interfaces.ConfinementOptions, sna
 // UpdateSnap "updates" an existing snap from YAML.
 func (s *BackendSuite) UpdateSnap(c *C, oldSnapInfo *snap.Info, opts interfaces.ConfinementOptions, snapYaml string, revision int) *snap.Info {
 	newSnapInfo := snaptest.MockInfo(c, snapYaml, &snap.SideInfo{
-		Revision:  snap.R(revision),
-		Developer: "acme",
+		Revision: snap.R(revision),
 	})
 	c.Assert(newSnapInfo.Name(), Equals, oldSnapInfo.Name())
 	s.removePlugsSlots(c, oldSnapInfo)

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -49,7 +49,6 @@ var _ = Suite(&DockerSupportInterfaceSuite{
 		PlugInfo: &snap.PlugInfo{
 			Snap: &snap.Info{
 				SuggestedName: "docker",
-				SideInfo:      snap.SideInfo{Developer: "docker"},
 			},
 			Name:      "docker-support",
 			Interface: "docker-support",
@@ -103,7 +102,6 @@ plugs:
 
 	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
 	c.Assert(err, IsNil)
-	info.SideInfo = snap.SideInfo{Developer: "docker"}
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["privileged"]}
 	err = s.iface.SanitizePlug(plug)
@@ -129,7 +127,6 @@ plugs:
 
 	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
 	c.Assert(err, IsNil)
-	info.SideInfo = snap.SideInfo{Developer: "docker"}
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["privileged"]}
 	err = s.iface.SanitizePlug(plug)
@@ -155,7 +152,6 @@ plugs:
 
 	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
 	c.Assert(err, IsNil)
-	info.SideInfo = snap.SideInfo{Developer: "docker"}
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["privileged"]}
 	err = s.iface.SanitizePlug(plug)

--- a/interfaces/builtin/docker_test.go
+++ b/interfaces/builtin/docker_test.go
@@ -40,7 +40,6 @@ var _ = Suite(&DockerInterfaceSuite{
 		SlotInfo: &snap.SlotInfo{
 			Snap: &snap.Info{
 				SuggestedName: "docker",
-				SideInfo:      snap.SideInfo{Developer: "docker"},
 			},
 			Name:      "docker-daemon",
 			Interface: "docker",

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -48,7 +48,6 @@ var _ = Suite(&LxdSupportInterfaceSuite{
 		PlugInfo: &snap.PlugInfo{
 			Snap: &snap.Info{
 				SuggestedName: "lxd",
-				SideInfo:      snap.SideInfo{Developer: "canonical"},
 			},
 			Name:      "lxd-support",
 			Interface: "lxd-support",

--- a/interfaces/builtin/lxd_test.go
+++ b/interfaces/builtin/lxd_test.go
@@ -48,7 +48,6 @@ var _ = Suite(&LxdInterfaceSuite{
 		PlugInfo: &snap.PlugInfo{
 			Snap: &snap.Info{
 				SuggestedName: "lxd",
-				SideInfo:      snap.SideInfo{Developer: "canonical"},
 			},
 			Name:      "lxd",
 			Interface: "lxd",

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -40,7 +40,7 @@ var _ = Suite(&UDisks2InterfaceSuite{
 		SlotInfo: &snap.SlotInfo{
 			Snap: &snap.Info{
 				SuggestedName: "udisks2",
-				SideInfo:      snap.SideInfo{Developer: "canonical"}},
+			},
 			Name:      "udisks2",
 			Interface: "udisks2",
 		},

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1376,7 +1376,7 @@ func (s *DisconnectSnapSuite) TestCrossConnection(c *C) {
 }
 
 func contentPolicyCheck(plug *Plug, slot *Slot) bool {
-	return plug.Snap.Developer == slot.Snap.Developer
+	return plug.Snap.PublisherID == slot.Snap.PublisherID
 }
 
 func contentAutoConnect(plug *Plug, slot *Slot) bool {
@@ -1436,9 +1436,9 @@ func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingContent(c *C)
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceNoMatchingDeveloper(c *C) {
 	repo, plugSnap, slotSnap := makeContentConnectionTestSnaps(c, "mylib", "mylib")
-	// this comes via SideInfo
-	plugSnap.Developer = "foo"
-	slotSnap.Developer = "bar"
+	// real code will use the assertions, this is just for emulation
+	plugSnap.PublisherID = "fooid"
+	slotSnap.PublisherID = "barid"
 
 	candidateSlots := repo.AutoConnectCandidates("content-plug-snap", "import-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -501,6 +501,26 @@ func SnapDeclaration(s *state.State, snapID string) (*asserts.SnapDeclaration, e
 	return a.(*asserts.SnapDeclaration), nil
 }
 
+// Publisher returns the account assertion for publisher of the given snap-id if it is present in the system assertion database.
+func Publisher(s *state.State, snapID string) (*asserts.Account, error) {
+	db := DB(s)
+	a, err := db.Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  release.Series,
+		"snap-id": snapID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	snapDecl := a.(*asserts.SnapDeclaration)
+	a, err = db.Find(asserts.AccountType, map[string]string{
+		"account-id": snapDecl.PublisherID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("internal error: cannot find account assertion for the publisher of snap %q: %v", snapDecl.SnapName(), err)
+	}
+	return a.(*asserts.Account), nil
+}
+
 // AutoAliases returns the auto-aliases list for the given installed snap.
 func AutoAliases(s *state.State, info *snap.Info) ([]string, error) {
 	if info.SnapID == "" {

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -998,3 +998,25 @@ func (s *assertMgrSuite) TestAutoAliases(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(aliases, DeepEquals, []string{"alias1", "alias2"})
 }
+
+func (s *assertMgrSuite) TestPublisher(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// have a declaration in the system db
+	err := assertstate.Add(s.state, s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, s.dev1Acct)
+	c.Assert(err, IsNil)
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+	err = assertstate.Add(s.state, snapDeclFoo)
+	c.Assert(err, IsNil)
+
+	_, err = assertstate.SnapDeclaration(s.state, "snap-id-other")
+	c.Check(err, Equals, asserts.ErrNotFound)
+
+	acct, err := assertstate.Publisher(s.state, "foo-id")
+	c.Assert(err, IsNil)
+	c.Check(acct.AccountID(), Equals, s.dev1Acct.AccountID())
+	c.Check(acct.Username(), Equals, "developer1")
+}

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -229,7 +229,9 @@ snaps:
 	c.Assert(err, IsNil)
 	c.Assert(info.SnapID, Equals, "snapidsnapid")
 	c.Assert(info.Revision, Equals, snap.R(128))
-	c.Assert(info.DeveloperID, Equals, "developerid")
+	pubAcct, err := assertstate.Publisher(st, info.SnapID)
+	c.Assert(err, IsNil)
+	c.Check(pubAcct.AccountID(), Equals, "developerid")
 
 	var snapst snapstate.SnapState
 	err = snapstate.Get(state, "foo", &snapst)
@@ -241,7 +243,6 @@ snaps:
 	c.Assert(err, IsNil)
 	c.Assert(info.SnapID, Equals, "")
 	c.Assert(info.Revision, Equals, snap.R("x1"))
-	c.Assert(info.DeveloperID, Equals, "")
 
 	// and ensure state is now considered seeded
 	var seeded bool
@@ -385,16 +386,20 @@ snaps:
 	// check foo
 	info, err := snapstate.CurrentInfo(state, "foo")
 	c.Assert(err, IsNil)
-	c.Assert(info.SnapID, Equals, "foosnapidsnapid")
-	c.Assert(info.Revision, Equals, snap.R(128))
-	c.Assert(info.DeveloperID, Equals, "developerid")
+	c.Check(info.SnapID, Equals, "foosnapidsnapid")
+	c.Check(info.Revision, Equals, snap.R(128))
+	pubAcct, err := assertstate.Publisher(st, info.SnapID)
+	c.Assert(err, IsNil)
+	c.Check(pubAcct.AccountID(), Equals, "developerid")
 
 	// check bar
 	info, err = snapstate.CurrentInfo(state, "bar")
 	c.Assert(err, IsNil)
-	c.Assert(info.SnapID, Equals, "barsnapidsnapid")
-	c.Assert(info.Revision, Equals, snap.R(65))
-	c.Assert(info.DeveloperID, Equals, "developerid")
+	c.Check(info.SnapID, Equals, "barsnapidsnapid")
+	c.Check(info.Revision, Equals, snap.R(65))
+	pubAcct, err = assertstate.Publisher(st, info.SnapID)
+	c.Assert(err, IsNil)
+	c.Check(pubAcct.AccountID(), Equals, "developerid")
 }
 
 func (s *FirstBootTestSuite) makeModelAssertion(c *C, modelStr string) *asserts.Model {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -120,7 +120,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	ms.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
 	ms.restoreTrusted = sysdb.InjectTrusted(ms.storeSigning.Trusted)
 
-	ms.devAcct = assertstest.NewAccount(ms.storeSigning, "devdevev", map[string]interface{}{
+	ms.devAcct = assertstest.NewAccount(ms.storeSigning, "devdevdev", map[string]interface{}{
 		"account-id": "devdevdev",
 	}, "")
 	err = ms.storeSigning.Add(ms.devAcct)
@@ -495,12 +495,15 @@ apps:
 
 	c.Check(info.Revision, Equals, snap.R(42))
 	c.Check(info.SnapID, Equals, fooSnapID)
-	c.Check(info.DeveloperID, Equals, "devdevdev")
 	c.Check(info.Version, Equals, "1.0")
 	c.Check(info.Summary(), Equals, "Foo")
 	c.Check(info.Description(), Equals, "this is a description")
-	c.Check(info.Developer, Equals, "bar")
 	c.Assert(osutil.FileExists(info.MountFile()), Equals, true)
+
+	pubAcct, err := assertstate.Publisher(st, info.SnapID)
+	c.Assert(err, IsNil)
+	c.Check(pubAcct.AccountID(), Equals, "devdevdev")
+	c.Check(pubAcct.Username(), Equals, "devdevdev")
 
 	snapRev42, err := assertstate.DB(st).Find(asserts.SnapRevisionType, map[string]string{
 		"snap-sha3-384": digest,
@@ -542,7 +545,6 @@ apps:
 
 	c.Check(info.Revision, Equals, snap.R(50))
 	c.Check(info.SnapID, Equals, fooSnapID)
-	c.Check(info.DeveloperID, Equals, "devdevdev")
 	c.Check(info.Version, Equals, "2.0")
 
 	snapRev50, err := assertstate.DB(st).Find(asserts.SnapRevisionType, map[string]string{
@@ -574,11 +576,9 @@ apps:
 	snapPath := makeTestSnap(c, snapYamlContent+"version: 1.5")
 
 	si := &snap.SideInfo{
-		RealName:    "foo",
-		SnapID:      fooSnapID,
-		Revision:    snap.R(55),
-		DeveloperID: "devdevdevID",
-		Developer:   "devdevdev",
+		RealName: "foo",
+		SnapID:   fooSnapID,
+		Revision: snap.R(55),
 	}
 
 	st := ms.o.State()
@@ -609,8 +609,6 @@ apps:
 	c.Assert(err, IsNil)
 	c.Check(info.Revision, Equals, snap.R(55))
 	c.Check(info.SnapID, Equals, fooSnapID)
-	c.Check(info.DeveloperID, Equals, "devdevdevID")
-	c.Check(info.Developer, Equals, "devdevdev")
 	c.Check(info.Version, Equals, "1.5")
 
 	// ensure that the binary wrapper file got generated with the right
@@ -648,11 +646,9 @@ slots:
 	snapPath := makeTestSnap(c, snapYamlContent+"version: 1.5")
 
 	si := &snap.SideInfo{
-		RealName:    "foo",
-		SnapID:      fooSnapID,
-		Revision:    snap.R(55),
-		DeveloperID: "devdevdevID",
-		Developer:   "devdevdev",
+		RealName: "foo",
+		SnapID:   fooSnapID,
+		Revision: snap.R(55),
 	}
 
 	st := ms.o.State()

--- a/snap/info.go
+++ b/snap/info.go
@@ -119,8 +119,6 @@ type SideInfo struct {
 	SnapID            string   `yaml:"snap-id" json:"snap-id"`
 	Revision          Revision `yaml:"revision" json:"revision"`
 	Channel           string   `yaml:"channel,omitempty" json:"channel,omitempty"`
-	DeveloperID       string   `yaml:"developer-id,omitempty" json:"developer-id,omitempty"`
-	Developer         string   `yaml:"developer,omitempty" json:"developer,omitempty"` // XXX: obsolete, will be retired after full backfilling of DeveloperID
 	EditedSummary     string   `yaml:"summary,omitempty" json:"summary,omitempty"`
 	EditedDescription string   `yaml:"description,omitempty" json:"description,omitempty"`
 	Private           bool     `yaml:"private,omitempty" json:"private,omitempty"`
@@ -159,8 +157,11 @@ type Info struct {
 	DownloadInfo
 
 	IconURL string
-	Prices  map[string]float64 `yaml:"prices,omitempty" json:"prices,omitempty"`
+	Prices  map[string]float64
 	MustBuy bool
+
+	PublisherID string
+	Publisher   string
 
 	Screenshots []ScreenshotInfo
 	Channels    map[string]*ChannelSnapInfo

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1095,7 +1095,8 @@ slots:
 	c.Check(info.Plugs, HasLen, 4)
 	c.Check(info.Slots, HasLen, 2)
 	// these don't come from snap.yaml
-	c.Check(info.Developer, Equals, "")
+	c.Check(info.Publisher, Equals, "")
+	c.Check(info.PublisherID, Equals, "")
 	c.Check(info.Channel, Equals, "")
 
 	app1 := info.Apps["daemon"]

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -65,7 +65,6 @@ func (s *infoSuite) TestSideInfoOverrides(c *C) {
 		EditedDescription: "fixed desc",
 		Revision:          snap.R(1),
 		SnapID:            "snapidsnapidsnapidsnapidsnapidsn",
-		DeveloperID:       "deviddeviddeviddeviddeviddevidde",
 	}
 
 	c.Check(info.Name(), Equals, "newname")
@@ -73,7 +72,6 @@ func (s *infoSuite) TestSideInfoOverrides(c *C) {
 	c.Check(info.Description(), Equals, "fixed desc")
 	c.Check(info.Revision, Equals, snap.R(1))
 	c.Check(info.SnapID, Equals, "snapidsnapidsnapidsnapidsnapidsn")
-	c.Check(info.DeveloperID, Equals, "deviddeviddeviddeviddeviddevidde")
 }
 
 func (s *infoSuite) TestAppInfoSecurityTag(c *C) {

--- a/store/details.go
+++ b/store/details.go
@@ -49,12 +49,10 @@ type snapDetails struct {
 	Type             snap.Type          `json:"content,omitempty"`
 	Version          string             `json:"version"`
 
-	// FIXME: the store should return "developer" to us instead of
-	//        origin
-	// This will be retired/obsoleted soon
-	Developer string `json:"origin"`
-	// The developer id is the new relevant field that we track
+	// TODO: have the store return a 'developer_username' for this
+	Developer   string `json:"origin"`
 	DeveloperID string `json:"developer_id"`
+
 	Private     bool   `json:"private"`
 	Confinement string `json:"confinement"`
 }

--- a/store/store.go
+++ b/store/store.go
@@ -112,8 +112,8 @@ func infoFromRemote(d snapDetails) *snap.Info {
 	info.Revision = snap.R(d.Revision)
 	info.EditedSummary = d.Summary
 	info.EditedDescription = d.Description
-	info.DeveloperID = d.DeveloperID
-	info.Developer = d.Developer // XXX: obsolete, will be retired after full backfilling of DeveloperID
+	info.PublisherID = d.DeveloperID
+	info.Publisher = d.Developer
 	info.Channel = d.Channel
 	info.Sha3_384 = d.DownloadSha3_384
 	info.Size = d.DownloadSize

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1423,7 +1423,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(result.Architectures, DeepEquals, []string{"all"})
 	c.Check(result.Revision, Equals, snap.R(27))
 	c.Check(result.SnapID, Equals, helloWorldSnapID)
-	c.Check(result.Developer, Equals, "canonical")
+	c.Check(result.Publisher, Equals, "canonical")
 	c.Check(result.Version, Equals, "6.3")
 	c.Check(result.Sha3_384, Matches, `[[:xdigit:]]{96}`)
 	c.Check(result.Size, Equals, int64(20480))
@@ -2400,7 +2400,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 	c.Assert(results[0].Revision, Equals, snap.R(26))
 	c.Assert(results[0].Version, Equals, "6.1")
 	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
-	c.Assert(results[0].DeveloperID, Equals, helloWorldDeveloperID)
+	c.Assert(results[0].PublisherID, Equals, helloWorldDeveloperID)
 	c.Assert(results[0].Deltas, HasLen, 0)
 }
 


### PR DESCRIPTION
This obtains installed snaps developer/publisher username through snap-declaration and publisher account assertion, instead of trusting what was captured at installation.

So it also drops this info from SideInfo and move the fields with the information purely for remote searches into snap.Info under PublisherID/Publisher.