### PR TITLE
interfaces/io-ports-control: use /dev/port, not /dev/ports

### DIFF
--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -32,7 +32,7 @@ const ioPortsControlConnectedPlugAppArmor = `
 
 capability sys_rawio, # required by iopl
 
-/dev/ports rw,
+/dev/port rw,
 `
 
 const ioPortsControlConnectedPlugSecComp = `
@@ -97,7 +97,7 @@ func (iface *IioPortsControlInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
-		const udevRule = `KERNEL=="ports", TAG+="%s"`
+		const udevRule = `KERNEL=="port", TAG+="%s"`
 		for appName := range plug.Apps {
 			tag := udevSnapSecurityName(plug.Snap.Name(), appName)
 			tagSnippet.WriteString(fmt.Sprintf(udevRule, tag))

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -97,7 +97,7 @@ func (s *IioPortsControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 
 capability sys_rawio, # required by iopl
 
-/dev/ports rw,
+/dev/port rw,
 `)
 
 	expectedSnippet2 := []byte(`
@@ -110,7 +110,7 @@ ioperm
 iopl
 `)
 
-	expectedSnippet3 := []byte(`KERNEL=="ports", TAG+="snap_client-snap_app-accessing-io-ports"
+	expectedSnippet3 := []byte(`KERNEL=="port", TAG+="snap_client-snap_app-accessing-io-ports"
 `)
 
 	// connected plugs have a non-nil security snippet for apparmor


### PR DESCRIPTION
Not sure how this slipped by, but 'man 4 mem' clearly states the device is /dev/port, not /dev/ports and /dev/ports does not exist in xenial or trusty. The name of the interface is correct, since 'man 4 mem' talks about 'I/O ports'.

Adjust the policy accordingly.