### PR TITLE
interfaces: fix default content attribute value

### DIFF
--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -47,7 +47,8 @@ func (iface *ContentInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 	content, ok := slot.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
-		return fmt.Errorf("content slot must have a content attribute set")
+		// content defaults to "slot" name if unspecified
+		slot.Attrs["content"] = slot.Name
 	}
 
 	// check that we have either a read or write path
@@ -75,7 +76,8 @@ func (iface *ContentInterface) SanitizePlug(plug *interfaces.Plug) error {
 	}
 	content, ok := plug.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
-		return fmt.Errorf("content plug must have a content attribute set")
+		// content defaults to "slot" name if unspecified
+		plug.Attrs["content"] = plug.Name
 	}
 	target, ok := plug.Attrs["target"].(string)
 	if !ok || len(target) == 0 {

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -69,7 +69,8 @@ slots:
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
 	err := s.iface.SanitizeSlot(slot)
-	c.Assert(err, ErrorMatches, `content slot must have a content attribute set`)
+	c.Assert(err, IsNil)
+	c.Assert(slot.Attrs["content"], Equals, slot.Name)
 }
 
 func (s *ContentSuite) TestSanitizeSlotNoPaths(c *C) {
@@ -144,7 +145,8 @@ plugs:
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["content-plug"]}
 	err := s.iface.SanitizePlug(plug)
-	c.Assert(err, ErrorMatches, `content plug must have a content attribute set`)
+	c.Assert(err, IsNil)
+	c.Assert(plug.Attrs["content"], Equals, plug.Name)
 }
 
 func (s *ContentSuite) TestSanitizePlugSimpleNoTarget(c *C) {

--- a/tests/lib/snaps/test-snapd-content-plug/bin/content-plug
+++ b/tests/lib/snaps/test-snapd-content-plug/bin/content-plug
@@ -4,7 +4,7 @@ set -e
 
 cat <<EOF
 Please run:
-sudo snap connect content-plug:shared-content-plug content-slot:shared-content-slot
+sudo snap connect content-plug:shared-content content-slot:shared-content
 if you see an permission denied error
 EOF
 

--- a/tests/lib/snaps/test-snapd-content-plug/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-plug/meta/snap.yaml
@@ -3,10 +3,9 @@ version: 1.0
 apps:
     content-plug:
         command: bin/content-plug
-        plugs: [shared-content-plug]
+        plugs: [shared-content]
 plugs:
-    shared-content-plug:
+    shared-content:
         interface: content
         target: import
-        content: mylib
         default-provider: test-snapd-tools

--- a/tests/lib/snaps/test-snapd-content-slot/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-slot/meta/snap.yaml
@@ -1,8 +1,7 @@
 name: test-snapd-content-slot
 version: 1.0
 slots:
-    shared-content-slot:
+    shared-content:
         interface: content
-        content: mylib
         read:
             - /

--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -10,14 +10,14 @@ details: |
 
 prepare: |
     echo "Given a snap declaring a content sharing slot is installed"
-    snap install --edge test-snapd-content-slot
+    snap install --beta test-snapd-content-slot
 
     echo "And a snap declaring a content sharing plug is installed"
-    snap install --edge test-snapd-content-plug
+    snap install --beta test-snapd-content-plug
 
 execute: |
-    CONNECTED_PATTERN="test-snapd-content-slot:shared-content-slot +test-snapd-content-plug:shared-content-plug"
-    DISCONNECTED_PATTERN="(?s).*?test-snapd-content-slot:shared-content-slot +-.*?- +test-snapd-content-plug:shared-content-plug"
+    CONNECTED_PATTERN="test-snapd-content-slot:shared-content +test-snapd-content-plug"
+    DISCONNECTED_PATTERN="(?s).*?test-snapd-content-slot:shared-content +-.*?- +test-snapd-content-plug"
 
     echo "Then the snap is listed as connected"
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
@@ -31,14 +31,14 @@ execute: |
     echo "============================================"
 
     echo "When the plug is disconnected"
-    snap disconnect test-snapd-content-plug:shared-content-plug test-snapd-content-slot:shared-content-slot
+    snap disconnect test-snapd-content-plug:shared-content test-snapd-content-slot:shared-content
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the fstab files are removed"
     [ $(find /var/lib/snapd/mount -type f -name "*.fstab" | wc -l) -eq 0 ]
 
     echo "When the plug is reconnected"
-    snap connect test-snapd-content-plug:shared-content-plug test-snapd-content-slot:shared-content-slot
+    snap connect test-snapd-content-plug:shared-content test-snapd-content-slot:shared-content
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the fstab files are recreated"

--- a/tests/main/snap-connect/task.yaml
+++ b/tests/main/snap-connect/task.yaml
@@ -36,11 +36,11 @@ execute: |
     # NOTE: Those only work when installed from the store as otherwise we don't
     # have snap declaration assertion and cannot check if a given connection
     # should be allowed.
-    CONTENT_CONNECTED_PATTERN='test-snapd-content-slot:shared-content-slot +test-snapd-content-plug:shared-content-plug'
+    CONTENT_CONNECTED_PATTERN='test-snapd-content-slot +test-snapd-content-plug'
 
     echo "The plug side auto-connects when content is installed"
-    snap install --edge test-snapd-content-slot
-    snap install --edge test-snapd-content-plug
+    snap install --beta test-snapd-content-slot
+    snap install --beta test-snapd-content-plug
 
     snap interfaces | MATCH "$CONTENT_CONNECTED_PATTERN"
 

--- a/tests/regression/lp-1615113/task.yaml
+++ b/tests/regression/lp-1615113/task.yaml
@@ -5,7 +5,7 @@ prepare: |
     install_local test-snapd-content-slot
     install_local test-snapd-content-plug
     echo "We can connect them together"
-    snap connect test-snapd-content-plug:shared-content-plug test-snapd-content-slot:shared-content-slot
+    snap connect test-snapd-content-plug:shared-content test-snapd-content-slot:shared-content
 execute: |
     echo "We can now see that the content is shared"
     test-snapd-content-plug.content-plug | grep "Some shared content"


### PR DESCRIPTION
Our documentation and tutorials state that the default value
for the "content" attribute in the content interface is the
plug/slot name if not specified otherwise. This branch ensures
this is the case.