### PR TITLE
tests: specify the core version to be unsquashfs'ed in the failover tests

### DIFF
--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -50,7 +50,7 @@ execute: |
         snap list | awk "/^${core_name} / {print(\$3)}" > prevBoot
 
         # unpack current target snap
-        unsquashfs -d /tmp/unpack /var/lib/snapd/snaps/${core_name}_*.snap
+        unsquashfs -d /tmp/unpack /var/lib/snapd/snaps/${core_name}_$(cat prevBoot).snap
 
         # set failure condition
         eval ${INJECT_FAILURE}


### PR DESCRIPTION
Passing a glob to unsquashfs while unpacking the target snap can cause errors when there has been more than one version installed, with this patch the current version is unpacked.