### PR TITLE
cmd/snap-confine,tests: bind-mount /etc/os-release

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -425,6 +425,11 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		// instead of trying to lstat it first.
 		if (readlink(etc_os_release, link_target, sizeof link_target) <
 		    0) {
+			// readlink returns EINVAL when the buffer size is negative or when
+			// the specified file is not a symbolic link. Since the buffer has
+			// a constant size and we know it's not negative we can special
+			// case EINVAL as an indicator that /etc/os-release is not a
+			// symbolic link and that we can just skip this whole section.
 			if (errno != EINVAL) {
 				die("cannot read target of symbolic link from %s", etc_os_release);
 			}

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -443,7 +443,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		      usr_lib_os_release, dst);
 		if (mount
 		    (usr_lib_os_release, dst, NULL, MS_BIND | MS_RDONLY,
-		     NULL) != 0) {
+		     NULL) < 0) {
 			die("cannot perform operation: mount --bind -o ro %s %s", usr_lib_os_release, dst);
 		}
 	}

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -404,10 +404,10 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			    dst);
 		}
 	}
-	// Since we mountec /etc from the host filesystem the /etc/os-release file
+	// Since we mounted /etc from the host filesystem the /etc/os-release file
 	// (which may not be present) may be a symbolic link. It is expected that
 	// we see the real /etc/os-release file so let's do our best to show
-	// /etc/os-release as it looks like on the clasic distribution.
+	// /etc/os-release as it looks like on the classic distribution.
 	//
 	// If the symbolic link in /etc is pointing to /usr/lib/os-release then
 	// bind mount /usr/lib/os-release over itself in the core snap. This way

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -411,8 +411,9 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	//
 	// If the symbolic link in /etc is pointing to /usr/lib/os-release then
 	// bind mount /usr/lib/os-release over itself in the core snap. This way
-	// the symlink (which we cannot over-bind mount anything) will work as
-	// expected.
+	// the symlink (which we cannot be the target of a bind mount as the kernel
+	// will always follow the link when performing the mount operation) will
+	// work as expected.
 	//
 	// https://bugs.launchpad.net/canonical-livepatch-client/+bug/1667470
 	if (config->on_classic) {

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -118,6 +118,10 @@
     mount options=(rw rbind) /etc/ -> /tmp/snap.rootfs_*/etc/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/etc/,
 
+    # Allow bind mounting /usr/lib/os-release over itself in the core snap.
+    # See mount-support.c for a longer explanation.
+    mount options=(rw bind) /usr/lib/os-release -> /tmp/snap.rootfs_*/usr/lib/os-release,
+
     mount options=(rw rbind) /home/ -> /tmp/snap.rootfs_*/home/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/home/,
 

--- a/tests/main/os-release/task.yaml
+++ b/tests/main/os-release/task.yaml
@@ -1,0 +1,31 @@
+summary: check that /etc/os-release is genuine
+details: |
+    Software may rely on the /etc/os-release file to identify the system where
+    a snap is running.  On a core system this is always ID=ubuntu-core but on
+    classic it is expected to be the /etc/os-release file from the host
+    distribution.
+    Since the /etc/os-release file may be a symlink (and it typically is) it
+    may point to other places, places that originate from the core snap, not
+    from the host system. In practice this happens, e.g. on xenial, where
+    /etc/os-release points to /usr/lib/os-release.
+    Since the symlink is resolved only after the chroot is set in place we
+    don't really know what it was previously pointing at. To counter this
+    snap-confine now bind mounts /etc/os-release over itself from the classic
+    distribution.
+prepare: |
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-tools
+execute: |
+    # The value on the host:
+    cat /etc/os-release > outside
+    test-snapd-tools.cmd cat /etc/os-release > inside 
+    cmp outside inside
+restore: |
+    rm -f outside inside
+debug: |
+    echo "/etc/os-release as seen on the outside of snaps"
+    cat outside
+    echo "/etc/os-release as seen on the inside of snaps"
+    cat inside
+
+


### PR DESCRIPTION
This patch changes snap-confine to allow to see the /etc/os-release file
from the host distribution even if it is a symlink to a well-known
location (/usr/lib/os-release).

Fixes: https://bugs.launchpad.net/canonical-livepatch-client/+bug/1667470
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>