### PR TITLE
Change default options for Arch Linux

### DIFF
--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -19,7 +19,7 @@ extra_opts=
 . /etc/os-release
 case "$ID" in
 	arch)
-		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-arch"
+		extra_opts="--libexecdir=/usr/lib/snapd --with-snap-mount-dir=/var/lib/snapd/snap --disable-apparmor --enable-nvidia-arch --enable-merged-usr"
 		;;
 	debian)
 		extra_opts="--libexecdir=/usr/lib/snapd"

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -122,7 +122,7 @@ func SetRootDir(rootdir string) {
 	GlobalRootDir = rootdir
 
 	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel":
+	case "fedora", "centos", "rhel", "arch":
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	default:
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)


### PR DESCRIPTION
- Arch Linux wants to respect FHS (https://bugs.archlinux.org/task/53656)  and they move /snap to /var/lib/snapd like Fedora. I changed the default in dirs/dirs.go for Arch Linux.
- I changed the default options in cmd/autogen.sh to the options used by the Arch Linux package (except for --prefix=/usr)