### PR TITLE
snap-confine,browser-support: /dev/tty for snap-confine, misc browser-support for gnome-shell

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -30,6 +30,7 @@
     /dev/random r,
     /dev/urandom r,
     /dev/pts/[0-9]* rw,
+    /dev/tty rw,
 
     # cgroups
     capability sys_admin,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -27,9 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/log-observe
 const browserSupportConnectedPlugAppArmor = `
-# Description: Can access various APIs needed by modern browers (eg, Google
+# Description: Can access various APIs needed by modern browsers (eg, Google
 # Chrome/Chromium and Mozilla) and file paths they expect. This interface is
 # transitional and is only in place while upstream's work to change their paths
 # and snappy is updated to properly mediate the APIs.
@@ -49,6 +48,9 @@ owner /{dev,run}/shm/{,.}com.google.Chrome.* rw,
 
 # Allow reading platform files
 /run/udev/data/+platform:* r,
+
+# Chromium content api in gnome-shell reads this
+/etc/opt/chrome/{,**} r,
 
 # Chrome/Chromium should be adjusted to not use gconf. It is only used with
 # legacy systems that don't have snapd
@@ -191,6 +193,9 @@ owner @{PROC}/@{pid}/gid_map rw,
 
 # Webkit uses a particular SHM names # LP: 1578217
 owner /{dev,run}/shm/WK2SharedMemory.* rw,
+
+# Chromium content api on (at least) later versions of Ubuntu just use this
+/dev/shm/shmfd-* rw,
 `
 
 const browserSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -199,7 +199,7 @@ owner /{dev,run}/shm/shmfd-* rw,
 `
 
 const browserSupportConnectedPlugSecComp = `
-# Description: Can access various APIs needed by modern browers (eg, Google
+# Description: Can access various APIs needed by modern browsers (eg, Google
 # Chrome/Chromium and Mozilla) and file paths they expect. This interface is
 # transitional and is only in place while upstream's work to change their paths
 # and snappy is updated to properly mediate the APIs.

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -195,7 +195,7 @@ owner @{PROC}/@{pid}/gid_map rw,
 owner /{dev,run}/shm/WK2SharedMemory.* rw,
 
 # Chromium content api on (at least) later versions of Ubuntu just use this
-/dev/shm/shmfd-* rw,
+owner /{dev,run}/shm/shmfd-* rw,
 `
 
 const browserSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -109,7 +109,7 @@ func (s *BrowserSupportInterfaceSuite) TestConnectedPlugSnippetWithoutAttrib(c *
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 	snippet := apparmorSpec.SnippetForTag("snap.other.app2")
-	c.Assert(string(snippet), testutil.Contains, `# Description: Can access various APIs needed by modern browers`)
+	c.Assert(string(snippet), testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(string(snippet), Not(testutil.Contains), `capability sys_admin,`)
 	c.Assert(string(snippet), testutil.Contains, `deny ptrace (trace) peer=snap.@{SNAP_NAME}.**`)
 
@@ -118,7 +118,7 @@ func (s *BrowserSupportInterfaceSuite) TestConnectedPlugSnippetWithoutAttrib(c *
 	c.Assert(err, IsNil)
 	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 	secCompSnippet := seccompSpec.SnippetForTag("snap.other.app2")
-	c.Assert(secCompSnippet, testutil.Contains, `# Description: Can access various APIs needed by modern browers`)
+	c.Assert(secCompSnippet, testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(secCompSnippet, Not(testutil.Contains), `chroot`)
 }
 
@@ -142,7 +142,7 @@ apps:
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.browser-support-plug-snap.app2"})
 	snippet := apparmorSpec.SnippetForTag("snap.browser-support-plug-snap.app2")
-	c.Assert(snippet, testutil.Contains, `# Description: Can access various APIs needed by modern browers`)
+	c.Assert(snippet, testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(snippet, Not(testutil.Contains), `capability sys_admin,`)
 	c.Assert(snippet, testutil.Contains, `deny ptrace (trace) peer=snap.@{SNAP_NAME}.**`)
 
@@ -151,7 +151,7 @@ apps:
 	c.Assert(err, IsNil)
 	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.browser-support-plug-snap.app2"})
 	secCompSnippet := seccompSpec.SnippetForTag("snap.browser-support-plug-snap.app2")
-	c.Assert(secCompSnippet, testutil.Contains, `# Description: Can access various APIs needed by modern browers`)
+	c.Assert(secCompSnippet, testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(secCompSnippet, Not(testutil.Contains), `chroot`)
 }
 
@@ -174,7 +174,7 @@ apps:
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.browser-support-plug-snap.app2"})
 	snippet := apparmorSpec.SnippetForTag("snap.browser-support-plug-snap.app2")
-	c.Assert(snippet, testutil.Contains, `# Description: Can access various APIs needed by modern browers`)
+	c.Assert(snippet, testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(snippet, testutil.Contains, `ptrace (trace) peer=snap.@{SNAP_NAME}.**`)
 	c.Assert(snippet, Not(testutil.Contains), `deny ptrace (trace) peer=snap.@{SNAP_NAME}.**`)
 
@@ -183,7 +183,7 @@ apps:
 	c.Assert(err, IsNil)
 	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.browser-support-plug-snap.app2"})
 	secCompSnippet := seccompSpec.SnippetForTag("snap.browser-support-plug-snap.app2")
-	c.Assert(secCompSnippet, testutil.Contains, `# Description: Can access various APIs needed by modern browers`)
+	c.Assert(secCompSnippet, testutil.Contains, `# Description: Can access various APIs needed by modern browsers`)
 	c.Assert(secCompSnippet, testutil.Contains, `chroot`)
 }
 


### PR DESCRIPTION
- snap-confine: allow access to /dev/tty sometimes needed for output (LP: #1681421)
- interfaces/browser-support: misc accesses for gnome-shell on zesty