### PR TITLE
store: increase the retry.LimitTime()

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -166,7 +166,7 @@ type Store struct {
 
 // the LimitTime should be slightly more than 3 times of our http.Client
 // Timeout value
-var defaultRetryStrategy = retry.LimitCount(5, retry.LimitTime(31*time.Second,
+var defaultRetryStrategy = retry.LimitCount(5, retry.LimitTime(33*time.Second,
 	retry.Exponential{
 		Initial: 100 * time.Millisecond,
 		Factor:  2.5,

--- a/store/store.go
+++ b/store/store.go
@@ -164,7 +164,9 @@ type Store struct {
 	suggestedCurrency string
 }
 
-var defaultRetryStrategy = retry.LimitCount(5, retry.LimitTime(10*time.Second,
+// the LimitTime should be slightly more than 3 times of our http.Client
+// Timeout value
+var defaultRetryStrategy = retry.LimitCount(5, retry.LimitTime(31*time.Second,
 	retry.Exponential{
 		Initial: 100 * time.Millisecond,
 		Factor:  2.5,


### PR DESCRIPTION
Our current default client timeout is 10s. The default LimitTime used
to be 10s as well. This means that we never retried once if we hit
a client timeout condition. By increasing this timeout to 31s we
will get at least 3 retries.

We have some options with the values, but we need to make sure that
client.Timeout is stricly smaller than our retry time limit.