### PR TITLE
tests: make the debugging of c-unit-tests more useful

### DIFF
--- a/tests/main/c-unit-tests/task.yaml
+++ b/tests/main/c-unit-tests/task.yaml
@@ -34,5 +34,5 @@ restore: |
 debug: |
     # Show the test suite failure log if there's one
     cat $SPREAD_PATH/cmd/autogarbage/test-suite.log || true
-    # Show kernel log as it may contain useful stuff
-    tail /var/log/kern.log
+    # Show seccomp audit messages
+    tail /var/log/kern.log | grep -F type=1326

--- a/tests/main/c-unit-tests/task.yaml
+++ b/tests/main/c-unit-tests/task.yaml
@@ -34,9 +34,5 @@ restore: |
 debug: |
     # Show the test suite failure log if there's one
     cat $SPREAD_PATH/cmd/autogarbage/test-suite.log || true
-    # Show any autogabare that may need cleaning
-    cd $SPREAD_PATH/cmd/
-    find . > after
-    diff -u $SPREAD_PATH/cmd/before $SPREAD_PATH/cmd/after
     # Show kernel log as it may contain useful stuff
     tail /var/log/kern.log


### PR DESCRIPTION
We don't want to look at the list of autogarbage files as this is reliable nowadays.
Instead let's look at seccomp denials (most of the mysterious failures were related to seccomp)