### PR TITLE
tests: restore the missing initialization of iface manager causing race

### DIFF
--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -377,8 +377,7 @@ slots:
 	s.mockIface(c, &interfaces.TestInterface{InterfaceName: "test"})
 
 	setup()
-
-	//mgr := s.manager(c)
+	_ = s.manager(c)
 
 	s.state.Lock()
 	change := s.state.NewChange("kind", "summary")


### PR DESCRIPTION
Restore the missing initialization of iface manager in one of the test helpers.

Interface manager in the tests must be instantiated early in the test after mock interfaces are setup, otherwise it will be "automatically" instantiated late during settle() causing occasional failures of tasks that are already in flight and need hook manager to be set up (hook manager initialization is part of interface manager instantiation in the test).