### PR TITLE
snapstate: disable running the configure hook on classic for the core snap

### DIFF
--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -5440,6 +5440,12 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasks(c *C) {
 		SnapType: "os",
 	})
 
+	// FIXME: we do not run the configure hook on classic for core, so
+	//        verifyInstallUpdateTasks() would fail, we mock this here
+	//        until LP: #1668738 is understood
+	r := release.MockOnClassic(false)
+	defer r()
+
 	tsl, err := snapstate.TransitionCore(s.state, "ubuntu-core", "core")
 	c.Assert(err, IsNil)
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -204,9 +204,14 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup) (*state.T
 	}
 
 	installSet := state.NewTaskSet(tasks...)
-	configSet := Configure(st, snapsup.Name(), defaults)
-	configSet.WaitAll(installSet)
-	installSet.AddAll(configSet)
+
+	// gross hack, do not run configure hook on classic (LP: #1668738)
+	// for now until we understand why it is failing for some people
+	if !(release.OnClassic && snapsup.Name() == "core") {
+		configSet := Configure(st, snapsup.Name(), defaults)
+		configSet.WaitAll(installSet)
+		installSet.AddAll(configSet)
+	}
 
 	return installSet, nil
 }


### PR DESCRIPTION
We see a large number of errors that looks like:
 `error: cannot find installed snap "core" at revision unset`
on core refrehes on classic. The reason is not yet understood.

We have no report about this error from an actual Ubuntu Core
system (this might be because the installed base is smaller there
though).

So far we disabled the configure hook for core but we need it on
Ubuntu Core systems because it contains important features like
disabling the sshd service and more. To unblock the situation
this branch will not run the configure hook for core on classic
(it is not very useful there anyway).