### PR TITLE
data: re-add snapd.refresh.{timer,service} with weekly schedule

### DIFF
--- a/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
+++ b/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
@@ -17,7 +17,7 @@ prepare: |
     cd /
     echo "Install hello-world"
     snap install hello-world
-    systemctl stop snapd.service snapd.socket
+    systemctl stop snapd.refresh.timer snapd.service snapd.socket
     # all of this ls madness can go away when we have remote environment
     # variables
     echo "Unmount original core snap"
@@ -31,7 +31,7 @@ prepare: |
     if [ ! -e $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) ]; then exit 1; fi
     echo "Mount modified core snap"
     mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)
-    systemctl start snapd.service snapd.socket
+    systemctl start snapd.refresh.timer snapd.service snapd.socket
 execute: |
     exit 0
     cd /
@@ -51,7 +51,7 @@ restore: |
     exit 0
     echo "Remove hello-world"
     snap remove hello-world
-    systemctl stop snapd.service snapd.socket
+    systemctl stop snapd.refresh.timer snapd.service snapd.socket
     echo "Unmount the modified core snap"
     # all of this ls madness can go away when we have remote environment
     # variables
@@ -66,4 +66,4 @@ restore: |
     udevadm settle
     udevadm trigger
     udevadm settle
-    systemctl start snapd.service snapd.socket
+    systemctl start snapd.refresh.timer snapd.service snapd.socket

--- a/data/systemd/snapd.refresh.service
+++ b/data/systemd/snapd.refresh.service
@@ -8,4 +8,4 @@ Documentation=man:snap(1)
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/snap refresh
-Environment=SNAP_REFRESH_FROM_EMERGENRY_TIMER=1
+Environment=SNAP_REFRESH_FROM_EMERGENCY_TIMER=1

--- a/data/systemd/snapd.refresh.service
+++ b/data/systemd/snapd.refresh.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Automatically refresh installed snaps
+After=network-online.target snapd.socket
+Requires=snapd.socket
+ConditionPathExistsGlob=/snap/*/current
+Documentation=man:snap(1)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/snap refresh
+Environment=SNAP_REFRESH_FROM_EMERGENRY_TIMER=1

--- a/data/systemd/snapd.refresh.timer
+++ b/data/systemd/snapd.refresh.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Timer to automatically refresh installed snaps
+
+[Timer]
+# do a weekly refresh using the time to ensure that we can still
+# fix any potential errors in the internal timer handling
+OnCalendar=weekly
+RandomizedDelaySec=6h
+AccuracySec=10min
+Persistent=true
+OnStartupSec=15m
+
+[Install]
+WantedBy=timers.target

--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -126,6 +126,8 @@ override_dh_install:
 	fi
 	# we install snapd's systemd units
 	mkdir -p debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
+	install --mode=0644 debian/snapd.refresh.timer debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
+	install --mode=0644 debian/snapd.refresh.service debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
 	install --mode=0644 debian/snapd.autoimport.service debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
 	install --mode=0644 debian/*.socket debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
 	install --mode=0644 debian/snapd.service debian/snapd/$(SYSTEMD_UNITS_DESTDIR)

--- a/packaging/ubuntu-14.04/snapd.postinst
+++ b/packaging/ubuntu-14.04/snapd.postinst
@@ -17,8 +17,8 @@ case "$1" in
             # snapd.system-shutdown.service is not strictly needed on 14.04. Its functionality
             # is limited to core devices, we still include it here for the sake of comppleteness
             # in comparison to 16.04 setups.
-            systemctl -f enable snapd.autoimport.service snapd.socket snapd.service snap.mount.service snapd.system-shutdown.service
-            systemctl start snapd.autoimport.service snapd.socket snapd.service snap.mount.service
+            systemctl -f enable snapd.refresh.timer snapd.refresh.service snapd.autoimport.service snapd.socket snapd.service snap.mount.service snapd.system-shutdown.service
+            systemctl start snapd.refresh.timer snapd.autoimport.service snapd.socket snapd.service snap.mount.service
         fi
 
 	case ":$PATH:" in

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -108,6 +108,15 @@ override_dh_systemd_enable:
 	dh_systemd_enable \
 		-psnapd \
 		data/systemd/snapd.autoimport.service
+	# we want the auto-update timer enabled by default
+	dh_systemd_enable \
+		-psnapd \
+		data/systemd/snapd.refresh.timer
+	# but the auto-update service disabled
+	dh_systemd_enable \
+		--no-enable \
+		-psnapd \
+		data/systemd/snapd.refresh.service
 	# enable snapd
 	dh_systemd_enable \
 		-psnapd \
@@ -120,6 +129,15 @@ override_dh_systemd_enable:
 		data/systemd/snapd.system-shutdown.service
 
 override_dh_systemd_start:
+	# we want to start the auto-update timer
+	dh_systemd_start \
+		-psnapd \
+		data/systemd/snapd.refresh.timer
+	# but not start the service
+	dh_systemd_start \
+		--no-start \
+		-psnapd \
+		data/systemd/snapd.refresh.service
 	# start snapd
 	dh_systemd_start \
 		-psnapd \
@@ -150,6 +168,8 @@ override_dh_install:
 	# debian/snapd.install because the ubuntu/14.04 release
 	# branch adds/changes bits here
 	mkdir -p debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
+	install --mode=0644 data/systemd/snapd.refresh.timer debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
+	install --mode=0644 data/systemd/snapd.refresh.service debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
 	install --mode=0644 data/systemd/snapd.autoimport.service debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
 	install --mode=0644 data/systemd/*.socket debian/snapd/$(SYSTEMD_UNITS_DESTDIR)
 	install --mode=0644 data/systemd/snapd.service debian/snapd/$(SYSTEMD_UNITS_DESTDIR)

--- a/spread.yaml
+++ b/spread.yaml
@@ -226,6 +226,7 @@ restore: |
     if [ "$SPREAD_BACKEND" = external ]; then
         # start and enable autorefresh
         if [ -e /snap/core/current/meta/hooks/configure ]; then
+            systemctl enable --now snapd.refresh.timer
             snap set core refresh.disabled=false
         fi
     fi

--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -65,6 +65,7 @@ if [ "$SPREAD_BACKEND" = external ]; then
    fi
    # stop and disable autorefresh
    if [ -e /snap/core/current/meta/hooks/configure ]; then
+       systemctl disable --now snapd.refresh.timer
        snap set core refresh.disabled=true
    fi
    exit 0

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -113,7 +113,6 @@ EOF
 
         # ensure no auto-refresh happens during the tests
         if [ -e /snap/core/current/meta/hooks/configure ]; then
-            systemctl disable --now snapd.refresh.timer
             snap set core refresh.disabled=true
         fi
 
@@ -338,7 +337,6 @@ prepare_all_snap() {
 
     # ensure no auto-refresh happens during the tests
     if [ -e /snap/core/current/meta/hooks/configure ]; then
-        systemctl disable --now snapd.refresh.timer
         snap set core refresh.disabled=true
     fi
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -113,6 +113,7 @@ EOF
 
         # ensure no auto-refresh happens during the tests
         if [ -e /snap/core/current/meta/hooks/configure ]; then
+            systemctl disable --now snapd.refresh.timer
             snap set core refresh.disabled=true
         fi
 
@@ -337,6 +338,7 @@ prepare_all_snap() {
 
     # ensure no auto-refresh happens during the tests
     if [ -e /snap/core/current/meta/hooks/configure ]; then
+        systemctl disable --now snapd.refresh.timer
         snap set core refresh.disabled=true
     fi
 


### PR DESCRIPTION
This will protect us against bugs in the new internal-refresh
code. If for some reason this fails we will still use a systemd
timer to refresh once a week.