### PR TITLE
tests: fix failing snapd-reexec test

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -299,6 +299,11 @@ suites:
             else
                 prepare_classic
             fi
+        prepare-each: |
+            . $TESTSLIB/prepare.sh
+            if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then
+                prepare_each_classic
+            fi
         restore: |
             $TESTSLIB/reset.sh
             if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -2,9 +2,6 @@ summary: Test that snapd reexecs itself into core
 
 systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
 
-environment:
-    SNAPD_CONF: /etc/systemd/system/snapd.service.d/local.conf 
-
 restore: |
     # extra cleanup in case something in this test went wrong
     rm -f /etc/systemd/system/snapd.service.d/no-reexec.conf
@@ -41,7 +38,7 @@ execute: |
     umount /snap/core/current/usr/lib/snapd/info
 
     echo "Ensure SNAP_REEXEC=0 is honored for snapd"
-    cat > /etc/systemd/system/snapd.service.d/no-reexec.conf <<EOF
+    cat > /etc/systemd/system/snapd.service.d/reexec.conf <<EOF
     [Service]
     Environment=SNAP_REEXEC=0
     EOF
@@ -62,7 +59,7 @@ execute: |
     echo "Revert back to normal"
     systemctl stop snapd.service snapd.socket
     umount /snap/core/current/usr/lib/snapd/snapd
-    rm -f /etc/systemd/system/snapd.service.d/no-reexec.conf
+    rm -f /etc/systemd/system/snapd.service.d/reexec.conf
     systemctl daemon-reload
     systemctl start snapd.service snapd.socket
 


### PR DESCRIPTION
The prepare was not run in the right prepare leading to stale systemd reexec.conf settings.

This should fix it, lets see if travis agrees :)