### PR TITLE
overlord/snapstate: improve error reporting around core migration

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -394,6 +394,8 @@ func (m *SnapManager) blockedTask(cand *state.Task, running []*state.Task) bool 
 // ensureUbuntuCoreTransition will migrate systems that use "ubuntu-core"
 // to the new "core" snap
 func (m *SnapManager) ensureUbuntuCoreTransition() error {
+	const fnName = "ensureUbuntuCoreTransition"
+
 	m.state.Lock()
 	defer m.state.Unlock()
 
@@ -403,7 +405,7 @@ func (m *SnapManager) ensureUbuntuCoreTransition() error {
 		return nil
 	}
 	if err != nil && err != state.ErrNoState {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get state of the ubuntu-core snap: %s", fnName, err)
 	}
 
 	// check that there is no change in flight already, this is a
@@ -419,7 +421,7 @@ func (m *SnapManager) ensureUbuntuCoreTransition() error {
 	var retryCount int
 	err = m.state.Get("ubuntu-core-transition-retry", &retryCount)
 	if err != nil && err != state.ErrNoState {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot get ubuntu core transition retry count: %s", fnName, err)
 	}
 	if retryCount > 6 {
 		// limit amount of retries
@@ -434,7 +436,7 @@ func (m *SnapManager) ensureUbuntuCoreTransition() error {
 
 	tss, err := TransitionCore(m.state, "ubuntu-core", "core")
 	if err != nil {
-		return err
+		return fmt.Errorf("(internal error, %s) cannot transition from ubuntu-core to core: %s", fnName, err)
 	}
 
 	msg := fmt.Sprintf(i18n.G("Transition ubuntu-core to core"))


### PR DESCRIPTION
This patch improves error reporting during the ubuntu-core -> core
transition. It should help us pinpoint the mysterious ErrNoState error
that shows up in the field.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>