### PR TITLE
cmd: don't reexec on RHEL family

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -62,11 +62,7 @@ func ExecInCoreSnap() {
 
 	// can we re-exec? some distributions will need extra work before re-exec really works.
 	switch release.ReleaseInfo.ID {
-	case "fedora":
-		fallthrough
-	case "centos":
-		fallthrough
-	case "rhel":
+	case "fedora", "centos", "rhel":
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -60,6 +60,17 @@ func ExecInCoreSnap() {
 		return
 	}
 
+	// can we re-exec? some distributions will need extra work before re-exec really works.
+	switch release.ReleaseInfo.ID {
+	case "fedora":
+		fallthrough
+	case "centos":
+		fallthrough
+	case "rhel":
+		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
+		return
+	}
+
 	// did we already re-exec?
 	if osutil.GetenvBool("SNAP_DID_REEXEC") {
 		return


### PR DESCRIPTION
This patch changes how snap commands decide to re-execute. The extra
check looks if we _can_ reexecute in a given distribution. Technically
due to how paths and libraries are used we cannot yet reexecute on
RHEL-family of distributions (fedora, centos, rhel). This restriction
can be lifted when the reexec from core work is fully merged and tested.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>