### PR TITLE
cmd/snap-confine: ensure that hostfs is root owned.

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -429,6 +429,15 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			    SC_HOSTFS_DIR);
 		}
 	}
+	// Ensure that hostfs isgroup owned by root. We may have (now or earlier)
+	// created the directory as the user who first ran a snap on a given
+	// system and the group identity of that user is visilbe on disk.
+	// This was LP:#1665004
+	if (chown(SC_HOSTFS_DIR, 0, 0) < 0) {
+		die("cannot change user/group owner of %s to root",
+		    SC_HOSTFS_DIR);
+	};
+
 	// Make the upcoming "put_old" directory for pivot_root private so that
 	// mount events don't propagate to any peer group. In practice pivot root
 	// has a number of undocumented requirements and one of them is that the

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -433,11 +433,16 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	// created the directory as the user who first ran a snap on a given
 	// system and the group identity of that user is visilbe on disk.
 	// This was LP:#1665004
-	if (chown(SC_HOSTFS_DIR, 0, 0) < 0) {
-		die("cannot change user/group owner of %s to root",
-		    SC_HOSTFS_DIR);
-	};
-
+	struct stat sb;
+	if (stat(SC_HOSTFS_DIR, &sb) < 0) {
+		die("cannot stat %s", SC_HOSTFS_DIR);
+	}
+	if (sb.st_uid != 0 || sb.st_gid != 0) {
+		if (chown(SC_HOSTFS_DIR, 0, 0) < 0) {
+			die("cannot change user/group owner of %s to root",
+			    SC_HOSTFS_DIR);
+		}
+	}
 	// Make the upcoming "put_old" directory for pivot_root private so that
 	// mount events don't propagate to any peer group. In practice pivot root
 	// has a number of undocumented requirements and one of them is that the

--- a/tests/regression/lp-1665004/task.yaml
+++ b/tests/regression/lp-1665004/task.yaml
@@ -1,0 +1,13 @@
+summary: ensure that /var/lib/snapd/hostfs is group-owned by root
+details: |
+    On a system that never ran any snap before the /var/lib/snapd/hostfs
+    directory does not exist. When snap-confine is used it will create the
+    directory on demand but that directory will retain the group identity of
+    the user.
+prepare: |
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-tools
+    rmdir /var/lib/snapd/hostfs
+execute: |
+    test-snapd-tools.cmd true
+    [ $(stat -c '%g' /var/lib/snapd/hostfs) -eq 0 ] 


### PR DESCRIPTION
On a system that never ran any snap before the /var/lib/snapd/hostfs
directory does not exist. When snap-confine is used it will create the
directory on demand but that directory will retain the group identity of
the user.

This patch fixes this issue by chown'ing the said directory to be
owned by the root user and the root group.

Fixes: https://bugs.launchpad.net/snap-confine/+bug/1665004
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>