### PR TITLE
git: ignore only the cmd/Makefile{,.in}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,9 @@ data/systemd/*.service
 *.log
 *.trs
 
-# Automake
-Makefile
-Makefile.in
+# Automake for the cmd/ parts
+cmd/Makefile
+cmd/Makefile.in
 snap-confine-*.tar.gz
 .deps
 


### PR DESCRIPTION
We need the other Makefiles (e.g. data/systemd/Makefile). This also fixes a FTBFS in the ppa:snappy-dev/edge that is caused by the snapd+vendor script not syncing files that are part of .gitignore.