### PR TITLE
screen-inhibit-control: add methods for delaying screensavers

### DIFF
--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -61,12 +61,11 @@ dbus (send)
 # gnome, kde and cinnamon screensaver
 dbus (send)
     bus=session
-    path=/{ScreenSaver,}
+    path=/{,ScreenSaver}
     interface=org.{gnome.ScreenSaver,kde.screensaver,cinnamon.ScreenSaver}
     member=SimulateUserActivity
     peer=(label=unconfined),
 `
-
 
 const screenInhibitControlConnectedPlugSecComp = `
 # Description: Can inhibit and uninhibit screen savers in desktop sessions.

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -55,9 +55,18 @@ dbus (send)
     bus=session
     path=/Screensaver
     interface=org.freedesktop.ScreenSaver
-    member=org.freedesktop.ScreenSaver.{Inhibit,UnInhibit}
+    member=org.freedesktop.ScreenSaver.{Inhibit,UnInhibit,SimulateUserActivity}
+    peer=(label=unconfined),
+
+# gnome, kde and cinnamon screensaver
+dbus (send)
+    bus=session
+    path=/{ScreenSaver,}
+    interface=org.{gnome.ScreenSaver,kde.screensaver,cinnamon.ScreenSaver}
+    member=SimulateUserActivity
     peer=(label=unconfined),
 `
+
 
 const screenInhibitControlConnectedPlugSecComp = `
 # Description: Can inhibit and uninhibit screen savers in desktop sessions.


### PR DESCRIPTION
Allow to call SimulateUserActivity on various supported screensavers.
