### PR TITLE
interfaces: recover panics when sanitizing plugs and slots

### DIFF
--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -186,3 +186,31 @@ func ValidateDBusBusName(busName string) error {
 	}
 	return nil
 }
+
+// SanitizePlug sanitizes the given plug with the given interface recovering panics.
+func SanitizePlug(iface Interface, plug *Plug) error {
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("cannot sanitize plug %q with interface %q, panicked: %s", plug.Name, iface.Name(), r)
+			}
+		}()
+		err = iface.SanitizePlug(plug)
+	}()
+	return err
+}
+
+// SanitizeSlot sanitizes the given slot with the given interface recovering panics.
+func SanitizeSlot(iface Interface, slot *Slot) error {
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("cannot sanitize slot %q with interface %q, panicked: %s", slot.Name, iface.Name(), r)
+			}
+		}()
+		err = iface.SanitizeSlot(slot)
+	}()
+	return err
+}

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -154,7 +154,7 @@ func (r *Repository) AddPlug(plug *Plug) error {
 		return fmt.Errorf("cannot add plug, interface %q is not known", plug.Interface)
 	}
 	// Reject plug that don't pass interface-specific sanitization
-	if err := i.SanitizePlug(plug); err != nil {
+	if err := SanitizePlug(i, plug); err != nil {
 		return fmt.Errorf("cannot add plug: %v", err)
 	}
 	if _, ok := r.plugs[snapName][plug.Name]; ok {
@@ -253,7 +253,7 @@ func (r *Repository) AddSlot(slot *Slot) error {
 	if i == nil {
 		return fmt.Errorf("cannot add slot, interface %q is not known", slot.Interface)
 	}
-	if err := i.SanitizeSlot(slot); err != nil {
+	if err := SanitizeSlot(i, slot); err != nil {
 		return fmt.Errorf("cannot add slot: %v", err)
 	}
 	if _, ok := r.slots[snapName][slot.Name]; ok {
@@ -783,7 +783,7 @@ func (r *Repository) AddSnap(snapInfo *snap.Info) error {
 			continue
 		}
 		plug := &Plug{PlugInfo: plugInfo}
-		if err := iface.SanitizePlug(plug); err != nil {
+		if err := SanitizePlug(iface, plug); err != nil {
 			bad.issues[plugName] = err.Error()
 			continue
 		}
@@ -805,7 +805,7 @@ func (r *Repository) AddSnap(snapInfo *snap.Info) error {
 			continue
 		}
 		slot := &Slot{SlotInfo: slotInfo}
-		if err := iface.SanitizeSlot(slot); err != nil {
+		if err := SanitizeSlot(iface, slot); err != nil {
 			bad.issues[slotName] = err.Error()
 			continue
 		}


### PR DESCRIPTION
This branch makes snapd more robust against denial of service attacks in case the interface code that is responsible for sanitization of user-controlled plug/slot definition itself panics.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>