### PR TITLE
overlord, store: move confinement filtering to the overlord (from The Store)

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -565,7 +565,6 @@ func findOne(c *Command, r *http.Request, user *auth.UserState, name string) Res
 	spec := store.SnapSpec{
 		Name:     name,
 		Channel:  "",
-		Devmode:  true,
 		Revision: snap.R(0),
 	}
 	snapInfo, err := theStore.SnapInfo(spec, user)

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -70,7 +70,6 @@ func DownloadSnap(sto Store, name string, revision snap.Revision, opts *Download
 	spec := store.SnapSpec{
 		Name:     name,
 		Channel:  opts.Channel,
-		Devmode:  opts.DevMode,
 		Revision: revision,
 	}
 	snap, err := sto.SnapInfo(spec, opts.User)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -112,6 +112,14 @@ func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 		}
 	}
 
+	confinement := snap.StrictConfinement
+	switch spec.Channel {
+	case "channel-for-devmode":
+		confinement = snap.DevModeConfinement
+	case "channel-for-classic":
+		confinement = snap.ClassicConfinement
+	}
+
 	info := &snap.Info{
 		SideInfo: snap.SideInfo{
 			RealName: strings.Split(spec.Name, ".")[0],
@@ -123,6 +131,7 @@ func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 		DownloadInfo: snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
+		Confinement: confinement,
 	}
 	f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{op: "storesvc-snap", name: spec.Name, revno: spec.Revision})
 
@@ -162,8 +171,14 @@ func (f *fakeStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserSta
 	}
 
 	revno := snap.R(11)
-	if cand.Channel == "channel-for-7" {
+	confinement := snap.StrictConfinement
+	switch cand.Channel {
+	case "channel-for-7":
 		revno = snap.R(7)
+	case "channel-for-classic":
+		confinement = snap.ClassicConfinement
+	case "channel-for-devmode":
+		confinement = snap.DevModeConfinement
 	}
 
 	info := &snap.Info{
@@ -177,6 +192,7 @@ func (f *fakeStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserSta
 		DownloadInfo: snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
+		Confinement: confinement,
 	}
 
 	var hit snap.Revision

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -259,7 +259,7 @@ func Store(st *state.State) StoreService {
 	panic("internal error: needing the store before managers have initialized it")
 }
 
-func updateInfo(st *state.State, snapst *SnapState, channel string, userID int, flags Flags) (*snap.Info, error) {
+func updateInfo(st *state.State, snapst *SnapState, channel string, userID int) (*snap.Info, error) {
 	user, err := userFromUserID(st, userID)
 	if err != nil {
 		return nil, err
@@ -275,9 +275,7 @@ func updateInfo(st *state.State, snapst *SnapState, channel string, userID int, 
 
 	refreshCand := &store.RefreshCandidate{
 		// the desired channel
-		Channel: channel,
-		DevMode: flags.DevModeAllowed(),
-
+		Channel:  channel,
 		SnapID:   curInfo.SnapID,
 		Revision: curInfo.Revision,
 		Epoch:    curInfo.Epoch,
@@ -293,10 +291,11 @@ func updateInfo(st *state.State, snapst *SnapState, channel string, userID int, 
 	if len(res) == 0 {
 		return nil, &snap.NoUpdateAvailableError{Snap: curInfo.Name()}
 	}
+
 	return res[0], nil
 }
 
-func snapInfo(st *state.State, name, channel string, revision snap.Revision, userID int, flags Flags) (*snap.Info, error) {
+func snapInfo(st *state.State, name, channel string, revision snap.Revision, userID int) (*snap.Info, error) {
 	user, err := userFromUserID(st, userID)
 	if err != nil {
 		return nil, err
@@ -306,7 +305,6 @@ func snapInfo(st *state.State, name, channel string, revision snap.Revision, use
 	spec := store.SnapSpec{
 		Name:     name,
 		Channel:  channel,
-		Devmode:  flags.DevModeAllowed(),
 		Revision: revision,
 	}
 	snap, err := theStore.SnapInfo(spec, user)
@@ -503,7 +501,6 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		spec := store.SnapSpec{
 			Name:     snapsup.Name(),
 			Channel:  snapsup.Channel,
-			Devmode:  snapsup.DevModeAllowed(),
 			Revision: snapsup.Revision(),
 		}
 		storeInfo, err = theStore.SnapInfo(spec, user)

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -185,6 +185,34 @@ func (s *snapmgrTestSuite) TestLastIndexFindsLast(c *C) {
 	c.Check(snapst.LastIndex(snap.R(11)), Equals, 2)
 }
 
+func (s *snapmgrTestSuite) TestInstallDevModeConfinementFiltering(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	_, err := snapstate.Install(s.state, "some-snap", "channel-for-devmode", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `cannot find snap "some-snap"`)
+
+	_, err = snapstate.Install(s.state, "some-snap", "channel-for-devmode", snap.R(0), s.user.ID, snapstate.Flags{DevMode: true})
+	c.Assert(err, IsNil)
+
+	_, err = snapstate.Install(s.state, "some-snap", "channel-for-strict", snap.R(0), s.user.ID, snapstate.Flags{DevMode: true})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestInstallClassicConfinementFiltering(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	_, err := snapstate.Install(s.state, "some-snap", "channel-for-classic", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `cannot find snap "some-snap"`)
+
+	_, err = snapstate.Install(s.state, "some-snap", "channel-for-classic", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
+	c.Assert(err, IsNil)
+
+	_, err = snapstate.Install(s.state, "some-snap", "channel-for-strict", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
+	c.Assert(err, IsNil)
+}
+
 func (s *snapmgrTestSuite) TestInstallTasks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -298,6 +326,59 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 	ts := tts[0]
 	verifyInstallUpdateTasks(c, unlinkBefore|cleanupAfter, 3, ts, s.state)
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyDevModeConfinementFiltering(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Channel:  "channel-for-devmode",
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	_, tts, _ := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	// FIXME: UpdateMany will not error out in this case (daemon catches this case, with a weird error)
+	c.Assert(tts, HasLen, 0)
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyClassicConfinementFiltering(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Channel:  "channel-for-classic",
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	_, tts, _ := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	// FIXME: UpdateMany will not error out in this case (daemon catches this case, with a weird error)
+	c.Assert(tts, HasLen, 0)
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyClassic(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Channel:  "channel-for-classic",
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Current:  snap.R(7),
+		SnapType: "app",
+		Flags:    snapstate.Flags{Classic: true},
+	})
+
+	// snap installed with classic: refresh gets classic
+	_, tts, err := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	c.Assert(err, IsNil)
+	c.Assert(tts, HasLen, 1)
 }
 
 func (s *snapmgrTestSuite) TestUpdateManyDevMode(c *C) {
@@ -646,7 +727,7 @@ func (s *snapmgrTestSuite) TestInstallPathSnapIDRevisionUnset(c *C) {
 	c.Assert(err, ErrorMatches, fmt.Sprintf(`internal error: snap id set to install %q but revision is unset`, mockSnap))
 }
 
-func (s *snapmgrTestSuite) TestUpdateTasksPropagtesErrors(c *C) {
+func (s *snapmgrTestSuite) TestUpdateTasksPropagatesErrors(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -695,6 +776,86 @@ func (s *snapmgrTestSuite) TestUpdateTasks(c *C) {
 	c.Check(snapsup.Channel, Equals, "some-channel")
 }
 
+func (s *snapmgrTestSuite) TestUpdateDevModeConfinementFiltering(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Channel:  "channel-for-devmode",
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	_, err := snapstate.Update(s.state, "some-snap", "", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `snap "some-snap" has no updates available`)
+
+	_, err = snapstate.Update(s.state, "some-snap", "", snap.R(0), s.user.ID, snapstate.Flags{DevMode: true})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateClassicConfinementFiltering(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Channel:  "channel-for-classic",
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Current:  snap.R(7),
+		SnapType: "app",
+	})
+
+	_, err := snapstate.Update(s.state, "some-snap", "", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `snap "some-snap" has no updates available`)
+
+	_, err = snapstate.Update(s.state, "some-snap", "", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateClassic(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Channel:  "channel-for-classic",
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Current:  snap.R(7),
+		SnapType: "app",
+		Flags:    snapstate.Flags{Classic: true},
+	})
+
+	// snap installed with classic: refresh gets classic
+	_, err := snapstate.Update(s.state, "some-snap", "", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	_, err = snapstate.Update(s.state, "some-snap", "", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateStrictFromClassic(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Channel:  "channel",
+		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+		Current:  snap.R(7),
+		SnapType: "app",
+		Flags:    snapstate.Flags{Classic: true},
+	})
+
+	// snap installed with classic: refresh gets classic
+	_, err := snapstate.Update(s.state, "some-snap", "", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	_, err = snapstate.Update(s.state, "some-snap", "", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
+	c.Assert(err, IsNil)
+}
+
 func (s *snapmgrTestSuite) TestUpdateChannelFallback(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -715,34 +876,6 @@ func (s *snapmgrTestSuite) TestUpdateChannelFallback(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapsup.Channel, Equals, "edge")
-}
-
-func (s *snapmgrTestSuite) TestUpdatePassDevMode(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
-		Current:  snap.R(7),
-		SnapType: "app",
-	})
-
-	_, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{DevMode: true})
-	c.Assert(err, IsNil)
-
-	c.Assert(s.fakeBackend.ops, HasLen, 1)
-	c.Check(s.fakeBackend.ops[0], DeepEquals, fakeOp{
-		op: "storesvc-list-refresh",
-		cand: store.RefreshCandidate{
-			SnapID:   "some-snap-id",
-			Revision: snap.R(7),
-			Epoch:    "",
-			DevMode:  true,
-			Channel:  "some-channel",
-		},
-		revno: snap.R(11),
-	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateConflict(c *C) {
@@ -992,7 +1125,6 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 				SnapID:   "some-snap-id",
 				Revision: snap.R(7),
 				Epoch:    "",
-				DevMode:  false,
 			},
 			revno: snap.R(11),
 		},
@@ -1167,7 +1299,6 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 				SnapID:   "some-snap-id",
 				Revision: snap.R(7),
 				Epoch:    "",
-				DevMode:  false,
 			},
 			revno: snap.R(11),
 		},
@@ -1333,7 +1464,6 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 				SnapID:   "some-snap-id",
 				Revision: snap.R(7),
 				Epoch:    "",
-				DevMode:  false,
 			},
 			revno: snap.R(11),
 		},
@@ -1593,7 +1723,6 @@ func (s *snapmgrTestSuite) TestSingleUpdateBlockedRevision(c *C) {
 			SnapID:   "some-snap-id",
 			Revision: snap.R(7),
 			Epoch:    "",
-			DevMode:  false,
 			Channel:  "some-channel",
 		},
 	})
@@ -1633,7 +1762,6 @@ func (s *snapmgrTestSuite) TestMultiUpdateBlockedRevision(c *C) {
 		cand: store.RefreshCandidate{
 			SnapID:   "some-snap-id",
 			Revision: snap.R(7),
-			DevMode:  false,
 		},
 	})
 
@@ -1671,7 +1799,6 @@ func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
 		cand: store.RefreshCandidate{
 			SnapID:   "some-snap-id",
 			Revision: snap.R(7),
-			DevMode:  false,
 			Block:    []snap.Revision{snap.R(11)},
 		},
 	})

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -313,7 +313,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 	}
 
 	if !validInfoForFlags(info, &snapst, flags) {
-		return nil, fmt.Errorf("cannot find snap %q", name)
+		return nil, store.ErrSnapNotFound
 	}
 
 	snapsup := &SnapSetup{
@@ -555,7 +555,7 @@ func validInfoForFlags(info *snap.Info, snapst *SnapState, flags Flags) bool {
 
 		return false
 	default:
-		logger.Panicf("unknown confinement %q", c)
+		logger.Noticef("unknown confinement %q", c)
 	}
 
 	return false

--- a/store/store.go
+++ b/store/store.go
@@ -964,7 +964,6 @@ type SnapSpec struct {
 	Name     string
 	Channel  string
 	Revision snap.Revision
-	Devmode  bool
 }
 
 // SnapInfo returns the snap.Info for the store-hosted snap matching the given spec, or an error.
@@ -980,14 +979,6 @@ func (s *Store) SnapInfo(snapSpec SnapSpec, user *auth.UserState) (*snap.Info, e
 	if !snapSpec.Revision.Unset() {
 		query.Set("revision", snapSpec.Revision.String())
 		query.Set("channel", "")
-	}
-
-	// if devmode then don't restrict by confinement as either is fine
-	// XXX: what we really want to do is have the store not specify
-	//      devmode, and have the business logic wrt what to do with
-	//      unwanted devmode further up
-	if !snapSpec.Devmode {
-		query.Set("confinement", string(snap.StrictConfinement))
 	}
 
 	u.RawQuery = query.Encode()
@@ -1088,7 +1079,11 @@ func (s *Store) Find(search *Search, user *auth.UserState) ([]*snap.Info, error)
 		q.Set("section", search.Section)
 	}
 
-	q.Set("confinement", "strict")
+	if release.OnClassic {
+		q.Set("confinement", "strict,classic")
+	} else {
+		q.Set("confinement", "strict")
+	}
 	u.RawQuery = q.Encode()
 
 	reqOptions := &requestOptions{
@@ -1168,7 +1163,6 @@ type RefreshCandidate struct {
 	SnapID   string
 	Revision snap.Revision
 	Epoch    string
-	DevMode  bool
 	Block    []snap.Revision
 
 	// the desired channel
@@ -1177,16 +1171,11 @@ type RefreshCandidate struct {
 
 // the exact bits that we need to send to the store
 type currentSnapJson struct {
-	SnapID   string `json:"snap_id"`
-	Channel  string `json:"channel"`
-	Revision int    `json:"revision,omitempty"`
-	Epoch    string `json:"epoch"`
-
-	// The store expects a "confinement" value {"strict", "devmode"}.
-	// We map this accordingly from our devmode bool, we do not
-	// use the value of the current snap as we are interested in the
-	// users intention, not the actual value of the snap itself.
-	Confinement snap.ConfinementType `json:"confinement"`
+	SnapID      string `json:"snap_id"`
+	Channel     string `json:"channel"`
+	Revision    int    `json:"revision,omitempty"`
+	Epoch       string `json:"epoch"`
+	Confinement string `json:"confinement"`
 }
 
 type metadataWrapper struct {
@@ -1210,17 +1199,12 @@ func (s *Store) ListRefresh(installed []*RefreshCandidate, user *auth.UserState)
 			continue
 		}
 
-		confinement := snap.StrictConfinement
-		if cs.DevMode {
-			confinement = snap.DevModeConfinement
-		}
-
 		currentSnaps = append(currentSnaps, currentSnapJson{
-			SnapID:      cs.SnapID,
-			Channel:     cs.Channel,
-			Confinement: confinement,
-			Epoch:       cs.Epoch,
-			Revision:    revision,
+			SnapID:   cs.SnapID,
+			Channel:  cs.Channel,
+			Epoch:    cs.Epoch,
+			Revision: revision,
+			// confinement purposely left empty
 		})
 		candidateMap[cs.SnapID] = cs
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1416,7 +1416,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	spec := SnapSpec{
 		Name:     "hello-world",
 		Channel:  "edge",
-		Devmode:  true,
 		Revision: snap.R(0),
 	}
 	result, err := repo.SnapInfo(spec, nil)
@@ -1475,7 +1474,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails500(c *C) {
 	spec := SnapSpec{
 		Name:     "hello-world",
 		Channel:  "edge",
-		Devmode:  true,
 		Revision: snap.R(0),
 	}
 	_, err = repo.SnapInfo(spec, nil)
@@ -1513,7 +1511,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails500once(c *C) {
 	spec := SnapSpec{
 		Name:     "hello-world",
 		Channel:  "edge",
-		Devmode:  true,
 		Revision: snap.R(0),
 	}
 	result, err := repo.SnapInfo(spec, nil)
@@ -1570,7 +1567,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 	spec := SnapSpec{
 		Name:     "hello-world",
 		Channel:  "",
-		Devmode:  false,
 		Revision: snap.R(0),
 	}
 	result, err := repo.SnapInfo(spec, nil)
@@ -1643,7 +1639,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNonDefaults(c *C) {
 	spec := SnapSpec{
 		Name:     "hello-world",
 		Channel:  "edge",
-		Devmode:  true,
 		Revision: snap.R(0),
 	}
 	result, err := repo.SnapInfo(spec, nil)
@@ -1677,7 +1672,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryStoreIDFromAuthContext(c 
 	spec := SnapSpec{
 		Name:     "hello-world",
 		Channel:  "edge",
-		Devmode:  true,
 		Revision: snap.R(0),
 	}
 	result, err := repo.SnapInfo(spec, nil)
@@ -1724,63 +1718,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRevision(c *C) {
 	spec := SnapSpec{
 		Name:     "hello-world",
 		Channel:  "edge",
-		Devmode:  true,
 		Revision: snap.R(26),
 	}
 	result, err := repo.SnapInfo(spec, t.user)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 	c.Check(result.Revision, DeepEquals, snap.R(27))
-}
-
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsDevmode(c *C) {
-	mockDevmodeJSON := strings.Replace(MockDetailsJSON, `"strict"`, `"devmode"`, -1)
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.UserAgent(), Equals, userAgent)
-
-		c.Check(r.URL.Path, Equals, "/details/hello-world")
-
-		query := r.URL.Query()
-		c.Check(query.Get("channel"), Equals, "edge")
-
-		if query.Get("confinement") == "strict" {
-			w.WriteHeader(http.StatusNotFound)
-			io.WriteString(w, "{}")
-		} else {
-			w.Header().Set("X-Suggested-Currency", "GBP")
-			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, mockDevmodeJSON)
-		}
-	}))
-
-	c.Assert(mockServer, NotNil)
-	defer mockServer.Close()
-
-	detailsURI, err := url.Parse(mockServer.URL + "/details/")
-	c.Assert(err, IsNil)
-	cfg := Config{
-		DetailsURI: detailsURI,
-	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
-
-	// the actual test
-	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Devmode:  false,
-		Revision: snap.R(0),
-	}
-	result, err := repo.SnapInfo(spec, nil)
-	c.Check(err, Equals, ErrSnapNotFound)
-	c.Check(result, IsNil)
-
-	spec.Devmode = true
-	result, err = repo.SnapInfo(spec, nil)
-	c.Assert(err, IsNil)
-	c.Check(result, NotNil)
-
-	c.Check(snap.Validate(result), IsNil)
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsOopses(c *C) {
@@ -1809,7 +1752,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsOopses(c *C) {
 	spec := SnapSpec{
 		Name:     "hello-world",
 		Channel:  "edge",
-		Devmode:  false,
 		Revision: snap.R(0),
 	}
 	_, err = repo.SnapInfo(spec, nil)
@@ -1859,7 +1801,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
 	spec := SnapSpec{
 		Name:     "no-such-pkg",
 		Channel:  "edge",
-		Devmode:  false,
 		Revision: snap.R(0),
 	}
 	result, err := repo.SnapInfo(spec, nil)
@@ -2166,7 +2107,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindBadBody(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query()
 		c.Check(query.Get("q"), Equals, "hello")
-		c.Check(query.Get("confinement"), Equals, "strict")
 		w.Header().Set("Content-Type", "application/hal+json")
 		io.WriteString(w, "<hello>")
 	}))
@@ -2251,7 +2191,11 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindAuthFailed(c *C) {
 
 		query := r.URL.Query()
 		c.Check(query.Get("q"), Equals, "foo")
-		c.Check(query.Get("confinement"), Equals, "strict")
+		if release.OnClassic {
+			c.Check(query.Get("confinement"), Matches, `strict,classic|classic,strict`)
+		} else {
+			c.Check(query.Get("confinement"), Equals, "strict")
+		}
 		w.Header().Set("Content-Type", "application/hal+json")
 		io.WriteString(w, MockSearchJSON)
 	}))
@@ -2369,7 +2313,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 			"channel":     "stable",
 			"revision":    float64(1),
 			"epoch":       "0",
-			"confinement": "strict",
+			"confinement": "",
 		})
 		c.Assert(resp.Fields, DeepEquals, detailFields)
 
@@ -2395,7 +2339,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 			Channel:  "stable",
 			Revision: snap.R(1),
 			Epoch:    "0",
-			DevMode:  false,
 		},
 	}, nil)
 	c.Assert(err, IsNil)
@@ -2437,7 +2380,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshUnauthorised(c
 			Channel:  "stable",
 			Revision: snap.R(24),
 			Epoch:    "0",
-			DevMode:  false,
 		},
 	}, nil)
 	c.Assert(n, Equals, 1)
@@ -2468,7 +2410,6 @@ func (t *remoteRepoTestSuite) TestListRefresh500(c *C) {
 			Channel:  "stable",
 			Revision: snap.R(24),
 			Epoch:    "0",
-			DevMode:  false,
 		},
 	}, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/updates/"`)
@@ -2501,7 +2442,6 @@ func (t *remoteRepoTestSuite) TestListRefresh500DurationExceeded(c *C) {
 			Channel:  "stable",
 			Revision: snap.R(24),
 			Epoch:    "0",
-			DevMode:  false,
 		},
 	}, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/updates/"`)
@@ -2525,7 +2465,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c 
 			"channel":     "stable",
 			"revision":    float64(26),
 			"epoch":       "0",
-			"confinement": "strict",
+			"confinement": "",
 		})
 
 		io.WriteString(w, MockUpdatesJSON)
@@ -2549,7 +2489,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c 
 			Channel:  "stable",
 			Revision: snap.R(26),
 			Epoch:    "0",
-			DevMode:  false,
 		},
 	}, nil)
 	c.Assert(err, IsNil)
@@ -2574,7 +2513,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipBlocked(c 
 			"channel":     "stable",
 			"revision":    float64(25),
 			"epoch":       "0",
-			"confinement": "strict",
+			"confinement": "",
 		})
 
 		io.WriteString(w, MockUpdatesJSON)
@@ -2598,7 +2537,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipBlocked(c 
 			Channel:  "stable",
 			Revision: snap.R(25),
 			Epoch:    "0",
-			DevMode:  false,
 			Block:    []snap.Revision{snap.R(26)},
 		},
 	}, nil)
@@ -2699,7 +2637,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *
 			"channel":     "stable",
 			"revision":    float64(24),
 			"epoch":       "0",
-			"confinement": "strict",
+			"confinement": "",
 		})
 		c.Assert(resp.Fields, DeepEquals, getStructFields(snapDetails{}))
 
@@ -2724,7 +2662,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *
 			Channel:  "stable",
 			Revision: snap.R(24),
 			Epoch:    "0",
-			DevMode:  false,
 		},
 	}, nil)
 	c.Assert(err, IsNil)
@@ -2774,7 +2711,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(
 			"channel":     "stable",
 			"revision":    float64(24),
 			"epoch":       "0",
-			"confinement": "strict",
+			"confinement": "",
 		})
 		c.Assert(resp.Fields, DeepEquals, detailFields)
 
@@ -2799,7 +2736,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(
 			Channel:  "stable",
 			Revision: snap.R(24),
 			Epoch:    "0",
-			DevMode:  false,
 		},
 	}, nil)
 	c.Assert(err, IsNil)
@@ -2823,7 +2759,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c 
 			"snap_id":     helloWorldSnapID,
 			"channel":     "stable",
 			"epoch":       "0",
-			"confinement": "devmode",
+			"confinement": "",
 		})
 
 		io.WriteString(w, MockUpdatesJSON)
@@ -2847,7 +2783,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c 
 			Channel:  "stable",
 			Revision: snap.R(-2),
 			Epoch:    "0",
-			DevMode:  true,
 		},
 	}, nil)
 	c.Assert(err, IsNil)
@@ -3062,7 +2997,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositorySuggestedCurrency(c *C) {
 	spec := SnapSpec{
 		Name:     "hello-world",
 		Channel:  "edge",
-		Devmode:  false,
 		Revision: snap.R(0),
 	}
 	result, err := repo.SnapInfo(spec, nil)
@@ -3567,7 +3501,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuy(c *C) {
 		spec := SnapSpec{
 			Name:     "hello-world",
 			Channel:  "edge",
-			Devmode:  false,
 			Revision: snap.R(0),
 		}
 		snap, err := repo.SnapInfo(spec, t.user)

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -23,12 +23,12 @@ execute: |
     # XXX want to move this to a more precise, verbose, user-friendly
     # error (e.g. "snap asks for devmode but not provided nor
     # overridden")
-    expected="snap not found|cannot find snap"
+    expected="snap not found"
     actual=$(snap install --channel beta $DEVMODE_SNAP 2>&1 && exit 1 || true)
     echo "$actual" | grep -Pzq "$expected"
 
     echo "Install devmode snap from stable"
-    expected="snap not found|cannot find snap"
+    expected="snap not found"
     actual=$(snap install --devmode $DEVMODE_SNAP 2>&1 && exit 1 || true)
     echo "$actual" | grep -Pzq "$expected"
 

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -23,12 +23,12 @@ execute: |
     # XXX want to move this to a more precise, verbose, user-friendly
     # error (e.g. "snap asks for devmode but not provided nor
     # overridden")
-    expected="snap not found"
+    expected="snap not found|cannot find snap"
     actual=$(snap install --channel beta $DEVMODE_SNAP 2>&1 && exit 1 || true)
     echo "$actual" | grep -Pzq "$expected"
 
     echo "Install devmode snap from stable"
-    expected="snap not found"
+    expected="snap not found|cannot find snap"
     actual=$(snap install --devmode $DEVMODE_SNAP 2>&1 && exit 1 || true)
     echo "$actual" | grep -Pzq "$expected"
 


### PR DESCRIPTION
For context: we decided to move confinement filtering from being requested from the store (that is, `github.com/snapcore/snapd/store` makes requests to the ubuntu store in such a way that responses are filtered by confinement) and into overlord; `store` requests are done in such a way that the details and metadata endpoints always return the thing, and overlord explicitly filters out confinement as needed.

Also, store's find now adds a comma-separated list of confinements to search (so it's either `strict` or `strict,classic` depending on whether you're on classic or not)