### PR TITLE
overlord: move configstate.Transaction stuff into configstate.config.Transaction

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -50,6 +50,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/ifacestate"
@@ -1421,13 +1422,13 @@ func getSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	s := c.d.overlord.State()
 	s.Lock()
-	transaction := configstate.NewTransaction(s)
+	tr := config.NewTransaction(s)
 	s.Unlock()
 
 	currentConfValues := make(map[string]interface{})
 	for _, key := range keys {
 		var value interface{}
-		if err := transaction.Get(snapName, key, &value); err != nil {
+		if err := tr.Get(snapName, key, &value); err != nil {
 			return BadRequest("%s", err)
 		}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -54,7 +54,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -2179,10 +2179,10 @@ func (s *apiSuite) TestGetConfSingleKey(c *check.C) {
 
 	// Set a config that we'll get in a moment
 	d.overlord.State().Lock()
-	transaction := configstate.NewTransaction(d.overlord.State())
-	transaction.Set("test-snap", "test-key1", "test-value1")
-	transaction.Set("test-snap", "test-key2", "test-value2")
-	transaction.Commit()
+	tr := config.NewTransaction(d.overlord.State())
+	tr.Set("test-snap", "test-key1", "test-value1")
+	tr.Set("test-snap", "test-key2", "test-value2")
+	tr.Commit()
 	d.overlord.State().Unlock()
 
 	result := s.runGetConf(c, []string{"test-key1"})

--- a/overlord/configstate/config/transaction.go
+++ b/overlord/configstate/config/transaction.go
@@ -17,7 +17,7 @@
  *
  */
 
-package configstate
+package config
 
 import (
 	"encoding/json"

--- a/overlord/configstate/handler.go
+++ b/overlord/configstate/handler.go
@@ -19,7 +19,10 @@
 
 package configstate
 
-import "github.com/snapcore/snapd/overlord/hookstate"
+import (
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/hookstate"
+)
 
 // configureHandler is the handler for the configure hook.
 type configureHandler struct {
@@ -32,23 +35,23 @@ type cachedTransaction struct{}
 
 // ContextTransaction retrieves the transaction cached within the context (and
 // creates one if it hasn't already been cached).
-func ContextTransaction(context *hookstate.Context) *Transaction {
+func ContextTransaction(context *hookstate.Context) *config.Transaction {
 	// Check for one already cached
-	transaction, ok := context.Cached(cachedTransaction{}).(*Transaction)
+	tr, ok := context.Cached(cachedTransaction{}).(*config.Transaction)
 	if ok {
-		return transaction
+		return tr
 	}
 
 	// It wasn't already cached, so create and cache a new one
-	transaction = NewTransaction(context.State())
+	tr = config.NewTransaction(context.State())
 
 	context.OnDone(func() error {
-		transaction.Commit()
+		tr.Commit()
 		return nil
 	})
 
-	context.Cache(cachedTransaction{}, transaction)
-	return transaction
+	context.Cache(cachedTransaction{}, tr)
+	return tr
 }
 
 func newConfigureHandler(context *hookstate.Context) hookstate.Handler {
@@ -60,14 +63,14 @@ func (h *configureHandler) Before() error {
 	h.context.Lock()
 	defer h.context.Unlock()
 
-	transaction := ContextTransaction(h.context)
+	tr := ContextTransaction(h.context)
 
 	// Initialize the transaction if there's a patch provided in the
 	// context.
 	var patch map[string]interface{}
 	if err := h.context.Get("patch", &patch); err == nil {
 		for key, value := range patch {
-			transaction.Set(h.context.SnapName(), key, value)
+			tr.Set(h.context.SnapName(), key, value)
 		}
 	}
 

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -20,6 +20,8 @@
 package configstate_test
 
 import (
+	"testing"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/overlord/configstate"
@@ -28,6 +30,8 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
+
+func TestConfigState(t *testing.T) { TestingT(t) }
 
 type configureHandlerSuite struct {
 	context *hookstate.Context
@@ -62,10 +66,10 @@ func (s *configureHandlerSuite) TestBeforeInitializesTransaction(c *C) {
 	c.Check(s.handler.Before(), IsNil)
 
 	s.context.Lock()
-	transaction := configstate.ContextTransaction(s.context)
+	tr := configstate.ContextTransaction(s.context)
 	s.context.Unlock()
 
 	var value string
-	c.Check(transaction.Get("test-snap", "foo", &value), IsNil)
+	c.Check(tr.Get("test-snap", "foo", &value), IsNil)
 	c.Check(value, Equals, "bar")
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -45,7 +45,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -624,7 +624,7 @@ func getSerialRequestConfig(t *state.Task) (*serialRequestConfig, error) {
 	}
 	gadgetName := gadgetInfo.Name()
 
-	tr := configstate.NewTransaction(t.State())
+	tr := config.NewTransaction(t.State())
 	var svcURL string
 	err = tr.GetMaybe(gadgetName, "device-service.url", &svcURL)
 	if err != nil {

--- a/overlord/hookstate/ctlcmd/get.go
+++ b/overlord/hookstate/ctlcmd/get.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 )
 
 type getCommand struct {
@@ -75,15 +76,15 @@ func (c *getCommand) Execute(args []string) error {
 
 	patch := make(map[string]interface{})
 	context.Lock()
-	transaction := configstate.ContextTransaction(context)
+	tr := configstate.ContextTransaction(context)
 	context.Unlock()
 
 	for _, key := range c.Positional.Keys {
 		var value interface{}
-		err := transaction.Get(c.context().SnapName(), key, &value)
+		err := tr.Get(c.context().SnapName(), key, &value)
 		if err == nil {
 			patch[key] = value
-		} else if configstate.IsNoOption(err) {
+		} else if config.IsNoOption(err) {
 			if !c.Typed {
 				value = ""
 			}

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -20,7 +20,7 @@
 package ctlcmd_test
 
 import (
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
@@ -53,9 +53,9 @@ func (s *getSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// Initialize configuration
-	transaction := configstate.NewTransaction(state)
-	transaction.Set("test-snap", "initial-key", "initial-value")
-	transaction.Commit()
+	tr := config.NewTransaction(state)
+	tr.Set("test-snap", "initial-key", "initial-value")
+	tr.Commit()
 }
 
 var getTests = []struct {
@@ -106,10 +106,10 @@ func (s *getSuite) TestGetTests(c *C) {
 		c.Check(err, IsNil)
 
 		// Initialize configuration
-		t := configstate.NewTransaction(state)
-		t.Set("test-snap", "test-key1", "test-value1")
-		t.Set("test-snap", "test-key2", 2)
-		t.Commit()
+		tr := config.NewTransaction(state)
+		tr.Set("test-snap", "test-key1", "test-value1")
+		tr.Set("test-snap", "test-key2", 2)
+		tr.Commit()
 
 		state.Unlock()
 

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -61,7 +61,7 @@ func (s *setCommand) Execute(args []string) error {
 	}
 
 	context.Lock()
-	transaction := configstate.ContextTransaction(context)
+	tr := configstate.ContextTransaction(context)
 	context.Unlock()
 
 	for _, patchValue := range s.Positional.ConfValues {
@@ -77,7 +77,7 @@ func (s *setCommand) Execute(args []string) error {
 			value = parts[1]
 		}
 
-		transaction.Set(s.context().SnapName(), key, value)
+		tr.Set(s.context().SnapName(), key, value)
 	}
 
 	return nil

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -20,7 +20,7 @@
 package ctlcmd_test
 
 import (
-	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
@@ -65,11 +65,11 @@ func (s *setSuite) TestCommand(c *C) {
 
 	// Verify that the previous set doesn't modify the global state
 	s.mockContext.State().Lock()
-	transaction := configstate.NewTransaction(s.mockContext.State())
+	tr := config.NewTransaction(s.mockContext.State())
 	s.mockContext.State().Unlock()
 	var value string
-	c.Check(transaction.Get("test-snap", "foo", &value), ErrorMatches, ".*snap.*has no.*configuration.*")
-	c.Check(transaction.Get("test-snap", "baz", &value), ErrorMatches, ".*snap.*has no.*configuration.*")
+	c.Check(tr.Get("test-snap", "foo", &value), ErrorMatches, ".*snap.*has no.*configuration.*")
+	c.Check(tr.Get("test-snap", "baz", &value), ErrorMatches, ".*snap.*has no.*configuration.*")
 
 	// Notify the context that we're done. This should save the config.
 	s.mockContext.Lock()
@@ -77,20 +77,20 @@ func (s *setSuite) TestCommand(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated.
-	transaction = configstate.NewTransaction(s.mockContext.State())
-	c.Check(transaction.Get("test-snap", "foo", &value), IsNil)
+	tr = config.NewTransaction(s.mockContext.State())
+	c.Check(tr.Get("test-snap", "foo", &value), IsNil)
 	c.Check(value, Equals, "bar")
-	c.Check(transaction.Get("test-snap", "baz", &value), IsNil)
+	c.Check(tr.Get("test-snap", "baz", &value), IsNil)
 	c.Check(value, Equals, "qux")
 }
 
 func (s *setSuite) TestCommandSavesDeltasOnly(c *C) {
 	// Setup an initial configuration
 	s.mockContext.State().Lock()
-	transaction := configstate.NewTransaction(s.mockContext.State())
-	transaction.Set("test-snap", "test-key1", "test-value1")
-	transaction.Set("test-snap", "test-key2", "test-value2")
-	transaction.Commit()
+	tr := config.NewTransaction(s.mockContext.State())
+	tr.Set("test-snap", "test-key1", "test-value1")
+	tr.Set("test-snap", "test-key2", "test-value2")
+	tr.Commit()
 	s.mockContext.State().Unlock()
 
 	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "test-key2=test-value3"})
@@ -104,11 +104,11 @@ func (s *setSuite) TestCommandSavesDeltasOnly(c *C) {
 	c.Check(s.mockContext.Done(), IsNil)
 
 	// Verify that the global config has been updated, but only test-key2
-	transaction = configstate.NewTransaction(s.mockContext.State())
+	tr = config.NewTransaction(s.mockContext.State())
 	var value string
-	c.Check(transaction.Get("test-snap", "test-key1", &value), IsNil)
+	c.Check(tr.Get("test-snap", "test-key1", &value), IsNil)
 	c.Check(value, Equals, "test-value1")
-	c.Check(transaction.Get("test-snap", "test-key2", &value), IsNil)
+	c.Check(tr.Get("test-snap", "test-key2", &value), IsNil)
 	c.Check(value, Equals, "test-value3")
 }
 


### PR DESCRIPTION
This is a split out of the work done in #2558. The goal is that we have the configuration available inside of snapstate so that snapstate can set the `core.refresh.last` configuration and also is able to read the new `core.refresh.schedule` setting. Currently snapstate can not import configstate because there is a circular dependency via "configstate->hookstate->snapstate".

The `config` package name is a strawman. But I think it read quite nice: `config.NewTransaction()` and `config.IsNoOption`.