### PR TITLE
many: fix plug auto-connect during core transition

### DIFF
--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -300,6 +300,18 @@ func (m *InterfaceManager) autoConnect(task *state.Task, snapName string, blackl
 			continue
 		}
 		candidates := m.repo.AutoConnectCandidateSlots(snapName, plug.Name, autochecker.check)
+		// If we are in a core transition we may have both the old ubuntu-core
+		// snap and the new core snap providing the same interface. In that
+		// situation we want to ignore any candidates in ubuntu-core and simply
+		// go with those from the new core snap.
+		if len(candidates) == 2 {
+			switch {
+			case candidates[0].Snap.Name() == "ubuntu-core" && candidates[1].Snap.Name() == "core":
+				candidates = candidates[1:2]
+			case candidates[1].Snap.Name() == "ubuntu-core" && candidates[0].Snap.Name() == "core":
+				candidates = candidates[0:1]
+			}
+		}
 		if len(candidates) != 1 {
 			continue
 		}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -1842,7 +1842,7 @@ func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCoreUndo(c *C) {
 // "network-bind-plug" and "core-support-plug" in order not to clash with slots
 // with the same names.
 func (s *interfaceManagerSuite) TestAutomaticCorePlugsRenamed(c *C) {
-	s.mockSnap(c, coreYaml+`
+	s.mockSnap(c, coreSnapYaml+`
 plugs:
   network-bind:
   core-support:

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -667,7 +667,7 @@ func (s *interfaceManagerSuite) addDiscardConnsChange(c *C, snapName string) *st
 	return change
 }
 
-var osSnapYaml = `
+var ubuntuCoreSnapYaml = `
 name: ubuntu-core
 version: 1
 type: os
@@ -710,7 +710,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsDisconnect(c *C) {
 	c.Skip("feature disabled until redesign/reimpl")
 	// Add an OS snap as well as a sample snap with a "network" plug.
 	// The plug is normally auto-connected.
-	s.mockSnap(c, osSnapYaml)
+	s.mockSnap(c, ubuntuCoreSnapYaml)
 	snapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Initialize the manager. This registers the two snaps.
@@ -749,7 +749,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsDisconnect(c *C) {
 // The setup-profiles task will auto-connect plugs with viable candidates.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsPlugs(c *C) {
 	// Add an OS snap.
-	s.mockSnap(c, osSnapYaml)
+	s.mockSnap(c, ubuntuCoreSnapYaml)
 
 	// Initialize the manager. This registers the OS snap.
 	mgr := s.manager(c)
@@ -796,7 +796,7 @@ func (s *interfaceManagerSuite) TestDoSetupSnapSecurityAutoConnectsSlots(c *C) {
 	// Mock the interface that will be used by the test
 	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
 	// Add an OS snap.
-	s.mockSnap(c, osSnapYaml)
+	s.mockSnap(c, ubuntuCoreSnapYaml)
 	// Add a consumer snap with unconnect plug (interface "test")
 	s.mockSnap(c, consumerYaml)
 
@@ -920,7 +920,7 @@ slots:
 // operates on or auto-connects to and will leave other state intact.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecuirtyKeepsExistingConnectionState(c *C) {
 	// Add an OS snap in place.
-	s.mockSnap(c, osSnapYaml)
+	s.mockSnap(c, ubuntuCoreSnapYaml)
 
 	// Initialize the manager. This registers the two snaps.
 	mgr := s.manager(c)
@@ -976,7 +976,7 @@ func (s *interfaceManagerSuite) TestDoSetupProfilesAddsImplicitSlots(c *C) {
 	mgr := s.manager(c)
 
 	// Add an OS snap.
-	snapInfo := s.mockSnap(c, osSnapYaml)
+	snapInfo := s.mockSnap(c, ubuntuCoreSnapYaml)
 
 	// Run the setup-profiles task and let it finish.
 	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
@@ -1096,7 +1096,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesHonorsDevMode(c *C) {
 // of the affected set.
 func (s *interfaceManagerSuite) TestSetupProfilesUsesFreshSnapInfo(c *C) {
 	// Put the OS and the sample snaps in place.
-	coreSnapInfo := s.mockSnap(c, osSnapYaml)
+	coreSnapInfo := s.mockSnap(c, ubuntuCoreSnapYaml)
 	oldSnapInfo := s.mockSnap(c, sampleSnapYaml)
 
 	// Put connection information between the OS snap and the sample snap.
@@ -1151,7 +1151,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesUsesFreshSnapInfo(c *C) {
 // setup-profiles needs to setup security for connected slots after autoconnection
 func (s *interfaceManagerSuite) TestAutoConnectSetupSecurityForConnectedSlots(c *C) {
 	// Add an OS snap.
-	coreSnapInfo := s.mockSnap(c, osSnapYaml)
+	coreSnapInfo := s.mockSnap(c, ubuntuCoreSnapYaml)
 
 	// Initialize the manager. This registers the OS snap.
 	mgr := s.manager(c)
@@ -1646,7 +1646,7 @@ slots:
 }
 
 func (s *interfaceManagerSuite) TestCheckInterfacesConsidersImplicitSlots(c *C) {
-	snapInfo := s.mockSnap(c, osSnapYaml)
+	snapInfo := s.mockSnap(c, ubuntuCoreSnapYaml)
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -710,6 +710,13 @@ slots:
   attr2: value2
 `
 
+var httpdSnapYaml = `name: httpd
+version: 1
+plugs:
+ network:
+  interface: network
+`
+
 // The setup-profiles task will not auto-connect an plug that was previously
 // explicitly disconnected by the user.
 func (s *interfaceManagerSuite) TestDoSetupSnapSecurityHonorsDisconnect(c *C) {
@@ -1746,26 +1753,9 @@ func (s *interfaceManagerSuite) TestUndoSetupProfilesOnRefresh(c *C) {
 	c.Check(s.secBackend.SetupCalls[0].Options, Equals, interfaces.ConfinementOptions{})
 }
 
-var ubuntuCoreYaml = `name: ubuntu-core
-version: 1
-type: os
-`
-
-var coreYaml = `name: core
-version: 1
-type: os
-`
-
-var httpdSnapYaml = `name: httpd
-version: 1
-plugs:
- network:
-  interface: network
-`
-
 func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCore(c *C) {
-	s.mockSnap(c, ubuntuCoreYaml)
-	s.mockSnap(c, coreYaml)
+	s.mockSnap(c, ubuntuCoreSnapYaml)
+	s.mockSnap(c, coreSnapYaml)
 	s.mockSnap(c, httpdSnapYaml)
 
 	mgr := s.manager(c)
@@ -1803,8 +1793,8 @@ func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCore(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestManagerTransitionConnectionsCoreUndo(c *C) {
-	s.mockSnap(c, ubuntuCoreYaml)
-	s.mockSnap(c, coreYaml)
+	s.mockSnap(c, ubuntuCoreSnapYaml)
+	s.mockSnap(c, coreSnapYaml)
 	s.mockSnap(c, httpdSnapYaml)
 
 	mgr := s.manager(c)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -673,6 +673,12 @@ version: 1
 type: os
 `
 
+var coreSnapYaml = `
+name: core
+version: 1
+type: os
+`
+
 var sampleSnapYaml = `
 name: snap
 version: 1
@@ -1862,5 +1868,54 @@ plugs:
 	// slots are present and unchanged
 	c.Assert(mgr.Repository().Slot("core", "network-bind"), Not(IsNil))
 	c.Assert(mgr.Repository().Slot("core", "core-support"), Not(IsNil))
+}
 
+func (s *interfaceManagerSuite) TestAutoConnectDuringCoreTransition(c *C) {
+	// Add both the old and new core snaps
+	s.mockSnap(c, ubuntuCoreSnapYaml)
+	s.mockSnap(c, coreSnapYaml)
+
+	// Initialize the manager. This registers both of the core snaps.
+	mgr := s.manager(c)
+
+	// Add a sample snap with a "network" plug which should be auto-connected.
+	// Normally it would not be auto connected because there are multiple
+	// provides but we have special support for this case so the old
+	// ubuntu-core snap is ignored and we pick the new core snap.
+	snapInfo := s.mockSnap(c, sampleSnapYaml)
+
+	// Run the setup-snap-security task and let it finish.
+	change := s.addSetupSnapSecurityChange(c, &snapstate.SnapSetup{
+		SideInfo: &snap.SideInfo{
+			RealName: snapInfo.Name(),
+			Revision: snapInfo.Revision,
+		},
+	})
+	mgr.Ensure()
+	mgr.Wait()
+	mgr.Stop()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// Ensure that the task succeeded.
+	c.Assert(change.Status(), Equals, state.DoneStatus)
+
+	// Ensure that "network" is now saved in the state as auto-connected and
+	// that it is connected to the new core snap rather than the old
+	// ubuntu-core snap.
+	var conns map[string]interface{}
+	err := s.state.Get("conns", &conns)
+	c.Assert(err, IsNil)
+	c.Check(conns, DeepEquals, map[string]interface{}{
+		"snap:network core:network": map[string]interface{}{
+			"interface": "network", "auto": true,
+		},
+	})
+
+	// Ensure that "network" is really connected.
+	repo := mgr.Repository()
+	plug := repo.Plug("snap", "network")
+	c.Assert(plug, Not(IsNil))
+	c.Check(plug.Connections, HasLen, 1)
 }

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -71,7 +71,7 @@ execute: |
         exit 1
     fi
     snap interfaces | MATCH ":network +test-snapd-python-webserver"
-    snap interfaces | MATCH ":network-bind +core:network-bind-plug,test-snapd-python-webserver"
+    snap interfaces | MATCH ":network-bind +test-snapd-python-webserver" 
     echo "Ensure the webserver is still working"
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
     curl http://localhost | MATCH "XKCD rocks"

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -43,7 +43,8 @@ execute: |
 
     snap install --${CORE_CHANNEL} ubuntu-core
     snap install test-snapd-python-webserver
-    snap interfaces |MATCH ":network.*test-snapd-python-webserver"
+    snap interfaces | MATCH ":network +test-snapd-python-webserver"
+    snap interfaces | MATCH ":network-bind +test-snapd-python-webserver"
 
     echo "Ensure the webserver is working"
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
@@ -69,7 +70,8 @@ execute: |
         echo "ubuntu-core still installed, transition failed"
         exit 1
     fi
-    snap interfaces |MATCH ":network.*test-snapd-python-webserver"
+    snap interfaces | MATCH ":network +test-snapd-python-webserver"
+    snap interfaces | MATCH ":network-bind +core:network-bind-plug,test-snapd-python-webserver"
     echo "Ensure the webserver is still working"
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
     curl http://localhost | MATCH "XKCD rocks"


### PR DESCRIPTION
This branch adjusts auto-connect logic for plugs so that during core transition the candidate slots
from the ubuntu-core snap will not be considered. There are also some miscellaneous cleanups
to tests so that variables have consistent (and correct) names.