### PR TITLE
interfaces/mount: add ReadMountInfo and LoadMountInfo

### DIFF
--- a/interfaces/mount/mountinfo_test.go
+++ b/interfaces/mount/mountinfo_test.go
@@ -143,8 +143,7 @@ func (s *profileSuite) TestReadMountInfo2(c *C) {
 
 // Test that loading mountinfo from a file works as expected.
 func (s *profileSuite) TestLoadMountInfo1(c *C) {
-	dir := c.MkDir()
-	fname := filepath.Join(dir, "mountinfo")
+	fname := filepath.Join(c.MkDir(), "mountinfo")
 	err := ioutil.WriteFile(fname, []byte(mountInfoSample), 0644)
 	c.Assert(err, IsNil)
 	entries, err := mount.LoadMountInfo(fname)
@@ -154,8 +153,7 @@ func (s *profileSuite) TestLoadMountInfo1(c *C) {
 
 // Test that loading mountinfo from a missing file reports an error.
 func (s *profileSuite) TestLoadMountInfo2(c *C) {
-	dir := c.MkDir()
-	fname := filepath.Join(dir, "mountinfo")
+	fname := filepath.Join(c.MkDir(), "mountinfo")
 	_, err := mount.LoadMountInfo(fname)
 	c.Assert(err, ErrorMatches, "*. no such file or directory")
 }


### PR DESCRIPTION
This patch adds a pair of functions for reading mountinfo data and for
loading mountinfo data from a file. They are going to be used by
snap-update-ns shortly.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>