### PR TITLE
interfaces/mount: add dedicated mount entry type

### DIFF
--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -38,22 +38,12 @@ import (
 // };
 type Entry struct {
 	Name    string
-	Dir     MntDir
+	Dir     string
 	Type    MntFsType
 	Options MntOptions
 
 	DumpFrequency   int
 	CheckPassNumber int
-}
-
-// MntDir represents mount directory in a mount entry.
-type MntDir string
-
-func (v MntDir) String() string {
-	if len(v) != 0 {
-		return escape(string(v))
-	}
-	return "none"
 }
 
 // MntOptions represents mount options in a mount entry.
@@ -98,6 +88,13 @@ func (e Entry) String() string {
 	} else {
 		name = "none"
 	}
+	var dir string
+	// Dir represents mount directory in a mount entry.
+	if len(e.Dir) != 0 {
+		dir = escape(e.Dir)
+	} else {
+		dir = "none"
+	}
 	return fmt.Sprintf("%s %s %s %s %d %d",
-		name, e.Dir, e.Type, e.Options, e.DumpFrequency, e.CheckPassNumber)
+		name, dir, e.Type, e.Options, e.DumpFrequency, e.CheckPassNumber)
 }

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -37,12 +37,13 @@ import (
 //     int   mnt_passno;   /* pass number on parallel fsck */
 // };
 type Entry struct {
-	FsName  MntFsName
+	Name    MntFsName
 	Dir     MntDir
-	FsType  MntFsType
+	Type    MntFsType
 	Options MntOptions
-	Freq    int
-	PassNum int
+
+	DumpFrequency   int
+	CheckPassNumber int
 }
 
 // MntFsName represents name of the device in a mount entry.
@@ -101,5 +102,5 @@ var whitespaceReplacer = strings.NewReplacer(
 
 func (e Entry) String() string {
 	return fmt.Sprintf("%s %s %s %s %d %d",
-		e.FsName, e.Dir, e.FsType, e.Options, e.Freq, e.PassNum)
+		e.Name, e.Dir, e.Type, e.Options, e.DumpFrequency, e.CheckPassNumber)
 }

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -39,7 +39,7 @@ import (
 type Entry struct {
 	Name    string
 	Dir     string
-	Type    MntFsType
+	Type    string
 	Options MntOptions
 
 	DumpFrequency   int
@@ -54,16 +54,6 @@ func (v MntOptions) String() string {
 		return escape(strings.Join(v, ","))
 	}
 	return "defaults"
-}
-
-// MntFsType represents file system type in a mount entry.
-type MntFsType string
-
-func (v MntFsType) String() string {
-	if len(v) != 0 {
-		return escape(string(v))
-	}
-	return "none"
 }
 
 // escape replaces whitespace characters so that getmntent can parse it correctly.
@@ -95,6 +85,13 @@ func (e Entry) String() string {
 	} else {
 		dir = "none"
 	}
+	// Type represents file system type in a mount entry.
+	var fsType string
+	if len(e.Type) != 0 {
+		fsType = escape(e.Type)
+	} else {
+		fsType = "none"
+	}
 	return fmt.Sprintf("%s %s %s %s %d %d",
-		name, dir, e.Type, e.Options, e.DumpFrequency, e.CheckPassNumber)
+		name, dir, fsType, e.Options, e.DumpFrequency, e.CheckPassNumber)
 }

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -40,20 +40,10 @@ type Entry struct {
 	Name    string
 	Dir     string
 	Type    string
-	Options MntOptions
+	Options []string
 
 	DumpFrequency   int
 	CheckPassNumber int
-}
-
-// MntOptions represents mount options in a mount entry.
-type MntOptions []string
-
-func (v MntOptions) String() string {
-	if len(v) != 0 {
-		return escape(strings.Join(v, ","))
-	}
-	return "defaults"
 }
 
 // escape replaces whitespace characters so that getmntent can parse it correctly.
@@ -92,6 +82,13 @@ func (e Entry) String() string {
 	} else {
 		fsType = "none"
 	}
+	// Options represents mount options in a mount entry.
+	var options string
+	if len(e.Options) != 0 {
+		options = escape(strings.Join(e.Options, ","))
+	} else {
+		options = "defaults"
+	}
 	return fmt.Sprintf("%s %s %s %s %d %d",
-		name, dir, fsType, e.Options, e.DumpFrequency, e.CheckPassNumber)
+		name, dir, fsType, options, e.DumpFrequency, e.CheckPassNumber)
 }

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -62,32 +62,24 @@ var whitespaceReplacer = strings.NewReplacer(
 
 func (e Entry) String() string {
 	// Name represents name of the device in a mount entry.
-	var name string
+	name := "none"
 	if len(e.Name) != 0 {
 		name = escape(e.Name)
-	} else {
-		name = "none"
 	}
-	var dir string
 	// Dir represents mount directory in a mount entry.
+	dir := "none"
 	if len(e.Dir) != 0 {
 		dir = escape(e.Dir)
-	} else {
-		dir = "none"
 	}
 	// Type represents file system type in a mount entry.
-	var fsType string
+	fsType := "none"
 	if len(e.Type) != 0 {
 		fsType = escape(e.Type)
-	} else {
-		fsType = "none"
 	}
 	// Options represents mount options in a mount entry.
-	var options string
+	options := "defaults"
 	if len(e.Options) != 0 {
 		options = escape(strings.Join(e.Options, ","))
-	} else {
-		options = "defaults"
 	}
 	return fmt.Sprintf("%s %s %s %s %d %d",
 		name, dir, fsType, options, e.DumpFrequency, e.CheckPassNumber)

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -63,17 +63,17 @@ var whitespaceReplacer = strings.NewReplacer(
 func (e Entry) String() string {
 	// Name represents name of the device in a mount entry.
 	name := "none"
-	if len(e.Name) != 0 {
+	if e.Name != "" {
 		name = escape(e.Name)
 	}
 	// Dir represents mount directory in a mount entry.
 	dir := "none"
-	if len(e.Dir) != 0 {
+	if e.Dir != "" {
 		dir = escape(e.Dir)
 	}
 	// Type represents file system type in a mount entry.
 	fsType := "none"
-	if len(e.Type) != 0 {
+	if e.Type != "" {
 		fsType = escape(e.Type)
 	}
 	// Options represents mount options in a mount entry.

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -28,13 +28,13 @@ import (
 //
 // Fields are named after names in struct returned by getmntent(3).
 //
-// struct Mntent {
-//     char *Mnt_fsname;   /* name of mounted filesystem */
-//     char *Mnt_dir;      /* filesystem path prefix */
-//     char *Mnt_type;     /* mount type (see Mntent.h) */
-//     char *Mnt_opts;     /* mount options (see Mntent.h) */
-//     int   Mnt_freq;     /* dump frequency in days */
-//     int   Mnt_passno;   /* pass number on parallel fsck */
+// struct mntent {
+//     char *mnt_fsname;   /* name of mounted filesystem */
+//     char *mnt_dir;      /* filesystem path prefix */
+//     char *mnt_type;     /* mount type (see Mntent.h) */
+//     char *mnt_opts;     /* mount options (see Mntent.h) */
+//     int   mnt_freq;     /* dump frequency in days */
+//     int   mnt_passno;   /* pass number on parallel fsck */
 // };
 type Entry struct {
 	FsName  MntFsName

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -1,0 +1,105 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Entry describes an /etc/fstab-like mount entry.
+//
+// Fields are named after names in struct returned by getmntent(3).
+//
+// struct Mntent {
+//     char *Mnt_fsname;   /* name of mounted filesystem */
+//     char *Mnt_dir;      /* filesystem path prefix */
+//     char *Mnt_type;     /* mount type (see Mntent.h) */
+//     char *Mnt_opts;     /* mount options (see Mntent.h) */
+//     int   Mnt_freq;     /* dump frequency in days */
+//     int   Mnt_passno;   /* pass number on parallel fsck */
+// };
+type Entry struct {
+	FsName  MntFsName
+	Dir     MntDir
+	FsType  MntFsType
+	Options MntOptions
+	Freq    int
+	PassNum int
+}
+
+// MntFsName represents name of the device in a mount entry.
+type MntFsName string
+
+func (v MntFsName) String() string {
+	if len(v) != 0 {
+		return escape(string(v))
+	}
+	return "none"
+}
+
+// MntDir represents mount directory in a mount entry.
+type MntDir string
+
+func (v MntDir) String() string {
+	if len(v) != 0 {
+		return escape(string(v))
+	}
+	return "none"
+}
+
+// MntOptions represents mount options in a mount entry.
+type MntOptions []string
+
+func (v MntOptions) String() string {
+	if len(v) != 0 {
+		return escape(strings.Join(v, ","))
+	}
+	return "defaults"
+}
+
+// MntFsType represents file system type in a mount entry.
+type MntFsType string
+
+func (v MntFsType) String() string {
+	if len(v) != 0 {
+		return escape(string(v))
+	}
+	return "none"
+}
+
+// escape replaces whitespace characters so that getmntent can parse it correctly.
+//
+// According to the manual page, the following characters need to be escaped.
+//  space     => (\040)
+//  tab       => (\011)
+//  newline   => (\012)
+//  backslash => (\134)
+func escape(s string) string {
+	return whitespaceReplacer.Replace(s)
+}
+
+var whitespaceReplacer = strings.NewReplacer(
+	" ", `\040`, "\t", `\011`, "\n", `\012`, "\\", `\134`)
+
+func (e Entry) String() string {
+	return fmt.Sprintf("%s %s %s %s %d %d",
+		e.FsName, e.Dir, e.FsType, e.Options, e.Freq, e.PassNum)
+}

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -37,23 +37,13 @@ import (
 //     int   mnt_passno;   /* pass number on parallel fsck */
 // };
 type Entry struct {
-	Name    MntFsName
+	Name    string
 	Dir     MntDir
 	Type    MntFsType
 	Options MntOptions
 
 	DumpFrequency   int
 	CheckPassNumber int
-}
-
-// MntFsName represents name of the device in a mount entry.
-type MntFsName string
-
-func (v MntFsName) String() string {
-	if len(v) != 0 {
-		return escape(string(v))
-	}
-	return "none"
 }
 
 // MntDir represents mount directory in a mount entry.
@@ -101,6 +91,13 @@ var whitespaceReplacer = strings.NewReplacer(
 	" ", `\040`, "\t", `\011`, "\n", `\012`, "\\", `\134`)
 
 func (e Entry) String() string {
+	// Name represents name of the device in a mount entry.
+	var name string
+	if len(e.Name) != 0 {
+		name = escape(e.Name)
+	} else {
+		name = "none"
+	}
 	return fmt.Sprintf("%s %s %s %s %d %d",
-		e.Name, e.Dir, e.Type, e.Options, e.DumpFrequency, e.CheckPassNumber)
+		name, e.Dir, e.Type, e.Options, e.DumpFrequency, e.CheckPassNumber)
 }

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -33,23 +33,23 @@ func (s *entrySuite) TestString(c *C) {
 	ent0 := mount.Entry{}
 	c.Assert(ent0.String(), Equals, "none none none defaults 0 0")
 	ent1 := mount.Entry{
-		FsName:  "/var/snap/foo/common",
+		Name:    "/var/snap/foo/common",
 		Dir:     "/var/snap/bar/common",
 		Options: []string{"bind"},
 	}
 	c.Assert(ent1.String(), Equals,
 		"/var/snap/foo/common /var/snap/bar/common none bind 0 0")
 	ent2 := mount.Entry{
-		FsName:  "/dev/sda5",
+		Name:    "/dev/sda5",
 		Dir:     "/media/foo",
-		FsType:  "ext4",
+		Type:    "ext4",
 		Options: []string{"rw,noatime"},
 	}
 	c.Assert(ent2.String(), Equals, "/dev/sda5 /media/foo ext4 rw,noatime 0 0")
 	ent3 := mount.Entry{
-		FsName:  "/dev/sda5",
+		Name:    "/dev/sda5",
 		Dir:     "/media/My Files",
-		FsType:  "ext4",
+		Type:    "ext4",
 		Options: []string{"rw,noatime"},
 	}
 	c.Assert(ent3.String(), Equals, `/dev/sda5 /media/My\040Files ext4 rw,noatime 0 0`)

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -1,0 +1,56 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/mount"
+)
+
+type entrySuite struct{}
+
+var _ = Suite(&entrySuite{})
+
+func (s *entrySuite) TestString(c *C) {
+	ent0 := mount.Entry{}
+	c.Assert(ent0.String(), Equals, "none none none defaults 0 0")
+	ent1 := mount.Entry{
+		FsName:  "/var/snap/foo/common",
+		Dir:     "/var/snap/bar/common",
+		Options: []string{"bind"},
+	}
+	c.Assert(ent1.String(), Equals,
+		"/var/snap/foo/common /var/snap/bar/common none bind 0 0")
+	ent2 := mount.Entry{
+		FsName:  "/dev/sda5",
+		Dir:     "/media/foo",
+		FsType:  "ext4",
+		Options: []string{"rw,noatime"},
+	}
+	c.Assert(ent2.String(), Equals, "/dev/sda5 /media/foo ext4 rw,noatime 0 0")
+	ent3 := mount.Entry{
+		FsName:  "/dev/sda5",
+		Dir:     "/media/My Files",
+		FsType:  "ext4",
+		Options: []string{"rw,noatime"},
+	}
+	c.Assert(ent3.String(), Equals, `/dev/sda5 /media/My\040Files ext4 rw,noatime 0 0`)
+}


### PR DESCRIPTION
This patch adds a MountEntry structure that contains broken-down fields
present in an /etc/fstab record. They will soon replace the simple
string based snippets.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>