### PR TITLE
interfaces: builtin: mir: allow recv and send

### DIFF
--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -50,13 +50,15 @@ listen
 setsockopt
 getsockname
 # Needed by server upon client connect
+send
 sendto
+sendmsg
 accept
 shmctl
 open
 getsockopt
+recv
 recvmsg
-sendmsg
 recvfrom
 `)
 
@@ -77,10 +79,13 @@ unix (receive, send) type=seqpacket addr=none peer=(label=###SLOT_SECURITY_TAGS#
 var mirConnectedPlugSecComp = []byte(`
 # Description: Permit clients to use Mir
 # Usage: common
-recvmsg
-sendmsg
-sendto
+recv
 recvfrom
+recvmsg
+send
+sendto
+sendmsg
+
 `)
 
 type MirInterface struct{}


### PR DESCRIPTION
Mir clients use recv and send which glibc may translate to
recv and send syscalls or recvfrom and sendto syscalls depending
on how glibc was configured.