### PR TITLE
interfaces: allow nice/setpriority to 0-19 values for calling process by default

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -143,6 +143,7 @@ var defaultTemplate = []byte(`
   /{,usr/}bin/mktemp ixr,
   /{,usr/}bin/more ixr,
   /{,usr/}bin/mv ixr,
+  /{,usr/}bin/nice ixr,
   /{,usr/}bin/openssl ixr, # may cause harmless capability block_suspend denial
   /{,usr/}bin/pgrep ixr,
   /{,usr/}bin/printenv ixr,

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -29,7 +29,8 @@ const processControlConnectedPlugAppArmor = `
 # all processes under root or processes running under the same UID otherwise.
 # Usage: reserved
 
-/{,usr/}bin/nice ixr,
+# /{,usr/}bin/nice is already in default policy, so just allow renice here
+/{,usr/}bin/renice ixr,
 
 capability sys_resource,
 capability sys_nice,
@@ -43,6 +44,8 @@ const processControlConnectedPlugSecComp = `
 # all processes under root or processes running under the same UID otherwise.
 # Usage: reserved
 
+# Allow setting the nice value/priority for any process
+nice
 setpriority
 sched_setaffinity
 sched_setparam

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -252,10 +252,16 @@ munmap
 
 nanosleep
 
-# LP: #1446748 - deny until we have syscall arg filtering. Alternatively, set
-# RLIMIT_NICE hard limit for apps, launch them under an appropriate nice value
-# and allow this call
-#nice
+# Allow using nice() with default or lower priority
+# FIXME: https://github.com/seccomp/libseccomp/issues/69 which means we
+# currently have to use <=19. When that bug is fixed, use >=0
+nice <=19
+# Allow using setpriority to set the priority of the calling process to default
+# or lower priority (eg, 'nice -n 9 <command>')
+# default or lower priority.
+# FIXME: https://github.com/seccomp/libseccomp/issues/69 which means we
+# currently have to use <=19. When that bug is fixed, use >=0
+setpriority PRIO_PROCESS 0 <=19
 
 # LP: #1446748 - support syscall arg filtering for mode_t with O_CREAT
 open


### PR DESCRIPTION
- adjust default apparmor template to use nice
- adjust default seccomp template to use nice values from 0-19 for the calling
  process
- adjust process-control to use renice binary and nice syscall

Note, https://github.com/seccomp/libseccomp/issues/69 is a limitation in the current handling of 32bit signed syscall arguments, so we use <=19 rather than >=0. This doesn't affect this PR but is something we'll want to address for things like >=-1.