### PR TITLE
cmd/snap: fix help string for version command

### DIFF
--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -38,7 +38,7 @@ and operating system.
 type cmdVersion struct{}
 
 func init() {
-	addCommand("version", shortHelpHelp, longHelpHelp, func() flags.Commander { return &cmdVersion{} }, nil, nil)
+	addCommand("version", shortVersionHelp, longVersionHelp, func() flags.Commander { return &cmdVersion{} }, nil, nil)
 }
 
 func (cmd cmdVersion) Execute(args []string) error {


### PR DESCRIPTION
This fixes a trivial copy-paste error on the help of the version command.

Fixes: https://bugs.launchpad.net/snappy/+bug/1673763
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>