### PR TITLE
tests: allow installing snapd from -proposed for SRU validation

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -35,6 +35,7 @@ environment:
     HTTPS_PROXY: "$(HOST: echo $HTTPS_PROXY)"
     NO_PROXY: "127.0.0.1"
     NEW_CORE_CHANNEL: "$(HOST: echo $SPREAD_NEW_CORE_CHANNEL)"
+    SRU_VALIDATION: "$(HOST: echo ${SPREAD_SRU_VALIDATION:-0})"
 
 backends:
     linode:

--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -10,14 +10,18 @@ execute: |
     . "$TESTSLIB/apt.sh"
     echo "Ensure core is gone and we have ubuntu-core instead"
     dpkg --purge snapd
-    apt_install_local ${GOPATH}/snapd_*.deb
+    if [ "$SRU_VALIDATION" = "1" ]; then
+        upgrade_snapd_from_proposed
+    else
+        apt_install_local ${GOPATH}/snapd_*.deb
+    fi
     snap install --${CORE_CHANNEL} ubuntu-core
 
     mkdir -p /root/.snap/
     echo '{}' > /root/.snap/auth.json
     mkdir -p /home/test/.snap/
     echo '{}' > /home/test/.snap/auth.json
-    
+
     echo "Ensure transition is triggered"
     snap debug ensure-state-soon
 

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -30,7 +30,11 @@ execute: |
     . "$TESTSLIB/apt.sh"
     echo "Ensure core is gone and we have ubuntu-core instead"
     dpkg --purge snapd
-    apt_install_local ${GOPATH}/snapd_*.deb
+    if [ "$SRU_VALIDATION" = "1" ]; then
+        upgrade_snapd_from_proposed
+    else
+        apt_install_local ${GOPATH}/snapd_*.deb
+    fi
 
     # modify daemon state to set ubuntu-core-transition-last-retry-time to the
     # current time to prevent the ubuntu-core transition before the test snap is
@@ -71,7 +75,7 @@ execute: |
         exit 1
     fi
     snap interfaces | MATCH ":network +test-snapd-python-webserver"
-    snap interfaces | MATCH ":network-bind +test-snapd-python-webserver" 
+    snap interfaces | MATCH ":network-bind +test-snapd-python-webserver"
     echo "Ensure the webserver is still working"
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
     curl http://localhost | MATCH "XKCD rocks"


### PR DESCRIPTION
With these changes we will be able to use the test suite to verify new snapd deb packages after they reache the `-proposed` pocket. In the main suite prepare stage the current snapd version is installed (from the main archive or the `-updates` pocket, whatever is available by default), then an upgrade is performed and the suite is executed with the upgraded package installed, resembling the actual upgrade path.

Apart from the host env var `SPREAD_SRU_VALIDATION` added by this PR, the validation is meant to be executed with these additional settings to prevent modifications of the core snap and to skip the tests that rely on testing keys:
```
export SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC=0
export SPREAD_TRUST_TEST_KEYS=false
```