### PR TITLE
asserts: implement SuggestFormat to help avoid specifying the wrong format iteration for an assertion

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -720,13 +720,13 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 		return nil, fmt.Errorf("cannot sign %q assertion with format %d higher than max supported format %d", assertType.Name, formatnum, assertType.MaxSupportedFormat())
 	}
 
-	suggestedFormatnum, err := SuggestFormat(assertType, finalHeaders, finalBody)
+	suggestedFormat, err := SuggestFormat(assertType, finalHeaders, finalBody)
 	if err != nil {
 		return nil, err
 	}
 
-	if suggestedFormatnum > formatnum {
-		return nil, fmt.Errorf("cannot sign %q assertion with format set to %d lower than min format %d covering included features", assertType.Name, formatnum, suggestedFormatnum)
+	if suggestedFormat > formatnum {
+		return nil, fmt.Errorf("cannot sign %q assertion with format set to %d lower than min format %d covering included features", assertType.Name, formatnum, suggestedFormat)
 	}
 
 	revision, err := checkRevision(finalHeaders)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -94,6 +94,11 @@ var typeRegistry = map[string]*AssertionType{
 	AccountKeyRequestType.Name:    AccountKeyRequestType,
 }
 
+// Type returns the AssertionType with name or nil
+func Type(name string) *AssertionType {
+	return typeRegistry[name]
+}
+
 var maxSupportedFormat = map[string]int{}
 
 func init() {
@@ -109,9 +114,18 @@ func MockMaxSupportedFormat(assertType *AssertionType, maxFormat int) (restore f
 	}
 }
 
-// Type returns the AssertionType with name or nil
-func Type(name string) *AssertionType {
-	return typeRegistry[name]
+var formatAnalyzer = map[*AssertionType]func(headers map[string]interface{}, body []byte) (formatnum int, err error){
+	SnapDeclarationType: snapDeclarationFormatAnalyze,
+}
+
+// SuggestFormat returns a minimum format that supports the features that would be used by an assertion with the given components.
+func SuggestFormat(assertType *AssertionType, headers map[string]interface{}, body []byte) (formatnum int, err error) {
+	analyzer := formatAnalyzer[assertType]
+	if analyzer == nil {
+		// no analyzer, format 0 is all there is
+		return 0, nil
+	}
+	return analyzer(headers, body)
 }
 
 // Ref expresses a reference to an assertion.
@@ -704,6 +718,15 @@ func assembleAndSign(assertType *AssertionType, headers map[string]interface{}, 
 
 	if formatnum > assertType.MaxSupportedFormat() {
 		return nil, fmt.Errorf("cannot sign %q assertion with format %d higher than max supported format %d", assertType.Name, formatnum, assertType.MaxSupportedFormat())
+	}
+
+	suggestedFormatnum, err := SuggestFormat(assertType, finalHeaders, finalBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if suggestedFormatnum > formatnum {
+		return nil, fmt.Errorf("cannot sign %q assertion with format set to %d lower than min format %d covering included features", assertType.Name, formatnum, suggestedFormatnum)
 	}
 
 	revision, err := checkRevision(finalHeaders)

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -46,6 +46,12 @@ func (as *assertsSuite) TestTypeMaxSupportedFormat(c *C) {
 	c.Check(asserts.Type("test-only").MaxSupportedFormat(), Equals, 1)
 }
 
+func (as *assertsSuite) TestSuggestFormat(c *C) {
+	fmtnum, err := asserts.SuggestFormat(asserts.Type("test-only-2"), nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(fmtnum, Equals, 0)
+}
+
 func (as *assertsSuite) TestRef(c *C) {
 	ref := &asserts.Ref{
 		Type:       asserts.TestOnly2Type,

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -492,6 +492,17 @@ func (safs *signAddFindSuite) TestSignUnsupportedFormat(c *C) {
 	c.Check(a1, IsNil)
 }
 
+func (safs *signAddFindSuite) TestSignInadequateFormat(c *C) {
+	headers := map[string]interface{}{
+		"authority-id":     "canonical",
+		"primary-key":      "a",
+		"format-1-feature": "true",
+	}
+	a1, err := safs.signingDB.Sign(asserts.TestOnlyType, headers, nil, safs.signingKeyID)
+	c.Assert(err, ErrorMatches, `cannot sign "test-only" assertion with format set to 0 lower than min format 1 covering included features`)
+	c.Check(a1, IsNil)
+}
+
 func (safs *signAddFindSuite) TestAddSuperseding(c *C) {
 	headers := map[string]interface{}{
 		"authority-id": "canonical",

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -146,6 +146,12 @@ func init() {
 	typeRegistry[TestOnly2Type.Name] = TestOnly2Type
 	typeRegistry[TestOnlyNoAuthorityType.Name] = TestOnlyNoAuthorityType
 	typeRegistry[TestOnlyNoAuthorityPKType.Name] = TestOnlyNoAuthorityPKType
+	formatAnalyzer[TestOnlyType] = func(headers map[string]interface{}, _ []byte) (int, error) {
+		if _, ok := headers["format-1-feature"]; ok {
+			return 1, nil
+		}
+		return 0, nil
+	}
 }
 
 // AccountKeyIsKeyValidAt exposes isKeyValidAt on AccountKey for tests

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -117,6 +117,15 @@ func (snapdcl *SnapDeclaration) Prerequisites() []*Ref {
 	}
 }
 
+func snapDeclarationFormatAnalyze(headers map[string]interface{}, body []byte) (formatnum int, err error) {
+	_, plugsOk := headers["plugs"]
+	_, slotsOk := headers["slots"]
+	if plugsOk || slotsOk {
+		return 1, nil
+	}
+	return 0, nil
+}
+
 var validAlias = regexp.MustCompile("^[a-zA-Z0-9][-_.a-zA-Z0-9]*$")
 
 func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -170,6 +170,7 @@ func (sds *snapDeclSuite) TestDecodeInvalid(c *C) {
 
 func (sds *snapDeclSuite) TestDecodePlugsAndSlots(c *C) {
 	encoded := `type: snap-declaration
+format: 1
 authority-id: canonical
 series: 16
 snap-id: snap-id-1
@@ -307,6 +308,30 @@ AXNpZw==`
 	c.Assert(slotRule4.AllowInstallation, HasLen, 1)
 	c.Check(slotRule4.AllowInstallation[0].SlotAttributes.Check(nil), ErrorMatches, `attribute "e1".*`)
 	c.Check(slotRule4.AllowInstallation[0].SlotSnapTypes, DeepEquals, []string{"app"})
+}
+
+func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
+	fmtnum, err := asserts.SuggestFormat(asserts.SnapDeclarationType, nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(fmtnum, Equals, 0)
+
+	headers := map[string]interface{}{
+		"plugs": map[string]interface{}{
+			"interface1": "true",
+		},
+	}
+	fmtnum, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
+	c.Assert(err, IsNil)
+	c.Check(fmtnum, Equals, 1)
+
+	headers = map[string]interface{}{
+		"slots": map[string]interface{}{
+			"interface2": "true",
+		},
+	}
+	fmtnum, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
+	c.Assert(err, IsNil)
+	c.Check(fmtnum, Equals, 1)
 }
 
 func prereqDevAccount(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {

--- a/overlord/ifacestate/ifacemgr_test.go
+++ b/overlord/ifacestate/ifacemgr_test.go
@@ -1613,6 +1613,7 @@ slots:
 	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
 
 	s.mockSnapDecl(c, "producer", "producer-publisher", map[string]interface{}{
+		"format": "1",
 		"slots": map[string]interface{}{
 			"test": "true",
 		},


### PR DESCRIPTION
It is also used inside the Sign code path to double check things. 