### PR TITLE
snap: added tasks subcommand

### DIFF
--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -77,7 +77,7 @@ func (c *cmdChanges) Execute(args []string) error {
 
 	if allDigits(c.Positional.Snap) {
 		// TRANSLATORS: the %s is the argument given by the user to "snap changes"
-		return fmt.Errorf(i18n.G(`"snap changes" command expects a snap name, try: "snap change %s"`), c.Positional.Snap)
+		return fmt.Errorf(i18n.G(`"snap changes" command expects a snap name, try: "snap task %s"`), c.Positional.Snap)
 	}
 
 	if c.Positional.Snap == "everything" {

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -46,7 +46,7 @@ type cmdChanges struct {
 
 type cmdChange struct {
 	Positional struct {
-		ID changeID `positional-arg-name:"<id>" required:"yes" hidden:"true"`
+		ID changeID `positional-arg-name:"<id>" required:"yes"`
 	} `positional-args:"yes"`
 }
 
@@ -58,7 +58,7 @@ type cmdTasks struct {
 
 func init() {
 	addCommand("changes", shortChangesHelp, longChangesHelp, func() flags.Commander { return &cmdChanges{} }, nil, nil)
-	addCommand("change", shortChangeHelp, longChangeHelp, func() flags.Commander { return &cmdChange{} }, nil, nil)
+	addCommand("change", shortChangeHelp, longChangeHelp, func() flags.Commander { return &cmdChange{} }, nil, nil).hidden = true
 	addCommand("tasks", shortChangeHelp, longChangeHelp, func() flags.Commander { return &cmdTasks{} }, nil, nil)
 }
 

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -46,6 +46,12 @@ type cmdChanges struct {
 
 type cmdChange struct {
 	Positional struct {
+		ID changeID `positional-arg-name:"<id>" required:"yes" hidden:"true"`
+	} `positional-args:"yes"`
+}
+
+type cmdTasks struct {
+	Positional struct {
 		ID changeID `positional-arg-name:"<id>" required:"yes"`
 	} `positional-args:"yes"`
 }
@@ -53,6 +59,7 @@ type cmdChange struct {
 func init() {
 	addCommand("changes", shortChangesHelp, longChangesHelp, func() flags.Commander { return &cmdChanges{} }, nil, nil)
 	addCommand("change", shortChangeHelp, longChangeHelp, func() flags.Commander { return &cmdChange{} }, nil, nil)
+	addCommand("tasks", shortChangeHelp, longChangeHelp, func() flags.Commander { return &cmdTasks{} }, nil, nil)
 }
 
 type changesByTime []*client.Change
@@ -113,9 +120,18 @@ func (c *cmdChanges) Execute(args []string) error {
 	return nil
 }
 
+func (c *cmdTasks) Execute([]string) error {
+	cli := Client()
+	return showChange(cli, c.Positional.ID)
+}
+
 func (c *cmdChange) Execute([]string) error {
 	cli := Client()
-	chg, err := cli.Change(string(c.Positional.ID))
+	return showChange(cli, c.Positional.ID)
+}
+
+func showChange(cli *client.Client, chid changeID) error {
+	chg, err := cli.Change(string(chid))
 	if err != nil {
 		return err
 	}

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -77,7 +77,7 @@ func (c *cmdChanges) Execute(args []string) error {
 
 	if allDigits(c.Positional.Snap) {
 		// TRANSLATORS: the %s is the argument given by the user to "snap changes"
-		return fmt.Errorf(i18n.G(`"snap changes" command expects a snap name, try: "snap task %s"`), c.Positional.Snap)
+		return fmt.Errorf(i18n.G(`"snap changes" command expects a snap name, try: "snap tasks %s"`), c.Positional.Snap)
 	}
 
 	if c.Positional.Snap == "everything" {

--- a/tests/main/change-errors/task.yaml
+++ b/tests/main/change-errors/task.yaml
@@ -1,7 +1,10 @@
-summary: Checks for cli errors of the change command.
+summary: Checks for cli errors of the tasks / change command.
 
 execute: |
-    echo "When an invalid ID is given to the change command it shows an error"
+    echo "When an invalid ID is given to the tasks command it shows an error"
+    if snap tasks 10000000; then
+        echo "Expected error when trying change on invalid ID" && exit 1
+    fi
     if snap change 10000000; then
         echo "Expected error when trying change on invalid ID" && exit 1
     fi

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -64,3 +64,6 @@ execute: |
     snap change $chg_id | MATCH "Undone.*Download snap \"${BAD_SNAP}\""
     snap change $chg_id | MATCH "Done.*Download snap \"${GOOD_SNAP}\""
     snap change $chg_id | MATCH "ERROR cannot verify snap \"test-snapd-tools\", no matching signatures found"
+
+    echo "Verify the 'snap tasks' is the same as 'snap change'"
+    snap tasks $chg_id | MATCH "Undone.*Download snap \"${BAD_SNAP}\""


### PR DESCRIPTION
Added 'tasks' subcommand to snap (works as 'change') and made 'change' hidden.