### PR TITLE
snap-confine: allow snap-confine to re-exec too

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -158,12 +158,12 @@ To test the `snapd` REST API daemon on a snappy system you need to
 transfer it to the snappy system and then run:
 
     sudo systemctl stop snapd.service snapd.socket
-    sudo /lib/systemd/systemd-activate -E SNAPD_DEBUG=3 -E SNAP_REEXEC=0 -E SNAPD_DEBUG_HTTP=3 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
+    sudo /lib/systemd/systemd-activate -E SNAPD_DEBUG=3 -E SNAPD_DEBUG_HTTP=3 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
 
 or with systemd version >= 230
 
     sudo systemctl stop snapd.service snapd.socket
-    sudo systemd-socket-activate -E SNAPD_DEBUG=3 -E SNAP_REEXEC=0 -E SNAPD_DEBUG_HTTP=3 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
+    sudo systemd-socket-activate -E SNAPD_DEBUG=3 -E SNAPD_DEBUG_HTTP=3 -l /run/snapd.socket -l /run/snapd-snap.socket ./snapd
 
 This will stop the installed snapd and activate the new one. Once it's
 printed out something like `Listening on /run/snapd.socket as 3.` you

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -91,6 +91,22 @@ func ExecInCoreSnap() {
 		}
 	}
 
+	// ensure we do not re-exec into an older version of snapd
+	currentSnapd, err := os.Stat(exe)
+	if err != nil {
+		logger.Noticef("cannot stat %q: %s", exe, err)
+		return
+	}
+	coreSnapSnapd, err := os.Stat(full)
+	if err != nil {
+		logger.Noticef("cannot stat %q: %s", full, err)
+		return
+	}
+	if currentSnapd.ModTime().After(coreSnapSnapd.ModTime()) {
+		logger.Noticef("not restarting into %q: older than %q", full, exe)
+		return
+	}
+
 	logger.Debugf("restarting into %q", full)
 
 	env := append(os.Environ(), key+"=0")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -47,7 +47,7 @@ const oldCore = "/snap/ubuntu-core/current"
 // old ubuntu-core snaps older than this aren't suitable targets for re-execage
 const minOldRevno = 126
 
-func shouldRexec(envKey string) bool {
+func shouldReexec(envKey string) bool {
 	val := os.Getenv(envKey)
 	if val == "" {
 		return true
@@ -68,7 +68,7 @@ func ExecInCoreSnap() {
 		return
 	}
 
-	if !shouldRexec(key) {
+	if !shouldReexec(key) {
 		return
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -69,7 +69,6 @@ func ExecInCoreSnap() {
 	}
 
 	if !shouldRexec(key) {
-		logger.Noticef("not restarting into core: disabled via env")
 		return
 	}
 
@@ -104,7 +103,7 @@ func ExecInCoreSnap() {
 		return
 	}
 	if currentSnapd.ModTime().After(coreSnapSnapd.ModTime()) {
-		logger.Noticef("not restarting into %q: older than %q", full, exe)
+		logger.Debugf("not restarting into %q: older than %q", full, exe)
 		return
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -69,6 +69,7 @@ func ExecInCoreSnap() {
 	}
 
 	if !shouldRexec(key) {
+		logger.Noticef("not restarting into core: disabled via env")
 		return
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -47,6 +47,19 @@ const oldCore = "/snap/ubuntu-core/current"
 // old ubuntu-core snaps older than this aren't suitable targets for re-execage
 const minOldRevno = 126
 
+func shouldRexec(envKey string) bool {
+	val := os.Getenv(envKey)
+	if val == "" {
+		return true
+	}
+
+	enabled, err := strconv.ParseBool(val)
+	if err != nil {
+		return true
+	}
+	return enabled
+}
+
 // ExecInCoreSnap makes sure you're executing the binary that ships in
 // the core snap.
 func ExecInCoreSnap() {
@@ -55,7 +68,7 @@ func ExecInCoreSnap() {
 		return
 	}
 
-	if !osutil.GetenvBool(key) {
+	if !shouldRexec(key) {
 		return
 	}
 

--- a/cmd/snap-confine/classic.c
+++ b/cmd/snap-confine/classic.c
@@ -3,6 +3,7 @@
 
 #include <unistd.h>
 
+// FIXME: use /etc/os-release instead
 bool is_running_on_classic_distribution()
 {
 	// NOTE: keep this list sorted please

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -23,6 +23,8 @@
     /lib/@{multiarch}/libseccomp.so* mr,
 
     @LIBEXECDIR@/snap-confine mr,
+    # allow re-exec
+    /snap/{ubuntu-core,core}/*/@LIBEXECDIR@/snap-confine mr,
 
     /dev/null rw,
     /dev/full rw,

--- a/spread.yaml
+++ b/spread.yaml
@@ -9,7 +9,6 @@ environment:
     PATH: $GOPATH/bin:/snap/bin:$PATH:/usr/lib/go-1.6/bin
     TESTSLIB: $PROJECT_PATH/tests/lib
     SNAPPY_TESTING: 1
-    SNAP_REEXEC: 0
     SPREAD_STORE_USER: "$(HOST: echo $SPREAD_STORE_USER)"
     SPREAD_STORE_PASSWORD: "$(HOST: echo $SPREAD_STORE_PASSWORD)"
     LANG: "$(echo ${LANG:-C.UTF-8})"
@@ -176,7 +175,7 @@ prepare: |
     [Unit]
     StartLimitInterval=0
     [Service]
-    Environment=SNAPD_DEBUG_HTTP=7 SNAP_REEXEC=0 SNAPPY_TESTING=1
+    Environment=SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1
     EOF
     mkdir -p /etc/systemd/system/snapd.socket.d
     cat <<EOF > /etc/systemd/system/snapd.socket.d/local.conf

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -20,7 +20,8 @@ update_core_snap_with_snap_exec_snapctl() {
     cp /usr/lib/snapd/snap-exec squashfs-root/usr/lib/snapd/
     cp /usr/bin/snapctl squashfs-root/usr/bin/
     mv "$snap" "${snap}.orig"
-    mksquashfs squashfs-root "$snap" -comp xz
+    # cheating to speed things up
+    mksquashfs squashfs-root "$snap" -comp gzip -Xcompression-level 1
     rm -rf squashfs-root
 
     # Now mount the new core snap

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -24,7 +24,12 @@ update_core_snap_with_snap_exec_snapctl() {
 
     # repack, cheating to speed things up (4sec vs 1.5min)
     mv "$snap" "${snap}.orig"
-    mksquashfs squashfs-root "$snap" -comp gzip -Xcompression-level 1
+    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
+        # trusty does not support  -Xcompression-level 1
+        mksquashfs squashfs-root "$snap" -comp gzip
+    else
+        mksquashfs squashfs-root "$snap" -comp gzip -Xcompression-level 1
+    fi
     rm -rf squashfs-root
 
     # Now mount the new core snap

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -36,7 +36,7 @@ update_core_snap_with_snap_exec_snapctl() {
     mount "$snap" "$core"
 
     # Make sure we're running with the correct copied bits
-    for p in /usr/lib/snapd/snap-exec /usr/bin/snapctl /usr/lib/snapd/snapd /usr/bin/snap; do
+    for p in /usr/lib/snapd/snap-exec /usr/bin/snapctl /usr/lib/snapd/snapd /usr/bin/snap /usr/lib/snapd/snap-confine; do
         if ! cmp ${p} ${core}${p}; then
             echo "$p in tree and $p in core snap are unexpectedly not the same"
             exit 1

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -1,5 +1,7 @@
 summary: Test that snapd rexecs itself into core
 
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+
 environment:
     SNAPD_CONF: /etc/systemd/system/snapd.service.d/local.conf 
 

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -6,26 +6,21 @@ environment:
 debug: |
     cat /var/log/syslog
 
-prepare: |
-    mv ${SNAPD_CONF} ${SNAPD_CONF}.old
-    systemctl daemon-reload
-    systemctl restart snapd.service snapd.socket
-
-restore: |
-    mv ${SNAPD_CONF}.old ${SNAPD_CONF}
-    systemctl daemon-reload
-    systemctl restart snapd.service snapd.socket
-
 execute: |
+    echo "Ensure we re-exec by default"
+    grep "restarting into" /var/log/syslog
+  
+    systemctl stop snapd.service snapd.socket
+    echo "mount something older than our freshly build snapd"
+    mount --bind /bin/true /snap/core/current/usr/lib/snapd/snapd
+    systemctl start snapd.service snapd.socket
+    
     echo "Ensure that we do not re-exec into older versions"
     snap list
     grep "not restarting into.*older than" /var/log/syslog
 
-    echo "Ensure we re-exec for newer versions"
-    mount --bind /usr/lib/snapd/snapd /snap/core/current/usr/lib/snapd/snapd
-    systemctl restart snapd.service snapd.socket
-    snap list
-    grep "restarting into" /var/log/syslog
-
     systemctl stop snapd.service snapd.socket
     umount /snap/core/current/usr/lib/snapd/snapd
+
+    # FIMXE: add test for SNAP_REXEC=0
+    

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -1,0 +1,31 @@
+summary: Test that snapd rexecs itself into core
+
+environment:
+    SNAPD_CONF: /etc/systemd/system/snapd.service.d/local.conf 
+
+debug: |
+    cat /var/log/syslog
+
+prepare: |
+    mv ${SNAPD_CONF} ${SNAPD_CONF}.old
+    systemctl daemon-reload
+    systemctl restart snapd.service snapd.socket
+
+restore: |
+    mv ${SNAPD_CONF}.old ${SNAPD_CONF}
+    systemctl daemon-reload
+    systemctl restart snapd.service snapd.socket
+
+execute: |
+    echo "Ensure that we do not re-exec into older versions"
+    snap list
+    grep "not restarting into.*older than" /var/log/syslog
+
+    echo "Ensure we re-exec for newer versions"
+    mount --bind /usr/lib/snapd/snapd /snap/core/current/usr/lib/snapd/snapd
+    systemctl restart snapd.service snapd.socket
+    snap list
+    grep "restarting into" /var/log/syslog
+
+    systemctl stop snapd.service snapd.socket
+    umount /snap/core/current/usr/lib/snapd/snapd


### PR DESCRIPTION
Based on https://github.com/snapcore/snapd/pull/2595

Still needs:
- find a way to reload snap-confine apparmor profile (/etc/apparmor.d/usr.lib.snapd/snap-confine) from the core snap (currently only the one from the deb is used)
- unittest(s)
- spread test fordisable (re-exec is default so it happens all the time)

Alternative we could detect in snap-exec when we need to run snap-confine from the /snap/core/current/ location. However for this we will need to solve the apparmor problem first because if we just do that we will not have any apparmor confinement until snap-confine loads something.