### PR TITLE
overlord/ifacestate: setup seccomp security on startup

### DIFF
--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -49,11 +49,13 @@ const mountObserveConnectedPlugSecComp = `
 # restricted because it gives privileged read access to mount arguments and
 # should only be used with trusted apps.
 
-quotactl Q_GETQUOTA - - -
-quotactl Q_GETINFO - - -
-quotactl Q_GETFMT - - -
-quotactl Q_XGETQUOTA - - -
-quotactl Q_XGETQSTAT - - -
+# FIXME: restore quotactl with parameter filtering once snap-confine can read
+# this syntax. See LP:#1662489 for context.
+#quotactl Q_GETQUOTA - - -
+#quotactl Q_GETINFO - - -
+#quotactl Q_GETFMT - - -
+#quotactl Q_XGETQUOTA - - -
+#quotactl Q_XGETQSTAT - - -
 `
 
 // NewMountObserveInterface returns a new "mount-observe" interface.

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -163,7 +163,10 @@ inotify_rm_watch
 
 # TIOCSTI allows for faking input (man tty_ioctl)
 # TODO: this should be scaled back even more
-ioctl - !TIOCSTI
+#ioctl - !TIOCSTI
+# FIXME: replace this with the filter of TIOCSTI once snap-confine can read this syntax
+# See LP:#1662489 for context.
+ioctl
 
 io_cancel
 io_destroy

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -50,6 +50,9 @@ func (m *InterfaceManager) initialize(extraInterfaces []interfaces.Interface, ex
 	if err := m.reloadConnections(""); err != nil {
 		return err
 	}
+	if err := m.unbreakTheWorld(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -92,6 +95,62 @@ func (m *InterfaceManager) addSnaps() error {
 			logger.Noticef("%s", err)
 		}
 	}
+	return nil
+}
+
+func (m *InterfaceManager) unbreakTheWorld() error {
+	// XXX: As a special measure to unbreak the world refresh seccomp security
+	// of all the snaps on the system. Later on this should be improved to
+	// either refresh all security backends or to know how to apply stashed
+	// (versioned) security that was preserved by snapd on upgrade to a new
+	// version of itself.
+
+	// Get all the security backends
+	securityBackends := m.repo.Backends()
+
+	// Get all the snap infos
+	snaps, err := snapstate.ActiveInfos(m.state)
+	if err != nil {
+		return err
+	}
+	// Add implicit slots to all snaps
+	for _, snapInfo := range snaps {
+		snap.AddImplicitSlots(snapInfo)
+	}
+
+	// From now on we don't fail if a particular operation fails, this is a
+	// best-effort service. It's not much of an unbreak-the-world idea if we
+	// bail out and don't start.
+
+	// For each snap:
+	for _, snapInfo := range snaps {
+		snapName := snapInfo.Name()
+		// Get the state of the snap so we can compute the confinement option
+		var snapst snapstate.SnapState
+		if err := snapstate.Get(m.state, snapName, &snapst); err != nil {
+			logger.Noticef("cannot get state of snap %q: %s", snapName, err)
+		}
+
+		// Compute confinement options
+		opts := confinementOptions(snapst.Flags)
+
+		// For each backend:
+		for _, backend := range securityBackends {
+			// The issue this is attempting to fix is only affecting seccomp so
+			// limit the work just to this backend.
+			shouldRefresh := backend.Name() == interfaces.SecuritySecComp
+			if !shouldRefresh {
+				continue
+			}
+			// Refresh security of this snap and backend
+			if err := backend.Setup(snapInfo, opts, m.repo); err != nil {
+				// Let's log this but carry on
+				logger.Noticef("cannot regenerate %s profile for snap %q: %s",
+					backend.Name(), snapName, err)
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This patch attempts to unbreak the world by automatically refreshing the
seccomp profiles on startp of snapd. Seccomp profiles are not expensive
to compute and don't require compilation or loading.

This lets us fix the problem that surfaced when snapd started generating
a syntax, in the seccomp profile, that only new snap-confine
understands. Because snap-confine does not conceptually re-execute yet
everyone that is on the edge channel is now experiencing problems.

This patch should be applied along the next patch that generates
compatible seccomp profiles, without the new syntax.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>