### PR TITLE
cmd/snap: make users Xauthority file available in snap environment

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -324,7 +324,10 @@ func migrateXauthority(info *snap.Info) (string, error) {
 		}
 
 		fout.Close()
-		os.Remove(targetPath)
+		if err := os.Remove(targetPath); err != nil {
+			logger.Noticef("WARNING: failed to remove existing file %s", targetPath)
+			return "", err
+		}
 
 		// Ensure we're validating the Xauthority file from the beginning
 		if _, err := fin.Seek(int64(os.SEEK_SET), 0); err != nil {
@@ -338,14 +341,6 @@ func migrateXauthority(info *snap.Info) (string, error) {
 	if err := x11.ValidateXauthorityFromFile(fin); err != nil {
 		logger.Noticef("WARNING: invalid Xauthority file: %s", err)
 		return "", nil
-	}
-
-	// Replace the file securely by removing and creating with O_CREATE|O_EXCL
-	if osutil.FileExists(targetPath) {
-		err := os.Remove(targetPath)
-		if err != nil {
-			logger.Noticef("WARNING: failed to remove existing file %s", targetPath)
-		}
 	}
 
 	// Read data from the beginning of the file

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -237,11 +237,6 @@ func migrateXauthority(info *snap.Info) error {
 		return fmt.Errorf(i18n.G("cannot get the current user: %v"), err)
 	}
 
-	// If we're running as root then we don't do anything
-	if u.Uid == "0" {
-		return nil
-	}
-
 	xauthPath := osGetenv("XAUTHORITY")
 	if len(xauthPath) == 0 || !osutil.FileExists(xauthPath) {
 		// Nothing to do for us. Most likely running outside of any
@@ -277,6 +272,7 @@ func migrateXauthority(info *snap.Info) error {
 	// either the data can't be parsed or there are no cookies in
 	// the file is invalid.
 	if err := x11.ValidateXauthority(tmpXauthPath); err != nil {
+		logger.Noticef("WARNING: invalid Xauthority file: %s", err)
 		return nil
 	}
 

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -234,7 +234,7 @@ func isReexeced() bool {
 func migrateXauthority(info *snap.Info) error {
 	u, err := userCurrent()
 	if err != nil {
-		return fmt.Errorf(i18n.G("cannot get the current user: %v"), err)
+		return fmt.Errorf(i18n.G("cannot get the current user: %s"), err)
 	}
 
 	xauthPath := osGetenv("XAUTHORITY")

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -509,6 +509,9 @@ func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
 	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine()()
 
+	// Ensure XDG_RUNTIME_DIR exists for the user we're testing with
+	os.MkdirAll(filepath.Join(dirs.XdgRuntimeDirBase, "1000")
+
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/x11"
 )
 
 var mockYaml = []byte(`name: snapname
@@ -498,4 +500,65 @@ func (s *SnapSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 		filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
+}
+
+func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
+	// mock installed snap
+	dirs.SetRootDir(c.MkDir())
+	defer func() { dirs.SetRootDir("/") }()
+	defer mockSnapConfine()()
+
+	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+		Revision: snap.R("x2"),
+	})
+	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
+	c.Assert(err, check.IsNil)
+
+	// redirect exec
+	execArg0 := ""
+	execArgs := []string{}
+	execEnv := []string{}
+	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		execArg0 = arg0
+		execArgs = args
+		execEnv = envv
+		return nil
+	})
+	defer restorer()
+
+	defer snaprun.MockUserCurrent(func() (*user.User, error) {
+		return &user.User{Uid: "1000"}, nil
+	})()
+
+	xauthPath, err := x11.MockXauthority(2)
+	c.Assert(err, check.IsNil)
+	defer os.Remove(xauthPath)
+
+	defer snaprun.MockGetEnv(func(name string) string {
+		if name == "XAUTHORITY" {
+			return xauthPath
+		}
+		return ""
+	})()
+
+	// and run it!
+	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{"snapname.app"})
+	c.Check(execArg0, check.Equals, filepath.Join(dirs.DistroLibExecDir, "snap-confine"))
+	c.Check(execArgs, check.DeepEquals, []string{
+		filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
+		"snap.snapname.app",
+		filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
+		"snapname.app"})
+
+	expectedXauthPath := filepath.Join(dirs.XdgRuntimeDirBase, "1000", "Xauthority")
+	c.Check(execEnv, testutil.Contains, fmt.Sprintf("XAUTHORITY=%s", expectedXauthPath))
+
+	info, err := os.Stat(expectedXauthPath)
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0600))
+
+	err = x11.ValidateXauthority(expectedXauthPath)
+	c.Assert(err, check.IsNil)
 }

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -510,7 +510,7 @@ func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
 	defer mockSnapConfine()()
 
 	// Ensure XDG_RUNTIME_DIR exists for the user we're testing with
-	os.MkdirAll(filepath.Join(dirs.XdgRuntimeDirBase, "1000")
+	os.MkdirAll(filepath.Join(dirs.XdgRuntimeDirBase, "1000"), 0700)
 
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R("x2"),

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -513,7 +513,8 @@ func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Ensure XDG_RUNTIME_DIR exists for the user we're testing with
-	os.MkdirAll(filepath.Join(dirs.XdgRuntimeDirBase, u.Uid), 0700)
+	err = os.MkdirAll(filepath.Join(dirs.XdgRuntimeDirBase, u.Uid), 0700)
+	c.Assert(err, check.IsNil)
 
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R("x2"),
@@ -532,9 +533,6 @@ func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
 		return nil
 	})
 	defer restorer()
-
-	// Ensure we have XDG_RUNTIME_DIR for the current user
-	os.MkdirAll(filepath.Join(dirs.XdgRuntimeDirBase, u.Uid), 0700)
 
 	xauthPath, err := x11.MockXauthority(2)
 	c.Assert(err, check.IsNil)

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -79,10 +79,10 @@ func MockStoreNew(f func(*store.Config, auth.AuthContext) *store.Store) (restore
 }
 
 func MockGetEnv(f func(name string) string) (restore func()) {
-	getEnvOrig := getEnv
-	getEnv = f
+	osGetenvOrig := osGetenv
+	osGetenv = f
 	return func() {
-		getEnv = getEnvOrig
+		osGetenv = osGetenvOrig
 	}
 }
 

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -78,6 +78,14 @@ func MockStoreNew(f func(*store.Config, auth.AuthContext) *store.Store) (restore
 	}
 }
 
+func MockGetEnv(f func(name string) string) (restore func()) {
+	getEnvOrig := getEnv
+	getEnv = f
+	return func() {
+		getEnv = getEnvOrig
+	}
+}
+
 func MockMountInfoPath(newMountInfoPath string) (restore func()) {
 	mountInfoPathOrig := mountInfoPath
 	mountInfoPath = newMountInfoPath

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -74,6 +74,7 @@ var (
 	DistroLibExecDir string
 	CoreLibExecDir   string
 
+	XdgRuntimeDirBase string
 	XdgRuntimeDirGlob string
 )
 
@@ -178,5 +179,6 @@ func SetRootDir(rootdir string) {
 
 	CoreLibExecDir = filepath.Join(rootdir, "/usr/lib/snapd")
 
-	XdgRuntimeDirGlob = filepath.Join(rootdir, "/run/user/*/")
+	XdgRuntimeDirBase = filepath.Join(rootdir, "/run/user")
+	XdgRuntimeDirGlob = filepath.Join(rootdir, XdgRuntimeDirBase, "*/")
 }

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -35,7 +35,8 @@ const x11ConnectedPlugAppArmor = `
 /var/cache/fontconfig/** mr,
 
 # Allow access to the user specific copy of the xauth file specified
-# in the XAUTHORITY environment variable snap run creates on startup.
+# in the XAUTHORITY environment variable, that "snap run" creates on
+# startup.
 owner /run/user/[0-9]*/Xauthority r,
 `
 

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -37,7 +37,7 @@ const x11ConnectedPlugAppArmor = `
 # Allow access to the user specific copy of the xauth file specified
 # in the XAUTHORITY environment variable, that "snap run" creates on
 # startup.
-owner /run/user/[0-9]*/Xauthority r,
+owner /run/user/[0-9]*/.Xauthority r,
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/x

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -33,6 +33,10 @@ const x11ConnectedPlugAppArmor = `
 
 /var/cache/fontconfig/   r,
 /var/cache/fontconfig/** mr,
+
+# Allow access to the user specific copy of the xauth file specified
+# in the XAUTHORITY environment variable snap run creates on startup.
+owner /run/user/[0-9]*/Xauthority r,
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/x

--- a/osutil/cmp.go
+++ b/osutil/cmp.go
@@ -58,10 +58,12 @@ func FilesAreEqual(a, b string) bool {
 		return false
 	}
 
-	return streamsEqual(fa, fb)
+	return FileStreamsEqual(fa, fb)
 }
 
-func streamsEqual(fa, fb io.Reader) bool {
+// FileStreamsEqual compares two file streams and returns true if both
+// have the same content.
+func FileStreamsEqual(fa, fb io.Reader) bool {
 	bufa := make([]byte, bufsz)
 	bufb := make([]byte, bufsz)
 	for {

--- a/osutil/cmp_test.go
+++ b/osutil/cmp_test.go
@@ -96,6 +96,6 @@ func (ts *CmpTestSuite) TestCmpStreams(c *C) {
 		{"hello", "world", false},
 		{"hello", "hell", false},
 	} {
-		c.Assert(streamsEqual(strings.NewReader(x.a), strings.NewReader(x.b)), Equals, x.r)
+		c.Assert(FileStreamsEqual(strings.NewReader(x.a), strings.NewReader(x.b)), Equals, x.r)
 	}
 }

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -34,12 +34,15 @@ import (
 //
 // It merges it with the existing os.Environ() and ensures the SNAP_*
 // overrides the any pre-existing environment variables.
-func ExecEnv(info *snap.Info) []string {
+func ExecEnv(info *snap.Info, extra map[string]string) []string {
 	// merge environment and the snap environment, note that the
 	// snap environment overrides pre-existing env entries
 	env := envMap(os.Environ())
 	snapEnv := snapEnv(info)
 	for k, v := range snapEnv {
+		env[k] = v
+	}
+	for k, v := range extra {
 		env[k] = v
 	}
 	return envFromMap(env)

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -136,3 +136,19 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 		})
 	}
 }
+
+func (s *HTestSuite) TestExtraEnvForExecEnv(c *C) {
+	info, err := snap.InfoFromSnapYaml(mockYaml)
+	c.Assert(err, IsNil)
+	info.SideInfo.Revision = snap.R(42)
+
+	env := ExecEnv(info, map[string]string{"FOO": "BAR"})
+	found := false
+	for _, item := range env {
+		if item == "FOO=BAR" {
+			found = true
+			break
+		}
+	}
+	c.Assert(found, Equals, true)
+}

--- a/tests/main/xauth-migration/task.yaml
+++ b/tests/main/xauth-migration/task.yaml
@@ -1,0 +1,77 @@
+summary: Check file XAUTHORITY env variable points to is migrated into the snap environment
+description: |
+    The XAUTHORITY environment variable points to a file which is located
+    in HOME, /run or /tmp depending on the distribution and desktop being
+    used. If the file ends up in /tmp then it wont be visible inside the
+    snap environment as each snap gets its private /tmp. To ensure the
+    file XAUTHORITY points to is always available no matter where it is
+    stored on the host system we migrate the file and copy it into
+    /run/$USER/.Xauthority and set the XAUTHORITY environment variable
+    accordingly.
+
+    This test verified the correct behaviour of the implemented logic
+    inside `snap run`.
+
+execute: |
+    snap install hello-world
+
+    ensure_xauth_path() {
+        export XAUTHORITY=$1
+        # Get rid of things to ensure a clean test bed
+        rm -f /var/snap/hello-world/common/xauth-content /run/user/0/.Xauthority
+        snap run --shell hello-world <<'EOF'
+    echo $XAUTHORITY > /var/snap/hello-world/common/xauth-content
+    exit
+    EOF
+        test "$(cat /var/snap/hello-world/common/xauth-content)" = "$2" || exit 1
+    }
+
+    mock_xauthority() {
+        # Generate valid Xauthority file which `snap run` will accept
+        rm -f $1; touch $1
+        for ((c=0; c<=$2; c++))
+        do
+            # Family
+            echo -n -e \\x01\\x00 >> $1
+            # Address
+            echo -n -e \\x00\\x04\\x73\\x6e\\x61\\x70 >> $1
+            # Number
+            echo -n -e \\x00\\x01\\xff >> $1
+            # Name
+            echo -n -e \\x00\\x05\\x73\\x6e\\x61\\x70\\x64 >> $1
+            # Data
+            echo -n -e \\x00\\x01\\xff >> $1
+        done
+    }
+
+    # An invalid Xauthority file should cause the XAUTHORITY
+    # environment variable to stay untouched.
+    echo "foo bar" > /tmp/invalid-xauthority
+    ensure_xauth_path /tmp/invalid-xauthority /tmp/invalid-xauthority
+    test ! -e /run/user/0/.Xauthority
+
+    echo > /tmp/invalid-xauthority
+    ensure_xauth_path /tmp/invalid-xauthority /tmp/invalid-xauthority
+    test ! -e /run/user/0/.Xauthority
+
+    # Generate valid Xauthority file which `snap run` will accept
+    mock_xauthority /tmp/valid-xauthority 4
+    chmod 600 /tmp/valid-xauthority
+
+    # Xauthority should be correctly migrated
+    ensure_xauth_path /tmp/valid-xauthority /run/user/0/.Xauthority
+    test -e /run/user/0/.Xauthority
+
+    # When we switch the owner the input xauth file shouldn't be moved.
+    chown 1000:1000 /tmp/valid-xauthority
+    ensure_xauth_path /tmp/valid-xauthority /tmp/valid-xauthority
+    test ! -e /run/user/0/.Xauthority
+
+    # We should not be able to get things like /etc/shadow migrated
+    # into the snap environment. When `snap run` does the migration
+    # it will change the content of the XAUTHORITY env variable
+    # inside the snap environment and otherwise leave the variable
+    # untouched. This is why the expected content of the XAUTHORITY
+    # env variable in this case is /etc/shadow
+    ensure_xauth_path /etc/shadow /etc/shadow
+    test ! -e /run/user/0/.Xauthority

--- a/tests/main/xauth-migration/task.yaml
+++ b/tests/main/xauth-migration/task.yaml
@@ -24,6 +24,7 @@ execute: |
     exit
     EOF
         test "$(cat /var/snap/hello-world/common/xauth-content)" = "$2" || exit 1
+        unset XAUTHORITY
     }
 
     mock_xauthority() {
@@ -43,6 +44,11 @@ execute: |
             echo -n -e \\x00\\x01\\xff >> $1
         done
     }
+
+    if [ ! -d /run/user/0 ]; then
+        mkdir -p /run/user/0
+        chmod 700 /run/user/0
+    fi
 
     # An invalid Xauthority file should cause the XAUTHORITY
     # environment variable to stay untouched.

--- a/tests/main/xauth-migration/task.yaml
+++ b/tests/main/xauth-migration/task.yaml
@@ -23,7 +23,9 @@ execute: |
     echo $XAUTHORITY > /var/snap/hello-world/common/xauth-content
     exit
     EOF
-        test "$(cat /var/snap/hello-world/common/xauth-content)" = "$2" || exit 1
+        env_path="$(cat /var/snap/hello-world/common/xauth-content)"
+        test "$env_path" = "$2" || exit 1
+        test "$(sh256sum $env_path)" = "$(sh256sum $1)"
         unset XAUTHORITY
     }
 

--- a/tests/main/xauth-migration/task.yaml
+++ b/tests/main/xauth-migration/task.yaml
@@ -16,7 +16,7 @@ execute: |
     snap install hello-world
 
     ensure_xauth_path() {
-        export XAUTHORITY=$1
+        export XAUTHORITY="$1"
         # Get rid of things to ensure a clean test bed
         rm -f /var/snap/hello-world/common/xauth-content /run/user/0/.Xauthority
         snap run --shell hello-world <<'EOF'

--- a/x11/xauth.go
+++ b/x11/xauth.go
@@ -100,18 +100,21 @@ func ValidateXauthority(path string) error {
 		return err
 	}
 	defer f.Close()
+	return ValidateXauthorityFromFile(f)
+}
 
+// ValidateXauthority validates a given Xauthority file. The file is valid
+// if it can be parsed and contains at least one cookie.
+func ValidateXauthorityFromFile(f *os.File) error {
 	cookies := 0
 	for {
 		xa := &xauth{}
-		err = xa.readFromFile(f)
+		err := xa.readFromFile(f)
 		if err == io.EOF {
 			break
 		} else if err != nil {
 			return err
 		}
-		// FIXME we can do further validation of the cookies like
-		// checking for valid families etc.
 		cookies++
 	}
 

--- a/x11/xauth.go
+++ b/x11/xauth.go
@@ -75,6 +75,7 @@ func (xa *xauth) readFromFile(f *os.File) error {
 	if err := readBytes(f, b[:]); err != nil {
 		return err
 	}
+	// The family field consists of two bytes
 	xa.Family = binary.BigEndian.Uint16(b[:])
 
 	var err error

--- a/x11/xauth.go
+++ b/x11/xauth.go
@@ -61,9 +61,11 @@ func readChunk(f *os.File) ([]byte, error) {
 
 func (xa *xauth) readFromFile(f *os.File) error {
 	b := [2]byte{}
-	_, err := f.Read(b[:])
+	n, err := f.Read(b[:])
 	if err != nil {
 		return err
+	} else if n != 2 {
+		return fmt.Errorf("Could not read enough bytes")
 	}
 	xa.Family = binary.BigEndian.Uint16(b[:])
 

--- a/x11/xauth.go
+++ b/x11/xauth.go
@@ -112,7 +112,7 @@ func ValidateXauthority(path string) error {
 		}
 		// FIXME we can do further validation of the cookies like
 		// checking for valid families etc.
-		cookies += 1
+		cookies++
 	}
 
 	if cookies <= 0 {

--- a/x11/xauth.go
+++ b/x11/xauth.go
@@ -1,0 +1,133 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package x11
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type xauth struct {
+	Family  uint16
+	Address []byte
+	Number  []byte
+	Name    []byte
+	Data    []byte
+}
+
+func readChunk(f *os.File) ([]byte, error) {
+	b := make([]byte, 2)
+	n, err := f.Read(b)
+	if err != nil {
+		return nil, err
+	} else if n != 2 {
+		return nil, fmt.Errorf("Could not read enough bytes")
+	}
+
+	size := int(binary.BigEndian.Uint16(b))
+	chunk := make([]byte, size)
+	n, err = f.Read(chunk)
+	if err != nil {
+		return nil, err
+	} else if n != size {
+		return nil, fmt.Errorf("Could not read enough bytes")
+	}
+
+	return chunk, nil
+}
+
+func (xa *xauth) ReadFromFile(f *os.File) error {
+	b := make([]byte, 2)
+	_, err := f.Read(b)
+	if err != nil {
+		return err
+	}
+	xa.Family = binary.BigEndian.Uint16(b)
+
+	xa.Address, err = readChunk(f)
+	if err != nil {
+		return err
+	}
+
+	xa.Number, err = readChunk(f)
+	if err != nil {
+		return err
+	}
+
+	xa.Name, err = readChunk(f)
+	if err != nil {
+		return err
+	}
+
+	xa.Data, err = readChunk(f)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ValidateXauthority(path string) (int, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0600)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	cookies := 0
+	for {
+		xa := &xauth{}
+		err = xa.ReadFromFile(f)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return 0, err
+		}
+		// FIXME we can do further validation of the cookies like
+		// checking for valid families etc.
+		cookies += 1
+	}
+
+	return cookies, nil
+}
+
+func MockXauthority(cookies int) string {
+	f, _ := ioutil.TempFile("", "xauth")
+	for n := 0; n < cookies; n++ {
+		data := []byte{
+			// Family
+			0x01, 0x00,
+			// Address
+			0x00, 0x04, 0x73, 0x6e, 0x61, 0x70,
+			// Number
+			0x00, 0x01, 0xff,
+			// Name
+			0x00, 0x05, 0x73, 0x6e, 0x61, 0x70, 0x64,
+			// Data
+			0x00, 0x01, 0xff,
+		}
+		f.Write(data)
+	}
+	f.Close()
+	return f.Name()
+}

--- a/x11/xauth_test.go
+++ b/x11/xauth_test.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package x11_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/x11"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type XauthTestSuite struct {}
+
+var _ = Suite(&XauthTestSuite{})
+
+func (s *XauthTestSuite) TestXauthFileNotAvailable(c *C) {
+	n, err := x11.ValidateXauthority("/does/not/exist")
+	c.Assert(n, Equals, 0)
+	c.Assert(err, Not(IsNil))
+}
+
+func (s *XauthTestSuite) TestXauthFileExistsButIsEmpty(c *C) {
+	f, err := ioutil.TempFile("", "xauth")
+	c.Assert(err, IsNil)
+	defer os.Remove(f.Name())
+
+	n, err := x11.ValidateXauthority(f.Name())
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 0)
+}
+
+func (s *XauthTestSuite) TestXauthFileExistsButHasInvalidContent(c *C) {
+	f, err := ioutil.TempFile("", "xauth")
+	c.Assert(err, IsNil)
+	defer os.Remove(f.Name())
+
+	data := []byte{0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99}
+	n, err := f.Write(data)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, len(data))
+
+	n, err = x11.ValidateXauthority(f.Name())
+	c.Assert(err, DeepEquals, fmt.Errorf("Could not read enough bytes"))
+	c.Assert(n, Equals, 0)
+}
+
+func (s *XauthTestSuite) TestValidXauthFile(c *C) {
+	path := x11.MockXauthority(1)
+	n, err := x11.ValidateXauthority(path)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 1)
+}

--- a/x11/xauth_test.go
+++ b/x11/xauth_test.go
@@ -65,8 +65,10 @@ func (s *xauthTestSuite) TestXauthFileExistsButHasInvalidContent(c *C) {
 }
 
 func (s *xauthTestSuite) TestValidXauthFile(c *C) {
-	path, err := x11.MockXauthority(1)
-	c.Assert(err, IsNil)
-	err = x11.ValidateXauthority(path)
-	c.Assert(err, IsNil)
+	for _, n := range []int{1, 2, 4} {
+		path, err := x11.MockXauthority(n)
+		c.Assert(err, IsNil)
+		err = x11.ValidateXauthority(path)
+		c.Assert(err, IsNil)
+	}
 }


### PR DESCRIPTION
Not all desktop environments set XAUTHORITY to something which is available
inside the environment we create for snaps. Some place the authority file
inside /tmp which a snap doesn't share with the host system. To workaround
this we copy the file XAUTHORITY points to when the snap is started into a
snap specific location in XDG_RUNTIME_DIR of the current user and allow
access via the x11 interface. This will work across all available desktop
environments.