### PR TITLE
snap-confine: make sc_map_search/read_number take const const char * arguments

### DIFF
--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -104,7 +104,7 @@ static scmp_datum_t sc_map_search(const char *s)
 	scmp_datum_t val = 0;
 	errno = 0;
 
-	e.key = (char*)s;
+	e.key = (char *)s;
 	if (hsearch_r(e, FIND, &ep, &sc_map_htab) == 0)
 		die("hsearch_r failed");
 

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -97,14 +97,14 @@ static struct sc_map_list sc_map_entries;
  * sc_map_search(s)	- if found, return scmp_datum_t for key, else set errno
  * sc_map_destroy()	- destroy the hash map and linked list
  */
-static scmp_datum_t sc_map_search(char *s)
+static scmp_datum_t sc_map_search(const char *s)
 {
 	ENTRY e;
 	ENTRY *ep = NULL;
 	scmp_datum_t val = 0;
 	errno = 0;
 
-	e.key = s;
+	e.key = (char*)s;
 	if (hsearch_r(e, FIND, &ep, &sc_map_htab) == 0)
 		die("hsearch_r failed");
 
@@ -337,7 +337,7 @@ static void sc_map_destroy()
 }
 
 /* Caller must check if errno != 0 */
-static scmp_datum_t read_number(char *s)
+static scmp_datum_t read_number(const char *s)
 {
 	scmp_datum_t val = 0;
 


### PR DESCRIPTION
Drive-by branch while looking at snap-confine. The  of sc_map_search() and read_number() should not modify the char * points so we should declare them const char *.