### PR TITLE
interfaces: dbus backend spec

### DIFF
--- a/interfaces/dbus/spec.go
+++ b/interfaces/dbus/spec.go
@@ -1,0 +1,131 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package dbus
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+// Specification keeps all the dbus snippets.
+type Specification struct {
+	// Snippets are indexed by security tag.
+	snippets     map[string][]string
+	securityTags []string
+}
+
+// AddSnippet adds a new dbus snippet.
+func (spec *Specification) AddSnippet(snippet string) {
+	if len(spec.securityTags) == 0 {
+		return
+	}
+	if spec.snippets == nil {
+		spec.snippets = make(map[string][]string)
+	}
+	for _, tag := range spec.securityTags {
+		spec.snippets[tag] = append(spec.snippets[tag], snippet)
+	}
+}
+
+// Snippets returns a deep copy of all the added snippets.
+func (spec *Specification) Snippets() map[string][]string {
+	result := make(map[string][]string, len(spec.snippets))
+	for k, v := range spec.snippets {
+		result[k] = append([]string(nil), v...)
+	}
+	return result
+}
+
+// SnippetForTag returns a combined snippet for given security tag with individual snippets
+// joined with newline character. Empty string is returned for non-existing security tag.
+func (spec *Specification) SnippetForTag(tag string) string {
+	var buffer bytes.Buffer
+	for _, snippet := range spec.snippets[tag] {
+		buffer.WriteString(snippet)
+		buffer.WriteRune('\n')
+	}
+	return buffer.String()
+}
+
+// SecurityTags returns a list of security tags which have a snippet.
+func (spec *Specification) SecurityTags() []string {
+	var tags []string
+	for t := range spec.snippets {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// Implementation of methods required by interfaces.Specification
+
+// AddConnectedPlug records dbus-specific side-effects of having a connected plug.
+func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		DBusConnectedPlug(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = plug.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.DBusConnectedPlug(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddConnectedSlot records dbus-specific side-effects of having a connected slot.
+func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	type definer interface {
+		DBusConnectedSlot(spec *Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = slot.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.DBusConnectedSlot(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddPermanentPlug records dbus-specific side-effects of having a plug.
+func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *interfaces.Plug) error {
+	type definer interface {
+		DBusPermanentPlug(spec *Specification, plug *interfaces.Plug) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = plug.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.DBusPermanentPlug(spec, plug)
+	}
+	return nil
+}
+
+// AddPermanentSlot records dbus-specific side-effects of having a slot.
+func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *interfaces.Slot) error {
+	type definer interface {
+		DBusPermanentSlot(spec *Specification, slot *interfaces.Slot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		spec.securityTags = slot.SecurityTags()
+		defer func() { spec.securityTags = nil }()
+		return iface.DBusPermanentSlot(spec, slot)
+	}
+	return nil
+}

--- a/interfaces/dbus/spec_test.go
+++ b/interfaces/dbus/spec_test.go
@@ -1,0 +1,105 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package dbus_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/dbus"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/snap"
+)
+
+type specSuite struct {
+	iface *ifacetest.TestInterface
+	spec  *dbus.Specification
+	plug  *interfaces.Plug
+	slot  *interfaces.Slot
+}
+
+var _ = Suite(&specSuite{
+	iface: &ifacetest.TestInterface{
+		InterfaceName: "test",
+		DBusConnectedPlugCallback: func(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			spec.AddSnippet("connected-plug")
+			return nil
+		},
+		DBusConnectedSlotCallback: func(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+			spec.AddSnippet("connected-slot")
+			return nil
+		},
+		DBusPermanentPlugCallback: func(spec *dbus.Specification, plug *interfaces.Plug) error {
+			spec.AddSnippet("permanent-plug")
+			return nil
+		},
+		DBusPermanentSlotCallback: func(spec *dbus.Specification, slot *interfaces.Slot) error {
+			spec.AddSnippet("permanent-slot")
+			return nil
+		},
+	},
+	plug: &interfaces.Plug{
+		PlugInfo: &snap.PlugInfo{
+			Snap:      &snap.Info{SuggestedName: "snap1"},
+			Name:      "name",
+			Interface: "test",
+			Apps: map[string]*snap.AppInfo{
+				"app1": {
+					Snap: &snap.Info{
+						SuggestedName: "snap1",
+					},
+					Name: "app1"}},
+		},
+	},
+	slot: &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "snap2"},
+			Name:      "name",
+			Interface: "test",
+			Apps: map[string]*snap.AppInfo{
+				"app2": {
+					Snap: &snap.Info{
+						SuggestedName: "snap2",
+					},
+					Name: "app2"}},
+		},
+	},
+})
+
+func (s *specSuite) SetUpTest(c *C) {
+	s.spec = &dbus.Specification{}
+}
+
+// The spec.Specification can be used through the interfaces.Specification interface
+func (s *specSuite) TestSpecificationIface(c *C) {
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface, s.plug), IsNil)
+	c.Assert(r.AddPermanentSlot(s.iface, s.slot), IsNil)
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
+		"snap.snap1.app1": {"connected-plug", "permanent-plug"},
+		"snap.snap2.app2": {"connected-slot", "permanent-slot"},
+	})
+	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.snap1.app1", "snap.snap2.app2"})
+	c.Assert(s.spec.SnippetForTag("snap.snap1.app1"), Equals, "connected-plug\npermanent-plug\n")
+
+	c.Assert(s.spec.SnippetForTag("non-existing"), Equals, "")
+}

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -90,6 +91,13 @@ type TestInterface struct {
 	SecCompConnectedSlotCallback func(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
 	SecCompPermanentPlugCallback func(spec *seccomp.Specification, plug *interfaces.Plug) error
 	SecCompPermanentSlotCallback func(spec *seccomp.Specification, slot *interfaces.Slot) error
+
+	// Support for interacting with the dbus backend.
+
+	DBusConnectedPlugCallback func(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	DBusConnectedSlotCallback func(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
+	DBusPermanentPlugCallback func(spec *dbus.Specification, plug *interfaces.Plug) error
+	DBusPermanentSlotCallback func(spec *dbus.Specification, slot *interfaces.Slot) error
 }
 
 // String() returns the same value as Name().
@@ -347,6 +355,36 @@ func (t *TestInterface) KModPermanentPlug(spec *kmod.Specification, plug *interf
 func (t *TestInterface) KModPermanentSlot(spec *kmod.Specification, slot *interfaces.Slot) error {
 	if t.KModPermanentSlotCallback != nil {
 		return t.KModPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}
+
+// Support for interacting with the dbus backend.
+
+func (t *TestInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.DBusConnectedPlugCallback != nil {
+		return t.DBusConnectedPlugCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) DBusConnectedSlot(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+	if t.DBusConnectedSlotCallback != nil {
+		return t.DBusConnectedSlotCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+	if t.DBusPermanentSlotCallback != nil {
+		return t.DBusPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) DBusPermanentPlug(spec *dbus.Specification, plug *interfaces.Plug) error {
+	if t.DBusPermanentPlugCallback != nil {
+		return t.DBusPermanentPlugCallback(spec, plug)
 	}
 	return nil
 }


### PR DESCRIPTION
Spec for dbus backend, following apparmor and seccomp specs. This PR just introduces it, it's not really used yet.