### PR TITLE
tests: ensure systemd override directory is available before using it

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -58,6 +58,7 @@ prepare_each_classic() {
     if [ -z "${SNAP_REEXEC:-}" ]; then
         rm -f /etc/systemd/system/snapd.service.d/reexec.conf
     else
+        mkdir -p /etc/systemd/system/snapd.service.d
         cat <<EOF > /etc/systemd/system/snapd.service.d/reexec.conf
 [Service]
 Environment=SNAP_REEXEC=$SNAP_REEXEC


### PR DESCRIPTION
I got a test failure where this dir is missing in https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-xenial-snappy-dev-image/xenial/i386/s/snapd/20170120_090606_a715e@/log.gz