### PR TITLE
tests: 2 workers on 14.04 and core 64, drop fixme system

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -39,6 +39,7 @@ backends:
         systems:
             - ubuntu-14.04-64:
                 kernel: GRUB 2
+                workers: 2
             - ubuntu-16.04-64:
                 kernel: GRUB 2
                 workers: 2
@@ -48,11 +49,7 @@ backends:
             - ubuntu-core-16-64:
                 kernel: Direct Disk
                 image: ubuntu-16.04-64
-            # FIXME restore of ubuntu-core does not properly reset
-            # boot variables and key snaps to their pristine state.
-            - ubuntu-core-16-64-fixme:
-                kernel: Direct Disk
-                image: ubuntu-16.04-64
+                workers: 2
     qemu:
         environment:
             APT_PROXY: "$(HOST: echo $APT_PROXY)"
@@ -236,7 +233,6 @@ restore: |
 suites:
     tests/main/:
         summary: Full-system tests for snapd
-        systems: [-ubuntu-core-16-64-fixme]
         prepare: |
             . $TESTSLIB/prepare.sh
             if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
@@ -258,7 +254,6 @@ suites:
 
     tests/regression/:
         summary: Regression tests for snapd
-        systems: [-ubuntu-core-16-64-fixme]
         prepare: |
             . $TESTSLIB/prepare.sh
             if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
@@ -277,7 +272,7 @@ suites:
 
     tests/upgrade/:
         summary: Tests for snapd upgrade
-        systems: [-ubuntu-core-16-64-fixme, -ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+        systems: [-ubuntu-core-16-*]
         restore: |
             if [ "$REMOTE_STORE" = staging ]; then
                 echo "skip upgrade tests while talking to the staging store"
@@ -293,7 +288,6 @@ suites:
 
     tests/unit/:
         summary: Suite to run non-go unit tests and go unit tests for other runtimes
-        systems: [-ubuntu-core-16-64-fixme]
         prepare: |
             . $TESTSLIB/prepare.sh
             if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then

--- a/tests/main/ubuntu-core-upgrade-no-gc/task.yaml
+++ b/tests/main/ubuntu-core-upgrade-no-gc/task.yaml
@@ -1,7 +1,7 @@
 summary: Upgrade the core snap a few times and ensure no GC happens
 
 systems:
-    - ubuntu-core-16-64-fixme
+    - ubuntu-core-16-64
     - ubuntu-core-16-arm-64
     - ubuntu-core-16-arm-32
 

--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -1,7 +1,7 @@
 summary: Upgrade the core snap and revert a few times
 
 systems:
-    - ubuntu-core-16-64-fixme
+    - ubuntu-core-16-64
     - ubuntu-core-16-arm-64
     - ubuntu-core-16-arm-32
 


### PR DESCRIPTION
On quick inspection, prepare.sh claims to have fixed the original problem that motivated the ubuntu-core-16-64-fixme system, and looking at test results using two workers on 14.04 and ubuntu-core-64 might cut about 20 minutes of testing time. This is an attempt to validate this theory. 