### PR TITLE
interfaces: allow reading installed files from previous revisions by default

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -306,6 +306,10 @@ var defaultTemplate = []byte(`
   @{INSTALL_DIR}/@{SNAP_NAME}/@{SNAP_REVISION}/    r,
   @{INSTALL_DIR}/@{SNAP_NAME}/@{SNAP_REVISION}/**  mrklix,
 
+  # Read-only install directory for other revisions to help with bugs like
+  # LP: #1616650 and LP: #1655992
+  @{INSTALL_DIR}/@{SNAP_NAME}/**  mrkix,
+
   # Read-only home area for other versions
   owner @{HOME}/snap/@{SNAP_NAME}/                  r,
   owner @{HOME}/snap/@{SNAP_NAME}/**                mrkix,


### PR DESCRIPTION
While daemon commands are restarted on upgrade, long running non-daemon
commands are not so when snap refresh is performed and the policy is
regenerated, these long running commands may try to access previous revisions
which has caused issues like LP: #1616650 and some of the denials found in
LP: #1655992. This commit does not fully address the problem with policy
reloads where the revision changes, but does ease the pain with regard to the
INSTALL_DIR. There is no harm in allowing read from previous install
directories, so just allow it by default.