### PR TITLE
interfaces: specs for apparmor, seccomp, udev

### DIFF
--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package apparmor
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+// Specification assists in collecting apparmor entries associated with an interface.
+type Specification struct {
+	// Snippets are indexed by security tag.
+	Snippets     map[string][][]byte
+	securityTags []string
+}
+
+// AddSnippet adds a new apparmor snippet.
+func (spec *Specification) AddSnippet(snippet []byte) error {
+	if len(spec.securityTags) == 0 {
+		return nil
+	}
+	if spec.Snippets == nil {
+		spec.Snippets = make(map[string][][]byte)
+	}
+	for _, tag := range spec.securityTags {
+		spec.Snippets[tag] = append(spec.Snippets[tag], snippet)
+	}
+
+	return nil
+}
+
+// Implementation of methods required by interfaces.Specification
+
+// AddConnectedPlug records apparmor-specific side-effects of having a connected plug.
+func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		AppArmorConnectedPlug(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = plug.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.AppArmorConnectedPlug(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddConnectedSlot records mount-specific side-effects of having a connected slot.
+func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		AppArmorConnectedSlot(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = slot.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.AppArmorConnectedSlot(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddPermanentPlug records mount-specific side-effects of having a plug.
+func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *interfaces.Plug) error {
+	type definer interface {
+		AppArmorPermanentPlug(spec *Specification, plug *interfaces.Plug) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = plug.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.AppArmorPermanentPlug(spec, plug)
+	}
+	return nil
+}
+
+// AddPermanentSlot records mount-specific side-effects of having a slot.
+func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *interfaces.Slot) error {
+	type definer interface {
+		AppArmorPermanentSlot(spec *Specification, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = slot.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.AppArmorPermanentSlot(spec, slot)
+	}
+	return nil
+}

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -25,8 +25,8 @@ import (
 
 // Specification assists in collecting apparmor entries associated with an interface.
 type Specification struct {
-	// Snippets are indexed by security tag.
-	Snippets     map[string][][]byte
+	// snippets are indexed by security tag.
+	snippets     map[string][][]byte
 	securityTags []string
 }
 
@@ -35,14 +35,29 @@ func (spec *Specification) AddSnippet(snippet []byte) error {
 	if len(spec.securityTags) == 0 {
 		return nil
 	}
-	if spec.Snippets == nil {
-		spec.Snippets = make(map[string][][]byte)
+	if spec.snippets == nil {
+		spec.snippets = make(map[string][][]byte)
 	}
 	for _, tag := range spec.securityTags {
-		spec.Snippets[tag] = append(spec.Snippets[tag], snippet)
+		spec.snippets[tag] = append(spec.snippets[tag], snippet)
 	}
 
 	return nil
+}
+
+// Snippets returns a deep copy of all the added snippets.
+func (spec *Specification) Snippets() map[string][][]byte {
+	result := make(map[string][][]byte, len(spec.snippets))
+	for k, v := range spec.snippets {
+		vCopy := make([][]byte, 0, len(v))
+		for _, vElem := range v {
+			vElemCopy := make([]byte, len(vElem))
+			copy(vElemCopy, vElem)
+			vCopy = append(vCopy, vElemCopy)
+		}
+		result[k] = vCopy
+	}
+	return result
 }
 
 // Implementation of methods required by interfaces.Specification

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package apparmor_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/snap"
+)
+
+type specSuite struct {
+	iface *ifacetest.TestInterface
+	spec  *apparmor.Specification
+	plug  *interfaces.Plug
+	slot  *interfaces.Slot
+}
+
+var _ = Suite(&specSuite{
+	iface: &ifacetest.TestInterface{
+		InterfaceName: "test",
+		AppArmorConnectedPlugCallback: func(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			return spec.AddSnippet([]byte("connected-plug"))
+		},
+		AppArmorConnectedSlotCallback: func(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			return spec.AddSnippet([]byte("connected-slot"))
+		},
+		AppArmorPermanentPlugCallback: func(spec *apparmor.Specification, plug *interfaces.Plug) error {
+			return spec.AddSnippet([]byte("permanent-plug"))
+		},
+		AppArmorPermanentSlotCallback: func(spec *apparmor.Specification, slot *interfaces.Slot) error {
+			return spec.AddSnippet([]byte("permanent-slot"))
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "snap1"},
+			Name:      "name",
+			Interface: "test",
+			Apps: map[string]*snap.AppInfo{
+				"app1": {
+					Snap: &snap.Info{
+						SuggestedName: "snap1",
+					},
+					Name: "app1"}},
+		},
+	},
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "snap2"},
+			Name:      "name",
+			Interface: "test",
+			Apps: map[string]*snap.AppInfo{
+				"app2": {
+					Snap: &snap.Info{
+						SuggestedName: "snap2",
+					},
+					Name: "app2"}},
+		},
+	},
+})
+
+func (s *specSuite) SetUpTest(c *C) {
+	s.spec = &apparmor.Specification{}
+}
+
+// The spec.Specification can be used through the interfaces.Specification interface
+func (s *specSuite) TestSpecificationIface(c *C) {
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
+	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
+	c.Assert(s.spec.Snippets, DeepEquals, map[string][][]byte{
+		"snap.snap1.app1": {[]byte("connected-plug"), []byte("permanent-plug")},
+		"snap.snap2.app2": {[]byte("connected-slot"), []byte("permanent-slot")},
+	})
+}

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -90,7 +90,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
 	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
-	c.Assert(s.spec.Snippets, DeepEquals, map[string][][]byte{
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][][]byte{
 		"snap.snap1.app1": {[]byte("connected-plug"), []byte("permanent-plug")},
 		"snap.snap2.app2": {[]byte("connected-slot"), []byte("permanent-slot")},
 	})

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -212,7 +212,7 @@ slots:
 		Dir:     "/snap/consumer/7/import",
 		Options: []string{"bind", "ro"},
 	}}
-	c.Assert(spec.MountEntries, DeepEquals, expectedMnt)
+	c.Assert(spec.MountEntries(), DeepEquals, expectedMnt)
 }
 
 // Check that sharing of read-only snap content is possible
@@ -240,7 +240,7 @@ slots:
 		Dir:     "/snap/consumer/7/import",
 		Options: []string{"bind", "ro"},
 	}}
-	c.Assert(spec.MountEntries, DeepEquals, expectedMnt)
+	c.Assert(spec.MountEntries(), DeepEquals, expectedMnt)
 
 	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
@@ -278,7 +278,7 @@ slots:
 		Dir:     "/var/snap/consumer/7/import",
 		Options: []string{"bind"},
 	}}
-	c.Assert(spec.MountEntries, DeepEquals, expectedMnt)
+	c.Assert(spec.MountEntries(), DeepEquals, expectedMnt)
 
 	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)
@@ -318,7 +318,7 @@ slots:
 		Dir:     "/var/snap/consumer/common/import",
 		Options: []string{"bind"},
 	}}
-	c.Assert(spec.MountEntries, DeepEquals, expectedMnt)
+	c.Assert(spec.MountEntries(), DeepEquals, expectedMnt)
 
 	content, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
 	c.Assert(err, IsNil)

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -69,6 +70,13 @@ type TestInterface struct {
 	UdevConnectedSlotCallback func(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
 	UdevPermanentPlugCallback func(spec *udev.Specification, plug *interfaces.Plug) error
 	UdevPermanentSlotCallback func(spec *udev.Specification, slot *interfaces.Slot) error
+
+	// Support for interacting with the apparmor backend.
+
+	AppArmorConnectedPlugCallback func(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	AppArmorConnectedSlotCallback func(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	AppArmorPermanentPlugCallback func(spec *apparmor.Specification, plug *interfaces.Plug) error
+	AppArmorPermanentSlotCallback func(spec *apparmor.Specification, slot *interfaces.Slot) error
 
 	// Support for interacting with the kmod backend.
 	KModConnectedPlugCallback func(spec *kmod.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
@@ -248,6 +256,37 @@ func (t *TestInterface) UdevPermanentSlot(spec *udev.Specification, slot *interf
 func (t *TestInterface) UdevConnectedSlot(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	if t.UdevConnectedSlotCallback != nil {
 		return t.UdevConnectedSlotCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+// Support for interacting with the apparmor backend.
+
+func (t *TestInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.AppArmorConnectedPlugCallback != nil {
+		return t.AppArmorConnectedPlugCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	if t.AppArmorPermanentSlotCallback != nil {
+		return t.AppArmorPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.AppArmorConnectedSlotCallback != nil {
+		return t.AppArmorConnectedSlotCallback(spec, plug, slot)
+
+	}
+	return nil
+}
+
+func (t *TestInterface) AppArmorPermanentPlug(spec *apparmor.Specification, plug *interfaces.Plug) error {
+	if t.AppArmorPermanentPlugCallback != nil {
+		return t.AppArmorPermanentPlugCallback(spec, plug)
 	}
 	return nil
 }

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
@@ -74,6 +75,13 @@ type TestInterface struct {
 	KModConnectedSlotCallback func(spec *kmod.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
 	KModPermanentPlugCallback func(spec *kmod.Specification, plug *interfaces.Plug) error
 	KModPermanentSlotCallback func(spec *kmod.Specification, slot *interfaces.Slot) error
+
+	// Support for interacting with the seccomp backend.
+
+	SecCompConnectedPlugCallback func(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	SecCompConnectedSlotCallback func(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	SecCompPermanentPlugCallback func(spec *seccomp.Specification, plug *interfaces.Plug) error
+	SecCompPermanentSlotCallback func(spec *seccomp.Specification, slot *interfaces.Slot) error
 }
 
 // String() returns the same value as Name().
@@ -223,13 +231,6 @@ func (t *TestInterface) UdevConnectedPlug(spec *udev.Specification, plug *interf
 	return nil
 }
 
-func (t *TestInterface) UdevConnectedSlot(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	if t.UdevConnectedSlotCallback != nil {
-		return t.UdevConnectedSlotCallback(spec, plug, slot)
-	}
-	return nil
-}
-
 func (t *TestInterface) UdevPermanentPlug(spec *udev.Specification, plug *interfaces.Plug) error {
 	if t.UdevPermanentPlugCallback != nil {
 		return t.UdevPermanentPlugCallback(spec, plug)
@@ -240,6 +241,43 @@ func (t *TestInterface) UdevPermanentPlug(spec *udev.Specification, plug *interf
 func (t *TestInterface) UdevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
 	if t.UdevPermanentSlotCallback != nil {
 		return t.UdevPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) UdevConnectedSlot(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.UdevConnectedSlotCallback != nil {
+		return t.UdevConnectedSlotCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+// Support for interacting with the seccomp backend.
+
+func (t *TestInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.SecCompConnectedPlugCallback != nil {
+		return t.SecCompConnectedPlugCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) SecCompConnectedSlot(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.SecCompConnectedSlotCallback != nil {
+		return t.SecCompConnectedSlotCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+	if t.SecCompPermanentSlotCallback != nil {
+		return t.SecCompPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) SecCompPermanentPlug(spec *seccomp.Specification, plug *interfaces.Plug) error {
+	if t.SecCompPermanentPlugCallback != nil {
+		return t.SecCompPermanentPlugCallback(spec, plug)
 	}
 	return nil
 }

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/interfaces/udev"
 )
 
 // TestInterface is a interface for various kind of tests.
@@ -60,6 +61,13 @@ type TestInterface struct {
 	MountConnectedSlotCallback func(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
 	MountPermanentPlugCallback func(spec *mount.Specification, plug *interfaces.Plug) error
 	MountPermanentSlotCallback func(spec *mount.Specification, slot *interfaces.Slot) error
+
+	// Support for interacting with the udev backend.
+
+	UdevConnectedPlugCallback func(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	UdevConnectedSlotCallback func(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	UdevPermanentPlugCallback func(spec *udev.Specification, plug *interfaces.Plug) error
+	UdevPermanentSlotCallback func(spec *udev.Specification, slot *interfaces.Slot) error
 
 	// Support for interacting with the kmod backend.
 	KModConnectedPlugCallback func(spec *kmod.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
@@ -202,6 +210,36 @@ func (t *TestInterface) MountPermanentPlug(spec *mount.Specification, plug *inte
 func (t *TestInterface) MountPermanentSlot(spec *mount.Specification, slot *interfaces.Slot) error {
 	if t.MountPermanentSlotCallback != nil {
 		return t.MountPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}
+
+// Support for interacting with the udev backend.
+
+func (t *TestInterface) UdevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.UdevConnectedPlugCallback != nil {
+		return t.UdevConnectedPlugCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) UdevConnectedSlot(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.UdevConnectedSlotCallback != nil {
+		return t.UdevConnectedSlotCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) UdevPermanentPlug(spec *udev.Specification, plug *interfaces.Plug) error {
+	if t.UdevPermanentPlugCallback != nil {
+		return t.UdevPermanentPlugCallback(spec, plug)
+	}
+	return nil
+}
+
+func (t *TestInterface) UdevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
+	if t.UdevPermanentSlotCallback != nil {
+		return t.UdevPermanentSlotCallback(spec, slot)
 	}
 	return nil
 }

--- a/interfaces/kmod/spec.go
+++ b/interfaces/kmod/spec.go
@@ -31,19 +31,28 @@ import (
 // holds internal state that is used by the kmod backend during the interface
 // setup process.
 type Specification struct {
-	Modules map[string]bool
+	modules map[string]bool
 }
 
 // AddModule adds a kernel module, trimming spaces and ignoring duplicated modules.
 func (spec *Specification) AddModule(module string) error {
 	m := strings.TrimSpace(module)
 	if len(m) > 0 {
-		if spec.Modules == nil {
-			spec.Modules = make(map[string]bool)
+		if spec.modules == nil {
+			spec.modules = make(map[string]bool)
 		}
-		spec.Modules[m] = true
+		spec.modules[m] = true
 	}
 	return nil
+}
+
+// Modules returns a copy of the kernel module names added.
+func (spec *Specification) Modules() map[string]bool {
+	result := make(map[string]bool, len(spec.modules))
+	for k, v := range spec.modules {
+		result[k] = v
+	}
+	return result
 }
 
 // Implementation of methods required by interfaces.Specification

--- a/interfaces/kmod/spec_test.go
+++ b/interfaces/kmod/spec_test.go
@@ -92,7 +92,7 @@ func (s *specSuite) TestSmoke(c *C) {
 	m2 := "module2"
 	c.Assert(s.spec.AddModule(m1), IsNil)
 	c.Assert(s.spec.AddModule(m2), IsNil)
-	c.Assert(s.spec.Modules, DeepEquals, map[string]bool{
+	c.Assert(s.spec.Modules(), DeepEquals, map[string]bool{
 		"module1": true, "module2": true})
 }
 
@@ -101,7 +101,7 @@ func (s *specSuite) TestDeduplication(c *C) {
 	mod := "module1"
 	c.Assert(s.spec.AddModule(mod), IsNil)
 	c.Assert(s.spec.AddModule(mod), IsNil)
-	c.Assert(s.spec.Modules, DeepEquals, map[string]bool{"module1": true})
+	c.Assert(s.spec.Modules(), DeepEquals, map[string]bool{"module1": true})
 
 	var r interfaces.Specification = s.spec
 	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), IsNil)
@@ -113,7 +113,7 @@ func (s *specSuite) TestDeduplication(c *C) {
 	c.Assert(r.AddConnectedSlot(s.iface2, s.plug, s.slot), IsNil)
 	c.Assert(r.AddPermanentPlug(s.iface2, s.plug), IsNil)
 	c.Assert(r.AddPermanentSlot(s.iface2, s.slot), IsNil)
-	c.Assert(s.spec.Modules, DeepEquals, map[string]bool{
+	c.Assert(s.spec.Modules(), DeepEquals, map[string]bool{
 		"module1": true, "module2": true, "module3": true, "module4": true, "module5": true, "module6": true})
 }
 
@@ -124,6 +124,6 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), IsNil)
 	c.Assert(r.AddPermanentPlug(s.iface1, s.plug), IsNil)
 	c.Assert(r.AddPermanentSlot(s.iface1, s.slot), IsNil)
-	c.Assert(s.spec.Modules, DeepEquals, map[string]bool{
+	c.Assert(s.spec.Modules(), DeepEquals, map[string]bool{
 		"module1": true, "module2": true, "module3": true, "module4": true})
 }

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -84,13 +84,13 @@ func (b *Backend) Remove(snapName string) error {
 // deriveContent computes .fstab tables based on requests made to the specification.
 func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.FileState {
 	// No entries? Nothing to do!
-	if len(spec.MountEntries) == 0 {
+	if len(spec.mountEntries) == 0 {
 		return nil
 	}
 	// Compute the contents of the fstab file. It should contain all the mount
 	// rules collected by the backend controller.
 	var buffer bytes.Buffer
-	for _, entry := range spec.MountEntries {
+	for _, entry := range spec.mountEntries {
 		fmt.Fprintf(&buffer, "%s\n", entry)
 	}
 	fstate := &osutil.FileState{Content: buffer.Bytes(), Mode: 0644}

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -29,13 +29,20 @@ import (
 // holds internal state that is used by the mount backend during the interface
 // setup process.
 type Specification struct {
-	MountEntries []Entry
+	mountEntries []Entry
 }
 
 // AddMountEntry adds a new mount entry.
 func (spec *Specification) AddMountEntry(e Entry) error {
-	spec.MountEntries = append(spec.MountEntries, e)
+	spec.mountEntries = append(spec.mountEntries, e)
 	return nil
+}
+
+// MountEntries returns a copy of the added mount entries.
+func (spec *Specification) MountEntries() []Entry {
+	result := make([]Entry, len(spec.mountEntries))
+	copy(result, spec.mountEntries)
+	return result
 }
 
 // Implementation of methods required by interfaces.Specification

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -77,7 +77,7 @@ func (s *specSuite) TestSmoke(c *C) {
 	ent1 := mount.Entry{Name: "fs2"}
 	c.Assert(s.spec.AddMountEntry(ent0), IsNil)
 	c.Assert(s.spec.AddMountEntry(ent1), IsNil)
-	c.Assert(s.spec.MountEntries, DeepEquals, []mount.Entry{ent0, ent1})
+	c.Assert(s.spec.MountEntries(), DeepEquals, []mount.Entry{ent0, ent1})
 }
 
 // The mount.Specification can be used through the interfaces.Specification interface
@@ -87,7 +87,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
 	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
-	c.Assert(s.spec.MountEntries, DeepEquals, []mount.Entry{
+	c.Assert(s.spec.MountEntries(), DeepEquals, []mount.Entry{
 		{Name: "connected-plug"}, {Name: "connected-slot"},
 		{Name: "permanent-plug"}, {Name: "permanent-slot"}})
 }

--- a/interfaces/seccomp/spec.go
+++ b/interfaces/seccomp/spec.go
@@ -24,7 +24,7 @@ import "github.com/snapcore/snapd/interfaces"
 // Specification keeps all the seccomp snippets.
 type Specification struct {
 	// Snippets are indexed by security tag.
-	Snippets     map[string][][]byte
+	snippets     map[string][][]byte
 	securityTags []string
 }
 
@@ -33,14 +33,29 @@ func (spec *Specification) AddSnippet(snippet []byte) error {
 	if len(spec.securityTags) == 0 {
 		return nil
 	}
-	if spec.Snippets == nil {
-		spec.Snippets = make(map[string][][]byte)
+	if spec.snippets == nil {
+		spec.snippets = make(map[string][][]byte)
 	}
 	for _, tag := range spec.securityTags {
-		spec.Snippets[tag] = append(spec.Snippets[tag], snippet)
+		spec.snippets[tag] = append(spec.snippets[tag], snippet)
 	}
 
 	return nil
+}
+
+// Snippets returns a deep copy of all the added snippets.
+func (spec *Specification) Snippets() map[string][][]byte {
+	result := make(map[string][][]byte, len(spec.snippets))
+	for k, v := range spec.snippets {
+		vCopy := make([][]byte, 0, len(v))
+		for _, vElem := range v {
+			vElemCopy := make([]byte, len(vElem))
+			copy(vElemCopy, vElem)
+			vCopy = append(vCopy, vElemCopy)
+		}
+		result[k] = vCopy
+	}
+	return result
 }
 
 // Implementation of methods required by interfaces.Specification

--- a/interfaces/seccomp/spec.go
+++ b/interfaces/seccomp/spec.go
@@ -1,0 +1,98 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seccomp
+
+import "github.com/snapcore/snapd/interfaces"
+
+// Specification keeps all the seccomp snippets.
+type Specification struct {
+	// Snippets are indexed by security tag.
+	Snippets     map[string][][]byte
+	securityTags []string
+}
+
+// AddSnippet adds a new seccomp snippet.
+func (spec *Specification) AddSnippet(snippet []byte) error {
+	if len(spec.securityTags) == 0 {
+		return nil
+	}
+	if spec.Snippets == nil {
+		spec.Snippets = make(map[string][][]byte)
+	}
+	for _, tag := range spec.securityTags {
+		spec.Snippets[tag] = append(spec.Snippets[tag], snippet)
+	}
+
+	return nil
+}
+
+// Implementation of methods required by interfaces.Specification
+
+// AddConnectedPlug records seccomp-specific side-effects of having a connected plug.
+func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		SecCompConnectedPlug(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = plug.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.SecCompConnectedPlug(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddConnectedSlot records seccomp-specific side-effects of having a connected slot.
+func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		SecCompConnectedSlot(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = slot.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.SecCompConnectedSlot(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddPermanentPlug records seccomp-specific side-effects of having a plug.
+func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *interfaces.Plug) error {
+	type definer interface {
+		SecCompPermanentPlug(spec *Specification, plug *interfaces.Plug) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = plug.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.SecCompPermanentPlug(spec, plug)
+	}
+	return nil
+}
+
+// AddPermanentSlot records seccomp-specific side-effects of having a slot.
+func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *interfaces.Slot) error {
+	type definer interface {
+		SecCompPermanentSlot(spec *Specification, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = slot.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.SecCompPermanentSlot(spec, slot)
+	}
+	return nil
+}

--- a/interfaces/seccomp/spec_test.go
+++ b/interfaces/seccomp/spec_test.go
@@ -90,7 +90,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
 	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
-	c.Assert(s.spec.Snippets, DeepEquals, map[string][][]byte{
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][][]byte{
 		"snap.snap1.app1": {[]byte("connected-plug"), []byte("permanent-plug")},
 		"snap.snap2.app2": {[]byte("connected-slot"), []byte("permanent-slot")},
 	})

--- a/interfaces/seccomp/spec_test.go
+++ b/interfaces/seccomp/spec_test.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package seccomp_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
+)
+
+type specSuite struct {
+	iface *ifacetest.TestInterface
+	spec  *seccomp.Specification
+	plug  *interfaces.Plug
+	slot  *interfaces.Slot
+}
+
+var _ = Suite(&specSuite{
+	iface: &ifacetest.TestInterface{
+		InterfaceName: "test",
+		SecCompConnectedPlugCallback: func(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			return spec.AddSnippet([]byte("connected-plug"))
+		},
+		SecCompConnectedSlotCallback: func(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			return spec.AddSnippet([]byte("connected-slot"))
+		},
+		SecCompPermanentPlugCallback: func(spec *seccomp.Specification, plug *interfaces.Plug) error {
+			return spec.AddSnippet([]byte("permanent-plug"))
+		},
+		SecCompPermanentSlotCallback: func(spec *seccomp.Specification, slot *interfaces.Slot) error {
+			return spec.AddSnippet([]byte("permanent-slot"))
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "snap1"},
+			Name:      "name",
+			Interface: "test",
+			Apps: map[string]*snap.AppInfo{
+				"app1": {
+					Snap: &snap.Info{
+						SuggestedName: "snap1",
+					},
+					Name: "app1"}},
+		},
+	},
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "snap2"},
+			Name:      "name",
+			Interface: "test",
+			Apps: map[string]*snap.AppInfo{
+				"app2": {
+					Snap: &snap.Info{
+						SuggestedName: "snap2",
+					},
+					Name: "app2"}},
+		},
+	},
+})
+
+func (s *specSuite) SetUpTest(c *C) {
+	s.spec = &seccomp.Specification{}
+}
+
+// The spec.Specification can be used through the interfaces.Specification interface
+func (s *specSuite) TestSpecificationIface(c *C) {
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
+	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
+	c.Assert(s.spec.Snippets, DeepEquals, map[string][][]byte{
+		"snap.snap1.app1": {[]byte("connected-plug"), []byte("permanent-plug")},
+		"snap.snap2.app2": {[]byte("connected-slot"), []byte("permanent-slot")},
+	})
+}

--- a/interfaces/udev/spec.go
+++ b/interfaces/udev/spec.go
@@ -26,16 +26,25 @@ import (
 // Specification assists in collecting udev snippets associated with an interface.
 type Specification struct {
 	// Snippets are stored in a map for de-duplication
-	Snippets map[string]bool
+	snippets map[string]bool
 }
 
 // AddSnippet adds a new udev snippet.
 func (spec *Specification) AddSnippet(snippet []byte) error {
-	if spec.Snippets == nil {
-		spec.Snippets = make(map[string]bool)
+	if spec.snippets == nil {
+		spec.snippets = make(map[string]bool)
 	}
-	spec.Snippets[string(snippet)] = true
+	spec.snippets[string(snippet)] = true
 	return nil
+}
+
+// Snippets returns a copy of all the snippets added so far.
+func (spec *Specification) Snippets() map[string]bool {
+	result := make(map[string]bool, len(spec.snippets))
+	for k, v := range spec.snippets {
+		result[k] = v
+	}
+	return result
 }
 
 // Implementation of methods required by interfaces.Specification

--- a/interfaces/udev/spec.go
+++ b/interfaces/udev/spec.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package udev
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+)
+
+// Specification assists in collecting udev snippets associated with an interface.
+type Specification struct {
+	// Snippets are stored in a map for de-duplication
+	Snippets map[string]bool
+}
+
+// AddSnippet adds a new udev snippet.
+func (spec *Specification) AddSnippet(snippet []byte) error {
+	if spec.Snippets == nil {
+		spec.Snippets = make(map[string]bool)
+	}
+	spec.Snippets[string(snippet)] = true
+	return nil
+}
+
+// Implementation of methods required by interfaces.Specification
+
+// AddConnectedPlug records udev-specific side-effects of having a connected plug.
+func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		UdevConnectedPlug(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.UdevConnectedPlug(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddConnectedSlot records mount-specific side-effects of having a connected slot.
+func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		UdevConnectedSlot(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.UdevConnectedSlot(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddPermanentPlug records mount-specific side-effects of having a plug.
+func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *interfaces.Plug) error {
+	type definer interface {
+		UdevPermanentPlug(spec *Specification, plug *interfaces.Plug) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.UdevPermanentPlug(spec, plug)
+	}
+	return nil
+}
+
+// AddPermanentSlot records mount-specific side-effects of having a slot.
+func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *interfaces.Slot) error {
+	type definer interface {
+		UdevPermanentSlot(spec *Specification, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.UdevPermanentSlot(spec, slot)
+	}
+	return nil
+}

--- a/interfaces/udev/spec_test.go
+++ b/interfaces/udev/spec_test.go
@@ -1,0 +1,91 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package udev_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+)
+
+type specSuite struct {
+	iface *ifacetest.TestInterface
+	spec  *udev.Specification
+	plug  *interfaces.Plug
+	slot  *interfaces.Slot
+}
+
+var _ = Suite(&specSuite{
+	iface: &ifacetest.TestInterface{
+		InterfaceName: "test",
+		UdevConnectedPlugCallback: func(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			return spec.AddSnippet([]byte("connected-plug"))
+		},
+		UdevConnectedSlotCallback: func(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			return spec.AddSnippet([]byte("connected-slot"))
+		},
+		UdevPermanentPlugCallback: func(spec *udev.Specification, plug *interfaces.Plug) error {
+			return spec.AddSnippet([]byte("permanent-plug"))
+		},
+		UdevPermanentSlotCallback: func(spec *udev.Specification, slot *interfaces.Slot) error {
+			return spec.AddSnippet([]byte("permanent-slot"))
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "snap1"},
+			Name:      "name",
+			Interface: "test",
+		},
+	},
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "snap2"},
+			Name:      "name",
+			Interface: "test",
+		},
+	},
+})
+
+func (s *specSuite) SetUpTest(c *C) {
+	s.spec = &udev.Specification{}
+}
+
+func (s *specSuite) TestAddSnippte(c *C) {
+	c.Assert(s.spec.AddSnippet([]byte("foo")), IsNil)
+	c.Assert(s.spec.Snippets, DeepEquals, map[string]bool{
+		"foo": true})
+}
+
+// The spec.Specification can be used through the interfaces.Specification interface
+func (s *specSuite) TestSpecificationIface(c *C) {
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
+	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
+	c.Assert(s.spec.Snippets, DeepEquals, map[string]bool{
+		"connected-plug": true, "permanent-plug": true,
+		"connected-slot": true, "permanent-slot": true,
+	})
+}

--- a/interfaces/udev/spec_test.go
+++ b/interfaces/udev/spec_test.go
@@ -73,7 +73,7 @@ func (s *specSuite) SetUpTest(c *C) {
 
 func (s *specSuite) TestAddSnippte(c *C) {
 	c.Assert(s.spec.AddSnippet([]byte("foo")), IsNil)
-	c.Assert(s.spec.Snippets, DeepEquals, map[string]bool{
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string]bool{
 		"foo": true})
 }
 
@@ -84,7 +84,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
 	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
-	c.Assert(s.spec.Snippets, DeepEquals, map[string]bool{
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string]bool{
 		"connected-plug": true, "permanent-plug": true,
 		"connected-slot": true, "permanent-slot": true,
 	})


### PR DESCRIPTION
Specs for apparmor, seccomp, udev previously proposed separately, now in a single PR to avoid conflicts.