### PR TITLE
many: break the /aliases mutation API with a clean 400 (aliases v2)

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2262,10 +2262,12 @@ func changeAliases(c *Command, r *http.Request, user *auth.UserState) Response {
 	if err := decoder.Decode(&a); err != nil {
 		return BadRequest("cannot decode request body into an alias action: %v", err)
 	}
-	if len(a.Aliases) == 0 {
-		return BadRequest("at least one alias name is required")
+	if len(a.Aliases) != 0 {
+		return BadRequest("cannot interpret request, snaps can no longer be expected to declare their aliases")
 	}
+	return BadRequest("cannot yet interpret request")
 
+	/* TODO: rework this
 	var summary string
 	var taskset *state.TaskSet
 	var err error
@@ -2298,6 +2300,7 @@ func changeAliases(c *Command, r *http.Request, user *auth.UserState) Response {
 	state.EnsureBefore(0)
 
 	return AsyncResponse(nil, &Meta{Change: change.ID()})
+	*/
 }
 
 type aliasStatus struct {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4847,6 +4847,7 @@ func (s *apiSuite) TestAliasSuccess(c *check.C) {
 	d.overlord.Loop()
 	defer d.overlord.Stop()
 
+	// TODO: the details of this will change
 	action := &aliasAction{
 		Action:  "alias",
 		Snap:    "alias-snap",
@@ -4859,10 +4860,15 @@ func (s *apiSuite) TestAliasSuccess(c *check.C) {
 	c.Assert(err, check.IsNil)
 	rec := httptest.NewRecorder()
 	aliasesCmd.POST(aliasesCmd, req, nil).ServeHTTP(rec, req)
-	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
-	err = json.Unmarshal(rec.Body.Bytes(), &body)
+	c.Check(rec.Code, check.Equals, 400)
+	var rsp resp
+	err = json.Unmarshal(rec.Body.Bytes(), &rsp)
 	c.Check(err, check.IsNil)
+	c.Check(rsp.Result, check.DeepEquals, map[string]interface{}{
+		"message": "cannot interpret request, snaps can no longer be expected to declare their aliases",
+	})
+
+	/* TODO: test the happy case again
 	id := body["change"].(string)
 
 	st := d.overlord.State()
@@ -4880,6 +4886,7 @@ func (s *apiSuite) TestAliasSuccess(c *check.C) {
 
 	// sanity check
 	c.Check(osutil.IsSymlink(filepath.Join(dirs.SnapBinariesDir, "alias1")), check.Equals, true)
+	*/
 }
 
 func (s *apiSuite) TestAliasErrors(c *check.C) {
@@ -4889,10 +4896,7 @@ func (s *apiSuite) TestAliasErrors(c *check.C) {
 		mangle func(*aliasAction)
 		err    string
 	}{
-		{func(a *aliasAction) { a.Action = "" }, `unsupported alias action: ""`},
-		{func(a *aliasAction) { a.Action = "what" }, `unsupported alias action: "what"`},
-		{func(a *aliasAction) { a.Aliases = nil }, `at least one alias name is required`},
-		{func(a *aliasAction) { a.Snap = "lalala" }, `cannot find snap "lalala"`},
+		{func(a *aliasAction) { a.Aliases = nil }, `cannot yet interpret request`},
 	}
 
 	for _, scen := range errScenarios {
@@ -4914,124 +4918,6 @@ func (s *apiSuite) TestAliasErrors(c *check.C) {
 		c.Check(rsp.Status, check.Equals, http.StatusBadRequest)
 		c.Check(rsp.Result.(*errorResult).Message, check.Matches, scen.err)
 	}
-}
-
-func (s *apiSuite) TestUnaliasSuccess(c *check.C) {
-	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
-	c.Assert(err, check.IsNil)
-	d := s.daemon(c)
-
-	s.mockSnap(c, aliasYaml)
-
-	oldAutoAliases := snapstate.AutoAliases
-	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
-		return nil, nil
-	}
-	defer func() { snapstate.AutoAliases = oldAutoAliases }()
-
-	d.overlord.Loop()
-	defer d.overlord.Stop()
-
-	action := &aliasAction{
-		Action:  "unalias",
-		Snap:    "alias-snap",
-		Aliases: []string{"alias1"},
-	}
-	text, err := json.Marshal(action)
-	c.Assert(err, check.IsNil)
-	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/v2/aliases", buf)
-	c.Assert(err, check.IsNil)
-	rec := httptest.NewRecorder()
-	aliasesCmd.POST(aliasesCmd, req, nil).ServeHTTP(rec, req)
-	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
-	err = json.Unmarshal(rec.Body.Bytes(), &body)
-	c.Check(err, check.IsNil)
-	id := body["change"].(string)
-
-	st := d.overlord.State()
-	st.Lock()
-	chg := st.Change(id)
-	st.Unlock()
-	c.Assert(chg, check.NotNil)
-
-	<-chg.Ready()
-
-	st.Lock()
-	defer st.Unlock()
-	err = chg.Err()
-	c.Assert(err, check.IsNil)
-
-	var allAliases map[string]map[string]string
-	err = st.Get("aliases", &allAliases)
-	c.Assert(err, check.IsNil)
-	c.Check(allAliases, check.DeepEquals, map[string]map[string]string{
-		"alias-snap": {"alias1": "disabled"},
-	})
-
-}
-
-func (s *apiSuite) TestResetAliasSuccess(c *check.C) {
-	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
-	c.Assert(err, check.IsNil)
-	d := s.daemon(c)
-
-	s.mockSnap(c, aliasYaml)
-
-	oldAutoAliases := snapstate.AutoAliases
-	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
-		return nil, nil
-	}
-	defer func() { snapstate.AutoAliases = oldAutoAliases }()
-
-	d.overlord.Loop()
-	defer d.overlord.Stop()
-
-	st := d.overlord.State()
-	st.Lock()
-	defer st.Unlock()
-
-	st.Set("aliases", map[string]map[string]string{
-		"alias-snap": {
-			"alias1": "disabled",
-		},
-	})
-
-	action := &aliasAction{
-		Action:  "reset",
-		Snap:    "alias-snap",
-		Aliases: []string{"alias1"},
-	}
-	text, err := json.Marshal(action)
-	c.Assert(err, check.IsNil)
-	buf := bytes.NewBuffer(text)
-	req, err := http.NewRequest("POST", "/v2/aliases", buf)
-	c.Assert(err, check.IsNil)
-	rec := httptest.NewRecorder()
-	st.Unlock()
-	aliasesCmd.POST(aliasesCmd, req, nil).ServeHTTP(rec, req)
-	st.Lock()
-	c.Check(rec.Code, check.Equals, 202)
-	var body map[string]interface{}
-	err = json.Unmarshal(rec.Body.Bytes(), &body)
-	c.Check(err, check.IsNil)
-	id := body["change"].(string)
-
-	chg := st.Change(id)
-	c.Assert(chg, check.NotNil)
-
-	st.Unlock()
-	<-chg.Ready()
-	st.Lock()
-
-	err = chg.Err()
-	c.Assert(err, check.IsNil)
-
-	var allAliases map[string]map[string]string
-	err = st.Get("aliases", &allAliases)
-	c.Assert(err, check.IsNil)
-	c.Check(allAliases, check.HasLen, 0)
 }
 
 func (s *apiSuite) TestAliases(c *check.C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1041,141 +1041,147 @@ apps:
 }
 
 func (ms *mgrsSuite) TestHappyAlias(c *C) {
-	st := ms.o.State()
-	st.Lock()
-	defer st.Unlock()
+	c.Skip("new semantics are wip")
+	/*
+			st := ms.o.State()
+			st.Lock()
+			defer st.Unlock()
 
-	fooYaml := `name: foo
-version: 1.0
-apps:
-  foo:
-    command: bin/foo
-    aliases: [foo_]
-  bar:
-    command: bin/bar
-    aliases: [bar,bar1]
-`
-	ms.installLocalTestSnap(c, fooYaml)
+			fooYaml := `name: foo
+		version: 1.0
+		apps:
+		  foo:
+		    command: bin/foo
+		    aliases: [foo_]
+		  bar:
+		    command: bin/bar
+		    aliases: [bar,bar1]
+		`
+			ms.installLocalTestSnap(c, fooYaml)
 
-	ts, err := snapstate.Alias(st, "foo", []string{"foo_", "bar", "bar1"})
-	c.Assert(err, IsNil)
-	chg := st.NewChange("alias", "...")
-	chg.AddAll(ts)
+			ts, err := snapstate.Alias(st, "foo", []string{"foo_", "bar", "bar1"})
+			c.Assert(err, IsNil)
+			chg := st.NewChange("alias", "...")
+			chg.AddAll(ts)
 
-	st.Unlock()
-	err = ms.o.Settle()
-	st.Lock()
-	c.Assert(err, IsNil)
+			st.Unlock()
+			err = ms.o.Settle()
+			st.Lock()
+			c.Assert(err, IsNil)
 
-	c.Assert(chg.Err(), IsNil)
-	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("alias change failed with: %v", chg.Err()))
+			c.Assert(chg.Err(), IsNil)
+			c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("alias change failed with: %v", chg.Err()))
 
-	foo_Alias := filepath.Join(dirs.SnapBinariesDir, "foo_")
-	dest, err := os.Readlink(foo_Alias)
-	c.Assert(err, IsNil)
+			foo_Alias := filepath.Join(dirs.SnapBinariesDir, "foo_")
+			dest, err := os.Readlink(foo_Alias)
+			c.Assert(err, IsNil)
 
-	c.Check(dest, Equals, "foo")
+			c.Check(dest, Equals, "foo")
 
-	barAlias := filepath.Join(dirs.SnapBinariesDir, "bar")
-	dest, err = os.Readlink(barAlias)
-	c.Assert(err, IsNil)
+			barAlias := filepath.Join(dirs.SnapBinariesDir, "bar")
+			dest, err = os.Readlink(barAlias)
+			c.Assert(err, IsNil)
 
-	c.Check(dest, Equals, "foo.bar")
+			c.Check(dest, Equals, "foo.bar")
 
-	bar1Alias := filepath.Join(dirs.SnapBinariesDir, "bar1")
-	dest, err = os.Readlink(bar1Alias)
-	c.Assert(err, IsNil)
+			bar1Alias := filepath.Join(dirs.SnapBinariesDir, "bar1")
+			dest, err = os.Readlink(bar1Alias)
+			c.Assert(err, IsNil)
 
-	c.Check(dest, Equals, "foo.bar")
+			c.Check(dest, Equals, "foo.bar")
 
-	var allAliases map[string]map[string]string
-	err = st.Get("aliases", &allAliases)
-	c.Assert(err, IsNil)
-	c.Check(allAliases, DeepEquals, map[string]map[string]string{
-		"foo": {
-			"foo_": "enabled",
-			"bar":  "enabled",
-			"bar1": "enabled",
-		},
-	})
+			var allAliases map[string]map[string]string
+			err = st.Get("aliases", &allAliases)
+			c.Assert(err, IsNil)
+			c.Check(allAliases, DeepEquals, map[string]map[string]string{
+				"foo": {
+					"foo_": "enabled",
+					"bar":  "enabled",
+					"bar1": "enabled",
+				},
+			})
 
-	ms.removeSnap(c, "foo")
+			ms.removeSnap(c, "foo")
 
-	c.Check(osutil.IsSymlink(foo_Alias), Equals, false)
-	c.Check(osutil.IsSymlink(barAlias), Equals, false)
-	c.Check(osutil.IsSymlink(bar1Alias), Equals, false)
+			c.Check(osutil.IsSymlink(foo_Alias), Equals, false)
+			c.Check(osutil.IsSymlink(barAlias), Equals, false)
+			c.Check(osutil.IsSymlink(bar1Alias), Equals, false)
 
-	allAliases = nil
-	err = st.Get("aliases", &allAliases)
-	c.Assert(err, IsNil)
-	c.Check(allAliases, HasLen, 0)
+			allAliases = nil
+			err = st.Get("aliases", &allAliases)
+			c.Assert(err, IsNil)
+			c.Check(allAliases, HasLen, 0)
+	*/
 }
 
 func (ms *mgrsSuite) TestHappyUnalias(c *C) {
-	st := ms.o.State()
-	st.Lock()
-	defer st.Unlock()
+	c.Skip("new semantics are wip")
+	/*
+			st := ms.o.State()
+			st.Lock()
+			defer st.Unlock()
 
-	fooYaml := `name: foo
-version: 1.0
-apps:
-  foo:
-    command: bin/foo
-    aliases: [foo_]
-`
-	ms.installLocalTestSnap(c, fooYaml)
+			fooYaml := `name: foo
+		version: 1.0
+		apps:
+		  foo:
+		    command: bin/foo
+		    aliases: [foo_]
+		`
+			ms.installLocalTestSnap(c, fooYaml)
 
-	ts, err := snapstate.Alias(st, "foo", []string{"foo_"})
-	c.Assert(err, IsNil)
-	chg := st.NewChange("alias", "...")
-	chg.AddAll(ts)
+			ts, err := snapstate.Alias(st, "foo", []string{"foo_"})
+			c.Assert(err, IsNil)
+			chg := st.NewChange("alias", "...")
+			chg.AddAll(ts)
 
-	st.Unlock()
-	err = ms.o.Settle()
-	st.Lock()
-	c.Assert(err, IsNil)
+			st.Unlock()
+			err = ms.o.Settle()
+			st.Lock()
+			c.Assert(err, IsNil)
 
-	c.Assert(chg.Err(), IsNil)
-	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("alias change failed with: %v", chg.Err()))
+			c.Assert(chg.Err(), IsNil)
+			c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("alias change failed with: %v", chg.Err()))
 
-	foo_Alias := filepath.Join(dirs.SnapBinariesDir, "foo_")
-	dest, err := os.Readlink(foo_Alias)
-	c.Assert(err, IsNil)
+			foo_Alias := filepath.Join(dirs.SnapBinariesDir, "foo_")
+			dest, err := os.Readlink(foo_Alias)
+			c.Assert(err, IsNil)
 
-	c.Check(dest, Equals, "foo")
+			c.Check(dest, Equals, "foo")
 
-	var allAliases map[string]map[string]string
-	err = st.Get("aliases", &allAliases)
-	c.Assert(err, IsNil)
-	c.Check(allAliases, DeepEquals, map[string]map[string]string{
-		"foo": {
-			"foo_": "enabled",
-		},
-	})
+			var allAliases map[string]map[string]string
+			err = st.Get("aliases", &allAliases)
+			c.Assert(err, IsNil)
+			c.Check(allAliases, DeepEquals, map[string]map[string]string{
+				"foo": {
+					"foo_": "enabled",
+				},
+			})
 
-	ts, err = snapstate.Unalias(st, "foo", []string{"foo_"})
-	c.Assert(err, IsNil)
-	chg = st.NewChange("unalias", "...")
-	chg.AddAll(ts)
+			ts, err = snapstate.Unalias(st, "foo", []string{"foo_"})
+			c.Assert(err, IsNil)
+			chg = st.NewChange("unalias", "...")
+			chg.AddAll(ts)
 
-	st.Unlock()
-	err = ms.o.Settle()
-	st.Lock()
-	c.Assert(err, IsNil)
+			st.Unlock()
+			err = ms.o.Settle()
+			st.Lock()
+			c.Assert(err, IsNil)
 
-	c.Assert(chg.Err(), IsNil)
-	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("unalias change failed with: %v", chg.Err()))
+			c.Assert(chg.Err(), IsNil)
+			c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("unalias change failed with: %v", chg.Err()))
 
-	c.Check(osutil.IsSymlink(foo_Alias), Equals, false)
+			c.Check(osutil.IsSymlink(foo_Alias), Equals, false)
 
-	allAliases = nil
-	err = st.Get("aliases", &allAliases)
-	c.Assert(err, IsNil)
-	c.Check(allAliases, DeepEquals, map[string]map[string]string{
-		"foo": {
-			"foo_": "disabled",
-		},
-	})
+			allAliases = nil
+			err = st.Get("aliases", &allAliases)
+			c.Assert(err, IsNil)
+			c.Check(allAliases, DeepEquals, map[string]map[string]string{
+				"foo": {
+					"foo_": "disabled",
+				},
+			})
+	*/
 }
 
 func (ms *mgrsSuite) TestHappyRemoteInstallAutoAliases(c *C) {

--- a/overlord/snapstate/aliases.go
+++ b/overlord/snapstate/aliases.go
@@ -73,72 +73,9 @@ func setAliases(st *state.State, snapName string, aliases map[string]string) {
 	st.Set("aliases", allAliases)
 }
 
-// Alias enables the provided aliases for the snap with the given name.
-func Alias(st *state.State, snapName string, aliases []string) (*state.TaskSet, error) {
-	var snapst SnapState
-	err := Get(st, snapName, &snapst)
-	if err == state.ErrNoState {
-		return nil, fmt.Errorf("cannot find snap %q", snapName)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if !snapst.Active {
-		return nil, fmt.Errorf("enabling aliases for disabled snap %q not supported", snapName)
-	}
-	if err := CheckChangeConflict(st, snapName, nil); err != nil {
-		return nil, err
-	}
+// TODO: reintroduce Alias, Unalias following the new meanings
 
-	snapsup := &SnapSetup{
-		SideInfo: &snap.SideInfo{RealName: snapName},
-	}
-
-	alias := st.NewTask("alias", fmt.Sprintf(i18n.G("Enable aliases for snap %q"), snapsup.Name()))
-	alias.Set("snap-setup", &snapsup)
-	toEnable := map[string]string{}
-	for _, alias := range aliases {
-		toEnable[alias] = "enabled"
-	}
-	alias.Set("aliases", toEnable)
-
-	return state.NewTaskSet(alias), nil
-}
-
-// Unalias explicitly disables the provided aliases for the snap with the given name.
-func Unalias(st *state.State, snapName string, aliases []string) (*state.TaskSet, error) {
-	var snapst SnapState
-	err := Get(st, snapName, &snapst)
-	if err == state.ErrNoState {
-		return nil, fmt.Errorf("cannot find snap %q", snapName)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if !snapst.Active {
-		return nil, fmt.Errorf("disabling aliases for disabled snap %q not supported", snapName)
-	}
-	if err := CheckChangeConflict(st, snapName, nil); err != nil {
-		return nil, err
-	}
-
-	snapsup := &SnapSetup{
-		SideInfo: &snap.SideInfo{RealName: snapName},
-	}
-
-	alias := st.NewTask("alias", fmt.Sprintf(i18n.G("Disable aliases for snap %q"), snapsup.Name()))
-	alias.Set("snap-setup", &snapsup)
-	toDisable := map[string]string{}
-	for _, alias := range aliases {
-		toDisable[alias] = "disabled"
-	}
-	alias.Set("aliases", toDisable)
-
-	return state.NewTaskSet(alias), nil
-}
-
-// ResetAliases resets the provided aliases for the snap with the given name to their default state, enabled for auto-aliases, disabled otherwise.
-func ResetAliases(st *state.State, snapName string, aliases []string) (*state.TaskSet, error) {
+func resetAliases(st *state.State, snapName string, aliases []string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, snapName, &snapst)
 	if err == state.ErrNoState {

--- a/overlord/snapstate/aliases_test.go
+++ b/overlord/snapstate/aliases_test.go
@@ -20,7 +20,6 @@
 package snapstate_test
 
 import (
-	"fmt"
 	"sort"
 
 	. "gopkg.in/check.v1"
@@ -133,24 +132,27 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliases(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestAliasTasks(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("new semantics are wip")
+	/*
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "some-snap", Revision: snap.R(11)},
-		},
-		Current: snap.R(11),
-		Active:  true,
-	})
+		snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+			Sequence: []*snap.SideInfo{
+				{RealName: "some-snap", Revision: snap.R(11)},
+			},
+			Current: snap.R(11),
+			Active:  true,
+		})
 
-	ts, err := snapstate.Alias(s.state, "some-snap", []string{"alias"})
-	c.Assert(err, IsNil)
+		ts, err := snapstate.Alias(s.state, "some-snap", []string{"alias"})
+		c.Assert(err, IsNil)
 
-	c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
-	c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
-		"alias",
-	})
+		c.Assert(s.state.TaskCount(), Equals, len(ts.Tasks()))
+		c.Assert(taskKinds(ts.Tasks()), DeepEquals, []string{
+			"alias",
+		})
+	*/
 }
 
 func (s *snapmgrTestSuite) TestDoSetupAliasesAuto(c *C) {
@@ -254,84 +256,93 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAuto(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestAliasRunThrough(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("new semantics are wip")
+	/*
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
-		Current: snap.R(11),
-		Active:  true,
-	})
+		snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+			Sequence: []*snap.SideInfo{
+				{RealName: "alias-snap", Revision: snap.R(11)},
+			},
+			Current: snap.R(11),
+			Active:  true,
+		})
 
-	chg := s.state.NewChange("alias", "enable an alias")
-	ts, err := snapstate.Alias(s.state, "alias-snap", []string{"alias1"})
-	c.Assert(err, IsNil)
-	chg.AddAll(ts)
+		chg := s.state.NewChange("alias", "enable an alias")
+		ts, err := snapstate.Alias(s.state, "alias-snap", []string{"alias1"})
+		c.Assert(err, IsNil)
+		chg.AddAll(ts)
 
-	s.state.Unlock()
-	defer s.snapmgr.Stop()
-	s.settle()
-	s.state.Lock()
+		s.state.Unlock()
+		defer s.snapmgr.Stop()
+		s.settle()
+		s.state.Lock()
 
-	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
-	expected := fakeOps{
-		{
-			op:      "update-aliases",
-			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
-		},
-	}
-	// start with an easier-to-read error if this fails:
-	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
-	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+		c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
+		expected := fakeOps{
+			{
+				op:      "update-aliases",
+				aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+			},
+		}
+		// start with an easier-to-read error if this fails:
+		c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+		c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 
-	var allAliases map[string]map[string]string
-	err = s.state.Get("aliases", &allAliases)
-	c.Assert(err, IsNil)
-	c.Check(allAliases, DeepEquals, map[string]map[string]string{
-		"alias-snap": {"alias1": "enabled"},
-	})
+		var allAliases map[string]map[string]string
+		err = s.state.Get("aliases", &allAliases)
+		c.Assert(err, IsNil)
+		c.Check(allAliases, DeepEquals, map[string]map[string]string{
+			"alias-snap": {"alias1": "enabled"},
+		})
+	*/
 }
 
 func (s *snapmgrTestSuite) TestUpdateAliasChangeConflict(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("new semantics are wip")
+	/*
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
-		Current:  snap.R(7),
-		SnapType: "app",
-	})
+		snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+			Active:   true,
+			Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+			Current:  snap.R(7),
+			SnapType: "app",
+		})
 
-	ts, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, IsNil)
-	// need a change to make the tasks visible
-	s.state.NewChange("update", "...").AddAll(ts)
+		ts, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
+		c.Assert(err, IsNil)
+		// need a change to make the tasks visible
+		s.state.NewChange("update", "...").AddAll(ts)
 
-	_, err = snapstate.Alias(s.state, "some-snap", []string{"alias1"})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+		_, err = snapstate.Alias(s.state, "some-snap", []string{"alias1"})
+		c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	*/
 }
 
 func (s *snapmgrTestSuite) TestUpdateUnaliasChangeConflict(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("new semantics are wip")
+	/*
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
-		Current:  snap.R(7),
-		SnapType: "app",
-	})
+		snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+			Active:   true,
+			Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+			Current:  snap.R(7),
+			SnapType: "app",
+		})
 
-	ts, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, IsNil)
-	// need a change to make the tasks visible
-	s.state.NewChange("update", "...").AddAll(ts)
+		ts, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
+		c.Assert(err, IsNil)
+		// need a change to make the tasks visible
+		s.state.NewChange("update", "...").AddAll(ts)
 
-	_, err = snapstate.Unalias(s.state, "some-snap", []string{"alias1"})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+		_, err = snapstate.Unalias(s.state, "some-snap", []string{"alias1"})
+		c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	*/
 }
 
 func (s *snapmgrTestSuite) TestUpdateResetAliasesChangeConflict(c *C) {
@@ -355,148 +366,163 @@ func (s *snapmgrTestSuite) TestUpdateResetAliasesChangeConflict(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestAliasUpdateChangeConflict(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("new semantics coming")
+	/*
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Active:   true,
-		Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
-		Current:  snap.R(7),
-		SnapType: "app",
-	})
+		snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+			Active:   true,
+			Sequence: []*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}},
+			Current:  snap.R(7),
+			SnapType: "app",
+		})
 
-	ts, err := snapstate.Alias(s.state, "some-snap", []string{"alias1"})
-	c.Assert(err, IsNil)
-	// need a change to make the tasks visible
-	s.state.NewChange("alias", "...").AddAll(ts)
+		ts, err := snapstate.Alias(s.state, "some-snap", []string{"alias1"})
+		c.Assert(err, IsNil)
+		// need a change to make the tasks visible
+		s.state.NewChange("alias", "...").AddAll(ts)
 
-	_, err = snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+		_, err = snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
+		c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	*/
 }
 
 func (s *snapmgrTestSuite) TestAliasNoAlias(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("should become a new app test")
+	/*
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "some-snap", Revision: snap.R(11)},
-		},
-		Current: snap.R(11),
-		Active:  true,
-	})
+		snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+			Sequence: []*snap.SideInfo{
+				{RealName: "some-snap", Revision: snap.R(11)},
+			},
+			Current: snap.R(11),
+			Active:  true,
+		})
 
-	chg := s.state.NewChange("alias", "enable an alias")
-	ts, err := snapstate.Alias(s.state, "some-snap", []string{"alias1"})
-	c.Assert(err, IsNil)
-	chg.AddAll(ts)
+		chg := s.state.NewChange("alias", "enable an alias")
+		ts, err := snapstate.Alias(s.state, "some-snap", []string{"alias1"})
+		c.Assert(err, IsNil)
+		chg.AddAll(ts)
 
-	s.state.Unlock()
+		s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+		s.snapmgr.Ensure()
+		s.snapmgr.Wait()
 
-	s.state.Lock()
+		s.state.Lock()
 
-	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1" for "some-snap", no such alias.*`)
+		c.Check(chg.Status(), Equals, state.ErrorStatus)
+		c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1" for "some-snap", no such alias.*`)
+	*/
 }
 
 func (s *snapmgrTestSuite) TestAliasAliasConflict(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("new semantics are wip")
+	/*
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
-		Current: snap.R(11),
-		Active:  true,
-	})
-	s.state.Set("aliases", map[string]map[string]string{
-		"other-snap": {"alias1": "enabled"},
-	})
+		snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+			Sequence: []*snap.SideInfo{
+				{RealName: "alias-snap", Revision: snap.R(11)},
+			},
+			Current: snap.R(11),
+			Active:  true,
+		})
+		s.state.Set("aliases", map[string]map[string]string{
+			"other-snap": {"alias1": "enabled"},
+		})
 
-	chg := s.state.NewChange("alias", "enable an alias")
-	ts, err := snapstate.Alias(s.state, "alias-snap", []string{"alias1"})
-	c.Assert(err, IsNil)
-	chg.AddAll(ts)
+		chg := s.state.NewChange("alias", "enable an alias")
+		ts, err := snapstate.Alias(s.state, "alias-snap", []string{"alias1"})
+		c.Assert(err, IsNil)
+		chg.AddAll(ts)
 
-	s.state.Unlock()
+		s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+		s.snapmgr.Ensure()
+		s.snapmgr.Wait()
 
-	s.state.Lock()
+		s.state.Lock()
 
-	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1" for "alias-snap", already enabled for "other-snap".*`)
+		c.Check(chg.Status(), Equals, state.ErrorStatus)
+		c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1" for "alias-snap", already enabled for "other-snap".*`)
+	*/
 }
 
 func (s *snapmgrTestSuite) TestAliasAutoAliasConflict(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("new semantics are wip")
+	/*
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
-		Current: snap.R(11),
-		Active:  true,
-	})
-	s.state.Set("aliases", map[string]map[string]string{
-		"other-snap": {"alias1": "auto"},
-	})
+		snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+			Sequence: []*snap.SideInfo{
+				{RealName: "alias-snap", Revision: snap.R(11)},
+			},
+			Current: snap.R(11),
+			Active:  true,
+		})
+		s.state.Set("aliases", map[string]map[string]string{
+			"other-snap": {"alias1": "auto"},
+		})
 
-	chg := s.state.NewChange("alias", "enable an alias")
-	ts, err := snapstate.Alias(s.state, "alias-snap", []string{"alias1"})
-	c.Assert(err, IsNil)
-	chg.AddAll(ts)
+		chg := s.state.NewChange("alias", "enable an alias")
+		ts, err := snapstate.Alias(s.state, "alias-snap", []string{"alias1"})
+		c.Assert(err, IsNil)
+		chg.AddAll(ts)
 
-	s.state.Unlock()
+		s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+		s.snapmgr.Ensure()
+		s.snapmgr.Wait()
 
-	s.state.Lock()
+		s.state.Lock()
 
-	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1" for "alias-snap", already enabled for "other-snap".*`)
+		c.Check(chg.Status(), Equals, state.ErrorStatus)
+		c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1" for "alias-snap", already enabled for "other-snap".*`)
+	*/
 }
 
 func (s *snapmgrTestSuite) TestAliasSnapCommandSpaceConflict(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("new semantics are wip")
+	/*
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
-		Current: snap.R(11),
-		Active:  true,
-	})
-	// the command namespace of this one will conflict
-	snapstate.Set(s.state, "alias1", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "alias1", Revision: snap.R(3)},
-		},
-		Current: snap.R(3),
-	})
+		snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+			Sequence: []*snap.SideInfo{
+				{RealName: "alias-snap", Revision: snap.R(11)},
+			},
+			Current: snap.R(11),
+			Active:  true,
+		})
+		// the command namespace of this one will conflict
+		snapstate.Set(s.state, "alias1", &snapstate.SnapState{
+			Sequence: []*snap.SideInfo{
+				{RealName: "alias1", Revision: snap.R(3)},
+			},
+			Current: snap.R(3),
+		})
 
-	chg := s.state.NewChange("alias", "enable an alias")
-	ts, err := snapstate.Alias(s.state, "alias-snap", []string{"alias1.cmd1"})
-	c.Assert(err, IsNil)
-	chg.AddAll(ts)
+		chg := s.state.NewChange("alias", "enable an alias")
+		ts, err := snapstate.Alias(s.state, "alias-snap", []string{"alias1.cmd1"})
+		c.Assert(err, IsNil)
+		chg.AddAll(ts)
 
-	s.state.Unlock()
+		s.state.Unlock()
 
-	s.snapmgr.Ensure()
-	s.snapmgr.Wait()
+		s.snapmgr.Ensure()
+		s.snapmgr.Wait()
 
-	s.state.Lock()
+		s.state.Lock()
 
-	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1.cmd1" for "alias-snap", it conflicts with the command namespace of installed snap "alias1".*`)
+		c.Check(chg.Status(), Equals, state.ErrorStatus)
+		c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias1.cmd1" for "alias-snap", it conflicts with the command namespace of installed snap "alias1".*`)
+	*/
 }
 
 func (s *snapmgrTestSuite) TestDoClearAliases(c *C) {
@@ -690,224 +716,6 @@ var statusesMatrix = []struct {
 	{"alias5gone", "auto", "reset", "", "-"},
 }
 
-func (s *snapmgrTestSuite) TestAliasMatrixRunThrough(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
-		Current: snap.R(11),
-		Active:  true,
-	})
-
-	// alias1 is a non auto-alias
-	// alias5 is an auto-alias
-	// alias1gone is a non auto-alias and doesn't have an entry in the current snap revision anymore
-	// alias5gone is an auto-alias and doesn't have an entry in the current snap revision anymore
-	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
-		c.Check(info.Name(), Equals, "alias-snap")
-		return map[string]string{"alias5": "cmd5", "alias5gone": "cmd5gone"}, nil
-	}
-	cmds := map[string]string{
-		"alias1": "cmd1",
-		"alias5": "cmd5",
-	}
-
-	defer s.snapmgr.Stop()
-	for _, scenario := range statusesMatrix {
-		scenAlias := scenario.alias
-		if scenario.beforeStatus != "" {
-			s.state.Set("aliases", map[string]map[string]string{
-				"alias-snap": {
-					scenAlias: scenario.beforeStatus,
-				},
-			})
-		} else {
-			s.state.Set("aliases", nil)
-		}
-
-		chg := s.state.NewChange("scenario", "...")
-		var err error
-		var ts *state.TaskSet
-		targets := []string{scenAlias}
-		switch scenario.action {
-		case "alias":
-			ts, err = snapstate.Alias(s.state, "alias-snap", targets)
-		case "unalias":
-			ts, err = snapstate.Unalias(s.state, "alias-snap", targets)
-		case "reset":
-			ts, err = snapstate.ResetAliases(s.state, "alias-snap", targets)
-		}
-		c.Assert(err, IsNil)
-
-		chg.AddAll(ts)
-
-		s.state.Unlock()
-		s.settle()
-		s.state.Lock()
-
-		c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%#v: %v", scenario, chg.Err()))
-		var aliases []*backend.Alias
-		var rmAliases []*backend.Alias
-		beAlias := &backend.Alias{Name: scenAlias, Target: fmt.Sprintf("alias-snap.%s", cmds[scenAlias])}
-		switch scenario.mutation {
-		case "-":
-		case "add":
-			aliases = []*backend.Alias{beAlias}
-		case "rm":
-			rmAliases = []*backend.Alias{beAlias}
-		}
-
-		comm := Commentf("%#v", scenario)
-		expected := fakeOps{
-			{
-				op:        "update-aliases",
-				aliases:   aliases,
-				rmAliases: rmAliases,
-			},
-		}
-		// start with an easier-to-read error if this fails:
-		c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops(), comm)
-		c.Check(s.fakeBackend.ops, DeepEquals, expected, comm)
-
-		var allAliases map[string]map[string]string
-		err = s.state.Get("aliases", &allAliases)
-		c.Assert(err, IsNil)
-		if scenario.status != "" {
-			c.Check(allAliases, DeepEquals, map[string]map[string]string{
-				"alias-snap": {scenAlias: scenario.status},
-			}, comm)
-		} else {
-			c.Check(allAliases, HasLen, 0, comm)
-		}
-
-		s.fakeBackend.ops = nil
-	}
-}
-
-func (s *snapmgrTestSuite) TestAliasMatrixTotalUndoRunThrough(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
-		Current: snap.R(11),
-		Active:  true,
-	})
-
-	// alias1 is a non auto-alias
-	// alias5 is an auto-alias
-	// alias1gone is a non auto-alias and doesn't have an entry in the snap anymore
-	// alias5gone is an auto-alias and doesn't have an entry in the snap any
-	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
-		c.Check(info.Name(), Equals, "alias-snap")
-		return map[string]string{"alias5": "cmd5", "alias5gone": "cmd5gone"}, nil
-	}
-	cmds := map[string]string{
-		"alias1": "cmd1",
-		"alias5": "cmd5",
-	}
-
-	defer s.snapmgr.Stop()
-	for _, scenario := range statusesMatrix {
-		scenAlias := scenario.alias
-		if scenario.beforeStatus != "" {
-			s.state.Set("aliases", map[string]map[string]string{
-				"alias-snap": {
-					scenAlias: scenario.beforeStatus,
-				},
-			})
-		} else {
-			s.state.Set("aliases", nil)
-		}
-
-		chg := s.state.NewChange("scenario", "...")
-		var err error
-		var ts *state.TaskSet
-		targets := []string{scenAlias}
-
-		switch scenario.action {
-		case "alias":
-			ts, err = snapstate.Alias(s.state, "alias-snap", targets)
-		case "unalias":
-			ts, err = snapstate.Unalias(s.state, "alias-snap", targets)
-		case "reset":
-			ts, err = snapstate.ResetAliases(s.state, "alias-snap", targets)
-		}
-		c.Assert(err, IsNil)
-
-		chg.AddAll(ts)
-
-		tasks := ts.Tasks()
-		last := tasks[len(tasks)-1]
-
-		terr := s.state.NewTask("error-trigger", "provoking total undo")
-		terr.WaitFor(last)
-		chg.AddTask(terr)
-
-		s.state.Unlock()
-		for i := 0; i < 3; i++ {
-			s.snapmgr.Ensure()
-			s.snapmgr.Wait()
-		}
-		s.state.Lock()
-
-		c.Assert(chg.Status(), Equals, state.ErrorStatus, Commentf("%#v: %v", scenario, chg.Err()))
-		var aliases []*backend.Alias
-		var rmAliases []*backend.Alias
-		beAlias := &backend.Alias{Name: scenAlias, Target: fmt.Sprintf("alias-snap.%s", cmds[scenAlias])}
-		switch scenario.mutation {
-		case "-":
-		case "add":
-			aliases = []*backend.Alias{beAlias}
-		case "rm":
-			rmAliases = []*backend.Alias{beAlias}
-		}
-
-		comm := Commentf("%#v", scenario)
-		expected := fakeOps{
-			{
-				op:        "update-aliases",
-				aliases:   aliases,
-				rmAliases: rmAliases,
-			},
-			{
-				op:      "matching-aliases",
-				aliases: aliases,
-			},
-			{
-				op:      "missing-aliases",
-				aliases: rmAliases,
-			},
-			{
-				op:        "update-aliases",
-				aliases:   rmAliases,
-				rmAliases: aliases,
-			},
-		}
-		// start with an easier-to-read error if this fails:
-		c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops(), comm)
-		c.Check(s.fakeBackend.ops, DeepEquals, expected, comm)
-
-		var allAliases map[string]map[string]string
-		err = s.state.Get("aliases", &allAliases)
-		c.Assert(err, IsNil)
-		if scenario.beforeStatus != "" {
-			c.Check(allAliases, DeepEquals, map[string]map[string]string{
-				"alias-snap": {scenAlias: scenario.beforeStatus},
-			}, comm)
-		} else {
-			c.Check(allAliases, HasLen, 0, comm)
-		}
-
-		s.fakeBackend.ops = nil
-	}
-}
-
 func (s *snapmgrTestSuite) TestDisabledSnapResetAliasesRunThrough(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1066,111 +874,114 @@ func (s *snapmgrTestSuite) TestDisabledSnapResetAliasesTotalUndoRunThrough(c *C)
 }
 
 func (s *snapmgrTestSuite) TestUnliasTotalUndoRunThroughAliasConflict(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
+	c.Skip("new semantics are wip")
+	/*
 
-	snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
-		Sequence: []*snap.SideInfo{
-			{RealName: "alias-snap", Revision: snap.R(11)},
-		},
-		Current: snap.R(11),
-		Active:  true,
-	})
+		s.state.Lock()
+		defer s.state.Unlock()
 
-	defer s.snapmgr.Stop()
-	s.state.Set("aliases", map[string]map[string]string{
-		"alias-snap": {
-			"alias1": "enabled",
-		},
-	})
+		snapstate.Set(s.state, "alias-snap", &snapstate.SnapState{
+			Sequence: []*snap.SideInfo{
+				{RealName: "alias-snap", Revision: snap.R(11)},
+			},
+			Current: snap.R(11),
+			Active:  true,
+		})
 
-	chg := s.state.NewChange("scenario", "...")
-	ts, err := snapstate.Unalias(s.state, "alias-snap", []string{"alias1"})
-	c.Assert(err, IsNil)
-
-	chg.AddAll(ts)
-
-	tasks := ts.Tasks()
-	last := tasks[len(tasks)-1]
-
-	grabAlias1 := func(t *state.Task, _ *tomb.Tomb) error {
-		st := t.State()
-		st.Lock()
-		defer st.Unlock()
-
-		var allAliases map[string]map[string]string
-		err := st.Get("aliases", &allAliases)
-		c.Assert(err, IsNil)
-		c.Assert(allAliases, DeepEquals, map[string]map[string]string{
+		defer s.snapmgr.Stop()
+		s.state.Set("aliases", map[string]map[string]string{
 			"alias-snap": {
-				"alias1": "disabled",
+				"alias1": "enabled",
 			},
 		})
 
-		st.Set("aliases", map[string]map[string]string{
-			"alias-snap": {
-				"alias1": "disabled",
+		chg := s.state.NewChange("scenario", "...")
+		ts, err := snapstate.Unalias(s.state, "alias-snap", []string{"alias1"})
+		c.Assert(err, IsNil)
+
+		chg.AddAll(ts)
+
+		tasks := ts.Tasks()
+		last := tasks[len(tasks)-1]
+
+		grabAlias1 := func(t *state.Task, _ *tomb.Tomb) error {
+			st := t.State()
+			st.Lock()
+			defer st.Unlock()
+
+			var allAliases map[string]map[string]string
+			err := st.Get("aliases", &allAliases)
+			c.Assert(err, IsNil)
+			c.Assert(allAliases, DeepEquals, map[string]map[string]string{
+				"alias-snap": {
+					"alias1": "disabled",
+				},
+			})
+
+			st.Set("aliases", map[string]map[string]string{
+				"alias-snap": {
+					"alias1": "disabled",
+				},
+				"other-snap": {
+					"alias1": "enabled",
+				},
+			})
+			return nil
+		}
+
+		s.snapmgr.AddAdhocTaskHandler("grab-alias1", grabAlias1, nil)
+
+		tgrab1 := s.state.NewTask("grab-alias1", "grab alias1 for other-snap")
+		tgrab1.WaitFor(last)
+		chg.AddTask(tgrab1)
+
+		terr := s.state.NewTask("error-trigger", "provoking total undo")
+		terr.WaitFor(tgrab1)
+		chg.AddTask(terr)
+
+		s.state.Unlock()
+
+		for i := 0; i < 5; i++ {
+			s.snapmgr.Ensure()
+			s.snapmgr.Wait()
+		}
+
+		s.state.Lock()
+
+		c.Assert(chg.Status(), Equals, state.ErrorStatus, Commentf("%v", chg.Err()))
+		rmAliases := []*backend.Alias{{"alias1", "alias-snap.cmd1"}}
+
+		expected := fakeOps{
+			{
+				op:        "update-aliases",
+				rmAliases: rmAliases,
 			},
+			{
+				op: "matching-aliases",
+			},
+			{
+				op: "missing-aliases",
+			},
+			{
+				op: "update-aliases",
+			},
+		}
+		// start with an easier-to-read error if this fails:
+		c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+		c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+		var allAliases map[string]map[string]string
+		err = s.state.Get("aliases", &allAliases)
+		c.Assert(err, IsNil)
+		c.Check(allAliases, DeepEquals, map[string]map[string]string{
 			"other-snap": {
 				"alias1": "enabled",
 			},
 		})
-		return nil
-	}
 
-	s.snapmgr.AddAdhocTaskHandler("grab-alias1", grabAlias1, nil)
-
-	tgrab1 := s.state.NewTask("grab-alias1", "grab alias1 for other-snap")
-	tgrab1.WaitFor(last)
-	chg.AddTask(tgrab1)
-
-	terr := s.state.NewTask("error-trigger", "provoking total undo")
-	terr.WaitFor(tgrab1)
-	chg.AddTask(terr)
-
-	s.state.Unlock()
-
-	for i := 0; i < 5; i++ {
-		s.snapmgr.Ensure()
-		s.snapmgr.Wait()
-	}
-
-	s.state.Lock()
-
-	c.Assert(chg.Status(), Equals, state.ErrorStatus, Commentf("%v", chg.Err()))
-	rmAliases := []*backend.Alias{{"alias1", "alias-snap.cmd1"}}
-
-	expected := fakeOps{
-		{
-			op:        "update-aliases",
-			rmAliases: rmAliases,
-		},
-		{
-			op: "matching-aliases",
-		},
-		{
-			op: "missing-aliases",
-		},
-		{
-			op: "update-aliases",
-		},
-	}
-	// start with an easier-to-read error if this fails:
-	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
-	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
-
-	var allAliases map[string]map[string]string
-	err = s.state.Get("aliases", &allAliases)
-	c.Assert(err, IsNil)
-	c.Check(allAliases, DeepEquals, map[string]map[string]string{
-		"other-snap": {
-			"alias1": "enabled",
-		},
-	})
-
-	c.Check(last.Log(), HasLen, 1)
-	c.Check(last.Log()[0], Matches, `.* ERROR cannot enable alias "alias1" for "alias-snap", already enabled for "other-snap"`)
-
+		c.Check(last.Log(), HasLen, 1)
+		c.Check(last.Log()[0], Matches, `.* ERROR cannot enable alias "alias1" for "alias-snap", already enabled for "other-snap"`)
+	*/
 }
 
 func (s *snapmgrTestSuite) TestAutoAliasesDelta(c *C) {

--- a/overlord/snapstate/aliases_test.go
+++ b/overlord/snapstate/aliases_test.go
@@ -118,12 +118,8 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliases(c *C) {
 			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
 		},
 		{
-			op:      "matching-aliases",
-			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
-		},
-		{
-			op:        "update-aliases",
-			rmAliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+			op:   "remove-snap-aliases",
+			name: "alias-snap",
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -242,12 +238,8 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAuto(c *C) {
 			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
 		},
 		{
-			op:      "matching-aliases",
-			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
-		},
-		{
-			op:        "update-aliases",
-			rmAliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
+			op:   "remove-snap-aliases",
+			name: "alias-snap",
 		},
 	}
 	// start with an easier-to-read error if this fails:

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -113,6 +113,8 @@ var (
 	CanDisable           = canDisable
 	CachedStore          = cachedStore
 	NameAndRevnoFromSnap = nameAndRevnoFromSnap
+
+	ResetAliases = resetAliases
 )
 
 func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -338,7 +338,7 @@ func Manager(st *state.State) (*SnapManager, error) {
 	runner.AddHandler("alias", m.doAlias, m.undoAlias)
 	runner.AddHandler("clear-aliases", m.doClearAliases, m.undoClearAliases)
 	runner.AddHandler("set-auto-aliases", m.doSetAutoAliases, m.undoClearAliases)
-	runner.AddHandler("setup-aliases", m.doSetupAliases, m.undoSetupAliases)
+	runner.AddHandler("setup-aliases", m.doSetupAliases, m.doRemoveAliases)
 	runner.AddHandler("remove-aliases", m.doRemoveAliases, m.doSetupAliases)
 
 	// control serialisation

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -614,7 +614,7 @@ func doUpdate(st *state.State, names []string, updates []*snap.Info, params func
 func applyAutoAliasesDelta(st *state.State, delta map[string][]string, op string, refreshAll bool, linkTs func(snapName string, ts *state.TaskSet)) (*state.TaskSet, error) {
 	applyTs := state.NewTaskSet()
 	for snapName, aliases := range delta {
-		ts, err := ResetAliases(st, snapName, aliases)
+		ts, err := resetAliases(st, snapName, aliases)
 		if err != nil {
 			if refreshAll {
 				// doing "refresh all", just skip this snap

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1722,10 +1722,8 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 			name: "/snap/some-snap/11",
 		},
 		{
-			op: "matching-aliases",
-		},
-		{
-			op: "update-aliases",
+			op:   "remove-snap-aliases",
+			name: "some-snap",
 		},
 		{
 			op:   "unlink-snap",
@@ -3763,10 +3761,8 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 			name: "/snap/some-snap/1",
 		},
 		{
-			op: "matching-aliases",
-		},
-		{
-			op: "update-aliases",
+			op:   "remove-snap-aliases",
+			name: "some-snap",
 		},
 		{
 			op:   "unlink-snap",

--- a/tests/main/alias/task.yaml
+++ b/tests/main/alias/task.yaml
@@ -1,10 +1,16 @@
 summary: Check snap alias and snap unalias
 
 prepare: |
+    echo "New semantics are WIP, skipping for now"
+    exit 0
+
     . $TESTSLIB/snaps.sh
     install_local aliases
 
 execute: |
+    echo "New semantics are WIP, skipping for now"
+    exit 0
+
     echo "Sanity check"
     aliases.cmd1|MATCH "ok command 1"
     aliases.cmd2|MATCH "ok command 2"


### PR DESCRIPTION
This also this breaks indirectly the commands with errors.  Also skip/comment out some tests that might be portable later, delete some that are unlikely to be relevant.

Also simplify the handler pair for setup-aliases, a symmetry we didn't notice the first time around but useful also in the new world.