### PR TITLE
interfaces/mount: add stub Change.{Needed,Perform}

### DIFF
--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -42,6 +42,21 @@ type Change struct {
 	Action Action
 }
 
+// Needed returns true if the change needs to be performed in the context of mount table.
+func (c Change) Needed(mounted []*InfoEntry) bool {
+	// Look through what is mounted and see if we shold perform the change. If
+	// the entry is already mounted then we don't need to mount it, if the
+	// entry is already unmounted then we don't need to unmount it.
+
+	// TODO: implement this
+	return true
+}
+
+func (c Change) Perform() error {
+	// TODO merge https://github.com/snapcore/snapd/pull/3138
+	return nil
+}
+
 // NeededChanges computes the changes required to change current to desired mount entries.
 //
 // The current and desired profiles is a fstab like list of mount entries. The


### PR DESCRIPTION
Those two stubs will be implemented for real in separate PRs but I need
them in the API to show the idea of how snap-update-ns algorithm looks
like.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>