### PR TITLE
cmd: use safer functions in sc_mount_opt2str

### DIFF
--- a/cmd/decode-mount-opts/decode-mount-opts.c
+++ b/cmd/decode-mount-opts/decode-mount-opts.c
@@ -32,6 +32,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "cannot parse given argument as a number\n");
 		return 1;
 	}
-	printf("%#lx is %s\n", mountflags, sc_mount_opt2str(mountflags));
+	char buf[1000];
+	printf("%#lx is %s\n", mountflags, sc_mount_opt2str(buf, sizeof buf, mountflags));
 	return 0;
 }

--- a/cmd/libsnap-confine-private/mount-opt-test.c
+++ b/cmd/libsnap-confine-private/mount-opt-test.c
@@ -23,41 +23,69 @@
 
 static void test_sc_mount_opt2str()
 {
-	g_assert_cmpstr(sc_mount_opt2str(0), ==, "");
-	g_assert_cmpstr(sc_mount_opt2str(MS_RDONLY), ==, "ro");
-	g_assert_cmpstr(sc_mount_opt2str(MS_NOSUID), ==, "nosuid");
-	g_assert_cmpstr(sc_mount_opt2str(MS_NODEV), ==, "nodev");
-	g_assert_cmpstr(sc_mount_opt2str(MS_NOEXEC), ==, "noexec");
-	g_assert_cmpstr(sc_mount_opt2str(MS_SYNCHRONOUS), ==, "sync");
-	g_assert_cmpstr(sc_mount_opt2str(MS_REMOUNT), ==, "remount");
-	g_assert_cmpstr(sc_mount_opt2str(MS_MANDLOCK), ==, "mand");
-	g_assert_cmpstr(sc_mount_opt2str(MS_DIRSYNC), ==, "dirsync");
-	g_assert_cmpstr(sc_mount_opt2str(MS_NOATIME), ==, "noatime");
-	g_assert_cmpstr(sc_mount_opt2str(MS_NODIRATIME), ==, "nodiratime");
-	g_assert_cmpstr(sc_mount_opt2str(MS_BIND), ==, "bind");
-	g_assert_cmpstr(sc_mount_opt2str(MS_REC | MS_BIND), ==, "rbind");
-	g_assert_cmpstr(sc_mount_opt2str(MS_MOVE), ==, "move");
-	g_assert_cmpstr(sc_mount_opt2str(MS_SILENT), ==, "silent");
-	g_assert_cmpstr(sc_mount_opt2str(MS_POSIXACL), ==, "acl");
-	g_assert_cmpstr(sc_mount_opt2str(MS_UNBINDABLE), ==, "unbindable");
-	g_assert_cmpstr(sc_mount_opt2str(MS_PRIVATE), ==, "private");
-	g_assert_cmpstr(sc_mount_opt2str(MS_REC | MS_PRIVATE), ==, "rprivate");
-	g_assert_cmpstr(sc_mount_opt2str(MS_SLAVE), ==, "slave");
-	g_assert_cmpstr(sc_mount_opt2str(MS_REC | MS_SLAVE), ==, "rslave");
-	g_assert_cmpstr(sc_mount_opt2str(MS_SHARED), ==, "shared");
-	g_assert_cmpstr(sc_mount_opt2str(MS_REC | MS_SHARED), ==, "rshared");
-	g_assert_cmpstr(sc_mount_opt2str(MS_RELATIME), ==, "relatime");
-	g_assert_cmpstr(sc_mount_opt2str(MS_KERNMOUNT), ==, "kernmount");
-	g_assert_cmpstr(sc_mount_opt2str(MS_I_VERSION), ==, "iversion");
-	g_assert_cmpstr(sc_mount_opt2str(MS_STRICTATIME), ==, "strictatime");
-	g_assert_cmpstr(sc_mount_opt2str(MS_LAZYTIME), ==, "lazytime");
+	char buf[1000];
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, 0), ==, "");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_RDONLY), ==, "ro");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOSUID), ==,
+			"nosuid");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NODEV), ==,
+			"nodev");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOEXEC), ==,
+			"noexec");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SYNCHRONOUS), ==,
+			"sync");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REMOUNT), ==,
+			"remount");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_MANDLOCK), ==,
+			"mand");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_DIRSYNC), ==,
+			"dirsync");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOATIME), ==,
+			"noatime");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NODIRATIME), ==,
+			"nodiratime");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_BIND), ==, "bind");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_BIND), ==,
+			"rbind");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_MOVE), ==, "move");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SILENT), ==,
+			"silent");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_POSIXACL), ==,
+			"acl");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_UNBINDABLE), ==,
+			"unbindable");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_PRIVATE), ==,
+			"private");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_PRIVATE),
+			==, "rprivate");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SLAVE), ==,
+			"slave");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_SLAVE),
+			==, "rslave");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_SHARED), ==,
+			"shared");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_REC | MS_SHARED),
+			==, "rshared");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_RELATIME), ==,
+			"relatime");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_KERNMOUNT), ==,
+			"kernmount");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_I_VERSION), ==,
+			"iversion");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_STRICTATIME), ==,
+			"strictatime");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_LAZYTIME), ==,
+			"lazytime");
 	// MS_NOSEC is not defined in userspace
 	// MS_BORN is not defined in userspace
-	g_assert_cmpstr(sc_mount_opt2str(MS_ACTIVE), ==, "active");
-	g_assert_cmpstr(sc_mount_opt2str(MS_NOUSER), ==, "nouser");
-	g_assert_cmpstr(sc_mount_opt2str(0x300), ==, "0x300");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_ACTIVE), ==,
+			"active");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOUSER), ==,
+			"nouser");
+	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, 0x300), ==, "0x300");
 	// random compositions do work
-	g_assert_cmpstr(sc_mount_opt2str(MS_RDONLY | MS_NOEXEC | MS_BIND), ==,
+	g_assert_cmpstr(sc_mount_opt2str
+			(buf, sizeof buf, MS_RDONLY | MS_NOEXEC | MS_BIND), ==,
 			"ro,noexec,bind");
 }
 

--- a/cmd/libsnap-confine-private/mount-opt.c
+++ b/cmd/libsnap-confine-private/mount-opt.c
@@ -109,7 +109,7 @@ const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags)
 		sc_string_append(buf, buf_size, of);
 	}
 	// Chop the excess comma from the end.
-	size_t len = strlen(buf);
+	size_t len = strnlen(buf, buf_size);
 	if (len > 0 && buf[len - 1] == ',') {
 		buf[len - 1] = 0;
 	}

--- a/cmd/libsnap-confine-private/mount-opt.c
+++ b/cmd/libsnap-confine-private/mount-opt.c
@@ -105,7 +105,7 @@ const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags)
 	// Render any flags that are unaccounted for.
 	if (flags) {
 		char of[128];
-		sprintf(of, "%#lx", flags);
+		sc_must_snprintf(of, sizeof of, "%#lx", flags);
 		sc_string_append(buf, buf_size, of);
 	}
 	// Chop the excess comma from the end.

--- a/cmd/libsnap-confine-private/mount-opt.c
+++ b/cmd/libsnap-confine-private/mount-opt.c
@@ -22,13 +22,13 @@
 #include <sys/mount.h>
 
 #include "../libsnap-confine-private/utils.h"
+#include "../libsnap-confine-private/string-utils.h"
 
-const char *sc_mount_opt2str(unsigned long flags)
+const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags)
 {
-	static char buf[1000];
 	unsigned long used = 0;
 	strcpy(buf, "");
-#define F(FLAG, TEXT) do if (flags & (FLAG)) { strcat(buf, #TEXT ","); flags ^= (FLAG); } while (0)
+#define F(FLAG, TEXT) do if (flags & (FLAG)) { sc_string_append(buf, buf_size, #TEXT ","); flags ^= (FLAG); } while (0)
 	F(MS_RDONLY, ro);
 	F(MS_NOSUID, nosuid);
 	F(MS_NODEV, nodev);
@@ -41,10 +41,10 @@ const char *sc_mount_opt2str(unsigned long flags)
 	F(MS_NODIRATIME, nodiratime);
 	if (flags & MS_BIND) {
 		if (flags & MS_REC) {
-			strcat(buf, "rbind,");
+			sc_string_append(buf, buf_size, "rbind,");
 			used |= MS_REC;
 		} else {
-			strcat(buf, "bind,");
+			sc_string_append(buf, buf_size, "bind,");
 		}
 		flags ^= MS_BIND;
 	}
@@ -57,28 +57,28 @@ const char *sc_mount_opt2str(unsigned long flags)
 	F(MS_UNBINDABLE, unbindable);
 	if (flags & MS_PRIVATE) {
 		if (flags & MS_REC) {
-			strcat(buf, "rprivate,");
+			sc_string_append(buf, buf_size, "rprivate,");
 			used |= MS_REC;
 		} else {
-			strcat(buf, "private,");
+			sc_string_append(buf, buf_size, "private,");
 		}
 		flags ^= MS_PRIVATE;
 	}
 	if (flags & MS_SLAVE) {
 		if (flags & MS_REC) {
-			strcat(buf, "rslave,");
+			sc_string_append(buf, buf_size, "rslave,");
 			used |= MS_REC;
 		} else {
-			strcat(buf, "slave,");
+			sc_string_append(buf, buf_size, "slave,");
 		}
 		flags ^= MS_SLAVE;
 	}
 	if (flags & MS_SHARED) {
 		if (flags & MS_REC) {
-			strcat(buf, "rshared,");
+			sc_string_append(buf, buf_size, "rshared,");
 			used |= MS_REC;
 		} else {
-			strcat(buf, "shared,");
+			sc_string_append(buf, buf_size, "shared,");
 		}
 		flags ^= MS_SHARED;
 	}
@@ -106,7 +106,7 @@ const char *sc_mount_opt2str(unsigned long flags)
 	if (flags) {
 		char of[128];
 		sprintf(of, "%#lx", flags);
-		strcat(buf, of);
+		sc_string_append(buf, buf_size, of);
 	}
 	// Chop the excess comma from the end.
 	size_t len = strlen(buf);

--- a/cmd/libsnap-confine-private/mount-opt.h
+++ b/cmd/libsnap-confine-private/mount-opt.h
@@ -18,12 +18,14 @@
 #ifndef SNAP_CONFINE_MOUNT_OPT_H
 #define SNAP_CONFINE_MOUNT_OPT_H
 
+#include <stddef.h>
+
 /**
  * Convert flags for mount(2) system call to a string representation. 
  *
  * The function uses an internal static buffer that is overwritten on each
  * request.
  **/
-const char *sc_mount_opt2str(unsigned long flags);
+const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags);
 
 #endif				// SNAP_CONFINE_MOUNT_OPT_H

--- a/cmd/snap-confine/quirks.c
+++ b/cmd/snap-confine/quirks.c
@@ -90,7 +90,8 @@ static void sc_quirk_mkdir_bind(const char *src_dir, const char *dest_dir,
 	if (sc_nonfatal_mkpath(dest_dir, 0755) < 0) {
 		die("cannot create empty directory at %s", dest_dir);
 	}
-	const char *flags_str = sc_mount_opt2str(flags);
+	char buf[1000];
+	const char *flags_str = sc_mount_opt2str(buf, sizeof buf, flags);
 	debug("performing operation: mount %s %s -o %s", src_dir, dest_dir,
 	      flags_str);
 	if (mount(src_dir, dest_dir, NULL, flags, NULL) != 0) {


### PR DESCRIPTION
This branch changes sc_mount_opt2str to use sc_string_append, sc_must_snprintf and strnlen
instead of the traditional and unchecked equivalents from the standard library.

This change now requires the caller to provide a buffer so all the code using this function
was patched to adapt. The buffer size stayed the same as the old hard-coded internal buffer.

Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com