### PR TITLE
interfaces: re-add reverted ioctl and quotactl (revert 21bc6b9f)

### DIFF
--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -49,13 +49,11 @@ const mountObserveConnectedPlugSecComp = `
 # restricted because it gives privileged read access to mount arguments and
 # should only be used with trusted apps.
 
-# FIXME: restore quotactl with parameter filtering once snap-confine can read
-# this syntax. See LP:#1662489 for context.
-#quotactl Q_GETQUOTA - - -
-#quotactl Q_GETINFO - - -
-#quotactl Q_GETFMT - - -
-#quotactl Q_XGETQUOTA - - -
-#quotactl Q_XGETQSTAT - - -
+quotactl Q_GETQUOTA - - -
+quotactl Q_GETINFO - - -
+quotactl Q_GETFMT - - -
+quotactl Q_XGETQUOTA - - -
+quotactl Q_XGETQSTAT - - -
 `
 
 // NewMountObserveInterface returns a new "mount-observe" interface.

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -165,10 +165,7 @@ inotify_rm_watch
 
 # TIOCSTI allows for faking input (man tty_ioctl)
 # TODO: this should be scaled back even more
-#ioctl - !TIOCSTI
-# FIXME: replace this with the filter of TIOCSTI once snap-confine can read this syntax
-# See LP:#1662489 for context.
-ioctl
+ioctl - !TIOCSTI
 
 io_cancel
 io_destroy


### PR DESCRIPTION
This reverts https://github.com/snapcore/snapd/commit/21bc6b9ffc327a726c790b21ecc4dc4fbc427c14 now that snap-confine is re-exec'd.