### PR TITLE
tests: skip lp-1644439 test on older kernels

### DIFF
--- a/tests/regression/lp-1644439/kernel-new-enough.sh
+++ b/tests/regression/lp-1644439/kernel-new-enough.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-# Check if the kernel is at least 4.4.0-67
-if ! uname -r | perl -ne '/^(\d+)\.(\d+)\.(\d+)-(\d+)/ or exit 1; exit 1 if $1<4; exit 1 if $2<4; exit 1 if $3==0 && $4<67'; then
-	exit 1
-fi

--- a/tests/regression/lp-1644439/kernel-new-enough.sh
+++ b/tests/regression/lp-1644439/kernel-new-enough.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Check if the kernel is at least 4.4.0-67
+if [ "$(uname -r | perl -ne 'print $1 if /^([0-9]+)\./')" -lt 4 ]; then
+	exit 1
+fi
+if [ "$(uname -r | perl -ne 'print $1 if /^[0-9]+\.([0-9]+)\./')" -lt 4 ]; then
+	exit 1
+fi
+if [ "$(uname -r | perl -ne 'print $1 if /^[0-9]+\.[0-9]+\.[0-9]+-([0-9]+)/')" -lt 67 ]; then
+	exit 1
+fi

--- a/tests/regression/lp-1644439/kernel-new-enough.sh
+++ b/tests/regression/lp-1644439/kernel-new-enough.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 # Check if the kernel is at least 4.4.0-67
-if [ "$(uname -r | perl -ne 'print $1 if /^([0-9]+)\./')" -lt 4 ]; then
-	exit 1
-fi
-if [ "$(uname -r | perl -ne 'print $1 if /^[0-9]+\.([0-9]+)\./')" -lt 4 ]; then
-	exit 1
-fi
-if [ "$(uname -r | perl -ne 'print $1 if /^[0-9]+\.[0-9]+\.[0-9]+-([0-9]+)/')" -lt 67 ]; then
+if ! uname -r | perl -ne '/^(\d+)\.(\d+)\.(\d+)-(\d+)/ or exit 1; exit 1 if $1<4; exit 1 if $2<4; exit 1 if $3==0 && $4<67'; then
 	exit 1
 fi

--- a/tests/regression/lp-1644439/task.yaml
+++ b/tests/regression/lp-1644439/task.yaml
@@ -1,8 +1,4 @@
 summary: Regression test for https://bugs.launchpad.net/snap-confine/+bug/1644439
-# NOTE: This test is excluded on core systems as the kernel release schedule
-# there is separate from classic Ubuntu. Once the fixed kernel is available
-# this line should be removed.
-systems: [-ubuntu-core-16-*]
 details: |
     snap-confine uses privately-shared /run/snapd/ns to store bind-mounted
     mount namespaces of each snap. In the case that snap-confine is invoked
@@ -18,6 +14,18 @@ prepare: |
     . $TESTSLIB/snaps.sh
     install_local_devmode test-snapd-tools
 execute: |
+    # Don't test on other architectures as (especially on arm) kernel versions
+    # are not synchronized with x86 and this test is not architecture specific
+    # to warrant the extra work to figure out which kernel revision got the fix
+    # to apparmor that this test depends on.
+    if [ "$(uname -m)" != x86_64 ] && [ "$(uname -m)" != i686 ]; then
+        echo "This test is only supported on x86_64 and i386"
+        exit 1
+    fi
+    if ! ./kernel-new-enough.sh; then
+        echo "This test is not supported on kernels older than 4.4.0-67"
+        exit 0
+    fi
     echo "We can now run a snap command from the namespace of a snap command and see it work"
     test-snapd-tools.cmd /bin/true
     test-snapd-tools.cmd /bin/sh -c "SNAP_CONFINE_DEBUG=yes /snap/bin/test-snapd-tools.cmd /bin/true"

--- a/tests/regression/lp-1644439/task.yaml
+++ b/tests/regression/lp-1644439/task.yaml
@@ -14,6 +14,13 @@ prepare: |
     . $TESTSLIB/snaps.sh
     install_local_devmode test-snapd-tools
 execute: |
+    # This test is meaningful only on Ubuntu for now as this is where we have
+    # the complete apparmor patch-set.
+    . /etc/os-release
+    if [ "$ID" != "ubuntu" && "$ID" != "ubuntu-core" ]; then
+        echo "This test is only supported on Ubuntu"
+        exit 0
+    fi
     # Don't test on other architectures as (especially on arm) kernel versions
     # are not synchronized with x86 and this test is not architecture specific
     # to warrant the extra work to figure out which kernel revision got the fix

--- a/tests/regression/lp-1644439/task.yaml
+++ b/tests/regression/lp-1644439/task.yaml
@@ -20,7 +20,7 @@ execute: |
     # to apparmor that this test depends on.
     if [ "$(uname -m)" != x86_64 ] && [ "$(uname -m)" != i686 ]; then
         echo "This test is only supported on x86_64 and i386"
-        exit 1
+        exit 0
     fi
     if ! ./kernel-new-enough.sh; then
         echo "This test is not supported on kernels older than 4.4.0-67"

--- a/tests/regression/lp-1644439/task.yaml
+++ b/tests/regression/lp-1644439/task.yaml
@@ -22,7 +22,8 @@ execute: |
         echo "This test is only supported on x86_64 and i386"
         exit 0
     fi
-    if ! ./kernel-new-enough.sh; then
+    # Check if the kernel is at least 4.4.0-67
+    if ! uname -r | perl -ne '/^(\d+)\.(\d+)\.(\d+)-(\d+)/ or exit 1; exit 1 if $1<4; exit 1 if $2<4; exit 1 if $3==0 && $4<67'; then
         echo "This test is not supported on kernels older than 4.4.0-67"
         exit 0
     fi


### PR DESCRIPTION
The autopkgtests runners are using older (assorted) collection of
kernels and we want our tests green again. This patch skips the
regression test if the kernel is too old.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>