### PR TITLE
interfaces/mount: add high-level Profile functions

### DIFF
--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -20,10 +20,7 @@
 package mount
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 	"syscall"
@@ -142,54 +139,6 @@ func ParseEntry(s string) (Entry, error) {
 	e.DumpFrequency = df
 	e.CheckPassNumber = cpn
 	return e, nil
-}
-
-// LoadFSTab reads and parses an fstab-like file.
-//
-// The supported format is described by fstab(5).
-func LoadFSTab(reader io.Reader) ([]Entry, error) {
-	var entries []Entry
-	scanner := bufio.NewScanner(reader)
-	for scanner.Scan() {
-		s := scanner.Text()
-		if i := strings.IndexByte(s, '#'); i != -1 {
-			s = s[0:i]
-		}
-		s = strings.TrimSpace(s)
-		if s == "" {
-			continue
-		}
-		entry, err := ParseEntry(s)
-		if err != nil {
-			return nil, err
-		}
-		entries = append(entries, entry)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return entries, nil
-}
-
-// SaveFSTab writes a list of entries to a fstab-like file.
-//
-// The supported format is described by fstab(5).
-//
-// Note that there is no support for comments, both the LoadFSTab function and
-// SaveFSTab just ignore them.
-//
-// Note that there is no attempt to use atomic file write/rename tricks. The
-// created file will typically live in /run/snapd/ns/$SNAP_NAME.fstab and will
-// be done so, while holidng a flock-based-lock, by the snap-update-ns program.
-func SaveFSTab(writer io.Writer, entries []Entry) error {
-	var buf bytes.Buffer
-	for i := range entries {
-		if _, err := fmt.Fprintf(&buf, "%s\n", entries[i]); err != nil {
-			return err
-		}
-	}
-	_, err := buf.WriteTo(writer)
-	return err
 }
 
 // OptsToFlags converts mount options strings to a mount flag.

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -20,8 +20,6 @@
 package mount_test
 
 import (
-	"bytes"
-	"strings"
 	"syscall"
 
 	. "gopkg.in/check.v1"
@@ -151,52 +149,6 @@ func (s *entrySuite) TestParseEntry6(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(e.DumpFrequency, Equals, 5)
 	c.Assert(e.CheckPassNumber, Equals, 7)
-}
-
-// Test that empty fstab is parsed without errors
-func (s *entrySuite) TestLoadFSTab1(c *C) {
-	entries, err := mount.LoadFSTab(strings.NewReader(""))
-	c.Assert(err, IsNil)
-	c.Assert(entries, HasLen, 0)
-}
-
-// Test that '#'-comments are skipped
-func (s *entrySuite) TestLoadFSTab2(c *C) {
-	entries, err := mount.LoadFSTab(strings.NewReader("# comment"))
-	c.Assert(err, IsNil)
-	c.Assert(entries, HasLen, 0)
-}
-
-// Test that simple profile can be loaded correctly.
-func (s *entrySuite) TestLoadFSTab3(c *C) {
-	entries, err := mount.LoadFSTab(strings.NewReader(`
-	name-1 dir-1 type-1 options-1 1 1 # 1st entry
-	name-2 dir-2 type-2 options-2 2 2 # 2nd entry`))
-	c.Assert(err, IsNil)
-	c.Assert(entries, HasLen, 2)
-	c.Assert(entries, DeepEquals, []mount.Entry{
-		{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
-		{"name-2", "dir-2", "type-2", []string{"options-2"}, 2, 2},
-	})
-}
-
-// Test that writing an empty fstab file works correctly.
-func (s *entrySuite) TestSaveFSTab1(c *C) {
-	var buf bytes.Buffer
-	mount.SaveFSTab(&buf, nil)
-	c.Assert(buf.String(), Equals, "")
-}
-
-// Test that writing an trivial fstab file works correctly.
-func (s *entrySuite) TestSaveFSTab2(c *C) {
-	var buf bytes.Buffer
-	mount.SaveFSTab(&buf, []mount.Entry{
-		{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
-		{"name-2", "dir-2", "type-2", []string{"options-2"}, 2, 2},
-	})
-	c.Assert(buf.String(), Equals, ("" +
-		"name-1 dir-1 type-1 options-1 1 1\n" +
-		"name-2 dir-2 type-2 options-2 2 2\n"))
 }
 
 // Test (string) options -> (int) flag conversion code.

--- a/interfaces/mount/profile.go
+++ b/interfaces/mount/profile.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+// Profile represents an array of mount entries.
+type Profile struct {
+	Entries []Entry
+}
+
+// LoadProfile loads a mount profile from a given file.
+//
+// The file may be absent, in such case an empty profile is returned without errors.
+func LoadProfile(fname string) (*Profile, error) {
+	f, err := os.Open(fname)
+	if err != nil && os.IsNotExist(err) {
+		return &Profile{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return ReadProfile(f)
+}
+
+// Save saves a mount profile (fstab-like) to a given file.
+// The profile is saved with an atomic write+rename+sync operation.
+func (p *Profile) Save(fname string) error {
+	var buf bytes.Buffer
+	if err := p.WriteTo(&buf); err != nil {
+		return err
+	}
+	return osutil.AtomicWriteFile(fname, buf.Bytes(), 0600, osutil.AtomicWriteFlags(0))
+}
+
+// ReadProfile reads and parses a mount profile.
+//
+// The supported format is described by fstab(5).
+func ReadProfile(reader io.Reader) (*Profile, error) {
+	var p Profile
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		s := scanner.Text()
+		if i := strings.IndexByte(s, '#'); i != -1 {
+			s = s[0:i]
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		entry, err := ParseEntry(s)
+		if err != nil {
+			return nil, err
+		}
+		p.Entries = append(p.Entries, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// WriteTo writes a mount profile to the given writer.
+//
+// The supported format is described by fstab(5).
+// Note that there is no support for comments.
+func (p *Profile) WriteTo(writer io.Writer) error {
+	for i := range p.Entries {
+		if _, err := fmt.Fprintf(writer, "%s\n", p.Entries[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/interfaces/mount/profile_test.go
+++ b/interfaces/mount/profile_test.go
@@ -1,0 +1,123 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mount_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/mount"
+)
+
+type profileSuite struct{}
+
+var _ = Suite(&profileSuite{})
+
+// Test that loading a profile from inexisting file returns an empty profile.
+func (s *profileSuite) TestLoadProfile1(c *C) {
+	dir := c.MkDir()
+	p, err := mount.LoadProfile(filepath.Join(dir, "missing"))
+	c.Assert(err, IsNil)
+	c.Assert(p.Entries, HasLen, 0)
+}
+
+// Test that loading profile from a file works as expected.
+func (s *profileSuite) TestLoadProfile2(c *C) {
+	dir := c.MkDir()
+	fname := filepath.Join(dir, "existing")
+	err := ioutil.WriteFile(fname, []byte("name-1 dir-1 type-1 options-1 1 1 # 1st entry"), 0644)
+	c.Assert(err, IsNil)
+	p, err := mount.LoadProfile(fname)
+	c.Assert(err, IsNil)
+	c.Assert(p.Entries, HasLen, 1)
+	c.Assert(p.Entries, DeepEquals, []mount.Entry{
+		{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
+	})
+}
+
+// Test that saving a profile to a file works correctly.
+func (s *profileSuite) TestSaveProfile1(c *C) {
+	dir := c.MkDir()
+	fname := filepath.Join(dir, "profile")
+	p := &mount.Profile{
+		Entries: []mount.Entry{
+			{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
+		},
+	}
+	err := p.Save(fname)
+	c.Assert(err, IsNil)
+	data, err := ioutil.ReadFile(fname)
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, "name-1 dir-1 type-1 options-1 1 1\n")
+}
+
+// Test that empty fstab is parsed without errors
+func (s *profileSuite) TestReadProfile1(c *C) {
+	p, err := mount.ReadProfile(strings.NewReader(""))
+	c.Assert(err, IsNil)
+	c.Assert(p.Entries, HasLen, 0)
+}
+
+// Test that '#'-comments are skipped
+func (s *profileSuite) TestReadProfile2(c *C) {
+	p, err := mount.ReadProfile(strings.NewReader("# comment"))
+	c.Assert(err, IsNil)
+	c.Assert(p.Entries, HasLen, 0)
+}
+
+// Test that simple profile can be loaded correctly.
+func (s *profileSuite) TestReadProfile3(c *C) {
+	p, err := mount.ReadProfile(strings.NewReader(`
+		name-1 dir-1 type-1 options-1 1 1 # 1st entry
+		name-2 dir-2 type-2 options-2 2 2 # 2nd entry`))
+	c.Assert(err, IsNil)
+	c.Assert(p.Entries, HasLen, 2)
+	c.Assert(p.Entries, DeepEquals, []mount.Entry{
+		{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
+		{"name-2", "dir-2", "type-2", []string{"options-2"}, 2, 2},
+	})
+}
+
+// Test that writing an empty fstab file works correctly.
+func (s *profileSuite) TestWriteTo1(c *C) {
+	p := &mount.Profile{}
+	var buf bytes.Buffer
+	p.WriteTo(&buf)
+	c.Assert(buf.String(), Equals, "")
+}
+
+// Test that writing an trivial fstab file works correctly.
+func (s *profileSuite) TestWriteTo2(c *C) {
+	p := &mount.Profile{
+		Entries: []mount.Entry{
+			{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
+			{"name-2", "dir-2", "type-2", []string{"options-2"}, 2, 2},
+		},
+	}
+	var buf bytes.Buffer
+	p.WriteTo(&buf)
+	c.Assert(buf.String(), Equals, ("" +
+		"name-1 dir-1 type-1 options-1 1 1\n" +
+		"name-2 dir-2 type-2 options-2 2 2\n"))
+}

--- a/interfaces/mount/profile_test.go
+++ b/interfaces/mount/profile_test.go
@@ -103,7 +103,9 @@ func (s *profileSuite) TestReadProfile3(c *C) {
 func (s *profileSuite) TestWriteTo1(c *C) {
 	p := &mount.Profile{}
 	var buf bytes.Buffer
-	p.WriteTo(&buf)
+	n, err := p.WriteTo(&buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(0))
 	c.Assert(buf.String(), Equals, "")
 }
 
@@ -116,7 +118,9 @@ func (s *profileSuite) TestWriteTo2(c *C) {
 		},
 	}
 	var buf bytes.Buffer
-	p.WriteTo(&buf)
+	n, err := p.WriteTo(&buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(68))
 	c.Assert(buf.String(), Equals, ("" +
 		"name-1 dir-1 type-1 options-1 1 1\n" +
 		"name-2 dir-2 type-2 options-2 2 2\n"))


### PR DESCRIPTION
This code tweaks earlier functions that operated on []Entry to operate
on *Profile (profile being simply a struct with []Entry field for now).

There are two more functions, one that loads and one that saves a profile
from a given file. Everything is fully tested.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>