### PR TITLE
Don't return null result for async responses

### DIFF
--- a/daemon/response.go
+++ b/daemon/response.go
@@ -51,7 +51,7 @@ type Response interface {
 type resp struct {
 	Status int          `json:"status-code"`
 	Type   ResponseType `json:"type"`
-	Result interface{}  `json:"result"`
+	Result interface{}  `json:"result,omitempty"`
 	*Meta
 }
 


### PR DESCRIPTION
Async responses don't contain a result field. This is sent as null currently:

$ sudo nc -C -U /run/snapd.socket
POST /v2/snaps/ohmygiraffe HTTP/1.1
Host: 
Content-Length: 19

{"action":"remove"} 
HTTP/1.1 202 Accepted
Content-Type: application/json
Date: Wed, 15 Feb 2017 23:18:20 GMT
Content-Length: 83

{"type":"async","status-code":202,"status":"Accepted","result":null,"change":"402"}
