### PR TITLE
overlord/ifacestate: don't unconditionally retry stuff

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -183,8 +183,7 @@ func (m *InterfaceManager) removeProfilesForSnap(task *state.Task, _ *tomb.Tomb,
 
 	// Remove security artefacts of the snap.
 	if err := removeSnapSecurity(task, snapName); err != nil {
-		// TODO: how long to wait?
-		return &state.Retry{}
+		return err
 	}
 
 	return nil
@@ -431,7 +430,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 		}
 		opts := confinementOptions(snapst.Flags)
 		if err := setupSnapSecurity(task, snapInfo, opts, m.repo); err != nil {
-			return &state.Retry{}
+			return err
 		}
 	}
 	for _, conn := range affectedConns {


### PR DESCRIPTION
This patch changes two unconditional state.Retry errors so that we don't
ever loop on those. It is better to surface the error and let us deal
with it rather than have the code spin somewhere, potentially forever.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>