### PR TITLE
snapstate: error in LinkSnap() if revision is unset

### DIFF
--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -58,6 +58,10 @@ func updateCurrentSymlinks(info *snap.Info) error {
 
 // LinkSnap makes the snap available by generating wrappers and setting the current symlinks.
 func (b Backend) LinkSnap(info *snap.Info) error {
+	if info.Revision.Unset() {
+		return fmt.Errorf("cannot link snap %q with unset revision", info.Name())
+	}
+
 	if err := generateWrappers(info); err != nil {
 		return err
 	}

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -210,3 +210,11 @@ apps:
 	c.Check(osutil.FileExists(currentActiveSymlink), Equals, false)
 	c.Check(osutil.FileExists(currentDataSymlink), Equals, false)
 }
+
+func (s *linkSuite) TestLinkFailsForUnsetRevision(c *C) {
+	info := &snap.Info{
+		SuggestedName: "foo",
+	}
+	err := s.be.LinkSnap(info)
+	c.Assert(err, ErrorMatches, `cannot link snap "foo" with unset revision`)
+}


### PR DESCRIPTION
We have some bugreports that indicate that we might sometimes write "unset" revisions to disk. This is something that should never happen so we error early.