### PR TITLE
snapstate: fix incorrect cut of the timestamps for the error reports

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -96,6 +96,12 @@ func MockOpenSnapFile(mock func(path string, si *snap.SideInfo) (*snap.Info, sna
 	return func() { openSnapFile = prevOpenSnapFile }
 }
 
+func MockErrtrackerReport(mock func(string, string, string) (string, error)) (restore func()) {
+	prev := errtrackerReport
+	errtrackerReport = mock
+	return func() { errtrackerReport = prev }
+}
+
 var (
 	CheckSnap            = checkSnap
 	CanRemove            = canRemove


### PR DESCRIPTION
When errors are reported we sometimes incorrectly cut the timestamp becuase rfc3339 is not as fixed length as the original code(r) assumed. This fixes it and also adds a test.