### PR TITLE
tests: remove stale apt proxy leftover from cloud-init

### DIFF
--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -72,6 +72,8 @@ if [ "$SPREAD_BACKEND" = external ]; then
 fi
 
 if [ "$SPREAD_BACKEND" = qemu ]; then
+   # qemu images may be built with pre-baked proxy settings that can be wrong
+   rm -f /etc/apt/apt.conf.d/90cloud-init-aptproxy
    # treat APT_PROXY as a location of apt-cacher-ng to use
    if [ -d /etc/apt/apt.conf.d ] && [ -n "${APT_PROXY:-}" ]; then
        printf 'Acquire::http::Proxy "%s";\n' "$APT_PROXY" > /etc/apt/apt.conf.d/99proxy


### PR DESCRIPTION
It seems that cloud init "marries" the image to the apt-proxy available
at the time the qemu image was built. While not common we should allow
moving a qemu image from one machine (with a set of apt proxy settings)
to another.

This patch removes the hard-coded apt proxy. Users interested in using
proxies have a range of environment settings at their disposal,
including HTTP_PROXY and APT_PROXY.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>