### PR TITLE
cmd/libsnap: add privilege elevation helpers

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -74,6 +74,8 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/mount-opt.h \
 	libsnap-confine-private/mountinfo.c \
 	libsnap-confine-private/mountinfo.h \
+	libsnap-confine-private/privs.c \
+	libsnap-confine-private/privs.h \
 	libsnap-confine-private/secure-getenv.c \
 	libsnap-confine-private/secure-getenv.h \
 	libsnap-confine-private/snap.c \

--- a/cmd/libsnap-confine-private/privs.c
+++ b/cmd/libsnap-confine-private/privs.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "privs.h"
+
+#include <stdbool.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "utils.h"
+
+static uid_t real_uid;
+static gid_t real_gid;
+
+void sc_privs_init()
+{
+	real_uid = getuid();
+	real_gid = getgid();
+}
+
+void sc_privs_lower_permanently()
+{
+	bool lowered = false;
+
+	if (getegid() == 0) {
+		// Note that we do not call setgroups() here because it is ok that the
+		// user keeps the groups he already belongs to.
+		if (setgid(real_gid) != 0) {
+			die("cannot set group identifier to %d", real_gid);
+		}
+		if (real_gid != 0 && (getuid() == 0 || geteuid() == 0)) {
+			die("cannot permanently lower permissions (gid still elevated)");
+		}
+		lowered = true;
+	}
+
+	if (geteuid() == 0) {
+		if (setuid(real_uid) != 0) {
+			die("cannot set user identifier to %d", real_uid);
+		}
+		if (real_uid != 0 && (getgid() == 0 || getegid() == 0)) {
+			die("cannot permanently lower permissions (uid still elevated)");
+		}
+		lowered = true;
+	}
+
+	if (lowered) {
+		debug("elevated permissions have been permanently lowered");
+	}
+}
+
+void sc_privs_lower_temporarily()
+{
+	bool lowered = false;
+
+	if (geteuid() == 0) {
+		if (setegid(real_gid) != 0) {
+			die("cannot set effective group identifier to %d",
+			    real_gid);
+		}
+		if (real_gid != 0 && geteuid() == 0) {
+			die("cannot temporarily lower permissions (gid still elevated)");
+		}
+		lowered = true;
+	}
+
+	if (getegid() == 0) {
+		if (seteuid(real_uid) != 0) {
+			die("cannot set effective user identifier to %d",
+			    real_uid);
+		}
+		if (real_uid != 0 && getegid() == 0) {
+			die("cannot temporarily lower permissions (uid still elevated)");
+		}
+		lowered = true;
+	}
+
+	if (lowered) {
+		debug("elevated permission have been temporarily lowered");
+	}
+}
+
+void sc_privs_raise()
+{
+	bool raised = false;
+
+	if (real_gid != 0) {
+		if (setegid(0) != 0) {
+			die("cannot set effective group identifier to %d", 0);
+		}
+		raised = true;
+	}
+
+	if (real_uid != 0) {
+		if (seteuid(0) != 0) {
+			die("cannot set effective user identifier to %d", 0);
+		}
+		raised = true;
+	}
+
+	if (raised) {
+		debug("permissions have been elevated");
+	}
+}

--- a/cmd/libsnap-confine-private/privs.h
+++ b/cmd/libsnap-confine-private/privs.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_PRIVS_H
+#define SNAP_CONFINE_PRIVS_H
+
+/**
+ * Initialize privilege control code.
+ *
+ * This function simply memorizes current user and group identifiers as
+ * returned by getuid(2) and getgid(2). The identifiers are kept in private
+ * global variables.
+ **/
+void sc_privs_init();
+
+/**
+ * Permanently lower elevated permissions.
+ *
+ * If the user has elevated permission as a result of running a setuid root
+ * application then such permission are permanently lowered.
+ *
+ * The function ensures that the elevated permission are lowered or dies if
+ * this cannot be achieved. Note that only the elevated permissions are
+ * lowered. When the process itself was started by root then this function does
+ * nothing at all.
+ **/
+void sc_privs_lower_permanently();
+
+/**
+ * Temporarily lower elevated permissions.
+ *
+ * If the user has elevated permission as a result of running a setuid root
+ * application then such permission are temporarily lowered.
+ *
+ * The function ensures that the elevated permission are lowered or dies if
+ * this cannot be achieved. Note that only the elevated permissions are
+ * lowered. When the process itself was started by root then this function does
+ * nothing at all.
+ **/
+void sc_privs_lower_temporarily();
+
+/**
+ * Raise permissions to elevated level again.
+ *
+ * This function sets the effective user and group identifiers to 0 (root).
+ * The function ensures that the elevated permission are attained or dies if
+ * this cannot be achieved.
+ *
+ * This function should be used in tandem with sc_privs_lower_temporarily.
+ **/
+void sc_privs_raise();
+
+#endif


### PR DESCRIPTION
This patch adds a small set of functions for working with privilege
elevation. Since snap-confine runs as root via the setuid-root mechanism
we always start with elevated permissions. For added security, througout
the execution of the process, permission are lowered and raised
(temporarily) as appropriate, to limit the extent of the possible damage
should the given code be compromised. Finally snap-confine permanently
lowers permissions before handing off to the next executable.

All this code was in snap-confine.c but now it is easier to reuse
elesewhere. The error messages have been cleaned up for clarity and
readability.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>