### PR TITLE
snapstate: revert PR#2958, run configure hook again everywhere

### DIFF
--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -5497,12 +5497,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasks(c *C) {
 		SnapType: "os",
 	})
 
-	// FIXME: we do not run the configure hook on classic for core, so
-	//        verifyInstallUpdateTasks() would fail, we mock this here
-	//        until LP: #1668738 is understood
-	r := release.MockOnClassic(false)
-	defer r()
-
 	tsl, err := snapstate.TransitionCore(s.state, "ubuntu-core", "core")
 	c.Assert(err, IsNil)
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -225,13 +225,9 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 
 	installSet := state.NewTaskSet(tasks...)
 
-	// gross hack, do not run configure hook on classic (LP: #1668738)
-	// for now until we understand why it is failing for some people
-	if !(release.OnClassic && snapsup.Name() == "core") {
-		configSet := Configure(st, snapsup.Name(), defaults)
-		configSet.WaitAll(installSet)
-		installSet.AddAll(configSet)
-	}
+	configSet := Configure(st, snapsup.Name(), defaults)
+	configSet.WaitAll(installSet)
+	installSet.AddAll(configSet)
 
 	return installSet, nil
 }


### PR DESCRIPTION
Running the configure hook for the core snap on classic was
disabled because of an unknown bug in the code. However with
the merge of PR#2992 this bug is now fixed so we can re-enable
it.