### PR TITLE
cmd: add autogen.sh

### DIFF
--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Welcome to the Happy Maintainer's Utility Script
+set -eux
+
+# We need the VERSION file to configure
+if [ ! -e VERSION ]; then
+	( cd .. && ./mkversion.sh )
+fi
+
+# Sanity check, are we in the right directory?
+test -f configure.ac
+
+# Regenerate the build system
+rm -f config.status
+autoreconf -i -f
+
+# Configure the build
+extra_opts=
+. /etc/os-release
+case "$ID" in
+	arch)
+		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-arch"
+		;;
+	debian)
+		extra_opts="--libexecdir=/usr/lib/snapd"
+		;;
+	ubuntu)
+		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-ubuntu"
+		;;
+esac
+
+./configure --enable-maintainer-mode --prefix=/usr $extra_opts


### PR DESCRIPTION
This patch adds a "OMG I don't know how to use autotools" utility script
that facilitates bootstrapping the development cycle of the C side of
snapd.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>