### PR TITLE
snapstate: introduce helper to apply to disk a alias states change for a snap (aliases v2)

### DIFF
--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -49,7 +49,9 @@ func composeTarget(snapName, targetApp string) string {
 	return fmt.Sprintf("%s.%s", snapName, targetApp)
 }
 
-// applyAliasChange applies the necessary changes to aliases on disk to go from prevStates to newStates for the aliases of snapName. It assumes that conflicts have already been checked.
+// applyAliasChange applies the necessary changes to aliases on disk
+// to go from prevStates to newStates for the aliases of snapName. It
+// assumes that conflicts have already been checked.
 func applyAliasChange(st *state.State, snapName string, prevStates map[string]*AliasState, newStates map[string]*AliasState, be managerBackend) error {
 	var add, remove []*backend.Alias
 	for alias, prevState := range prevStates {

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -26,24 +26,33 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 )
 
-// AliasTargets carries the targets of an alias in the context of snap.
+// AliasesStatus represents the global automatic aliases status for a snap.
+type AliasesStatus string
+
+// Possible global automatic aliases statuses for a snap.
+const (
+	EnabledAliases  AliasesStatus = "enabled"
+	DisabledAliases AliasesStatus = "disabled"
+)
+
+// AliasTarget carries the targets of an alias in the context of snap.
 // If Manual is set it is the target of an enabled manual alias.
 // Auto is set to the target for an automatic alias, enabled or
 // disabled depending on the aliases status of the whole snap.
-type AliasTargets struct {
+type AliasTarget struct {
 	Manual string `json:"manual"`
 	Auto   string `json:"auto"`
 }
 
-// Effective returns the target to use based on the aliasStatus of the whole snap, returns "" if the alias is disabled.
-func (at *AliasTargets) Effective(aliasesStatus string) string {
+// Effective returns the target to use based on the aliasesStatus of the whole snap, returns "" if the alias is disabled.
+func (at *AliasTarget) Effective(aliasesStatus AliasesStatus) string {
 	if at == nil {
 		return ""
 	}
 	if at.Manual != "" {
 		return at.Manual
 	}
-	if aliasesStatus == "enabled" {
+	if aliasesStatus == EnabledAliases {
 		return at.Auto
 	}
 	return ""
@@ -61,7 +70,7 @@ func composeTarget(snapName, targetApp string) string {
 // to go from prevAliases under the snap global prevStatus for
 // automatic aliases to newAliases under newStatus for snapName.
 // It assumes that conflicts have already been checked.
-func applyAliasesChange(st *state.State, snapName string, prevStatus string, prevAliases map[string]*AliasTargets, newStatus string, newAliases map[string]*AliasTargets, be managerBackend) error {
+func applyAliasesChange(st *state.State, snapName string, prevStatus AliasesStatus, prevAliases map[string]*AliasTarget, newStatus AliasesStatus, newAliases map[string]*AliasTarget, be managerBackend) error {
 	var add, remove []*backend.Alias
 	for alias, prevTargets := range prevAliases {
 		if _, ok := newAliases[alias]; ok {

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -40,8 +40,8 @@ const (
 // Auto is set to the target for an automatic alias, enabled or
 // disabled depending on the aliases status of the whole snap.
 type AliasTarget struct {
-	Manual string `json:"manual"`
-	Auto   string `json:"auto"`
+	Manual string `json:"manual,omitempty"`
+	Auto   string `json:"auto,omitempty"`
 }
 
 // Effective returns the target to use based on the aliasesStatus of the whole snap, returns "" if the alias is disabled.

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// AliasState describes the state of an alias in the context of a snap.
+// aliases-v2 top state entry is a snapName -> alias -> AliasState map.
+type AliasState struct {
+	Status string `json:"status"` // one of: auto,disabled,manual,overridden
+	Target string `json:"target"`
+}
+
+func (as *AliasState) Enabled() bool {
+	switch as.Status {
+	case "auto", "manual", "overridden":
+		return true
+	}
+	return false
+}
+
+// TODO: helper from snap
+func composeTarget(snapName, targetApp string) string {
+	if targetApp == snapName {
+		return targetApp
+	}
+	return fmt.Sprintf("%s.%s", snapName, targetApp)
+}
+
+// applyAliasChange applies the necessary changes to aliases on disk to go from prevStates to newStates for the aliases of snapName. It assumes that conflicts have already been checked.
+func applyAliasChange(st *state.State, snapName string, prevStates map[string]*AliasState, newStates map[string]*AliasState, be managerBackend) error {
+	var add, remove []*backend.Alias
+	for alias, prevState := range prevStates {
+		_, ok := newStates[alias]
+		if ok {
+			continue
+		}
+		// gone
+		if prevState.Enabled() {
+			remove = append(remove, &backend.Alias{
+				Name:   alias,
+				Target: composeTarget(snapName, prevState.Target),
+			})
+		}
+	}
+	for alias, newState := range newStates {
+		prevState := prevStates[alias]
+		if prevState == nil {
+			prevState = &AliasState{Status: "-"}
+		}
+		if prevState.Enabled() == newState.Enabled() && (!newState.Enabled() || prevState.Target == newState.Target) {
+			// nothing to do
+			continue
+		}
+		if prevState.Enabled() {
+			remove = append(remove, &backend.Alias{
+				Name:   alias,
+				Target: composeTarget(snapName, prevState.Target),
+			})
+		}
+		if newState.Enabled() {
+			add = append(add, &backend.Alias{
+				Name:   alias,
+				Target: composeTarget(snapName, newState.Target),
+			})
+		}
+	}
+	st.Unlock()
+	err := be.UpdateAliases(add, remove)
+	st.Lock()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -1,0 +1,129 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"fmt"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
+)
+
+func (s *snapmgrTestSuite) TestApplyAliasChange(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	scenarios := []struct {
+		status    string
+		newStatus string
+		target    string
+		newTarget string
+		ops       string
+	}{
+		{status: "-", newStatus: "disabled", target: "cmd1", ops: ""},
+		{status: "disabled", newStatus: "disabled", target: "cmd1", ops: ""},
+		{status: "disabled", newStatus: "disabled", target: "cmd1", newTarget: "cmd2", ops: ""},
+		{status: "disabled", newStatus: "-", target: "cmd1", ops: ""},
+		{status: "-", newStatus: "manual", target: "cmd1", ops: "add"},
+		{status: "manual", newStatus: "manual", target: "cmd1", newTarget: "cmd2", ops: "rm add"},
+		{status: "overridden", newStatus: "auto", target: "cmd1", ops: ""},
+		{status: "auto", newStatus: "disabled", target: "cmd1", ops: "rm"},
+		{status: "auto", newStatus: "-", target: "cmd1", ops: "rm"},
+	}
+
+	for _, scenario := range scenarios {
+		prevStates := make(map[string]*snapstate.AliasState)
+		if scenario.status != "-" {
+			prevStates["myalias"] = &snapstate.AliasState{
+				Status: scenario.status,
+				Target: scenario.target,
+			}
+		}
+		newStates := make(map[string]*snapstate.AliasState)
+		if scenario.newStatus != "-" {
+			newState := &snapstate.AliasState{
+				Status: scenario.newStatus,
+			}
+			if scenario.newTarget != "" {
+				newState.Target = scenario.newTarget
+			} else {
+				newState.Target = scenario.target
+				scenario.newTarget = scenario.target
+			}
+			newStates["myalias"] = newState
+		}
+
+		err := snapstate.ApplyAliasChange(s.state, "alias-snap1", prevStates, newStates, s.fakeBackend)
+		c.Assert(err, IsNil)
+
+		var add, rm []*backend.Alias
+		if strings.Contains(scenario.ops, "rm") {
+			rm = []*backend.Alias{{"myalias", fmt.Sprintf("alias-snap1.%s", scenario.target)}}
+		}
+
+		if strings.Contains(scenario.ops, "add") {
+			add = []*backend.Alias{{"myalias", fmt.Sprintf("alias-snap1.%s", scenario.newTarget)}}
+		}
+
+		expected := fakeOps{
+			{
+				op:        "update-aliases",
+				rmAliases: rm,
+				aliases:   add,
+			},
+		}
+
+		// start with an easier-to-read error if this fails:
+		c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops(), Commentf("%v", scenario))
+		c.Assert(s.fakeBackend.ops, DeepEquals, expected, Commentf("%v", scenario))
+
+		s.fakeBackend.ops = nil
+	}
+}
+
+func (s *snapmgrTestSuite) TestApplyAliasChangeMulti(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	prevStates := map[string]*snapstate.AliasState{
+		"myalias0": {Status: "auto", Target: "cmd0"},
+	}
+	newStates := map[string]*snapstate.AliasState{
+		"myalias1": {Status: "auto", Target: "alias-snap1"},
+	}
+
+	err := snapstate.ApplyAliasChange(s.state, "alias-snap1", prevStates, newStates, s.fakeBackend)
+	c.Assert(err, IsNil)
+
+	expected := fakeOps{
+		{
+			op:        "update-aliases",
+			rmAliases: []*backend.Alias{{"myalias0", "alias-snap1.cmd0"}},
+			aliases:   []*backend.Alias{{"myalias1", "alias-snap1"}},
+		},
+	}
+
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+}

--- a/overlord/snapstate/backend/aliases.go
+++ b/overlord/snapstate/backend/aliases.go
@@ -77,17 +77,17 @@ func (b Backend) MatchingAliases(aliases []*Alias) ([]*Alias, error) {
 
 // UpdateAliases adds and removes the given aliases.
 func (b Backend) UpdateAliases(add []*Alias, remove []*Alias) error {
-	for _, alias := range add {
-		err := os.Symlink(alias.Target, filepath.Join(dirs.SnapBinariesDir, alias.Name))
-		if err != nil {
-			return fmt.Errorf("cannot create alias symlink: %v", err)
-		}
-	}
-
 	for _, alias := range remove {
 		err := os.Remove(filepath.Join(dirs.SnapBinariesDir, alias.Name))
 		if err != nil {
 			return fmt.Errorf("cannot remove alias symlink: %v", err)
+		}
+	}
+
+	for _, alias := range add {
+		err := os.Symlink(alias.Target, filepath.Join(dirs.SnapBinariesDir, alias.Name))
+		if err != nil {
+			return fmt.Errorf("cannot create alias symlink: %v", err)
 		}
 	}
 	return nil

--- a/overlord/snapstate/backend/aliases_test.go
+++ b/overlord/snapstate/backend/aliases_test.go
@@ -99,6 +99,24 @@ func (s *aliasesSuite) TestUpdateAliasesRemove(c *C) {
 	c.Check(match, HasLen, 0)
 }
 
+func (s *aliasesSuite) TestUpdateAliasesAddRemoveOverlap(c *C) {
+	before := []*backend.Alias{{"bar", "x.bar"}}
+	after := []*backend.Alias{{"bar", "x.baz"}}
+
+	err := s.be.UpdateAliases(before, nil)
+	c.Assert(err, IsNil)
+
+	err = s.be.UpdateAliases(after, before)
+	c.Assert(err, IsNil)
+
+	match, err := s.be.MatchingAliases(before)
+	c.Assert(err, IsNil)
+	c.Check(match, HasLen, 0)
+	match, err = s.be.MatchingAliases(after)
+	c.Assert(err, IsNil)
+	c.Check(match, HasLen, len(after))
+}
+
 func (s *aliasesSuite) TestRemoveSnapAliases(c *C) {
 	aliases := []*backend.Alias{{"x", "x"}, {"bar", "x.bar"}, {"baz", "y.baz"}, {"y", "y"}}
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -118,3 +118,8 @@ var (
 func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {
 	return snapst.previousSideInfo()
 }
+
+// aliases v2
+var (
+	ApplyAliasChange = applyAliasChange
+)

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -121,5 +121,5 @@ func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {
 
 // aliases v2
 var (
-	ApplyAliasChange = applyAliasChange
+	ApplyAliasesChange = applyAliasesChange
 )


### PR DESCRIPTION
This also introduces a struct AliasTargets to keep track of enabled manual targets/aliases and the automatic alias targets for a snap.

The conceptual plan is to have:

    type SnapState struct {
         ...
         Aliases map[string]*AliasTargets
         AliasesStatus AliasesStatus // global snap status for automatic aliases: enabled|disabled...
    }

It's likely not possible because how we use the state lock vs conflicts on updating SnapStates :/

Install and refresh etc will make sure that the content of Aliases reflects the current snap-declaration together with the current snap revision, all other operations on aliases should be able to work only with those two fields.

In order to support changes of targets also teach the backend how to deal with overlapping add/remove of aliases.