### PR TITLE
cmd: autoconf for centos

### DIFF
--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -27,7 +27,7 @@ case "$ID" in
 	ubuntu)
 		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-ubuntu"
 		;;
-	fedora)
+	fedora|centos)
 		extra_opts="--libexecdir=/usr/libexec/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-merged-usr --disable-apparmor"
 		;;
 esac


### PR DESCRIPTION
CentOS is treated the same as Fedora is.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>