### PR TITLE
interfaces/builtin: fold network-bind into core-support

### DIFF
--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -79,7 +79,9 @@ owner /boot/uboot/config.txt.tmp rwk,
 func NewCoreSupportInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "core-support",
-		connectedPlugAppArmor: coreSupportConnectedPlugAppArmor,
+		// NOTE: cure-support implicitly contains the rules from network-bind.
+		connectedPlugAppArmor: coreSupportConnectedPlugAppArmor + networkBindConnectedPlugAppArmor,
+		connectedPlugSecComp:  "" + networkBindConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>