### PR TITLE
interfaces: add an interface for use by thumbnailer

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -51,6 +51,7 @@ var allInterfaces = []interfaces.Interface{
 	&PppInterface{},
 	&PulseAudioInterface{},
 	&SerialPortInterface{},
+	&ThumbnailerInterface{},
 	&TimeControlInterface{},
 	&UDisks2Interface{},
 	&UbuntuDownloadManagerInterface{},

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -54,6 +54,7 @@ func (s *AllSuite) TestInterfaces(c *C) {
 	c.Check(all, Contains, &builtin.PhysicalMemoryObserveInterface{})
 	c.Check(all, Contains, &builtin.PulseAudioInterface{})
 	c.Check(all, Contains, &builtin.SerialPortInterface{})
+	c.Check(all, Contains, &builtin.ThumbnailerInterface{})
 	c.Check(all, Contains, &builtin.TimeControlInterface{})
 	c.Check(all, Contains, &builtin.UDisks2Interface{})
 	c.Check(all, Contains, &builtin.UbuntuDownloadManagerInterface{})

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -495,6 +495,11 @@ slots:
       slot-snap-type:
         - core
     deny-auto-connection: true
+  thumbnailer:
+    allow-installation:
+      slot-snap-type:
+        - app
+    deny-auto-connection: true
   time-control:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -500,6 +500,7 @@ slots:
       slot-snap-type:
         - app
     deny-auto-connection: true
+    deny-connection: true
   time-control:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -417,6 +417,7 @@ var (
 		"ppp":                     {"core"},
 		"pulseaudio":              {"app", "core"},
 		"serial-port":             {"core", "gadget"},
+		"thumbnailer":             {"app"},
 		"udisks2":                 {"app"},
 		"uhid":                    {"core"},
 		"unity8-calendar":         {"app"},

--- a/interfaces/builtin/basedeclaration_test.go
+++ b/interfaces/builtin/basedeclaration_test.go
@@ -554,6 +554,7 @@ func (s *baseDeclSuite) TestConnection(c *C) {
 		"location-observe":        true,
 		"lxd":                     true,
 		"mir":                     true,
+		"thumbnailer":             true,
 		"udisks2":                 true,
 		"unity8-calendar":         true,
 		"unity8-contacts":         true,

--- a/interfaces/builtin/thumbnailer.go
+++ b/interfaces/builtin/thumbnailer.go
@@ -1,0 +1,96 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const thumbnailerPermanentSlotAppArmor = `
+# Description: Allow use of aa_query_label API
+
+/sys/module/apparmor/parameters/enabled r,
+@{PROC}/@{pid}/mounts                   r,
+/sys/kernel/security/apparmor/.access   rw,
+`
+
+const thumbnailerConnectedSlotAppArmor = `
+# Description: Allow access to plug's data directory
+
+@{INSTALL_DIR}/###PLUG_SNAP_NAME###/**     r,
+owner @{HOME}/snap/###PLUG_SNAP_NAME###/** r,
+/var/snap/###PLUG_SNAP_NAME###/**          r,
+`
+
+type ThumbnailerInterface struct{}
+
+func (iface *ThumbnailerInterface) Name() string {
+	return "thumbnailer"
+}
+
+func (iface *ThumbnailerInterface) PermanentPlugSnippet(plug *interfaces.Plug, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+func (iface *ThumbnailerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+func (iface *ThumbnailerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		return []byte(thumbnailerPermanentSlotAppArmor), nil
+	}
+	return nil, nil
+}
+
+func (iface *ThumbnailerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	switch securitySystem {
+	case interfaces.SecurityAppArmor:
+		snippet := []byte(thumbnailerConnectedSlotAppArmor)
+		old := []byte("###PLUG_SNAP_NAME###")
+		new := []byte(plug.Snap.Name())
+		snippet = bytes.Replace(snippet, old, new, -1)
+
+		return snippet, nil
+	}
+	return nil, nil
+}
+
+func (iface *ThumbnailerInterface) SanitizePlug(plug *interfaces.Plug) error {
+	if iface.Name() != plug.Interface {
+		panic(fmt.Sprintf("plug is not of interface %q", iface))
+	}
+	return nil
+}
+
+func (iface *ThumbnailerInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("slot is not of interface %q", iface))
+	}
+	return nil
+}
+
+func (iface *ThumbnailerInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+	return true
+}

--- a/interfaces/builtin/thumbnailer.go
+++ b/interfaces/builtin/thumbnailer.go
@@ -79,14 +79,14 @@ func (iface *ThumbnailerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, s
 
 func (iface *ThumbnailerInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
+		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
 func (iface *ThumbnailerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
+		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
 	return nil
 }

--- a/interfaces/builtin/thumbnailer_test.go
+++ b/interfaces/builtin/thumbnailer_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/interfaces/builtin/thumbnailer_test.go
+++ b/interfaces/builtin/thumbnailer_test.go
@@ -1,0 +1,84 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type ThumbnailerInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&ThumbnailerInterfaceSuite{
+	iface: &builtin.ThumbnailerInterface{},
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "server", Type: snap.TypeOS},
+			Name:      "thumbnailer",
+			Interface: "thumbnailer",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "client"},
+			Name:      "thumbnailer",
+			Interface: "thumbnailer",
+		},
+	},
+})
+
+func (s *ThumbnailerInterfaceSuite) TestName(c *C) {
+	c.Check(s.iface.Name(), Equals, "thumbnailer")
+}
+
+func (s *ThumbnailerInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Check(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "thumbnailer"`)
+	c.Check(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "thumbnailer"`)
+}
+
+func (s *ThumbnailerInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected slots have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	// slots have a permanent non-nil security snippet for apparmor
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}
+
+func (s *ThumbnailerInterfaceSuite) TestSlotGrantedAccessToPlugFiles(c *C) {
+	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+
+	c.Check(string(snippet), testutil.Contains, `@{INSTALL_DIR}/client/**`)
+	c.Check(string(snippet), testutil.Contains, `@{HOME}/snap/client/**`)
+	c.Check(string(snippet), testutil.Contains, `/var/snap/client/**`)
+}


### PR DESCRIPTION
This pull request adds a snapd interface for use by [thumbnailer](https://launchpad.net/thumbnailer/).  On Ubuntu Phone, `thumbnailer-service` was a D-Bus service that provided a shared thumbnail cache to applications: both for local pictures/music/videos, and for online album art.  It ran unconfined, and used the `aa_query_label()` API to determine whether the caller had permission to read the file it had asked to thumbnail.  Moving forward to Ubuntu Personal, we want to confine the daemon.

While the generic `dbus` interface was enough to get the online album art feature working, but to thumbnail local files we need to be able to read files owned by the caller.  So this interface does two things:

1. When connecting this interface, add an AppArmor snippet on the slot side that grants access to the plug snap's data directories.
2. Give the slot snap the permissions needed to actually use the `aa_query_label()` API.

This allows `thumbnailer-service` to read data belonging to snaps that choose to use thumbnailer (and only those snaps), which seems like an improvement over running unconfined.  It is a pretty wide ranging permission though, so ideally only the thumbnailer package would be allowed to offer this slot by default.  I'm not sure how easy that is though.

There are still a few open issues even with the changes in this pull request applied:

1. While this solves the problem of reading files, we're still running into some problems with reading files under the home directory due to `aa_query_label()` not handling rules that use the `owner` modifier (see [bug 1620635](https://bugs.launchpad.net/apparmor/+bug/1620635)).

2. We're also still using the generic `dbus` interface at the moment.  I wonder if it would make sense to fold the required D-Bus permissions into this snap to reduce the number of connections that need to be made between snaps.