### PR TITLE
interfaces/builtin/core-support: Allow modifying logind configuration from the core snap

### DIFF
--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -51,9 +51,12 @@ const coreSupportConnectedPlugAppArmor = `
 @{PROC}/sys/{,**}                      r,
 @{PROC}/sys/**                         w,
 
-# Allow modifying logind configuration from the core snap
-/etc/systemd/logind.conf.d/{,*}         r,
-/etc/systemd/logind.conf.d/{,core.conf} w,
+# Allow modifying logind configuration. For now, allow reading all logind
+# configuration but only allow modifying NN-snap*.conf and snap*.conf files
+# in /etc/systemd/logind.conf.d.
+/etc/systemd/logind.conf                            r,
+/etc/systemd/logind.conf.d/{,*}                     r,
+/etc/systemd/logind.conf.d/{,[0-9][0-9]-}snap*.conf w,
 `
 
 const coreSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -50,6 +50,10 @@ const coreSupportConnectedPlugAppArmor = `
 /{,usr/}{,s}bin/sysctl                 ixr,
 @{PROC}/sys/{,**}                      r,
 @{PROC}/sys/**                         w,
+
+# Allow modifying logind configuration from the core snap
+/etc/systemd/logind.conf.d/{,*}         r,
+/etc/systemd/logind.conf.d/{,core.conf} w,
 `
 
 const coreSupportConnectedPlugSecComp = `


### PR DESCRIPTION
This change allows the core snap configure hook to change logind options by writing them to `/etc/systemd/logind.conf.d/core.conf` 