### PR TITLE
daemon: show "$snapname (delta)" in progress when downloading deltas

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/httputil"
+	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -1479,7 +1480,7 @@ func (s *Store) downloadAndApplyDelta(name, targetPath string, downloadInfo *sna
 	deltaInfo := &downloadInfo.Deltas[0]
 
 	deltaPath := fmt.Sprintf("%s.%s-%d-to-%d.partial", targetPath, deltaInfo.Format, deltaInfo.FromRevision, deltaInfo.ToRevision)
-	deltaName := filepath.Base(deltaPath)
+	deltaName := fmt.Sprintf(i18n.G("%s (delta)"), name)
 
 	w, err := os.Create(deltaPath)
 	if err != nil {


### PR DESCRIPTION
We currently display something like `core_1126.snap.xdelta3-1119-to-1126.partial` which is a bit too much :)