### PR TITLE
tests: run gccgo only on ubuntu-16.04-64

### DIFF
--- a/tests/unit/gccgo/task.yaml
+++ b/tests/unit/gccgo/task.yaml
@@ -1,4 +1,5 @@
 summary: Check that snapd builds with gccgo
+# We only need to check that snapd builds with gccgo in one architecture.
 systems: [ubuntu-16.04-64]
 prepare: |
     echo Installing gccgo-6 and pretending it is the default go

--- a/tests/unit/gccgo/task.yaml
+++ b/tests/unit/gccgo/task.yaml
@@ -1,5 +1,5 @@
 summary: Check that snapd builds with gccgo
-systems: [-ubuntu-14.04-64]
+systems: [ubuntu-16.04-64]
 prepare: |
     echo Installing gccgo-6 and pretending it is the default go
     apt install -y gccgo-6


### PR DESCRIPTION
We only need to check that snapd builds with gccgo in one architecture.