### PR TITLE
tests: do *not* nuke the entire /etc/systemd/system/snapd.conf.d dir when changing store settings

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -66,7 +66,10 @@ prepare_each_classic() {
 Environment=SNAP_REEXEC=$SNAP_REEXEC
 EOF
     fi
-
+    if [ ! -f /etc/systemd/system/snapd.service.d/local.conf ]; then
+        echo "/etc/systemd/system/snapd.service.d/local.conf vanished!"
+        exit 1
+    fi
 }
 
 prepare_classic() {

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -5,7 +5,8 @@ STORE_CONFIG=/etc/systemd/system/snapd.service.d/store.conf
 
 _configure_store_backends(){
     systemctl stop snapd.service snapd.socket
-    rm -rf $(dirname $STORE_CONFIG) && mkdir -p $(dirname $STORE_CONFIG)
+    mkdir -p $(dirname $STORE_CONFIG)
+    rm -f $STORE_CONFIG
     cat > $STORE_CONFIG <<EOF
 [Service]
 Environment=SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1


### PR DESCRIPTION
Removing /etc/systemd/system/snapd.conf.d/local.conf kills all our custom envinronment like SNAPPY_TESTING=1