### PR TITLE
tests: disable some ppc64el on yakkety and zesty too

### DIFF
--- a/tests/main/chattr/task.yaml
+++ b/tests/main/chattr/task.yaml
@@ -1,7 +1,7 @@
 summary: test chattr
 # ubuntu-core doesn't have go :-)
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2503
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el]
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 prepare: |
   go build -o toggle ./toggle.go
 execute: |

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -1,7 +1,7 @@
 summary: Check different completions
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el]
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 prepare: |
     mkdir -p testdir

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for snap create-key
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el]
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 prepare: |
     . "$TESTSLIB/mkpinentry.sh"

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that find works with private snaps.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-16.04-ppc64el]
+systems: [-ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 details: |
     These tests rely on the existence of a snap in the production store set to private.

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the upower-observe interface works.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2504
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el]
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 summary: |
     The upower-observe interface allows a snap to query UPower for power devices, history

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -1,7 +1,7 @@
 summary: Checks for snap login
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el]
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 restore: |
     snap logout || true

--- a/tests/main/security-devpts/task.yaml
+++ b/tests/main/security-devpts/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the basic devpts security rules are in place.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el]
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 prepare: |
     echo "Given a basic snap is installed"

--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the security rules for private tmp are in place.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el]
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 environment:
     SNAP_INSTALL_DIR: $(pwd)/snap-install-dir

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -1,7 +1,7 @@
 summary: Run snap sign to sign a model assertion
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el]
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 prepare: |
     . "$TESTSLIB/mkpinentry.sh"


### PR DESCRIPTION
This unbreaks tests on ppc64el for yakkety/zesty.

We could probably write this shorter if https://github.com/snapcore/spread/pull/15 lands.