### PR TITLE
cmd: rename all unit tests to $command/unit-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,13 +19,13 @@ po/snappy.pot
 cmd/decode-mount-opts/decode-mount-opts
 cmd/libsnap-confine-private/unit-tests
 cmd/snap-confine/snap-confine
-cmd/snap-confine/snap-confine-unit-tests
 cmd/snap-confine/snap-confine.apparmor
+cmd/snap-confine/unit-tests
 cmd/snap-discard-ns/snap-discard-ns
 cmd/snap-update-ns/snap-update-ns
 cmd/snap-update-ns/unit-tests
 cmd/system-shutdown/system-shutdown
-cmd/system-shutdown/system-shutdown-unit-tests
+cmd/system-shutdown/unit-tests
 
 # manual pages
 cmd/*/*.[1-9]

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -35,11 +35,11 @@ endif
 
 .PHONY: check-unit-tests
 if WITH_UNIT_TESTS
-check-unit-tests: snap-confine/snap-confine-unit-tests system-shutdown/system-shutdown-unit-tests libsnap-confine-private/unit-tests snap-update-ns/unit-tests
+check-unit-tests: snap-confine/unit-tests system-shutdown/unit-tests libsnap-confine-private/unit-tests snap-update-ns/unit-tests
 	$(HAVE_VALGRIND) ./libsnap-confine-private/unit-tests
-	$(HAVE_VALGRIND) ./snap-confine/snap-confine-unit-tests
+	$(HAVE_VALGRIND) ./snap-confine/unit-tests
 	$(HAVE_VALGRIND) ./snap-update-ns/unit-tests
-	$(HAVE_VALGRIND) ./system-shutdown/system-shutdown-unit-tests
+	$(HAVE_VALGRIND) ./system-shutdown/unit-tests
 else
 check-unit-tests:
 	echo "unit tests are disabled (rebuild with --enable-unit-tests)"
@@ -246,8 +246,8 @@ snap-confine/snap-confine-debug$(EXEEXT): $(snap_confine_snap_confine_debug_OBJE
 snap-confine/snap-confine-debug$(EXEEXT): LIBS += -Wl,-Bstatic -lcap -Wl,-Bdynamic
 
 if WITH_UNIT_TESTS
-noinst_PROGRAMS += snap-confine/snap-confine-unit-tests
-snap_confine_snap_confine_unit_tests_SOURCES = \
+noinst_PROGRAMS += snap-confine/unit-tests
+snap_confine_unit_tests_SOURCES = \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
 	libsnap-confine-private/unit-tests.h \
@@ -258,16 +258,16 @@ snap_confine_snap_confine_unit_tests_SOURCES = \
 	snap-confine/quirks.c \
 	snap-confine/quirks.h \
 	snap-confine/snap-confine-args-test.c
-snap_confine_snap_confine_unit_tests_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(GLIB_CFLAGS)
-snap_confine_snap_confine_unit_tests_LDADD = $(snap_confine_snap_confine_LDADD) $(GLIB_LIBS)
-snap_confine_snap_confine_unit_tests_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)
+snap_confine_unit_tests_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(GLIB_CFLAGS)
+snap_confine_unit_tests_LDADD = $(snap_confine_snap_confine_LDADD) $(GLIB_LIBS)
+snap_confine_unit_tests_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)
 
 
-snap-confine/snap-confine-unit-tests$(EXEEXT): $(snap_confine_snap_confine_unit_tests_OBJECTS) $(snap_confine_snap_confine_unit_tests_DEPENDENCIES) $(EXTRA_snap_confine_snap_confine_unit_tests_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
-	@rm -f snap-confine/snap-confine-unit-tests$(EXEEXT)
-	$(AM_V_CCLD)$(snap_confine_snap_confine_unit_tests_LINK) $(snap_confine_snap_confine_unit_tests_OBJECTS) $(snap_confine_snap_confine_unit_tests_LDADD) $(LIBS)
+snap-confine/unit-tests$(EXEEXT): $(snap_confine_unit_tests_OBJECTS) $(snap_confine_unit_tests_DEPENDENCIES) $(EXTRA_snap_confine_unit_tests_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
+	@rm -f snap-confine/unit-tests$(EXEEXT)
+	$(AM_V_CCLD)$(snap_confine_unit_tests_LINK) $(snap_confine_unit_tests_OBJECTS) $(snap_confine_unit_tests_LDADD) $(LIBS)
 
-snap-confine/snap-confine-unit-tests$(EXEEXT): LIBS += -Wl,-Bstatic -lcap -Wl,-Bdynamic
+snap-confine/unit-tests$(EXEEXT): LIBS += -Wl,-Bstatic -lcap -Wl,-Bdynamic
 
 endif
 
@@ -374,14 +374,14 @@ system_shutdown_system_shutdown_CFLAGS = $(filter-out -fPIE -pie,$(CFLAGS)) -sta
 system_shutdown_system_shutdown_LDFLAGS = $(filter-out -fPIE -pie,$(LDFLAGS)) -static
 
 if WITH_UNIT_TESTS
-noinst_PROGRAMS += system-shutdown/system-shutdown-unit-tests
-system_shutdown_system_shutdown_unit_tests_SOURCES = \
+noinst_PROGRAMS += system-shutdown/unit-tests
+system_shutdown_unit_tests_SOURCES = \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
 	system-shutdown/system-shutdown-utils-test.c
-system_shutdown_system_shutdown_unit_tests_LDADD = libsnap-confine-private.a
-system_shutdown_system_shutdown_unit_tests_CFLAGS = $(GLIB_CFLAGS)
-system_shutdown_system_shutdown_unit_tests_LDADD +=  $(GLIB_LIBS)
+system_shutdown_unit_tests_LDADD = libsnap-confine-private.a
+system_shutdown_unit_tests_CFLAGS = $(GLIB_CFLAGS)
+system_shutdown_unit_tests_LDADD +=  $(GLIB_LIBS)
 endif
 
 ##


### PR DESCRIPTION
This patch renames snap-confine-unit-tests and
system-shutdown-unit-tests to just unit-tests.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>