### PR TITLE
cmd: explicitly set _GNU_SOURCE and _FILE_OFFSET_BITS for xfs support

### DIFF
--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -23,7 +23,8 @@ AC_SYS_LARGEFILE
 AC_CHECK_HEADERS([fcntl.h limits.h stdlib.h string.h sys/mount.h unistd.h])
 AC_CHECK_HEADERS([sys/quota.h], [], [AC_MSG_ERROR(sys/quota.h unavailable)])
 AC_CHECK_HEADERS([xfs/xqm.h], [], [AC_MSG_ERROR(xfs/xqm.h unavailable)],
-[[#define _FILE_OFFSET_BITS 64
+[[#define _GNU_SOURCE
+#define _FILE_OFFSET_BITS 64
 #include <xfs/xqm.h>
 ]])
 

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -34,8 +34,18 @@
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <termios.h>
-#include <xfs/xqm.h>
 #include <unistd.h>
+
+// The XFS interface requires a 64 bit file system interface
+// but we don't want to leak this anywhere else if not globally
+// defined.
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#include <xfs/xqm.h>
+#undef _FILE_OFFSET_BITS
+#else
+#include <xfs/xqm.h>
+#endif
 
 #include <seccomp.h>
 


### PR DESCRIPTION
This will unblock builds on i386 on other distributions not being Debian
or Ubuntu.

Also see https://patchwork.kernel.org/patch/9486535/ and
https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html