### PR TITLE
release: don't force devmode on LinuxMint "serena"

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -52,6 +52,17 @@ func (os *OS) ForceDevMode() bool {
 		default:
 			return true
 		}
+	case "linuxmint":
+		// NOTE: mint uses "LinuxMint" (mixed capitalization) but this is
+		// normalized by readOSRelease.
+		switch os.VersionID {
+		case "18.1":
+			// Linux Mint 18.1 aka "serena" should use apparmor confinement
+			// given that it shares packages with Ubuntu 16.04.
+			return false
+		default:
+			return true
+		}
 	default:
 		// NOTE: Other distributions can move out of devmode by
 		// integrating with the interface security backends. This will

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -139,6 +139,8 @@ func (s *ReleaseTestSuite) TestForceDevMode(c *C) {
 		{id: "rhel", devmode: true},
 		{id: "ubuntu", devmode: false},
 		{id: "ubuntu-core", devmode: false},
+		{id: "linuxmint", devmode: true},
+		{id: "linuxmint", idVersion: "18.1", devmode: false},
 	}
 	for _, distro := range distros {
 		rel := &release.OS{ID: distro.id, VersionID: distro.idVersion}


### PR DESCRIPTION
LinuxMint "serena" is derived from Ubuntu 16.04 and, as long as some
updates are instsalled, supports confinement. Now if only Mint didn't
disable essential security updates...

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>