### PR TITLE
snap: use "size" as the json tag in snap.ChannelSnapInfo

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -175,7 +175,7 @@ type ChannelSnapInfo struct {
 	Version     string          `json:"version"`
 	Channel     string          `json:"channel"`
 	Epoch       string          `json:"epoch"`
-	Size        int64           `json:"binary_filesize"`
+	Size        int64           `json:"size"`
 }
 
 // Name returns the blessed name for the snap.

--- a/store/details.go
+++ b/store/details.go
@@ -66,3 +66,14 @@ type snapDeltaDetail struct {
 	Size            int64  `json:"binary_filesize,omitempty"`
 	Sha3_384        string `json:"download_sha3_384,omitempty"`
 }
+
+// channelSnapInfoDetails is identical to snap.ChannelSnapInfo except
+// for the "Size" json tag, we use just "size" in our internal API for that
+type channelSnapInfoDetails struct {
+	Revision    int    `json:"revision"` // store revisions are ints starting at 1
+	Confinement string `json:"confinement"`
+	Version     string `json:"version"`
+	Channel     string `json:"channel"`
+	Epoch       string `json:"epoch"`
+	Size        int64  `json:"binary_filesize"`
+}

--- a/store/details.go
+++ b/store/details.go
@@ -67,13 +67,13 @@ type snapDeltaDetail struct {
 	Sha3_384        string `json:"download_sha3_384,omitempty"`
 }
 
-// channelSnapInfoDetails is identical to snap.ChannelSnapInfo except
-// for the "Size" json tag, we use just "size" in our internal API for that
+// channelSnapInfoDetails is the subset of snapDetails we need to get
+// information about the snaps in the various channels
 type channelSnapInfoDetails struct {
-	Revision    int    `json:"revision"` // store revisions are ints starting at 1
-	Confinement string `json:"confinement"`
-	Version     string `json:"version"`
-	Channel     string `json:"channel"`
-	Epoch       string `json:"epoch"`
-	Size        int64  `json:"binary_filesize"`
+	Revision     int    `json:"revision"` // store revisions are ints starting at 1
+	Confinement  string `json:"confinement"`
+	Version      string `json:"version"`
+	Channel      string `json:"channel"`
+	Epoch        string `json:"epoch"`
+	DownloadSize int64  `json:"binary_filesize"`
 }

--- a/store/store.go
+++ b/store/store.go
@@ -931,7 +931,7 @@ func (s *Store) fakeChannels(snapID string, user *auth.UserState) (map[string]*s
 
 	var results struct {
 		Payload struct {
-			SnapDetails []*snapDetails `json:"clickindex:package"`
+			ChannelSnapInfoDetails []*channelSnapInfoDetails `json:"clickindex:package"`
 		} `json:"_embedded"`
 	}
 
@@ -945,7 +945,7 @@ func (s *Store) fakeChannels(snapID string, user *auth.UserState) (map[string]*s
 	}
 
 	channelInfos := make(map[string]*snap.ChannelSnapInfo, 4)
-	for _, item := range results.Payload.SnapDetails {
+	for _, item := range results.Payload.ChannelSnapInfoDetails {
 		channelInfos[item.Channel] = &snap.ChannelSnapInfo{
 			Revision:    snap.R(item.Revision),
 			Confinement: snap.ConfinementType(item.Confinement),

--- a/store/store.go
+++ b/store/store.go
@@ -354,7 +354,7 @@ type sectionResults struct {
 var detailFields = getStructFields(snapDetails{})
 
 // The fields we are interested in for snap.ChannelSnapInfos
-var channelSnapInfoFields = getStructFields(snap.ChannelSnapInfo{})
+var channelSnapInfoFields = getStructFields(channelSnapInfoDetails{})
 
 // The default delta format if not configured.
 var defaultSupportedDeltaFormat = "xdelta3"


### PR DESCRIPTION
The "size" json is much nicer than the store "binary_filesize"
so we use "size" in our REST protocol.