### PR TITLE
interfaces: miscellaneous updates for default and network-control (LP: #1658793, #1658298)

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -119,6 +119,7 @@ var defaultTemplate = []byte(`
   /{,usr/}bin/expr ixr,
   /{,usr/}bin/false ixr,
   /{,usr/}bin/find ixr,
+  /{,usr/}bin/flock ixr,
   /{,usr/}bin/fmt ixr,
   /{,usr/}bin/getopt ixr,
   /{,usr/}bin/groups ixr,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -202,6 +202,8 @@ setpriority
 const browserSupportConnectedPlugSecCompWithSandbox = `
 # Policy needed only when using the chrome/chromium setuid sandbox
 chroot
+sched_setscheduler
+
 # TODO: fine-tune when seccomp arg filtering available in stable distro
 # releases
 setuid

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -97,8 +97,8 @@ network sna,
 network netlink dgram,
 
 # ip, et al
-/etc/iproute2/ r,
-/etc/iproute2/* r,
+/etc/iproute2/{,*} r,
+/etc/iproute2/rt_{protos,realms,scopes,tables} w,
 
 # ping - child profile would be nice but seccomp causes problems with that
 /{,usr/}{,s}bin/ping ixr,

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -111,6 +111,16 @@ capability setuid,
 @{PROC}/@{pid}/loginuid r,
 @{PROC}/@{pid}/mounts r,
 
+# resolvconf
+/sbin/resolvconf ixr,
+/run/resolvconf/{,**} r,
+/run/resolvconf/** w,
+/etc/resolvconf/{,**} r,
+/lib/resolvconf/* ix,
+# Required by resolvconf
+/bin/run-parts ixr,
+/etc/resolvconf/update.d/* ix,
+
 # route
 /etc/networks r,
 

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -45,6 +45,8 @@ const processControlConnectedPlugSecComp = `
 
 setpriority
 sched_setaffinity
+sched_setparam
+sched_setscheduler
 `
 
 // NewProcessControlInterface returns a new "process-control" interface.

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -312,9 +312,11 @@ sched_get_priority_max
 sched_get_priority_min
 sched_getscheduler
 sched_rr_get_interval
-# LP: #1446748 - when support syscall arg filtering, enforce pid_t is 0 so the
-# app may only change its own scheduler
-sched_setscheduler
+# enforce pid_t is 0 so the app may only change its own scheduler and affinity.
+# Use process-control interface for controlling other pids.
+sched_setaffinity 0 - -
+sched_setparam 0 -
+sched_setscheduler 0 - -
 
 sched_yield
 

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -95,16 +95,14 @@ chmod
 fchmod
 fchmodat
 
-# snappy doesn't currently support per-app UID/GIDs so don't allow chown. To
-# properly support chown, we need to have syscall arg filtering (LP: #1446748)
-# and per-app UID/GIDs.
-#chown
-#chown32
-#fchown
-#fchown32
-#fchownat
-#lchown
-#lchown32
+# snappy doesn't currently support per-app UID/GIDs. All daemons run as 'root'
+# so allow chown to 'root'. DAC will prevent non-root from chowning to root.
+chown - 0 0
+chown32 - 0 0
+fchown - 0 0
+fchown32 - 0 0
+lchown - 0 0
+lchown32 - 0 0
 
 clock_getres
 clock_gettime


### PR DESCRIPTION
- interfaces: allow /usr/bin/flock by default
- interfaces/network-control: allow use of resolvconf (LP: #1658793)
- interfaces/network-control: allow write to rt_tables and friends (LP: #1658298)
- interfaces: allow chown to uid/gid 0:0 (root:root)
- interfaces: finetune sched_set{affinity,scheduler,param}

All of these changes only expand access and are therefore safe with the exception of:
```
-sched_setscheduler
+sched_setscheduler 0 - -
```

The policy in the default template now enforces only changing the scheduler for the calling process and if you want to change other pids, you must 'plugs: [ process-control ]'. I did a code search of Debian for sched_setscheduler and compared that to existing snaps. Most code used `sched_setscheduler(0, ...) and thus unaffected) and the affected snaps were those using 'browser-support' and mysql. Added 'sched_setscheduler' to browser-support and mysql already 'plugs: [ process-control ]' so there should be no issues with this change.