### PR TITLE
cmd: link libcap dynamically

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -107,17 +107,7 @@ libsnap_confine_private_unit_tests_SOURCES = \
 libsnap_confine_private_unit_tests_CFLAGS = $(GLIB_CFLAGS)
 libsnap_confine_private_unit_tests_LDADD = $(GLIB_LIBS)
 libsnap_confine_private_unit_tests_CFLAGS += -D_ENABLE_FAULT_INJECTION
-
-# XXX: This injects a dependency on libcap in a way that makes automake happy
-# and allows us to link libcap statically. We need to link in libcap statically
-# as at this time adding runtime dependencies to snap-confine is tricky.
-
-libsnap-confine-private/unit-tests$(EXEEXT): $(libsnap_confine_private_unit_tests_OBJECTS) $(libsnap_confine_private_unit_tests_DEPENDENCIES) $(EXTRA_libsnap_confine_private_unit_tests_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
-	@rm -f libsnap-confine-private/unit-tests$(EXEEXT)
-	$(AM_V_CCLD)$(libsnap_confine_private_unit_tests_LINK) $(libsnap_confine_private_unit_tests_OBJECTS) $(libsnap_confine_private_unit_tests_LDADD) $(LIBS)
-
-libsnap-confine-private/unit-tests$(EXEEXT): LIBS += -Wl,-Bstatic -lcap -Wl,-Bdynamic
-
+libsnap_confine_private_unit_tests_LDADD += -lcap
 endif
 
 ##
@@ -129,15 +119,7 @@ noinst_PROGRAMS += decode-mount-opts/decode-mount-opts
 decode_mount_opts_decode_mount_opts_SOURCES = \
 	decode-mount-opts/decode-mount-opts.c
 decode_mount_opts_decode_mount_opts_LDADD = libsnap-confine-private.a
-# XXX: this makes automake generate decode_mount_opts_decode_mount_opts_LINK
-decode_mount_opts_decode_mount_opts_CFLAGS = -D_fake
-
-decode-mount-opts/decode-mount-opts$(EXEEXT): $(decode_mount_opts_decode_mount_opts_OBJECTS) $(decode_mount_opts_decode_mount_opts_DEPENDENCIES) $(EXTRA_decode_mount_opts_decode_mount_opts_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
-	@rm -f decode-mount-opts/decode-mount-opts$(EXEEXT)
-	$(AM_V_CCLD)$(decode_mount_opts_decode_mount_opts_LINK) $(decode_mount_opts_decode_mount_opts_OBJECTS) $(decode_mount_opts_decode_mount_opts_LDADD) $(LIBS)
-
-decode-mount-opts/decode-mount-opts$(EXEEXT): LIBS += -Wl,-Bstatic -lcap -Wl,-Bdynamic
-
+decode_mount_opts_decode_mount_opts_LDADD += -lcap
 ##
 ## snap-confine
 ##
@@ -205,12 +187,7 @@ snap_confine_snap_confine_LDFLAGS = $(AM_LDFLAGS)
 snap_confine_snap_confine_LDADD = libsnap-confine-private.a
 snap_confine_snap_confine_CFLAGS += $(LIBUDEV_CFLAGS)
 snap_confine_snap_confine_LDADD += $(LIBUDEV_LIBS)
-
-snap-confine/snap-confine$(EXEEXT): $(snap_confine_snap_confine_OBJECTS) $(snap_confine_snap_confine_DEPENDENCIES) $(EXTRA_snap_confine_snap_confine_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
-	@rm -f snap-confine/snap-confine$(EXEEXT)
-	$(AM_V_CCLD)$(snap_confine_snap_confine_LINK) $(snap_confine_snap_confine_OBJECTS) $(snap_confine_snap_confine_LDADD) $(LIBS)
-
-snap-confine/snap-confine$(EXEEXT): LIBS += -Wl,-Bstatic -lcap -Wl,-Bdynamic
+snap_confine_snap_confine_LDADD += -lcap
 
 # This is here to help fix rpmlint hardening issue.
 # https://en.opensuse.org/openSUSE:Packaging_checks#non-position-independent-executable
@@ -238,12 +215,7 @@ snap_confine_snap_confine_debug_CFLAGS = $(snap_confine_snap_confine_CFLAGS)
 snap_confine_snap_confine_debug_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)
 snap_confine_snap_confine_debug_LDADD = $(snap_confine_snap_confine_LDADD)
 snap_confine_snap_confine_debug_CFLAGS += -DSNAP_CONFINE_DEBUG_BUILD=1
-
-snap-confine/snap-confine-debug$(EXEEXT): $(snap_confine_snap_confine_debug_OBJECTS) $(snap_confine_snap_confine_debug_DEPENDENCIES) $(EXTRA_snap_confine_snap_confine_debug_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
-	@rm -f snap-confine/snap-confine-debug$(EXEEXT)
-	$(AM_V_CCLD)$(snap_confine_snap_confine_debug_LINK) $(snap_confine_snap_confine_debug_OBJECTS) $(snap_confine_snap_confine_debug_LDADD) $(LIBS)
-
-snap-confine/snap-confine-debug$(EXEEXT): LIBS += -Wl,-Bstatic -lcap -Wl,-Bdynamic
+snap_confine_snap_confine_debug_LDADD += -lcap
 
 if WITH_UNIT_TESTS
 noinst_PROGRAMS += snap-confine/snap-confine-unit-tests
@@ -261,13 +233,7 @@ snap_confine_snap_confine_unit_tests_SOURCES = \
 snap_confine_snap_confine_unit_tests_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(GLIB_CFLAGS)
 snap_confine_snap_confine_unit_tests_LDADD = $(snap_confine_snap_confine_LDADD) $(GLIB_LIBS)
 snap_confine_snap_confine_unit_tests_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)
-
-
-snap-confine/snap-confine-unit-tests$(EXEEXT): $(snap_confine_snap_confine_unit_tests_OBJECTS) $(snap_confine_snap_confine_unit_tests_DEPENDENCIES) $(EXTRA_snap_confine_snap_confine_unit_tests_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
-	@rm -f snap-confine/snap-confine-unit-tests$(EXEEXT)
-	$(AM_V_CCLD)$(snap_confine_snap_confine_unit_tests_LINK) $(snap_confine_snap_confine_unit_tests_OBJECTS) $(snap_confine_snap_confine_unit_tests_LDADD) $(LIBS)
-
-snap-confine/snap-confine-unit-tests$(EXEEXT): LIBS += -Wl,-Bstatic -lcap -Wl,-Bdynamic
+snap_confine_snap_confine_unit_tests_LDADD += -lcap
 
 endif
 

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -12,15 +12,16 @@
     /lib/@{multiarch}/librt{,-[0-9]*}.so* mr,
     /lib/@{multiarch}/libgcc_s.so* mr,
     # normal libs in order
+    /lib/@{multiarch}/libcap.so.* mr,
     /lib/@{multiarch}/libapparmor.so* mr,
     /lib/@{multiarch}/libcgmanager.so* mr,
-    /lib/@{multiarch}/libdl-[0-9]*.so* mr,
-    /lib/@{multiarch}/libnih.so* mr,
-    /lib/@{multiarch}/libnih-dbus.so* mr,
     /lib/@{multiarch}/libdbus-1.so* mr,
+    /lib/@{multiarch}/libdl-[0-9]*.so* mr,
+    /lib/@{multiarch}/libnih-dbus.so* mr,
+    /lib/@{multiarch}/libnih.so* mr,
+    /lib/@{multiarch}/libseccomp.so* mr,
     /lib/@{multiarch}/libudev.so* mr,
     /usr/lib/@{multiarch}/libseccomp.so* mr,
-    /lib/@{multiarch}/libseccomp.so* mr,
 
     @LIBEXECDIR@/snap-confine mr,
 


### PR DESCRIPTION
This patch undoes an earlier hack that linked to libcap statically. This
is no longer required as the core snap ships libcap.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>