### PR TITLE
interfaces: remove some syscalls already in the default policy plus comment cleanups

### DIFF
--- a/interfaces/builtin/avahi_observe.go
+++ b/interfaces/builtin/avahi_observe.go
@@ -109,14 +109,11 @@ const avahiObserveConnectedPlugSecComp = `
 # Description: allows domain browsing, service browsing and service resolving
 
 # dbus
-connect
-getsockname
 recvfrom
 recvmsg
 send
 sendto
 sendmsg
-socket
 `
 
 func NewAvahiObserveInterface() interfaces.Interface {

--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -50,7 +50,6 @@ const bluetoothControlConnectedPlugSecComp = `
 #  because this gives privileged access to the system.
 # Usage: reserved
 bind
-getsockopt
 `
 
 func NewBluetoothControlInterface() interfaces.Interface {

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -136,10 +136,6 @@ var bluezPermanentSlotSecComp = []byte(`
 accept
 accept4
 bind
-connect
-getpeername
-getsockname
-getsockopt
 listen
 recv
 recvfrom
@@ -149,10 +145,7 @@ send
 sendmmsg
 sendmsg
 sendto
-setsockopt
 shutdown
-socketpair
-socket
 `)
 
 var bluezConnectedPlugSecComp = []byte(`
@@ -161,14 +154,11 @@ var bluezConnectedPlugSecComp = []byte(`
 # Usage: reserved
 
 # Can communicate with DBus system service
-connect
-getsockname
 recv
 recvmsg
 send
 sendto
 sendmsg
-socket
 `)
 
 var bluezPermanentSlotDBus = []byte(`

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -31,7 +31,6 @@ const cupsControlConnectedPlugAppArmor = `
 const cupsControlConnectedPlugSecComp = `
 recvfrom
 sendto
-setsockopt
 `
 
 // NewCupsControlInterface returns a new "cups" interface.

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -106,7 +106,6 @@ dbus (receive)
 
 const dbusPermanentSlotSecComp = `
 # Description: Allow owning a name on DBus public bus
-getsockname
 recvmsg
 sendmsg
 sendto
@@ -185,7 +184,6 @@ dbus (receive, send)
 `
 
 const dbusConnectedPlugSecComp = `
-getsockname
 recvmsg
 sendmsg
 sendto

--- a/interfaces/builtin/dbus_test.go
+++ b/interfaces/builtin/dbus_test.go
@@ -375,7 +375,7 @@ func (s *DbusInterfaceSuite) TestPermanentSlotSeccomp(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 
-	c.Check(string(snippet), testutil.Contains, "getsockname\n")
+	c.Check(string(snippet), testutil.Contains, "recvmsg\n")
 }
 
 func (s *DbusInterfaceSuite) TestPermanentSlotDBusSession(c *C) {
@@ -482,7 +482,7 @@ func (s *DbusInterfaceSuite) TestConnectedPlugSeccomp(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 
-	c.Check(string(snippet), testutil.Contains, "getsockname\n")
+	c.Check(string(snippet), testutil.Contains, "recvmsg\n")
 }
 
 func (s *DbusInterfaceSuite) TestConnectionFirst(c *C) {

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -39,7 +39,6 @@ const dockerConnectedPlugSecComp = `
 # access to the system via Docker's socket API.
 # Usage: reserved
 
-setsockopt
 bind
 `
 

--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -90,9 +90,6 @@ const firewallControlConnectedPlugSecComp = `
 
 # for connecting to xtables abstract socket
 bind
-connect
-getsockname
-getsockopt
 recv
 recvfrom
 recvmsg
@@ -101,8 +98,6 @@ send
 sendmmsg
 sendmsg
 sendto
-setsockopt
-socket
 
 # for ping and ping6
 capset

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -164,12 +164,10 @@ var fwupdPermanentSlotSecComp = []byte(`
 # Usage: reserved
 # Can communicate with DBus system service
 bind
-getsockname
 recvfrom
 recvmsg
 sendmsg
 sendto
-setsockopt
 `)
 
 var fwupdConnectedPlugSecComp = []byte(`
@@ -177,13 +175,10 @@ var fwupdConnectedPlugSecComp = []byte(`
 # privileged access to the fwupd service.
 # Usage: reserved
 bind
-getsockname
-getsockopt
 recvfrom
 recvmsg
 sendmsg
 sendto
-setsockopt
 `)
 
 // FwupdInterface type

--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -46,13 +46,10 @@ const gsettingsConnectedPlugSecComp = `
 # gsettings and allows adjusting settings of other applications.
 
 # dbus
-connect
-getsockname
 recvmsg
 send
 sendto
 sendmsg
-socket
 `
 
 // NewGsettingsInterface returns a new "gsettings" interface.

--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -27,15 +27,11 @@ const libvirtConnectedPlugAppArmor = `
 `
 
 const libvirtConnectedPlugSecComp = `
-connect
-getsockname
 recv
 recvmsg
 send
 sendto
 sendmsg
-socket
-socketpair
 listen
 accept
 `

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -123,14 +123,12 @@ dbus (receive)
 `)
 
 var locationControlPermanentSlotSecComp = []byte(`
-getsockname
 recvmsg
 sendmsg
 sendto
 `)
 
 var locationControlConnectedPlugSecComp = []byte(`
-getsockname
 recvmsg
 sendmsg
 sendto

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -188,14 +188,12 @@ dbus (receive)
 `)
 
 var locationObservePermanentSlotSecComp = []byte(`
-getsockname
 recvmsg
 sendmsg
 sendto
 `)
 
 var locationObserveConnectedPlugSecComp = []byte(`
-getsockname
 recvmsg
 sendmsg
 sendto

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -47,16 +47,12 @@ var mirPermanentSlotSecComp = []byte(`
 # Needed for server launch
 bind
 listen
-setsockopt
-getsockname
 # Needed by server upon client connect
 send
 sendto
 sendmsg
 accept
 shmctl
-open
-getsockopt
 recv
 recvmsg
 recvfrom

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -142,10 +142,6 @@ var modemManagerPermanentSlotSecComp = []byte(`
 accept
 accept4
 bind
-connect
-getpeername
-getsockname
-getsockopt
 listen
 recv
 recvfrom
@@ -155,10 +151,7 @@ send
 sendmmsg
 sendmsg
 sendto
-setsockopt
 shutdown
-socketpair
-socket
 `)
 
 var modemManagerConnectedPlugSecComp = []byte(`
@@ -167,15 +160,12 @@ var modemManagerConnectedPlugSecComp = []byte(`
 # Usage: reserved
 
 # Can communicate with DBus system service
-connect
-getsockname
 recv
 recvmsg
 recvfrom
 send
 sendto
 sendmsg
-socket
 `)
 
 var modemManagerPermanentSlotDBus = []byte(`

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -140,14 +140,12 @@ dbus (send)
 `)
 
 var mprisPermanentSlotSecComp = []byte(`
-getsockname
 recvmsg
 sendmsg
 sendto
 `)
 
 var mprisConnectedPlugSecComp = []byte(`
-getsockname
 recvmsg
 sendmsg
 sendto

--- a/interfaces/builtin/mpris_test.go
+++ b/interfaces/builtin/mpris_test.go
@@ -186,7 +186,7 @@ func (s *MprisInterfaceSuite) TestConnectedPlugSecComp(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 
-	c.Check(string(snippet), testutil.Contains, "getsockname\n")
+	c.Check(string(snippet), testutil.Contains, "recvmsg\n")
 }
 
 // The label uses short form when exactly one app is bound to the mpris slot
@@ -325,7 +325,7 @@ func (s *MprisInterfaceSuite) TestPermanentSlotSecComp(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 
-	c.Check(string(snippet), testutil.Contains, "getsockname\n")
+	c.Check(string(snippet), testutil.Contains, "recvmsg\n")
 }
 
 func (s *MprisInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -37,10 +37,6 @@ const networkConnectedPlugSecComp = `
 # Description: Can access the network as a client.
 # Usage: common
 bind
-connect
-getpeername
-getsockname
-getsockopt
 recv
 recvfrom
 recvmmsg
@@ -49,17 +45,7 @@ send
 sendmmsg
 sendmsg
 sendto
-setsockopt
 shutdown
-
-# LP: #1446748 - limit this to AF_UNIX/AF_LOCAL and perhaps AF_NETLINK
-socket
-
-# This is an older interface and single entry point that can be used instead
-# of socket(), bind(), connect(), etc individually. While we could allow it,
-# we wouldn't be able to properly arg filter socketcall for AF_INET/AF_INET6
-# when LP: #1446748 is implemented.
-socketcall
 `
 
 // NewNetworkInterface returns a new "network" interface.

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -66,10 +66,6 @@ const networkBindConnectedPlugSecComp = `
 accept
 accept4
 bind
-connect
-getpeername
-getsockname
-getsockopt
 listen
 recv
 recvfrom
@@ -79,17 +75,7 @@ send
 sendmmsg
 sendmsg
 sendto
-setsockopt
 shutdown
-
-# LP: #1446748 - limit this to AF_INET/AF_INET6
-socket
-
-# This is an older interface and single entry point that can be used instead
-# of socket(), bind(), connect(), etc individually. While we could allow it,
-# we wouldn't be able to properly arg filter socketcall for AF_INET/AF_INET6
-# when LP: #1446748 is implemented.
-socketcall
 `
 
 // NewNetworkBindInterface returns a new "network-bind" interface.

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -203,10 +203,6 @@ var networkManagerPermanentSlotSecComp = []byte(`
 accept
 accept4
 bind
-connect
-getpeername
-getsockname
-getsockopt
 listen
 recv
 recvfrom
@@ -216,11 +212,8 @@ send
 sendmmsg
 sendmsg
 sendto
-setsockopt
 sethostname
 shutdown
-socketpair
-socket
 # Needed for keyfile settings plugin to allow adding settings
 # for different users. This is currently at runtime only used
 # to make new created network settings files only editable by
@@ -245,15 +238,12 @@ var networkManagerConnectedPlugSecComp = []byte(`
 # Usage: reserved
 
 # Can communicate with DBus system service
-connect
-getsockname
 recv
 recvmsg
 recvfrom
 send
 sendto
 sendmsg
-socket
 `)
 
 var networkManagerPermanentSlotDBus = []byte(`

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -139,7 +139,6 @@ const ofonoPermanentSlotSecComp = `
 accept
 accept4
 bind
-getsockopt
 listen
 recv
 recvfrom

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -57,19 +57,11 @@ const openglConnectedPlugAppArmor = `
   /run/udev/data/c226:[0-9]* r,  # 226 drm
 `
 
-const openglConnectedPlugSecComp = `
-# Description: Can access opengl.
-# Usage: reserved
-
-getsockopt
-`
-
 // NewOpenglInterface returns a new "opengl" interface.
 func NewOpenglInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "opengl",
 		connectedPlugAppArmor: openglConnectedPlugAppArmor,
-		connectedPlugSecComp:  openglConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/openvswitch.go
+++ b/interfaces/builtin/openvswitch.go
@@ -26,14 +26,11 @@ const openvswitchConnectedPlugAppArmor = `
 `
 
 const openvswitchConnectedPlugSecComp = `
-connect
 recv
 recvmsg
 send
 sendto
 sendmsg
-socket
-socketpair
 `
 
 func NewOpenvSwitchInterface() interfaces.Interface {

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -48,13 +48,8 @@ owner /{,var/}run/user/*/pulse/native rwk,
 `
 
 const pulseaudioConnectedPlugSecComp = `
-getsockopt
-setsockopt
-connect
 sendto
 shmctl
-getsockname
-getpeername
 sendmsg
 recvmsg
 `
@@ -106,16 +101,12 @@ const pulseaudioPermanentSlotSecComp = `
 # The following are needed for UNIX sockets
 personality
 setpriority
-setsockopt
-getsockname
 bind
 listen
 sendto
 recvfrom
 accept4
 shmctl
-getsockname
-getpeername
 sendmsg
 recvmsg
 # Needed to set root as group for different state dirs

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -62,14 +62,11 @@ dbus (send)
 const screenInhibitControlConnectedPlugSecComp = `
 # Description: Can inhibit and uninhibit screen savers in desktop sessions.
 # dbus
-connect
-getsockname
 recvfrom
 recvmsg
 send
 sendto
 sendmsg
-socket
 `
 
 // NewScreenInhibitControlInterface returns a new "screen-inhibit-control" interface.

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -37,15 +37,11 @@ const snapdControlConnectedPlugSecComp = `
 # Usage: reserved
 
 # Can communicate with snapd abstract socket
-connect
-getsockname
 recv
 recvmsg
 send
 sendto
 sendmsg
-socket
-socketpair
 `
 
 // NewSnapdControlInterface returns a new "snapd-control" interface.

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -85,14 +85,11 @@ const systemObserveConnectedPlugSecComp = `
 #@deny ptrace
 
 # for connecting to /org/freedesktop/hostname1 over DBus
-connect
-getsockname
 recvfrom
 recvmsg
 send
 sendto
 sendmsg
-socket
 `
 
 // NewSystemObserveInterface returns a new "system-observe" interface.

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -85,14 +85,11 @@ capability sys_time,
 `
 const timeControlConnectedPlugSecComp = `
 # dbus
-connect
-getsockname
 recvmsg
 recvfrom
 send
 sendto
 sendmsg
-socket
 `
 
 // The type for the rtc interface

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -70,14 +70,11 @@ dbus (receive)
 `
 const timeserverControlConnectedPlugSecComp = `
 # dbus
-connect
-getsockname
 recvmsg
 recvfrom
 send
 sendto
 sendmsg
-socket
 `
 
 // NewTimeserverControlInterface returns a new "timeserver-control" interface.

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -71,14 +71,11 @@ dbus (receive)
 
 const timezoneControlConnectedPlugSecComp = `
 # dbus
-connect
-getsockname
 recvmsg
 recvfrom
 send
 sendto
 sendmsg
-socket
 `
 
 // NewTimezoneControlInterface returns a new "timezone-control" interface.

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -188,24 +188,20 @@ var downloadConnectedPlugSecComp = []byte(`
 # Description: Can access download manager.
 
 # dbus
-connect
 recvmsg
 send
 sendto
 sendmsg
-socket
 `)
 
 var downloadPermanentSlotSecComp = []byte(`
 # Description: Can act as a download manager.
 
 # dbus
-connect
 recvmsg
 send
 sendto
 sendmsg
-socket
 `)
 
 type UbuntuDownloadManagerInterface struct{}

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -152,8 +152,6 @@ fchown32
 fchownat
 lchown
 lchown32
-getsockname
-setsockopt
 mount
 recv
 recvfrom
@@ -167,7 +165,6 @@ umount2
 `
 
 const udisks2ConnectedPlugSecComp = `
-getsockname
 recv
 recvfrom
 recvmsg

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -440,20 +440,15 @@ const unity7ConnectedPlugSecComp = `
 # eavesdropping or apps interfering with one another.
 
 # X
-getpeername
 recvfrom
 recvmsg
 shutdown
-getsockopt
 
 # dbus
-connect
-getsockname
 recvmsg
 send
 sendto
 sendmsg
-socket
 `
 
 // NewUnity7Interface returns a new "unity7" interface.

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -198,14 +198,11 @@ const upowerObserveConnectedPlugSecComp = `
 # Description: Can query UPower for power devices, history and statistics.
 
 # dbus
-connect
-getsockname
 recvfrom
 recvmsg
 send
 sendto
 sendmsg
-socket
 `
 
 type UpowerObserveInterface struct{}

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -42,9 +42,6 @@ const x11ConnectedPlugSecComp = `
 # eavesdropping or apps interfering with one another.
 # Usage: reserved
 
-getpeername
-getsockname
-getsockopt
 recvfrom
 recvmsg
 sendmsg

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -90,9 +90,9 @@ func (s *X11InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-// The getsockname system call is allowed
+// The recvfrom system call is allowed
 func (s *X11InterfaceSuite) TestLP1574526(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
 	c.Assert(err, IsNil)
-	c.Check(string(snippet), testutil.Contains, "getsockname\n")
+	c.Check(string(snippet), testutil.Contains, "recvfrom\n")
 }

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -167,7 +167,7 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 	for _, line := range []string{
 		// NOTE: a few randomly picked lines from the real profile.  Comments
 		// and empty lines are avoided as those can be discarded in the future.
-		"deny init_module\n",
+		"# - create_module, init_module, finit_module, delete_module (kernel modules)\n",
 		"open\n",
 		"getuid\n",
 	} {

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -399,7 +399,7 @@ sigtimedwait
 sigwaitinfo
 
 # AppArmor mediates AF_UNIX/AF_LOCAL via 'unix' rules and all other AF_*
-# domains via 'network' rules. We won't allow bare 'network' AppArmor rules, so 
+# domains via 'network' rules. We won't allow bare 'network' AppArmor rules, so
 # we can allow 'socket' for any domain and let AppArmor handle the rest.
 socket
 

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -109,6 +109,10 @@ clock_gettime
 clock_nanosleep
 clone
 close
+
+# needed by ls -l
+connect
+
 creat
 dup
 dup2
@@ -394,9 +398,10 @@ sigsuspend
 sigtimedwait
 sigwaitinfo
 
-# needed by ls -l
+# AppArmor mediates AF_UNIX/AF_LOCAL via 'unix' rules and all other AF_*
+# domains via 'network' rules. We won't allow bare 'network' AppArmor rules, so 
+# we can allow 'socket' for any domain and let AppArmor handle the rest.
 socket
-connect
 
 # needed by snapctl
 getsockopt

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,53 +20,25 @@
 package seccomp
 
 // defaultTemplate contains default seccomp template.
-//
 // It can be overridden for testing using MockTemplate().
-//
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/templates/ubuntu-core/16.04/default
 var defaultTemplate = []byte(`
 # Description: Allows access to app-specific directories and basic runtime
-# Usage: common
 #
+# The default seccomp policy is default deny with a whitelist of allowed
+# syscalls. The default policy is intended to be safe for any application to
+# use and should be evaluated in conjuction with other security backends (eg
+# AppArmor). For example, a few particularly problematic syscalls that are left
+# out of the default policy are (non-exhaustive):
+# - kexec_load
+# - create_module, init_module, finit_module, delete_module (kernel modules)
+# - name_to_handle_at (history of vulnerabilities)
+# - open_by_handle_at (history of vulnerabilities)
+# - ptrace (can be used to break out of sandbox with <4.8 kernels)
+# - add_key, keyctl, request_key (kernel keyring)
 
-# Dangerous syscalls that we don't ever want to allow.
-# Note: may uncomment once ubuntu-core-launcher understands @deny rules and
-# if/when we conditionally deny these in the future.
-
-# kexec
-#@deny kexec_load
-
-# kernel modules
-#@deny create_module
-#@deny init_module
-#@deny finit_module
-#@deny delete_module
-
-# these have a history of vulnerabilities, are not widely used, and
-# open_by_handle_at has been used to break out of docker containers by brute
-# forcing the handle value: http://stealth.openwall.net/xSports/shocker.c
-#@deny name_to_handle_at
-#@deny open_by_handle_at
-
-# Explicitly deny ptrace since it can be abused to break out of the seccomp
-# sandbox
-#@deny ptrace
-
-# Explicitly deny capability mknod so apps can't create devices
-#@deny mknod
-#@deny mknodat
-
-# Explicitly deny (u)mount so apps can't change mounts in their namespace
-#@deny mount
-#@deny umount
-#@deny umount2
-
-# Explicitly deny kernel keyring access
-#@deny add_key
-#@deny keyctl
-#@deny request_key
-
-# end dangerous syscalls
+#
+# Allowed accesses
+#
 
 access
 faccessat

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -26,7 +26,7 @@ var defaultTemplate = []byte(`
 #
 # The default seccomp policy is default deny with a whitelist of allowed
 # syscalls. The default policy is intended to be safe for any application to
-# use and should be evaluated in conjuction with other security backends (eg
+# use and should be evaluated in conjunction with other security backends (eg
 # AppArmor). For example, a few particularly problematic syscalls that are left
 # out of the default policy are (non-exhaustive):
 # - kexec_load


### PR DESCRIPTION
- This removes connect, getpeername, getsockname, getsockopt, open, setsockopt, socket, socketcall, and socketpair from all interfaces except docker_support.go (which is left to make comparing to the upstream list easier) since these are all in the default template
- interfaces/seccomp: clarify/cleanup comments in default seccomp template