### PR TITLE
interfaces: add support for location-observe for dbus::ObjectManager session paths

### DIFF
--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -163,10 +163,38 @@ dbus (send)
     member="{Start,Stop}VelocityUpdates"
     peer=(label=###SLOT_SECURITY_TAGS###),
 
+dbus (send)
+    bus=system
+    path=/com/ubuntu/location/Service/sessions/*
+    interface=com.ubuntu.location.Service.Session
+    member="{Start,Stop}PositionUpdates"
+    peer=(label=###SLOT_SECURITY_TAGS###),
+
+dbus (send)
+    bus=system
+    path=/com/ubuntu/location/Service/sessions/*
+    interface=com.ubuntu.location.Service.Session
+    member="{Start,Stop}HeadingUpdates"
+    peer=(label=###SLOT_SECURITY_TAGS###),
+
+dbus (send)
+    bus=system
+    path=/com/ubuntu/location/Service/sessions/*
+    interface=com.ubuntu.location.Service.Session
+    member="{Start,Stop}VelocityUpdates"
+    peer=(label=###SLOT_SECURITY_TAGS###),
+
 # Allow clients to receive updates from the service
 dbus (receive)
     bus=system
     path=/sessions/*
+    interface=com.ubuntu.location.Service.Session
+    member="Update{Position,Heading,Velocity}"
+    peer=(label=###SLOT_SECURITY_TAGS###),
+
+dbus (receive)
+    bus=system
+    path=/com/ubuntu/location/Service/sessions/*
     interface=com.ubuntu.location.Service.Session
     member="Update{Position,Heading,Velocity}"
     peer=(label=###SLOT_SECURITY_TAGS###),


### PR DESCRIPTION
From version 4.0.0 onwards, sessions will be hosted under new paths
to enable dbus::ObjectManager support for locationd. We keep both path
setups in place to support previous versions of locationd.