### PR TITLE
interfaces: miscellaneous updates for hardware-observe, kernel-module-control, unity7 and default

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -277,6 +277,7 @@ var defaultTemplate = []byte(`
   @{PROC}/sys/fs/file-max r,
   @{PROC}/sys/kernel/pid_max r,
   @{PROC}/sys/kernel/random/uuid r,
+  @{PROC}/sys/kernel/random/boot_id r,
   /sys/devices/virtual/tty/{console,tty*}/active r,
   /{,usr/}lib/ r,
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -257,6 +257,7 @@ var defaultTemplate = []byte(`
   @{PROC}/version_signature r,
   /etc/{,writable/}hostname r,
   /etc/{,writable/}localtime r,
+  /etc/{,writable/}mailname r,
   /etc/{,writable/}timezone r,
   @{PROC}/@{pid}/io r,
   owner @{PROC}/@{pid}/limits r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -347,6 +347,11 @@ var defaultTemplate = []byte(`
   # abstract or anonymous socket
   unix peer=(label=snap.@{SNAP_NAME}.*),
 
+  # Allow apps from the same package to communicate with each other via DBus.
+  # Note: this does not grant access to the DBus sockets of well known buses
+  # (will still need to use an appropriate interface for that).
+  dbus (receive, send) peer=(label=snap.@{SNAP_NAME}.*),
+
   # Allow apps from the same package to signal each other via signals
   signal peer=snap.@{SNAP_NAME}.*,
 

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type HardwareObserveInterfaceSuite struct {
@@ -83,4 +84,10 @@ func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
+	c.Check(string(snippet), testutil.Contains, "capability sys_rawio,\n")
+	// connected plugs have a non-nil security snippet for seccomp
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	c.Check(string(snippet), testutil.Contains, "iopl\n")
 }

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -29,9 +29,13 @@ const kernelModuleControlConnectedPlugAppArmor = `
   capability sys_module,
   @{PROC}/modules r,
 
-  # NOTE: needed by lscpu. In the future this may be moved to system-trace or
-  # system-observe.
+  # FIXME: moved to physical-memory-observe (remove this in series 18)
   /dev/mem r,
+
+  # Required to use SYSLOG_ACTION_READ_ALL and SYSLOG_ACTION_SIZE_BUFFER when
+  # /proc/sys/kernel/dmesg_restrict is '1' (syslog(2)). These operations are
+  # required to verify kernel modules that are loaded.
+  capability syslog,
 `
 
 const kernelModuleControlConnectedPlugSecComp = `

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -62,6 +62,12 @@ const unity7ConnectedPlugAppArmor = `
 /usr/share/thumbnailer/icons/**            r,
 /usr/share/themes/**                       r,
 
+# The snapcraft desktop part may look for schema files in various locations, so
+# allow reading system installed schemas.
+/usr/share/glib*/schemas/{,*}              r,
+/usr/share/gnome/glib*/schemas/{,*}        r,
+/usr/share/ubuntu/glib*/schemas/{,*}       r,
+
 # Snappy's 'xdg-open' talks to the snapd-xdg-open service which currently works
 # only in environments supporting dbus-send (eg, X11). In the future once
 # snappy's xdg-open supports all snaps images, this access may move to another


### PR DESCRIPTION
- interfaces/unity7: allow reading glib schemas files
- interfaces: allow reading /etc/mailname by default (LP: #1630690)
- interfaces/kernel-module-control: allow 'capability syslog'
- interfaces/hardware-observe: allow read on /proc/bus/pci/**, etc (LP: #1660865)
    Support lspci:
    - allow reading /etc/modprobe.d/{,*}
    - allow capability sys_admin
    - allow read on @{PROC}/bus/pci/{,**} (lspci -A linux-proc)
    - allow iopl syscall (lspci -A intel-conf*)
    - allow read on @{PROC}/interrupts
    Support lshw:
    - allow read on @{PROC}/devices
    - allow read on @{PROC}/ide/{,**}
    - allow read on @{PROC}/scsi/{,**}
    - allow read on @{PROC}/device-tree/{,**}
    - allow read on /sys/kernel/debug/usb/devices
    - allow read on @{PROC}/sys/abi/{,*}