### PR TITLE
tests: download and install additional dependencies when using prepackaged snapd

### DIFF
--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -35,9 +35,13 @@ build_deb(){
 download_from_ppa(){
     local ppa_version="$1"
 
-    for pkg in snapd; do
+    for pkg in snapd snap-confine ubuntu-core-launcher; do
         file="${pkg}_${ppa_version}_$(dpkg --print-architecture).deb"
         curl -L -o "$GOPATH/$file" "https://launchpad.net/~snappy-dev/+archive/ubuntu/snapd-${ppa_version}/+files/$file"
+    done
+
+    for dep in snap-confine ubuntu-core-launcher; do
+        dpkg -i "${GOPATH}/${dep}_${ppa_version}_$(dpkg --print-architecture).deb"
     done
 }
 

--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -35,10 +35,15 @@ build_deb(){
 download_from_ppa(){
     local ppa_version="$1"
 
+    # we need to install snap-confine and ubunntu-core-launcher for versions < 2.23
     for pkg in snapd snap-confine ubuntu-core-launcher; do
         file="${pkg}_${ppa_version}_$(dpkg --print-architecture).deb"
         curl -L -o "$GOPATH/$file" "https://launchpad.net/~snappy-dev/+archive/ubuntu/snapd-${ppa_version}/+files/$file"
     done
+}
+
+install_dependencies_from_ppa(){
+    local ppa_version="$1"
 
     for dep in snap-confine ubuntu-core-launcher; do
         dpkg -i "${GOPATH}/${dep}_${ppa_version}_$(dpkg --print-architecture).deb"
@@ -128,6 +133,8 @@ if [ -z "$SNAPD_PPA_VERSION" ]; then
     build_deb
 else
     download_from_ppa "$SNAPD_PPA_VERSION"
+
+    install_dependencies_from_ppa "$SNAPD_PPA_VERSION"
 fi
 
 # Build snapbuild.


### PR DESCRIPTION
This aims to solve the dependency errors that we are getting on the 2.211 -> edge reexec scenario [1], when using a prepackaged snapd the additional dependencies are also downloaded and installed.

[1] https://travis-ci.org/snapcore/spread-cron/builds/216619076#L376