### PR TITLE
interfaces: builtin: add ssh-control interface

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -87,6 +87,7 @@ var allInterfaces = []interfaces.Interface{
 	NewScreenInhibitControlInterface(),
 	NewShutdownInterface(),
 	NewSnapdControlInterface(),
+	NewSshControlInterface(),
 	NewSystemObserveInterface(),
 	NewSystemTraceInterface(),
 	NewTimeserverControlInterface(),

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -466,6 +466,11 @@ slots:
       slot-snap-type:
         - core
     deny-auto-connection: true
+  ssh-control:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
   system-observe:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/ssh-control.go
+++ b/interfaces/builtin/ssh-control.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const sshControlConnectedPlugAppArmor = `
+# Description: Allow modifying the system SSH configuration
+
+/etc/ssh/sshd_not_to_be_run rw,
+`
+
+// NewSshControlInterface returns a new "ssh-control" interface.
+func NewSshControlInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "ssh-control",
+		connectedPlugAppArmor: sshControlConnectedPlugAppArmor,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/ssh-control_test.go
+++ b/interfaces/builtin/ssh-control_test.go
@@ -1,0 +1,93 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SshControlInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&SshControlInterfaceSuite{
+	iface: builtin.NewSshControlInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Name:      "ssh-control",
+			Interface: "ssh-control",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "ssh-control",
+			Interface: "ssh-control",
+		},
+	},
+})
+
+func (s *SshControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "ssh-control")
+}
+
+func (s *SshControlInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "ssh-control",
+		Interface: "ssh-control",
+	}})
+	c.Assert(err, ErrorMatches, "ssh-control slots are reserved for the operating system snap")
+}
+
+func (s *SshControlInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *SshControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "ssh-control"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "ssh-control"`)
+}
+
+func (s *SshControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *SshControlInterfaceSuite) TestConnectedPlugSnippet(c *C) {
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `/etc/ssh`)
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -57,6 +57,7 @@ var implicitSlots = []string{
 	"removable-media",
 	"shutdown",
 	"snapd-control",
+	"ssh-control",
 	"system-observe",
 	"system-trace",
 	"time-control",

--- a/tests/lib/snaps/ssh-control-consumer/bin/read
+++ b/tests/lib/snaps/ssh-control-consumer/bin/read
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec cat /etc/ssh/sshd_not_to_be_run

--- a/tests/lib/snaps/ssh-control-consumer/bin/write
+++ b/tests/lib/snaps/ssh-control-consumer/bin/write
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo $1 > /etc/ssh/sshd_not_to_be_run

--- a/tests/lib/snaps/ssh-control-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/ssh-control-consumer/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: ssh-control-consumer
+version: 1.0
+summary: Basic ssh-control consumer snap
+description: A basic snap declaring a plug on a ssh-control slot
+
+apps:
+  read:
+    command: bin/read
+    plugs: [ssh-control]
+  write:
+    command: bin/write
+    plugs: [ssh-control]

--- a/tests/main/interfaces-ssh-control/task.yaml
+++ b/tests/main/interfaces-ssh-control/task.yaml
@@ -1,0 +1,36 @@
+summary: Check that SSH configuration accessible through an interface
+
+details: |
+    This test makes sure that a snap using the ssh-control interface can
+    access the system ssh configuration.
+
+systems: [ubuntu-core-16-64]
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    echo "Given a snap declaring a plug on ssh-control is installed"
+    . $TESTSLIB/snaps.sh
+    install_local ssh-control-consumer
+
+    echo "And the ssh-control plug is connected"
+    . "$TESTSLIB/names.sh"
+    snap connect ssh-control-consumer:ssh-control ${core_name}:ssh-control
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    /snap/bin/ssh-control-consumer.write foo
+    test `/snap/bin/ssh-control-consumer.read` = foo


### PR DESCRIPTION
This introduces an interface which gives read-write access to the SSH configuration of the system in /etc/ssh

Currently this is required for the configure hook of the core snap which receives a configuration option to allow disabling the sshd service on a device. As a hook of the core snap is not different than for any other snap it is running fully confined and therefor need the right interfaces to allow things it has to change.

Currently this interface only allows read/write access to /etc/ssh/sshd_not_to_be_run as that is the only thing the hook has to touch. If needed this interface can be extended later to allow access to other things in /etc/ssh