### PR TITLE
interfaces/builtin: add network-setup-control which allows rw access to netplan

### DIFF
--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -78,6 +78,7 @@ var allInterfaces = []interfaces.Interface{
 	NewNetworkControlInterface(),
 	NewNetworkInterface(),
 	NewNetworkObserveInterface(),
+	NewNetworkSetupControlInterface(),
 	NewNetworkSetupObserveInterface(),
 	NewOpenglInterface(),
 	NewOpenvSwitchInterface(),

--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -397,6 +397,11 @@ slots:
       slot-snap-type:
         - core
     deny-auto-connection: true
+  network-setup-control:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
   network-setup-observe:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+const networkSetupControlConnectedPlugAppArmor = `
+# Description: Can read/write netplan configuration files
+
+/etc/netplan/{,**} rw,
+/etc/network/{,**} rw,
+`
+
+// NewNetworkSetupControlInterface returns a new "network-setup-control" interface.
+func NewNetworkSetupControlInterface() interfaces.Interface {
+	return &commonInterface{
+		name: "network-setup-control",
+		connectedPlugAppArmor: networkSetupControlConnectedPlugAppArmor,
+		reservedForOS:         true,
+	}
+}

--- a/interfaces/builtin/network_setup_control_test.go
+++ b/interfaces/builtin/network_setup_control_test.go
@@ -1,0 +1,86 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+)
+
+type NetworkSetupControlInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&NetworkSetupControlInterfaceSuite{
+	iface: builtin.NewNetworkSetupControlInterface(),
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Name:      "network-setup-control",
+			Interface: "network-setup-control",
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "other"},
+			Name:      "network-setup-control",
+			Interface: "network-setup-control",
+		},
+	},
+})
+
+func (s *NetworkSetupControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "network-setup-control")
+}
+
+func (s *NetworkSetupControlInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "network-setup-control",
+		Interface: "network-setup-control",
+	}})
+	c.Assert(err, ErrorMatches, "network-setup-control slots are reserved for the operating system snap")
+}
+
+func (s *NetworkSetupControlInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *NetworkSetupControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "network-setup-control"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "network-setup-control"`)
+}
+
+func (s *NetworkSetupControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+}

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -48,6 +48,7 @@ var implicitSlots = []string{
 	"network-bind",
 	"network-control",
 	"network-observe",
+	"network-setup-control",
 	"network-setup-observe",
 	"opengl",
 	"openvswitch-support",


### PR DESCRIPTION
The network-manager interface already allows read-write access to /etc/netplan but we need to write into that directory also from a configure hook. 