### PR TITLE
client, daemon: move "snap list" name filtering into snapd.

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/snap"
@@ -123,6 +124,9 @@ func (client *Client) List(names []string, opts *ListOptions) ([]*Snap, error) {
 	if opts.All {
 		q.Add("select", "all")
 	}
+	if len(names) > 0 {
+		q.Add("snaps", strings.Join(names, ","))
+	}
 
 	snaps, _, err := client.snapsFromPath("/v2/snaps", q)
 	if err != nil {
@@ -133,23 +137,7 @@ func (client *Client) List(names []string, opts *ListOptions) ([]*Snap, error) {
 		return nil, ErrNoSnapsInstalled
 	}
 
-	if len(names) == 0 {
-		return snaps, nil
-	}
-
-	wanted := make(map[string]bool, len(names))
-	for _, name := range names {
-		wanted[name] = true
-	}
-
-	var result []*Snap
-	for _, snap := range snaps {
-		if wanted[snap.Name] {
-			result = append(result, snap)
-		}
-	}
-
-	return result, nil
+	return snaps, nil
 }
 
 // Sections returns the list of existing snap sections in the store

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -140,9 +140,6 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 		Private:       true,
 		DevMode:       false,
 	}})
-	otherApps, err := cs.cli.List([]string{"foo"}, nil)
-	c.Check(err, check.IsNil)
-	c.Check(otherApps, check.HasLen, 0)
 }
 
 func (cs *clientSuite) TestClientFilterSnaps(c *check.C) {

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -142,7 +142,8 @@ func (s *SnapSuite) TestListWithNoMatchingQuery(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17}]}`)
+			c.Check(r.URL.Query().Get("snaps"), check.Equals, "quux")
+			fmt.Fprintln(w, `{"type": "sync", "result": []}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -160,7 +161,7 @@ func (s *SnapSuite) TestListWithQuery(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
-			c.Check(r.URL.Query(), check.HasLen, 0)
+			c.Check(r.URL.Query().Get("snaps"), check.Equals, "foo")
 			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17}]}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -33,6 +33,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -1016,28 +1017,69 @@ func (s *apiSuite) TestUserFromRequestHeaderValidUser(c *check.C) {
 }
 
 func (s *apiSuite) TestSnapsInfoOnePerIntegration(c *check.C) {
+	s.checkSnapInfoOnePerIntegration(c, false, nil)
+}
+
+func (s *apiSuite) TestSnapsInfoOnePerIntegrationSome(c *check.C) {
+	s.checkSnapInfoOnePerIntegration(c, false, []string{"foo", "baz"})
+}
+
+func (s *apiSuite) TestSnapsInfoOnePerIntegrationAll(c *check.C) {
+	s.checkSnapInfoOnePerIntegration(c, true, nil)
+}
+
+func (s *apiSuite) TestSnapsInfoOnePerIntegrationAllSome(c *check.C) {
+	s.checkSnapInfoOnePerIntegration(c, true, []string{"foo", "baz"})
+}
+
+func (s *apiSuite) checkSnapInfoOnePerIntegration(c *check.C, all bool, names []string) {
 	d := s.daemon(c)
 
-	req, err := http.NewRequest("GET", "/v2/snaps", nil)
-	c.Assert(err, check.IsNil)
-
 	type tsnap struct {
-		name string
-		dev  string
-		ver  string
-		rev  int
+		name   string
+		dev    string
+		ver    string
+		rev    int
+		active bool
+
+		wanted bool
 	}
 
 	tsnaps := []tsnap{
-		{"foo", "bar", "v1", 5},
-		{"bar", "baz", "v2", 10},
-		{"baz", "qux", "v3", 15},
-		{"qux", "mip", "v4", 20},
+		{name: "foo", dev: "bar", ver: "v0.9", rev: 1},
+		{name: "foo", dev: "bar", ver: "v1", rev: 5, active: true},
+		{name: "bar", dev: "baz", ver: "v2", rev: 10, active: true},
+		{name: "baz", dev: "qux", ver: "v3", rev: 15, active: true},
+		{name: "qux", dev: "mip", ver: "v4", rev: 20, active: true},
 	}
+	numExpected := 0
 
 	for _, snp := range tsnaps {
-		s.mkInstalledInState(c, d, snp.name, snp.dev, snp.ver, snap.R(snp.rev), false, "")
+		if all || snp.active {
+			if len(names) == 0 {
+				numExpected++
+				snp.wanted = true
+			}
+			for _, n := range names {
+				if snp.name == n {
+					numExpected++
+					snp.wanted = true
+					break
+				}
+			}
+		}
+		s.mkInstalledInState(c, d, snp.name, snp.dev, snp.ver, snap.R(snp.rev), snp.active, "")
 	}
+
+	q := url.Values{}
+	if all {
+		q.Set("select", "all")
+	}
+	if len(names) > 0 {
+		q.Set("snaps", strings.Join(names, ","))
+	}
+	req, err := http.NewRequest("GET", "/v2/snaps?"+q.Encode(), nil)
+	c.Assert(err, check.IsNil)
 
 	rsp, ok := getSnapsInfo(snapsCmd, req, nil).(*resp)
 	c.Assert(ok, check.Equals, true)
@@ -1047,12 +1089,15 @@ func (s *apiSuite) TestSnapsInfoOnePerIntegration(c *check.C) {
 	c.Check(rsp.Result, check.NotNil)
 
 	snaps := snapList(rsp.Result)
-	c.Check(snaps, check.HasLen, len(tsnaps))
+	c.Check(snaps, check.HasLen, numExpected)
 
 	for _, s := range tsnaps {
+		if !((all || s.active) && s.wanted) {
+			continue
+		}
 		var got map[string]interface{}
 		for _, got = range snaps {
-			if got["name"].(string) == s.name {
+			if got["name"].(string) == s.name && got["revision"].(string) == snap.R(s.rev).String() {
 				break
 			}
 		}

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -105,7 +105,7 @@ func localSnapInfo(st *state.State, name string) (aboutSnap, error) {
 }
 
 // allLocalSnapInfos returns the information about the all current snaps and their SnapStates.
-func allLocalSnapInfos(st *state.State, all bool) ([]aboutSnap, error) {
+func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]aboutSnap, error) {
 	st.Lock()
 	defer st.Unlock()
 
@@ -116,7 +116,10 @@ func allLocalSnapInfos(st *state.State, all bool) ([]aboutSnap, error) {
 	about := make([]aboutSnap, 0, len(snapStates))
 
 	var firstErr error
-	for _, snapst := range snapStates {
+	for name, snapst := range snapStates {
+		if len(wanted) > 0 && !wanted[name] {
+			continue
+		}
 		var aboutThis []aboutSnap
 		var info *snap.Info
 		var publisher string


### PR DESCRIPTION
#2970 reminded me that I was going to move the filtering used for `snap list foo` into snapd at some point. Thank you @justincan!