### PR TITLE
tests: add extra test after the core transition for snap get/set core

### DIFF
--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -53,8 +53,11 @@ const coreSupportConnectedPlugAppArmor = `
 
 # Allow modifying logind configuration. For now, allow reading all logind
 # configuration but only allow modifying NN-snap*.conf and snap*.conf files
-# in /etc/systemd/logind.conf.d.
+# in /etc/systemd/logind.conf.d. Also allow creating the logind.conf.d 
+# directory as it may not be there for existing installs (wirtable-path 
+# magic oddness).
 /etc/systemd/logind.conf                            r,
+/etc/systemd/logind.conf.d/                         rw,
 /etc/systemd/logind.conf.d/{,*}                     r,
 /etc/systemd/logind.conf.d/{,[0-9][0-9]-}snap*.conf w,
 

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -81,3 +81,11 @@ execute: |
 
     echo "Ensure interfaces are connected"
     snap interfaces | MATCH ":core-support.*core:core-support-plug"
+
+    echo "Ensure snap set core works"
+    snap set core system.power-key-action=ignore
+    if [ "$(snap get core system.power-key-action)" != "ignore" ]; then
+        echo "snap get did not return the expected result: "
+        snap get core system.power-key-action
+        exit 1
+    fi


### PR DESCRIPTION
This also uncovered a bug in our handling of `snap set core system.power-key-action=`, i.e. the interface was not granting permission to create the needed `/etc/systemd/logind.conf.d/ `