### PR TITLE
cmd: add fault injection support code

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -88,6 +88,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/error-test.c \
 	libsnap-confine-private/mount-opt-test.c \
 	libsnap-confine-private/mountinfo-test.c \
+	libsnap-confine-private/fault-injection-test.c \
 	libsnap-confine-private/secure-getenv-test.c \
 	libsnap-confine-private/snap-test.c \
 	libsnap-confine-private/unit-tests-main.c \
@@ -96,6 +97,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/utils-test.c
 libsnap_confine_private_unit_tests_CFLAGS = $(GLIB_CFLAGS)
 libsnap_confine_private_unit_tests_LDADD = $(GLIB_LIBS)
+libsnap_confine_private_unit_tests_CFLAGS += -D_ENABLE_FAULT_INJECTION
 endif
 
 ##

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -83,16 +83,17 @@ libsnap_confine_private_a_SOURCES = \
 if WITH_UNIT_TESTS
 noinst_PROGRAMS += libsnap-confine-private/unit-tests
 libsnap_confine_private_unit_tests_SOURCES = \
-	libsnap-confine-private/classic.c \
-	libsnap-confine-private/classic.h \
+	libsnap-confine-private/classic-test.c \
 	libsnap-confine-private/cleanup-funcs-test.c \
+	libsnap-confine-private/error-test.c \
 	libsnap-confine-private/mount-opt-test.c \
 	libsnap-confine-private/mountinfo-test.c \
+	libsnap-confine-private/secure-getenv-test.c \
+	libsnap-confine-private/snap-test.c \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
 	libsnap-confine-private/unit-tests.h \
 	libsnap-confine-private/utils-test.c
-	libsnap-confine-private/verify-executable-name-test.c
 libsnap_confine_private_unit_tests_CFLAGS = $(GLIB_CFLAGS)
 libsnap_confine_private_unit_tests_LDADD = $(GLIB_LIBS)
 endif

--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "classic.h"
+#include "classic.c"
+
+#include <glib.h>
+
+// TODO: write some tests

--- a/cmd/libsnap-confine-private/fault-injection-test.c
+++ b/cmd/libsnap-confine-private/fault-injection-test.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fault-injection.h"
+#include "fault-injection.c"
+
+#include <errno.h>
+#include <glib.h>
+
+static bool broken(struct sc_fault_state *state, void *ptr)
+{
+	return true;
+}
+
+static bool broken_alter_msg(struct sc_fault_state *state, void *ptr)
+{
+	char **s = ptr;
+	*s = "broken";
+	return true;
+}
+
+static void test_fault_injection()
+{
+	g_assert_false(sc_faulty("foo", NULL));
+
+	sc_break("foo", broken);
+	g_assert_true(sc_faulty("foo", NULL));
+
+	sc_reset_faults();
+	g_assert_false(sc_faulty("foo", NULL));
+
+	const char *msg = NULL;
+	if (!sc_faulty("foo", &msg)) {
+		msg = "working";
+	}
+	g_assert_cmpstr(msg, ==, "working");
+
+	sc_break("foo", broken_alter_msg);
+	if (!sc_faulty("foo", &msg)) {
+		msg = "working";
+	}
+	g_assert_cmpstr(msg, ==, "broken");
+	sc_reset_faults();
+}
+
+static void __attribute__ ((constructor)) init()
+{
+	g_test_add_func("/fault-injection", test_fault_injection);
+}

--- a/cmd/libsnap-confine-private/fault-injection.c
+++ b/cmd/libsnap-confine-private/fault-injection.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fault-injection.h"
+
+#ifdef _ENABLE_FAULT_INJECTION
+
+#include <stdlib.h>
+#include <string.h>
+
+struct sc_fault {
+	const char *name;
+	struct sc_fault *next;
+	sc_fault_fn fn;
+	struct sc_fault_state state;
+};
+
+static struct sc_fault *sc_faults = NULL;
+
+bool sc_faulty(const char *name, void *ptr)
+{
+	for (struct sc_fault * fault = sc_faults; fault != NULL;
+	     fault = fault->next) {
+		if (strcmp(name, fault->name) == 0) {
+			bool is_faulty = fault->fn(&fault->state, ptr);
+			fault->state.ncalls++;
+			return is_faulty;
+		}
+	}
+	return false;
+}
+
+void sc_break(const char *name, sc_fault_fn fn)
+{
+	struct sc_fault *fault = calloc(1, sizeof *fault);
+	if (fault == NULL) {
+		abort();
+	}
+	fault->name = name;
+	fault->next = sc_faults;
+	fault->fn = fn;
+	fault->state.ncalls = 0;
+	sc_faults = fault;
+}
+
+void sc_reset_faults()
+{
+	struct sc_fault *next_fault;
+	for (struct sc_fault * fault = sc_faults; fault != NULL;
+	     fault = next_fault) {
+		next_fault = fault->next;
+		free(fault);
+	}
+	sc_faults = NULL;
+}
+
+#else				// ifndef _ENABLE_FAULT_INJECTION
+
+bool sc_faulty(const char *name, void *ptr)
+{
+	return false;
+}
+
+#endif				// ifndef _ENABLE_FAULT_INJECTION

--- a/cmd/libsnap-confine-private/fault-injection.h
+++ b/cmd/libsnap-confine-private/fault-injection.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_FAULT_INJECTION_H
+#define SNAP_CONFINE_FAULT_INJECTION_H
+
+#include <stdbool.h>
+
+/**
+ * Check for an injected fault.
+ *
+ * The name of the fault must match what was passed to sc_break(). The second
+ * argument can be modified by the fault callback function. The return value
+ * indicates if a fault was injected. It is assumed that once a fault was
+ * injected the passed pointer was used to modify the state in useful way.
+ *
+ * When the pre-processor macro _ENABLE_FAULT_INJECTION is not defined this
+ * function always returns false and does nothing at all.
+ **/
+bool sc_faulty(const char *name, void *ptr);
+
+#ifdef _ENABLE_FAULT_INJECTION
+
+struct sc_fault_state;
+
+typedef bool(*sc_fault_fn) (struct sc_fault_state * state, void *ptr);
+
+struct sc_fault_state {
+	int ncalls;
+};
+
+/**
+ * Inject a fault for testing.
+ *
+ * The name of the fault must match the expected calls to sc_faulty().  The
+ * second argument is a callback that is invoked each time sc_faulty() is
+ * called. It is designed to inspect an argument passed to sc_faulty() and as
+ * well as the state of the fault injection point and return a boolean
+ * indicating that a fault has occured.
+ *
+ * After testing faults should be reset using sc_reset_faults().
+ **/
+
+void sc_break(const char *name, sc_fault_fn fn);
+
+/**
+ * Remove all the injected faults.
+ **/
+void sc_reset_faults();
+
+#endif				// ifndef _ENABLE_FAULT_INJECTION
+
+#endif

--- a/cmd/libsnap-confine-private/fault-injection.h
+++ b/cmd/libsnap-confine-private/fault-injection.h
@@ -50,7 +50,7 @@ struct sc_fault_state {
  * second argument is a callback that is invoked each time sc_faulty() is
  * called. It is designed to inspect an argument passed to sc_faulty() and as
  * well as the state of the fault injection point and return a boolean
- * indicating that a fault has occured.
+ * indicating that a fault has occurred.
  *
  * After testing faults should be reset using sc_reset_faults().
  **/

--- a/cmd/libsnap-confine-private/secure-getenv-test.c
+++ b/cmd/libsnap-confine-private/secure-getenv-test.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "secure-getenv.h"
+#include "secure-getenv.c"
+
+#include <glib.h>
+
+// TODO: write some tests

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
This patch adds simple fault injection code for testing. Outside of unit
tests it does nothing but inside tests it allows to inject faults at a
desired location.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>