### PR TITLE
release: detect if we are in ForcedDevMode by inspecting the kernel

### DIFF
--- a/release/export_test.go
+++ b/release/export_test.go
@@ -31,3 +31,19 @@ func MockOSReleasePath(filename string) (restore func()) {
 		fallbackOsReleasePath = oldFallback
 	}
 }
+
+func MockVersionSignature(path string) (restorer func()) {
+	old := versionSignaturePath
+	versionSignaturePath = path
+	return func() {
+		versionSignaturePath = old
+	}
+}
+
+func MockApparmorSysPath(path string) (restorer func()) {
+	old := apparmorSysPath
+	apparmorSysPath = path
+	return func() {
+		apparmorSysPath = old
+	}
+}

--- a/release/release.go
+++ b/release/release.go
@@ -21,7 +21,9 @@ package release
 
 import (
 	"bufio"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"unicode"
 )
@@ -35,30 +37,33 @@ type OS struct {
 	VersionID string `json:"version-id,omitempty"`
 }
 
+var (
+	versionSignaturePath = "/proc/version_signature"
+	apparmorSysPath      = "/sys/kernel/security/apparmor/"
+)
+
 // ForceDevMode returns true if the distribution doesn't implement required
 // security features for confinement and devmode is forced.
-func (os *OS) ForceDevMode() bool {
-	switch os.ID {
-	case "neon":
-		return false
-	case "ubuntu":
-		return false
-	case "ubuntu-core":
-		return false
-	case "elementary":
-		switch os.VersionID {
-		case "0.4":
-			return false
-		default:
-			return true
-		}
-	default:
-		// NOTE: Other distributions can move out of devmode by
-		// integrating with the interface security backends. This will
-		// be documented separately in the porting guide.
+func (o *OS) ForceDevMode() bool {
+	// Check if kernel signature contains "Ubuntu", currently only
+	// the Ubuntu kernels have all the required apparmor patches
+	// (but those are getting upstreamed so at some point we need
+	// to make this check smater)
+	versionSig, err := ioutil.ReadFile(versionSignaturePath)
+	if err != nil {
+		return true
+	}
+	if !strings.HasPrefix(string(versionSig), "Ubuntu ") {
 		return true
 	}
 
+	// Also ensure appamor is enabled (cannot use osutil.FileExists() here
+	// because of cyclic imports)
+	if _, err := os.Stat(apparmorSysPath); err != nil {
+		return true
+	}
+
+	return false
 }
 
 var (
@@ -141,4 +146,36 @@ func MockReleaseInfo(osRelease *OS) (restore func()) {
 	old := ReleaseInfo
 	ReleaseInfo = *osRelease
 	return func() { ReleaseInfo = old }
+}
+
+// MockForcedDevmode fake the system to believe its in a distro
+// that is in ForcedDevmode
+func MockForcedDevmode(isDevmode bool) (restore func()) {
+	oldVersionSignaturePath := versionSignaturePath
+	oldApparmorSysPath := apparmorSysPath
+
+	temp, err := ioutil.TempDir("", "mock-forced-devmode")
+	if err != nil {
+		panic(err)
+	}
+	fakeVersionSignaturePath := filepath.Join(temp, "version_signature")
+	fakeApparmorSysPath := filepath.Join(temp, "apparmor")
+	if !isDevmode {
+		if err := ioutil.WriteFile(fakeVersionSignaturePath, []byte("Ubuntu 4.8.0-39.42-generic 4.8.17"), 0644); err != nil {
+			panic(err)
+		}
+		if err := os.MkdirAll(fakeApparmorSysPath, 0755); err != nil {
+			panic(err)
+		}
+	}
+	versionSignaturePath = fakeVersionSignaturePath
+	apparmorSysPath = fakeApparmorSysPath
+
+	return func() {
+		if err := os.RemoveAll(temp); err != nil {
+			panic(err)
+		}
+		versionSignaturePath = oldVersionSignaturePath
+		apparmorSysPath = oldApparmorSysPath
+	}
 }


### PR DESCRIPTION
So far we are detecting if we need to go into "forced-devmode" by
inspecting the os-release file. The downside of this is that we
do not catch a lot of Ubuntu derivates that work just fine but
that we do not have in our code that checks /etc/os-release.

The result is that snapd thinks it is on a devmode distro and
will not generate an apparmor profile. But snap-confine is build
with the Ubuntu defaults which means it will have apparmor enabled
and expects a generated profile. The result is that no snap works
on a derived distro.

The new code will check via /proc/version_signature if we are
running on a Ubuntu kernel and if apparmor is enabled. Only if
this is not the case we will switch to "forced-devmode". This
will enable Mint 18.1, Zorin 12 and any other 16.04 derivate that
uses the Ubuntu kernel to work correctly.