### PR TITLE
cmd: rename mountinfo to sc_mountinfo

### DIFF
--- a/cmd/libsnap-confine-private/mountinfo-test.c
+++ b/cmd/libsnap-confine-private/mountinfo-test.c
@@ -24,9 +24,9 @@ static void test_parse_mountinfo_entry__sysfs()
 {
 	const char *line =
 	    "19 25 0:18 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw";
-	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 19);
 	g_assert_cmpint(entry->parent_id, ==, 25);
 	g_assert_cmpint(entry->dev_major, ==, 0);
@@ -48,9 +48,9 @@ static void test_parse_mountinfo_entry__snapd_ns()
 {
 	const char *line =
 	    "104 23 0:19 /snapd/ns /run/snapd/ns rw,nosuid,noexec,relatime - tmpfs tmpfs rw,size=99840k,mode=755";
-	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 104);
 	g_assert_cmpint(entry->parent_id, ==, 23);
 	g_assert_cmpint(entry->dev_major, ==, 0);
@@ -69,9 +69,9 @@ static void test_parse_mountinfo_entry__snapd_mnt()
 {
 	const char *line =
 	    "256 104 0:3 mnt:[4026532509] /run/snapd/ns/hello-world.mnt rw - nsfs nsfs rw";
-	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 256);
 	g_assert_cmpint(entry->parent_id, ==, 104);
 	g_assert_cmpint(entry->dev_major, ==, 0);
@@ -89,7 +89,7 @@ static void test_parse_mountinfo_entry__snapd_mnt()
 static void test_parse_mountinfo_entry__garbage()
 {
 	const char *line = "256 104 0:3";
-	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_null(entry);
 }
 
@@ -97,9 +97,9 @@ static void test_parse_mountinfo_entry__no_tags()
 {
 	const char *line =
 	    "1 2 3:4 root mount-dir mount-opts - fs-type mount-source super-opts";
-	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 1);
 	g_assert_cmpint(entry->parent_id, ==, 2);
 	g_assert_cmpint(entry->dev_major, ==, 3);
@@ -118,9 +118,9 @@ static void test_parse_mountinfo_entry__one_tag()
 {
 	const char *line =
 	    "1 2 3:4 root mount-dir mount-opts tag:1 - fs-type mount-source super-opts";
-	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 1);
 	g_assert_cmpint(entry->parent_id, ==, 2);
 	g_assert_cmpint(entry->dev_major, ==, 3);
@@ -139,9 +139,9 @@ static void test_parse_mountinfo_entry__two_tags()
 {
 	const char *line =
 	    "1 2 3:4 root mount-dir mount-opts tag:1 tag:2 - fs-type mount-source super-opts";
-	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
 	g_assert_cmpint(entry->mount_id, ==, 1);
 	g_assert_cmpint(entry->parent_id, ==, 2);
 	g_assert_cmpint(entry->dev_major, ==, 3);
@@ -160,22 +160,22 @@ static void test_accessor_funcs()
 {
 	const char *line =
 	    "256 104 0:3 mnt:[4026532509] /run/snapd/ns/hello-world.mnt rw - nsfs nsfs rw";
-	struct mountinfo_entry *entry = parse_mountinfo_entry(line);
+	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
 	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) free_mountinfo_entry, entry);
-	g_assert_cmpint(mountinfo_entry_mount_id(entry), ==, 256);
-	g_assert_cmpint(mountinfo_entry_parent_id(entry), ==, 104);
-	g_assert_cmpint(mountinfo_entry_dev_major(entry), ==, 0);
-	g_assert_cmpint(mountinfo_entry_dev_minor(entry), ==, 3);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
+	g_assert_cmpint(sc_mountinfo_entry_mount_id(entry), ==, 256);
+	g_assert_cmpint(sc_mountinfo_entry_parent_id(entry), ==, 104);
+	g_assert_cmpint(sc_mountinfo_entry_dev_major(entry), ==, 0);
+	g_assert_cmpint(sc_mountinfo_entry_dev_minor(entry), ==, 3);
 
-	g_assert_cmpstr(mountinfo_entry_root(entry), ==, "mnt:[4026532509]");
-	g_assert_cmpstr(mountinfo_entry_mount_dir(entry), ==,
+	g_assert_cmpstr(sc_mountinfo_entry_root(entry), ==, "mnt:[4026532509]");
+	g_assert_cmpstr(sc_mountinfo_entry_mount_dir(entry), ==,
 			"/run/snapd/ns/hello-world.mnt");
-	g_assert_cmpstr(mountinfo_entry_mount_opts(entry), ==, "rw");
-	g_assert_cmpstr(mountinfo_entry_optional_fields(entry), ==, "");
-	g_assert_cmpstr(mountinfo_entry_fs_type(entry), ==, "nsfs");
-	g_assert_cmpstr(mountinfo_entry_mount_source(entry), ==, "nsfs");
-	g_assert_cmpstr(mountinfo_entry_super_opts(entry), ==, "rw");
+	g_assert_cmpstr(sc_mountinfo_entry_mount_opts(entry), ==, "rw");
+	g_assert_cmpstr(sc_mountinfo_entry_optional_fields(entry), ==, "");
+	g_assert_cmpstr(sc_mountinfo_entry_fs_type(entry), ==, "nsfs");
+	g_assert_cmpstr(sc_mountinfo_entry_mount_source(entry), ==, "nsfs");
+	g_assert_cmpstr(sc_mountinfo_entry_super_opts(entry), ==, "rw");
 }
 
 static void __attribute__ ((constructor)) init()

--- a/cmd/libsnap-confine-private/mountinfo.c
+++ b/cmd/libsnap-confine-private/mountinfo.c
@@ -83,9 +83,6 @@ static void sc_free_mountinfo(struct sc_mountinfo *info)
 static void sc_free_mountinfo_entry(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
-static void cleanup_fclose(FILE ** ptr);
-static void cleanup_free(char **ptr);
-
 struct sc_mountinfo_entry *sc_first_mountinfo_entry(struct sc_mountinfo *info)
 {
 	return info->first;
@@ -161,12 +158,13 @@ struct sc_mountinfo *sc_parse_mountinfo(const char *fname)
 	if (fname == NULL) {
 		fname = "/proc/self/mountinfo";
 	}
-	FILE *f __attribute__ ((cleanup(cleanup_fclose))) = fopen(fname, "rt");
+	FILE *f __attribute__ ((cleanup(sc_cleanup_file))) = NULL;
+	f = fopen(fname, "rt");
 	if (f == NULL) {
 		free(info);
 		return NULL;
 	}
-	char *line __attribute__ ((cleanup(cleanup_free))) = NULL;
+	char *line __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
 	size_t line_size = 0;
 	struct sc_mountinfo_entry *entry, *last = NULL;
 	for (;;) {
@@ -286,14 +284,4 @@ static void sc_free_mountinfo(struct sc_mountinfo *info)
 static void sc_free_mountinfo_entry(struct sc_mountinfo_entry *entry)
 {
 	free(entry);
-}
-
-static void cleanup_fclose(FILE ** ptr)
-{
-	fclose(*ptr);
-}
-
-static void cleanup_free(char **ptr)
-{
-	free(*ptr);
 }

--- a/cmd/libsnap-confine-private/mountinfo.h
+++ b/cmd/libsnap-confine-private/mountinfo.h
@@ -14,91 +14,92 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SC_MOUNTINFO_H
-#define SC_MOUNTINFO_H
+#ifndef SNAP_CONFINE_MOUNTINFO_H
+#define SNAP_CONFINE_MOUNTINFO_H
 
 /**
- * Structure describing entire /proc/self/mountinfo file
+ * Structure describing entire /proc/self/sc_mountinfo file
  **/
-struct mountinfo;
+struct sc_mountinfo;
 
 /**
- * Structure describing a single entry in /proc/self/mountinfo
+ * Structure describing a single entry in /proc/self/sc_mountinfo
  **/
-struct mountinfo_entry;
+struct sc_mountinfo_entry;
 
 /**
- * Parse a file in according to mountinfo syntax.
+ * Parse a file in according to sc_mountinfo syntax.
  *
  * The argument can be used to parse an arbitrary file.  NULL can be used to
- * implicitly parse /proc/self/mountinfo, that is the mount information
+ * implicitly parse /proc/self/sc_mountinfo, that is the mount information
  * associated with the current process.
  **/
-struct mountinfo *parse_mountinfo(const char *fname);
+struct sc_mountinfo *sc_parse_mountinfo(const char *fname);
 
 /**
- * Free a mountinfo structure.
+ * Free a sc_mountinfo structure.
  *
  * This function is designed to be used with __attribute__((cleanup)) so it
  * takes a pointer to the freed object (which is also a pointer).
  **/
-void cleanup_mountinfo(struct mountinfo **ptr) __attribute__ ((nonnull(1)));
-
-/**
- * Get the first mountinfo entry.
- *
- * The returned value may be NULL if the parsed file contained no entries. The
- * returned value is bound to the lifecycle of the whole mountinfo structure
- * and should not be freed explicitly.
- **/
-struct mountinfo_entry *first_mountinfo_entry(struct mountinfo *info)
+void sc_cleanup_mountinfo(struct sc_mountinfo **ptr)
     __attribute__ ((nonnull(1)));
 
 /**
- * Get the next mountinfo entry.
+ * Get the first sc_mountinfo entry.
  *
- * The returned value is a pointer to the next mountinfo entry or NULL if this
- * was the last entry. The returned value is bound to the lifecycle of the
- * whole mountinfo structure and should not be freed explicitly.
+ * The returned value may be NULL if the parsed file contained no entries. The
+ * returned value is bound to the lifecycle of the whole sc_mountinfo structure
+ * and should not be freed explicitly.
  **/
-struct mountinfo_entry *next_mountinfo_entry(struct mountinfo_entry
-					     *entry)
+struct sc_mountinfo_entry *sc_first_mountinfo_entry(struct sc_mountinfo *info)
+    __attribute__ ((nonnull(1)));
+
+/**
+ * Get the next sc_mountinfo entry.
+ *
+ * The returned value is a pointer to the next sc_mountinfo entry or NULL if this
+ * was the last entry. The returned value is bound to the lifecycle of the
+ * whole sc_mountinfo structure and should not be freed explicitly.
+ **/
+struct sc_mountinfo_entry *sc_next_mountinfo_entry(struct sc_mountinfo_entry
+						   *entry)
     __attribute__ ((nonnull(1)));
 
 /**
  * Get the mount identifier of a given mount entry.
  **/
-int mountinfo_entry_mount_id(struct mountinfo_entry *entry)
+int sc_mountinfo_entry_mount_id(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 /**
  * Get the parent mount identifier of a given mount entry.
  **/
-int mountinfo_entry_parent_id(struct mountinfo_entry *entry)
+int sc_mountinfo_entry_parent_id(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
-unsigned mountinfo_entry_dev_major(struct mountinfo_entry *entry)
+unsigned sc_mountinfo_entry_dev_major(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
-unsigned mountinfo_entry_dev_minor(struct mountinfo_entry *entry)
+unsigned sc_mountinfo_entry_dev_minor(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 /**
  * Get the root directory of a given mount entry.
  **/
-const char *mountinfo_entry_root(struct mountinfo_entry *entry)
+const char *sc_mountinfo_entry_root(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 /**
  * Get the mount point of a given mount entry.
  **/
-const char *mountinfo_entry_mount_dir(struct mountinfo_entry *entry)
+const char *sc_mountinfo_entry_mount_dir(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 /**
  * Get the mount options of a given mount entry.
  **/
-const char *mountinfo_entry_mount_opts(struct mountinfo_entry *entry)
+const char *sc_mountinfo_entry_mount_opts(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 /**
@@ -121,25 +122,25 @@ const char *mountinfo_entry_mount_opts(struct mountinfo_entry *entry)
  * group under the same root, then only the "master:X" field is present and not
  * the "propagate_from:X" field.
  **/
-const char *mountinfo_entry_optional_fields(struct mountinfo_entry *entry)
+const char *sc_mountinfo_entry_optional_fields(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 /**
  * Get the file system type of a given mount entry.
  **/
-const char *mountinfo_entry_fs_type(struct mountinfo_entry *entry)
+const char *sc_mountinfo_entry_fs_type(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 /**
  * Get the source of a given mount entry.
  **/
-const char *mountinfo_entry_mount_source(struct mountinfo_entry *entry)
+const char *sc_mountinfo_entry_mount_source(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 /**
  * Get the super block options of a given mount entry.
  **/
-const char *mountinfo_entry_super_opts(struct mountinfo_entry *entry)
+const char *sc_mountinfo_entry_super_opts(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 #endif

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -147,24 +147,24 @@ static const char *sc_ns_dir = SC_NS_DIR;
  **/
 static bool sc_is_ns_group_dir_private()
 {
-	struct mountinfo *info
-	    __attribute__ ((cleanup(cleanup_mountinfo))) = NULL;
-	info = parse_mountinfo(NULL);
+	struct sc_mountinfo *info
+	    __attribute__ ((cleanup(sc_cleanup_mountinfo))) = NULL;
+	info = sc_parse_mountinfo(NULL);
 	if (info == NULL) {
 		die("cannot parse /proc/self/mountinfo");
 	}
-	struct mountinfo_entry *entry = first_mountinfo_entry(info);
+	struct sc_mountinfo_entry *entry = sc_first_mountinfo_entry(info);
 	while (entry != NULL) {
-		const char *mount_dir = mountinfo_entry_mount_dir(entry);
+		const char *mount_dir = sc_mountinfo_entry_mount_dir(entry);
 		const char *optional_fields =
-		    mountinfo_entry_optional_fields(entry);
+		    sc_mountinfo_entry_optional_fields(entry);
 		if (strcmp(mount_dir, sc_ns_dir) == 0
 		    && strcmp(optional_fields, "") == 0) {
 			// If /run/snapd/ns has no optional fields, we know it is mounted
 			// private and there is nothing else to do.
 			return true;
 		}
-		entry = next_mountinfo_entry(entry);
+		entry = sc_next_mountinfo_entry(entry);
 	}
 	return false;
 }

--- a/cmd/system-shutdown/system-shutdown-utils.c
+++ b/cmd/system-shutdown/system-shutdown-utils.c
@@ -120,21 +120,22 @@ bool umount_all()
 	bool had_writable = false;
 
 	for (int i = 0; i < 10 && did_umount; i++) {
-		struct mountinfo *mounts = parse_mountinfo(NULL);
+		struct sc_mountinfo *mounts = sc_parse_mountinfo(NULL);
 		if (!mounts) {
 			// oh dear
 			die("unable to get mount info; giving up");
 		}
-		struct mountinfo_entry *cur = first_mountinfo_entry(mounts);
+		struct sc_mountinfo_entry *cur =
+		    sc_first_mountinfo_entry(mounts);
 
 		had_writable = false;
 		did_umount = false;
 		while (cur) {
-			const char *dir = mountinfo_entry_mount_dir(cur);
-			const char *src = mountinfo_entry_mount_source(cur);
-			unsigned major = mountinfo_entry_dev_major(cur);
+			const char *dir = sc_mountinfo_entry_mount_dir(cur);
+			const char *src = sc_mountinfo_entry_mount_source(cur);
+			unsigned major = sc_mountinfo_entry_dev_major(cur);
 
-			cur = next_mountinfo_entry(cur);
+			cur = sc_next_mountinfo_entry(cur);
 
 			if (streq("/", dir)) {
 				continue;
@@ -161,7 +162,7 @@ bool umount_all()
 				did_umount = true;
 			}
 		}
-		cleanup_mountinfo(&mounts);
+		sc_cleanup_mountinfo(&mounts);
 	}
 
 	return !had_writable;


### PR DESCRIPTION
Just moving towards all the non-static functions to have an sc_ prefix
to ensure we have consistent namespace.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>