### PR TITLE
overlord: fix TestEnsureLoopPrune not to be so racy

### DIFF
--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -370,11 +370,42 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 	chg1.AddTask(t1)
 	chg2 := st.NewChange("prune", "...")
 	chg2.SetStatus(state.DoneStatus)
+	t0 := chg2.SpawnTime()
 	st.Unlock()
+
+	// observe the loop cycles to detect when prune should have happened
+	pruneHappened := make(chan struct{})
+	cycles := -1
+	waitForPrune := func(_ *state.State) error {
+		if cycles == -1 {
+			if time.Since(t0) > 100*time.Millisecond {
+				cycles = 2 // wait a couple more loop cycles
+			}
+			return nil
+		}
+		if cycles > 0 {
+			cycles--
+			if cycles == 0 {
+				close(pruneHappened)
+			}
+		}
+		return nil
+	}
+	witness := &witnessManager{
+		ensureCallback: waitForPrune,
+	}
+	se := o.Engine()
+	se.AddManager(witness)
 
 	markSeeded(o)
 	o.Loop()
-	time.Sleep(150 * time.Millisecond)
+
+	select {
+	case <-pruneHappened:
+	case <-time.After(2 * time.Second):
+		c.Fatal("Pruning should have happened by now")
+	}
+
 	err = o.Stop()
 	c.Assert(err, IsNil)
 

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -374,7 +374,7 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 
 	markSeeded(o)
 	o.Loop()
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	err = o.Stop()
 	c.Assert(err, IsNil)
 
@@ -412,7 +412,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	o.Loop()
 
 	// ensure the first change is pruned
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	st.Lock()
 	c.Check(st.Changes(), HasLen, 1)
 	st.Unlock()
@@ -421,7 +421,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	st.Lock()
 	chg2.SetStatus(state.DoneStatus)
 	st.Unlock()
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	st.Lock()
 	c.Check(st.Changes(), HasLen, 0)
 	st.Unlock()

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -370,7 +370,7 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 	chg1.AddTask(t1)
 	chg2 := st.NewChange("prune", "...")
 	chg2.SetStatus(state.DoneStatus)
-	t0 := chg2.SpawnTime()
+	t0 := chg2.ReadyTime()
 	st.Unlock()
 
 	// observe the loop cycles to detect when prune should have happened

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -374,7 +374,7 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 
 	markSeeded(o)
 	o.Loop()
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
 	err = o.Stop()
 	c.Assert(err, IsNil)
 
@@ -412,7 +412,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	o.Loop()
 
 	// ensure the first change is pruned
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
 	st.Lock()
 	c.Check(st.Changes(), HasLen, 1)
 	st.Unlock()
@@ -421,7 +421,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	st.Lock()
 	chg2.SetStatus(state.DoneStatus)
 	st.Unlock()
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
 	st.Lock()
 	c.Check(st.Changes(), HasLen, 0)
 	st.Unlock()


### PR DESCRIPTION
We are seeing many failures that involve the TestEnsureLoopPrune test.
This test is inherently racy as it uses a actual time to wait for
something to happen. In case the machine is loaded heavily and other
processes contend for resources it may not get scheduled in time for
this to happen

This branch contains (now) a more sophisticated approach suggested
and demonstrated by pedronis.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>