### PR TITLE
cmd/libsnap: add sc_quote_string

### DIFF
--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -433,6 +433,350 @@ static void test_sc_string_append_char_pair__normal()
 	g_assert_cmpint(len, ==, 6);
 }
 
+static void test_sc_string_quote_NULL_str()
+{
+	if (g_test_subprocess()) {
+		char buf[16] = { 0 };
+		sc_string_quote(buf, sizeof buf, NULL);
+
+		g_test_message("expected sc_string_quote not to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("cannot quote string: string is NULL\n");
+}
+
+static void test_sc_string_quote()
+{
+#define DQ "\""
+	char buf[16];
+	bool is_tested[256] = { false };
+
+	void test_quoting_of(int c, const char *expected) {
+		g_assert_cmpint(c, >=, 0);
+		g_assert_cmpint(c, <=, 255);
+
+		// Create an input string with one character.
+		char input[2] = { (unsigned char)c, 0 };
+		sc_string_quote(buf, sizeof buf, input);
+
+		// Ensure it was quoted as we expected.
+		g_assert_cmpstr(buf, ==, expected);
+
+		is_tested[c] = true;
+	}
+
+	// Exhaustive test for quoting of every 8bit input.  This is very verbose
+	// but the goal is to have a very obvious and correct test that ensures no
+	// edge case is lost.
+	//
+	// block 1: 0x00 - 0x0f
+	test_quoting_of(0x00, DQ "" DQ);
+	test_quoting_of(0x01, DQ "\\x01" DQ);
+	test_quoting_of(0x02, DQ "\\x02" DQ);
+	test_quoting_of(0x03, DQ "\\x03" DQ);
+	test_quoting_of(0x04, DQ "\\x04" DQ);
+	test_quoting_of(0x05, DQ "\\x05" DQ);
+	test_quoting_of(0x06, DQ "\\x06" DQ);
+	test_quoting_of(0x07, DQ "\\x07" DQ);
+	test_quoting_of(0x08, DQ "\\x08" DQ);
+	test_quoting_of(0x09, DQ "\\t" DQ);
+	test_quoting_of(0x0a, DQ "\\n" DQ);
+	test_quoting_of(0x0b, DQ "\\v" DQ);
+	test_quoting_of(0x0c, DQ "\\x0c" DQ);
+	test_quoting_of(0x0d, DQ "\\r" DQ);
+	test_quoting_of(0x0e, DQ "\\x0e" DQ);
+	test_quoting_of(0x0f, DQ "\\x0f" DQ);
+	// block 2: 0x10 - 0x1f
+	test_quoting_of(0x10, DQ "\\x10" DQ);
+	test_quoting_of(0x11, DQ "\\x11" DQ);
+	test_quoting_of(0x12, DQ "\\x12" DQ);
+	test_quoting_of(0x13, DQ "\\x13" DQ);
+	test_quoting_of(0x14, DQ "\\x14" DQ);
+	test_quoting_of(0x15, DQ "\\x15" DQ);
+	test_quoting_of(0x16, DQ "\\x16" DQ);
+	test_quoting_of(0x17, DQ "\\x17" DQ);
+	test_quoting_of(0x18, DQ "\\x18" DQ);
+	test_quoting_of(0x19, DQ "\\x19" DQ);
+	test_quoting_of(0x1a, DQ "\\x1a" DQ);
+	test_quoting_of(0x1b, DQ "\\x1b" DQ);
+	test_quoting_of(0x1c, DQ "\\x1c" DQ);
+	test_quoting_of(0x1d, DQ "\\x1d" DQ);
+	test_quoting_of(0x1e, DQ "\\x1e" DQ);
+	test_quoting_of(0x1f, DQ "\\x1f" DQ);
+	// block 3: 0x20 - 0x2f
+	test_quoting_of(0x20, DQ " " DQ);
+	test_quoting_of(0x21, DQ "!" DQ);
+	test_quoting_of(0x22, DQ "\\\"" DQ);
+	test_quoting_of(0x23, DQ "#" DQ);
+	test_quoting_of(0x24, DQ "$" DQ);
+	test_quoting_of(0x25, DQ "%" DQ);
+	test_quoting_of(0x26, DQ "&" DQ);
+	test_quoting_of(0x27, DQ "'" DQ);
+	test_quoting_of(0x28, DQ "(" DQ);
+	test_quoting_of(0x29, DQ ")" DQ);
+	test_quoting_of(0x2a, DQ "*" DQ);
+	test_quoting_of(0x2b, DQ "+" DQ);
+	test_quoting_of(0x2c, DQ "," DQ);
+	test_quoting_of(0x2d, DQ "-" DQ);
+	test_quoting_of(0x2e, DQ "." DQ);
+	test_quoting_of(0x2f, DQ "/" DQ);
+	// block 4: 0x30 - 0x3f
+	test_quoting_of(0x30, DQ "0" DQ);
+	test_quoting_of(0x31, DQ "1" DQ);
+	test_quoting_of(0x32, DQ "2" DQ);
+	test_quoting_of(0x33, DQ "3" DQ);
+	test_quoting_of(0x34, DQ "4" DQ);
+	test_quoting_of(0x35, DQ "5" DQ);
+	test_quoting_of(0x36, DQ "6" DQ);
+	test_quoting_of(0x37, DQ "7" DQ);
+	test_quoting_of(0x38, DQ "8" DQ);
+	test_quoting_of(0x39, DQ "9" DQ);
+	test_quoting_of(0x3a, DQ ":" DQ);
+	test_quoting_of(0x3b, DQ ";" DQ);
+	test_quoting_of(0x3c, DQ "<" DQ);
+	test_quoting_of(0x3d, DQ "=" DQ);
+	test_quoting_of(0x3e, DQ ">" DQ);
+	test_quoting_of(0x3f, DQ "?" DQ);
+	// block 5: 0x40 - 0x4f
+	test_quoting_of(0x40, DQ "@" DQ);
+	test_quoting_of(0x41, DQ "A" DQ);
+	test_quoting_of(0x42, DQ "B" DQ);
+	test_quoting_of(0x43, DQ "C" DQ);
+	test_quoting_of(0x44, DQ "D" DQ);
+	test_quoting_of(0x45, DQ "E" DQ);
+	test_quoting_of(0x46, DQ "F" DQ);
+	test_quoting_of(0x47, DQ "G" DQ);
+	test_quoting_of(0x48, DQ "H" DQ);
+	test_quoting_of(0x49, DQ "I" DQ);
+	test_quoting_of(0x4a, DQ "J" DQ);
+	test_quoting_of(0x4b, DQ "K" DQ);
+	test_quoting_of(0x4c, DQ "L" DQ);
+	test_quoting_of(0x4d, DQ "M" DQ);
+	test_quoting_of(0x4e, DQ "N" DQ);
+	test_quoting_of(0x4f, DQ "O" DQ);
+	// block 6: 0x50 - 0x5f
+	test_quoting_of(0x50, DQ "P" DQ);
+	test_quoting_of(0x51, DQ "Q" DQ);
+	test_quoting_of(0x52, DQ "R" DQ);
+	test_quoting_of(0x53, DQ "S" DQ);
+	test_quoting_of(0x54, DQ "T" DQ);
+	test_quoting_of(0x55, DQ "U" DQ);
+	test_quoting_of(0x56, DQ "V" DQ);
+	test_quoting_of(0x57, DQ "W" DQ);
+	test_quoting_of(0x58, DQ "X" DQ);
+	test_quoting_of(0x59, DQ "Y" DQ);
+	test_quoting_of(0x5a, DQ "Z" DQ);
+	test_quoting_of(0x5b, DQ "[" DQ);
+	test_quoting_of(0x5c, DQ "\\\\" DQ);
+	test_quoting_of(0x5d, DQ "]" DQ);
+	test_quoting_of(0x5e, DQ "^" DQ);
+	test_quoting_of(0x5f, DQ "_" DQ);
+	// block 7: 0x60 - 0x6f
+	test_quoting_of(0x60, DQ "`" DQ);
+	test_quoting_of(0x61, DQ "a" DQ);
+	test_quoting_of(0x62, DQ "b" DQ);
+	test_quoting_of(0x63, DQ "c" DQ);
+	test_quoting_of(0x64, DQ "d" DQ);
+	test_quoting_of(0x65, DQ "e" DQ);
+	test_quoting_of(0x66, DQ "f" DQ);
+	test_quoting_of(0x67, DQ "g" DQ);
+	test_quoting_of(0x68, DQ "h" DQ);
+	test_quoting_of(0x69, DQ "i" DQ);
+	test_quoting_of(0x6a, DQ "j" DQ);
+	test_quoting_of(0x6b, DQ "k" DQ);
+	test_quoting_of(0x6c, DQ "l" DQ);
+	test_quoting_of(0x6d, DQ "m" DQ);
+	test_quoting_of(0x6e, DQ "n" DQ);
+	test_quoting_of(0x6f, DQ "o" DQ);
+	// block 8: 0x70 - 0x7f
+	test_quoting_of(0x70, DQ "p" DQ);
+	test_quoting_of(0x71, DQ "q" DQ);
+	test_quoting_of(0x72, DQ "r" DQ);
+	test_quoting_of(0x73, DQ "s" DQ);
+	test_quoting_of(0x74, DQ "t" DQ);
+	test_quoting_of(0x75, DQ "u" DQ);
+	test_quoting_of(0x76, DQ "v" DQ);
+	test_quoting_of(0x77, DQ "w" DQ);
+	test_quoting_of(0x78, DQ "x" DQ);
+	test_quoting_of(0x79, DQ "y" DQ);
+	test_quoting_of(0x7a, DQ "z" DQ);
+	test_quoting_of(0x7b, DQ "{" DQ);
+	test_quoting_of(0x7c, DQ "|" DQ);
+	test_quoting_of(0x7d, DQ "}" DQ);
+	test_quoting_of(0x7e, DQ "~" DQ);
+	test_quoting_of(0x7f, DQ "\\x7f" DQ);
+	// block 9 (8-bit): 0x80 - 0x8f
+	test_quoting_of(0x80, DQ "\\x80" DQ);
+	test_quoting_of(0x81, DQ "\\x81" DQ);
+	test_quoting_of(0x82, DQ "\\x82" DQ);
+	test_quoting_of(0x83, DQ "\\x83" DQ);
+	test_quoting_of(0x84, DQ "\\x84" DQ);
+	test_quoting_of(0x85, DQ "\\x85" DQ);
+	test_quoting_of(0x86, DQ "\\x86" DQ);
+	test_quoting_of(0x87, DQ "\\x87" DQ);
+	test_quoting_of(0x88, DQ "\\x88" DQ);
+	test_quoting_of(0x89, DQ "\\x89" DQ);
+	test_quoting_of(0x8a, DQ "\\x8a" DQ);
+	test_quoting_of(0x8b, DQ "\\x8b" DQ);
+	test_quoting_of(0x8c, DQ "\\x8c" DQ);
+	test_quoting_of(0x8d, DQ "\\x8d" DQ);
+	test_quoting_of(0x8e, DQ "\\x8e" DQ);
+	test_quoting_of(0x8f, DQ "\\x8f" DQ);
+	// block 10 (8-bit): 0x90 - 0x9f
+	test_quoting_of(0x90, DQ "\\x90" DQ);
+	test_quoting_of(0x91, DQ "\\x91" DQ);
+	test_quoting_of(0x92, DQ "\\x92" DQ);
+	test_quoting_of(0x93, DQ "\\x93" DQ);
+	test_quoting_of(0x94, DQ "\\x94" DQ);
+	test_quoting_of(0x95, DQ "\\x95" DQ);
+	test_quoting_of(0x96, DQ "\\x96" DQ);
+	test_quoting_of(0x97, DQ "\\x97" DQ);
+	test_quoting_of(0x98, DQ "\\x98" DQ);
+	test_quoting_of(0x99, DQ "\\x99" DQ);
+	test_quoting_of(0x9a, DQ "\\x9a" DQ);
+	test_quoting_of(0x9b, DQ "\\x9b" DQ);
+	test_quoting_of(0x9c, DQ "\\x9c" DQ);
+	test_quoting_of(0x9d, DQ "\\x9d" DQ);
+	test_quoting_of(0x9e, DQ "\\x9e" DQ);
+	test_quoting_of(0x9f, DQ "\\x9f" DQ);
+	// block 11 (8-bit): 0xa0 - 0xaf
+	test_quoting_of(0xa0, DQ "\\xa0" DQ);
+	test_quoting_of(0xa1, DQ "\\xa1" DQ);
+	test_quoting_of(0xa2, DQ "\\xa2" DQ);
+	test_quoting_of(0xa3, DQ "\\xa3" DQ);
+	test_quoting_of(0xa4, DQ "\\xa4" DQ);
+	test_quoting_of(0xa5, DQ "\\xa5" DQ);
+	test_quoting_of(0xa6, DQ "\\xa6" DQ);
+	test_quoting_of(0xa7, DQ "\\xa7" DQ);
+	test_quoting_of(0xa8, DQ "\\xa8" DQ);
+	test_quoting_of(0xa9, DQ "\\xa9" DQ);
+	test_quoting_of(0xaa, DQ "\\xaa" DQ);
+	test_quoting_of(0xab, DQ "\\xab" DQ);
+	test_quoting_of(0xac, DQ "\\xac" DQ);
+	test_quoting_of(0xad, DQ "\\xad" DQ);
+	test_quoting_of(0xae, DQ "\\xae" DQ);
+	test_quoting_of(0xaf, DQ "\\xaf" DQ);
+	// block 12 (8-bit): 0xb0 - 0xbf
+	test_quoting_of(0xb0, DQ "\\xb0" DQ);
+	test_quoting_of(0xb1, DQ "\\xb1" DQ);
+	test_quoting_of(0xb2, DQ "\\xb2" DQ);
+	test_quoting_of(0xb3, DQ "\\xb3" DQ);
+	test_quoting_of(0xb4, DQ "\\xb4" DQ);
+	test_quoting_of(0xb5, DQ "\\xb5" DQ);
+	test_quoting_of(0xb6, DQ "\\xb6" DQ);
+	test_quoting_of(0xb7, DQ "\\xb7" DQ);
+	test_quoting_of(0xb8, DQ "\\xb8" DQ);
+	test_quoting_of(0xb9, DQ "\\xb9" DQ);
+	test_quoting_of(0xba, DQ "\\xba" DQ);
+	test_quoting_of(0xbb, DQ "\\xbb" DQ);
+	test_quoting_of(0xbc, DQ "\\xbc" DQ);
+	test_quoting_of(0xbd, DQ "\\xbd" DQ);
+	test_quoting_of(0xbe, DQ "\\xbe" DQ);
+	test_quoting_of(0xbf, DQ "\\xbf" DQ);
+	// block 13 (8-bit): 0xc0 - 0xcf
+	test_quoting_of(0xc0, DQ "\\xc0" DQ);
+	test_quoting_of(0xc1, DQ "\\xc1" DQ);
+	test_quoting_of(0xc2, DQ "\\xc2" DQ);
+	test_quoting_of(0xc3, DQ "\\xc3" DQ);
+	test_quoting_of(0xc4, DQ "\\xc4" DQ);
+	test_quoting_of(0xc5, DQ "\\xc5" DQ);
+	test_quoting_of(0xc6, DQ "\\xc6" DQ);
+	test_quoting_of(0xc7, DQ "\\xc7" DQ);
+	test_quoting_of(0xc8, DQ "\\xc8" DQ);
+	test_quoting_of(0xc9, DQ "\\xc9" DQ);
+	test_quoting_of(0xca, DQ "\\xca" DQ);
+	test_quoting_of(0xcb, DQ "\\xcb" DQ);
+	test_quoting_of(0xcc, DQ "\\xcc" DQ);
+	test_quoting_of(0xcd, DQ "\\xcd" DQ);
+	test_quoting_of(0xce, DQ "\\xce" DQ);
+	test_quoting_of(0xcf, DQ "\\xcf" DQ);
+	// block 14 (8-bit): 0xd0 - 0xdf
+	test_quoting_of(0xd0, DQ "\\xd0" DQ);
+	test_quoting_of(0xd1, DQ "\\xd1" DQ);
+	test_quoting_of(0xd2, DQ "\\xd2" DQ);
+	test_quoting_of(0xd3, DQ "\\xd3" DQ);
+	test_quoting_of(0xd4, DQ "\\xd4" DQ);
+	test_quoting_of(0xd5, DQ "\\xd5" DQ);
+	test_quoting_of(0xd6, DQ "\\xd6" DQ);
+	test_quoting_of(0xd7, DQ "\\xd7" DQ);
+	test_quoting_of(0xd8, DQ "\\xd8" DQ);
+	test_quoting_of(0xd9, DQ "\\xd9" DQ);
+	test_quoting_of(0xda, DQ "\\xda" DQ);
+	test_quoting_of(0xdb, DQ "\\xdb" DQ);
+	test_quoting_of(0xdc, DQ "\\xdc" DQ);
+	test_quoting_of(0xdd, DQ "\\xdd" DQ);
+	test_quoting_of(0xde, DQ "\\xde" DQ);
+	test_quoting_of(0xdf, DQ "\\xdf" DQ);
+	// block 15 (8-bit): 0xe0 - 0xef
+	test_quoting_of(0xe0, DQ "\\xe0" DQ);
+	test_quoting_of(0xe1, DQ "\\xe1" DQ);
+	test_quoting_of(0xe2, DQ "\\xe2" DQ);
+	test_quoting_of(0xe3, DQ "\\xe3" DQ);
+	test_quoting_of(0xe4, DQ "\\xe4" DQ);
+	test_quoting_of(0xe5, DQ "\\xe5" DQ);
+	test_quoting_of(0xe6, DQ "\\xe6" DQ);
+	test_quoting_of(0xe7, DQ "\\xe7" DQ);
+	test_quoting_of(0xe8, DQ "\\xe8" DQ);
+	test_quoting_of(0xe9, DQ "\\xe9" DQ);
+	test_quoting_of(0xea, DQ "\\xea" DQ);
+	test_quoting_of(0xeb, DQ "\\xeb" DQ);
+	test_quoting_of(0xec, DQ "\\xec" DQ);
+	test_quoting_of(0xed, DQ "\\xed" DQ);
+	test_quoting_of(0xee, DQ "\\xee" DQ);
+	test_quoting_of(0xef, DQ "\\xef" DQ);
+	// block 16 (8-bit): 0xf0 - 0xff
+	test_quoting_of(0xf0, DQ "\\xf0" DQ);
+	test_quoting_of(0xf1, DQ "\\xf1" DQ);
+	test_quoting_of(0xf2, DQ "\\xf2" DQ);
+	test_quoting_of(0xf3, DQ "\\xf3" DQ);
+	test_quoting_of(0xf4, DQ "\\xf4" DQ);
+	test_quoting_of(0xf5, DQ "\\xf5" DQ);
+	test_quoting_of(0xf6, DQ "\\xf6" DQ);
+	test_quoting_of(0xf7, DQ "\\xf7" DQ);
+	test_quoting_of(0xf8, DQ "\\xf8" DQ);
+	test_quoting_of(0xf9, DQ "\\xf9" DQ);
+	test_quoting_of(0xfa, DQ "\\xfa" DQ);
+	test_quoting_of(0xfb, DQ "\\xfb" DQ);
+	test_quoting_of(0xfc, DQ "\\xfc" DQ);
+	test_quoting_of(0xfd, DQ "\\xfd" DQ);
+	test_quoting_of(0xfe, DQ "\\xfe" DQ);
+	test_quoting_of(0xff, DQ "\\xff" DQ);
+
+	// Ensure the search was exhaustive.
+	for (int i = 0; i <= 0xff; ++i) {
+		g_assert_true(is_tested[i]);
+	}
+
+	// Few extra tests (repeated) for specific things.
+
+	// Smoke test
+	sc_string_quote(buf, sizeof buf, "hello 123");
+	g_assert_cmpstr(buf, ==, DQ "hello 123" DQ);
+
+	// Whitespace
+	sc_string_quote(buf, sizeof buf, "\n");
+	g_assert_cmpstr(buf, ==, DQ "\\n" DQ);
+	sc_string_quote(buf, sizeof buf, "\r");
+	g_assert_cmpstr(buf, ==, DQ "\\r" DQ);
+	sc_string_quote(buf, sizeof buf, "\t");
+	g_assert_cmpstr(buf, ==, DQ "\\t" DQ);
+	sc_string_quote(buf, sizeof buf, "\v");
+	g_assert_cmpstr(buf, ==, DQ "\\v" DQ);
+
+	// Escape character itself
+	sc_string_quote(buf, sizeof buf, "\\");
+	g_assert_cmpstr(buf, ==, DQ "\\\\" DQ);
+
+	// Double quote character
+	sc_string_quote(buf, sizeof buf, "\"");
+	g_assert_cmpstr(buf, ==, DQ "\\\"" DQ);
+
+#undef DQ
+}
+
 static void __attribute__ ((constructor)) init()
 {
 	g_test_add_func("/string-utils/sc_streq", test_sc_streq);
@@ -483,4 +827,7 @@ static void __attribute__ ((constructor)) init()
 	     test_sc_string_append_char_pair__invalid_zero_c2);
 	g_test_add_func("/string-utils/sc_string_append_char_pair__normal",
 			test_sc_string_append_char_pair__normal);
+	g_test_add_func("/string-utils/sc_string_quote__NULL_buf",
+			test_sc_string_quote_NULL_str);
+	g_test_add_func("/string-utils/sc_string_quote", test_sc_string_quote);
 }

--- a/cmd/libsnap-confine-private/string-utils.c
+++ b/cmd/libsnap-confine-private/string-utils.c
@@ -161,3 +161,86 @@ void sc_string_init(char *buf, size_t buf_size)
 	}
 	buf[0] = '\0';
 }
+
+void sc_string_quote(char *buf, size_t buf_size, const char *str)
+{
+	if (str == NULL) {
+		die("cannot quote string: string is NULL");
+	}
+	// NOTE: this also checks buf/buf_size sanity so that we don't have to.
+	sc_string_init(buf, buf_size);
+	sc_string_append_char(buf, buf_size, '"');
+	for (char c; (c = *str) != 0; ++str) {
+		switch (c) {
+			// Pass ASCII letters and digits unmodified.
+		case '0' ... '9':
+		case 'A' ... 'Z':
+		case 'a' ... 'z':
+			// Pass most of the punctuation unmodified.
+		case ' ':
+		case '!':
+		case '#':
+		case '$':
+		case '%':
+		case '&':
+		case '(':
+		case ')':
+		case '*':
+		case '+':
+		case ',':
+		case '-':
+		case '.':
+		case '/':
+		case ':':
+		case ';':
+		case '<':
+		case '=':
+		case '>':
+		case '?':
+		case '@':
+		case '[':
+		case '\'':
+		case ']':
+		case '^':
+		case '_':
+		case '`':
+		case '{':
+		case '|':
+		case '}':
+		case '~':
+			sc_string_append_char(buf, buf_size, c);
+			break;
+			// Escape special whitespace characters.
+		case '\n':
+			sc_string_append_char_pair(buf, buf_size, '\\', 'n');
+			break;
+		case '\r':
+			sc_string_append_char_pair(buf, buf_size, '\\', 'r');
+			break;
+		case '\t':
+			sc_string_append_char_pair(buf, buf_size, '\\', 't');
+			break;
+		case '\v':
+			sc_string_append_char_pair(buf, buf_size, '\\', 'v');
+			break;
+			// Escape the escape character.
+		case '\\':
+			sc_string_append_char_pair(buf, buf_size, '\\', '\\');
+			break;
+			// Escape double quote character.
+		case '"':
+			sc_string_append_char_pair(buf, buf_size, '\\', '"');
+			break;
+			// Escape everything else as a generic hexadecimal escape string.
+		default:
+			{
+				char escape_buf[8];
+				sc_must_snprintf(escape_buf, sizeof escape_buf,
+						 "\\x%02x", (unsigned char)c);
+				sc_string_append(buf, buf_size, escape_buf);
+			}
+			break;
+		}
+	}
+	sc_string_append_char(buf, buf_size, '"');
+}

--- a/cmd/libsnap-confine-private/string-utils.h
+++ b/cmd/libsnap-confine-private/string-utils.h
@@ -43,7 +43,7 @@ int sc_must_snprintf(char *str, size_t size, const char *format, ...);
  * Append a string to a buffer containing a string.
  *
  * This version is fully aware of the destination buffer and is extra careful
- * not to overflow it. If any argument is NULL a buffer overflow is detected
+ * not to overflow it. If any argument is NULL or a buffer overflow is detected
  * then the function dies.
  *
  * The buffers cannot overlap.
@@ -82,5 +82,25 @@ size_t sc_string_append_char_pair(char *dst, size_t dst_size, char c1, char c2);
  * Initialize a string as empty, ensuring buf is non-NULL buf_size is > 0.
  **/
 void sc_string_init(char *buf, size_t buf_size);
+
+/**
+ * Quote a string so it is safe for printing.
+ *
+ * This function is fully aware of the destination buffer and is extra careful
+ * not to overflow it. If any argument is NULL or a buffer overflow is detected
+ * then the function dies.
+ *
+ * The function "quotes" the content of the given string into the given buffer.
+ * The buffer must be of sufficient size. Apart from letters and digits and
+ * some punctuation all characters are escaped using their hexadecimal escape
+ * codes.
+ *
+ * As a practical consideration the buffer should be of the following capacity:
+ * strlen(str) * 4 + 2 + 1; This corresponds to the most pessimistic escape
+ * process (each character is escaped to a hexadecimal value like \x05, two
+ * double-quote characters (one front, one rear) and the final string
+ * terminator character.
+ **/
+void sc_string_quote(char *buf, size_t buf_size, const char *str);
 
 #endif


### PR DESCRIPTION
This patch adds a function for safely quoting valid C strings that are
coming from unknown sources. The output is similar to python's repr()
where most typical printable characters are unmodified with the
following exceptions.

The double-quote character and various whitespace (e.g. newline)
characters are escaped with their typical escape sequences. The escape
character is also escaped the same way. Every other character is escaped
with the syntax "\xff" where "ff" is the hexadecimal code of the
character.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>