### PR TITLE
interfaces/builtin: add core-support

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -60,6 +60,7 @@ var allInterfaces = []interfaces.Interface{
 	NewAvahiObserveInterface(),
 	NewBluetoothControlInterface(),
 	NewCameraInterface(),
+	NewCoreSupportInterface(),
 	NewCupsControlInterface(),
 	NewDcdbasControlInterface(),
 	NewFirewallControlInterface(),

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -138,6 +138,10 @@ authority-id: canonical
 series: 16
 revision: 0
 plugs:
+  core-support:
+    allow-installation:
+      plug-snap-type:
+        - core
   docker-support:
     allow-installation: false
     deny-auto-connection: true
@@ -198,6 +202,11 @@ slots:
     allow-auto-connection:
       plug-publisher-id:
         - $SLOT_PUBLISHER_ID
+  core-support:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
   cups-control:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -129,6 +129,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 	// own separate tests
 	snowflakes := map[string]bool{
 		"content":       true,
+		"core-support":  true,
 		"home":          true,
 		"lxd-support":   true,
 		"snapd-control": true,
@@ -350,6 +351,7 @@ var (
 		"bool-file":               {"core", "gadget"},
 		"browser-support":         {"core"},
 		"content":                 {"app", "gadget"},
+		"core-support":            {"core"},
 		"dbus":                    {"app"},
 		"docker-support":          {"core"},
 		"fwupd":                   {"app"},
@@ -378,6 +380,17 @@ var (
 		"docker": nil,
 		"lxd":    nil,
 	}
+
+	restrictedPlugInstallation = map[string][]string{
+		"core-support": {"core"},
+	}
+
+	snapTypeMap = map[string]snap.Type{
+		"core":   snap.TypeOS,
+		"app":    snap.TypeApp,
+		"kernel": snap.TypeKernel,
+		"gadget": snap.TypeGadget,
+	}
 )
 
 func contains(l []string, s string) bool {
@@ -390,13 +403,6 @@ func contains(l []string, s string) bool {
 }
 
 func (s *baseDeclSuite) TestSlotInstallation(c *C) {
-	typMap := map[string]snap.Type{
-		"core":   snap.TypeOS,
-		"app":    snap.TypeApp,
-		"kernel": snap.TypeKernel,
-		"gadget": snap.TypeGadget,
-	}
-
 	all := builtin.Interfaces()
 
 	for _, iface := range all {
@@ -411,7 +417,7 @@ func (s *baseDeclSuite) TestSlotInstallation(c *C) {
 			// snowflake needs to be tested specially
 			continue
 		}
-		for name, snapType := range typMap {
+		for name, snapType := range snapTypeMap {
 			ok := contains(types, name)
 			ic := s.installSlotCand(c, iface.Name(), snapType, ``)
 			slotInfo := ic.Snap.Slots[iface.Name()]
@@ -457,13 +463,31 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 	}
 
 	for _, iface := range all {
-		ic := s.installPlugCand(c, iface.Name(), snap.TypeApp, ``)
-		err := ic.Check()
-		comm := Commentf("%s", iface.Name())
-		if restricted[iface.Name()] {
-			c.Check(err, NotNil, comm)
+		types, ok := restrictedPlugInstallation[iface.Name()]
+		// If plug installation is restricted to specific snap types we
+		// need to make sure this is really the case here. If that is not
+		// the case we continue as normal.
+		if ok {
+			for name, snapType := range snapTypeMap {
+				ok := contains(types, name)
+				ic := s.installPlugCand(c, iface.Name(), snapType, ``)
+				err := ic.Check()
+				comm := Commentf("%s by %s snap", iface.Name(), name)
+				if ok {
+					c.Check(err, IsNil, comm)
+				} else {
+					c.Check(err, NotNil, comm)
+				}
+			}
 		} else {
-			c.Check(err, IsNil, comm)
+			ic := s.installPlugCand(c, iface.Name(), snap.TypeApp, ``)
+			err := ic.Check()
+			comm := Commentf("%s", iface.Name())
+			if restricted[iface.Name()] {
+				c.Check(err, NotNil, comm)
+			} else {
+				c.Check(err, IsNil, comm)
+			}
 		}
 	}
 }
@@ -548,6 +572,7 @@ func (s *baseDeclSuite) TestSanity(c *C) {
 	// given how the rules work this can be delicate,
 	// listed here to make sure that was a conscious decision
 	bothSides := map[string]bool{
+		"core-support":          true,
 		"docker-support":        true,
 		"kernel-module-control": true,
 		"lxd-support":           true,

--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -1,0 +1,131 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const coreSupportConnectedPlugAppArmor = `
+# Description: Can start/stop/restart existing services via the systemd dbus API
+# and enable/disable ssh. This interface gives privileged access to all snap and
+# system services.
+
+#include <abstractions/dbus-strict>
+
+# Allows use of dbus-send. We prefer this over systemctl because systemctl
+# start/stop/restart require additional rules beyond using the DBus API. Example
+# usage:
+#
+# Via manager:
+#   dbus-send --system --print-reply --dest=org.freedesktop.systemd1 \
+#       /org/freedesktop/systemd1 \
+#       org.freedesktop.systemd1.Manager.StartUnit \
+#       string:"test.service" string:"replace"
+#
+# Via unit object:
+#   dbus-send --system --print-reply --dest=org.freedesktop.systemd1 \
+#       /org/freedesktop/systemd1/unit/test_2eservice \
+#       org.freedesktop.systemd1.Unit.Start string:"replace"
+#
+# Finding units:
+#   dbus-send --system --print-reply --dest=org.freedesktop.systemd1 \
+#       /org/freedesktop/systemd1 \
+#       org.freedesktop.systemd1.Manager.ListUnits
+#   dbus-send --system --print-reply --dest=org.freedesktop.systemd1 \
+#       /org/freedesktop/systemd1 \
+#       org.freedesktop.systemd1.Manager.GetUnit \
+#       string:"test.service"
+#
+# Properties of units:
+#   dbus-send --system --print-reply --dest=org.freedesktop.systemd1 \
+#       /org/freedesktop/systemd1/unit/test_2eservice \
+#       org.freedesktop.DBus.Properties.GetAll
+#       string:"org.freedesktop.systemd1.Unit"
+#   dbus-send --system --print-reply --dest=org.freedesktop.systemd1 \
+#       /org/freedesktop/systemd1/unit/test_2eservice \
+#       org.freedesktop.DBus.Properties.Get \
+#       string:"org.freedesktop.systemd1.Unit" string:"ActiveState"
+
+/{,usr/}bin/dbus-send ixr,
+
+# Allow listing units and obtaining unit names
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.systemd1.Manager
+    member=ListUnits
+    peer=(label=unconfined),
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.systemd1.Manager
+    member=GetUnit
+    peer=(label=unconfined),
+
+# Allow connected snaps to start, stop, or restart a single
+# systemd unit either via the global Manager or via the
+# specific unit object.
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1
+    interface=org.freedesktop.systemd1.Manager
+    member={Start,Stop,Restart}Unit
+    peer=(label=unconfined),
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1/unit/**
+    interface=org.freedesktop.systemd1.Unit
+    member={Start,Stop,Restart,TryRestart}
+    peer=(label=unconfined),
+
+# Allow querying for unit properties
+dbus (send)
+    bus=system
+    path=/org/freedesktop/systemd1/unit/**
+    interface=org.freedesktop.DBus.Properties
+    member=Get{,All}
+    peer=(label=unconfined),
+
+# Allow creation and removal of this specific file which disables
+# the system sshd service. This will be used by the configure hook
+# of the core snap.
+/etc/ssh/sshd_not_to_be_run rw,
+`
+
+const coreSupportConnectedPlugSecComp = `
+# Description: Can control existing services via the systemd
+# dbus API (start, stop, restart).
+recvfrom
+recvmsg
+send
+sendto
+sendmsg
+`
+
+// NewShutdownInterface returns a new "shutdown" interface.
+func NewCoreSupportInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "core-support",
+		connectedPlugAppArmor: coreSupportConnectedPlugAppArmor,
+		connectedPlugSecComp:  coreSupportConnectedPlugSecComp,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type CoreSupportInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&CoreSupportInterfaceSuite{
+	iface: builtin.NewCoreSupportInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Name:      "core-support",
+			Interface: "core-support",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "core-support",
+			Interface: "core-support",
+		},
+	},
+})
+
+func (s *CoreSupportInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "core-support")
+}
+
+func (s *CoreSupportInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "core-support",
+		Interface: "core-support",
+	}})
+	c.Assert(err, ErrorMatches, "core-support slots are reserved for the operating system snap")
+}
+
+func (s *CoreSupportInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *CoreSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "core-support"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "core-support"`)
+}
+
+func (s *CoreSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *CoreSupportInterfaceSuite) TestConnectedPlugSnippet(c *C) {
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `org.freedesktop.systemd1.Unit`)
+
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(string(snippet), testutil.Contains, `recvfrom`)
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -31,6 +31,7 @@ var implicitSlots = []string{
 	"alsa",
 	"bluetooth-control",
 	"camera",
+	"core-support",
 	"dcdbas-control",
 	"docker-support",
 	"firewall-control",


### PR DESCRIPTION
The core-support interface is especially build to allow certain things
to the core snap only. As the core snap is taken as any other snap for
applications and hooks everything runs strictly confined and with that
we need to have proper interfaces in place for everything a hook or
applications wnats to do.

This new interface will cover the basic bits of what is needed. So far
we grant access to the systemd service to allow service start/stop/
restart and modifications inside /etc/ssh to allow disabling the
system sshd service.