### PR TITLE
interfaces: port mount backend to new APIs, unify content of per app/hook profiles

### DIFF
--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -175,14 +176,6 @@ func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot 
 		}
 
 		return contentSnippet.Bytes(), nil
-	case interfaces.SecurityMount:
-		for _, r := range iface.path(slot, "read") {
-			fmt.Fprintln(contentSnippet, mountEntry(plug, slot, r, ",ro"))
-		}
-		for _, w := range iface.path(slot, "write") {
-			fmt.Fprintln(contentSnippet, mountEntry(plug, slot, w, ""))
-		}
-		return contentSnippet.Bytes(), nil
 	}
 	return nil, nil
 }
@@ -194,4 +187,16 @@ func (iface *ContentInterface) PermanentPlugSnippet(plug *interfaces.Plug, secur
 func (iface *ContentInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
+}
+
+// Interactions with the mount backend.
+
+func (iface *ContentInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	for _, r := range iface.path(slot, "read") {
+		spec.AddSnippet(mountEntry(plug, slot, r, ",ro"))
+	}
+	for _, w := range iface.path(slot, "write") {
+		spec.AddSnippet(mountEntry(plug, slot, w, ""))
+	}
+	return nil
 }

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -24,12 +24,13 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 type ContentSuite struct {
-	iface interfaces.Interface
+	iface *builtin.ContentInterface
 }
 
 var _ = Suite(&ContentSuite{
@@ -204,10 +205,12 @@ slots:
 	producerInfo := snaptest.MockInfo(c, producerYaml, &snap.SideInfo{Revision: snap.R(5)})
 	slot := &interfaces.Slot{SlotInfo: producerInfo.Slots["content"]}
 
-	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityMount)
-	c.Assert(err, IsNil)
-	expected := "/snap/producer/5/export /snap/consumer/7/import none bind,ro 0 0\n"
-	c.Assert(string(content), Equals, expected)
+	spec := &mount.Specification{}
+	c.Assert(s.iface.MountConnectedPlug(spec, plug, slot), IsNil)
+	expectedSnippets := []string{
+		"/snap/producer/5/export /snap/consumer/7/import none bind,ro 0 0",
+	}
+	c.Assert(spec.Snippets, DeepEquals, expectedSnippets)
 }
 
 // Check that sharing of read-only snap content is possible
@@ -228,14 +231,16 @@ slots:
 	producerInfo := snaptest.MockInfo(c, producerYaml, &snap.SideInfo{Revision: snap.R(5)})
 	slot := &interfaces.Slot{SlotInfo: producerInfo.Slots["content"]}
 
-	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityMount)
-	c.Assert(err, IsNil)
-	expected := "/snap/producer/5/export /snap/consumer/7/import none bind,ro 0 0\n"
-	c.Assert(string(content), Equals, expected)
+	spec := &mount.Specification{}
+	c.Assert(s.iface.MountConnectedPlug(spec, plug, slot), IsNil)
+	expectedSnippets := []string{
+		"/snap/producer/5/export /snap/consumer/7/import none bind,ro 0 0",
+	}
+	c.Assert(spec.Snippets, DeepEquals, expectedSnippets)
 
-	content, err = s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
+	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	expected = `
+	expected := `
 # In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files
 # read-only.
@@ -262,14 +267,16 @@ slots:
 	producerInfo := snaptest.MockInfo(c, producerYaml, &snap.SideInfo{Revision: snap.R(5)})
 	slot := &interfaces.Slot{SlotInfo: producerInfo.Slots["content"]}
 
-	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityMount)
-	c.Assert(err, IsNil)
-	expected := "/var/snap/producer/5/export /var/snap/consumer/7/import none bind 0 0\n"
-	c.Assert(string(content), Equals, expected)
+	spec := &mount.Specification{}
+	c.Assert(s.iface.MountConnectedPlug(spec, plug, slot), IsNil)
+	expectedSnippets := []string{
+		"/var/snap/producer/5/export /var/snap/consumer/7/import none bind 0 0",
+	}
+	c.Assert(spec.Snippets, DeepEquals, expectedSnippets)
 
-	content, err = s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
+	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	expected = `
+	expected := `
 # In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files. Due
 # to a limitation in the kernel's LSM hooks for AF_UNIX, these
@@ -298,14 +305,16 @@ slots:
 	producerInfo := snaptest.MockInfo(c, producerYaml, &snap.SideInfo{Revision: snap.R(5)})
 	slot := &interfaces.Slot{SlotInfo: producerInfo.Slots["content"]}
 
-	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityMount)
-	c.Assert(err, IsNil)
-	expected := "/var/snap/producer/common/export /var/snap/consumer/common/import none bind 0 0\n"
-	c.Assert(string(content), Equals, expected)
+	spec := &mount.Specification{}
+	c.Assert(s.iface.MountConnectedPlug(spec, plug, slot), IsNil)
+	expectedSnippets := []string{
+		"/var/snap/producer/common/export /var/snap/consumer/common/import none bind 0 0",
+	}
+	c.Assert(spec.Snippets, DeepEquals, expectedSnippets)
 
-	content, err = s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
+	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
-	expected = `
+	expected := `
 # In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files. Due
 # to a limitation in the kernel's LSM hooks for AF_UNIX, these

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/mount"
 )
 
 // TestInterface is a interface for various kind of tests.
@@ -51,6 +52,13 @@ type TestInterface struct {
 	TestConnectedSlotCallback func(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
 	TestPermanentPlugCallback func(spec *Specification, plug *interfaces.Plug) error
 	TestPermanentSlotCallback func(spec *Specification, slot *interfaces.Slot) error
+
+	// Support for interacting with the mount backend.
+
+	MountConnectedPlugCallback func(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	MountConnectedSlotCallback func(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	MountPermanentPlugCallback func(spec *mount.Specification, plug *interfaces.Plug) error
+	MountPermanentSlotCallback func(spec *mount.Specification, slot *interfaces.Slot) error
 }
 
 // String() returns the same value as Name().
@@ -157,6 +165,36 @@ func (t *TestInterface) TestPermanentPlug(spec *Specification, plug *interfaces.
 func (t *TestInterface) TestPermanentSlot(spec *Specification, slot *interfaces.Slot) error {
 	if t.TestPermanentSlotCallback != nil {
 		return t.TestPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}
+
+// Support for interacting with the mount backend.
+
+func (t *TestInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.MountConnectedPlugCallback != nil {
+		return t.MountConnectedPlugCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) MountConnectedSlot(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.MountConnectedSlotCallback != nil {
+		return t.MountConnectedSlotCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) MountPermanentPlug(spec *mount.Specification, plug *interfaces.Plug) error {
+	if t.MountPermanentPlugCallback != nil {
+		return t.MountPermanentPlugCallback(spec, plug)
+	}
+	return nil
+}
+
+func (t *TestInterface) MountPermanentSlot(spec *mount.Specification, slot *interfaces.Slot) error {
+	if t.MountPermanentSlotCallback != nil {
+		return t.MountPermanentSlotCallback(spec, slot)
 	}
 	return nil
 }

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -81,7 +81,7 @@ func (b *Backend) Remove(snapName string) error {
 	return nil
 }
 
-// deriveContent computes .fstab tables based on requests made to the recorder.
+// deriveContent computes .fstab tables based on requests made to the specification.
 func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.FileState {
 	// No snippets? Nothing to do!
 	if len(spec.Snippets) == 0 {

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -50,24 +50,20 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 
 // Setup creates mount mount profile files specific to a given snap.
 func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementOptions, repo *interfaces.Repository) error {
+	// Collect all the mount snipptes
 	snapName := snapInfo.Name()
-	// Get the snippets that apply to this snap
-	snippets, err := repo.SecuritySnippetsForSnap(snapInfo.Name(), interfaces.SecurityMount)
+	spec, err := repo.SnapSpecification(b.Name(), snapName)
 	if err != nil {
 		return fmt.Errorf("cannot obtain mount security snippets for snap %q: %s", snapName, err)
 	}
-	// Get the files that this snap should have
-	content, err := b.combineSnippets(snapInfo, snippets)
-	if err != nil {
-		return fmt.Errorf("cannot obtain expected mount configuration files for snap %q: %s", snapName, err)
-	}
+	content := deriveContent(spec.(*Specification), snapInfo)
+	// synchronize the content with the filesystem
 	glob := fmt.Sprintf("%s.fstab", interfaces.SecurityTagGlob(snapName))
 	dir := dirs.SnapMountPolicyDir
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("cannot create directory for mount configuration files %q: %s", dir, err)
 	}
-	_, _, err = osutil.EnsureDirState(dir, glob, content)
-	if err != nil {
+	if _, _, err := osutil.EnsureDirState(dir, glob, content); err != nil {
 		return fmt.Errorf("cannot synchronize mount configuration files for snap %q: %s", snapName, err)
 	}
 	return nil
@@ -85,50 +81,32 @@ func (b *Backend) Remove(snapName string) error {
 	return nil
 }
 
-// combineSnippets combines security snippets collected from all the interfaces
-// affecting a given snap into a content map applicable to EnsureDirState.
-func (b *Backend) combineSnippets(snapInfo *snap.Info, snippets map[string][][]byte) (content map[string]*osutil.FileState, err error) {
-	for _, appInfo := range snapInfo.Apps {
-		securityTag := appInfo.SecurityTag()
-		appSnippets := snippets[securityTag]
-		if len(appSnippets) == 0 {
-			continue
-		}
-		if content == nil {
-			content = make(map[string]*osutil.FileState)
-		}
-
-		addContent(securityTag, appSnippets, content)
+// deriveContent computes .fstab tables based on requests made to the recorder.
+func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.FileState {
+	// No snippets? Nothing to do!
+	if len(spec.Snippets) == 0 {
+		return nil
 	}
-
-	for _, hookInfo := range snapInfo.Hooks {
-		securityTag := hookInfo.SecurityTag()
-		hookSnippets := snippets[securityTag]
-		if len(hookSnippets) == 0 {
-			continue
-		}
-		if content == nil {
-			content = make(map[string]*osutil.FileState)
-		}
-
-		addContent(securityTag, hookSnippets, content)
-	}
-	return content, nil
-}
-
-func addContent(securityTag string, executableSnippets [][]byte, content map[string]*osutil.FileState) {
+	// Compute the contents of the fstab file. It should contain all the mount
+	// rules collected by the backend controller.
 	var buffer bytes.Buffer
-	for _, snippet := range executableSnippets {
-		buffer.Write(snippet)
-		buffer.WriteRune('\n')
+	for _, snippet := range spec.Snippets {
+		fmt.Fprintf(&buffer, "%s\n", snippet)
 	}
-
-	content[fmt.Sprintf("%s.fstab", securityTag)] = &osutil.FileState{
-		Content: buffer.Bytes(),
-		Mode:    0644,
+	fstate := &osutil.FileState{Content: buffer.Bytes(), Mode: 0644}
+	content := make(map[string]*osutil.FileState)
+	// Add legacy per-app/per-hook fstab files. Those are identical but
+	// snap-confine doesn't yet load it from a per-snap location. This can be
+	// safely removed once snap-confine is updated.
+	for _, appInfo := range snapInfo.Apps {
+		content[fmt.Sprintf("%s.fstab", appInfo.SecurityTag())] = fstate
 	}
+	for _, hookInfo := range snapInfo.Hooks {
+		content[fmt.Sprintf("%s.fstab", hookInfo.SecurityTag())] = fstate
+	}
+	return content
 }
 
 func (b *Backend) NewSpecification() interfaces.Specification {
-	panic(fmt.Errorf("%s is not using specifications yet", b.Name()))
+	return &Specification{}
 }

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -53,6 +53,8 @@ func (s *backendSuite) SetUpTest(c *C) {
 	s.Backend = &mount.Backend{}
 	s.BackendSuite.SetUpTest(c)
 
+	c.Assert(s.Repo.AddBackend(s.Backend), IsNil)
+
 	err := os.MkdirAll(dirs.SnapMountPolicyDir, 0700)
 	c.Assert(err, IsNil)
 
@@ -79,8 +81,12 @@ func (s *backendSuite) TestRemove(c *C) {
 	err = ioutil.WriteFile(hookCanaryToGo, []byte("ni! ni! ni!"), 0644)
 	c.Assert(err, IsNil)
 
-	canaryToStay := filepath.Join(dirs.SnapMountPolicyDir, "snap.i-stay.really.fstab")
-	err = ioutil.WriteFile(canaryToStay, []byte("stay!"), 0644)
+	appCanaryToStay := filepath.Join(dirs.SnapMountPolicyDir, "snap.i-stay.really.fstab")
+	err = ioutil.WriteFile(appCanaryToStay, []byte("stay!"), 0644)
+	c.Assert(err, IsNil)
+
+	snapCanaryToStay := filepath.Join(dirs.SnapMountPolicyDir, "snap.i-stay.fstab")
+	err = ioutil.WriteFile(snapCanaryToStay, []byte("stay!"), 0644)
 	c.Assert(err, IsNil)
 
 	err = s.Backend.Remove("hello-world")
@@ -88,7 +94,10 @@ func (s *backendSuite) TestRemove(c *C) {
 
 	c.Assert(osutil.FileExists(appCanaryToGo), Equals, false)
 	c.Assert(osutil.FileExists(hookCanaryToGo), Equals, false)
-	content, err := ioutil.ReadFile(canaryToStay)
+	content, err := ioutil.ReadFile(appCanaryToStay)
+	c.Assert(err, IsNil)
+	c.Assert(string(content), Equals, "stay!")
+	content, err = ioutil.ReadFile(snapCanaryToStay)
 	c.Assert(err, IsNil)
 	c.Assert(string(content), Equals, "stay!")
 }
@@ -100,47 +109,40 @@ apps:
     app2:
 hooks:
     configure:
-        plugs: [iface-plug, iface2-plug]
+        plugs: [iface-plug]
 plugs:
     iface-plug:
         interface: iface
-    iface2-plug:
-        interface: iface2
 slots:
     iface-slot:
-        interface: iface
-    iface2-slot:
         interface: iface2
 `
 
 func (s *backendSuite) TestSetupSetsupSimple(c *C) {
-	fsEntryIF1 := "/src-1 /dst-1 none bind,ro 0 0"
-	fsEntryIF2 := "/src-2 /dst-2 none bind,ro 0 0"
+	fsEntry1 := "/src-1 /dst-1 none bind,ro 0 0"
+	fsEntry2 := "/src-2 /dst-2 none bind,ro 0 0"
 
-	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-		return []byte(fsEntryIF1), nil
+	// Give the plug a permanent effect
+	s.Iface.MountPermanentPlugCallback = func(spec *mount.Specification, plug *interfaces.Plug) error {
+		return spec.AddSnippet(fsEntry1)
 	}
-	s.Iface.PermanentPlugSnippetCallback = func(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-		return []byte(fsEntryIF1), nil
-	}
-	s.iface2.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-		return []byte(fsEntryIF2), nil
-	}
-	s.iface2.PermanentPlugSnippetCallback = func(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-		return []byte(fsEntryIF2), nil
+	// Give the slot a permanent effect
+	s.iface2.MountPermanentSlotCallback = func(spec *mount.Specification, slot *interfaces.Slot) error {
+		return spec.AddSnippet(fsEntry2)
 	}
 
 	// confinement options are irrelevant to this security backend
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, mockSnapYaml, 0)
 
-	// ensure both security snippets for iface/iface2 are combined
-	expected := strings.Split(fmt.Sprintf("%s\n%s\n", fsEntryIF1, fsEntryIF2), "\n")
+	// ensure both security effects from iface/iface2 are combined
+	// (because mount profiles are global in the whole snap)
+	expected := strings.Split(fmt.Sprintf("%s\n%s\n", fsEntry1, fsEntry2), "\n")
 	sort.Strings(expected)
-	// and we have them both for both apps and the hook
+	// and that we have the legacy, per app/hook files as well.
 	for _, binary := range []string{"app1", "app2", "hook.configure"} {
-		fn1 := filepath.Join(dirs.SnapMountPolicyDir, fmt.Sprintf("snap.snap-name.%s.fstab", binary))
-		content, err := ioutil.ReadFile(fn1)
-		c.Assert(err, IsNil, Commentf("Expected mount file for %q", binary))
+		fn := filepath.Join(dirs.SnapMountPolicyDir, fmt.Sprintf("snap.snap-name.%s.fstab", binary))
+		content, err := ioutil.ReadFile(fn)
+		c.Assert(err, IsNil, Commentf("Expected mount profile for %q", binary))
 		got := strings.Split(string(content), "\n")
 		sort.Strings(got)
 		c.Check(got, DeepEquals, expected)
@@ -148,11 +150,8 @@ func (s *backendSuite) TestSetupSetsupSimple(c *C) {
 }
 
 func (s *backendSuite) TestSetupSetsupWithoutDir(c *C) {
-	s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-		return []byte("xxx"), nil
-	}
-	s.Iface.PermanentPlugSnippetCallback = func(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-		return []byte("xxx"), nil
+	s.Iface.MountPermanentPlugCallback = func(spec *mount.Specification, plug *interfaces.Plug) error {
+		return spec.AddSnippet("")
 	}
 
 	// Ensure that backend.Setup() creates the required dir on demand

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+// Specification assists in collecting mount entries associated with an interface.
+//
+// Unlike the Backend itself (which is stateless and non-persistent) this type
+// holds internal state that is used by the mount backend during the interface
+// setup process.
+type Specification struct {
+	Snippets []string
+}
+
+// AddMountEntry adds a new mount entry.
+func (spec *Specification) AddSnippet(snippet string) error {
+	spec.Snippets = append(spec.Snippets, snippet)
+	return nil
+}
+
+// Implementation of methods required by interfaces.Specification
+
+// ConnectedPlug records mount-specific side-effects of having a connected plug.
+func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		MountConnectedPlug(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.MountConnectedPlug(spec, plug, slot)
+	}
+	return nil
+}
+
+// ConnectedSlot records mount-specific side-effects of having a connected slot.
+func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		MountConnectedSlot(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.MountConnectedSlot(spec, plug, slot)
+	}
+	return nil
+}
+
+// PermanentPlug records mount-specific side-effects of having a plug.
+func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *interfaces.Plug) error {
+	type definer interface {
+		MountPermanentPlug(spec *Specification, plug *interfaces.Plug) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.MountPermanentPlug(spec, plug)
+	}
+	return nil
+}
+
+// PermanentSlot records mount-specific side-effects of having a slot.
+func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *interfaces.Slot) error {
+	type definer interface {
+		MountPermanentSlot(spec *Specification, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.MountPermanentSlot(spec, slot)
+	}
+	return nil
+}

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -28,14 +28,14 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-type recorderSuite struct {
+type specSuite struct {
 	iface *ifacetest.TestInterface
 	spec  *mount.Specification
 	plug  *interfaces.Plug
 	slot  *interfaces.Slot
 }
 
-var _ = Suite(&recorderSuite{
+var _ = Suite(&specSuite{
 	iface: &ifacetest.TestInterface{
 		InterfaceName: "test",
 		MountConnectedPlugCallback: func(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
@@ -67,12 +67,12 @@ var _ = Suite(&recorderSuite{
 	},
 })
 
-func (s *recorderSuite) SetUpTest(c *C) {
+func (s *specSuite) SetUpTest(c *C) {
 	s.spec = &mount.Specification{}
 }
 
 // AddMountEntry is not broken
-func (s *recorderSuite) TestSmoke(c *C) {
+func (s *specSuite) TestSmoke(c *C) {
 	ent0 := "fs1"
 	ent1 := "fs2"
 	c.Assert(s.spec.AddSnippet(ent0), IsNil)
@@ -81,7 +81,7 @@ func (s *recorderSuite) TestSmoke(c *C) {
 }
 
 // The mount.Specification can be used through the interfaces.Specification interface
-func (s *recorderSuite) TestSpecificationIface(c *C) {
+func (s *specSuite) TestSpecificationIface(c *C) {
 	var r interfaces.Specification = s.spec
 	c.Assert(r.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -1,0 +1,92 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/snap"
+)
+
+type recorderSuite struct {
+	iface *ifacetest.TestInterface
+	spec  *mount.Specification
+	plug  *interfaces.Plug
+	slot  *interfaces.Slot
+}
+
+var _ = Suite(&recorderSuite{
+	iface: &ifacetest.TestInterface{
+		InterfaceName: "test",
+		MountConnectedPlugCallback: func(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			return spec.AddSnippet("connected-plug")
+		},
+		MountConnectedSlotCallback: func(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			return spec.AddSnippet("connected-slot")
+		},
+		MountPermanentPlugCallback: func(spec *mount.Specification, plug *interfaces.Plug) error {
+			return spec.AddSnippet("permanent-plug")
+		},
+		MountPermanentSlotCallback: func(spec *mount.Specification, slot *interfaces.Slot) error {
+			return spec.AddSnippet("permanent-slot")
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "snap"},
+			Name:      "name",
+			Interface: "test",
+		},
+	},
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "snap"},
+			Name:      "name",
+			Interface: "test",
+		},
+	},
+})
+
+func (s *recorderSuite) SetUpTest(c *C) {
+	s.spec = &mount.Specification{}
+}
+
+// AddMountEntry is not broken
+func (s *recorderSuite) TestSmoke(c *C) {
+	ent0 := "fs1"
+	ent1 := "fs2"
+	c.Assert(s.spec.AddSnippet(ent0), IsNil)
+	c.Assert(s.spec.AddSnippet(ent1), IsNil)
+	c.Assert(s.spec.Snippets, DeepEquals, []string{ent0, ent1})
+}
+
+// The mount.Specification can be used through the interfaces.Specification interface
+func (s *recorderSuite) TestSpecificationIface(c *C) {
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
+	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
+	c.Assert(s.spec.Snippets, DeepEquals, []string{
+		"connected-plug", "connected-slot", "permanent-plug", "permanent-slot"})
+}


### PR DESCRIPTION
This branch changes the mount backend and the content interface to use new interface APIs. The mount backend now exposes a simple specification with an `AddSnippet` method so that things can mostly stay as they were before. The one significant difference is that there is no more differentiation between what each profile contains. In the past it was possible to define a different profile for two apps from the same snap. This would also incorrectly populate the mount namespace differently depending on which application started first. This is now unified so all the applications and hooks see the exact same profile text.