### PR TITLE
cmd/snap-confine: check for rst2man on configure

### DIFF
--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -161,5 +161,8 @@ AS_IF([test "x$enable_caps_over_setuid" = "xyes"], [
     AC_DEFINE([CAPS_OVER_SETUID], [1],
         [Use capabilities rather than setuid bit])])
 
+AC_PATH_PROG([HAVE_RST2MAN],[rst2man])
+AS_IF([test "x$HAVE_RST2MAN" = "x"], [AC_MSG_ERROR(["cannot find the rst2man tool, install python-docutils or similar"])])
+
 AC_CONFIG_FILES([Makefile snap-confine/Makefile snap-confine/tests/Makefile snap-confine/manpages/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/snap-confine/+bug/1618679
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>