### PR TITLE
tests: fix interfaces-network-bind to match the new core

### DIFF
--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -35,7 +35,7 @@ restore: |
 execute: |
     CONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
-    :network-bind +core:network-bind-plug,$SNAP_NAME"
+    :network-bind +$SNAP_NAME"
     DISCONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
     - +$SNAP_NAME:network-bind"


### PR DESCRIPTION
The new core does only have a single `core-support-plug`, the network-bind-plug is gone so this test needs updating.