### PR TITLE
packaging: add `built-using` header for 16.04 packaging

### DIFF
--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -71,7 +71,7 @@ Depends: adduser,
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23~14.04)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23~14.04)
 Conflicts: snap (<< 2013-11-29-1ubuntu1)
-Built-Using: ${misc:Built-Using}
+Built-Using: ${Built-Using} ${misc:Built-Using}
 Description: Tool to interact with Ubuntu Core Snappy.
  Install, configure, refresh and remove snap packages. Snaps are
  'universal' packages that work across many different Linux systems,

--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -44,6 +44,9 @@ ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
 	TAGS=-tags withtestkeys
 endif
 
+BUILT_USING_PACKAGES= libcap-dev libapparmor-dev libseccomp-dev
+BUILT_USING=$(shell dpkg-query -f '$${source:Package} (= $${source:Version}), ' -W $(BUILT_USING_PACKAGES))
+
 # export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 # DPKG_EXPORT_BUILDFLAGS = 1
 # include /usr/share/dpkg/buildflags.mk
@@ -150,3 +153,6 @@ snap.8:
 override_dh_auto_clean:
 	dh_auto_clean -O--buildsystem=golang
 	rm -vf snap.8
+
+override_dh_gencontrol:
+	dh_gencontrol -- -VBuilt-Using="$(BUILT_USING)"

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -65,7 +65,7 @@ Depends: adduser,
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22)
 Conflicts: snap (<< 2013-11-29-1ubuntu1)
-Built-Using: ${misc:Built-Using}
+Built-Using: ${Built-Using} ${misc:Built-Using}
 Description: Tool to interact with Ubuntu Core Snappy.
  Install, configure, refresh and remove snap packages. Snaps are
  'universal' packages that work across many different Linux systems,

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -37,6 +37,9 @@ ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
 	TAGS=-tags withtestkeys
 endif
 
+BUILT_USING_PACKAGES= libcap-dev libapparmor-dev libseccomp-dev
+BUILT_USING=$(shell dpkg-query -f '$${source:Package} (= $${source:Version}), ' -W $(BUILT_USING_PACKAGES))
+
 # export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 # DPKG_EXPORT_BUILDFLAGS = 1
 # include /usr/share/dpkg/buildflags.mk
@@ -200,3 +203,6 @@ snap.8:
 override_dh_auto_clean:
 	dh_auto_clean -O--buildsystem=golang
 	rm -vf snap.8
+
+override_dh_gencontrol:
+	dh_gencontrol -- -VBuilt-Using="$(BUILT_USING)"

--- a/tests/main/debs-have-built-using/task.yaml
+++ b/tests/main/debs-have-built-using/task.yaml
@@ -1,0 +1,9 @@
+summary: Ensure that our debs have the "built-using" header
+systems: [-ubuntu-core-*]
+execute: |
+    out=$(dpkg -I $GOPATH/snapd_*.deb)
+    echo $out | MATCH "Built-Using:.*apparmor \(="
+    echo $out | MATCH "Built-Using:.*libcap2 \(="
+    echo $out | MATCH "Built-Using:.*libseccomp \(="
+
+  


### PR DESCRIPTION
The `Built-Using` header allow the security team to track what statically linked packages need a rebuild when e.g. a security issue in a library comes up. Requested by the SRU team (thank you guys, you rock!).

This also needs a corresponding 14.04 and a test but I create the branch as is to ensure its on the 2.25 radar.