### PR TITLE
Rename unity8-download-manager interface to ubuntu-download-manager

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -53,7 +53,7 @@ var allInterfaces = []interfaces.Interface{
 	&SerialPortInterface{},
 	&TimeControlInterface{},
 	&UDisks2Interface{},
-	&Unity8DownloadManagerInterface{},
+	&UbuntuDownloadManagerInterface{},
 	&UpowerObserveInterface{},
 	&UhidInterface{},
 	NewAlsaInterface(),

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -56,7 +56,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.SerialPortInterface{})
 	c.Check(all, Contains, &builtin.TimeControlInterface{})
 	c.Check(all, Contains, &builtin.UDisks2Interface{})
-	c.Check(all, Contains, &builtin.Unity8DownloadManagerInterface{})
+	c.Check(all, Contains, &builtin.UbuntuDownloadManagerInterface{})
 	c.Check(all, Contains, &builtin.UpowerObserveInterface{})
 	c.Check(all, Contains, &builtin.UhidInterface{})
 	c.Check(all, DeepContains, builtin.NewAlsaInterface())

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -523,7 +523,7 @@ slots:
         - app
     deny-auto-connection: true
     deny-connection: true
-  unity8-download-manager:
+  ubuntu-download-manager:
     allow-installation:
       slot-snap-type:
         - app

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -146,7 +146,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		"pulseaudio":              true,
 		"screen-inhibit-control":  true,
 		"unity7":                  true,
-		"unity8-download-manager": true,
+		"ubuntu-download-manager": true,
 		"upower-observe":          true,
 		"x11":                     true,
 	}
@@ -372,7 +372,7 @@ var (
 		"uhid":                    {"core"},
 		"unity8-calendar":         {"app"},
 		"unity8-contacts":         {"app"},
-		"unity8-download-manager": {"app"},
+		"ubuntu-download-manager": {"app"},
 		"upower-observe":          {"app", "core"},
 		// snowflakes
 		"docker": nil,
@@ -484,7 +484,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 		"udisks2":                 true,
 		"unity8-calendar":         true,
 		"unity8-contacts":         true,
-		"unity8-download-manager": true,
+		"ubuntu-download-manager": true,
 	}
 
 	for _, iface := range all {

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -208,21 +208,21 @@ sendmsg
 socket
 `)
 
-type Unity8DownloadManagerInterface struct{}
+type UbuntuDownloadManagerInterface struct{}
 
-func (iface *Unity8DownloadManagerInterface) Name() string {
-	return "unity8-download-manager"
+func (iface *UbuntuDownloadManagerInterface) Name() string {
+	return "ubuntu-download-manager"
 }
 
-func (iface *Unity8DownloadManagerInterface) String() string {
+func (iface *UbuntuDownloadManagerInterface) String() string {
 	return iface.Name()
 }
 
-func (iface *Unity8DownloadManagerInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *UbuntuDownloadManagerInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
 }
 
-func (iface *Unity8DownloadManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *UbuntuDownloadManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		old := []byte("###SLOT_SECURITY_TAGS###")
@@ -235,7 +235,7 @@ func (iface *Unity8DownloadManagerInterface) ConnectedPlugSnippet(plug *interfac
 	return nil, nil
 }
 
-func (iface *Unity8DownloadManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *UbuntuDownloadManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		return downloadPermanentSlotAppArmor, nil
@@ -245,7 +245,7 @@ func (iface *Unity8DownloadManagerInterface) PermanentSlotSnippet(slot *interfac
 	return nil, nil
 }
 
-func (iface *Unity8DownloadManagerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *UbuntuDownloadManagerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		old := []byte("###PLUG_SECURITY_TAGS###")
@@ -259,21 +259,21 @@ func (iface *Unity8DownloadManagerInterface) ConnectedSlotSnippet(plug *interfac
 	return nil, nil
 }
 
-func (iface *Unity8DownloadManagerInterface) SanitizePlug(slot *interfaces.Plug) error {
+func (iface *UbuntuDownloadManagerInterface) SanitizePlug(slot *interfaces.Plug) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
 	return nil
 }
 
-func (iface *Unity8DownloadManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *UbuntuDownloadManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
 	}
 	return nil
 }
 
-func (iface *Unity8DownloadManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *UbuntuDownloadManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/ubuntu_download_manager_test.go
+++ b/interfaces/builtin/ubuntu_download_manager_test.go
@@ -27,58 +27,58 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-type Unity8DownloadManagerInterfaceSuite struct {
+type UbuntuDownloadManagerInterfaceSuite struct {
 	iface interfaces.Interface
 	slot  *interfaces.Slot
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&Unity8DownloadManagerInterfaceSuite{
-	iface: &builtin.Unity8DownloadManagerInterface{},
+var _ = Suite(&UbuntuDownloadManagerInterfaceSuite{
+	iface: &builtin.UbuntuDownloadManagerInterface{},
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
-			Name:      "unity8-download-manager",
-			Interface: "unity8-download-manager",
+			Name:      "ubuntu-download-manager",
+			Interface: "ubuntu-download-manager",
 		},
 	},
 	plug: &interfaces.Plug{
 		PlugInfo: &snap.PlugInfo{
 			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "unity8-download-manager",
-			Interface: "unity8-download-manager",
+			Name:      "ubuntu-download-manager",
+			Interface: "ubuntu-download-manager",
 		},
 	},
 })
 
-func (s *Unity8DownloadManagerInterfaceSuite) TestName(c *C) {
-	c.Assert(s.iface.Name(), Equals, "unity8-download-manager")
+func (s *UbuntuDownloadManagerInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "ubuntu-download-manager")
 }
 
-func (s *Unity8DownloadManagerInterfaceSuite) TestSanitizePlug(c *C) {
+func (s *UbuntuDownloadManagerInterfaceSuite) TestSanitizePlug(c *C) {
 	err := s.iface.SanitizePlug(s.plug)
 	c.Assert(err, IsNil)
 }
 
-func (s *Unity8DownloadManagerInterfaceSuite) TestSanitizeSlot(c *C) {
+func (s *UbuntuDownloadManagerInterfaceSuite) TestSanitizeSlot(c *C) {
 	err := s.iface.SanitizeSlot(s.slot)
 	c.Assert(err, IsNil)
 	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
-		Name:      "unity8-download-manager",
-		Interface: "unity8-download-manager",
+		Name:      "ubuntu-download-manager",
+		Interface: "ubuntu-download-manager",
 	}})
 	c.Assert(err, IsNil)
 }
 
-func (s *Unity8DownloadManagerInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+func (s *UbuntuDownloadManagerInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "unity8-download-manager"`)
+		PanicMatches, `slot is not of interface "ubuntu-download-manager"`)
 	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "unity8-download-manager"`)
+		PanicMatches, `plug is not of interface "ubuntu-download-manager"`)
 }
 
-func (s *Unity8DownloadManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
+func (s *UbuntuDownloadManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
As per mailinglist discussion: https://lists.ubuntu.com/archives/snapcraft/2017-January/002679.html