### PR TITLE
httputils: ensure User-Agent works accross redirects

### DIFF
--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -56,7 +56,7 @@ func (s *SnapSuite) TestList(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
 			c.Check(r.URL.RawQuery, check.Equals, "")
-			http.Redirect(w, r, r.URL)
+			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17}]}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -56,7 +56,7 @@ func (s *SnapSuite) TestList(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
 			c.Check(r.URL.RawQuery, check.Equals, "")
-			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17}]}`)
+			http.Redirect(w, r, r.URL)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}

--- a/httputil/logger.go
+++ b/httputil/logger.go
@@ -110,10 +110,12 @@ func NewHTTPClient(opts *ClientOpts) *http.Client {
 			if len(via) > 10 {
 				return errors.New("stopped after 10 redirects")
 			}
-			// preserve the range header across redirects
+			// preserve some headers across redirects
 			// to the CDN
-			v := via[0].Header.Get("Range")
-			req.Header.Set("Range", v)
+			for _, header := range []string{"Range", "User-Agent"} {
+				v := via[0].Header.Get(header)
+				req.Header.Set(header, v)
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
This should give us accurate data for the download logs.