### PR TITLE
snapstate: retry ubuntu-core -> core transition every 6h

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -21,7 +21,6 @@ package snapstate
 
 import (
 	"errors"
-	"time"
 
 	"gopkg.in/tomb.v2"
 
@@ -82,12 +81,6 @@ func MockReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, error))
 	old := readInfo
 	readInfo = mock
 	return func() { readInfo = old }
-}
-
-func MockLastUbuntuCoreTransitionAttempt(m *SnapManager, last time.Time) (restorer func()) {
-	orig := m.lastUbuntuCoreTransitionAttempt
-	m.lastUbuntuCoreTransitionAttempt = last
-	return func() { m.lastUbuntuCoreTransitionAttempt = orig }
 }
 
 func MockOpenSnapFile(mock func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error)) (restore func()) {


### PR DESCRIPTION
As suggested by Gustavo we want to retry the transition every 6h.

This will need extra careful reviewing because it has the potential to re-create the storm we saw last week.