### PR TITLE
debian/tests: drop stale autopkgtest dependencies.

### DIFF
--- a/packaging/ubuntu-16.04/tests/control
+++ b/packaging/ubuntu-16.04/tests/control
@@ -6,7 +6,4 @@ Depends: @builddeps@,
          git,
          golang-golang-x-net-dev,
          openssh-server,
-         snapd,
-         unity,
-         x11-utils,
-         xvfb
+         snapd


### PR DESCRIPTION
The test that needed them is currently disabled https://github.com/snapcore/snapd/blob/master/tests/main/unity/task.yaml

LP: #1659783