### PR TITLE
interfaces/mount: pass mount.Profile to mount.NeededChanges

### DIFF
--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -48,12 +48,12 @@ type Change struct {
 // lists are processed and a "diff" of mount changes is produced. The mount
 // changes, when applied in order, transform the current profile into the
 // desired profile.
-func NeededChanges(currentProfile, desiredProfile []Entry) []Change {
-	// Copy both as we will want to mutate them.
-	current := make([]Entry, len(currentProfile))
-	copy(current, currentProfile)
-	desired := make([]Entry, len(desiredProfile))
-	copy(desired, desiredProfile)
+func NeededChanges(currentProfile, desiredProfile *Profile) []Change {
+	// Copy both profiles as we will want to mutate them.
+	current := make([]Entry, len(currentProfile.Entries))
+	copy(current, currentProfile.Entries)
+	desired := make([]Entry, len(desiredProfile.Entries))
+	copy(desired, desiredProfile.Entries)
 
 	// Clean the directory part of both profiles. This is done so that we can
 	// easily test if a given directory is a subdirectory with

--- a/interfaces/mount/change_test.go
+++ b/interfaces/mount/change_test.go
@@ -31,45 +31,47 @@ var _ = Suite(&changeSuite{})
 
 // When there are no profiles we don't do anything.
 func (s *changeSuite) TestNeededChangesNoProfiles(c *C) {
-	changes := mount.NeededChanges(nil, nil)
+	current := &mount.Profile{}
+	desired := &mount.Profile{}
+	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, IsNil)
 }
 
 // When the profiles are the same we don't do anything.
 func (s *changeSuite) TestNeededChangesNoChange(c *C) {
-	current := []mount.Entry{{Dir: "/common/stuf"}}
-	desired := []mount.Entry{{Dir: "/common/stuf"}}
+	current := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
+	desired := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, IsNil)
 }
 
 // When the content interface is connected we should mount the new entry.
 func (s *changeSuite) TestNeededChangesTrivialMount(c *C) {
-	var current []mount.Entry
-	desired := []mount.Entry{{Dir: "/common/stuf"}}
+	current := &mount.Profile{}
+	desired := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Entry: desired[0], Action: mount.Mount},
+		{Entry: desired.Entries[0], Action: mount.Mount},
 	})
 }
 
 // When the content interface is disconnected we should unmount the mounted entry.
 func (s *changeSuite) TestNeededChangesTrivialUnmount(c *C) {
-	current := []mount.Entry{{Dir: "/common/stuf"}}
-	var desired []mount.Entry
+	current := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
+	desired := &mount.Profile{}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
-		{Entry: current[0], Action: mount.Unmount},
+		{Entry: current.Entries[0], Action: mount.Unmount},
 	})
 }
 
 // When umounting we unmount children before parents.
 func (s *changeSuite) TestNeededChangesUnmountOrder(c *C) {
-	current := []mount.Entry{
+	current := &mount.Profile{Entries: []mount.Entry{
 		{Dir: "/common/stuf/extra"},
 		{Dir: "/common/stuf"},
-	}
-	var desired []mount.Entry
+	}}
+	desired := &mount.Profile{}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
 		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: mount.Unmount},
@@ -79,11 +81,11 @@ func (s *changeSuite) TestNeededChangesUnmountOrder(c *C) {
 
 // When mounting we mount the parents before the children.
 func (s *changeSuite) TestNeededChangesMountOrder(c *C) {
-	var current []mount.Entry
-	desired := []mount.Entry{
+	current := &mount.Profile{}
+	desired := &mount.Profile{Entries: []mount.Entry{
 		{Dir: "/common/stuf/extra"},
 		{Dir: "/common/stuf"},
-	}
+	}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
 		{Entry: mount.Entry{Dir: "/common/stuf"}, Action: mount.Mount},
@@ -93,16 +95,16 @@ func (s *changeSuite) TestNeededChangesMountOrder(c *C) {
 
 // When parent changes we don't reuse its children
 func (s *changeSuite) TestNeededChangesChangedParentSameChild(c *C) {
-	current := []mount.Entry{
+	current := &mount.Profile{Entries: []mount.Entry{
 		{Dir: "/common/stuf", Name: "/dev/sda1"},
 		{Dir: "/common/stuf/extra"},
 		{Dir: "/common/unrelated"},
-	}
-	desired := []mount.Entry{
+	}}
+	desired := &mount.Profile{Entries: []mount.Entry{
 		{Dir: "/common/stuf", Name: "/dev/sda2"},
 		{Dir: "/common/stuf/extra"},
 		{Dir: "/common/unrelated"},
-	}
+	}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
 		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: mount.Unmount},
@@ -114,16 +116,16 @@ func (s *changeSuite) TestNeededChangesChangedParentSameChild(c *C) {
 
 // When child changes we don't touch the unchanged parent
 func (s *changeSuite) TestNeededChangesSameParentChangedChild(c *C) {
-	current := []mount.Entry{
+	current := &mount.Profile{Entries: []mount.Entry{
 		{Dir: "/common/stuf"},
 		{Dir: "/common/stuf/extra", Name: "/dev/sda1"},
 		{Dir: "/common/unrelated"},
-	}
-	desired := []mount.Entry{
+	}}
+	desired := &mount.Profile{Entries: []mount.Entry{
 		{Dir: "/common/stuf"},
 		{Dir: "/common/stuf/extra", Name: "/dev/sda2"},
 		{Dir: "/common/unrelated"},
-	}
+	}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
 		{Entry: mount.Entry{Dir: "/common/stuf/extra", Name: "/dev/sda1"}, Action: mount.Unmount},
@@ -137,17 +139,17 @@ func (s *changeSuite) TestNeededChangesSameParentChangedChild(c *C) {
 // We are smart about comparing entries as directories. Here even though "/a/b"
 // is a prefix of "/a/b-1" it is correctly reused.
 func (s *changeSuite) TestNeededChangesSmartEntryComparison(c *C) {
-	current := []mount.Entry{
+	current := &mount.Profile{Entries: []mount.Entry{
 		{Dir: "/a/b", Name: "/dev/sda1"},
 		{Dir: "/a/b-1"},
 		{Dir: "/a/b-1/3"},
 		{Dir: "/a/b/c"},
-	}
-	desired := []mount.Entry{
+	}}
+	desired := &mount.Profile{Entries: []mount.Entry{
 		{Dir: "/a/b", Name: "/dev/sda2"},
 		{Dir: "/a/b-1"},
 		{Dir: "/a/b/c"},
-	}
+	}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
 		{Entry: mount.Entry{Dir: "/a/b/c"}, Action: mount.Unmount},


### PR DESCRIPTION
This just updates the interface after the mount.Profile type was created.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>