### PR TITLE
interfaces,overlord: log interface auto-connection failures

### DIFF
--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -45,7 +45,7 @@ type PlugRef struct {
 }
 
 // String returns the "snap:plug" representation of a plug reference.
-func (ref *PlugRef) String() string {
+func (ref PlugRef) String() string {
 	return fmt.Sprintf("%s:%s", ref.Snap, ref.Name)
 }
 
@@ -67,7 +67,7 @@ type SlotRef struct {
 }
 
 // String returns the "snap:slot" representation of a slot reference.
-func (ref *SlotRef) String() string {
+func (ref SlotRef) String() string {
 	return fmt.Sprintf("%s:%s", ref.Snap, ref.Name)
 }
 

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -133,6 +133,8 @@ func (s *CoreSuite) TestPlugRef(c *C) {
 func (s *CoreSuite) TestPlugRefString(c *C) {
 	ref := PlugRef{Snap: "snap", Name: "plug"}
 	c.Check(ref.String(), Equals, "snap:plug")
+	refPtr := &PlugRef{Snap: "snap", Name: "plug"}
+	c.Check(refPtr.String(), Equals, "snap:plug")
 }
 
 // Slot.Ref works as expected
@@ -147,6 +149,8 @@ func (s *CoreSuite) TestSlotRef(c *C) {
 func (s *CoreSuite) TestSlotRefString(c *C) {
 	ref := SlotRef{Snap: "snap", Name: "slot"}
 	c.Check(ref.String(), Equals, "snap:slot")
+	refPtr := &SlotRef{Snap: "snap", Name: "slot"}
+	c.Check(refPtr.String(), Equals, "snap:slot")
 }
 
 // ConnRef.ID works as expected


### PR DESCRIPTION
We recently learned that the auto-connection logic is not as nice as we would like it to be.
As the first step towards fixing it let's add some diagnostic messages that we can use
to reason about what is going on in a given system.