### PR TITLE
unity7: support missing signals and methods for status icons

### DIFF
--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -334,7 +334,7 @@ dbus (send)
     bus=session
     path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
     interface=org.kde.StatusNotifierItem
-    member="New{AttentionIcon,Icon,OverlayIcon,Status,Title,ToolTip}"
+    member="New{AttentionIcon,Icon,IconThemePath,OverlayIcon,Status,Title,ToolTip}"
     peer=(name=org.freedesktop.DBus, label=unconfined),
 
 dbus (send)
@@ -435,7 +435,7 @@ dbus (receive)
 
 
 # Lttng tracing is very noisy and should not be allowed by confined apps. Can
-# safely deny. LP: #1260491
+# safely deny. <a href='https://pad.lv/1260491'>LP: #1260491</a>
 deny /{,var/}{dev,run}/shm/lttng-ust-* r,
 `
 

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -297,7 +297,7 @@ dbus (receive)
     member="{AboutTo*,Event*}"
     peer=(label=unconfined),
 
-# notifications
+# app-indicators
 dbus (send)
     bus=session
     path=/StatusNotifierWatcher
@@ -337,6 +337,13 @@ dbus (send)
     member="New{AttentionIcon,Icon,IconThemePath,OverlayIcon,Status,Title,ToolTip}"
     peer=(name=org.freedesktop.DBus, label=unconfined),
 
+dbus (receive)
+    bus=session
+    path=/{StatusNotifierItem,org/ayatana/NotificationItem/*}
+    interface=org.kde.StatusNotifierItem
+    member={Activate,ContextMenu,Scroll,SecondaryActivate,XAyatanaSecondaryActivate}
+    peer=(label=unconfined),
+
 dbus (send)
     bus=session
     path=/{StatusNotifierItem/menu,org/ayatana/NotificationItem/*/Menu}
@@ -351,6 +358,7 @@ dbus (receive)
     member={Get*,AboutTo*,Event*}
     peer=(label=unconfined),
 
+# notifications
 dbus (send)
     bus=session
     path=/org/freedesktop/Notifications
@@ -435,7 +443,7 @@ dbus (receive)
 
 
 # Lttng tracing is very noisy and should not be allowed by confined apps. Can
-# safely deny. <a href='https://pad.lv/1260491'>LP: #1260491</a>
+# safely deny. <a href='https://pad.lv/1260491'><a href='https://pad.lv/1260491'>LP: #1260491</a></a>
 deny /{,var/}{dev,run}/shm/lttng-ust-* r,
 `
 

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -443,7 +443,7 @@ dbus (receive)
 
 
 # Lttng tracing is very noisy and should not be allowed by confined apps. Can
-# safely deny. <a href='https://pad.lv/1260491'><a href='https://pad.lv/1260491'>LP: #1260491</a></a>
+# safely deny. LP: #1260491
 deny /{,var/}{dev,run}/shm/lttng-ust-* r,
 `
 


### PR DESCRIPTION
Apps needs to be able to emit NewIconTheme path signal when their custom theme path
has changed, and they also have some callable methods that we currently don't support in snapd.

See https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/

[LP: #1664297](https://bugs.launchpad.net/snappy/+bug/1664297)