### PR TITLE
boot: log error in KernelOrOsRebootRequired

### DIFF
--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -166,6 +166,7 @@ func KernelOrOsRebootRequired(s *snap.Info) bool {
 
 	m, err := bootloader.GetBootVars(nextBoot, goodBoot)
 	if err != nil {
+		logger.Noticef("cannot get boot variables: %s", err)
 		return false
 	}
 


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>