### PR TITLE
interfaces: miscellaneous policy updates for unity7, udisks2 and browser-support (LP: #1667480)

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -50,6 +50,10 @@ owner /{dev,run}/shm/{,.}com.google.Chrome.* rw,
 deny dbus (send)
     bus=session
     interface="org.gnome.GConf.Server",
+
+# Lttng tracing is very noisy and should not be allowed by confined apps. Can
+# safely deny. LP: #1260491
+deny /{dev,run,var/run}/shm/lttng-ust-* r,
 `
 
 const browserSupportConnectedPlugAppArmorWithoutSandbox = `

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -45,6 +45,9 @@ owner /var/tmp/etilqs_* rw,
 owner /{dev,run}/shm/{,.}org.chromium.Chromium.* rw,
 owner /{dev,run}/shm/{,.}com.google.Chrome.* rw,
 
+# Allow reading platform files
+/run/udev/data/+platform:* r,
+
 # Chrome/Chromium should be adjusted to not use gconf. It is only used with
 # legacy systems that don't have snapd
 deny dbus (send)
@@ -107,7 +110,6 @@ owner @{PROC}/@{pid}/fd/[0-9]* w,
 /run/udev/data/+acpi:* r,
 /run/udev/data/+hwmon:hwmon[0-9]* r,
 /run/udev/data/+i2c:* r,
-/run/udev/data/+platform:* r,
 /sys/devices/**/bConfigurationValue r,
 /sys/devices/**/descriptors r,
 /sys/devices/**/manufacturer r,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -57,6 +57,10 @@ deny dbus (send)
 # Lttng tracing is very noisy and should not be allowed by confined apps. Can
 # safely deny. LP: #1260491
 deny /{dev,run,var/run}/shm/lttng-ust-* r,
+
+# webbrowser-app/webapp-container tries to read this file to determine if it is
+# confined or not, so explicitly deny to avoid noise in the logs.
+deny @{PROC}/@{pid}/attr/current r,
 `
 
 const browserSupportConnectedPlugAppArmorWithoutSandbox = `

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -87,6 +87,9 @@ umount /{,run/}media/**,
 # give raw read access to the system disks and therefore the entire system.
 /dev/sd* r,
 /dev/mmcblk* r,
+
+# Needed for probing raw devices
+capability sys_rawio,
 `
 
 var udisks2ConnectedSlotAppArmor = []byte(`

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -457,7 +457,7 @@ dbus (send)
 
 # Lttng tracing is very noisy and should not be allowed by confined apps. Can
 # safely deny. LP: #1260491
-deny /{,var/}{dev,run}/shm/lttng-ust-* r,
+deny /{dev,run,var/run}/shm/lttng-ust-* r,
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/unity7

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -31,6 +31,7 @@ var implicitSlots = []string{
 	"account-control",
 	"alsa",
 	"bluetooth-control",
+	"browser-support",
 	"camera",
 	"classic-support",
 	"core-support",
@@ -73,7 +74,6 @@ var implicitSlots = []string{
 
 var implicitClassicSlots = []string{
 	"avahi-observe",
-	"browser-support",
 	"cups-control",
 	"gsettings",
 	"libvirt",


### PR DESCRIPTION
- interfaces/unity7: correct imprecise deny rule for lttng
- interfaces/browser-support: explicitly deny reading Lttng trace files
- interfaces/browser-support: always allow read on /run/udev/data/+platform:*
- interfaces/browser-support: explicitly deny reading the process' security label
- interfaces/browser-support: adjust to be implicit interface (LP: #1667480)
    Currently browser-support is an implicit classic interface which means that it
    cannot be used on all snaps systems. Since Oxide, webbrowser-app and
    webapp-container can all run with Mir and mir snaps exist for all snaps, move
    browser-support to be an implicit interface instead of implicit classic.
- interfaces/udisks2: allow capability sys_rawio for probing devices