### PR TITLE
vet: fix for unkeyed fields error on aliases_test.go

### DIFF
--- a/overlord/snapstate/aliases_test.go
+++ b/overlord/snapstate/aliases_test.go
@@ -750,7 +750,7 @@ func (s *snapmgrTestSuite) TestAliasMatrixRunThrough(c *C) {
 		c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%#v: %v", scenario, chg.Err()))
 		var aliases []*backend.Alias
 		var rmAliases []*backend.Alias
-		beAlias := &backend.Alias{scenAlias, fmt.Sprintf("alias-snap.%s", cmds[scenAlias])}
+		beAlias := &backend.Alias{Name: scenAlias, Target: fmt.Sprintf("alias-snap.%s", cmds[scenAlias])}
 		switch scenario.mutation {
 		case "-":
 		case "add":
@@ -858,7 +858,7 @@ func (s *snapmgrTestSuite) TestAliasMatrixTotalUndoRunThrough(c *C) {
 		c.Assert(chg.Status(), Equals, state.ErrorStatus, Commentf("%#v: %v", scenario, chg.Err()))
 		var aliases []*backend.Alias
 		var rmAliases []*backend.Alias
-		beAlias := &backend.Alias{scenAlias, fmt.Sprintf("alias-snap.%s", cmds[scenAlias])}
+		beAlias := &backend.Alias{Name: scenAlias, Target: fmt.Sprintf("alias-snap.%s", cmds[scenAlias])}
 		switch scenario.mutation {
 		case "-":
 		case "add":


### PR DESCRIPTION
Fix for:
Running vet
overlord/snapstate/aliases_test.go:753: github.com/snapcore/snapd/overlord/snapstate/backend.Alias composite literal uses unkeyed fields
overlord/snapstate/aliases_test.go:861: github.com/snapcore/snapd/overlord/snapstate/backend.Alias composite literal uses unkeyed fields