### PR TITLE
tests: add test ensuring manual pages are shipped

### DIFF
--- a/tests/main/manpages/task.yaml
+++ b/tests/main/manpages/task.yaml
@@ -1,4 +1,6 @@
 summary: the essential manual pages are installed by the native package
+# core systems don't ship man or manual pages
+systems: [-ubuntu-core-16-64, -ubuntu-core-16-64-fixme, -ubuntu-core-16-arm-32, -ubuntu-core-16-arm-64]
 execute: |
     for manpage in snap snap-confine snap-discard-ns ubuntu-core-launcher; do
         if ! man --what $manpage; then

--- a/tests/main/manpages/task.yaml
+++ b/tests/main/manpages/task.yaml
@@ -1,0 +1,9 @@
+summary: the essential manual pages are installed by the native package
+execute: |
+    for manpage in snap snap-confine snap-discard-ns ubuntu-core-launcher; do
+        if ! man --what $manpage; then
+            echo "Expected to see manual page for $manpage"
+            exit 1
+        fi
+    done
+# TODO: add manual pages for snapctl, snap-exec and snapd


### PR DESCRIPTION
When I branched off master I assumed we still have a bug where some manual pages are not
packaged. I'm glad to see that I was wrong. The spread test will ensure that this is true for
a longer time.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>