### PR TITLE
debian: add "Recommends: squashfuse"

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -62,6 +62,7 @@ Depends: adduser,
          xdelta3,
          ${misc:Depends},
          ${shlibs:Depends}
+Recommends: squashfuse
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22)
 Conflicts: snap (<< 2013-11-29-1ubuntu1)


### PR DESCRIPTION
With squashfuse snapd will work correctly inside containers. The
MIR for squashfuse is done so we can include it now in 16.04 or
higher (it is not available in 14.04).

Note that even though this is only a recommends, this will mean
that `apt-get update && apt-get upgrade` will hold the package
back and not upgrade it :/

LP: #1628289