### PR TITLE
overlord/ifacestate: automatically rename connections on core snap

### DIFF
--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -171,12 +171,13 @@ func (m *InterfaceManager) renameCorePlugConnections() error {
 		oldPlugRef := interfaces.PlugRef{Snap: "core", Name: plugName}
 		oldConnRef := interfaces.ConnRef{PlugRef: oldPlugRef, SlotRef: slotRef}
 		oldID := oldConnRef.ID()
-		// new connection
-		newPlugRef := interfaces.PlugRef{Snap: "core", Name: plugName + "-plug"}
-		newConnRef := interfaces.ConnRef{PlugRef: newPlugRef, SlotRef: slotRef}
-		newID := newConnRef.ID()
 		// if the old connection is saved, replace it with the new connection
 		if cState, ok := conns[oldID]; ok {
+			// new connection
+			newPlugRef := interfaces.PlugRef{Snap: "core", Name: plugName + "-plug"}
+			newConnRef := interfaces.ConnRef{PlugRef: newPlugRef, SlotRef: slotRef}
+			newID := newConnRef.ID()
+
 			delete(conns, oldID)
 			conns[newID] = cState
 			changed = true

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -47,7 +47,7 @@ func (m *InterfaceManager) initialize(extraInterfaces []interfaces.Interface, ex
 	if err := m.addSnaps(); err != nil {
 		return err
 	}
-	if err := m.renameCorePlugConnections(); err != nil {
+	if err := m.renameCorePlugConnection(); err != nil {
 		return err
 	}
 	if err := m.reloadConnections(""); err != nil {
@@ -156,34 +156,30 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 	return nil
 }
 
-// renameCorePlugConnections renames connections from plugs to slots on the
-// core snap if the plug and slot name are the same the plug gets suffixed with
-// "-plug". This matches a similar rename in addSnaps above.
-func (m *InterfaceManager) renameCorePlugConnections() error {
+// renameCorePlugConnection renames one connection from "core-support" plug to
+// slot so that the plug name is "core-support-plug" while the slot is
+// unchanged. This matches a change introduced in 2.24, where the core snap no
+// longer has the "core-support" plug as that was clashing with the slot with
+// the same name.
+func (m *InterfaceManager) renameCorePlugConnection() error {
 	conns, err := getConns(m.state)
 	if err != nil {
 		return err
 	}
-	changed := false
-	for _, plugName := range []string{"network-bind", "core-support"} {
-		// old connection, note that slotRef is the same in both
-		slotRef := interfaces.SlotRef{Snap: "core", Name: plugName}
-		oldPlugRef := interfaces.PlugRef{Snap: "core", Name: plugName}
-		oldConnRef := interfaces.ConnRef{PlugRef: oldPlugRef, SlotRef: slotRef}
-		oldID := oldConnRef.ID()
-		// if the old connection is saved, replace it with the new connection
-		if cState, ok := conns[oldID]; ok {
-			// new connection
-			newPlugRef := interfaces.PlugRef{Snap: "core", Name: plugName + "-plug"}
-			newConnRef := interfaces.ConnRef{PlugRef: newPlugRef, SlotRef: slotRef}
-			newID := newConnRef.ID()
-
-			delete(conns, oldID)
-			conns[newID] = cState
-			changed = true
-		}
-	}
-	if changed {
+	const oldPlugName = "core-support"
+	const newPlugName = "core-support-plug"
+	// old connection, note that slotRef is the same in both
+	slotRef := interfaces.SlotRef{Snap: "core", Name: oldPlugName}
+	oldPlugRef := interfaces.PlugRef{Snap: "core", Name: oldPlugName}
+	oldConnRef := interfaces.ConnRef{PlugRef: oldPlugRef, SlotRef: slotRef}
+	oldID := oldConnRef.ID()
+	// if the old connection is saved, replace it with the new connection
+	if cState, ok := conns[oldID]; ok {
+		newPlugRef := interfaces.PlugRef{Snap: "core", Name: newPlugName}
+		newConnRef := interfaces.ConnRef{PlugRef: newPlugRef, SlotRef: slotRef}
+		newID := newConnRef.ID()
+		delete(conns, oldID)
+		conns[newID] = cState
 		setConns(m.state, conns)
 	}
 	return nil

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1842,15 +1842,12 @@ func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCoreUndo(c *C) {
 	})
 }
 
-// Test that "network-bind" and "core-support" connections that loop back to
-// core are renamed to match the rename of the plugs.
+// Test "core-support" connections that loop back to core is
+// renamed to match the rename of the plug.
 func (s *interfaceManagerSuite) TestCoreConnectionsRenamed(c *C) {
 	// Put state with old connection data.
 	s.state.Lock()
 	s.state.Set("conns", map[string]interface{}{
-		"core:network-bind core:network-bind": map[string]interface{}{
-			"interface": "network-bind", "auto": true,
-		},
 		"core:core-support core:core-support": map[string]interface{}{
 			"interface": "core-support", "auto": true,
 		},
@@ -1863,16 +1860,13 @@ func (s *interfaceManagerSuite) TestCoreConnectionsRenamed(c *C) {
 	// Start the manager, this is where renames happen.
 	s.manager(c)
 
-	// Check that "network-bind" and "core-support" connections got renamed.
+	// Check that "core-support" connection got renamed.
 	s.state.Lock()
 	var conns map[string]interface{}
 	err := s.state.Get("conns", &conns)
 	s.state.Unlock()
 	c.Assert(err, IsNil)
 	c.Assert(conns, DeepEquals, map[string]interface{}{
-		"core:network-bind-plug core:network-bind": map[string]interface{}{
-			"interface": "network-bind", "auto": true,
-		},
 		"core:core-support-plug core:core-support": map[string]interface{}{
 			"interface": "core-support", "auto": true,
 		},


### PR DESCRIPTION
This patch completes the rename cycle by renaming stored connections
to and from the core snap with clashing plug and slot name.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>