### PR TITLE
asserts: don't allow revocations with other items for the same developer

### DIFF
--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -911,12 +911,8 @@ func checkDevelopers(headers map[string]interface{}) (map[string][]*dateRange, e
 		previouslyRevoked, ok := revocationStatus[accountID]
 		if !ok {
 			revocationStatus[accountID] = revoked
-		} else if previouslyRevoked && revoked {
-			return nil, fmt.Errorf(`revocation %s conflicts with previous revocation`, what)
-		} else if previouslyRevoked && !revoked {
-			return nil, fmt.Errorf(`non-revoking item %s conflicts with previous revocation`, what)
-		} else if !previouslyRevoked && revoked {
-			return nil, fmt.Errorf(`revocation %s conflicts with previous non-revoking item`, what)
+		} else if previouslyRevoked || revoked {
+			return nil, fmt.Errorf(`revocation for developer %q must be standalone but found other "developers" items`, accountID)
 		}
 
 		developerRanges[accountID] = append(developerRanges[accountID], &dateRange{since, until})

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -875,6 +875,11 @@ func checkDevelopers(headers map[string]interface{}) (map[string][]*dateRange, e
 		return nil, nil
 	}
 
+	// Used to check for a developer with revoking and non-revoking items.
+	// No entry means developer not yet seen, false means seen but not revoked,
+	// true means seen and revoked.
+	revocationStatus := map[string]bool{}
+
 	developerRanges := make(map[string][]*dateRange)
 	for i, item := range developers {
 		developer, ok := item.(map[string]interface{})
@@ -899,6 +904,19 @@ func checkDevelopers(headers map[string]interface{}) (map[string][]*dateRange, e
 		}
 		if !until.IsZero() && since.After(until) {
 			return nil, fmt.Errorf(`"since" %s must be less than or equal to "until"`, what)
+		}
+
+		// Track/check for revocation conflicts.
+		revoked := since.Equal(until)
+		previouslyRevoked, ok := revocationStatus[accountID]
+		if !ok {
+			revocationStatus[accountID] = revoked
+		} else if previouslyRevoked && revoked {
+			return nil, fmt.Errorf(`revocation %s conflicts with previous revocation`, what)
+		} else if previouslyRevoked && !revoked {
+			return nil, fmt.Errorf(`non-revoking item %s conflicts with previous revocation`, what)
+		} else if !previouslyRevoked && revoked {
+			return nil, fmt.Errorf(`revocation %s conflicts with previous non-revoking item`, what)
 		}
 
 		developerRanges[accountID] = append(developerRanges[accountID], &dateRange{since, until})

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -1454,76 +1454,42 @@ func (sds *snapDevSuite) TestDecodeInvalid(c *C) {
 
 func (sds *snapDevSuite) TestRevokedValidation(c *C) {
 	// Multiple non-revoking items are fine.
-	encoded := strings.Replace(sds.validEncoded, sds.developersLines, ""+
+	encoded := strings.Replace(sds.validEncoded, sds.developersLines,
 		"developers:\n"+
-		"  -\n"+
-		"    developer-id: dev-id2\n"+
-		"    since: 2017-01-01T00:00:00.0Z\n"+
-		"    until: 2017-02-01T00:00:00.0Z\n"+
-		"  -\n"+
-		"    developer-id: dev-id2\n"+
-		"    since: 2017-03-01T00:00:00.0Z\n",
+			"  -\n    developer-id: dev-id2\n    since: 2017-01-01T00:00:00.0Z\n    until: 2017-02-01T00:00:00.0Z\n"+
+			"  -\n    developer-id: dev-id2\n    since: 2017-03-01T00:00:00.0Z\n",
 		1)
 	_, err := asserts.Decode([]byte(encoded))
 	c.Check(err, IsNil)
 
 	// Multiple revocations for different developers are fine.
-	encoded = strings.Replace(sds.validEncoded, sds.developersLines, ""+
+	encoded = strings.Replace(sds.validEncoded, sds.developersLines,
 		"developers:\n"+
-		"  -\n"+
-		"    developer-id: dev-id2\n"+
-		"    since: 2017-01-01T00:00:00.0Z\n"+
-		"    until: 2017-01-01T00:00:00.0Z\n"+
-		"  -\n"+
-		"    developer-id: dev-id3\n"+
-		"    since: 2017-02-01T00:00:00.0Z\n"+
-		"    until: 2017-02-01T00:00:00.0Z\n",
+			"  -\n    developer-id: dev-id2\n    since: 2017-01-01T00:00:00.0Z\n    until: 2017-01-01T00:00:00.0Z\n"+
+			"  -\n    developer-id: dev-id3\n    since: 2017-02-01T00:00:00.0Z\n    until: 2017-02-01T00:00:00.0Z\n",
 		1)
 	_, err = asserts.Decode([]byte(encoded))
 	c.Check(err, IsNil)
 
-	// Multiple revocations is invalid.
-	encoded = strings.Replace(sds.validEncoded, sds.developersLines, ""+
-		"developers:\n"+
-		"  -\n"+
-		"    developer-id: dev-id2\n"+
-		"    since: 2017-01-01T00:00:00.0Z\n"+
-		"    until: 2017-01-01T00:00:00.0Z\n"+
-		"  -\n"+
-		"    developer-id: dev-id2\n"+
-		"    since: 2017-02-01T00:00:00.0Z\n"+
-		"    until: 2017-02-01T00:00:00.0Z\n",
-		1)
-	_, err = asserts.Decode([]byte(encoded))
-	c.Check(err, ErrorMatches, snapDevErrPrefix+`revocation in "developers" item 2 for developer "dev-id2" conflicts with previous revocation`)
-
-	// Revocation after a non-revoking item is invalid.
-	encoded = strings.Replace(sds.validEncoded, sds.developersLines, ""+
-		"developers:\n"+
-		"  -\n"+
-		"    developer-id: dev-id2\n"+
-		"    since: 2017-01-01T00:00:00.0Z\n"+
-		"  -\n"+
-		"    developer-id: dev-id2\n"+
-		"    since: 2017-03-01T00:00:00.0Z\n"+
-		"    until: 2017-03-01T00:00:00.0Z\n",
-		1)
-	_, err = asserts.Decode([]byte(encoded))
-	c.Check(err, ErrorMatches, snapDevErrPrefix+`revocation in "developers" item 2 for developer "dev-id2" conflicts with previous non-revoking item`)
-
-	// Non-revoking item after revocation is invalid.
-	encoded = strings.Replace(sds.validEncoded, sds.developersLines, ""+
-		"developers:\n"+
-		"  -\n"+
-		"    developer-id: dev-id2\n"+
-		"    since: 2017-01-01T00:00:00.0Z\n"+
-		"    until: 2017-01-01T00:00:00.0Z\n"+
-		"  -\n"+
-		"    developer-id: dev-id2\n"+
-		"    since: 2017-02-01T00:00:00.0Z\n",
-		1)
-	_, err = asserts.Decode([]byte(encoded))
-	c.Check(err, ErrorMatches, snapDevErrPrefix+`non-revoking item in "developers" item 2 for developer "dev-id2" conflicts with previous revocation`)
+	invalidTests := []string{
+		// Multiple revocations.
+		"developers:\n" +
+			"  -\n    developer-id: dev-id2\n    since: 2017-01-01T00:00:00.0Z\n    until: 2017-01-01T00:00:00.0Z\n" +
+			"  -\n    developer-id: dev-id2\n    since: 2017-02-01T00:00:00.0Z\n    until: 2017-02-01T00:00:00.0Z\n",
+		// Revocation after non-revoking.
+		"developers:\n" +
+			"  -\n    developer-id: dev-id2\n    since: 2017-01-01T00:00:00.0Z\n" +
+			"  -\n    developer-id: dev-id2\n    since: 2017-03-01T00:00:00.0Z\n    until: 2017-03-01T00:00:00.0Z\n",
+		// Non-revoking after revocation.
+		"developers:\n" +
+			"  -\n    developer-id: dev-id2\n    since: 2017-01-01T00:00:00.0Z\n    until: 2017-01-01T00:00:00.0Z\n" +
+			"  -\n    developer-id: dev-id2\n    since: 2017-02-01T00:00:00.0Z\n",
+	}
+	for _, test := range invalidTests {
+		encoded := strings.Replace(sds.validEncoded, sds.developersLines, test, 1)
+		_, err := asserts.Decode([]byte(encoded))
+		c.Check(err, ErrorMatches, snapDevErrPrefix+`revocation for developer "dev-id2" must be standalone but found other "developers" items`)
+	}
 }
 
 func (sds *snapDevSuite) TestAuthorityIsPublisher(c *C) {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -1452,6 +1452,80 @@ func (sds *snapDevSuite) TestDecodeInvalid(c *C) {
 	}
 }
 
+func (sds *snapDevSuite) TestRevokedValidation(c *C) {
+	// Multiple non-revoking items are fine.
+	encoded := strings.Replace(sds.validEncoded, sds.developersLines, ""+
+		"developers:\n"+
+		"  -\n"+
+		"    developer-id: dev-id2\n"+
+		"    since: 2017-01-01T00:00:00.0Z\n"+
+		"    until: 2017-02-01T00:00:00.0Z\n"+
+		"  -\n"+
+		"    developer-id: dev-id2\n"+
+		"    since: 2017-03-01T00:00:00.0Z\n",
+		1)
+	_, err := asserts.Decode([]byte(encoded))
+	c.Check(err, IsNil)
+
+	// Multiple revocations for different developers are fine.
+	encoded = strings.Replace(sds.validEncoded, sds.developersLines, ""+
+		"developers:\n"+
+		"  -\n"+
+		"    developer-id: dev-id2\n"+
+		"    since: 2017-01-01T00:00:00.0Z\n"+
+		"    until: 2017-01-01T00:00:00.0Z\n"+
+		"  -\n"+
+		"    developer-id: dev-id3\n"+
+		"    since: 2017-02-01T00:00:00.0Z\n"+
+		"    until: 2017-02-01T00:00:00.0Z\n",
+		1)
+	_, err = asserts.Decode([]byte(encoded))
+	c.Check(err, IsNil)
+
+	// Multiple revocations is invalid.
+	encoded = strings.Replace(sds.validEncoded, sds.developersLines, ""+
+		"developers:\n"+
+		"  -\n"+
+		"    developer-id: dev-id2\n"+
+		"    since: 2017-01-01T00:00:00.0Z\n"+
+		"    until: 2017-01-01T00:00:00.0Z\n"+
+		"  -\n"+
+		"    developer-id: dev-id2\n"+
+		"    since: 2017-02-01T00:00:00.0Z\n"+
+		"    until: 2017-02-01T00:00:00.0Z\n",
+		1)
+	_, err = asserts.Decode([]byte(encoded))
+	c.Check(err, ErrorMatches, snapDevErrPrefix+`revocation in "developers" item 2 for developer "dev-id2" conflicts with previous revocation`)
+
+	// Revocation after a non-revoking item is invalid.
+	encoded = strings.Replace(sds.validEncoded, sds.developersLines, ""+
+		"developers:\n"+
+		"  -\n"+
+		"    developer-id: dev-id2\n"+
+		"    since: 2017-01-01T00:00:00.0Z\n"+
+		"  -\n"+
+		"    developer-id: dev-id2\n"+
+		"    since: 2017-03-01T00:00:00.0Z\n"+
+		"    until: 2017-03-01T00:00:00.0Z\n",
+		1)
+	_, err = asserts.Decode([]byte(encoded))
+	c.Check(err, ErrorMatches, snapDevErrPrefix+`revocation in "developers" item 2 for developer "dev-id2" conflicts with previous non-revoking item`)
+
+	// Non-revoking item after revocation is invalid.
+	encoded = strings.Replace(sds.validEncoded, sds.developersLines, ""+
+		"developers:\n"+
+		"  -\n"+
+		"    developer-id: dev-id2\n"+
+		"    since: 2017-01-01T00:00:00.0Z\n"+
+		"    until: 2017-01-01T00:00:00.0Z\n"+
+		"  -\n"+
+		"    developer-id: dev-id2\n"+
+		"    since: 2017-02-01T00:00:00.0Z\n",
+		1)
+	_, err = asserts.Decode([]byte(encoded))
+	c.Check(err, ErrorMatches, snapDevErrPrefix+`non-revoking item in "developers" item 2 for developer "dev-id2" conflicts with previous revocation`)
+}
+
 func (sds *snapDevSuite) TestAuthorityIsPublisher(c *C) {
 	storeDB, db := makeStoreAndCheckDB(c)
 	devDB := setup3rdPartySigning(c, "dev-id1", storeDB, db)


### PR DESCRIPTION
Allowing a revocation at the same time as other items for the same developer is a bit weird - it's somewhat ambiguous and potentially confusing for the publisher to reason about.

There's also more potential for programming errors, e.g. by allowing something due to a valid item when there's also a revocation. (snapd should be fine, but other systems also need to analyse collaborators).

Finally, removing a developer's revocation should be a safe & explicit operation. Removal should not accidentally re-activate other items for the same developer.