### PR TITLE
overlord/snapstate: remove restrictions on ResetAliases

### DIFF
--- a/overlord/snapstate/aliases.go
+++ b/overlord/snapstate/aliases.go
@@ -212,7 +212,7 @@ func (m *SnapManager) doAlias(t *state.Task, _ *tomb.Tomb) error {
 	var add []*backend.Alias
 	var remove []*backend.Alias
 	for alias, newStatus := range changes {
-		if aliasStatuses[alias] == newStatus {
+		if newStatus != "auto" && aliasStatuses[alias] == newStatus {
 			// nothing to do
 			continue
 		}
@@ -303,7 +303,7 @@ func (m *SnapManager) undoAlias(t *state.Task, _ *tomb.Tomb) error {
 	var remove []*backend.Alias
 Next:
 	for alias, newStatus := range changes {
-		if oldStatuses[alias] == newStatus {
+		if newStatus != "auto" && oldStatuses[alias] == newStatus {
 			// nothing to undo
 			continue
 		}

--- a/overlord/snapstate/aliases_test.go
+++ b/overlord/snapstate/aliases_test.go
@@ -674,7 +674,7 @@ var statusesMatrix = []struct {
 	{"alias1", "", "reset", "", "-"},
 	{"alias1", "enabled", "reset", "", "rm"},
 	{"alias1", "disabled", "reset", "", "-"},
-	{"alias1", "auto", "reset", "auto", "-"},
+	{"alias1", "auto", "reset", "", "rm"}, // used to retire auto-aliases
 	{"alias5", "", "reset", "auto", "add"},
 	{"alias5", "enabled", "reset", "auto", "-"},
 	{"alias5", "disabled", "reset", "auto", "add"},
@@ -682,11 +682,11 @@ var statusesMatrix = []struct {
 	{"alias1gone", "", "reset", "", "-"},
 	{"alias1gone", "enabled", "reset", "", "-"},
 	{"alias1gone", "disabled", "reset", "", "-"},
-	{"alias1gone", "auto", "reset", "auto", "-"},
+	{"alias1gone", "auto", "reset", "", "-"},
 	{"alias5gone", "", "reset", "", "-"},
 	{"alias5gone", "enabled", "reset", "", "-"},
 	{"alias5gone", "disabled", "reset", "", "-"},
-	{"alias5gone", "auto", "reset", "auto", "-"},
+	{"alias5gone", "auto", "reset", "", "-"},
 }
 
 func (s *snapmgrTestSuite) TestAliasMatrixRunThrough(c *C) {
@@ -769,7 +769,7 @@ func (s *snapmgrTestSuite) TestAliasMatrixRunThrough(c *C) {
 		}
 		// start with an easier-to-read error if this fails:
 		c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops(), comm)
-		c.Assert(s.fakeBackend.ops, DeepEquals, expected, comm)
+		c.Check(s.fakeBackend.ops, DeepEquals, expected, comm)
 
 		var allAliases map[string]map[string]string
 		err = s.state.Get("aliases", &allAliases)
@@ -890,7 +890,7 @@ func (s *snapmgrTestSuite) TestAliasMatrixTotalUndoRunThrough(c *C) {
 		}
 		// start with an easier-to-read error if this fails:
 		c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops(), comm)
-		c.Assert(s.fakeBackend.ops, DeepEquals, expected, comm)
+		c.Check(s.fakeBackend.ops, DeepEquals, expected, comm)
 
 		var allAliases map[string]map[string]string
 		err = s.state.Get("aliases", &allAliases)

--- a/overlord/snapstate/aliases_test.go
+++ b/overlord/snapstate/aliases_test.go
@@ -707,7 +707,7 @@ func (s *snapmgrTestSuite) TestAliasMatrixRunThrough(c *C) {
 	// alias5gone is an auto-alias and doesn't have an entry in the current snap revision anymore
 	snapstate.AutoAliases = func(st *state.State, info *snap.Info) ([]string, error) {
 		c.Check(info.Name(), Equals, "alias-snap")
-		return []string{"alias5", "alias5lost"}, nil
+		return []string{"alias5", "alias5gone"}, nil
 	}
 	cmds := map[string]string{
 		"alias1": "cmd1",
@@ -800,11 +800,11 @@ func (s *snapmgrTestSuite) TestAliasMatrixTotalUndoRunThrough(c *C) {
 
 	// alias1 is a non auto-alias
 	// alias5 is an auto-alias
-	// alias1lost is a non auto-alias and doesn't have an entry in the snap anymore
-	// alias5lost is an auto-alias and doesn't have an entry in the snap any
+	// alias1gone is a non auto-alias and doesn't have an entry in the snap anymore
+	// alias5gone is an auto-alias and doesn't have an entry in the snap any
 	snapstate.AutoAliases = func(st *state.State, info *snap.Info) ([]string, error) {
 		c.Check(info.Name(), Equals, "alias-snap")
-		return []string{"alias5", "alias5lost"}, nil
+		return []string{"alias5", "alias5gone"}, nil
 	}
 	cmds := map[string]string{
 		"alias1": "cmd1",
@@ -925,7 +925,7 @@ func (s *snapmgrTestSuite) TestDisabledSnapResetAliasesRunThrough(c *C) {
 	// alias5gone is an auto-alias and doesn't have an entry in the current snap revision anymore
 	snapstate.AutoAliases = func(st *state.State, info *snap.Info) ([]string, error) {
 		c.Check(info.Name(), Equals, "alias-snap")
-		return []string{"alias5", "alias5lost"}, nil
+		return []string{"alias5", "alias5gone"}, nil
 	}
 
 	defer s.snapmgr.Stop()
@@ -994,11 +994,11 @@ func (s *snapmgrTestSuite) TestDisabledSnapResetAliasesTotalUndoRunThrough(c *C)
 
 	// alias1 is a non auto-alias
 	// alias5 is an auto-alias
-	// alias1lost is a non auto-alias and doesn't have an entry in the snap anymore
-	// alias5lost is an auto-alias and doesn't have an entry in the snap any
+	// alias1gone is a non auto-alias and doesn't have an entry in the snap anymore
+	// alias5gone is an auto-alias and doesn't have an entry in the snap any
 	snapstate.AutoAliases = func(st *state.State, info *snap.Info) ([]string, error) {
 		c.Check(info.Name(), Equals, "alias-snap")
-		return []string{"alias5", "alias5lost"}, nil
+		return []string{"alias5", "alias5gone"}, nil
 	}
 
 	defer s.snapmgr.Stop()

--- a/overlord/snapstate/aliases_test.go
+++ b/overlord/snapstate/aliases_test.go
@@ -931,7 +931,7 @@ func (s *snapmgrTestSuite) TestDisabledSnapResetAliasesRunThrough(c *C) {
 	defer s.snapmgr.Stop()
 	for _, scenario := range statusesMatrix {
 		if scenario.action != "reset" {
-			// only reset
+			// we reuse the scenarios but here want to test only reset i.e. ResetAliases for the disabled snap case (the other actions are still unsupported for disabled snaps)
 			continue
 		}
 
@@ -1004,7 +1004,7 @@ func (s *snapmgrTestSuite) TestDisabledSnapResetAliasesTotalUndoRunThrough(c *C)
 	defer s.snapmgr.Stop()
 	for _, scenario := range statusesMatrix {
 		if scenario.action != "reset" {
-			// only reset
+			// we reuse the scenarios but here want to test only reset i.e. ResetAliases for the disabled snap case (the other actions are still unsupported for disabled snaps)
 			continue
 		}
 


### PR DESCRIPTION
This allows ResetAliases to be used:
* to retire auto-aliases
* to be used on disabled snaps as well