### PR TITLE
interfaces/seccomp: add bind to default seccomp template for hooks

### DIFF
--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -43,6 +43,11 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+const (
+	isHook = 1 << iota
+	isApp
+)
+
 // Backend is responsible for maintaining seccomp profiles for ubuntu-core-launcher.
 type Backend struct{}
 
@@ -101,20 +106,20 @@ func (b *Backend) deriveContent(spec *Specification, opts interfaces.Confinement
 			content = make(map[string]*osutil.FileState)
 		}
 		securityTag := hookInfo.SecurityTag()
-		addContent(securityTag, opts, spec.SnippetForTag(securityTag), content)
+		addContent(securityTag, isHook, opts, spec.SnippetForTag(securityTag), content)
 	}
 	for _, appInfo := range snapInfo.Apps {
 		if content == nil {
 			content = make(map[string]*osutil.FileState)
 		}
 		securityTag := appInfo.SecurityTag()
-		addContent(securityTag, opts, spec.SnippetForTag(securityTag), content)
+		addContent(securityTag, isApp, opts, spec.SnippetForTag(securityTag), content)
 	}
 
 	return content, nil
 }
 
-func addContent(securityTag string, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState) {
+func addContent(securityTag string, flags int, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState) {
 	var buffer bytes.Buffer
 	if opts.Classic && !opts.JailMode {
 		// NOTE: This is understood by snap-confine
@@ -126,6 +131,9 @@ func addContent(securityTag string, opts interfaces.ConfinementOptions, snippetF
 	}
 
 	buffer.Write(defaultTemplate)
+	if flags&isHook != 0 {
+		buffer.Write(defaultHookTemplate)
+	}
 	buffer.WriteString(snippetForTag)
 
 	content[securityTag] = &osutil.FileState{

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -500,3 +500,16 @@ pwritev
 # of socket(), bind(), connect(), etc individually.
 socketcall
 `)
+
+// defaultHookTemplate contains default seccomp template for hooks.
+// It can be overridden for testing using MockTemplate().
+var defaultHookTemplate = []byte(`
+# Needed to workaround LP #1674193; when snapctl is executed inside a
+# hook it tries to connect to snapd via dirs.SnapSocket and
+# dirs.SnapdSocket. Given how golang performs the connection internally
+# the code will use bind which is denied by the default seccomp policy
+# which will lead to a hang of snapctl in environments where only
+# seccomp confinement is enabled. To workaround this will additionally
+# allow the bind syscall just for hooks.
+bind
+`)


### PR DESCRIPTION
This is have a mid term for for LP #1674193 which occurs when AppArmor confinement is disabled and Seccomp is enabled. See also the other referenced bugs in the bug report for more details.