### PR TITLE
daemon: Give the snap directories via GET /v2/system-info

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -244,9 +244,11 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		"os-release":     release.ReleaseInfo,
 		"on-classic":     release.OnClassic,
 		"managed":        len(users) > 0,
-		"snap-mount-dir": dirs.SnapMountDir,
-		"snap-bin-dir":   dirs.SnapBinariesDir,
 		"kernel-version": release.KernelVersion(),
+		"locations": map[string]interface{}{
+			"snap-mount-dir": dirs.SnapMountDir,
+			"snap-bin-dir":   dirs.SnapBinariesDir,
+		},
 	}
 
 	// TODO: set the store-id here from the model information

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -239,13 +239,14 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	m := map[string]interface{}{
-		"series":     release.Series,
-		"version":    c.d.Version,
-		"os-release": release.ReleaseInfo,
-		"on-classic": release.OnClassic,
-		"managed":    len(users) > 0,
-
-		"kernel-version": release.KernelVersion(),
+		"series":             release.Series,
+		"version":            c.d.Version,
+		"os-release":         release.ReleaseInfo,
+		"on-classic":         release.OnClassic,
+		"managed":            len(users) > 0,
+		"mount-directory":    dirs.SnapMountDir,
+		"binaries-directory": dirs.SnapBinariesDir,
+		"kernel-version":     release.KernelVersion(),
 	}
 
 	// TODO: set the store-id here from the model information

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -239,14 +239,14 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	m := map[string]interface{}{
-		"series":             release.Series,
-		"version":            c.d.Version,
-		"os-release":         release.ReleaseInfo,
-		"on-classic":         release.OnClassic,
-		"managed":            len(users) > 0,
-		"mount-directory":    dirs.SnapMountDir,
-		"binaries-directory": dirs.SnapBinariesDir,
-		"kernel-version":     release.KernelVersion(),
+		"series":         release.Series,
+		"version":        c.d.Version,
+		"os-release":     release.ReleaseInfo,
+		"on-classic":     release.OnClassic,
+		"managed":        len(users) > 0,
+		"snap-mount-dir": dirs.SnapMountDir,
+		"snap-bin-dir":   dirs.SnapBinariesDir,
+		"kernel-version": release.KernelVersion(),
 	}
 
 	// TODO: set the store-id here from the model information

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -556,10 +556,10 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 			"id":         "distro-id",
 			"version-id": "1.2",
 		},
-		"on-classic":         true,
-		"managed":            false,
-		"mount-directory":    dirs.SnapMountDir,
-		"binaries-directory": dirs.SnapBinariesDir,
+		"on-classic":     true,
+		"managed":        false,
+		"snap-mount-dir": dirs.SnapMountDir,
+		"snap-bin-dir":   dirs.SnapBinariesDir,
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -556,10 +556,12 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 			"id":         "distro-id",
 			"version-id": "1.2",
 		},
-		"on-classic":     true,
-		"managed":        false,
-		"snap-mount-dir": dirs.SnapMountDir,
-		"snap-bin-dir":   dirs.SnapBinariesDir,
+		"on-classic": true,
+		"managed":    false,
+		"locations": map[string]interface{}{
+			"snap-mount-dir": dirs.SnapMountDir,
+			"snap-bin-dir":   dirs.SnapBinariesDir,
+		},
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -556,8 +556,10 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 			"id":         "distro-id",
 			"version-id": "1.2",
 		},
-		"on-classic": true,
-		"managed":    false,
+		"on-classic":         true,
+		"managed":            false,
+		"mount-directory":    dirs.SnapMountDir,
+		"binaries-directory": dirs.SnapBinariesDir,
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)


### PR DESCRIPTION
This allows us to find the appropriate bin directory to execute snap binaries from.