### PR TITLE
debian: skip snap-confine unit tests on nocheck

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -109,8 +109,10 @@ ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	[ $$(strings _build/bin/snapd|grep -c -E "public-key-sha3-384: [a-zA-Z0-9_-]{64}") -eq 1 ]
 	strings _build/bin/snapd|grep -c "^public-key-sha3-384: -CvQKAwRQ5h3Ffn10FILJoEZUXOv6km9FwA80-Rcj-f-6jadQ89VRswHNiEB9Lxk$$"
 endif
+ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	# run the snap-confine tests
 	$(MAKE) -C cmd check
+endif
 
 override_dh_systemd_enable:
 	# enable auto-import

--- a/debian/rules
+++ b/debian/rules
@@ -104,6 +104,7 @@ override_dh_auto_build:
 
 override_dh_auto_test:
 	dh_auto_test -- $(GCCGOFLAGS)
+# a tested default (production) build should have no test keys
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 	# check that only the main trusted account-key is included
 	[ $$(strings _build/bin/snapd|grep -c -E "public-key-sha3-384: [a-zA-Z0-9_-]{64}") -eq 1 ]


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>