### PR TITLE
interfaces: fix default content attribute value (2.23)

### DIFF
--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -76,7 +76,7 @@ func (iface *ContentInterface) SanitizePlug(plug *interfaces.Plug) error {
 	}
 	content, ok := plug.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
-		// content defaults to "slot" name if unspecified
+		// content defaults to "plug" name if unspecified
 		plug.Attrs["content"] = plug.Name
 	}
 	target, ok := plug.Attrs["target"].(string)

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -47,7 +47,8 @@ func (iface *ContentInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 	content, ok := slot.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
-		return fmt.Errorf("content slot must have a content attribute set")
+		// content defaults to "slot" name if unspecified
+		slot.Attrs["content"] = slot.Name
 	}
 
 	// check that we have either a read or write path
@@ -75,7 +76,8 @@ func (iface *ContentInterface) SanitizePlug(plug *interfaces.Plug) error {
 	}
 	content, ok := plug.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
-		return fmt.Errorf("content plug must have a content attribute set")
+		// content defaults to "slot" name if unspecified
+		plug.Attrs["content"] = plug.Name
 	}
 	target, ok := plug.Attrs["target"].(string)
 	if !ok || len(target) == 0 {

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -57,7 +57,7 @@ slots:
 	c.Assert(err, IsNil)
 }
 
-func (s *ContentSuite) TestSanitizeSlotNoContentLabel(c *C) {
+func (s *ContentSuite) TestSanitizeSlotContentLabelDefault(c *C) {
 	const mockSnapYaml = `name: content-slot-snap
 version: 1.0
 slots:
@@ -69,7 +69,8 @@ slots:
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
 	err := s.iface.SanitizeSlot(slot)
-	c.Assert(err, ErrorMatches, `content slot must have a content attribute set`)
+	c.Assert(err, IsNil)
+	c.Assert(slot.Attrs["content"], Equals, slot.Name)
 }
 
 func (s *ContentSuite) TestSanitizeSlotNoPaths(c *C) {
@@ -133,7 +134,7 @@ plugs:
 	c.Assert(err, IsNil)
 }
 
-func (s *ContentSuite) TestSanitizePlugNoContentLabel(c *C) {
+func (s *ContentSuite) TestSanitizePlugContentLabelDefault(c *C) {
 	const mockSnapYaml = `name: content-slot-snap
 version: 1.0
 plugs:
@@ -144,7 +145,8 @@ plugs:
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["content-plug"]}
 	err := s.iface.SanitizePlug(plug)
-	c.Assert(err, ErrorMatches, `content plug must have a content attribute set`)
+	c.Assert(err, IsNil)
+	c.Assert(plug.Attrs["content"], Equals, plug.Name)
 }
 
 func (s *ContentSuite) TestSanitizePlugSimpleNoTarget(c *C) {

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -11,7 +11,7 @@ systemctl_stop() {
 }
 
 if [ "$1" = "purge" ]; then
-    mounts=$(systemctl list-unit-files | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')
+    mounts=$(systemctl list-unit-files --full | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')
     services=$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')
 
     for unit in $mounts; do

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -11,7 +11,7 @@ systemctl_stop() {
 }
 
 if [ "$1" = "purge" ]; then
-    mounts=$(systemctl list-unit-files | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')
+    mounts=$(systemctl list-unit-files --full | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')
     services=$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')
     for unit in $services $mounts; do
         # ensure its really a snapp mount unit or systemd unit

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -129,7 +129,7 @@ EOF
         update_core_snap_for_classic_reexec
 
         systemctl daemon-reload
-        mounts="$(systemctl list-unit-files | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
+        mounts="$(systemctl list-unit-files --full | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
         services="$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"
         for unit in $services $mounts; do
             systemctl stop $unit

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -25,7 +25,7 @@ reset_classic() {
 
     if [ "$1" = "--reuse-core" ]; then
         $(cd / && tar xzf $SPREAD_PATH/snapd-state.tar.gz)
-        mounts="$(systemctl list-unit-files | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
+        mounts="$(systemctl list-unit-files --full | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
         services="$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"
         systemctl daemon-reload # Workaround for http://paste.ubuntu.com/17735820/
         for unit in $mounts $services; do

--- a/tests/lib/snaps/test-snapd-content-plug-empty-content-attr/bin/content-plug
+++ b/tests/lib/snaps/test-snapd-content-plug-empty-content-attr/bin/content-plug
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+cat <<EOF
+Please run:
+sudo snap connect content-plug:shared-content content-slot:shared-content
+if you see an permission denied error
+EOF
+
+cat $SNAP/import/shared-content

--- a/tests/lib/snaps/test-snapd-content-plug-empty-content-attr/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-plug-empty-content-attr/meta/snap.yaml
@@ -1,0 +1,11 @@
+name: test-snapd-content-plug-empty-content-attr
+version: 1.0
+apps:
+    content-plug:
+        command: bin/content-plug
+        plugs: [shared-content]
+plugs:
+    shared-content:
+        interface: content
+        target: import
+        default-provider: test-snapd-tools

--- a/tests/lib/snaps/test-snapd-content-slot-empty-content-attr/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-slot-empty-content-attr/meta/snap.yaml
@@ -1,0 +1,7 @@
+name: test-snapd-content-slot-empty-content-attr
+version: 1.0
+slots:
+    shared-content:
+        interface: content
+        read:
+            - /

--- a/tests/lib/snaps/test-snapd-content-slot-empty-content-attr/shared-content
+++ b/tests/lib/snaps/test-snapd-content-slot-empty-content-attr/shared-content
@@ -1,0 +1,3 @@
+Some shared content
+
+Is here!

--- a/tests/main/interfaces-content-empty-content-attr/task.yaml
+++ b/tests/main/interfaces-content-empty-content-attr/task.yaml
@@ -1,0 +1,37 @@
+summary: Ensure that the content sharing interface with defaults work.
+
+prepare: |
+    echo "Given a snap declaring a content sharing slot is installed"
+    snap install --edge test-snapd-content-slot-empty-content-attr
+
+    echo "And a snap declaring a content sharing plug is installed"
+    snap install --edge test-snapd-content-plug-empty-content-attr
+
+execute: |
+    CONNECTED_PATTERN="test-snapd-content-slot-empty-content-attr:shared-content +test-snapd-content-plug-empty-content-attr"
+    DISCONNECTED_PATTERN="(?s).*?test-snapd-content-slot-empty-content-attr:shared-content +-.*?- +test-snapd-content-plug-empty-content-attr"
+
+    echo "Then the snap is listed as connected"
+    snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
+
+    echo "And fstab files are created"
+    [ $(find /var/lib/snapd/mount -type f -name "*.fstab" | wc -l) -gt 0 ]
+
+    echo "And we can use the shared content"
+    test-snapd-content-plug-empty-content-attr.content-plug | grep "Some shared content"
+
+    echo "============================================"
+
+    echo "When the plug is disconnected"
+    snap disconnect test-snapd-content-plug-empty-content-attr:shared-content test-snapd-content-slot-empty-content-attr:shared-content
+    snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
+
+    echo "Then the fstab files are removed"
+    [ $(find /var/lib/snapd/mount -type f -name "*.fstab" | wc -l) -eq 0 ]
+
+    echo "When the plug is reconnected"
+    snap connect test-snapd-content-plug-empty-content-attr:shared-content test-snapd-content-slot-empty-content-attr:shared-content
+    snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
+
+    echo "Then the fstab files are recreated"
+    [ $(find /var/lib/snapd/mount -type f -name "*.fstab" | wc -l) -gt 0 ]


### PR DESCRIPTION
Our documentation and tutorials state that the default value
for the "content" attribute in the content interface is the
plug/slot name if not specified otherwise. This branch ensures
this is the case.