### PR TITLE
tests: add ubuntu-core-16-32 system to the external backend and fix docker test

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -144,6 +144,11 @@ backends:
                     TRUST_TEST_KEYS: "false"
                 username: test
                 password: ubuntu
+            - ubuntu-core-16-32:
+                environment:
+                    TRUST_TEST_KEYS: "false"
+                username: test
+                password: ubuntu
             - ubuntu-core-16-arm-64:
                 username: test
                 password: ubuntu

--- a/tests/external-backend.md
+++ b/tests/external-backend.md
@@ -18,8 +18,7 @@ script, if that's not the case you can pass the created username as a third argu
 to the script.
 
 * From the snapd project's root execute the suite selecting the type of system of
-the instance, currently `ubuntu-core-16-64`, `ubuntu-core-16-arm-32` and
-`ubuntu-core-16-arm-64` are supported:
+the instance, currently `ubuntu-core-16-64`, `ubuntu-core-16-32`, `ubuntu-core-16-arm-32` and `ubuntu-core-16-arm-64` are supported:
 ```
 $ spread -v -reuse external:ubuntu-core-16-64
 ```

--- a/tests/main/ack/task.yaml
+++ b/tests/main/ack/task.yaml
@@ -1,5 +1,5 @@
 summary: Check snap ack
-systems: [-ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-arm-*]
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"

--- a/tests/main/auth-errors/task.yaml
+++ b/tests/main/auth-errors/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that the authentication errors are properly reported.
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 prepare: |
     mkdir -p /home/test/.snap

--- a/tests/main/chattr/task.yaml
+++ b/tests/main/chattr/task.yaml
@@ -1,7 +1,7 @@
 summary: test chattr
 # ubuntu-core doesn't have go :-)
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2503
-systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 prepare: |
   go build -o toggle ./toggle.go
 execute: |

--- a/tests/main/chattr/task.yaml
+++ b/tests/main/chattr/task.yaml
@@ -1,7 +1,7 @@
 summary: test chattr
 # ubuntu-core doesn't have go :-)
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2503
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 prepare: |
   go build -o toggle ./toggle.go
 execute: |

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -1,7 +1,7 @@
 summary: Check different completions
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
     mkdir -p testdir

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -1,7 +1,7 @@
 summary: Check different completions
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 prepare: |
     mkdir -p testdir

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -4,7 +4,7 @@ details: |
     classic confinement can be executed correctly. There are two variants of
     this test (classic and jailmode) and the snap (this particular one) should
     function correctly in both cases.
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-core-16-64-fixme]
+systems: [-ubuntu-core-16-*]
 environment:
     INSTALL_FLAGS/classic: --classic
     INSTALL_FLAGS/classic_and_jailmode: --classic --jailmode

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for snap create-key
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 prepare: |
     . "$TESTSLIB/mkpinentry.sh"

--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure create-user functionality
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 environment:
     USER_EMAIL: mvo@ubuntu.com

--- a/tests/main/docker/task.yaml
+++ b/tests/main/docker/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that the docker snap works
 
-systems: [ubuntu-16.04-64, ubuntu-16.04-32, ubuntu-core-16-64, ubuntu-16.04-armhf, ubuntu-14.04-64]
+systems: [ubuntu-16.04-64, ubuntu-16.04-32, ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-32, ubuntu-core-16-arm-64, ubuntu-14.04-64]
 
 prepare: |
     if apt show linux-image-extra-$(uname -r); then
@@ -25,10 +25,13 @@ execute: |
 
     prefix=""
     case "$SPREAD_SYSTEM" in
-        "ubuntu-*-armhf")
+        "ubuntu-core-16-arm-32")
             prefix=armhf/
         ;;
-        "ubuntu-*-i386")
+        "ubuntu-core-16-arm-64")
+            prefix=aarch64/
+        ;;
+        "ubuntu-core-16-32")
             prefix=i386/
         ;;
         "ubuntu-16.04-32")

--- a/tests/main/docker/task.yaml
+++ b/tests/main/docker/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that the docker snap works
 
-systems: [ubuntu-16.04-64, ubuntu-16.04-32, ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-32, ubuntu-core-16-arm-64, ubuntu-14.04-64]
+systems: [ubuntu-16.04-*, ubuntu-core-16-*64, ubuntu-14.04-64]
 
 prepare: |
     if apt show linux-image-extra-$(uname -r); then

--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -1,6 +1,6 @@
 summary: check that the core and kernel snaps roll back correctly after a failed upgrade
 
-systems: [ubuntu-core-16-64, ubuntu-core-16-arm-32, ubuntu-core-16-arm-64]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-32, ubuntu-core-16-arm-64]
 
 details: |
     This test ensures that the system can survive to a failed upgrade of a fundamental

--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -1,6 +1,6 @@
 summary: check that the core and kernel snaps roll back correctly after a failed upgrade
 
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-32, ubuntu-core-16-arm-64]
+systems: [ubuntu-core-16-*]
 
 details: |
     This test ensures that the system can survive to a failed upgrade of a fundamental

--- a/tests/main/firstboot/task.yaml
+++ b/tests/main/firstboot/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that firstboot assertions are imported and snaps installed
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 environment:
     SEED_DIR: /var/lib/snapd/seed
 prepare: |

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for cli errors installing snaps
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 environment:
     SNAP_NAME: test-snapd-tools

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for special cases of snap install from the store
 
-systems: [+ubuntu-core-16-64]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-32, ubuntu-core-16-arm-64]
 
 environment:
     SNAP_NAME: test-snapd-tools

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for special cases of snap install from the store
 
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-32, ubuntu-core-16-arm-64]
+systems: [ubuntu-core-16-*]
 
 environment:
     SNAP_NAME: test-snapd-tools

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that the cups interface works.
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 details: |
     The cups-control interface allows a snap to access the locale configuration.

--- a/tests/main/interfaces-locale-control/task.yaml
+++ b/tests/main/interfaces-locale-control/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that the locale-control interface works.
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 summary: |
     The locale-control interface allows a snap to access the locale configuration.

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the upower-observe interface works.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2504
-systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 summary: |
     The upower-observe interface allows a snap to query UPower for power devices, history

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the upower-observe interface works.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2504
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 summary: |
     The upower-observe interface allows a snap to query UPower for power devices, history

--- a/tests/main/local-install-w-metadata/task.yaml
+++ b/tests/main/local-install-w-metadata/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for local install with metadata from assertions
 # XXX we would need to bother with curl there atm
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 restore: |
     rm -f test-snapd-tools_*.{snap,assert}
 execute: |

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -1,7 +1,7 @@
 summary: Checks for snap login
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 restore: |
     snap logout || true

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -1,7 +1,7 @@
 summary: Checks for snap login
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 restore: |
     snap logout || true

--- a/tests/main/manpages/task.yaml
+++ b/tests/main/manpages/task.yaml
@@ -1,6 +1,6 @@
 summary: the essential manual pages are installed by the native package
 # core systems don't ship man or manual pages
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-64-fixme, -ubuntu-core-16-arm-32, -ubuntu-core-16-arm-64]
+systems: [-ubuntu-core-16-*]
 execute: |
     for manpage in snap snap-confine snap-discard-ns; do
         if ! man --what $manpage; then

--- a/tests/main/op-install-failed-undone/task.yaml
+++ b/tests/main/op-install-failed-undone/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that all tasks of a failed installtion are undone
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 restore: |
     rm -rf /snap/test-snapd-tools

--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that postrm purge works
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 execute: |
     echo "When some snaps are installed"

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that prepare-image works for grub-systems
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 backends: [-autopkgtest]
 # TODO: use the real stores with proper assertions fully as well once possible
 environment:

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that undo for snap refresh works
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 environment:
     BLOB_DIR: $(pwd)/fake-store-blobdir

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that more than one snap is refreshed.
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 details: |
     We use only the fake store for this test because we currently

--- a/tests/main/security-devpts/task.yaml
+++ b/tests/main/security-devpts/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the basic devpts security rules are in place.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
     echo "Given a basic snap is installed"

--- a/tests/main/security-devpts/task.yaml
+++ b/tests/main/security-devpts/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the basic devpts security rules are in place.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 prepare: |
     echo "Given a basic snap is installed"

--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the security rules for private tmp are in place.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 environment:
     SNAP_INSTALL_DIR: $(pwd)/snap-install-dir

--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the security rules for private tmp are in place.
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 environment:
     SNAP_INSTALL_DIR: $(pwd)/snap-install-dir

--- a/tests/main/snap-run-alias/task.yaml
+++ b/tests/main/snap-run-alias/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that alias symlinks work correctly
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 prepare: |
     echo Ensure we have a os snap with snap run

--- a/tests/main/snap-run-symlink/task.yaml
+++ b/tests/main/snap-run-symlink/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that symlinks to /usr/bin/snap trigger `snap run`
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 prepare: |
     echo Ensure we have a os snap with snap run

--- a/tests/main/snap-run-userdata-current/task.yaml
+++ b/tests/main/snap-run-userdata-current/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that 'current' symlink is created with 'snap run'
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 prepare: |
     . $TESTSLIB/snaps.sh

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -1,7 +1,7 @@
 summary: Run snap sign to sign a model assertion
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
     . "$TESTSLIB/mkpinentry.sh"

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -1,7 +1,7 @@
 summary: Run snap sign to sign a model assertion
 
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
 
 prepare: |
     . "$TESTSLIB/mkpinentry.sh"

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -1,6 +1,6 @@
 summary: Test that snapd reexecs itself into core
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 restore: |
     # extra cleanup in case something in this test went wrong

--- a/tests/main/static/task.yaml
+++ b/tests/main/static/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that snapd can be built without cgo
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 execute: |
     CGO_ENABLED=0 go build -o snapd.static github.com/snapcore/snapd/cmd/snapd
     ldd snapd.static && exit 1 || true

--- a/tests/main/try-non-fatal/task.yaml
+++ b/tests/main/try-non-fatal/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks that removing the base directory of a tried snap works.
 
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 execute: |
     echo "Given a tried snap"

--- a/tests/main/try-snap-is-optional/task.yaml
+++ b/tests/main/try-snap-is-optional/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that try command works when snap dir is omitted
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 execute: |
     echo "When try is executed inside a snap directory"
     cd $TESTSLIB/snaps/test-snapd-tools

--- a/tests/main/try-twice-with-daemon/task.yaml
+++ b/tests/main/try-twice-with-daemon/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that try command works when daemon line is added to snap.yaml
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 
 environment:
   SERVICE: snap.test-snapd-service-try.service.service

--- a/tests/main/try/task.yaml
+++ b/tests/main/try/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that try command works
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32]
+systems: [-ubuntu-core-16-*]
 environment:
     PORT: 8081
     SERVICE_FILE: "./service.sh"

--- a/tests/main/ubuntu-core-apt/task.yaml
+++ b/tests/main/ubuntu-core-apt/task.yaml
@@ -1,5 +1,5 @@
 summary: Ensure that the apt output on ubuntu-core is correct
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-*]
 execute: |
     expected="Ubuntu Core does not use apt-get, see 'snap --help'!"
     output=$(apt-get update)

--- a/tests/main/ubuntu-core-apt/task.yaml
+++ b/tests/main/ubuntu-core-apt/task.yaml
@@ -1,5 +1,5 @@
 summary: Ensure that the apt output on ubuntu-core is correct
-systems: [ubuntu-core-16-64, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
 execute: |
     expected="Ubuntu Core does not use apt-get, see 'snap --help'!"
     output=$(apt-get update)

--- a/tests/main/ubuntu-core-classic/task.yaml
+++ b/tests/main/ubuntu-core-classic/task.yaml
@@ -1,5 +1,5 @@
 summary: Ensure classic dimension works correctly
-systems: [ubuntu-core-16-64, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
 environment:
     # We need to set the SUDO_USER here to simulate the real
     # behavior. I.e. when entering classic it happens via

--- a/tests/main/ubuntu-core-classic/task.yaml
+++ b/tests/main/ubuntu-core-classic/task.yaml
@@ -1,5 +1,5 @@
 summary: Ensure classic dimension works correctly
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-*]
 environment:
     # We need to set the SUDO_USER here to simulate the real
     # behavior. I.e. when entering classic it happens via

--- a/tests/main/ubuntu-core-create-user/task.yaml
+++ b/tests/main/ubuntu-core-create-user/task.yaml
@@ -1,5 +1,5 @@
 summary: Ensure that snap create-user works in ubuntu-core
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-*]
 restore: |
     # meh, deluser has no --extrausers support
     sed -i '/^mvo/d' /var/lib/extrausers/passwd

--- a/tests/main/ubuntu-core-create-user/task.yaml
+++ b/tests/main/ubuntu-core-create-user/task.yaml
@@ -1,5 +1,5 @@
 summary: Ensure that snap create-user works in ubuntu-core
-systems: [ubuntu-core-16-64, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
 restore: |
     # meh, deluser has no --extrausers support
     sed -i '/^mvo/d' /var/lib/extrausers/passwd

--- a/tests/main/ubuntu-core-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-device-reg/task.yaml
@@ -1,7 +1,7 @@
 summary: |
     Ensure after device initialisation registration worked and
     we have a serial and can acquire a session macaroon
-systems: [ubuntu-core-16-64, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
 execute: |
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done

--- a/tests/main/ubuntu-core-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-device-reg/task.yaml
@@ -1,7 +1,7 @@
 summary: |
     Ensure after device initialisation registration worked and
     we have a serial and can acquire a session macaroon
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-*]
 execute: |
     echo "Wait for first boot to be done"
     while ! snap changes | grep -q "Done.*Initialize system state"; do sleep 1; done

--- a/tests/main/ubuntu-core-fan/task.yaml
+++ b/tests/main/ubuntu-core-fan/task.yaml
@@ -1,5 +1,5 @@
 summary: Test ubuntu-fan
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-*]
 prepare: |
     IP=$(ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | cut -d' ' -f1|head -1)
     fanctl up 241.0.0.0/8 $IP/16

--- a/tests/main/ubuntu-core-fan/task.yaml
+++ b/tests/main/ubuntu-core-fan/task.yaml
@@ -1,5 +1,5 @@
 summary: Test ubuntu-fan
-systems: [ubuntu-core-16-64, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
 prepare: |
     IP=$(ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | cut -d' ' -f1|head -1)
     fanctl up 241.0.0.0/8 $IP/16

--- a/tests/main/ubuntu-core-os-release/task.yaml
+++ b/tests/main/ubuntu-core-os-release/task.yaml
@@ -1,5 +1,5 @@
 summary: check that os-release is correct
-systems: [ubuntu-core-16-64, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
 execute: |
     cat /etc/os-release
     grep "ID=ubuntu-core" /etc/os-release

--- a/tests/main/ubuntu-core-os-release/task.yaml
+++ b/tests/main/ubuntu-core-os-release/task.yaml
@@ -1,5 +1,5 @@
 summary: check that os-release is correct
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-*]
 execute: |
     cat /etc/os-release
     grep "ID=ubuntu-core" /etc/os-release

--- a/tests/main/ubuntu-core-reboot/task.yaml
+++ b/tests/main/ubuntu-core-reboot/task.yaml
@@ -2,6 +2,7 @@ summary: Ensure that service and apparmor profiles work after a reboot
 
 systems:
     - ubuntu-core-16-64
+    - ubuntu-core-16-32
     - ubuntu-core-16-arm-64
     - ubuntu-core-16-arm-32
 

--- a/tests/main/ubuntu-core-uboot/task.yaml
+++ b/tests/main/ubuntu-core-uboot/task.yaml
@@ -1,5 +1,5 @@
 summary: Ensure we have unpacked kernel.img/initrd.img on uboot systems
-systems: [ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-arm-*]
 environment:
     NAME/initrdimg: initrd.img*
     NAME/kernelimg: kernel.img*

--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -1,10 +1,6 @@
 summary: Upgrade the core snap and revert a few times
 
-systems:
-    - ubuntu-core-16-64
-    - ubuntu-core-16-32
-    - ubuntu-core-16-arm-64
-    - ubuntu-core-16-arm-32
+systems: [ubuntu-core-16-*]
 
 debug: |
     snap list

--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -2,6 +2,7 @@ summary: Upgrade the core snap and revert a few times
 
 systems:
     - ubuntu-core-16-64
+    - ubuntu-core-16-32
     - ubuntu-core-16-arm-64
     - ubuntu-core-16-arm-32
 

--- a/tests/main/ubuntu-core-writablepaths/task.yaml
+++ b/tests/main/ubuntu-core-writablepaths/task.yaml
@@ -1,5 +1,5 @@
 summary: Ensure that the writable paths on the image are correct
-systems: [ubuntu-core-16-64, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
 execute: |
     echo "Ensure everything in writable-paths is actually writable"
     cat /etc/system-image/writable-paths | while read -r line; do

--- a/tests/main/ubuntu-core-writablepaths/task.yaml
+++ b/tests/main/ubuntu-core-writablepaths/task.yaml
@@ -1,5 +1,5 @@
 summary: Ensure that the writable paths on the image are correct
-systems: [ubuntu-core-16-64, ubuntu-core-16-32, ubuntu-core-16-arm-64, ubuntu-core-16-arm-32]
+systems: [ubuntu-core-16-*]
 execute: |
     echo "Ensure everything in writable-paths is actually writable"
     cat /etc/system-image/writable-paths | while read -r line; do

--- a/tests/regression/lp-1580018/task.yaml
+++ b/tests/regression/lp-1580018/task.yaml
@@ -5,7 +5,7 @@ details: |
     to rely on deterministic behavior, isolated from any changes imposed by
     Debian's alternatives system.
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-32, -ubuntu-core-16-arm-64]
+systems: [-ubuntu-core-16-*]
 prepare: |
     echo "Having installed the test snap"
     . $TESTSLIB/snaps.sh

--- a/tests/regression/lp-1595444/task.yaml
+++ b/tests/regression/lp-1595444/task.yaml
@@ -3,7 +3,7 @@ details: |
     This task checks the behavior of snap-confine when it is started from
     a directory that doesn't exist in the execution environment (chroot).
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-32, -ubuntu-core-16-arm-64]
+systems: [-ubuntu-core-16-*]
 prepare: |
     echo "Having installed the test snap"
     . $TESTSLIB/snaps.sh

--- a/tests/regression/lp-1597839/task.yaml
+++ b/tests/regression/lp-1597839/task.yaml
@@ -1,6 +1,6 @@
 summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1597839
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-32, -ubuntu-core-16-arm-64]
+systems: [-ubuntu-core-16-*]
 details: |
     The snappy execution environment should contain the /lib/modules directory
     from the host filesystem when running on a classic distribution

--- a/tests/regression/lp-1597842/task.yaml
+++ b/tests/regression/lp-1597842/task.yaml
@@ -4,7 +4,7 @@ details: |
     directory from the classic distribution. Certain snaps may use that to
     access kernel sources.
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-32, -ubuntu-core-16-arm-64]
+systems: [-ubuntu-core-16-*]
 prepare: |
     echo "Having installed the test snap"
     . $TESTSLIB/snaps.sh

--- a/tests/regression/lp-1613845/task.yaml
+++ b/tests/regression/lp-1613845/task.yaml
@@ -5,7 +5,7 @@ details: |
     the host filesystem. While this would never work in an all-snap image it is
     still important to ensure that it works in classic devmode environment.
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-32, -ubuntu-core-16-arm-64]
+systems: [-ubuntu-core-16-*]
 prepare: |
     echo "Having installed the test snap in devmode"
     . $TESTSLIB/snaps.sh

--- a/tests/unit/c-unit-tests/task.yaml
+++ b/tests/unit/c-unit-tests/task.yaml
@@ -1,5 +1,5 @@
 summary: Run the test suite for C code
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-32, -ubuntu-core-16-arm-64]
+systems: [-ubuntu-core-16-*]
 environment:
     EXTRA_PKGS: autoconf automake autotools-dev indent libapparmor-dev libglib2.0-dev libseccomp-dev libudev-dev pkg-config python3-docutils udev
 prepare: |

--- a/tests/unit/gccgo/task.yaml
+++ b/tests/unit/gccgo/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that snapd builds with gccgo
-systems: [-ubuntu-core-16-64, -ubuntu-core-16-arm-64, -ubuntu-core-16-arm-32, -ubuntu-14.04-64]
+systems: [-ubuntu-core-16-*]
 prepare: |
     echo Installing gccgo-6 and pretending it is the default go
     apt install -y gccgo-6

--- a/tests/unit/gccgo/task.yaml
+++ b/tests/unit/gccgo/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that snapd builds with gccgo
-systems: [-ubuntu-core-16-*]
+systems: [-ubuntu-core-16-*, -ubuntu-14.04-64]
 prepare: |
     echo Installing gccgo-6 and pretending it is the default go
     apt install -y gccgo-6


### PR DESCRIPTION
I've taken the opportunity to use spread's system glob in the negative filters, it doesn't seem to do the right thing in the positive cases.