### PR TITLE
tests: use higher version number during tests

### DIFF
--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -74,10 +74,8 @@ if [ "$(which govendor)" = "" ]; then
 fi
 quiet govendor sync
 
-# increment version so upgrade can work, use "zzz" as version
-# component to ensure that its higher than any "ubuntuN" version
-# that might also be in the archive
-dch -lzzz "testing build"
+# Use fake version to ensure we are always bigger than anything else
+dch --newversion "1337.$(dpkg-parsechangelog --show-field Version)" "testing build"
 
 if ! id test >& /dev/null; then
    # manually setting the UID and GID to 12345 because we need to


### PR DESCRIPTION
This ensures that when we test a local build against an unmodified core we still use the local build.