### PR TITLE
Support spread testing with proxy

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -31,6 +31,9 @@ environment:
     DELTA_REF: 2.17
     DELTA_PREFIX: snapd-$DELTA_REF/
     SNAPD_PPA_VERSION: "$(HOST: echo $SPREAD_SNAPD_PPA_VERSION)"
+    http_proxy: "$(HOST: echo $http_proxy)"
+    https_proxy: "$(HOST: echo $https_proxy)"
+    no_proxy: "127.0.0.1"
 
 backends:
     linode:

--- a/spread.yaml
+++ b/spread.yaml
@@ -31,7 +31,7 @@ environment:
     DELTA_REF: 2.17
     DELTA_PREFIX: snapd-$DELTA_REF/
     SNAPD_PPA_VERSION: "$(HOST: echo $SPREAD_SNAPD_PPA_VERSION)"
-    HTTPS_PROXY: "$(HOST: echo $HTTPS_PROXY)"
+    HTTP_PROXY: "$(HOST: echo $HTTP_PROXY)"
     HTTPS_PROXY: "$(HOST: echo $HTTPS_PROXY)"
     NO_PROXY: "127.0.0.1"
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -31,9 +31,9 @@ environment:
     DELTA_REF: 2.17
     DELTA_PREFIX: snapd-$DELTA_REF/
     SNAPD_PPA_VERSION: "$(HOST: echo $SPREAD_SNAPD_PPA_VERSION)"
-    http_proxy: "$(HOST: echo $http_proxy)"
-    https_proxy: "$(HOST: echo $https_proxy)"
-    no_proxy: "127.0.0.1"
+    HTTPS_PROXY: "$(HOST: echo $HTTPS_PROXY)"
+    HTTPS_PROXY: "$(HOST: echo $HTTPS_PROXY)"
+    NO_PROXY: "127.0.0.1"
 
 backends:
     linode:

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -22,7 +22,7 @@ execute: |
     verify_asserts classic_*.assert
 
     echo "Snap download can download snaps as user"
-    su -l -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE https_proxy=$https_proxy snap download test-snapd-tools" test
+    su -l -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE HTTPS_PROXY=$HTTPS_PROXY snap download test-snapd-tools" test
     ls /home/test/test-snapd-tools_*.snap
     verify_asserts /home/test/test-snapd-tools_*.assert
 restore: |

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -22,7 +22,8 @@ execute: |
     verify_asserts classic_*.assert
 
     echo "Snap download can download snaps as user"
-    su -l -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap download test-snapd-tools" test
+    su -l -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE https_proxy=$https_proxy snap download test-snapd-tools" test
+    ls /home/test/test-snapd-tools_*.snap
     ls /home/test/test-snapd-tools_*.snap
     verify_asserts /home/test/test-snapd-tools_*.assert
 restore: |

--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -24,7 +24,6 @@ execute: |
     echo "Snap download can download snaps as user"
     su -l -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE https_proxy=$https_proxy snap download test-snapd-tools" test
     ls /home/test/test-snapd-tools_*.snap
-    ls /home/test/test-snapd-tools_*.snap
     verify_asserts /home/test/test-snapd-tools_*.assert
 restore: |
     rm -f *.snap


### PR DESCRIPTION
This fork allows all spread tests to pass in an environment with http_proxy and https_proxy set. If we are able to land this in the master branch, I would like to look at porting it to other release branches as well so we can run automated testing on those.