### PR TITLE
cmd: add /usr/local/* to PATH

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -143,9 +143,12 @@ int main(int argc, char **argv)
 			debug
 			    ("resetting PATH to values in sync with core snap");
 			setenv("PATH",
-			       "/usr/local/sbin:" "/usr/sbin:" "/usr/local/bin:"
-			       "/usr/bin:" "/sbin:" "/bin:" "/usr/local/games:"
-			       "/usr/games", 1);
+			       "/usr/local/sbin:"
+			       "/usr/local/bin:"
+			       "/usr/sbin:"
+			       "/usr/bin:"
+			       "/sbin:"
+			       "/bin:" "/usr/games:" "/usr/local/games", 1);
 			struct snappy_udev udev_s;
 			if (snappy_udev_init(security_tag, &udev_s) == 0)
 				setup_devices_cgroup(security_tag, &udev_s);

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -143,7 +143,9 @@ int main(int argc, char **argv)
 			debug
 			    ("resetting PATH to values in sync with core snap");
 			setenv("PATH",
-			       "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games", 1);
+			       "/usr/local/sbin:" "/usr/sbin:" "/usr/local/bin:"
+			       "/usr/bin:" "/sbin:" "/bin:" "/usr/local/games:"
+			       "/usr/games", 1);
 			struct snappy_udev udev_s;
 			if (snappy_udev_init(security_tag, &udev_s) == 0)
 				setup_devices_cgroup(security_tag, &udev_s);

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -34,6 +34,6 @@ execute: |
 
     echo "Ensure that SNAP, PATH and HOME are what we expect"
     egrep -q '^SNAP=/snap/test-snapd-tools/x1$' misc-vars.txt
-    egrep -q '^PATH=/usr/local/sbin:/usr/sbin:/usr/local/bin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games$' misc-vars.txt
+    egrep -q '^PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games$' misc-vars.txt
     egrep -q '^HOME=/root/snap/test-snapd-tools/x1$' misc-vars.txt
     test $(wc -l < misc-vars.txt) -eq 3

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -11,6 +11,8 @@ execute: |
     echo "Collect SNAP and XDG environment variables"
     test-snapd-tools.env | egrep '^SNAP_' | egrep -v '^SNAP_DID_REEXEC'| sort > snap-vars.txt
     test-snapd-tools.env | egrep '^XDG_' | sort > xdg-vars.txt 
+    echo "Collect PATH and HOME environment variables"
+    test-snapd-tools.env | egrep '^(SNAP|PATH|HOME)=' | sort > misc-vars.txt
 
     echo "Ensure that SNAP environment variables are what we expect"
     egrep -q '^SNAP_ARCH=(amd64|i386|arm64|armhf|ppc64el)$' snap-vars.txt
@@ -29,3 +31,9 @@ execute: |
     echo "Enure that XDG environment variables are what we expect"
     egrep -q '^XDG_RUNTIME_DIR=/run/user/0/snap.test-snapd-tools$' xdg-vars.txt
     test $(wc -l < xdg-vars.txt) -ge 1
+
+    echo "Ensure that SNAP, PATH and HOME are what we expect"
+    egrep -q '^SNAP=/snap/test-snapd-tools/x1$' misc-vars.txt
+    egrep -q '^PATH=/usr/local/sbin:/usr/sbin:/usr/local/bin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games$' misc-vars.txt
+    egrep -q '^HOME=/root/snap/test-snapd-tools/x1$' misc-vars.txt
+    test $(wc -l < misc-vars.txt) -eq 3

--- a/tests/regression/lp-1630479/task.yaml
+++ b/tests/regression/lp-1630479/task.yaml
@@ -17,7 +17,7 @@ execute: |
     echo "We can see that PATH is stable across calls"
     [ "$one" = "$two" ]
     echo "We can make sure that it has the right value"
-    [ "$one" = "/usr/local/sbin:/usr/sbin:/usr/local/bin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games" ]
+    [ "$one" = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" ]
     # NOTE: the following parts are notably absent from PATH
     #  - /snap/test-snapd-tools/$revision/bin
     #  - /snap/test-snapd-tools/$revision/usr/bin

--- a/tests/regression/lp-1630479/task.yaml
+++ b/tests/regression/lp-1630479/task.yaml
@@ -17,7 +17,7 @@ execute: |
     echo "We can see that PATH is stable across calls"
     [ "$one" = "$two" ]
     echo "We can make sure that it has the right value"
-    [ "$one" = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games" ]
+    [ "$one" = "/usr/local/sbin:/usr/sbin:/usr/local/bin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games" ]
     # NOTE: the following parts are notably absent from PATH
     #  - /snap/test-snapd-tools/$revision/bin
     #  - /snap/test-snapd-tools/$revision/usr/bin


### PR DESCRIPTION
Surprisingly /usr/local plays a role in the core snap. It is there where
the image build system splices additional files that don't come from a
typical deb. This includes the fake 'apt' script but most notably the
special 'xdg-open' executable that is necessary for snapd-xdg-open to
work.

The patch also expands the existing test that checks environment to
check PATH (and SNAP and HOME while I was a it it). One regression test
also needed changes as it was measuring the stability of PATH across
invocations of snap-confine.

Fixes: https://bugs.launchpad.net/snapcraft/+bug/1661023
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>