### PR TITLE
overlord/hookstate/ctlcmd: helper function for creating a deep copy of interface attributes

### DIFF
--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -22,6 +22,7 @@ package ctlcmd
 import "fmt"
 
 var AttributesTask = attributesTask
+var CopyAttributes = copyAttributes
 
 func AddMockCommand(name string) *MockCommand {
 	mockCommand := NewMockCommand()

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -181,7 +181,7 @@ func copyRecursive(value interface{}) (interface{}, error) {
 	case bool:
 		return v, nil
 	case int:
-		return v, nil
+		return int64(v), nil
 	case int64:
 		return v, nil
 	case []interface{}:

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -165,3 +165,52 @@ func (s *setCommand) setInterfaceSetting(context *hookstate.Context, plugOrSlot 
 	attrsTask.Set(which, attributes)
 	return nil
 }
+
+func copyAttributes(value map[string]interface{}) (map[string]interface{}, error) {
+	var cpy interface{}
+	if err := copyRecursive(value, &cpy); err != nil {
+		return nil, err
+	}
+	return cpy.(map[string]interface{}), nil
+}
+
+func copyRecursive(value interface{}, out *interface{}) error {
+	switch v := value.(type) {
+	case string:
+		*out = v
+		return nil
+	case bool:
+		*out = v
+		return nil
+	case int:
+		*out = v
+		return nil
+	case int64:
+		*out = v
+		return nil
+	case []interface{}:
+		arr := make([]interface{}, len(v))
+		for i, el := range v {
+			err := copyRecursive(el, &arr[i])
+			if err != nil {
+				return err
+			}
+		}
+		*out = arr
+		return nil
+	case map[string]interface{}:
+		mp := make(map[string]interface{}, len(v))
+		for key, item := range v {
+			var tmp interface{}
+			err := copyRecursive(item, &tmp)
+			if err != nil {
+				return err
+			}
+			mp[key] = tmp
+		}
+		*out = mp
+		return nil
+	default:
+		return fmt.Errorf("unsupported attribute type '%T', value '%v'", value, value)
+	}
+}

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -167,50 +167,44 @@ func (s *setCommand) setInterfaceSetting(context *hookstate.Context, plugOrSlot 
 }
 
 func copyAttributes(value map[string]interface{}) (map[string]interface{}, error) {
-	var cpy interface{}
-	if err := copyRecursive(value, &cpy); err != nil {
+	cpy, err := copyRecursive(value)
+	if err != nil {
 		return nil, err
 	}
-	return cpy.(map[string]interface{}), nil
+	return cpy.(map[string]interface{}), err
 }
 
-func copyRecursive(value interface{}, out *interface{}) error {
+func copyRecursive(value interface{}) (interface{}, error) {
 	switch v := value.(type) {
 	case string:
-		*out = v
-		return nil
+		return v, nil
 	case bool:
-		*out = v
-		return nil
+		return v, nil
 	case int:
-		*out = v
-		return nil
+		return v, nil
 	case int64:
-		*out = v
-		return nil
+		return v, nil
 	case []interface{}:
 		arr := make([]interface{}, len(v))
 		for i, el := range v {
-			err := copyRecursive(el, &arr[i])
+			tmp, err := copyRecursive(el)
 			if err != nil {
-				return err
+				return nil, err
 			}
+			arr[i] = tmp
 		}
-		*out = arr
-		return nil
+		return arr, nil
 	case map[string]interface{}:
 		mp := make(map[string]interface{}, len(v))
 		for key, item := range v {
-			var tmp interface{}
-			err := copyRecursive(item, &tmp)
+			tmp, err := copyRecursive(item)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			mp[key] = tmp
 		}
-		*out = mp
-		return nil
+		return mp, nil
 	default:
-		return fmt.Errorf("unsupported attribute type '%T', value '%v'", value, value)
+		return nil, fmt.Errorf("unsupported attribute type '%T', value '%v'", value, value)
 	}
 }

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -20,6 +20,8 @@
 package ctlcmd_test
 
 import (
+	"reflect"
+
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
@@ -261,7 +263,7 @@ func (s *setAttrSuite) TestCopyAttributes(c *C) {
 	orig := map[string]interface{}{
 		"a": "A",
 		"b": true,
-		"c": 100,
+		"c": int(100),
 		"d": []interface{}{"x", "y", true},
 		"e": map[string]interface{}{
 			"e1": "E1",
@@ -270,6 +272,11 @@ func (s *setAttrSuite) TestCopyAttributes(c *C) {
 
 	cpy, err := ctlcmd.CopyAttributes(orig)
 	c.Assert(err, IsNil)
+	// verify that int is converted into int64
+	c.Check(reflect.TypeOf(cpy["c"]).Kind(), Equals, reflect.Int64)
+	c.Check(reflect.TypeOf(orig["c"]).Kind(), Equals, reflect.Int)
+	// change the type of orig's value to int64 to make DeepEquals happy in the test
+	orig["c"] = int64(100)
 	c.Check(cpy, DeepEquals, orig)
 
 	cpy["d"].([]interface{})[0] = 999

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -256,3 +256,30 @@ func (s *setAttrSuite) TestSetCommandFailsOutsideOfValidContext(c *C) {
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
 }
+
+func (s *setAttrSuite) TestCopyAttributes(c *C) {
+	orig := map[string]interface{}{
+		"a": "A",
+		"b": true,
+		"c": 100,
+		"d": []interface{}{"x", "y", true},
+		"e": map[string]interface{}{
+			"e1": "E1",
+		},
+	}
+
+	cpy, err := ctlcmd.CopyAttributes(orig)
+	c.Assert(err, IsNil)
+	c.Check(cpy, DeepEquals, orig)
+
+	cpy["d"].([]interface{})[0] = 999
+	c.Check(orig["d"].([]interface{})[0], Equals, "x")
+	cpy["e"].(map[string]interface{})["e1"] = "x"
+	c.Check(orig["e"].(map[string]interface{})["e1"], Equals, "E1")
+
+	type unsupported struct{}
+	var x unsupported
+	_, err = ctlcmd.CopyAttributes(map[string]interface{}{"x": x})
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, "unsupported attribute type 'ctlcmd_test.unsupported', value '{}'")
+}


### PR DESCRIPTION
Helper function for creating a deep copy of map[string]interface{} data used by interface attributes, only supports select data types. It will be used by snapctl set from the upcoming interface hooks branch, so added it to set.go for now.