### PR TITLE
errtracker: add support for error reporting via daisy.ubuntu.com

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/errtracker"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
 )
@@ -36,6 +37,8 @@ func init() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: failed to activate logging: %s\n", err)
 	}
+	// set here to avoid accidental submits in e.g. unit tests
+	errtracker.CrashDbURLBase = "https://daisy.ubuntu.com/"
 }
 
 func main() {

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package errtracker
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"labix.org/v2/mgo/bson"
+
+	"github.com/snapcore/snapd/arch"
+	"github.com/snapcore/snapd/httputil"
+)
+
+var (
+	crashDbUrlBase = "https://daisy.ubuntu.com/"
+	machineID      = "/var/lib/dbus/machine-id"
+
+	timeNow = time.Now
+)
+
+func Report(snap, channel, errMsg string) error {
+	machineID, err := ioutil.ReadFile(machineID)
+	if err != nil {
+		return err
+	}
+	identifier := fmt.Sprintf("%x", sha512.Sum512(machineID))
+
+	crashDbUrl := fmt.Sprintf("%s/%s", crashDbUrlBase, identifier)
+
+	report := map[string]string{
+		"ProblemType":  "Snap",
+		"Architecture": arch.UbuntuArchitecture(),
+		"Date":         fmt.Sprintf("%s", timeNow()),
+		"Snap":         snap,
+		"Channel":      channel,
+		"ErrorMessage": errMsg,
+	}
+	reportBson, err := bson.Marshal(report)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", crashDbUrl, bytes.NewBuffer(reportBson))
+	req.Header.Add("Content-Type", "application/octet-stream")
+	req.Header.Add("X-Whoopsie-Version", httputil.UserAgent())
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("cannot upload error report, return code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -27,7 +27,7 @@ import (
 	"net/http"
 	"time"
 
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/httputil"

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -82,6 +82,9 @@ func Report(snap, channel, errMsg string) (string, error) {
 	}
 	client := &http.Client{}
 	req, err := http.NewRequest("POST", crashDbUrl, bytes.NewBuffer(reportBson))
+	if err != nil {
+		return "", err
+	}
 	req.Header.Add("Content-Type", "application/octet-stream")
 	req.Header.Add("X-Whoopsie-Version", httputil.UserAgent())
 	resp, err := client.Do(req)

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -41,6 +41,16 @@ var (
 	timeNow = time.Now
 )
 
+// distroRelease returns a distro release as it is expected by daisy.ubuntu.com
+func distroRelease() string {
+	ID := release.ReleaseInfo.ID
+	if ID == "ubuntu" {
+		ID = "Ubuntu"
+	}
+
+	return fmt.Sprintf("%s %s", ID, release.ReleaseInfo.VersionID)
+}
+
 func Report(snap, channel, errMsg string) (string, error) {
 	machineID, err := ioutil.ReadFile(machineID)
 	if err != nil {
@@ -54,7 +64,7 @@ func Report(snap, channel, errMsg string) (string, error) {
 	report := map[string]string{
 		"ProblemType":        "Snap",
 		"Architecture":       arch.UbuntuArchitecture(),
-		"DistroRelease":      fmt.Sprintf("%s %s", release.ReleaseInfo.ID, release.ReleaseInfo.VersionID),
+		"DistroRelease":      distroRelease(),
 		"Date":               timeNow().Format(time.ANSIC),
 		"Snap":               snap,
 		"Channel":            channel,

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -55,7 +55,7 @@ func Report(snap, channel, errMsg string) (string, error) {
 		"ProblemType":        "Snap",
 		"Architecture":       arch.UbuntuArchitecture(),
 		"DistroRelease":      fmt.Sprintf("%s %s", release.ReleaseInfo.ID, release.ReleaseInfo.VersionID),
-		"Date":               fmt.Sprintf("%s", timeNow()),
+		"Date":               timeNow().Format(time.ANSIC),
 		"Snap":               snap,
 		"Channel":            channel,
 		"ErrorMessage":       errMsg,

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/httputil"
+	"github.com/snapcore/snapd/release"
 )
 
 var (
@@ -45,17 +46,19 @@ func Report(snap, channel, errMsg string) error {
 	if err != nil {
 		return err
 	}
+	machineID = bytes.TrimSpace(machineID)
 	identifier := fmt.Sprintf("%x", sha512.Sum512(machineID))
 
 	crashDbUrl := fmt.Sprintf("%s/%s", crashDbUrlBase, identifier)
 
 	report := map[string]string{
-		"ProblemType":  "Snap",
-		"Architecture": arch.UbuntuArchitecture(),
-		"Date":         fmt.Sprintf("%s", timeNow()),
-		"Snap":         snap,
-		"Channel":      channel,
-		"ErrorMessage": errMsg,
+		"ProblemType":   "Snap",
+		"Architecture":  arch.UbuntuArchitecture(),
+		"DistroRelease": fmt.Sprintf("%s %s", release.ReleaseInfo.ID, release.ReleaseInfo.VersionID),
+		"Date":          fmt.Sprintf("%s", timeNow()),
+		"Snap":          snap,
+		"Channel":       channel,
+		"ErrorMessage":  errMsg,
 	}
 	reportBson, err := bson.Marshal(report)
 	if err != nil {

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -35,8 +35,9 @@ import (
 )
 
 var (
-	crashDbUrlBase = "https://daisy.ubuntu.com/"
-	machineID      = "/var/lib/dbus/machine-id"
+	CrashDbURLBase string
+
+	machineID = "/var/lib/dbus/machine-id"
 
 	timeNow = time.Now
 )
@@ -52,6 +53,10 @@ func distroRelease() string {
 }
 
 func Report(snap, channel, errMsg string) (string, error) {
+	if CrashDbURLBase == "" {
+		return "", nil
+	}
+
 	machineID, err := ioutil.ReadFile(machineID)
 	if err != nil {
 		return "", err
@@ -59,7 +64,7 @@ func Report(snap, channel, errMsg string) (string, error) {
 	machineID = bytes.TrimSpace(machineID)
 	identifier := fmt.Sprintf("%x", sha512.Sum512(machineID))
 
-	crashDbUrl := fmt.Sprintf("%s/%s", crashDbUrlBase, identifier)
+	crashDbUrl := fmt.Sprintf("%s/%s", CrashDbURLBase, identifier)
 
 	report := map[string]string{
 		"ProblemType":        "Snap",

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -61,18 +61,20 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 			err = bson.Unmarshal(b, &data)
 			c.Assert(err, IsNil)
 			c.Check(data, DeepEquals, map[string]string{
-				"ProblemType":   "Snap",
-				"DistroRelease": fmt.Sprintf("%s %s", release.ReleaseInfo.ID, release.ReleaseInfo.VersionID),
-				"Snap":          "some-snap",
-				"Date":          "2017-02-17 09:51:00 +0000 UTC",
-				"Channel":       "beta",
-				"ErrorMessage":  "failed to do stuff",
-				"Architecture":  arch.UbuntuArchitecture(),
+				"ProblemType":        "Snap",
+				"DistroRelease":      fmt.Sprintf("%s %s", release.ReleaseInfo.ID, release.ReleaseInfo.VersionID),
+				"Snap":               "some-snap",
+				"Date":               "2017-02-17 09:51:00 +0000 UTC",
+				"Channel":            "beta",
+				"ErrorMessage":       "failed to do stuff",
+				"DuplicateSignature": "snap-install: failed to do stuff",
+				"Architecture":       arch.UbuntuArchitecture(),
 			})
+			fmt.Fprintf(w, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 		case 1:
 			c.Check(r.Method, Equals, "POST")
 			c.Check(r.URL.Path, Matches, identifier)
-
+			fmt.Fprintf(w, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 		default:
 			c.Fatalf("expected one request, got %d", n+1)
 		}
@@ -87,12 +89,13 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 	restorer = errtracker.MockTimeNow(func() time.Time { return time.Date(2017, 2, 17, 9, 51, 0, 0, time.UTC) })
 	defer restorer()
 
-	err := errtracker.Report("some-snap", "beta", "failed to do stuff")
+	id, err := errtracker.Report("some-snap", "beta", "failed to do stuff")
 	c.Check(err, IsNil)
+	c.Check(id, Equals, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 	c.Check(n, Equals, 1)
 
 	// run again, verify identifier is unchanged
-	err = errtracker.Report("some-other-snap", "edge", "failed to do more stuff")
+	id, err = errtracker.Report("some-other-snap", "edge", "failed to do more stuff")
 	c.Check(err, IsNil)
 	c.Check(n, Equals, 2)
 }

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -64,7 +64,7 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 				"ProblemType":        "Snap",
 				"DistroRelease":      fmt.Sprintf("%s %s", release.ReleaseInfo.ID, release.ReleaseInfo.VersionID),
 				"Snap":               "some-snap",
-				"Date":               "2017-02-17 09:51:00 +0000 UTC",
+				"Date":               "Fri Feb 17 09:51:00 2017",
 				"Channel":            "beta",
 				"ErrorMessage":       "failed to do stuff",
 				"DuplicateSignature": "snap-install: failed to do stuff",

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -20,6 +20,7 @@
 package errtracker_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -32,6 +33,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/errtracker"
+	"github.com/snapcore/snapd/release"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -59,12 +61,13 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 			err = bson.Unmarshal(b, &data)
 			c.Assert(err, IsNil)
 			c.Check(data, DeepEquals, map[string]string{
-				"ProblemType":  "Snap",
-				"Snap":         "some-snap",
-				"Date":         "2017-02-17 09:51:00 +0000 UTC",
-				"Channel":      "beta",
-				"ErrorMessage": "failed to do stuff",
-				"Architecture": arch.UbuntuArchitecture(),
+				"ProblemType":   "Snap",
+				"DistroRelease": fmt.Sprintf("%s %s", release.ReleaseInfo.ID, release.ReleaseInfo.VersionID),
+				"Snap":          "some-snap",
+				"Date":          "2017-02-17 09:51:00 +0000 UTC",
+				"Channel":       "beta",
+				"ErrorMessage":  "failed to do stuff",
+				"Architecture":  arch.UbuntuArchitecture(),
 			})
 		case 1:
 			c.Check(r.Method, Equals, "POST")

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 
 	. "gopkg.in/check.v1"
 

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -98,5 +98,6 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 	// run again, verify identifier is unchanged
 	id, err = errtracker.Report("some-other-snap", "edge", "failed to do more stuff")
 	c.Check(err, IsNil)
+	c.Check(id, Equals, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 	c.Check(n, Equals, 2)
 }

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,7 +63,7 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 			c.Assert(err, IsNil)
 			c.Check(data, DeepEquals, map[string]string{
 				"ProblemType":        "Snap",
-				"DistroRelease":      fmt.Sprintf("%s %s", release.ReleaseInfo.ID, release.ReleaseInfo.VersionID),
+				"DistroRelease":      fmt.Sprintf("%s %s", strings.Title(release.ReleaseInfo.ID), release.ReleaseInfo.VersionID),
 				"Snap":               "some-snap",
 				"Date":               "Fri Feb 17 09:51:00 2017",
 				"Channel":            "beta",

--- a/errtracker/export_test.go
+++ b/errtracker/export_test.go
@@ -24,10 +24,10 @@ import (
 )
 
 func MockCrashDbURL(url string) (restorer func()) {
-	old := crashDbUrlBase
-	crashDbUrlBase = url
+	old := CrashDbURLBase
+	CrashDbURLBase = url
 	return func() {
-		crashDbUrlBase = old
+		CrashDbURLBase = old
 	}
 }
 

--- a/errtracker/export_test.go
+++ b/errtracker/export_test.go
@@ -1,0 +1,40 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package errtracker
+
+import (
+	"time"
+)
+
+func MockCrashDbURL(url string) (restorer func()) {
+	old := crashDbUrlBase
+	crashDbUrlBase = url
+	return func() {
+		crashDbUrlBase = old
+	}
+}
+
+func MockTimeNow(f func() time.Time) (restorer func()) {
+	old := timeNow
+	timeNow = f
+	return func() {
+		timeNow = old
+	}
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -552,9 +552,8 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	var logMsg []string
 	for _, t := range t.Change().Tasks() {
-		if t.Status() == state.ErrorStatus {
-			logMsg = append(logMsg, t.Log()...)
-		}
+		logMsg = append(logMsg, fmt.Sprintf("%s: %s", t.Kind(), t.Status()))
+		logMsg = append(logMsg, t.Log()...)
 	}
 
 	st.Unlock()

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -556,7 +556,12 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 	st.Unlock()
-	errtracker.Report(snapsup.SideInfo.RealName, snapsup.SideInfo.Channel, strings.Join(logMsg, "\n"))
+	oopsid, err := errtracker.Report(snapsup.SideInfo.RealName, snapsup.SideInfo.Channel, strings.Join(logMsg, "\n"))
+	if err == nil {
+		logger.Noticef("Reported problem as %s", oopsid)
+	} else {
+		logger.Debugf("Cannot report problem: %s", err)
+	}
 
 	return nil
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -553,7 +553,15 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	var logMsg []string
 	for _, t := range t.Change().Tasks() {
 		logMsg = append(logMsg, fmt.Sprintf("%s: %s", t.Kind(), t.Status()))
-		logMsg = append(logMsg, t.Log()...)
+		for _, l := range t.Log() {
+			// cut of the rfc339 timestamp to ensure duplicate
+			// detection works in daisy
+			tStampLen := len("2006-01-02T15:04:05Z07:00")
+			if len(l) < tStampLen {
+				continue
+			}
+			logMsg = append(logMsg, l[tStampLen:])
+		}
 	}
 
 	st.Unlock()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -110,6 +110,18 @@
 			"revisionTime": "2015-01-21T11:42:31Z"
 		},
 		{
+			"checksumSHA1": "YsB2DChSV9HxdzHaKATllAUKWSI=",
+			"path": "gopkg.in/mgo.v2/bson",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "XQsrqoNT1U0KzLxOFcAZVvqhLfk=",
+			"path": "gopkg.in/mgo.v2/internal/json",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
 			"checksumSHA1": "lBMMakT63h9ywP4d5wlkhOYMCAs=",
 			"path": "gopkg.in/retry.v1",
 			"revision": "c09f6b86ba4d5d2cf5bdf0665364aec9fd4815db",
@@ -132,12 +144,6 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "49c95bdc21843256fb6c4e0d370a05f24a0bf213",
 			"revisionTime": "2015-02-24T22:57:58Z"
-		},
-		{
-			"checksumSHA1": "aM4ZlRetn5gV4qipnYoAYWKbh+4=",
-			"path": "labix.org/v2/mgo/bson",
-			"revision": "287",
-			"revisionTime": "2014-07-01T14:00:51Z"
 		}
 	],
 	"rootPath": "github.com/snapcore/snapd"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -132,6 +132,12 @@
 			"path": "gopkg.in/yaml.v2",
 			"revision": "49c95bdc21843256fb6c4e0d370a05f24a0bf213",
 			"revisionTime": "2015-02-24T22:57:58Z"
+		},
+		{
+			"checksumSHA1": "aM4ZlRetn5gV4qipnYoAYWKbh+4=",
+			"path": "labix.org/v2/mgo/bson",
+			"revision": "287",
+			"revisionTime": "2014-07-01T14:00:51Z"
 		}
 	],
 	"rootPath": "github.com/snapcore/snapd"


### PR DESCRIPTION
This adds snap side support to track install errors for snaps via errors.ubuntu.com. 

There is also server side work so that it understands the new "ProblemType: Snap".