### PR TITLE
configstate,hookstate: timeout the configure hook after 5 mins, report failures to the errtracker

### DIFF
--- a/overlord/configstate/tasksets.go
+++ b/overlord/configstate/tasksets.go
@@ -21,6 +21,8 @@ package configstate
 
 import (
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/overlord/hookstate"
@@ -32,13 +34,26 @@ func init() {
 	snapstate.Configure = Configure
 }
 
+func configureHookTimeout() time.Duration {
+	timeout := 5 * time.Minute
+	if s := os.Getenv("SNAPD_CONFIGURE_HOOK_TIMEOUT"); s != "" {
+		if to, err := time.ParseDuration(s); err == nil {
+			timeout = to
+		}
+	}
+	return timeout
+}
+
 // Configure returns a taskset to apply the given configuration patch.
 func Configure(s *state.State, snapName string, patch map[string]interface{}, flags int) *state.TaskSet {
 	hooksup := &hookstate.HookSetup{
-		Snap:       snapName,
-		Hook:       "configure",
-		Optional:   len(patch) == 0,
-		IgnoreFail: flags&snapstate.IgnoreHookFailure != 0,
+		Snap:        snapName,
+		Hook:        "configure",
+		Optional:    len(patch) == 0,
+		IgnoreError: flags&snapstate.IgnoreHookError != 0,
+		TrackError:  flags&snapstate.TrackHookError != 0,
+		// all configure hooks must finish within this timeout
+		Timeout: configureHookTimeout(),
 	}
 	var contextData map[string]interface{}
 	if len(patch) > 0 {

--- a/overlord/configstate/tasksets_test.go
+++ b/overlord/configstate/tasksets_test.go
@@ -20,6 +20,8 @@
 package configstate_test
 
 import (
+	"time"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/overlord/configstate"
@@ -40,32 +42,32 @@ func (s *tasksetsSuite) SetUpTest(c *C) {
 }
 
 var configureTests = []struct {
-	patch      map[string]interface{}
-	optional   bool
-	ignoreFail bool
+	patch       map[string]interface{}
+	optional    bool
+	ignoreError bool
 }{{
-	patch:      nil,
-	optional:   true,
-	ignoreFail: false,
+	patch:       nil,
+	optional:    true,
+	ignoreError: false,
 }, {
-	patch:      map[string]interface{}{},
-	optional:   true,
-	ignoreFail: false,
+	patch:       map[string]interface{}{},
+	optional:    true,
+	ignoreError: false,
 }, {
-	patch:      map[string]interface{}{"foo": "bar"},
-	optional:   false,
-	ignoreFail: false,
+	patch:       map[string]interface{}{"foo": "bar"},
+	optional:    false,
+	ignoreError: false,
 }, {
-	patch:      nil,
-	optional:   true,
-	ignoreFail: true,
+	patch:       nil,
+	optional:    true,
+	ignoreError: true,
 }}
 
 func (s *tasksetsSuite) TestConfigure(c *C) {
 	for _, test := range configureTests {
 		var flags int
-		if test.ignoreFail {
-			flags |= snapstate.IgnoreHookFailure
+		if test.ignoreError {
+			flags |= snapstate.IgnoreHookError
 		}
 
 		s.state.Lock()
@@ -93,7 +95,8 @@ func (s *tasksetsSuite) TestConfigure(c *C) {
 		c.Assert(hooksup.Snap, Equals, "test-snap")
 		c.Assert(hooksup.Hook, Equals, "configure")
 		c.Assert(hooksup.Optional, Equals, test.optional)
-		c.Assert(hooksup.IgnoreFail, Equals, test.ignoreFail)
+		c.Assert(hooksup.IgnoreError, Equals, test.ignoreError)
+		c.Assert(hooksup.Timeout, Equals, 5*time.Minute)
 
 		context, err := hookstate.NewContext(task, &hooksup, nil)
 		c.Check(err, IsNil)

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -37,6 +38,7 @@ type Context struct {
 	setup   *HookSetup
 	id      string
 	handler Handler
+	timeout time.Duration
 
 	cache  map[interface{}]interface{}
 	onDone []func() error
@@ -76,6 +78,11 @@ func (c *Context) SnapRevision() snap.Revision {
 // HookName returns the name of the hook in this context.
 func (c *Context) HookName() string {
 	return c.setup.Hook
+}
+
+// Timeout returns the maximum time this hook can run
+func (c *Context) Timeout() time.Duration {
+	return c.setup.Timeout
 }
 
 // ID returns the ID of the context.

--- a/overlord/hookstate/export_test.go
+++ b/overlord/hookstate/export_test.go
@@ -19,10 +19,37 @@
 
 package hookstate
 
+import (
+	"syscall"
+	"time"
+)
+
 func MockReadlink(f func(string) (string, error)) func() {
 	oldReadlink := osReadlink
 	osReadlink = f
 	return func() {
 		osReadlink = oldReadlink
 	}
+}
+
+func MockSyscallKill(f func(int, syscall.Signal) error) func() {
+	oldSyscallKill := syscallKill
+	syscallKill = f
+	return func() {
+		syscallKill = oldSyscallKill
+	}
+}
+
+func MockCmdWaitTimeout(timeout time.Duration) func() {
+	oldCmdWaitTimeout := cmdWaitTimeout
+	cmdWaitTimeout = timeout
+	return func() {
+		cmdWaitTimeout = oldCmdWaitTimeout
+	}
+}
+
+func MockErrtrackerReport(mock func(string, string, string, map[string]string) (string, error)) (restore func()) {
+	prev := errtrackerReport
+	errtrackerReport = mock
+	return func() { errtrackerReport = prev }
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -804,7 +804,7 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	oopsid, err := errtrackerReport(snapsup.SideInfo.RealName, strings.Join(logMsg, "\n"), strings.Join(dupSig, "\n"), extra)
 	st.Lock()
 	if err == nil {
-		logger.Noticef("Reported problem as %s", oopsid)
+		logger.Noticef("Reported install problem for %q as %s", snapsup.SideInfo.RealName, oopsid)
 	} else {
 		logger.Debugf("Cannot report problem: %s", err)
 	}

--- a/overlord/snapstate/snapmgr_test.go
+++ b/overlord/snapstate/snapmgr_test.go
@@ -887,8 +887,8 @@ func (s *snapmgrTestSuite) TestUpdateTasksCoreSetsIgnoreOnConfigure(c *C) {
 	_, err := snapstate.Update(s.state, "core", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	// ensure the core snap sets the "ignore-hook-failure" flag
-	c.Check(configureFlags&snapstate.IgnoreHookFailure, Equals, 1)
+	// ensure the core snap sets the "ignore-hook-error" flag
+	c.Check(configureFlags&snapstate.IgnoreHookError, Equals, 1)
 }
 
 func (s *snapmgrTestSuite) TestUpdateDevModeConfinementFiltering(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -43,7 +43,8 @@ const (
 
 // control flags for "Configure()"
 const (
-	IgnoreHookFailure = 1 << iota
+	IgnoreHookError = 1 << iota
+	TrackHookError
 )
 
 func needsMaybeCore(typ snap.Type) int {
@@ -235,7 +236,8 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	// of hardcoding the name here. Unfortunately we do not have the
 	// type until we actually run the change.
 	if snapsup.Name() == "core" {
-		confFlags |= IgnoreHookFailure
+		confFlags |= IgnoreHookError
+		confFlags |= TrackHookError
 	}
 	configSet := Configure(st, snapsup.Name(), defaults, confFlags)
 	configSet.WaitAll(installSet)

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -88,7 +88,7 @@ prepare_classic() {
 [Unit]
 StartLimitInterval=0
 [Service]
-Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1
+Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_CONFIGURE_HOOK_TIMEOUT=30s
 EOF
     mkdir -p /etc/systemd/system/snapd.socket.d
     cat <<EOF > /etc/systemd/system/snapd.socket.d/local.conf

--- a/tests/main/refresh-core-with-hanging-configure-hook/task.yaml
+++ b/tests/main/refresh-core-with-hanging-configure-hook/task.yaml
@@ -10,12 +10,14 @@ restore:
     rm -rf squashfs-root
     rm -f $BROKEN_CORE_SNAP
 
+kill-timeout: 2m
+
 execute: |
     snap list | awk "/^core / {print(\$3)}" > prevBoot
     
-    echo "Breaking the configure hook of the core snap"
+    echo "Breaking the configure hook of the core snap to hang forever"
     unsquashfs /var/lib/snapd/snaps/core_$(cat prevBoot).snap
-    printf '#!/bin/sh\necho somethingbroken\nfalse\n' > squashfs-root/meta/hooks/configure
+    printf '#!/bin/sh\necho ithangs\nsleep 9999\n' > squashfs-root/meta/hooks/configure
     chmod 755 squashfs-root/meta/hooks/configure
 
     . $TESTSLIB/snaps.sh
@@ -32,6 +34,10 @@ execute: |
 
     echo "Verify the snap change"
     snap change $chg_id | MATCH ".*ERROR ignoring failure in hook \"configure\".*"
-    snap change $chg_id | MATCH ".*somethingbroken.*"
+    snap change $chg_id | MATCH ".*ithangs.*"
+
+    # max-runtime set in prepare.sh via SNAPD_CONFIGURE_HOOK_TIMEOUT=30s
+    # in the environment
+    snap change $chg_id | MATCH ".*exceeded maximum runtime of 30s.*"
 
     journalctl -u snapd | MATCH "Reported hook failure from \"configure\" for snap \"core\" as.*"


### PR DESCRIPTION
Only allow all configure hooks to run for a limited amount of time. The
limit is 5 minutes currently to be on the safe side on very slow systems.
We may gradually decrease this timeout.

Also add support to report hook failures to the error tracker and report
failures in the core snap configure hook.

Allow overriding this via SNAPD_CONFIGURE_HOOK_TIMEOUT in the
tests.