### PR TITLE
cmd: add sc_string_append

### DIFF
--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -152,7 +152,7 @@ static void test_sc_string_append__overflow()
 	g_test_trap_subprocess(NULL, 0, 0);
 	g_test_trap_assert_failed();
 	g_test_trap_assert_stderr
-	    ("cannot append string: buffer overflow of 1 byte(s)\n");
+	    ("cannot append string: str is too long or unterminated\n");
 }
 
 // Check that the uninitialized buffer detection works.
@@ -160,7 +160,6 @@ static void test_sc_string_append__uninitialized_buf()
 {
 	if (g_test_subprocess()) {
 		char buf[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
-		volatile char canary = 0;
 
 		// Try to append a string to a buffer which is not a valic C-string.
 		sc_string_append(buf, sizeof buf, "");
@@ -172,7 +171,7 @@ static void test_sc_string_append__uninitialized_buf()
 	g_test_trap_subprocess(NULL, 0, 0);
 	g_test_trap_assert_failed();
 	g_test_trap_assert_stderr
-	    ("cannot append string: uninitialized buffer detected\n");
+	    ("cannot append string: dst is unterminated\n");
 }
 
 // Check that `buf' cannot be NULL.

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -307,7 +307,7 @@ static void test_sc_must_stpcpy__huge_buf_size()
 	g_test_trap_subprocess(NULL, 0, 0);
 	g_test_trap_assert_failed();
 	g_test_trap_assert_stderr
-	    ("cannot append string: buffer size (18446744073709551615) exceeds internal limit\n");
+	    ("cannot append string: buffer size (-1) exceeds internal limit\n");
 }
 
 static void __attribute__ ((constructor)) init()

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -80,9 +80,9 @@ static void test_sc_must_stpcpy()
 	union {
 		char bigbuf[6];
 		struct {
-			char canary1;
+			signed char canary1;
 			char buf[4];
-			char canary2;
+			signed char canary2;
 		};
 	} data = {
 		.buf = {
@@ -114,9 +114,9 @@ static void test_sc_must_stpcpy__empty_to_full()
 	union {
 		char bigbuf[6];
 		struct {
-			char canary1;
+			signed char canary1;
 			char buf[4];
-			char canary2;
+			signed char canary2;
 		};
 	} data = {
 		.buf = {

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -17,6 +17,7 @@
 
 #include "string-utils.h"
 
+#include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -68,4 +69,46 @@ int sc_must_snprintf(char *str, size_t size, const char *format, ...)
 		die("cannot format string: %s", str);
 
 	return n;
+}
+
+char *sc_must_stpcpy(char *buf, size_t buf_size, char *dest, const char *src)
+{
+	// Set errno in case we die.
+	errno = 0;
+	if (buf == NULL) {
+		die("cannot append string: buffer is NULL");
+	}
+	if (dest == NULL) {
+		die("cannot append string: destination is NULL");
+	}
+	if (src == NULL) {
+		die("cannot append string: source is NULL");
+	}
+	// Sanity check, the code doesn't need buffers larger than a few KBs so
+	// prevent corrupted or otherwise huge buffers from seeming "valid".
+	if (buf_size >= 0xFFFF) {
+		die("cannot append string: buffer size (%zu) exceeds internal limit", buf_size);
+
+	}
+	size_t src_len = strlen(src);
+	// Sanity check, dest points to the inside of the buffer.
+	if (dest == &buf[buf_size]) {
+		die("cannot append string: destination points"
+		    " to the end of the buffer");
+	}
+	if (dest > &buf[buf_size] && src_len > 0) {
+		die("cannot append string: destination points"
+		    " %td byte(s) beyond the buffer", dest - &buf[buf_size]);
+	}
+	if (dest < buf) {
+		die("cannot append string: destination points"
+		    " %td byte(s) in front of the buffer", buf - dest);
+	}
+	// Sanity check the new content fits the buffer.
+	if (&dest[src_len] >= &buf[buf_size]) {
+		die("cannot append string: buffer overflow of %td byte(s)",
+		    &dest[src_len] - &buf[buf_size] + 1);
+	}
+	memcpy(dest, src, src_len + 1);
+	return &dest[src_len + 1];
 }

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -87,7 +87,10 @@ char *sc_must_stpcpy(char *buf, size_t buf_size, char *dest, const char *src)
 	// Sanity check, the code doesn't need buffers larger than a few KBs so
 	// prevent corrupted or otherwise huge buffers from seeming "valid".
 	if (buf_size >= 0xFFFF) {
-		die("cannot append string: buffer size (%zu) exceeds internal limit", buf_size);
+		// NOTE: using %zd to format size_t as ssize_t which is more useful for
+		// -1 and similar huge values and also is better to test as it is
+		// independent of machine word size.
+		die("cannot append string: buffer size (%zd) exceeds internal limit", (ssize_t) buf_size);
 
 	}
 	size_t src_len = strlen(src);

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -93,7 +93,6 @@ char *sc_must_stpcpy(char *buf, size_t buf_size, char *dest, const char *src)
 		die("cannot append string: buffer size (%zd) exceeds internal limit", (ssize_t) buf_size);
 
 	}
-	size_t src_len = strlen(src);
 	// Sanity check, dest points to the inside of the buffer.
 	if (dest == &buf[buf_size]) {
 		die("cannot append string: destination points"
@@ -108,6 +107,7 @@ char *sc_must_stpcpy(char *buf, size_t buf_size, char *dest, const char *src)
 		    " %td byte(s) in front of the buffer", buf - dest);
 	}
 	// Sanity check the new content fits the buffer.
+	size_t src_len = strlen(src);
 	if (&dest[src_len] >= &buf[buf_size]) {
 		die("cannot append string: buffer overflow of %td byte(s)",
 		    &dest[src_len] - &buf[buf_size] + 1);

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -99,7 +99,7 @@ char *sc_must_stpcpy(char *buf, size_t buf_size, char *dest, const char *src)
 		die("cannot append string: destination points"
 		    " to the end of the buffer");
 	}
-	if (dest > &buf[buf_size] && src_len > 0) {
+	if (dest > &buf[buf_size]) {
 		die("cannot append string: destination points"
 		    " %td byte(s) beyond the buffer", dest - &buf[buf_size]);
 	}

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -46,8 +46,8 @@ int sc_must_snprintf(char *str, size_t size, const char *format, ...);
  * not to overflow it. If any argument is NULL a buffer overflow is detected
  * then the function dies.
  *
- * The string cannot overlap the buffer in any way.
+ * The buffers cannot overlap.
  **/
-void sc_string_append(char *buf, size_t buf_size, const char *str);
+size_t sc_string_append(char *dst, size_t dst_size, const char *str);
 
 #endif

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -40,27 +40,14 @@ __attribute__ ((format(printf, 3, 4)))
 int sc_must_snprintf(char *str, size_t size, const char *format, ...);
 
 /**
- * Safer version of stpcpy.
+ * Append a string to a buffer containing a string.
  *
- * This version is fully aware of the output buffer and is extra careful not to
- * overflow it. If any argument is NULL, buffer size is unrealistic (see below)
- * or a buffer overflow is detected then the function dies.
+ * This version is fully aware of the destination buffer and is extra careful
+ * not to overflow it. If any argument is NULL a buffer overflow is detected
+ * then the function dies.
  *
- * Since snap-confine has very modest requirements buffers larger than 0xFFFF
- * are not allowed. This is meant as an extra sanity check to prevent
- * '-1'-sized buffers from allowing memory corruption to go on unnoticed.
- *
- * As a tip, the function should be used like this:
- *
- *   char buf[100];
- *   char *to = buf;
- *
- *   to = sc_must_stpcpy(buf, sizeof buf, to, "hello");
- *   to = sc_must_stpcpy(buf, sizeof buf, to, " ");
- *   sc_must_stpcpy(buf, sizeof buf, to, "world");
- *
- * The return value can be discarded when no more appending is necessary.
+ * The string cannot overlap the buffer in any way.
  **/
-char *sc_must_stpcpy(char *buf, size_t buf_size, char *dest, const char *src);
+void sc_string_append(char *buf, size_t buf_size, const char *str);
 
 #endif

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -39,4 +39,28 @@ bool sc_endswith(const char *str, const char *suffix);
 __attribute__ ((format(printf, 3, 4)))
 int sc_must_snprintf(char *str, size_t size, const char *format, ...);
 
+/**
+ * Safer version of stpcpy.
+ *
+ * This version is fully aware of the output buffer and is extra careful not to
+ * overflow it. If any argument is NULL, buffer size is unrealistic (see below)
+ * or a buffer overflow is detected then the function dies.
+ *
+ * Since snap-confine has very modest requirements buffers larger than 0xFFFF
+ * are not allowed. This is meant as an extra sanity check to prevent
+ * '-1'-sized buffers from allowing memory corruption to go on unnoticed.
+ *
+ * As a tip, the function should be used like this:
+ *
+ *   char buf[100];
+ *   char *to = buf;
+ *
+ *   to = sc_must_stpcpy(buf, sizeof buf, to, "hello");
+ *   to = sc_must_stpcpy(buf, sizeof buf, to, " ");
+ *   sc_must_stpcpy(buf, sizeof buf, to, "world");
+ *
+ * The return value can be discarded when no more appending is necessary.
+ **/
+char *sc_must_stpcpy(char *buf, size_t buf_size, char *dest, const char *src);
+
 #endif


### PR DESCRIPTION
This patch adds a security-paranoid version of strcat that is more
sensitive to buffer overflows and other misuse of common string
utilities.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>