### PR TITLE
overlord: make seeding work also on classic, optionally

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -229,6 +229,8 @@ func (s *apiBaseSuite) daemon(c *check.C) *Daemon {
 	st.Lock()
 	defer st.Unlock()
 	snapstate.ReplaceStore(st, s)
+	// mark as already seeded
+	st.Set("seeded", true)
 
 	s.d = d
 	return d
@@ -1792,7 +1794,7 @@ func (s *apiSuite) TestSideloadSnapJailModeAndDevmode(c *check.C) {
 		"\r\n" +
 		"true\r\n" +
 		"----hello--\r\n"
-	d := newTestDaemon(c)
+	d := s.daemon(c)
 	d.overlord.Loop()
 	defer d.overlord.Stop()
 
@@ -1816,7 +1818,7 @@ func (s *apiSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
 		"\r\n" +
 		"true\r\n" +
 		"----hello--\r\n"
-	d := newTestDaemon(c)
+	d := s.daemon(c)
 	d.overlord.Loop()
 	defer d.overlord.Stop()
 
@@ -1833,7 +1835,7 @@ func (s *apiSuite) TestSideloadSnapJailModeInDevModeOS(c *check.C) {
 }
 
 func (s *apiSuite) TestLocalInstallSnapDeriveSideInfo(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.daemon(c)
 	d.overlord.Loop()
 	defer d.overlord.Stop()
 	// add the assertions first
@@ -1915,7 +1917,7 @@ func (s *apiSuite) TestSideloadSnapNoSignaturesDangerOff(c *check.C) {
 		"\r\n" +
 		"xyzzy\r\n" +
 		"----hello--\r\n"
-	d := newTestDaemon(c)
+	d := s.daemon(c)
 	d.overlord.Loop()
 	defer d.overlord.Stop()
 
@@ -1958,7 +1960,7 @@ func (s *apiSuite) TestSideloadSnapNotValidFormFile(c *check.C) {
 }
 
 func (s *apiSuite) TestTrySnap(c *check.C) {
-	d := newTestDaemon(c)
+	d := s.daemon(c)
 	d.overlord.Loop()
 	defer d.overlord.Stop()
 
@@ -2073,7 +2075,7 @@ func (s *apiSuite) TestTrySnapNotDir(c *check.C) {
 }
 
 func (s *apiSuite) sideloadCheck(c *check.C, content string, head map[string]string, expectedFlags snapstate.Flags, hasCoreSnap bool) string {
-	d := newTestDaemon(c)
+	d := s.daemon(c)
 	d.overlord.Loop()
 	defer d.overlord.Stop()
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -225,6 +225,12 @@ func (l *witnessAcceptListener) Accept() (net.Conn, error) {
 
 func (s *daemonSuite) TestStartStop(c *check.C) {
 	d := newTestDaemon(c)
+	st := d.overlord.State()
+	// mark as already seeded
+	st.Lock()
+	st.Set("seeded", true)
+	st.Unlock()
+
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, check.IsNil)
 
@@ -265,6 +271,12 @@ func (s *daemonSuite) TestStartStop(c *check.C) {
 
 func (s *daemonSuite) TestRestartWiring(c *check.C) {
 	d := newTestDaemon(c)
+	// mark as already seeded
+	st := d.overlord.State()
+	st.Lock()
+	st.Set("seeded", true)
+	st.Unlock()
+
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, check.IsNil)
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -219,17 +219,6 @@ func (m *DeviceManager) ensureSeedYaml() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	// FIXME: enable on classic?
-	//
-	// Disable seed.yaml on classic for now. In the long run we want
-	// classic to have a seed parsing as well so that we can install
-	// snaps in a classic environment (LP: #1609903). However right
-	// now it is under heavy development so until the dust
-	// settles we disable it.
-	if release.OnClassic {
-		return nil
-	}
-
 	var seeded bool
 	err := m.state.Get("seeded", &seeded)
 	if err != nil && err != state.ErrNoState {
@@ -243,10 +232,13 @@ func (m *DeviceManager) ensureSeedYaml() error {
 		return nil
 	}
 
-	coreInfo, err := snapstate.CoreInfo(m.state)
-	if err == nil && coreInfo.Name() == "ubuntu-core" {
-		// already seeded... recover
-		return m.alreadyFirstbooted()
+	if !release.OnClassic {
+		// XXX: drop this old repair code?
+		coreInfo, err := snapstate.CoreInfo(m.state)
+		if err == nil && coreInfo.Name() == "ubuntu-core" {
+			// already seeded... recover
+			return m.alreadyFirstbooted()
+		}
 	}
 
 	tsAll, err := populateStateFromSeed(m.state)

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -184,6 +184,17 @@ func importAssertionsFromSeed(st *state.State) (*asserts.Model, error) {
 	}
 	modelAssertion := a.(*asserts.Model)
 
+	classicModel := modelAssertion.Classic()
+	if release.OnClassic != classicModel {
+		var msg string
+		if classicModel {
+			msg = "cannot seed an all-snaps system with a classic model"
+		} else {
+			msg = "cannot seed a classic system with an all-snaps model"
+		}
+		return nil, fmt.Errorf(msg)
+	}
+
 	// set device,model from the model assertion
 	device.Brand = modelAssertion.BrandID()
 	device.Model = modelAssertion.Model()

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -173,10 +173,19 @@ func (wm *witnessManager) Stop() {
 func (wm *witnessManager) Wait() {
 }
 
+// markSeeded flags the state under the overlord as seeded to avoid running the seeding code in these tests
+func markSeeded(o *overlord.Overlord) {
+	st := o.State()
+	st.Lock()
+	st.Set("seeded", true)
+	st.Unlock()
+}
+
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
 
+	markSeeded(o)
 	o.Loop()
 
 	err = o.Stop()
@@ -196,6 +205,7 @@ func (ovs *overlordSuite) TestEnsureLoopRunAndStop(c *C) {
 	}
 	o.Engine().AddManager(witness)
 
+	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -231,6 +241,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeImmediate(c *C) {
 	se := o.Engine()
 	se.AddManager(witness)
 
+	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -261,6 +272,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBefore(c *C) {
 	se := o.Engine()
 	se.AddManager(witness)
 
+	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -293,6 +305,7 @@ func (ovs *overlordSuite) TestEnsureBeforeSleepy(c *C) {
 	se := o.Engine()
 	se.AddManager(witness)
 
+	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -324,6 +337,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeOutsideEnsure(c *C) 
 	se := o.Engine()
 	se.AddManager(witness)
 
+	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -357,6 +371,7 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 	chg2.SetStatus(state.DoneStatus)
 	st.Unlock()
 
+	markSeeded(o)
 	o.Loop()
 	time.Sleep(150 * time.Millisecond)
 	err = o.Stop()
@@ -391,6 +406,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	c.Check(st.Changes(), HasLen, 2)
 	st.Unlock()
 
+	markSeeded(o)
 	// start the loop that runs the prune ticker
 	o.Loop()
 
@@ -508,6 +524,7 @@ func (ovs *overlordSuite) TestTrivialSettle(c *C) {
 
 	s.Unlock()
 
+	markSeeded(o)
 	o.Settle()
 
 	s.Lock()
@@ -542,6 +559,7 @@ func (ovs *overlordSuite) TestSettleChain(c *C) {
 
 	s.Unlock()
 
+	markSeeded(o)
 	o.Settle()
 
 	s.Lock()
@@ -584,6 +602,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 	chg.AddTask(t)
 	s.Unlock()
 
+	markSeeded(o)
 	o.Settle()
 
 	s.Lock()

--- a/tests/lib/assertions/developer1-my-classic.model
+++ b/tests/lib/assertions/developer1-my-classic.model
@@ -1,0 +1,19 @@
+type: model
+authority-id: developer1
+series: 16
+brand-id: developer1
+model: my-classic
+classic: true
+timestamp: 2017-02-07T15:41:09+00:00
+sign-key-sha3-384: EAD4DbLxK_kn0gzNCXOs3kd6DeMU3f-L6BEsSEuJGBqCORR0gXkdDxMbOm11mRFu
+
+AcLBUgQAAQoABgUCWJnq8wAAN3IQABb3sWbLyF9hBR/x5BaQLHpd2QCwmnkSsZwrJ5inTzSMfYuf
+5fwxhsAsNDmtupK5SsCIRqGyWIW/3ERHnELNJs2z/ghYY7GYfB/QR4KiJgQd/JXB6WqU5VoJ/qHP
+tezkApd/nAh1UdyRPYfTlJg9C3tOHtrtODL4spbwSmqsOz1D8UiKdeut45qu38kWyugMXWP7Rdh7
+E2ai2fo7I67Dh4UU6iZXYSIVINzmgbjoXjy+li/o3YcSol2V/Hfq5KUHhpgQYFQxOfB1jaur7mFJ
+/n6SSk+4I/DkOxKqDgpWuPHavRF5PKS840P2Eww9aVGiEg6V36lxZSzs+p1nDaJyVEoEKk7Txmxi
+NnmY49IfoFxZ377I8U7Q4/+ruHqhOmgoOP1MGDVK9fDjf0iCtP5X1dF6VqwrmPM+nx66sxs+yPRl
+DcBqOvF+tAzvLYjuLXrl9FNRFwnedqI8kk2ZBR2ueWog7h+uqew7IV378Nrk7R3KVTtzNldoos2n
+DQaSJzZXb8XwJDA4xjCnqyFCEVOASUTyJ656XOnzWyFNk2ivjc8ML5Ztqd7NcgVCJlojVxUgZYps
+zuQCl7eHqB7xzbWO2FIpOsMFreCAfLUBHjr/pnX4oY/8sRq1bt8BZfT8t8D8GvLwQ0G1UDxK19BG
+xCBz7A+6hsw7sZmpGnhGnrZEqtuh

--- a/tests/lib/changes.sh
+++ b/tests/lib/changes.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+change_id() {
+    # takes <summary pattern> [<status>]
+    local SUMMARY_PAT=$1
+    local STATUS=${2:-}
+    snap changes|grep -o -P "^\d+(?= *${STATUS}.*${SUMMARY_PAT}.*)"
+}

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -32,10 +32,13 @@ reset_classic() {
             systemctl start $unit
         done
     fi
-    systemctl start snapd.socket
 
-    # wait for snapd listening
-    while ! printf "GET / HTTP/1.0\r\n\r\n" | nc -U -q 1 /run/snapd.socket; do sleep 0.5; done
+    if [ "$1" != "--keep-stopped" ]; then
+        systemctl start snapd.socket
+
+        # wait for snapd listening
+        while ! printf "GET / HTTP/1.0\r\n\r\n" | nc -U -q 1 /run/snapd.socket; do sleep 0.5; done
+    fi
 }
 
 reset_all_snap() {
@@ -58,7 +61,9 @@ reset_all_snap() {
     rm -rf /var/lib/snapd/*
     $(cd / && tar xzf $SPREAD_PATH/snapd-state.tar.gz)
     rm -rf /root/.snap
-    systemctl start snapd.service snapd.socket
+    if [ "$1" != "--keep-stopped" ]; then
+        systemctl start snapd.service snapd.socket
+    fi
 }
 
 if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then

--- a/tests/main/classic-firstboot/task.yaml
+++ b/tests/main/classic-firstboot/task.yaml
@@ -1,0 +1,72 @@
+summary: Check that firstboot assertions are imported and snaps installed also on classic
+systems: [-ubuntu-core-16-*]
+environment:
+    SEED_DIR: /var/lib/snapd/seed
+prepare: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    snapbuild $TESTSLIB/snaps/basic .
+    snap download --$CORE_CHANNEL core
+
+    $TESTSLIB/reset.sh --keep-stopped
+    mkdir -p $SEED_DIR/snaps
+    mkdir -p $SEED_DIR/assertions
+    cat > $SEED_DIR/seed.yaml <<EOF
+    snaps:
+      - name: core
+        channel: $CORE_CHANNEL
+        file: core.snap
+      - name: basic
+        unasserted: true
+        file: basic.snap
+    EOF
+
+    echo Copy the needed assertions to /var/lib/snapd/
+    cp core_*.assert $SEED_DIR/assertions
+    cp $TESTSLIB/assertions/developer1.account $SEED_DIR/assertions
+    cp $TESTSLIB/assertions/developer1.account-key $SEED_DIR/assertions
+    cp $TESTSLIB/assertions/developer1-my-classic.model $SEED_DIR/assertions
+    cp $TESTSLIB/assertions/testrootorg-store.account-key $SEED_DIR/assertions
+    echo Copy the needed snaps to $SEED_DIR/snaps
+    cp ./core_*.snap $SEED_DIR/snaps/core.snap
+    cp ./basic_1.0_all.snap $SEED_DIR/snaps/basic.snap
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    rm -r $SEED_DIR
+    rm -f *.snap
+    rm -f *.assert
+    systemctl start snapd.socket snapd.service
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    echo "Start the daemon with an empty state, this will make it import "
+    echo "assertions from the $SEED_DIR/assertions subdirectory and "
+    echo "install the seed snaps."
+    systemctl start snapd.socket snapd.service
+
+    echo "Wait for Seed change to be finished"
+    for i in `seq 120`; do
+        if snap list 2>/dev/null |grep -q -E "^basic" ; then
+            break
+        fi
+        sleep 1
+    done
+
+    echo "Verifying the imported assertions"
+    if ! snap known model|MATCH "model: my-classic" ; then
+        echo "Model assertion was not imported on firstboot"
+        exit 1
+    fi
+
+    snap list|grep -q -E "^basic"
+    test -f $SEED_DIR/snaps/basic.snap

--- a/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -34,10 +34,10 @@ execute: |
     systemctl stop snapd.service snapd.socket
     systemctl start snapd.service snapd.socket
 
+    . $TESTSLIB/changes.sh
     while ! snap changes|grep ".*Done.*Transition ubuntu-core to core"; do
         snap changes
-        chg_id=$(snap changes|grep -o -P "^\d+(?= .*Transition ubuntu-core to core)" || true)
-        snap change $chg_id||true
+        snap change $(change_id "Transition ubuntu-core to core")||true
         sleep 1
     done
 

--- a/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -36,7 +36,7 @@ execute: |
 
     while ! snap changes|grep ".*Done.*Transition ubuntu-core to core"; do
         snap changes
-        chg_id=$(snap changes|grep -o -P "^\d+(?= .*Transition ubuntu-core to core)")
+        chg_id=$(snap changes|grep -o -P "^\d+(?= .*Transition ubuntu-core to core)" || true)
         snap change $chg_id||true
         sleep 1
     done

--- a/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -36,7 +36,8 @@ execute: |
 
     while ! snap changes|grep ".*Done.*Transition ubuntu-core to core"; do
         snap changes
-        snap change 3||true
+        chg_id=$(snap changes|grep -o -P "^\d+(?= .*Transition ubuntu-core to core)")
+        snap change $chg_id||true
         sleep 1
     done
 

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -39,10 +39,10 @@ execute: |
     systemctl stop snapd.service snapd.socket
     systemctl start snapd.service snapd.socket
 
+    . $TESTSLIB/changes.sh
     while ! snap changes|grep ".*Done.*Transition ubuntu-core to core"; do
         snap changes
-        chg_id=$(snap changes|grep -o -P "^\d+(?= .*Transition ubuntu-core to core)" || true)
-        snap change $chg_id||true
+        snap change $(change_id "Transition ubuntu-core to core")||true
         sleep 1
     done
 

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -41,7 +41,7 @@ execute: |
 
     while ! snap changes|grep ".*Done.*Transition ubuntu-core to core"; do
         snap changes
-        chg_id=$(snap changes|grep -o -P "^\d+(?= .*Transition ubuntu-core to core)")
+        chg_id=$(snap changes|grep -o -P "^\d+(?= .*Transition ubuntu-core to core)" || true)
         snap change $chg_id||true
         sleep 1
     done

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -41,7 +41,8 @@ execute: |
 
     while ! snap changes|grep ".*Done.*Transition ubuntu-core to core"; do
         snap changes
-        snap change 3||true
+        chg_id=$(snap changes|grep -o -P "^\d+(?= .*Transition ubuntu-core to core)")
+        snap change $chg_id||true
         sleep 1
     done
 

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -57,7 +57,9 @@ execute: |
     echo "But the bad snap did not get updated"
     snap list | MATCH -E "${BAD_SNAP}"| MATCH -v "fake"
 
+    chg_id=$(snap changes|grep -o -P "^\d+(?= *Error.*Refresh snap.*)")
+
     echo "Verify the snap change"
-    snap change 5 | MATCH "Undone.*Download snap \"${BAD_SNAP}\""
-    snap change 5 | MATCH "Done.*Download snap \"${GOOD_SNAP}\""
-    snap change 5 | MATCH "ERROR cannot verify snap \"test-snapd-tools\", no matching signatures found"
+    snap change $chg_id | MATCH "Undone.*Download snap \"${BAD_SNAP}\""
+    snap change $chg_id | MATCH "Done.*Download snap \"${GOOD_SNAP}\""
+    snap change $chg_id | MATCH "ERROR cannot verify snap \"test-snapd-tools\", no matching signatures found"

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -57,7 +57,8 @@ execute: |
     echo "But the bad snap did not get updated"
     snap list | MATCH -E "${BAD_SNAP}"| MATCH -v "fake"
 
-    chg_id=$(snap changes|grep -o -P "^\d+(?= *Error.*Refresh snap.*)")
+    . $TESTSLIB/changes.sh
+    chg_id=$(change_id "Refresh snap" Error)
 
     echo "Verify the snap change"
     snap change $chg_id | MATCH "Undone.*Download snap \"${BAD_SNAP}\""


### PR DESCRIPTION
This makes seeding work also on classic, optionally.

Most changes are to tests to avoid triggering seeding in the background when not wanted/needed.

Comes with a spread test.