### PR TITLE
debian: add maintscript helper to remove usr.lib.snapd.snap-confine in snap-confine

### DIFF
--- a/packaging/ubuntu-16.04/snap-confine.maintscript
+++ b/packaging/ubuntu-16.04/snap-confine.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/apparmor.d/usr.lib.snapd.snap-confine 2.23.6~


### PR DESCRIPTION
The old snap-confine package used to own the usr.lib.snapd.snap-confine
conffile. So we need to put the maintscript helper into the transitional
snap-confine package to get this file really removed.

LP: 1682023