### PR TITLE
cmd: add sc_is_debug_enabled

### DIFF
--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -116,9 +116,14 @@ static bool getenv_bool(const char *name)
 	return value;
 }
 
+bool sc_is_debug_enabled()
+{
+	return getenv_bool("SNAP_CONFINE_DEBUG");
+}
+
 void debug(const char *msg, ...)
 {
-	if (getenv_bool("SNAP_CONFINE_DEBUG")) {
+	if (sc_is_debug_enabled()) {
 		va_list va;
 		va_start(va, msg);
 		fprintf(stderr, "DEBUG: ");

--- a/cmd/libsnap-confine-private/utils.h
+++ b/cmd/libsnap-confine-private/utils.h
@@ -14,11 +14,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include <stdlib.h>
-#include <stdbool.h>
-
 #ifndef CORE_LAUNCHER_UTILS_H
 #define CORE_LAUNCHER_UTILS_H
+
+#include <stdlib.h>
+#include <stdbool.h>
 
 __attribute__ ((noreturn))
     __attribute__ ((format(printf, 1, 2)))
@@ -29,6 +29,13 @@ bool error(const char *fmt, ...);
 
 __attribute__ ((format(printf, 1, 2)))
 void debug(const char *fmt, ...);
+
+/**
+ * Return true if debugging is enabled.
+ *
+ * This can used to avoid costly computation that is only useful for debugging.
+ **/
+bool sc_is_debug_enabled();
 
 void write_string_to_file(const char *filepath, const char *buf);
 


### PR DESCRIPTION
This patch exposes a way to check if debugging should be enabled in
snap-confine and friends. I plan to use it to avoid computing some
diagnostic messages unless they are really needed.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>