### PR TITLE
testutils: address review feedback from PR#2997

### DIFF
--- a/overlord/hookstate/export_test.go
+++ b/overlord/hookstate/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -34,6 +34,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -264,6 +264,7 @@ func snapCmd() string {
 
 	exe, err := osReadlink("/proc/self/exe")
 	if err != nil {
+		logger.Noticef("cannot read /proc/self/exe: %v, using default snap command", err)
 		return snapCmd
 	}
 	if !strings.HasPrefix(exe, dirs.SnapMountDir) {

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -46,7 +46,9 @@ echo >> %[1]q
 %s
 `
 
-// MockCommand adds a mocked command to PATH.
+// MockCommand adds a mocked command. If the basename argument is a command
+// it is added to PATH. If it is an absolute path it is just created there.
+// the caller is responsible for the cleanup in this case.
 //
 // The command logs all invocations to a dedicated log file. If script is
 // non-empty then it is used as is and the caller is responsible for how the


### PR DESCRIPTION
This improves the documentation of testutils.MockCommand() and also
log an error to the logger if /proc/self/exe cannot be read.
Thanks to zyga!