### PR TITLE
interfaces/builtin/alsa: add read access to alsa state dir

### DIFF
--- a/interfaces/builtin/alsa.go
+++ b/interfaces/builtin/alsa.go
@@ -28,6 +28,9 @@ const alsaConnectedPlugAppArmor = `
 /dev/snd/* rw,
 
 /run/udev/data/c116:[0-9]* r, # alsa
+
+# Allow access to the alsa state dir
+/var/lib/alsa/{,*}         r,
 `
 
 func NewAlsaInterface() interfaces.Interface {


### PR DESCRIPTION
We have a commercial requirement to provide an initial alsa state file from the gadget snap so that the mixer values on a new system are correct.

We want to have the gadget snap deposit this file in `/var/lib/alsa/`. We will update the `alsa-utils` snap with logic to get its initial state from this file and then maintain its own state internally (so no write access to `/var/lib/alsa/` is required.