### PR TITLE
Add a check for an empty argv in snap-confine.c

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -40,6 +40,9 @@
 
 int main(int argc, char **argv)
 {
+	if (argc == 0) {
+		exit(1);
+	}
 	if (argc == 2 && strcmp(argv[1], "--version") == 0) {
 		printf("%s %s\n", PACKAGE, PACKAGE_VERSION);
 		return 0;


### PR DESCRIPTION
Right now the setuid executable snap-confine can
be made to segfault like this:

```
user@ubuntu:/tmp/test$ ls -l /usr/lib/snapd/snap-confine 
-rwsr-xr-x 1 root root 55376 jan 13 19:39 /usr/lib/snapd/snap-confine
user@ubuntu:/tmp/test$ cat a.c

int main()
{
    char *arguments[] = { 0 };
    execv("/usr/lib/snapd/snap-confine", &arguments[0]);
    return 0;
}
user@ubuntu:/tmp/test$ gcc a.c
user@ubuntu:/tmp/test$ ./a.out
Segmentation fault (core dumped)
user@ubuntu:/tmp/test$
```

This patch avoids the seqfault from happening.