### PR TITLE
store: add download test with EOF in the middle

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -221,6 +221,10 @@ func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(dirs.SnapMountDir, 0755), IsNil)
 
+	oldSnapdDebug := os.Getenv("SNAPD_DEBUG")
+	os.Setenv("SNAPD_DEBUG", "1")
+	t.AddCleanup(func() { os.Setenv("SNAPD_DEBUG", oldSnapdDebug) })
+
 	t.logbuf = bytes.NewBuffer(nil)
 	l, err := logger.NewConsoleLog(t.logbuf, logger.DefaultFlags)
 	c.Assert(err, IsNil)
@@ -366,6 +370,8 @@ func (t *remoteRepoTestSuite) TestDownloadEOFHandlesResumeHashCorrectly(c *C) {
 	content, err := ioutil.ReadFile(targetFn)
 	c.Assert(err, IsNil)
 	c.Assert(content, DeepEquals, buf)
+
+	c.Assert(t.logbuf.String(), Matches, "(?s).*Retrying .* attempt 2, .*")
 }
 
 func (t *remoteRepoTestSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {


### PR DESCRIPTION
This adds a test that checks if the download function handles
the EOF case in the middle of the download correctly.