### PR TITLE
spread: exclude .o and .a files

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -154,6 +154,8 @@ exclude:
     - cmd/snapd/snapd
     - cmd/snapctl/snapctl
     - cmd/snap-exec/snap-exec
+    - "*.o"
+    - "*.a"
 
 prepare-each: |
     # systemd on 14.04 does not know about --rotate


### PR DESCRIPTION
Those files sometimes cause build failures as timestamps may be skewed and architectures may not match (e.g. i386 build typically fails when the tree contains amd64 build artifacts). In addition sending them is wasteful as they are typically big.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>