### PR TITLE
asserts: improve error message when key is not valid at the given time

### DIFF
--- a/asserts/account_test.go
+++ b/asserts/account_test.go
@@ -147,7 +147,7 @@ func (s *accountSuite) TestCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(account)
-	c.Assert(err, ErrorMatches, "account assertion timestamp outside of signing key validity")
+	c.Assert(err, ErrorMatches, `account assertion timestamp outside of signing key validity \(key valid between.*\)`)
 }
 
 func (s *accountSuite) TestCheckUntrustedAuthority(c *C) {

--- a/asserts/account_test.go
+++ b/asserts/account_test.go
@@ -147,7 +147,7 @@ func (s *accountSuite) TestCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(account)
-	c.Assert(err, ErrorMatches, `account assertion timestamp outside of signing key validity \(key valid between.*\)`)
+	c.Assert(err, ErrorMatches, `account assertion timestamp outside of signing key validity \(key valid since.*\)`)
 }
 
 func (s *accountSuite) TestCheckUntrustedAuthority(c *C) {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -522,7 +522,7 @@ func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey
 	if tstamped, ok := assert.(timestamped); ok {
 		checkTime := tstamped.Timestamp()
 		if !signingKey.isKeyValidAt(checkTime) {
-			return fmt.Errorf("%s assertion timestamp outside of signing key validity", assert.Type().Name)
+			return fmt.Errorf("%s assertion timestamp outside of signing key validity (key valid between %q and %q)", assert.Type().Name, signingKey.Since(), signingKey.Until())
 		}
 	}
 	return nil

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -522,7 +522,11 @@ func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey
 	if tstamped, ok := assert.(timestamped); ok {
 		checkTime := tstamped.Timestamp()
 		if !signingKey.isKeyValidAt(checkTime) {
-			return fmt.Errorf("%s assertion timestamp outside of signing key validity (key valid between %q and %q)", assert.Type().Name, signingKey.Since(), signingKey.Until())
+			until := ""
+			if !signingKey.Until().IsZero() {
+				until = fmt.Sprintf(" until %q", signingKey.Until())
+			}
+			return fmt.Errorf("%s assertion timestamp outside of signing key validity (key valid since %q%s)", assert.Type().Name, signingKey.Since(), until)
 		}
 	}
 	return nil

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -216,7 +216,7 @@ func (mods *modelSuite) TestModelCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(model)
-	c.Assert(err, ErrorMatches, "model assertion timestamp outside of signing key validity")
+	c.Assert(err, ErrorMatches, `model assertion timestamp outside of signing key validity \(key valid between.*\)`)
 }
 
 type serialSuite struct {

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -216,7 +216,7 @@ func (mods *modelSuite) TestModelCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(model)
-	c.Assert(err, ErrorMatches, `model assertion timestamp outside of signing key validity \(key valid between.*\)`)
+	c.Assert(err, ErrorMatches, `model assertion timestamp outside of signing key validity \(key valid since.*\)`)
 }
 
 type serialSuite struct {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -563,7 +563,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(snapBuild)
-	c.Assert(err, ErrorMatches, `snap-build assertion timestamp outside of signing key validity \(key valid between.*\)`)
+	c.Assert(err, ErrorMatches, `snap-build assertion timestamp outside of signing key validity \(key valid since.*\)`)
 }
 
 type snapRevSuite struct {
@@ -701,7 +701,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(snapRev)
-	c.Assert(err, ErrorMatches, `snap-revision assertion timestamp outside of signing key validity \(key valid between.*\)`)
+	c.Assert(err, ErrorMatches, `snap-revision assertion timestamp outside of signing key validity \(key valid since.*\)`)
 }
 
 func (srs *snapRevSuite) TestSnapRevisionCheckUntrustedAuthority(c *C) {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -563,7 +563,7 @@ func (sbs *snapBuildSuite) TestSnapBuildCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(snapBuild)
-	c.Assert(err, ErrorMatches, "snap-build assertion timestamp outside of signing key validity")
+	c.Assert(err, ErrorMatches, `snap-build assertion timestamp outside of signing key validity \(key valid between.*\)`)
 }
 
 type snapRevSuite struct {
@@ -701,7 +701,7 @@ func (srs *snapRevSuite) TestSnapRevisionCheckInconsistentTimestamp(c *C) {
 	c.Assert(err, IsNil)
 
 	err = db.Check(snapRev)
-	c.Assert(err, ErrorMatches, "snap-revision assertion timestamp outside of signing key validity")
+	c.Assert(err, ErrorMatches, `snap-revision assertion timestamp outside of signing key validity \(key valid between.*\)`)
 }
 
 func (srs *snapRevSuite) TestSnapRevisionCheckUntrustedAuthority(c *C) {


### PR DESCRIPTION
A user ran into this today and this makes it easier for the user
to know what exactly the problem is.