### PR TITLE
tests: handle case when both .real and plain are present

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -30,7 +30,11 @@ update_core_snap_for_classic_reexec() {
     # also inject new version of snap-confine and snap-scard-ns
     cp -a /usr/lib/snapd/snap-discard-ns squashfs-root/usr/lib/snapd/
     cp -a /usr/lib/snapd/snap-confine squashfs-root/usr/lib/snapd/
-    cp -a -t squashfs-root/etc/apparmor.d/ /etc/apparmor.d/usr.lib.snapd.snap-confine*
+    if [ -e /etc/apparmor.d/usr.lib.snapd.snap-confine.real ]; then
+        cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine.real squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine
+    else
+        cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine      squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine
+    fi
     # also add snap/snapd because we re-exec by default and want to test
     # this version
     cp -a /usr/lib/snapd/snapd squashfs-root/usr/lib/snapd/

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -30,7 +30,7 @@ update_core_snap_for_classic_reexec() {
     # also inject new version of snap-confine and snap-scard-ns
     cp -a /usr/lib/snapd/snap-discard-ns squashfs-root/usr/lib/snapd/
     cp -a /usr/lib/snapd/snap-confine squashfs-root/usr/lib/snapd/
-    cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine* squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine.real
+    cp -a -t squashfs-root/etc/apparmor.d/ /etc/apparmor.d/usr.lib.snapd.snap-confine*
     # also add snap/snapd because we re-exec by default and want to test
     # this version
     cp -a /usr/lib/snapd/snapd squashfs-root/usr/lib/snapd/


### PR DESCRIPTION
The testbed setup copies the apparmor profile of snap-confine into the
repackaged core snap. The file may be named either
usr.lib.snapd.snap-confine or usr.lib.snapd.snap-confine.real. In some
circumstances both files may be present and the copy command choked on
this. This patch fixes it.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>