### PR TITLE
interfaces/core-support: allow modifying systemd-timesyncd and sysctl configuration

### DIFF
--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -35,6 +35,10 @@ const coreSupportConnectedPlugAppArmor = `
 # now, only allow modifying NN-snap*.conf and snap*.conf files.
 /etc/rsyslog.d/{,*}                     r,
 /etc/rsyslog.d/{,[0-9][0-9]-}snap*.conf w,
+
+# Allow modifying /etc/systemd/timesyncd.conf for adjusting systemd-timesyncd's
+# timeservers
+/etc/systemd/timesyncd.conf rw,
 `
 
 const coreSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -24,10 +24,11 @@ import (
 )
 
 const coreSupportConnectedPlugAppArmor = `
-# Description: Can control all aspects of systemd via the systemctl command
-# and update rsyslog configuration. The interface allows execution of the
-# systemctl binary unconfined. As such, this gives device ownership to the
-# snap.
+# Description: Can control all aspects of systemd via the systemctl command,
+# update rsyslog configuration, update systemd-timesyncd configuration and
+# update/apply sysctl configuration. The interface allows execution of the
+# systemctl binary unconfined and modifying all sysctl configuration. As such,
+# this gives device ownership to the snap.
 
 /bin/systemctl Uxr,
 

--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -39,6 +39,16 @@ const coreSupportConnectedPlugAppArmor = `
 # Allow modifying /etc/systemd/timesyncd.conf for adjusting systemd-timesyncd's
 # timeservers
 /etc/systemd/timesyncd.conf rw,
+
+# Allow modifying sysctl configuration and applying the changes. For now, allow
+# reading all sysctl files but only allow modifying NN-snap*.conf and
+# snap*.conf files in /etc/sysctl.d.
+/etc/sysctl.conf                       r,
+/etc/sysctl.d/{,*}                     r,
+/etc/sysctl.d/{,[0-9][0-9]-}snap*.conf w,
+/{,usr/}{,s}bin/sysctl                 ixr,
+@{PROC}/sys/{,**}                      r,
+@{PROC}/sys/**                         w,
 `
 
 const coreSupportConnectedPlugSecComp = `


### PR DESCRIPTION
LP: #1504657  is in the process of being fixed and part of that fix involves allowing the core snap to modify 
/etc/systemd/timesyncd.conf.

LP: #1552679 is in the process of being fixed and part of that fix involves allowing the core snap to write files in /etc/sysctl.d. For now, only allow modifying NN-snap*.conf and snap*.conf files. This allows flexibility for sysctl conf file ordering while still preserving the 'snap' filename namespace.