### PR TITLE
cmd: validate SNAP_NAME

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -85,6 +85,42 @@ static void test_sc_snap_name_validate()
 		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
 	g_assert_cmpstr(sc_error_msg(err), ==, "invalid snap name \"\"");
 	sc_error_free(err);
+
+	const char *valid_names[] = {
+		"a", "aa", "aaa", "aaaa",
+		"a-a", "aa-a", "a-aa", "a-b-c",
+		"a0", "a-0", "a-0a",
+		"01game", "1-or-2"
+	};
+	for (int i = 0; i < sizeof valid_names / sizeof *valid_names; ++i) {
+		g_test_message("checking snap name: %s", valid_names[i]);
+		sc_snap_name_validate(valid_names[i], &err);
+		g_assert_null(err);
+	}
+	const char *invalid_names[] = {
+		// name cannot be empty
+		"",
+		// dashes alone are not a name
+		"-", "--",
+		// double dashes in a name are not allowed
+		"a--a",
+		// name should not end with a dash
+		"a-",
+		// name cannot have any spaces in it
+		"a ", " a", "a a",
+		// a number alone is not a name
+		"0", "123",
+		// identifier must be plain ASCII
+		"日本語", "한글", "ру́сский язы́к",
+	};
+	for (int i = 0; i < sizeof invalid_names / sizeof *invalid_names; ++i) {
+		g_test_message("checking snap name: %s", invalid_names[i]);
+		sc_snap_name_validate(invalid_names[i], &err);
+		g_assert_nonnull(err);
+		g_assert_true(sc_error_match
+			      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+		sc_error_free(err);
+	}
 }
 
 static void test_sc_snap_name_validate__respects_error_protocol()

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -69,21 +69,65 @@ static void test_sc_snap_name_validate()
 	sc_snap_name_validate("hello-world", &err);
 	g_assert_null(err);
 
-	// Smoke test: invalid snap name (spaces are not allowed)
+	// Smoke test: invalid character 
 	sc_snap_name_validate("hello world", &err);
 	g_assert_nonnull(err);
 	g_assert_true(sc_error_match
 		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
 	g_assert_cmpstr(sc_error_msg(err), ==,
-			"invalid snap name \"hello world\"");
+			"snap name must use lower case letters, digits or dashes");
 	sc_error_free(err);
 
-	// Smoke test: empty name is not valid
+	// Smoke test: no letters
 	sc_snap_name_validate("", &err);
 	g_assert_nonnull(err);
 	g_assert_true(sc_error_match
 		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==, "invalid snap name \"\"");
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"snap name must contain at least one letter");
+	sc_error_free(err);
+
+	// Smoke test: leading dash
+	sc_snap_name_validate("-foo", &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"snap name cannot start with a dash");
+	sc_error_free(err);
+
+	// Smoke test: NULL name is not valid
+	sc_snap_name_validate(NULL, &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+	g_assert_cmpstr(sc_error_msg(err), ==, "snap name cannot be NULL");
+	sc_error_free(err);
+
+	// Smoke test: trailing dash
+	sc_snap_name_validate("foo-", &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"snap name cannot end with a dash");
+	sc_error_free(err);
+
+	// Smoke test: double dash
+	sc_snap_name_validate("f--oo", &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"snap name cannot contain two consecutive dashes");
+	sc_error_free(err);
+
+	// Smoke test: NULL name is not valid
+	sc_snap_name_validate(NULL, &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+	g_assert_cmpstr(sc_error_msg(err), ==, "snap name cannot be NULL");
 	sc_error_free(err);
 
 	const char *valid_names[] = {
@@ -93,7 +137,7 @@ static void test_sc_snap_name_validate()
 		"01game", "1-or-2"
 	};
 	for (int i = 0; i < sizeof valid_names / sizeof *valid_names; ++i) {
-		g_test_message("checking snap name: %s", valid_names[i]);
+		g_test_message("checking valid snap name: %s", valid_names[i]);
 		sc_snap_name_validate(valid_names[i], &err);
 		g_assert_null(err);
 	}
@@ -114,7 +158,8 @@ static void test_sc_snap_name_validate()
 		"日本語", "한글", "ру́сский язы́к",
 	};
 	for (int i = 0; i < sizeof invalid_names / sizeof *invalid_names; ++i) {
-		g_test_message("checking snap name: %s", invalid_names[i]);
+		g_test_message("checking invalid snap name: >%s<",
+			       invalid_names[i]);
 		sc_snap_name_validate(invalid_names[i], &err);
 		g_assert_nonnull(err);
 		g_assert_true(sc_error_match
@@ -133,7 +178,8 @@ static void test_sc_snap_name_validate__respects_error_protocol()
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
 	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr("invalid snap name \"hello world\"\n");
+	g_test_trap_assert_stderr
+	    ("snap name must use lower case letters, digits or dashes\n");
 }
 
 static void __attribute__ ((constructor)) init()

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -96,14 +96,6 @@ static void test_sc_snap_name_validate()
 			"snap name cannot start with a dash");
 	sc_error_free(err);
 
-	// Smoke test: NULL name is not valid
-	sc_snap_name_validate(NULL, &err);
-	g_assert_nonnull(err);
-	g_assert_true(sc_error_match
-		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
-	g_assert_cmpstr(sc_error_msg(err), ==, "snap name cannot be NULL");
-	sc_error_free(err);
-
 	// Smoke test: trailing dash
 	sc_snap_name_validate("foo-", &err);
 	g_assert_nonnull(err);

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -61,7 +61,50 @@ static void test_verify_security_tag()
 	g_assert_false(verify_security_tag("snap.name.app.."));
 }
 
+static void test_sc_snap_name_validate()
+{
+	struct sc_error *err = NULL;
+
+	// Smoke test, a valid snap name
+	sc_snap_name_validate("hello-world", &err);
+	g_assert_null(err);
+
+	// Smoke test: invalid snap name (spaces are not allowed)
+	sc_snap_name_validate("hello world", &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+	g_assert_cmpstr(sc_error_msg(err), ==,
+			"invalid snap name \"hello world\"");
+	sc_error_free(err);
+
+	// Smoke test: empty name is not valid
+	sc_snap_name_validate("", &err);
+	g_assert_nonnull(err);
+	g_assert_true(sc_error_match
+		      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
+	g_assert_cmpstr(sc_error_msg(err), ==, "invalid snap name \"\"");
+	sc_error_free(err);
+}
+
+static void test_sc_snap_name_validate__respects_error_protocol()
+{
+	if (g_test_subprocess()) {
+		sc_snap_name_validate("hello world", NULL);
+		g_test_message("expected sc_snap_name_validate to return");
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("invalid snap name \"hello world\"\n");
+}
+
 static void __attribute__ ((constructor)) init()
 {
 	g_test_add_func("/snap/verify_security_tag", test_verify_security_tag);
+	g_test_add_func("/snap/sc_snap_name_validate",
+			test_sc_snap_name_validate);
+	g_test_add_func("/snap/sc_snap_name_validate/respects_error_protocol",
+			test_sc_snap_name_validate__respects_error_protocol);
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -17,11 +17,17 @@
 #include "config.h"
 #include "snap.h"
 
+#include <regex.h>
 #include <stddef.h>
 #include <stdlib.h>
-#include <regex.h>
+#include <string.h>
+#include <errno.h>
 
-#include "../libsnap-confine-private/utils.h"
+#include "utils.h"
+#include "string-utils.h"
+#include "cleanup-funcs.h"
+
+static regex_t sc_valid_snap_name_re;
 
 bool verify_security_tag(const char *security_tag)
 {
@@ -42,4 +48,48 @@ bool verify_security_tag(const char *security_tag)
 	regfree(&re);
 
 	return (status == 0);
+}
+
+void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
+{
+	struct sc_error *err = NULL;
+
+	if (regexec(&sc_valid_snap_name_re, snap_name, 0, NULL, 0) != 0) {
+		char *quote_buf __attribute__ ((cleanup(sc_cleanup_string))) =
+		    NULL;
+		size_t quote_buf_size = strlen(snap_name) * 4 + 3;
+
+		quote_buf = calloc(1, quote_buf_size);
+		if (quote_buf == NULL) {
+			err =
+			    sc_error_init_from_errno(errno,
+						     "cannot allocate memory for quoted snap name");
+			goto out;
+		}
+
+		sc_string_quote(quote_buf, quote_buf_size, snap_name);
+		err =
+		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
+				  "invalid snap name %s", quote_buf);
+	}
+
+ out:
+	sc_error_forward(errorp, err);
+}
+
+static void __attribute__ ((constructor)) init_snap()
+{
+	// NOTE: this regular expression should be kept in sync with what is in
+	// snap/validate.go, in the validSnapName variable.
+	const char *name_re = "^([a-z0-9]+-?)*[a-z](-?[a-z0-9])*$";
+
+	if (regcomp(&sc_valid_snap_name_re, name_re, REG_EXTENDED | REG_NOSUB)
+	    != 0) {
+		die("cannot compile regex %s", name_re);
+	}
+}
+
+static void __attribute__ ((destructor)) fini_snap()
+{
+	regfree(&sc_valid_snap_name_re);
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -17,7 +17,6 @@
 #include "config.h"
 #include "snap.h"
 
-#include <ctype.h>
 #include <errno.h>
 #include <regex.h>
 #include <stddef.h>
@@ -54,7 +53,7 @@ bool verify_security_tag(const char *security_tag)
 static int skip_lowercase_letters(const char **p)
 {
 	int skipped = 0;
-	for (const char *c = *p; islower(*c); ++c) {
+	for (const char *c = *p; *c >= 'a' && *c <= 'z'; ++c) {
 		skipped += 1;
 	}
 	*p = (*p) + skipped;
@@ -64,7 +63,7 @@ static int skip_lowercase_letters(const char **p)
 static int skip_digits(const char **p)
 {
 	int skipped = 0;
-	for (const char *c = *p; isdigit(*c); ++c) {
+	for (const char *c = *p; *c >= '0' && *c <= '9'; ++c) {
 		skipped += 1;
 	}
 	*p = (*p) + skipped;

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -17,11 +17,12 @@
 #include "config.h"
 #include "snap.h"
 
+#include <ctype.h>
+#include <errno.h>
 #include <regex.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 
 #include "utils.h"
 #include "string-utils.h"
@@ -50,11 +51,65 @@ bool verify_security_tag(const char *security_tag)
 	return (status == 0);
 }
 
+// This is a regexp-free routine hand-codes the following pattern:
+//
+// "^([a-z0-9]+-?)*[a-z](-?[a-z0-9])*$"
+//
+// The only motivation for not using regular expressions is so that we don't
+// run untrusted input against a potentially complex regular expression engine.
+static bool is_valid_name(const char *snap_name)
+{
+	// Ensure that snap name is not empty.
+	if (*snap_name == '\0') {
+		return false;
+	}
+	// Ensure that snap name does not start with the dash.
+	if (*snap_name == '-') {
+		return false;
+	}
+	// Ensure that snap name does not end with the dash.
+	if (snap_name[strlen(snap_name) - 1] == '-') {
+		return false;
+	}
+	// Ensure that snap name does not have two consecutive dashes.
+	if (strstr(snap_name, "--")) {
+		return false;
+	}
+	// Ensure that all the characters in the snap name are alphanumeric
+	// (lowercase) or the dash. This does not ensure any particular ordering
+	// but can be used to filter out obviously incorrect input easily.
+	char c;
+	for (const char *cp = snap_name; (c = *cp) != '\0'; ++cp) {
+		if (!(islower(c) || isdigit(c) || c == '-')) {
+			return false;
+		}
+	}
+	// Ensure that snap name has at least one letter in it.
+	bool has_alpha = false;
+	for (const char *cp = snap_name; (c = *cp) != '\0'; ++cp) {
+		if (islower(c)) {
+			has_alpha = true;
+			break;
+		}
+	}
+	if (!has_alpha) {
+		return false;
+	}
+	return true;
+}
+
 void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 {
 	struct sc_error *err = NULL;
 
-	if (regexec(&sc_valid_snap_name_re, snap_name, 0, NULL, 0) != 0) {
+	// Ensure that name is not NULL
+	if (snap_name == NULL) {
+		err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
+				    "snap name cannot be NULL");
+		goto out;
+	}
+
+	if (!is_valid_name(snap_name)) {
 		char *quote_buf __attribute__ ((cleanup(sc_cleanup_string))) =
 		    NULL;
 		size_t quote_buf_size = strlen(snap_name) * 4 + 3;
@@ -75,21 +130,4 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 
  out:
 	sc_error_forward(errorp, err);
-}
-
-static void __attribute__ ((constructor)) init_snap()
-{
-	// NOTE: this regular expression should be kept in sync with what is in
-	// snap/validate.go, in the validSnapName variable.
-	const char *name_re = "^([a-z0-9]+-?)*[a-z](-?[a-z0-9])*$";
-
-	if (regcomp(&sc_valid_snap_name_re, name_re, REG_EXTENDED | REG_NOSUB)
-	    != 0) {
-		die("cannot compile regex %s", name_re);
-	}
-}
-
-static void __attribute__ ((destructor)) fini_snap()
-{
-	regfree(&sc_valid_snap_name_re);
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -27,8 +27,6 @@
 #include "string-utils.h"
 #include "cleanup-funcs.h"
 
-static regex_t sc_valid_snap_name_re;
-
 bool verify_security_tag(const char *security_tag)
 {
 	// The executable name is of form:

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -51,51 +51,33 @@ bool verify_security_tag(const char *security_tag)
 	return (status == 0);
 }
 
-// This is a regexp-free routine hand-codes the following pattern:
-//
-// "^([a-z0-9]+-?)*[a-z](-?[a-z0-9])*$"
-//
-// The only motivation for not using regular expressions is so that we don't
-// run untrusted input against a potentially complex regular expression engine.
-static bool is_valid_name(const char *snap_name)
+static int skip_lowercase_letters(const char **p)
 {
-	// Ensure that snap name is not empty.
-	if (*snap_name == '\0') {
-		return false;
+	int skipped = 0;
+	for (const char *c = *p; islower(*c); ++c) {
+		skipped += 1;
 	}
-	// Ensure that snap name does not start with the dash.
-	if (*snap_name == '-') {
-		return false;
+	*p = (*p) + skipped;
+	return skipped;
+}
+
+static int skip_digits(const char **p)
+{
+	int skipped = 0;
+	for (const char *c = *p; isdigit(*c); ++c) {
+		skipped += 1;
 	}
-	// Ensure that snap name does not end with the dash.
-	if (snap_name[strlen(snap_name) - 1] == '-') {
-		return false;
+	*p = (*p) + skipped;
+	return skipped;
+}
+
+static int skip_one_char(const char **p, char c)
+{
+	if (**p == c) {
+		*p += 1;
+		return 1;
 	}
-	// Ensure that snap name does not have two consecutive dashes.
-	if (strstr(snap_name, "--")) {
-		return false;
-	}
-	// Ensure that all the characters in the snap name are alphanumeric
-	// (lowercase) or the dash. This does not ensure any particular ordering
-	// but can be used to filter out obviously incorrect input easily.
-	char c;
-	for (const char *cp = snap_name; (c = *cp) != '\0'; ++cp) {
-		if (!(islower(c) || isdigit(c) || c == '-')) {
-			return false;
-		}
-	}
-	// Ensure that snap name has at least one letter in it.
-	bool has_alpha = false;
-	for (const char *cp = snap_name; (c = *cp) != '\0'; ++cp) {
-		if (islower(c)) {
-			has_alpha = true;
-			break;
-		}
-	}
-	if (!has_alpha) {
-		return false;
-	}
-	return true;
+	return 0;
 }
 
 void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
@@ -108,24 +90,52 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 				    "snap name cannot be NULL");
 		goto out;
 	}
-
-	if (!is_valid_name(snap_name)) {
-		char *quote_buf __attribute__ ((cleanup(sc_cleanup_string))) =
-		    NULL;
-		size_t quote_buf_size = strlen(snap_name) * 4 + 3;
-
-		quote_buf = calloc(1, quote_buf_size);
-		if (quote_buf == NULL) {
-			err =
-			    sc_error_init_from_errno(errno,
-						     "cannot allocate memory for quoted snap name");
-			goto out;
+	// This is a regexp-free routine hand-codes the following pattern:
+	//
+	// "^([a-z0-9]+-?)*[a-z](-?[a-z0-9])*$"
+	//
+	// The only motivation for not using regular expressions is so that we
+	// don't run untrusted input against a potentially complex regular
+	// expression engine.
+	const char *p = snap_name;
+	if (skip_one_char(&p, '-')) {
+		err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
+				    "snap name cannot start with a dash");
+		goto out;
+	}
+	bool got_letter = false;
+	for (; *p != '\0';) {
+		if (skip_lowercase_letters(&p) > 0) {
+			got_letter = true;
+			continue;
 		}
-
-		sc_string_quote(quote_buf, quote_buf_size, snap_name);
-		err =
-		    sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
-				  "invalid snap name %s", quote_buf);
+		if (skip_digits(&p) > 0) {
+			continue;
+		}
+		if (skip_one_char(&p, '-') > 0) {
+			if (*p == '\0') {
+				err =
+				    sc_error_init(SC_SNAP_DOMAIN,
+						  SC_SNAP_INVALID_NAME,
+						  "snap name cannot end with a dash");
+				goto out;
+			}
+			if (skip_one_char(&p, '-') > 0) {
+				err =
+				    sc_error_init(SC_SNAP_DOMAIN,
+						  SC_SNAP_INVALID_NAME,
+						  "snap name cannot contain two consecutive dashes");
+				goto out;
+			}
+			continue;
+		}
+		err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
+				    "snap name must use lower case letters, digits or dashes");
+		goto out;
+	}
+	if (!got_letter) {
+		err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
+				    "snap name must contain at least one letter");
 	}
 
  out:

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -20,6 +20,29 @@
 
 #include <stdbool.h>
 
+#include "error.h"
+
+/**
+ * Error domain for errors related to the snap module.
+ **/
+#define SC_SNAP_DOMAIN "snap"
+
+enum {
+	/** The name of the snap is not valid. */
+	SC_SNAP_INVALID_NAME = 1,
+};
+
+/**
+ * Validate the given snap name.
+ *
+ * Snaps have strict naming requirements.
+ * Please refer to snapd source code for details.
+ *
+ * The error protocol is observed so if the caller doesn't provide an outgoing
+ * error pointer the function will die on any error.
+ **/
+void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp);
+
 bool verify_security_tag(const char *security_tag);
 
 #endif

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -35,8 +35,8 @@ enum {
 /**
  * Validate the given snap name.
  *
- * Snaps have strict naming requirements.
- * Please refer to snapd source code for details.
+ * Valid name cannot be NULL and must match a regular expression describing the
+ * strict naming requirements. Please refer to snapd source code for details.
  *
  * The error protocol is observed so if the caller doesn't provide an outgoing
  * error pointer the function will die on any error.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -81,6 +81,9 @@ int main(int argc, char **argv)
 	if (!verify_security_tag(security_tag))
 		die("security tag %s not allowed", security_tag);
 
+	const char *snap_name = getenv("SNAP_NAME");
+	sc_snap_name_validate(snap_name, NULL);
+
 #ifndef CAPS_OVER_SETUID
 	// this code always needs to run as root for the cgroup/udev setup,
 	// however for the tests we allow it to run as non-root
@@ -120,7 +123,6 @@ int main(int argc, char **argv)
 			debug
 			    ("skipping sandbox setup, classic confinement in use");
 		} else {
-			const char *snap_name = getenv("SNAP_NAME");
 			const char *group_name = snap_name;
 			if (group_name == NULL) {
 				die("SNAP_NAME is not set");

--- a/cmd/snap-confine/tests/common.sh
+++ b/cmd/snap-confine/tests/common.sh
@@ -47,7 +47,7 @@ trap 'rm -rf $TMP' EXIT
 export SNAPPY_LAUNCHER_SECCOMP_PROFILE_DIR="$TMP"
 export SNAPPY_LAUNCHER_INSIDE_TESTS="1"
 export SNAP_CONFINE_NO_ROOT=1
-export SNAP_NAME=name.app
+export SNAP_NAME=name
 
 FAIL() {
     printf ": FAIL\n"


### PR DESCRIPTION
This branch adds routine for validating SNAP_NAME against malicious input and uses it to check SNAP_NAME inside snap confine.

This also fixes one of the points raised by the OpenSUSE security review of snap-confine https://bugzilla.suse.com/show_bug.cgi?id=986050

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

