### PR TITLE
cmd/snap-confine-suid-trampoline: add new helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ po/snappy.pot
 .dirstamp
 cmd/decode-mount-opts/decode-mount-opts
 cmd/libsnap-confine-private/unit-tests
+cmd/snap-confine-suid-trampoline/snap-confine-suid-trampoline
 cmd/snap-confine/snap-confine
 cmd/snap-confine/snap-confine-unit-tests
 cmd/snap-confine/snap-confine.apparmor

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -6,7 +6,7 @@ dist_man_MANS =
 noinst_PROGRAMS =
 noinst_LIBRARIES =
 
-subdirs = snap-confine snap-discard-ns system-shutdown libsnap-confine-private snap-update-ns
+subdirs = snap-confine snap-discard-ns system-shutdown libsnap-confine-private snap-update-ns snap-confine-suid-trampoline
 
 # Run check-syntax when checking
 # TODO: conver those to autotools-style tests later
@@ -418,3 +418,25 @@ snap_update_ns_unit_tests_LDADD = libsnap-confine-private.a
 snap_update_ns_unit_tests_CFLAGS = $(GLIB_CFLAGS)
 snap_update_ns_unit_tests_LDADD +=  $(GLIB_LIBS)
 endif
+
+##
+## snap-confine-suid-trampoline
+##
+
+libexec_PROGRAMS += snap-confine-suid-trampoline/snap-confine-suid-trampoline
+CLEANFILES += snap-confine-suid-trampoline/snap-confine-suid-trampoline.5
+EXTRA_DIST += snap-confine-suid-trampoline/snap-confine-suid-trampoline.rst
+dist_man_MANS += snap-confine-suid-trampoline/snap-confine-suid-trampoline.5
+
+snap_confine_suid_trampoline_snap_confine_suid_trampoline_SOURCES = \
+	snap-confine-suid-trampoline/main.c
+snap_confine_suid_trampoline_snap_confine_suid_trampoline_CFLAGS = $(filter-out -fPIE -pie,$(CFLAGS)) -static
+snap_confine_suid_trampoline_snap_confine_suid_trampoline_LDFLAGS = $(filter-out -fPIE -pie,$(LDFLAGS)) -static
+
+snap-confine-suid-trampoline/%.5: snap-confine-suid-trampoline/%.rst
+	mkdir -p snap-confine-suid-trampoline
+	$(HAVE_RST2MAN) $^ > $@
+
+# Ensure that suid-trampoline is +s (setuid)
+install-exec-hook::
+	chmod 4755 $(DESTDIR)$(libexecdir)/snap-confine-suid-trampoline

--- a/cmd/snap-confine-suid-trampoline/main.c
+++ b/cmd/snap-confine-suid-trampoline/main.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "config.h"		// for SNAP_MOUNT_PATH
+
+/**
+ * The goal of the snap-confine-suid-trampoline program is to assist snapd in
+ * running snap-confine from the core snap. To do this correctly we need to use
+ * the dynamic linker from the core snap as the host system may not have the
+ * right libraries. 
+ *
+ * The trampoline program is intended to be compiled to a static setuid root
+ * binary. Once executed it unconditionally runs the linker from the core snap
+ * to run snap-confine from the core snap (and to resolve shared libraries
+ * there).
+ *
+ * This program is necessary as otherwise the trick with running the dynamic
+ * linker would not allow snap-confine to retain it's root powers.
+ **/
+
+/**
+ * Path where the current revision of the core snap is mounted.
+ **/
+#define CORE_SNAP_ROOT SNAP_MOUNT_DIR "/core/current"
+
+int main(int argc, char **argv)
+{
+#if defined(__x86_64)
+#define ARCH_TRIPLET "x86_64-linux-gnu"
+#elif defined(__i386)
+#define ARCH_TRIPLET "i386-linux-gnu"
+#elif defined(__aarch64__)
+#define ARCH_TRIPLET "aarch64-linux-gnu"
+#elif defined(__ARMEL__) && __ARM_ARCH == 7
+#define ARCH_TRIPLET "arm-linux-gnueabihf"
+#elif defined(__PPC64__)
+#define ARCH_TRIPLET "powerpc64le-linux-gnu"
+#else
+#error "where is the dynamic linker in the core snap for this architecture?"
+#endif
+
+	// Some of the paths to ld-so may contain symbolic links that use absolute
+	// paths. This makes sense in a root filesystem but in an unknown
+	// environment we just want to avoid them by having a good path to each
+	// dynamic linker used by the (few) core snaps (one per architecture) that
+	// are supported.
+	const char *ld_so_path =
+	    CORE_SNAP_ROOT "/lib/" ARCH_TRIPLET "/ld-2.23.so";
+
+	// Argument array for the dynamic linker.
+	// NOTE: argc + 4 and not argc + 5 because we don't need to copy argv[0].
+	char *ld_so_argv[argc + 4];
+	ld_so_argv[0] = "ld-2.23.so";
+	// Use those libraries please.
+	ld_so_argv[1] = "--library-path";
+	ld_so_argv[2] = (CORE_SNAP_ROOT "/lib/" ARCH_TRIPLET ":"
+			 CORE_SNAP_ROOT "/usr/lib" ARCH_TRIPLET);
+	// Run snap-confine please.
+	ld_so_argv[3] = CORE_SNAP_ROOT "/usr/lib/snapd/snap-confine";
+	// Along with any arguments that we got.
+	for (int i = 1; i < argc; ++i) {
+		ld_so_argv[3 + i] = argv[i];
+	}
+	// Terminate the list of arguments.
+	ld_so_argv[3 + argc] = NULL;
+	// Run it
+	execv(ld_so_path, ld_so_argv);
+	perror("execv failed");
+	return 1;
+}

--- a/cmd/snap-confine-suid-trampoline/snap-confine-suid-trampoline.rst
+++ b/cmd/snap-confine-suid-trampoline/snap-confine-suid-trampoline.rst
@@ -1,0 +1,54 @@
+==============================
+ snap-confine-suid-trampoline
+==============================
+
+-----------------------------------------------------------------
+internal tool for running snap-confine from the core snap as root
+-----------------------------------------------------------------
+
+:Author: zygmunt.krynicki@canonical.com
+:Date:   2017-03-14
+:Copyright: Canonical Ltd.
+:Version: 2.24
+:Manual section: 5
+:Manual group: snappy
+
+SYNOPSIS
+========
+
+	snap-confine-suid-trampoline ...
+
+DESCRIPTION
+===========
+
+`snap-confine-suid-trampoline` program assists snapd in running `snap-confine`
+from the *core* snap. It is not meant to be used directly.
+
+OPTIONS
+=======
+
+The `snap-confine-suid-trampoline` program does not support any options
+directly, all the command line arguments are forwarded as-is to the copy of
+`snap-confine` in the core snap.
+
+ENVIRONMENT
+===========
+
+See the manual page of `snap-confine` for details.
+
+FILES
+=====
+
+`/snap/core/current/lib/$ARCH_TRIPLET/ld-2.30.so`:
+    Path of the dynamic linker in the core snap.
+
+`/snap/core/current/usr/lib/snapd/snap-confine`:
+    Path of the `snap-confine` in the *core* snap.
+
+Note that your distribution may have moved the `/snap` directory to
+`/var/lib/snapd/snap`. This manual page text is static.
+
+BUGS
+====
+
+Please report all bugs with https://bugs.launchpad.net/snap-confine/+filebug

--- a/packaging/ubuntu-14.04/snapd.install
+++ b/packaging/ubuntu-14.04/snapd.install
@@ -19,8 +19,10 @@ etc/apparmor.d/usr.lib.snapd.snap-confine
 lib/udev/rules.d/80-snappy-assign.rules
 lib/udev/snappy-app-dev
 usr/lib/snapd/snap-confine
+usr/lib/snapd/snap-confine-suid-trampoline
 usr/lib/snapd/snap-discard-ns
 usr/lib/snapd/snap-update-ns
+usr/share/man/man5/snap-confine-suid-trampoline.5
 usr/share/man/man5/snap-confine.5
 usr/share/man/man5/snap-update-ns.5
 usr/share/man/man5/snap-discard-ns.5

--- a/packaging/ubuntu-16.04/snapd.install
+++ b/packaging/ubuntu-16.04/snapd.install
@@ -20,8 +20,10 @@ etc/apparmor.d/usr.lib.snapd.snap-confine
 lib/udev/rules.d/80-snappy-assign.rules
 lib/udev/snappy-app-dev
 usr/lib/snapd/snap-confine
+usr/lib/snapd/snap-confine-suid-trampoline
 usr/lib/snapd/snap-discard-ns
 usr/lib/snapd/snap-update-ns
+usr/share/man/man5/snap-confine-suid-trampoline.5
 usr/share/man/man5/snap-confine.5
 usr/share/man/man5/snap-update-ns.5
 usr/share/man/man5/snap-discard-ns.5


### PR DESCRIPTION
This patch adds a new helper static program that assists in running
snap-confine from the core snap. Please refer to the code comments and
the manual page for details.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>