### PR TITLE
many: fixes for `go vet` in go 1.7

### DIFF
--- a/interfaces/mount/profile_test.go
+++ b/interfaces/mount/profile_test.go
@@ -95,7 +95,7 @@ func (s *profileSuite) TestReadProfile3(c *C) {
 	c.Assert(p.Entries, HasLen, 2)
 	c.Assert(p.Entries, DeepEquals, []mount.Entry{
 		{Name: "name-1", Dir: "dir-1", Type: "type-1", Options: []string{"options-1"}, DumpFrequency: 1, CheckPassNumber: 1},
-		{Name: "name-2", Dir: "dir-2", Type: "type-2", Options: []string{"option-2"}, DumpFrequency: 2, CheckPassNumber: 2},
+		{Name: "name-2", Dir: "dir-2", Type: "type-2", Options: []string{"options-2"}, DumpFrequency: 2, CheckPassNumber: 2},
 	})
 }
 
@@ -114,7 +114,7 @@ func (s *profileSuite) TestWriteTo2(c *C) {
 	p := &mount.Profile{
 		Entries: []mount.Entry{
 			{Name: "name-1", Dir: "dir-1", Type: "type-1", Options: []string{"options-1"}, DumpFrequency: 1, CheckPassNumber: 1},
-			{Name: "name-2", Dir: "dir-2", Type: "type-2", Options: []string{"option-2"}, DumpFrequency: 2, CheckPassNumber: 2},
+			{Name: "name-2", Dir: "dir-2", Type: "type-2", Options: []string{"options-2"}, DumpFrequency: 2, CheckPassNumber: 2},
 		},
 	}
 	var buf bytes.Buffer

--- a/interfaces/mount/profile_test.go
+++ b/interfaces/mount/profile_test.go
@@ -52,7 +52,7 @@ func (s *profileSuite) TestLoadProfile2(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(p.Entries, HasLen, 1)
 	c.Assert(p.Entries, DeepEquals, []mount.Entry{
-		{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
+		{Name: "name-1", Dir: "dir-1", Type: "type-1", Options: []string{"options-1"}, DumpFrequency: 1, CheckPassNumber: 1},
 	})
 }
 
@@ -62,7 +62,7 @@ func (s *profileSuite) TestSaveProfile1(c *C) {
 	fname := filepath.Join(dir, "profile")
 	p := &mount.Profile{
 		Entries: []mount.Entry{
-			{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
+			{Name: "name-1", Dir: "dir-1", Type: "type-1", Options: []string{"options-1"}, DumpFrequency: 1, CheckPassNumber: 1},
 		},
 	}
 	err := p.Save(fname)
@@ -94,8 +94,8 @@ func (s *profileSuite) TestReadProfile3(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(p.Entries, HasLen, 2)
 	c.Assert(p.Entries, DeepEquals, []mount.Entry{
-		{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
-		{"name-2", "dir-2", "type-2", []string{"options-2"}, 2, 2},
+		{Name: "name-1", Dir: "dir-1", Type: "type-1", Options: []string{"options-1"}, DumpFrequency: 1, CheckPassNumber: 1},
+		{Name: "name-2", Dir: "dir-2", Type: "type-2", Options: []string{"option-2"}, DumpFrequency: 2, CheckPassNumber: 2},
 	})
 }
 
@@ -113,8 +113,8 @@ func (s *profileSuite) TestWriteTo1(c *C) {
 func (s *profileSuite) TestWriteTo2(c *C) {
 	p := &mount.Profile{
 		Entries: []mount.Entry{
-			{"name-1", "dir-1", "type-1", []string{"options-1"}, 1, 1},
-			{"name-2", "dir-2", "type-2", []string{"options-2"}, 2, 2},
+			{Name: "name-1", Dir: "dir-1", Type: "type-1", Options: []string{"options-1"}, DumpFrequency: 1, CheckPassNumber: 1},
+			{Name: "name-2", Dir: "dir-2", Type: "type-2", Options: []string{"option-2"}, DumpFrequency: 2, CheckPassNumber: 2},
 		},
 	}
 	var buf bytes.Buffer

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -947,7 +947,7 @@ func (s *RepositorySuite) TestResolveDisconnectMatrixTypical(c *C) {
 	c.Assert(s.testRepo.AddSnap(s.coreSnap), IsNil)
 	c.Assert(s.testRepo.AddPlug(s.plug), IsNil)
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
-	connRef := ConnRef{s.plug.Ref(), s.slot.Ref()}
+	connRef := ConnRef{PlugRef: s.plug.Ref(), SlotRef: s.slot.Ref()}
 	c.Assert(s.testRepo.Connect(connRef), IsNil)
 
 	scenarios := []struct {
@@ -1178,13 +1178,13 @@ func (s *RepositorySuite) TestConnectedFindsConnections(c *C) {
 	conns, err := s.testRepo.Connected(s.plug.Snap.Name(), s.plug.Name)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []ConnRef{
-		{s.plug.Ref(), s.slot.Ref()},
+		{PlugRef: s.plug.Ref(), SlotRef: s.slot.Ref()},
 	})
 
 	conns, err = s.testRepo.Connected(s.slot.Snap.Name(), s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []ConnRef{
-		{s.plug.Ref(), s.slot.Ref()},
+		{PlugRef: s.plug.Ref(), SlotRef: s.slot.Ref()},
 	})
 }
 
@@ -1204,7 +1204,7 @@ func (s *RepositorySuite) TestConnectedFindsCoreSnap(c *C) {
 	conns, err := s.testRepo.Connected("", s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Check(conns, DeepEquals, []ConnRef{
-		{s.plug.Ref(), slot.Ref()},
+		{PlugRef: s.plug.Ref(), SlotRef: slot.Ref()},
 	})
 }
 
@@ -1215,7 +1215,7 @@ func (s *RepositorySuite) TestDisconnectAll(c *C) {
 	c.Assert(s.testRepo.AddSlot(s.slot), IsNil)
 	c.Assert(s.testRepo.Connect(ConnRef{PlugRef: s.plug.Ref(), SlotRef: s.slot.Ref()}), IsNil)
 
-	conns := []ConnRef{{s.plug.Ref(), s.slot.Ref()}}
+	conns := []ConnRef{{PlugRef: s.plug.Ref(), SlotRef: s.slot.Ref()}}
 	s.testRepo.DisconnectAll(conns)
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
 		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},


### PR DESCRIPTION
The golang vet in zesty (1.7) complains about our code. This branches makes it happy again.