### PR TITLE
cmd/snap-update-ns: add function for sorting mount entries

### DIFF
--- a/cmd/snap-update-ns/mount-entry-test.c
+++ b/cmd/snap-update-ns/mount-entry-test.c
@@ -225,6 +225,31 @@ static void test_sc_clone_mount_entry_from_mntent()
 	g_assert_null(next);
 }
 
+static void test_sc_sort_mount_entries()
+{
+	struct sc_mount_entry *list;
+
+	// Sort an empty list, it should not blow up.
+	list = NULL;
+	sc_sort_mount_entries(&list);
+	g_assert(list == NULL);
+
+	// Create a list with two items in wrong order (backwards).
+	struct sc_mount_entry entry_1 = test_entry_1;
+	struct sc_mount_entry entry_2 = test_entry_2;
+	list = &entry_2;
+	entry_2.next = &entry_1;
+	entry_1.next = NULL;
+
+	// Sort the list
+	sc_sort_mount_entries(&list);
+
+	// Ensure that the linkage now follows the right order.
+	g_assert(list == &entry_1);
+	g_assert(entry_1.next == &entry_2);
+	g_assert(entry_2.next == NULL);
+}
+
 static void __attribute__ ((constructor)) init()
 {
 	g_test_add_func("/mount-entry/sc_load_mount_profile",
@@ -237,4 +262,6 @@ static void __attribute__ ((constructor)) init()
 			test_sc_compare_mount_entry);
 	g_test_add_func("/mount-entry/test_sc_clone_mount_entry_from_mntent",
 			test_sc_clone_mount_entry_from_mntent);
+	g_test_add_func("/mount-entry/test_sort_mount_entries",
+			test_sc_sort_mount_entries);
 }

--- a/cmd/snap-update-ns/mount-entry.c
+++ b/cmd/snap-update-ns/mount-entry.c
@@ -182,3 +182,44 @@ void sc_save_mount_profile(const struct sc_mount_entry *first,
 		}
 	}
 }
+
+void sc_sort_mount_entries(struct sc_mount_entry **first)
+{
+	if (*first == NULL) {
+		// NULL list is an empty list
+		return;
+	}
+	// Count the items
+	size_t count;
+	struct sc_mount_entry *entry;
+	for (count = 0, entry = *first; entry != NULL;
+	     ++count, entry = entry->next) ;
+
+	// Allocate an array of pointers
+	struct sc_mount_entry **entryp_array = NULL;
+	entryp_array = calloc(count, sizeof *entryp_array);
+	if (entryp_array == NULL) {
+		die("cannot allocate memory");
+	}
+	// Populate the array
+	entry = *first;
+	for (size_t i = 0; i < count; ++i) {
+		entryp_array[i] = entry;
+		entry = entry->next;
+	}
+
+	// Sort the array according to lexical sorting of all the elements.
+	qsort(entryp_array, count, sizeof(void *),
+	      (int (*)(const void *, const void *))
+	      sc_indirect_compare_mount_entry);
+
+	// Rewrite all the next pointers of each element.
+	for (size_t i = 0; i < count - 1; ++i) {
+		entryp_array[i]->next = entryp_array[i + 1];
+	}
+	entryp_array[count - 1]->next = NULL;
+
+	// Rewrite the pointer to the head of the list.
+	*first = entryp_array[0];
+	free(entryp_array);
+}

--- a/cmd/snap-update-ns/mount-entry.h
+++ b/cmd/snap-update-ns/mount-entry.h
@@ -60,6 +60,15 @@ sc_compare_mount_entry(const struct sc_mount_entry *a,
 		       const struct sc_mount_entry *b);
 
 /**
+ * Sort the linked list of mount entries.
+ *
+ * The initial argument is a pointer to the first element (which can be NULL).
+ * The list is sorted and all the next pointers are updated to point to the
+ * lexically subsequent element.
+ **/
+void sc_sort_mount_entries(struct sc_mount_entry **first);
+
+/**
  * Free a dynamically allocated list of strct sc_mount_entry objects.
  *
  * This function is designed to be used with


### PR DESCRIPTION
Mount entries can form a linked list that by itself is hard to sort. We
can resort to indirect sorting by allocating an array of pointers that
matches the length of the list. The array can be sorted with any of the
standard library routines (e.g. with qsort). Finally the linked list
must be re-written (all the next pointers as well as the first) pointer
to follow consecutive items in the intermediate array.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>