### PR TITLE
interfaces: add systemd-control interface

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -89,6 +89,7 @@ var allInterfaces = []interfaces.Interface{
 	NewSnapdControlInterface(),
 	NewSystemObserveInterface(),
 	NewSystemTraceInterface(),
+	NewSystemdControlInterface(),
 	NewTimeserverControlInterface(),
 	NewTimezoneControlInterface(),
 	NewTpmInterface(),

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -150,6 +150,11 @@ plugs:
   snapd-control:
     allow-installation: false
     deny-auto-connection: true
+  systemd-control:
+    allow-installation:
+      plug-snap-type:
+        - core
+    deny-auto-connection: true
 slots:
   alsa:
     allow-installation:
@@ -472,6 +477,11 @@ slots:
         - core
     deny-auto-connection: true
   system-trace:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+  systemd-control:
     allow-installation:
       slot-snap-type:
         - core

--- a/interfaces/builtin/systemd-control.go
+++ b/interfaces/builtin/systemd-control.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const systemdControlConnectedPlugAppArmor = `
+# Description: Can control existing services via the systemd
+# dbus API (start, stop, restart).
+
+#include <abstractions/dbus-strict>
+
+# Allow connected snaps to start, stop, or restart a single
+# systemd unit either via the global Manager or via the
+# specific unit object.
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.systemd1.Manager
+    member={StartUnit,StopUnit,RestartUnit}
+    peer=(label=unconfined),
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1/unit/**
+    interface=org.freedesktop.systemd1.Unit
+    member={Start,Stop,Restart,TryRestart}
+    peer=(label=unconfined),
+
+# Allow connected snaps to retrieve all or single properties
+# of all available systemd units.
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1/unit/**
+    interface=org.freedesktop.DBus.Properties
+    member=Get{,All}
+    peer=(label=unconfined),
+`
+
+const systemdControlConnectedPlugSecComp = `
+# Description: Can control existing services via the systemd
+# dbus API (start, stop, restart).
+recvfrom
+recvmsg
+send
+sendto
+sendmsg
+`
+
+// NewShutdownInterface returns a new "shutdown" interface.
+func NewSystemdControlInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "systemd-control",
+		connectedPlugAppArmor: systemdControlConnectedPlugAppArmor,
+		connectedPlugSecComp:  systemdControlConnectedPlugSecComp,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/systemd-control_test.go
+++ b/interfaces/builtin/systemd-control_test.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SystemdControlInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&SystemdControlInterfaceSuite{
+	iface: builtin.NewSystemdControlInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Name:      "systemd-control",
+			Interface: "systemd-control",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "systemd-control",
+			Interface: "systemd-control",
+		},
+	},
+})
+
+func (s *SystemdControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "systemd-control")
+}
+
+func (s *SystemdControlInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "systemd-control",
+		Interface: "systemd-control",
+	}})
+	c.Assert(err, ErrorMatches, "systemd-control slots are reserved for the operating system snap")
+}
+
+func (s *SystemdControlInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *SystemdControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "systemd-control"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "systemd-control"`)
+}
+
+func (s *SystemdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *SystemdControlInterfaceSuite) TestConnectedPlugSnippet(c *C) {
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `/org/freedesktop/systemd1`)
+
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `recvfrom`)
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -59,6 +59,7 @@ var implicitSlots = []string{
 	"snapd-control",
 	"system-observe",
 	"system-trace",
+	"systemd-control",
 	"time-control",
 	"timeserver-control",
 	"timezone-control",

--- a/tests/lib/snaps/systemd-control-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/systemd-control-consumer/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: systemd-control-consumer
+version: 1.0
+summary: Basic systemd-control consumer snap
+description: A basic snap declaring a plug on a systemd-control slot
+
+apps:
+  dbus-send:
+    command: bin/dbus-send
+    plugs: [systemd-control]

--- a/tests/main/interfaces-systemd-control/task.yaml
+++ b/tests/main/interfaces-systemd-control/task.yaml
@@ -1,0 +1,70 @@
+summary: Check that systemd is accessible through an interface
+
+details: |
+    This test makes sure that a snap using the systemd-control interface
+    can access systemd properly.
+
+systems: [ubuntu-core-16-64, ubuntu-core-16-arm-32, ubuntu-core-16-arm-64]
+
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    echo "Given a snap declaring a plug on systemd-control is installed"
+    . $TESTSLIB/snaps.sh
+
+    # Copy dbus-send binary into the snap directory so we can use
+    # it from inside the snap.
+    mkdir -p $TESTSLIB/snaps/systemd-control-consumer/bin
+    cp /usr/bin/dbus-send $TESTSLIB/snaps/systemd-control-consumer/bin
+
+    install_local systemd-control-consumer
+
+    echo "And the systemd-control plug is connected"
+    . "$TESTSLIB/names.sh"
+    snap connect systemd-control-consumer:systemd-control ${core_name}
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    rm -f /etc/systemd/system/test-unit.service
+    systemctl daemon-reload
+
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    cat << EOF > /etc/systemd/system/test-unit.service
+    [Unit]
+    Description=Test Unit
+    [Service]
+    Type=oneshot
+    RemainAfterexit=yes
+    ExecStart=/bin/true
+    ExecStop=/bin/false
+    EOF
+    /bin/systemctl daemon-reload
+
+    # Ensure we can start, stop or restart a unit
+    /snap/bin/systemd-control-consumer.dbus-send --system --print-reply \
+        --dest=org.freedesktop.systemd1 \
+        /org/freedesktop/systemd1 \
+        org.freedesktop.systemd1.Manager.StartUnit \
+        string:"test-unit.service" string:"replace"
+    /snap/bin/systemd-control-consumer.dbus-send --system --print-reply \
+        --dest=org.freedesktop.systemd1 \
+        /org/freedesktop/systemd1 \
+        org.freedesktop.systemd1.Manager.StopUnit \
+        string:"test-unit.service" string:"replace"
+    /snap/bin/systemd-control-consumer.dbus-send --system --print-reply \
+        --dest=org.freedesktop.systemd1 \
+        /org/freedesktop/systemd1 \
+        org.freedesktop.systemd1.Manager.RestartUnit \
+        string:"test-unit.service" string:"replace"


### PR DESCRIPTION
Add systemd-control interface which we need for a configure hook of the core snap to restart the sshd service.