### PR TITLE
store: tests for unexpected EOF

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2589,7 +2589,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 	mockPermanentlyBrokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		permanentlyBrokenSrvCalls++
 		w.Header().Add("Content-Length", "1000")
-		return
 	}))
 	mockSomewhatBrokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		somewhatBrokenSrvCalls++
@@ -2598,7 +2597,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 			return
 		}
 		w.Header().Add("Content-Length", "1000")
-		return
 	}))
 
 	queryServer := func(mockServer *httptest.Server) error {
@@ -2615,13 +2613,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 		repo := New(&cfg, authContext)
 		c.Assert(repo, NotNil)
 
-		_, err = repo.ListRefresh([]*RefreshCandidate{
-			{
-				SnapID:   helloWorldSnapID,
-				Channel:  "stable",
-				Revision: snap.R(1),
-				Epoch:    "0",
-			},
+		_, err = repo.ListRefresh([]*RefreshCandidate{{
+			SnapID:   helloWorldSnapID,
+			Channel:  "stable",
+			Revision: snap.R(1),
+			Epoch:    "0",
+		},
 		}, nil)
 		return err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2628,11 +2628,13 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err, Equals, io.ErrUnexpectedEOF)
 	c.Assert(err, ErrorMatches, "unexpected EOF")
+	// check that we exhausted all retries (as defined by mocked retry strategy)
 	c.Assert(permanentlyBrokenSrvCalls, Equals, 5)
 
 	// Check that we retry on unexpected EOF and eventually succeed
 	err = queryServer(mockSomewhatBrokenServer)
 	c.Assert(err, IsNil)
+	// check that we retried 4 times
 	c.Assert(somewhatBrokenSrvCalls, Equals, 4)
 }
 


### PR DESCRIPTION
Implemented a simple test for unexpected EOF. It verifies that:
- we propagate unexpected EOF after all retries failed.
- we retry on unexpected EOF and eventually succeed.