### PR TITLE
many: rebased uname branch for 2.22

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -287,6 +287,7 @@ type ServerVersion struct {
 	OSID        string
 	OSVersionID string
 	OnClassic   bool
+	Kernel      string
 }
 
 func (client *Client) ServerVersion() (*ServerVersion, error) {
@@ -301,6 +302,7 @@ func (client *Client) ServerVersion() (*ServerVersion, error) {
 		OSID:        sysInfo.OSRelease.ID,
 		OSVersionID: sysInfo.OSRelease.VersionID,
 		OnClassic:   sysInfo.OnClassic,
+		Kernel:      sysInfo.Kernel,
 	}, nil
 }
 
@@ -365,6 +367,7 @@ type SysInfo struct {
 	OSRelease OSRelease `json:"os-release"`
 	OnClassic bool      `json:"on-classic"`
 	Managed   bool      `json:"managed"`
+	Kernel    string    `json:"kernel,omitempty"`
 }
 
 func (rsp *response) err() error {

--- a/client/client.go
+++ b/client/client.go
@@ -287,7 +287,8 @@ type ServerVersion struct {
 	OSID        string
 	OSVersionID string
 	OnClassic   bool
-	Kernel      string
+
+	KernelVersion string
 }
 
 func (client *Client) ServerVersion() (*ServerVersion, error) {
@@ -302,7 +303,8 @@ func (client *Client) ServerVersion() (*ServerVersion, error) {
 		OSID:        sysInfo.OSRelease.ID,
 		OSVersionID: sysInfo.OSRelease.VersionID,
 		OnClassic:   sysInfo.OnClassic,
-		Kernel:      sysInfo.Kernel,
+
+		KernelVersion: sysInfo.KernelVersion,
 	}, nil
 }
 
@@ -367,7 +369,8 @@ type SysInfo struct {
 	OSRelease OSRelease `json:"os-release"`
 	OnClassic bool      `json:"on-classic"`
 	Managed   bool      `json:"managed"`
-	Kernel    string    `json:"kernel,omitempty"`
+
+	KernelVersion string `json:"kernel-version,omitempty"`
 }
 
 func (rsp *response) err() error {

--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -69,8 +69,8 @@ func printVersions() error {
 	if sv.OnClassic {
 		fmt.Fprintf(w, "%s\t%s\n", sv.OSID, sv.OSVersionID)
 	}
-	if sv.Kernel != "" {
-		fmt.Fprintf(w, "kernel\t%s\n", sv.Kernel)
+	if sv.KernelVersion != "" {
+		fmt.Fprintf(w, "kernel\t%s\n", sv.KernelVersion)
 	}
 	w.Flush()
 

--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -69,6 +69,9 @@ func printVersions() error {
 	if sv.OnClassic {
 		fmt.Fprintf(w, "%s\t%s\n", sv.OSID, sv.OSVersionID)
 	}
+	if sv.Kernel != "" {
+		fmt.Fprintf(w, "kernel\t%s\n", sv.Kernel)
+	}
 	w.Flush()
 
 	return err

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -237,6 +237,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		"os-release": release.ReleaseInfo,
 		"on-classic": release.OnClassic,
 		"managed":    len(users) > 0,
+		"kernel":     release.KernelVersion(),
 	}
 
 	// TODO: set the store-id here from the model information

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -237,7 +237,8 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		"os-release": release.ReleaseInfo,
 		"on-classic": release.OnClassic,
 		"managed":    len(users) > 0,
-		"kernel":     release.KernelVersion(),
+
+		"kernel-version": release.KernelVersion(),
 	}
 
 	// TODO: set the store-id here from the model information

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -558,6 +558,9 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
+	// Ensure that we had a kernel-verrsion but don't check the actual value.
+	c.Check(rsp.Result.(map[string]interface{})["kerenl-version"], check.Not(check.Equals), "")
+	delete(rsp.Result.(map[string]interface{}), "kernel-version")
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -559,8 +559,9 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	c.Check(rsp.Status, check.Equals, 200)
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	// Ensure that we had a kernel-verrsion but don't check the actual value.
-	c.Check(rsp.Result.(map[string]interface{})["kerenl-version"], check.Not(check.Equals), "")
-	delete(rsp.Result.(map[string]interface{}), "kernel-version")
+	const kernelVersionKey = "kernel-version"
+	c.Check(rsp.Result.(map[string]interface{})[kernelVersionKey], check.Not(check.Equals), "")
+	delete(rsp.Result.(map[string]interface{}), kernelVersionKey)
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 

--- a/httputil/export_test.go
+++ b/httputil/export_test.go
@@ -20,8 +20,9 @@
 package httputil
 
 var (
-	GetFlags         = (*LoggedTransport).getFlags
-	StripUnsafeRunes = stripUnsafeRunes
+	GetFlags              = (*LoggedTransport).getFlags
+	StripUnsafeRunes      = stripUnsafeRunes
+	SanitizeKernelVersion = sanitizeKernelVersion
 )
 
 func MockUserAgent(mock string) (restore func()) {

--- a/httputil/export_test.go
+++ b/httputil/export_test.go
@@ -19,7 +19,10 @@
 
 package httputil
 
-var GetFlags = (*LoggedTransport).getFlags
+var (
+	GetFlags         = (*LoggedTransport).getFlags
+	StripUnsafeRunes = stripUnsafeRunes
+)
 
 func MockUserAgent(mock string) (restore func()) {
 	old := userAgent

--- a/httputil/useragent.go
+++ b/httputil/useragent.go
@@ -75,14 +75,15 @@ func sanitizeKernelVersion(in string) string {
 	return out
 }
 
-func stripUnsafeRunes(in string) string {
-	mapping := func(r rune) rune {
-		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
-			return r
-		}
-		return -1
+func safeRuneMapper(r rune) rune {
+	if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+		return r
 	}
-	return strings.Map(mapping, in)
+	return -1
+}
+
+func stripUnsafeRunes(in string) string {
+	return strings.Map(safeRuneMapper, in)
 }
 
 // UserAgent returns the user-agent string setup through SetUserAgentFromVersion.

--- a/httputil/useragent.go
+++ b/httputil/useragent.go
@@ -60,7 +60,7 @@ func SetUserAgentFromVersion(version string, extraProds ...string) {
 	// xxx this assumes ReleaseInfo's ID and VersionID don't have weird characters
 	// (see rfc 7231 for values of weird)
 	// assumption checks out in practice, q.v. https://github.com/zyga/os-release-zoo
-	userAgent = fmt.Sprintf("snapd/%v (%s)%s %s/%s (%s %s)", version,
+	userAgent = fmt.Sprintf("snapd/%v (%s)%s %s/%s (%s) linux/%s", version,
 		strings.Join(extras, "; "), extraProdStr, release.ReleaseInfo.ID,
 		release.ReleaseInfo.VersionID, string(arch.UbuntuArchitecture()),
 		stripUnsafeRunes(release.KernelVersion()))

--- a/httputil/useragent.go
+++ b/httputil/useragent.go
@@ -63,7 +63,16 @@ func SetUserAgentFromVersion(version string, extraProds ...string) {
 	userAgent = fmt.Sprintf("snapd/%v (%s)%s %s/%s (%s) linux/%s", version,
 		strings.Join(extras, "; "), extraProdStr, release.ReleaseInfo.ID,
 		release.ReleaseInfo.VersionID, string(arch.UbuntuArchitecture()),
-		stripUnsafeRunes(release.KernelVersion()))
+		sanitizeKernelVersion(release.KernelVersion()))
+}
+
+func sanitizeKernelVersion(in string) string {
+	out := stripUnsafeRunes(in)
+	// Arbitrary choice, limit kernel version to 20 characters
+	if len(out) > 20 {
+		out = out[:20]
+	}
+	return out
 }
 
 func stripUnsafeRunes(in string) string {

--- a/httputil/useragent.go
+++ b/httputil/useragent.go
@@ -63,7 +63,17 @@ func SetUserAgentFromVersion(version string, extraProds ...string) {
 	userAgent = fmt.Sprintf("snapd/%v (%s)%s %s/%s (%s %s)", version,
 		strings.Join(extras, "; "), extraProdStr, release.ReleaseInfo.ID,
 		release.ReleaseInfo.VersionID, string(arch.UbuntuArchitecture()),
-		release.KernelVersion())
+		stripUnsafeRunes(release.KernelVersion()))
+}
+
+func stripUnsafeRunes(in string) string {
+	mapping := func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			return r
+		}
+		return -1
+	}
+	return strings.Map(mapping, in)
 }
 
 // UserAgent returns the user-agent string setup through SetUserAgentFromVersion.

--- a/httputil/useragent.go
+++ b/httputil/useragent.go
@@ -68,9 +68,9 @@ func SetUserAgentFromVersion(version string, extraProds ...string) {
 
 func sanitizeKernelVersion(in string) string {
 	out := stripUnsafeRunes(in)
-	// Arbitrary choice, limit kernel version to 20 characters
-	if len(out) > 20 {
-		out = out[:20]
+	// Arbitrary choice, limit kernel version to 25 characters
+	if len(out) > 25 {
+		out = out[:25]
 	}
 	return out
 }

--- a/httputil/useragent.go
+++ b/httputil/useragent.go
@@ -60,7 +60,10 @@ func SetUserAgentFromVersion(version string, extraProds ...string) {
 	// xxx this assumes ReleaseInfo's ID and VersionID don't have weird characters
 	// (see rfc 7231 for values of weird)
 	// assumption checks out in practice, q.v. https://github.com/zyga/os-release-zoo
-	userAgent = fmt.Sprintf("snapd/%v (%s)%s %s/%s (%s)", version, strings.Join(extras, "; "), extraProdStr, release.ReleaseInfo.ID, release.ReleaseInfo.VersionID, string(arch.UbuntuArchitecture()))
+	userAgent = fmt.Sprintf("snapd/%v (%s)%s %s/%s (%s %s)", version,
+		strings.Join(extras, "; "), extraProdStr, release.ReleaseInfo.ID,
+		release.ReleaseInfo.VersionID, string(arch.UbuntuArchitecture()),
+		release.KernelVersion())
 }
 
 // UserAgent returns the user-agent string setup through SetUserAgentFromVersion.

--- a/httputil/useragent_test.go
+++ b/httputil/useragent_test.go
@@ -71,9 +71,9 @@ func (s *UASuite) TestStripUnsafeRunes(c *C) {
 }
 
 func (s *UASuite) TestSanitizeKernelVersion(c *C) {
-	// Ensure that it is not too long (at most 20 runes)
+	// Ensure that it is not too long (at most 25 runes)
 	const in = "this-is-a-very-long-thing-that-pretends-to-be-a-kernel-version-string"
-	const out = "this-is-a-very-long-"
+	const out = "this-is-a-very-long-thing"
 	c.Check(httputil.SanitizeKernelVersion(in), Equals, out)
 
 }

--- a/httputil/useragent_test.go
+++ b/httputil/useragent_test.go
@@ -69,3 +69,11 @@ func (s *UASuite) TestStripUnsafeRunes(c *C) {
 	}
 
 }
+
+func (s *UASuite) TestSanitizeKernelVersion(c *C) {
+	// Ensure that it is not too long (at most 20 runes)
+	const in = "this-is-a-very-long-thing-that-pretends-to-be-a-kernel-version-string"
+	const out = "this-is-a-very-long-"
+	c.Check(httputil.SanitizeKernelVersion(in), Equals, out)
+
+}

--- a/httputil/useragent_test.go
+++ b/httputil/useragent_test.go
@@ -50,3 +50,22 @@ func (s *UASuite) TestUserAgent(c *C) {
 	ua = httputil.UserAgent()
 	c.Check(strings.Contains(ua, "extraProd"), Equals, true)
 }
+
+func (s *UASuite) TestStripUnsafeRunes(c *C) {
+	// Sanity check, strings like that are not modified
+	for _, unchanged := range []string{
+		"abc-xyz-ABC-XYZ-0-9",
+		".", "-", "_",
+		"4.4.0-62-generic",
+		"4.8.6-x86_64-linode78",
+	} {
+		c.Check(httputil.StripUnsafeRunes(unchanged), Equals, unchanged, Commentf("%q", unchanged))
+	}
+	for _, t := range []struct{ orig, changed string }{
+		{"space bar", "spacebar"},
+		{"~;+()[]", ""}, // most punctuation goes away
+	} {
+		c.Check(httputil.StripUnsafeRunes(t.orig), Equals, t.changed)
+	}
+
+}

--- a/release/export_linux_test.go
+++ b/release/export_linux_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package release
+
+var (
+	GetKernelRelease = getKernelRelease
+)

--- a/release/uname_linux.go
+++ b/release/uname_linux.go
@@ -1,0 +1,43 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package release
+
+import (
+	"syscall"
+)
+
+func int8ToString(input []int8) string {
+	output := make([]byte, len(input))
+	for i, c := range input {
+		output[i] = byte(c)
+	}
+	return string(output)
+}
+
+// KernelVersion returns the version of the kernel or the empty string if one cannot be determined.
+func KernelVersion() string {
+	var buf syscall.Utsname
+	err := syscall.Uname(&buf)
+	if err != nil {
+		return ""
+	}
+	// Release is more informative than Version.
+	return int8ToString(buf.Release[:])
+}

--- a/release/uname_linux.go
+++ b/release/uname_linux.go
@@ -23,14 +23,6 @@ import (
 	"syscall"
 )
 
-func int8ToString(input []int8) string {
-	output := make([]byte, len(input))
-	for i, c := range input {
-		output[i] = byte(c)
-	}
-	return string(output)
-}
-
 // KernelVersion returns the version of the kernel or the empty string if one cannot be determined.
 func KernelVersion() string {
 	var buf syscall.Utsname
@@ -39,5 +31,18 @@ func KernelVersion() string {
 		return ""
 	}
 	// Release is more informative than Version.
-	return int8ToString(buf.Release[:])
+	input := buf.Release[:]
+	// The Utsname structures uses [65]int8 or [65]uint8, depending on
+	// architecture, to represent various fields. We need to conver them to
+	// strings.
+	output := make([]byte, 0, len(input))
+	for _, c := range input {
+		// The input buffer has fixed size but we want to break at the first
+		// zero we encounter.
+		if c == 0 {
+			break
+		}
+		output = append(output, byte(c))
+	}
+	return string(output)
 }

--- a/release/uname_linux.go
+++ b/release/uname_linux.go
@@ -23,14 +23,7 @@ import (
 	"syscall"
 )
 
-// KernelVersion returns the version of the kernel or the empty string if one cannot be determined.
-func KernelVersion() string {
-	var buf syscall.Utsname
-	err := syscall.Uname(&buf)
-	if err != nil {
-		return ""
-	}
-	// Release is more informative than Version.
+func getKernelRelease(buf *syscall.Utsname) string {
 	input := buf.Release[:]
 	// The Utsname structures uses [65]int8 or [65]uint8, depending on
 	// architecture, to represent various fields. We need to conver them to
@@ -45,4 +38,15 @@ func KernelVersion() string {
 		output = append(output, byte(c))
 	}
 	return string(output)
+}
+
+// KernelVersion returns the version of the kernel or the empty string if one cannot be determined.
+func KernelVersion() string {
+	var buf syscall.Utsname
+	err := syscall.Uname(&buf)
+	if err != nil {
+		return ""
+	}
+	// Release is more informative than Version.
+	return getKernelRelease(&buf)
 }

--- a/release/uname_linux_test.go
+++ b/release/uname_linux_test.go
@@ -20,6 +20,8 @@
 package release_test
 
 import (
+	"syscall"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/release"
@@ -29,4 +31,22 @@ func (s *ReleaseTestSuite) TestKernelVersion(c *C) {
 	ver := release.KernelVersion()
 	// Ensure that we got something.
 	c.Check(ver, Not(Equals), "")
+}
+
+func (s *ReleaseTestSuite) TestGetKenrelRelease(c *C) {
+	var buf syscall.Utsname
+	c.Check(release.GetKernelRelease(&buf), Equals, "")
+
+	buf.Release[0] = 'f'
+	buf.Release[1] = 'o'
+	buf.Release[2] = 'o'
+	buf.Release[3] = 0
+	buf.Release[4] = 'u'
+	buf.Release[5] = 'n'
+	buf.Release[6] = 'u'
+	buf.Release[7] = 's'
+	buf.Release[8] = 'e'
+	buf.Release[9] = 'd'
+
+	c.Check(release.GetKernelRelease(&buf), Equals, "foo")
 }

--- a/release/uname_test.go
+++ b/release/uname_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/release/uname_test.go
+++ b/release/uname_test.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package release_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/release"
+)
+
+func (s *ReleaseTestSuite) TestKernelVersion(c *C) {
+	ver := release.KernelVersion()
+	// Ensure that we got something.
+	c.Check(ver, Not(Equals), "")
+}


### PR DESCRIPTION
This branch adds information about the kernel version to the user agent and to the version data. It can also be used to report errors back to daisy (in a separate branch).