### PR TITLE
packaging, tests: use "systemctl list-unit-files --full" everywhere

### DIFF
--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -12,7 +12,7 @@ systemctl_stop() {
 
 if [ "$1" = "purge" ]; then
     mounts=$(systemctl list-unit-files --full | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')
-    services=$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')
+    services=$(systemctl list-unit-files --full | grep '^snap[-.].*\.service' | cut -f1 -d ' ')
 
     for unit in $mounts; do
         # ensure its really a snap mount unit or systemd unit

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -12,7 +12,7 @@ systemctl_stop() {
 
 if [ "$1" = "purge" ]; then
     mounts=$(systemctl list-unit-files --full | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')
-    services=$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')
+    services=$(systemctl list-unit-files --full | grep '^snap[-.].*\.service' | cut -f1 -d ' ')
     for unit in $services $mounts; do
         # ensure its really a snapp mount unit or systemd unit
         if ! grep -q 'What=/var/lib/snapd/snaps/' "/etc/systemd/system/$unit" && ! grep -q 'X-Snappy=yes' "/etc/systemd/system/$unit"; then

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -133,7 +133,7 @@ EOF
 
         systemctl daemon-reload
         mounts="$(systemctl list-unit-files --full | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
-        services="$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"
+        services="$(systemctl list-unit-files --full | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"
         for unit in $services $mounts; do
             systemctl stop $unit
         done

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -26,7 +26,7 @@ reset_classic() {
     if [ "$1" = "--reuse-core" ]; then
         $(cd / && tar xzf $SPREAD_PATH/snapd-state.tar.gz)
         mounts="$(systemctl list-unit-files --full | grep '^snap[-.].*\.mount' | cut -f1 -d ' ')"
-        services="$(systemctl list-unit-files | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"
+        services="$(systemctl list-unit-files --full | grep '^snap[-.].*\.service' | cut -f1 -d ' ')"
         systemctl daemon-reload # Workaround for http://paste.ubuntu.com/17735820/
         for unit in $mounts $services; do
             systemctl start $unit


### PR DESCRIPTION
The default of list-unit-files is to shorten long unit file names
to something like "prefix...suffix". As we are using this to
find the actual file names this is undesirable and we need to
always use --full.