### PR TITLE
cmd/snap-confine: set TMPDIR and TEMPDIR each time

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -127,15 +127,6 @@ static void setup_private_mount(const char *snap_name)
 	if (chdir(pwd) != 0)
 		die("cannot change current working directory to the original directory");
 	free(pwd);
-
-	// ensure we set the various TMPDIRs to our newly created tmpdir
-	const char *tmpd[] = { "TMPDIR", "TEMPDIR", NULL };
-	int i;
-	for (i = 0; tmpd[i] != NULL; i++) {
-		if (setenv(tmpd[i], "/tmp", 1) != 0) {
-			die("cannot set environment variable '%s'", tmpd[i]);
-		}
-	}
 }
 
 // TODO: fold this into bootstrap

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -175,6 +175,17 @@ int main(int argc, char **argv)
 			       "/usr/bin:"
 			       "/sbin:"
 			       "/bin:" "/usr/games:" "/usr/local/games", 1);
+			// Ensure we set the various TMPDIRs to /tmp.
+			// One of the parts of setting up the mount namespace is to create a private /tmp
+			// directory (this is done in sc_populate_mount_ns() above). The host environment
+			// may point to a directory not accessible by snaps so we need to reset it here.
+			const char *tmpd[] = { "TMPDIR", "TEMPDIR", NULL };
+			int i;
+			for (i = 0; tmpd[i] != NULL; i++) {
+				if (setenv(tmpd[i], "/tmp", 1) != 0) {
+					die("cannot set environment variable '%s'", tmpd[i]);
+				}
+			}
 			struct snappy_udev udev_s;
 			if (snappy_udev_init(security_tag, &udev_s) == 0)
 				setup_devices_cgroup(security_tag, &udev_s);


### PR DESCRIPTION
We used to set TMPDIR and TEMPDIR and point them at /tmp when
constructing the mount namespace (the code was simply next to the code
that creates private /tmp) but after the move to per-snap persistent
namespaces the logic was unchanged. This means that the two variables
were set only the first time a given snap application was launched.

This patch corrects this by setting all environment in one place, right
next to the existing code that changes PATH.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>