### PR TITLE
hookstate: run the right "snap" command in the hookmanager

### DIFF
--- a/overlord/hookstate/export_test.go
+++ b/overlord/hookstate/export_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package hookstate
+
+func MockReadlink(f func(string) (string, error)) func() {
+	oldReadlink := osReadlink
+	osReadlink = f
+	return func() {
+		osReadlink = oldReadlink
+	}
+}

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -26,11 +26,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -250,8 +253,30 @@ func MockRunHook(hookInvoke func(c *Context, tomb *tomb.Tomb) ([]byte, error)) (
 	}
 }
 
+var osReadlink = os.Readlink
+
+// snapCmd returns the "snap" command to run. If snapd is re-execed
+// it will be the snap command from the core snap, otherwise it will
+// be the system "snap" command (c.f. LP: #1668738).
+func snapCmd() string {
+	// sensible default, assume PATH is correct
+	snapCmd := "snap"
+
+	exe, err := osReadlink("/proc/self/exe")
+	if err != nil {
+		return snapCmd
+	}
+	if !strings.HasPrefix(exe, dirs.SnapMountDir) {
+		return snapCmd
+	}
+
+	// snap is running from the core snap, we know the relative
+	// location of "snap" from "snapd"
+	return filepath.Join(filepath.Dir(exe), "../../bin/snap")
+}
+
 func runHookAndWait(snapName string, revision snap.Revision, hookName, hookContext string, tomb *tomb.Tomb) ([]byte, error) {
-	command := exec.Command("snap", "run", "--hook", hookName, "-r", revision.String(), snapName)
+	command := exec.Command(snapCmd(), "run", "--hook", hookName, "-r", revision.String(), snapName)
 
 	// Make sure the hook has its context defined so it can communicate via the
 	// REST API.

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -54,7 +54,7 @@ echo >> %[1]q
 // the command exits successfully without any other side-effect.
 func MockCommand(c *check.C, basename, script string) *MockCmd {
 	var binDir, exeFile, logFile string
-	if strings.HasPrefix(basename, "/") {
+	if filepath.IsAbs(basename) {
 		binDir = filepath.Dir(basename)
 		exeFile = basename
 		logFile = basename + ".log"


### PR DESCRIPTION
When the hook manager needs to run "snap run" it needs to run the right `snap` command. As this is happening inside snapd the "no-reexec" environment is already set. So just running "snap" may lead to running the old "snap" command which will result in (very) confusing errors, c.f. #1668738

The alternative to this might be something like:
```
+               // clear env so that subsequent snap commands run from
+               // inside will not see this
+               os.Unsetenv("SNAP_DID_REEXEC")
```
but that won't work with older versions of snapd that did not differentiate between the user setting to disable re-exec and the internal setting to indicate that re-exec already happend.