### PR TITLE
interfaces: add missing recvfrom syscall to dbus interface

### DIFF
--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -109,6 +109,7 @@ const dbusPermanentSlotSecComp = `
 recvmsg
 sendmsg
 sendto
+recvfrom
 `
 
 const dbusPermanentSlotDBus = `


### PR DESCRIPTION
Trivial drive-by for https://bugs.launchpad.net/snappy/+bug/1663177

LP: #1663177