### PR TITLE
tests: fix classic-ubuntu-core-transition race

### DIFF
--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -7,6 +7,9 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 warn-timeout: 1m
 kill-timeout: 5m
 
+restore: |
+    rm -f state-json.new
+
 execute: |
     wait_for_service() {
         local service_name="$1"

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -7,9 +7,6 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 warn-timeout: 1m
 kill-timeout: 5m
 
-restore: |
-    rm -f prevValue state.json.copy
-
 execute: |
     wait_for_service() {
         local service_name="$1"
@@ -35,12 +32,11 @@ execute: |
     # modify daemon state to set ubuntu-core-transition-last-retry-time to the
     # current time to prevent the ubuntu-core transition before the test snap is
     # installed
-    cat /var/lib/snapd/state.json | jq '.["ubuntu-core-transition-last-retry-time"]' > prevValue
-    systemctl stop snapd.service snapd.socket
-    cp /var/lib/snapd/state.json state.json.copy
-    now=$(date --utc --rfc-3339=ns | tr ' ' T)
-    cat state.json.copy | jq -c '. + {"ubuntu-core-transition-last-retry-time": "'"$now"'"}' > /var/lib/snapd/state.json
-    systemctl start snapd.service snapd.socket
+    systemctl stop snapd.{service,socket}
+    now=$(date --utc -Ins)
+    cat /var/lib/snapd/state.json | jq -c '. + {data: (.data + {"ubuntu-core-transition-last-retry-time": "'"$now"'"})}' > state.json.new
+    mv state.json.new /var/lib/snapd/state.json
+    systemctl start snapd.{service,socket}
 
     snap install --${CORE_CHANNEL} ubuntu-core
     snap install test-snapd-python-webserver
@@ -51,14 +47,10 @@ execute: |
     curl http://localhost | MATCH "XKCD rocks"
 
     # restore ubuntu-core-transition-last-retry-time to its previous value and restart the daemon
-    systemctl stop snapd.service snapd.socket
-    cp /var/lib/snapd/state.json state.json.copy
-    if [ "$(cat prevValue)" = null ]; then
-        cat state.json.copy | jq -c 'del(.["ubuntu-core-transition-last-retry-time"])' > /var/lib/snapd/state.json
-    else
-        cat state.json.copy | jq -c '. + {"ubuntu-core-transition-last-retry-time": "'"$(cat prevValue)"'"}' > /var/lib/snapd/state.json
-    fi
-    systemctl start snapd.service snapd.socket
+    systemctl stop snapd.{service,socket}
+    cat /var/lib/snapd/state.json | jq -c 'del(.["data"]["ubuntu-core-transition-last-retry-time"])' > state.json.new
+    mv state.json.new /var/lib/snapd/state.json
+    systemctl start snapd.{service,socket}
 
     echo "Ensure transition is triggered"
     snap debug ensure-state-soon

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -8,7 +8,7 @@ warn-timeout: 1m
 kill-timeout: 5m
 
 restore: |
-    rm -f state-json.new
+    rm -f state.json.new
 
 execute: |
     wait_for_service() {


### PR DESCRIPTION
These changes set the ubuntu-core-transition-last-retry-time value under the data entry, instead of setting it at the top level of the state object, in order to properly stop the transition until the setup is done.