### PR TITLE
interfaces/apparmor: compensate for kernel behavior change

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -352,6 +352,9 @@ profile "snap.samba.smbd" (attach_disconnected) {
 
   # Read-only access to the core snap.
   @{INSTALL_DIR}/core/** r,
+  # Read only access to the core snap to load libc from.
+  # This is related to LP: #1666897
+  @{INSTALL_DIR}/core/*/{,usr/}lib/@{multiarch}/{,**/}lib*.so* m,
 
 snippet
 }

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -426,4 +426,7 @@ var classicTemplate = []byte(`
 var classicJailmodeSnippet = []byte(`
   # Read-only access to the core snap.
   @{INSTALL_DIR}/core/** r,
+  # Read only access to the core snap to load libc from.
+  # This is related to LP: #1666897
+  @{INSTALL_DIR}/core/*/{,usr/}lib/@{multiarch}/{,**/}lib*.so* m,
 `)


### PR DESCRIPTION
During the end of the zesty development cycle the kernel was changed (as
a bugfix to apparmor bug related to locking files) and now there are
denials when accessing libc.

Jamie Strandboge suggested to add a rule to allow this and John Johansen
confirmed that it should be used by default as the relevant kernel
bugfix is valid and must stay as-is.

Fixes: https://bugs.launchpad.net/snapd/+bug/1666897
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>