### PR TITLE
interfaces/builtin: don't panic if content plug has nil attrs

### DIFF
--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -77,6 +77,9 @@ func (iface *ContentInterface) SanitizePlug(plug *interfaces.Plug) error {
 	}
 	content, ok := plug.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
+		if plug.Attrs == nil {
+			plug.Attrs = make(map[string]interface{})
+		}
 		// content defaults to "plug" name if unspecified
 		plug.Attrs["content"] = plug.Name
 	}

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -179,6 +179,20 @@ plugs:
 	c.Assert(err, ErrorMatches, "content interface target path is not clean:.*")
 }
 
+func (s *ContentSuite) TestSanitizePlugNilAttrMap(c *C) {
+	const mockSnapYaml = `name: content-slot-snap
+version: 1.0
+apps:
+  foo:
+    command: foo
+    plugs: [content]
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	plug := &interfaces.Plug{PlugInfo: info.Plugs["content"]}
+	err := s.iface.SanitizePlug(plug)
+	c.Assert(err, ErrorMatches, "content plug must contain target path")
+}
+
 func (s *ContentSuite) TestResolveSpecialVariable(c *C) {
 	info := snaptest.MockInfo(c, "name: name", &snap.SideInfo{Revision: snap.R(42)})
 	c.Check(builtin.ResolveSpecialVariable("foo", info), Equals, "/snap/name/42/foo")


### PR DESCRIPTION
This patch fixes a bug that was reported on the forum
https://forum.snapcraft.io/t/snapd-service-doesnt-start/319

A plug that has nil attr map will fail to sanitize and will cause a
panic instead. This patch fixes the issue so that the plug can correctly
sanitize and return an error.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>