### PR TITLE
cmd: move seccomp cleanup function to seccomp-support

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -280,8 +280,6 @@ snap_discard_ns_snap_discard_ns_SOURCES = \
 snap_discard_ns_snap_discard_ns_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_discard_ns_snap_discard_ns_LDFLAGS = $(AM_LDFLAGS)
 snap_discard_ns_snap_discard_ns_LDADD = libsnap-confine-private.a
-snap_discard_ns_snap_discard_ns_CFLAGS += $(SECCOMP_CFLAGS)
-snap_discard_ns_snap_discard_ns_LDADD += $(SECCOMP_LIBS)
 
 if APPARMOR
 snap_discard_ns_snap_discard_ns_CFLAGS += $(APPARMOR_CFLAGS)

--- a/cmd/snap-confine/cleanup-funcs.c
+++ b/cmd/snap-confine/cleanup-funcs.c
@@ -37,13 +37,6 @@ void sc_cleanup_endmntent(FILE ** ptr)
 		endmntent(*ptr);
 }
 
-#ifdef HAVE_SECCOMP
-void sc_cleanup_seccomp_release(scmp_filter_ctx * ptr)
-{
-	seccomp_release(*ptr);
-}
-#endif				// HAVE_SECCOMP
-
 void sc_cleanup_closedir(DIR ** ptr)
 {
 	if (*ptr != NULL) {

--- a/cmd/snap-confine/cleanup-funcs.h
+++ b/cmd/snap-confine/cleanup-funcs.h
@@ -24,9 +24,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#ifdef HAVE_SECCOMP
-#include <seccomp.h>
-#endif				// HAVE_SECCOMP
 #include <sys/types.h>
 #include <dirent.h>
 
@@ -53,16 +50,6 @@ void sc_cleanup_file(FILE ** ptr);
  * __attribute__((cleanup(sc_cleanup_endmntent))).
  **/
 void sc_cleanup_endmntent(FILE ** ptr);
-
-#ifdef HAVE_SECCOMP
-/**
- * Release a seccomp context with seccomp_release(3)
- *
- * This function is designed to be used with
- * __attribute__((cleanup(sc_cleanup_seccomp_release))).
- **/
-void sc_cleanup_seccomp_release(scmp_filter_ctx * ptr);
-#endif				// HAVE_SECCOMP
 
 /**
  * Close an open directory with closedir(3)

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -757,3 +757,8 @@ void sc_load_seccomp_context(scmp_filter_ctx ctx)
 			die("dropping privs after seccomp_load did not work");
 	}
 }
+
+void sc_cleanup_seccomp_release(scmp_filter_ctx * ptr)
+{
+	seccomp_release(*ptr);
+}

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -42,4 +42,12 @@ scmp_filter_ctx sc_prepare_seccomp_context(const char *security_tag);
  **/
 void sc_load_seccomp_context(scmp_filter_ctx ctx);
 
+/**
+ * Release a seccomp context with seccomp_release(3)
+ *
+ * This function is designed to be used with
+ * __attribute__((cleanup(sc_cleanup_seccomp_release))).
+ **/
+void sc_cleanup_seccomp_release(scmp_filter_ctx * ptr);
+
 #endif


### PR DESCRIPTION
The seccomp cleanup function was incorrectly placed in
cleanup-funcs.[ch] which caused anything that needed to include it
(almost everything) to also link to libseccomp unless disabled at
configuration time. This was annoying and wasteful so let's couple
seccomp cleanup with other seccomp specific functionality.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>