### PR TITLE
interfaces: allow executing ld.so (needed with new AppArmor base abstraction)

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -132,6 +132,8 @@ var defaultTemplate = `
   /{,usr/}bin/infocmp ixr,
   /{,usr/}bin/kill ixr,
   /{,usr/}bin/ldd ixr,
+  /{usr/,}lib{,32,64}/ld{,32,64}-*.so ix,
+  /{usr/,}lib/@{multiarch}/ld{,32,64}-*.so ix,
   /{,usr/}bin/less{,file,pipe} ixr,
   /{,usr/}bin/ln ixr,
   /{,usr/}bin/line ixr,


### PR DESCRIPTION
AppArmor upstream changed the base abstraction to remove 'ix' for ld.so (as needed by ldd) when performing the usr-merge changes. snapd allows ix access to ldd, so it now needs to add back the ix rules for ld.so for systems with newer apparmor (eg, Ubuntu 17.04).

AppArmor upstream bug: https://bugs.launchpad.net/apparmor/+bug/1677587