### PR TITLE
hookstate: disable configure hook for core on classic

### DIFF
--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -176,7 +176,7 @@ func (m *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	// FIXME: gross hack, do not run configure hook on classic
 	// (LP: #1668738) for now until we understand why it is
 	// failing for some people
-	if release.OnClassic && hooksup.Snap == "core" && hooksup.Optional {
+	if release.OnClassic && hooksup.Snap == "core" && hooksup.Hook == "configure" && hooksup.Optional {
 		logger.Noticef("skipping configure hook for core on classic")
 		return nil
 	}

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -5497,12 +5497,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasks(c *C) {
 		SnapType: "os",
 	})
 
-	// FIXME: we do not run the configure hook on classic for core, so
-	//        verifyInstallUpdateTasks() would fail, we mock this here
-	//        until LP: #1668738 is understood
-	r := release.MockOnClassic(false)
-	defer r()
-
 	tsl, err := snapstate.TransitionCore(s.state, "ubuntu-core", "core")
 	c.Assert(err, IsNil)
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -225,13 +225,9 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 
 	installSet := state.NewTaskSet(tasks...)
 
-	// gross hack, do not run configure hook on classic (LP: #1668738)
-	// for now until we understand why it is failing for some people
-	if !(release.OnClassic && snapsup.Name() == "core") {
-		configSet := Configure(st, snapsup.Name(), defaults)
-		configSet.WaitAll(installSet)
-		installSet.AddAll(configSet)
-	}
+	configSet := Configure(st, snapsup.Name(), defaults)
+	configSet.WaitAll(installSet)
+	installSet.AddAll(configSet)
 
 	return installSet, nil
 }


### PR DESCRIPTION
In PR#2958 the configure hook got disabled for classic because we
got a large number of errors on classic of the form:

  `error: cannot find installed snap "core" at revision unset`

However because on refresh the code that runs will insert a configure
task for the core snap. And only after the task got already inserted
snapd will re-exec. So we need to add the "ignore-core-hook-configure"
hack a bit later.

This will need to get backported to 2.23.1