### PR TITLE
cmd: rework header check for xfs/xqm.h

### DIFF
--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -22,7 +22,10 @@ AC_SYS_LARGEFILE
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h limits.h stdlib.h string.h sys/mount.h unistd.h])
 AC_CHECK_HEADERS([sys/quota.h], [], [AC_MSG_ERROR(sys/quota.h unavailable)])
-AC_CHECK_HEADERS([xfs/xqm.h],   [], [AC_MSG_ERROR(xfs/xqm.h unavailable)])
+AC_CHECK_HEADERS([xfs/xqm.h], [], [AC_MSG_ERROR(xfs/xqm.h unavailable)],
+[[#define _FILE_OFFSET_BITS 64
+#include <xfs/xqm.h>
+]])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL


### PR DESCRIPTION
Building snap-confine on i386 fails on other operating systems with:

configure: WARNING: xfs/xqm.h: present but cannot be compiled
configure: WARNING: xfs/xqm.h:     check for missing prerequisite headers?
configure: WARNING: xfs/xqm.h: see the Autoconf documentation
configure: WARNING: xfs/xqm.h:     section "Present But Cannot Be Compiled"
configure: WARNING: xfs/xqm.h: proceeding with the compiler's result
[...]
checking for xfs/xqm.h... no
configure: error: xfs/xqm.h unavailable

The official autoconf documentation recommends using a proper include
check in the AC_CHECK_HEADERS macro.