### PR TITLE
tests: prevent automatic transition before setting the initial state of the test

### DIFF
--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -35,7 +35,7 @@ execute: |
     # modify daemon state to set ubuntu-core-transition-last-retry-time to the
     # current time to prevent the ubuntu-core transition before the test snap is
     # installed
-    cat /var/lib/snapd/state.json | jq -j '."ubuntu-core-transition-last-retry-time"' > prevValue
+    cat /var/lib/snapd/state.json | jq '.["ubuntu-core-transition-last-retry-time"]' > prevValue
     systemctl stop snapd.service snapd.socket
     cp /var/lib/snapd/state.json state.json.copy
     now=$(date --utc --rfc-3339=ns | tr ' ' T)
@@ -54,7 +54,7 @@ execute: |
     systemctl stop snapd.service snapd.socket
     cp /var/lib/snapd/state.json state.json.copy
     if [ "$(cat prevValue)" = null ]; then
-        cat state.json.copy | jq -c 'del(."ubuntu-core-transition-last-retry-time")' > /var/lib/snapd/state.json
+        cat state.json.copy | jq -c 'del(.["ubuntu-core-transition-last-retry-time"])' > /var/lib/snapd/state.json
     else
         cat state.json.copy | jq -c '. + {"ubuntu-core-transition-last-retry-time": "'"$(cat prevValue)"'"}' > /var/lib/snapd/state.json
     fi

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -6,6 +6,10 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 warn-timeout: 1m
 kill-timeout: 5m
+
+restore: |
+    rm -f prevValue state.json.copy
+
 execute: |
     wait_for_service() {
         local service_name="$1"
@@ -27,6 +31,17 @@ execute: |
     echo "Ensure core is gone and we have ubuntu-core instead"
     dpkg --purge snapd
     apt_install_local ${GOPATH}/snapd_*.deb
+
+    # modify daemon state to set ubuntu-core-transition-last-retry-time to the
+    # current time to prevent the ubuntu-core transition before the test snap is
+    # installed
+    cat /var/lib/snapd/state.json | jq -j '."ubuntu-core-transition-last-retry-time"' > prevValue
+    systemctl stop snapd.service snapd.socket
+    cp /var/lib/snapd/state.json state.json.copy
+    now=$(date --utc --rfc-3339=ns | tr ' ' T)
+    cat state.json.copy | jq -c '. + {"ubuntu-core-transition-last-retry-time": "'"$now"'"}' > /var/lib/snapd/state.json
+    systemctl start snapd.service snapd.socket
+
     snap install --${CORE_CHANNEL} ubuntu-core
     snap install test-snapd-python-webserver
     snap interfaces |MATCH ":network.*test-snapd-python-webserver"
@@ -34,6 +49,16 @@ execute: |
     echo "Ensure the webserver is working"
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
     curl http://localhost | MATCH "XKCD rocks"
+
+    # restore ubuntu-core-transition-last-retry-time to its previous value and restart the daemon
+    systemctl stop snapd.service snapd.socket
+    cp /var/lib/snapd/state.json state.json.copy
+    if [ "$(cat prevValue)" = null ]; then
+        cat state.json.copy | jq -c 'del(."ubuntu-core-transition-last-retry-time")' > /var/lib/snapd/state.json
+    else
+        cat state.json.copy | jq -c '. + {"ubuntu-core-transition-last-retry-time": "'"$(cat prevValue)"'"}' > /var/lib/snapd/state.json
+    fi
+    systemctl start snapd.service snapd.socket
 
     echo "Ensure transition is triggered"
     snap debug ensure-state-soon


### PR DESCRIPTION
We are getting random errors on `tests/main/classic-ubuntu-core-transition` while setting up the test initial state. The installation of the `test-snapd-python-webserver` test snap after installing ubuntu-core can succeed or fail depending on the status of the automatically triggered ubuntu-core -> transition, if it has already started we get an error `cannot install "test-snapd-python-webserver": ubuntu-core to core transition in progress, no other changes allowed until this is done` and if it hasn't started yet the setup is done correctly.

These changes prevent the automatic transition by setting the `ubuntu-core-transition-last-retry-time` field in `state.json`, so that we can reliably set the initial conditions of the test.