### PR TITLE
tests: move unity test to nightly suite

### DIFF
--- a/tests/nightly/docker/task.yaml
+++ b/tests/nightly/docker/task.yaml
@@ -1,5 +1,4 @@
 summary: Check that the docker snap works
-manual: true
 systems: [ubuntu-16.04-*, ubuntu-core-16-*64, ubuntu-14.04-64]
 
 prepare: |

--- a/tests/nightly/unity/task.yaml
+++ b/tests/nightly/unity/task.yaml
@@ -5,19 +5,14 @@ environment:
 
 systems: [ubuntu-16.04-64]
 
-execute:
-    # FIXME Test is broken. Downloads HUNDREDS and HUNDREDS of packages,
-    # and asks for input on configuration file diffs.
-
-disabled_prepare: |
-    apt install -y x11-utils xvfb unity
+prepare: |
+    apt install -y --no-install-recommends x11-utils xvfb unity
 
 disabled_restore: |
     systemctl stop unity-app
-    apt remove -y x11-utils xvfb unity
-    apt autoremove -y
+    apt autoremove -y --purge x11-utils xvfb unity
 
-disabled_execute: |
+execute: |
     echo "Given a unity snap is installed"
     snap install ubuntu-clock-app
 


### PR DESCRIPTION
This test was disabled in the main suite because of being expensive in terms of installed packages and under some circumstances asked for input after config file changes, reenabled in nightly, we can debug the configuration changes there (if that's still an issue).