### PR TITLE
tests/lib/fakestore/refresh: some more info when we fail to copy asserts

### DIFF
--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
 )
 
 func MakeFakeRefreshForSnaps(snaps []string, blobDir string) error {
@@ -66,7 +67,7 @@ func MakeFakeRefreshForSnaps(snaps []string, blobDir string) error {
 		case 1:
 			return as[0], nil
 		case 0:
-			return nil, asserts.ErrNotFound
+			return nil, &store.AssertionNotFoundError{Ref: ref}
 		default:
 			panic(fmt.Sprintf("multiple assertions when retrieving by primary key: %v", ref))
 		}


### PR DESCRIPTION
This to help debugging staging tests flakiness.