### PR TITLE
tests: add extra debugging to security-setuid-root test

### DIFF
--- a/tests/main/security-setuid-root/task.yaml
+++ b/tests/main/security-setuid-root/task.yaml
@@ -17,3 +17,8 @@ execute: |
         exit 1
     fi
     su test -c "sh -c \"SNAP_NAME=test-snapd-tools /snap/${core_name}/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>&1\"" | MATCH "Refusing to continue to avoid permission escalation attacks"
+debug: |
+    ls -ld /snap/core/current/usr/lib/snapd/snap-confine || true
+    ls -ld /snap/ubuntu-core/current/usr/lib/snapd/snap-confine || true
+    ls -ld /usr/lib/snapd/snap-confine || true
+    snap list


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>