### PR TITLE
tests: enable docker test for more ubuntu-core systems

### DIFF
--- a/tests/nightly/docker/task.yaml
+++ b/tests/nightly/docker/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that the docker snap works
-systems: [ubuntu-16.04-*, ubuntu-core-16-*64, ubuntu-14.04-64]
+systems: [ubuntu-16.04-*, ubuntu-core-16-*, ubuntu-14.04-64]
 
 prepare: |
     if apt show linux-image-extra-$(uname -r); then


### PR DESCRIPTION
Probably a typo in the previous changes to use system globbing, the docker test doesn't currently run on pi2 and pi3 systems, this PR fixes it.