### PR TITLE
store: handle EOF via url.Error check

### DIFF
--- a/store/retry.go
+++ b/store/retry.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"gopkg.in/retry.v1"
@@ -69,6 +70,9 @@ func shouldRetryHttpResponse(attempt *retry.Attempt, resp *http.Response) bool {
 func shouldRetryError(attempt *retry.Attempt, err error) bool {
 	if !attempt.More() {
 		return false
+	}
+	if urlErr, ok := err.(*url.Error); ok {
+		return urlErr.Err == io.ErrUnexpectedEOF || urlErr.Err == io.EOF
 	}
 	if netErr, ok := err.(net.Error); ok {
 		return netErr.Timeout()

--- a/store/retry.go
+++ b/store/retry.go
@@ -73,8 +73,11 @@ func shouldRetryError(attempt *retry.Attempt, err error) bool {
 	}
 	if urlErr, ok := err.(*url.Error); ok {
 		err = urlErr.Err
-	} else if netErr, ok := err.(net.Error); ok {
-		return netErr.Timeout()
+	}
+	if netErr, ok := err.(net.Error); ok {
+		if netErr.Timeout() {
+			return true
+		}
 	}
 	return err == io.ErrUnexpectedEOF || err == io.EOF
 }

--- a/store/retry.go
+++ b/store/retry.go
@@ -72,9 +72,8 @@ func shouldRetryError(attempt *retry.Attempt, err error) bool {
 		return false
 	}
 	if urlErr, ok := err.(*url.Error); ok {
-		return urlErr.Err == io.ErrUnexpectedEOF || urlErr.Err == io.EOF
-	}
-	if netErr, ok := err.(net.Error); ok {
+		err = urlErr.Err
+	} else if netErr, ok := err.(net.Error); ok {
 		return netErr.Timeout()
 	}
 	return err == io.ErrUnexpectedEOF || err == io.EOF

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2547,7 +2547,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshEOF(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	var err error
 	bulkURI, err := url.Parse(mockServer.URL + "/updates/")
 	c.Assert(err, IsNil)
 	cfg := Config{
@@ -2582,7 +2581,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshUnauthorised(c
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	var err error
 	bulkURI, err := url.Parse(mockServer.URL + "/updates/")
 	c.Assert(err, IsNil)
 	cfg := Config{

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2497,26 +2497,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *
 			mockServer.CloseClientConnections()
 			return
 		}
-		jsonReq, err := ioutil.ReadAll(r.Body)
-		c.Assert(err, IsNil)
-		var resp struct {
-			Snaps  []map[string]interface{} `json:"snaps"`
-			Fields []string                 `json:"fields"`
-		}
-
-		err = json.Unmarshal(jsonReq, &resp)
-		c.Assert(err, IsNil)
-
-		c.Assert(resp.Snaps, HasLen, 1)
-		c.Assert(resp.Snaps[0], DeepEquals, map[string]interface{}{
-			"snap_id":     helloWorldSnapID,
-			"channel":     "stable",
-			"revision":    float64(1),
-			"epoch":       "0",
-			"confinement": "",
-		})
-		c.Assert(resp.Fields, DeepEquals, detailFields)
-
 		io.WriteString(w, MockUpdatesJSON)
 	}))
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2497,6 +2497,13 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *
 			mockServer.CloseClientConnections()
 			return
 		}
+		var resp struct {
+			Snaps  []map[string]interface{} `json:"snaps"`
+			Fields []string                 `json:"fields"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&resp)
+		c.Assert(err, IsNil)
+		c.Assert(resp.Snaps, HasLen, 1)
 		io.WriteString(w, MockUpdatesJSON)
 	}))
 


### PR DESCRIPTION
Handle EOF errors such as "Post http://127.0.0.1:36904/updates/: EOF" by introspection via url.Error. Added  test cases for EOF.