### PR TITLE
overlord: when shutting down assume errors might be due to cancellation so retry

### DIFF
--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -79,6 +79,8 @@ type mgrsSuite struct {
 	serveIDtoName map[string]string
 	serveSnapPath map[string]string
 	serveRevision map[string]string
+
+	hijackServeSnap func(http.ResponseWriter)
 }
 
 var (
@@ -402,6 +404,10 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 			}
 			w.Write(output)
 		case "snap":
+			if ms.hijackServeSnap != nil {
+				ms.hijackServeSnap(w)
+				return
+			}
 			snapR, err := os.Open(ms.serveSnapPath[comps[2]])
 			if err != nil {
 				panic(err)
@@ -1497,6 +1503,83 @@ apps:
 	dest, err = os.Readlink(app3Alias)
 	c.Assert(err, IsNil)
 	c.Check(dest, Equals, "bar.app3")
+}
+
+func (ms *mgrsSuite) TestHappyStopWhileDownloadingHeader(c *C) {
+	ms.prereqSnapAssertions(c)
+
+	snapYamlContent := `name: foo
+version: 1.0
+`
+	snapPath, _ := ms.makeStoreTestSnap(c, snapYamlContent, "42")
+	ms.serveSnap(snapPath, "42")
+
+	stopped := make(chan struct{})
+	ms.hijackServeSnap = func(_ http.ResponseWriter) {
+		ms.o.Stop()
+		close(stopped)
+	}
+
+	mockServer := ms.mockStore(c)
+	defer mockServer.Close()
+
+	st := ms.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	ts, err := snapstate.Install(st, "foo", "stable", snap.R(0), 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg := st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	st.Unlock()
+	ms.o.Loop()
+
+	<-stopped
+
+	st.Lock()
+	c.Assert(chg.Status(), Equals, state.DoingStatus, Commentf("install-snap change failed with: %v", chg.Err()))
+}
+
+func (ms *mgrsSuite) TestHappyStopWhileDownloadingBody(c *C) {
+	ms.prereqSnapAssertions(c)
+
+	snapYamlContent := `name: foo
+version: 1.0
+`
+	snapPath, _ := ms.makeStoreTestSnap(c, snapYamlContent, "42")
+	ms.serveSnap(snapPath, "42")
+
+	stopped := make(chan struct{})
+	ms.hijackServeSnap = func(w http.ResponseWriter) {
+		w.WriteHeader(200)
+		// best effort to reach the body reading part in the client
+		w.Write(make([]byte, 10000))
+		time.Sleep(100 * time.Millisecond)
+		w.Write(make([]byte, 10000))
+		ms.o.Stop()
+		close(stopped)
+	}
+
+	mockServer := ms.mockStore(c)
+	defer mockServer.Close()
+
+	st := ms.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	ts, err := snapstate.Install(st, "foo", "stable", snap.R(0), 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg := st.NewChange("install-snap", "...")
+	chg.AddAll(ts)
+
+	st.Unlock()
+	ms.o.Loop()
+
+	<-stopped
+
+	st.Lock()
+	c.Assert(chg.Status(), Equals, state.DoingStatus, Commentf("install-snap change failed with: %v", chg.Err()))
 }
 
 type authContextSetupSuite struct {

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -159,7 +159,13 @@ func (r *TaskRunner) run(t *Task) {
 			r.state.EnsureBefore(0)
 		}
 
-		switch err := tomb.Err(); x := err.(type) {
+		err := tomb.Err()
+		if err != nil && r.stopped {
+			// we are shutting down, errors might be due
+			// to cancellations, to be safe retry
+			err = &Retry{}
+		}
+		switch x := err.(type) {
 		case *Retry:
 			// Handler asked to be called again later.
 			// TODO Allow postponing retries past the next Ensure.

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -160,11 +160,19 @@ func (r *TaskRunner) run(t *Task) {
 		}
 
 		err := tomb.Err()
-		if err != nil && r.stopped {
-			// we are shutting down, errors might be due
-			// to cancellations, to be safe retry
-			err = &Retry{}
+		switch err.(type) {
+		case nil:
+			// we are ok
+		case *Retry:
+			// preserve
+		default:
+			if r.stopped {
+				// we are shutting down, errors might be due
+				// to cancellations, to be safe retry
+				err = &Retry{}
+			}
 		}
+
 		switch x := err.(type) {
 		case *Retry:
 			// Handler asked to be called again later.

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -440,7 +440,7 @@ func (ts *taskRunnerSuite) TestStopAskForRetry(c *C) {
 		ch <- true
 		<-tb.Dying()
 		// ask for retry
-		return &state.Retry{}
+		return &state.Retry{After: 2 * time.Minute}
 	}, nil)
 
 	st.Lock()
@@ -456,6 +456,7 @@ func (ts *taskRunnerSuite) TestStopAskForRetry(c *C) {
 	st.Lock()
 	defer st.Unlock()
 	c.Check(t.Status(), Equals, state.DoingStatus)
+	c.Check(t.AtTime().IsZero(), Equals, false)
 }
 
 func (ts *taskRunnerSuite) TestRetryAfterDuration(c *C) {

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -399,6 +399,36 @@ func (ts *taskRunnerSuite) TestStopHandlerJustFinishing(c *C) {
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
 
+func (ts *taskRunnerSuite) TestErrorsOnStopAreRetried(c *C) {
+	sb := &stateBackend{}
+	st := state.New(sb)
+	r := state.NewTaskRunner(st)
+	defer r.Stop()
+
+	ch := make(chan bool)
+	r.AddHandler("error-on-stop", func(t *state.Task, tb *tomb.Tomb) error {
+		ch <- true
+		<-tb.Dying()
+		// error here could be due to cancellation, task will be retried
+		return errors.New("error at stop")
+	}, nil)
+
+	st.Lock()
+	chg := st.NewChange("install", "...")
+	t := st.NewTask("error-on-stop", "...")
+	chg.AddTask(t)
+	st.Unlock()
+
+	r.Ensure()
+	<-ch
+	r.Stop()
+
+	st.Lock()
+	defer st.Unlock()
+	// still Doing, will be retried
+	c.Check(t.Status(), Equals, state.DoingStatus)
+}
+
 func (ts *taskRunnerSuite) TestStopAskForRetry(c *C) {
 	sb := &stateBackend{}
 	st := state.New(sb)


### PR DESCRIPTION
Change the task runner, when shutting down we assume errors might be due to cancellation so we keep the affected tasks to potentially retry