### PR TITLE
snap: add {Plug,Slot}Info.SecurityTags

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
@@ -308,6 +309,30 @@ type PlugInfo struct {
 	Label     string
 	Apps      map[string]*AppInfo
 	Hooks     map[string]*HookInfo
+}
+
+// SecurityTags returns security tags associated with a given plug.
+func (plug *PlugInfo) SecurityTags() []string {
+	var tags []string
+	for _, app := range plug.Apps {
+		tags = append(tags, app.SecurityTag())
+	}
+	for _, hook := range plug.Hooks {
+		tags = append(tags, hook.SecurityTag())
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// SecurityTags returns security tags associated with a given slot.
+func (slot *SlotInfo) SecurityTags() []string {
+	var tags []string
+	for _, app := range slot.Apps {
+		tags = append(tags, app.SecurityTag())
+	}
+	// NOTE: hooks cannot have slots
+	sort.Strings(tags)
+	return tags
 }
 
 // SlotInfo provides information about a slot.

--- a/snap/info.go
+++ b/snap/info.go
@@ -313,7 +313,7 @@ type PlugInfo struct {
 
 // SecurityTags returns security tags associated with a given plug.
 func (plug *PlugInfo) SecurityTags() []string {
-	var tags []string
+	tags := make([]string, 0, len(plug.Apps)+len(plug.Hooks))
 	for _, app := range plug.Apps {
 		tags = append(tags, app.SecurityTag())
 	}
@@ -326,7 +326,7 @@ func (plug *PlugInfo) SecurityTags() []string {
 
 // SecurityTags returns security tags associated with a given slot.
 func (slot *SlotInfo) SecurityTags() []string {
-	var tags []string
+	tags := make([]string, 0, len(slot.Apps))
 	for _, app := range slot.Apps {
 		tags = append(tags, app.SecurityTag())
 	}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -79,6 +79,25 @@ func (s *infoSuite) TestAppInfoSecurityTag(c *C) {
 	c.Check(appInfo.SecurityTag(), Equals, "snap.http.GET")
 }
 
+func (s *infoSuite) TestPlugSlotSecurityTags(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`name: name
+apps:
+    app1:
+    app2:
+hooks:
+    hook1:
+plugs:
+    plug:
+slots:
+    slot:
+`))
+	c.Assert(err, IsNil)
+	c.Assert(info.Plugs["plug"].SecurityTags(), DeepEquals, []string{
+		"snap.name.app1", "snap.name.app2", "snap.name.hook.hook1"})
+	c.Assert(info.Slots["slot"].SecurityTags(), DeepEquals, []string{
+		"snap.name.app1", "snap.name.app2"})
+}
+
 func (s *infoSuite) TestAppInfoWrapperPath(c *C) {
 	info, err := snap.InfoFromSnapYaml([]byte(`name: foo
 apps:


### PR DESCRIPTION
This patch adds two trivial methods that obtain a list of security tags
related to a given plug or a given slot. Those are going to be used by
various security backends.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>