### PR TITLE
interfaces/mount: compute mount changes required to transition mount profiles

### DIFF
--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -64,9 +64,9 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 		desired[i].Dir = path.Clean(desired[i].Dir)
 	}
 
-	// Sort both lists by directory name.
-	sort.Sort(byDir(current))
-	sort.Sort(byDir(desired))
+	// Sort both lists by directory name with implicit trailing slash.
+	sort.Sort(byMagicDir(current))
+	sort.Sort(byMagicDir(desired))
 
 	// Construct a desired directory map.
 	// Maps from a directory to a pointer to an Entry from the desired list.

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -91,11 +91,9 @@ func NeededChanges(current, desired []Entry) []Change {
 		if skipPrefix != "" && strings.HasPrefix(dir, skipPrefix) && dir[len(skipPrefix)] == '/' {
 			continue
 		}
-		if entry, ok := dm[dir]; ok {
-			if EqualEntries(&c[i], entry) {
-				reuse[dir] = true
-				continue
-			}
+		if entry, ok := dm[dir]; ok && EqualEntries(&c[i], entry) {
+			reuse[dir] = true
+			continue
 		}
 		skipPrefix = dir
 	}

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -83,18 +83,18 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 	// then mark this directory / entry for reuse.
 	//
 	// Don't reuse any children if their parent changes.
-	var skipPrefix string
+	var skipDir string
 	for i := range current {
 		dir := current[i].Dir
-		if skipPrefix != "" && strings.HasPrefix(dir, skipPrefix) && dir[len(skipPrefix)] == '/' {
+		if skipDir != "" && strings.HasPrefix(dir, skipDir) && dir[len(skipDir)] == '/' {
 			continue
 		}
-		skipPrefix = "" // reset skip prefix as it no longer applies
+		skipDir = "" // reset skip prefix as it no longer applies
 		if entry, ok := desiredMap[dir]; ok && current[i].Equal(entry) {
 			reuse[dir] = true
 			continue
 		}
-		skipPrefix = dir // set skip prefix as we're not reusing this entry
+		skipDir = dir // set skip prefix as we're not reusing this entry
 	}
 
 	// We are now ready to compute the necessary mount changes.

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -86,7 +86,7 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 	var skipDir string
 	for i := range current {
 		dir := current[i].Dir
-		if skipDir != "" && strings.HasPrefix(dir, skipDir) && dir[len(skipDir)] == '/' {
+		if skipDir != "" && strings.HasPrefix(dir, skipDir) {
 			continue
 		}
 		skipDir = "" // reset skip prefix as it no longer applies
@@ -94,7 +94,7 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 			reuse[dir] = true
 			continue
 		}
-		skipDir = dir // set skip prefix as we're not reusing this entry
+		skipDir = strings.TrimSuffix(dir, "/") + "/"
 	}
 
 	// We are now ready to compute the necessary mount changes.

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -91,7 +91,7 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 			continue
 		}
 		skipPrefix = "" // reset skip prefix as it no longer applies
-		if entry, ok := desiredMap[dir]; ok && EqualEntries(&current[i], entry) {
+		if entry, ok := desiredMap[dir]; ok && current[i].Equal(entry) {
 			reuse[dir] = true
 			continue
 		}

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -46,33 +46,33 @@ type Change struct {
 // lists are processed and a "diff" of mount changes is produced. The mount
 // changes, when applied in order, transform the current profile into the
 // desired profile.
-func NeededChanges(current, desired []Entry) []Change {
+func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 	var changes []Change
 	// Copy both as we will want to mutate them.
-	c := make([]Entry, len(current))
-	copy(c, current)
-	d := make([]Entry, len(desired))
-	copy(d, desired)
+	current := make([]Entry, len(currentProfile))
+	copy(current, currentProfile)
+	desired := make([]Entry, len(desiredProfile))
+	copy(desired, desiredProfile)
 
 	// Clean the directory part of both profiles. This is done so that we can
 	// easily test if a given directory is a subdirectory with
 	// strings.HasPrefix coupled with an extra slash character.
-	for i := range c {
-		c[i].Dir = path.Clean(c[i].Dir)
+	for i := range current {
+		current[i].Dir = path.Clean(current[i].Dir)
 	}
-	for i := range d {
-		d[i].Dir = path.Clean(d[i].Dir)
+	for i := range desired {
+		desired[i].Dir = path.Clean(desired[i].Dir)
 	}
 
 	// Sort both lists by directory name.
-	sort.Sort(byDir(c))
-	sort.Sort(byDir(d))
+	sort.Sort(byDir(current))
+	sort.Sort(byDir(desired))
 
 	// Construct a desired directory map.
 	// Maps from a directory to a pointer to an Entry from the desired list.
 	dm := make(map[string]*Entry)
-	for i := range d {
-		dm[d[i].Dir] = &d[i]
+	for i := range desired {
+		dm[desired[i].Dir] = &desired[i]
 	}
 
 	// Reuse map, indexed by Entry.Dir.
@@ -86,12 +86,12 @@ func NeededChanges(current, desired []Entry) []Change {
 	//
 	// Don't reuse any children if their parent changes.
 	var skipPrefix string
-	for i := range c {
-		dir := c[i].Dir
+	for i := range current {
+		dir := current[i].Dir
 		if skipPrefix != "" && strings.HasPrefix(dir, skipPrefix) && dir[len(skipPrefix)] == '/' {
 			continue
 		}
-		if entry, ok := dm[dir]; ok && EqualEntries(&c[i], entry) {
+		if entry, ok := dm[dir]; ok && EqualEntries(&current[i], entry) {
 			reuse[dir] = true
 			continue
 		}
@@ -101,16 +101,16 @@ func NeededChanges(current, desired []Entry) []Change {
 	// Unmount all the current entries (unless flagged for reuse).
 	// Because c is sorted by directory name we can iterate in reverse
 	// to ensure we unmount children before we try to unmount parents.
-	for i := len(c) - 1; i >= 0; i-- {
-		if !reuse[c[i].Dir] {
-			changes = append(changes, Change{Action: Unmount, Entry: c[i]})
+	for i := len(current) - 1; i >= 0; i-- {
+		if !reuse[current[i].Dir] {
+			changes = append(changes, Change{Action: Unmount, Entry: current[i]})
 		}
 	}
 
 	// Mount all the desired entries (unless flagged for reuse).
-	for i := range d {
-		if !reuse[d[i].Dir] {
-			changes = append(changes, Change{Action: Mount, Entry: d[i]})
+	for i := range desired {
+		if !reuse[desired[i].Dir] {
+			changes = append(changes, Change{Action: Mount, Entry: desired[i]})
 		}
 	}
 

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -36,8 +36,8 @@ const (
 
 // Change describes a change to the mount table (action and the entry to act on).
 type Change struct {
-	Action Action
 	Entry  Entry
+	Action Action
 }
 
 // NeededChanges computes the changes required to change current to desired mount entries.

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -47,7 +47,6 @@ type Change struct {
 // changes, when applied in order, transform the current profile into the
 // desired profile.
 func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
-	var changes []Change
 	// Copy both as we will want to mutate them.
 	current := make([]Entry, len(currentProfile))
 	copy(current, currentProfile)
@@ -98,6 +97,9 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 		}
 		skipPrefix = dir // set skip prefix as we're not reusing this entry
 	}
+
+	// We are now ready to compute the necessary mount changes.
+	var changes []Change
 
 	// Unmount all the current entries (unless flagged for reuse).
 	// Because c is sorted by directory name we can iterate in reverse

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -70,9 +70,9 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 
 	// Construct a desired directory map.
 	// Maps from a directory to a pointer to an Entry from the desired list.
-	dm := make(map[string]*Entry)
+	desiredMap := make(map[string]*Entry)
 	for i := range desired {
-		dm[desired[i].Dir] = &desired[i]
+		desiredMap[desired[i].Dir] = &desired[i]
 	}
 
 	// Reuse map, indexed by Entry.Dir.
@@ -91,7 +91,7 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 		if skipPrefix != "" && strings.HasPrefix(dir, skipPrefix) && dir[len(skipPrefix)] == '/' {
 			continue
 		}
-		if entry, ok := dm[dir]; ok && EqualEntries(&current[i], entry) {
+		if entry, ok := desiredMap[dir]; ok && EqualEntries(&current[i], entry) {
 			reuse[dir] = true
 			continue
 		}

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -91,11 +91,12 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 		if skipPrefix != "" && strings.HasPrefix(dir, skipPrefix) && dir[len(skipPrefix)] == '/' {
 			continue
 		}
+		skipPrefix = "" // reset skip prefix as it no longer applies
 		if entry, ok := desiredMap[dir]; ok && EqualEntries(&current[i], entry) {
 			reuse[dir] = true
 			continue
 		}
-		skipPrefix = dir
+		skipPrefix = dir // set skip prefix as we're not reusing this entry
 	}
 
 	// Unmount all the current entries (unless flagged for reuse).

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -24,15 +24,18 @@ import (
 	"sort"
 )
 
+// Action represents a mount action (mount, remount, unmount, etc).
+type Action string
+
 const (
-	Mount = iota
-	Unmount
+	Mount   Action = "mount"
+	Unmount Action = "umount"
 	// Remount when needed
 )
 
 // Change describes a change to the mount table (action and the entry to act on).
 type Change struct {
-	Action int
+	Action Action
 	Entry  Entry
 }
 

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -73,16 +73,9 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 		desiredMap[desired[i].Dir] = &desired[i]
 	}
 
-	// Reuse map, indexed by Entry.Dir.
-	// All reused entries will not be unmounted or mounted. Reused entries must
-	// naturally exist in the desired and current maps or no reuse is possible.
-	reuse := make(map[string]bool)
-
-	// See if there are any directories that we can reuse. Go over all the
-	// entries in the current entries and if there's an identical desired entry
-	// then mark this directory / entry for reuse.
-	//
-	// Don't reuse any children if their parent changes.
+	// Compute reusable entries: those which are equal in current and desired and which
+	// are not prefixed by another entry that changed.
+	var reuse map[string]bool
 	var skipDir string
 	for i := range current {
 		dir := current[i].Dir
@@ -91,6 +84,9 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 		}
 		skipDir = "" // reset skip prefix as it no longer applies
 		if entry, ok := desiredMap[dir]; ok && current[i].Equal(entry) {
+			if reuse == nil {
+				reuse = make(map[string]bool)
+			}
 			reuse[dir] = true
 			continue
 		}

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -100,16 +100,14 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 	// We are now ready to compute the necessary mount changes.
 	var changes []Change
 
-	// Unmount all the current entries (unless flagged for reuse).
-	// Because c is sorted by directory name we can iterate in reverse
-	// to ensure we unmount children before we try to unmount parents.
+	// Unmount entries not reused in reverse to handle children before their parent.
 	for i := len(current) - 1; i >= 0; i-- {
 		if !reuse[current[i].Dir] {
 			changes = append(changes, Change{Action: Unmount, Entry: current[i]})
 		}
 	}
 
-	// Mount all the desired entries (unless flagged for reuse).
+	// Mount desired entries not reused.
 	for i := range desired {
 		if !reuse[desired[i].Dir] {
 			changes = append(changes, Change{Action: Mount, Entry: desired[i]})

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -68,7 +68,6 @@ func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
 	sort.Sort(byMagicDir(desired))
 
 	// Construct a desired directory map.
-	// Maps from a directory to a pointer to an Entry from the desired list.
 	desiredMap := make(map[string]*Entry)
 	for i := range desired {
 		desiredMap[desired[i].Dir] = &desired[i]

--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -1,0 +1,109 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount
+
+import (
+	"path"
+	"sort"
+)
+
+const (
+	Mount = iota
+	Unmount
+	// Remount when needed
+)
+
+// Change describes a change to the mount table (action and the entry to act on).
+type Change struct {
+	Action int
+	Entry  Entry
+}
+
+// NeededChanges computes the changes required to change current to desired mount entries.
+//
+// The current and desired profiles is a fstab like list of mount entries. The
+// lists are processed and a "diff" of mount changes is produced. The mount
+// changes, when applied in order, transform the current profile into the
+// desired profile.
+func NeededChanges(current, desired []Entry) []Change {
+	var changes []Change
+	// Copy both as we will want to mutate them.
+	c := make([]Entry, len(current))
+	copy(c, current)
+	d := make([]Entry, len(desired))
+	copy(d, desired)
+
+	// Clean the directory part of both profiles. This is done so that we can
+	// easily test if a given directory is a subdirectory with
+	// strings.HasPrefix coupled with an extra slash character.
+	for i := range c {
+		c[i].Dir = path.Clean(c[i].Dir)
+	}
+	for i := range d {
+		d[i].Dir = path.Clean(d[i].Dir)
+	}
+
+	// Sort both lists by directory name.
+	sort.Sort(byDir(c))
+	sort.Sort(byDir(d))
+
+	// Construct a desired directory map.
+	// Maps from a directory to a pointer to an Entry from the desired list.
+	dm := make(map[string]*Entry)
+	for i := range d {
+		dm[d[i].Dir] = &d[i]
+	}
+
+	// Reuse map, indexed by Entry.Dir.
+	// All reused entries will not be unmounted or mounted. Reused entries must
+	// naturally exist in the desired and current maps or no reuse is possible.
+	reuse := make(map[string]bool)
+
+	// See if there are any directories that we can reuse. Go over all the
+	// entries in the current entries and if there's an identical desired entry
+	// then mark this directory / entry for reuse.
+	//
+	// TODO: Don't reuse any children if their parent changes.
+	for i := range c {
+		if entry, ok := dm[c[i].Dir]; ok {
+			if EqualEntries(&c[i], entry) {
+				reuse[entry.Dir] = true
+			}
+		}
+	}
+
+	// Unmount all the current entries (unless flagged for reuse).
+	// Because c is sorted by directory name we can iterate in reverse
+	// to ensure we unmount children before we try to unmount parents.
+	for i := len(c) - 1; i >= 0; i-- {
+		if !reuse[c[i].Dir] {
+			changes = append(changes, Change{Action: Unmount, Entry: c[i]})
+		}
+	}
+
+	// Mount all the desired entries (unless flagged for reuse).
+	for i := range d {
+		if !reuse[d[i].Dir] {
+			changes = append(changes, Change{Action: Mount, Entry: d[i]})
+		}
+	}
+
+	return changes
+}

--- a/interfaces/mount/change_test.go
+++ b/interfaces/mount/change_test.go
@@ -1,0 +1,92 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/mount"
+)
+
+type changeSuite struct{}
+
+var _ = Suite(&changeSuite{})
+
+// When there are no profiles we don't do anything.
+func (s *changeSuite) TestNeededChangesNoProfiles(c *C) {
+	changes := mount.NeededChanges(nil, nil)
+	c.Assert(changes, IsNil)
+}
+
+// When the profiles are the same we don't do anything.
+func (s *changeSuite) TestNeededChangesNoChange(c *C) {
+	current := []mount.Entry{{Dir: "/var/snap/foo/common/stuf"}}
+	desired := []mount.Entry{{Dir: "/var/snap/foo/common/stuf"}}
+	changes := mount.NeededChanges(current, desired)
+	c.Assert(changes, IsNil)
+}
+
+// When the content interface is connected we should mount the new entry.
+func (s *changeSuite) TestNeededChangesTrivialMount(c *C) {
+	var current []mount.Entry
+	desired := []mount.Entry{{Dir: "/var/snap/foo/common/stuf"}}
+	changes := mount.NeededChanges(current, desired)
+	c.Assert(changes, DeepEquals, []mount.Change{
+		{Action: mount.Mount, Entry: desired[0]},
+	})
+}
+
+// When the content interface is disconnected we should unmount the mounted entry.
+func (s *changeSuite) TestNeededChangesTrivialUnmount(c *C) {
+	current := []mount.Entry{{Dir: "/var/snap/foo/common/stuf"}}
+	var desired []mount.Entry
+	changes := mount.NeededChanges(current, desired)
+	c.Assert(changes, DeepEquals, []mount.Change{
+		{Action: mount.Unmount, Entry: current[0]},
+	})
+}
+
+// When umounting we unmount children before parents.
+func (s *changeSuite) TestNeededChangesUnmountOrder(c *C) {
+	current := []mount.Entry{
+		{Dir: "/var/snap/foo/common/stuf/extra"},
+		{Dir: "/var/snap/foo/common/stuf"},
+	}
+	var desired []mount.Entry
+	changes := mount.NeededChanges(current, desired)
+	c.Assert(changes, DeepEquals, []mount.Change{
+		{Action: mount.Unmount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}},
+		{Action: mount.Unmount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf"}},
+	})
+}
+
+// When mounting we mount the parents before the children.
+func (s *changeSuite) TestNeededChangesMountOrder(c *C) {
+	var current []mount.Entry
+	desired := []mount.Entry{
+		{Dir: "/var/snap/foo/common/stuf/extra"},
+		{Dir: "/var/snap/foo/common/stuf"},
+	}
+	changes := mount.NeededChanges(current, desired)
+	c.Assert(changes, DeepEquals, []mount.Change{
+		{Action: mount.Mount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf"}},
+		{Action: mount.Mount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}},
+	})
+}

--- a/interfaces/mount/change_test.go
+++ b/interfaces/mount/change_test.go
@@ -111,3 +111,22 @@ func (s *changeSuite) TestNeededChangesChangedParentSameChild(c *C) {
 		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}, Action: mount.Mount},
 	})
 }
+
+// When child changes we don't touch the unchanged parent
+func (s *changeSuite) TestNeededChangesSameParentChangedChild(c *C) {
+	current := []mount.Entry{
+		{Dir: "/var/snap/foo/common/stuf"},
+		{Dir: "/var/snap/foo/common/stuf/extra", Name: "/dev/sda1"},
+		{Dir: "/var/snap/foo/common/unrelated"},
+	}
+	desired := []mount.Entry{
+		{Dir: "/var/snap/foo/common/stuf"},
+		{Dir: "/var/snap/foo/common/stuf/extra", Name: "/dev/sda2"},
+		{Dir: "/var/snap/foo/common/unrelated"},
+	}
+	changes := mount.NeededChanges(current, desired)
+	c.Assert(changes, DeepEquals, []mount.Change{
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra", Name: "/dev/sda1"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra", Name: "/dev/sda2"}, Action: mount.Mount},
+	})
+}

--- a/interfaces/mount/change_test.go
+++ b/interfaces/mount/change_test.go
@@ -49,7 +49,7 @@ func (s *changeSuite) TestNeededChangesTrivialMount(c *C) {
 	desired := []mount.Entry{{Dir: "/var/snap/foo/common/stuf"}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Action: mount.Mount, Entry: desired[0]},
+		{Entry: desired[0], Action: mount.Mount},
 	})
 }
 
@@ -59,7 +59,7 @@ func (s *changeSuite) TestNeededChangesTrivialUnmount(c *C) {
 	var desired []mount.Entry
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Action: mount.Unmount, Entry: current[0]},
+		{Entry: current[0], Action: mount.Unmount},
 	})
 }
 
@@ -72,8 +72,8 @@ func (s *changeSuite) TestNeededChangesUnmountOrder(c *C) {
 	var desired []mount.Entry
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Action: mount.Unmount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}},
-		{Action: mount.Unmount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf"}},
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf"}, Action: mount.Unmount},
 	})
 }
 
@@ -86,8 +86,8 @@ func (s *changeSuite) TestNeededChangesMountOrder(c *C) {
 	}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Action: mount.Mount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf"}},
-		{Action: mount.Mount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}},
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf"}, Action: mount.Mount},
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}, Action: mount.Mount},
 	})
 }
 
@@ -105,9 +105,9 @@ func (s *changeSuite) TestNeededChangesChangedParentSameChild(c *C) {
 	}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Action: mount.Unmount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}},
-		{Action: mount.Unmount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda1"}},
-		{Action: mount.Mount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda2"}},
-		{Action: mount.Mount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}},
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda1"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda2"}, Action: mount.Mount},
+		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}, Action: mount.Mount},
 	})
 }

--- a/interfaces/mount/change_test.go
+++ b/interfaces/mount/change_test.go
@@ -37,8 +37,8 @@ func (s *changeSuite) TestNeededChangesNoProfiles(c *C) {
 
 // When the profiles are the same we don't do anything.
 func (s *changeSuite) TestNeededChangesNoChange(c *C) {
-	current := []mount.Entry{{Dir: "/var/snap/foo/common/stuf"}}
-	desired := []mount.Entry{{Dir: "/var/snap/foo/common/stuf"}}
+	current := []mount.Entry{{Dir: "/common/stuf"}}
+	desired := []mount.Entry{{Dir: "/common/stuf"}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, IsNil)
 }
@@ -46,7 +46,7 @@ func (s *changeSuite) TestNeededChangesNoChange(c *C) {
 // When the content interface is connected we should mount the new entry.
 func (s *changeSuite) TestNeededChangesTrivialMount(c *C) {
 	var current []mount.Entry
-	desired := []mount.Entry{{Dir: "/var/snap/foo/common/stuf"}}
+	desired := []mount.Entry{{Dir: "/common/stuf"}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
 		{Entry: desired[0], Action: mount.Mount},
@@ -55,7 +55,7 @@ func (s *changeSuite) TestNeededChangesTrivialMount(c *C) {
 
 // When the content interface is disconnected we should unmount the mounted entry.
 func (s *changeSuite) TestNeededChangesTrivialUnmount(c *C) {
-	current := []mount.Entry{{Dir: "/var/snap/foo/common/stuf"}}
+	current := []mount.Entry{{Dir: "/common/stuf"}}
 	var desired []mount.Entry
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
@@ -66,14 +66,14 @@ func (s *changeSuite) TestNeededChangesTrivialUnmount(c *C) {
 // When umounting we unmount children before parents.
 func (s *changeSuite) TestNeededChangesUnmountOrder(c *C) {
 	current := []mount.Entry{
-		{Dir: "/var/snap/foo/common/stuf/extra"},
-		{Dir: "/var/snap/foo/common/stuf"},
+		{Dir: "/common/stuf/extra"},
+		{Dir: "/common/stuf"},
 	}
 	var desired []mount.Entry
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}, Action: mount.Unmount},
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/common/stuf"}, Action: mount.Unmount},
 	})
 }
 
@@ -81,52 +81,52 @@ func (s *changeSuite) TestNeededChangesUnmountOrder(c *C) {
 func (s *changeSuite) TestNeededChangesMountOrder(c *C) {
 	var current []mount.Entry
 	desired := []mount.Entry{
-		{Dir: "/var/snap/foo/common/stuf/extra"},
-		{Dir: "/var/snap/foo/common/stuf"},
+		{Dir: "/common/stuf/extra"},
+		{Dir: "/common/stuf"},
 	}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf"}, Action: mount.Mount},
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}, Action: mount.Mount},
+		{Entry: mount.Entry{Dir: "/common/stuf"}, Action: mount.Mount},
+		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: mount.Mount},
 	})
 }
 
 // When parent changes we don't reuse its children
 func (s *changeSuite) TestNeededChangesChangedParentSameChild(c *C) {
 	current := []mount.Entry{
-		{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda1"},
-		{Dir: "/var/snap/foo/common/stuf/extra"},
-		{Dir: "/var/snap/foo/common/unrelated"},
+		{Dir: "/common/stuf", Name: "/dev/sda1"},
+		{Dir: "/common/stuf/extra"},
+		{Dir: "/common/unrelated"},
 	}
 	desired := []mount.Entry{
-		{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda2"},
-		{Dir: "/var/snap/foo/common/stuf/extra"},
-		{Dir: "/var/snap/foo/common/unrelated"},
+		{Dir: "/common/stuf", Name: "/dev/sda2"},
+		{Dir: "/common/stuf/extra"},
+		{Dir: "/common/unrelated"},
 	}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}, Action: mount.Unmount},
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda1"}, Action: mount.Unmount},
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda2"}, Action: mount.Mount},
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}, Action: mount.Mount},
+		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/common/stuf", Name: "/dev/sda1"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/common/stuf", Name: "/dev/sda2"}, Action: mount.Mount},
+		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: mount.Mount},
 	})
 }
 
 // When child changes we don't touch the unchanged parent
 func (s *changeSuite) TestNeededChangesSameParentChangedChild(c *C) {
 	current := []mount.Entry{
-		{Dir: "/var/snap/foo/common/stuf"},
-		{Dir: "/var/snap/foo/common/stuf/extra", Name: "/dev/sda1"},
-		{Dir: "/var/snap/foo/common/unrelated"},
+		{Dir: "/common/stuf"},
+		{Dir: "/common/stuf/extra", Name: "/dev/sda1"},
+		{Dir: "/common/unrelated"},
 	}
 	desired := []mount.Entry{
-		{Dir: "/var/snap/foo/common/stuf"},
-		{Dir: "/var/snap/foo/common/stuf/extra", Name: "/dev/sda2"},
-		{Dir: "/var/snap/foo/common/unrelated"},
+		{Dir: "/common/stuf"},
+		{Dir: "/common/stuf/extra", Name: "/dev/sda2"},
+		{Dir: "/common/unrelated"},
 	}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra", Name: "/dev/sda1"}, Action: mount.Unmount},
-		{Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra", Name: "/dev/sda2"}, Action: mount.Mount},
+		{Entry: mount.Entry{Dir: "/common/stuf/extra", Name: "/dev/sda1"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/common/stuf/extra", Name: "/dev/sda2"}, Action: mount.Mount},
 	})
 }

--- a/interfaces/mount/change_test.go
+++ b/interfaces/mount/change_test.go
@@ -90,3 +90,24 @@ func (s *changeSuite) TestNeededChangesMountOrder(c *C) {
 		{Action: mount.Mount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}},
 	})
 }
+
+// When parent changes we don't reuse its children
+func (s *changeSuite) TestNeededChangesChangedParentSameChild(c *C) {
+	current := []mount.Entry{
+		{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda1"},
+		{Dir: "/var/snap/foo/common/stuf/extra"},
+		{Dir: "/var/snap/foo/common/unrelated"},
+	}
+	desired := []mount.Entry{
+		{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda2"},
+		{Dir: "/var/snap/foo/common/stuf/extra"},
+		{Dir: "/var/snap/foo/common/unrelated"},
+	}
+	changes := mount.NeededChanges(current, desired)
+	c.Assert(changes, DeepEquals, []mount.Change{
+		{Action: mount.Unmount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}},
+		{Action: mount.Unmount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda1"}},
+		{Action: mount.Mount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf", Name: "/dev/sda2"}},
+		{Action: mount.Mount, Entry: mount.Entry{Dir: "/var/snap/foo/common/stuf/extra"}},
+	})
+}

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -46,6 +46,25 @@ type Entry struct {
 	CheckPassNumber int
 }
 
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal checks if one entry is equal to another
+func EqualEntries(a, b *Entry) bool {
+	return (a.Name == b.Name && a.Dir == b.Dir && a.Type == b.Type &&
+		sameStrings(a.Options, b.Options) && a.DumpFrequency == b.DumpFrequency &&
+		a.CheckPassNumber == b.CheckPassNumber)
+}
+
 // escape replaces whitespace characters so that getmntent can parse it correctly.
 //
 // According to the manual page, the following characters need to be escaped.

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -58,7 +58,7 @@ func sameStrings(a, b []string) bool {
 	return true
 }
 
-// Equal checks if one entry is equal to another
+// EqualEntries checks if one entry is equal to another
 func EqualEntries(a, b *Entry) bool {
 	return (a.Name == b.Name && a.Dir == b.Dir && a.Type == b.Type &&
 		sameStrings(a.Options, b.Options) && a.DumpFrequency == b.DumpFrequency &&

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -59,7 +59,7 @@ func sameStrings(a, b []string) bool {
 }
 
 // EqualEntries checks if one entry is equal to another
-func EqualEntries(a, b *Entry) bool {
+func (a *Entry) Equal(b *Entry) bool {
 	return (a.Name == b.Name && a.Dir == b.Dir && a.Type == b.Type &&
 		sameStrings(a.Options, b.Options) && a.DumpFrequency == b.DumpFrequency &&
 		a.CheckPassNumber == b.CheckPassNumber)

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -46,7 +46,7 @@ type Entry struct {
 	CheckPassNumber int
 }
 
-func sameStrings(a, b []string) bool {
+func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -61,7 +61,7 @@ func sameStrings(a, b []string) bool {
 // EqualEntries checks if one entry is equal to another
 func (a *Entry) Equal(b *Entry) bool {
 	return (a.Name == b.Name && a.Dir == b.Dir && a.Type == b.Type &&
-		sameStrings(a.Options, b.Options) && a.DumpFrequency == b.DumpFrequency &&
+		equalStrings(a.Options, b.Options) && a.DumpFrequency == b.DumpFrequency &&
 		a.CheckPassNumber == b.CheckPassNumber)
 }
 

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -56,13 +56,23 @@ func (s *entrySuite) TestString(c *C) {
 }
 
 func (s *entrySuite) TestEqual(c *C) {
-	c.Assert(mount.EqualEntries(&mount.Entry{}, &mount.Entry{}), Equals, true)
-	c.Assert(mount.EqualEntries(&mount.Entry{Dir: "foo"}, &mount.Entry{Dir: "foo"}), Equals, true)
-	c.Assert(mount.EqualEntries(&mount.Entry{Options: []string{"ro"}},
-		&mount.Entry{Options: []string{"ro"}}), Equals, true)
-
-	c.Assert(mount.EqualEntries(&mount.Entry{Dir: "foo"}, &mount.Entry{Dir: "bar"}), Equals, false)
-	c.Assert(mount.EqualEntries(&mount.Entry{}, &mount.Entry{Options: []string{"ro"}}), Equals, false)
-	c.Assert(mount.EqualEntries(&mount.Entry{Options: []string{"ro"}},
-		&mount.Entry{Options: []string{"rw"}}), Equals, false)
+	var a, b *mount.Entry
+	a = &mount.Entry{}
+	b = &mount.Entry{}
+	c.Assert(a.Equal(b), Equals, true)
+	a = &mount.Entry{Dir: "foo"}
+	b = &mount.Entry{Dir: "foo"}
+	c.Assert(a.Equal(b), Equals, true)
+	a = &mount.Entry{Options: []string{"ro"}}
+	b = &mount.Entry{Options: []string{"ro"}}
+	c.Assert(a.Equal(b), Equals, true)
+	a = &mount.Entry{Dir: "foo"}
+	b = &mount.Entry{Dir: "bar"}
+	c.Assert(a.Equal(b), Equals, false)
+	a = &mount.Entry{}
+	b = &mount.Entry{Options: []string{"ro"}}
+	c.Assert(a.Equal(b), Equals, false)
+	a = &mount.Entry{Options: []string{"ro"}}
+	b = &mount.Entry{Options: []string{"rw"}}
+	c.Assert(a.Equal(b), Equals, false)
 }

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -54,3 +54,15 @@ func (s *entrySuite) TestString(c *C) {
 	}
 	c.Assert(ent3.String(), Equals, `/dev/sda5 /media/My\040Files ext4 rw,noatime 0 0`)
 }
+
+func (s *entrySuite) TestEqual(c *C) {
+	c.Assert(mount.EqualEntries(&mount.Entry{}, &mount.Entry{}), Equals, true)
+	c.Assert(mount.EqualEntries(&mount.Entry{Dir: "foo"}, &mount.Entry{Dir: "foo"}), Equals, true)
+	c.Assert(mount.EqualEntries(&mount.Entry{Options: []string{"ro"}},
+		&mount.Entry{Options: []string{"ro"}}), Equals, true)
+
+	c.Assert(mount.EqualEntries(&mount.Entry{Dir: "foo"}, &mount.Entry{Dir: "bar"}), Equals, false)
+	c.Assert(mount.EqualEntries(&mount.Entry{}, &mount.Entry{Options: []string{"ro"}}), Equals, false)
+	c.Assert(mount.EqualEntries(&mount.Entry{Options: []string{"ro"}},
+		&mount.Entry{Options: []string{"rw"}}), Equals, false)
+}

--- a/interfaces/mount/sorting.go
+++ b/interfaces/mount/sorting.go
@@ -19,10 +19,24 @@
 
 package mount
 
-type byDir []Entry
+import (
+	"strings"
+)
 
-func (c byDir) Len() int      { return len(c) }
-func (c byDir) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c byDir) Less(i, j int) bool {
-	return c[i].Dir < c[j].Dir
+// byMagicDir allows sorting an array of entries that automagically assumes
+// each entry ends with a trailing slash.
+type byMagicDir []Entry
+
+func (c byMagicDir) Len() int      { return len(c) }
+func (c byMagicDir) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c byMagicDir) Less(i, j int) bool {
+	iDir := c[i].Dir
+	jDir := c[j].Dir
+	if !strings.HasSuffix(iDir, "/") {
+		iDir = iDir + "/"
+	}
+	if !strings.HasSuffix(jDir, "/") {
+		jDir = jDir + "/"
+	}
+	return iDir < jDir
 }

--- a/interfaces/mount/sorting.go
+++ b/interfaces/mount/sorting.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount
+
+type byDir []Entry
+
+func (c byDir) Len() int      { return len(c) }
+func (c byDir) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c byDir) Less(i, j int) bool {
+	return c[i].Dir < c[j].Dir
+}

--- a/interfaces/mount/sorting_test.go
+++ b/interfaces/mount/sorting_test.go
@@ -1,0 +1,38 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount
+
+import (
+	"sort"
+
+	. "gopkg.in/check.v1"
+)
+
+type sortSuite struct{}
+
+var _ = Suite(&sortSuite{})
+
+func (s *sortSuite) TestTrailingSlashesComparison(c *C) {
+	entries := []Entry{{Dir: "b"}, {Dir: "ba"}, {Dir: "ab"}, {Dir: "a"}}
+	sort.Sort(byDir(entries))
+	c.Assert(entries, DeepEquals, []Entry{
+		{Dir: "a"}, {Dir: "ab"}, {Dir: "b"}, {Dir: "ba"},
+	})
+}

--- a/interfaces/mount/sorting_test.go
+++ b/interfaces/mount/sorting_test.go
@@ -30,9 +30,19 @@ type sortSuite struct{}
 var _ = Suite(&sortSuite{})
 
 func (s *sortSuite) TestTrailingSlashesComparison(c *C) {
-	entries := []Entry{{Dir: "b"}, {Dir: "ba"}, {Dir: "ab"}, {Dir: "a"}}
-	sort.Sort(byDir(entries))
+	// Naively sorted entries.
+	entries := []Entry{
+		{Dir: "/a/b"},
+		{Dir: "/a/b-1"},
+		{Dir: "/a/b-1/3"},
+		{Dir: "/a/b/c"},
+	}
+	sort.Sort(byMagicDir(entries))
+	// Entries sorted as if they had a trailing slash.
 	c.Assert(entries, DeepEquals, []Entry{
-		{Dir: "a"}, {Dir: "ab"}, {Dir: "b"}, {Dir: "ba"},
+		{Dir: "/a/b-1"},
+		{Dir: "/a/b-1/3"},
+		{Dir: "/a/b"},
+		{Dir: "/a/b/c"},
 	})
 }


### PR DESCRIPTION
This branch adds a function that can be used to look at two mount profiles (as created by the mount backend) and compute a sequence of changes needed to transform a system from one mount profile to another. This will be used as the key part of `snap-update-ns` to perform modifications to existing mount namespaces.