### PR TITLE
tests: adjust to look for network-bind-plug

### DIFF
--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -35,7 +35,7 @@ restore: |
 execute: |
     CONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
-    :network-bind +core,$SNAP_NAME"
+    :network-bind +core:network-bind-plug,$SNAP_NAME"
     DISCONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
     - +$SNAP_NAME:network-bind"


### PR DESCRIPTION
With https://github.com/snapcore/core/pull/32 merged we need to adjust master to let tests pass again. They are using the edge core snap and that has just been built with `network-bind-plug`.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>