### PR TITLE
interfaces: allow reading non-PCI-attached usb devices via raw-usb

### DIFF
--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -32,6 +32,7 @@ const rawusbConnectedPlugAppArmor = `
 # Allow detection of usb devices. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,
 /sys/devices/pci**/usb[0-9]** r,
+/sys/devices/platform/soc/*.usb/usb[0-9]** r,
 
 /run/udev/data/c16[67]:[0-9] r, # ACM USB modems
 /run/udev/data/b180:*    r, # various USB block devices


### PR DESCRIPTION
This patch extends the rules for raw-usb to allow looking at devices
taht are not attached to the PCI bus (e.g. USB on the Rasberry Pi).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>