### PR TITLE
errtracker: forward port the 2.22.7 fixes

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -58,7 +58,7 @@ func distroRelease() string {
 	return fmt.Sprintf("%s %s", ID, release.ReleaseInfo.VersionID)
 }
 
-func Report(snap, channel, errMsg string, extra map[string]string) (string, error) {
+func Report(snap, errMsg, dupSig string, extra map[string]string) (string, error) {
 	if CrashDbURLBase == "" {
 		return "", nil
 	}
@@ -98,10 +98,9 @@ func Report(snap, channel, errMsg string, extra map[string]string) (string, erro
 		"CoreSnapdBuildID":   coreBuildID,
 		"Date":               timeNow().Format(time.ANSIC),
 		"Snap":               snap,
-		"Channel":            channel,
 		"KernelVersion":      release.KernelVersion(),
 		"ErrorMessage":       errMsg,
-		"DuplicateSignature": fmt.Sprintf("snap-install: %s", errMsg),
+		"DuplicateSignature": dupSig,
 	}
 	for k, v := range extra {
 		// only set if empty

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -95,7 +95,7 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 				"Channel":            "beta",
 				"KernelVersion":      release.KernelVersion(),
 				"ErrorMessage":       "failed to do stuff",
-				"DuplicateSignature": "snap-install: failed to do stuff",
+				"DuplicateSignature": "[failed to do stuff]",
 				"Architecture":       arch.UbuntuArchitecture(),
 			})
 			fmt.Fprintf(w, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
@@ -117,13 +117,15 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 	restorer = errtracker.MockTimeNow(func() time.Time { return time.Date(2017, 2, 17, 9, 51, 0, 0, time.UTC) })
 	defer restorer()
 
-	id, err := errtracker.Report("some-snap", "beta", "failed to do stuff", nil)
+	id, err := errtracker.Report("some-snap", "failed to do stuff", "[failed to do stuff]", map[string]string{
+		"Channel": "beta",
+	})
 	c.Check(err, IsNil)
 	c.Check(id, Equals, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 	c.Check(n, Equals, 1)
 
 	// run again, verify identifier is unchanged
-	id, err = errtracker.Report("some-other-snap", "edge", "failed to do more stuff", nil)
+	id, err = errtracker.Report("some-other-snap", "failed to do more stuff", "[failed to do more stuff]", nil)
 	c.Check(err, IsNil)
 	c.Check(id, Equals, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 	c.Check(n, Equals, 2)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -690,13 +690,28 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	if osutil.GetenvBool("SNAPPY_TESTING") {
 		return nil
 	}
-	if snapsup.SideInfo.RealName == "" {
+	if snapsup.SideInfo == nil || snapsup.SideInfo.RealName == "" {
 		return nil
 	}
 
 	var logMsg []string
-	for _, t := range t.Change().Tasks() {
-		logMsg = append(logMsg, fmt.Sprintf("%s: %s", t.Kind(), t.Status()))
+	var snapSetup string
+	dupSig := []string{"snap-install:"}
+	chg := t.Change()
+	logMsg = append(logMsg, fmt.Sprintf("change %q: %q", chg.Kind(), chg.Summary()))
+	for _, t := range chg.Tasks() {
+		// TODO: report only tasks in intersecting lanes?
+		tintro := fmt.Sprintf("%s: %s", t.Kind(), t.Status())
+		logMsg = append(logMsg, tintro)
+		dupSig = append(dupSig, tintro)
+		if snapsup, err := TaskSnapSetup(t); err == nil && snapsup.SideInfo != nil {
+			snapSetup1 := fmt.Sprintf(" snap-setup: %q (%v) %q", snapsup.SideInfo.RealName, snapsup.SideInfo.Revision, snapsup.SideInfo.Channel)
+			if snapSetup1 != snapSetup {
+				snapSetup = snapSetup1
+				logMsg = append(logMsg, snapSetup)
+				dupSig = append(dupSig, fmt.Sprintf(" snap-setup: %q", snapsup.SideInfo.RealName))
+			}
+		}
 		for _, l := range t.Log() {
 			// cut of the rfc339 timestamp to ensure duplicate
 			// detection works in daisy
@@ -705,7 +720,9 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 				continue
 			}
 			// not tStampLen+1 because the indent is nice
-			logMsg = append(logMsg, l[tStampLen:])
+			entry := l[tStampLen:]
+			logMsg = append(logMsg, entry)
+			dupSig = append(dupSig, entry)
 		}
 	}
 
@@ -714,13 +731,16 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil && err != state.ErrNoState {
 		return err
 	}
-	extra := map[string]string{}
+	extra := map[string]string{
+		"Channel":  snapsup.Channel,
+		"Revision": snapsup.SideInfo.Revision.String(),
+	}
 	if ubuntuCoreTransitionCount > 0 {
 		extra["UbuntuCoreTransitionCount"] = strconv.Itoa(ubuntuCoreTransitionCount)
 	}
 
 	st.Unlock()
-	oopsid, err := errtrackerReport(snapsup.SideInfo.RealName, snapsup.SideInfo.Channel, strings.Join(logMsg, "\n"), extra)
+	oopsid, err := errtrackerReport(snapsup.SideInfo.RealName, strings.Join(logMsg, "\n"), strings.Join(dupSig, "\n"), extra)
 	st.Lock()
 	if err == nil {
 		logger.Noticef("Reported problem as %s", oopsid)

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -3955,13 +3955,13 @@ func (s *snapmgrTestSuite) TestUndoMountSnapFailsInCopyData(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestRefreshFailureCausesErrorReport(c *C) {
-	var errSnap, errChannel, errMsg string
+	var errSnap, errMsg, errSig string
 	var errExtra map[string]string
 	var n int
-	restore := snapstate.MockErrtrackerReport(func(aSnap, aChannel, aErrMsg string, extra map[string]string) (string, error) {
+	restore := snapstate.MockErrtrackerReport(func(aSnap, aErrMsg, aDupSig string, extra map[string]string) (string, error) {
 		errSnap = aSnap
-		errChannel = aChannel
 		errMsg = aErrMsg
+		errSig = aDupSig
 		errExtra = extra
 		n += 1
 		return "oopsid", nil
@@ -4000,11 +4000,27 @@ func (s *snapmgrTestSuite) TestRefreshFailureCausesErrorReport(c *C) {
 	// verify we generated a failure report
 	c.Check(n, Equals, 1)
 	c.Check(errSnap, Equals, "some-snap")
-	c.Check(errChannel, Equals, "some-channel")
 	c.Check(errExtra, DeepEquals, map[string]string{
 		"UbuntuCoreTransitionCount": "7",
+		"Channel":                   "some-channel",
+		"Revision":                  "11",
 	})
-	c.Check(errMsg, Matches, `(?sm)download-snap: Undoing
+	c.Check(errMsg, Matches, `(?sm)change "install": "install a snap"
+download-snap: Undoing
+ snap-setup: "some-snap" \(11\) "some-channel"
+validate-snap: Done
+.*
+link-snap: Error
+ INFO unlink
+ ERROR fail
+set-auto-aliases: Hold
+setup-aliases: Hold
+start-snap-services: Hold
+cleanup: Hold
+run-hook: Hold`)
+	c.Check(errSig, Matches, `(?sm)snap-install:
+download-snap: Undoing
+ snap-setup: "some-snap"
 validate-snap: Done
 .*
 link-snap: Error
@@ -4028,7 +4044,11 @@ run-hook: Hold`)
 	s.state.Lock()
 	// verify that we excluded this field from the bugreport
 	c.Check(n, Equals, 2)
-	c.Check(errExtra, DeepEquals, map[string]string{})
+	c.Check(errExtra, DeepEquals, map[string]string{
+		"Channel":  "some-channel",
+		"Revision": "11",
+	})
+
 }
 
 func (s *snapmgrTestSuite) verifyRefreshLast(c *C) {

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -5,6 +5,14 @@ snapd (2.23) UNRELEASED; urgency=medium
 
  -- Michael Vogt <michael.vogt@ubuntu.com>  Mon, 30 Jan 2017 14:42:46 +0100
 
+snapd (2.22.7) xenial; urgency=medium
+
+  * New upstream release:
+    - errtracker,overlord/snapstate: more info in errtracker reports
+    - interfaces/apparmor: compensate for kernel behavior change
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Fri, 24 Feb 2017 19:24:11 +0100
+
 snapd (2.22.6) xenial; urgency=medium
 
   * New upstream release, LP: #1667105


### PR DESCRIPTION
This is just brining the already reviewed fixes in 2.22.7 (and .8) to master.