### PR TITLE
tests: copy snap-confine apparmor profile into testbed

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -27,10 +27,10 @@ update_core_snap_for_classic_reexec() {
     unsquashfs "$snap"
     cp -a /usr/lib/snapd/snap-exec squashfs-root/usr/lib/snapd/
     cp -a /usr/bin/snapctl squashfs-root/usr/bin/
-    cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine.real squashfs-root/etc/apparmor.d/
     # also inject new version of snap-confine and snap-scard-ns
     cp -a /usr/lib/snapd/snap-discard-ns squashfs-root/usr/lib/snapd/
     cp -a /usr/lib/snapd/snap-confine squashfs-root/usr/lib/snapd/
+    cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine* squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine.real
     # also add snap/snapd because we re-exec by default and want to test
     # this version
     cp -a /usr/lib/snapd/snapd squashfs-root/usr/lib/snapd/

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -27,6 +27,7 @@ update_core_snap_for_classic_reexec() {
     unsquashfs "$snap"
     cp -a /usr/lib/snapd/snap-exec squashfs-root/usr/lib/snapd/
     cp -a /usr/bin/snapctl squashfs-root/usr/bin/
+    cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine.real squashfs-root/etc/apparmor.d/
     # also inject new version of snap-confine and snap-scard-ns
     cp -a /usr/lib/snapd/snap-discard-ns squashfs-root/usr/lib/snapd/
     cp -a /usr/lib/snapd/snap-confine squashfs-root/usr/lib/snapd/


### PR DESCRIPTION
Ever since we started executing snap-confine from the core snap we rely
on a copy of the apparmor profile from the Debian package to generate
the apparmor profile for snap-confine in the core snap.

My recent changes to the snap-confine required an update to the profile
and I noticed that all the test have failed because apparmor profile
in the core snap was not kept up-to-date.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>