### PR TITLE
asserts: introduce a variant of model assertions for classic systems

### DIFF
--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -181,9 +181,8 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 	}
 
 	if classic {
-		_, ok := assert.headers["kernel"]
-		if ok {
-			return nil, fmt.Errorf("classic model cannot specify explicitly a kernel")
+		if _, ok := assert.headers["kernel"]; ok {
+			return nil, fmt.Errorf("cannot specify a kernel with a classic model")
 		}
 	}
 

--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -30,6 +30,7 @@ import (
 // about the properties of a device model.
 type Model struct {
 	assertionBase
+	classic          bool
 	requiredSnaps    []string
 	sysUserAuthority []string
 	timestamp        time.Time
@@ -58,6 +59,11 @@ func (mod *Model) DisplayName() string {
 // Series returns the series of the core software the model uses.
 func (mod *Model) Series() string {
 	return mod.HeaderString("series")
+}
+
+// Classic returns whether the model is a classic system.
+func (mod *Model) Classic() bool {
+	return mod.classic
 }
 
 // Architecture returns the archicteture the model is based on.
@@ -153,7 +159,10 @@ func checkOptionalSystemUserAuthority(headers map[string]interface{}, brandID st
 	return nil, fmt.Errorf("%q header must be '*' or a list of account ids", name)
 }
 
-var modelMandatory = []string{"architecture", "gadget", "kernel"}
+var (
+	modelMandatory       = []string{"architecture", "gadget", "kernel"}
+	classicModelOptional = []string{"architecture", "gadget"}
+)
 
 func assembleModel(assert assertionBase) (Assertion, error) {
 	err := checkAuthorityMatchesBrand(&assert)
@@ -166,8 +175,27 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 
-	for _, mandatory := range modelMandatory {
-		if _, err := checkNotEmptyString(assert.headers, mandatory); err != nil {
+	classic, err := checkOptionalBool(assert.headers, "classic")
+	if err != nil {
+		return nil, err
+	}
+
+	if classic {
+		_, ok := assert.headers["kernel"]
+		if ok {
+			return nil, fmt.Errorf("classic model cannot specify explicitly a kernel")
+		}
+	}
+
+	checker := checkNotEmptyString
+	toCheck := modelMandatory
+	if classic {
+		checker = checkOptionalString
+		toCheck = classicModelOptional
+	}
+
+	for _, h := range toCheck {
+		if _, err := checker(assert.headers, h); err != nil {
 			return nil, err
 		}
 	}
@@ -209,6 +237,7 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 	// ignore extra headers and non-empty body for future compatibility
 	return &Model{
 		assertionBase:    assert,
+		classic:          classic,
 		requiredSnaps:    reqSnaps,
 		sysUserAuthority: sysUserAuthority,
 		timestamp:        timestamp,

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -265,7 +265,7 @@ func (mods *modelSuite) TestClassicDecodeInvalid(c *C) {
 		{"classic: true\n", "classic: foo\n", `"classic" header must be 'true' or 'false'`},
 		{"architecture: amd64\n", "architecture:\n  - foo\n", `"architecture" header must be a string`},
 		{"gadget: brand-gadget\n", "gadget:\n  - foo\n", `"gadget" header must be a string`},
-		{"gadget: brand-gadget\n", "kernel: brand-kernel\n", `classic model cannot specify explicitly a kernel`},
+		{"gadget: brand-gadget\n", "kernel: brand-kernel\n", `cannot specify a kernel with a classic model`},
 	}
 
 	for _, test := range invalidTests {

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -48,23 +48,42 @@ const (
 	sysUserAuths = "system-user-authority: *\n"
 )
 
-const modelExample = "type: model\n" +
-	"authority-id: brand-id1\n" +
-	"series: 16\n" +
-	"brand-id: brand-id1\n" +
-	"model: baz-3000\n" +
-	"display-name: Baz 3000\n" +
-	"architecture: amd64\n" +
-	"gadget: brand-gadget\n" +
-	"kernel: baz-linux\n" +
-	"store: brand-store\n" +
-	sysUserAuths +
-	reqSnaps +
-	"TSLINE" +
-	"body-length: 0\n" +
-	"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
-	"\n\n" +
-	"AXNpZw=="
+const (
+	modelExample = "type: model\n" +
+		"authority-id: brand-id1\n" +
+		"series: 16\n" +
+		"brand-id: brand-id1\n" +
+		"model: baz-3000\n" +
+		"display-name: Baz 3000\n" +
+		"architecture: amd64\n" +
+		"gadget: brand-gadget\n" +
+		"kernel: baz-linux\n" +
+		"store: brand-store\n" +
+		sysUserAuths +
+		reqSnaps +
+		"TSLINE" +
+		"body-length: 0\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+		"\n\n" +
+		"AXNpZw=="
+
+	classicModelExample = "type: model\n" +
+		"authority-id: brand-id1\n" +
+		"series: 16\n" +
+		"brand-id: brand-id1\n" +
+		"model: baz-3000\n" +
+		"display-name: Baz 3000\n" +
+		"classic: true\n" +
+		"architecture: amd64\n" +
+		"gadget: brand-gadget\n" +
+		"store: brand-store\n" +
+		reqSnaps +
+		"TSLINE" +
+		"body-length: 0\n" +
+		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
+		"\n\n" +
+		"AXNpZw=="
+)
 
 func (mods *modelSuite) TestDecodeOK(c *C) {
 	encoded := strings.Replace(modelExample, "TSLINE", mods.tsLine, 1)
@@ -217,6 +236,56 @@ func (mods *modelSuite) TestModelCheckInconsistentTimestamp(c *C) {
 
 	err = db.Check(model)
 	c.Assert(err, ErrorMatches, `model assertion timestamp outside of signing key validity \(key valid since.*\)`)
+}
+
+func (mods *modelSuite) TestClassicDecodeOK(c *C) {
+	encoded := strings.Replace(classicModelExample, "TSLINE", mods.tsLine, 1)
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.ModelType)
+	model := a.(*asserts.Model)
+	c.Check(model.AuthorityID(), Equals, "brand-id1")
+	c.Check(model.Timestamp(), Equals, mods.ts)
+	c.Check(model.Series(), Equals, "16")
+	c.Check(model.BrandID(), Equals, "brand-id1")
+	c.Check(model.Model(), Equals, "baz-3000")
+	c.Check(model.DisplayName(), Equals, "Baz 3000")
+	c.Check(model.Classic(), Equals, true)
+	c.Check(model.Architecture(), Equals, "amd64")
+	c.Check(model.Gadget(), Equals, "brand-gadget")
+	c.Check(model.Kernel(), Equals, "")
+	c.Check(model.Store(), Equals, "brand-store")
+	c.Check(model.RequiredSnaps(), DeepEquals, []string{"foo", "bar"})
+}
+
+func (mods *modelSuite) TestClassicDecodeInvalid(c *C) {
+	encoded := strings.Replace(classicModelExample, "TSLINE", mods.tsLine, 1)
+
+	invalidTests := []struct{ original, invalid, expectedErr string }{
+		{"classic: true\n", "classic: foo\n", `"classic" header must be 'true' or 'false'`},
+		{"architecture: amd64\n", "architecture:\n  - foo\n", `"architecture" header must be a string`},
+		{"gadget: brand-gadget\n", "gadget:\n  - foo\n", `"gadget" header must be a string`},
+		{"gadget: brand-gadget\n", "kernel: brand-kernel\n", `classic model cannot specify explicitly a kernel`},
+	}
+
+	for _, test := range invalidTests {
+		invalid := strings.Replace(encoded, test.original, test.invalid, 1)
+		_, err := asserts.Decode([]byte(invalid))
+		c.Check(err, ErrorMatches, modelErrPrefix+test.expectedErr)
+	}
+}
+
+func (mods *modelSuite) TestClassicDecodeGadgetAndArchOptional(c *C) {
+	encoded := strings.Replace(classicModelExample, "TSLINE", mods.tsLine, 1)
+	encoded = strings.Replace(encoded, "gadget: brand-gadget\n", "", 1)
+	encoded = strings.Replace(encoded, "architecture: amd64\n", "", 1)
+	a, err := asserts.Decode([]byte(encoded))
+	c.Assert(err, IsNil)
+	c.Check(a.Type(), Equals, asserts.ModelType)
+	model := a.(*asserts.Model)
+	c.Check(model.Classic(), Equals, true)
+	c.Check(model.Architecture(), Equals, "")
+	c.Check(model.Gadget(), Equals, "")
 }
 
 type serialSuite struct {

--- a/image/image.go
+++ b/image/image.go
@@ -117,6 +117,11 @@ func Prepare(opts *Options) error {
 		return err
 	}
 
+	// TODO: might make sense to support this later
+	if model.Classic() {
+		return fmt.Errorf("classic models are not supported")
+	}
+
 	local, err := localSnaps(opts)
 	if err != nil {
 		return err

--- a/image/image.go
+++ b/image/image.go
@@ -119,7 +119,7 @@ func Prepare(opts *Options) error {
 
 	// TODO: might make sense to support this later
 	if model.Classic() {
-		return fmt.Errorf("classic models are not supported")
+		return fmt.Errorf("cannot prepare image of a classic model")
 	}
 
 	local, err := localSnaps(opts)


### PR DESCRIPTION
This introduces a variant of model assertions for classic systems. It is marked by an optional header "classic" set to true:

- kernel header is not supported
- gadget and architecture become optional