### PR TITLE
tests: increase service retries

### DIFF
--- a/tests/main/ubuntu-core-reboot/task.yaml
+++ b/tests/main/ubuntu-core-reboot/task.yaml
@@ -16,7 +16,7 @@ execute: |
     snap list | grep network-bind-consumer
 
     echo "Ensure the service is (still) running."
-    retries=30
+    retries=60
     while ! systemctl is-active snap.network-bind-consumer.network-consumer.service; do
         if [ $retries -eq 0 ]; then
             echo "Service did not activate."


### PR DESCRIPTION
`tests/main/ubuntu-core-reboot` is still failing eventually on dragonboard because we don't wait enough for the service to be up.