### PR TITLE
interfaces/opengl: allow access to the nvidia abstract socket

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -38,6 +38,7 @@ const openglConnectedPlugAppArmor = `
   /dev/nvidiactl rw,
   /dev/nvidia-modeset rw,
   /dev/nvidia* rw,
+  unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),
 
   # eglfs
   /dev/vchiq rw,


### PR DESCRIPTION
X (at least) creates an abstract socket when using the proprietary nvidia
driver. This socket is not used by nouveau and appears not to be documented
publicly.