### PR TITLE
Fix retries on ubuntu-core-reboot for Pi 2/3

### DIFF
--- a/tests/main/ubuntu-core-reboot/task.yaml
+++ b/tests/main/ubuntu-core-reboot/task.yaml
@@ -17,7 +17,7 @@ execute: |
     snap list | grep network-bind-consumer
 
     echo "Ensure the service is (still) running."
-    retries=60
+    retries=120
     while ! systemctl is-active snap.network-bind-consumer.network-consumer.service; do
         if [ $retries -eq 0 ]; then
             echo "Service did not activate."


### PR DESCRIPTION
Increase the number of retries to allow Rasberry Pi 2/3 to fully boot on ubuntu-core-reboot test. This gives it enough time.