### PR TITLE
cmd/snap-update-ns: add actual implementation

### DIFF
--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -25,6 +25,9 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -53,12 +56,68 @@ func run() error {
 	if err := parseArgs(os.Args[1:]); err != nil {
 		return err
 	}
+
 	// There is some C code that runs before main() is started.
 	// That code always runs and sets an error condition if it fails.
 	// Here we just check for the error.
 	if err := BootstrapError(); err != nil {
 		return err
 	}
-	// TODO: implement this
-	return fmt.Errorf("not implemented")
+
+	// TODO: lock the mount namespace so that concurrent invocations of
+	// snap-confine are synchronized. This should be done only after
+	// https://github.com/snapcore/snapd/pull/3149 lands so that we can use the
+	// lock at "/run/snapd/lock/$SNAP_NAME.lock"
+
+	// Read the current and desired mount profiles. Note that missing files
+	// count as empty profiles so that we can gracefully handle a mount
+	// interface connection/disconnection.
+	snapName := opts.Positionals.SnapName
+	currentProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapMountPolicyDir, snapName)
+	desiredProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapRunNsDir, snapName)
+	current, err := mount.LoadProfile(currentProfilePath)
+	if err != nil {
+		return fmt.Errorf("cannot load current mount profile: %s", err)
+	}
+	desired, err := mount.LoadProfile(desiredProfilePath)
+	if err != nil {
+		return fmt.Errorf("cannot load desired mount profile: %s", err)
+	}
+
+	// Compute the needed changes and perform each change if needed, collecting
+	// those that we managed to perform or that were performed already.
+	changesNeeded := mount.NeededChanges(current, desired)
+	var changesMade []mount.Change
+	for _, change := range changesNeeded {
+		// Read mount info each time as our operations may have unexpected
+		// consequences and we want to know the real state of what is mounted
+		// at each iteration.
+		mounted, err := mount.LoadMountInfo(mount.ProcSelfMountInfo)
+		if err != nil {
+			return fmt.Errorf("cannot read mount-info table: %s", err)
+		}
+		if !change.Needed(mounted) {
+			changesMade = append(changesMade, change)
+			continue
+		}
+		fmt.Printf("%s", change)
+		if err := change.Perform(); err != nil {
+			logger.Noticef("cannot perform mount change %s: %s", change, err)
+			continue
+		}
+		changesMade = append(changesMade, change)
+	}
+
+	// Compute the new current profile so that it contains only changes that were made
+	// and save it back for next runs.
+	current = &mount.Profile{
+		Entries: make([]mount.Entry, 0, len(changesMade)),
+	}
+	for _, change := range changesMade {
+		current.Entries = append(current.Entries, change.Entry)
+	}
+	if err := current.Save(currentProfilePath); err != nil {
+		return fmt.Errorf("cannot save current mount profile: %s", err)
+	}
+	return nil
 }


### PR DESCRIPTION
This patch adds a non-dummy implementation of snap-update-ns. There
are still three pieces missing. There's no locking so concurrently
running snap-confine is not synchronized. The function that determines
if a mount change is needed is dummy and always returns true.
The mount changes are not really performed yet as the Perform function
is just a stub.

The stubs will be addressed with separate PRs (one is already up), I just
wanted to land the general idea of how the tool operates.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>