### PR TITLE
snap: error when `snap list foo` is run and no snap is installed

### DIFF
--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -67,17 +67,23 @@ func (x *cmdList) Execute(args []string) error {
 	return listSnaps(names, x.All)
 }
 
+var ErrNoMatchingSnaps = errors.New(i18n.G("no matching snaps installed"))
+
 func listSnaps(names []string, all bool) error {
 	cli := Client()
 	snaps, err := cli.List(names, &client.ListOptions{All: all})
 	if err != nil {
 		if err == client.ErrNoSnapsInstalled {
-			fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet. Try \"snap install hello-world\"."))
-			return nil
+			if len(names) == 0 {
+				fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet. Try \"snap install hello-world\"."))
+				return nil
+			} else {
+				return ErrNoMatchingSnaps
+			}
 		}
 		return err
 	} else if len(snaps) == 0 {
-		return errors.New(i18n.G("no matching snaps installed"))
+		return ErrNoMatchingSnaps
 	}
 	sort.Sort(snapsByName(snaps))
 

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -131,11 +131,8 @@ func (s *SnapSuite) TestListEmptyWithQuery(c *check.C) {
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"list", "quux"})
-	c.Assert(err, check.IsNil)
-	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Equals, "")
-	c.Check(s.Stderr(), check.Equals, "No snaps are installed yet. Try \"snap install hello-world\".\n")
+	_, err := snap.Parser().ParseArgs([]string{"list", "quux"})
+	c.Assert(err, check.ErrorMatches, `no matching snaps installed`)
 }
 
 func (s *SnapSuite) TestListWithNoMatchingQuery(c *check.C) {


### PR DESCRIPTION
When `snap list` is run on a system without any snaps it returns
a zero exit code and a friendly message. But `snap list foo` also
does this and that is inconsistent with the behaviour of
`snap list foo` if some snaps are installed but not "foo". This
branch makes `snap list foo` fail in the same way regardless if
snaps are instaled or not.

LP: #1664383