### PR TITLE
interfaces/mount: add parser for mountinfo entries

### DIFF
--- a/interfaces/mount/mountinfo.go
+++ b/interfaces/mount/mountinfo.go
@@ -19,6 +19,12 @@
 
 package mount
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // InfoEntry contains data from /proc/$PID/mountinfo
 //
 // For details please refer to mountinfo documentation at
@@ -35,4 +41,65 @@ type InfoEntry struct {
 	FsType       string
 	MountSource  string
 	SuperOpts    string
+}
+
+// ParseInfoEntry parses a single line of /proc/$PID/mountinfo file.
+func ParseInfoEntry(s string) (InfoEntry, error) {
+	var e InfoEntry
+	var err error
+	fields := strings.Fields(s)
+	// The format is variable-length, but at least 10 fields are mandatory.
+	// The (7) below is a list of optional field which is terminated with (8).
+	// 36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+	// (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
+	if len(fields) < 10 {
+		return e, fmt.Errorf("incorrect number of fields, expected at least 10 but found %d", len(fields))
+	}
+	// Parse MountID (decimal number).
+	e.MountID, err = strconv.Atoi(fields[0])
+	if err != nil {
+		return e, fmt.Errorf("cannot parse mount ID: %q", fields[0])
+	}
+	// Parse ParentID (decimal number).
+	e.ParentID, err = strconv.Atoi(fields[1])
+	if err != nil {
+		return e, fmt.Errorf("cannot parse parent mount ID: %q", fields[1])
+	}
+	// Parses DevMajor:DevMinor pair (decimal numbers separated by colon).
+	subFields := strings.FieldsFunc(fields[2], func(r rune) bool { return r == ':' })
+	if len(subFields) != 2 {
+		return e, fmt.Errorf("cannot parse device major:minor number pair: %q", fields[2])
+	}
+	e.DevMajor, err = strconv.Atoi(subFields[0])
+	if err != nil {
+		return e, fmt.Errorf("cannot parse device major number: %q", subFields[0])
+	}
+	e.DevMinor, err = strconv.Atoi(subFields[1])
+	if err != nil {
+		return e, fmt.Errorf("cannot parse device minor number: %q", subFields[1])
+	}
+	// NOTE: All string fields use the same escape/unescape logic as fstab files.
+	// Parse Root, MountDir and MountOpts fields.
+	e.Root = unescape(fields[3])
+	e.MountDir = unescape(fields[4])
+	e.MountOpts = unescape(fields[5])
+	// Optional fields are terminated with a "-" value and start
+	// after the mount options field. Skip ahead until we see the "-"
+	// marker.
+	var i int
+	for i = 6; i < len(fields) && fields[i] != "-"; i++ {
+	}
+	if i == len(fields) {
+		return e, fmt.Errorf("list of optional fields is not terminated properly")
+	}
+	e.OptionalFlds = strings.Join(fields[6:i], " ")
+	// Parse the last three fixed fields.
+	tailFields := fields[i+1:]
+	if len(tailFields) != 3 {
+		return e, fmt.Errorf("incorrect number of tail fields, expected 3 but found %d", len(tailFields))
+	}
+	e.FsType = unescape(tailFields[0])
+	e.MountSource = unescape(tailFields[1])
+	e.SuperOpts = unescape(tailFields[2])
+	return e, nil
 }

--- a/interfaces/mount/mountinfo_test.go
+++ b/interfaces/mount/mountinfo_test.go
@@ -22,9 +22,98 @@ package mount_test
 import (
 	. "gopkg.in/check.v1"
 
-	_ "github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/interfaces/mount"
 )
 
 type mountinfoSuite struct{}
 
 var _ = Suite(&mountinfoSuite{})
+
+// Check that parsing the example from kernel documentation works correctly.
+func (s *mountinfoSuite) TestParseInfoEntry1(c *C) {
+	entry, err := mount.ParseInfoEntry(
+		"36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue")
+	c.Assert(err, IsNil)
+	c.Assert(entry.MountID, Equals, 36)
+	c.Assert(entry.ParentID, Equals, 35)
+	c.Assert(entry.DevMajor, Equals, 98)
+	c.Assert(entry.DevMinor, Equals, 0)
+	c.Assert(entry.Root, Equals, "/mnt1")
+	c.Assert(entry.MountDir, Equals, "/mnt2")
+	c.Assert(entry.MountOpts, Equals, "rw,noatime")
+	c.Assert(entry.OptionalFlds, Equals, "master:1")
+	c.Assert(entry.FsType, Equals, "ext3")
+	c.Assert(entry.MountSource, Equals, "/dev/root")
+	c.Assert(entry.SuperOpts, Equals, "rw,errors=continue")
+}
+
+// Check that various combinations of optional fields are parsed correctly.
+func (s *mountinfoSuite) TestParseInfoEntry2(c *C) {
+	// No optional fields.
+	entry, err := mount.ParseInfoEntry(
+		"36 35 98:0 /mnt1 /mnt2 rw,noatime - ext3 /dev/root rw,errors=continue")
+	c.Assert(err, IsNil)
+	c.Assert(entry.MountOpts, Equals, "rw,noatime")
+	c.Assert(entry.OptionalFlds, Equals, "")
+	c.Assert(entry.FsType, Equals, "ext3")
+	// One optional field.
+	entry, err = mount.ParseInfoEntry(
+		"36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue")
+	c.Assert(err, IsNil)
+	c.Assert(entry.MountOpts, Equals, "rw,noatime")
+	c.Assert(entry.OptionalFlds, Equals, "master:1")
+	c.Assert(entry.FsType, Equals, "ext3")
+	// Two optional fields.
+	entry, err = mount.ParseInfoEntry(
+		"36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 slave:2 - ext3 /dev/root rw,errors=continue")
+	c.Assert(err, IsNil)
+	c.Assert(entry.MountOpts, Equals, "rw,noatime")
+	c.Assert(entry.OptionalFlds, Equals, "master:1 slave:2")
+	c.Assert(entry.FsType, Equals, "ext3")
+}
+
+// Check that white-space is unescaped correctly, except for OptionalFlds which are space-separated.
+func (s *mountinfoSuite) TestParseInfoEntry3(c *C) {
+	entry, err := mount.ParseInfoEntry(
+		`36 35 98:0 /mnt\0401 /mnt\0402 rw\040,noatime mas\040ter:1 - ext\0403 /dev/ro\040ot rw\040,errors=continue`)
+	c.Assert(err, IsNil)
+	c.Assert(entry.MountID, Equals, 36)
+	c.Assert(entry.ParentID, Equals, 35)
+	c.Assert(entry.DevMajor, Equals, 98)
+	c.Assert(entry.DevMinor, Equals, 0)
+	c.Assert(entry.Root, Equals, "/mnt 1")
+	c.Assert(entry.MountDir, Equals, "/mnt 2")
+	c.Assert(entry.MountOpts, Equals, "rw ,noatime")
+	// This field is still escaped as it is space-separated and needs further parsing.
+	c.Assert(entry.OptionalFlds, Equals, `mas\040ter:1`)
+	c.Assert(entry.FsType, Equals, "ext 3")
+	c.Assert(entry.MountSource, Equals, "/dev/ro ot")
+	c.Assert(entry.SuperOpts, Equals, "rw ,errors=continue")
+}
+
+// Check that various malformed entries are detected.
+func (s *mountinfoSuite) TestParseInfoEntry4(c *C) {
+	var err error
+	_, err = mount.ParseInfoEntry("36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue foo")
+	c.Assert(err, ErrorMatches, "incorrect number of tail fields, expected 3 but found 4")
+	_, err = mount.ParseInfoEntry("36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root")
+	c.Assert(err, ErrorMatches, "incorrect number of tail fields, expected 3 but found 2")
+	_, err = mount.ParseInfoEntry("36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3")
+	c.Assert(err, ErrorMatches, "incorrect number of fields, expected at least 10 but found 9")
+	_, err = mount.ParseInfoEntry("36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 -")
+	c.Assert(err, ErrorMatches, "incorrect number of fields, expected at least 10 but found 8")
+	_, err = mount.ParseInfoEntry("36 35 98:0 /mnt1 /mnt2 rw,noatime master:1")
+	c.Assert(err, ErrorMatches, "incorrect number of fields, expected at least 10 but found 7")
+	_, err = mount.ParseInfoEntry("36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 garbage1 garbage2 garbage3")
+	c.Assert(err, ErrorMatches, "list of optional fields is not terminated properly")
+	_, err = mount.ParseInfoEntry("foo 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue foo")
+	c.Assert(err, ErrorMatches, `cannot parse mount ID: "foo"`)
+	_, err = mount.ParseInfoEntry("36 bar 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue foo")
+	c.Assert(err, ErrorMatches, `cannot parse parent mount ID: "bar"`)
+	_, err = mount.ParseInfoEntry("36 35 froz:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue foo")
+	c.Assert(err, ErrorMatches, `cannot parse device major number: "froz"`)
+	_, err = mount.ParseInfoEntry("36 35 98:bot /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue foo")
+	c.Assert(err, ErrorMatches, `cannot parse device minor number: "bot"`)
+	_, err = mount.ParseInfoEntry("36 35 corrupt /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue foo")
+	c.Assert(err, ErrorMatches, `cannot parse device major:minor number pair: "corrupt"`)
+}


### PR DESCRIPTION
This patch adds a parser for mountinfo entries. Optional fields as well
as various mount options are not parsed deeeply but that is not required
yet.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>