### PR TITLE
interfaces/mount: add function for parsing mount entries

### DIFF
--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -21,6 +21,7 @@ package mount
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -73,11 +74,26 @@ func (a *Entry) Equal(b *Entry) bool {
 //  newline   => (\012)
 //  backslash => (\134)
 func escape(s string) string {
-	return whitespaceReplacer.Replace(s)
+	return whitespaceEscape.Replace(s)
 }
 
-var whitespaceReplacer = strings.NewReplacer(
-	" ", `\040`, "\t", `\011`, "\n", `\012`, "\\", `\134`)
+// unescape replaces escape sequences used by setmnt with whitespace characters.
+//
+// According to the manual page, the following characters need to be unescaped.
+//  space     <= (\040)
+//  tab       <= (\011)
+//  newline   <= (\012)
+//  backslash <= (\134)
+func unescape(s string) string {
+	return whitespaceUnescape.Replace(s)
+}
+
+var (
+	whitespaceEscape = strings.NewReplacer(
+		" ", `\040`, "\t", `\011`, "\n", `\012`, "\\", `\134`)
+	whitespaceUnescape = strings.NewReplacer(
+		`\040`, " ", `\011`, "\t", `\012`, "\n", `\134`, "\\")
+)
 
 func (e Entry) String() string {
 	// Name represents name of the device in a mount entry.
@@ -102,4 +118,29 @@ func (e Entry) String() string {
 	}
 	return fmt.Sprintf("%s %s %s %s %d %d",
 		name, dir, fsType, options, e.DumpFrequency, e.CheckPassNumber)
+}
+
+// ParseEntry parses a fstab-like entry.
+func ParseEntry(s string) (Entry, error) {
+	var e Entry
+	fields := strings.Fields(s)
+	// do all error checks before any assignments to `e'
+	if len(fields) != 6 {
+		return e, fmt.Errorf("expected exactly six fields, found %d", len(fields))
+	}
+	df, err := strconv.Atoi(fields[4])
+	if err != nil {
+		return e, fmt.Errorf("cannot parse dump frequency: %s", err)
+	}
+	cpn, err := strconv.Atoi(fields[5])
+	if err != nil {
+		return e, fmt.Errorf("cannot parse check pass number: %s", err)
+	}
+	e.Name = unescape(fields[0])
+	e.Dir = unescape(fields[1])
+	e.Type = unescape(fields[2])
+	e.Options = strings.Split(unescape(fields[3]), ",")
+	e.DumpFrequency = df
+	e.CheckPassNumber = cpn
+	return e, nil
 }

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -125,7 +125,7 @@ func ParseEntry(s string) (Entry, error) {
 	var e Entry
 	var err error
 	var df, cpn int
-	fields := strings.Fields(s)
+	fields := strings.FieldsFunc(s, func(r rune) bool { return r == ' ' || r == '\t' })
 	// do all error checks before any assignments to `e'
 	if len(fields) < 4 || len(fields) > 6 {
 		return e, fmt.Errorf("expected between 4 and 6 fields, found %d", len(fields))

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -123,18 +123,26 @@ func (e Entry) String() string {
 // ParseEntry parses a fstab-like entry.
 func ParseEntry(s string) (Entry, error) {
 	var e Entry
+	var err error
+	var df, cpn int
 	fields := strings.Fields(s)
 	// do all error checks before any assignments to `e'
-	if len(fields) != 6 {
-		return e, fmt.Errorf("expected exactly six fields, found %d", len(fields))
+	if len(fields) < 4 || len(fields) > 6 {
+		return e, fmt.Errorf("expected between 4 and 6 fields, found %d", len(fields))
 	}
-	df, err := strconv.Atoi(fields[4])
-	if err != nil {
-		return e, fmt.Errorf("cannot parse dump frequency: %s", err)
+	// Parse DumpFrequency if we have at least 5 fields
+	if len(fields) >= 5 {
+		df, err = strconv.Atoi(fields[4])
+		if err != nil {
+			return e, fmt.Errorf("cannot parse dump frequency: %s", err)
+		}
 	}
-	cpn, err := strconv.Atoi(fields[5])
-	if err != nil {
-		return e, fmt.Errorf("cannot parse check pass number: %s", err)
+	// Parse CheckPassNumber if we have at least 6 fields
+	if len(fields) >= 6 {
+		cpn, err = strconv.Atoi(fields[5])
+		if err != nil {
+			return e, fmt.Errorf("cannot parse check pass number: %s", err)
+		}
 	}
 	e.Name = unescape(fields[0])
 	e.Dir = unescape(fields[1])

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -73,9 +73,7 @@ func (a *Entry) Equal(b *Entry) bool {
 //  tab       => (\011)
 //  newline   => (\012)
 //  backslash => (\134)
-func escape(s string) string {
-	return whitespaceEscape.Replace(s)
-}
+var escape = strings.NewReplacer(" ", `\040`, "\t", `\011`, "\n", `\012`, "\\", `\134`).Replace
 
 // unescape replaces escape sequences used by setmnt with whitespace characters.
 //
@@ -84,16 +82,7 @@ func escape(s string) string {
 //  tab       <= (\011)
 //  newline   <= (\012)
 //  backslash <= (\134)
-func unescape(s string) string {
-	return whitespaceUnescape.Replace(s)
-}
-
-var (
-	whitespaceEscape = strings.NewReplacer(
-		" ", `\040`, "\t", `\011`, "\n", `\012`, "\\", `\134`)
-	whitespaceUnescape = strings.NewReplacer(
-		`\040`, " ", `\011`, "\t", `\012`, "\n", `\134`, "\\")
-)
+var unescape = strings.NewReplacer(`\040`, " ", `\011`, "\t", `\012`, "\n", `\134`, "\\").Replace
 
 func (e Entry) String() string {
 	// Name represents name of the device in a mount entry.

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -116,10 +116,10 @@ func (s *entrySuite) TestParseEntry3(c *C) {
 // Test that number of fields is checked
 func (s *entrySuite) TestParseEntry4(c *C) {
 	for _, s := range []string{
-		"", "1", "1 2", "1 2 3", "1 2 3 4", "1 2 3 4 5" /* skip 6 */, "1 2 3 4 5 6 7",
+		"", "1", "1 2", "1 2 3" /* skip 4, 5 and 6 fields (valid case) */, "1 2 3 4 5 6 7",
 	} {
 		_, err := mount.ParseEntry(s)
-		c.Assert(err, ErrorMatches, "expected exactly six fields, found [0-7]")
+		c.Assert(err, ErrorMatches, "expected between 4 and 6 fields, found [01237]")
 	}
 }
 
@@ -129,4 +129,22 @@ func (s *entrySuite) TestParseEntry5(c *C) {
 	c.Assert(err, ErrorMatches, "cannot parse dump frequency: .*")
 	_, err = mount.ParseEntry("name dir type options 0 foo")
 	c.Assert(err, ErrorMatches, "cannot parse check pass number: .*")
+}
+
+// Test that last two integer fields default to zero if not present.
+func (s *entrySuite) TestParseEntry6(c *C) {
+	e, err := mount.ParseEntry("name dir type options")
+	c.Assert(err, IsNil)
+	c.Assert(e.DumpFrequency, Equals, 0)
+	c.Assert(e.CheckPassNumber, Equals, 0)
+
+	e, err = mount.ParseEntry("name dir type options 5")
+	c.Assert(err, IsNil)
+	c.Assert(e.DumpFrequency, Equals, 5)
+	c.Assert(e.CheckPassNumber, Equals, 0)
+
+	e, err = mount.ParseEntry("name dir type options 5 7")
+	c.Assert(err, IsNil)
+	c.Assert(e.DumpFrequency, Equals, 5)
+	c.Assert(e.CheckPassNumber, Equals, 7)
 }

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -76,3 +76,57 @@ func (s *entrySuite) TestEqual(c *C) {
 	b = &mount.Entry{Options: []string{"rw"}}
 	c.Assert(a.Equal(b), Equals, false)
 }
+
+// Test that typical fstab entry is parsed correctly.
+func (s *entrySuite) TestParseEntry1(c *C) {
+	e, err := mount.ParseEntry("UUID=394f32c0-1f94-4005-9717-f9ab4a4b570b /               ext4    errors=remount-ro 0       1")
+	c.Assert(err, IsNil)
+	c.Assert(e.Name, Equals, "UUID=394f32c0-1f94-4005-9717-f9ab4a4b570b")
+	c.Assert(e.Dir, Equals, "/")
+	c.Assert(e.Type, Equals, "ext4")
+	c.Assert(e.Options, DeepEquals, []string{"errors=remount-ro"})
+	c.Assert(e.DumpFrequency, Equals, 0)
+	c.Assert(e.CheckPassNumber, Equals, 1)
+}
+
+// Test that options are parsed correctly
+func (s *entrySuite) TestParseEntry2(c *C) {
+	e, err := mount.ParseEntry("name dir type options,comma,separated 0 0")
+	c.Assert(err, IsNil)
+	c.Assert(e.Name, Equals, "name")
+	c.Assert(e.Dir, Equals, "dir")
+	c.Assert(e.Type, Equals, "type")
+	c.Assert(e.Options, DeepEquals, []string{"options", "comma", "separated"})
+	c.Assert(e.DumpFrequency, Equals, 0)
+	c.Assert(e.CheckPassNumber, Equals, 0)
+}
+
+// Test that whitespace escape codes are honored
+func (s *entrySuite) TestParseEntry3(c *C) {
+	e, err := mount.ParseEntry(`na\040me d\011ir ty\012pe optio\134ns 0 0`)
+	c.Assert(err, IsNil)
+	c.Assert(e.Name, Equals, "na me")
+	c.Assert(e.Dir, Equals, "d\tir")
+	c.Assert(e.Type, Equals, "ty\npe")
+	c.Assert(e.Options, DeepEquals, []string{`optio\ns`})
+	c.Assert(e.DumpFrequency, Equals, 0)
+	c.Assert(e.CheckPassNumber, Equals, 0)
+}
+
+// Test that number of fields is checked
+func (s *entrySuite) TestParseEntry4(c *C) {
+	for _, s := range []string{
+		"", "1", "1 2", "1 2 3", "1 2 3 4", "1 2 3 4 5" /* skip 6 */, "1 2 3 4 5 6 7",
+	} {
+		_, err := mount.ParseEntry(s)
+		c.Assert(err, ErrorMatches, "expected exactly six fields, found [0-7]")
+	}
+}
+
+// Test that integers are parsed and error checked
+func (s *entrySuite) TestParseEntry5(c *C) {
+	_, err := mount.ParseEntry("name dir type options foo 0")
+	c.Assert(err, ErrorMatches, "cannot parse dump frequency: .*")
+	_, err = mount.ParseEntry("name dir type options 0 foo")
+	c.Assert(err, ErrorMatches, "cannot parse check pass number: .*")
+}


### PR DESCRIPTION
This patch adds a simple function for parsing fstab-like mount entries
along with full suite of tests.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>