### PR TITLE
wrappers: add DBusActivatable to the allowed values for desktop files

### DIFF
--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -61,6 +61,8 @@ var validDesktopFilePrefixes = []string{
 	"Keywords=",
 	"StartupNotify=",
 	"StartupWMClass=",
+	// LP: #1648990
+	"DBusActivatable=",
 }
 
 // name desktop file keys are localized as key[LOCALE]=:

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -278,3 +278,15 @@ func (s *sanitizeDesktopFileSuite) TestTrimLang(c *C) {
 		c.Assert(wrappers.TrimLang(t.in), Equals, t.out)
 	}
 }
+
+func (s *sanitizeDesktopFileSuite) TestValidKeys(c *C) {
+	for _, t := range []struct {
+		in   string
+		good bool
+	}{
+		{"Activactable=true", false},
+		{"DBusActivatable=true", true},
+	} {
+		c.Check(wrappers.IsValidDesktopFilePrefix(t.in), Equals, t.good)
+	}
+}

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -29,9 +29,10 @@ var (
 	GenerateSnapServiceFile = generateSnapServiceFile
 
 	// desktop
-	SanitizeDesktopFile = sanitizeDesktopFile
-	RewriteExecLine     = rewriteExecLine
-	TrimLang            = trimLang
+	SanitizeDesktopFile      = sanitizeDesktopFile
+	RewriteExecLine          = rewriteExecLine
+	TrimLang                 = trimLang
+	IsValidDesktopFilePrefix = isValidDesktopFilePrefix
 )
 
 func MockKillWait(wait time.Duration) (restore func()) {


### PR DESCRIPTION
This allows desktop files to declare that they are dbus activatable.

This makes progress towards LP: #1648990