### PR TITLE
interfaces/builtin: allow full access to properties iface of the udisks service

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -127,11 +127,10 @@ const udisks2ConnectedPlugAppArmor = `
 
 #include <abstractions/dbus-strict>
 
-dbus (receive)
+dbus (receive, send)
     bus=system
     path=/org/freedesktop/UDisks2/**
     interface=org.freedesktop.DBus.Properties
-    member=PropertiesChanged
     peer=(label=###SLOT_SECURITY_TAGS###),
 
 dbus (receive, send)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/snappy/+bug/1683364