### PR TITLE
overlord,tests: have enable/disable affect security profiles

### DIFF
--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -618,6 +618,7 @@ func (s *snapmgrTestSuite) TestDisableTasks(c *C) {
 		"stop-snap-services",
 		"remove-aliases",
 		"unlink-snap",
+		"remove-profiles",
 	})
 }
 
@@ -3737,6 +3738,11 @@ func (s *snapmgrTestSuite) TestDisableRunThrough(c *C) {
 		{
 			op:   "unlink-snap",
 			name: "/snap/some-snap/7",
+		},
+		{
+			op:    "remove-profiles:Doing",
+			name:  "some-snap",
+			revno: snap.R(7),
 		},
 	}
 	// start with an easier-to-read error if this fails:

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -592,6 +592,7 @@ func (s *snapmgrTestSuite) TestEnableTasks(c *C) {
 	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
 	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
 		"prepare-snap",
+		"setup-profiles",
 		"link-snap",
 		"setup-aliases",
 		"start-snap-services",
@@ -3670,6 +3671,11 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 	s.state.Lock()
 
 	expected := fakeOps{
+		{
+			op:    "setup-profiles:Doing",
+			name:  "some-snap",
+			revno: snap.R(7),
+		},
 		{
 			op:    "candidate",
 			sinfo: si,

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -850,7 +850,11 @@ func Disable(st *state.State, name string) (*state.TaskSet, error) {
 	unlinkSnap.Set("snap-setup-task", stopSnapServices.ID())
 	unlinkSnap.WaitFor(removeAliases)
 
-	return state.NewTaskSet(stopSnapServices, removeAliases, unlinkSnap), nil
+	removeProfiles := st.NewTask("remove-profiles", fmt.Sprintf(i18n.G("Remove security profiles of snap %q"), snapsup.Name()))
+	removeProfiles.Set("snap-setup-task", stopSnapServices.ID())
+	removeProfiles.WaitFor(unlinkSnap)
+
+	return state.NewTaskSet(stopSnapServices, removeAliases, unlinkSnap, removeProfiles), nil
 }
 
 // canDisable verifies that a snap can be deactivated.

--- a/tests/main/enable-disable/task.yaml
+++ b/tests/main/enable-disable/task.yaml
@@ -14,8 +14,21 @@ execute: |
         exit 1
     fi
 
+    echo "Ensure the test-snapd-tools security profiles are no longer there"
+    if ls /var/lib/snapd/apparmor/profiles/snap.test-snapd-tools*; then
+        echo "test-snapd-tools securiry profiles are not disabled"
+        exit 1
+    fi
+
     echo "Enable test-snapd-tools again and ensure it is no longer listed as disabled"
     snap enable test-snapd-tools|grep -v disabled
+
+    echo "Ensure the test-snapd-tools security profiles are present"
+    if !ls /var/lib/snapd/apparmor/profiles/snap.test-snapd-tools*; then
+        echo "test-snapd-tools securiry profiles are not present"
+        exit 1
+    fi
+
     echo "Ensure test-snapd-tools runs normally after it was enabled"
     test-snapd-tools.echo Hello |grep Hello
 


### PR DESCRIPTION
This branch changes enable/disable to also setup and remove security profiles of the affected snap.