### PR TITLE
many: only tweak core config if hook exists

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -225,7 +225,9 @@ prepare: |
 restore: |
     if [ "$SPREAD_BACKEND" = external ]; then
         # start and enable autorefresh
-        snap set core refresh.disabled=false
+        if [ -e /snap/core/current/meta/hooks/configure ]; then
+            snap set core refresh.disabled=false
+        fi
     fi
 
     rm -f $SPREAD_PATH/snapd-state.tar.gz

--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -64,7 +64,9 @@ if [ "$SPREAD_BACKEND" = external ]; then
        snap remove test-snapd-snapbuild
    fi
    # stop and disable autorefresh
-   snap set core refresh.disabled=true
+   if [ -e /snap/core/current/meta/hooks/configure ]; then
+       snap set core refresh.disabled=true
+   fi
    exit 0
 fi
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -112,7 +112,9 @@ EOF
         snap list | grep core
 
         # ensure no auto-refresh happens during the tests
-        snap set core refresh.disabled=true
+        if [ -e /snap/core/current/meta/hooks/configure ]; then
+            snap set core refresh.disabled=true
+        fi
 
         echo "Ensure that the grub-editenv list output is empty on classic"
         output=$(grub-editenv list)
@@ -334,7 +336,9 @@ prepare_all_snap() {
     done
 
     # ensure no auto-refresh happens during the tests
-    snap set core refresh.disabled=true
+    if [ -e /snap/core/current/meta/hooks/configure ]; then
+        snap set core refresh.disabled=true
+    fi
 
     # Snapshot the fresh state (including boot/bootenv)
     if [ ! -f $SPREAD_PATH/snapd-state.tar.gz ]; then

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -4,13 +4,17 @@ prepare: |
     snap install --devmode jq
 
 restore: |
-    snap set core refresh.disabled=true
+    if [ -e /snap/core/current/meta/hooks/configure ]; then
+        snap set core refresh.disabled=true
+    fi
     
 execute: |
     echo "Install a snap from stable"
     snap install test-snapd-tools
     snap list | MATCH 'test-snapd-tools +[0-9]+\.[0-9]+'
-    snap set core refresh.disabled=false
+    if [ -e /snap/core/current/meta/hooks/configure ]; then
+        snap set core refresh.disabled=false
+    fi
     
     systemctl stop snapd.{service,socket}
     echo "Modify the snap to track the edge channel"

--- a/tests/regression/lp-1665004/task.yaml
+++ b/tests/regression/lp-1665004/task.yaml
@@ -7,7 +7,7 @@ details: |
 prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
-    rmdir /var/lib/snapd/hostfs
+    if [ -d /var/lib/snapd/hostfs ]; then rmdir /var/lib/snapd/hostfs; fi
 execute: |
     test-snapd-tools.cmd true
     [ $(stat -c '%g' /var/lib/snapd/hostfs) -eq 0 ] 


### PR DESCRIPTION
With the woes that the core snap went through last week (mostly related
to the presence of the configure hook) we are now at a stage where the
configure hook may or may not be there. When the configure hook is not
available in the core snap published on the edge channel then no pull
request can pass the CI system. To unbreak the world we need to make
changes to the code effectively so this patch makes all uses of the
"snap set core" conditional on the configure hook being present.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>