### PR TITLE
cmd/libsnap: add sc_string_append_char

### DIFF
--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -312,18 +312,24 @@ static void test_sc_string_append_char__invalid_zero()
 static void test_sc_string_append_char__normal()
 {
 	char buf[16];
+	size_t len;
 	sc_string_init(buf, sizeof buf);
 
-	sc_string_append_char(buf, sizeof buf, 'h');
+	len = sc_string_append_char(buf, sizeof buf, 'h');
 	g_assert_cmpstr(buf, ==, "h");
-	sc_string_append_char(buf, sizeof buf, 'e');
+	g_assert_cmpint(len, ==, 1);
+	len = sc_string_append_char(buf, sizeof buf, 'e');
 	g_assert_cmpstr(buf, ==, "he");
-	sc_string_append_char(buf, sizeof buf, 'l');
+	g_assert_cmpint(len, ==, 2);
+	len = sc_string_append_char(buf, sizeof buf, 'l');
 	g_assert_cmpstr(buf, ==, "hel");
-	sc_string_append_char(buf, sizeof buf, 'l');
+	g_assert_cmpint(len, ==, 3);
+	len = sc_string_append_char(buf, sizeof buf, 'l');
 	g_assert_cmpstr(buf, ==, "hell");
-	sc_string_append_char(buf, sizeof buf, 'o');
+	g_assert_cmpint(len, ==, 4);
+	len = sc_string_append_char(buf, sizeof buf, 'o');
 	g_assert_cmpstr(buf, ==, "hello");
+	g_assert_cmpint(len, ==, 5);
 }
 
 static void __attribute__ ((constructor)) init()

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -293,38 +293,6 @@ static void test_sc_string_append_char__overflow()
 	    ("cannot append character: not enough space\n");
 }
 
-static void test_sc_string_append_char__invalid_too_small()
-{
-	if (g_test_subprocess()) {
-		char buf[2] = { 0 };
-		sc_string_append_char(buf, sizeof buf, -1);
-
-		g_test_message("expected sc_string_append_char not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character: character out of range\n");
-}
-
-static void test_sc_string_append_char__invalid_too_large()
-{
-	if (g_test_subprocess()) {
-		char buf[2] = { 0 };
-		sc_string_append_char(buf, sizeof buf, 256);
-
-		g_test_message("expected sc_string_append_char not to return");
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot append character: character out of range\n");
-}
-
 static void test_sc_string_append_char__invalid_zero()
 {
 	if (g_test_subprocess()) {
@@ -391,12 +359,6 @@ static void __attribute__ ((constructor)) init()
 			test_sc_string_append_char__NULL_buf);
 	g_test_add_func("/string-utils/sc_string_append_char__overflow",
 			test_sc_string_append_char__overflow);
-	g_test_add_func
-	    ("/string-utils/sc_string_append_char__invalid_too_large",
-	     test_sc_string_append_char__invalid_too_large);
-	g_test_add_func
-	    ("/string-utils/sc_string_append_char__invalid_too_small",
-	     test_sc_string_append_char__invalid_too_small);
 	g_test_add_func("/string-utils/sc_string_append_char__invalid_zero",
 			test_sc_string_append_char__invalid_zero);
 	g_test_add_func("/string-utils/sc_string_append_char__normal",

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -247,6 +247,117 @@ static void test_sc_string_init__NULL_buf()
 	g_test_trap_assert_stderr("cannot initialize string, buffer is NULL\n");
 }
 
+static void test_sc_string_append_char__uninitialized_buf()
+{
+	if (g_test_subprocess()) {
+		char buf[2] = { 0xFF, 0xFF };
+		sc_string_append_char(buf, sizeof buf, 'a');
+
+		g_test_message("expected sc_string_append_char not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("cannot append character: dst is unterminated\n");
+}
+
+static void test_sc_string_append_char__NULL_buf()
+{
+	if (g_test_subprocess()) {
+		sc_string_append_char(NULL, 2, 'a');
+
+		g_test_message("expected sc_string_append_char not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("cannot append character: buffer is NULL\n");
+}
+
+static void test_sc_string_append_char__overflow()
+{
+	if (g_test_subprocess()) {
+		char buf[1] = { 0 };
+		sc_string_append_char(buf, sizeof buf, 'a');
+
+		g_test_message("expected sc_string_append_char not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("cannot append character: not enough space\n");
+}
+
+static void test_sc_string_append_char__invalid_too_small()
+{
+	if (g_test_subprocess()) {
+		char buf[2] = { 0 };
+		sc_string_append_char(buf, sizeof buf, -1);
+
+		g_test_message("expected sc_string_append_char not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("cannot append character: character out of range\n");
+}
+
+static void test_sc_string_append_char__invalid_too_large()
+{
+	if (g_test_subprocess()) {
+		char buf[2] = { 0 };
+		sc_string_append_char(buf, sizeof buf, 256);
+
+		g_test_message("expected sc_string_append_char not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("cannot append character: character out of range\n");
+}
+
+static void test_sc_string_append_char__invalid_zero()
+{
+	if (g_test_subprocess()) {
+		char buf[2] = { 0 };
+		sc_string_append_char(buf, sizeof buf, '\0');
+
+		g_test_message("expected sc_string_append_char not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr
+	    ("cannot append character: cannot append string terminator\n");
+}
+
+static void test_sc_string_append_char__normal()
+{
+	char buf[16];
+	sc_string_init(buf, sizeof buf);
+
+	sc_string_append_char(buf, sizeof buf, 'h');
+	g_assert_cmpstr(buf, ==, "h");
+	sc_string_append_char(buf, sizeof buf, 'e');
+	g_assert_cmpstr(buf, ==, "he");
+	sc_string_append_char(buf, sizeof buf, 'l');
+	g_assert_cmpstr(buf, ==, "hel");
+	sc_string_append_char(buf, sizeof buf, 'l');
+	g_assert_cmpstr(buf, ==, "hell");
+	sc_string_append_char(buf, sizeof buf, 'o');
+	g_assert_cmpstr(buf, ==, "hello");
+}
+
 static void __attribute__ ((constructor)) init()
 {
 	g_test_add_func("/string-utils/sc_streq", test_sc_streq);
@@ -273,4 +384,21 @@ static void __attribute__ ((constructor)) init()
 			test_sc_string_init__empty_buf);
 	g_test_add_func("/string-utils/sc_string_init/NULL_buf",
 			test_sc_string_init__NULL_buf);
+	g_test_add_func
+	    ("/string-utils/sc_string_append_char__uninitialized_buf",
+	     test_sc_string_append_char__uninitialized_buf);
+	g_test_add_func("/string-utils/sc_string_append_char__NULL_buf",
+			test_sc_string_append_char__NULL_buf);
+	g_test_add_func("/string-utils/sc_string_append_char__overflow",
+			test_sc_string_append_char__overflow);
+	g_test_add_func
+	    ("/string-utils/sc_string_append_char__invalid_too_large",
+	     test_sc_string_append_char__invalid_too_large);
+	g_test_add_func
+	    ("/string-utils/sc_string_append_char__invalid_too_small",
+	     test_sc_string_append_char__invalid_too_small);
+	g_test_add_func("/string-utils/sc_string_append_char__invalid_zero",
+			test_sc_string_append_char__invalid_zero);
+	g_test_add_func("/string-utils/sc_string_append_char__normal",
+			test_sc_string_append_char__normal);
 }

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -121,7 +121,7 @@ size_t sc_string_append_char(char *dst, size_t dst_size, char c)
 	dst[dst_len + 0] = c;
 	dst[dst_len + 1] = '\0';
 	// Return the new size
-	return strlen(dst);
+	return dst_len + 1;
 }
 
 void sc_string_init(char *buf, size_t buf_size)

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -99,6 +99,34 @@ size_t sc_string_append(char *dst, size_t dst_size, const char *str)
 	return strlen(dst);
 }
 
+size_t sc_string_append_char(char *dst, size_t dst_size, int c)
+{
+	// Set errno in case we die.
+	errno = 0;
+	if (dst == NULL) {
+		die("cannot append character: buffer is NULL");
+	}
+	size_t dst_len = strnlen(dst, dst_size);
+	if (dst_len == dst_size) {
+		die("cannot append character: dst is unterminated");
+	}
+	size_t max_str_len = dst_size - dst_len;
+	if (max_str_len < 2) {
+		die("cannot append character: not enough space");
+	}
+	if (c < 0 || c > 255) {
+		die("cannot append character: character out of range");
+	}
+	if (c == 0) {
+		die("cannot append character: cannot append string terminator");
+	}
+	// Append the character and terminate the string.
+	dst[dst_len + 0] = c;
+	dst[dst_len + 1] = '\0';
+	// Return the new size
+	return strlen(dst);
+}
+
 void sc_string_init(char *buf, size_t buf_size)
 {
 	errno = 0;

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -99,7 +99,7 @@ size_t sc_string_append(char *dst, size_t dst_size, const char *str)
 	return strlen(dst);
 }
 
-size_t sc_string_append_char(char *dst, size_t dst_size, int c)
+size_t sc_string_append_char(char *dst, size_t dst_size, char c)
 {
 	// Set errno in case we die.
 	errno = 0;
@@ -113,9 +113,6 @@ size_t sc_string_append_char(char *dst, size_t dst_size, int c)
 	size_t max_str_len = dst_size - dst_len;
 	if (max_str_len < 2) {
 		die("cannot append character: not enough space");
-	}
-	if (c < 0 || c > 255) {
-		die("cannot append character: character out of range");
 	}
 	if (c == 0) {
 		die("cannot append character: cannot append string terminator");

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -59,7 +59,7 @@ size_t sc_string_append(char *dst, size_t dst_size, const char *str);
  *
  * The character cannot be the string terminator.
  *
- * The return value is the new lenght of the string.
+ * The return value is the new length of the string.
  **/
 size_t sc_string_append_char(char *dst, size_t dst_size, char c);
 

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -58,6 +58,8 @@ size_t sc_string_append(char *dst, size_t dst_size, const char *str);
  * then the function dies.
  *
  * The character cannot be the string terminator.
+ *
+ * The return value is the new lenght of the string.
  **/
 size_t sc_string_append_char(char *dst, size_t dst_size, char c);
 

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -51,6 +51,18 @@ int sc_must_snprintf(char *str, size_t size, const char *format, ...);
 size_t sc_string_append(char *dst, size_t dst_size, const char *str);
 
 /**
+ * Append a single character to a buffer containing a string.
+ *
+ * This version is fully aware of the destination buffer and is extra careful
+ * not to overflow it. If any argument is NULL or a buffer overflow is detected
+ * then the function dies.
+ *
+ * The character cannot be the string terminator and it must fit into an
+ * eight-bit value.
+ **/
+size_t sc_string_append_char(char *dst, size_t dst_size, int c);
+
+/**
  * Initialize a string (make it empty).
  *
  * Initialize a string as empty, ensuring buf is non-NULL buf_size is > 0.

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -57,10 +57,9 @@ size_t sc_string_append(char *dst, size_t dst_size, const char *str);
  * not to overflow it. If any argument is NULL or a buffer overflow is detected
  * then the function dies.
  *
- * The character cannot be the string terminator and it must fit into an
- * eight-bit value.
+ * The character cannot be the string terminator.
  **/
-size_t sc_string_append_char(char *dst, size_t dst_size, int c);
+size_t sc_string_append_char(char *dst, size_t dst_size, char c);
 
 /**
  * Initialize a string (make it empty).


### PR DESCRIPTION
This patch adds a paranoid-security function for appending a character
to a C string along with complete test suite.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>