### PR TITLE
vet: fix vet error on mount test.

### DIFF
--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -124,8 +124,8 @@ slots:
 `
 
 func (s *backendSuite) TestSetupSetsupSimple(c *C) {
-	fsEntry1 := mount.Entry{"/src-1", "/dst-1", "none", []string{"bind", "ro"}, 0, 0}
-	fsEntry2 := mount.Entry{"/src-2", "/dst-2", "none", []string{"bind", "ro"}, 0, 0}
+	fsEntry1 := mount.Entry{Name: "/src-1", Dir: "/dst-1", Type: "none", Options: []string{"bind", "ro"}, DumpFrequency: 0, CheckPassNumber: 0}
+	fsEntry2 := mount.Entry{Name: "/src-2", Dir: "/dst-2", Type: "none", Options: []string{"bind", "ro"}, DumpFrequency: 0, CheckPassNumber: 0}
 
 	// Give the plug a permanent effect
 	s.Iface.MountPermanentPlugCallback = func(spec *mount.Specification, plug *interfaces.Plug) error {


### PR DESCRIPTION
Fix for vet error on my box:
interfaces/mount/backend_test.go:127: github.com/snapcore/snapd/interfaces/mount.Entry composite literal uses unkeyed fields