### PR TITLE
tests: address review comments from #3186

### DIFF
--- a/tests/lib/apt.sh
+++ b/tests/lib/apt.sh
@@ -9,3 +9,17 @@ apt_install_local() {
         apt install -y "$@"
     fi
 }
+
+install_build_snapd(){
+    if [ "$SRU_VALIDATION" = "1" ]; then
+        apt install -y snapd
+        cp /etc/apt/sources.list sources.list.back
+        echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -c -s)-proposed restricted main multiverse universe" | tee /etc/apt/sources.list -a
+        apt update
+        apt install -y --only-upgrade snapd
+        mv sources.list.back /etc/apt/sources.list
+        apt update
+    else
+        apt_install_local ${GOPATH}/snapd_*.deb
+    fi
+}

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -57,16 +57,6 @@ update_core_snap_for_classic_reexec() {
     done
 }
 
-upgrade_snapd_from_proposed(){
-    apt install -y snapd
-    cp /etc/apt/sources.list sources.list.back
-    echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -c -s)-proposed restricted main multiverse universe" | tee /etc/apt/sources.list -a
-    apt update
-    apt install -y --only-upgrade snapd
-    mv sources.list.back /etc/apt/sources.list
-    apt update
-}
-
 prepare_each_classic() {
     mkdir -p /etc/systemd/system/snapd.service.d
     if [ -z "${SNAP_REEXEC:-}" ]; then
@@ -84,11 +74,7 @@ EOF
 }
 
 prepare_classic() {
-    if [ "$SRU_VALIDATION" = "1" ]; then
-        upgrade_snapd_from_proposed
-    else
-        apt_install_local ${GOPATH}/snapd_*.deb
-    fi
+    install_build_snapd
     if snap --version |MATCH unknown; then
         echo "Package build incorrect, 'snap --version' mentions 'unknown'"
         snap --version

--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -10,7 +10,7 @@ execute: |
     . "$TESTSLIB/apt.sh"
     echo "Ensure core is gone and we have ubuntu-core instead"
     dpkg --purge --force-depends snapd
-    apt-get install -f
+    apt-get install -f -y
     install_build_snapd
     snap install --${CORE_CHANNEL} ubuntu-core
 

--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -10,6 +10,7 @@ execute: |
     . "$TESTSLIB/apt.sh"
     echo "Ensure core is gone and we have ubuntu-core instead"
     dpkg --purge --force-depends snapd
+    apt-get install -f
     install_build_snapd
     snap install --${CORE_CHANNEL} ubuntu-core
 

--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -9,12 +9,8 @@ kill-timeout: 5m
 execute: |
     . "$TESTSLIB/apt.sh"
     echo "Ensure core is gone and we have ubuntu-core instead"
-    dpkg --purge snapd
-    if [ "$SRU_VALIDATION" = "1" ]; then
-        upgrade_snapd_from_proposed
-    else
-        apt_install_local ${GOPATH}/snapd_*.deb
-    fi
+    dpkg --purge --force-depends snapd
+    install_build_snapd
     snap install --${CORE_CHANNEL} ubuntu-core
 
     mkdir -p /root/.snap/

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -29,12 +29,8 @@ execute: |
 
     . "$TESTSLIB/apt.sh"
     echo "Ensure core is gone and we have ubuntu-core instead"
-    dpkg --purge snapd
-    if [ "$SRU_VALIDATION" = "1" ]; then
-        upgrade_snapd_from_proposed
-    else
-        apt_install_local ${GOPATH}/snapd_*.deb
-    fi
+    dpkg --purge --force-depends snapd
+    install_build_snapd
 
     # modify daemon state to set ubuntu-core-transition-last-retry-time to the
     # current time to prevent the ubuntu-core transition before the test snap is

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -30,7 +30,7 @@ execute: |
     . "$TESTSLIB/apt.sh"
     echo "Ensure core is gone and we have ubuntu-core instead"
     dpkg --purge --force-depends snapd
-    apt-get install -f
+    apt-get install -f -y
     install_build_snapd
 
     # modify daemon state to set ubuntu-core-transition-last-retry-time to the

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -30,6 +30,7 @@ execute: |
     . "$TESTSLIB/apt.sh"
     echo "Ensure core is gone and we have ubuntu-core instead"
     dpkg --purge --force-depends snapd
+    apt-get install -f
     install_build_snapd
 
     # modify daemon state to set ubuntu-core-transition-last-retry-time to the


### PR DESCRIPTION
Apart from refactoring the common code to `install_build_snap` as suggested in #3186, a `--force-depends` is called in the `dpkg --purge` call included in the transition tests to prevent complains from snap-confine (the only goal of the uninstall is removing the core snap, snapd is installed again right after that).