### PR TITLE
tests: increase snap-service kill-timeout

### DIFF
--- a/tests/main/snap-service/task.yaml
+++ b/tests/main/snap-service/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that `snap run --command=reload` works
 
-kill-timeout: 1m
+kill-timeout: 3m
 execute: |
     echo "When the service snap is installed"
     . $TESTSLIB/snaps.sh
@@ -18,4 +18,3 @@ execute: |
             break
         fi
     done
-  


### PR DESCRIPTION
`tests/main/snap-service` is eventually failing on the arm platforms because of the kill timeout being reached, all works fine after waiting more time in those cases.