### PR TITLE
cmd: ensure that all .c files have a -test.c file

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -83,16 +83,17 @@ libsnap_confine_private_a_SOURCES = \
 if WITH_UNIT_TESTS
 noinst_PROGRAMS += libsnap-confine-private/unit-tests
 libsnap_confine_private_unit_tests_SOURCES = \
-	libsnap-confine-private/classic.c \
-	libsnap-confine-private/classic.h \
+	libsnap-confine-private/classic-test.c \
 	libsnap-confine-private/cleanup-funcs-test.c \
+	libsnap-confine-private/error-test.c \
 	libsnap-confine-private/mount-opt-test.c \
 	libsnap-confine-private/mountinfo-test.c \
+	libsnap-confine-private/secure-getenv-test.c \
+	libsnap-confine-private/snap-test.c \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
 	libsnap-confine-private/unit-tests.h \
 	libsnap-confine-private/utils-test.c
-	libsnap-confine-private/verify-executable-name-test.c
 libsnap_confine_private_unit_tests_CFLAGS = $(GLIB_CFLAGS)
 libsnap_confine_private_unit_tests_LDADD = $(GLIB_LIBS)
 endif

--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "classic.h"
+#include "classic.c"
+
+#include <glib.h>
+
+// TODO: write some tests

--- a/cmd/libsnap-confine-private/secure-getenv-test.c
+++ b/cmd/libsnap-confine-private/secure-getenv-test.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "secure-getenv.h"
+#include "secure-getenv.c"
+
+#include <glib.h>
+
+// TODO: write some tests

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
Since each foo-test.c includes both foo.c and foo.h (internally) then it
is illegal to link both foo.c and foo-test.c into one program.  To
ensure there are no odd mistakes and that nothing is missing we now link
only the foo-test.c files into the test executable.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>