### PR TITLE
snap: require snap name for 'revert'

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -853,7 +853,7 @@ type cmdRevert struct {
 	Revision   string `long:"revision"`
 	Positional struct {
 		Snap installedSnapName `positional-arg-name:"<snap>"`
-	} `positional-args:"yes"`
+	} `positional-args:"yes" required:"yes"`
 }
 
 var shortRevertHelp = i18n.G("Reverts the given snap to the previous state")

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -446,6 +446,12 @@ func (s *SnapOpSuite) TestRevertClassic(c *check.C) {
 	s.runRevertTest(c, &client.SnapOptions{Classic: true})
 }
 
+func (s *SnapOpSuite) TestRevertMissingName(c *check.C) {
+	_, err := snap.Parser().ParseArgs([]string{"revert"})
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, "the required argument `<snap>` was not provided")
+}
+
 func (s *SnapSuite) TestRefreshList(c *check.C) {
 	n := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This fixes the confusing error message from 'snap revert':
https://bugs.launchpad.net/snapd/+bug/1674758