### PR TITLE
interfaces/mount: add partial implementation of Change.Needed

### DIFF
--- a/interfaces/mount/mountinfo_test.go
+++ b/interfaces/mount/mountinfo_test.go
@@ -29,6 +29,17 @@ type mountinfoSuite struct{}
 
 var _ = Suite(&mountinfoSuite{})
 
+// mockMountInfo returns parsed list of mountinfo entries, one for each line.
+func mockMountInfo(c *C, lines ...string) []*mount.InfoEntry {
+	entries := make([]*mount.InfoEntry, 0, len(lines))
+	for _, line := range lines {
+		entry, err := mount.ParseInfoEntry(line)
+		c.Assert(err, IsNil)
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
 // Check that parsing the example from kernel documentation works correctly.
 func (s *mountinfoSuite) TestParseInfoEntry1(c *C) {
 	entry, err := mount.ParseInfoEntry(


### PR DESCRIPTION
This patch adds a partial implementation of Change.Needed that works for
things that aren't bind mounted. Bind mounting requires some additional
detection because the fstab entry doesn't contain the whole information
and that needs to be reconstructed by looking at mountinfo.

To be precise, the source of the bind mount is only defined indirectly.
In a simple bind mount /src -> /dst the /src is a "pointer" to whatever
is mounted there (cound be something mounted directly at /src or could
be a fragment of the bigger mount at /).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>