### PR TITLE
Allow seeding a snap with classic confinement.

### DIFF
--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -86,6 +86,9 @@ func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 	tsAll := []*state.TaskSet{}
 	for i, sn := range seed.Snaps {
 		var flags snapstate.Flags
+		if sn.Classic {
+			flags.Classic = true
+		}
 		if sn.DevMode {
 			flags.DevMode = true
 		}

--- a/snap/seed_yaml.go
+++ b/snap/seed_yaml.go
@@ -41,6 +41,7 @@ type SeedSnap struct {
 	// bits that are orthongonal/not in assertions
 	Channel string `yaml:"channel,omitempty"`
 	DevMode bool   `yaml:"devmode,omitempty"`
+	Classic bool   `yaml:"classic,omitempty"`
 
 	Private bool `yaml:"private,omitempty"`
 


### PR DESCRIPTION
This should make it possible to use seed.yaml to seed a classic snap on a system. The core snap is still required, and the system needs to be otherwise properly configured (such as having the right model assertion).