### PR TITLE
interfaces/apparmor: allow reading from ecryptfs

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -386,6 +386,15 @@ var defaultTemplate = []byte(`
   /sys/class/ r,
   /sys/class/**/ r,
 
+  # Workaround https://launchpad.net/bugs/359338 until upstream handles
+  # stacked filesystems generally.
+  # encrypted ~/.Private and old-style encrypted $HOME
+  @{HOME}/.Private/ r,
+  @{HOME}/.Private/** mrixwlk,
+  # new-style encrypted $HOME
+  @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
+  @{HOMEDIRS}/.ecryptfs/*/.Private/** mrixwlk,
+
 ###SNIPPETS###
 }
 `)


### PR DESCRIPTION
This patch changes the base apparmor template to allow reading from
ecryptfs. This seems to be required when a snap with a hook lives on a
$HOME directory that is on a crypted filesystem. When that snap is in
try mode the actual files will be encrypted and will end up being
resolved as a set of encrypted files under the /home directory. A
similar patch exists in snap-confine's apparmor profile for the very
same reason.

Fixes: https://bugs.launchpad.net/snapd/+bug/1637596
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>