### PR TITLE
tests: improve debug output when reexec is used 

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -56,6 +56,12 @@ func ExecInCoreSnap() {
 
 	// should we re-exec? no option in the environment means yes
 	if !osutil.GetenvBool(key, true) {
+		logger.Debugf("re-exec disabled by user")
+		return
+	}
+
+	// did we already re-exec?
+	if osutil.GetenvBool("SNAP_DID_REEXEC") {
 		return
 	}
 
@@ -104,6 +110,6 @@ func ExecInCoreSnap() {
 
 	logger.Debugf("restarting into %q", full)
 
-	env := append(os.Environ(), key+"=0")
+	env := append(os.Environ(), "SNAP_DID_REEXEC=1")
 	panic(syscall.Exec(full, os.Args, env))
 }

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -8,7 +8,7 @@ debug: |
     cat *-vars.txt
 execute: |
     echo "Collect SNAP and XDG environment variables"
-    test-snapd-tools.env | egrep '^SNAP_' | sort > snap-vars.txt 
+    test-snapd-tools.env | egrep '^SNAP_' | egrep -v '^SNAP_DID_REEXEC'| sort > snap-vars.txt
     test-snapd-tools.env | egrep '^XDG_' | sort > xdg-vars.txt 
 
     echo "Ensure that SNAP environment variables are what we expect"
@@ -23,7 +23,7 @@ execute: |
     egrep -q '^SNAP_USER_COMMON=/root/snap/test-snapd-tools/common$' snap-vars.txt
     egrep -q '^SNAP_USER_DATA=/root/snap/test-snapd-tools/x1$' snap-vars.txt
     egrep -q '^SNAP_VERSION=1.0$' snap-vars.txt
-    test $(wc -l < snap-vars.txt) -eq 11
+    test $(wc -l < snap-vars.txt) -eq 10
 
     echo "Enure that XDG environment variables are what we expect"
     egrep -q '^XDG_RUNTIME_DIR=/run/user/0/snap.test-snapd-tools$' xdg-vars.txt

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -4,6 +4,8 @@ prepare: |
     snap install --dangerous test-snapd-tools_1.0_all.snap
 restore: |
     rm -f *.snap
+debug: |
+    cat *-vars.txt
 execute: |
     echo "Collect SNAP and XDG environment variables"
     test-snapd-tools.env | egrep '^SNAP_' | sort > snap-vars.txt 
@@ -21,10 +23,8 @@ execute: |
     egrep -q '^SNAP_USER_COMMON=/root/snap/test-snapd-tools/common$' snap-vars.txt
     egrep -q '^SNAP_USER_DATA=/root/snap/test-snapd-tools/x1$' snap-vars.txt
     egrep -q '^SNAP_VERSION=1.0$' snap-vars.txt
-    test $(wc -l < snap-vars.txt) -eq 10
+    test $(wc -l < snap-vars.txt) -eq 11
 
     echo "Enure that XDG environment variables are what we expect"
     egrep -q '^XDG_RUNTIME_DIR=/run/user/0/snap.test-snapd-tools$' xdg-vars.txt
     test $(wc -l < xdg-vars.txt) -ge 1
-debug: |
-    cat *-vars.txt

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -17,6 +17,10 @@ restore: |
     fi
     rm -f /tmp/old-info
 
+debug: |
+    ls /etc/systemd/system/snapd.service.d
+    cat /etc/systemd/system/snapd.service.d/*
+
 execute: |
     if [ "${SNAP_REEXEC:-}" = "0" ]; then
         echo "skipping test when SNAP_REEXEC is disabled"


### PR DESCRIPTION
This should help finding a test failure in spread-cron that looks like a ordering issue in the tests.