### PR TITLE
errtracker: include the number of ubuntu-core -> core retries

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -52,7 +52,7 @@ func distroRelease() string {
 	return fmt.Sprintf("%s %s", ID, release.ReleaseInfo.VersionID)
 }
 
-func Report(snap, channel, errMsg string) (string, error) {
+func Report(snap, channel, errMsg string, extra map[string]string) (string, error) {
 	if CrashDbURLBase == "" {
 		return "", nil
 	}
@@ -77,6 +77,12 @@ func Report(snap, channel, errMsg string) (string, error) {
 		"KernelVersion":      release.KernelVersion(),
 		"ErrorMessage":       errMsg,
 		"DuplicateSignature": fmt.Sprintf("snap-install: %s", errMsg),
+	}
+	for k, v := range extra {
+		// only set if empty
+		if _, ok := report[k]; !ok {
+			report[k] = v
+		}
 	}
 	reportBson, err := bson.Marshal(report)
 	if err != nil {

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -109,13 +109,13 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 	restorer = errtracker.MockTimeNow(func() time.Time { return time.Date(2017, 2, 17, 9, 51, 0, 0, time.UTC) })
 	defer restorer()
 
-	id, err := errtracker.Report("some-snap", "beta", "failed to do stuff")
+	id, err := errtracker.Report("some-snap", "beta", "failed to do stuff", nil)
 	c.Check(err, IsNil)
 	c.Check(id, Equals, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 	c.Check(n, Equals, 1)
 
 	// run again, verify identifier is unchanged
-	id, err = errtracker.Report("some-other-snap", "edge", "failed to do more stuff")
+	id, err = errtracker.Report("some-other-snap", "edge", "failed to do more stuff", nil)
 	c.Check(err, IsNil)
 	c.Check(id, Equals, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 	c.Check(n, Equals, 2)

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -89,7 +89,7 @@ func MockOpenSnapFile(mock func(path string, si *snap.SideInfo) (*snap.Info, sna
 	return func() { openSnapFile = prevOpenSnapFile }
 }
 
-func MockErrtrackerReport(mock func(string, string, string) (string, error)) (restore func()) {
+func MockErrtrackerReport(mock func(string, string, string, map[string]string) (string, error)) (restore func()) {
 	prev := errtrackerReport
 	errtrackerReport = mock
 	return func() { errtrackerReport = prev }

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -21,7 +21,6 @@ package snapstate
 
 import (
 	"errors"
-	"time"
 
 	"gopkg.in/tomb.v2"
 
@@ -82,12 +81,6 @@ func MockReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, error))
 	old := readInfo
 	readInfo = mock
 	return func() { readInfo = old }
-}
-
-func MockLastUbuntuCoreTransitionAttempt(m *SnapManager, last time.Time) (restorer func()) {
-	orig := m.lastUbuntuCoreTransitionAttempt
-	m.lastUbuntuCoreTransitionAttempt = last
-	return func() { m.lastUbuntuCoreTransitionAttempt = orig }
 }
 
 func MockOpenSnapFile(mock func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error)) (restore func()) {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -575,8 +575,9 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil && err != state.ErrNoState {
 		return err
 	}
-	extra := map[string]string{
-		"UbuntuCoreTransitionCount": strconv.Itoa(ubuntuCoreTransitionCount),
+	extra := map[string]string{}
+	if ubuntuCoreTransitionCount > 0 {
+		extra["UbuntuCoreTransitionCount"] = strconv.Itoa(ubuntuCoreTransitionCount)
 	}
 
 	st.Unlock()

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -569,8 +570,17 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
+	var ubuntuCoreTransitionCount int
+	err = st.Get("ubuntu-core-transition-retry", &ubuntuCoreTransitionCount)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	extra := map[string]string{
+		"UbuntuCoreTransitionCount": strconv.Itoa(ubuntuCoreTransitionCount),
+	}
+
 	st.Unlock()
-	oopsid, err := errtrackerReport(snapsup.SideInfo.RealName, snapsup.SideInfo.Channel, strings.Join(logMsg, "\n"))
+	oopsid, err := errtrackerReport(snapsup.SideInfo.RealName, snapsup.SideInfo.Channel, strings.Join(logMsg, "\n"), extra)
 	st.Lock()
 	if err == nil {
 		logger.Noticef("Reported problem as %s", oopsid)


### PR DESCRIPTION
Build on top of https://github.com/snapcore/snapd/pull/2914

This branch adds the amount of retries for the ubuntu-core -> core migration to the error report.