### PR TITLE
interfaces: network-manager: allow rw access to /etc/netplan

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -69,6 +69,12 @@ network packet,
 
 /run/udev/data/* r,
 
+# Allow read and write access for all netplan configuration files
+# as NetworkManager will start using them to store the network
+# configuration instead of using its own internal keyfile based
+# format.
+/etc/netplan/{,**} rw,
+
 # Allow access to configuration files generated on the fly
 # from netplan and let NetworkManager store its DHCP leases
 # in the dhcp subdirectory so that console-conf can access


### PR DESCRIPTION
Allow read and write access for all netplan configuration files as NetworkManager will start using them to store the network configuration instead of using its own internal keyfile based format.