### PR TITLE
don't install govendor each  time

### DIFF
--- a/get-deps.sh
+++ b/get-deps.sh
@@ -2,8 +2,10 @@
 
 set -eu
 
-echo Installing govendor
-go get -u github.com/kardianos/govendor
+if [ -z "$(which govendor)" ];then
+	echo Installing govendor
+	go get -u github.com/kardianos/govendor
+fi
 export PATH=$PATH:$GOPATH/bin
 
 echo Obtaining dependencies


### PR DESCRIPTION
Reinstalling govendor takes time and slows down local testing.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>