### PR TITLE
store: use xdelta3 from core if available and not on the regular system

### DIFF
--- a/osutil/exec.go
+++ b/osutil/exec.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+func libraryPathForCore(confPath string) []string {
+	root := filepath.Join(dirs.SnapMountDir, "/core/current")
+
+	f, err := os.Open(filepath.Join(root, confPath))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var out []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "#"):
+			// nothing
+		case strings.TrimSpace(line) == "":
+			// nothing
+		case strings.HasPrefix(line, "include "):
+			l := strings.SplitN(line, "include ", 2)
+			files, err := filepath.Glob(filepath.Join(root, l[1]))
+			if err != nil {
+				return nil
+			}
+			for _, f := range files {
+				out = append(out, libraryPathForCore(f[len(root):])...)
+			}
+		default:
+			out = append(out, filepath.Join(root, line))
+		}
+
+	}
+	if err := scanner.Err(); err != nil {
+		return nil
+	}
+
+	return out
+}
+
+func CommandFromCore(name string, arg ...string) *exec.Cmd {
+	root := filepath.Join(dirs.SnapMountDir, "/core/current")
+
+	coreLdSo := filepath.Join(root, "/lib/ld-linux.so.2")
+	cmdPath := filepath.Join(root, name)
+
+	ldLibraryPathForCore := libraryPathForCore("/etc/ld.so.conf")
+	ldSoArgs := []string{"--library-path", strings.Join(ldLibraryPathForCore, ":"), cmdPath}
+
+	allArgs := append(ldSoArgs, arg...)
+	return exec.Command(coreLdSo, allArgs...)
+}

--- a/osutil/exec.go
+++ b/osutil/exec.go
@@ -109,7 +109,11 @@ func CommandFromCore(name string, arg ...string) (*exec.Cmd, error) {
 		if err != nil {
 			return nil, err
 		}
-		coreLdSo = filepath.Join(root, link)
+		if strings.HasPrefix(link, "/") {
+			coreLdSo = filepath.Join(root, link)
+		} else {
+			coreLdSo = filepath.Join(filepath.Dir(coreLdSo), link)
+		}
 	}
 
 	ldLibraryPathForCore := libraryPathForCore("/etc/ld.so.conf")

--- a/osutil/exec.go
+++ b/osutil/exec.go
@@ -103,8 +103,14 @@ func CommandFromCore(name string, arg ...string) (*exec.Cmd, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	coreLdSo := filepath.Join(root, interp)
+	if IsSymlink(coreLdSo) {
+		link, err := os.Readlink(coreLdSo)
+		if err != nil {
+			return nil, err
+		}
+		coreLdSo = filepath.Join(root, link)
+	}
 
 	ldLibraryPathForCore := libraryPathForCore("/etc/ld.so.conf")
 	ldSoArgs := []string{"--library-path", strings.Join(ldLibraryPathForCore, ":"), cmdPath}

--- a/osutil/exec.go
+++ b/osutil/exec.go
@@ -94,17 +94,21 @@ func elfInterp(cmd string) (string, error) {
 	return "", fmt.Errorf("cannot find PT_INTERP header")
 }
 
+// CommandFromCore runs a command from the core snap using the proper
+// interpreter and library paths.
+//
+// At the moment it can only run ELF files, expects a standard ld.so
+// interpreter, and can't handle RPATH.
 func CommandFromCore(name string, arg ...string) (*exec.Cmd, error) {
 	root := filepath.Join(dirs.SnapMountDir, "/core/current")
 
 	cmdPath := filepath.Join(root, name)
-	// FIXME: support `#!/...` style in addition to elf
 	interp, err := elfInterp(cmdPath)
 	if err != nil {
 		return nil, err
 	}
 	coreLdSo := filepath.Join(root, interp)
-	if IsSymlink(coreLdSo) {
+	for IsSymlink(coreLdSo) {
 		link, err := os.Readlink(coreLdSo)
 		if err != nil {
 			return nil, err

--- a/osutil/exec_test.go
+++ b/osutil/exec_test.go
@@ -1,0 +1,80 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+type commandFromCoreSuite struct{}
+
+var _ = Suite(&commandFromCoreSuite{})
+
+func (s *commandFromCoreSuite) SetUpTest(c *C) {
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *commandFromCoreSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("")
+}
+
+func (s *commandFromCoreSuite) makeMockLdSoConf(c *C) {
+	ldSoConf := filepath.Join(dirs.SnapMountDir, "/core/current/etc/ld.so.conf")
+	ldSoConfD := ldSoConf + ".d"
+
+	err := os.MkdirAll(filepath.Dir(ldSoConf), 0755)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(ldSoConfD, 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(ldSoConf, []byte("include /etc/ld.so.conf.d/*.conf"), 0644)
+	c.Assert(err, IsNil)
+
+	ldSoConf1 := filepath.Join(ldSoConfD, "x86_64-linux-gnu.conf")
+
+	err = ioutil.WriteFile(ldSoConf1, []byte(`
+# Multiarch support
+/lib/x86_64-linux-gnu
+/usr/lib/x86_64-linux-gnu`), 0644)
+	c.Assert(err, IsNil)
+}
+
+func (s *commandFromCoreSuite) TestCommandFromCore(c *C) {
+	s.makeMockLdSoConf(c)
+
+	cmd := osutil.CommandFromCore("/usr/bin/xdelta3", "--some-xdelta-arg")
+
+	root := filepath.Join(dirs.SnapMountDir, "/core/current")
+	c.Check(cmd.Args, DeepEquals, []string{
+		filepath.Join(root, "/lib/ld-linux.so.2"),
+		"--library-path",
+		fmt.Sprintf("%s/lib/x86_64-linux-gnu:%s/usr/lib/x86_64-linux-gnu", root, root),
+		filepath.Join(dirs.SnapMountDir, "/core/current/usr/bin/xdelta3"),
+		"--some-xdelta-arg",
+	})
+}

--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -64,7 +64,6 @@ Depends: adduser,
          systemd (>= 204-5ubuntu20.20),
 # only needed on trusty to pull in the right version.
          util-linux (>=2.20.1-5.1ubuntu20.9),
-         xdelta3,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23~14.04)

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -58,7 +58,6 @@ Depends: adduser,
          gnupg1 | gnupg,
          squashfs-tools,
          systemd,
-         xdelta3,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22)

--- a/store/store.go
+++ b/store/store.go
@@ -1439,7 +1439,7 @@ func getXdelta3Cmd(args ...string) (*exec.Cmd, error) {
 	case osutil.ExecutableExists("xdelta3"):
 		return exec.Command("xdelta3", args...), nil
 	case osutil.FileExists(filepath.Join(dirs.SnapMountDir, "/core/current/usr/bin/xdelta3")):
-		return osutil.CommandFromCore("/usr/bin/xdelta3"), nil
+		return osutil.CommandFromCore("/usr/bin/xdelta3", args...)
 	}
 	return nil, fmt.Errorf("cannot find xdelta3 binary in PATH or core snap")
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -697,31 +697,32 @@ func (t *remoteRepoTestSuite) TestUseDeltas(c *C) {
 		exeInCore bool
 		expected  bool
 	}{
-		{"", false, false, false, false},  // no env, not on classic, no executable, no exe in core => no delta
-		{"", false, true, false, false},   // no env, not on classic, executable, no exe in core => no delta
-		{"", true, false, false, false},   // no env, on classic, no executable, no exe in core => no delta
-		{"", true, true, false, true},     // no env, on classic, executable, no exe in core => DELTA!
-		{"0", false, false, false, false}, // env says NO, not classic, no executable, no exe in core => no delta
-		{"0", false, true, false, false},  // env says NO, not classic, executable, no exe in core => no delta
-		{"0", true, false, false, false},  // env says NO, classic, no executable, no exe in core => no delta
-		{"0", true, true, false, false},   // env says NO, classic, executable, no exe in core => no delta
-		{"1", false, false, false, false}, // env says YES, no classic, no executable, no exe in core => no delta
-		{"1", false, true, false, true},   // env says YES, no classic, executable, no exe in core => DELTA!
-		{"1", true, false, false, false},  // env says YES, classic, no executable, no exe in core => no delta
-		{"1", true, true, false, true},    // env says YES, classic, executable, no exe in core => DELTA!
-
+		{"", false, false, false, false}, // no env, not on classic, no executable, no exe in core => no delta
 		{"", false, false, true, false},  // no env, not on classic, no executable, exe in core => no delta
+		{"", false, true, false, false},  // no env, not on classic, executable, no exe in core => no delta
 		{"", false, true, true, false},   // no env, not on classic, executable, exe in core => no delta
+		{"", true, false, false, false},  // no env, on classic, no executable, no exe in core => no delta
 		{"", true, false, true, true},    // no env, on classic, no executable, exe in core => no delta
+		{"", true, true, false, true},    // no env, on classic, executable, no exe in core => DELTA!
 		{"", true, true, true, true},     // no env, on classic, executable, exe in core => DELTA!
-		{"0", false, false, true, false}, // env says NO, not classic, no executable, exe in core => no delta
-		{"0", false, true, true, false},  // env says NO, not classic, executable, exe in core => no delta
-		{"0", true, false, true, false},  // env says NO, classic, no executable, exe in core => no delta
-		{"0", true, true, true, false},   // env says NO, classic, executable, exe in core => no delta
-		{"1", false, false, true, true},  // env says YES, no classic, no executable, exe in core => no delta
-		{"1", false, true, true, true},   // env says YES, no classic, executable, exe in core => DELTA!
-		{"1", true, false, true, true},   // env says YES, classic, no executable, exe in core => no delta
-		{"1", true, true, true, true},    // env says YES, classic, executable, exe in core => DELTA!
+
+		{"0", false, false, false, false}, // env says NO, not classic, no executable, no exe in core => no delta
+		{"0", false, false, true, false},  // env says NO, not classic, no executable, exe in core => no delta
+		{"0", false, true, false, false},  // env says NO, not classic, executable, no exe in core => no delta
+		{"0", false, true, true, false},   // env says NO, not classic, executable, exe in core => no delta
+		{"0", true, false, false, false},  // env says NO, classic, no executable, no exe in core => no delta
+		{"0", true, false, true, false},   // env says NO, classic, no executable, exe in core => no delta
+		{"0", true, true, false, false},   // env says NO, classic, executable, no exe in core => no delta
+		{"0", true, true, true, false},    // env says NO, classic, executable, exe in core => no delta
+
+		{"1", false, false, false, false}, // env says YES, no classic, no executable, no exe in core => no delta
+		{"1", false, false, true, true},   // env says YES, no classic, no executable, exe in core => no delta
+		{"1", false, true, false, true},   // env says YES, no classic, executable, no exe in core => DELTA!
+		{"1", false, true, true, true},    // env says YES, no classic, executable, exe in core => DELTA!
+		{"1", true, false, false, false},  // env says YES, classic, no executable, no exe in core => no delta
+		{"1", true, false, true, true},    // env says YES, classic, no executable, exe in core => no delta
+		{"1", true, true, false, true},    // env says YES, classic, executable, no exe in core => DELTA!
+		{"1", true, true, true, true},     // env says YES, classic, executable, exe in core => DELTA!
 
 	}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -728,7 +728,7 @@ func (t *remoteRepoTestSuite) TestUseDeltas(c *C) {
 
 	for _, scenario := range scenarios {
 		if scenario.exeInCore {
-			ioutil.WriteFile(exeInCorePath, nil, 0755)
+			osutil.CopyFile("/bin/true", exeInCorePath, 0)
 		} else {
 			os.Remove(exeInCorePath)
 		}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -693,37 +693,37 @@ func (t *remoteRepoTestSuite) TestUseDeltas(c *C) {
 	scenarios := []struct {
 		env       string
 		classic   bool
-		exe       bool
+		exeInHost bool
 		exeInCore bool
-		expected  bool
+
+		wantDelta bool
 	}{
-		{"", false, false, false, false}, // no env, not on classic, no executable, no exe in core => no delta
-		{"", false, false, true, false},  // no env, not on classic, no executable, exe in core => no delta
-		{"", false, true, false, false},  // no env, not on classic, executable, no exe in core => no delta
-		{"", false, true, true, false},   // no env, not on classic, executable, exe in core => no delta
-		{"", true, false, false, false},  // no env, on classic, no executable, no exe in core => no delta
-		{"", true, false, true, true},    // no env, on classic, no executable, exe in core => no delta
-		{"", true, true, false, true},    // no env, on classic, executable, no exe in core => DELTA!
-		{"", true, true, true, true},     // no env, on classic, executable, exe in core => DELTA!
+		{env: "", classic: false, exeInHost: false, exeInCore: false, wantDelta: false},
+		{env: "", classic: false, exeInHost: false, exeInCore: true, wantDelta: false},
+		{env: "", classic: false, exeInHost: true, exeInCore: false, wantDelta: false},
+		{env: "", classic: false, exeInHost: true, exeInCore: true, wantDelta: false},
+		{env: "", classic: true, exeInHost: false, exeInCore: false, wantDelta: false},
+		{env: "", classic: true, exeInHost: false, exeInCore: true, wantDelta: true},
+		{env: "", classic: true, exeInHost: true, exeInCore: false, wantDelta: true},
+		{env: "", classic: true, exeInHost: true, exeInCore: true, wantDelta: true},
 
-		{"0", false, false, false, false}, // env says NO, not classic, no executable, no exe in core => no delta
-		{"0", false, false, true, false},  // env says NO, not classic, no executable, exe in core => no delta
-		{"0", false, true, false, false},  // env says NO, not classic, executable, no exe in core => no delta
-		{"0", false, true, true, false},   // env says NO, not classic, executable, exe in core => no delta
-		{"0", true, false, false, false},  // env says NO, classic, no executable, no exe in core => no delta
-		{"0", true, false, true, false},   // env says NO, classic, no executable, exe in core => no delta
-		{"0", true, true, false, false},   // env says NO, classic, executable, no exe in core => no delta
-		{"0", true, true, true, false},    // env says NO, classic, executable, exe in core => no delta
+		{env: "0", classic: false, exeInHost: false, exeInCore: false, wantDelta: false},
+		{env: "0", classic: false, exeInHost: false, exeInCore: true, wantDelta: false},
+		{env: "0", classic: false, exeInHost: true, exeInCore: false, wantDelta: false},
+		{env: "0", classic: false, exeInHost: true, exeInCore: true, wantDelta: false},
+		{env: "0", classic: true, exeInHost: false, exeInCore: false, wantDelta: false},
+		{env: "0", classic: true, exeInHost: false, exeInCore: true, wantDelta: false},
+		{env: "0", classic: true, exeInHost: true, exeInCore: false, wantDelta: false},
+		{env: "0", classic: true, exeInHost: true, exeInCore: true, wantDelta: false},
 
-		{"1", false, false, false, false}, // env says YES, no classic, no executable, no exe in core => no delta
-		{"1", false, false, true, true},   // env says YES, no classic, no executable, exe in core => no delta
-		{"1", false, true, false, true},   // env says YES, no classic, executable, no exe in core => DELTA!
-		{"1", false, true, true, true},    // env says YES, no classic, executable, exe in core => DELTA!
-		{"1", true, false, false, false},  // env says YES, classic, no executable, no exe in core => no delta
-		{"1", true, false, true, true},    // env says YES, classic, no executable, exe in core => no delta
-		{"1", true, true, false, true},    // env says YES, classic, executable, no exe in core => DELTA!
-		{"1", true, true, true, true},     // env says YES, classic, executable, exe in core => DELTA!
-
+		{env: "1", classic: false, exeInHost: false, exeInCore: false, wantDelta: false},
+		{env: "1", classic: false, exeInHost: false, exeInCore: true, wantDelta: true},
+		{env: "1", classic: false, exeInHost: true, exeInCore: false, wantDelta: true},
+		{env: "1", classic: false, exeInHost: true, exeInCore: true, wantDelta: true},
+		{env: "1", classic: true, exeInHost: false, exeInCore: false, wantDelta: false},
+		{env: "1", classic: true, exeInHost: false, exeInCore: true, wantDelta: true},
+		{env: "1", classic: true, exeInHost: true, exeInCore: false, wantDelta: true},
+		{env: "1", classic: true, exeInHost: true, exeInCore: true, wantDelta: true},
 	}
 
 	for _, scenario := range scenarios {
@@ -734,13 +734,13 @@ func (t *remoteRepoTestSuite) TestUseDeltas(c *C) {
 		}
 		os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", scenario.env)
 		release.MockOnClassic(scenario.classic)
-		if scenario.exe {
+		if scenario.exeInHost {
 			os.Setenv("PATH", origPath)
 		} else {
 			os.Setenv("PATH", altPath)
 		}
 
-		c.Check(useDeltas(), Equals, scenario.expected, Commentf("%#v", scenario))
+		c.Check(useDeltas(), Equals, scenario.wantDelta, Commentf("%#v", scenario))
 	}
 }
 

--- a/tests/main/refresh-delta-from-core/task.yaml
+++ b/tests/main/refresh-delta-from-core/task.yaml
@@ -1,0 +1,23 @@
+summary: Check refresh works with xdelta3 from the core snap
+
+# delta downloads are currently disabled by default on core
+systems: [-ubuntu-core-*]
+
+environment:
+    SNAP_NAME: test-snapd-delta-refresh
+
+prepare: |
+    echo "Ensure no xdelta3 is installed on the host"
+    apt-get remove -y xdelta3
+
+    echo "Given a snap is installed"
+    snap install --edge $SNAP_NAME
+
+restore: |
+    apt-get install -y xdelta3
+
+execute: |
+    echo "When the snap is refreshed"
+    snap refresh --beta $SNAP_NAME
+    echo "Then deltas are successfully applied"
+    journalctl -u snapd | MATCH "Successfully applied delta"

--- a/tests/main/refresh-delta-from-core/task.yaml
+++ b/tests/main/refresh-delta-from-core/task.yaml
@@ -7,14 +7,18 @@ environment:
     SNAP_NAME: test-snapd-delta-refresh
 
 prepare: |
-    echo "Ensure no xdelta3 is installed on the host"
-    apt-get remove -y xdelta3
+    echo "Ensure no xdelta3 available on the host"
+    if [ -e /usr/bin/xdelta3 ]; then
+        mv /usr/bin/xdelta3{,.disabled)
+    fi
 
     echo "Given a snap is installed"
     snap install --edge $SNAP_NAME
 
 restore: |
-    apt-get install -y xdelta3
+    if [ -e /usr/bin/xdelta3.disabled ]; then
+        mv /usr/bin/xdelta3{.disabled,)
+    fi
 
 execute: |
     echo "When the snap is refreshed"

--- a/tests/main/refresh-delta-from-core/task.yaml
+++ b/tests/main/refresh-delta-from-core/task.yaml
@@ -9,7 +9,7 @@ environment:
 prepare: |
     echo "Ensure no xdelta3 available on the host"
     if [ -e /usr/bin/xdelta3 ]; then
-        mv /usr/bin/xdelta3{,.disabled)
+        mv /usr/bin/xdelta3{,.disabled}
     fi
 
     echo "Given a snap is installed"
@@ -17,7 +17,7 @@ prepare: |
 
 restore: |
     if [ -e /usr/bin/xdelta3.disabled ]; then
-        mv /usr/bin/xdelta3{.disabled,)
+        mv /usr/bin/xdelta3{.disabled,}
     fi
 
 execute: |


### PR DESCRIPTION
This avoids us having to add a dependency to snapd for xdelta3 (and fixes the issues that snapd 2.0.10 from Ubuntu 16.04.1 won't `apt-get upgrade` with any new dependencies).

It is slightly complicated because we want to ensure that the correct ld-linux.so is used and also that the correct libraries from core (instead of from the host) are used.