### PR TITLE
interfaces/seccomp: add bind as part of the default seccomp policy (backport)

### DIFF
--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	. "gopkg.in/check.v1"
 
@@ -172,6 +173,37 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 		"getuid\n",
 	} {
 		c.Assert(string(data), testutil.Contains, line)
+	}
+}
+
+func (s *backendSuite) TestRealDefaultHookTemplateIsNormallyUsed(c *C) {
+	snapInfo := snaptest.MockInfo(c, ifacetest.SambaYamlWithHook, nil)
+	// NOTE: we don't call seccomp.MockTemplate()
+	err := s.Backend.Setup(snapInfo, interfaces.ConfinementOptions{}, s.Repo)
+	c.Assert(err, IsNil)
+	profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.hook.configure")
+	data, err := ioutil.ReadFile(profile)
+	c.Assert(err, IsNil)
+	for _, line := range []string{
+		"\nbind\n",
+	} {
+		c.Assert(string(data), testutil.Contains, line)
+	}
+}
+
+func (s *backendSuite) TestRealDefaultTemplateDoesNotHaveDefaultHookTemplate(c *C) {
+	snapInfo := snaptest.MockInfo(c, ifacetest.SambaYamlV1, nil)
+	// NOTE: we don't call seccomp.MockTemplate()
+	err := s.Backend.Setup(snapInfo, interfaces.ConfinementOptions{}, s.Repo)
+	c.Assert(err, IsNil)
+	profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.smbd")
+	data, err := ioutil.ReadFile(profile)
+	c.Assert(err, IsNil)
+	for _, line := range []string{
+		"# Needed to workaround LP #1674193; when snapctl is executed inside a",
+	} {
+		match, _ := regexp.MatchString(line, string(data))
+		c.Assert(match, Equals, false)
 	}
 }
 

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -498,3 +498,16 @@ pwritev
 # of socket(), bind(), connect(), etc individually.
 socketcall
 `)
+
+// defaultHookTemplate contains default seccomp template for hooks.
+// It can be overridden for testing using MockTemplate().
+var defaultHookTemplate = []byte(`
+# Needed to workaround LP #1674193; when snapctl is executed inside a
+# hook it tries to connect to snapd via dirs.SnapSocket and
+# dirs.SnapdSocket. Given how golang performs the connection internally
+# the code will use bind which is denied by the default seccomp policy
+# which will lead to a hang of snapctl in environments where only
+# seccomp confinement is enabled. To workaround this will additionally
+# allow the bind syscall just for hooks.
+bind
+`)


### PR DESCRIPTION
…r hooks (#3091)

This is have a mid term for for LP #1674193 which occurs when AppArmor confinement is disabled and Seccomp is enabled. See also the other referenced bugs in the bug report for more details.