### PR TITLE
[2.24] tests: relax network-bind interface regexps

### DIFF
--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -44,7 +44,7 @@ execute: |
     snap install --${CORE_CHANNEL} ubuntu-core
     snap install test-snapd-python-webserver
     snap interfaces | MATCH ":network +test-snapd-python-webserver"
-    snap interfaces | MATCH ":network-bind +test-snapd-python-webserver"
+    snap interfaces | MATCH ":network-bind +.*test-snapd-python-webserver"
 
     echo "Ensure the webserver is working"
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
@@ -71,7 +71,8 @@ execute: |
         exit 1
     fi
     snap interfaces | MATCH ":network +test-snapd-python-webserver"
-    snap interfaces | MATCH ":network-bind +test-snapd-python-webserver" 
+    snap interfaces | MATCH ":network-bind +.*test-snapd-python-webserver"
+ and stable core
     echo "Ensure the webserver is still working"
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
     curl http://localhost | MATCH "XKCD rocks"

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -35,7 +35,7 @@ restore: |
 execute: |
     CONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
-    :network-bind +$SNAP_NAME"
+    :network-bind +.*$SNAP_NAME"
     DISCONNECTED_PATTERN="(?s)Slot +Plug\n\
     .*?\n\
     - +$SNAP_NAME:network-bind"


### PR DESCRIPTION
Port to 2.24 so that we have it in the 2.24 branch in case we need to do another release.

This ensures that the tests work with both the edge and the stable core snap. The stable core snap still has network-bind interface but the edge,beta,candidate core does not.

We can revert this again once the stable core with 2.23.6 is released.