### PR TITLE
cmd: enable large file support

### DIFF
--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -16,6 +16,9 @@ AC_PROG_RANLIB
 AC_LANG([C])
 # Checks for libraries.
 
+# check for large file support
+AC_SYS_LARGEFILE
+
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h limits.h stdlib.h string.h sys/mount.h unistd.h])
 AC_CHECK_HEADERS([sys/quota.h], [], [AC_MSG_ERROR(sys/quota.h unavailable)])


### PR DESCRIPTION
This is needed to use xfs.h on 32bit platforms:

/usr/include/xfs/xfs.h:53:12: error: size of array ‘xfs_assert_largefile’ is too large
 extern int xfs_assert_largefile[sizeof(off_t)-8];