### PR TITLE
store: enable download deltas on classic by default

### DIFF
--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -65,6 +65,7 @@ Depends: adduser,
          systemd (>= 204-5ubuntu20.20),
 # only needed on trusty to pull in the right version.
          util-linux (>=2.20.1-5.1ubuntu20.9),
+         xdelta3,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -59,6 +59,7 @@ Depends: adduser,
          snap-confine (= ${binary:Version}),
          squashfs-tools,
          systemd,
+         xdelta3,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9)

--- a/store/store.go
+++ b/store/store.go
@@ -192,8 +192,10 @@ func getStructFields(s interface{}) []string {
 	return fields
 }
 
+// Deltas enabled by default on classic, but allow opting in or out on both classic and core.
 func useDeltas() bool {
-	return osutil.GetenvBool("SNAPD_USE_DELTAS_EXPERIMENTAL")
+	deltasDefault := release.OnClassic
+	return osutil.GetenvBool("SNAPD_USE_DELTAS_EXPERIMENTAL", deltasDefault)
 }
 
 func useStaging() bool {


### PR DESCRIPTION
Additionally, provide option to opt in or out on both classic and core. As discussed with @mvo5, further benchmarking of deltas on core may be useful to determine an approach to policy there before this is enabled by default.