### PR TITLE
overlord/ifacestate: use ParseConnRef

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -454,8 +454,8 @@ func (m *InterfaceManager) transitionConnectionsCoreMigration(st *state.State, o
 	}
 
 	for id := range conns {
-		connRef := interfaces.ConnRef{}
-		if err := connRef.ParseID(id); err != nil {
+		connRef, err := interfaces.ParseConnRef(id)
+		if err != nil {
 			return err
 		}
 		if connRef.SlotRef.Snap == oldName {


### PR DESCRIPTION
This fixes master that was broken by separate (but temporally close)
landing of two branches that changed the ConnRef APIs (one changed it
one added new use of the API).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>