### PR TITLE
cmd/libsnap: make mountinfo structures public

### DIFF
--- a/cmd/libsnap-confine-private/mountinfo-test.c
+++ b/cmd/libsnap-confine-private/mountinfo-test.c
@@ -156,28 +156,6 @@ static void test_parse_mountinfo_entry__many_tags()
 	g_assert_null(entry->next);
 }
 
-static void test_accessor_funcs()
-{
-	const char *line =
-	    "256 104 0:3 mnt:[4026532509] /run/snapd/ns/hello-world.mnt rw - nsfs nsfs rw";
-	struct sc_mountinfo_entry *entry = sc_parse_mountinfo_entry(line);
-	g_assert_nonnull(entry);
-	g_test_queue_destroy((GDestroyNotify) sc_free_mountinfo_entry, entry);
-	g_assert_cmpint(sc_mountinfo_entry_mount_id(entry), ==, 256);
-	g_assert_cmpint(sc_mountinfo_entry_parent_id(entry), ==, 104);
-	g_assert_cmpint(sc_mountinfo_entry_dev_major(entry), ==, 0);
-	g_assert_cmpint(sc_mountinfo_entry_dev_minor(entry), ==, 3);
-
-	g_assert_cmpstr(sc_mountinfo_entry_root(entry), ==, "mnt:[4026532509]");
-	g_assert_cmpstr(sc_mountinfo_entry_mount_dir(entry), ==,
-			"/run/snapd/ns/hello-world.mnt");
-	g_assert_cmpstr(sc_mountinfo_entry_mount_opts(entry), ==, "rw");
-	g_assert_cmpstr(sc_mountinfo_entry_optional_fields(entry), ==, "");
-	g_assert_cmpstr(sc_mountinfo_entry_fs_type(entry), ==, "nsfs");
-	g_assert_cmpstr(sc_mountinfo_entry_mount_source(entry), ==, "nsfs");
-	g_assert_cmpstr(sc_mountinfo_entry_super_opts(entry), ==, "rw");
-}
-
 static void __attribute__ ((constructor)) init()
 {
 	g_test_add_func("/mountinfo/parse_mountinfo_entry/sysfs",
@@ -194,5 +172,4 @@ static void __attribute__ ((constructor)) init()
 			test_parse_mountinfo_entry__one_tag);
 	g_test_add_func("/mountinfo/parse_mountinfo_entry/many_tags",
 			test_parse_mountinfo_entry__many_tags);
-	g_test_add_func("/mountinfo/accessor_funcs", test_accessor_funcs);
 }

--- a/cmd/libsnap-confine-private/mountinfo.c
+++ b/cmd/libsnap-confine-private/mountinfo.c
@@ -23,31 +23,6 @@
 
 #include "cleanup-funcs.h"
 
-struct sc_mountinfo {
-	struct sc_mountinfo_entry *first;
-};
-
-struct sc_mountinfo_entry {
-	int mount_id;
-	int parent_id;
-	unsigned dev_major, dev_minor;
-	char *root;
-	char *mount_dir;
-	char *mount_opts;
-	char *optional_fields;
-	char *fs_type;
-	char *mount_source;
-	char *super_opts;
-
-	struct sc_mountinfo_entry *next;
-	// Buffer holding all of the text data above.
-	//
-	// The buffer must be the last element of the structure. It is allocated
-	// along with the structure itself and does not need to be freed
-	// separately.
-	char line_buf[0];
-};
-
 /**
  * Parse a single mountinfo entry (line).
  *
@@ -92,61 +67,6 @@ struct sc_mountinfo_entry *sc_next_mountinfo_entry(struct sc_mountinfo_entry
 						   *entry)
 {
 	return entry->next;
-}
-
-int sc_mountinfo_entry_mount_id(struct sc_mountinfo_entry *entry)
-{
-	return entry->mount_id;
-}
-
-int sc_mountinfo_entry_parent_id(struct sc_mountinfo_entry *entry)
-{
-	return entry->parent_id;
-}
-
-unsigned sc_mountinfo_entry_dev_major(struct sc_mountinfo_entry *entry)
-{
-	return entry->dev_major;
-}
-
-unsigned sc_mountinfo_entry_dev_minor(struct sc_mountinfo_entry *entry)
-{
-	return entry->dev_minor;
-}
-
-const char *sc_mountinfo_entry_root(struct sc_mountinfo_entry *entry)
-{
-	return entry->root;
-}
-
-const char *sc_mountinfo_entry_mount_dir(struct sc_mountinfo_entry *entry)
-{
-	return entry->mount_dir;
-}
-
-const char *sc_mountinfo_entry_mount_opts(struct sc_mountinfo_entry *entry)
-{
-	return entry->mount_opts;
-}
-
-const char *sc_mountinfo_entry_optional_fields(struct sc_mountinfo_entry *entry)
-{
-	return entry->optional_fields;
-}
-
-const char *sc_mountinfo_entry_fs_type(struct sc_mountinfo_entry *entry)
-{
-	return entry->fs_type;
-}
-
-const char *sc_mountinfo_entry_mount_source(struct sc_mountinfo_entry *entry)
-{
-	return entry->mount_source;
-}
-
-const char *sc_mountinfo_entry_super_opts(struct sc_mountinfo_entry *entry)
-{
-	return entry->super_opts;
 }
 
 struct sc_mountinfo *sc_parse_mountinfo(const char *fname)

--- a/cmd/libsnap-confine-private/mountinfo.h
+++ b/cmd/libsnap-confine-private/mountinfo.h
@@ -20,12 +20,78 @@
 /**
  * Structure describing entire /proc/self/sc_mountinfo file
  **/
-struct sc_mountinfo;
+struct sc_mountinfo {
+	struct sc_mountinfo_entry *first;
+};
 
 /**
  * Structure describing a single entry in /proc/self/sc_mountinfo
  **/
-struct sc_mountinfo_entry;
+struct sc_mountinfo_entry {
+	/**
+	 * The mount identifier of a given mount entry.
+	 **/
+	int mount_id;
+	/**
+	 * The parent mount identifier of a given mount entry.
+	 **/
+	int parent_id;
+	unsigned dev_major, dev_minor;
+	/**
+	 * The root directory of a given mount entry.
+	 **/
+	char *root;
+	/**
+	 * The mount point of a given mount entry.
+	 **/
+	char *mount_dir;
+	/**
+	 * The mount options of a given mount entry.
+	 **/
+	char *mount_opts;
+	/**
+	 * Optional tagged data associated of a given mount entry.
+	 *
+	 * The return value is a string (possibly empty but never NULL) in the format
+	 * tag[:value]. Known tags are:
+	 *
+	 * "shared:X":
+	 * 		mount is shared in peer group X
+	 * "master:X":
+	 * 		mount is slave to peer group X
+	 * "propagate_from:X"
+	 * 		mount is slave and receives propagation from peer group X (*)
+	 * "unbindable":
+	 * 		mount is unbindable
+	 *
+	 * (*) X is the closest dominant peer group under the process's root.
+	 * If X is the immediate master of the mount, or if there's no dominant peer
+	 * group under the same root, then only the "master:X" field is present and not
+	 * the "propagate_from:X" field.
+	 **/
+	char *optional_fields;
+	/**
+	 * The file system type of a given mount entry.
+	 **/
+	char *fs_type;
+	/**
+	 * The source of a given mount entry.
+	 **/
+	char *mount_source;
+	/**
+	 * The super block options of a given mount entry.
+	 **/
+	char *super_opts;
+
+	struct sc_mountinfo_entry *next;
+
+	// Buffer holding all of the text data above.
+	//
+	// The buffer must be the last element of the structure. It is allocated
+	// along with the structure itself and does not need to be freed
+	// separately.
+	char line_buf[0];
+};
 
 /**
  * Parse a file in according to sc_mountinfo syntax.
@@ -64,83 +130,6 @@ struct sc_mountinfo_entry *sc_first_mountinfo_entry(struct sc_mountinfo *info)
  **/
 struct sc_mountinfo_entry *sc_next_mountinfo_entry(struct sc_mountinfo_entry
 						   *entry)
-    __attribute__ ((nonnull(1)));
-
-/**
- * Get the mount identifier of a given mount entry.
- **/
-int sc_mountinfo_entry_mount_id(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-/**
- * Get the parent mount identifier of a given mount entry.
- **/
-int sc_mountinfo_entry_parent_id(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-unsigned sc_mountinfo_entry_dev_major(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-unsigned sc_mountinfo_entry_dev_minor(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-/**
- * Get the root directory of a given mount entry.
- **/
-const char *sc_mountinfo_entry_root(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-/**
- * Get the mount point of a given mount entry.
- **/
-const char *sc_mountinfo_entry_mount_dir(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-/**
- * Get the mount options of a given mount entry.
- **/
-const char *sc_mountinfo_entry_mount_opts(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-/**
- * Get optional tagged data associated of a given mount entry.
- *
- * The return value is a string (possibly empty but never NULL) in the format
- * tag[:value]. Known tags are:
- *
- * "shared:X":
- * 		mount is shared in peer group X
- * "master:X":
- * 		mount is slave to peer group X
- * "propagate_from:X"
- * 		mount is slave and receives propagation from peer group X (*)
- * "unbindable":
- * 		mount is unbindable
- *
- * (*) X is the closest dominant peer group under the process's root.
- * If X is the immediate master of the mount, or if there's no dominant peer
- * group under the same root, then only the "master:X" field is present and not
- * the "propagate_from:X" field.
- **/
-const char *sc_mountinfo_entry_optional_fields(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-/**
- * Get the file system type of a given mount entry.
- **/
-const char *sc_mountinfo_entry_fs_type(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-/**
- * Get the source of a given mount entry.
- **/
-const char *sc_mountinfo_entry_mount_source(struct sc_mountinfo_entry *entry)
-    __attribute__ ((nonnull(1)));
-
-/**
- * Get the super block options of a given mount entry.
- **/
-const char *sc_mountinfo_entry_super_opts(struct sc_mountinfo_entry *entry)
     __attribute__ ((nonnull(1)));
 
 #endif

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -156,9 +156,8 @@ static bool sc_is_ns_group_dir_private()
 	}
 	struct sc_mountinfo_entry *entry = sc_first_mountinfo_entry(info);
 	while (entry != NULL) {
-		const char *mount_dir = sc_mountinfo_entry_mount_dir(entry);
-		const char *optional_fields =
-		    sc_mountinfo_entry_optional_fields(entry);
+		const char *mount_dir = entry->mount_dir;
+		const char *optional_fields = entry->optional_fields;
 		if (strcmp(mount_dir, sc_ns_dir) == 0
 		    && strcmp(optional_fields, "") == 0) {
 			// If /run/snapd/ns has no optional fields, we know it is mounted

--- a/cmd/system-shutdown/system-shutdown-utils.c
+++ b/cmd/system-shutdown/system-shutdown-utils.c
@@ -100,9 +100,9 @@ bool umount_all()
 		had_writable = false;
 		did_umount = false;
 		while (cur) {
-			const char *dir = sc_mountinfo_entry_mount_dir(cur);
-			const char *src = sc_mountinfo_entry_mount_source(cur);
-			unsigned major = sc_mountinfo_entry_dev_major(cur);
+			const char *dir = cur->mount_dir;
+			const char *src = cur->mount_source;
+			unsigned major = cur->dev_major;
 
 			cur = sc_next_mountinfo_entry(cur);
 


### PR DESCRIPTION
The mountinfo structure has a set of functions that just expose the
internal fields and since this is a tightly coupled library we can just
acess them directly.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>