### PR TITLE
interfaces: miscellaneous policy updates for network-control, unity7, pulseaudio, default and home

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -127,6 +127,7 @@ var defaultTemplate = []byte(`
   /{,usr/}bin/hostname ixr,
   /{,usr/}bin/id ixr,
   /{,usr/}bin/igawk ixr,
+  /{,usr/}bin/infocmp ixr,
   /{,usr/}bin/kill ixr,
   /{,usr/}bin/ldd ixr,
   /{,usr/}bin/less{,file,pipe} ixr,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -243,6 +243,10 @@ var defaultTemplate = []byte(`
   owner @{PROC}/@{pid}/cmdline r,
   owner @{PROC}/@{pid}/comm r,
 
+  # Per man(5) proc, the kernel enforces that a thread may only modify its comm
+  # value or those in its thread group.
+  owner @{PROC}/@{pid}/task/@{tid}/comm rw,
+
   # Miscellaneous accesses
   /dev/{,u}random w,
   /etc/machine-id r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -327,7 +327,7 @@ var defaultTemplate = []byte(`
   # App-specific access to files and directories in /dev/shm. We allow file
   # access in /dev/shm for shm_open() and files in subdirectories for open()
   /{dev,run}/shm/snap.@{SNAP_NAME}.** mrwlkix,
-  # Also allow app-specific access to sem_open()
+  # Also allow app-specific access for sem_open()
   /{dev,run}/shm/sem.snap.@{SNAP_NAME}.* rwk,
 
   # Snap-specific XDG_RUNTIME_DIR that is based on the UID of the user

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -327,6 +327,8 @@ var defaultTemplate = []byte(`
   # App-specific access to files and directories in /dev/shm. We allow file
   # access in /dev/shm for shm_open() and files in subdirectories for open()
   /{dev,run}/shm/snap.@{SNAP_NAME}.** mrwlkix,
+  # Also allow app-specific access to sem_open()
+  /{dev,run}/shm/sem.snap.@{SNAP_NAME}.* rwk,
 
   # Snap-specific XDG_RUNTIME_DIR that is based on the UID of the user
   owner /{dev,run}/user/[0-9]*/snap.@{SNAP_NAME}/   rw,

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -45,8 +45,8 @@ owner @{HOME}/{s,sn,sna}{,/} rwk,
 
 # Allow access to gvfs mounts for files owned by the user (including hidden
 # files; only allow writes to files, not the mount point).
-owner /run/user/[0-9]*/gvfs/**   r,
-owner /run/user/[0-9]*/gvfs/*/** w,
+owner /run/user/[0-9]*/gvfs/{,**} r,
+owner /run/user/[0-9]*/gvfs/*/**  w,
 `
 
 // NewHomeInterface returns a new "home" interface.

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -116,6 +116,9 @@ capability setuid,
 
 # TUN/TAP
 /dev/net/tun rw,
+# These are dynamically created via ioctl() on /dev/net/tun
+/dev/tun[0-9]{,[0-9]*} rw,
+/dev/tap[0-9]{,[0-9]*} rw,
 
 # Network namespaces via 'ip netns'. In order to create network namespaces
 # that persist outside of the process and be entered (eg, via

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -121,6 +121,7 @@ recvmsg
 # Needed to set root as group for different state dirs
 # pulseaudio creates on startup.
 setgroups
+setgroups32
 `
 
 type PulseAudioInterface struct{}

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -255,6 +255,14 @@ dbus (send)
     member=Changed
     peer=(name=org.freedesktop.DBus, label=unconfined),
 
+# Ubuntu menus
+dbus (send)
+    bus=session
+    path="/com/ubuntu/MenuRegistrar"
+    interface="com.ubuntu.MenuRegistrar"
+    member="{Register,Unregister}{App,Surface}Menu"
+    peer=(label=unconfined),
+
 # url helper
 dbus (send)
     bus=session

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -67,6 +67,7 @@ const unity7ConnectedPlugAppArmor = `
 # snappy's xdg-open supports all snaps images, this access may move to another
 # interface.
 /usr/local/bin/xdg-open ixr,
+/usr/local/share/applications/{,*} r,
 /usr/bin/dbus-send ixr,
 dbus (send)
     bus=session


### PR DESCRIPTION
interfaces/network-control: allow rw on /dev/tun* and /dev/tap* (https://github.com/snapcore/snapd/issues/2557)
interfaces/unity7: allow snaps to read /usr/local/share/applications/* (LP: #1654666)
interfaces/pulseaudio: allow setgroups32 for armhf (LP: #1654585)
interfaces/default: allow use of infocmp by default (LP: #1646085)
interfaces/default: allow rw to /dev/shm/sem.snap.@{SNAP_NAME}.* (LP: #1653955)
interfaces/default: allow threads to modify comm values for its thread group
interfaces/unity7: allow use of Ubuntu MenuRegistrar (LP: #1646479)
interfaces/home: allow directory listing of /run/user/*/gvfs (LP: #1645413)