### PR TITLE
Fix checks failing on code formatting

### DIFF
--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -154,7 +154,7 @@ too short
 
 	l, err := snap.AutoImportCandidates()
 	c.Check(err, IsNil)
-	c.Check(l, DeepEquals, files[1:len(files)])
+	c.Check(l, DeepEquals, files[1:])
 }
 
 func (s *SnapSuite) TestAutoImportAssertsHappyNotOnClassic(c *C) {


### PR DESCRIPTION
This is caught when running on Ubuntu 17.04 (zesty). This problem doesn't seem to occur on 16.04 LTS.