### PR TITLE
snap: add support user-sessions from snaps

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -58,6 +58,7 @@ var (
 
 	SnapBinariesDir     string
 	SnapServicesDir     string
+	SnapUserServicesDir string
 	SnapDesktopFilesDir string
 	SnapBusPolicyDir    string
 
@@ -132,6 +133,7 @@ func SetRootDir(rootdir string) {
 
 	SnapBinariesDir = filepath.Join(SnapMountDir, "bin")
 	SnapServicesDir = filepath.Join(rootdir, "/etc/systemd/system")
+	SnapUserServicesDir = filepath.Join(rootdir, "/etc/systemd/user")
 	SnapBusPolicyDir = filepath.Join(rootdir, "/etc/dbus-1/system.d")
 
 	CloudMetaDataFile = filepath.Join(rootdir, "/var/lib/cloud/seed/nocloud-net/meta-data")

--- a/snap/info.go
+++ b/snap/info.go
@@ -360,6 +360,7 @@ type AppInfo struct {
 	ReloadCommand   string
 	PostStopCommand string
 	RestartCond     systemd.RestartCondition
+	UserService     bool
 
 	// TODO: this should go away once we have more plumbing and can change
 	// things vs refactor
@@ -439,6 +440,9 @@ func (app *AppInfo) LauncherPostStopCommand() string {
 
 // ServiceFile returns the systemd service file path for the daemon app.
 func (app *AppInfo) ServiceFile() string {
+	if app.UserService {
+		return filepath.Join(dirs.SnapUserServicesDir, app.SecurityTag()+".service")
+	}
 	return filepath.Join(dirs.SnapServicesDir, app.SecurityTag()+".service")
 }
 

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -62,8 +62,10 @@ type appYaml struct {
 	StopTimeout     timeout.Timeout `yaml:"stop-timeout,omitempty"`
 
 	RestartCond systemd.RestartCondition `yaml:"restart-condition,omitempty"`
-	SlotNames   []string                 `yaml:"slots,omitempty"`
-	PlugNames   []string                 `yaml:"plugs,omitempty"`
+	UserService bool                     `yaml:"user-service,omitempty"`
+
+	SlotNames []string `yaml:"slots,omitempty"`
+	PlugNames []string `yaml:"plugs,omitempty"`
 
 	BusName string `yaml:"bus-name,omitempty"`
 
@@ -234,6 +236,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			ReloadCommand:   yApp.ReloadCommand,
 			PostStopCommand: yApp.PostStopCommand,
 			RestartCond:     yApp.RestartCond,
+			UserService:     yApp.UserService,
 			BusName:         yApp.BusName,
 			Environment:     yApp.Environment,
 		}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -501,3 +501,13 @@ func (s *infoSuite) TestDirAndFileMethods(c *C) {
 	c.Check(info.CommonDataHomeDir(), Equals, "/home/*/snap/name/common")
 	c.Check(info.XdgRuntimeDirs(), Equals, "/run/user/*/snap.name")
 }
+
+func (s *infoSuite) TestAppMethods(c *C) {
+	dirs.SetRootDir("")
+	info := &snap.Info{SuggestedName: "snap-name"}
+	app := &snap.AppInfo{Snap: info, Name: "app-name"}
+	c.Check(app.ServiceFile(), Equals, "/etc/systemd/system/snap.snap-name.app-name.service")
+
+	app.UserService = true
+	c.Check(app.ServiceFile(), Equals, "/etc/systemd/user/snap.snap-name.app-name.service")
+}


### PR DESCRIPTION
The ubuntu-personal team asked about support for user sessions. It seems we have most pieces in place. Here is a minimal branch, mostly to start a discussion (for a final branch we will need a bunch more tests).

The strawman in this branch is to use:
```
name: snap
apps:
 daemon1:
  command: foo --daemon
  daemon: simple
  user-service: true
```
alternatively we could use something like: `daemon-scope: {user,system}` or just `scope: {user,system}`. Or something entirely differently, I'm open for ideas :)