### PR TITLE
WIP: cmd/snap-confine: always pass xauth file through regardless where it is located

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -197,7 +197,9 @@ snap_confine_snap_confine_SOURCES = \
 	snap-confine/udev-support.c \
 	snap-confine/udev-support.h \
 	snap-confine/user-support.c \
-	snap-confine/user-support.h
+	snap-confine/user-support.h \
+	snap-confine/xauth.c \
+	snap-confine/xauth.h
 
 snap_confine_snap_confine_CFLAGS = -Wall -Werror $(AM_CFLAGS)
 snap_confine_snap_confine_LDFLAGS = $(AM_LDFLAGS)

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -37,6 +37,7 @@
 #endif				// ifdef HAVE_SECCOMP
 #include "udev-support.h"
 #include "user-support.h"
+#include "xauth.h"
 
 int main(int argc, char **argv)
 {
@@ -110,6 +111,8 @@ int main(int argc, char **argv)
 	    __attribute__ ((cleanup(sc_cleanup_seccomp_release))) = NULL;
 	seccomp_ctx = sc_prepare_seccomp_context(security_tag);
 #endif				// ifdef HAVE_SECCOMP
+
+	sc_xauth_load_from_env();
 
 	if (geteuid() == 0) {
 		if (classic_confinement) {
@@ -210,6 +213,7 @@ int main(int argc, char **argv)
 		if (real_uid != 0 && (getgid() == 0 || getegid() == 0))
 			die("permanently dropping privs did not work");
 	}
+	sc_xauth_populate();
 	// and exec the new binary
 	execv(binary, (char *const *)&argv[NR_ARGS]);
 	perror("execv failed");

--- a/cmd/snap-confine/xauth.c
+++ b/cmd/snap-confine/xauth.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../libsnap-confine-private/secure-getenv.h"
+
+#include "xauth.h"
+
+#include <memory.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <linux/limits.h>
+
+static char *xauth_data = NULL;
+static long xauth_data_length = 0;
+
+void sc_xauth_load_from_env(void)
+{
+	const char *xauth_path = getenv("XAUTHORITY");
+	if (!xauth_path)
+		return;
+
+	FILE *f = fopen(xauth_path, "rb");
+	if (!f)
+		return;
+
+	fseek(f, 0, SEEK_END);
+	long length = ftell(f);
+	fseek(f, 0, SEEK_SET);
+
+	xauth_data = (char*) malloc(sizeof(char) * length);
+	if (!xauth_data) {
+		fclose(f);
+		return;
+	}
+
+	if (fread(xauth_data, 1, length, f) != length) {
+		free(xauth_data);
+		xauth_data = NULL;
+	} else {
+		xauth_data_length = length;
+	}
+
+	fclose(f);
+}
+
+void sc_xauth_populate(void)
+{
+	if (xauth_data == NULL)
+		return;
+
+	char name[] = "/tmp/xauth.XXXXXX";
+	int fd = mkstemp(name);
+	if (fd < 0 || write(fd, xauth_data, xauth_data_length) != xauth_data_length) {
+		// FIXME print warning or die?
+	}
+
+	free(xauth_data);
+	xauth_data = NULL;
+	xauth_data_length = 0;
+
+	char fd_path[PATH_MAX], path[PATH_MAX];
+	snprintf(fd_path, PATH_MAX, "/proc/self/fd/%d", fd);
+	memset(path, 0, sizeof(path));
+	if (readlink(fd_path, path, sizeof(path)-1) > 0)
+		setenv("XAUTHORITY", path, 1);
+
+	close(fd);
+}

--- a/cmd/snap-confine/xauth.h
+++ b/cmd/snap-confine/xauth.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_XAUTH_H
+#define SNAP_XAUTH_H
+
+void sc_xauth_load_from_env(void);
+void sc_xauth_populate(void);
+
+#endif


### PR DESCRIPTION
Normally XAUTHORITY points to a file in /run/user/<UID> or /home/<user> and both
are allowed in the x11 interface for a snap to use. However in a few cases like
in KDE on openSUSE the file XAUTHORITY points to is placed in /tmp which doesn't
work with our current setup. As /tmp is not shared with the host namespace we
need to take the content of the file XAUTHORITY points to through and restore
it inside the snap environment.

Fixes LP #1677513

------

Implementation is still a bit rough and test cases are missing. Pushing this for a first discussion and review.