### PR TITLE
tests: generate higher local version than any "ubuntuN" version from the archive

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -240,8 +240,10 @@ prepare: |
     go get -u github.com/kardianos/govendor
     govendor sync
 
-    # increment version so upgrade can work
-    dch -i "testing build"
+    # increment version so upgrade can work, use "zzz" as version
+    # component to ensure that its higher than any "ubuntuN" version
+    # that might also be in the archive
+    dch -lzzz "testing build"
 
     if ! id test >& /dev/null; then
         # manually setting the UID and GID to 12345 because we need to


### PR DESCRIPTION
If we have a version in ubuntu that contains e.g. "2.20.1ubuntu1" but the git tree only has "2.20.1" our current `dch -i` will  generate a version 2.20.1ubuntu1 which is identical to the archive version. To avoid this, use a custom dch version suffix that is higher than "ubuntuN".