### PR TITLE
interfaces: allow 'getent' by default with some missing dbs to various interfaces

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -121,6 +121,7 @@ var defaultTemplate = []byte(`
   /{,usr/}bin/find ixr,
   /{,usr/}bin/flock ixr,
   /{,usr/}bin/fmt ixr,
+  /{,usr/}bin/getent ixr,
   /{,usr/}bin/getopt ixr,
   /{,usr/}bin/groups ixr,
   /{,usr/}bin/gzip ixr,

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -127,6 +127,7 @@ capability setuid,
 
 # route
 /etc/networks r,
+/etc/ethers r,
 
 # TUN/TAP
 /dev/net/tun rw,

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -129,6 +129,8 @@ capability setuid,
 /etc/networks r,
 /etc/ethers r,
 
+/etc/rpc r,
+
 # TUN/TAP
 /dev/net/tun rw,
 # These are dynamically created via ioctl() on /dev/net/tun

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -84,6 +84,7 @@ network inet6 raw,
 
 # route
 /etc/networks r,
+/etc/ethers r,
 
 # network devices
 /sys/devices/**/net/** r,

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -86,6 +86,8 @@ network inet6 raw,
 /etc/networks r,
 /etc/ethers r,
 
+/etc/rpc r,
+
 # network devices
 /sys/devices/**/net/** r,
 `


### PR DESCRIPTION
`getent` is a handy tool for reading various databases. Most of the databases (eg, passwd, group, hosts, ahosts*, networks, protocols, and services) are available by default or in various interfaces. In addition to allowing use of the getent command, this adds /etc/rpc and /etc/ethers to network-control and network-observe.