### PR TITLE
overlord,overlord/snapstate: have UpdateMany retire/enable auto-aliases even without new revision

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -32,6 +32,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -1429,7 +1430,8 @@ apps:
 
 	updated, tss, err := snapstate.UpdateMany(st, nil, 0)
 	c.Assert(err, IsNil)
-	c.Assert(updated, DeepEquals, []string{"foo"})
+	sort.Strings(updated)
+	c.Assert(updated, DeepEquals, []string{"bar", "foo"})
 	c.Assert(tss, HasLen, 3)
 	chg = st.NewChange("upgrade-snaps", "...")
 	chg.AddAll(tss[0])

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1321,6 +1321,161 @@ apps:
 	c.Check(dest, Equals, "foo.app2")
 }
 
+func (ms *mgrsSuite) TestHappyOrthogonalRefreshAutoAliases(c *C) {
+	ms.prereqSnapAssertions(c, map[string]interface{}{
+		"snap-name":    "foo",
+		"auto-aliases": []interface{}{"app1"},
+	}, map[string]interface{}{
+		"snap-name": "bar",
+	})
+
+	fooYaml := `name: foo
+version: @VERSION@
+apps:
+ app1:
+  command: bin/app1
+  aliases: [app1]
+ app2:
+  command: bin/app2
+  aliases: [app2]
+`
+
+	barYaml := `name: bar
+version: @VERSION@
+apps:
+ app1:
+  command: bin/app1
+  aliases: [app1]
+ app3:
+  command: bin/app3
+  aliases: [app3]
+`
+
+	fooPath, _ := ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
+	ms.serveSnap(fooPath, "10")
+
+	barPath, _ := ms.makeStoreTestSnap(c, strings.Replace(barYaml, "@VERSION@", "2.0", -1), "20")
+	ms.serveSnap(barPath, "20")
+
+	mockServer := ms.mockStore(c)
+	defer mockServer.Close()
+
+	st := ms.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	ts, err := snapstate.Install(st, "foo", "stable", snap.R(0), 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg := st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	st.Unlock()
+	err = ms.o.Settle()
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
+
+	ts, err = snapstate.Install(st, "bar", "stable", snap.R(0), 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg = st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	st.Unlock()
+	err = ms.o.Settle()
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("install-snap change failed with: %v", chg.Err()))
+
+	info, err := snapstate.CurrentInfo(st, "foo")
+	c.Assert(err, IsNil)
+	c.Check(info.Revision, Equals, snap.R(10))
+	c.Check(info.Version, Equals, "1.0")
+
+	info, err = snapstate.CurrentInfo(st, "bar")
+	c.Assert(err, IsNil)
+	c.Check(info.Revision, Equals, snap.R(20))
+	c.Check(info.Version, Equals, "2.0")
+
+	var allAliases map[string]map[string]string
+	err = st.Get("aliases", &allAliases)
+	c.Check(err, IsNil)
+	c.Check(allAliases, DeepEquals, map[string]map[string]string{
+		"foo": {
+			"app1": "auto",
+		},
+	})
+
+	ms.prereqSnapAssertions(c, map[string]interface{}{
+		"snap-name":    "foo",
+		"auto-aliases": []interface{}{"app2"},
+		"revision":     "1",
+	}, map[string]interface{}{
+		"snap-name":    "bar",
+		"auto-aliases": []interface{}{"app1", "app3"},
+		"revision":     "1",
+	})
+
+	// new foo version/revision
+	fooPath, _ = ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.5", -1), "15")
+	ms.serveSnap(fooPath, "15")
+
+	// refresh all
+	err = assertstate.RefreshSnapDeclarations(st, 0)
+	c.Assert(err, IsNil)
+
+	updated, tss, err := snapstate.UpdateMany(st, nil, 0)
+	c.Assert(err, IsNil)
+	c.Assert(updated, DeepEquals, []string{"foo"})
+	c.Assert(tss, HasLen, 3)
+	chg = st.NewChange("upgrade-snaps", "...")
+	chg.AddAll(tss[0])
+	chg.AddAll(tss[1])
+	chg.AddAll(tss[2])
+
+	st.Unlock()
+	err = ms.o.Settle()
+	st.Lock()
+	c.Assert(err, IsNil)
+
+	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("upgrade-snap change failed with: %v", chg.Err()))
+
+	info, err = snapstate.CurrentInfo(st, "foo")
+	c.Assert(err, IsNil)
+	c.Check(info.Revision, Equals, snap.R(15))
+	c.Check(info.Version, Equals, "1.5")
+
+	allAliases = nil
+	err = st.Get("aliases", &allAliases)
+	c.Check(err, IsNil)
+	c.Check(allAliases, DeepEquals, map[string]map[string]string{
+		"foo": {
+			"app2": "auto",
+		},
+		"bar": {
+			"app1": "auto",
+			"app3": "auto",
+		},
+	})
+
+	app2Alias := filepath.Join(dirs.SnapBinariesDir, "app2")
+	dest, err := os.Readlink(app2Alias)
+	c.Assert(err, IsNil)
+	c.Check(dest, Equals, "foo.app2")
+
+	app1Alias := filepath.Join(dirs.SnapBinariesDir, "app1")
+	dest, err = os.Readlink(app1Alias)
+	c.Assert(err, IsNil)
+	c.Check(dest, Equals, "bar.app1")
+	app3Alias := filepath.Join(dirs.SnapBinariesDir, "app3")
+	dest, err = os.Readlink(app3Alias)
+	c.Assert(err, IsNil)
+	c.Check(dest, Equals, "bar.app3")
+}
+
 type authContextSetupSuite struct {
 	o  *overlord.Overlord
 	ac auth.AuthContext

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -1678,6 +1678,156 @@ func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
 
 }
 
+func (s *snapmgrTestSuite) TestUpdateManyAutoAliasesScenarios(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "other-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "other-snap", SnapID: "other-snap-id", Revision: snap.R(2)},
+		},
+		Current:  snap.R(2),
+		SnapType: "app",
+	})
+
+	snapstate.AutoAliases = func(st *state.State, info *snap.Info) ([]string, error) {
+		switch info.Name() {
+		case "some-snap":
+			return []string{"aliasA"}, nil
+		case "other-snap":
+			return []string{"aliasB"}, nil
+		}
+		return nil, nil
+	}
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(4)},
+		},
+		Current:  snap.R(4),
+		SnapType: "app",
+	})
+
+	scenarios := []struct {
+		aliasesBefore map[string][]string
+		names         []string
+		retire        []string
+		update        bool
+		new           bool
+	}{
+		{nil, nil, nil, true, true},
+		{nil, []string{"some-snap"}, nil, true, false},
+		{nil, []string{"other-snap"}, nil, false, true},
+		{map[string][]string{"some-snap": {"aliasA", "aliasC"}}, []string{"some-snap"}, nil, true, false},
+		{map[string][]string{"other-snap": {"aliasB", "aliasC"}}, []string{"other-snap"}, []string{"other-snap"}, false, false},
+		{map[string][]string{"other-snap": {"aliasB", "aliasC"}}, nil, []string{"other-snap"}, true, false},
+		{map[string][]string{"other-snap": {"aliasB", "aliasC"}}, []string{"some-snap"}, nil, true, false},
+		{map[string][]string{"other-snap": {"aliasC"}}, []string{"other-snap"}, []string{"other-snap"}, false, true},
+		{map[string][]string{"other-snap": {"aliasC"}}, nil, []string{"other-snap"}, true, true},
+		{map[string][]string{"other-snap": {"aliasC"}}, []string{"some-snap"}, nil, true, false},
+		{map[string][]string{"some-snap": {"aliasB"}, "other-snap": {"aliasA"}}, []string{"some-snap"}, []string{"other-snap"}, true, false},
+		{map[string][]string{"some-snap": {"aliasB"}, "other-snap": {"aliasA"}}, nil, []string{"other-snap", "some-snap"}, true, true},
+		{map[string][]string{"some-snap": {"aliasB"}, "other-snap": {"aliasA"}}, []string{"other-snap"}, []string{"other-snap", "some-snap"}, false, true},
+		{map[string][]string{"some-snap": {"aliasB"}}, nil, []string{"some-snap"}, true, true},
+		{map[string][]string{"some-snap": {"aliasB"}}, []string{"other-snap"}, []string{"some-snap"}, false, true},
+		{map[string][]string{"some-snap": {"aliasB"}}, []string{"some-snap"}, nil, true, false},
+		{map[string][]string{"other-snap": {"aliasA"}}, nil, []string{"other-snap"}, true, true},
+		{map[string][]string{"other-snap": {"aliasA"}}, []string{"other-snap"}, []string{"other-snap"}, false, true},
+		{map[string][]string{"other-snap": {"aliasA"}}, []string{"some-snap"}, []string{"other-snap"}, true, false},
+	}
+
+	expectedAuto := func(aliases []string) map[string]string {
+		res := make(map[string]string, len(aliases))
+		for _, alias := range aliases {
+			res[alias] = "auto"
+		}
+		return res
+	}
+
+	for _, scen := range scenarios {
+		aliases := make(map[string]map[string]string)
+		for snapName, autoAliases := range scen.aliasesBefore {
+			statuses := make(map[string]string)
+			for _, alias := range autoAliases {
+				statuses[alias] = "auto"
+			}
+			aliases[snapName] = statuses
+		}
+		s.state.Set("aliases", aliases)
+
+		_, tts, err := snapstate.UpdateMany(s.state, scen.names, s.user.ID)
+		c.Check(err, IsNil)
+		j := 0
+		new, retiring, err := snapstate.AutoAliasesDelta(s.state, []string{"some-snap", "other-snap"})
+		c.Assert(err, IsNil)
+		var expectedRetiring map[string]map[string]string
+		var retireTs *state.TaskSet
+		if len(scen.retire) != 0 {
+			retireTs = tts[0]
+			j++
+			taskAliases := make(map[string]map[string]string)
+			for _, aliasTask := range retireTs.Tasks() {
+				c.Check(aliasTask.Kind(), Equals, "alias")
+				var aliases map[string]string
+				err := aliasTask.Get("aliases", &aliases)
+				c.Assert(err, IsNil)
+				snapsup, err := snapstate.TaskSnapSetup(aliasTask)
+				c.Assert(err, IsNil)
+				taskAliases[snapsup.Name()] = aliases
+			}
+			expectedRetiring = make(map[string]map[string]string)
+			for _, snapName := range scen.retire {
+				expectedRetiring[snapName] = expectedAuto(retiring[snapName])
+			}
+			c.Check(taskAliases, DeepEquals, expectedRetiring)
+		}
+		if scen.update {
+			updateTs := tts[j]
+			j++
+			first := updateTs.Tasks()[0]
+			c.Check(first.Kind(), Equals, "download-snap")
+			wait := false
+			if expectedRetiring["other-snap"]["aliasA"] != "" {
+				wait = true
+			} else if expectedRetiring["some-snap"] != nil {
+				wait = true
+			}
+			if wait {
+				c.Check(first.WaitTasks(), DeepEquals, retireTs.Tasks())
+			} else {
+				c.Check(first.WaitTasks(), HasLen, 0)
+			}
+		}
+		if scen.new {
+			newTs := tts[j]
+			j++
+			tasks := newTs.Tasks()
+			c.Check(tasks, HasLen, 1)
+			aliasTask := tasks[0]
+			c.Check(aliasTask.Kind(), Equals, "alias")
+			var aliases map[string]string
+			err := aliasTask.Get("aliases", &aliases)
+			c.Assert(err, IsNil)
+			c.Check(aliases, DeepEquals, expectedAuto(new["other-snap"]))
+			wait := false
+			if expectedRetiring["some-snap"]["aliasB"] != "" {
+				wait = true
+			} else if expectedRetiring["other-snap"] != nil {
+				wait = true
+			}
+			if wait {
+				c.Check(aliasTask.WaitTasks(), DeepEquals, retireTs.Tasks())
+			} else {
+				c.Check(aliasTask.WaitTasks(), HasLen, 0)
+			}
+		}
+		c.Assert(j, Equals, len(tts))
+	}
+
+}
+
 func (s *snapmgrTestSuite) TestUpdateLocalSnapFails(c *C) {
 	si := snap.SideInfo{
 		RealName: "some-snap",

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -460,8 +460,32 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 		}
 	}
 
-	updated := make([]string, 0, len(updates))
 	tasksets := make([]*state.TaskSet, 0, len(updates))
+	var retiredAutoAliasesTs *state.TaskSet
+
+	newAutoAliases, mustRetireAutoAliases, transferTargets, err := autoAliasesUpdate(st, names, updates)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(mustRetireAutoAliases) != 0 {
+		retiredAutoAliasesTs = state.NewTaskSet()
+		for name, retired := range mustRetireAutoAliases {
+			ts, err := ResetAliases(st, name, retired)
+			if err != nil {
+				if len(names) == 0 {
+					// doing "refresh all", just skip this snap
+					logger.Noticef("cannot retire automatic aliases for snap %q: %v", name, err)
+					continue
+				}
+				return nil, nil, err
+			}
+			retiredAutoAliasesTs.AddAll(ts)
+		}
+		tasksets = append(tasksets, retiredAutoAliasesTs)
+	}
+
+	updated := make([]string, 0, len(updates))
 	for _, update := range updates {
 		snapst := stateByID[update.SnapID]
 
@@ -484,11 +508,116 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 		}
 		ts.JoinLane(st.NewLane())
 
+		if retiredAutoAliasesTs != nil && (mustRetireAutoAliases[update.Name()] != nil || transferTargets[update.Name()]) {
+			ts.WaitAll(retiredAutoAliasesTs)
+		}
+
 		updated = append(updated, update.Name())
 		tasksets = append(tasksets, ts)
 	}
 
+	if len(newAutoAliases) != 0 {
+		addAutoAliasesTs := state.NewTaskSet()
+		for name, added := range newAutoAliases {
+			ts, err := ResetAliases(st, name, added)
+			if err != nil {
+				if len(names) == 0 {
+					// doing "refresh all", just skip this snap
+					logger.Noticef("cannot enable automatic aliases for snap %q: %v", name, err)
+					continue
+				}
+				return nil, nil, err
+			}
+			if retiredAutoAliasesTs != nil && (mustRetireAutoAliases[name] != nil || transferTargets[name]) {
+				ts.WaitAll(retiredAutoAliasesTs)
+			}
+			addAutoAliasesTs.AddAll(ts)
+		}
+		tasksets = append(tasksets, addAutoAliasesTs)
+	}
+
 	return updated, tasksets, nil
+}
+
+func autoAliasesUpdate(st *state.State, names []string, updates []*snap.Info) (new map[string][]string, mustRetire map[string][]string, transferTargets map[string]bool, err error) {
+	new, retired, err := AutoAliasesDelta(st, nil)
+	if err != nil {
+		if len(names) != 0 {
+			// not "refresh all", error
+			return nil, nil, nil, err
+		}
+		// log and continue
+		logger.Noticef("cannot find the delta for automatic aliases for some snaps: %v", err)
+	}
+
+	refreshAll := len(names) == 0
+
+	// retired alias -> snapName
+	retiringAliases := make(map[string]string, len(retired))
+	for snapName, aliases := range retired {
+		for _, alias := range aliases {
+			retiringAliases[alias] = snapName
+		}
+	}
+
+	// filter new considering only names if set:
+	// we add auto-aliases only for mentioned snaps
+	if !refreshAll && len(new) != 0 {
+		filteredNew := make(map[string][]string, len(new))
+		for _, name := range names {
+			if new[name] != nil {
+				filteredNew[name] = new[name]
+			}
+		}
+		new = filteredNew
+	}
+
+	// mark snaps that are sources or target of transfers
+	transferSources := make(map[string]bool, len(retired))
+	transferTargets = make(map[string]bool, len(new))
+	for snapName, aliases := range new {
+		for _, alias := range aliases {
+			if source := retiringAliases[alias]; source != "" {
+				transferTargets[snapName] = true
+				transferSources[source] = true
+			}
+		}
+	}
+
+	// snaps with updates
+	updating := make(map[string]bool, len(updates))
+	for _, info := range updates {
+		updating[info.Name()] = true
+	}
+
+	// add explicitly auto-aliases only for snaps that are not updated
+	for snapName := range new {
+		if updating[snapName] {
+			delete(new, snapName)
+		}
+	}
+
+	// retire explicitly auto-aliases only for snaps that are mentioned
+	// and not updated OR the source of transfers
+	mustRetire = make(map[string][]string, len(retired))
+	for snapName := range transferSources {
+		mustRetire[snapName] = retired[snapName]
+	}
+	if refreshAll {
+		for snapName, aliases := range retired {
+			if !updating[snapName] {
+				mustRetire[snapName] = aliases
+			}
+		}
+	} else {
+		for _, name := range names {
+			if !updating[name] && retired[name] != nil {
+				mustRetire[name] = retired[name]
+			}
+		}
+	}
+
+	return new, mustRetire, transferTargets, nil
 }
 
 // Update initiates a change updating a snap.


### PR DESCRIPTION
This makes it so UpdateMany considers changes to auto-aliases from the snap-declaration even if there's no new updated revision.

Also tries to deal gracefully with auto-aliases transfers (even if likely rare) by retiring transfer sources' auto-aliases first.

TODO: need  most of same logic to happen also just for Update (done in #2606)