### PR TITLE
overlord/ifacestate: loudly ignore ErrNoState where we cannot handle it

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -57,7 +57,7 @@ func (m *InterfaceManager) setupAffectedSnaps(task *state.Task, affectingSnap st
 			if err == state.ErrNoState {
 				// NOTE: This is a temporary measure until the root cause of issue
 				// like this can be found and corrected.
-				task.Errorf("cannot get state of snap %q that was affected by a change to snap %q -- skipping setup of security profiles",
+				task.Errorf("cannot get state of snap %q that was affected by a change to snap %q -- skipping setup of its security profiles",
 					affectedSnapName, affectingSnap)
 				continue
 			}
@@ -374,7 +374,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		// NOTE: This is a temporary measure until the root cause of issue
 		// like this can be found and corrected.
-		task.Errorf("cannot get state of snap %q (slot side) -- skipping setup of security profiles", connRef.SlotRef.Snap)
+		task.Errorf("cannot get state of snap %q (slot side) -- skipping setup of its security profiles", connRef.SlotRef.Snap)
 	} else {
 		slotOpts := confinementOptions(slotSnapst.Flags)
 		if err := setupSnapSecurity(task, slot.Snap, slotOpts, m.repo); err != nil {
@@ -390,7 +390,7 @@ func (m *InterfaceManager) doConnect(task *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		// NOTE: This is a temporary measure until the root cause of issue
 		// like this can be found and corrected.
-		task.Errorf("cannot get state of snap %q (plug side) -- skipping setup of security profiles", connRef.PlugRef.Snap)
+		task.Errorf("cannot get state of snap %q (plug side) -- skipping setup of its security profiles", connRef.PlugRef.Snap)
 	} else {
 		plugOpts := confinementOptions(plugSnapst.Flags)
 		if err := setupSnapSecurity(task, plug.Snap, plugOpts, m.repo); err != nil {
@@ -445,7 +445,7 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 			if err == state.ErrNoState {
 				// NOTE: This is a temporary measure until the root cause of issue
 				// like this can be found and corrected.
-				task.Errorf("cannot get state of snap %q that was affected by the disconnection of %s %s -- skipping setup of security profiles",
+				task.Errorf("cannot get state of snap %q that was affected by the disconnection of %s %s -- skipping setup of its security profiles",
 					snapName, plugRef, slotRef)
 				continue
 			}

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -54,6 +54,13 @@ func (m *InterfaceManager) setupAffectedSnaps(task *state.Task, affectingSnap st
 		}
 		var snapst snapstate.SnapState
 		if err := snapstate.Get(st, affectedSnapName, &snapst); err != nil {
+			if err == state.ErrNoState {
+				// NOTE: This is a temporary measure until the root cause of issue
+				// like this can be found and corrected.
+				task.Errorf("cannot get state of snap %q that was affected by a change to snap %q -- skipping setup of security profiles",
+					affectedSnapName, affectingSnap)
+				continue
+			}
 			return err
 		}
 		affectedSnapInfo, err := snapst.CurrentInfo()

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -442,6 +442,13 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 	for _, snapName := range affectedSnaps {
 		var snapst snapstate.SnapState
 		if err := snapstate.Get(st, snapName, &snapst); err != nil {
+			if err == state.ErrNoState {
+				// NOTE: This is a temporary measure until the root cause of issue
+				// like this can be found and corrected.
+				task.Errorf("cannot get state of snap %q that was affected by the disconnection of %s %s -- skipping setup of security profiles",
+					snapName, plugRef, slotRef)
+				continue
+			}
 			return err
 		}
 		snapInfo, err := snapst.CurrentInfo()


### PR DESCRIPTION
This branch patches three places where the interface manager needs to get the state of a snap in order to finish the setup of security profiles. While we don't have a confirmation we suspect that this is responsible for failures that block snapd update in the field.

This is related to https://bugs.launchpad.net/snappy/+bug/1666978 but is not a real fix, just a way to get those devices moving. Eventually we will fix the "issues" this causes by refreshing security of every snap on startup.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>