### PR TITLE
interfaces/default: don't allow TIOCSTI ioctl

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -124,6 +124,7 @@ all_tests = \
     snap-confine/tests/test_bad_seccomp_filter_args_prctl \
     snap-confine/tests/test_bad_seccomp_filter_args_prio \
     snap-confine/tests/test_bad_seccomp_filter_args_socket \
+    snap-confine/tests/test_bad_seccomp_filter_args_termios \
     snap-confine/tests/test_bad_seccomp_filter_length \
     snap-confine/tests/test_bad_seccomp_filter_missing_trailing_newline \
     snap-confine/tests/test_complain \
@@ -136,6 +137,7 @@ all_tests = \
     snap-confine/tests/test_restrictions_working_args_prctl \
     snap-confine/tests/test_restrictions_working_args_prio \
     snap-confine/tests/test_restrictions_working_args_socket \
+    snap-confine/tests/test_restrictions_working_args_termios \
     snap-confine/tests/test_unrestricted \
     snap-confine/tests/test_unrestricted_missed \
     snap-confine/tests/test_whitelist

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -17,6 +17,7 @@
 #include "config.h"
 #include "seccomp-support.h"
 
+#include <asm/ioctls.h>
 #include <ctype.h>
 #include <errno.h>
 #include <linux/can.h>		// needed for search mappings
@@ -31,6 +32,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
+#include <termios.h>
 #include <unistd.h>
 
 #include <seccomp.h>
@@ -281,6 +283,9 @@ static void sc_map_init()
 	sc_map_add(CLONE_NEWPID);
 	sc_map_add(CLONE_NEWUSER);
 	sc_map_add(CLONE_NEWUTS);
+
+	// man 4 tty_ioctl
+	sc_map_add(TIOCSTI);
 
 	// initialize the htab for our map
 	memset((void *)&sc_map_htab, 0, sizeof(sc_map_htab));

--- a/cmd/snap-confine/tests/test_bad_seccomp_filter_args_termios
+++ b/cmd/snap-confine/tests/test_bad_seccomp_filter_args_termios
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+. "${srcdir:-.}/snap-confine/tests/common.sh"
+
+get_common_syscalls >"$TMP"/tmpl
+cat >>"$TMP"/tmpl <<EOF
+# what we are testing
+EOF
+
+for i in 'TIOCST' 'TIOCSTII' 'TIOCST1' ; do
+    printf "Test bad seccomp arg filtering (ioctl - %s)" "$i"
+    cat "$TMP"/tmpl >"$TMP"/snap.name.app
+    echo "ioctl - $i" >>"$TMP"/snap.name.app
+
+    if $L snap.name.app /bin/true 2>/dev/null; then
+        # true returned successfully, bad arg test failed
+        cat "$TMP"/snap.name.app
+        FAIL
+    fi
+
+    # all good
+    PASS
+done

--- a/cmd/snap-confine/tests/test_restrictions_working_args_termios
+++ b/cmd/snap-confine/tests/test_restrictions_working_args_termios
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+. "${srcdir:-.}/snap-confine/tests/common.sh"
+
+get_common_syscalls >"$TMP"/tmpl
+cat >>"$TMP"/tmpl <<EOF
+getpriority
+EOF
+
+for i in TIOCSTI ; do
+    cat "$TMP"/tmpl >"$TMP"/snap.name.app
+    echo "ioctl - $i" >>"$TMP"/snap.name.app
+
+    printf "Test good seccomp arg filtering (ioctl - %s)" "$i"
+    # ensure that the command "true" can run with the right filter
+    if $L snap.name.app /bin/true ; then
+        PASS
+    else
+        dmesg|tail -n1
+        FAIL
+    fi
+done

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -185,8 +185,9 @@ inotify_init
 inotify_init1
 inotify_rm_watch
 
-# Needed by shell
-ioctl
+# TIOCSTI allows for faking input (man tty_ioctl)
+# TODO: this should be scaled back even more
+ioctl - !TIOCSTI
 
 io_cancel
 io_destroy


### PR DESCRIPTION
From `man tty_ioctl`: "TIOCSTI: Insert the given byte in the input queue". We need to allow the ioctl syscall for many applications, but when a snap is started it has the ability to use TIOCSTI to inject input into the parent session which means that a snap could trivially inject input into the terminal's input buffer. As such, deny use of ioctl when TIOCSTI is specified.