### PR TITLE
cmd/snap: fix internal naming in snap connect

### DIFF
--- a/cmd/snap/cmd_connect.go
+++ b/cmd/snap/cmd_connect.go
@@ -27,8 +27,8 @@ import (
 
 type cmdConnect struct {
 	Positionals struct {
-		Offer SnapAndName `required:"yes"`
-		Use   SnapAndName
+		Use   SnapAndName `required:"yes"`
+		Offer SnapAndName
 	} `positional-args:"true"`
 }
 
@@ -68,14 +68,14 @@ func (x *cmdConnect) Execute(args []string) error {
 	}
 
 	// snap connect <plug> <snap>[:<slot>]
-	if x.Positionals.Offer.Snap != "" && x.Positionals.Offer.Name == "" {
+	if x.Positionals.Use.Snap != "" && x.Positionals.Use.Name == "" {
 		// Move the value of .Snap to .Name and keep .Snap empty
-		x.Positionals.Offer.Name = x.Positionals.Offer.Snap
-		x.Positionals.Offer.Snap = ""
+		x.Positionals.Use.Name = x.Positionals.Use.Snap
+		x.Positionals.Use.Snap = ""
 	}
 
 	cli := Client()
-	id, err := cli.Connect(x.Positionals.Offer.Snap, x.Positionals.Offer.Name, x.Positionals.Use.Snap, x.Positionals.Use.Name)
+	id, err := cli.Connect(x.Positionals.Use.Snap, x.Positionals.Use.Name, x.Positionals.Offer.Snap, x.Positionals.Offer.Name)
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_connect.go
+++ b/cmd/snap/cmd_connect.go
@@ -27,8 +27,8 @@ import (
 
 type cmdConnect struct {
 	Positionals struct {
-		Use   SnapAndName `required:"yes"`
-		Offer SnapAndName
+		PlugSpec SnapAndName `required:"yes"`
+		SlotSpec SnapAndName
 	} `positional-args:"true"`
 }
 
@@ -68,14 +68,14 @@ func (x *cmdConnect) Execute(args []string) error {
 	}
 
 	// snap connect <plug> <snap>[:<slot>]
-	if x.Positionals.Use.Snap != "" && x.Positionals.Use.Name == "" {
+	if x.Positionals.PlugSpec.Snap != "" && x.Positionals.PlugSpec.Name == "" {
 		// Move the value of .Snap to .Name and keep .Snap empty
-		x.Positionals.Use.Name = x.Positionals.Use.Snap
-		x.Positionals.Use.Snap = ""
+		x.Positionals.PlugSpec.Name = x.Positionals.PlugSpec.Snap
+		x.Positionals.PlugSpec.Snap = ""
 	}
 
 	cli := Client()
-	id, err := cli.Connect(x.Positionals.Use.Snap, x.Positionals.Use.Name, x.Positionals.Offer.Snap, x.Positionals.Offer.Name)
+	id, err := cli.Connect(x.Positionals.PlugSpec.Snap, x.Positionals.PlugSpec.Name, x.Positionals.SlotSpec.Snap, x.Positionals.SlotSpec.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The connect command uses two positional arguments "Use" and "Offer" but
their semantics was swapped around (probably since before the plug and
slot names were swapped). With this patch "Use" refers to the plug side
and "Offer" to the slot side.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>