### PR TITLE
interfaces/builtin: add send/recv syscalls for upower-observe interface as required on ARM

### DIFF
--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -108,6 +108,8 @@ recvmsg
 sendmsg
 sendto
 recvfrom
+send
+recv
 `
 
 const upowerObservePermanentSlotDBus = `
@@ -198,6 +200,7 @@ const upowerObserveConnectedPlugSecComp = `
 # Description: Can query UPower for power devices, history and statistics.
 
 # dbus
+recv
 recvfrom
 recvmsg
 send


### PR DESCRIPTION
On arm based devices both syscalls are required for dbus communication
which isn't the case on x86* devices.