### PR TITLE
[WIP] overlord: switching to explicit targets for enabled/auto aliases

### DIFF
--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -62,6 +62,7 @@ func (sds *snapDeclSuite) TestDecodeOK(c *C) {
 		"refresh-control:\n  - foo\n  - bar\n" +
 		"auto-aliases:\n  - cmd1\n  - cmd_2\n  - Cmd-3\n  - CMD.4\n" +
 		sds.tsLine +
+		"aliases:\n  - cmd1=cmd-1\n  - cmd_2=cmd-2\n  - Cmd-3=cmd-3\n  - CMD.4=cmd-4\n  - cmd-5\n" +
 		"body-length: 0\n" +
 		"sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij" +
 		"\n\n" +
@@ -78,6 +79,13 @@ func (sds *snapDeclSuite) TestDecodeOK(c *C) {
 	c.Check(snapDecl.PublisherID(), Equals, "dev-id1")
 	c.Check(snapDecl.RefreshControl(), DeepEquals, []string{"foo", "bar"})
 	c.Check(snapDecl.AutoAliases(), DeepEquals, []string{"cmd1", "cmd_2", "Cmd-3", "CMD.4"})
+	c.Check(snapDecl.Aliases(), DeepEquals, map[string]string{
+		"cmd1":  "cmd-1",
+		"cmd_2": "cmd-2",
+		"Cmd-3": "cmd-3",
+		"CMD.4": "cmd-4",
+		"cmd-5": "cmd-5",
+	})
 }
 
 func (sds *snapDeclSuite) TestEmptySnapName(c *C) {

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -523,8 +523,8 @@ func Publisher(s *state.State, snapID string) (*asserts.Account, error) {
 	return a.(*asserts.Account), nil
 }
 
-// AutoAliases returns the auto-aliases list for the given installed snap.
-func AutoAliases(s *state.State, info *snap.Info) ([]string, error) {
+// AutoAliases returns the explicit auto-aliases alias=>app mapping for the given installed snap.
+func AutoAliases(s *state.State, info *snap.Info) (map[string]string, error) {
 	if info.SnapID == "" {
 		// without declaration
 		return nil, nil
@@ -533,7 +533,26 @@ func AutoAliases(s *state.State, info *snap.Info) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("internal error: cannot find snap-declaration for installed snap %q: %v", info.Name(), err)
 	}
-	return decl.AutoAliases(), nil
+	explicitAliases := decl.Aliases()
+	if len(explicitAliases) != 0 {
+		return explicitAliases, nil
+	}
+	// old header fallback
+	oldAutoAliases := decl.AutoAliases()
+	if len(oldAutoAliases) == 0 {
+		return nil, nil
+	}
+	res := make(map[string]string, len(oldAutoAliases))
+	for _, alias := range oldAutoAliases {
+		app := info.Aliases[alias]
+		if app == nil {
+			// not a known alias anymore or yet, skip
+			continue
+
+		}
+		res[alias] = app.Name
+	}
+	return res, nil
 }
 
 func init() {

--- a/overlord/assertstate/assertmgr_test.go
+++ b/overlord/assertstate/assertmgr_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -947,7 +948,67 @@ func (s *assertMgrSuite) TestSnapDeclaration(c *C) {
 	c.Check(snapDecl.SnapName(), Equals, "foo")
 }
 
-func (s *assertMgrSuite) TestAutoAliases(c *C) {
+func (s *assertMgrSuite) TestAutoAliasesBackwardCompat(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// prereqs for developer assertions in the system db
+	err := assertstate.Add(s.state, s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	// not from the store
+	aliases, err := assertstate.AutoAliases(s.state, &snap.Info{SuggestedName: "local"})
+	c.Assert(err, IsNil)
+	c.Check(aliases, HasLen, 0)
+
+	// missing
+	_, err = assertstate.AutoAliases(s.state, &snap.Info{
+		SideInfo: snap.SideInfo{
+			RealName: "baz",
+			SnapID:   "baz-id",
+		},
+	})
+	c.Check(err, ErrorMatches, `internal error: cannot find snap-declaration for installed snap "baz": assertion not found`)
+
+	info := snaptest.MockInfo(c, `
+name: foo
+apps:
+   cmd1:
+     aliases: [alias1]
+   cmd2:
+     aliases: [alias2]
+`, &snap.SideInfo{
+		RealName: "foo",
+		SnapID:   "foo-id",
+	})
+
+	// empty list
+	// have a declaration in the system db
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+	err = assertstate.Add(s.state, snapDeclFoo)
+	c.Assert(err, IsNil)
+	aliases, err = assertstate.AutoAliases(s.state, info)
+	c.Assert(err, IsNil)
+	c.Check(aliases, HasLen, 0)
+
+	// some aliases
+	snapDeclFoo = s.snapDecl(c, "foo", map[string]interface{}{
+		"auto-aliases": []interface{}{"alias1", "alias2", "alias3"},
+		"revision":     "1",
+	})
+	err = assertstate.Add(s.state, snapDeclFoo)
+	c.Assert(err, IsNil)
+	aliases, err = assertstate.AutoAliases(s.state, info)
+	c.Assert(err, IsNil)
+	c.Check(aliases, DeepEquals, map[string]string{
+		"alias1": "cmd1",
+		"alias2": "cmd2",
+	})
+}
+
+func (s *assertMgrSuite) TestAutoAliasesExplicit(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -987,8 +1048,8 @@ func (s *assertMgrSuite) TestAutoAliases(c *C) {
 
 	// some aliases
 	snapDeclFoo = s.snapDecl(c, "foo", map[string]interface{}{
-		"auto-aliases": []interface{}{"alias1", "alias2"},
-		"revision":     "1",
+		"aliases":  []interface{}{"alias1=cmd1", "alias2=cmd2"},
+		"revision": "1",
 	})
 	err = assertstate.Add(s.state, snapDeclFoo)
 	c.Assert(err, IsNil)
@@ -999,7 +1060,10 @@ func (s *assertMgrSuite) TestAutoAliases(c *C) {
 		},
 	})
 	c.Assert(err, IsNil)
-	c.Check(aliases, DeepEquals, []string{"alias1", "alias2"})
+	c.Check(aliases, DeepEquals, map[string]string{
+		"alias1": "cmd1",
+		"alias2": "cmd2",
+	})
 }
 
 func (s *assertMgrSuite) TestPublisher(c *C) {

--- a/overlord/snapstate/backend/aliases.go
+++ b/overlord/snapstate/backend/aliases.go
@@ -77,17 +77,17 @@ func (b Backend) MatchingAliases(aliases []*Alias) ([]*Alias, error) {
 
 // UpdateAliases adds and removes the given aliases.
 func (b Backend) UpdateAliases(add []*Alias, remove []*Alias) error {
-	for _, alias := range add {
-		err := os.Symlink(alias.Target, filepath.Join(dirs.SnapBinariesDir, alias.Name))
-		if err != nil {
-			return fmt.Errorf("cannot create alias symlink: %v", err)
-		}
-	}
-
 	for _, alias := range remove {
 		err := os.Remove(filepath.Join(dirs.SnapBinariesDir, alias.Name))
 		if err != nil {
 			return fmt.Errorf("cannot remove alias symlink: %v", err)
+		}
+	}
+
+	for _, alias := range add {
+		err := os.Symlink(alias.Target, filepath.Join(dirs.SnapBinariesDir, alias.Name))
+		if err != nil {
+			return fmt.Errorf("cannot create alias symlink: %v", err)
 		}
 	}
 	return nil

--- a/overlord/snapstate/backend/aliases_test.go
+++ b/overlord/snapstate/backend/aliases_test.go
@@ -99,6 +99,24 @@ func (s *aliasesSuite) TestUpdateAliasesRemove(c *C) {
 	c.Check(match, HasLen, 0)
 }
 
+func (s *aliasesSuite) TestUpdateAliasesAddRemoveOverlap(c *C) {
+	before := []*backend.Alias{{"bar", "x.bar"}}
+	after := []*backend.Alias{{"bar", "x.baz"}}
+
+	err := s.be.UpdateAliases(before, nil)
+	c.Assert(err, IsNil)
+
+	err = s.be.UpdateAliases(after, before)
+	c.Assert(err, IsNil)
+
+	match, err := s.be.MatchingAliases(before)
+	c.Assert(err, IsNil)
+	c.Check(match, HasLen, 0)
+	match, err = s.be.MatchingAliases(after)
+	c.Assert(err, IsNil)
+	c.Check(match, HasLen, len(after))
+}
+
 func (s *aliasesSuite) TestRemoveSnapAliases(c *C) {
 	aliases := []*backend.Alias{{"x", "x"}, {"bar", "x.bar"}, {"baz", "y.baz"}, {"y", "y"}}
 

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -67,7 +67,7 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	bs.snapmgr.AddForeignTaskHandlers(bs.fakeBackend)
 
 	snapstate.SetSnapManagerBackend(bs.snapmgr, bs.fakeBackend)
-	snapstate.AutoAliases = func(*state.State, *snap.Info) ([]string, error) {
+	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil
 	}
 }

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -101,7 +101,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.state.Unlock()
 
-	snapstate.AutoAliases = func(*state.State, *snap.Info) ([]string, error) {
+	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil
 	}
 }
@@ -1966,12 +1966,12 @@ func (s *snapmgrTestSuite) TestUpdateManyAutoAliasesScenarios(c *C) {
 		SnapType: "app",
 	})
 
-	snapstate.AutoAliases = func(st *state.State, info *snap.Info) ([]string, error) {
+	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
 		switch info.Name() {
 		case "some-snap":
-			return []string{"aliasA"}, nil
+			return map[string]string{"aliasA": "cmdA"}, nil
 		case "other-snap":
-			return []string{"aliasB"}, nil
+			return map[string]string{"aliasB": "cmdB"}, nil
 		}
 		return nil, nil
 	}
@@ -2105,12 +2105,12 @@ func (s *snapmgrTestSuite) TestUpdateOneAutoAliasesScenarios(c *C) {
 		SnapType: "app",
 	})
 
-	snapstate.AutoAliases = func(st *state.State, info *snap.Info) ([]string, error) {
+	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
 		switch info.Name() {
 		case "some-snap":
-			return []string{"aliasA"}, nil
+			return map[string]string{"aliasA": "cmdA"}, nil
 		case "other-snap":
-			return []string{"aliasB"}, nil
+			return map[string]string{"aliasB": "cmdB"}, nil
 		}
 		return nil, nil
 	}


### PR DESCRIPTION
This is WIP. Creating the PR to get some early feedback.  

The basic idea is to switch the state kept for aliases  for "auto" and "enabled",  to  `"auto:<target>"`, `"enabled:<target>"`.  We could also implement this with an explicit struct with custom unmarshalling capable of dealing with the old string format, we have done that a few times.

The code is capable to deal with and complete the old statuses as needed, to deal with the transition and old tasks.

The idea is to force converging to the new format in two ways, without needing a patch:

* for "auto":  in the code that deals with auto-aliases deltas used on refreshes, triggering alias tasks that will end up just converting the state for those
* for "enabled": in a new task or the remove-aliases task run at the beginning of snap refresh(etc) task chains

these are not done yet, but there are TODOs in the relevant spots. For now mainly the code in assertstate.AutoAliases and  doAliases has been changed. doAliases passes its mostly unchanged unit tests.

Based on #2860 which isn't quite the final form yet, the changes in asserts can be ignored for now.