### PR TITLE
tests: improve cleanup for c-unit-tests

### DIFF
--- a/tests/main/c-unit-tests/task.yaml
+++ b/tests/main/c-unit-tests/task.yaml
@@ -8,7 +8,7 @@ prepare: |
     apt-get install --yes $EXTRA_PKGS
     # Remove any autogarbage from sent by developer
     rm -rf $SPREAD_PATH/cmd/{autom4te.cache,configure,test-driver,config.guess,config.sub,config.h.in,compile,install-sh,depcomp,build,missing,aclocal.m4}
-    find $SPREAD_PATH/cmd/ -name Makefile.in -exec rm -f {} \;
+    find $SPREAD_PATH/cmd/ \( -name Makefile.in -o -name Makefile \) -exec rm -vf {} \;
     make -C $SPREAD_PATH/cmd distclean || true
 execute: |
     # Refresh autotools build system
@@ -26,7 +26,7 @@ execute: |
     make -C snap-confine check-unit-tests
 restore: |
     # Remove autogarbage leftover from testing
-    find $SPREAD_PATH/cmd/ -name Makefile.in -exec rm -f {} \;
+    find $SPREAD_PATH/cmd/ \( -name Makefile.in -o -name Makefile \) -exec rm -vf {} \;
     rm -rf $SPREAD_PATH/cmd/{autom4te.cache,configure,test-driver,config.guess,config.sub,config.h.in,compile,install-sh,depcomp,build,missing,aclocal.m4}
     # Remove the build tree
     rm -rf $SPREAD_PATH/cmd/autogarbage/


### PR DESCRIPTION
We didn't use to remove automatically generated makefiles that may be present on the test machine (repeated testing) or erroneously sent over from the local machine to the test machine.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>