### PR TITLE
tests: remove core_name variable

### DIFF
--- a/tests/lib/names.sh
+++ b/tests/lib/names.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 gadget_name=$(snap list | sed -n 's/^\(pc\|pi[23]\|dragonboard\) .*/\1/p')
 kernel_name=$gadget_name-kernel
-core_name=$(snap list | awk '/^(ubuntu-)?core / {print $1; exit}')
 
 if [ "$kernel_name" = "pi3-kernel" ]; then
     kernel_name=pi2-kernel

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -329,7 +329,7 @@ prepare_all_snap() {
 
     echo "Ensure fundamental snaps are still present"
     . $TESTSLIB/names.sh
-    for name in $gadget_name $kernel_name $core_name; do
+    for name in $gadget_name $kernel_name core; do
         if ! snap list | grep $name; then
             echo "Not all fundamental snaps are available, all-snap image not valid"
             echo "Currently installed snaps"

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -48,7 +48,7 @@ reset_all_snap() {
     for snap in /snap/*; do
         snap="${snap:6}"
         case "$snap" in
-            "bin" | "$gadget_name" | "$kernel_name" | "$core_name" )
+            "bin" | "$gadget_name" | "$kernel_name" | core )
                 ;;
             *)
                 snap remove "$snap"

--- a/tests/main/enable-disable-units-gpio/task.yaml
+++ b/tests/main/enable-disable-units-gpio/task.yaml
@@ -57,8 +57,7 @@ prepare: |
     systemctl enable --now gpio-mock.service
 
     echo "And the gpio plug is connected"
-    . "$TESTSLIB/names.sh"
-    snap connect gpio-consumer:gpio ${core_name}:gpio-pin
+    snap connect gpio-consumer:gpio gpio-pin
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/enable-disable-units-gpio/task.yaml
+++ b/tests/main/enable-disable-units-gpio/task.yaml
@@ -57,7 +57,7 @@ prepare: |
     systemctl enable --now gpio-mock.service
 
     echo "And the gpio plug is connected"
-    snap connect gpio-consumer:gpio gpio-pin
+    snap connect gpio-consumer:gpio :gpio-pin
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/enable-disable/task.yaml
+++ b/tests/main/enable-disable/task.yaml
@@ -34,7 +34,7 @@ execute: |
 
     echo "Ensure the important snaps can not be disabled"
     . $TESTSLIB/names.sh
-    for sn in $core_name $kernel_name $gadget_name; do
+    for sn in core $kernel_name $gadget_name; do
         if snap disable $sn; then
             echo "It should not be possible to disable $sn"
             exit 1

--- a/tests/main/failover/task.yaml
+++ b/tests/main/failover/task.yaml
@@ -43,20 +43,19 @@ execute: |
         truncate -s 0 /tmp/unpack/lib/systemd/systemd
     }
 
-    . $TESTSLIB/names.sh
     . $TESTSLIB/boot.sh
     if [ "$SPREAD_REBOOT" = 0 ]; then
         # first pass, save current target snap revision
-        snap list | awk "/^${core_name} / {print(\$3)}" > prevBoot
+        snap list | awk "/^core / {print(\$3)}" > prevBoot
 
         # unpack current target snap
-        unsquashfs -d /tmp/unpack /var/lib/snapd/snaps/${core_name}_*.snap
+        unsquashfs -d /tmp/unpack /var/lib/snapd/snaps/core_*.snap
 
         # set failure condition
         eval ${INJECT_FAILURE}
 
         # repack new target snap
-        snapbuild /tmp/unpack . && mv ${core_name}_*.snap failing.snap
+        snapbuild /tmp/unpack . && mv core_*.snap failing.snap
 
         # install new target snap
         chg_id=$(snap install --dangerous failing.snap --no-wait)
@@ -64,9 +63,9 @@ execute: |
         while ! snap change ${chg_id}|grep -q "^Done.*Make snap.*available to the system" ; do sleep 1 ; done
 
         # check boot env vars
-        snap list | awk "/^${core_name} / {print(\$3)}" > failBoot
-        test "$(bootenv snap_core)" = "${core_name}_$(cat prevBoot).snap"
-        test "$(bootenv snap_try_core)" = "${core_name}_$(cat failBoot).snap"
+        snap list | awk "/^core / {print(\$3)}" > failBoot
+        test "$(bootenv snap_core)" = "core_$(cat prevBoot).snap"
+        test "$(bootenv snap_try_core)" = "core_$(cat failBoot).snap"
 
         REBOOT
     fi
@@ -74,7 +73,7 @@ execute: |
     # after rollback, we have the original target snap for a while
     # wait until the kernel and core snap revisions are in place
     while true ; do
-        current=$(snap list | awk "/^${core_name} / {print(\$3)}")
+        current=$(snap list | awk "/^core / {print(\$3)}")
         if [ "$current" = "$(cat prevBoot)" ] ; then
             break
         fi
@@ -87,6 +86,6 @@ execute: |
         sleep 1
     done
 
-    test "$(bootenv snap_core)" = "${core_name}_$(cat prevBoot).snap"
+    test "$(bootenv snap_core)" = "core_$(cat prevBoot).snap"
     # FIXME: reenable the last check when we reset properly snap_try_{core,kernel} on rollback
     # test "$(bootenv snap_try_${TARGET_SNAP})" = ""

--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -10,8 +10,7 @@ prepare: |
     install_local account-control-consumer
 
     echo "And the account-control plug is connected"
-    . "$TESTSLIB/names.sh"
-    snap connect account-control-consumer:account-control ${core_name}
+    snap connect account-control-consumer:account-control
 
 systems: [ubuntu-core-16-64]
 

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -40,7 +40,6 @@ restore: |
 execute: |
     CONNECTED_PATTERN=":cups-control +test-snapd-cups-control-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +test-snapd-cups-control-consumer:cups-control"
-    . "$TESTSLIB/names.sh"
 
     echo "Then it is not shown as connected"
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
@@ -48,7 +47,7 @@ execute: |
     echo "===================================="
 
     echo "When the plug is connected"
-    snap connect test-snapd-cups-control-consumer:cups-control ${core_name}:cups-control
+    snap connect test-snapd-cups-control-consumer:cups-control
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap command is able to print files"
@@ -59,7 +58,7 @@ execute: |
     echo "===================================="
 
     echo "When the plug is disconnected"
-    snap disconnect test-snapd-cups-control-consumer:cups-control ${core_name}:cups-control
+    snap disconnect test-snapd-cups-control-consumer:cups-control
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the snap command is not able to print files"

--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -47,7 +47,6 @@ restore: |
 execute: |
     CONNECTED_PATTERN=":firewall-control +firewall-control-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +firewall-control-consumer:firewall-control"
-    . "$TESTSLIB/names.sh"
 
     echo "Then it is not connected by default"
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
@@ -55,7 +54,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is connected"
-    snap connect firewall-control-consumer:firewall-control ${core_name}:firewall-control
+    snap connect firewall-control-consumer:firewall-control
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "And the snap creates a firewall rule"
@@ -73,7 +72,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is disconnected"
-    snap disconnect firewall-control-consumer:firewall-control ${core_name}:firewall-control
+    snap disconnect firewall-control-consumer:firewall-control
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the snap is not able to configure the firewall"

--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -29,8 +29,6 @@ restore: |
     rm -rf $MOUNT_POINT fuse.error
 
 execute: |
-    . "$TESTSLIB/names.sh"
-
     CONNECTED_PATTERN=":fuse-support +test-snapd-fuse-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +test-snapd-fuse-consumer:fuse-support"
 
@@ -47,7 +45,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is connected"
-    snap connect test-snapd-fuse-consumer:fuse-support ${core_name}:fuse-support
+    snap connect test-snapd-fuse-consumer:fuse-support
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to create a fuse filesystem"

--- a/tests/main/interfaces-hardware-observe/task.yaml
+++ b/tests/main/interfaces-hardware-observe/task.yaml
@@ -18,8 +18,6 @@ restore: |
     rm -f hardware-observe-consumer_1.0_all.snap hw.error
 
 execute: |
-    . "$TESTSLIB/names.sh"
-
     CONNECTED_PATTERN=":hardware-observe +hardware-observe-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +hardware-observe-consumer:hardware-observe"
 
@@ -29,7 +27,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is connected"
-    snap connect hardware-observe-consumer:hardware-observe ${core_name}:hardware-observe
+    snap connect hardware-observe-consumer:hardware-observe
 
     echo "Then the snap is able to read hardware information"
     hardware-observe-consumer.consumer
@@ -37,7 +35,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is disconnected"
-    snap disconnect hardware-observe-consumer:hardware-observe ${core_name}:hardware-observe
+    snap disconnect hardware-observe-consumer:hardware-observe
 
     echo "Then the snap is not able to read the hardware information"
     if hardware-observe-consumer.consumer 2>hw.error; then

--- a/tests/main/interfaces-home/task.yaml
+++ b/tests/main/interfaces-home/task.yaml
@@ -34,8 +34,6 @@ restore: |
     rm -f $SNAP_FILE $READABLE_FILE $WRITABLE_FILE $CREATABLE_FILE $HIDDEN_READABLE_FILE
 
 execute: |
-    . "$TESTSLIB/names.sh"
-
     CONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
     :home +home-consumer"
@@ -48,7 +46,7 @@ execute: |
         snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
         echo "And the plug can be connected"
-        snap connect home-consumer:home ${core_name}:home
+        snap connect home-consumer:home
         snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
     else
         echo "Then the snap is listed as connected"
@@ -57,17 +55,17 @@ execute: |
         echo "============================================"
 
         echo "When the plug is disconnected"
-        snap disconnect home-consumer:home ${core_name}:home
+        snap disconnect home-consumer:home
         snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
         echo "Then the plug can be connected again"
-        snap connect home-consumer:home ${core_name}:home
+        snap connect home-consumer:home
         snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
     fi
     echo "============================================"
 
     echo "When the plug is connected"
-    snap connect home-consumer:home ${core_name}:home
+    snap connect home-consumer:home
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to read home files"
@@ -76,7 +74,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is disconnected"
-    snap disconnect home-consumer:home ${core_name}:home
+    snap disconnect home-consumer:home
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then snap can't read home files"
@@ -87,7 +85,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is connected"
-    snap connect home-consumer:home ${core_name}:home
+    snap connect home-consumer:home
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to append to home files"
@@ -97,7 +95,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is disconnected"
-    snap disconnect home-consumer:home ${core_name}:home
+    snap disconnect home-consumer:home
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then snap can't append to home files"
@@ -108,7 +106,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is connected"
-    snap connect home-consumer:home ${core_name}:home
+    snap connect home-consumer:home
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to create home files"
@@ -118,7 +116,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is disconnected"
-    snap disconnect home-consumer:home ${core_name}:home
+    snap disconnect home-consumer:home
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then snap can't create home files"
@@ -129,7 +127,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is connected"
-    snap connect home-consumer:home ${core_name}:home
+    snap connect home-consumer:home
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is not able to read hidden home files"
@@ -140,7 +138,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is connected"
-    snap connect home-consumer:home ${core_name}:home
+    snap connect home-consumer:home
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is not able to write hidden home files"

--- a/tests/main/interfaces-iio/task.yaml
+++ b/tests/main/interfaces-iio/task.yaml
@@ -26,8 +26,7 @@ prepare: |
     install_local iio-consumer
 
     echo "And the iio plug is connected"
-    . "$TESTSLIB/names.sh"
-    snap connect iio-consumer:iio ${core_name}:iio0
+    snap connect iio-consumer:iio core:iio0
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/interfaces-locale-control/task.yaml
+++ b/tests/main/interfaces-locale-control/task.yaml
@@ -27,8 +27,6 @@ restore: |
     mv locale.back /etc/default/locale
 
 execute: |
-    . "$TESTSLIB/names.sh"
-
     CONNECTED_PATTERN=":locale-control +locale-control-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +locale-control-consumer:locale-control"
 
@@ -38,7 +36,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is connected"
-    snap connect locale-control-consumer:locale-control ${core_name}:locale-control
+    snap connect locale-control-consumer:locale-control
 
     echo "Then the snap is able to read the locale configuration"
     [ "$(su -l -c 'locale-control-consumer.get LANG' test)" = "$LANG" ]
@@ -46,7 +44,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is disconnected"
-    snap disconnect locale-control-consumer:locale-control ${core_name}:locale-control
+    snap disconnect locale-control-consumer:locale-control
 
     echo "Then the snap is not able to read the locale configuration"
     if su -l -c "locale-control-consumer.get LANG 2>${PWD}/locale-read.error" test; then
@@ -58,7 +56,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is connected"
-    snap connect locale-control-consumer:locale-control ${core_name}:locale-control
+    snap connect locale-control-consumer:locale-control
 
     echo "Then the snap is able to write the locale configuration"
     locale-control-consumer.set LANG mylang
@@ -67,7 +65,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is disconnected"
-    snap disconnect locale-control-consumer:locale-control ${core_name}:locale-control
+    snap disconnect locale-control-consumer:locale-control
 
     echo "Then the snap is not able to read the locale configuration"
     if locale-control-consumer.set LANG mysecondlang 2>${PWD}/locale-write.error; then

--- a/tests/main/interfaces-log-observe/task.yaml
+++ b/tests/main/interfaces-log-observe/task.yaml
@@ -22,8 +22,6 @@ restore: |
     rm -f $SNAP_FILE
 
 execute: |
-    . "$TESTSLIB/names.sh"
-
     CONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
     :$PLUG +$SNAP_NAME"
@@ -37,17 +35,17 @@ execute: |
     echo "============================================"
 
     echo "When the plug is connected"
-    snap connect $SNAP_NAME:$PLUG ${core_name}:$PLUG
+    snap connect $SNAP_NAME:$PLUG
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the plug can be disconnected again"
-    snap disconnect $SNAP_NAME:$PLUG ${core_name}:$PLUG
+    snap disconnect $SNAP_NAME:$PLUG
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "============================================"
 
     echo "When the plug is connected"
-    snap connect $SNAP_NAME:$PLUG ${core_name}:$PLUG
+    snap connect $SNAP_NAME:$PLUG
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to access the system logs"
@@ -56,7 +54,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is disconnected"
-    snap disconnect $SNAP_NAME:$PLUG ${core_name}:$PLUG
+    snap disconnect $SNAP_NAME:$PLUG
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then snap can't access the system logs"

--- a/tests/main/interfaces-mount-observe/task.yaml
+++ b/tests/main/interfaces-mount-observe/task.yaml
@@ -20,7 +20,6 @@ restore: |
     rm -f mount-observe-consumer_1.0_all.snap
 
 execute: |
-    . "$TESTSLIB/names.sh"
     CONNECTED_PATTERN=":mount-observe +mount-observe-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +mount-observe-consumer:mount-observe"
 
@@ -30,7 +29,7 @@ execute: |
     echo "========================================="
 
     echo "When the plug is connected"
-    snap connect mount-observe-consumer:mount-observe ${core_name}:mount-observe
+    snap connect mount-observe-consumer:mount-observe
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the mount info is reachable"
@@ -40,7 +39,7 @@ execute: |
     echo "========================================="
 
     echo "When the plug is disconnected"
-    snap disconnect mount-observe-consumer:mount-observe ${core_name}:mount-observe
+    snap disconnect mount-observe-consumer:mount-observe
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the mount info is not reachable"
@@ -52,7 +51,7 @@ execute: |
     echo "========================================="
 
     echo "When the plug is connected"
-    snap connect mount-observe-consumer:mount-observe ${core_name}:mount-observe
+    snap connect mount-observe-consumer:mount-observe
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "And a new mount is created"

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -33,7 +33,6 @@ restore: |
     rm -f $SNAP_FILE $REQUEST_FILE
 
 execute: |
-    . "$TESTSLIB/names.sh"
     CONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
     :network-bind +$SNAP_NAME"
@@ -47,17 +46,17 @@ execute: |
     echo "============================================"
 
     echo "When the plug is disconnected"
-    snap disconnect $SNAP_NAME:network-bind ${core_name}:network-bind
+    snap disconnect $SNAP_NAME:network-bind
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the plug can be connected again"
-    snap connect $SNAP_NAME:network-bind ${core_name}:network-bind
+    snap connect $SNAP_NAME:network-bind
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "============================================"
 
     echo "When the plug is connected"
-    snap connect $SNAP_NAME:network-bind ${core_name}:network-bind
+    snap connect $SNAP_NAME:network-bind
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the service is accessible by a client"
@@ -66,7 +65,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is disconnected"
-    snap disconnect $SNAP_NAME:network-bind ${core_name}:network-bind
+    snap disconnect $SNAP_NAME:network-bind
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the service is not accessible by a client"

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -40,7 +40,6 @@ restore: |
     arp -d $ARP_ENTRY_ADDR -i $(get_default_iface) || true
 
 execute: |
-    . "$TESTSLIB/names.sh"
     . "$TESTSLIB/network.sh"
 
     CONNECTED_PATTERN=":network-control +network-control-consumer"
@@ -53,7 +52,7 @@ execute: |
     echo "===================================="
 
     echo "When the plug is connected"
-    snap connect network-control-consumer:network-control ${core_name}:network-control
+    snap connect network-control-consumer:network-control
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap command can query network status information"
@@ -62,7 +61,7 @@ execute: |
     echo "===================================="
 
     echo "When the plug is disconnected"
-    snap disconnect network-control-consumer:network-control ${core_name}:network-control
+    snap disconnect network-control-consumer:network-control
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the snap command can not query network status information"
@@ -74,7 +73,7 @@ execute: |
     echo "===================================="
 
     echo "When the plug is connected"
-    snap connect network-control-consumer:network-control ${core_name}:network-control
+    snap connect network-control-consumer:network-control
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap command can modify the network configuration"
@@ -85,7 +84,7 @@ execute: |
     echo "===================================="
 
     echo "When the plug is disconnected"
-    snap disconnect network-control-consumer:network-control ${core_name}:network-control
+    snap disconnect network-control-consumer:network-control
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the snap command can not modify the network configuration"

--- a/tests/main/interfaces-network-observe/task.yaml
+++ b/tests/main/interfaces-network-observe/task.yaml
@@ -31,13 +31,11 @@ prepare: |
 
 restore: |
     . "$TESTSLIB/systemd.sh"
-    
+
     systemd_stop_and_destroy_unit $SERVICE_NAME
     rm -f network-observe-consumer_1.0_all.snap net-query.output $SERVICE_FILE
 
 execute: |
-    . "$TESTSLIB/names.sh"
-
     CONNECTED_PATTERN=":network-observe +network-observe-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +network-observe-consumer:network-observe"
 
@@ -47,7 +45,7 @@ execute: |
     echo "===================================="
 
     echo "When the plug is connected"
-    snap connect network-observe-consumer:network-observe ${core_name}:network-observe
+    snap connect network-observe-consumer:network-observe
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap command can query network status information"
@@ -56,7 +54,7 @@ execute: |
     echo "===================================="
 
     echo "When the plug is disconnected"
-    snap disconnect network-observe-consumer:network-observe ${core_name}:network-observe
+    snap disconnect network-observe-consumer:network-observe
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the snap command can not query network status information"

--- a/tests/main/interfaces-network/task.yaml
+++ b/tests/main/interfaces-network/task.yaml
@@ -35,8 +35,6 @@ restore: |
     rm -f $SNAP_FILE $SERVICE_FILE
 
 execute: |
-    . "$TESTSLIB/names.sh"
-
     CONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
     :network +$SNAP_NAME"
@@ -50,17 +48,17 @@ execute: |
     echo "============================================"
 
     echo "When the plug is disconnected"
-    snap disconnect $SNAP_NAME:network ${core_name}:network
+    snap disconnect $SNAP_NAME:network
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the plug can be connected again"
-    snap connect $SNAP_NAME:network ${core_name}:network
+    snap connect $SNAP_NAME:network
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "============================================"
 
     echo "When the plug is connected"
-    snap connect $SNAP_NAME:network ${core_name}:network
+    snap connect $SNAP_NAME:network
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to access a network service"
@@ -69,7 +67,7 @@ execute: |
     echo "============================================"
 
     echo "When the plug is disconnected"
-    snap disconnect $SNAP_NAME:network ${core_name}:network
+    snap disconnect $SNAP_NAME:network
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then snap can't access a network service"

--- a/tests/main/interfaces-process-control/task.yaml
+++ b/tests/main/interfaces-process-control/task.yaml
@@ -21,8 +21,6 @@ restore: |
     rm -f process-control-consumer_1.0_all.snap process-kill.error process-nice.error
 
 execute: |
-    . "$TESTSLIB/names.sh"
-
     CONNECTED_PATTERN=":process-control +process-control-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +process-control-consumer:process-control"
 
@@ -32,7 +30,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is connected"
-    snap connect process-control-consumer:process-control ${core_name}:process-control
+    snap connect process-control-consumer:process-control
 
     echo "Then the snap is able to kill an existing process"
     while :; do sleep 1; done &
@@ -44,7 +42,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is disconnected"
-    snap disconnect process-control-consumer:process-control ${core_name}:process-control
+    snap disconnect process-control-consumer:process-control
 
     echo "Then the snap is not able to kill an existing process"
     while :; do sleep 1; done &

--- a/tests/main/interfaces-snapd-control/task.yaml
+++ b/tests/main/interfaces-snapd-control/task.yaml
@@ -22,8 +22,6 @@ restore: |
     rm -f snapd.error
 
 execute: |
-    . "$TESTSLIB/names.sh"
-
     CONNECTED_PATTERN=":snapd-control +test-snapd-control-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +test-snapd-control-consumer:snapd-control"
 
@@ -33,7 +31,7 @@ execute: |
     echo "================================================"
 
     echo "When the plug is disconnected"
-    snap disconnect test-snapd-control-consumer:snapd-control ${core_name}:snapd-control
+    snap disconnect test-snapd-control-consumer:snapd-control
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the snap command is not able to control snapd"
@@ -46,7 +44,7 @@ execute: |
     echo "================================================"
 
     echo "When the plug is connected"
-    snap connect test-snapd-control-consumer:snapd-control ${core_name}:snapd-control
+    snap connect test-snapd-control-consumer:snapd-control
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap command is able to control snapd"

--- a/tests/main/interfaces-system-observe/task.yaml
+++ b/tests/main/interfaces-system-observe/task.yaml
@@ -17,7 +17,6 @@ restore: |
     rm -f system-observe-consumer_1.0_all.snap
 
 execute: |
-    . "$TESTSLIB/names.sh"
     CONNECTED_PATTERN=":system-observe +system-observe-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +system-observe-consumer:system-observe"
 
@@ -27,7 +26,7 @@ execute: |
     echo "==========================================="
 
     echo "When the plug is connected"
-    snap connect system-observe-consumer:system-observe ${core_name}:system-observe
+    snap connect system-observe-consumer:system-observe
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to get system information"
@@ -37,7 +36,7 @@ execute: |
     echo "==========================================="
 
     echo "When the plug is disconnected"
-    snap disconnect system-observe-consumer:system-observe ${core_name}:system-observe
+    snap disconnect system-observe-consumer:system-observe
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the snap is not able to get system information"

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -25,7 +25,6 @@ restore: |
     apt-get autoremove --purge -y
 
 execute: |
-    . "$TESTSLIB/names.sh"
     CONNECTED_PATTERN=":upower-observe +test-snapd-upower-observe-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +test-snapd-upower-observe-consumer:upower-observe"
 
@@ -35,7 +34,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is disconnected"
-    snap disconnect test-snapd-upower-observe-consumer:upower-observe ${core_name}:upower-observe
+    snap disconnect test-snapd-upower-observe-consumer:upower-observe
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
 
     echo "Then the snap is not able to dump info about the upower devices"
@@ -48,7 +47,7 @@ execute: |
     echo "==================================="
 
     echo "When the plug is connected"
-    snap connect test-snapd-upower-observe-consumer:upower-observe ${core_name}:upower-observe
+    snap connect test-snapd-upower-observe-consumer:upower-observe
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to dump info about the upower devices"

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -5,14 +5,13 @@ prepare: |
     install_local test-snapd-tools
 
 execute: |
-    . "$TESTSLIB/names.sh"
 
     echo "List prints core snap version"
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
-        expected="^${core_name} +.*? +(\d{2}\-\d+) + x\d+ +- *"
+        expected="^core +.*? +(\d{2}\-\d+) + x\d+ +- *"
     else
-        expected="^${core_name} +.*? +(\d{2}\-\d+) + \d+ +canonical +- *"
+        expected="^core +.*? +(\d{2}\-\d+) + \d+ +canonical +- *"
     fi
     snap list | grep -Pq "$expected"
 

--- a/tests/main/remove-errors/task.yaml
+++ b/tests/main/remove-errors/task.yaml
@@ -7,7 +7,7 @@ execute: |
 
     . "$TESTSLIB/names.sh"
     echo "Ensure the important snaps can not be removed"
-    for sn in $core_name $kernel_name $gadget_name; do
+    for sn in core $kernel_name $gadget_name; do
         if snap remove $sn; then
             echo "It should not be possible to remove $sn"
             exit 1

--- a/tests/main/security-setuid-root/task.yaml
+++ b/tests/main/security-setuid-root/task.yaml
@@ -1,4 +1,4 @@
-summary: Check that snap-confine refuses to run unconfined 
+summary: Check that snap-confine refuses to run unconfined
 details: |
     snap-confine is setuid root but is only confined with an apparmor profile
     when invoked as a system-installed package or when running in the core from
@@ -8,15 +8,14 @@ prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
 execute: |
-    . $TESTSLIB/names.sh
     # NOTE: This has to run as the test user because the protection is only
     # active if user gains elevated permissions as a result of using setuid
     # root snap-confine.
-    if su test -c "sh -c \"SNAP_NAME=test-snapd-tools /snap/${core_name}/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>/dev/null\""; then
+    if su test -c "sh -c \"SNAP_NAME=test-snapd-tools /snap/core/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>/dev/null\""; then
         echo "snap-confine didn't refuse to run!"
         exit 1
     fi
-    su test -c "sh -c \"SNAP_NAME=test-snapd-tools /snap/${core_name}/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>&1\"" | MATCH "Refusing to continue to avoid permission escalation attacks"
+    su test -c "sh -c \"SNAP_NAME=test-snapd-tools /snap/core/current/usr/lib/snapd/snap-confine snap.test-snapd-tools.cmd /bin/true 2>&1\"" | MATCH "Refusing to continue to avoid permission escalation attacks"
 debug: |
     ls -ld /snap/core/current/usr/lib/snapd/snap-confine || true
     ls -ld /snap/ubuntu-core/current/usr/lib/snapd/snap-confine || true

--- a/tests/main/snap-connect/task.yaml
+++ b/tests/main/snap-connect/task.yaml
@@ -1,32 +1,29 @@
 summary: Check that snap connect works
 
 prepare: |
-    . $TESTSLIB/names.sh
     . $TESTSLIB/snaps.sh
 
     echo "Install a test snap"
     install_local home-consumer
     # the home interface is not autoconnected on all-snap systems
     if [[ ! "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
-        snap disconnect home-consumer:home "${core_name}:home"
+        snap disconnect home-consumer:home
     fi
 
 execute: |
-    . $TESTSLIB/names.sh
-
     CONNECTED_PATTERN=':home +home-consumer'
 
     echo "The plug can be connected to a matching slot of OS snap without snap:slot argument"
     snap connect home-consumer:home
     snap interfaces | MATCH "$CONNECTED_PATTERN"
 
-    snap disconnect home-consumer:home "${core_name}:home"
+    snap disconnect home-consumer:home
 
     echo "The plug can be connected to a matching slot with slot name omitted"
-    snap connect home-consumer:home "${core_name}"
+    snap connect home-consumer:home
     snap interfaces | MATCH "$CONNECTED_PATTERN"
 
-    snap disconnect home-consumer:home "${core_name}:home"
+    snap disconnect home-consumer:home
 
     echo "The plug can be connected to a slot on the core snap using abbreviated syntax"
     snap connect home-consumer:home :home

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -14,31 +14,29 @@ restore: |
     rm -f *.snap
 
 execute: |
-    . $TESTSLIB/names.sh
-
     DISCONNECTED_PATTERN="\-\s+home-consumer:home"
 
     echo "Disconnect everything from given slot"
-    snap connect home-consumer:home ${core_name}:home
-    snap disconnect ${core_name}:home
+    snap connect home-consumer:home core:home
+    snap disconnect core:home
     snap interfaces | grep -Pzqe "$DISCONNECTED_PATTERN"
 
     echo "Disconnect everything from given slot (abbreviated)"
-    snap connect home-consumer:home ${core_name}:home
+    snap connect home-consumer:home core:home
     snap disconnect :home
     snap interfaces | grep -Pzqe "$DISCONNECTED_PATTERN"
 
     echo "Disconnect everything from given plug"
-    snap connect home-consumer:home ${core_name}:home
+    snap connect home-consumer:home core:home
     snap disconnect home-consumer:home
     snap interfaces | grep -Pzqe "$DISCONNECTED_PATTERN"
 
     echo "Disconnect specific plug and slot"
-    snap connect home-consumer:home ${core_name}:home
-    snap disconnect home-consumer:home ${core_name}:home
+    snap connect home-consumer:home core:home
+    snap disconnect home-consumer:home core:home
     snap interfaces | grep -Pzqe "$DISCONNECTED_PATTERN"
 
     echo "Disconnect specific plug and slot (abbreviated)"
-    snap connect home-consumer:home ${core_name}:home
+    snap connect home-consumer:home core:home
     snap disconnect home-consumer:home :home
     snap interfaces | grep -Pzqe "$DISCONNECTED_PATTERN"

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -74,19 +74,18 @@ execute: |
     umount /snap/core/current/usr/bin/snap
 
     echo "Ensure a core refresh restart snapd"
-    . $TESTSLIB/names.sh
-    prev_core=$(snap list | awk "/^${core_name} / {print(\$3)}")
-    snap install --dangerous /var/lib/snapd/snaps/${core_name}_${prev_core}.snap
+    prev_core=$(snap list | awk "/^core / {print(\$3)}")
+    snap install --dangerous /var/lib/snapd/snaps/core_${prev_core}.snap
     journalctl | MATCH "Requested daemon restart"
 
     echo "Ensure the right snapd (from the new core) is running"
-    now_core=$(snap list | awk "/^${core_name} / {print(\$3)}")
+    now_core=$(snap list | awk "/^core / {print(\$3)}")
     if [ "$now_core" = "$prev_core" ]; then
         echo "Test broken $now_core and $prev_Core are the same"
         exit 1
     fi
     SNAPD_PATH=$(readlink -f /proc/$(pidof snapd)/exe)
-    if [ "$SNAPD_PATH" != "/snap/${core_name}/${now_core}/usr/lib/snapd/snapd" ]; then
+    if [ "$SNAPD_PATH" != "/snap/core/${now_core}/usr/lib/snapd/snapd" ]; then
         echo "unexpected $SNAPD_PATH for $now_core snap (previous $prev_core)"
         exit 1
     fi

--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -18,11 +18,9 @@ restore: |
     rm -f prevBoot nextBoot curChg
 
 prepare: |
-    . $TESTSLIB/names.sh
-    snap list | awk "/^${core_name} / {print(\$3)}" > nextBoot
+    snap list | awk "/^core / {print(\$3)}" > nextBoot
 
 execute: |
-    . $TESTSLIB/names.sh
     . $TESTSLIB/boot.sh
 
     # FIXME Why it starting with snap_mode=try the first time?
@@ -35,12 +33,12 @@ execute: |
         done
 
         echo "Ensure the bootloader is correct after reboot"
-        test "$(bootenv snap_core)" = "${core_name}_$(cat nextBoot).snap"
+        test "$(bootenv snap_core)" = "core_$(cat nextBoot).snap"
         test "$(bootenv snap_try_core)" = ""
         test "$(bootenv snap_mode)" = ""
     fi
 
-    snap list | awk "/^${core_name} / {print(\$3)}" > prevBoot
+    snap list | awk "/^core / {print(\$3)}" > prevBoot
 
     # wait for ongoing change if there is one
     if [ -f curChg ] ; then
@@ -50,10 +48,10 @@ execute: |
 
     case $SPREAD_REBOOT in
 
-    0) cmd="snap install --dangerous /var/lib/snapd/snaps/${core_name}_$(cat prevBoot).snap" ;;
-    1) cmd="snap revert ${core_name}" ;;
-    2) cmd="snap install --dangerous /var/lib/snapd/snaps/${core_name}_$(cat prevBoot).snap" ;;
-    3) cmd="snap revert ${core_name}" ;;
+    0) cmd="snap install --dangerous /var/lib/snapd/snaps/core_$(cat prevBoot).snap" ;;
+    1) cmd="snap revert core" ;;
+    2) cmd="snap install --dangerous /var/lib/snapd/snaps/core_$(cat prevBoot).snap" ;;
+    3) cmd="snap revert core" ;;
     4) exit 0 ;;
 
     esac
@@ -68,9 +66,9 @@ execute: |
     while ! snap change ${chg_id}|grep -q "^Done.*Make snap.*available to the system" ; do sleep 1 ; done
 
     echo "Ensure the bootloader is correct before reboot"
-    snap list | awk "/^${core_name} / {print(\$3)}" > nextBoot
+    snap list | awk "/^core / {print(\$3)}" > nextBoot
     test "$(cat prevBoot)" != "$(cat nextBoot)"
-    test "$(bootenv snap_try_core)" = "${core_name}_$(cat nextBoot).snap"
+    test "$(bootenv snap_try_core)" = "core_$(cat nextBoot).snap"
     test "$(bootenv snap_mode)" = "try"
 
     echo "Ensure the device is scheduled for auto-reboot"

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -48,10 +48,8 @@ execute: |
     echo Hello > /var/tmp/myevil.txt
     test-snapd-tools.cat /var/tmp/myevil.txt && exit 1 || true
 
-    . "$TESTSLIB/names.sh"
-
     echo Check migrating to types in state
-    coreType=$(jq -r '.data.snaps["'${core_name}'"].type' /var/lib/snapd/state.json)
+    coreType=$(jq -r '.data.snaps["core"].type' /var/lib/snapd/state.json)
     testSnapType=$(jq -r '.data.snaps["test-snapd-tools"].type' /var/lib/snapd/state.json)
     [ "$coreType" = "os" ]
     [ "$testSnapType" = "app" ]


### PR DESCRIPTION
We can safely assume in the spread tests that the core snap name will be always `core` from now on unless we explicitly install `ubuntu-core`. Also, the interface tests are updated to use the abbreviated connection form without including the core snap name (except in the test that exercises the different connection formats).