### PR TITLE
tests: adjust network-bind test

### DIFF
--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -36,7 +36,7 @@ execute: |
     . "$TESTSLIB/names.sh"
     CONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
-    :network-bind +$SNAP_NAME"
+    :network-bind +core,$SNAP_NAME"
     DISCONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
     - +$SNAP_NAME:network-bind"


### PR DESCRIPTION
The network-bind interface is now also connected to core so the regexp
that described the test had to be tweaked a little.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>