### PR TITLE
interfaces: allow querying added security backends

### DIFF
--- a/interfaces/ifacetest/backend.go
+++ b/interfaces/ifacetest/backend.go
@@ -26,6 +26,7 @@ import (
 
 // TestSecurityBackend is a security backend intended for testing.
 type TestSecurityBackend struct {
+	BackendName interfaces.SecuritySystem
 	// SetupCalls stores information about all calls to Setup
 	SetupCalls []TestSetupCall
 	// RemoveCalls stores information about all calls to Remove
@@ -46,7 +47,7 @@ type TestSetupCall struct {
 
 // Name returns the name of the security backend.
 func (b *TestSecurityBackend) Name() interfaces.SecuritySystem {
-	return "test"
+	return b.BackendName
 }
 
 // Setup records information about the call and calls the setup callback if one is defined.

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -611,6 +611,19 @@ func (r *Repository) disconnect(plug *Plug, slot *Slot) {
 	}
 }
 
+// Backends returns all the security backends.
+func (r *Repository) Backends() []SecurityBackend {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	var result []SecurityBackend
+	for _, backend := range r.backends {
+		result = append(result, backend)
+	}
+	sort.Sort(byBackendName(result))
+	return result
+}
+
 // Interfaces returns object holding a lists of all the plugs and slots and their connections.
 func (r *Repository) Interfaces() *Interfaces {
 	r.m.Lock()

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -616,7 +616,7 @@ func (r *Repository) Backends() []SecurityBackend {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	var result []SecurityBackend
+	result := make([]SecurityBackend, 0, len(r.backends))
 	for _, backend := range r.backends {
 		result = append(result, backend)
 	}

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -142,6 +142,14 @@ func (s *RepositorySuite) TestAddBackend(c *C) {
 	c.Assert(err, ErrorMatches, `cannot add backend "test", security system name is in use`)
 }
 
+func (s *RepositorySuite) TestBackends(c *C) {
+	b1 := &ifacetest.TestSecurityBackend{BackendName: "b1"}
+	b2 := &ifacetest.TestSecurityBackend{BackendName: "b2"}
+	c.Assert(s.emptyRepo.AddBackend(b2), IsNil)
+	c.Assert(s.emptyRepo.AddBackend(b1), IsNil)
+	c.Assert(s.emptyRepo.Backends(), DeepEquals, []SecurityBackend{b1, b2})
+}
+
 // Tests for Repository.Interface()
 
 func (s *RepositorySuite) TestInterface(c *C) {

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -136,7 +136,7 @@ func (s *RepositorySuite) TestAddInterfaceInvalidName(c *C) {
 }
 
 func (s *RepositorySuite) TestAddBackend(c *C) {
-	backend := &ifacetest.TestSecurityBackend{}
+	backend := &ifacetest.TestSecurityBackend{BackendName: "test"}
 	c.Assert(s.emptyRepo.AddBackend(backend), IsNil)
 	err := s.emptyRepo.AddBackend(backend)
 	c.Assert(err, ErrorMatches, `cannot add backend "test", security system name is in use`)
@@ -1349,7 +1349,8 @@ func (s *RepositorySuite) TestSlotSnippetsForSnapSuccess(c *C) {
 
 func (s *RepositorySuite) TestSnapSpecification(c *C) {
 	repo := s.emptyRepo
-	c.Assert(repo.AddBackend(&ifacetest.TestSecurityBackend{}), IsNil)
+	backend := &ifacetest.TestSecurityBackend{BackendName: testSecurity}
+	c.Assert(repo.AddBackend(backend), IsNil)
 	c.Assert(repo.AddInterface(testInterface), IsNil)
 	c.Assert(repo.AddPlug(s.plug), IsNil)
 	c.Assert(repo.AddSlot(s.slot), IsNil)

--- a/interfaces/sorting.go
+++ b/interfaces/sorting.go
@@ -62,3 +62,14 @@ func (c bySlotSnapAndName) Less(i, j int) bool {
 	}
 	return c[i].Name < c[j].Name
 }
+
+type byBackendName []SecurityBackend
+
+func (c byBackendName) Len() int      { return len(c) }
+func (c byBackendName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c byBackendName) Less(i, j int) bool {
+	if c[i].Name() != c[j].Name() {
+		return c[i].Name() < c[j].Name()
+	}
+	return c[i].Name() < c[j].Name()
+}


### PR DESCRIPTION
This branch adds a simple method to return a list of registered security
backends from a given repository. This will be subsequently used to decouple
the interfaces/backends.All from overlord/ifacestate that currently uses it.
The interface manager will simply refer to the backends that the repository
knows about.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>