### PR TITLE
Mount backend

### DIFF
--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -91,6 +91,9 @@ func (b *Backend) Name() string {
 // Setup creates mount mount profile files specific to a given snap.
 func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementOptions, repo *interfaces.Repository) error {
 	snapName := snapInfo.Name()
+	// TODO: replace this with a pass over all the interfaces, each one that
+	// implements MountAware interface gets interrogated. The rest is similar
+	// with the exception that merging the collected data is easier.
 	// Get the snippets that apply to this snap
 	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityMount)
 	if err != nil {

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -41,7 +41,47 @@ import (
 )
 
 // Backend is responsible for maintaining mount files for snap-confine
-type Backend struct{}
+type Backend struct {
+}
+
+// BackendCtrl assists in collecting mount entries associated with an interface.
+//
+// Unlike the Backend itself (which is stateless and non-persistent) this type
+// holds internal state that is used by the mount backend during the interface
+// setup process.
+type BackendCtrl struct {
+	mountEntries []Entry
+}
+
+// AddMountEntry adds a new mount entry.
+func (b *BackendCtrl) AddMountEntry(e Entry) {
+	b.mountEntries = append(b.mountEntries, e)
+}
+
+// MountAware describes the APIs required to interact with the mount backend.
+// Each of the four methods there replaces one of the older snippet based
+// methods. Instead of returning a snippet those methods should call APIs on
+// the backend instance (e.g. the AddMountEntry method) to express their
+// intents.
+type MountAware interface {
+	// ConnectedPlugMounts registers mount entries desired when a given plug
+	// and slot are connected. The entries will be effective in the snap
+	// containing the plug.
+	ConnectedPlugMounts(b *BackendCtrl, plug *interfaces.Plug, slot *interfaces.Slot) error
+
+	// ConnectedSlotMounts registers mount entries desired when a given plug
+	// and slot are connected. The entries will be effective in the snap
+	// containing the slot.
+	ConnectedSlotMounts(b *BackendCtrl, plug *interfaces.Plug, slot *interfaces.Slot) error
+
+	// PermanentPlugMounts registers mount entries desired whenever a given
+	// plug exists.
+	PermanentPlugMounts(b *BackendCtrl, plug *interfaces.Plug) error
+
+	// PermanentSlotMounts registers mount entries desired whenever a given
+	// slot exists.
+	PermanentSlotMounts(b *BackendCtrl, slot *interfaces.Slot) error
+}
 
 // Name returns the name of the backend.
 func (b *Backend) Name() string {

--- a/interfaces/mount/snippet.go
+++ b/interfaces/mount/snippet.go
@@ -1,0 +1,110 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Snippet describes mount entries that an interface wishes to create.
+type Snippet struct {
+	MountEntries []Entry `json:"mount-entries,omitempty"`
+}
+
+// MountEntry describes an /etc/fstab-like mount entry.
+//
+// Fields are named after names in struct returned by getmntent(3).
+//
+// struct mntent {
+//     char *mnt_fsname;   /* name of mounted filesystem */
+//     char *mnt_dir;      /* filesystem path prefix */
+//     char *mnt_type;     /* mount type (see mntent.h) */
+//     char *mnt_opts;     /* mount options (see mntent.h) */
+//     int   mnt_freq;     /* dump frequency in days */
+//     int   mnt_passno;   /* pass number on parallel fsck */
+// };
+type Entry struct {
+	FsName  mntFsName  `json:"fs-name,omitempty"`
+	Dir     mntDir     `json:"dir,omitempty"`
+	FsType  mntFsType  `json:"fs-type,omitempty"`
+	Options mntOptions `json:"options,omitempty"`
+	Freq    int        `json:"frequency,omitempty"`
+	PassNum int        `json:"pass-number,omitempty"`
+}
+
+// mntFsName represents name of the device in a mount entry.
+type mntFsName string
+
+func (v mntFsName) String() string {
+	if len(v) != 0 {
+		return escape(string(v))
+	}
+	return "none"
+}
+
+// mntDir represents mount directory in a mount entry.
+type mntDir string
+
+func (v mntDir) String() string {
+	if len(v) != 0 {
+		return escape(string(v))
+	}
+	return "none"
+}
+
+// mntOptions represents mount options in a mount entry.
+type mntOptions []string
+
+func (v mntOptions) String() string {
+	if len(v) != 0 {
+		return escape(strings.Join(v, ","))
+	}
+	return "defaults"
+}
+
+// mntFsType represents file system type in a mount entry.
+type mntFsType string
+
+func (v mntFsType) String() string {
+	if len(v) != 0 {
+		return escape(string(v))
+	}
+	return "none"
+}
+
+// escape replaces whitespace characters so that getmntent can parse it correctly.
+//
+// According to the manual page, the following characters need to be escaped.
+//  space     => (\040)
+//  tab       => (\011)
+//  newline   => (\012)
+//  backslash => (\134)
+func escape(s string) string {
+	return whitespaceReplacer.Replace(s)
+}
+
+var whitespaceReplacer = strings.NewReplacer(
+	" ", `\040`, "\t", `\011`, "\n", `\012`, "\\", `\134`)
+
+func (e Entry) String() string {
+	return fmt.Sprintf("%s %s %s %s %d %d",
+		e.FsName, e.Dir, e.FsType, e.Options, e.Freq, e.PassNum)
+}

--- a/interfaces/mount/snippet_test.go
+++ b/interfaces/mount/snippet_test.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/mount"
+)
+
+type snippetSuite struct{}
+
+var _ = Suite(&snippetSuite{})
+
+func (s *snippetSuite) TestString(c *C) {
+	ent0 := mount.Entry{}
+	c.Assert(ent0.String(), Equals, "none none none defaults 0 0")
+	ent1 := mount.Entry{
+		FsName:  "/var/snap/foo/common",
+		Dir:     "/var/snap/bar/common",
+		Options: []string{"bind"},
+	}
+	c.Assert(ent1.String(), Equals,
+		"/var/snap/foo/common /var/snap/bar/common none bind 0 0")
+	ent2 := mount.Entry{
+		FsName:  "/dev/sda5",
+		Dir:     "/media/foo",
+		FsType:  "ext4",
+		Options: []string{"rw,noatime"},
+	}
+	c.Assert(ent2.String(), Equals, "/dev/sda5 /media/foo ext4 rw,noatime 0 0")
+	ent3 := mount.Entry{
+		FsName:  "/dev/sda5",
+		Dir:     "/media/My Files",
+		FsType:  "ext4",
+		Options: []string{"rw,noatime"},
+	}
+	c.Assert(ent3.String(), Equals, `/dev/sda5 /media/My\040Files ext4 rw,noatime 0 0`)
+}


### PR DESCRIPTION
Strawman proposal to progress on https://github.com/snapcore/snapd/pull/2587

From the commit message:

```
This patch begins the transition of the mount security backend and the
single interface using it, content, to the new interface API.

Instead of offering snippets, interfaces can now implement a
backend-specific interface, here called MountAware, to enter into rich
interaction with a specific security backend. Each of the new methods
gets a backend controller object (for lack of a better name) that has
APIs for defining desired security changes. The mount backend uses just
one method, AddMountEntry.

Ulinke in the past, there are no opaque strings with internal structure
passes around. Everything is recorded in a fully typed manner. The
backend can use the collected data to perform its job.

This has the advantage of being easier to process inside the backend as
there's no need to parse snippets. It also has the potential to be
easier to work with in actual interfaces as the backend controller can
offer intuitive methods rather than forcing developers to come up with
syntax-perfect snippet strings.
```