### PR TITLE
cmd/snap-confine-tests: reformat test to pass shellcheck

### DIFF
--- a/cmd/snap-confine/tests/test_restrictions_working_args_termios
+++ b/cmd/snap-confine/tests/test_restrictions_working_args_termios
@@ -9,16 +9,14 @@ cat >>"$TMP"/tmpl <<EOF
 getpriority
 EOF
 
-for i in TIOCSTI ; do
-    cat "$TMP"/tmpl >"$TMP"/snap.name.app
-    echo "ioctl - $i" >>"$TMP"/snap.name.app
+cat "$TMP"/tmpl >"$TMP"/snap.name.app
+echo "ioctl - TIOCSTI" >>"$TMP"/snap.name.app
 
-    printf "Test good seccomp arg filtering (ioctl - %s)" "$i"
-    # ensure that the command "true" can run with the right filter
-    if $L snap.name.app /bin/true ; then
-        PASS
-    else
-        dmesg|tail -n1
-        FAIL
-    fi
-done
+printf "Test good seccomp arg filtering (ioctl - %s)" "TIOCSTI"
+# ensure that the command "true" can run with the right filter
+if $L snap.name.app /bin/true ; then
+	PASS
+else
+	dmesg|tail -n1
+	FAIL
+fi


### PR DESCRIPTION
The loop over one element was upsetting shellcheck so let's remove the
loop entirely.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>