### PR TITLE
snapstate: restart as needed if we undid unlinking aka relinked core or kernels snap (2.23)

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -104,6 +104,9 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 		}
 		// if not on classic check there was no rollback
 		if !release.OnClassic {
+			// TODO: double check that we really rebooted
+			// otherwise this could be just a spurious restart
+			// of snapd
 			name, rev, err := snapstate.CurrentBootNameAndRevision(snap.TypeOS)
 			if err == snapstate.ErrBootNameAndRevisionAgain {
 				return &state.Retry{After: 5 * time.Second}

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -120,8 +120,8 @@ var ErrBootNameAndRevisionAgain = errors.New("boot revision not yet established"
 
 // CurrentBootNameAndRevision returns the currently set name and
 // revision for boot for the given type of snap, which can be core or
-// kernel. Returns ErrBootNameAndRevisionAgain if the value are not
-// temporarily established.
+// kernel. Returns ErrBootNameAndRevisionAgain if the values are
+// temporarily not established.
 func CurrentBootNameAndRevision(typ snap.Type) (name string, revision snap.Revision, err error) {
 	var kind string
 	var bootVar string
@@ -152,7 +152,7 @@ func CurrentBootNameAndRevision(typ snap.Type) (name string, revision snap.Revis
 		return "", snap.Revision{}, fmt.Errorf(errorPrefix+"%s", err)
 	}
 
-	if m["snap_mode"] != "" {
+	if m["snap_mode"] == "trying" {
 		return "", snap.Revision{}, ErrBootNameAndRevisionAgain
 	}
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -1078,8 +1078,11 @@ func (m *SnapManager) undoUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
 	// mark as active again
 	Set(st, snapsup.Name(), snapst)
 
-	return nil
+	// if we just put back a previous a core snap, request a restart
+	// so that we switch executing its snapd
+	maybeRestart(t, oldInfo)
 
+	return nil
 }
 
 func (m *SnapManager) doUnlinkCurrentSnap(t *state.Task, _ *tomb.Tomb) error {
@@ -1240,20 +1243,27 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 
 	// if we just installed a core snap, request a restart
 	// so that we switch executing its snapd
-	if release.OnClassic && newInfo.Type == snap.TypeOS {
+	maybeRestart(t, newInfo)
+
+	return nil
+}
+
+// maybeRestart will schedule a reboot or restart as needed for the just linked
+// snap with info if it's a core or kernel snap.
+func maybeRestart(t *state.Task, info *snap.Info) {
+	st := t.State()
+	if release.OnClassic && info.Type == snap.TypeOS {
 		t.Logf("Requested daemon restart.")
 		st.Unlock()
 		st.RequestRestart(state.RestartDaemon)
 		st.Lock()
 	}
-	if !release.OnClassic && boot.KernelOrOsRebootRequired(newInfo) {
+	if !release.OnClassic && boot.KernelOrOsRebootRequired(info) {
 		t.Logf("Requested system restart.")
 		st.Unlock()
 		st.RequestRestart(state.RestartSystem)
 		st.Lock()
 	}
-
-	return nil
 }
 
 func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {


### PR DESCRIPTION
Schedule as needed a restart or reboot when undoing unlink-current-snap.