### PR TITLE
cmd/snap-update-ns: move test data and helpers to new module

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -358,7 +358,11 @@ noinst_PROGRAMS += snap-update-ns/unit-tests
 snap_update_ns_unit_tests_SOURCES = \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
-	snap-update-ns/mount-entry-test.c
+	snap-update-ns/mount-entry-test.c \
+	snap-update-ns/test-data.c \
+	snap-update-ns/test-data.h \
+	snap-update-ns/test-utils.c \
+	snap-update-ns/test-utils.h
 snap_update_ns_unit_tests_LDADD = libsnap-confine-private.a
 snap_update_ns_unit_tests_CFLAGS = $(GLIB_CFLAGS)
 snap_update_ns_unit_tests_LDADD +=  $(GLIB_LIBS)

--- a/cmd/snap-update-ns/mount-entry-test.c
+++ b/cmd/snap-update-ns/mount-entry-test.c
@@ -22,102 +22,16 @@
 
 #include <glib.h>
 
-static const char *test_entry_str_1 = "fsname-1 dir-1 type-1 opts-1 1 2";
-static const char *test_entry_str_2 = "fsname-2 dir-2 type-2 opts-2 3 4";
-
-static const struct sc_mount_entry test_entry_1 = {
-	.entry = {
-		  .mnt_fsname = "fsname-1",
-		  .mnt_dir = "dir-1",
-		  .mnt_type = "type-1",
-		  .mnt_opts = "opts-1",
-		  .mnt_freq = 1,
-		  .mnt_passno = 2,
-		  }
-};
-
-static void test_looks_like_test_entry_1(const struct sc_mount_entry *entry)
-{
-	g_assert_cmpstr(entry->entry.mnt_fsname, ==, "fsname-1");
-	g_assert_cmpstr(entry->entry.mnt_dir, ==, "dir-1");
-	g_assert_cmpstr(entry->entry.mnt_type, ==, "type-1");
-	g_assert_cmpstr(entry->entry.mnt_opts, ==, "opts-1");
-	g_assert_cmpint(entry->entry.mnt_freq, ==, 1);
-	g_assert_cmpint(entry->entry.mnt_passno, ==, 2);
-}
-
-static const struct sc_mount_entry test_entry_2 = {
-	.entry = {
-		  .mnt_fsname = "fsname-2",
-		  .mnt_dir = "dir-2",
-		  .mnt_type = "type-2",
-		  .mnt_opts = "opts-2",
-		  .mnt_freq = 3,
-		  .mnt_passno = 4,
-		  }
-};
-
-static void test_looks_like_test_entry_2(const struct sc_mount_entry *entry)
-{
-	g_assert_cmpstr(entry->entry.mnt_fsname, ==, "fsname-2");
-	g_assert_cmpstr(entry->entry.mnt_dir, ==, "dir-2");
-	g_assert_cmpstr(entry->entry.mnt_type, ==, "type-2");
-	g_assert_cmpstr(entry->entry.mnt_opts, ==, "opts-2");
-	g_assert_cmpint(entry->entry.mnt_freq, ==, 3);
-	g_assert_cmpint(entry->entry.mnt_passno, ==, 4);
-}
-
-static const struct mntent test_mnt_1 = {
-	.mnt_fsname = "fsname-1",
-	.mnt_dir = "dir-1",
-	.mnt_type = "type-1",
-	.mnt_opts = "opts-1",
-	.mnt_freq = 1,
-	.mnt_passno = 2,
-};
-
-static const struct mntent test_mnt_2 = {
-	.mnt_fsname = "fsname-2",
-	.mnt_dir = "dir-2",
-	.mnt_type = "type-2",
-	.mnt_opts = "opts-2",
-	.mnt_freq = 3,
-	.mnt_passno = 4,
-};
-
-static void test_write_lines(const char *name, ...) __attribute__ ((sentinel));
-
-static void test_remove_file(const char *name)
-{
-	remove(name);
-}
-
-static void test_write_lines(const char *name, ...)
-{
-	FILE *f = NULL;
-	f = fopen(name, "wt");
-	va_list ap;
-	va_start(ap, name);
-	const char *line;
-	while ((line = va_arg(ap, const char *)) != NULL) {
-		fprintf(f, "%s\n", line);
-	}
-	va_end(ap);
-	fclose(f);
-
-	// Cast-away the const qualifier. This just calls unlink and we don't
-	// modify the name in any way. This way the signature is compatible with
-	// that of GDestroyNotify.
-	g_test_queue_destroy((GDestroyNotify) test_remove_file, (char *)name);
-}
+#include "test-utils.h"
+#include "test-data.h"
 
 static void test_sc_load_mount_profile()
 {
 	struct sc_mount_entry *fstab
 	    __attribute__ ((cleanup(sc_cleanup_mount_entry_list))) = NULL;
 	struct sc_mount_entry *entry;
-	test_write_lines("test.fstab", test_entry_str_1, test_entry_str_2,
-			 NULL);
+	sc_test_write_lines("test.fstab", test_entry_str_1, test_entry_str_2,
+			    NULL);
 	fstab = sc_load_mount_profile("test.fstab");
 	g_assert_nonnull(fstab);
 
@@ -151,7 +65,7 @@ static void test_sc_save_mount_profile()
 	// Cast-away the const qualifier. This just calls unlink and we don't
 	// modify the name in any way. This way the signature is compatible with
 	// that of GDestroyNotify.
-	g_test_queue_destroy((GDestroyNotify) test_remove_file,
+	g_test_queue_destroy((GDestroyNotify) sc_test_remove_file,
 			     (char *)"test.fstab");
 
 	// After reading the generated file it looks as expected.

--- a/cmd/snap-update-ns/test-data.c
+++ b/cmd/snap-update-ns/test-data.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "test-data.h"
+
+#include <glib.h>
+
+const char *test_entry_str_1 = "fsname-1 dir-1 type-1 opts-1 1 2";
+const char *test_entry_str_2 = "fsname-2 dir-2 type-2 opts-2 3 4";
+
+const struct sc_mount_entry test_entry_1 = {.entry = {
+						      .mnt_fsname = "fsname-1",
+						      .mnt_dir = "dir-1",
+						      .mnt_type = "type-1",
+						      .mnt_opts = "opts-1",
+						      .mnt_freq = 1,
+						      .mnt_passno = 2,
+						      }
+};
+
+const struct sc_mount_entry test_entry_2 = {.entry = {
+						      .mnt_fsname = "fsname-2",
+						      .mnt_dir = "dir-2",
+						      .mnt_type = "type-2",
+						      .mnt_opts = "opts-2",
+						      .mnt_freq = 3,
+						      .mnt_passno = 4,
+						      }
+};
+
+const struct mntent test_mnt_1 = {
+	.mnt_fsname = "fsname-1",
+	.mnt_dir = "dir-1",
+	.mnt_type = "type-1",
+	.mnt_opts = "opts-1",
+	.mnt_freq = 1,
+	.mnt_passno = 2,
+};
+
+const struct mntent test_mnt_2 = {
+	.mnt_fsname = "fsname-2",
+	.mnt_dir = "dir-2",
+	.mnt_type = "type-2",
+	.mnt_opts = "opts-2",
+	.mnt_freq = 3,
+	.mnt_passno = 4,
+};
+
+void test_looks_like_test_entry_1(const struct sc_mount_entry *entry)
+{
+	g_assert_cmpstr(entry->entry.mnt_fsname, ==, "fsname-1");
+	g_assert_cmpstr(entry->entry.mnt_dir, ==, "dir-1");
+	g_assert_cmpstr(entry->entry.mnt_type, ==, "type-1");
+	g_assert_cmpstr(entry->entry.mnt_opts, ==, "opts-1");
+	g_assert_cmpint(entry->entry.mnt_freq, ==, 1);
+	g_assert_cmpint(entry->entry.mnt_passno, ==, 2);
+}
+
+void test_looks_like_test_entry_2(const struct sc_mount_entry *entry)
+{
+	g_assert_cmpstr(entry->entry.mnt_fsname, ==, "fsname-2");
+	g_assert_cmpstr(entry->entry.mnt_dir, ==, "dir-2");
+	g_assert_cmpstr(entry->entry.mnt_type, ==, "type-2");
+	g_assert_cmpstr(entry->entry.mnt_opts, ==, "opts-2");
+	g_assert_cmpint(entry->entry.mnt_freq, ==, 3);
+	g_assert_cmpint(entry->entry.mnt_passno, ==, 4);
+}

--- a/cmd/snap-update-ns/test-data.h
+++ b/cmd/snap-update-ns/test-data.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_TEST_DATA_H
+#define SNAP_CONFINE_TEST_DATA_H
+
+#include "mount-entry.h"
+
+extern const char *test_entry_str_1;
+extern const char *test_entry_str_2;
+
+extern const struct sc_mount_entry test_entry_1;
+extern const struct sc_mount_entry test_entry_2;
+
+extern const struct mntent test_mnt_1;
+extern const struct mntent test_mnt_2;
+
+void test_looks_like_test_entry_1(const struct sc_mount_entry *entry);
+void test_looks_like_test_entry_2(const struct sc_mount_entry *entry);
+
+#endif

--- a/cmd/snap-update-ns/test-utils.c
+++ b/cmd/snap-update-ns/test-utils.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "test-utils.h"
+
+#include <glib.h>
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void sc_test_remove_file(const char *name)
+{
+	int err = remove(name);
+	g_assert_cmpint(err, ==, 0);
+}
+
+void sc_test_write_lines(const char *name, ...)
+{
+	FILE *f = fopen(name, "wt");
+	g_assert_nonnull(f);
+
+	va_list ap;
+	va_start(ap, name);
+	const char *line;
+	while ((line = va_arg(ap, const char *)) != NULL) {
+		fprintf(f, "%s\n", line);
+	}
+	va_end(ap);
+	fclose(f);
+
+	// Cast-away the const qualifier. This just calls unlink and we don't
+	// modify the name in any way. This way the signature is compatible with
+	// that of GDestroyNotify.
+	g_test_queue_destroy((GDestroyNotify) sc_test_remove_file,
+			     (char *)name);
+}

--- a/cmd/snap-update-ns/test-utils.h
+++ b/cmd/snap-update-ns/test-utils.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SC_SNAP_CONFINE_TEST_UTILS_H
+#define SC_SNAP_CONFINE_TEST_UTILS_H
+
+/**
+ * Write a sequence of lines to the given file.
+ *
+ * Lines are provided as arguments. The list must be terminated with a NULL
+ * pointer. Lines should not contain a trailing newline as that is added
+ * automatically.
+ *
+ * The written file is automatically removed when the test terminates.
+ **/
+void sc_test_write_lines(const char *name, ...) __attribute__ ((sentinel));
+
+/**
+ * Remove a file created during testing.
+ *
+ * This function is compatible with GDestroyNotify. It just calls
+ * remove(3) but has a different signature.
+ **/
+void sc_test_remove_file(const char *name);
+
+#endif


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>