### PR TITLE
cmd/snap-update-ns: add compare function for mount entries

### DIFF
--- a/cmd/snap-update-ns/mount-entry-test.c
+++ b/cmd/snap-update-ns/mount-entry-test.c
@@ -176,6 +176,44 @@ static void test_sc_save_mount_profile()
 	fclose(f);
 }
 
+static void test_sc_compare_mount_entry()
+{
+	// Do trivial comparison checks.
+	g_assert_cmpint(sc_compare_mount_entry(&test_entry_1, &test_entry_1),
+			==, 0);
+	g_assert_cmpint(sc_compare_mount_entry(&test_entry_1, &test_entry_2), <,
+			0);
+	g_assert_cmpint(sc_compare_mount_entry(&test_entry_2, &test_entry_1), >,
+			0);
+	g_assert_cmpint(sc_compare_mount_entry(&test_entry_2, &test_entry_2),
+			==, 0);
+
+	// Ensure that each field is compared.
+	struct sc_mount_entry a = test_entry_1;
+	struct sc_mount_entry b = test_entry_1;
+	g_assert_cmpint(sc_compare_mount_entry(&a, &b), ==, 0);
+
+	b.entry.mnt_fsname = test_entry_2.entry.mnt_fsname;
+	g_assert_cmpint(sc_compare_mount_entry(&a, &b), <, 0);
+	b = test_entry_1;
+
+	b.entry.mnt_dir = test_entry_2.entry.mnt_dir;
+	g_assert_cmpint(sc_compare_mount_entry(&a, &b), <, 0);
+	b = test_entry_1;
+
+	b.entry.mnt_opts = test_entry_2.entry.mnt_opts;
+	g_assert_cmpint(sc_compare_mount_entry(&a, &b), <, 0);
+	b = test_entry_1;
+
+	b.entry.mnt_freq = test_entry_2.entry.mnt_freq;
+	g_assert_cmpint(sc_compare_mount_entry(&a, &b), <, 0);
+	b = test_entry_1;
+
+	b.entry.mnt_passno = test_entry_2.entry.mnt_passno;
+	g_assert_cmpint(sc_compare_mount_entry(&a, &b), <, 0);
+	b = test_entry_1;
+}
+
 static void test_sc_clone_mount_entry_from_mntent()
 {
 	struct sc_mount_entry *entry =
@@ -195,6 +233,8 @@ static void __attribute__ ((constructor)) init()
 			test_sc_load_mount_profile__no_such_file);
 	g_test_add_func("/mount-entry/sc_save_mount_profile",
 			test_sc_save_mount_profile);
+	g_test_add_func("/mount-entry/sc_compare_mount_entry",
+			test_sc_compare_mount_entry);
 	g_test_add_func("/mount-entry/test_sc_clone_mount_entry_from_mntent",
 			test_sc_clone_mount_entry_from_mntent);
 }

--- a/cmd/snap-update-ns/mount-entry.c
+++ b/cmd/snap-update-ns/mount-entry.c
@@ -31,6 +31,16 @@
 #include "../libsnap-confine-private/cleanup-funcs.h"
 
 /**
+ * Compare two mount entries (through indirect pointers).
+ **/
+static int
+sc_indirect_compare_mount_entry(const struct sc_mount_entry **a,
+				const struct sc_mount_entry **b)
+{
+	return sc_compare_mount_entry(*a, *b);
+}
+
+/**
  * Copy struct mntent into a freshly-allocated struct sc_mount_entry.
  *
  * The next pointer is initialized to NULL, it should be managed by the caller.
@@ -92,6 +102,37 @@ void sc_cleanup_mount_entry_list(struct sc_mount_entry **entryp)
 		sc_free_mount_entry_list(*entryp);
 		*entryp = NULL;
 	}
+}
+
+int sc_compare_mount_entry(const struct sc_mount_entry *a,
+			   const struct sc_mount_entry *b)
+{
+	int result;
+	if (a == NULL || b == NULL) {
+		die("cannot compare NULL mount entry");
+	}
+	result = strcmp(a->entry.mnt_fsname, b->entry.mnt_fsname);
+	if (result != 0) {
+		return result;
+	}
+	result = strcmp(a->entry.mnt_dir, b->entry.mnt_dir);
+	if (result != 0) {
+		return result;
+	}
+	result = strcmp(a->entry.mnt_type, b->entry.mnt_type);
+	if (result != 0) {
+		return result;
+	}
+	result = strcmp(a->entry.mnt_opts, b->entry.mnt_opts);
+	if (result != 0) {
+		return result;
+	}
+	result = a->entry.mnt_freq - b->entry.mnt_freq;
+	if (result != 0) {
+		return result;
+	}
+	result = a->entry.mnt_passno - b->entry.mnt_passno;
+	return result;
 }
 
 struct sc_mount_entry *sc_load_mount_profile(const char *pathname)

--- a/cmd/snap-update-ns/mount-entry.h
+++ b/cmd/snap-update-ns/mount-entry.h
@@ -49,6 +49,17 @@ void sc_save_mount_profile(const struct sc_mount_entry *first,
 			   const char *pathname);
 
 /**
+ * Compare two mount entries.
+ *
+ * Returns 0 if both entries are equal, a number less than zero if the first
+ * entry sorts before the second entry or a number greater than zero if the
+ * second entry sorts before the second entry.
+ **/
+int
+sc_compare_mount_entry(const struct sc_mount_entry *a,
+		       const struct sc_mount_entry *b);
+
+/**
  * Free a dynamically allocated list of strct sc_mount_entry objects.
  *
  * This function is designed to be used with


### PR DESCRIPTION
This patch adds a simple function for comparing mount entries. This will
be followed up with a simple routine that sorts two lists of mount
entries quickly.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>