### PR TITLE
many: extract the logging http client and user-agent handling for use in devicestate

### DIFF
--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -35,15 +35,15 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/store"
 )
 
 func init() {
 	// set User-Agent for when 'snap' talks to the store directly (snap download etc...)
-	store.SetUserAgentFromVersion(cmd.Version, "snap")
+	httputil.SetUserAgentFromVersion(cmd.Version, "snap")
 }
 
 // Standard streams, redirected for testing.

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/store"
 )
 
 func init() {
@@ -47,7 +47,7 @@ func main() {
 }
 
 func run() error {
-	store.SetUserAgentFromVersion(cmd.Version)
+	httputil.SetUserAgentFromVersion(cmd.Version)
 
 	d, err := daemon.New()
 	if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -35,13 +35,13 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/store"
 )
 
 // A Daemon listens for requests and routes them to the right command
@@ -248,7 +248,7 @@ func (d *Daemon) Init() error {
 	d.addRoutes()
 
 	logger.Debugf("init done in %s", time.Now().Sub(t0))
-	logger.Noticef("started %v.", store.UserAgent())
+	logger.Noticef("started %v.", httputil.UserAgent())
 
 	return nil
 }

--- a/httputil/export_test.go
+++ b/httputil/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,19 +17,14 @@
  *
  */
 
-package store
+package httputil
 
-import (
-	"github.com/snapcore/snapd/testutil"
+var GetFlags = (*LoggedTransport).getFlags
 
-	"gopkg.in/retry.v1"
-)
-
-// MockDefaultRetryStrategy mocks the retry strategy used by several store requests
-func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
-	originalDefaultRetryStrategy := defaultRetryStrategy
-	defaultRetryStrategy = strategy
-	t.AddCleanup(func() {
-		defaultRetryStrategy = originalDefaultRetryStrategy
-	})
+func MockUserAgent(mock string) (restore func()) {
+	old := userAgent
+	userAgent = mock
+	return func() {
+		userAgent = old
+	}
 }

--- a/httputil/logger.go
+++ b/httputil/logger.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
  *
  */
 
-package store
+package httputil
 
 import (
 	"errors"
@@ -87,16 +87,16 @@ func (tr *LoggedTransport) getFlags() debugflag {
 	return debugflag(flags)
 }
 
-type httpClientOpts struct {
+type ClientOpts struct {
 	Timeout    time.Duration
 	MayLogBody bool
 }
 
-// returns a new http.Client with a LoggedTransport, a Timeout and preservation
-// of range requests across redirects
-func newHTTPClient(opts *httpClientOpts) *http.Client {
+// NewHTTPCLient returns a new http.Client with a LoggedTransport, a
+// Timeout and preservation of range requests across redirects
+func NewHTTPClient(opts *ClientOpts) *http.Client {
 	if opts == nil {
-		opts = &httpClientOpts{}
+		opts = &ClientOpts{}
 	}
 
 	return &http.Client{

--- a/httputil/logger_test.go
+++ b/httputil/logger_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,7 +17,7 @@
  *
  */
 
-package store_test
+package httputil_test
 
 import (
 	"bytes"
@@ -26,13 +26,16 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"testing"
 
 	"gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 )
+
+func TestHTTPUtil(t *testing.T) { check.TestingT(t) }
 
 type loggerSuite struct {
 	logbuf *bytes.Buffer
@@ -54,17 +57,17 @@ func (s *loggerSuite) SetUpTest(c *check.C) {
 
 func (loggerSuite) TestFlags(c *check.C) {
 	for _, f := range []interface{}{
-		store.DebugRequest,
-		store.DebugResponse,
-		store.DebugBody,
-		store.DebugRequest | store.DebugResponse | store.DebugBody,
+		httputil.DebugRequest,
+		httputil.DebugResponse,
+		httputil.DebugBody,
+		httputil.DebugRequest | httputil.DebugResponse | httputil.DebugBody,
 	} {
 		os.Setenv("TEST_FOO", fmt.Sprintf("%d", f))
-		tr := &store.LoggedTransport{
+		tr := &httputil.LoggedTransport{
 			Key: "TEST_FOO",
 		}
 
-		c.Check(store.GetFlags(tr), check.Equals, f)
+		c.Check(httputil.GetFlags(tr), check.Equals, f)
 	}
 }
 
@@ -85,7 +88,7 @@ func (s loggerSuite) TestLogging(c *check.C) {
 		Status:     "999 WAT",
 		StatusCode: 999,
 	}
-	tr := &store.LoggedTransport{
+	tr := &httputil.LoggedTransport{
 		Transport: &fakeTransport{
 			rsp: rsp,
 		},
@@ -113,7 +116,7 @@ func (s loggerSuite) TestNotLoggingOctetStream(c *check.C) {
 		},
 		Body: ioutil.NopCloser(strings.NewReader(needle)),
 	}
-	tr := &store.LoggedTransport{
+	tr := &httputil.LoggedTransport{
 		Transport: &fakeTransport{
 			rsp: rsp,
 		},

--- a/httputil/useragent.go
+++ b/httputil/useragent.go
@@ -1,0 +1,69 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package httputil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
+)
+
+// UserAgent to send
+// TODO: this should actually be set per client request, and include the client user agent
+var userAgent = "unset"
+
+var isTesting bool
+
+func init() {
+	if osutil.GetenvBool("SNAPPY_TESTING") {
+		isTesting = true
+	}
+}
+
+// SetUserAgentFromVersion sets up a user-agent string.
+func SetUserAgentFromVersion(version string, extraProds ...string) {
+	extras := make([]string, 1, 3)
+	extras[0] = "series " + release.Series
+	if release.OnClassic {
+		extras = append(extras, "classic")
+	}
+	if release.ReleaseInfo.ForceDevMode() {
+		extras = append(extras, "devmode")
+	}
+	if isTesting {
+		extras = append(extras, "testing")
+	}
+	extraProdStr := ""
+	if len(extraProds) != 0 {
+		extraProdStr = " " + strings.Join(extraProds, " ")
+	}
+	// xxx this assumes ReleaseInfo's ID and VersionID don't have weird characters
+	// (see rfc 7231 for values of weird)
+	// assumption checks out in practice, q.v. https://github.com/zyga/os-release-zoo
+	userAgent = fmt.Sprintf("snapd/%v (%s)%s %s/%s (%s)", version, strings.Join(extras, "; "), extraProdStr, release.ReleaseInfo.ID, release.ReleaseInfo.VersionID, string(arch.UbuntuArchitecture()))
+}
+
+// UserAgent returns the user-agent string setup through SetUserAgentFromVersion.
+func UserAgent() string {
+	return userAgent
+}

--- a/httputil/useragent_test.go
+++ b/httputil/useragent_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -17,19 +17,36 @@
  *
  */
 
-package store
+package httputil_test
 
 import (
-	"github.com/snapcore/snapd/testutil"
+	"strings"
 
-	"gopkg.in/retry.v1"
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/httputil"
 )
 
-// MockDefaultRetryStrategy mocks the retry strategy used by several store requests
-func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
-	originalDefaultRetryStrategy := defaultRetryStrategy
-	defaultRetryStrategy = strategy
-	t.AddCleanup(func() {
-		defaultRetryStrategy = originalDefaultRetryStrategy
-	})
+type UASuite struct {
+	restore func()
+}
+
+var _ = Suite(&UASuite{})
+
+func (s *UASuite) SetUpTest(c *C) {
+	s.restore = httputil.MockUserAgent("-")
+}
+
+func (s *UASuite) TearDownTest(c *C) {
+	s.restore()
+}
+
+func (s *UASuite) TestUserAgent(c *C) {
+	httputil.SetUserAgentFromVersion("10")
+	ua := httputil.UserAgent()
+	c.Check(strings.HasPrefix(ua, "snapd/10 "), Equals, true)
+
+	httputil.SetUserAgentFromVersion("10", "extraProd")
+	ua = httputil.UserAgent()
+	c.Check(strings.Contains(ua, "extraProd"), Equals, true)
 }

--- a/httputil/withtestkeys.go
+++ b/httputil/withtestkeys.go
@@ -2,7 +2,7 @@
 // +build withtestkeys
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -18,7 +18,7 @@
  *
  */
 
-package store
+package httputil
 
 func init() {
 	// mark as testing if we carry testing keys

--- a/osutil/mount.go
+++ b/osutil/mount.go
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package osutil
 
 import (

--- a/overlord/devicestate/devicemgr_test.go
+++ b/overlord/devicestate/devicemgr_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -179,18 +180,23 @@ func (s *deviceMgrSuite) settle() {
 }
 
 func (s *deviceMgrSuite) mockServer(c *C, reqID string) *httptest.Server {
+	expectedUserAgent := httputil.UserAgent()
+
 	var mu sync.Mutex
 	count := 0
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/identity/api/v1/request-id":
 			w.WriteHeader(http.StatusOK)
+			c.Check(r.Header.Get("User-Agent"), Equals, expectedUserAgent)
 			io.WriteString(w, fmt.Sprintf(`{"request-id": "%s"}`, reqID))
 
 		case "/identity/api/v1/serial":
 			c.Check(r.Header.Get("X-Extra-Header"), Equals, "extra")
 			fallthrough
 		case "/identity/api/v1/devices":
+			c.Check(r.Header.Get("User-Agent"), Equals, expectedUserAgent)
+
 			mu.Lock()
 			serialNum := 9999 + count
 			count++

--- a/store/auth.go
+++ b/store/auth.go
@@ -28,6 +28,8 @@ import (
 	"net/http"
 
 	"gopkg.in/macaroon.v1"
+
+	"github.com/snapcore/snapd/httputil"
 )
 
 var (
@@ -94,7 +96,7 @@ func requestStoreMacaroon() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", httputil.UserAgent())
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 
@@ -135,7 +137,7 @@ func requestDischargeMacaroon(endpoint string, data map[string]string) (string, 
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", httputil.UserAgent())
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 
@@ -218,7 +220,7 @@ func requestStoreDeviceNonce() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", httputil.UserAgent())
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := httpClient.Do(req)
@@ -263,7 +265,7 @@ func requestDeviceSession(serialAssertion, sessionRequest, previousSession strin
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", httputil.UserAgent())
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	if previousSession != "" {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -945,6 +946,10 @@ func (t *remoteRepoTestSuite) TestApplyDelta(c *C) {
 		c.Assert(os.Remove(deltaPath), IsNil)
 	}
 }
+
+var (
+	userAgent = httputil.UserAgent()
+)
 
 func (t *remoteRepoTestSuite) TestDoRequestSetsAuth(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/store/userinfo.go
+++ b/store/userinfo.go
@@ -27,10 +27,12 @@ import (
 	"time"
 
 	"gopkg.in/retry.v1"
+
+	"github.com/snapcore/snapd/httputil"
 )
 
 var (
-	httpClient = newHTTPClient(&httpClientOpts{
+	httpClient = httputil.NewHTTPClient(&httputil.ClientOpts{
 		Timeout:    10 * time.Second,
 		MayLogBody: true,
 	})

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/asserts/systestkeys"
+	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
@@ -71,7 +72,7 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 	mux := http.NewServeMux()
 	var sto *store.Store
 	if assertFallback {
-		store.SetUserAgentFromVersion("unknown", "fakestore")
+		httputil.SetUserAgentFromVersion("unknown", "fakestore")
 		sto = store.New(nil, nil)
 	}
 	store := &Store{


### PR DESCRIPTION
This moves the http logging client to httputil, and also moves the basics of user-agent handling.
Then these are used from devicestate as well with the device registration HTTP requests.