### PR TITLE
overlord/state: make sure that setting to nil a state key is equivalent to deleting it

### DIFF
--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1288,8 +1288,7 @@ func (s *interfaceManagerSuite) testUndoDicardConns(c *C, snapName string) {
 
 	var removed map[string]interface{}
 	err = change.Tasks()[0].Get("removed", &removed)
-	c.Assert(err, IsNil)
-	c.Check(removed, HasLen, 0)
+	c.Check(err, Equals, state.ErrNoState)
 }
 
 func (s *interfaceManagerSuite) TestDoRemove(c *C) {

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -58,6 +58,10 @@ func (data customData) get(key string, value interface{}) error {
 }
 
 func (data customData) set(key string, value interface{}) {
+	if value == nil {
+		delete(data, key)
+		return
+	}
 	serialized, err := json.Marshal(value)
 	if err != nil {
 		logger.Panicf("internal error: could not marshal value for state entry %q: %v", key, err)

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -97,6 +97,39 @@ func (ss *stateSuite) TestGetNoState(c *C) {
 	c.Check(err, Equals, state.ErrNoState)
 }
 
+func (ss *stateSuite) TestSetToNilDeletes(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	st.Set("a", map[string]int{"a": 1})
+	var v map[string]int
+	err := st.Get("a", &v)
+	c.Assert(err, IsNil)
+	c.Check(v, HasLen, 1)
+
+	st.Set("a", nil)
+
+	var v1 map[string]int
+	err = st.Get("a", &v1)
+	c.Check(err, Equals, state.ErrNoState)
+	c.Check(v1, HasLen, 0)
+}
+
+func (ss *stateSuite) TestNullMeansNoState(c *C) {
+	buf := bytes.NewBufferString(`{"data": {"a": null}}`)
+	st, err := state.ReadState(nil, buf)
+	c.Assert(err, IsNil)
+
+	st.Lock()
+	defer st.Unlock()
+
+	var v1 map[string]int
+	err = st.Get("a", &v1)
+	c.Check(err, Equals, state.ErrNoState)
+	c.Check(v1, HasLen, 0)
+}
+
 func (ss *stateSuite) TestGetUnmarshalProblem(c *C) {
 	st := state.New(nil)
 	st.Lock()


### PR DESCRIPTION
This also clarifies a corner case in which the behavior across disk serialization or not was different.