### PR TITLE
spread: refresh apt cache before first install

### DIFF
--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -35,6 +35,8 @@ if [ "$SPREAD_BACKEND" = qemu ]; then
    fi
 fi
 
+quiet apt-get update
+
 if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
     if [ ! -d debian-ubuntu-14.04 ]; then
         echo "no debian-ubuntu-14.04/ directory "
@@ -46,7 +48,6 @@ if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
     rm -rf debian
     mv debian-ubuntu-14.04 debian
 
-    quiet apt-get update
     quiet apt-get install -y software-properties-common
 
     echo 'deb http://archive.ubuntu.com/ubuntu/ trusty-proposed main universe' >> /etc/apt/sources.list


### PR DESCRIPTION
The apt cache that comes with various image is always somewhat stale. If
we are lucky we may not notice this. If the package we wish to install
gets updated an "apt-get install" command will complain about 404 error.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>