### PR TITLE
tests: add libvirt interface spread test

### DIFF
--- a/tests/lib/snaps/test-snapd-libvirt-consumer/bin/machine-down
+++ b/tests/lib/snaps/test-snapd-libvirt-consumer/bin/machine-down
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$SNAP/usr/bin/virsh destroy ping-unikernel

--- a/tests/lib/snaps/test-snapd-libvirt-consumer/bin/machine-up
+++ b/tests/lib/snaps/test-snapd-libvirt-consumer/bin/machine-up
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$SNAP/usr/bin/virsh create /snap/test-snapd-libvirt-consumer/current/vm/ping-unikernel.xml

--- a/tests/lib/snaps/test-snapd-libvirt-consumer/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-libvirt-consumer/snapcraft.yaml
@@ -1,0 +1,49 @@
+name: test-snapd-libvirt-consumer
+
+version: 1.0
+
+summary: Basic snap declaring a plug on the libvirt interface
+
+description: |
+    Apart from consuming the libvirt interface this snap packages a tiny vm
+    to be run with libvirt and be able to run some checks. The vm is a solo5
+    unikernel which is built during snap creation.
+
+    As a prerrequisite, a tap interface must be available for the vm to be
+    connected, the default name is tap100 and can be created with
+        ip tuntap add tap100 mode tap
+        ip addr add 10.0.0.1/24 dev tap100
+        ip link set dev tap100 up
+
+    With this in place, the vm would be accessible at 10.0.0.2
+
+    Once you execute machine-up, the vm will respond to ping requests.
+
+apps:
+    machine-up:
+        command: bin/machine-up
+        plugs: [libvirt]
+
+    machine-down:
+        command: bin/machine-down
+        plugs: [libvirt]
+
+parts:
+    unikernel:
+        plugin: make
+        source: https://github.com/fgimenez/solo5.git
+        source-type: git
+        build-packages:
+            - gcc
+        artifacts:
+            - tests/test_ping_serve/test_ping_serve.virtio
+    glue:
+        plugin: make
+        stage-packages:
+            - libvirt-bin
+        after: [unikernel]
+        source: .
+        snap:
+            - bin/
+            - vm/
+            - usr/

--- a/tests/lib/snaps/test-snapd-libvirt-consumer/vm/ping-unikernel.xml
+++ b/tests/lib/snaps/test-snapd-libvirt-consumer/vm/ping-unikernel.xml
@@ -1,0 +1,22 @@
+<domain type='qemu' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name>ping-unikernel</name>
+  <memory>128000</memory>
+  <os>
+    <type>hvm</type>
+    <kernel>/snap/test-snapd-libvirt-consumer/current/tests/test_ping_serve/test_ping_serve.virtio</kernel>
+  </os>
+  <features></features>
+  <serial type='stdio'>
+    <target port='0'/>
+  </serial>
+  <qemu:commandline>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='virtio-net,netdev=n0'/>
+    <qemu:arg value='-netdev'/>
+    <qemu:arg value='tap,id=n0,ifname=tap100,script=no,downscript=no'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='isa-debug-exit'/>
+    <qemu:arg value='-append'/>
+    <qemu:arg value='limit'/>
+  </qemu:commandline>
+</domain>

--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the libvirt interface works.
 
 systems: [ubuntu-16.04-64]
 
-summary: |
+details: |
     The libvirt interface allows a snap to access the libvirtd socket in order to manage
     libvirt domains and other resources.
 
@@ -19,6 +19,7 @@ prepare: |
     sysctl -w net.ipv6.conf.all.disable_ipv6=1
     trap "sysctl -w net.ipv6.conf.all.disable_ipv6=0" EXIT
     apt install -y libvirt-bin qemu
+    # add test user to the libvirtd group
     adduser test libvirtd
 
     echo "And libvirt is configured to manage /dev/net/tun"
@@ -38,11 +39,12 @@ prepare: |
     ip link set dev tap100 up
 
 restore: |
-    systemctl stop libvirtd.service
-    systemctl stop virtlogd.socket
-    apt remove -y --purge libvirt-bin qemu
+    apt autoremove -y --purge libvirt-bin qemu &&
 
     ip link delete tap100
+
+    # remove test user from the libvirtd group
+    deluser test libvirtd
 
 execute: |
     CONNECTED_PATTERN=":libvirt +test-snapd-libvirt-consumer"
@@ -79,4 +81,4 @@ execute: |
         echo "Expected permission error accessing libvirtd socket with disconnected plug"
         exit 1
     fi
-    grep -q "Failed to connect socket to '/var/run/libvirt/libvirt-sock': Permission denied" creation.error
+    cat creation.error | MATCH "Failed to connect socket to '/var/run/libvirt/libvirt-sock': Permission denied"

--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -1,0 +1,82 @@
+summary: Ensure that the libvirt interface works.
+
+systems: [ubuntu-16.04-64]
+
+summary: |
+    The libvirt interface allows a snap to access the libvirtd socket in order to manage
+    libvirt domains and other resources.
+
+    A snap which defines a libvirt plug must be shown in the interfaces list.
+    The plug must not be autoconnected on install and, as usual, must be able to be
+    reconnected.
+
+    A snap declaring a plug on this interface must be able to create and destroy a domain.
+    The test uses a snap that carries a unikernel built to be run on top of qemu, boot and
+    respond to ping. Once the domain is created, the test checks connectivity to the unikernel.
+
+prepare: |
+    echo "Given libvirt and qemu are installed"
+    sysctl -w net.ipv6.conf.all.disable_ipv6=1
+    trap "sysctl -w net.ipv6.conf.all.disable_ipv6=0" EXIT
+    apt install -y libvirt-bin qemu
+    adduser test libvirtd
+
+    echo "And libvirt is configured to manage /dev/net/tun"
+    systemctl stop libvirtd.service || true
+    echo 'cgroup_device_acl = ["/dev/net/tun", "/dev/random", "/dev/urandom"]' | tee -a /etc/libvirt/qemu.conf
+
+    echo "And the required services up"
+    systemctl start libvirtd.service
+    systemctl start virtlogd.socket
+
+    echo "And a snap declaring a plug on the libvirt interface is installed"
+    snap install --edge test-snapd-libvirt-consumer
+
+    echo "And the required tap interface is in place"
+    ip tuntap add tap100 mode tap
+    ip addr add 10.0.0.1/24 dev tap100
+    ip link set dev tap100 up
+
+restore: |
+    systemctl stop libvirtd.service
+    systemctl stop virtlogd.socket
+    apt remove -y libvirt-bin qemu
+
+    ip link delete tap100
+
+execute: |
+    CONNECTED_PATTERN=":libvirt +test-snapd-libvirt-consumer"
+    DISCONNECTED_PATTERN="\- +test-snapd-libvirt-consumer:libvirt"
+
+    echo "The plug is not connected by default"
+    snap interfaces | MATCH "$DISCONNECTED_PATTERN"
+
+    echo "==================================="
+
+    echo "When the plug is connected"
+    snap connect test-snapd-libvirt-consumer:libvirt
+    snap interfaces | MATCH "$CONNECTED_PATTERN"
+
+    echo "Then the snap is able to create the unikernel domain"
+    su -l -c "test-snapd-libvirt-consumer.machine-up" test
+    virsh list | MATCH ping-unikernel
+
+    echo "And the unikernel is accesible"
+    ping -c 1 -q -W 1 10.0.0.2
+
+    echo "And the snap is able to destroy the unikernel domain"
+    su -l -c "test-snapd-libvirt-consumer.machine-down" test
+    virsh list | MATCH -v ping-unikernel
+
+    echo "==================================="
+
+    echo "When the plug is disconnected"
+    snap disconnect test-snapd-libvirt-consumer:libvirt
+    snap interfaces | MATCH "$DISCONNECTED_PATTERN"
+
+    echo "Then the snap is not able to create a domain"
+    if su -l -c "test-snapd-libvirt-consumer.machine-up 2>${PWD}/creation.error" test; then
+        echo "Expected permission error accessing libvirtd socket with disconnected plug"
+        exit 1
+    fi
+    grep -q "Failed to connect socket to '/var/run/libvirt/libvirt-sock': Permission denied" creation.error

--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -39,7 +39,7 @@ prepare: |
     ip link set dev tap100 up
 
 restore: |
-    apt autoremove -y --purge libvirt-bin qemu &&
+    apt autoremove -y --purge libvirt-bin qemu
 
     ip link delete tap100
 

--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -40,7 +40,7 @@ prepare: |
 restore: |
     systemctl stop libvirtd.service
     systemctl stop virtlogd.socket
-    apt remove -y libvirt-bin qemu
+    apt remove -y --purge libvirt-bin qemu
 
     ip link delete tap100
 


### PR DESCRIPTION
For exercising the libvirt interface, instead of building a vm or download hundreds of megs during the test, in this case we ship in the test snap a solo5 unikernel which is about 250 kilobytes in size, boots in milliseconds and is able to respond to ping.
