### PR TITLE
errtracker: include snapd version in err reports

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -39,6 +39,7 @@ func init() {
 	}
 	// set here to avoid accidental submits in e.g. unit tests
 	errtracker.CrashDbURLBase = "https://daisy.ubuntu.com/"
+	errtracker.SnapdVersion = cmd.Version
 }
 
 func main() {

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -36,10 +36,10 @@ import (
 
 var (
 	CrashDbURLBase string
+	SnapdVersion   string
 
 	machineID = "/var/lib/dbus/machine-id"
-
-	timeNow = time.Now
+	timeNow   = time.Now
 )
 
 // distroRelease returns a distro release as it is expected by daisy.ubuntu.com
@@ -69,6 +69,7 @@ func Report(snap, channel, errMsg string) (string, error) {
 	report := map[string]string{
 		"ProblemType":        "Snap",
 		"Architecture":       arch.UbuntuArchitecture(),
+		"SnapdVersion":       SnapdVersion,
 		"DistroRelease":      distroRelease(),
 		"Date":               timeNow().Format(time.ANSIC),
 		"Snap":               snap,

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -62,7 +62,10 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 	n := 0
 	identifier := ""
 
+	prev := errtracker.SnapdVersion
+	defer func() { errtracker.SnapdVersion = prev }()
 	errtracker.SnapdVersion = "some-snapd-version"
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch n {
 		case 0:

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -62,6 +62,7 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 	n := 0
 	identifier := ""
 
+	errtracker.SnapdVersion = "some-snapd-version"
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch n {
 		case 0:
@@ -77,6 +78,7 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 			c.Check(data, DeepEquals, map[string]string{
 				"ProblemType":        "Snap",
 				"DistroRelease":      fmt.Sprintf("%s %s", strings.Title(release.ReleaseInfo.ID), release.ReleaseInfo.VersionID),
+				"SnapdVersion":       "some-snapd-version",
 				"Snap":               "some-snap",
 				"Date":               "Fri Feb 17 09:51:00 2017",
 				"Channel":            "beta",


### PR DESCRIPTION
Trivial branch to include the snapd version that caused the failure.