### PR TITLE
overlord/ifacestate: improve error messages

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -44,6 +44,8 @@ func confinementOptions(flags snapstate.Flags) interfaces.ConfinementOptions {
 }
 
 func (m *InterfaceManager) setupAffectedSnaps(task *state.Task, affectingSnap string, affectedSnaps []string) error {
+	const fnName = "setupAffectedSnaps"
+
 	st := task.State()
 
 	// Setup security of the affected snaps.
@@ -54,41 +56,51 @@ func (m *InterfaceManager) setupAffectedSnaps(task *state.Task, affectingSnap st
 		}
 		var snapst snapstate.SnapState
 		if err := snapstate.Get(st, affectedSnapName, &snapst); err != nil {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot get state of snap %q (affected by change of %q): %s",
+				fnName, affectedSnapName, affectingSnap, err)
 		}
 		affectedSnapInfo, err := snapst.CurrentInfo()
 		if err != nil {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot get current information about snap %q (affected by change of %q): %s",
+				fnName, affectedSnapName, affectingSnap, err)
 		}
 		snap.AddImplicitSlots(affectedSnapInfo)
 		opts := confinementOptions(snapst.Flags)
 		if err := setupSnapSecurity(task, affectedSnapInfo, opts, m.repo); err != nil {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot setup security profiles for snap %q (affected by change of %q): %s",
+				fnName, affectedSnapName, affectingSnap, err)
 		}
 	}
 	return nil
 }
 
 func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) error {
+	const fnName = "doSetupProfiles"
+
 	task.State().Lock()
 	defer task.State().Unlock()
 
 	// Get snap.Info from bits handed by the snap manager.
 	snapsup, err := snapstate.TaskSnapSetup(task)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get snap setup data: %s", fnName, err)
 	}
 
 	snapInfo, err := snap.ReadInfo(snapsup.Name(), snapsup.SideInfo)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot read info of snap %q: %s", fnName, snapsup.Name(), err)
 	}
 
 	opts := confinementOptions(snapsup.Flags)
-	return m.setupProfilesForSnap(task, tomb, snapInfo, opts)
+	if err := m.setupProfilesForSnap(task, tomb, snapInfo, opts); err != nil {
+		return fmt.Errorf("(internal error, %s) cannot setup security profiles for snap %q: %s", fnName, snapInfo.Name(), err)
+	}
+	return nil
 }
 
 func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, snapInfo *snap.Info, opts interfaces.ConfinementOptions) error {
+	const fnName = "setupProfilesForSnap"
+
 	snap.AddImplicitSlots(snapInfo)
 	snapName := snapInfo.Name()
 
@@ -104,31 +116,31 @@ func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, 
 	// - setup the security of all the affected snaps
 	disconnectedSnaps, err := m.repo.DisconnectSnap(snapName)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot temporarily disconnect interface repository connections of snap %q: %s", fnName, snapName, err)
 	}
 	// XXX: what about snap renames? We should remove the old name (or switch
 	// to IDs in the interfaces repository)
 	if err := m.repo.RemoveSnap(snapName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot temporarily remove snap %q from the interface repository: %s", fnName, snapName, err)
 	}
 	if err := m.repo.AddSnap(snapInfo); err != nil {
 		if _, ok := err.(*interfaces.BadInterfacesError); ok {
 			task.Logf("%s", err)
 		} else {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot re-add snap %q to interface repository: %s", fnName, snapName, err)
 		}
 	}
 	if err := m.reloadConnections(snapName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot reload interface repository connections of snap %q: %s", fnName, snapName, err)
 	}
 	// FIXME: here we should not reconnect auto-connect plug/slot
 	// pairs that were explicitly disconnected by the user
 	connectedSnaps, err := m.autoConnect(task, snapName, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot auto-connect snap %q: %s", fnName, snapName, err)
 	}
 	if err := setupSnapSecurity(task, snapInfo, opts, m.repo); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot setup security profiles for snap %q: %s", fnName, snapName, err)
 	}
 	affectedSet := make(map[string]bool)
 	for _, name := range disconnectedSnaps {
@@ -144,10 +156,15 @@ func (m *InterfaceManager) setupProfilesForSnap(task *state.Task, _ *tomb.Tomb, 
 		affectedSnaps = append(affectedSnaps, name)
 	}
 	sort.Strings(affectedSnaps)
-	return m.setupAffectedSnaps(task, snapName, affectedSnaps)
+	if err := m.setupAffectedSnaps(task, snapName, affectedSnaps); err != nil {
+		return fmt.Errorf("(internal error, %s) cannot setup security profiles for snaps %q affected by changes to connections of snap %q: %s", fnName, affectedSnaps, snapName, err)
+	}
+	return nil
 }
 
 func (m *InterfaceManager) doRemoveProfiles(task *state.Task, tomb *tomb.Tomb) error {
+	const fnName = "doRemoveProfiles"
+
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
@@ -155,48 +172,56 @@ func (m *InterfaceManager) doRemoveProfiles(task *state.Task, tomb *tomb.Tomb) e
 	// Get SnapSetup for this snap. This is gives us the name of the snap.
 	snapSetup, err := snapstate.TaskSnapSetup(task)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get snap setup data: %s", fnName, err)
 	}
 	snapName := snapSetup.Name()
 
-	return m.removeProfilesForSnap(task, tomb, snapName)
+	if err := m.removeProfilesForSnap(task, tomb, snapName); err != nil {
+		return fmt.Errorf("(internal error, %s) cannot remove security profiles of snap %q: %s", fnName, snapName, err)
+	}
+	return nil
 }
 
 func (m *InterfaceManager) removeProfilesForSnap(task *state.Task, _ *tomb.Tomb, snapName string) error {
+	const fnName = "removeProfilesForSnap"
+
 	// Disconnect the snap entirely.
 	// This is required to remove the snap from the interface repository.
 	// The returned list of affected snaps will need to have its security setup
 	// to reflect the change.
 	affectedSnaps, err := m.repo.DisconnectSnap(snapName)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot disconnect interface repository connections of snap %q: %s", fnName, snapName, err)
 	}
+
 	if err := m.setupAffectedSnaps(task, snapName, affectedSnaps); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot setup security of snaps (%s) affected by changes to connections of snap %q: %s", fnName, affectedSnaps, snapName, err)
 	}
 
 	// Remove the snap from the interface repository.
 	// This discards all the plugs and slots belonging to that snap.
 	if err := m.repo.RemoveSnap(snapName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot remove snap %q from the interface repository: %s", fnName, snapName, err)
 	}
 
 	// Remove security artefacts of the snap.
 	if err := removeSnapSecurity(task, snapName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot remove security profiles of snap %q: %s", fnName, snapName, err)
 	}
 
 	return nil
 }
 
 func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) error {
+	const fnName = "undoSetupProfiles"
+
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
 
 	snapsup, err := snapstate.TaskSnapSetup(task)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get snap setup data: %s", fnName, err)
 	}
 	snapName := snapsup.Name()
 
@@ -205,31 +230,38 @@ func (m *InterfaceManager) undoSetupProfiles(task *state.Task, tomb *tomb.Tomb) 
 	var snapst snapstate.SnapState
 	err = snapstate.Get(st, snapName, &snapst)
 	if err != nil && err != state.ErrNoState {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get state of snap %q: %s", fnName, snapName, err)
 	}
 	sideInfo := snapst.CurrentSideInfo()
 	if sideInfo == nil {
 		// The snap was not installed before so undo should remove security profiles.
-		return m.removeProfilesForSnap(task, tomb, snapName)
+		if err := m.removeProfilesForSnap(task, tomb, snapName); err != nil {
+			return fmt.Errorf("(internal error, %s) cannot remove security profiles of snap %q: %s", fnName, snapName, err)
+		}
 	} else {
 		// The snap was installed before so undo should setup the old security profiles.
 		snapInfo, err := snap.ReadInfo(snapName, sideInfo)
 		if err != nil {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot read info of snap %q: %s", fnName, snapName, err)
 		}
 		opts := confinementOptions(snapst.Flags)
-		return m.setupProfilesForSnap(task, tomb, snapInfo, opts)
+		if err := m.setupProfilesForSnap(task, tomb, snapInfo, opts); err != nil {
+			return fmt.Errorf("(internal error, %s) cannot setup security profiles of snap %q: %s", fnName, snapName, err)
+		}
 	}
+	return nil
 }
 
 func (m *InterfaceManager) doDiscardConns(task *state.Task, _ *tomb.Tomb) error {
+	const fnName = "doDiscardConns"
+
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
 
 	snapSetup, err := snapstate.TaskSnapSetup(task)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get snap setup data: %s", fnName, err)
 	}
 
 	snapName := snapSetup.Name()
@@ -237,7 +269,7 @@ func (m *InterfaceManager) doDiscardConns(task *state.Task, _ *tomb.Tomb) error 
 	var snapst snapstate.SnapState
 	err = snapstate.Get(st, snapName, &snapst)
 	if err != nil && err != state.ErrNoState {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get state of snap %q: %s", fnName, snapName, err)
 	}
 
 	if err == nil && len(snapst.Sequence) != 0 {
@@ -245,13 +277,13 @@ func (m *InterfaceManager) doDiscardConns(task *state.Task, _ *tomb.Tomb) error 
 	}
 	conns, err := getConns(st)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get state of connections: %s", fnName, err)
 	}
 	removed := make(map[string]connState)
 	for id := range conns {
 		connRef, err := interfaces.ParseConnRef(id)
 		if err != nil {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot parse connection reference %q: %s", fnName, id, err)
 		}
 		if connRef.PlugRef.Snap == snapName || connRef.SlotRef.Snap == snapName {
 			removed[id] = conns[id]
@@ -264,6 +296,8 @@ func (m *InterfaceManager) doDiscardConns(task *state.Task, _ *tomb.Tomb) error 
 }
 
 func (m *InterfaceManager) undoDiscardConns(task *state.Task, _ *tomb.Tomb) error {
+	const fnName = "undoDiscardConns"
+
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
@@ -271,12 +305,12 @@ func (m *InterfaceManager) undoDiscardConns(task *state.Task, _ *tomb.Tomb) erro
 	var removed map[string]connState
 	err := task.Get("removed", &removed)
 	if err != nil && err != state.ErrNoState {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get removed connections: %s", fnName, err)
 	}
 
 	conns, err := getConns(st)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get state of connections: %s", fnName, err)
 	}
 
 	for id, connState := range removed {
@@ -288,18 +322,20 @@ func (m *InterfaceManager) undoDiscardConns(task *state.Task, _ *tomb.Tomb) erro
 }
 
 func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
+	const fnName = "doConnect"
+
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
 
 	plugRef, slotRef, err := getPlugAndSlotRefs(task)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get plug and slot references: %s", fnName, err)
 	}
 
 	conns, err := getConns(st)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get state of connections: %s", fnName, err)
 	}
 
 	connRef := interfaces.ConnRef{PlugRef: plugRef, SlotRef: slotRef}
@@ -332,7 +368,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 
 	baseDecl, err := assertstate.BaseDeclaration(st)
 	if err != nil {
-		return fmt.Errorf("internal error: cannot find base declaration: %v", err)
+		return fmt.Errorf("(internal error, %s) cannot find base declaration: %v", fnName, err)
 	}
 
 	// check the connection against the declarations' rules
@@ -356,26 +392,33 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 
 	err = m.repo.Connect(connRef)
 	if err != nil {
+		// NOTE: repository.Connect already produces useful error messages
 		return err
 	}
 
 	var plugSnapst snapstate.SnapState
 	if err := snapstate.Get(st, connRef.PlugRef.Snap, &plugSnapst); err != nil {
-		return err
+		// XXX: ErrNoState not handled (but unexpected in doConnect)
+		return fmt.Errorf("(internal error, %s) cannot get state of snap %q (plug-side, just-connected): %s",
+			fnName, connRef.PlugRef.Snap, err)
 	}
 
 	var slotSnapst snapstate.SnapState
 	if err := snapstate.Get(st, connRef.SlotRef.Snap, &slotSnapst); err != nil {
-		return err
+		// XXX: ErrNoState not handled (but unexpected in doConnect)
+		return fmt.Errorf("(internal error, %s) cannot get state of snap %q (slot-side, just-connected): %s",
+			fnName, connRef.SlotRef.Snap, err)
 	}
 
 	slotOpts := confinementOptions(slotSnapst.Flags)
 	if err := setupSnapSecurity(task, slot.Snap, slotOpts, m.repo); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot setup security of snap %q (slot-side, just-connected): %s",
+			fnName, slot.Snap.Name(), err)
 	}
 	plugOpts := confinementOptions(plugSnapst.Flags)
 	if err := setupSnapSecurity(task, plug.Snap, plugOpts, m.repo); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot setup security of snap %q (plug-side, just-connected): %s",
+			fnName, plug.Snap.Name(), err)
 	}
 
 	conns[connRef.ID()] = connState{Interface: plug.Interface}
@@ -399,38 +442,45 @@ func snapNamesFromConns(conns []interfaces.ConnRef) []string {
 }
 
 func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
+	const fnName = "doDisconnect"
+
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
 
 	plugRef, slotRef, err := getPlugAndSlotRefs(task)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get plug and slot references: %s", fnName, err)
 	}
 
 	conns, err := getConns(st)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get state of connections: %s", fnName, err)
 	}
 
 	affectedConns, err := m.repo.ResolveDisconnect(plugRef.Snap, plugRef.Name, slotRef.Snap, slotRef.Name)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get resolve disconnect %q:%q %q:%q: %s",
+			fnName, plugRef.Snap, plugRef.Name, slotRef.Snap, slotRef.Name, err)
 	}
 	m.repo.DisconnectAll(affectedConns)
 	affectedSnaps := snapNamesFromConns(affectedConns)
 	for _, snapName := range affectedSnaps {
 		var snapst snapstate.SnapState
+		// XXX: ErrNoState not handled (but unexpected in doDisconnect)
 		if err := snapstate.Get(st, snapName, &snapst); err != nil {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot get state of snap %q (affected by disconnect): %s",
+				fnName, snapName, err)
 		}
 		snapInfo, err := snapst.CurrentInfo()
 		if err != nil {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot get current info of snap %q (affected by disconnect): %s",
+				fnName, snapName, err)
 		}
 		opts := confinementOptions(snapst.Flags)
 		if err := setupSnapSecurity(task, snapInfo, opts, m.repo); err != nil {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot setup security of snap %q (affected by disconnect): %s",
+				fnName, snapInfo.Name(), err)
 		}
 	}
 	for _, conn := range affectedConns {
@@ -446,16 +496,18 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 // know that newName supports everything that oldName supports,
 // otherwise you will be in a world of pain.
 func (m *InterfaceManager) transitionConnectionsCoreMigration(st *state.State, oldName, newName string) error {
+	const fnName = "transitionConnectionsCoreMigration"
+
 	// transition over, ubuntu-core has only slots
 	conns, err := getConns(st)
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get state of connections: %s", fnName, err)
 	}
 
 	for id := range conns {
 		connRef, err := interfaces.ParseConnRef(id)
 		if err != nil {
-			return err
+			return fmt.Errorf("(internal error, %s) cannot parse connection reference %q: %s", fnName, id, err)
 		}
 		if connRef.SlotRef.Snap == oldName {
 			connRef.SlotRef.Snap = newName
@@ -471,32 +523,40 @@ func (m *InterfaceManager) transitionConnectionsCoreMigration(st *state.State, o
 	// exactly the same profiles and nothing in the generated policies
 	// has the slot-name encoded.
 	if err := m.reloadConnections(oldName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot reload connections of old core %q: %s", fnName, oldName, err)
 	}
 	if err := m.reloadConnections(newName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot reload connections of new core %q: %s", fnName, newName, err)
 	}
 
 	return nil
 }
 
 func (m *InterfaceManager) doTransitionUbuntuCore(t *state.Task, _ *tomb.Tomb) error {
+	const fnName = "doTransitionUbuntuCore"
+
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
 
 	var oldName, newName string
 	if err := t.Get("old-name", &oldName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get name of the old core: %s", fnName, err)
 	}
 	if err := t.Get("new-name", &newName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get name of the new core: %s", fnName, err)
 	}
 
-	return m.transitionConnectionsCoreMigration(st, oldName, newName)
+	if err := m.transitionConnectionsCoreMigration(st, oldName, newName); err != nil {
+		return fmt.Errorf("(internal error, %s) cannot transition connections for core migration %q -> %q: %s", fnName, oldName, newName, err)
+	}
+
+	return nil
 }
 
 func (m *InterfaceManager) undoTransitionUbuntuCore(t *state.Task, _ *tomb.Tomb) error {
+	const fnName = "undoTransitionUbuntuCore"
+
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -504,11 +564,15 @@ func (m *InterfaceManager) undoTransitionUbuntuCore(t *state.Task, _ *tomb.Tomb)
 	// symmetrical to the "do" method, just reverse them again
 	var oldName, newName string
 	if err := t.Get("old-name", &oldName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get name of the old core: %s", fnName, err)
 	}
 	if err := t.Get("new-name", &newName); err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get name of the new core: %s", fnName, err)
 	}
 
-	return m.transitionConnectionsCoreMigration(st, newName, oldName)
+	if err := m.transitionConnectionsCoreMigration(st, newName, oldName); err != nil {
+		return fmt.Errorf("(internal error, %s) cannot transition connections for core migration %q -> %q: %s", fnName, newName, oldName, err)
+	}
+
+	return nil
 }

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -183,8 +183,7 @@ func (m *InterfaceManager) removeProfilesForSnap(task *state.Task, _ *tomb.Tomb,
 
 	// Remove security artefacts of the snap.
 	if err := removeSnapSecurity(task, snapName); err != nil {
-		// TODO: how long to wait?
-		return &state.Retry{}
+		return err
 	}
 
 	return nil
@@ -431,7 +430,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 		}
 		opts := confinementOptions(snapst.Flags)
 		if err := setupSnapSecurity(task, snapInfo, opts, m.repo); err != nil {
-			return &state.Retry{}
+			return err
 		}
 	}
 	for _, conn := range affectedConns {

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -460,8 +460,8 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 
 	affectedConns, err := m.repo.ResolveDisconnect(plugRef.Snap, plugRef.Name, slotRef.Snap, slotRef.Name)
 	if err != nil {
-		return fmt.Errorf("(internal error, %s) cannot get resolve disconnect %q:%q %q:%q: %s",
-			fnName, plugRef.Snap, plugRef.Name, slotRef.Snap, slotRef.Name, err)
+		// NOTE: ResolveDisconnect already produces nice error messages
+		return err
 	}
 	m.repo.DisconnectAll(affectedConns)
 	affectedSnaps := snapNamesFromConns(affectedConns)


### PR DESCRIPTION
This patch changes error reporting in the handlers for interface manager
tasks. Hopefully with the extra detailed errors we can figure out what
is failing in the field.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
