### PR TITLE
interfaces/mount: parse mount options to map[string]string

### DIFF
--- a/interfaces/mount/mountinfo_test.go
+++ b/interfaces/mount/mountinfo_test.go
@@ -40,11 +40,11 @@ func (s *mountinfoSuite) TestParseInfoEntry1(c *C) {
 	c.Assert(entry.DevMinor, Equals, 0)
 	c.Assert(entry.Root, Equals, "/mnt1")
 	c.Assert(entry.MountDir, Equals, "/mnt2")
-	c.Assert(entry.MountOptions, Equals, "rw,noatime")
+	c.Assert(entry.MountOptions, DeepEquals, map[string]string{"rw": "", "noatime": ""})
 	c.Assert(entry.OptionalFields, DeepEquals, []string{"master:1"})
 	c.Assert(entry.FsType, Equals, "ext3")
 	c.Assert(entry.MountSource, Equals, "/dev/root")
-	c.Assert(entry.SuperOptions, Equals, "rw,errors=continue")
+	c.Assert(entry.SuperOptions, DeepEquals, map[string]string{"rw": "", "errors": "continue"})
 }
 
 // Check that various combinations of optional fields are parsed correctly.
@@ -53,21 +53,21 @@ func (s *mountinfoSuite) TestParseInfoEntry2(c *C) {
 	entry, err := mount.ParseInfoEntry(
 		"36 35 98:0 /mnt1 /mnt2 rw,noatime - ext3 /dev/root rw,errors=continue")
 	c.Assert(err, IsNil)
-	c.Assert(entry.MountOptions, Equals, "rw,noatime")
+	c.Assert(entry.MountOptions, DeepEquals, map[string]string{"rw": "", "noatime": ""})
 	c.Assert(entry.OptionalFields, HasLen, 0)
 	c.Assert(entry.FsType, Equals, "ext3")
 	// One optional field.
 	entry, err = mount.ParseInfoEntry(
 		"36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue")
 	c.Assert(err, IsNil)
-	c.Assert(entry.MountOptions, Equals, "rw,noatime")
+	c.Assert(entry.MountOptions, DeepEquals, map[string]string{"rw": "", "noatime": ""})
 	c.Assert(entry.OptionalFields, DeepEquals, []string{"master:1"})
 	c.Assert(entry.FsType, Equals, "ext3")
 	// Two optional fields.
 	entry, err = mount.ParseInfoEntry(
 		"36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 slave:2 - ext3 /dev/root rw,errors=continue")
 	c.Assert(err, IsNil)
-	c.Assert(entry.MountOptions, Equals, "rw,noatime")
+	c.Assert(entry.MountOptions, DeepEquals, map[string]string{"rw": "", "noatime": ""})
 	c.Assert(entry.OptionalFields, DeepEquals, []string{"master:1", "slave:2"})
 	c.Assert(entry.FsType, Equals, "ext3")
 }
@@ -83,12 +83,12 @@ func (s *mountinfoSuite) TestParseInfoEntry3(c *C) {
 	c.Assert(entry.DevMinor, Equals, 0)
 	c.Assert(entry.Root, Equals, "/mnt 1")
 	c.Assert(entry.MountDir, Equals, "/mnt 2")
-	c.Assert(entry.MountOptions, Equals, "rw ,noatime")
+	c.Assert(entry.MountOptions, DeepEquals, map[string]string{"rw ": "", "noatime": ""})
 	// This field is still escaped as it is space-separated and needs further parsing.
 	c.Assert(entry.OptionalFields, DeepEquals, []string{"mas ter:1"})
 	c.Assert(entry.FsType, Equals, "ext 3")
 	c.Assert(entry.MountSource, Equals, "/dev/ro ot")
-	c.Assert(entry.SuperOptions, Equals, "rw ,errors=continue")
+	c.Assert(entry.SuperOptions, DeepEquals, map[string]string{"rw ": "", "errors": "continue"})
 }
 
 // Check that various malformed entries are detected.


### PR DESCRIPTION
Mount options are comma-separated string of key=value pairs or just
plain values. This patch changes the mountinfo parser to parse the mount
and superblock options this way.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>