### PR TITLE
interfaces: log if the system goes into ForceDevMode

### DIFF
--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/systemd"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/release"
 )
 
@@ -42,7 +43,9 @@ var All = []interfaces.SecurityBackend{
 }
 
 func init() {
-	if !release.ReleaseInfo.ForceDevMode() {
+	if release.ReleaseInfo.ForceDevMode() {
+		logger.Noticef("Cannot find sufficient apparmor support, disabling apparmor security backend")
+	} else {
 		All = append(All, &apparmor.Backend{})
 	}
 }

--- a/spread.yaml
+++ b/spread.yaml
@@ -166,6 +166,10 @@ exclude:
     - "*.a"
 
 prepare-each: |
+    if journalctl |grep "Cannot find sufficient apparmor support"; then
+        echo "Insufficient apparmor supported detect, this should never happen"
+        exit 1
+    fi
     # systemd on 14.04 does not know about --rotate
     # or --vacuum-time.
     # TODO: Find a way to clean out systemd logs on


### PR DESCRIPTION
Small drive-by branch: I noticed we don't actually log that we go into ForceDevMode. Which seems very useful to do. Plus now that the apparmor detection is more dynamic we want to know about potential issues early.

Also update tests to fail if snapd ever goes into ForceDevMode during
the tests.