### PR TITLE
cmd/snap-update-ns: compute next action to transition mount profile

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -345,9 +345,11 @@ EXTRA_DIST += snap-update-ns/snap-update-ns.rst
 snap_update_ns_snap_update_ns_LDADD = libsnap-confine-private.a
 
 snap_update_ns_snap_update_ns_SOURCES = \
-	snap-update-ns/snap-update-ns.c \
+	snap-update-ns/mount-entry-change.c \
+	snap-update-ns/mount-entry-change.h \
+	snap-update-ns/mount-entry.c \
 	snap-update-ns/mount-entry.h \
-	snap-update-ns/mount-entry.c
+	snap-update-ns/snap-update-ns.c
 
 snap-update-ns/%.5: snap-update-ns/%.rst
 	mkdir -p snap-update-ns
@@ -358,6 +360,7 @@ noinst_PROGRAMS += snap-update-ns/unit-tests
 snap_update_ns_unit_tests_SOURCES = \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
+	snap-update-ns/mount-entry-change-test.c \
 	snap-update-ns/mount-entry-test.c \
 	snap-update-ns/test-data.c \
 	snap-update-ns/test-data.h \

--- a/cmd/snap-update-ns/mount-entry-change-test.c
+++ b/cmd/snap-update-ns/mount-entry-change-test.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mount-entry-change.h"
+#include "mount-entry-change.c"
+
+#include "test-utils.h"
+#include "test-data.h"
+
+#include <glib.h>
+
+// Scenario: there is nothing to do yet at all.
+static void test_sc_compute_required_mount_changes__scenario0()
+{
+	struct sc_mount_entry *current = NULL;
+	struct sc_mount_entry *desired = NULL;
+	struct sc_mount_change change;
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_null(desired);
+	g_assert_null(current);
+	g_assert_cmpint(change.action, ==, SC_ACTION_NONE);
+	g_assert_null(change.entry);
+}
+
+// Scenario: the current profile contains things but the desired profile does
+// not. We should see two unmounts taking place.
+static void test_sc_compute_required_mount_changes__scenario1()
+{
+	struct sc_mount_entry *current;
+	struct sc_mount_entry *desired;
+	struct sc_mount_change change;
+
+	sc_test_write_lines("current.fstab",
+			    test_entry_str_1, test_entry_str_2, NULL);
+	sc_test_write_lines("desired.fstab", NULL);
+
+	current = sc_load_mount_profile("current.fstab");
+	desired = sc_load_mount_profile("desired.fstab");
+	g_test_queue_destroy((GDestroyNotify) sc_free_mount_entry_list,
+			     current);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mount_entry_list,
+			     desired);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_cmpint(change.action, ==, SC_ACTION_UNMOUNT);
+	g_assert_nonnull(change.entry);
+	test_looks_like_test_entry_1(change.entry);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_cmpint(change.action, ==, SC_ACTION_UNMOUNT);
+	g_assert_nonnull(change.entry);
+	test_looks_like_test_entry_2(change.entry);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_null(desired);
+	g_assert_null(current);
+	g_assert_cmpint(change.action, ==, SC_ACTION_NONE);
+	g_assert_null(change.entry);
+}
+
+// Scenario: the current profile is empty but the desired profile
+// contains two entries. We should see two mounts taking place.
+static void test_sc_compute_required_mount_changes__scenario2()
+{
+	struct sc_mount_entry *current;
+	struct sc_mount_entry *desired;
+	struct sc_mount_change change;
+
+	sc_test_write_lines("current.fstab", NULL);
+	sc_test_write_lines("desired.fstab",
+			    test_entry_str_1, test_entry_str_2, NULL);
+
+	current = sc_load_mount_profile("current.fstab");
+	desired = sc_load_mount_profile("desired.fstab");
+	g_test_queue_destroy((GDestroyNotify) sc_free_mount_entry_list,
+			     current);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mount_entry_list,
+			     desired);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_cmpint(change.action, ==, SC_ACTION_MOUNT);
+	g_assert_nonnull(change.entry);
+	test_looks_like_test_entry_1(change.entry);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_cmpint(change.action, ==, SC_ACTION_MOUNT);
+	g_assert_nonnull(change.entry);
+	test_looks_like_test_entry_2(change.entry);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_null(desired);
+	g_assert_null(current);
+	g_assert_cmpint(change.action, ==, SC_ACTION_NONE);
+	g_assert_null(change.entry);
+}
+
+// Scenario: the current profile contains one entry but the desired profile
+// contains two entries. We should see one mount change (for the 2nd entry).
+static void test_sc_compute_required_mount_changes__scenario3()
+{
+	struct sc_mount_entry *current;
+	struct sc_mount_entry *desired;
+	struct sc_mount_change change;
+
+	sc_test_write_lines("current.fstab", test_entry_str_1, NULL);
+	sc_test_write_lines("desired.fstab",
+			    test_entry_str_1, test_entry_str_2, NULL);
+
+	current = sc_load_mount_profile("current.fstab");
+	desired = sc_load_mount_profile("desired.fstab");
+	g_test_queue_destroy((GDestroyNotify) sc_free_mount_entry_list,
+			     current);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mount_entry_list,
+			     desired);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_cmpint(change.action, ==, SC_ACTION_MOUNT);
+	g_assert_nonnull(change.entry);
+	test_looks_like_test_entry_2(change.entry);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_null(desired);
+	g_assert_null(current);
+	g_assert_cmpint(change.action, ==, SC_ACTION_NONE);
+	g_assert_null(change.entry);
+}
+
+// Scenario: the current profile contains one entry and the desired profile
+// contains one entry but they are different. We should see the unmount
+// followed by the mount.
+static void test_sc_compute_required_mount_changes__scenario4()
+{
+	struct sc_mount_entry *current;
+	struct sc_mount_entry *desired;
+	struct sc_mount_change change;
+
+	sc_test_write_lines("current.fstab", test_entry_str_1, NULL);
+	sc_test_write_lines("desired.fstab", test_entry_str_2, NULL);
+
+	current = sc_load_mount_profile("current.fstab");
+	desired = sc_load_mount_profile("desired.fstab");
+	g_test_queue_destroy((GDestroyNotify) sc_free_mount_entry_list,
+			     current);
+	g_test_queue_destroy((GDestroyNotify) sc_free_mount_entry_list,
+			     desired);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_cmpint(change.action, ==, SC_ACTION_UNMOUNT);
+	g_assert_nonnull(change.entry);
+	test_looks_like_test_entry_1(change.entry);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_cmpint(change.action, ==, SC_ACTION_MOUNT);
+	g_assert_nonnull(change.entry);
+	test_looks_like_test_entry_2(change.entry);
+
+	sc_compute_required_mount_changes(&desired, &current, &change);
+	g_assert_null(desired);
+	g_assert_null(current);
+	g_assert_cmpint(change.action, ==, SC_ACTION_NONE);
+	g_assert_null(change.entry);
+}
+
+static void __attribute__ ((constructor)) init()
+{
+	g_test_add_func
+	    ("/mount-entry-change/sc_compute_required_mount_changes/0",
+	     test_sc_compute_required_mount_changes__scenario0);
+	g_test_add_func
+	    ("/mount-entry-change/sc_compute_required_mount_changes/1",
+	     test_sc_compute_required_mount_changes__scenario1);
+	g_test_add_func
+	    ("/mount-entry-change/sc_compute_required_mount_changes/2",
+	     test_sc_compute_required_mount_changes__scenario2);
+	g_test_add_func
+	    ("/mount-entry-change/sc_compute_required_mount_changes/3",
+	     test_sc_compute_required_mount_changes__scenario3);
+	g_test_add_func
+	    ("/mount-entry-change/sc_compute_required_mount_changes/4",
+	     test_sc_compute_required_mount_changes__scenario4);
+}

--- a/cmd/snap-update-ns/mount-entry-change.c
+++ b/cmd/snap-update-ns/mount-entry-change.c
@@ -71,7 +71,7 @@ sc_compute_required_mount_changes(struct sc_mount_entry * *desiredp,
 				again = true;
 				continue;
 			} else {
-				// Non-identail entries mean that we need to unmount the current
+				// Non-identical entries mean that we need to unmount the current
 				// entry and mount the desired entry.
 				//
 				// Let's process all the unmounts first. This way we can "clear the

--- a/cmd/snap-update-ns/mount-entry-change.c
+++ b/cmd/snap-update-ns/mount-entry-change.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mount-entry-change.h"
+
+#include <stdlib.h>
+
+#include "../libsnap-confine-private/utils.h"
+
+void
+sc_compute_required_mount_changes(struct sc_mount_entry * *desiredp,
+				  struct sc_mount_entry * *currentp,
+				  struct sc_mount_change *change)
+{
+	struct sc_mount_entry *d, *c;
+	if (desiredp == NULL) {
+		die("cannot compute required mount changes, desiredp is NULL");
+	}
+	if (currentp == NULL) {
+		die("cannot compute required mount changes, currentp is NULL");
+	}
+	if (change == NULL) {
+		die("cannot compute required mount changes, change is NULL");
+	}
+	d = *desiredp;
+	c = *currentp;
+ again:
+	if (c == NULL && d == NULL) {
+		// Both profiles exhausted. There is nothing to do left.
+		change->action = SC_ACTION_NONE;
+		change->entry = NULL;
+		*currentp = NULL;
+		*desiredp = NULL;
+	} else if (c == NULL && d != NULL) {
+		// Current profile exhausted but desired profile is not.
+		// Generate a MOUNT action based on desired profile and advance it.
+		change->action = SC_ACTION_MOUNT;
+		change->entry = d;
+		*currentp = NULL;
+		*desiredp = d->next;
+	} else if (c != NULL && d == NULL) {
+		// Current profile is not exhausted but the desired profile is.
+		// Generate an UNMOUNT action based on the current profile and advance it.
+		change->action = SC_ACTION_UNMOUNT;
+		change->entry = c;
+		*currentp = c->next;
+		*desiredp = NULL;
+	} else if (c != NULL && d != NULL) {
+		// Both profiles have entries to consider.
+		if (sc_compare_mount_entry(c, d) == 0) {
+			// Identical entries are just skipped and the algorithm continues.
+			c = c->next;
+			d = d->next;
+			goto again;
+		} else {
+			// Non-identail entries mean that we need to unmount the current
+			// entry and mount the desired entry.
+			//
+			// Let's process all the unmounts first. This way we can "clear the
+			// stage" (so to speak). Either the tip of the current profile and
+			// tip of the desired profile become identical (we're in sync) or
+			// we're eventually going to exhaust the current profile and the
+			// code above will start to process items in the desired profile
+			// (which will cause all the mount calls to happen).
+			change->action = SC_ACTION_UNMOUNT;
+			change->entry = c;
+			*currentp = c->next;
+			*desiredp = d;
+		}
+	}
+}

--- a/cmd/snap-update-ns/mount-entry-change.c
+++ b/cmd/snap-update-ns/mount-entry-change.c
@@ -38,48 +38,53 @@ sc_compute_required_mount_changes(struct sc_mount_entry * *desiredp,
 	}
 	d = *desiredp;
 	c = *currentp;
- again:
-	if (c == NULL && d == NULL) {
-		// Both profiles exhausted. There is nothing to do left.
-		change->action = SC_ACTION_NONE;
-		change->entry = NULL;
-		*currentp = NULL;
-		*desiredp = NULL;
-	} else if (c == NULL && d != NULL) {
-		// Current profile exhausted but desired profile is not.
-		// Generate a MOUNT action based on desired profile and advance it.
-		change->action = SC_ACTION_MOUNT;
-		change->entry = d;
-		*currentp = NULL;
-		*desiredp = d->next;
-	} else if (c != NULL && d == NULL) {
-		// Current profile is not exhausted but the desired profile is.
-		// Generate an UNMOUNT action based on the current profile and advance it.
-		change->action = SC_ACTION_UNMOUNT;
-		change->entry = c;
-		*currentp = c->next;
-		*desiredp = NULL;
-	} else if (c != NULL && d != NULL) {
-		// Both profiles have entries to consider.
-		if (sc_compare_mount_entry(c, d) == 0) {
-			// Identical entries are just skipped and the algorithm continues.
-			c = c->next;
-			d = d->next;
-			goto again;
-		} else {
-			// Non-identail entries mean that we need to unmount the current
-			// entry and mount the desired entry.
-			//
-			// Let's process all the unmounts first. This way we can "clear the
-			// stage" (so to speak). Either the tip of the current profile and
-			// tip of the desired profile become identical (we're in sync) or
-			// we're eventually going to exhaust the current profile and the
-			// code above will start to process items in the desired profile
-			// (which will cause all the mount calls to happen).
+	bool again;
+	do {
+		again = false;
+		if (c == NULL && d == NULL) {
+			// Both profiles exhausted. There is nothing to do left.
+			change->action = SC_ACTION_NONE;
+			change->entry = NULL;
+			*currentp = NULL;
+			*desiredp = NULL;
+		} else if (c == NULL && d != NULL) {
+			// Current profile exhausted but desired profile is not.
+			// Generate a MOUNT action based on desired profile and advance it.
+			change->action = SC_ACTION_MOUNT;
+			change->entry = d;
+			*currentp = NULL;
+			*desiredp = d->next;
+		} else if (c != NULL && d == NULL) {
+			// Current profile is not exhausted but the desired profile is.
+			// Generate an UNMOUNT action based on the current profile and advance it.
 			change->action = SC_ACTION_UNMOUNT;
 			change->entry = c;
 			*currentp = c->next;
-			*desiredp = d;
+			*desiredp = NULL;
+		} else if (c != NULL && d != NULL) {
+			// Both profiles have entries to consider.
+			if (sc_compare_mount_entry(c, d) == 0) {
+				// Identical entries are just skipped and the algorithm continues.
+				c = c->next;
+				d = d->next;
+				// Do another pass over the algorithm.
+				again = true;
+				continue;
+			} else {
+				// Non-identail entries mean that we need to unmount the current
+				// entry and mount the desired entry.
+				//
+				// Let's process all the unmounts first. This way we can "clear the
+				// stage" (so to speak). Either the tip of the current profile and
+				// tip of the desired profile become identical (we're in sync) or
+				// we're eventually going to exhaust the current profile and the
+				// code above will start to process items in the desired profile
+				// (which will cause all the mount calls to happen).
+				change->action = SC_ACTION_UNMOUNT;
+				change->entry = c;
+				*currentp = c->next;
+				*desiredp = d;
+			}
 		}
-	}
+	} while (again);
 }

--- a/cmd/snap-update-ns/mount-entry-change.h
+++ b/cmd/snap-update-ns/mount-entry-change.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_MOUNT_ENTRY_CHANGE_H
+#define SNAP_CONFINE_MOUNT_ENTRY_CHANGE_H
+
+#include "mount-entry.h"
+
+/**
+ * Mount action describes activity affecting a mount entry.
+ **/
+enum sc_mount_action {
+	SC_ACTION_NONE,		/*< Nothing to do. */
+	SC_ACTION_MOUNT,	/*< A mount operation should be attempted. */
+	SC_ACTION_UNMOUNT,	/*< A umount operation should be attempted. */
+	// TODO: support SC_ACTION_REMOUNT when needed.
+};
+
+/**
+ * Description of a change to the given mount entry.
+ *
+ * The structure pairs an action with an entry to act on.
+ **/
+struct sc_mount_change {
+	enum sc_mount_action action;
+	const struct sc_mount_entry *entry;
+};
+
+/**
+ * Compare two sorted list of mount entries and compute actionable deltas.
+ *
+ * The function traverses two lists of mount entries (desired and current).
+ * Each element that is in the current entry that is not in the desired entry
+ * results in an umount change. Each element in the desired entry that is not
+ * in the current entry results in a mount change.
+ *
+ * Both lists *must* be sorted by the caller prior to using this function.
+ *
+ * The result is written back to all the there pointers passed to the
+ * functions. Both desired and current are advanced as the algorithm traverses
+ * the list. The change is always written. The caller should stop when desired
+ * and current both become NULL. At that time the resulting change will become
+ * SC_ACTION_NONE.
+ **/
+void
+sc_compute_required_mount_changes(struct sc_mount_entry **desiredp,
+				  struct sc_mount_entry **currentp,
+				  struct sc_mount_change *change);
+
+#endif

--- a/cmd/snap-update-ns/mount-entry-change.h
+++ b/cmd/snap-update-ns/mount-entry-change.h
@@ -50,10 +50,10 @@ struct sc_mount_change {
  *
  * Both lists *must* be sorted by the caller prior to using this function.
  *
- * The result is written back to all the there pointers passed to the
- * functions. Both desired and current are advanced as the algorithm traverses
- * the list. The change is always written. The caller should stop when desired
- * and current both become NULL. At that time the resulting change will become
+ * The result is written back to all the pointers passed to the functions. Both
+ * desired and current are advanced as the algorithm traverses the list. The
+ * change is always written. The caller should stop when desired and current
+ * both become NULL. At that time the resulting change will become
  * SC_ACTION_NONE.
  **/
 void

--- a/cmd/snap-update-ns/mount-entry-change.h
+++ b/cmd/snap-update-ns/mount-entry-change.h
@@ -34,10 +34,12 @@ enum sc_mount_action {
  * Description of a change to the given mount entry.
  *
  * The structure pairs an action with an entry to act on.
+ * Structures can be chained with simple single-linked list.
  **/
 struct sc_mount_change {
 	enum sc_mount_action action;
 	const struct sc_mount_entry *entry;
+	struct sc_mount_change *next;
 };
 
 /**
@@ -50,15 +52,14 @@ struct sc_mount_change {
  *
  * Both lists *must* be sorted by the caller prior to using this function.
  *
- * The result is written back to all the pointers passed to the functions. Both
- * desired and current are advanced as the algorithm traverses the list. The
- * change is always written. The caller should stop when desired and current
- * both become NULL. At that time the resulting change will become
- * SC_ACTION_NONE.
+ * The result is computed internally and returned to the caller as
+ * newly-allocated chain of sc_mount_change structures. Note that it is
+ * possible for the function to return NULL when no changes are required.
+ *
+ * The caller must ensure that each element of the chain is freed.
  **/
-void
-sc_compute_required_mount_changes(struct sc_mount_entry **desiredp,
-				  struct sc_mount_entry **currentp,
-				  struct sc_mount_change *change);
+struct sc_mount_change *sc_compute_required_mount_changes(struct sc_mount_entry
+							  *desired, struct sc_mount_entry
+							  *current);
 
 #endif

--- a/cmd/snap-update-ns/mount-entry.h
+++ b/cmd/snap-update-ns/mount-entry.h
@@ -30,6 +30,7 @@
 struct sc_mount_entry {
 	struct mntent entry;
 	struct sc_mount_entry *next;
+	unsigned flag;		// general-purpose flag, not compared
 };
 
 /**


### PR DESCRIPTION
This patch adds a function that given two sorted mount profiles (current
and desired) computes the next action that needs to be taken to
transition the current profile to the desired profile.

The function operates on a simple principle. Identical entires are
skipped. Entries that don't show up in the desired profile but exist in
the current profile are umounted. Entries that are in the desired
profile but are not in the current profile are mounted.

The logic ensures that we always unmount everything that should be
unmounted before proceeding with the first thing to be mounted.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>