### PR TITLE
store: request no CDN via a header using SNAPPY_STORE_NO_CDN envvar

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -778,6 +778,7 @@ func (s *Store) newRequest(reqOptions *requestOptions, user *auth.UserState) (*h
 	req.Header.Set("X-Ubuntu-Series", s.series)
 	req.Header.Set("X-Ubuntu-Classic", strconv.FormatBool(release.OnClassic))
 	req.Header.Set("X-Ubuntu-Wire-Protocol", UbuntuCoreWireProtocol)
+	req.Header.Set("X-Ubuntu-No-CDN", strconv.FormatBool(osutil.GetenvBool("SNAPPY_STORE_NO_CDN")))
 
 	if reqOptions.ContentType != "" {
 		req.Header.Set("Content-Type", reqOptions.ContentType)

--- a/store/store.go
+++ b/store/store.go
@@ -182,6 +182,8 @@ type Store struct {
 	architecture string
 	series       string
 
+	noCDN bool
+
 	fallbackStoreID string
 
 	detailFields []string
@@ -422,6 +424,7 @@ func New(cfg *Config, authContext auth.AuthContext) *Store {
 		sectionsURI:     sectionsURI,
 		series:          series,
 		architecture:    architecture,
+		noCDN:           osutil.GetenvBool("SNAPPY_STORE_NO_CDN"),
 		fallbackStoreID: cfg.StoreID,
 		detailFields:    fields,
 		authContext:     authContext,
@@ -778,7 +781,7 @@ func (s *Store) newRequest(reqOptions *requestOptions, user *auth.UserState) (*h
 	req.Header.Set("X-Ubuntu-Series", s.series)
 	req.Header.Set("X-Ubuntu-Classic", strconv.FormatBool(release.OnClassic))
 	req.Header.Set("X-Ubuntu-Wire-Protocol", UbuntuCoreWireProtocol)
-	req.Header.Set("X-Ubuntu-No-CDN", strconv.FormatBool(osutil.GetenvBool("SNAPPY_STORE_NO_CDN")))
+	req.Header.Set("X-Ubuntu-No-CDN", strconv.FormatBool(s.noCDN))
 
 	if reqOptions.ContentType != "" {
 		req.Header.Set("Content-Type", reqOptions.ContentType)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1609,6 +1609,8 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNonDefaults(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
+	os.Setenv("SNAPPY_STORE_NO_CDN", "1")
+	defer os.Unsetenv("SNAPPY_STORE_NO_CDN")
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		storeID := r.Header.Get("X-Ubuntu-Store")
@@ -1621,6 +1623,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNonDefaults(c *C) {
 		c.Check(r.Header.Get("X-Ubuntu-Series"), Equals, "21")
 		c.Check(r.Header.Get("X-Ubuntu-Architecture"), Equals, "archXYZ")
 		c.Check(r.Header.Get("X-Ubuntu-Classic"), Equals, "true")
+		c.Check(r.Header.Get("X-Ubuntu-No-CDN"), Equals, "true")
 
 		w.WriteHeader(http.StatusOK)
 		io.WriteString(w, MockDetailsJSON)


### PR DESCRIPTION
Another option instead of multiplying headers is adding flags to X-Ubuntu-Wire-Protocol, which is not used yet atm in the store:

X-Ubuntu-Wire-Protocol: 1 no-cdn