### PR TITLE
cmd/snap: add shell completion to connect

### DIFF
--- a/cmd/snap/cmd_connect.go
+++ b/cmd/snap/cmd_connect.go
@@ -27,7 +27,7 @@ import (
 
 type cmdConnect struct {
 	Positionals struct {
-		PlugSpec SnapAndName `required:"yes"`
+		PlugSpec connectPlugSpec `required:"yes"`
 		SlotSpec SnapAndName
 	} `positional-args:"true"`
 }

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -146,13 +146,27 @@ func (cps connectPlugSpec) Complete(match string) []flags.Completion {
 		for snapName := range snaps {
 			for _, plug := range ifaces.Plugs {
 				if plug.Snap == snapName && strings.HasPrefix(plug.Name, plugPrefix) {
-					ret = append(ret, flags.Completion{Item: fmt.Sprintf("%s:%s", plug.Snap, plug.Name)})
+					// TODO: in the future annotate plugs that can take
+					// multiple connection sensibly and don't skip those even
+					// if they have connections already.
+					if len(plug.Connections) == 0 {
+						ret = append(ret, flags.Completion{Item: fmt.Sprintf("%s:%s", plug.Snap, plug.Name)})
+					}
 				}
 			}
 		}
 	} else {
 		for snapName := range snaps {
-			ret = append(ret, flags.Completion{Item: fmt.Sprintf("%s:", snapName)})
+			for _, plug := range ifaces.Plugs {
+				if plug.Snap == snapName {
+					if len(plug.Connections) == 0 {
+						// TODO: in the future annotate plugs that can take
+						// multiple connection sensibly and don't skip those
+						// even if they have connections already.
+						ret = append(ret, flags.Completion{Item: fmt.Sprintf("%s:", snapName)})
+					}
+				}
+			}
 		}
 	}
 

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -121,20 +121,16 @@ func (cps connectPlugSpec) Complete(match string) []flags.Completion {
 	var ret []flags.Completion
 
 	var snapPrefix, plugPrefix string
-	switch len(parts) {
-	case 2:
-		// The user typed the colon, means they know the snap they
-		// want; go with that.
+	if len(parts) == 2 {
+		// The user typed the colon, means they know the snap they want;
+		// go with that.
 		plugPrefix = parts[1]
 		snaps[parts[0]] = true
-	case 1:
-		// The user started typing a snap name but didn't reach the
-		// colon yet. Offer plugs for snaps with names that start like
-		// that.
+	} else {
+		// The user is about to or has started typing a snap name but didn't
+		// reach the colon yet. Offer plugs for snaps with names that start
+		// like that.
 		snapPrefix = parts[0]
-		fallthrough
-	case 0:
-		// note "" prefixes any snap name :-)
 		for _, plug := range ifaces.Plugs {
 			if strings.HasPrefix(plug.Snap, snapPrefix) {
 				snaps[plug.Snap] = true

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -105,11 +105,9 @@ type connectPlugSpec struct {
 }
 
 func (cps connectPlugSpec) Complete(match string) []flags.Completion {
-	match = strings.Trim(match, "\"'")
-
 	// Parse what the user typed so far, it can be either
 	// nothing (""), a "snap", a "snap:" or a "snap:name".
-	parts := strings.Split(match, ":")
+	parts := strings.SplitN(match, ":", 2)
 
 	// Ask snapd about available interfaces.
 	cli := Client()
@@ -117,51 +115,46 @@ func (cps connectPlugSpec) Complete(match string) []flags.Completion {
 	if err != nil {
 		return nil
 	}
+
+	snaps := make(map[string]bool)
+
 	var ret []flags.Completion
+
+	var snapPrefix, plugPrefix string
 	switch len(parts) {
-	case 0:
-		// The user didn't input anything yet. Let's start by offering
-		// suggestion containing snap names that have at least one plug.
-		snaps := make(map[string]bool)
-		for _, plug := range ifaces.Plugs {
-			snaps[plug.Snap] = true
-		}
-		for snapName := range snaps {
-			ret = append(ret, flags.Completion{Item: fmt.Sprintf("%s:", snapName)})
-		}
-		break
+	case 2:
+		// The user typed the colon, means they know the snap they
+		// want; go with that.
+		plugPrefix = parts[1]
+		snaps[parts[0]] = true
 	case 1:
-		// The user started typing a snap name but didn't reach the colon yet.
-		// Let's help by offering suggestions containing snap names that start
-		// with the given text and have at least one plug.
-		partialSnapName := parts[0]
-		snaps := make(map[string]bool)
+		// The user started typing a snap name but didn't reach the
+		// colon yet. Offer plugs for snaps with names that start like
+		// that.
+		snapPrefix = parts[0]
+		fallthrough
+	case 0:
+		// note "" prefixes any snap name :-)
 		for _, plug := range ifaces.Plugs {
-			if partialSnapName == "" || strings.HasPrefix(plug.Snap, partialSnapName) {
+			if strings.HasPrefix(plug.Snap, snapPrefix) {
 				snaps[plug.Snap] = true
 			}
 		}
+	}
+
+	if len(snaps) == 1 {
+		for snapName := range snaps {
+			for _, plug := range ifaces.Plugs {
+				if plug.Snap == snapName && strings.HasPrefix(plug.Name, plugPrefix) {
+					ret = append(ret, flags.Completion{Item: fmt.Sprintf("%s:%s", plug.Snap, plug.Name)})
+				}
+			}
+		}
+	} else {
 		for snapName := range snaps {
 			ret = append(ret, flags.Completion{Item: fmt.Sprintf("%s:", snapName)})
 		}
-		break
-	case 2:
-		// The user typed the snap name and the colon and is starting to narrow
-		// down the input to specify plug name. Let's help by offering full
-		// suggestions containing the suggestions of possible plug names that
-		// start with the given text (the plug part of if).
-		snapName := parts[0]
-		partialPlugName := parts[1]
-		plugs := make(map[string]bool)
-		for _, plug := range ifaces.Plugs {
-			if plug.Snap == snapName && (partialPlugName == "" || strings.HasPrefix(plug.Name, partialPlugName)) {
-				plugs[plug.Name] = true
-			}
-		}
-		for plugName := range plugs {
-			ret = append(ret, flags.Completion{Item: fmt.Sprintf("%s:%s", snapName, plugName)})
-		}
-		break
 	}
+
 	return ret
 }

--- a/data/completion/snap
+++ b/data/completion/snap
@@ -1,5 +1,6 @@
 # -*- sh -*-
 _complete() {
+    # TODO: add support for sourcing this function from the core snap.
     local cur prev words cword
     _init_completion -n : || return
 

--- a/data/completion/snap
+++ b/data/completion/snap
@@ -33,7 +33,7 @@ _complete() {
             _filedir -d
             ;;
         connect)
-            if [ -n "$COMPREPLY" -a -z "${COMPREPLY%%*:}" ]; then
+            if [[ "$COMPREPLY" == *: ]]; then
                 compopt -o nospace
             fi
     esac

--- a/data/completion/snap
+++ b/data/completion/snap
@@ -1,7 +1,7 @@
 # -*- sh -*-
 _complete() {
     local cur prev words cword
-    _init_completion || return
+    _init_completion -n : || return
 
     local command
     if [[ ${#words[@]} -gt 2 ]]; then
@@ -32,7 +32,13 @@ _complete() {
         try)
             _filedir -d
             ;;
+        connect)
+            if [ -n "$COMPREPLY" -a -z "${COMPREPLY%%*:}" ]; then
+                compopt -o nospace
+            fi
     esac
+
+    __ltrim_colon_completions "$cur"
 
     return 0
 }


### PR DESCRIPTION
This patch adds somewhat imperfect support for shell completion to "snap
connect". The part that is not so nice yet is that colon seems to
terminate the completion input (in bash at least) unless the user
manually adds quotes around the argument and goes back (after the
initial suggestion) to place the cursor immediately before the closing
double quote but after the colon.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>