### PR TITLE
cmd: explicit use of snapd sockets (for 2.23)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -39,7 +39,7 @@ func unixDialer(socketPath string) func(string, string) (net.Conn, error) {
 	if socketPath == "" {
 		socketPath = dirs.SnapdSocket
 	}
-	return func(a, b string) (net.Conn, error) {
+	return func(_, _ string) (net.Conn, error) {
 		return net.Dial("unix", socketPath)
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -31,9 +31,14 @@ import (
 	"os"
 	"path"
 	"time"
+
+	"github.com/snapcore/snapd/dirs"
 )
 
 func unixDialer(socketPath string) func(string, string) (net.Conn, error) {
+	if socketPath == "" {
+		socketPath = dirs.SnapdSocket
+	}
 	return func(a, b string) (net.Conn, error) {
 		return net.Dial("unix", socketPath)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -252,7 +252,9 @@ func (cs *clientSuite) TestSnapClientIntegration(c *C) {
 	srv.Start()
 	defer srv.Close()
 
-	cli := client.New(nil)
+	cli := client.New(&client.Config{
+		Socket: dirs.SnapSocket,
+	})
 	options := &client.SnapCtlOptions{
 		ContextID: "foo",
 		Args:      []string{"bar", "--baz"},

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -209,7 +209,10 @@ snaps on the system. Start with 'snap list' to see installed snaps.
 }
 
 // ClientConfig is the configuration of the Client used by all commands.
-var ClientConfig client.Config
+var ClientConfig = client.Config{
+	// we need the powerful snapd socket
+	Socket: dirs.SnapdSocket,
+}
 
 // Client returns a new client using ClientConfig as configuration.
 func Client() *client.Client {

--- a/cmd/snapctl/main.go
+++ b/cmd/snapctl/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/dirs"
 )
 
 var clientConfig = client.Config{
@@ -31,6 +32,9 @@ var clientConfig = client.Config{
 	// result in apparmor denials and configure task failures
 	// (LP: #1660941)
 	DisableAuth: true,
+
+	// we need the less privileged snap socket in snapctl
+	Socket: dirs.SnapSocket,
 }
 
 func main() {


### PR DESCRIPTION
Backport of https://github.com/snapcore/snapd/pull/3098 to 2.23