### PR TITLE
data/systemd: tweak data/systemd/Makefile to be slightly simpler

### DIFF
--- a/data/systemd/Makefile
+++ b/data/systemd/Makefile
@@ -33,7 +33,7 @@ SYSTEMD_UNITS := ${SYSTEMD_UNITS_GENERATED} snapd.refresh.timer snapd.socket
 all: ${SYSTEMD_UNITS}
 
 install: $(SYSTEMD_UNITS)
-	$(foreach u,$^,install -D -m 0644 ${u} ${DESTDIR}/${SYSTEMDSYSTEMUNITDIR}/${u};)
+	install -D -m 0644 -t ${DESTDIR}/${SYSTEMDSYSTEMUNITDIR} ${SYSTEMD_UNITS}
 
 clean:
 	rm -f ${SYSTEMD_UNITS_GENERATED}

--- a/data/systemd/Makefile
+++ b/data/systemd/Makefile
@@ -33,7 +33,7 @@ SYSTEMD_UNITS := ${SYSTEMD_UNITS_GENERATED} snapd.refresh.timer snapd.socket
 all: ${SYSTEMD_UNITS}
 
 install: $(SYSTEMD_UNITS)
-	install -D -m 0644 -t ${DESTDIR}/${SYSTEMDSYSTEMUNITDIR} ${SYSTEMD_UNITS}
+	install -D -m 0644 -t ${DESTDIR}/${SYSTEMDSYSTEMUNITDIR} $^
 
 clean:
 	rm -f ${SYSTEMD_UNITS_GENERATED}


### PR DESCRIPTION
Trivial tweak for the systemd data Makefile to make it use less magic (also avoid the overhead of calling install multiple times which surely will shave milliseconds of the build time ;)