### PR TITLE
interfaces: fold network bind into core support with tests

### DIFF
--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -79,7 +79,9 @@ owner /boot/uboot/config.txt.tmp rwk,
 func NewCoreSupportInterface() interfaces.Interface {
 	return &commonInterface{
 		name: "core-support",
-		connectedPlugAppArmor: coreSupportConnectedPlugAppArmor,
+		// NOTE: cure-support implicitly contains the rules from network-bind.
+		connectedPlugAppArmor: coreSupportConnectedPlugAppArmor + networkBindConnectedPlugAppArmor,
+		connectedPlugSecComp:  "" + networkBindConnectedPlugSecComp,
 		reservedForOS:         true,
 	}
 }

--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -30,3 +30,6 @@ execute: |
         echo "ubuntu-core still installed, transition failed"
         exit 1
     fi
+
+    echo "Ensure interfaces are connected"
+    snap interfaces | MATCH ":core-support.*core:core-support-plug"

--- a/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -45,3 +45,6 @@ execute: |
         exit 1
     fi
     snap interfaces |MATCH ":network.*test-snapd-python-webserver"
+
+    echo "Ensure interfaces are connected"
+    snap interfaces | MATCH ":core-support.*core:core-support-plug"

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -78,3 +78,6 @@ execute: |
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
     echo "Ensure the webserver is working after a snap restart"
     curl http://localhost | MATCH "XKCD rocks"
+
+    echo "Ensure interfaces are connected"
+    snap interfaces | MATCH ":core-support.*core:core-support-plug"


### PR DESCRIPTION
Based on #3166. 

This works around the issue that when we transition ubuntu-core to core the "network-bind" plug is not connected to core which leads to failures in the core configure hook (because systemctl needs to bind). 

The root cause of this is described in https://forum.snapcraft.io/t/auto-connect-logic-starting-from-slots-of-an-installed-refreshed-snap-is-naive/236 - when we fix the auto-connect issue later we will still need code that ensures that core-support is correctly connected. But currently this branch is sufficient to unblock 2.24 because a) it fixes existing systems (core-support is connected and has network-bind now) b) with just core-support the transition works correctly (currently).

For 2.25 we need to fix the auto-connect issue and ensure that core-support is still connected during the transition but the spread tests will ensure this. Once this is landed we should also land https://github.com/snapcore/core/pull/33