### PR TITLE
interfaces: allow writing config.txt.tmp  in the core-support interface

### DIFF
--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -69,6 +69,7 @@ const coreSupportConnectedPlugAppArmor = `
 # Allow read/write access to the pi2 boot config.txt. WARNING: improperly
 # editing this file may render the system unbootable.
 owner /boot/uboot/config.txt rwk,
+owner /boot/uboot/config.txt.tmp rwk,
 `
 
 // NewShutdownInterface returns a new "shutdown" interface.


### PR DESCRIPTION
Fix the configure hook for the pi2/pi3 by allowing to write to
a /boot/uboot/config.txt.tmp file so that we can prepare the
new file and mv once things are ready.