### PR TITLE
cmd: autoconf for RHEL

### DIFF
--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -27,7 +27,7 @@ case "$ID" in
 	ubuntu)
 		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-ubuntu"
 		;;
-	fedora|centos)
+	fedora|centos|rhel)
 		extra_opts="--libexecdir=/usr/libexec/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-merged-usr --disable-apparmor"
 		;;
 esac


### PR DESCRIPTION
Red Hat Enterprise Linux is treated the same as CentOS and Fedora.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>