### PR TITLE
cmd: use per-snap mount profile to populate the mount namespace

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -77,7 +77,7 @@ static const char *sc_get_outer_core_mount_point()
 
 // TODO: simplify this, after all it is just a tmpfs
 // TODO: fold this into bootstrap
-static void setup_private_mount(const char *security_tag)
+static void setup_private_mount(const char *snap_name)
 {
 	uid_t uid = getuid();
 	gid_t gid = getgid();
@@ -89,7 +89,7 @@ static void setup_private_mount(const char *security_tag)
 	// Under that basedir, we put a 1777 /tmp dir that is then bind
 	// mounted for the applications to use
 	sc_must_snprintf(tmpdir, sizeof(tmpdir), "/tmp/snap.%d_%s_XXXXXX", uid,
-			 security_tag);
+			 snap_name);
 	if (mkdtemp(tmpdir) == NULL) {
 		die("cannot create temporary directory essential for private /tmp");
 	}
@@ -190,16 +190,16 @@ static void setup_private_pts()
  * either the core snap on an all-snap system or the core snap + punched holes
  * on a classic system.
  **/
-static void sc_setup_mount_profiles(const char *security_tag)
+static void sc_setup_mount_profiles(const char *snap_name)
 {
-	debug("%s: %s", __FUNCTION__, security_tag);
+	debug("%s: %s", __FUNCTION__, snap_name);
 
 	FILE *f __attribute__ ((cleanup(sc_cleanup_endmntent))) = NULL;
 	const char *mount_profile_dir = "/var/lib/snapd/mount";
 
 	char profile_path[PATH_MAX];
-	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.fstab",
-			 mount_profile_dir, security_tag);
+	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/snap.%s.fstab",
+			 mount_profile_dir, snap_name);
 
 	debug("opening mount profile %s", profile_path);
 	f = setmntent(profile_path, "r");
@@ -581,7 +581,7 @@ static bool __attribute__ ((used))
 	return false;
 }
 
-void sc_populate_mount_ns(const char *security_tag)
+void sc_populate_mount_ns(const char *snap_name)
 {
 	// Get the current working directory before we start fiddling with
 	// mounts and possibly pivot_root.  At the end of the whole process, we
@@ -643,7 +643,7 @@ void sc_populate_mount_ns(const char *security_tag)
 
 	// set up private mounts
 	// TODO: rename this and fold it into bootstrap
-	setup_private_mount(security_tag);
+	setup_private_mount(snap_name);
 
 	// set up private /dev/pts
 	// TODO: fold this into bootstrap
@@ -654,7 +654,7 @@ void sc_populate_mount_ns(const char *security_tag)
 		sc_setup_quirks();
 	}
 	// setup the security backend bind mounts
-	sc_setup_mount_profiles(security_tag);
+	sc_setup_mount_profiles(snap_name);
 
 	// Try to re-locate back to vanilla working directory. This can fail
 	// because that directory is no longer present.

--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -31,6 +31,6 @@
  * The function will also try to preserve the current working directory but if
  * this is impossible it will chdir to SC_VOID_DIR.
  **/
-void sc_populate_mount_ns(const char *security_tag);
+void sc_populate_mount_ns(const char *snap_name);
 
 #endif

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -120,7 +120,8 @@ int main(int argc, char **argv)
 			debug
 			    ("skipping sandbox setup, classic confinement in use");
 		} else {
-			const char *group_name = getenv("SNAP_NAME");
+			const char *snap_name = getenv("SNAP_NAME");
+			const char *group_name = snap_name;
 			if (group_name == NULL) {
 				die("SNAP_NAME is not set");
 			}
@@ -130,7 +131,7 @@ int main(int argc, char **argv)
 			sc_lock_ns_mutex(group);
 			sc_create_or_join_ns_group(group, &apparmor);
 			if (sc_should_populate_ns_group(group)) {
-				sc_populate_mount_ns(security_tag);
+				sc_populate_mount_ns(snap_name);
 				sc_preserve_populated_ns_group(group);
 			}
 			sc_unlock_ns_mutex(group);


### PR DESCRIPTION
This is stacked on top #2773 

This patch changes snap-confine to use the one-per-snap mount profile,
away from the old security-tag (app/hook specific) mount profiles.

Ever since the persistent, per-snap, mount namespaces were created it
was meaningless to associated different profiles with particular
application.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>