### PR TITLE
interfaces: allow recv* and send* by default, accept4 with accept and other cleanups

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -53,9 +53,6 @@ capability fsetid,
 
 // Needed because useradd uses a netlink socket
 const accountControlConnectedPlugSecComp = `
-sendto
-recvfrom
-
 # useradd requires chowning to 'shadow'
 # TODO: dynamically determine the shadow gid to support alternate cores
 fchown - 0 42

--- a/interfaces/builtin/account_control_test.go
+++ b/interfaces/builtin/account_control_test.go
@@ -88,5 +88,5 @@ func (s *AccountControlSuite) TestUsedSecuritySystems(c *C) {
 
 	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
 	c.Assert(err, IsNil)
-	c.Check(string(snippet), testutil.Contains, "\nsendto\nrecvfrom\n")
+	c.Check(string(snippet), testutil.Contains, "\nfchown - 0 42\n")
 }

--- a/interfaces/builtin/avahi_observe.go
+++ b/interfaces/builtin/avahi_observe.go
@@ -105,22 +105,10 @@ dbus (receive)
     peer=(label=unconfined),
 `
 
-const avahiObserveConnectedPlugSecComp = `
-# Description: allows domain browsing, service browsing and service resolving
-
-# dbus
-recvfrom
-recvmsg
-send
-sendto
-sendmsg
-`
-
 func NewAvahiObserveInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "avahi-observe",
 		connectedPlugAppArmor: avahiObserveConnectedPlugAppArmor,
-		connectedPlugSecComp:  avahiObserveConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -85,9 +85,4 @@ func (s *AvahiObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 	c.Check(string(snippet), testutil.Contains, "name=org.freedesktop.Avahi")
-
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "sendto")
 }

--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -25,8 +25,7 @@ import (
 
 const bluetoothControlConnectedPlugAppArmor = `
 # Description: Allow managing the kernel side Bluetooth stack. Reserved
-#  because this gives privileged access to the system.
-# Usage: reserved
+# because this gives privileged access to the system.
 
   network bluetooth,
   # For crypto functionality the kernel offers
@@ -47,8 +46,7 @@ const bluetoothControlConnectedPlugAppArmor = `
 
 const bluetoothControlConnectedPlugSecComp = `
 # Description: Allow managing the kernel side Bluetooth stack. Reserved
-#  because this gives privileged access to the system.
-# Usage: reserved
+# because this gives privileged access to the system.
 bind
 `
 

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -27,8 +27,7 @@ import (
 
 var bluezPermanentSlotAppArmor = []byte(`
 # Description: Allow operating as the bluez service. Reserved because this
-#  gives privileged access to the system.
-# Usage: reserved
+# gives privileged access to the system.
 
   network bluetooth,
 
@@ -97,8 +96,7 @@ var bluezPermanentSlotAppArmor = []byte(`
 
 var bluezConnectedPlugAppArmor = []byte(`
 # Description: Allow using bluez service. Reserved because this gives
-#  privileged access to the bluez service.
-# Usage: reserved
+# privileged access to the bluez service.
 
 #include <abstractions/dbus-strict>
 
@@ -130,9 +128,7 @@ dbus (receive)
 
 var bluezPermanentSlotSecComp = []byte(`
 # Description: Allow operating as the bluez service. Reserved because this
-# gives
-#  privileged access to the system.
-# Usage: reserved
+# gives privileged access to the system.
 accept
 accept4
 bind

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -137,28 +137,7 @@ accept
 accept4
 bind
 listen
-recv
-recvfrom
-recvmmsg
-recvmsg
-send
-sendmmsg
-sendmsg
-sendto
 shutdown
-`)
-
-var bluezConnectedPlugSecComp = []byte(`
-# Description: Allow using bluez service. Reserved because this gives
-#  privileged access to the bluez service.
-# Usage: reserved
-
-# Can communicate with DBus system service
-recv
-recvmsg
-send
-sendto
-sendmsg
 `)
 
 var bluezPermanentSlotDBus = []byte(`
@@ -200,8 +179,6 @@ func (iface *BluezInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *i
 		new := slotAppLabelExpr(slot)
 		snippet := bytes.Replace(bluezConnectedPlugAppArmor, old, new, -1)
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return bluezConnectedPlugSecComp, nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -26,8 +26,8 @@ import (
 )
 
 var bluezPermanentSlotAppArmor = []byte(`
-# Description: Allow operating as the bluez service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the bluez service. This gives privileged
+# access to the system.
 
   network bluetooth,
 
@@ -95,8 +95,8 @@ var bluezPermanentSlotAppArmor = []byte(`
 `)
 
 var bluezConnectedPlugAppArmor = []byte(`
-# Description: Allow using bluez service. Reserved because this gives
-# privileged access to the bluez service.
+# Description: Allow using bluez service. This gives privileged access to the
+# bluez service.
 
 #include <abstractions/dbus-strict>
 
@@ -127,8 +127,8 @@ dbus (receive)
 `)
 
 var bluezPermanentSlotSecComp = []byte(`
-# Description: Allow operating as the bluez service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the bluez service. This gives privileged
+# access to the system.
 accept
 accept4
 bind

--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -117,20 +117,19 @@ func (s *BluezInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c *C) {
 }
 
 func (s *BluezInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
-		interfaces.SecuritySecComp}
-	for _, system := range systems {
-		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -31,7 +31,6 @@ const browserSupportConnectedPlugAppArmor = `
 # Chrome/Chromium and Mozilla) and file paths they expect. This interface is
 # transitional and is only in place while upstream's work to change their paths
 # and snappy is updated to properly mediate the APIs.
-# Usage: reserved
 
 # This allows raising the OOM score of other processes owned by the user.
 owner @{PROC}/@{pid}/oom_score_adj rw,
@@ -187,7 +186,6 @@ const browserSupportConnectedPlugSecComp = `
 # Chrome/Chromium and Mozilla) and file paths they expect. This interface is
 # transitional and is only in place while upstream's work to change their paths
 # and snappy is updated to properly mediate the APIs.
-# Usage: reserved
 
 # for anonymous sockets
 bind

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -193,6 +193,7 @@ const browserSupportConnectedPlugSecComp = `
 bind
 listen
 accept
+accept4
 
 # TODO: fine-tune when seccomp arg filtering available in stable distro
 # releases

--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -63,19 +63,11 @@ const coreSupportConnectedPlugAppArmor = `
 /{,usr/}{,s}bin/hostnamectl           ixr,
 `
 
-const coreSupportConnectedPlugSecComp = `
-sendmsg
-recvmsg
-sendto
-recvfrom
-`
-
 // NewShutdownInterface returns a new "shutdown" interface.
 func NewCoreSupportInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "core-support",
 		connectedPlugAppArmor: coreSupportConnectedPlugAppArmor,
-		connectedPlugSecComp:  coreSupportConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -84,17 +84,10 @@ func (s *CoreSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
-	// connected plugs have a non-nil security snippet for seccomp
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
 }
 
 func (s *CoreSupportInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(string(snippet), testutil.Contains, `/bin/systemctl Uxr,`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `sendmsg`)
 }

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -28,17 +28,11 @@ const cupsControlConnectedPlugAppArmor = `
 #include <abstractions/cups-client>
 `
 
-const cupsControlConnectedPlugSecComp = `
-recvfrom
-sendto
-`
-
 // NewCupsControlInterface returns a new "cups" interface.
 func NewCupsControlInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "cups-control",
 		connectedPlugAppArmor: cupsControlConnectedPlugAppArmor,
-		connectedPlugSecComp:  cupsControlConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -104,14 +104,6 @@ dbus (receive)
     peer=(label=unconfined),
 `
 
-const dbusPermanentSlotSecComp = `
-# Description: Allow owning a name on DBus public bus
-recvmsg
-sendmsg
-sendto
-recvfrom
-`
-
 const dbusPermanentSlotDBus = `
 <policy user="root">
     <allow own="###DBUS_NAME###"/>
@@ -182,12 +174,6 @@ dbus (receive, send)
     bus=###DBUS_BUS###
     path=###DBUS_PATH###
     peer=(label=###SLOT_SECURITY_TAGS###),
-`
-
-const dbusConnectedPlugSecComp = `
-recvmsg
-sendmsg
-sendto
 `
 
 type DbusInterface struct{}
@@ -317,8 +303,6 @@ func (iface *DbusInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *in
 		snippet = bytes.Replace(snippet, old, new, -1)
 
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return []byte(dbusConnectedPlugSecComp), nil
 	}
 	return nil, nil
 }
@@ -354,8 +338,6 @@ func (iface *DbusInterface) PermanentSlotSnippet(slot *interfaces.Slot, security
 		}
 
 		return snippets.Bytes(), nil
-	case interfaces.SecuritySecComp:
-		return []byte(dbusPermanentSlotSecComp), nil
 	case interfaces.SecurityDBus:
 		bus, name, err := iface.getAttribs(slot.Attrs)
 		if err != nil {

--- a/interfaces/builtin/dbus_test.go
+++ b/interfaces/builtin/dbus_test.go
@@ -124,19 +124,11 @@ func (s *DbusInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 
-	snippet, err = s.iface.PermanentSlotSnippet(s.sessionSlot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
 	snippet, err = s.iface.ConnectedSlotSnippet(s.connectedSessionPlug, s.connectedSessionSlot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 
 	snippet, err = s.iface.ConnectedPlugSnippet(s.connectedSessionPlug, s.connectedSessionSlot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	snippet, err = s.iface.ConnectedPlugSnippet(s.connectedSessionPlug, s.connectedSessionSlot, interfaces.SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
@@ -370,14 +362,6 @@ func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSystem(c *C) {
 	c.Check(string(snippet), testutil.Contains, "interface=\"org.test-system-slot{,.*}\"\n")
 }
 
-func (s *DbusInterfaceSuite) TestPermanentSlotSeccomp(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.sessionSlot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "recvmsg\n")
-}
-
 func (s *DbusInterfaceSuite) TestPermanentSlotDBusSession(c *C) {
 	snippet, err := s.iface.PermanentSlotSnippet(s.sessionSlot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
@@ -475,14 +459,6 @@ func (s *DbusInterfaceSuite) TestConnectedPlugAppArmorSystem(c *C) {
 
 	// verify interface in rule
 	c.Check(string(snippet), testutil.Contains, "interface=\"org.test-system-connected{,.*}\"\n")
-}
-
-func (s *DbusInterfaceSuite) TestConnectedPlugSeccomp(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.connectedSessionPlug, s.connectedSessionSlot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "recvmsg\n")
 }
 
 func (s *DbusInterfaceSuite) TestConnectionFirst(c *C) {

--- a/interfaces/builtin/dcdbas_control.go
+++ b/interfaces/builtin/dcdbas_control.go
@@ -33,8 +33,6 @@ const dcdbasControlConnectedPlugAppArmor = `
 #
 # See http://linux.dell.com/libsmbios/main/ for more information about the libsmbios project.
 
-# Usage: reserved
-
 # entries pertaining to System Management Interrupts (SMI)
 /sys/devices/platform/dcdbas/smi_data rw,
 /sys/devices/platform/dcdbas/smi_data_buf_phys_addr rw,

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -28,7 +28,6 @@ import (
 const dockerConnectedPlugAppArmor = `
 # Description: allow access to the Docker daemon socket. This gives privileged
 # access to the system via Docker's socket API.
-# Usage: reserved
 
 # Allow talking to the docker daemon
 /{,var/}run/docker.sock rw,
@@ -37,7 +36,6 @@ const dockerConnectedPlugAppArmor = `
 const dockerConnectedPlugSecComp = `
 # Description: allow access to the Docker daemon socket. This gives privileged
 # access to the system via Docker's socket API.
-# Usage: reserved
 
 bind
 `

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -31,7 +31,6 @@ const dockerSupportConnectedPlugAppArmor = `
 # errors and not for security confinement. The Docker daemon by design requires
 # extensive access to the system and cannot be effectively confined against
 # malicious activity.
-# Usage: reserved
 
 #include <abstractions/dbus-strict>
 
@@ -114,7 +113,6 @@ const dockerSupportConnectedPlugSecComp = `
 # errors and not for security confinement. The Docker daemon by design requires
 # extensive access to the system and cannot be effectively confined against
 # malicious activity.
-# Usage: reserved
 
 # Because seccomp may only go more strict, we must allow all syscalls to Docker
 # that it expects to give to containers in addition to what it needs to run and

--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -27,7 +27,6 @@ import (
 const firewallControlConnectedPlugAppArmor = `
 # Description: Can configure firewall. This is restricted because it gives
 # privileged access to networking and should only be used with trusted apps.
-# Usage: reserved
 
 #include <abstractions/nameservice>
 
@@ -86,7 +85,6 @@ unix (bind) type=stream addr="@xtables",
 const firewallControlConnectedPlugSecComp = `
 # Description: Can configure firewall. This is restricted because it gives
 # privileged access to networking and should only be used with trusted apps.
-# Usage: reserved
 
 # for connecting to xtables abstract socket
 bind

--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -90,14 +90,6 @@ const firewallControlConnectedPlugSecComp = `
 
 # for connecting to xtables abstract socket
 bind
-recv
-recvfrom
-recvmsg
-recvmmsg
-send
-sendmmsg
-sendmsg
-sendto
 
 # for ping and ping6
 capset

--- a/interfaces/builtin/fuse_support.go
+++ b/interfaces/builtin/fuse_support.go
@@ -26,8 +26,6 @@ const fuseSupportConnectedPlugSecComp = `
 # not supported at this time.
 
 mount
-# for communicating with kernel
-recvmsg
 `
 
 const fuseSupportConnectedPlugAppArmor = `

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -26,8 +26,8 @@ import (
 )
 
 var fwupdPermanentSlotAppArmor = []byte(`
-# Description: Allow operating as the fwupd service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the fwupd service. This gives privileged
+# access to the system.
 
   # Allow read/write access for old efivars sysfs interface
   capability sys_admin,
@@ -86,8 +86,8 @@ var fwupdPermanentSlotAppArmor = []byte(`
 `)
 
 var fwupdConnectedPlugAppArmor = []byte(`
-# Description: Allow using fwupd service. Reserved because this gives
-# privileged access to the fwupd service.
+# Description: Allow using fwupd service. This gives # privileged access to the
+# fwupd service.
 
   #Can access the network
   #include <abstractions/nameservice>
@@ -111,8 +111,8 @@ var fwupdConnectedPlugAppArmor = []byte(`
 `)
 
 var fwupdConnectedSlotAppArmor = []byte(`
-# Description: Allow firmware update using fwupd service. Reserved because this gives
-# privileged access to the fwupd service.
+# Description: Allow firmware update using fwupd service. This gives privileged
+# access to the fwupd service.
 
   # Allow traffic to/from org.freedesktop.DBus for fwupd service
   dbus (receive, send)
@@ -156,8 +156,8 @@ var fwupdPermanentSlotDBus = []byte(`
 `)
 
 var fwupdPermanentSlotSecComp = []byte(`
-# Description: Allow operating as the fwupd service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the fwupd service. This gives privileged
+# access to the system.
 # Can communicate with DBus system service
 bind
 `)

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -28,7 +28,6 @@ import (
 var fwupdPermanentSlotAppArmor = []byte(`
 # Description: Allow operating as the fwupd service. Reserved because this
 # gives privileged access to the system.
-# Usage: reserved
 
   # Allow read/write access for old efivars sysfs interface
   capability sys_admin,
@@ -89,7 +88,6 @@ var fwupdPermanentSlotAppArmor = []byte(`
 var fwupdConnectedPlugAppArmor = []byte(`
 # Description: Allow using fwupd service. Reserved because this gives
 # privileged access to the fwupd service.
-# Usage: reserved
 
   #Can access the network
   #include <abstractions/nameservice>
@@ -115,7 +113,6 @@ var fwupdConnectedPlugAppArmor = []byte(`
 var fwupdConnectedSlotAppArmor = []byte(`
 # Description: Allow firmware update using fwupd service. Reserved because this gives
 # privileged access to the fwupd service.
-# Usage: reserved
 
   # Allow traffic to/from org.freedesktop.DBus for fwupd service
   dbus (receive, send)
@@ -161,7 +158,6 @@ var fwupdPermanentSlotDBus = []byte(`
 var fwupdPermanentSlotSecComp = []byte(`
 # Description: Allow operating as the fwupd service. Reserved because this
 # gives privileged access to the system.
-# Usage: reserved
 # Can communicate with DBus system service
 bind
 `)
@@ -169,7 +165,6 @@ bind
 var fwupdConnectedPlugSecComp = []byte(`
 # Description: Allow using fwupd service. Reserved because this gives
 # privileged access to the fwupd service.
-# Usage: reserved
 bind
 `)
 

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -164,10 +164,6 @@ var fwupdPermanentSlotSecComp = []byte(`
 # Usage: reserved
 # Can communicate with DBus system service
 bind
-recvfrom
-recvmsg
-sendmsg
-sendto
 `)
 
 var fwupdConnectedPlugSecComp = []byte(`
@@ -175,10 +171,6 @@ var fwupdConnectedPlugSecComp = []byte(`
 # privileged access to the fwupd service.
 # Usage: reserved
 bind
-recvfrom
-recvmsg
-sendmsg
-sendto
 `)
 
 // FwupdInterface type

--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -27,7 +27,6 @@ const gsettingsConnectedPlugAppArmor = `
 # Description: Can access global gsettings of the user's session. Restricted
 # because this gives privileged access to sensitive information stored in
 # gsettings and allows adjusting settings of other applications.
-# Usage: reserved
 
 #include <abstractions/dbus-session-strict>
 

--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -40,24 +40,11 @@ dbus (receive, send)
     peer=(label=unconfined),
 `
 
-const gsettingsConnectedPlugSecComp = `
-# Description: Can access global gsettings of the user's session. Restricted
-# because this gives privileged access to sensitive information stored in
-# gsettings and allows adjusting settings of other applications.
-
-# dbus
-recvmsg
-send
-sendto
-sendmsg
-`
-
 // NewGsettingsInterface returns a new "gsettings" interface.
 func NewGsettingsInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "gsettings",
 		connectedPlugAppArmor: gsettingsConnectedPlugAppArmor,
-		connectedPlugSecComp:  gsettingsConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -27,7 +27,6 @@ import (
 const homeConnectedPlugAppArmor = `
 # Description: Can access non-hidden files in user's $HOME. This is restricted
 # because it gives file access to all of the user's $HOME.
-# Usage: reserved
 
 # Note, @{HOME} is the user's $HOME, not the snap's $HOME
 

--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -29,6 +29,7 @@ const libvirtConnectedPlugAppArmor = `
 const libvirtConnectedPlugSecComp = `
 listen
 accept
+accept4
 `
 
 func NewLibvirtInterface() interfaces.Interface {

--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -27,11 +27,6 @@ const libvirtConnectedPlugAppArmor = `
 `
 
 const libvirtConnectedPlugSecComp = `
-recv
-recvmsg
-send
-sendto
-sendmsg
 listen
 accept
 `

--- a/interfaces/builtin/locale_control.go
+++ b/interfaces/builtin/locale_control.go
@@ -26,7 +26,6 @@ import (
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/locale-control
 const localeControlConnectedPlugAppArmor = `
 # Description: Can manage locales directly separate from 'config ubuntu-core'.
-# Usage: reserved
 
 # TODO: this won't work until snappy exposes this configurability
 /etc/default/locale rw,

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -122,18 +122,6 @@ dbus (receive)
     peer=(label=unconfined),
 `)
 
-var locationControlPermanentSlotSecComp = []byte(`
-recvmsg
-sendmsg
-sendto
-`)
-
-var locationControlConnectedPlugSecComp = []byte(`
-recvmsg
-sendmsg
-sendto
-`)
-
 var locationControlPermanentSlotDBus = []byte(`
 <policy user="root">
     <allow own="com.ubuntu.location.Service"/>
@@ -169,8 +157,6 @@ func (iface *LocationControlInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 		return snippet, nil
 	case interfaces.SecurityDBus:
 		return locationControlConnectedPlugDBus, nil
-	case interfaces.SecuritySecComp:
-		return locationControlConnectedPlugSecComp, nil
 	}
 	return nil, nil
 }
@@ -181,8 +167,6 @@ func (iface *LocationControlInterface) PermanentSlotSnippet(slot *interfaces.Slo
 		return locationControlPermanentSlotAppArmor, nil
 	case interfaces.SecurityDBus:
 		return locationControlPermanentSlotDBus, nil
-	case interfaces.SecuritySecComp:
-		return locationControlPermanentSlotSecComp, nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -26,8 +26,8 @@ import (
 )
 
 var locationControlPermanentSlotAppArmor = []byte(`
-# Description: Allow operating as the location service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the location service. This gives privileged
+# access to the system.
 
 # DBus accesses
 #include <abstractions/dbus-strict>
@@ -85,8 +85,8 @@ dbus (send)
 `)
 
 var locationControlConnectedPlugAppArmor = []byte(`
-# Description: Allow using location service. Reserved because this gives
-# privileged access to the service.
+# Description: Allow using location service. This gives privileged access to
+# the service.
 
 #include <abstractions/dbus-strict>
 

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -27,8 +27,7 @@ import (
 
 var locationControlPermanentSlotAppArmor = []byte(`
 # Description: Allow operating as the location service. Reserved because this
-#  gives privileged access to the system.
-# Usage: reserved
+# gives privileged access to the system.
 
 # DBus accesses
 #include <abstractions/dbus-strict>
@@ -87,8 +86,7 @@ dbus (send)
 
 var locationControlConnectedPlugAppArmor = []byte(`
 # Description: Allow using location service. Reserved because this gives
-#  privileged access to the service.
-# Usage: reserved
+# privileged access to the service.
 
 #include <abstractions/dbus-strict>
 

--- a/interfaces/builtin/location_control_test.go
+++ b/interfaces/builtin/location_control_test.go
@@ -177,17 +177,13 @@ func (s *LocationControlInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne
 }
 
 func (s *LocationControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
-		interfaces.SecuritySecComp, interfaces.SecurityDBus}
-	for _, system := range systems {
-		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-	}
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -187,18 +187,6 @@ dbus (receive)
     peer=(label=unconfined),
 `)
 
-var locationObservePermanentSlotSecComp = []byte(`
-recvmsg
-sendmsg
-sendto
-`)
-
-var locationObserveConnectedPlugSecComp = []byte(`
-recvmsg
-sendmsg
-sendto
-`)
-
 var locationObservePermanentSlotDBus = []byte(`
 <policy user="root">
     <allow own="com.ubuntu.location.Service"/>
@@ -239,8 +227,6 @@ func (iface *LocationObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 		return snippet, nil
 	case interfaces.SecurityDBus:
 		return locationObserveConnectedPlugDBus, nil
-	case interfaces.SecuritySecComp:
-		return locationObserveConnectedPlugSecComp, nil
 	default:
 		return nil, nil
 	}
@@ -252,8 +238,6 @@ func (iface *LocationObserveInterface) PermanentSlotSnippet(slot *interfaces.Slo
 		return locationObservePermanentSlotAppArmor, nil
 	case interfaces.SecurityDBus:
 		return locationObservePermanentSlotDBus, nil
-	case interfaces.SecuritySecComp:
-		return locationObservePermanentSlotSecComp, nil
 	default:
 		return nil, nil
 	}

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -26,8 +26,8 @@ import (
 )
 
 var locationObservePermanentSlotAppArmor = []byte(`
-# Description: Allow operating as the location service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the location service. This gives privileged
+# access to the system.
 
 # DBus accesses
 #include <abstractions/dbus-strict>
@@ -120,8 +120,8 @@ dbus (send)
 `)
 
 var locationObserveConnectedPlugAppArmor = []byte(`
-# Description: Allow using location service. Reserved because this gives
-# privileged access to the service.
+# Description: Allow using location service. This gives privileged access to
+# the service.
 
 #include <abstractions/dbus-strict>
 

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -27,8 +27,7 @@ import (
 
 var locationObservePermanentSlotAppArmor = []byte(`
 # Description: Allow operating as the location service. Reserved because this
-#  gives privileged access to the system.
-# Usage: reserved
+# gives privileged access to the system.
 
 # DBus accesses
 #include <abstractions/dbus-strict>
@@ -122,8 +121,7 @@ dbus (send)
 
 var locationObserveConnectedPlugAppArmor = []byte(`
 # Description: Allow using location service. Reserved because this gives
-#  privileged access to the service.
-# Usage: reserved
+# privileged access to the service.
 
 #include <abstractions/dbus-strict>
 

--- a/interfaces/builtin/location_observe_test.go
+++ b/interfaces/builtin/location_observe_test.go
@@ -177,17 +177,13 @@ func (s *LocationObserveInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne
 }
 
 func (s *LocationObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
-		interfaces.SecuritySecComp, interfaces.SecurityDBus}
-	for _, system := range systems {
-		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-	}
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }

--- a/interfaces/builtin/log_observe.go
+++ b/interfaces/builtin/log_observe.go
@@ -26,7 +26,6 @@ import (
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/log-observe
 const logObserveConnectedPlugAppArmor = `
 # Description: Can read system logs and set kernel log rate-limiting
-# Usage: reserved
 
 /var/log/ r,
 /var/log/** r,

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -48,14 +48,8 @@ var mirPermanentSlotSecComp = []byte(`
 bind
 listen
 # Needed by server upon client connect
-send
-sendto
-sendmsg
 accept
 shmctl
-recv
-recvmsg
-recvfrom
 `)
 
 var mirConnectedSlotAppArmor = []byte(`
@@ -70,18 +64,6 @@ var mirConnectedPlugAppArmor = []byte(`
 unix (receive, send) type=seqpacket addr=none peer=(label=###SLOT_SECURITY_TAGS###),
 /run/mir_socket rw,
 /run/user/[0-9]*/mir_socket rw,
-`)
-
-var mirConnectedPlugSecComp = []byte(`
-# Description: Permit clients to use Mir
-# Usage: common
-recv
-recvfrom
-recvmsg
-send
-sendto
-sendmsg
-
 `)
 
 type MirInterface struct{}
@@ -101,8 +83,6 @@ func (iface *MirInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *int
 		new := slotAppLabelExpr(slot)
 		snippet := bytes.Replace(mirConnectedPlugAppArmor, old, new, -1)
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return mirConnectedPlugSecComp, nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -49,6 +49,7 @@ bind
 listen
 # Needed by server upon client connect
 accept
+accept4
 shmctl
 `)
 

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -28,7 +28,7 @@ import (
 var mirPermanentSlotAppArmor = []byte(`
 # Description: Allow operating as the Mir server. Reserved because this
 # gives privileged access to the system.
-# Usage: reserved
+
 # needed since Mir is the display server, to configure tty devices
 capability sys_tty_config,
 /{dev,run}/shm/\#* rw,
@@ -55,13 +55,11 @@ shmctl
 
 var mirConnectedSlotAppArmor = []byte(`
 # Description: Permit clients to use Mir
-# Usage: reserved
 unix (receive, send) type=seqpacket addr=none peer=(label=###PLUG_SECURITY_TAGS###),
 `)
 
 var mirConnectedPlugAppArmor = []byte(`
 # Description: Permit clients to use Mir
-# Usage: common
 unix (receive, send) type=seqpacket addr=none peer=(label=###SLOT_SECURITY_TAGS###),
 /run/mir_socket rw,
 /run/user/[0-9]*/mir_socket rw,

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -26,8 +26,8 @@ import (
 )
 
 var mirPermanentSlotAppArmor = []byte(`
-# Description: Allow operating as the Mir server. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the Mir server. This gives privileged access
+# to the system.
 
 # needed since Mir is the display server, to configure tty devices
 capability sys_tty_config,
@@ -42,8 +42,8 @@ network netlink raw,
 `)
 
 var mirPermanentSlotSecComp = []byte(`
-# Description: Allow operating as the mir server. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the mir server. This gives privileged access
+# to the system.
 # Needed for server launch
 bind
 listen

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -62,11 +62,11 @@ func (s *MirInterfaceSuite) TestUsedSecuritySystems(c *C) {
 		snippet, err := s.iface.PermanentSlotSnippet(s.slot, system)
 		c.Assert(err, IsNil)
 		c.Assert(snippet, Not(IsNil))
-		snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
 		if system != interfaces.SecuritySecComp {
 			snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, system)
+			c.Assert(err, IsNil)
+			c.Assert(snippet, Not(IsNil))
+			snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
 			c.Assert(err, IsNil)
 			c.Assert(snippet, Not(IsNil))
 		}

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -143,29 +143,7 @@ accept
 accept4
 bind
 listen
-recv
-recvfrom
-recvmmsg
-recvmsg
-send
-sendmmsg
-sendmsg
-sendto
 shutdown
-`)
-
-var modemManagerConnectedPlugSecComp = []byte(`
-# Description: Allow using ModemManager service. Reserved because this gives
-#  privileged access to the ModemManager service.
-# Usage: reserved
-
-# Can communicate with DBus system service
-recv
-recvmsg
-recvfrom
-send
-sendto
-sendmsg
 `)
 
 var modemManagerPermanentSlotDBus = []byte(`
@@ -1196,8 +1174,6 @@ func (iface *ModemManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, 
 			snippet = append(snippet, modemManagerConnectedPlugAppArmorClassic...)
 		}
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return modemManagerConnectedPlugSecComp, nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -27,8 +27,8 @@ import (
 )
 
 var modemManagerPermanentSlotAppArmor = []byte(`
-# Description: Allow operating as the ModemManager service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the ModemManager service. This gives
+# privileged access to the system.
 
 # To check present devices
 /run/udev/data/* r,
@@ -100,8 +100,8 @@ dbus (receive, send)
 `)
 
 var modemManagerConnectedPlugAppArmor = []byte(`
-# Description: Allow using ModemManager service. Reserved because this gives
-# privileged access to the ModemManager service.
+# Description: Allow using ModemManager service. This gives privileged access
+# to the ModemManager service.
 
 #include <abstractions/dbus-strict>
 
@@ -133,8 +133,8 @@ dbus (receive, send)
 `)
 
 var modemManagerPermanentSlotSecComp = []byte(`
-# Description: Allow operating as the ModemManager service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the ModemManager service. This gives
+# privileged access to the system.
 
 # TODO: add ioctl argument filters when seccomp arg filtering is implemented
 accept

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -28,8 +28,7 @@ import (
 
 var modemManagerPermanentSlotAppArmor = []byte(`
 # Description: Allow operating as the ModemManager service. Reserved because this
-#  gives privileged access to the system.
-# Usage: reserved
+# gives privileged access to the system.
 
 # To check present devices
 /run/udev/data/* r,
@@ -102,8 +101,7 @@ dbus (receive, send)
 
 var modemManagerConnectedPlugAppArmor = []byte(`
 # Description: Allow using ModemManager service. Reserved because this gives
-#  privileged access to the ModemManager service.
-# Usage: reserved
+# privileged access to the ModemManager service.
 
 #include <abstractions/dbus-strict>
 
@@ -136,8 +134,8 @@ dbus (receive, send)
 
 var modemManagerPermanentSlotSecComp = []byte(`
 # Description: Allow operating as the ModemManager service. Reserved because this
-#  gives privileged access to the system.
-# Usage: reserved
+# gives privileged access to the system.
+
 # TODO: add ioctl argument filters when seccomp arg filtering is implemented
 accept
 accept4

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -135,22 +135,25 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabel
 }
 
 func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
-		interfaces.SecuritySecComp}
-	for _, system := range systems {
-		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
+
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecuritySecComp)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityUDev)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -30,7 +30,6 @@ import (
 
 var mprisPermanentSlotAppArmor = []byte(`
 # Description: Allow operating as an MPRIS player.
-# Usage: common
 
 # DBus accesses
 #include <abstractions/dbus-session-strict>
@@ -109,7 +108,6 @@ dbus (receive)
 
 var mprisConnectedPlugAppArmor = []byte(`
 # Description: Allow connecting to an MPRIS player.
-# Usage: common
 
 #include <abstractions/dbus-session-strict>
 

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -139,18 +139,6 @@ dbus (send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `)
 
-var mprisPermanentSlotSecComp = []byte(`
-recvmsg
-sendmsg
-sendto
-`)
-
-var mprisConnectedPlugSecComp = []byte(`
-recvmsg
-sendmsg
-sendto
-`)
-
 type MprisInterface struct{}
 
 func (iface *MprisInterface) Name() string {
@@ -168,8 +156,6 @@ func (iface *MprisInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *i
 		new := slotAppLabelExpr(slot)
 		snippet := bytes.Replace(mprisConnectedPlugAppArmor, old, new, -1)
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return mprisConnectedPlugSecComp, nil
 	}
 	return nil, nil
 }
@@ -191,8 +177,6 @@ func (iface *MprisInterface) PermanentSlotSnippet(slot *interfaces.Slot, securit
 			snippet = append(snippet, mprisConnectedSlotAppArmorClassic...)
 		}
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return mprisPermanentSlotSecComp, nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/mpris_test.go
+++ b/interfaces/builtin/mpris_test.go
@@ -181,14 +181,6 @@ func (s *MprisInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c *C) {
 	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.mpris.{app1,app2}"),`)
 }
 
-func (s *MprisInterfaceSuite) TestConnectedPlugSecComp(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "recvmsg\n")
-}
-
 // The label uses short form when exactly one app is bound to the mpris slot
 func (s *MprisInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c *C) {
 	app := &snap.AppInfo{Name: "app"}
@@ -320,26 +312,11 @@ func (s *MprisInterfaceSuite) TestPermanentSlotAppArmorClassic(c *C) {
 	c.Check(string(snippet), testutil.Contains, "# Allow unconfined clients to interact with the player on classic\n")
 }
 
-func (s *MprisInterfaceSuite) TestPermanentSlotSecComp(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecuritySecComp)
+func (s *MprisInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "recvmsg\n")
-}
-
-func (s *MprisInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
-		interfaces.SecuritySecComp}
-	for _, system := range systems {
-		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-	}
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -37,14 +37,6 @@ const networkConnectedPlugSecComp = `
 # Description: Can access the network as a client.
 # Usage: common
 bind
-recv
-recvfrom
-recvmmsg
-recvmsg
-send
-sendmmsg
-sendmsg
-sendto
 shutdown
 `
 

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -24,7 +24,6 @@ import "github.com/snapcore/snapd/interfaces"
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network
 const networkConnectedPlugAppArmor = `
 # Description: Can access the network as a client.
-# Usage: common
 #include <abstractions/nameservice>
 #include <abstractions/ssl_certs>
 
@@ -35,7 +34,6 @@ const networkConnectedPlugAppArmor = `
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/network
 const networkConnectedPlugSecComp = `
 # Description: Can access the network as a client.
-# Usage: common
 bind
 shutdown
 `

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -26,7 +26,6 @@ import (
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network-bind
 const networkBindConnectedPlugAppArmor = `
 # Description: Can access the network as a server.
-# Usage: common
 #include <abstractions/nameservice>
 #include <abstractions/ssl_certs>
 
@@ -62,7 +61,6 @@ const networkBindConnectedPlugAppArmor = `
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/network-bind
 const networkBindConnectedPlugSecComp = `
 # Description: Can access the network as a server.
-# Usage: common
 accept
 accept4
 bind

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -67,14 +67,6 @@ accept
 accept4
 bind
 listen
-recv
-recvfrom
-recvmmsg
-recvmsg
-send
-sendmmsg
-sendmsg
-sendto
 shutdown
 `
 

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -184,10 +184,6 @@ capset
 # network configuration files into /etc in that namespace. See man ip-netns(8)
 # for details.
 bind
-sendmsg
-sendto
-recvfrom
-recvmsg
 
 mount
 umount

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -204,14 +204,6 @@ accept
 accept4
 bind
 listen
-recv
-recvfrom
-recvmmsg
-recvmsg
-send
-sendmmsg
-sendmsg
-sendto
 sethostname
 shutdown
 # Needed for keyfile settings plugin to allow adding settings
@@ -230,20 +222,6 @@ fchown32
 fchownat
 lchown
 lchown32
-`)
-
-var networkManagerConnectedPlugSecComp = []byte(`
-# Description: Allow using NetworkManager service. Reserved because this gives
-#  privileged access to the NetworkManager service.
-# Usage: reserved
-
-# Can communicate with DBus system service
-recv
-recvmsg
-recvfrom
-send
-sendto
-sendmsg
 `)
 
 var networkManagerPermanentSlotDBus = []byte(`
@@ -416,8 +394,6 @@ func (iface *NetworkManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug
 		}
 		snippet := bytes.Replace(networkManagerConnectedPlugAppArmor, old, new, -1)
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return networkManagerConnectedPlugSecComp, nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -28,8 +28,7 @@ import (
 
 var networkManagerPermanentSlotAppArmor = []byte(`
 # Description: Allow operating as the NetworkManager service. Reserved because this
-#  gives privileged access to the system.
-# Usage: reserved
+# gives privileged access to the system.
 
 capability net_admin,
 capability net_bind_service,
@@ -184,8 +183,7 @@ dbus (receive, send)
 
 var networkManagerConnectedPlugAppArmor = []byte(`
 # Description: Allow using NetworkManager service. Reserved because this gives
-#  privileged access to the NetworkManager service.
-# Usage: reserved
+# privileged access to the NetworkManager service.
 
 #include <abstractions/dbus-strict>
 
@@ -198,8 +196,7 @@ dbus (receive, send)
 
 var networkManagerPermanentSlotSecComp = []byte(`
 # Description: Allow operating as the NetworkManager service. Reserved because this
-#  gives privileged access to the system.
-# Usage: reserved
+# gives privileged access to the system.
 accept
 accept4
 bind

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -27,8 +27,8 @@ import (
 )
 
 var networkManagerPermanentSlotAppArmor = []byte(`
-# Description: Allow operating as the NetworkManager service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the NetworkManager service. This gives
+# privileged access to the system.
 
 capability net_admin,
 capability net_bind_service,
@@ -182,8 +182,8 @@ dbus (receive, send)
 `)
 
 var networkManagerConnectedPlugAppArmor = []byte(`
-# Description: Allow using NetworkManager service. Reserved because this gives
-# privileged access to the NetworkManager service.
+# Description: Allow using NetworkManager service. This gives privileged access
+# to the NetworkManager service.
 
 #include <abstractions/dbus-strict>
 
@@ -195,8 +195,8 @@ dbus (receive, send)
 `)
 
 var networkManagerPermanentSlotSecComp = []byte(`
-# Description: Allow operating as the NetworkManager service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the NetworkManager service. This gives
+# privileged access to the system.
 accept
 accept4
 bind

--- a/interfaces/builtin/network_manager_test.go
+++ b/interfaces/builtin/network_manager_test.go
@@ -129,20 +129,19 @@ func (s *NetworkManagerInterfaceSuite) TestConnectedPlugSnippedUsesUnconfinedLab
 }
 
 func (s *NetworkManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
-		interfaces.SecuritySecComp}
-	for _, system := range systems {
-		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-		snippet, err = s.iface.PermanentSlotSnippet(s.slot, system)
-		c.Assert(err, IsNil)
-		c.Assert(snippet, Not(IsNil))
-	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -28,7 +28,6 @@ const networkObserveConnectedPlugAppArmor = `
 # Description: Can query network status information. This is restricted because
 # it gives privileged read-only access to networking information and should
 # only be used with trusted apps.
-# Usage: reserved
 
 # network-monitor can't allow this otherwise we are basically
 # network-management, but don't explicitly deny since someone might try to use
@@ -95,7 +94,6 @@ const networkObserveConnectedPlugSecComp = `
 # Description: Can query network status information. This is restricted because
 # it gives privileged read-only access to networking information and should
 # only be used with trusted apps.
-# Usage: reserved
 
 # for ping and ping6
 capset

--- a/interfaces/builtin/network_setup_observe.go
+++ b/interfaces/builtin/network_setup_observe.go
@@ -25,7 +25,6 @@ import (
 
 const networkSetupObserveConnectedPlugAppArmor = `
 # Description: Can read netplan configuration files
-# Usage: reserved
 
 /etc/netplan/{,**} r,
 /etc/network/{,**} r,

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -27,8 +27,8 @@ import (
 )
 
 const ofonoPermanentSlotAppArmor = `
-# Description: Allow operating as the ofono service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the ofono service. This gives privileged
+# access to the system.
 
 # to create ppp network interfaces
 capability net_admin,
@@ -109,8 +109,8 @@ dbus (receive, send)
 `
 
 const ofonoConnectedPlugAppArmor = `
-# Description: Allow using Ofono service. Reserved because this gives
-# privileged access to the Ofono service.
+# Description: Allow using Ofono service. This gives privileged access to the
+# Ofono service.
 
 #include <abstractions/dbus-strict>
 
@@ -132,8 +132,8 @@ dbus (receive, send)
 `
 
 const ofonoPermanentSlotSecComp = `
-# Description: Allow operating as the ofono service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the ofono service. This gives privileged
+# access to the system.
 
 # Communicate with DBus, netlink, rild
 accept

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -140,28 +140,7 @@ accept
 accept4
 bind
 listen
-recv
-recvfrom
-recvmmsg
-recvmsg
-send
-sendmmsg
-sendmsg
-sendto
 shutdown
-`
-
-const ofonoConnectedPlugSecComp = `
-# Description: Allow using ofono service. Reserved because this gives
-# privileged access to the ofono service.
-
-# Can communicate with DBus system service
-recv
-recvmsg
-recvfrom
-send
-sendto
-sendmsg
 `
 
 const ofonoPermanentSlotDBus = `
@@ -274,8 +253,6 @@ func (iface *OfonoInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *i
 			snippet = append(snippet, ofonoConnectedPlugAppArmorClassic...)
 		}
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return []byte(ofonoConnectedPlugSecComp), nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/ofono_test.go
+++ b/interfaces/builtin/ofono_test.go
@@ -140,14 +140,6 @@ func (s *OfonoInterfaceSuite) TestConnectedPlugSnippetAppArmor(c *C) {
 	c.Assert(string(snippet), Not(testutil.Contains), "peer=(label=unconfined),")
 }
 
-func (s *OfonoInterfaceSuite) TestConnectedPlugSnippetSecComp(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "send\n")
-}
-
 func (s *OfonoInterfaceSuite) TestConnectedSlotSnippetAppArmor(c *C) {
 	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -25,7 +25,6 @@ import (
 
 const openglConnectedPlugAppArmor = `
 # Description: Can access opengl.
-# Usage: reserved
 
   # specific gl libs
   /var/lib/snapd/lib/gl/ r,

--- a/interfaces/builtin/openvswitch.go
+++ b/interfaces/builtin/openvswitch.go
@@ -25,19 +25,10 @@ const openvswitchConnectedPlugAppArmor = `
 /run/openvswitch/db.sock rw,
 `
 
-const openvswitchConnectedPlugSecComp = `
-recv
-recvmsg
-send
-sendto
-sendmsg
-`
-
 func NewOpenvSwitchInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "openvswitch",
 		connectedPlugAppArmor: openvswitchConnectedPlugAppArmor,
-		connectedPlugSecComp:  openvswitchConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -24,8 +24,8 @@ import (
 )
 
 var pppConnectedPlugAppArmor = []byte(`
-# Description: Allow operating ppp daemon. Reserved because this gives
-# privileged access to the ppp daemon.
+# Description: Allow operating ppp daemon. This gives privileged access to the
+# ppp daemon.
 
 # Needed for modem connections using PPP
 /usr/sbin/pppd ix,

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -25,8 +25,7 @@ import (
 
 var pppConnectedPlugAppArmor = []byte(`
 # Description: Allow operating ppp daemon. Reserved because this gives
-#  privileged access to the ppp daemon.
-# Usage: reserved
+# privileged access to the ppp daemon.
 
 # Needed for modem connections using PPP
 /usr/sbin/pppd ix,

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -27,7 +27,6 @@ const processControlConnectedPlugAppArmor = `
 # Description: This interface allows for controlling other processes via
 # signals and nice. This is reserved because it grants privileged access to
 # all processes under root or processes running under the same UID otherwise.
-# Usage: reserved
 
 # /{,usr/}bin/nice is already in default policy, so just allow renice here
 /{,usr/}bin/renice ixr,
@@ -42,7 +41,6 @@ const processControlConnectedPlugSecComp = `
 # Description: This interface allows for controlling other processes via
 # signals and nice. This is reserved because it grants privileged access to
 # all processes under root or processes running under the same UID otherwise.
-# Usage: reserved
 
 # Allow setting the nice value/priority for any process
 nice

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -100,6 +100,7 @@ personality
 setpriority
 bind
 listen
+accept
 accept4
 shmctl
 # Needed to set root as group for different state dirs

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -48,10 +48,7 @@ owner /{,var/}run/user/*/pulse/native rwk,
 `
 
 const pulseaudioConnectedPlugSecComp = `
-sendto
 shmctl
-sendmsg
-recvmsg
 `
 
 const pulseaudioPermanentSlotAppArmor = `
@@ -103,12 +100,8 @@ personality
 setpriority
 bind
 listen
-sendto
-recvfrom
 accept4
 shmctl
-sendmsg
-recvmsg
 # Needed to set root as group for different state dirs
 # pulseaudio creates on startup.
 setgroups

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -26,7 +26,6 @@ import (
 const rawusbConnectedPlugAppArmor = `
 # Description: Allow raw access to all connected USB devices.
 # Reserved because this gives privileged access to the system.
-# Usage: reserved
 /dev/bus/usb/[0-9][0-9][0-9]/[0-9][0-9][0-9] rw,
 
 # Allow detection of usb devices. Leaks plugged in USB device info

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -25,7 +25,7 @@ import (
 
 const rawusbConnectedPlugAppArmor = `
 # Description: Allow raw access to all connected USB devices.
-# Reserved because this gives privileged access to the system.
+# This gives privileged access to the system.
 /dev/bus/usb/[0-9][0-9][0-9]/[0-9][0-9][0-9] rw,
 
 # Allow detection of usb devices. Leaks plugged in USB device info

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -59,22 +59,11 @@ dbus (send)
     peer=(label=unconfined),
 `
 
-const screenInhibitControlConnectedPlugSecComp = `
-# Description: Can inhibit and uninhibit screen savers in desktop sessions.
-# dbus
-recvfrom
-recvmsg
-send
-sendto
-sendmsg
-`
-
 // NewScreenInhibitControlInterface returns a new "screen-inhibit-control" interface.
 func NewScreenInhibitControlInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "screen-inhibit-control",
 		connectedPlugAppArmor: screenInhibitControlConnectedPlugAppArmor,
-		connectedPlugSecComp:  screenInhibitControlConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -43,22 +43,11 @@ dbus (send)
     peer=(label=unconfined),
 `
 
-const shutdownConnectedPlugSecComp = `
-# Description: Can reboot, power-off and halt the system.
-# Following things are needed for dbus connectivity
-recvfrom
-recvmsg
-send
-sendto
-sendmsg
-`
-
 // NewShutdownInterface returns a new "shutdown" interface.
 func NewShutdownInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "shutdown",
 		connectedPlugAppArmor: shutdownConnectedPlugAppArmor,
-		connectedPlugSecComp:  shutdownConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/shutdown_test.go
+++ b/interfaces/builtin/shutdown_test.go
@@ -84,18 +84,10 @@ func (s *ShutdownInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
-	// connected plugs have a non-nil security snippet for seccomp
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
 }
 
 func (s *ShutdownInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(string(snippet), testutil.Contains, `org.freedesktop.systemd1`)
-
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `recvfrom`)
 }

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -31,25 +31,11 @@ const snapdControlConnectedPlugAppArmor = `
 /run/snapd.socket rw,
 `
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/snapd-control
-const snapdControlConnectedPlugSecComp = `
-# Description: Can use snapd.
-# Usage: reserved
-
-# Can communicate with snapd abstract socket
-recv
-recvmsg
-send
-sendto
-sendmsg
-`
-
 // NewSnapdControlInterface returns a new "snapd-control" interface.
 func NewSnapdControlInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "snapd-control",
 		connectedPlugAppArmor: snapdControlConnectedPlugAppArmor,
-		connectedPlugSecComp:  snapdControlConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -26,7 +26,6 @@ import (
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/snapd-control
 const snapdControlConnectedPlugAppArmor = `
 # Description: Can manage snaps via snapd.
-# Usage: reserved
 
 /run/snapd.socket rw,
 `

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -70,7 +70,6 @@ dbus (send)
     peer=(label=unconfined),
 `
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/system-observe
 const systemObserveConnectedPlugSecComp = `
 # Description: Can query system status information. This is restricted because
 # it gives privileged read access to all processes on the system and should
@@ -83,13 +82,6 @@ const systemObserveConnectedPlugSecComp = `
 # Note: may uncomment once ubuntu-core-launcher understands @deny rules and
 # if/when we conditionally deny this in the future.
 #@deny ptrace
-
-# for connecting to /org/freedesktop/hostname1 over DBus
-recvfrom
-recvmsg
-send
-sendto
-sendmsg
 `
 
 // NewSystemObserveInterface returns a new "system-observe" interface.

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -28,7 +28,6 @@ const systemObserveConnectedPlugAppArmor = `
 # Description: Can query system status information. This is restricted because
 # it gives privileged read access to all processes on the system and should
 # only be used with trusted apps.
-# Usage: reserved
 
 # Needed by 'ps'
 @{PROC}/tty/drivers r,
@@ -74,7 +73,6 @@ const systemObserveConnectedPlugSecComp = `
 # Description: Can query system status information. This is restricted because
 # it gives privileged read access to all processes on the system and should
 # only be used with trusted apps.
-# Usage: reserved
 
 # ptrace can be used to break out of the seccomp sandbox, but ps requests
 # 'ptrace (trace)' from apparmor. 'ps' does not need the ptrace syscall though,

--- a/interfaces/builtin/system_trace.go
+++ b/interfaces/builtin/system_trace.go
@@ -27,7 +27,6 @@ const systemTraceConnectedPlugAppArmor = `
 # Description: Can use kernel tracing facilities. This is restricted because it
 # gives privileged access to all processes on the system and should only be
 # used with trusted apps.
-# Usage: reserved
 
   # For the bpf() syscall and manipulating bpf map types
   capability sys_admin,
@@ -51,7 +50,6 @@ const systemTraceConnectedPlugSecComp = `
 # Description: Can use kernel tracing facilities. This is restricted because it
 # gives privileged access to all processes on the system and should only be
 # used with trusted apps.
-# Usage: reserved
 
 bpf
 perf_event_open

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -83,14 +83,6 @@ capability sys_time,
 # device nodes.
 /sbin/hwclock ixr,
 `
-const timeControlConnectedPlugSecComp = `
-# dbus
-recvmsg
-recvfrom
-send
-sendto
-sendmsg
-`
 
 // The type for the rtc interface
 type TimeControlInterface struct{}
@@ -138,9 +130,6 @@ func (iface *TimeControlInterface) ConnectedPlugSnippet(plug *interfaces.Plug, s
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		return []byte(timeControlConnectedPlugAppArmor), nil
-
-	case interfaces.SecuritySecComp:
-		return []byte(timeControlConnectedPlugSecComp), nil
 
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -31,7 +31,6 @@ const timeControlConnectedPlugAppArmor = `
 # Can read all properties of /org/freedesktop/timedate1 D-Bus object; see
 # https://www.freedesktop.org/wiki/Software/systemd/timedated/; This also
 # gives full access to the RTC device nodes and relevant parts of sysfs.
-# Usage: reserved
 
 #include <abstractions/dbus-strict>
 

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -94,10 +94,6 @@ func (s *TimeControlTestInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
-	// connected plugs have a non-nil security snippet for seccomp
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
 	// connected plugs have a non-nil security snippet for udev
 	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -68,21 +68,12 @@ dbus (receive)
     member=PropertiesChanged
     peer=(label=unconfined),
 `
-const timeserverControlConnectedPlugSecComp = `
-# dbus
-recvmsg
-recvfrom
-send
-sendto
-sendmsg
-`
 
 // NewTimeserverControlInterface returns a new "timeserver-control" interface.
 func NewTimeserverControlInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "timeserver-control",
 		connectedPlugAppArmor: timeserverControlConnectedPlugAppArmor,
-		connectedPlugSecComp:  timeserverControlConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -29,7 +29,6 @@ const timeserverControlConnectedPlugAppArmor = `
 # Can enable system clock NTP synchronization via timedated D-Bus interface,
 # Can read all properties of /org/freedesktop/timedate1 D-Bus object; see
 # https://www.freedesktop.org/wiki/Software/systemd/timedated/
-# Usage: reserved
 
 #include <abstractions/dbus-strict>
 

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -29,7 +29,6 @@ const timezoneControlConnectedPlugAppArmor = `
 # Can change timezone via timedated D-Bus interface,
 # Can read all properties of /org/freedesktop/timedate1 D-Bus object, see:
 # https://www.freedesktop.org/wiki/Software/systemd/timedated/
-# Usage: reserved
 
 #include <abstractions/dbus-strict>
 

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -69,21 +69,11 @@ dbus (receive)
     peer=(label=unconfined),
 `
 
-const timezoneControlConnectedPlugSecComp = `
-# dbus
-recvmsg
-recvfrom
-send
-sendto
-sendmsg
-`
-
 // NewTimezoneControlInterface returns a new "timezone-control" interface.
 func NewTimezoneControlInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "timezone-control",
 		connectedPlugAppArmor: timezoneControlConnectedPlugAppArmor,
-		connectedPlugSecComp:  timezoneControlConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/interfaces/builtin/tpm.go
+++ b/interfaces/builtin/tpm.go
@@ -23,7 +23,6 @@ import "github.com/snapcore/snapd/interfaces"
 
 const tpmConnectedPlugAppArmor = `
 # Description: for those who need to talk to the system TPM chip over /dev/tpm0
-# Usage: reserved
 
 /dev/tpm0 rw,
 `

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -184,26 +184,6 @@ owner @{HOME}/snap/###PLUG_NAME###/common/Downloads/    rw,
 owner @{HOME}/snap/###PLUG_NAME###/common/Downloads/**  rwk,
 `)
 
-var downloadConnectedPlugSecComp = []byte(`
-# Description: Can access download manager.
-
-# dbus
-recvmsg
-send
-sendto
-sendmsg
-`)
-
-var downloadPermanentSlotSecComp = []byte(`
-# Description: Can act as a download manager.
-
-# dbus
-recvmsg
-send
-sendto
-sendmsg
-`)
-
 type UbuntuDownloadManagerInterface struct{}
 
 func (iface *UbuntuDownloadManagerInterface) Name() string {
@@ -225,8 +205,6 @@ func (iface *UbuntuDownloadManagerInterface) ConnectedPlugSnippet(plug *interfac
 		new := slotAppLabelExpr(slot)
 		snippet := bytes.Replace(downloadConnectedPlugAppArmor, old, new, -1)
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return downloadConnectedPlugSecComp, nil
 	}
 	return nil, nil
 }
@@ -235,8 +213,6 @@ func (iface *UbuntuDownloadManagerInterface) PermanentSlotSnippet(slot *interfac
 	switch securitySystem {
 	case interfaces.SecurityAppArmor:
 		return downloadPermanentSlotAppArmor, nil
-	case interfaces.SecuritySecComp:
-		return downloadPermanentSlotSecComp, nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/ubuntu_download_manager_test.go
+++ b/interfaces/builtin/ubuntu_download_manager_test.go
@@ -83,8 +83,4 @@ func (s *UbuntuDownloadManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
-	// connected plugs have a non-nil security snippet for seccomp
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
 }

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -26,8 +26,8 @@ import (
 )
 
 const udisks2PermanentSlotAppArmor = `
-# Description: Allow operating as the udisks2. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the udisks2. This gives privileged access to
+# the system.
 
 # DBus accesses
 #include <abstractions/dbus-strict>
@@ -90,8 +90,8 @@ umount /{,run/}media/**,
 `
 
 var udisks2ConnectedSlotAppArmor = []byte(`
-# Allow connected clients to interact with the service. Reserved because this
-# gives privileged access to the system.
+# Allow connected clients to interact with the service. This gives privileged
+# access to the system.
 
 dbus (send)
     bus=system
@@ -115,8 +115,8 @@ dbus (receive, send)
 `)
 
 var udisks2ConnectedPlugAppArmor = []byte(`
-# Description: Allow using udisks service. Reserved because this gives
-# privileged access to the service.
+# Description: Allow using udisks service. This gives privileged access to the
+# service.
 
 #include <abstractions/dbus-strict>
 

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -28,7 +28,6 @@ import (
 const udisks2PermanentSlotAppArmor = `
 # Description: Allow operating as the udisks2. Reserved because this
 # gives privileged access to the system.
-# Usage: reserved
 
 # DBus accesses
 #include <abstractions/dbus-strict>
@@ -93,7 +92,6 @@ umount /{,run/}media/**,
 var udisks2ConnectedSlotAppArmor = []byte(`
 # Allow connected clients to interact with the service. Reserved because this
 # gives privileged access to the system.
-# Usage: reserved
 
 dbus (send)
     bus=system
@@ -119,7 +117,6 @@ dbus (receive, send)
 var udisks2ConnectedPlugAppArmor = []byte(`
 # Description: Allow using udisks service. Reserved because this gives
 # privileged access to the service.
-# Usage: reserved
 
 #include <abstractions/dbus-strict>
 

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -153,24 +153,9 @@ fchownat
 lchown
 lchown32
 mount
-recv
-recvfrom
-recvmsg
-send
-sendmsg
-sendto
 shmctl
 umount
 umount2
-`
-
-const udisks2ConnectedPlugSecComp = `
-recv
-recvfrom
-recvmsg
-send
-sendmsg
-sendto
 `
 
 const udisks2PermanentSlotDBus = `
@@ -363,8 +348,6 @@ func (iface *UDisks2Interface) ConnectedPlugSnippet(plug *interfaces.Plug, slot 
 		return snippet, nil
 	case interfaces.SecurityDBus:
 		return []byte(udisks2ConnectedPlugDBus), nil
-	case interfaces.SecuritySecComp:
-		return []byte(udisks2ConnectedPlugSecComp), nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -185,7 +185,7 @@ func (s *UDisks2InterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne(c *C) {
 
 func (s *UDisks2InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
-		interfaces.SecuritySecComp, interfaces.SecurityDBus}
+		interfaces.SecurityDBus}
 	for _, system := range systems {
 		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
 		c.Assert(err, IsNil)
@@ -198,6 +198,9 @@ func (s *UDisks2InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityUDev)
+	c.Assert(err, IsNil)
+	c.Assert(snippet, Not(IsNil))
+	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecuritySecComp)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -28,7 +28,6 @@ const unity7ConnectedPlugAppArmor = `
 # Description: Can access Unity7. Restricted because Unity 7 runs on X and
 # requires access to various DBus services and this environment does not prevent
 # eavesdropping or apps interfering with one another.
-# Usage: reserved
 
 #include <abstractions/dbus-strict>
 #include <abstractions/dbus-session-strict>

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -446,15 +446,7 @@ const unity7ConnectedPlugSecComp = `
 # eavesdropping or apps interfering with one another.
 
 # X
-recvfrom
-recvmsg
 shutdown
-
-# dbus
-recvmsg
-send
-sendto
-sendmsg
 `
 
 // NewUnity7Interface returns a new "unity7" interface.

--- a/interfaces/builtin/unity8_calendar.go
+++ b/interfaces/builtin/unity8_calendar.go
@@ -24,8 +24,8 @@ import (
 )
 
 const unity8CalendarPermanentSlotAppArmor = `
-# Description: Allow operating as the EDS service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the EDS service. This gives privileged access
+# to the system.
 
 # DBus accesses
 dbus (bind)

--- a/interfaces/builtin/unity8_calendar_test.go
+++ b/interfaces/builtin/unity8_calendar_test.go
@@ -74,10 +74,6 @@ func (s *Unity8CalendarInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
-	// connected plugs have a non-nil security snippet for seccomp
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
 }
 
 // The label glob when all apps are bound to the calendar slot
@@ -161,14 +157,6 @@ func (s *Unity8CalendarInterfaceSuite) TestConnectedPlugSnippetAppArmor(c *C) {
 	c.Assert(string(snippet), testutil.Contains, "#include <abstractions/dbus-session-strict>")
 	// verify classic didn't connect
 	c.Assert(string(snippet), Not(testutil.Contains), "peer=(label=unconfined),")
-}
-
-func (s *Unity8CalendarInterfaceSuite) TestConnectedPlugSnippetSecComp(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "send\n")
 }
 
 func (s *Unity8CalendarInterfaceSuite) TestConnectedSlotSnippetAppArmor(c *C) {

--- a/interfaces/builtin/unity8_contacts.go
+++ b/interfaces/builtin/unity8_contacts.go
@@ -24,8 +24,8 @@ import (
 )
 
 const unity8ContactsPermanentSlotAppArmor = `
-# Description: Allow operating as the EDS service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the EDS service. This gives privileged access
+# to the system.
 
 # Allow binding the service to the requested connection name
 dbus (bind)

--- a/interfaces/builtin/unity8_contacts_test.go
+++ b/interfaces/builtin/unity8_contacts_test.go
@@ -74,10 +74,6 @@ func (s *Unity8ContactsInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
-	// connected plugs have a non-nil security snippet for seccomp
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
 }
 
 // The label glob when all apps are bound to the contacts slot
@@ -161,14 +157,6 @@ func (s *Unity8ContactsInterfaceSuite) TestConnectedPlugSnippetAppArmor(c *C) {
 	c.Assert(string(snippet), testutil.Contains, "#include <abstractions/dbus-session-strict>")
 	// verify classic didn't connect
 	c.Assert(string(snippet), Not(testutil.Contains), "peer=(label=unconfined),")
-}
-
-func (s *Unity8ContactsInterfaceSuite) TestConnectedPlugSnippetSecComp(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "send\n")
 }
 
 func (s *Unity8ContactsInterfaceSuite) TestConnectedSlotSnippetAppArmor(c *C) {

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -28,8 +28,8 @@ import (
 )
 
 const unity8PimCommonPermanentSlotAppArmor = `
-# Description: Allow operating as the EDS service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the EDS service. This gives privileged access
+# to the system.
 
 # DBus accesses
 #include <abstractions/dbus-session-strict>
@@ -83,8 +83,8 @@ dbus (receive, send)
 `
 
 const unity8PimCommonPermanentSlotSecComp = `
-# Description: Allow operating as the EDS service. Reserved because this
-# gives privileged access to the system.
+# Description: Allow operating as the EDS service. This gives privileged access
+# to the system.
 accept
 accept4
 bind

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -89,27 +89,7 @@ accept
 accept4
 bind
 listen
-recv
-recvfrom
-recvmmsg
-recvmsg
-send
-sendmmsg
-sendmsg
-sendto
 shutdown
-`
-
-const unity8PimCommonConnectedPlugSecComp = `
-# Description: Allow using EDS service. Reserved because this gives
-# privileged access to the eds service.
-
-# Can communicate with DBus system service
-recv
-recvmsg
-send
-sendto
-sendmsg
 `
 
 type unity8PimCommonInterface struct {
@@ -144,8 +124,6 @@ func (iface *unity8PimCommonInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 		}
 
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return []byte(unity8PimCommonConnectedPlugSecComp), nil
 	default:
 		return nil, nil
 	}

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -104,12 +104,6 @@ dbus (receive, send)
 
 const upowerObservePermanentSlotSeccomp = `
 bind
-recvmsg
-sendmsg
-sendto
-recvfrom
-send
-recv
 `
 
 const upowerObservePermanentSlotDBus = `
@@ -196,18 +190,6 @@ dbus (receive)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
-const upowerObserveConnectedPlugSecComp = `
-# Description: Can query UPower for power devices, history and statistics.
-
-# dbus
-recv
-recvfrom
-recvmsg
-send
-sendto
-sendmsg
-`
-
 type UpowerObserveInterface struct{}
 
 func (iface *UpowerObserveInterface) Name() string {
@@ -229,8 +211,6 @@ func (iface *UpowerObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plug,
 		}
 		snippet := bytes.Replace([]byte(upowerObserveConnectedPlugAppArmor), old, new, -1)
 		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return []byte(upowerObserveConnectedPlugSecComp), nil
 	}
 	return nil, nil
 }

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -85,10 +85,6 @@ func (s *UPowerObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
-	// connected plugs have a non-nil security snippet for seccomp
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
 }
 
 // The label glob when all apps are bound to the ofono slot
@@ -172,13 +168,6 @@ func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetAppArmor(c *C) {
 	c.Assert(string(snippet), testutil.Contains, "#include <abstractions/dbus-strict>")
 	// verify classic didn't connect
 	c.Assert(string(snippet), Not(testutil.Contains), "peer=(label=unconfined),")
-}
-
-func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetSecComp(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "send\n")
 }
 
 func (s *UPowerObserveInterfaceSuite) TestPermanentSlotSnippetAppArmor(c *C) {

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -42,9 +42,6 @@ const x11ConnectedPlugSecComp = `
 # eavesdropping or apps interfering with one another.
 # Usage: reserved
 
-recvfrom
-recvmsg
-sendmsg
 shutdown
 `
 

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -27,7 +27,6 @@ import (
 const x11ConnectedPlugAppArmor = `
 # Description: Can access the X server. Restricted because X does not prevent
 # eavesdropping or apps interfering with one another.
-# Usage: reserved
 
 #include <abstractions/X>
 #include <abstractions/fonts>
@@ -40,7 +39,6 @@ const x11ConnectedPlugAppArmor = `
 const x11ConnectedPlugSecComp = `
 # Description: Can access the X server. Restricted because X does not prevent
 # eavesdropping or apps interfering with one another.
-# Usage: reserved
 
 shutdown
 `

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -90,9 +90,9 @@ func (s *X11InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(snippet, Not(IsNil))
 }
 
-// The recvfrom system call is allowed
+// The shutdown system call is allowed
 func (s *X11InterfaceSuite) TestLP1574526(c *C) {
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
 	c.Assert(err, IsNil)
-	c.Check(string(snippet), testutil.Contains, "recvfrom\n")
+	c.Check(string(snippet), testutil.Contains, "shutdown\n")
 }

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -268,6 +268,13 @@ readahead
 readdir
 readlink
 readlinkat
+
+# allow reading from sockets
+recv
+recvfrom
+recvmsg
+recvmmsg
+
 remap_file_pages
 
 removexattr
@@ -324,6 +331,13 @@ semctl
 semget
 semop
 semtimedop
+
+# allow sending to sockets
+send
+sendto
+sendmsg
+sendmmsg
+
 sendfile
 sendfile64
 


### PR DESCRIPTION
- interfaces/default: allow recv* and send* by default
    Various interfaces had some combination of recv, recvfrom, recvmsg, recvmmsg,
    send, sendto, sendmsg and sendmmsg when they should've had all of them. Also,
    snap developers are specifying 'network' or 'network-bind' in order to use
    local sockets, which is wrong.
    
    Since we already allow 'socket' and various other socket syscalls, allow these
    read and send syscalls by default and remove them from the various interfaces
    that specified them.
- interfaces: allow accept4 everywhere we allow accept and vice versa
- interfaces: remove unused 'Usage' comment meta-tag since we don't need it
    with base declaration

The recv/send and accept* commits fix latent bugs in the policy and only allow more access. The 'Usage' commit is a comments only change and will help with interface reviews with copy/pasted code.