### PR TITLE
cmd: fix hardcoded paths to rst2man and support rst2man.py

### DIFF
--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -162,7 +162,7 @@ AS_IF([test "x$enable_caps_over_setuid" = "xyes"], [
     AC_DEFINE([CAPS_OVER_SETUID], [1],
         [Use capabilities rather than setuid bit])])
 
-AC_PATH_PROG([HAVE_RST2MAN],[rst2man])
+AC_PATH_PROGS([HAVE_RST2MAN],[rst2man rst2man.py])
 AS_IF([test "x$HAVE_RST2MAN" = "x"], [AC_MSG_ERROR(["cannot find the rst2man tool, install python-docutils or similar"])])
 
 AC_CONFIG_FILES([Makefile snap-confine/Makefile snap-confine/tests/Makefile snap-confine/manpages/Makefile])

--- a/cmd/snap-confine/manpages/Makefile.am
+++ b/cmd/snap-confine/manpages/Makefile.am
@@ -4,7 +4,7 @@ CLEANFILES = snap-confine.5 snap-discard-ns.5 ubuntu-core-launcher.1
 EXTRA_DIST = snap-confine.rst snap-discard-ns.rst ubuntu-core-launcher.rst
 
 %.5: %.rst
-	rst2man $^ > $@
+	$(HAVE_RST2MAN) $^ > $@
 
 ubuntu-core-launcher.1: ubuntu-core-launcher.rst
-	rst2man $^ > $@
+	$(HAVE_RST2MAN) $^ > $@


### PR DESCRIPTION
On gentoo the `rst2man` script is actually called `rst2man.py`. The build system offered no way to use an alternate name and even if an alternate name was found the executable name was hard-coded. This patch fixes both of those issues.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
