### PR TITLE
dirs: use the right snap mount dir for the distribution

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -176,13 +176,13 @@ func runSnapConfine(info *snap.Info, securityTag, snapApp, command, hook string,
 	}
 
 	cmd := []string{
-		filepath.Join(dirs.LibExecDir, "snap-confine"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 	}
 	if info.NeedsClassic() {
 		cmd = append(cmd, "--classic")
 	}
 	cmd = append(cmd, securityTag)
-	cmd = append(cmd, filepath.Join(dirs.LibExecDir, "snap-exec"))
+	cmd = append(cmd, filepath.Join(dirs.CoreLibExecDir, "snap-exec"))
 
 	if command != "" {
 		cmd = append(cmd, "--command="+command)

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -89,11 +89,11 @@ func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {
 	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
-	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		filepath.Join(dirs.LibExecDir, "snap-confine"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 		"snap.snapname.app",
-		filepath.Join(dirs.LibExecDir, "snap-exec"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
 }
@@ -125,11 +125,11 @@ func (s *SnapSuite) TestSnapRunClassicAppIntegration(c *check.C) {
 	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
-	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		filepath.Join(dirs.LibExecDir, "snap-confine"), "--classic",
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"), "--classic",
 		"snap.snapname.app",
-		filepath.Join(dirs.LibExecDir, "snap-exec"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
 }
@@ -160,11 +160,11 @@ func (s *SnapSuite) TestSnapRunAppWithCommandIntegration(c *check.C) {
 	// and run it!
 	err = snaprun.SnapRunApp("snapname.app", "my-command", []string{"arg1", "arg2"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		filepath.Join(dirs.LibExecDir, "snap-confine"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 		"snap.snapname.app",
-		filepath.Join(dirs.LibExecDir, "snap-exec"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
 		"--command=my-command", "snapname.app", "arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
 }
@@ -212,11 +212,11 @@ func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {
 	// Run a hook from the active revision
 	_, err = snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "snapname"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		filepath.Join(dirs.LibExecDir, "snap-confine"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 		"snap.snapname.hook.configure",
-		filepath.Join(dirs.LibExecDir, "snap-exec"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
 		"--hook=configure", "snapname"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
 }
@@ -247,11 +247,11 @@ func (s *SnapSuite) TestSnapRunHookUnsetRevisionIntegration(c *check.C) {
 	// Specifically pass "unset" which would use the active version.
 	_, err = snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=unset", "snapname"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		filepath.Join(dirs.LibExecDir, "snap-confine"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 		"snap.snapname.hook.configure",
-		filepath.Join(dirs.LibExecDir, "snap-exec"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
 		"--hook=configure", "snapname"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=42")
 }
@@ -284,11 +284,11 @@ func (s *SnapSuite) TestSnapRunHookSpecificRevisionIntegration(c *check.C) {
 	// Run a hook on revision 41
 	_, err := snaprun.Parser().ParseArgs([]string{"run", "--hook=configure", "-r=41", "snapname"})
 	c.Assert(err, check.IsNil)
-	c.Check(execArg0, check.Equals, filepath.Join(dirs.LibExecDir, "snap-confine"))
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
 	c.Check(execArgs, check.DeepEquals, []string{
-		filepath.Join(dirs.LibExecDir, "snap-confine"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 		"snap.snapname.hook.configure",
-		filepath.Join(dirs.LibExecDir, "snap-exec"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
 		"--hook=configure", "snapname"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=41")
 }

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/snapcore/snapd/release"
 )
 
 // the various file paths
@@ -65,7 +67,8 @@ var (
 
 	ClassicDir string
 
-	LibExecDir string
+	DistroLibExecDir string
+	CoreLibExecDir   string
 
 	XdgRuntimeDirGlob string
 )
@@ -143,7 +146,18 @@ func SetRootDir(rootdir string) {
 	LocaleDir = filepath.Join(rootdir, "/usr/share/locale")
 	ClassicDir = filepath.Join(rootdir, "/writable/classic")
 
-	LibExecDir = filepath.Join(rootdir, "/usr/lib/snapd")
+	switch release.ReleaseInfo.ID {
+	case "fedora":
+		fallthrough
+	case "centos":
+		fallthrough
+	case "rhel":
+		DistroLibExecDir = filepath.Join(rootdir, "/usr/libexec/snapd")
+	default:
+		DistroLibExecDir = filepath.Join(rootdir, "/usr/lib/snapd")
+	}
+
+	CoreLibExecDir = filepath.Join(rootdir, "/usr/lib/snapd")
 
 	XdgRuntimeDirGlob = filepath.Join(rootdir, "/run/user/*/")
 }

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -108,7 +108,17 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	SnapMountDir = filepath.Join(rootdir, "/snap")
+	switch release.ReleaseInfo.ID {
+	case "fedora":
+		fallthrough
+	case "centos":
+		fallthrough
+	case "rhel":
+		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
+	default:
+		SnapMountDir = filepath.Join(rootdir, "/snap")
+	}
+
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/snap/")
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -116,7 +116,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	ms.udev = testutil.MockCommand(c, "udevadm", "")
 	ms.umount = testutil.MockCommand(c, "umount", "")
 	ms.snapDiscardNs = testutil.MockCommand(c, "snap-discard-ns", "")
-	dirs.LibExecDir = ms.snapDiscardNs.BinDir()
+	dirs.DistroLibExecDir = ms.snapDiscardNs.BinDir()
 
 	ms.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
 	ms.restoreTrusted = sysdb.InjectTrusted(ms.storeSigning.Trusted)

--- a/overlord/snapstate/backend/ns.go
+++ b/overlord/snapstate/backend/ns.go
@@ -38,7 +38,7 @@ func mountNsPath(snapName string) string {
 func (b Backend) runNamespaceTool(toolName, snapName string) ([]byte, error) {
 	mntFile := mountNsPath(snapName)
 	if osutil.FileExists(mntFile) {
-		toolPath := filepath.Join(dirs.LibExecDir, toolName)
+		toolPath := filepath.Join(dirs.DistroLibExecDir, toolName)
 		cmd := exec.Command(toolPath, snapName)
 		output, err := cmd.CombinedOutput()
 		return output, err

--- a/overlord/snapstate/backend/ns_test.go
+++ b/overlord/snapstate/backend/ns_test.go
@@ -33,9 +33,9 @@ import (
 )
 
 type nsSuite struct {
-	be            backend.Backend
-	nullProgress  progress.NullProgress
-	oldLibExecDir string
+	be                  backend.Backend
+	nullProgress        progress.NullProgress
+	oldDistroLibExecDir string
 }
 
 var _ = Suite(&nsSuite{})
@@ -43,12 +43,12 @@ var _ = Suite(&nsSuite{})
 func (s *nsSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	// Mock enough bits so that we can observe calls to snap-discard-ns
-	s.oldLibExecDir = dirs.LibExecDir
+	s.oldDistroLibExecDir = dirs.DistroLibExecDir
 }
 
 func (s *nsSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-	dirs.LibExecDir = s.oldLibExecDir
+	dirs.DistroLibExecDir = s.oldDistroLibExecDir
 }
 
 func (s *nsSuite) TestDiscardNamespaceMnt(c *C) {
@@ -79,7 +79,7 @@ func (s *nsSuite) TestDiscardNamespaceMnt(c *C) {
 			res:    [][]string{{"snap-discard-ns", "snap-name"}}},
 	} {
 		cmd := testutil.MockCommand(c, "snap-discard-ns", t.cmd)
-		dirs.LibExecDir = cmd.BinDir()
+		dirs.DistroLibExecDir = cmd.BinDir()
 		defer cmd.Restore()
 
 		if t.mnt {
@@ -127,7 +127,7 @@ func (s *nsSuite) TestUpdateNamespaceMnt(c *C) {
 			res:    [][]string{{"snap-update-ns", "snap-name"}}},
 	} {
 		cmd := testutil.MockCommand(c, "snap-update-ns", t.cmd)
-		dirs.LibExecDir = cmd.BinDir()
+		dirs.DistroLibExecDir = cmd.BinDir()
 		defer cmd.Restore()
 
 		if t.mnt {


### PR DESCRIPTION
Stacked on #2844 

Some distributions use /var/lib/snapd/snap as the place where snaps are mounted
so make this a dynamic runtime choice made on startup of snapd and other tools.
    
Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>