### PR TITLE
cmd/snap-confine: don't use plain "classic" term

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -240,7 +240,7 @@ struct sc_mount_config {
 	const char *rootfs_dir;
 	// The struct is terminated with an entry with NULL path.
 	const struct sc_mount *mounts;
-	bool on_classic;
+	bool on_classic_distro;
 };
 
 /**
@@ -397,7 +397,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 	// uniform way after pivot_root but this is good enough and requires less
 	// code changes the nvidia code assumes it has access to the existing
 	// pre-pivot filesystem.
-	if (config->on_classic) {
+	if (config->on_classic_distro) {
 		sc_mount_nvidia_driver(scratch_dir);
 	}
 	// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -527,8 +527,8 @@ void sc_populate_mount_ns(const char *snap_name)
 		die("cannot get the current working directory");
 	}
 	// Remember if we are on classic, some things behave differently there.
-	bool on_classic = is_running_on_classic_distribution();
-	if (on_classic) {
+	bool on_classic_distro = is_running_on_classic_distribution();
+	if (on_classic_distro) {
 		const struct sc_mount mounts[] = {
 			{"/dev"},	// because it contains devices on host OS
 			{"/etc"},	// because that's where /etc/resolv.conf lives, perhaps a bad idea
@@ -555,7 +555,7 @@ void sc_populate_mount_ns(const char *snap_name)
 		struct sc_mount_config classic_config = {
 			.rootfs_dir = sc_get_outer_core_mount_point(),
 			.mounts = mounts,
-			.on_classic = true,
+			.on_classic_distro = true,
 		};
 		sc_bootstrap_mount_namespace(&classic_config);
 	} else {
@@ -585,7 +585,7 @@ void sc_populate_mount_ns(const char *snap_name)
 	setup_private_pts();
 
 	// setup quirks for specific snaps
-	if (on_classic) {
+	if (on_classic_distro) {
 		sc_setup_quirks();
 	}
 	// setup the security backend bind mounts


### PR DESCRIPTION
The term classic is overloaded, it can mean either classic distributions
or classic confinement (or the "classic" snap but this is not used
here). To make it clearer what is going on use the variable
on_classic_distro rather than just on_classic.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>