### PR TITLE
interfaces: use apparmor spec in the apparmor backend

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -113,11 +113,14 @@ func (b *Backend) Remove(snapName string) error {
 }
 
 var (
-	templatePattern          = regexp.MustCompile("(###[A-Z]+###)")
+	templatePattern = regexp.MustCompile("(###[A-Z]+###)")
+	attachPattern   = regexp.MustCompile(`\(attach_disconnected\)`)
+)
+
+const (
 	placeholderVar           = "###VAR###"
 	placeholderSnippets      = "###SNIPPETS###"
 	placeholderProfileAttach = "###PROFILEATTACH###"
-	attachPattern            = regexp.MustCompile(`\(attach_disconnected\)`)
 	attachComplain           = "(attach_disconnected,complain)"
 )
 

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -38,12 +38,12 @@
 package apparmor
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
@@ -67,13 +67,12 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 // them or application present in the snap.
 func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions, repo *interfaces.Repository) error {
 	snapName := snapInfo.Name()
-	// Get the snippets that apply to this snap
-	snippets, err := repo.SecuritySnippetsForSnap(snapName, interfaces.SecurityAppArmor)
+	spec, err := repo.SnapSpecification(b.Name(), snapName)
 	if err != nil {
-		return fmt.Errorf("cannot obtain security snippets for snap %q: %s", snapName, err)
+		return fmt.Errorf("cannot obtain apparmor specification for snap %q: %s", snapName, err)
 	}
 	// Get the files that this snap should have
-	content, err := b.combineSnippets(snapInfo, opts, snippets)
+	content, err := b.deriveContent(spec.(*Specification), snapInfo, opts)
 	if err != nil {
 		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapName, err)
 	}
@@ -115,73 +114,71 @@ func (b *Backend) Remove(snapName string) error {
 
 var (
 	templatePattern          = regexp.MustCompile("(###[A-Z]+###)")
-	placeholderVar           = []byte("###VAR###")
-	placeholderSnippets      = []byte("###SNIPPETS###")
-	placeholderProfileAttach = []byte("###PROFILEATTACH###")
+	placeholderVar           = "###VAR###"
+	placeholderSnippets      = "###SNIPPETS###"
+	placeholderProfileAttach = "###PROFILEATTACH###"
 	attachPattern            = regexp.MustCompile(`\(attach_disconnected\)`)
-	attachComplain           = []byte("(attach_disconnected,complain)")
+	attachComplain           = "(attach_disconnected,complain)"
 )
 
-// combineSnippets combines security snippets collected from all the interfaces
-// affecting a given snap into a content map applicable to EnsureDirState. The
-// backend delegates writing those files to higher layers.
-func (b *Backend) combineSnippets(snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippets map[string][][]byte) (content map[string]*osutil.FileState, err error) {
+func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts interfaces.ConfinementOptions) (content map[string]*osutil.FileState, err error) {
 	for _, appInfo := range snapInfo.Apps {
 		if content == nil {
 			content = make(map[string]*osutil.FileState)
 		}
-		addContent(appInfo.SecurityTag(), snapInfo, opts, snippets, content)
+		securityTag := appInfo.SecurityTag()
+		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content)
 	}
 
 	for _, hookInfo := range snapInfo.Hooks {
 		if content == nil {
 			content = make(map[string]*osutil.FileState)
 		}
-		addContent(hookInfo.SecurityTag(), snapInfo, opts, snippets, content)
+		securityTag := hookInfo.SecurityTag()
+		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content)
 	}
 
 	return content, nil
 }
 
-func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippets map[string][][]byte, content map[string]*osutil.FileState) {
-	var policy []byte
+func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState) {
+	var policy string
 	if opts.Classic && !opts.JailMode {
 		policy = classicTemplate
 	} else {
 		policy = defaultTemplate
 	}
 	if (opts.DevMode || opts.Classic) && !opts.JailMode {
-		policy = attachPattern.ReplaceAll(policy, attachComplain)
+		policy = attachPattern.ReplaceAllString(policy, attachComplain)
 	}
-	policy = templatePattern.ReplaceAllFunc(policy, func(placeholder []byte) []byte {
+	policy = templatePattern.ReplaceAllStringFunc(policy, func(placeholder string) string {
 		switch {
-		case bytes.Equal(placeholder, placeholderVar):
+		case placeholder == placeholderVar:
 			return templateVariables(snapInfo, securityTag)
-		case bytes.Equal(placeholder, placeholderProfileAttach):
-			return []byte(fmt.Sprintf("profile \"%s\"", securityTag))
-		case bytes.Equal(placeholder, placeholderSnippets):
-			var tagSnippets [][]byte
+		case placeholder == placeholderProfileAttach:
+			return fmt.Sprintf("profile \"%s\"", securityTag)
+		case placeholder == placeholderSnippets:
+			var tagSnippets string
 
 			if opts.Classic && opts.JailMode {
 				// Add a special internal snippet for snaps using classic confinement
 				// and jailmode together. This snippet provides access to the core snap
 				// so that the dynamic linker and shared libraries can be used.
-				tagSnippets = append(tagSnippets, classicJailmodeSnippet)
-				tagSnippets = append(tagSnippets, snippets[securityTag]...)
+				tagSnippets = strings.Join([]string{classicJailmodeSnippet, snippetForTag}, "\n")
 			} else if opts.Classic && !opts.JailMode {
 				// When classic confinement (without jailmode) is in effect we
 				// are ignoring all apparmor snippets as they may conflict with
 				// the super-broad template we are starting with.
 			} else {
-				tagSnippets = snippets[securityTag]
+				tagSnippets = snippetForTag
 			}
-			return bytes.Join(tagSnippets, []byte("\n"))
+			return tagSnippets
 		}
-		return nil
+		return ""
 	})
 
 	content[securityTag] = &osutil.FileState{
-		Content: policy,
+		Content: []byte(policy),
 		Mode:    0644,
 	}
 }
@@ -207,5 +204,5 @@ func unloadProfiles(profiles []string) error {
 }
 
 func (b *Backend) NewSpecification() interfaces.Specification {
-	panic(fmt.Errorf("%s is not using specifications yet", b.Name()))
+	return &Specification{}
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -382,7 +382,8 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 			if scenario.snippet == "" {
 				return nil
 			}
-			return spec.AddSnippet(scenario.snippet)
+			spec.AddSnippet(scenario.snippet)
+			return nil
 		}
 		snapInfo := s.InstallSnap(c, scenario.opts, ifacetest.SambaYamlV1, 1)
 		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -85,6 +85,7 @@ fi
 func (s *backendSuite) SetUpTest(c *C) {
 	s.Backend = &apparmor.Backend{}
 	s.BackendSuite.SetUpTest(c)
+	c.Assert(s.Repo.AddBackend(s.Backend), IsNil)
 
 	// Prepare a directory for apparmor profiles.
 	// NOTE: Normally this is a part of the OS snap.
@@ -363,25 +364,25 @@ snippet
 
 func (s *backendSuite) TestCombineSnippets(c *C) {
 	// NOTE: replace the real template with a shorter variant
-	restoreTemplate := apparmor.MockTemplate([]byte("\n" +
+	restoreTemplate := apparmor.MockTemplate("\n" +
 		"###VAR###\n" +
 		"###PROFILEATTACH### (attach_disconnected) {\n" +
 		"###SNIPPETS###\n" +
-		"}\n"))
+		"}\n")
 	defer restoreTemplate()
-	restoreClassicTemplate := apparmor.MockClassicTemplate([]byte("\n" +
+	restoreClassicTemplate := apparmor.MockClassicTemplate("\n" +
 		"#classic\n" +
 		"###VAR###\n" +
 		"###PROFILEATTACH### (attach_disconnected) {\n" +
 		"###SNIPPETS###\n" +
-		"}\n"))
+		"}\n")
 	defer restoreClassicTemplate()
 	for _, scenario := range combineSnippetsScenarios {
-		s.Iface.PermanentSlotSnippetCallback = func(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+		s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *interfaces.Slot) error {
 			if scenario.snippet == "" {
-				return nil, nil
+				return nil
 			}
-			return []byte(scenario.snippet), nil
+			return spec.AddSnippet(scenario.snippet)
 		}
 		snapInfo := s.InstallSnap(c, scenario.opts, ifacetest.SambaYamlV1, 1)
 		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -35,14 +35,14 @@ func MockProfilesPath(t *testutil.BaseTest, profiles string) {
 //
 // NOTE: The real apparmor template is long. For testing it is convenient for
 // replace it with a shorter snippet.
-func MockTemplate(fakeTemplate []byte) (restore func()) {
+func MockTemplate(fakeTemplate string) (restore func()) {
 	orig := defaultTemplate
 	defaultTemplate = fakeTemplate
 	return func() { defaultTemplate = orig }
 }
 
 // MockClassicTemplate replaces the classic apprmor template.
-func MockClassicTemplate(fakeTemplate []byte) (restore func()) {
+func MockClassicTemplate(fakeTemplate string) (restore func()) {
 	orig := classicTemplate
 	classicTemplate = fakeTemplate
 	return func() { classicTemplate = orig }

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -34,29 +34,24 @@ type Specification struct {
 }
 
 // AddSnippet adds a new apparmor snippet.
-func (spec *Specification) AddSnippet(snippet string) error {
+func (spec *Specification) AddSnippet(snippet string) {
 	if len(spec.securityTags) == 0 {
-		return nil
+		return
 	}
 	if spec.snippets == nil {
 		spec.snippets = make(map[string][]string)
 	}
 	for _, tag := range spec.securityTags {
 		spec.snippets[tag] = append(spec.snippets[tag], snippet)
+		sort.Strings(spec.snippets[tag])
 	}
-
-	return nil
 }
 
 // Snippets returns a deep copy of all the added snippets.
 func (spec *Specification) Snippets() map[string][]string {
 	result := make(map[string][]string, len(spec.snippets))
 	for k, v := range spec.snippets {
-		vCopy := make([]string, 0, len(v))
-		for _, vElem := range v {
-			vCopy = append(vCopy, vElem)
-		}
-		result[k] = vCopy
+		result[k] = append([]string(nil), v...)
 	}
 	return result
 }
@@ -64,7 +59,6 @@ func (spec *Specification) Snippets() map[string][]string {
 // SnippetForTag returns a combined snippet for given security tag with individual snippets
 // joined with newline character. Empty string is returned for non-existing security tag.
 func (spec *Specification) SnippetForTag(tag string) string {
-	sort.Strings(spec.snippets[tag])
 	return strings.Join(spec.snippets[tag], "\n")
 }
 

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -21,22 +21,25 @@ package apparmor
 
 import (
 	"github.com/snapcore/snapd/interfaces"
+
+	"sort"
+	"strings"
 )
 
 // Specification assists in collecting apparmor entries associated with an interface.
 type Specification struct {
 	// snippets are indexed by security tag.
-	snippets     map[string][][]byte
+	snippets     map[string][]string
 	securityTags []string
 }
 
 // AddSnippet adds a new apparmor snippet.
-func (spec *Specification) AddSnippet(snippet []byte) error {
+func (spec *Specification) AddSnippet(snippet string) error {
 	if len(spec.securityTags) == 0 {
 		return nil
 	}
 	if spec.snippets == nil {
-		spec.snippets = make(map[string][][]byte)
+		spec.snippets = make(map[string][]string)
 	}
 	for _, tag := range spec.securityTags {
 		spec.snippets[tag] = append(spec.snippets[tag], snippet)
@@ -46,18 +49,33 @@ func (spec *Specification) AddSnippet(snippet []byte) error {
 }
 
 // Snippets returns a deep copy of all the added snippets.
-func (spec *Specification) Snippets() map[string][][]byte {
-	result := make(map[string][][]byte, len(spec.snippets))
+func (spec *Specification) Snippets() map[string][]string {
+	result := make(map[string][]string, len(spec.snippets))
 	for k, v := range spec.snippets {
-		vCopy := make([][]byte, 0, len(v))
+		vCopy := make([]string, 0, len(v))
 		for _, vElem := range v {
-			vElemCopy := make([]byte, len(vElem))
-			copy(vElemCopy, vElem)
-			vCopy = append(vCopy, vElemCopy)
+			vCopy = append(vCopy, vElem)
 		}
 		result[k] = vCopy
 	}
 	return result
+}
+
+// SnippetForTag returns a combined snippet for given security tag with individual snippets
+// joined with newline character. Empty string is returned for non-existing security tag.
+func (spec *Specification) SnippetForTag(tag string) string {
+	sort.Strings(spec.snippets[tag])
+	return strings.Join(spec.snippets[tag], "\n")
+}
+
+// SecurityTags returns a list of security tags which have a snippet.
+func (spec *Specification) SecurityTags() []string {
+	var tags []string
+	for t := range spec.snippets {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags)
+	return tags
 }
 
 // Implementation of methods required by interfaces.Specification

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -39,16 +39,20 @@ var _ = Suite(&specSuite{
 	iface: &ifacetest.TestInterface{
 		InterfaceName: "test",
 		AppArmorConnectedPlugCallback: func(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-			return spec.AddSnippet("connected-plug")
+			spec.AddSnippet("connected-plug")
+			return nil
 		},
 		AppArmorConnectedSlotCallback: func(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-			return spec.AddSnippet("connected-slot")
+			spec.AddSnippet("connected-slot")
+			return nil
 		},
 		AppArmorPermanentPlugCallback: func(spec *apparmor.Specification, plug *interfaces.Plug) error {
-			return spec.AddSnippet("permanent-plug")
+			spec.AddSnippet("permanent-plug")
+			return nil
 		},
 		AppArmorPermanentSlotCallback: func(spec *apparmor.Specification, slot *interfaces.Slot) error {
-			return spec.AddSnippet("permanent-slot")
+			spec.AddSnippet("permanent-slot")
+			return nil
 		},
 	},
 	plug: &interfaces.Plug{

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -39,16 +39,16 @@ var _ = Suite(&specSuite{
 	iface: &ifacetest.TestInterface{
 		InterfaceName: "test",
 		AppArmorConnectedPlugCallback: func(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-			return spec.AddSnippet([]byte("connected-plug"))
+			return spec.AddSnippet("connected-plug")
 		},
 		AppArmorConnectedSlotCallback: func(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-			return spec.AddSnippet([]byte("connected-slot"))
+			return spec.AddSnippet("connected-slot")
 		},
 		AppArmorPermanentPlugCallback: func(spec *apparmor.Specification, plug *interfaces.Plug) error {
-			return spec.AddSnippet([]byte("permanent-plug"))
+			return spec.AddSnippet("permanent-plug")
 		},
 		AppArmorPermanentSlotCallback: func(spec *apparmor.Specification, slot *interfaces.Slot) error {
-			return spec.AddSnippet([]byte("permanent-slot"))
+			return spec.AddSnippet("permanent-slot")
 		},
 	},
 	plug: &interfaces.Plug{
@@ -90,8 +90,8 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
 	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
-	c.Assert(s.spec.Snippets(), DeepEquals, map[string][][]byte{
-		"snap.snap1.app1": {[]byte("connected-plug"), []byte("permanent-plug")},
-		"snap.snap2.app2": {[]byte("connected-slot"), []byte("permanent-slot")},
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
+		"snap.snap1.app1": {"connected-plug", "permanent-plug"},
+		"snap.snap2.app2": {"connected-slot", "permanent-slot"},
 	})
 }

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -24,7 +24,7 @@ package apparmor
 // It can be overridden for testing using MockTemplate().
 //
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/templates/ubuntu-core/16.04/default
-var defaultTemplate = []byte(`
+var defaultTemplate = `
 # Description: Allows access to app-specific directories and basic runtime
 # Usage: common
 
@@ -389,7 +389,7 @@ var defaultTemplate = []byte(`
 
 ###SNIPPETS###
 }
-`)
+`
 
 // classicTemplate contains apparmor template used for snaps with classic
 // confinement. This template was Designed by jdstrand:
@@ -400,7 +400,7 @@ var defaultTemplate = []byte(`
 // label instead of 'unconfined'.
 //
 // It can be overridden for testing using MockClassicTemplate().
-var classicTemplate = []byte(`
+var classicTemplate = `
 #include <tunables/global>
 
 ###VAR###
@@ -426,16 +426,16 @@ var classicTemplate = []byte(`
 
 ###SNIPPETS###
 }
-`)
+`
 
 // classicJailmodeSnippet contains extra rules that allow snaps using classic
 // confinement, that were put in to jailmode, to execute by at least having
 // access to the core snap (e.g. for the dynamic linker and libc).
 
-var classicJailmodeSnippet = []byte(`
+var classicJailmodeSnippet = `
   # Read-only access to the core snap.
   @{INSTALL_DIR}/core/** r,
   # Read only access to the core snap to load libc from.
   # This is related to LP: #1666897
   @{INSTALL_DIR}/core/*/{,usr/}lib/@{multiarch}/{,**/}lib*.so* m,
-`)
+`

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -29,12 +29,12 @@ import (
 
 // templateVariables returns text defining apparmor variables that can be used in the
 // apparmor template and by apparmor snippets.
-func templateVariables(info *snap.Info, securityTag string) []byte {
+func templateVariables(info *snap.Info, securityTag string) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", info.Name())
 	fmt.Fprintf(&buf, "@{SNAP_REVISION}=\"%s\"\n", info.Revision)
 	fmt.Fprintf(&buf, "@{PROFILE_DBUS}=\"%s\"\n",
 		dbus.SafePath(securityTag))
 	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"/snap\"")
-	return buf.Bytes()
+	return buf.String()
 }

--- a/interfaces/builtin/account_control_test.go
+++ b/interfaces/builtin/account_control_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -95,10 +96,11 @@ func (s *AccountControlSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *AccountControlSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Assert(string(snippet), testutil.Contains, "/{,usr/}sbin/chpasswd")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "/{,usr/}sbin/chpasswd")
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -23,8 +23,10 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -34,23 +36,27 @@ type AlsaInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&AlsaInterfaceSuite{
-	iface: builtin.NewAlsaInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&AlsaInterfaceSuite{})
+
+func (s *AlsaInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [alsa]
+`
+	s.iface = builtin.NewAlsaInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "alsa",
 			Interface: "alsa",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "alsa",
-			Interface: "alsa",
-		},
-	},
-})
+	}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["alsa"]}
+}
 
 func (s *AlsaInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "alsa")
@@ -81,8 +87,9 @@ func (s *AlsaInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *AlsaInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "/dev/snd/* rw,")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/dev/snd/* rw,")
 }

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -23,8 +23,10 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -34,23 +36,27 @@ type AvahiObserveInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&AvahiObserveInterfaceSuite{
-	iface: builtin.NewAvahiObserveInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&AvahiObserveInterfaceSuite{})
+
+func (s *AvahiObserveInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [avahi-observe]
+`
+	s.iface = builtin.NewAvahiObserveInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "avahi-observe",
 			Interface: "avahi-observe",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "avahi-observe",
-			Interface: "avahi-observe",
-		},
-	},
-})
+	}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["avahi-observe"]}
+}
 
 func (s *AvahiObserveInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "avahi-observe")
@@ -81,8 +87,9 @@ func (s *AvahiObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *AvahiObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "name=org.freedesktop.Avahi")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "name=org.freedesktop.Avahi")
 }

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -94,9 +95,12 @@ func (s *BluetoothControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *BluetoothControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "capability net_admin")
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -189,14 +189,16 @@ func (iface *BluezInterface) AppArmorConnectedPlug(spec *apparmor.Specification,
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(bluezConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *BluezInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(bluezConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *BluezInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -204,7 +206,8 @@ func (iface *BluezInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *i
 }
 
 func (iface *BluezInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(bluezPermanentSlotAppArmor)
+	spec.AddSnippet(bluezPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *BluezInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -20,9 +20,10 @@
 package builtin
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
@@ -184,21 +185,30 @@ func (iface *BluezInterface) PermanentPlugSnippet(plug *interfaces.Plug, securit
 	return nil, nil
 }
 
+func (iface *BluezInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(bluezConnectedPlugAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *BluezInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(bluezConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *BluezInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(bluezConnectedPlugAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
+}
+
+func (iface *BluezInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(bluezPermanentSlotAppArmor)
 }
 
 func (iface *BluezInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(bluezPermanentSlotAppArmor), nil
 	case interfaces.SecurityDBus:
 		return []byte(bluezPermanentSlotDBus), nil
 	}
@@ -210,13 +220,6 @@ func (iface *BluezInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 }
 
 func (iface *BluezInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(bluezConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -148,6 +148,7 @@ func (s *BluezInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	err = apparmorSpec.AddPermanentSlot(s.iface, s.slot)
+	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), HasLen, 2)
 
 	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)

--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -80,9 +81,12 @@ func (s *BluezInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.bluez.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `peer=(label="snap.bluez.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the bluez slot
@@ -101,9 +105,12 @@ func (s *BluezInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.bluez.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `peer=(label="snap.bluez.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the bluez slot
@@ -120,27 +127,30 @@ func (s *BluezInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.bluez.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `peer=(label="snap.bluez.app"),`)
 }
 
 func (s *BluezInterfaceSuite) TestConnectedSlotSnippetAppArmor(c *C) {
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, `peer=(label="snap.other.app2")`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.bluez.app1"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.bluez.app1"), testutil.Contains, `peer=(label="snap.other.app2")`)
 }
 
 func (s *BluezInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	err = apparmorSpec.AddPermanentSlot(s.iface, s.slot)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 2)
+
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -96,7 +96,7 @@ func (iface *BoolFileInterface) AppArmorPermanentSlot(spec *apparmor.Specificati
 `
 
 	if iface.isGPIO(slot) {
-		return spec.AddSnippet(gpioSnippet)
+		spec.AddSnippet(gpioSnippet)
 	}
 	return nil
 }
@@ -110,7 +110,8 @@ func (iface *BoolFileInterface) AppArmorConnectedPlug(spec *apparmor.Specificati
 	if err != nil {
 		return fmt.Errorf("cannot compute plug security snippet: %v", err)
 	}
-	return spec.AddSnippet(fmt.Sprintf("%s rwk,\n", path))
+	spec.AddSnippet(fmt.Sprintf("%s rwk,\n", path))
+	return nil
 }
 
 // ConnectedPlugSnippet returns security snippet specific to a given connection between the bool-file plug and some slot.

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -110,7 +110,7 @@ func (iface *BoolFileInterface) AppArmorConnectedPlug(spec *apparmor.Specificati
 	if err != nil {
 		return fmt.Errorf("cannot compute plug security snippet: %v", err)
 	}
-	spec.AddSnippet(fmt.Sprintf("%s rwk,\n", path))
+	spec.AddSnippet(fmt.Sprintf("%s rwk,", path))
 	return nil
 }
 

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 // BoolFileInterface is the type of all the bool-file interfaces.
@@ -83,41 +84,38 @@ func (iface *BoolFileInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot
 	return nil, nil
 }
 
-// PermanentSlotSnippet returns security snippet permanently granted to bool-file slots.
-// Applications associated with the slot, if the slot is a GPIO, gain permission to export, unexport and set direction of any GPIO pin.
 func (iface *BoolFileInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	gpioSnippet := []byte(`
+	return nil, nil
+}
+
+func (iface *BoolFileInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	gpioSnippet := `
 /sys/class/gpio/export rw,
 /sys/class/gpio/unexport rw,
 /sys/class/gpio/gpio[0-9]+/direction rw,
-`)
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		// To provide GPIOs we need extra permissions to export/unexport and to
-		// set the direction of each pin.
-		if iface.isGPIO(slot) {
-			return gpioSnippet, nil
-		}
-		return nil, nil
+`
+
+	if iface.isGPIO(slot) {
+		return spec.AddSnippet(gpioSnippet)
 	}
-	return nil, nil
+	return nil
+}
+
+func (iface *BoolFileInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	// Allow write and lock on the file designated by the path.
+	// Dereference symbolic links to file path handed out to apparmor since
+	// sysfs is full of symlinks and apparmor requires uses real path for
+	// filtering.
+	path, err := iface.dereferencedPath(slot)
+	if err != nil {
+		return fmt.Errorf("cannot compute plug security snippet: %v", err)
+	}
+	return spec.AddSnippet(fmt.Sprintf("%s rwk,\n", path))
 }
 
 // ConnectedPlugSnippet returns security snippet specific to a given connection between the bool-file plug and some slot.
 // Applications associated with the plug gain permission to read, write and lock the designated file.
 func (iface *BoolFileInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		// Allow write and lock on the file designated by the path.
-		// Dereference symbolic links to file path handed out to apparmor since
-		// sysfs is full of symlinks and apparmor requires uses real path for
-		// filtering.
-		path, err := iface.dereferencedPath(slot)
-		if err != nil {
-			return nil, fmt.Errorf("cannot compute plug security snippet: %v", err)
-		}
-		return []byte(fmt.Sprintf("%s rwk,\n", path)), nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -95,6 +95,8 @@ plugs:
 	s.badInterfacePlug = &interfaces.Plug{PlugInfo: info.Plugs["bad-interface-plug"]}
 }
 
+// TODO: add test for permanent slot when we have hook support.
+
 func (s *BoolFileInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "bool-file")
 }

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -20,13 +20,13 @@
 package builtin_test
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -56,6 +56,14 @@ var _ = Suite(&BoolFileInterfaceSuite{
 })
 
 func (s *BoolFileInterfaceSuite) SetUpTest(c *C) {
+	plugSnapinfo := snaptest.MockInfo(c, `
+name: other
+plugs:
+ plug: bool-file
+apps:
+ app:
+  command: foo
+`, nil)
 	info := snaptest.MockInfo(c, `
 name: ubuntu-core
 slots:
@@ -83,7 +91,7 @@ plugs:
 	s.badPathSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-path"]}
 	s.parentDirPathSlot = &interfaces.Slot{SlotInfo: info.Slots["parent-dir-path"]}
 	s.badInterfaceSlot = &interfaces.Slot{SlotInfo: info.Slots["bad-interface-slot"]}
-	s.plug = &interfaces.Plug{PlugInfo: info.Plugs["plug"]}
+	s.plug = &interfaces.Plug{PlugInfo: plugSnapinfo.Plugs["plug"]}
 	s.badInterfacePlug = &interfaces.Plug{PlugInfo: info.Plugs["bad-interface-plug"]}
 }
 
@@ -127,9 +135,11 @@ func (s *BoolFileInterfaceSuite) TestPlugSnippetHandlesSymlinkErrors(c *C) {
 	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
 		return "", fmt.Errorf("broken symbolic link")
 	})
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.gpioSlot)
 	c.Assert(err, ErrorMatches, "cannot compute plug security snippet: broken symbolic link")
-	c.Assert(snippet, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
 }
 
 func (s *BoolFileInterfaceSuite) TestPlugSnippetDereferencesSymlinks(c *C) {
@@ -139,37 +149,25 @@ func (s *BoolFileInterfaceSuite) TestPlugSnippetDereferencesSymlinks(c *C) {
 	})
 	// Extra apparmor permission to access GPIO value
 	// The path uses dereferenced symbolic links.
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.gpioSlot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.gpioSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, []byte(
-		"(dereferenced)/sys/class/gpio/gpio13/value rwk,\n"))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), Equals, "(dereferenced)/sys/class/gpio/gpio13/value rwk,\n")
 	// Extra apparmor permission to access LED brightness.
 	// The path uses dereferenced symbolic links.
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.ledSlot, interfaces.SecurityAppArmor)
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.ledSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, []byte(
-		"(dereferenced)/sys/class/leds/input27::capslock/brightness rwk,\n"))
-}
-
-func (s *BoolFileInterfaceSuite) TestPermanentPlugSecurityDoesNotContainSlotSecurity(c *C) {
-	// Use a fake (successful) dereferencing function for the remainder of the test.
-	builtin.MockEvalSymlinks(&s.BaseTest, func(path string) (string, error) {
-		return path, nil
-	})
-	var err error
-	var slotSnippet, plugSnippet []byte
-	plugSnippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	slotSnippet, err = s.iface.PermanentSlotSnippet(s.gpioSlot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	// Ensure that we don't accidentally give plug-side permissions to slot-side.
-	c.Assert(bytes.Contains(plugSnippet, slotSnippet), Equals, false)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), Equals, "(dereferenced)/sys/class/leds/input27::capslock/brightness rwk,\n")
 }
 
 func (s *BoolFileInterfaceSuite) TestConnectedPlugSnippetPanicksOnUnsanitizedSlots(c *C) {
 	// Unsanitized slots should never be used and cause a panic.
 	c.Assert(func() {
-		s.iface.ConnectedPlugSnippet(s.plug, s.missingPathSlot, interfaces.SecurityAppArmor)
+		apparmorSpec := &apparmor.Specification{}
+		apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.missingPathSlot)
 	}, PanicMatches, "slot is not sanitized")
 }
 
@@ -213,30 +211,4 @@ func (s *BoolFileInterfaceSuite) TestPermanentPlugSnippetUnusedSecuritySystems(c
 	snippet, err = s.iface.PermanentPlugSnippet(s.plug, interfaces.SecurityUDev)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
-}
-
-func (s *BoolFileInterfaceSuite) TestPermanentSlotSnippetGivesExtraPermissionsToConfigureGPIOs(c *C) {
-	// Extra apparmor permission to provide GPIOs
-	expectedGPIOSnippet := []byte(`
-/sys/class/gpio/export rw,
-/sys/class/gpio/unexport rw,
-/sys/class/gpio/gpio[0-9]+/direction rw,
-`)
-	snippet, err := s.iface.PermanentSlotSnippet(s.gpioSlot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedGPIOSnippet)
-}
-
-func (s *BoolFileInterfaceSuite) TestPermanentSlotSnippetGivesNoExtraPermissionsToConfigureLEDs(c *C) {
-	// No extra apparmor permission to provide LEDs
-	snippet, err := s.iface.PermanentSlotSnippet(s.ledSlot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, IsNil)
-}
-
-func (s *BoolFileInterfaceSuite) TestPermanentSlotSnippetPanicksOnUnsanitizedSlots(c *C) {
-	// Unsanitized slots should never be used and cause a panic.
-	c.Assert(func() {
-		s.iface.PermanentSlotSnippet(s.missingPathSlot, interfaces.SecurityAppArmor)
-	}, PanicMatches, "slot is not sanitized")
 }

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -155,14 +155,14 @@ func (s *BoolFileInterfaceSuite) TestPlugSnippetDereferencesSymlinks(c *C) {
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.gpioSlot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
-	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), Equals, "(dereferenced)/sys/class/gpio/gpio13/value rwk,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), Equals, "(dereferenced)/sys/class/gpio/gpio13/value rwk,")
 	// Extra apparmor permission to access LED brightness.
 	// The path uses dereferenced symbolic links.
 	apparmorSpec = &apparmor.Specification{}
 	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.ledSlot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
-	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), Equals, "(dereferenced)/sys/class/leds/input27::capslock/brightness rwk,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), Equals, "(dereferenced)/sys/class/leds/input27::capslock/brightness rwk,")
 }
 
 func (s *BoolFileInterfaceSuite) TestConnectedPlugSnippetPanicksOnUnsanitizedSlots(c *C) {

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
@@ -258,18 +259,18 @@ func (iface *BrowserSupportInterface) PermanentSlotSnippet(slot *interfaces.Slot
 	return nil, nil
 }
 
-func (iface *BrowserSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *BrowserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	allowSandbox, _ := plug.Attrs["allow-sandbox"].(bool)
-
-	if securitySystem == interfaces.SecurityAppArmor {
-		snippet := []byte(browserSupportConnectedPlugAppArmor)
-		if allowSandbox {
-			snippet = append(snippet, browserSupportConnectedPlugAppArmorWithSandbox...)
-		} else {
-			snippet = append(snippet, browserSupportConnectedPlugAppArmorWithoutSandbox...)
-		}
-		return snippet, nil
+	snippet := browserSupportConnectedPlugAppArmor
+	if allowSandbox {
+		snippet = snippet + "\n" + browserSupportConnectedPlugAppArmorWithSandbox
+	} else {
+		snippet = snippet + "\n" + browserSupportConnectedPlugAppArmorWithoutSandbox
 	}
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *BrowserSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
 }
 

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -261,13 +261,13 @@ func (iface *BrowserSupportInterface) PermanentSlotSnippet(slot *interfaces.Slot
 
 func (iface *BrowserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	allowSandbox, _ := plug.Attrs["allow-sandbox"].(bool)
-	if err := spec.AddSnippet(browserSupportConnectedPlugAppArmor); err != nil {
-		return err
-	}
+	spec.AddSnippet(browserSupportConnectedPlugAppArmor)
 	if allowSandbox {
-		return spec.AddSnippet(browserSupportConnectedPlugAppArmorWithSandbox)
+		spec.AddSnippet(browserSupportConnectedPlugAppArmorWithSandbox)
+	} else {
+		spec.AddSnippet(browserSupportConnectedPlugAppArmorWithoutSandbox)
 	}
-	return spec.AddSnippet(browserSupportConnectedPlugAppArmorWithoutSandbox)
+	return nil
 }
 
 func (iface *BrowserSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -261,13 +261,13 @@ func (iface *BrowserSupportInterface) PermanentSlotSnippet(slot *interfaces.Slot
 
 func (iface *BrowserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	allowSandbox, _ := plug.Attrs["allow-sandbox"].(bool)
-	snippet := browserSupportConnectedPlugAppArmor
-	if allowSandbox {
-		snippet = snippet + "\n" + browserSupportConnectedPlugAppArmorWithSandbox
-	} else {
-		snippet = snippet + "\n" + browserSupportConnectedPlugAppArmorWithoutSandbox
+	if err := spec.AddSnippet(browserSupportConnectedPlugAppArmor); err != nil {
+		return err
 	}
-	return spec.AddSnippet(snippet)
+	if allowSandbox {
+		return spec.AddSnippet(browserSupportConnectedPlugAppArmorWithSandbox)
+	}
+	return spec.AddSnippet(browserSupportConnectedPlugAppArmorWithoutSandbox)
 }
 
 func (iface *BrowserSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/classic_support_test.go
+++ b/interfaces/builtin/classic_support_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -39,7 +40,7 @@ type ClassicSupportInterfaceSuite struct {
 const classicSupportMockPlugSnapInfoYaml = `name: other
 version: 1.0
 apps:
- app2:
+ app:
   command: foo
   plugs: [classic-support]
 `
@@ -82,16 +83,19 @@ func (s *ClassicSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *ClassicSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.other.app")
 	c.Check(string(snippet), testutil.Contains, "/usr/bin/systemd-run Uxr,\n")
 	c.Check(string(snippet), testutil.Contains, "/bin/systemctl Uxr,\n")
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	snippets := seccompSpec.Snippets()
-	c.Assert(len(snippets["snap.other.app2"]), Equals, 1)
-	c.Check(string(snippets["snap.other.app2"][0]), testutil.Contains, "mount\n")
+	c.Assert(len(snippets["snap.other.app"]), Equals, 1)
+	c.Check(string(snippets["snap.other.app"][0]), testutil.Contains, "mount\n")
 }

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -85,6 +86,13 @@ func (iface *commonInterface) PermanentPlugSnippet(plug *interfaces.Plug, securi
 	return nil, nil
 }
 
+func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if iface.connectedPlugAppArmor != "" {
+		return spec.AddSnippet(iface.connectedPlugAppArmor)
+	}
+	return nil
+}
+
 // ConnectedPlugSnippet returns the snippet of text for the given security
 // system that is used by affected application, while a specific connection
 // between a plug and a slot exists.
@@ -92,9 +100,6 @@ func (iface *commonInterface) PermanentPlugSnippet(plug *interfaces.Plug, securi
 // Connected plugs get the static seccomp and apparmor blobs defined by the
 // instance variables.  They are not really connection specific in this case.
 func (iface *commonInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	if securitySystem == interfaces.SecurityAppArmor {
-		return []byte(iface.connectedPlugAppArmor), nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -88,7 +88,7 @@ func (iface *commonInterface) PermanentPlugSnippet(plug *interfaces.Plug, securi
 
 func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	if iface.connectedPlugAppArmor != "" {
-		return spec.AddSnippet(iface.connectedPlugAppArmor)
+		spec.AddSnippet(iface.connectedPlugAppArmor)
 	}
 	return nil
 }

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/snap"
 )
@@ -149,41 +150,40 @@ func mountEntry(plug *interfaces.Plug, slot *interfaces.Slot, relSrc string, ext
 	}
 }
 
-func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *ContentInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	contentSnippet := bytes.NewBuffer(nil)
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-
-		writePaths := iface.path(slot, "write")
-		if len(writePaths) > 0 {
-			fmt.Fprintf(contentSnippet, `
+	writePaths := iface.path(slot, "write")
+	if len(writePaths) > 0 {
+		fmt.Fprintf(contentSnippet, `
 # In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files. Due
 # to a limitation in the kernel's LSM hooks for AF_UNIX, these
 # are needed for using named sockets within the exported
 # directory.
 `)
-			for _, w := range writePaths {
-				fmt.Fprintf(contentSnippet, "%s/** mrwklix,\n",
-					resolveSpecialVariable(w, slot.Snap))
-			}
+		for _, w := range writePaths {
+			fmt.Fprintf(contentSnippet, "%s/** mrwklix,\n",
+				resolveSpecialVariable(w, slot.Snap))
 		}
+	}
 
-		readPaths := iface.path(slot, "read")
-		if len(readPaths) > 0 {
-			fmt.Fprintf(contentSnippet, `
+	readPaths := iface.path(slot, "read")
+	if len(readPaths) > 0 {
+		fmt.Fprintf(contentSnippet, `
 # In addition to the bind mount, add any AppArmor rules so that
 # snaps may directly access the slot implementation's files
 # read-only.
 `)
-			for _, r := range readPaths {
-				fmt.Fprintf(contentSnippet, "%s/** mrkix,\n",
-					resolveSpecialVariable(r, slot.Snap))
-			}
+		for _, r := range readPaths {
+			fmt.Fprintf(contentSnippet, "%s/** mrkix,\n",
+				resolveSpecialVariable(r, slot.Snap))
 		}
-
-		return contentSnippet.Bytes(), nil
 	}
+
+	return spec.AddSnippet(contentSnippet.String())
+}
+
+func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
 }
 

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -180,7 +180,8 @@ func (iface *ContentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 		}
 	}
 
-	return spec.AddSnippet(contentSnippet.String())
+	spec.AddSnippet(contentSnippet.String())
+	return nil
 }
 
 func (iface *ContentInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -41,10 +41,9 @@ var _ = Suite(&CoreSupportInterfaceSuite{})
 func (s *CoreSupportInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfo = `name: other
 version: 1.0
-apps:
- app:
-  command: foo
-  plugs: [core-support]
+hooks:
+ prepare-device:
+     plugs: [core-support]
 `
 	s.iface = builtin.NewCoreSupportInterface()
 	s.slot = &interfaces.Slot{
@@ -98,6 +97,6 @@ func (s *CoreSupportInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
-	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/bin/systemctl Uxr,`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.hook.prepare-device"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.hook.prepare-device"), testutil.Contains, `/bin/systemctl Uxr,`)
 }

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -301,7 +301,8 @@ func (iface *DbusInterface) AppArmorConnectedPlug(spec *apparmor.Specification, 
 	new = slotAppLabelExpr(slot)
 	snippet = strings.Replace(snippet, old, new, -1)
 
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *DbusInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -313,8 +314,6 @@ func (iface *DbusInterface) AppArmorPermanentSlot(spec *apparmor.Specification, 
 	if err != nil {
 		return err
 	}
-
-	snippets := bytes.NewBufferString("")
 
 	// well-known DBus name-specific permanent slot policy
 	snippet := getAppArmorSnippet(dbusPermanentSlotAppArmor, bus, name)
@@ -328,15 +327,13 @@ func (iface *DbusInterface) AppArmorPermanentSlot(spec *apparmor.Specification, 
 	old := "###DBUS_ABSTRACTION###"
 	new := abstraction
 	snippet = strings.Replace(snippet, old, new, -1)
-
-	snippets.WriteString(snippet)
+	spec.AddSnippet(snippet)
 
 	if release.OnClassic {
 		// classic-only policy
-		snippets.WriteString(getAppArmorSnippet(dbusPermanentSlotAppArmorClassic, bus, name))
+		spec.AddSnippet(getAppArmorSnippet(dbusPermanentSlotAppArmorClassic, bus, name))
 	}
-
-	return spec.AddSnippet(snippets.String())
+	return nil
 }
 
 func (iface *DbusInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -392,8 +389,8 @@ func (iface *DbusInterface) AppArmorConnectedSlot(spec *apparmor.Specification, 
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet = strings.Replace(snippet, old, new, -1)
-
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *DbusInterface) SanitizePlug(plug *interfaces.Plug) error {

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/release"
 )
 
@@ -231,14 +232,14 @@ func getAppArmorAbstraction(bus string) (string, error) {
 }
 
 // Calculate individual snippet policy based on bus and name
-func getAppArmorSnippet(policy []byte, bus string, name string) []byte {
-	old := []byte("###DBUS_BUS###")
-	new := []byte(bus)
-	snippet := bytes.Replace(policy, old, new, -1)
+func getAppArmorSnippet(policy string, bus string, name string) string {
+	old := "###DBUS_BUS###"
+	new := bus
+	snippet := strings.Replace(policy, old, new, -1)
 
-	old = []byte("###DBUS_NAME###")
-	new = []byte(name)
-	snippet = bytes.Replace(snippet, old, new, -1)
+	old = "###DBUS_NAME###"
+	new = name
+	snippet = strings.Replace(snippet, old, new, -1)
 
 	// convert name to AppArmor dbus path (eg 'org.foo' to '/org/foo{,/**}')
 	var pathBuf bytes.Buffer
@@ -246,9 +247,9 @@ func getAppArmorSnippet(policy []byte, bus string, name string) []byte {
 	pathBuf.WriteString(strings.Replace(name, ".", "/", -1))
 	pathBuf.WriteString(`{,/**}"`)
 
-	old = []byte("###DBUS_PATH###")
-	new = pathBuf.Bytes()
-	snippet = bytes.Replace(snippet, old, new, -1)
+	old = "###DBUS_PATH###"
+	new = pathBuf.String()
+	snippet = strings.Replace(snippet, old, new, -1)
 
 	// convert name to AppArmor dbus interface (eg, 'org.foo' to 'org.foo{,.*}')
 	var ifaceBuf bytes.Buffer
@@ -256,9 +257,9 @@ func getAppArmorSnippet(policy []byte, bus string, name string) []byte {
 	ifaceBuf.WriteString(name)
 	ifaceBuf.WriteString(`{,.*}"`)
 
-	old = []byte("###DBUS_INTERFACE###")
-	new = ifaceBuf.Bytes()
-	snippet = bytes.Replace(snippet, old, new, -1)
+	old = "###DBUS_INTERFACE###"
+	new = ifaceBuf.String()
+	snippet = strings.Replace(snippet, old, new, -1)
 
 	return snippet
 }
@@ -267,77 +268,79 @@ func (iface *DbusInterface) PermanentPlugSnippet(plug *interfaces.Plug, security
 	return nil, nil
 }
 
-func (iface *DbusInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *DbusInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	bus, name, err := iface.getAttribs(plug.Attrs)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	busSlot, nameSlot, err := iface.getAttribs(slot.Attrs)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// ensure that we only connect to slot with matching attributes
 	if bus != busSlot || name != nameSlot {
-		return nil, nil
+		return nil
 	}
 
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		// well-known DBus name-specific connected plug policy
-		snippet := getAppArmorSnippet([]byte(dbusConnectedPlugAppArmor), bus, name)
+	// well-known DBus name-specific connected plug policy
+	snippet := getAppArmorSnippet(dbusConnectedPlugAppArmor, bus, name)
 
-		// abstraction policy
-		abstraction, err := getAppArmorAbstraction(bus)
-		if err != nil {
-			return nil, err
-		}
-
-		old := []byte("###DBUS_ABSTRACTION###")
-		new := []byte(abstraction)
-		snippet = bytes.Replace(snippet, old, new, -1)
-
-		old = []byte("###SLOT_SECURITY_TAGS###")
-		new = slotAppLabelExpr(slot)
-		snippet = bytes.Replace(snippet, old, new, -1)
-
-		return snippet, nil
+	// abstraction policy
+	abstraction, err := getAppArmorAbstraction(bus)
+	if err != nil {
+		return err
 	}
+
+	old := "###DBUS_ABSTRACTION###"
+	new := abstraction
+	snippet = strings.Replace(snippet, old, new, -1)
+
+	old = "###SLOT_SECURITY_TAGS###"
+	new = slotAppLabelExpr(slot)
+	snippet = strings.Replace(snippet, old, new, -1)
+
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *DbusInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
+}
+
+func (iface *DbusInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	bus, name, err := iface.getAttribs(slot.Attrs)
+	if err != nil {
+		return err
+	}
+
+	snippets := bytes.NewBufferString("")
+
+	// well-known DBus name-specific permanent slot policy
+	snippet := getAppArmorSnippet(dbusPermanentSlotAppArmor, bus, name)
+
+	// abstraction policy
+	abstraction, err := getAppArmorAbstraction(bus)
+	if err != nil {
+		return err
+	}
+
+	old := "###DBUS_ABSTRACTION###"
+	new := abstraction
+	snippet = strings.Replace(snippet, old, new, -1)
+
+	snippets.WriteString(snippet)
+
+	if release.OnClassic {
+		// classic-only policy
+		snippets.WriteString(getAppArmorSnippet(dbusPermanentSlotAppArmorClassic, bus, name))
+	}
+
+	return spec.AddSnippet(snippets.String())
 }
 
 func (iface *DbusInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		bus, name, err := iface.getAttribs(slot.Attrs)
-		if err != nil {
-			return nil, err
-		}
-
-		snippets := bytes.NewBufferString("")
-
-		// well-known DBus name-specific permanent slot policy
-		snippet := getAppArmorSnippet([]byte(dbusPermanentSlotAppArmor), bus, name)
-
-		// abstraction policy
-		abstraction, err := getAppArmorAbstraction(bus)
-		if err != nil {
-			return nil, err
-		}
-
-		old := []byte("###DBUS_ABSTRACTION###")
-		new := []byte(abstraction)
-		snippet = bytes.Replace(snippet, old, new, -1)
-
-		snippets.Write(snippet)
-
-		if release.OnClassic {
-			// classic-only policy
-			snippets.Write(getAppArmorSnippet([]byte(dbusPermanentSlotAppArmorClassic), bus, name))
-		}
-
-		return snippets.Bytes(), nil
 	case interfaces.SecurityDBus:
 		bus, name, err := iface.getAttribs(slot.Attrs)
 		if err != nil {
@@ -360,14 +363,18 @@ func (iface *DbusInterface) PermanentSlotSnippet(slot *interfaces.Slot, security
 }
 
 func (iface *DbusInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+func (iface *DbusInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	bus, name, err := iface.getAttribs(slot.Attrs)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	busPlug, namePlug, err := iface.getAttribs(plug.Attrs)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// ensure that we only connect to slot with matching attributes. This
@@ -376,21 +383,17 @@ func (iface *DbusInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *in
 	// TODO: we can fix the 'snap interfaces' issue when interface/policy
 	// checkers when they are available
 	if bus != busPlug || name != namePlug {
-		return nil, nil
+		return nil
 	}
 
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		// well-known DBus name-specific connected slot policy
-		snippet := getAppArmorSnippet([]byte(dbusConnectedSlotAppArmor), bus, name)
+	// well-known DBus name-specific connected slot policy
+	snippet := getAppArmorSnippet(dbusConnectedSlotAppArmor, bus, name)
 
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet = bytes.Replace(snippet, old, new, -1)
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet = strings.Replace(snippet, old, new, -1)
 
-		return snippet, nil
-	}
-	return nil, nil
+	return spec.AddSnippet(snippet)
 }
 
 func (iface *DbusInterface) SanitizePlug(plug *interfaces.Plug) error {

--- a/interfaces/builtin/dbus_test.go
+++ b/interfaces/builtin/dbus_test.go
@@ -20,9 +20,11 @@
 package builtin_test
 
 import (
+	//	"fmt"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -120,20 +122,6 @@ func (s *DbusInterfaceSuite) SetUpTest(c *C) {
 
 func (s *DbusInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "dbus")
-}
-
-func (s *DbusInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.sessionSlot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	snippet, err = s.iface.ConnectedSlotSnippet(s.connectedSessionPlug, s.connectedSessionSlot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	snippet, err = s.iface.ConnectedPlugSnippet(s.connectedSessionPlug, s.connectedSessionSlot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
 }
 
 func (s *DbusInterfaceSuite) TestValidSessionBusName(c *C) {
@@ -303,66 +291,74 @@ plugs:
 }
 
 func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSession(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.sessionSlot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.sessionSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-provider"})
+	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-session-provider")
 
 	// verify abstraction rule
-	c.Check(string(snippet), testutil.Contains, "#include <abstractions/dbus-session-strict>\n")
+	c.Check(snippet, testutil.Contains, "#include <abstractions/dbus-session-strict>\n")
 
 	// verify shared permanent slot policy
-	c.Check(string(snippet), testutil.Contains, "dbus (send)\n    bus=session\n    path=/org/freedesktop/DBus\n    interface=org.freedesktop.DBus\n    member=\"{Request,Release}Name\"\n    peer=(name=org.freedesktop.DBus, label=unconfined),\n")
+	c.Check(snippet, testutil.Contains, "dbus (send)\n    bus=session\n    path=/org/freedesktop/DBus\n    interface=org.freedesktop.DBus\n    member=\"{Request,Release}Name\"\n    peer=(name=org.freedesktop.DBus, label=unconfined),\n")
 
 	// verify individual bind rules
-	c.Check(string(snippet), testutil.Contains, "dbus (bind)\n    bus=session\n    name=org.test-session-slot,\n")
+	c.Check(snippet, testutil.Contains, "dbus (bind)\n    bus=session\n    name=org.test-session-slot,\n")
 
 	// verify individual path in rules
-	c.Check(string(snippet), testutil.Contains, "path=\"/org/test-session-slot{,/**}\"\n")
+	c.Check(snippet, testutil.Contains, "path=\"/org/test-session-slot{,/**}\"\n")
 
 	// verify interface in rule
-	c.Check(string(snippet), testutil.Contains, "interface=\"org.test-session-slot{,.*}\"\n")
+	c.Check(snippet, testutil.Contains, "interface=\"org.test-session-slot{,.*}\"\n")
 }
 
 func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSessionNative(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 	iface := &builtin.DbusInterface{}
-	snippet, err := iface.PermanentSlotSnippet(s.sessionSlot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(iface, s.sessionSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-provider"})
 
 	// verify classic rule not present
-	c.Check(string(snippet), Not(testutil.Contains), "# allow us to respond to unconfined clients via \"org.test-session-slot{,.*}\"\n")
+	c.Check(apparmorSpec.SnippetForTag("snap.test-dbus.test-session-provider"), Not(testutil.Contains), "# allow us to respond to unconfined clients via \"org.test-session-slot{,.*}\"\n")
 }
 
 func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSessionClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 	iface := &builtin.DbusInterface{}
-	snippet, err := iface.PermanentSlotSnippet(s.sessionSlot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(iface, s.sessionSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-provider"})
 
 	// verify classic rule
-	c.Check(string(snippet), testutil.Contains, "# allow us to respond to unconfined clients via \"org.test-session-slot{,.*}\"\n")
+	c.Check(apparmorSpec.SnippetForTag("snap.test-dbus.test-session-provider"), testutil.Contains, "# allow us to respond to unconfined clients via \"org.test-session-slot{,.*}\"\n")
 }
 
 func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSystem(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.systemSlot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.systemSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-system-provider"})
+	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-system-provider")
 
 	// verify abstraction rule
-	c.Check(string(snippet), testutil.Contains, "#include <abstractions/dbus-strict>\n")
+	c.Check(snippet, testutil.Contains, "#include <abstractions/dbus-strict>\n")
 
 	// verify bind rule
-	c.Check(string(snippet), testutil.Contains, "dbus (bind)\n    bus=system\n    name=org.test-system-slot,\n")
+	c.Check(snippet, testutil.Contains, "dbus (bind)\n    bus=system\n    name=org.test-system-slot,\n")
 
 	// verify path in rule
-	c.Check(string(snippet), testutil.Contains, "path=\"/org/test-system-slot{,/**}\"\n")
+	c.Check(snippet, testutil.Contains, "path=\"/org/test-system-slot{,/**}\"\n")
 
 	// verify interface in rule
-	c.Check(string(snippet), testutil.Contains, "interface=\"org.test-system-slot{,.*}\"\n")
+	c.Check(snippet, testutil.Contains, "interface=\"org.test-system-slot{,.*}\"\n")
 }
 
 func (s *DbusInterfaceSuite) TestPermanentSlotDBusSession(c *C) {
@@ -382,47 +378,56 @@ func (s *DbusInterfaceSuite) TestPermanentSlotDBusSystem(c *C) {
 
 func (s *DbusInterfaceSuite) TestConnectedSlotAppArmorSession(c *C) {
 	iface := &builtin.DbusInterface{}
-	snippet, err := iface.ConnectedSlotSnippet(s.connectedSessionPlug, s.connectedSessionSlot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(iface, s.connectedSessionPlug, s.connectedSessionSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-consumer", "snap.test-dbus.test-session-provider", "snap.test-dbus.test-system-consumer", "snap.test-dbus.test-system-provider"})
+	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-session-provider")
 
 	// verify introspectable rule
-	c.Check(string(snippet), testutil.Contains, "dbus (receive)\n    bus=session\n    interface=org.freedesktop.DBus.Introspectable\n    member=Introspect\n    peer=(label=\"snap.test-dbus.*\"),\n")
+	c.Check(snippet, testutil.Contains, "dbus (receive)\n    bus=session\n    interface=org.freedesktop.DBus.Introspectable\n    member=Introspect\n    peer=(label=\"snap.test-dbus.*\"),\n")
 
 	// verify bind rule not present
-	c.Check(string(snippet), Not(testutil.Contains), "dbus (bind)")
+	c.Check(snippet, Not(testutil.Contains), "dbus (bind)")
 
 	// verify individual path in rules
-	c.Check(string(snippet), testutil.Contains, "path=\"/org/test-session-connected{,/**}\"\n")
+	c.Check(snippet, testutil.Contains, "path=\"/org/test-session-connected{,/**}\"\n")
 
 	// verify interface in rule
-	c.Check(string(snippet), testutil.Contains, "interface=\"org.test-session-connected{,.*}\"\n")
+	c.Check(snippet, testutil.Contains, "interface=\"org.test-session-connected{,.*}\"\n")
 }
 
 func (s *DbusInterfaceSuite) TestConnectedSlotAppArmorSystem(c *C) {
 	iface := &builtin.DbusInterface{}
-	snippet, err := iface.ConnectedSlotSnippet(s.connectedSystemPlug, s.connectedSystemSlot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(iface, s.connectedSystemPlug, s.connectedSystemSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-consumer", "snap.test-dbus.test-session-provider", "snap.test-dbus.test-system-consumer", "snap.test-dbus.test-system-provider"})
+	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-session-provider")
 
 	// verify introspectable rule
-	c.Check(string(snippet), testutil.Contains, "dbus (receive)\n    bus=system\n    interface=org.freedesktop.DBus.Introspectable\n    member=Introspect\n    peer=(label=\"snap.test-dbus.*\"),\n")
+	c.Check(snippet, testutil.Contains, "dbus (receive)\n    bus=system\n    interface=org.freedesktop.DBus.Introspectable\n    member=Introspect\n    peer=(label=\"snap.test-dbus.*\"),\n")
 
 	// verify bind rule not present
-	c.Check(string(snippet), Not(testutil.Contains), "dbus (bind)")
+	c.Check(snippet, Not(testutil.Contains), "dbus (bind)")
 
 	// verify individual path in rules
-	c.Check(string(snippet), testutil.Contains, "path=\"/org/test-system-connected{,/**}\"\n")
+	c.Check(snippet, testutil.Contains, "path=\"/org/test-system-connected{,/**}\"\n")
 
 	// verify interface in rule
-	c.Check(string(snippet), testutil.Contains, "interface=\"org.test-system-connected{,.*}\"\n")
+	c.Check(snippet, testutil.Contains, "interface=\"org.test-system-connected{,.*}\"\n")
 }
 
 func (s *DbusInterfaceSuite) TestConnectedPlugAppArmorSession(c *C) {
 	iface := &builtin.DbusInterface{}
-	snippet, err := iface.ConnectedPlugSnippet(s.connectedSessionPlug, s.connectedSessionSlot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(iface, s.connectedSessionPlug, s.connectedSessionSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-consumer", "snap.test-dbus.test-session-provider", "snap.test-dbus.test-system-consumer", "snap.test-dbus.test-system-provider"})
+	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-session-consumer")
 
 	// verify introspectable rule
 	c.Check(string(snippet), testutil.Contains, "dbus (send)\n    bus=session\n    interface=org.freedesktop.DBus.Introspectable\n    member=Introspect\n    peer=(label=\"snap.test-dbus.*\"),\n")
@@ -444,9 +449,12 @@ func (s *DbusInterfaceSuite) TestConnectedPlugAppArmorSession(c *C) {
 
 func (s *DbusInterfaceSuite) TestConnectedPlugAppArmorSystem(c *C) {
 	iface := &builtin.DbusInterface{}
-	snippet, err := iface.ConnectedPlugSnippet(s.connectedSystemPlug, s.connectedSystemSlot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(iface, s.connectedSystemPlug, s.connectedSystemSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-consumer", "snap.test-dbus.test-session-provider", "snap.test-dbus.test-system-consumer", "snap.test-dbus.test-system-provider"})
+	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-session-consumer")
 
 	// verify introspectable rule
 	c.Check(string(snippet), testutil.Contains, "dbus (send)\n    bus=system\n    interface=org.freedesktop.DBus.Introspectable\n    member=Introspect\n    peer=(label=\"snap.test-dbus.*\"),\n")
@@ -472,6 +480,9 @@ plugs:
   interface: dbus
   bus: session
   name: org.slotter.session
+apps:
+ app:
+  command: foo
 `
 	const slotYaml = `name: slotter
 version: 1.0
@@ -493,17 +504,21 @@ slots:
 	matchingSlot := &interfaces.Slot{SlotInfo: slotInfo.Slots["this"]}
 	nonmatchingSlot := &interfaces.Slot{SlotInfo: slotInfo.Slots["that"]}
 
-	snippet, err := s.iface.ConnectedPlugSnippet(matchingPlug, matchingSlot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, matchingPlug, matchingSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "org.slotter.session")
-	c.Check(string(snippet), testutil.Contains, "bus=session")
-	c.Check(string(snippet), Not(testutil.Contains), "org.slotter.other-session")
-	c.Check(string(snippet), Not(testutil.Contains), "bus=system")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.plugger.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.plugger.app")
 
-	snippet, err = s.iface.ConnectedPlugSnippet(matchingPlug, nonmatchingSlot, interfaces.SecurityAppArmor)
+	c.Check(snippet, testutil.Contains, "org.slotter.session")
+	c.Check(snippet, testutil.Contains, "bus=session")
+	c.Check(snippet, Not(testutil.Contains), "org.slotter.other-session")
+	c.Check(snippet, Not(testutil.Contains), "bus=system")
+
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedPlug(s.iface, matchingPlug, nonmatchingSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
 }
 
 func (s *DbusInterfaceSuite) TestConnectionSecond(c *C) {
@@ -514,6 +529,9 @@ plugs:
   interface: dbus
   bus: system
   name: org.slotter.other-session
+apps:
+ app:
+  command: foo
 `
 	const slotYaml = `name: slotter
 version: 1.0
@@ -535,17 +553,21 @@ slots:
 	matchingSlot := &interfaces.Slot{SlotInfo: slotInfo.Slots["that"]}
 	nonmatchingSlot := &interfaces.Slot{SlotInfo: slotInfo.Slots["this"]}
 
-	snippet, err := s.iface.ConnectedPlugSnippet(matchingPlug, matchingSlot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, matchingPlug, matchingSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "org.slotter.other-session")
-	c.Check(string(snippet), testutil.Contains, "bus=system")
-	c.Check(string(snippet), Not(testutil.Contains), "org.slotter.session")
-	c.Check(string(snippet), Not(testutil.Contains), "bus=session")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.plugger.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.plugger.app")
 
-	snippet, err = s.iface.ConnectedPlugSnippet(matchingPlug, nonmatchingSlot, interfaces.SecurityAppArmor)
+	c.Check(snippet, testutil.Contains, "org.slotter.other-session")
+	c.Check(snippet, testutil.Contains, "bus=system")
+	c.Check(snippet, Not(testutil.Contains), "org.slotter.session")
+	c.Check(snippet, Not(testutil.Contains), "bus=session")
+
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedPlug(s.iface, matchingPlug, nonmatchingSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
 }
 
 func (s *DbusInterfaceSuite) TestConnectionBoth(c *C) {
@@ -560,6 +582,9 @@ plugs:
   interface: dbus
   bus: session
   name: org.slotter.session
+apps:
+ app:
+  command: foo
 `
 	const slotYaml = `name: slotter
 version: 1.0
@@ -582,17 +607,21 @@ slots:
 	matchingSlot1 := &interfaces.Slot{SlotInfo: slotInfo.Slots["this"]}
 	matchingSlot2 := &interfaces.Slot{SlotInfo: slotInfo.Slots["that"]}
 
-	snippet, err := s.iface.ConnectedPlugSnippet(matchingPlug1, matchingSlot1, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, matchingPlug1, matchingSlot1)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "org.slotter.session")
-	c.Check(string(snippet), testutil.Contains, "bus=session")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.plugger.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.plugger.app")
+	c.Check(snippet, testutil.Contains, "org.slotter.session")
+	c.Check(snippet, testutil.Contains, "bus=session")
 
-	snippet, err = s.iface.ConnectedPlugSnippet(matchingPlug2, matchingSlot2, interfaces.SecurityAppArmor)
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedPlug(s.iface, matchingPlug2, matchingSlot2)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "org.slotter.other-session")
-	c.Check(string(snippet), testutil.Contains, "bus=system")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.plugger.app"})
+	snippet = apparmorSpec.SnippetForTag("snap.plugger.app")
+	c.Check(snippet, testutil.Contains, "org.slotter.other-session")
+	c.Check(snippet, testutil.Contains, "bus=system")
 }
 
 func (s *DbusInterfaceSuite) TestConnectionMismatchBus(c *C) {
@@ -619,9 +648,10 @@ slots:
 	slotInfo := snaptest.MockInfo(c, slotYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: slotInfo.Slots["this"]}
 
-	snippet, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
 }
 
 func (s *DbusInterfaceSuite) TestConnectionMismatchName(c *C) {
@@ -648,7 +678,8 @@ slots:
 	slotInfo := snaptest.MockInfo(c, slotYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: slotInfo.Slots["this"]}
 
-	snippet, err := s.iface.ConnectedPlugSnippet(plug, slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
 }

--- a/interfaces/builtin/dbus_test.go
+++ b/interfaces/builtin/dbus_test.go
@@ -20,7 +20,6 @@
 package builtin_test
 
 import (
-	//	"fmt"
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
@@ -51,11 +52,11 @@ func (iface *DockerInterface) PermanentPlugSnippet(plug *interfaces.Plug, securi
 	return nil, nil
 }
 
+func (iface *DockerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(dockerConnectedPlugAppArmor)
+}
+
 func (iface *DockerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	if securitySystem == interfaces.SecurityAppArmor {
-		snippet := []byte(dockerConnectedPlugAppArmor)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -53,7 +53,8 @@ func (iface *DockerInterface) PermanentPlugSnippet(plug *interfaces.Plug, securi
 }
 
 func (iface *DockerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(dockerConnectedPlugAppArmor)
+	spec.AddSnippet(dockerConnectedPlugAppArmor)
+	return nil
 }
 
 func (iface *DockerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -532,11 +532,9 @@ func (iface *DockerSupportInterface) PermanentPlugSnippet(plug *interfaces.Plug,
 
 func (iface *DockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	privileged, _ := plug.Attrs["privileged-containers"].(bool)
-	if err := spec.AddSnippet(dockerSupportConnectedPlugAppArmor); err != nil {
-		return err
-	}
+	spec.AddSnippet(dockerSupportConnectedPlugAppArmor)
 	if privileged {
-		return spec.AddSnippet(dockerSupportPrivilegedAppArmor)
+		spec.AddSnippet(dockerSupportPrivilegedAppArmor)
 	}
 	return nil
 }

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
@@ -529,15 +530,16 @@ func (iface *DockerSupportInterface) PermanentPlugSnippet(plug *interfaces.Plug,
 	return nil, nil
 }
 
-func (iface *DockerSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+func (iface *DockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	privileged, _ := plug.Attrs["privileged-containers"].(bool)
-	if securitySystem == interfaces.SecurityAppArmor {
-		snippet := []byte(dockerSupportConnectedPlugAppArmor)
-		if privileged {
-			snippet = append(snippet, dockerSupportPrivilegedAppArmor...)
-		}
-		return snippet, nil
+	snippet := dockerSupportConnectedPlugAppArmor
+	if privileged {
+		snippet += "\n" + dockerSupportPrivilegedAppArmor
 	}
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *DockerSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
 }
 

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -532,11 +532,13 @@ func (iface *DockerSupportInterface) PermanentPlugSnippet(plug *interfaces.Plug,
 
 func (iface *DockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	privileged, _ := plug.Attrs["privileged-containers"].(bool)
-	snippet := dockerSupportConnectedPlugAppArmor
-	if privileged {
-		snippet += "\n" + dockerSupportPrivilegedAppArmor
+	if err := spec.AddSnippet(dockerSupportConnectedPlugAppArmor); err != nil {
+		return err
 	}
-	return spec.AddSnippet(snippet)
+	if privileged {
+		return spec.AddSnippet(dockerSupportPrivilegedAppArmor)
+	}
+	return nil
 }
 
 func (iface *DockerSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -67,9 +68,10 @@ func (s *DockerSupportInterfaceSuite) TestName(c *C) {
 
 func (s *DockerSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
 
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
@@ -79,16 +81,18 @@ func (s *DockerSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 }
 
 func (s *DockerSupportInterfaceSuite) TestConnectedPlugSnippet(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `pivot_root`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.docker.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.docker.app"), testutil.Contains, `pivot_root`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	snippets := seccompSpec.Snippets()
-	c.Assert(len(snippets), Equals, 1)
-	c.Assert(len(snippets["snap.docker.app"]), Equals, 1)
+	c.Assert(snippets, HasLen, 1)
+	c.Assert(snippets["snap.docker.app"], HasLen, 1)
 	c.Check(string(snippets["snap.docker.app"][0]), testutil.Contains, "pivot_root\n")
 }
 
@@ -123,9 +127,11 @@ apps:
 	err = s.iface.SanitizePlug(plug)
 	c.Assert(err, IsNil)
 
-	snippet, err := s.iface.ConnectedPlugSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `change_profile -> *,`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.docker.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.docker.app"), testutil.Contains, `change_profile -> *,`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, plug, s.slot)
@@ -157,9 +163,11 @@ apps:
 	err = s.iface.SanitizePlug(plug)
 	c.Assert(err, IsNil)
 
-	snippet, err := s.iface.ConnectedPlugSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), Not(testutil.Contains), `change_profile -> *,`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.docker.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.docker.app"), Not(testutil.Contains), `change_profile -> *,`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, plug, s.slot)

--- a/interfaces/builtin/docker_test.go
+++ b/interfaces/builtin/docker_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -65,17 +66,12 @@ func (s *DockerInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "docker")
 }
 
-func (s *DockerInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-}
-
 func (s *DockerInterfaceSuite) TestConnectedPlugSnippet(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `run/docker.sock`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.docker.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.docker.app"), testutil.Contains, `run/docker.sock`)
 
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -23,11 +23,13 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type FirewallControlInterfaceSuite struct {
@@ -88,9 +90,12 @@ func (s *FirewallControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *FirewallControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `capability net_raw`)
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -77,7 +77,8 @@ func (iface *FramebufferInterface) PermanentSlotSnippet(slot *interfaces.Slot, s
 }
 
 func (iface *FramebufferInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(framebufferConnectedPlugAppArmor)
+	spec.AddSnippet(framebufferConnectedPlugAppArmor)
+	return nil
 }
 
 // Getter for the security snippet specific to the plug

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 const framebufferConnectedPlugAppArmor = `
@@ -75,12 +76,13 @@ func (iface *FramebufferInterface) PermanentSlotSnippet(slot *interfaces.Slot, s
 	return nil, nil
 }
 
+func (iface *FramebufferInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(framebufferConnectedPlugAppArmor)
+}
+
 // Getter for the security snippet specific to the plug
 func (iface *FramebufferInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(framebufferConnectedPlugAppArmor), nil
-
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
 		const udevRule = `KERNEL=="fb[0-9]*", TAG+="%s"`

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -88,22 +89,25 @@ func (s *FramebufferInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 }
 
 func (s *FramebufferInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	expectedSnippet1 := []byte(`
+	expectedSnippet1 := `
 # Description: Allow reading and writing to the universal framebuffer (/dev/fb*) which
 # gives privileged access to the console framebuffer.
 
 /dev/fb[0-9]* rw,
 /run/udev/data/c29:[0-9]* r,
-`)
+`
 	expectedSnippet2 := []byte(`KERNEL=="fb[0-9]*", TAG+="snap_client-snap_app-accessing-framebuffer"
 `)
 
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, snippet))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-framebuffer"})
+	aasnippet := apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-framebuffer")
+	c.Assert(aasnippet, Equals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, aasnippet))
 
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, expectedSnippet2, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet2, snippet))
 }

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,9 +89,12 @@ func (s *FuseSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *FuseSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `/dev/fuse`)
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -187,7 +187,8 @@ func (iface *FwupdInterface) AppArmorConnectedPlug(spec *apparmor.Specification,
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(fwupdConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 // ConnectedPlugSnippet returns security snippets for plug at connection
@@ -196,7 +197,9 @@ func (iface *FwupdInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *i
 }
 
 func (iface *FwupdInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(fwupdPermanentSlotAppArmor)
+	spec.AddSnippet(fwupdPermanentSlotAppArmor)
+	return nil
+
 }
 
 // PermanentSlotSnippet returns security snippets for slot at install
@@ -212,7 +215,8 @@ func (iface *FwupdInterface) AppArmorConnectedSlot(spec *apparmor.Specification,
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(fwupdConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 // ConnectedSlotSnippet returns security snippets for slot at connection

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -47,7 +48,7 @@ apps:
 const mockSlotSnapInfoYaml = `name: uefi-fw-tools
 version: 1.0
 apps:
- app:
+ app2:
   command: foo
   slots: [fwupd]
 `
@@ -81,9 +82,13 @@ func (s *FwupdInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	// connected plugs have a non-nil security snippet for apparmor
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.uefi-fw-tools.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.uefi-fw-tools.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.uefi-fw-tools.app"), testutil.Contains, `peer=(label="snap.uefi-fw-tools.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the fwupd slot
@@ -102,29 +107,35 @@ func (s *FwupdInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.uefi-fw-tools.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.uefi-fw-tools.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.uefi-fw-tools.app"), testutil.Contains, `peer=(label="snap.uefi-fw-tools.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the fwupd slot
 func (s *FwupdInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.uefi-fw-tools.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.uefi-fw-tools.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.uefi-fw-tools.app"), testutil.Contains, `peer=(label="snap.uefi-fw-tools.app2"),`)
 }
 
 func (s *FwupdInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	// connected plugs have a non-nil security snippet for apparmor
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
+	err = apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	err = apparmorSpec.AddPermanentSlot(s.iface, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.uefi-fw-tools.app", "snap.uefi-fw-tools.app2"})
+
+	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 }
@@ -135,8 +146,8 @@ func (s *FwupdInterfaceSuite) TestPermanentSlotSnippetSecComp(c *C) {
 	c.Assert(err, IsNil)
 	snippets := seccompSpec.Snippets()
 	c.Assert(len(snippets), Equals, 1)
-	c.Assert(len(snippets["snap.uefi-fw-tools.app"]), Equals, 1)
-	c.Check(string(snippets["snap.uefi-fw-tools.app"][0]), testutil.Contains, "bind\n")
+	c.Assert(len(snippets["snap.uefi-fw-tools.app2"]), Equals, 1)
+	c.Check(string(snippets["snap.uefi-fw-tools.app2"][0]), testutil.Contains, "bind\n")
 }
 
 func (s *FwupdInterfaceSuite) TestConnectedPlugSnippetSecComp(c *C) {

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -97,7 +97,7 @@ func (iface *GpioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, 
 	if err != nil {
 		return err
 	}
-	spec.AddSnippet(fmt.Sprintf("%s/* rwk,\n", dereferencedPath))
+	spec.AddSnippet(fmt.Sprintf("%s/* rwk,", dereferencedPath))
 	return nil
 
 }

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -97,7 +97,9 @@ func (iface *GpioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, 
 	if err != nil {
 		return err
 	}
-	return spec.AddSnippet(fmt.Sprintf("%s/* rwk,\n", dereferencedPath))
+	spec.AddSnippet(fmt.Sprintf("%s/* rwk,\n", dereferencedPath))
+	return nil
+
 }
 
 // ConnectedPlugSnippet returns security snippets for plug at connection

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,10 +89,12 @@ func (s *HardwareObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "capability sys_rawio,\n")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "capability sys_rawio,\n")
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -148,7 +148,7 @@ func (iface *HidrawInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 	if iface.hasUsbAttrs(slot) {
 		// This apparmor rule must match hidrawDeviceNodePattern
 		// UDev tagging and device cgroups will restrict down to the specific device
-		spec.AddSnippet("/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,\n")
+		spec.AddSnippet("/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,")
 		return nil
 	}
 
@@ -158,7 +158,7 @@ func (iface *HidrawInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 		return nil
 	}
 	cleanedPath := filepath.Clean(path)
-	spec.AddSnippet(fmt.Sprintf("%s rw,\n", cleanedPath))
+	spec.AddSnippet(fmt.Sprintf("%s rw,", cleanedPath))
 	return nil
 
 }

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -148,7 +148,8 @@ func (iface *HidrawInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 	if iface.hasUsbAttrs(slot) {
 		// This apparmor rule must match hidrawDeviceNodePattern
 		// UDev tagging and device cgroups will restrict down to the specific device
-		return spec.AddSnippet("/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,\n")
+		spec.AddSnippet("/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,\n")
+		return nil
 	}
 
 	// Path to fixed device node (no udev tagging)
@@ -157,7 +158,9 @@ func (iface *HidrawInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 		return nil
 	}
 	cleanedPath := filepath.Clean(path)
-	return spec.AddSnippet(fmt.Sprintf("%s rw,\n", cleanedPath))
+	spec.AddSnippet(fmt.Sprintf("%s rw,\n", cleanedPath))
+	return nil
+
 }
 
 // ConnectedPlugSnippet returns security snippet specific to the plug

--- a/interfaces/builtin/hidraw_test.go
+++ b/interfaces/builtin/hidraw_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -232,21 +233,30 @@ SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="ffff", ATTRS{idProduct
 }
 
 func (s *HidrawInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
-	expectedSnippet1 := []byte(`/dev/hidraw0 rw,
-`)
-	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testSlot1, interfaces.SecurityAppArmor)
+	expectedSnippet1 := `/dev/hidraw0 rw,
+`
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testSlot1)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-2-devices"})
+	snippet := apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-2-devices")
 	c.Assert(snippet, DeepEquals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, snippet))
 
-	expectedSnippet2 := []byte(`/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,
-`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityAppArmor)
+	expectedSnippet2 := `/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,
+`
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUdev1)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-2-devices"})
+	snippet = apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-2-devices")
 	c.Assert(snippet, DeepEquals, expectedSnippet2, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet2, snippet))
 
-	expectedSnippet3 := []byte(`/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,
-`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.testPlugPort2, s.testUdev2, interfaces.SecurityAppArmor)
+	expectedSnippet3 := `/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,
+`
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort2, s.testUdev2)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-2-devices"})
+	snippet = apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-2-devices")
 	c.Assert(snippet, DeepEquals, expectedSnippet3, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet3, snippet))
 }

--- a/interfaces/builtin/hidraw_test.go
+++ b/interfaces/builtin/hidraw_test.go
@@ -233,8 +233,7 @@ SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="ffff", ATTRS{idProduct
 }
 
 func (s *HidrawInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
-	expectedSnippet1 := `/dev/hidraw0 rw,
-`
+	expectedSnippet1 := `/dev/hidraw0 rw,`
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testSlot1)
 	c.Assert(err, IsNil)
@@ -242,8 +241,7 @@ func (s *HidrawInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 	snippet := apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-2-devices")
 	c.Assert(snippet, DeepEquals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, snippet))
 
-	expectedSnippet2 := `/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,
-`
+	expectedSnippet2 := `/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,`
 	apparmorSpec = &apparmor.Specification{}
 	err = apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUdev1)
 	c.Assert(err, IsNil)
@@ -251,8 +249,7 @@ func (s *HidrawInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 	snippet = apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-2-devices")
 	c.Assert(snippet, DeepEquals, expectedSnippet2, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet2, snippet))
 
-	expectedSnippet3 := `/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,
-`
+	expectedSnippet3 := `/dev/hidraw[0-9]{,[0-9],[0-9][0-9]} rw,`
 	apparmorSpec = &apparmor.Specification{}
 	err = apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort2, s.testUdev2)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -95,7 +95,7 @@ func (iface *I2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	}
 
 	cleanedPath := filepath.Clean(path)
-	spec.AddSnippet(fmt.Sprintf("%s rw,\n", cleanedPath))
+	spec.AddSnippet(fmt.Sprintf("%s rw,", cleanedPath))
 	return nil
 }
 

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -95,7 +95,8 @@ func (iface *I2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	}
 
 	cleanedPath := filepath.Clean(path)
-	return spec.AddSnippet(fmt.Sprintf("%s rw,\n", cleanedPath))
+	spec.AddSnippet(fmt.Sprintf("%s rw,\n", cleanedPath))
+	return nil
 }
 
 // Getter for the security snippet specific to the plug

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -188,12 +189,14 @@ func (s *I2cInterfaceSuite) TestConnectedPlugUdevSnippets(c *C) {
 }
 
 func (s *I2cInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
-	expectedSnippet1 := []byte(`/dev/i2c-1 rw,
-`)
-	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityAppArmor)
+	expectedSnippet1 := `/dev/i2c-1 rw,
+`
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUdev1)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-1-port"})
+	snippet := apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-1-port")
 	c.Assert(snippet, DeepEquals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, snippet))
-
 }
 
 func (s *I2cInterfaceSuite) TestAutoConnect(c *C) {

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -189,8 +189,7 @@ func (s *I2cInterfaceSuite) TestConnectedPlugUdevSnippets(c *C) {
 }
 
 func (s *I2cInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
-	expectedSnippet1 := `/dev/i2c-1 rw,
-`
+	expectedSnippet1 := `/dev/i2c-1 rw,`
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUdev1)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -113,7 +113,8 @@ func (iface *IioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	deviceName := strings.TrimPrefix(path, "/dev/")
 	snippet = strings.Replace(snippet, "###IIO_DEVICE_NAME###", deviceName, -1)
 
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 // Getter for the security snippet specific to the plug

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -179,17 +180,19 @@ func (s *IioInterfaceSuite) TestConnectedPlugUdevSnippets(c *C) {
 }
 
 func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
-	expectedSnippet1 := []byte(`
+	expectedSnippet1 := `
 # Description: Give access to a specific IIO device on the system.
 
 /dev/iio:device1 rw,
 /sys/bus/iio/devices/iio:device1/ r,
 /sys/bus/iio/devices/iio:device1/** rwk,
-`)
-	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityAppArmor)
+`
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, s.testUdev1)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-1-port"})
+	snippet := apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-1-port")
 	c.Assert(snippet, DeepEquals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, snippet))
-
 }
 
 func (s *IioInterfaceSuite) TestAutoConnect(c *C) {

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
@@ -87,12 +88,13 @@ func (iface *IioPortsControlInterface) PermanentSlotSnippet(slot *interfaces.Slo
 	return nil, nil
 }
 
+func (iface *IioPortsControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(ioPortsControlConnectedPlugAppArmor)
+}
+
 // Getter for the security snippet specific to the plug
 func (iface *IioPortsControlInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(ioPortsControlConnectedPlugAppArmor), nil
-
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
 		const udevRule = `KERNEL=="port", TAG+="%s"`

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -89,7 +89,8 @@ func (iface *IioPortsControlInterface) PermanentSlotSnippet(slot *interfaces.Slo
 }
 
 func (iface *IioPortsControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(ioPortsControlConnectedPlugAppArmor)
+	spec.AddSnippet(ioPortsControlConnectedPlugAppArmor)
+	return nil
 }
 
 // Getter for the security snippet specific to the plug

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,9 +89,12 @@ func (s *KernelModuleControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C)
 
 func (s *KernelModuleControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "capability sys_module,")
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type LocaleControlInterfaceSuite struct {
@@ -33,23 +36,27 @@ type LocaleControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&LocaleControlInterfaceSuite{
-	iface: builtin.NewLocaleControlInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&LocaleControlInterfaceSuite{})
+
+func (s *LocaleControlInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [locale-control]
+`
+	s.iface = builtin.NewLocaleControlInterface()
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["locale-control"]}
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "locale-control",
 			Interface: "locale-control",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "locale-control",
-			Interface: "locale-control",
-		},
-	},
-})
+	}
+}
 
 func (s *LocaleControlInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "locale-control")
@@ -80,7 +87,11 @@ func (s *LocaleControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *LocaleControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	aasnippets := apparmorSpec.Snippets()
+	c.Assert(aasnippets, HasLen, 1)
+	c.Assert(aasnippets["snap.other.app"], HasLen, 1)
+	c.Assert(string(aasnippets["snap.other.app"][0]), testutil.Contains, "/etc/default/locale")
 }

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -20,9 +20,10 @@
 package builtin
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 const locationControlPermanentSlotAppArmor = `
@@ -148,37 +149,41 @@ func (iface *LocationControlInterface) PermanentPlugSnippet(plug *interfaces.Plu
 	return nil, nil
 }
 
+func (iface *LocationControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(locationControlConnectedPlugAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *LocationControlInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(locationControlConnectedPlugAppArmor), old, new, -1)
-		return snippet, nil
 	case interfaces.SecurityDBus:
 		return []byte(locationControlConnectedPlugDBus), nil
 	}
 	return nil, nil
 }
 
+func (iface *LocationControlInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(locationControlPermanentSlotAppArmor)
+}
+
 func (iface *LocationControlInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(locationControlPermanentSlotAppArmor), nil
 	case interfaces.SecurityDBus:
 		return []byte(locationControlPermanentSlotDBus), nil
 	}
 	return nil, nil
 }
 
+func (iface *LocationControlInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(locationControlConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *LocationControlInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(locationControlConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -153,7 +153,8 @@ func (iface *LocationControlInterface) AppArmorConnectedPlug(spec *apparmor.Spec
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(locationControlConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *LocationControlInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -165,7 +166,8 @@ func (iface *LocationControlInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 }
 
 func (iface *LocationControlInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(locationControlPermanentSlotAppArmor)
+	spec.AddSnippet(locationControlPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *LocationControlInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -180,7 +182,8 @@ func (iface *LocationControlInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(locationControlConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *LocationControlInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/location_control_test.go
+++ b/interfaces/builtin/location_control_test.go
@@ -23,8 +23,10 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -34,23 +36,35 @@ type LocationControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&LocationControlInterfaceSuite{
-	iface: &builtin.LocationControlInterface{},
-	slot: &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "location"},
-			Name:      "location",
-			Interface: "location-control",
-		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "location"},
-			Name:      "location-client",
-			Interface: "location-control",
-		},
-	},
-})
+var _ = Suite(&LocationControlInterfaceSuite{})
+
+func (s *LocationControlInterfaceSuite) SetUpTest(c *C) {
+	var plugSnapInfoYaml = `name: location-consumer
+version: 1.0
+plugs:
+ location-client:
+  interface: location-control
+apps:
+ app:
+  command: foo
+  plugs: [location-client]
+`
+	var slotSnapInfoYaml = `name: location
+version: 1.0
+slots:
+ location:
+  interface: location-control
+apps:
+ app2:
+  command: foo
+  slots: [location]
+`
+	s.iface = &builtin.LocationControlInterface{}
+	snapInfo := snaptest.MockInfo(c, plugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["location-client"]}
+	snapInfo = snaptest.MockInfo(c, slotSnapInfoYaml, nil)
+	s.slot = &interfaces.Slot{SlotInfo: snapInfo.Slots["location"]}
+}
 
 func (s *LocationControlInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "location-control")
@@ -71,9 +85,12 @@ func (s *LocationControlInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.location-consumer.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.location-consumer.app"), testutil.Contains, `peer=(label="snap.location.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the location slot
@@ -92,9 +109,12 @@ func (s *LocationControlInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSom
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.location-consumer.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.location-consumer.app"), testutil.Contains, `peer=(label="snap.location.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the location slot
@@ -111,9 +131,12 @@ func (s *LocationControlInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.location-consumer.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.location-consumer.app"), testutil.Contains, `peer=(label="snap.location.app"),`)
 }
 
 // The label glob when all apps are bound to the location plug
@@ -131,9 +154,12 @@ func (s *LocationControlInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelAll
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.location.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.location.app2"), testutil.Contains, `peer=(label="snap.location.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the location plug
@@ -152,9 +178,12 @@ func (s *LocationControlInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelSom
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.location.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.location.app2"), testutil.Contains, `peer=(label="snap.location.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the location plug
@@ -171,19 +200,10 @@ func (s *LocationControlInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.app"),`)
-}
 
-func (s *LocationControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.location.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.location.app2"), testutil.Contains, `peer=(label="snap.location.app"),`)
 }

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -221,7 +221,8 @@ func (iface *LocationObserveInterface) AppArmorConnectedPlug(spec *apparmor.Spec
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(locationObserveConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *LocationObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -234,7 +235,8 @@ func (iface *LocationObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 }
 
 func (iface *LocationObserveInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(locationObservePermanentSlotAppArmor)
+	spec.AddSnippet(locationObservePermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *LocationObserveInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -250,7 +252,8 @@ func (iface *LocationObserveInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(locationObserveConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *LocationObserveInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -20,9 +20,10 @@
 package builtin
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 const locationObservePermanentSlotAppArmor = `
@@ -216,13 +217,15 @@ func (iface *LocationObserveInterface) PermanentPlugSnippet(plug *interfaces.Plu
 	return nil, nil
 }
 
+func (iface *LocationObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(locationObserveConnectedPlugAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *LocationObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(locationObserveConnectedPlugAppArmor), old, new, -1)
-		return snippet, nil
 	case interfaces.SecurityDBus:
 		return []byte(locationObserveConnectedPlugDBus), nil
 	default:
@@ -230,10 +233,12 @@ func (iface *LocationObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 	}
 }
 
+func (iface *LocationObserveInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(locationObservePermanentSlotAppArmor)
+}
+
 func (iface *LocationObserveInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(locationObservePermanentSlotAppArmor), nil
 	case interfaces.SecurityDBus:
 		return []byte(locationObservePermanentSlotDBus), nil
 	default:
@@ -241,16 +246,15 @@ func (iface *LocationObserveInterface) PermanentSlotSnippet(slot *interfaces.Slo
 	}
 }
 
+func (iface *LocationObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(locationObserveConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *LocationObserveInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(locationObserveConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	default:
-		return nil, nil
-	}
+	return nil, nil
 }
 
 func (iface *LocationObserveInterface) SanitizePlug(plug *interfaces.Plug) error {

--- a/interfaces/builtin/location_observe_test.go
+++ b/interfaces/builtin/location_observe_test.go
@@ -23,8 +23,10 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -34,23 +36,29 @@ type LocationObserveInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&LocationObserveInterfaceSuite{
-	iface: &builtin.LocationObserveInterface{},
-	slot: &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "location"},
-			Name:      "location",
-			Interface: "location-observe",
-		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "location"},
-			Name:      "location-client",
-			Interface: "location-observe",
-		},
-	},
-})
+var _ = Suite(&LocationObserveInterfaceSuite{})
+
+func (s *LocationObserveInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [location-observe]
+`
+	var mockSlotSnapInfoYaml = `name: location
+version: 1.0
+apps:
+ app2:
+  command: foo
+  slots: [location-observe]
+`
+	s.iface = &builtin.LocationObserveInterface{}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["location-observe"]}
+	snapInfo = snaptest.MockInfo(c, mockSlotSnapInfoYaml, nil)
+	s.slot = &interfaces.Slot{SlotInfo: snapInfo.Slots["location-observe"]}
+}
 
 func (s *LocationObserveInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "location-observe")
@@ -71,9 +79,12 @@ func (s *LocationObserveInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.location.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the location slot
@@ -92,9 +103,12 @@ func (s *LocationObserveInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSom
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.location.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the location slot
@@ -111,9 +125,12 @@ func (s *LocationObserveInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.location.app"),`)
 }
 
 // The label glob when all apps are bound to the location plug
@@ -131,9 +148,12 @@ func (s *LocationObserveInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelAll
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.location.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.location.app2"), testutil.Contains, `peer=(label="snap.location.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the location plug
@@ -152,9 +172,12 @@ func (s *LocationObserveInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelSom
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.location.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.location.app2"), testutil.Contains, `peer=(label="snap.location.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the location plug
@@ -171,19 +194,10 @@ func (s *LocationObserveInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.location.app"),`)
-}
 
-func (s *LocationObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.location.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.location.app2"), testutil.Contains, `peer=(label="snap.location.app"),`)
 }

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
@@ -50,10 +51,11 @@ func (iface *LxdInterface) PermanentPlugSnippet(plug *interfaces.Plug, securityS
 	return nil, nil
 }
 
+func (iface *LxdInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(lxdConnectedPlugAppArmor)
+}
+
 func (iface *LxdInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	if securitySystem == interfaces.SecurityAppArmor {
-		return []byte(lxdConnectedPlugAppArmor), nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -52,7 +52,8 @@ func (iface *LxdInterface) PermanentPlugSnippet(plug *interfaces.Plug, securityS
 }
 
 func (iface *LxdInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(lxdConnectedPlugAppArmor)
+	spec.AddSnippet(lxdConnectedPlugAppArmor)
+	return nil
 }
 
 func (iface *LxdInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -21,6 +21,7 @@ package builtin
 
 import (
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
@@ -48,10 +49,11 @@ func (iface *LxdSupportInterface) PermanentPlugSnippet(plug *interfaces.Plug, se
 	return nil, nil
 }
 
+func (iface *LxdSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(lxdSupportConnectedPlugAppArmor)
+}
+
 func (iface *LxdSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	if securitySystem == interfaces.SecurityAppArmor {
-		return []byte(lxdSupportConnectedPlugAppArmor), nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -50,7 +50,8 @@ func (iface *LxdSupportInterface) PermanentPlugSnippet(plug *interfaces.Plug, se
 }
 
 func (iface *LxdSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(lxdSupportConnectedPlugAppArmor)
+	spec.AddSnippet(lxdSupportConnectedPlugAppArmor)
+	return nil
 }
 
 func (iface *LxdSupportInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -75,15 +76,18 @@ func (s *LxdSupportInterfaceSuite) TestSanitizePlug(c *C) {
 
 func (s *LxdSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
 }
 
 func (s *LxdSupportInterfaceSuite) TestPermanentSlotPolicyAppArmor(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Check(string(snippet), testutil.Contains, "/usr/sbin/aa-exec ux,\n")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.lxd.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.lxd.app"), testutil.Contains, "/usr/sbin/aa-exec ux,\n")
 }
 
 func (s *LxdSupportInterfaceSuite) TestConnectedPlugPolicySecComp(c *C) {

--- a/interfaces/builtin/maliit.go
+++ b/interfaces/builtin/maliit.go
@@ -20,10 +20,12 @@
 package builtin
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
 const maliitPermanentSlotAppArmor = `
@@ -122,34 +124,36 @@ func (iface *MaliitInterface) PermanentPlugSnippet(plug *interfaces.Plug, securi
 }
 
 func (iface *MaliitInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(maliitConnectedPlugAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
+}
+
+func (iface *MaliitInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(maliitConnectedPlugAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *MaliitInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(maliitPermanentSlotSecComp)
 }
 
 func (iface *MaliitInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(maliitPermanentSlotAppArmor), nil
-	case interfaces.SecuritySecComp:
-		return []byte(maliitPermanentSlotSecComp), nil
-	}
 	return nil, nil
 }
 
+func (iface *MaliitInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(maliitPermanentSlotAppArmor)
+}
+
+func (iface *MaliitInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(maliitConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *MaliitInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(maliitConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/maliit.go
+++ b/interfaces/builtin/maliit.go
@@ -131,7 +131,8 @@ func (iface *MaliitInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(maliitConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *MaliitInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
@@ -143,14 +144,16 @@ func (iface *MaliitInterface) PermanentSlotSnippet(slot *interfaces.Slot, securi
 }
 
 func (iface *MaliitInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(maliitPermanentSlotAppArmor)
+	spec.AddSnippet(maliitPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *MaliitInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(maliitConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *MaliitInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -89,14 +89,16 @@ func (iface *MirInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(mirConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *MirInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(mirConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *MirInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -104,7 +106,8 @@ func (iface *MirInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *int
 }
 
 func (iface *MirInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(mirPermanentSlotAppArmor)
+	spec.AddSnippet(mirPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *MirInterface) PermanentSlotSnippet(

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -20,9 +20,10 @@
 package builtin
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
@@ -84,23 +85,31 @@ func (iface *MirInterface) PermanentPlugSnippet(plug *interfaces.Plug, securityS
 	return nil, nil
 }
 
+func (iface *MirInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(mirConnectedPlugAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *MirInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(mirConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *MirInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(mirConnectedPlugAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
+}
+
+func (iface *MirInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(mirPermanentSlotAppArmor)
 }
 
 func (iface *MirInterface) PermanentSlotSnippet(
 	slot *interfaces.Slot,
 	securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	if securitySystem == interfaces.SecurityAppArmor {
-		return []byte(mirPermanentSlotAppArmor), nil
-	}
 	return nil, nil
 }
 
@@ -109,13 +118,6 @@ func (iface *MirInterface) SecCompPermanentSlot(spec *seccomp.Specification, slo
 }
 
 func (iface *MirInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(mirConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -23,45 +23,57 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type MirInterfaceSuite struct {
-	iface interfaces.Interface
-	slot  *interfaces.Slot
-	plug  *interfaces.Plug
+	iface       interfaces.Interface
+	coreSlot    *interfaces.Slot
+	classicSlot *interfaces.Slot
+	plug        *interfaces.Plug
 }
 
-var _ = Suite(&MirInterfaceSuite{
-	iface: &builtin.MirInterface{},
-	slot: &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "mir-server", Type: snap.TypeOS},
-			Name:      "mir-server",
-			Interface: "mir",
-		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "mir-client",
-			Interface: "mir",
-		},
-	},
-})
+var _ = Suite(&MirInterfaceSuite{})
 
 func (s *MirInterfaceSuite) SetUpTest(c *C) {
-	s.slot = &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "mir-server", Type: snap.TypeOS},
-			Name:      "mir-server",
-			Interface: "mir",
-		},
-	}
+	// a pulseaudio slot on the core snap (as automatically added on classic)
+	const mirMockClassicSlotSnapInfoYaml = `name: core
+type: os
+slots:
+ mir:
+  interface: mir
+`
+	const mirMockSlotSnapInfoYaml = `name: mir-server
+version: 1.0
+slots:
+ mir:
+  interface: mir
+apps:
+ mir:
+  command: foo
+  slots: [mir]
+`
+	const mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app2:
+  command: foo
+  plugs: [mir]
+`
+	s.iface = &builtin.MirInterface{}
+	// mir snap with mir-server slot on an core/all-snap install.
+	snapInfo := snaptest.MockInfo(c, mirMockSlotSnapInfoYaml, nil)
+	s.coreSlot = &interfaces.Slot{SlotInfo: snapInfo.Slots["mir"]}
+	// mir slot on a core snap in a classic install.
+	snapInfo = snaptest.MockInfo(c, mirMockClassicSlotSnapInfoYaml, nil)
+	s.classicSlot = &interfaces.Slot{SlotInfo: snapInfo.Slots["mir"]}
+	// snap with the mir plug
+	snapInfo = snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["mir"]}
 }
 
 func (s *MirInterfaceSuite) TestName(c *C) {
@@ -69,15 +81,28 @@ func (s *MirInterfaceSuite) TestName(c *C) {
 }
 
 func (s *MirInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.mir-server.mir"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.mir-server.mir"), testutil.Contains, "capability sys_tty_config")
+
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddPermanentSlot(s.iface, s.classicSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
+
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.mir-server.mir"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.mir-server.mir"), testutil.Contains, "unix (receive, send) type=seqpacket addr=none peer=(label=\"snap.other")
+
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.coreSlot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "/run/mir_socket rw,")
 }
 
 const mirMockSlotSnapInfoYaml = `name: mir-server
@@ -93,11 +118,8 @@ apps:
 `
 
 func (s *MirInterfaceSuite) TestSecComp(c *C) {
-	slotSnap := snaptest.MockInfo(c, mirMockSlotSnapInfoYaml, nil)
-	slot := &interfaces.Slot{SlotInfo: slotSnap.Slots["mir-server"]}
-
 	seccompSpec := &seccomp.Specification{}
-	err := seccompSpec.AddPermanentSlot(s.iface, slot)
+	err := seccompSpec.AddPermanentSlot(s.iface, s.coreSlot)
 	c.Assert(err, IsNil)
 	snippets := seccompSpec.Snippets()
 	c.Assert(len(snippets), Equals, 1)
@@ -107,7 +129,7 @@ func (s *MirInterfaceSuite) TestSecComp(c *C) {
 
 func (s *MirInterfaceSuite) TestSecCompOnClassic(c *C) {
 	seccompSpec := &seccomp.Specification{}
-	err := seccompSpec.AddPermanentSlot(s.iface, s.slot)
+	err := seccompSpec.AddPermanentSlot(s.iface, s.classicSlot)
 	c.Assert(err, IsNil)
 	snippets := seccompSpec.Snippets()
 	// no permanent seccomp snippet for the slot

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -20,9 +20,10 @@
 package builtin
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
 )
@@ -1160,27 +1161,31 @@ func (iface *ModemManagerInterface) PermanentPlugSnippet(plug *interfaces.Plug, 
 	return nil, nil
 }
 
+func (iface *ModemManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(modemManagerConnectedPlugAppArmor, old, new, -1)
+	if release.OnClassic {
+		// Let confined apps access unconfined ofono on classic
+		snippet += modemManagerConnectedPlugAppArmorClassic
+	}
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *ModemManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
 	case interfaces.SecurityDBus:
 		return []byte(modemManagerConnectedPlugDBus), nil
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(modemManagerConnectedPlugAppArmor), old, new, -1)
-		if release.OnClassic {
-			// Let confined apps access unconfined ofono on classic
-			snippet = append(snippet, modemManagerConnectedPlugAppArmorClassic...)
-		}
-		return snippet, nil
 	}
 	return nil, nil
 }
 
+func (iface *ModemManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(modemManagerPermanentSlotAppArmor)
+}
+
 func (iface *ModemManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(modemManagerPermanentSlotAppArmor), nil
 	case interfaces.SecurityUDev:
 		return []byte(modemManagerPermanentSlotUdev), nil
 	case interfaces.SecurityDBus:
@@ -1189,18 +1194,18 @@ func (iface *ModemManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, 
 	return nil, nil
 }
 
+func (iface *ModemManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(modemManagerConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *ModemManagerInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	return spec.AddSnippet(modemManagerPermanentSlotSecComp)
 }
 
 func (iface *ModemManagerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(modemManagerConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1164,12 +1164,11 @@ func (iface *ModemManagerInterface) PermanentPlugSnippet(plug *interfaces.Plug, 
 func (iface *ModemManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
-	snippet := strings.Replace(modemManagerConnectedPlugAppArmor, old, new, -1)
+	spec.AddSnippet(strings.Replace(modemManagerConnectedPlugAppArmor, old, new, -1))
 	if release.OnClassic {
 		// Let confined apps access unconfined ofono on classic
-		snippet += modemManagerConnectedPlugAppArmorClassic
+		spec.AddSnippet(modemManagerConnectedPlugAppArmorClassic)
 	}
-	spec.AddSnippet(snippet)
 	return nil
 }
 

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1169,7 +1169,8 @@ func (iface *ModemManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 		// Let confined apps access unconfined ofono on classic
 		snippet += modemManagerConnectedPlugAppArmorClassic
 	}
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *ModemManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -1181,7 +1182,8 @@ func (iface *ModemManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, 
 }
 
 func (iface *ModemManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(modemManagerPermanentSlotAppArmor)
+	spec.AddSnippet(modemManagerPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *ModemManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -1198,7 +1200,8 @@ func (iface *ModemManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specifi
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(modemManagerConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *ModemManagerInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
@@ -43,6 +44,18 @@ apps:
  mm:
   command: foo
   slots: [modem-manager]
+`
+
+const modemmgrMockPlugSnapInfoYaml = `name: modem-manager
+version: 1.0
+plugs:
+ modem-manager:
+  interface: modem-manager
+apps:
+ mmcli:
+  command: foo
+  plugs:
+   - modem-manager
 `
 
 var _ = Suite(&ModemManagerInterfaceSuite{})
@@ -71,7 +84,7 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c 
 	slot := &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap: &snap.Info{
-				SuggestedName: "modem-manager",
+				SuggestedName: "modem-manager-prod",
 				Apps:          map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 			},
 			Name:      "modem-manager",
@@ -80,9 +93,15 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c 
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
+	plug := &interfaces.Plug{PlugInfo: plugSnap.Plugs["modem-manager"]}
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.modem-manager.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.modem-manager.mmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.modem-manager.mmcli"), testutil.Contains, `peer=(label="snap.modem-manager-prod.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the modem-manager slot
@@ -102,9 +121,15 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
+	plug := &interfaces.Plug{PlugInfo: plugSnap.Plugs["modem-manager"]}
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.modem-manager.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.modem-manager.mmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.modem-manager.mmcli"), testutil.Contains, `peer=(label="snap.modem-manager.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the modem-manager slot
@@ -122,34 +147,52 @@ func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c 
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
+	plug := &interfaces.Plug{PlugInfo: plugSnap.Plugs["modem-manager"]}
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.modem-manager.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.modem-manager.mmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.modem-manager.mmcli"), testutil.Contains, `peer=(label="snap.modem-manager.app"),`)
 }
 
 func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabelNot(c *C) {
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
+	plug := &interfaces.Plug{PlugInfo: plugSnap.Plugs["modem-manager"]}
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), Not(testutil.Contains), "peer=(label=unconfined),")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.modem-manager.mmcli"})
+	snippet := apparmorSpec.SnippetForTag("snap.modem-manager.mmcli")
+	c.Assert(snippet, Not(testutil.Contains), "peer=(label=unconfined),")
+	c.Assert(snippet, testutil.Contains, "org/freedesktop/ModemManager1")
 }
 
 func (s *ModemManagerInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabelOnClassic(c *C) {
 	release.OnClassic = true
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+
+	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
+	plug := &interfaces.Plug{PlugInfo: plugSnap.Plugs["modem-manager"]}
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, "peer=(label=unconfined),")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.modem-manager.mmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.modem-manager.mmcli"), testutil.Contains, "peer=(label=unconfined),")
 }
 
 func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	plugSnap := snaptest.MockInfo(c, modemmgrMockPlugSnapInfoYaml, nil)
+	plug := &interfaces.Plug{PlugInfo: plugSnap.Plugs["modem-manager"]}
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
 
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type MountObserveInterfaceSuite struct {
@@ -33,23 +36,27 @@ type MountObserveInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&MountObserveInterfaceSuite{
-	iface: builtin.NewMountObserveInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&MountObserveInterfaceSuite{})
+
+func (s *MountObserveInterfaceSuite) SetUpTest(c *C) {
+	const mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [mount-observe]
+`
+	s.iface = builtin.NewMountObserveInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "mount-observe",
 			Interface: "mount-observe",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "mount-observe",
-			Interface: "mount-observe",
-		},
-	},
-})
+	}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["mount-observe"]}
+}
 
 func (s *MountObserveInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "mount-observe")
@@ -80,7 +87,9 @@ func (s *MountObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *MountObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/etc/fstab")
 }

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -151,8 +151,7 @@ func (iface *MprisInterface) PermanentPlugSnippet(plug *interfaces.Plug, securit
 func (iface *MprisInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
-	snippet := strings.Replace(mprisConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	return spec.AddSnippet(strings.Replace(mprisConnectedPlugAppArmor, old, new, -1))
 }
 
 func (iface *MprisInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -167,20 +166,21 @@ func (iface *MprisInterface) AppArmorPermanentSlot(spec *apparmor.Specification,
 
 	old := "###MPRIS_NAME###"
 	new := name
-	snippet := strings.Replace(mprisPermanentSlotAppArmor, old, new, -1)
+	if err := spec.AddSnippet(strings.Replace(mprisPermanentSlotAppArmor, old, new, -1)); err != nil {
+		return err
+	}
 	// on classic, allow unconfined remotes to control the player
 	// (eg, indicator-sound)
 	if release.OnClassic {
-		snippet += "\n" + mprisConnectedSlotAppArmorClassic
+		return spec.AddSnippet(mprisConnectedSlotAppArmorClassic)
 	}
-	return spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *MprisInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
-	snippet := strings.Replace(mprisConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	return spec.AddSnippet(strings.Replace(mprisConnectedSlotAppArmor, old, new, -1))
 }
 
 func (iface *MprisInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -20,11 +20,12 @@
 package builtin
 
 import (
-	"bytes"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/release"
 )
 
@@ -147,46 +148,46 @@ func (iface *MprisInterface) PermanentPlugSnippet(plug *interfaces.Plug, securit
 	return nil, nil
 }
 
+func (iface *MprisInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(mprisConnectedPlugAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *MprisInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(mprisConnectedPlugAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 
-func (iface *MprisInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		name, err := iface.getName(slot.Attrs)
-		if err != nil {
-			return nil, err
-		}
-
-		old := []byte("###MPRIS_NAME###")
-		new := []byte(name)
-		snippet := bytes.Replace([]byte(mprisPermanentSlotAppArmor), old, new, -1)
-		// on classic, allow unconfined remotes to control the player
-		// (eg, indicator-sound)
-		if release.OnClassic {
-			snippet = append(snippet, mprisConnectedSlotAppArmorClassic...)
-		}
-		return snippet, nil
+func (iface *MprisInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	name, err := iface.getName(slot.Attrs)
+	if err != nil {
+		return err
 	}
+
+	old := "###MPRIS_NAME###"
+	new := name
+	snippet := strings.Replace(mprisPermanentSlotAppArmor, old, new, -1)
+	// on classic, allow unconfined remotes to control the player
+	// (eg, indicator-sound)
+	if release.OnClassic {
+		snippet += "\n" + mprisConnectedSlotAppArmorClassic
+	}
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *MprisInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(mprisConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *MprisInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
 }
 
 func (iface *MprisInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(mprisConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -151,7 +151,8 @@ func (iface *MprisInterface) PermanentPlugSnippet(plug *interfaces.Plug, securit
 func (iface *MprisInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
-	return spec.AddSnippet(strings.Replace(mprisConnectedPlugAppArmor, old, new, -1))
+	spec.AddSnippet(strings.Replace(mprisConnectedPlugAppArmor, old, new, -1))
+	return nil
 }
 
 func (iface *MprisInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -166,13 +167,11 @@ func (iface *MprisInterface) AppArmorPermanentSlot(spec *apparmor.Specification,
 
 	old := "###MPRIS_NAME###"
 	new := name
-	if err := spec.AddSnippet(strings.Replace(mprisPermanentSlotAppArmor, old, new, -1)); err != nil {
-		return err
-	}
+	spec.AddSnippet(strings.Replace(mprisPermanentSlotAppArmor, old, new, -1))
 	// on classic, allow unconfined remotes to control the player
 	// (eg, indicator-sound)
 	if release.OnClassic {
-		return spec.AddSnippet(mprisConnectedSlotAppArmorClassic)
+		spec.AddSnippet(mprisConnectedSlotAppArmorClassic)
 	}
 	return nil
 }
@@ -180,7 +179,8 @@ func (iface *MprisInterface) AppArmorPermanentSlot(spec *apparmor.Specification,
 func (iface *MprisInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
-	return spec.AddSnippet(strings.Replace(mprisConnectedSlotAppArmor, old, new, -1))
+	spec.AddSnippet(strings.Replace(mprisConnectedSlotAppArmor, old, new, -1))
+	return nil
 }
 
 func (iface *MprisInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/mpris_test.go
+++ b/interfaces/builtin/mpris_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -36,23 +37,30 @@ type MprisInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&MprisInterfaceSuite{
-	iface: &builtin.MprisInterface{},
-	slot: &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "mpris"},
-			Name:      "mpris-player",
-			Interface: "mpris",
-		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "mpris"},
-			Name:      "mpris-client",
-			Interface: "mpris",
-		},
-	},
-})
+var _ = Suite(&MprisInterfaceSuite{})
+
+func (s *MprisInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [mpris]
+`
+	var mockSlotSnapInfoYaml = `name: mpris
+version: 1.0
+apps:
+ app:
+  command: foo
+  slots: [mpris]
+`
+
+	s.iface = &builtin.MprisInterface{}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["mpris"]}
+	snapInfo = snaptest.MockInfo(c, mockSlotSnapInfoYaml, nil)
+	s.slot = &interfaces.Slot{SlotInfo: snapInfo.Slots["mpris"]}
+}
 
 func (s *MprisInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "mpris")
@@ -155,9 +163,12 @@ func (s *MprisInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.mpris.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.mpris.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps are bound to the mpris slot
@@ -176,9 +187,12 @@ func (s *MprisInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.mpris.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.mpris.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the mpris slot
@@ -195,9 +209,12 @@ func (s *MprisInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.mpris.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.mpris.app"),`)
 }
 
 // The label glob when all apps are bound to the mpris plug
@@ -215,9 +232,12 @@ func (s *MprisInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelAll(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.mpris.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.mpris.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.mpris.app"), testutil.Contains, `peer=(label="snap.mpris.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the mpris plug
@@ -236,9 +256,12 @@ func (s *MprisInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelSome(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.mpris.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.mpris.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.mpris.app"), testutil.Contains, `peer=(label="snap.mpris.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the mpris plug
@@ -255,18 +278,22 @@ func (s *MprisInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.mpris.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.mpris.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.mpris.app"), testutil.Contains, `peer=(label="snap.mpris.app"),`)
 }
 
 func (s *MprisInterfaceSuite) TestPermanentSlotAppArmor(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.mpris.app"})
 
 	// verify bind rule
-	c.Check(string(snippet), testutil.Contains, "dbus (bind)\n    bus=session\n    name=\"org.mpris.MediaPlayer2.@{SNAP_NAME}{,.*}\",\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.mpris.app"), testutil.Contains, "dbus (bind)\n    bus=session\n    name=\"org.mpris.MediaPlayer2.@{SNAP_NAME}{,.*}\",\n")
 }
 
 func (s *MprisInterfaceSuite) TestPermanentSlotAppArmorWithName(c *C) {
@@ -276,47 +303,44 @@ slots:
  mpris-slot:
   interface: mpris
   name: foo
+apps:
+ app:
+  command: foo
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
-	iface := &builtin.MprisInterface{}
-	snippet, err := iface.PermanentSlotSnippet(slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.mpris-client.app"})
 
 	// verify bind rule
-	c.Check(string(snippet), testutil.Contains, "dbus (bind)\n    bus=session\n    name=\"org.mpris.MediaPlayer2.foo{,.*}\",\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.mpris-client.app"), testutil.Contains, "dbus (bind)\n    bus=session\n    name=\"org.mpris.MediaPlayer2.foo{,.*}\",\n")
 }
 
 func (s *MprisInterfaceSuite) TestPermanentSlotAppArmorNative(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
-	iface := &builtin.MprisInterface{}
-	snippet, err := iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.mpris.app"})
 
 	// verify classic rule not present
-	c.Check(string(snippet), Not(testutil.Contains), "# Allow unconfined clients to interact with the player on classic\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.mpris.app"), Not(testutil.Contains), "# Allow unconfined clients to interact with the player on classic\n")
 }
 
 func (s *MprisInterfaceSuite) TestPermanentSlotAppArmorClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
-	iface := &builtin.MprisInterface{}
-	snippet, err := iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.mpris.app"})
 
 	// verify classic rule present
-	c.Check(string(snippet), testutil.Contains, "# Allow unconfined clients to interact with the player on classic\n")
-}
-
-func (s *MprisInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SnippetForTag("snap.mpris.app"), testutil.Contains, "# Allow unconfined clients to interact with the player on classic\n")
 }

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -87,9 +88,12 @@ func (s *NetworkBindInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *NetworkBindInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `/sys/net`)
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,10 +89,12 @@ func (s *NetworkControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *NetworkControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "/run/netns/* rw,\n")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "/run/netns/* rw,\n")
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -391,14 +391,16 @@ func (iface *NetworkManagerInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 		new = slotAppLabelExpr(slot)
 	}
 	snippet := strings.Replace(networkManagerConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *NetworkManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(networkManagerConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *NetworkManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -406,7 +408,8 @@ func (iface *NetworkManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug
 }
 
 func (iface *NetworkManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(networkManagerPermanentSlotAppArmor)
+	spec.AddSnippet(networkManagerPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *NetworkManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/network_manager_test.go
+++ b/interfaces/builtin/network_manager_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
@@ -37,6 +38,17 @@ type NetworkManagerInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
+const netmgrMockPlugSnapInfoYaml = `name: network-manager-client
+version: 1.0
+plugs:
+ network-manager:
+  interface: network-manager
+apps:
+ nmcli:
+  command: foo
+  plugs:
+   - network-manager
+`
 const netmgrMockSlotSnapInfoYaml = `name: network-manager
 version: 1.0
 apps:
@@ -49,13 +61,9 @@ var _ = Suite(&NetworkManagerInterfaceSuite{})
 
 func (s *NetworkManagerInterfaceSuite) SetUpTest(c *C) {
 	s.iface = &builtin.NetworkManagerInterface{}
-	s.plug = &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "network-manager"},
-			Name:      "nmcli",
-			Interface: "network-manager",
-		},
-	}
+	plugSnap := snaptest.MockInfo(c, netmgrMockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["network-manager"]}
+
 	slotSnap := snaptest.MockInfo(c, netmgrMockSlotSnapInfoYaml, nil)
 	s.slot = &interfaces.Slot{SlotInfo: slotSnap.Slots["network-manager"]}
 }
@@ -80,9 +88,13 @@ func (s *NetworkManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	// connected plugs have a non-nil security snippet for apparmor
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.network-manager.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.network-manager-client.nmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager-client.nmcli"), testutil.Contains, `peer=(label="snap.network-manager.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the network-manager slot
@@ -102,9 +114,12 @@ func (s *NetworkManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.network-manager.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.network-manager-client.nmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager-client.nmcli"), testutil.Contains, `peer=(label="snap.network-manager.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the network-manager slot
@@ -122,35 +137,40 @@ func (s *NetworkManagerInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.network-manager.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.network-manager-client.nmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager-client.nmcli"), testutil.Contains, `peer=(label="snap.network-manager.app"),`)
 }
 
 func (s *NetworkManagerInterfaceSuite) TestConnectedPlugSnippedUsesUnconfinedLabelOnClassic(c *C) {
 	slot := &interfaces.Slot{}
 	release.OnClassic = true
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, "peer=(label=unconfined),")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.network-manager-client.nmcli"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager-client.nmcli"), testutil.Contains, "peer=(label=unconfined),")
 }
 
 func (s *NetworkManagerInterfaceSuite) TestConnectedSlotSnippetAppArmor(c *C) {
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "peer=(label=\"snap.network-manager.*\")")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.network-manager.nm"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.network-manager.nm"), testutil.Contains, `/org/freedesktop/NetworkManager`)
 }
 
 func (s *NetworkManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	err = apparmorSpec.AddPermanentSlot(s.iface, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 2)
+
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,9 +89,12 @@ func (s *NetworkObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *NetworkObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `net_raw`)
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type NetworkSetupObserveInterfaceSuite struct {
@@ -33,23 +36,27 @@ type NetworkSetupObserveInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&NetworkSetupObserveInterfaceSuite{
-	iface: builtin.NewNetworkSetupObserveInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&NetworkSetupObserveInterfaceSuite{})
+
+func (s *NetworkSetupObserveInterfaceSuite) SetUpTest(c *C) {
+	const mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [network-setup-observe]
+`
+	s.iface = builtin.NewNetworkSetupObserveInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "network-setup-observe",
 			Interface: "network-setup-observe",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "network-setup-observe",
-			Interface: "network-setup-observe",
-		},
-	},
-})
+	}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["network-setup-observe"]}
+}
 
 func (s *NetworkSetupObserveInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "network-setup-observe")
@@ -80,7 +87,9 @@ func (s *NetworkSetupObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C)
 
 func (s *NetworkSetupObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/etc/netplan")
 }

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,9 +89,12 @@ func (s *NetworkInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *NetworkInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `tcp_fastopen`)
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -20,9 +20,10 @@
 package builtin
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
 )
@@ -243,25 +244,28 @@ func (iface *OfonoInterface) PermanentPlugSnippet(plug *interfaces.Plug, securit
 	return nil, nil
 }
 
-func (iface *OfonoInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(ofonoConnectedPlugAppArmor), old, new, -1)
-		if release.OnClassic {
-			// Let confined apps access unconfined ofono on classic
-			snippet = append(snippet, ofonoConnectedPlugAppArmorClassic...)
-		}
-		return snippet, nil
+func (iface *OfonoInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(ofonoConnectedPlugAppArmor, old, new, -1)
+	if release.OnClassic {
+		// Let confined apps access unconfined ofono on classic
+		snippet += "\n" + ofonoConnectedPlugAppArmorClassic
 	}
+	return spec.AddSnippet(snippet)
+
+}
+
+func (iface *OfonoInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
+}
+
+func (iface *OfonoInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(ofonoPermanentSlotAppArmor)
 }
 
 func (iface *OfonoInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(ofonoPermanentSlotAppArmor), nil
 	case interfaces.SecurityUDev:
 		return []byte(ofonoPermanentSlotUdev), nil
 	case interfaces.SecurityDBus:
@@ -270,18 +274,18 @@ func (iface *OfonoInterface) PermanentSlotSnippet(slot *interfaces.Slot, securit
 	return nil, nil
 }
 
+func (iface *OfonoInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(ofonoConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *OfonoInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	return spec.AddSnippet(ofonoPermanentSlotSecComp)
 }
 
 func (iface *OfonoInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(ofonoConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -247,12 +247,14 @@ func (iface *OfonoInterface) PermanentPlugSnippet(plug *interfaces.Plug, securit
 func (iface *OfonoInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
-	snippet := strings.Replace(ofonoConnectedPlugAppArmor, old, new, -1)
+	if err := spec.AddSnippet(strings.Replace(ofonoConnectedPlugAppArmor, old, new, -1)); err != nil {
+		return err
+	}
 	if release.OnClassic {
 		// Let confined apps access unconfined ofono on classic
-		snippet += "\n" + ofonoConnectedPlugAppArmorClassic
+		return spec.AddSnippet(ofonoConnectedPlugAppArmorClassic)
 	}
-	return spec.AddSnippet(snippet)
+	return nil
 
 }
 
@@ -277,8 +279,7 @@ func (iface *OfonoInterface) PermanentSlotSnippet(slot *interfaces.Slot, securit
 func (iface *OfonoInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
-	snippet := strings.Replace(ofonoConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	return spec.AddSnippet(strings.Replace(ofonoConnectedSlotAppArmor, old, new, -1))
 }
 
 func (iface *OfonoInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -247,12 +247,10 @@ func (iface *OfonoInterface) PermanentPlugSnippet(plug *interfaces.Plug, securit
 func (iface *OfonoInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
-	if err := spec.AddSnippet(strings.Replace(ofonoConnectedPlugAppArmor, old, new, -1)); err != nil {
-		return err
-	}
+	spec.AddSnippet(strings.Replace(ofonoConnectedPlugAppArmor, old, new, -1))
 	if release.OnClassic {
 		// Let confined apps access unconfined ofono on classic
-		return spec.AddSnippet(ofonoConnectedPlugAppArmorClassic)
+		spec.AddSnippet(ofonoConnectedPlugAppArmorClassic)
 	}
 	return nil
 
@@ -263,7 +261,8 @@ func (iface *OfonoInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *i
 }
 
 func (iface *OfonoInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(ofonoPermanentSlotAppArmor)
+	spec.AddSnippet(ofonoPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *OfonoInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -279,7 +278,8 @@ func (iface *OfonoInterface) PermanentSlotSnippet(slot *interfaces.Slot, securit
 func (iface *OfonoInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
-	return spec.AddSnippet(strings.Replace(ofonoConnectedSlotAppArmor, old, new, -1))
+	spec.AddSnippet(strings.Replace(ofonoConnectedSlotAppArmor, old, new, -1))
+	return nil
 }
 
 func (iface *OfonoInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {

--- a/interfaces/builtin/openvswitch_test.go
+++ b/interfaces/builtin/openvswitch_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type OpenvSwitchInterfaceSuite struct {
@@ -33,23 +36,27 @@ type OpenvSwitchInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&OpenvSwitchInterfaceSuite{
-	iface: builtin.NewOpenvSwitchInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&OpenvSwitchInterfaceSuite{})
+
+func (s *OpenvSwitchInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [openvswitch]
+`
+	s.iface = builtin.NewOpenvSwitchInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "openvswitch",
 			Interface: "openvswitch",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "openvswitch",
-			Interface: "openvswitch",
-		},
-	},
-})
+	}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["openvswitch"]}
+}
 
 func (s *OpenvSwitchInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "openvswitch")
@@ -79,8 +86,9 @@ func (s *OpenvSwitchInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 }
 
 func (s *OpenvSwitchInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "run/openvswitch/db.sock rw")
 }

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 const physicalMemoryControlConnectedPlugAppArmor = `
@@ -79,12 +80,13 @@ func (iface *PhysicalMemoryControlInterface) PermanentSlotSnippet(slot *interfac
 	return nil, nil
 }
 
+func (iface *PhysicalMemoryControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(physicalMemoryControlConnectedPlugAppArmor)
+}
+
 // Getter for the security snippet specific to the plug
 func (iface *PhysicalMemoryControlInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(physicalMemoryControlConnectedPlugAppArmor), nil
-
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
 		const udevRule = `KERNEL=="mem", TAG+="%s"`

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -81,7 +81,8 @@ func (iface *PhysicalMemoryControlInterface) PermanentSlotSnippet(slot *interfac
 }
 
 func (iface *PhysicalMemoryControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(physicalMemoryControlConnectedPlugAppArmor)
+	spec.AddSnippet(physicalMemoryControlConnectedPlugAppArmor)
+	return nil
 }
 
 // Getter for the security snippet specific to the plug

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -88,7 +89,7 @@ func (s *PhysicalMemoryControlInterfaceSuite) TestSanitizeIncorrectInterface(c *
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	expectedSnippet1 := []byte(`
+	expectedSnippet1 := `
 # Description: With kernels with STRICT_DEVMEM=n, write access to all physical
 # memory.
 #
@@ -98,16 +99,19 @@ func (s *PhysicalMemoryControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 # (eg, X without KMS, dosemu, etc).
 capability sys_rawio,
 /dev/mem rw,
-`)
+`
 	expectedSnippet2 := []byte(`KERNEL=="mem", TAG+="snap_client-snap_app-accessing-physical-memory"
 `)
 
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, snippet))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-physical-memory"})
+	aasnippet := apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-physical-memory")
+	c.Assert(aasnippet, Equals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, aasnippet))
 
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, expectedSnippet2, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet2, snippet))
 }

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -77,7 +77,8 @@ func (iface *PhysicalMemoryObserveInterface) PermanentSlotSnippet(slot *interfac
 }
 
 func (iface *PhysicalMemoryObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(physicalMemoryObserveConnectedPlugAppArmor)
+	spec.AddSnippet(physicalMemoryObserveConnectedPlugAppArmor)
+	return nil
 }
 
 // Getter for the security snippet specific to the plug

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 const physicalMemoryObserveConnectedPlugAppArmor = `
@@ -75,12 +76,13 @@ func (iface *PhysicalMemoryObserveInterface) PermanentSlotSnippet(slot *interfac
 	return nil, nil
 }
 
+func (iface *PhysicalMemoryObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(physicalMemoryObserveConnectedPlugAppArmor)
+}
+
 // Getter for the security snippet specific to the plug
 func (iface *PhysicalMemoryObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(physicalMemoryObserveConnectedPlugAppArmor), nil
-
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
 		const udevRule = `KERNEL=="mem", TAG+="%s"`

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -21,6 +21,7 @@ package builtin
 
 import (
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/kmod"
 )
 
@@ -58,11 +59,11 @@ func (iface *PppInterface) PermanentPlugSnippet(plug *interfaces.Plug, securityS
 	return nil, nil
 }
 
+func (iface *PppInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(pppConnectedPlugAppArmor)
+}
+
 func (iface *PppInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(pppConnectedPlugAppArmor), nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -60,7 +60,8 @@ func (iface *PppInterface) PermanentPlugSnippet(plug *interfaces.Plug, securityS
 }
 
 func (iface *PppInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(pppConnectedPlugAppArmor)
+	spec.AddSnippet(pppConnectedPlugAppArmor)
+	return nil
 }
 
 func (iface *PppInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/ppp_test.go
+++ b/interfaces/builtin/ppp_test.go
@@ -23,9 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/kmod"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type PppInterfaceSuite struct {
@@ -34,37 +36,50 @@ type PppInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&PppInterfaceSuite{
-	iface: &builtin.PppInterface{},
-	slot: &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "ppp"},
-			Name:      "ppp",
-			Interface: "ppp",
-		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "ppp"},
-			Name:      "mmcli",
-			Interface: "ppp",
-		},
-	},
-})
+var _ = Suite(&PppInterfaceSuite{})
+
+func (s *PppInterfaceSuite) SetUpTest(c *C) {
+	const mockPlugSnapInfo = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [ppp]
+`
+
+	const mockSlotSnapInfo = `name: ppp
+version: 1.0
+apps:
+ app:
+  command: foo
+  slots: [ppp]
+`
+
+	s.iface = &builtin.PppInterface{}
+	slotSnap := snaptest.MockInfo(c, mockPlugSnapInfo, nil)
+	s.slot = &interfaces.Slot{SlotInfo: slotSnap.Slots["ppp"]}
+
+	plugSnap := snaptest.MockInfo(c, mockPlugSnapInfo, nil)
+	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["ppp"]}
+}
 
 func (s *PppInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "ppp")
 }
 
 func (s *PppInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/usr/sbin/pppd ix,`)
 
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddPermanentSlot(s.iface, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
+
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityDBus)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, IsNil)
 	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityDBus)

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,9 +89,12 @@ func (s *ProcessControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *ProcessControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "capability sys_resource")
+
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -20,8 +20,6 @@
 package builtin
 
 import (
-	"bytes"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -122,13 +120,11 @@ func (iface *PulseAudioInterface) PermanentPlugSnippet(plug *interfaces.Plug, se
 }
 
 func (iface *PulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	spec.AddSnippet(pulseaudioConnectedPlugAppArmor)
 	if release.OnClassic {
-		b := bytes.NewBuffer([]byte(pulseaudioConnectedPlugAppArmor))
-		b.WriteString(pulseaudioConnectedPlugAppArmorDesktop)
-		return spec.AddSnippet(b.String())
-	} else {
-		return spec.AddSnippet(pulseaudioConnectedPlugAppArmor)
+		spec.AddSnippet(pulseaudioConnectedPlugAppArmorDesktop)
 	}
+	return nil
 }
 
 func (iface *PulseAudioInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -136,7 +132,8 @@ func (iface *PulseAudioInterface) ConnectedPlugSnippet(plug *interfaces.Plug, sl
 }
 
 func (iface *PulseAudioInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(pulseaudioPermanentSlotAppArmor)
+	spec.AddSnippet(pulseaudioPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *PulseAudioInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
 )
@@ -120,16 +121,25 @@ func (iface *PulseAudioInterface) PermanentPlugSnippet(plug *interfaces.Plug, se
 	return nil, nil
 }
 
-func (iface *PulseAudioInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	if securitySystem == interfaces.SecurityAppArmor {
-		if release.OnClassic {
-			b := bytes.NewBuffer([]byte(pulseaudioConnectedPlugAppArmor))
-			b.Write([]byte(pulseaudioConnectedPlugAppArmorDesktop))
-			return b.Bytes(), nil
-		} else {
-			return []byte(pulseaudioConnectedPlugAppArmor), nil
-		}
+func (iface *PulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if release.OnClassic {
+		b := bytes.NewBuffer([]byte(pulseaudioConnectedPlugAppArmor))
+		b.WriteString(pulseaudioConnectedPlugAppArmorDesktop)
+		return spec.AddSnippet(b.String())
+	} else {
+		return spec.AddSnippet(pulseaudioConnectedPlugAppArmor)
 	}
+}
+
+func (iface *PulseAudioInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+func (iface *PulseAudioInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(pulseaudioPermanentSlotAppArmor)
+}
+
+func (iface *PulseAudioInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
 }
 
@@ -139,13 +149,6 @@ func (iface *PulseAudioInterface) SecCompConnectedPlug(spec *seccomp.Specificati
 
 func (iface *PulseAudioInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	return spec.AddSnippet(pulseaudioPermanentSlotSecComp)
-}
-
-func (iface *PulseAudioInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	if securitySystem == interfaces.SecurityAppArmor {
-		return []byte(pulseaudioPermanentSlotAppArmor), nil
-	}
-	return nil, nil
 }
 
 func (iface *PulseAudioInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type RemovableMediaInterfaceSuite struct {
@@ -33,23 +36,26 @@ type RemovableMediaInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&RemovableMediaInterfaceSuite{
-	iface: builtin.NewRemovableMediaInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&RemovableMediaInterfaceSuite{})
+
+func (s *RemovableMediaInterfaceSuite) SetUpTest(c *C) {
+	consumingSnapInfo := snaptest.MockInfo(c, `
+name: client-snap
+apps:
+  other:
+    command: foo
+    plugs: [removable-media]
+`, nil)
+	s.iface = builtin.NewRemovableMediaInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "removable-media",
 			Interface: "removable-media",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "removable-media",
-			Interface: "removable-media",
-		},
-	},
-})
+	}
+	s.plug = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["removable-media"]}
+}
 
 func (s *RemovableMediaInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "removable-media")
@@ -80,7 +86,9 @@ func (s *RemovableMediaInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *RemovableMediaInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.other"})
+	c.Check(apparmorSpec.SnippetForTag("snap.client-snap.other"), testutil.Contains, "/{,run/}media/*/ r")
 }

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type ScreenInhibitControlInterfaceSuite struct {
@@ -33,23 +36,27 @@ type ScreenInhibitControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&ScreenInhibitControlInterfaceSuite{
-	iface: builtin.NewScreenInhibitControlInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&ScreenInhibitControlInterfaceSuite{})
+
+func (s *ScreenInhibitControlInterfaceSuite) SetUpTest(c *C) {
+	const mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [screen-inhibit-control]
+`
+	s.iface = builtin.NewScreenInhibitControlInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "screen-inhibit-control",
 			Interface: "screen-inhibit-control",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "screen-inhibit-control",
-			Interface: "screen-inhibit-control",
-		},
-	},
-})
+	}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["screen-inhibit-control"]}
+}
 
 func (s *ScreenInhibitControlInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "screen-inhibit-control")
@@ -80,7 +87,9 @@ func (s *ScreenInhibitControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C
 
 func (s *ScreenInhibitControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/com/canonical/Unity/Screen")
 }

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -155,7 +155,7 @@ func (iface *SerialPortInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 		// This apparmor rule is an approximation of serialDeviceNodePattern
 		// (AARE is different than regex, so we must approximate).
 		// UDev tagging and device cgroups will restrict down to the specific device
-		spec.AddSnippet("/dev/tty[A-Z]*[0-9] rw,\n")
+		spec.AddSnippet("/dev/tty[A-Z]*[0-9] rw,")
 		return nil
 	}
 
@@ -165,7 +165,7 @@ func (iface *SerialPortInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 		return nil
 	}
 	cleanedPath := filepath.Clean(path)
-	spec.AddSnippet(fmt.Sprintf("%s rw,\n", cleanedPath))
+	spec.AddSnippet(fmt.Sprintf("%s rw,", cleanedPath))
 	return nil
 }
 

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -155,7 +155,8 @@ func (iface *SerialPortInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 		// This apparmor rule is an approximation of serialDeviceNodePattern
 		// (AARE is different than regex, so we must approximate).
 		// UDev tagging and device cgroups will restrict down to the specific device
-		return spec.AddSnippet("/dev/tty[A-Z]*[0-9] rw,\n")
+		spec.AddSnippet("/dev/tty[A-Z]*[0-9] rw,\n")
+		return nil
 	}
 
 	// Path to fixed device node (no udev tagging)
@@ -164,7 +165,8 @@ func (iface *SerialPortInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 		return nil
 	}
 	cleanedPath := filepath.Clean(path)
-	return spec.AddSnippet(fmt.Sprintf("%s rw,\n", cleanedPath))
+	spec.AddSnippet(fmt.Sprintf("%s rw,\n", cleanedPath))
+	return nil
 }
 
 // ConnectedPlugSnippet returns security snippet specific to the plug

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -298,36 +298,28 @@ func (s *SerialPortInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 		c.Assert(snippet, DeepEquals, expectedSnippet, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet, snippet))
 	}
 
-	expectedSnippet1 := `/dev/ttyS0 rw,
-`
+	expectedSnippet1 := `/dev/ttyS0 rw,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot1, expectedSnippet1)
-	expectedSnippet2 := `/dev/ttyUSB927 rw,
-`
+	expectedSnippet2 := `/dev/ttyUSB927 rw,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot2, expectedSnippet2)
 
-	expectedSnippet3 := `/dev/ttyS42 rw,
-`
+	expectedSnippet3 := `/dev/ttyS42 rw,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot3, expectedSnippet3)
 
-	expectedSnippet4 := `/dev/ttyO0 rw,
-`
+	expectedSnippet4 := `/dev/ttyO0 rw,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot4, expectedSnippet4)
 
-	expectedSnippet5 := `/dev/ttyACM0 rw,
-`
+	expectedSnippet5 := `/dev/ttyACM0 rw,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot5, expectedSnippet5)
 
-	expectedSnippet6 := `/dev/ttyXRUSB0 rw,
-`
+	expectedSnippet6 := `/dev/ttyXRUSB0 rw,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot5, expectedSnippet5)
 
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot6, expectedSnippet6)
 
-	expectedSnippet7 := `/dev/tty[A-Z]*[0-9] rw,
-`
+	expectedSnippet7 := `/dev/tty[A-Z]*[0-9] rw,`
 	checkConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, expectedSnippet7)
 
-	expectedSnippet8 := `/dev/tty[A-Z]*[0-9] rw,
-`
+	expectedSnippet8 := `/dev/tty[A-Z]*[0-9] rw,`
 	checkConnectedPlugSnippet(s.testPlugPort2, s.testUdev2, expectedSnippet8)
 }

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -287,51 +288,46 @@ SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="ffff", ATTRS{idProduct}==
 }
 
 func (s *SerialPortInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
-	expectedSnippet1 := []byte(`/dev/ttyS0 rw,
-`)
-	snippet, err := s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testSlot1, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, snippet))
+	checkConnectedPlugSnippet := func(plug *interfaces.Plug, slot *interfaces.Slot, expectedSnippet string) {
+		apparmorSpec := &apparmor.Specification{}
+		err := apparmorSpec.AddConnectedPlug(s.iface, plug, slot)
+		c.Assert(err, IsNil)
 
-	expectedSnippet2 := []byte(`/dev/ttyUSB927 rw,
-`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testSlot2, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet2, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet2, snippet))
+		c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-2-ports"})
+		snippet := apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-2-ports")
+		c.Assert(snippet, DeepEquals, expectedSnippet, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet, snippet))
+	}
 
-	expectedSnippet3 := []byte(`/dev/ttyS42 rw,
-`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testSlot3, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet3, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet3, snippet))
+	expectedSnippet1 := `/dev/ttyS0 rw,
+`
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot1, expectedSnippet1)
+	expectedSnippet2 := `/dev/ttyUSB927 rw,
+`
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot2, expectedSnippet2)
 
-	expectedSnippet4 := []byte(`/dev/ttyO0 rw,
-`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testSlot4, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet4, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet4, snippet))
+	expectedSnippet3 := `/dev/ttyS42 rw,
+`
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot3, expectedSnippet3)
 
-	expectedSnippet5 := []byte(`/dev/ttyACM0 rw,
-`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testSlot5, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet5, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet5, snippet))
+	expectedSnippet4 := `/dev/ttyO0 rw,
+`
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot4, expectedSnippet4)
 
-	expectedSnippet6 := []byte(`/dev/ttyXRUSB0 rw,
-`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testSlot6, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet6, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet6, snippet))
+	expectedSnippet5 := `/dev/ttyACM0 rw,
+`
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot5, expectedSnippet5)
 
-	expectedSnippet7 := []byte(`/dev/tty[A-Z]*[0-9] rw,
-`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet7, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet7, snippet))
+	expectedSnippet6 := `/dev/ttyXRUSB0 rw,
+`
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot5, expectedSnippet5)
 
-	expectedSnippet8 := []byte(`/dev/tty[A-Z]*[0-9] rw,
-`)
-	snippet, err = s.iface.ConnectedPlugSnippet(s.testPlugPort2, s.testUdev2, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, DeepEquals, expectedSnippet8, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet8, snippet))
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testSlot6, expectedSnippet6)
+
+	expectedSnippet7 := `/dev/tty[A-Z]*[0-9] rw,
+`
+	checkConnectedPlugSnippet(s.testPlugPort1, s.testUdev1, expectedSnippet7)
+
+	expectedSnippet8 := `/dev/tty[A-Z]*[0-9] rw,
+`
+	checkConnectedPlugSnippet(s.testPlugPort2, s.testUdev2, expectedSnippet8)
 }

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type SnapdControlInterfaceSuite struct {
@@ -33,23 +36,26 @@ type SnapdControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&SnapdControlInterfaceSuite{
-	iface: builtin.NewSnapdControlInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&SnapdControlInterfaceSuite{})
+
+func (s *SnapdControlInterfaceSuite) SetUpTest(c *C) {
+	consumingSnapInfo := snaptest.MockInfo(c, `
+name: other
+apps:
+ app:
+    command: foo
+    plugs: [snapd-control]
+`, nil)
+	s.iface = builtin.NewSnapdControlInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "snapd-control",
 			Interface: "snapd-control",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "snapd-control",
-			Interface: "snapd-control",
-		},
-	},
-})
+	}
+	s.plug = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["snapd-control"]}
+}
 
 func (s *SnapdControlInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "snapd-control")
@@ -80,7 +86,9 @@ func (s *SnapdControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *SnapdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `/run/snapd.socket rw,`)
 }

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,9 +89,12 @@ func (s *SystemObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *SystemObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "ptrace")
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/thumbnailer.go
+++ b/interfaces/builtin/thumbnailer.go
@@ -20,10 +20,11 @@
 package builtin
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 const thumbnailerPermanentSlotAppArmor = `
@@ -87,39 +88,39 @@ func (iface *ThumbnailerInterface) PermanentPlugSnippet(plug *interfaces.Plug, s
 	return nil, nil
 }
 
+func (iface *ThumbnailerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	snippet := thumbnailerConnectedPlugAppArmor
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet = strings.Replace(snippet, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *ThumbnailerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		snippet := []byte(thumbnailerConnectedPlugAppArmor)
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet = bytes.Replace(snippet, old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
+}
+
+func (iface *ThumbnailerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(thumbnailerPermanentSlotAppArmor)
 }
 
 func (iface *ThumbnailerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(thumbnailerPermanentSlotAppArmor), nil
-	}
 	return nil, nil
 }
 
-func (iface *ThumbnailerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		snippet := []byte(thumbnailerConnectedSlotAppArmor)
-		old := []byte("###PLUG_SNAP_NAME###")
-		new := []byte(plug.Snap.Name())
-		snippet = bytes.Replace(snippet, old, new, -1)
+func (iface *ThumbnailerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	snippet := thumbnailerConnectedSlotAppArmor
+	old := "###PLUG_SNAP_NAME###"
+	new := plug.Snap.Name()
+	snippet = strings.Replace(snippet, old, new, -1)
 
-		old = []byte("###PLUG_SECURITY_TAGS###")
-		new = plugAppLabelExpr(plug)
-		snippet = bytes.Replace(snippet, old, new, -1)
-		return snippet, nil
-	}
+	old = "###PLUG_SECURITY_TAGS###"
+	new = plugAppLabelExpr(plug)
+	snippet = strings.Replace(snippet, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *ThumbnailerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
 }
 

--- a/interfaces/builtin/thumbnailer.go
+++ b/interfaces/builtin/thumbnailer.go
@@ -93,7 +93,8 @@ func (iface *ThumbnailerInterface) AppArmorConnectedPlug(spec *apparmor.Specific
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet = strings.Replace(snippet, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *ThumbnailerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -101,7 +102,8 @@ func (iface *ThumbnailerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, s
 }
 
 func (iface *ThumbnailerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(thumbnailerPermanentSlotAppArmor)
+	spec.AddSnippet(thumbnailerPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *ThumbnailerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -117,7 +119,8 @@ func (iface *ThumbnailerInterface) AppArmorConnectedSlot(spec *apparmor.Specific
 	old = "###PLUG_SECURITY_TAGS###"
 	new = plugAppLabelExpr(plug)
 	snippet = strings.Replace(snippet, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *ThumbnailerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/thumbnailer_test.go
+++ b/interfaces/builtin/thumbnailer_test.go
@@ -23,34 +23,56 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type ThumbnailerInterfaceSuite struct {
-	iface interfaces.Interface
-	slot  *interfaces.Slot
-	plug  *interfaces.Plug
+	iface       interfaces.Interface
+	coreSlot    *interfaces.Slot
+	classicSlot *interfaces.Slot
+	plug        *interfaces.Plug
 }
 
-var _ = Suite(&ThumbnailerInterfaceSuite{
-	iface: &builtin.ThumbnailerInterface{},
-	slot: &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "server", Type: snap.TypeOS},
-			Name:      "thumbnailer",
-			Interface: "thumbnailer",
-		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "client"},
-			Name:      "thumbnailer",
-			Interface: "thumbnailer",
-		},
-	},
-})
+var _ = Suite(&ThumbnailerInterfaceSuite{})
+
+func (s *ThumbnailerInterfaceSuite) SetUpTest(c *C) {
+	// a thumbnailer slot on a thumbnailer snap
+	const thumbnailerMockCoreSlotSnapInfoYaml = `name: thumbnailer
+version: 1.0
+apps:
+ app:
+  command: foo
+  slots: [thumbnailer]
+`
+	// a thumbnailer slot on the core snap (as automatically added on classic)
+	const thumbnailerMockClassicSlotSnapInfoYaml = `name: core
+type: os
+slots:
+ thumbnailer:
+  interface: thumbnailer
+`
+	const mockPlugSnapInfo = `name: client
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [thumbnailer]
+`
+	s.iface = &builtin.ThumbnailerInterface{}
+	// thumbnailer snap with thumbnailer slot on an core/all-snap install.
+	snapInfo := snaptest.MockInfo(c, thumbnailerMockCoreSlotSnapInfoYaml, nil)
+	s.coreSlot = &interfaces.Slot{SlotInfo: snapInfo.Slots["thumbnailer"]}
+	// thumbnailer slot on a core snap in a classic install.
+	snapInfo = snaptest.MockInfo(c, thumbnailerMockClassicSlotSnapInfoYaml, nil)
+	s.classicSlot = &interfaces.Slot{SlotInfo: snapInfo.Slots["thumbnailer"]}
+
+	plugSnap := snaptest.MockInfo(c, mockPlugSnapInfo, nil)
+	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["thumbnailer"]}
+}
 
 func (s *ThumbnailerInterfaceSuite) TestName(c *C) {
 	c.Check(s.iface.Name(), Equals, "thumbnailer")
@@ -65,20 +87,33 @@ func (s *ThumbnailerInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *ThumbnailerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected slots have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.thumbnailer.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.thumbnailer.app"), testutil.Contains, `interface=com.canonical.Thumbnailer`)
+
+	// slots have no permanent snippet on classic
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.classicSlot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 0)
+
 	// slots have a permanent non-nil security snippet for apparmor
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec = &apparmor.Specification{}
+	err = apparmorSpec.AddPermanentSlot(s.iface, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.thumbnailer.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.thumbnailer.app"), testutil.Contains, `member={RequestName,ReleaseName,GetConnectionCredentials}`)
 }
 
 func (s *ThumbnailerInterfaceSuite) TestSlotGrantedAccessToPlugFiles(c *C) {
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.coreSlot)
 	c.Assert(err, IsNil)
-
-	c.Check(string(snippet), testutil.Contains, `@{INSTALL_DIR}/client/**`)
-	c.Check(string(snippet), testutil.Contains, `@{HOME}/snap/client/**`)
-	c.Check(string(snippet), testutil.Contains, `/var/snap/client/**`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.thumbnailer.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.thumbnailer.app")
+	c.Check(snippet, testutil.Contains, `@{INSTALL_DIR}/client/**`)
+	c.Check(snippet, testutil.Contains, `@{HOME}/snap/client/**`)
+	c.Check(snippet, testutil.Contains, `/var/snap/client/**`)
 }

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -126,7 +126,8 @@ func (iface *TimeControlInterface) PermanentSlotSnippet(slot *interfaces.Slot, s
 }
 
 func (iface *TimeControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(timeControlConnectedPlugAppArmor)
+	spec.AddSnippet(timeControlConnectedPlugAppArmor)
+	return nil
 }
 
 // Getter for the security snippet specific to the plug

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 const timeControlConnectedPlugAppArmor = `
@@ -124,12 +125,13 @@ func (iface *TimeControlInterface) PermanentSlotSnippet(slot *interfaces.Slot, s
 	return nil, nil
 }
 
+func (iface *TimeControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(timeControlConnectedPlugAppArmor)
+}
+
 // Getter for the security snippet specific to the plug
 func (iface *TimeControlInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(timeControlConnectedPlugAppArmor), nil
-
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
 		const udevRule = `KERNEL=="/dev/rtc0", TAG+="%s"`

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -23,9 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type TimeControlTestInterfaceSuite struct {
@@ -88,11 +90,14 @@ func (s *TimeControlTestInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	expectedUDevSnippet := []byte(`KERNEL=="/dev/rtc0", TAG+="snap_client-snap_app-accessing-time-control"`)
 
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-time-control"})
+	c.Check(apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-time-control"), testutil.Contains, "org/freedesktop/timedate1")
+
 	// connected plugs have a non-nil security snippet for udev
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
+	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityUDev)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, DeepEquals, expectedUDevSnippet, Commentf("\nexpected:\n%s\nfound:\n%s", expectedUDevSnippet, snippet))
 }

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type TimezoneControlInterfaceSuite struct {
@@ -33,23 +36,27 @@ type TimezoneControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&TimezoneControlInterfaceSuite{
-	iface: builtin.NewTimezoneControlInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&TimezoneControlInterfaceSuite{})
+
+func (s *TimezoneControlInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [timezone-control]
+`
+	s.iface = builtin.NewTimezoneControlInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "timezone-control",
 			Interface: "timezone-control",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "timezone-control",
-			Interface: "timezone-control",
-		},
-	},
-})
+	}
+	plugSnap := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["timezone-control"]}
+}
 
 func (s *TimezoneControlInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "timezone-control")
@@ -78,9 +85,11 @@ func (s *TimezoneControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 		PanicMatches, `plug is not of interface "timezone-control"`)
 }
 
-func (s *TimezoneControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
+func (s *TimezoneControlInterfaceSuite) TestConnectedPlug(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `timedate1`)
 }

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type TpmInterfaceSuite struct {
@@ -33,23 +36,27 @@ type TpmInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&TpmInterfaceSuite{
-	iface: builtin.NewTpmInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&TpmInterfaceSuite{})
+
+func (s *TpmInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [tpm]
+`
+	s.iface = builtin.NewTpmInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "tpm",
 			Interface: "tpm",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "tpm",
-			Interface: "tpm",
-		},
-	},
-})
+	}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["tpm"]}
+}
 
 func (s *TpmInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "tpm")
@@ -80,7 +87,9 @@ func (s *TpmInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *TpmInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/dev/tpm0")
 }

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -203,7 +203,8 @@ func (iface *UbuntuDownloadManagerInterface) AppArmorConnectedPlug(spec *apparmo
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(downloadConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *UbuntuDownloadManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -211,7 +212,8 @@ func (iface *UbuntuDownloadManagerInterface) ConnectedPlugSnippet(plug *interfac
 }
 
 func (iface *UbuntuDownloadManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(downloadPermanentSlotAppArmor)
+	spec.AddSnippet(downloadPermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *UbuntuDownloadManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -225,7 +227,8 @@ func (iface *UbuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmo
 	old = "###PLUG_NAME###"
 	new = plug.Snap.Name()
 	snippet = strings.Replace(snippet, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *UbuntuDownloadManagerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -20,10 +20,11 @@
 package builtin
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 /* The methods: allowGSMDownload, createMmsDownload, exit and setDefaultThrottle
@@ -198,36 +199,36 @@ func (iface *UbuntuDownloadManagerInterface) PermanentPlugSnippet(plug *interfac
 	return nil, nil
 }
 
+func (iface *UbuntuDownloadManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(downloadConnectedPlugAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *UbuntuDownloadManagerInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(downloadConnectedPlugAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
+}
+
+func (iface *UbuntuDownloadManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(downloadPermanentSlotAppArmor)
 }
 
 func (iface *UbuntuDownloadManagerInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(downloadPermanentSlotAppArmor), nil
-	}
 	return nil, nil
 }
 
+func (iface *UbuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(downloadConnectedSlotAppArmor, old, new, -1)
+	old = "###PLUG_NAME###"
+	new = plug.Snap.Name()
+	snippet = strings.Replace(snippet, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *UbuntuDownloadManagerInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(downloadConnectedSlotAppArmor), old, new, -1)
-		old = []byte("###PLUG_NAME###")
-		new = []byte(plug.Snap.Name())
-		snippet = bytes.Replace(snippet, old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/ubuntu_download_manager_test.go
+++ b/interfaces/builtin/ubuntu_download_manager_test.go
@@ -23,8 +23,11 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type UbuntuDownloadManagerInterfaceSuite struct {
@@ -33,23 +36,27 @@ type UbuntuDownloadManagerInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&UbuntuDownloadManagerInterfaceSuite{
-	iface: &builtin.UbuntuDownloadManagerInterface{},
-	slot: &interfaces.Slot{
+var _ = Suite(&UbuntuDownloadManagerInterfaceSuite{})
+
+func (s *UbuntuDownloadManagerInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [ubuntu-download-manager]
+`
+	s.iface = &builtin.UbuntuDownloadManagerInterface{}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["ubuntu-download-manager"]}
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "ubuntu-download-manager",
 			Interface: "ubuntu-download-manager",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "ubuntu-download-manager",
-			Interface: "ubuntu-download-manager",
-		},
-	},
-})
+	}
+}
 
 func (s *UbuntuDownloadManagerInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "ubuntu-download-manager")
@@ -80,7 +87,9 @@ func (s *UbuntuDownloadManagerInterfaceSuite) TestSanitizeIncorrectInterface(c *
 
 func (s *UbuntuDownloadManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "path=/com/canonical/applications/download/**")
 }

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -20,9 +20,10 @@
 package builtin
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
@@ -340,23 +341,27 @@ func (iface *UDisks2Interface) PermanentPlugSnippet(plug *interfaces.Plug, secur
 	return nil, nil
 }
 
+func (iface *UDisks2Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	snippet := strings.Replace(udisks2ConnectedPlugAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *UDisks2Interface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(udisks2ConnectedPlugAppArmor), old, new, -1)
-		return snippet, nil
 	case interfaces.SecurityDBus:
 		return []byte(udisks2ConnectedPlugDBus), nil
 	}
 	return nil, nil
 }
 
+func (iface *UDisks2Interface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(udisks2PermanentSlotAppArmor)
+}
+
 func (iface *UDisks2Interface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(udisks2PermanentSlotAppArmor), nil
 	case interfaces.SecurityDBus:
 		return []byte(udisks2PermanentSlotDBus), nil
 	case interfaces.SecurityUDev:
@@ -365,18 +370,18 @@ func (iface *UDisks2Interface) PermanentSlotSnippet(slot *interfaces.Slot, secur
 	return nil, nil
 }
 
+func (iface *UDisks2Interface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(udisks2ConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *UDisks2Interface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	return spec.AddSnippet(udisks2PermanentSlotSecComp)
 }
 
 func (iface *UDisks2Interface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(udisks2ConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -345,7 +345,8 @@ func (iface *UDisks2Interface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(udisks2ConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *UDisks2Interface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -357,7 +358,8 @@ func (iface *UDisks2Interface) ConnectedPlugSnippet(plug *interfaces.Plug, slot 
 }
 
 func (iface *UDisks2Interface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(udisks2PermanentSlotAppArmor)
+	spec.AddSnippet(udisks2PermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *UDisks2Interface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -374,7 +376,8 @@ func (iface *UDisks2Interface) AppArmorConnectedSlot(spec *apparmor.Specificatio
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(udisks2ConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *UDisks2Interface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -78,7 +79,7 @@ func (s *UDisks2InterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
 	slot := &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap: &snap.Info{
-				SuggestedName: "udisks2",
+				SuggestedName: "udisks2prod",
 				Apps:          map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 			},
 			Name:      "udisks2",
@@ -86,9 +87,12 @@ func (s *UDisks2InterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.udisks2.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.udisks2.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.udisks2.app"), testutil.Contains, `peer=(label="snap.udisks2prod.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the udisks2 slot
@@ -99,7 +103,7 @@ func (s *UDisks2InterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c *C) 
 	slot := &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap: &snap.Info{
-				SuggestedName: "udisks2",
+				SuggestedName: "udisks2prod",
 				Apps:          map[string]*snap.AppInfo{"app1": app1, "app2": app2, "app3": app3},
 			},
 			Name:      "udisks2",
@@ -107,9 +111,12 @@ func (s *UDisks2InterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(c *C) 
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.udisks2.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.udisks2.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.udisks2.app"), testutil.Contains, `peer=(label="snap.udisks2prod.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the udisks2 slot
@@ -126,9 +133,12 @@ func (s *UDisks2InterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.udisks2.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.udisks2.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.udisks2.app"), testutil.Contains, `peer=(label="snap.udisks2.app"),`)
 }
 
 // The label glob when all apps are bound to the udisks2 plug
@@ -138,7 +148,7 @@ func (s *UDisks2InterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelAll(c *C) {
 	plug := &interfaces.Plug{
 		PlugInfo: &snap.PlugInfo{
 			Snap: &snap.Info{
-				SuggestedName: "udisks2",
+				SuggestedName: "udisks2client",
 				Apps:          map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 			},
 			Name:      "udisks2",
@@ -146,9 +156,12 @@ func (s *UDisks2InterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelAll(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.udisks2.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.udisks2.app1"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.udisks2.app1"), testutil.Contains, `peer=(label="snap.udisks2client.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the udisks2 plug
@@ -167,9 +180,12 @@ func (s *UDisks2InterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelSome(c *C) 
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.udisks2.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.udisks2.app1"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.udisks2.app1"), testutil.Contains, `peer=(label="snap.udisks2.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the udisks2 plug
@@ -186,14 +202,16 @@ func (s *UDisks2InterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne(c *C) {
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.udisks2.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.udisks2.app1"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.udisks2.app1"), testutil.Contains, `peer=(label="snap.udisks2.app"),`)
 }
 
 func (s *UDisks2InterfaceSuite) TestUsedSecuritySystems(c *C) {
-	systems := [...]interfaces.SecuritySystem{interfaces.SecurityAppArmor,
-		interfaces.SecurityDBus}
+	systems := [...]interfaces.SecuritySystem{interfaces.SecurityDBus}
 	for _, system := range systems {
 		snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, system)
 		c.Assert(err, IsNil)
@@ -202,10 +220,15 @@ func (s *UDisks2InterfaceSuite) TestUsedSecuritySystems(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(snippet, Not(IsNil))
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	snippet, err = s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityUDev)
+	err = apparmorSpec.AddPermanentSlot(s.iface, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 2)
+
+	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityUDev)
 	c.Assert(err, IsNil)
 	c.Assert(snippet, Not(IsNil))
 

--- a/interfaces/builtin/uhid.go
+++ b/interfaces/builtin/uhid.go
@@ -70,7 +70,8 @@ func (iface *UhidInterface) PermanentSlotSnippet(slot *interfaces.Slot, security
 }
 
 func (iface *UhidInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	return spec.AddSnippet(uhidConnectedPlugAppArmor)
+	spec.AddSnippet(uhidConnectedPlugAppArmor)
+	return nil
 }
 
 // Getter for the security system specific to the plug

--- a/interfaces/builtin/uhid.go
+++ b/interfaces/builtin/uhid.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
 const uhidConnectedPlugAppArmor = `
@@ -68,12 +69,13 @@ func (iface *UhidInterface) PermanentSlotSnippet(slot *interfaces.Slot, security
 	return nil, nil
 }
 
+func (iface *UhidInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(uhidConnectedPlugAppArmor)
+}
+
 // Getter for the security system specific to the plug
 func (iface *UhidInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		return []byte(uhidConnectedPlugAppArmor), nil
-
 	case interfaces.SecurityUDev:
 		var tagSnippet bytes.Buffer
 		const udevRule = `KERNEL=="uhid", TAG+="%s"`

--- a/interfaces/builtin/uhid_test.go
+++ b/interfaces/builtin/uhid_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -78,10 +79,11 @@ func (s *UhidInterfaceSuite) TestSanitizePlug(c *C) {
 
 func (s *UhidInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "/dev/uhid rw,\n")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-slot-1"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-slot-1"), testutil.Contains, "/dev/uhid rw,\n")
 }
 
 func (s *UhidInterfaceSuite) TestConnectedPlugUdevSnippets(c *C) {

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,9 +89,12 @@ func (s *Unity7InterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `/usr/share/pixmaps`)
+
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -100,7 +100,8 @@ func (iface *Unity8Interface) AppArmorConnectedPlug(spec *apparmor.Specification
 	oldTags := "###SLOT_SECURITY_TAGS###"
 	newTags := slotAppLabelExpr(slot)
 	snippet := strings.Replace(unity8ConnectedPlugAppArmor, oldTags, newTags, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *Unity8Interface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -20,10 +20,12 @@
 package builtin
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
 const unity8ConnectedPlugAppArmor = `
@@ -94,20 +96,22 @@ func (iface *Unity8Interface) PermanentPlugSnippet(plug *interfaces.Plug, securi
 	return nil, nil
 }
 
-func (iface *Unity8Interface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		oldTags := []byte("###SLOT_SECURITY_TAGS###")
-		newTags := slotAppLabelExpr(slot)
-		snippet := bytes.Replace([]byte(unity8ConnectedPlugAppArmor), oldTags, newTags, -1)
-		return snippet, nil
-	case interfaces.SecuritySecComp:
-		return []byte(unity8ConnectedPlugSecComp), nil
-	}
-	return nil, nil
+func (iface *Unity8Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	oldTags := "###SLOT_SECURITY_TAGS###"
+	newTags := slotAppLabelExpr(slot)
+	snippet := strings.Replace(unity8ConnectedPlugAppArmor, oldTags, newTags, -1)
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *Unity8Interface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	return spec.AddSnippet(unity8ConnectedPlugSecComp)
 }
 
 func (iface *Unity8Interface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+func (iface *Unity8Interface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
 }
 

--- a/interfaces/builtin/unity8_calendar_test.go
+++ b/interfaces/builtin/unity8_calendar_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
@@ -32,28 +33,44 @@ import (
 )
 
 type Unity8CalendarInterfaceSuite struct {
-	iface interfaces.Interface
-	slot  *interfaces.Slot
-	plug  *interfaces.Plug
+	iface    interfaces.Interface
+	slot     *interfaces.Slot
+	coreSlot *interfaces.Slot
+	plug     *interfaces.Plug
 }
 
-var _ = Suite(&Unity8CalendarInterfaceSuite{
-	iface: builtin.NewUnity8CalendarInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&Unity8CalendarInterfaceSuite{})
+
+func (s *Unity8CalendarInterfaceSuite) SetUpTest(c *C) {
+	const mockCoreSlotInfoYaml = `name: unity8-calendar
+version: 1.0
+apps:
+ app:
+  command: foo
+  slots: [unity8-calendar]
+`
+	const mockPlugSnapInfo = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [unity8-calendar]
+`
+	s.iface = builtin.NewUnity8CalendarInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "unity8-calendar",
 			Interface: "unity8-calendar",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "unity8-calendar",
-			Interface: "unity8-calendar",
-		},
-	},
-})
+	}
+
+	plugSnap := snaptest.MockInfo(c, mockPlugSnapInfo, nil)
+	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["unity8-calendar"]}
+
+	slotSnap := snaptest.MockInfo(c, mockCoreSlotInfoYaml, nil)
+	s.coreSlot = &interfaces.Slot{SlotInfo: slotSnap.Slots["unity8-calendar"]}
+}
 
 func (s *Unity8CalendarInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "unity8-calendar")
@@ -73,9 +90,10 @@ func (s *Unity8CalendarInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *Unity8CalendarInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
 }
 
 // The label glob when all apps are bound to the calendar slot
@@ -94,9 +112,12 @@ func (s *Unity8CalendarInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.unity8.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.unity8.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the calendar slot
@@ -116,9 +137,12 @@ func (s *Unity8CalendarInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.unity8.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.unity8.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the calendar slot
@@ -136,64 +160,63 @@ func (s *Unity8CalendarInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.unity8.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.unity8.app"),`)
 }
 
 func (s *Unity8CalendarInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabelOnClassic(c *C) {
 	release.OnClassic = true
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.other.app")
 	// verify apparmor connected
-	c.Assert(string(snippet), testutil.Contains, "#include <abstractions/dbus-session-strict>")
+	c.Assert(snippet, testutil.Contains, "#include <abstractions/dbus-session-strict>")
 	// verify classic connected
-	c.Assert(string(snippet), testutil.Contains, "peer=(label=unconfined),")
+	c.Assert(snippet, testutil.Contains, "peer=(label=unconfined),")
 }
 
 func (s *Unity8CalendarInterfaceSuite) TestConnectedPlugSnippetAppArmor(c *C) {
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.other.app")
 	// verify apparmor connected
-	c.Assert(string(snippet), testutil.Contains, "#include <abstractions/dbus-session-strict>")
+	c.Assert(snippet, testutil.Contains, "#include <abstractions/dbus-session-strict>")
 	// verify classic didn't connect
-	c.Assert(string(snippet), Not(testutil.Contains), "peer=(label=unconfined),")
+	c.Assert(snippet, Not(testutil.Contains), "peer=(label=unconfined),")
 }
 
 func (s *Unity8CalendarInterfaceSuite) TestConnectedSlotSnippetAppArmor(c *C) {
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "peer=(label=\"snap.other.*\")")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.unity8-calendar.app"})
+	c.Check(apparmorSpec.SnippetForTag("snap.unity8-calendar.app"), testutil.Contains, "peer=(label=\"snap.other.app\")")
 }
 
 func (s *Unity8CalendarInterfaceSuite) TestPermanentSlotSnippetAppArmor(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "name=\"org.gnome.evolution.dataserver.Sources5\"")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.unity8-calendar.app"})
+	c.Check(apparmorSpec.SnippetForTag("snap.unity8-calendar.app"), testutil.Contains, "name=\"org.gnome.evolution.dataserver.Sources5\"")
 }
 
-const unity8mockSlotInfoYaml = `name: cal
-version: 1.0
-apps:
- app:
-  command: foo
-  slots: [unity8-calendar]
-`
-
 func (s *Unity8CalendarInterfaceSuite) TestPermanentSlotSnippetSecComp(c *C) {
-	slotSnap := snaptest.MockInfo(c, unity8mockSlotInfoYaml, nil)
-	slot := &interfaces.Slot{SlotInfo: slotSnap.Slots["unity8-calendar"]}
-
 	seccompSpec := &seccomp.Specification{}
-	err := seccompSpec.AddPermanentSlot(s.iface, slot)
+	err := seccompSpec.AddPermanentSlot(s.iface, s.coreSlot)
 	c.Assert(err, IsNil)
 	snippets := seccompSpec.Snippets()
 	c.Assert(len(snippets), Equals, 1)
-	c.Assert(len(snippets["snap.cal.app"]), Equals, 1)
-	c.Check(string(snippets["snap.cal.app"][0]), testutil.Contains, "listen\n")
+	c.Assert(len(snippets["snap.unity8-calendar.app"]), Equals, 1)
+	c.Check(string(snippets["snap.unity8-calendar.app"][0]), testutil.Contains, "listen\n")
 }

--- a/interfaces/builtin/unity8_contacts_test.go
+++ b/interfaces/builtin/unity8_contacts_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
@@ -32,28 +33,45 @@ import (
 )
 
 type Unity8ContactsInterfaceSuite struct {
-	iface interfaces.Interface
-	slot  *interfaces.Slot
-	plug  *interfaces.Plug
+	iface    interfaces.Interface
+	slot     *interfaces.Slot
+	coreSlot *interfaces.Slot
+	plug     *interfaces.Plug
 }
 
-var _ = Suite(&Unity8ContactsInterfaceSuite{
-	iface: builtin.NewUnity8ContactsInterface(),
-	slot: &interfaces.Slot{
+var _ = Suite(&Unity8ContactsInterfaceSuite{})
+
+func (s *Unity8ContactsInterfaceSuite) SetUpTest(c *C) {
+	const mockPlugSnapInfo = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [unity8-contacts]
+`
+
+	const mockCoreSlotInfoYaml = `name: contacts
+version: 1.0
+apps:
+ app:
+  command: foo
+  slots: [unity8-contacts]
+`
+	s.iface = builtin.NewUnity8ContactsInterface()
+	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
 			Name:      "unity8-contacts",
 			Interface: "unity8-contacts",
 		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "unity8-contacts",
-			Interface: "unity8-contacts",
-		},
-	},
-})
+	}
+
+	plugSnap := snaptest.MockInfo(c, mockPlugSnapInfo, nil)
+	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["unity8-contacts"]}
+
+	slotSnap := snaptest.MockInfo(c, mockCoreSlotInfoYaml, nil)
+	s.coreSlot = &interfaces.Slot{SlotInfo: slotSnap.Slots["unity8-contacts"]}
+}
 
 func (s *Unity8ContactsInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "unity8-contacts")
@@ -73,9 +91,10 @@ func (s *Unity8ContactsInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *Unity8ContactsInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), HasLen, 1)
 }
 
 // The label glob when all apps are bound to the contacts slot
@@ -94,9 +113,12 @@ func (s *Unity8ContactsInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.unity8.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.unity8.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the contacts slot
@@ -116,9 +138,12 @@ func (s *Unity8ContactsInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.unity8.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.unity8.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the calendar slot
@@ -136,61 +161,62 @@ func (s *Unity8ContactsInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.unity8.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.unity8.app"),`)
 }
 
 func (s *Unity8ContactsInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabelOnClassic(c *C) {
 	release.OnClassic = true
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.other.app")
+
 	// verify apparmor connected
-	c.Assert(string(snippet), testutil.Contains, "#include <abstractions/dbus-session-strict>")
+	c.Assert(snippet, testutil.Contains, "#include <abstractions/dbus-session-strict>")
 	// verify classic connected
-	c.Assert(string(snippet), testutil.Contains, "peer=(label=unconfined),")
+	c.Assert(snippet, testutil.Contains, "peer=(label=unconfined),")
 }
 
 func (s *Unity8ContactsInterfaceSuite) TestConnectedPlugSnippetAppArmor(c *C) {
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.other.app")
 	// verify apparmor connected
-	c.Assert(string(snippet), testutil.Contains, "#include <abstractions/dbus-session-strict>")
+	c.Assert(snippet, testutil.Contains, "#include <abstractions/dbus-session-strict>")
 	// verify classic didn't connect
-	c.Assert(string(snippet), Not(testutil.Contains), "peer=(label=unconfined),")
+	c.Assert(snippet, Not(testutil.Contains), "peer=(label=unconfined),")
 }
 
 func (s *Unity8ContactsInterfaceSuite) TestConnectedSlotSnippetAppArmor(c *C) {
-	snippet, err := s.iface.ConnectedSlotSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.plug, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "peer=(label=\"snap.other.*\")")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.contacts.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.contacts.app"), testutil.Contains, "peer=(label=\"snap.other.app\")")
 }
 
 func (s *Unity8ContactsInterfaceSuite) TestPermanentSlotSnippetAppArmor(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-
-	c.Check(string(snippet), testutil.Contains, "name=\"org.gnome.evolution.dataserver.Sources5\"")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.contacts.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.contacts.app"), testutil.Contains, "name=\"org.gnome.evolution.dataserver.Sources5\"")
 }
 
-const unity8contactsMockSlotInfoYaml = `name: contacts
-version: 1.0
-apps:
- app:
-  command: foo
-  slots: [unity8-contacts]
-`
-
 func (s *Unity8ContactsInterfaceSuite) TestPermanentSlotSnippetSecComp(c *C) {
-	slotSnap := snaptest.MockInfo(c, unity8contactsMockSlotInfoYaml, nil)
-	slot := &interfaces.Slot{SlotInfo: slotSnap.Slots["unity8-contacts"]}
-
 	seccompSpec := &seccomp.Specification{}
-	err := seccompSpec.AddPermanentSlot(s.iface, slot)
+	err := seccompSpec.AddPermanentSlot(s.iface, s.coreSlot)
 	c.Assert(err, IsNil)
 	snippets := seccompSpec.Snippets()
 	c.Assert(len(snippets), Equals, 1)

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -20,10 +20,11 @@
 package builtin
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
 )
@@ -108,34 +109,35 @@ func (iface *unity8PimCommonInterface) PermanentPlugSnippet(plug *interfaces.Plu
 	return nil, nil
 }
 
-func (iface *unity8PimCommonInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
+func (iface *unity8PimCommonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
 
-		originalSnippet := append([]byte(unity8PimCommonConnectedPlugAppArmor), iface.connectedPlugAppArmor...)
-		snippet := bytes.Replace(originalSnippet, old, new, -1)
+	originalSnippet := unity8PimCommonConnectedPlugAppArmor + "\n" + iface.connectedPlugAppArmor
+	snippet := strings.Replace(originalSnippet, old, new, -1)
 
-		// classic mode
-		if release.OnClassic {
-			// Let confined apps access unconfined service on classic
-			classicSnippet := bytes.Replace(originalSnippet, old, []byte("unconfined"), -1)
-			snippet = append(snippet, classicSnippet...)
-		}
-
-		return snippet, nil
-	default:
-		return nil, nil
+	// classic mode
+	if release.OnClassic {
+		// Let confined apps access unconfined service on classic
+		classicSnippet := strings.Replace(originalSnippet, old, "unconfined", -1)
+		snippet += "\n" + classicSnippet
 	}
+
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *unity8PimCommonInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
+	return nil, nil
+}
+
+func (iface *unity8PimCommonInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	snippet := unity8PimCommonPermanentSlotAppArmor
+	snippet += "\n" + iface.permanentSlotAppArmor
+	return spec.AddSnippet(snippet)
 }
 
 func (iface *unity8PimCommonInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		snippet := []byte(unity8PimCommonPermanentSlotAppArmor)
-		snippet = append(snippet, iface.permanentSlotAppArmor...)
-		return snippet, nil
 	case interfaces.SecurityDBus:
 		//FIXME: Implement support after session services are available.
 		return nil, nil
@@ -144,20 +146,20 @@ func (iface *unity8PimCommonInterface) PermanentSlotSnippet(slot *interfaces.Slo
 	}
 }
 
+func (iface *unity8PimCommonInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := unity8PimCommonConnectedSlotAppArmor
+	snippet += "\n" + iface.connectedSlotAppArmor
+	snippet = strings.Replace(snippet, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *unity8PimCommonInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	return spec.AddSnippet(unity8PimCommonPermanentSlotSecComp)
 }
 
 func (iface *unity8PimCommonInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := []byte(unity8PimCommonConnectedSlotAppArmor)
-		snippet = append(snippet, iface.connectedSlotAppArmor...)
-		snippet = bytes.Replace(snippet, old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -123,7 +123,8 @@ func (iface *unity8PimCommonInterface) AppArmorConnectedPlug(spec *apparmor.Spec
 		snippet += "\n" + classicSnippet
 	}
 
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *unity8PimCommonInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -133,7 +134,8 @@ func (iface *unity8PimCommonInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 func (iface *unity8PimCommonInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	snippet := unity8PimCommonPermanentSlotAppArmor
 	snippet += "\n" + iface.permanentSlotAppArmor
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *unity8PimCommonInterface) PermanentSlotSnippet(slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -152,7 +154,8 @@ func (iface *unity8PimCommonInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 	snippet := unity8PimCommonConnectedSlotAppArmor
 	snippet += "\n" + iface.connectedSlotAppArmor
 	snippet = strings.Replace(snippet, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *unity8PimCommonInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -114,16 +114,14 @@ func (iface *unity8PimCommonInterface) AppArmorConnectedPlug(spec *apparmor.Spec
 	new := slotAppLabelExpr(slot)
 
 	originalSnippet := unity8PimCommonConnectedPlugAppArmor + "\n" + iface.connectedPlugAppArmor
-	snippet := strings.Replace(originalSnippet, old, new, -1)
+	spec.AddSnippet(strings.Replace(originalSnippet, old, new, -1))
 
 	// classic mode
 	if release.OnClassic {
 		// Let confined apps access unconfined service on classic
-		classicSnippet := strings.Replace(originalSnippet, old, "unconfined", -1)
-		snippet += "\n" + classicSnippet
+		spec.AddSnippet(strings.Replace(originalSnippet, old, "unconfined", -1))
 	}
 
-	spec.AddSnippet(snippet)
 	return nil
 }
 
@@ -132,9 +130,8 @@ func (iface *unity8PimCommonInterface) ConnectedPlugSnippet(plug *interfaces.Plu
 }
 
 func (iface *unity8PimCommonInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	snippet := unity8PimCommonPermanentSlotAppArmor
-	snippet += "\n" + iface.permanentSlotAppArmor
-	spec.AddSnippet(snippet)
+	spec.AddSnippet(unity8PimCommonPermanentSlotAppArmor)
+	spec.AddSnippet(iface.permanentSlotAppArmor)
 	return nil
 }
 

--- a/interfaces/builtin/unity8_test.go
+++ b/interfaces/builtin/unity8_test.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -40,23 +42,9 @@ type unity8InterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&unity8InterfaceSuite{
-	iface: &builtin.Unity8Interface{},
-	slot: &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "unity8-session"},
-			Name:      "unity8-session",
-			Interface: "unity8",
-		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "unity8-app"},
-			Name:      "unity8-app",
-			Interface: "unity8",
-		},
-	},
-})
+var _ = Suite(&unity8InterfaceSuite{})
+
+var _ = Suite(&FirewallControlInterfaceSuite{})
 
 func createMockFooPlug(c *C, content string) *interfaces.Plug {
 	info := snaptest.MockSnap(c, content, "", &snap.SideInfo{Revision: snap.R(3)})
@@ -80,7 +68,25 @@ func createMockFooPlug(c *C, content string) *interfaces.Plug {
 }
 
 func (s *unity8InterfaceSuite) SetUpTest(c *C) {
+	const mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ unity8-app:
+  command: foo
+  plugs: [unity8]
+`
 	dirs.SetRootDir(c.MkDir())
+	s.iface = &builtin.Unity8Interface{}
+	s.slot = &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "unity8-session"},
+			Name:      "unity8-session",
+			Interface: "unity8",
+		},
+	}
+	plugSnap := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["unity8"]}
+
 }
 
 func (s *unity8InterfaceSuite) TearDownTest(c *C) {
@@ -93,20 +99,26 @@ func (s *unity8InterfaceSuite) TestName(c *C) {
 
 func (s *unity8InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "name=com.canonical.URLDispatcher")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.unity8-app"})
+	c.Check(apparmorSpec.SnippetForTag("snap.other.unity8-app"), testutil.Contains, "name=com.canonical.URLDispatcher")
 
 	// connected plugs have a non-nil security snippet for seccomp
-	snippet, err = s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecuritySecComp)
+	seccompSpec := &seccomp.Specification{}
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "shutdown\n")
+	snippets := seccompSpec.Snippets()
+	c.Assert(snippets, HasLen, 1)
+	c.Assert(snippets["snap.other.unity8-app"], HasLen, 1)
+	c.Check(string(snippets["snap.other.unity8-app"][0]), testutil.Contains, "shutdown\n")
 }
 
 func (s *unity8InterfaceSuite) TestSecurityTags(c *C) {
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Check(string(snippet), testutil.Contains, "label=\"snap.unity8-session.*\"")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.unity8-app"})
+	c.Check(apparmorSpec.SnippetForTag("snap.other.unity8-app"), testutil.Contains, "label=\"snap.unity8-session.*\"")
 }

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -210,7 +210,8 @@ func (iface *UpowerObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 		new = "unconfined"
 	}
 	snippet := strings.Replace(upowerObserveConnectedPlugAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *UpowerObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
@@ -218,7 +219,8 @@ func (iface *UpowerObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plug,
 }
 
 func (iface *UpowerObserveInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
-	return spec.AddSnippet(upowerObservePermanentSlotAppArmor)
+	spec.AddSnippet(upowerObservePermanentSlotAppArmor)
+	return nil
 }
 
 func (iface *UpowerObserveInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
@@ -237,7 +239,8 @@ func (iface *UpowerObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specif
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(upowerObserveConnectedSlotAppArmor, old, new, -1)
-	return spec.AddSnippet(snippet)
+	spec.AddSnippet(snippet)
+	return nil
 }
 
 func (iface *UpowerObserveInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -20,10 +20,11 @@
 package builtin
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -201,19 +202,23 @@ func (iface *UpowerObserveInterface) PermanentPlugSnippet(plug *interfaces.Plug,
 	return nil, nil
 }
 
-func (iface *UpowerObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###SLOT_SECURITY_TAGS###")
-		new := slotAppLabelExpr(slot)
-		if release.OnClassic {
-			// Let confined apps access unconfined upower on classic
-			new = []byte("unconfined")
-		}
-		snippet := bytes.Replace([]byte(upowerObserveConnectedPlugAppArmor), old, new, -1)
-		return snippet, nil
+func (iface *UpowerObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###SLOT_SECURITY_TAGS###"
+	new := slotAppLabelExpr(slot)
+	if release.OnClassic {
+		// Let confined apps access unconfined upower on classic
+		new = "unconfined"
 	}
+	snippet := strings.Replace(upowerObserveConnectedPlugAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
+func (iface *UpowerObserveInterface) ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
 	return nil, nil
+}
+
+func (iface *UpowerObserveInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+	return spec.AddSnippet(upowerObservePermanentSlotAppArmor)
 }
 
 func (iface *UpowerObserveInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
@@ -224,20 +229,18 @@ func (iface *UpowerObserveInterface) PermanentSlotSnippet(slot *interfaces.Slot,
 	switch securitySystem {
 	case interfaces.SecurityDBus:
 		return []byte(upowerObservePermanentSlotDBus), nil
-	case interfaces.SecurityAppArmor:
-		return []byte(upowerObservePermanentSlotAppArmor), nil
 	}
 	return nil, nil
 }
 
+func (iface *UpowerObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	old := "###PLUG_SECURITY_TAGS###"
+	new := plugAppLabelExpr(plug)
+	snippet := strings.Replace(upowerObserveConnectedSlotAppArmor, old, new, -1)
+	return spec.AddSnippet(snippet)
+}
+
 func (iface *UpowerObserveInterface) ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, securitySystem interfaces.SecuritySystem) ([]byte, error) {
-	switch securitySystem {
-	case interfaces.SecurityAppArmor:
-		old := []byte("###PLUG_SECURITY_TAGS###")
-		new := plugAppLabelExpr(plug)
-		snippet := bytes.Replace([]byte(upowerObserveConnectedSlotAppArmor), old, new, -1)
-		return snippet, nil
-	}
 	return nil, nil
 }
 

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
@@ -32,35 +33,56 @@ import (
 )
 
 type UPowerObserveInterfaceSuite struct {
-	iface interfaces.Interface
-	slot  *interfaces.Slot
-	plug  *interfaces.Plug
+	iface       interfaces.Interface
+	coreSlot    *interfaces.Slot
+	classicSlot *interfaces.Slot
+	plug        *interfaces.Plug
 }
 
-var _ = Suite(&UPowerObserveInterfaceSuite{
-	iface: &builtin.UpowerObserveInterface{},
-	slot: &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
-			Name:      "upower-observe",
-			Interface: "upower-observe",
-		},
-	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "other"},
-			Name:      "upower-observe",
-			Interface: "upower-observe",
-		},
-	},
-})
+var _ = Suite(&UPowerObserveInterfaceSuite{})
+
+func (s *UPowerObserveInterfaceSuite) SetUpTest(c *C) {
+	const mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [upower-observe]
+`
+	const upowerMockClassicSlotSnapInfoYaml = `name: core
+type: os
+slots:
+ upower-observe:
+  interface: upower-observe
+`
+	const upowerMockSlotSnapInfoYaml = `name: upowerd
+version: 1.0
+slots:
+ upower-observe:
+  interface: upower-observe
+apps:
+ app:
+  command: foo
+  slots: [upower-observe]
+`
+	s.iface = &builtin.UpowerObserveInterface{}
+	// upower snap with upower-server slot on an core/all-snap install.
+	snapInfo := snaptest.MockInfo(c, upowerMockSlotSnapInfoYaml, nil)
+	s.coreSlot = &interfaces.Slot{SlotInfo: snapInfo.Slots["upower-observe"]}
+	// upower-observe slot on a core snap in a classic install.
+	snapInfo = snaptest.MockInfo(c, upowerMockClassicSlotSnapInfoYaml, nil)
+	s.classicSlot = &interfaces.Slot{SlotInfo: snapInfo.Slots["upower-observe"]}
+	// snap with the upower-observe plug
+	snapInfo = snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["upower-observe"]}
+}
 
 func (s *UPowerObserveInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "upower-observe")
 }
 
 func (s *UPowerObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
+	err := s.iface.SanitizeSlot(s.coreSlot)
 	c.Assert(err, IsNil)
 	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
@@ -82,13 +104,6 @@ func (s *UPowerObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 		PanicMatches, `plug is not of interface "upower-observe"`)
 }
 
-func (s *UPowerObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
-	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-}
-
 // The label glob when all apps are bound to the ofono slot
 func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
 	app1 := &snap.AppInfo{Name: "app1"}
@@ -104,10 +119,14 @@ func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c
 			Apps:      map[string]*snap.AppInfo{"app1": app1, "app2": app2},
 		},
 	}
+
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.upower.*"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.upower.*"),`)
 }
 
 // The label uses alternation when some, but not all, apps is bound to the ofono slot
@@ -127,9 +146,12 @@ func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelSome(
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.upower.{app1,app2}"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.upower.{app1,app2}"),`)
 }
 
 // The label uses short form when exactly one app is bound to the upower-observe slot
@@ -147,15 +169,21 @@ func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelOne(c
 		},
 	}
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, slot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.upower.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `peer=(label="snap.upower.app"),`)
 }
 
 func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabelOnClassic(c *C) {
 	release.OnClassic = true
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.classicSlot)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.other.app")
 	// verify apparmor connected
 	c.Assert(string(snippet), testutil.Contains, "#include <abstractions/dbus-strict>")
 	// verify classic connected
@@ -164,8 +192,11 @@ func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetUsesUnconfinedLabe
 
 func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetAppArmor(c *C) {
 	release.OnClassic = false
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.coreSlot)
 	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	snippet := apparmorSpec.SnippetForTag("snap.other.app")
 	// verify apparmor connected
 	c.Assert(string(snippet), testutil.Contains, "#include <abstractions/dbus-strict>")
 	// verify classic didn't connect
@@ -173,10 +204,11 @@ func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetAppArmor(c *C) {
 }
 
 func (s *UPowerObserveInterfaceSuite) TestPermanentSlotSnippetAppArmor(c *C) {
-	snippet, err := s.iface.PermanentSlotSnippet(s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
-	c.Check(string(snippet), testutil.Contains, "org.freedesktop.UPower")
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.upowerd.app"})
+	c.Check(apparmorSpec.SnippetForTag("snap.upowerd.app"), testutil.Contains, "org.freedesktop.UPower")
 }
 
 const upowerObserveMockSlotSnapInfoYaml = `name: upower
@@ -188,16 +220,13 @@ apps:
 `
 
 func (s *UPowerObserveInterfaceSuite) TestPermanentSlotSnippetSecComp(c *C) {
-	slotSnap := snaptest.MockInfo(c, upowerObserveMockSlotSnapInfoYaml, nil)
-	slot := &interfaces.Slot{SlotInfo: slotSnap.Slots["upower-observe"]}
-
 	seccompSpec := &seccomp.Specification{}
-	err := seccompSpec.AddPermanentSlot(s.iface, slot)
+	err := seccompSpec.AddPermanentSlot(s.iface, s.coreSlot)
 	c.Assert(err, IsNil)
 	snippets := seccompSpec.Snippets()
 	c.Assert(len(snippets), Equals, 1)
-	c.Assert(len(snippets["snap.upower.app1"]), Equals, 1)
-	c.Check(string(snippets["snap.upower.app1"][0]), testutil.Contains, "bind\n")
+	c.Assert(len(snippets["snap.upowerd.app"]), Equals, 1)
+	c.Check(string(snippets["snap.upowerd.app"][0]), testutil.Contains, "bind\n")
 }
 
 func (s *UPowerObserveInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne(c *C) {
@@ -213,7 +242,10 @@ func (s *UPowerObserveInterfaceSuite) TestConnectedSlotSnippetUsesPlugLabelOne(c
 			Apps:      map[string]*snap.AppInfo{"app": app},
 		},
 	}
-	snippet, err := s.iface.ConnectedSlotSnippet(plug, s.slot, interfaces.SecurityAppArmor)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedSlot(s.iface, plug, s.coreSlot)
 	c.Assert(err, IsNil)
-	c.Assert(string(snippet), testutil.Contains, `peer=(label="snap.upower.app"),`)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.upowerd.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.upowerd.app"), testutil.Contains, `peer=(label="snap.upower.app"),`)
 }

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -35,7 +35,7 @@ import (
 // - "snap.$snap.$app" if there is exactly one app bound
 // - "snap.$snap.{$app1,...$appN}" if there are some, but not all, apps bound
 // - "snap.$snap.*" if all apps are bound to the slot
-func appLabelExpr(apps map[string]*snap.AppInfo, snap *snap.Info) []byte {
+func appLabelExpr(apps map[string]*snap.AppInfo, snap *snap.Info) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, `"snap.%s.`, snap.Name())
 	if len(apps) == 1 {
@@ -59,14 +59,14 @@ func appLabelExpr(apps map[string]*snap.AppInfo, snap *snap.Info) []byte {
 		buf.WriteByte('}')
 	}
 	buf.WriteByte('"')
-	return buf.Bytes()
+	return buf.String()
 }
 
-func slotAppLabelExpr(slot *interfaces.Slot) []byte {
+func slotAppLabelExpr(slot *interfaces.Slot) string {
 	return appLabelExpr(slot.Apps, slot.Snap)
 }
 
-func plugAppLabelExpr(plug *interfaces.Plug) []byte {
+func plugAppLabelExpr(plug *interfaces.Plug) string {
 	return appLabelExpr(plug.Apps, plug.Snap)
 }
 

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -23,6 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
@@ -88,9 +89,11 @@ func (s *X11InterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 
 func (s *X11InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
-	snippet, err := s.iface.ConnectedPlugSnippet(s.plug, s.slot, interfaces.SecurityAppArmor)
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(snippet, Not(IsNil))
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `fontconfig`)
 }
 
 // The shutdown system call is allowed


### PR DESCRIPTION
Use apparmor spec in the apparmor backend. Updated all affected interfaces. Use strings for apparmor snippets.