### PR TITLE
speed up unit test run by doing "go test -i" before go test itself.

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -134,6 +134,7 @@ if [ "$UNIT" = 1 ]; then
     # tests
     echo Running tests from $(pwd)
     for pkg in $(go list ./... | grep -v '/vendor/' ); do
+        go test -i $pkg
         $goctest -v -coverprofile=.coverage/profile.out $pkg
         append_coverage .coverage/profile.out
     done


### PR DESCRIPTION
this cuts the unit test run in half, on my machine at least.