### PR TITLE
cmd: add poky to the list of distros which don't support reexec

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -62,7 +62,7 @@ func ExecInCoreSnap() {
 
 	// can we re-exec? some distributions will need extra work before re-exec really works.
 	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "opensuse", "suse":
+	case "fedora", "centos", "rhel", "opensuse", "suse", "poky":
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return
 	}


### PR DESCRIPTION
'poky' is the std. release id for the Yocto reference distribution. This
wont cover all Yocto based product as Yocto is a meta distribution so
users are fine to change the release id to whatever they want. However
this clearly takes care just about our reference Yocto system.