### PR TITLE
snapstate: ensure snapstate.CanAutoRefresh is nil in tests

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -104,6 +104,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	os.Setenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS", "1")
+	snapstate.CanAutoRefresh = nil
 
 	// create a fake systemd environment
 	os.MkdirAll(filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants"), 0755)

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -51,6 +51,7 @@ func (ovs *overlordSuite) SetUpTest(c *C) {
 	tmpdir := c.MkDir()
 	dirs.SetRootDir(tmpdir)
 	dirs.SnapStateFile = filepath.Join(tmpdir, "test.json")
+	snapstate.CanAutoRefresh = nil
 }
 
 func (ovs *overlordSuite) TearDownTest(c *C) {


### PR DESCRIPTION
To avoid tests exploding on s390x and powerpc