### PR TITLE
interfaces: allow writing to /run/systemd/journal/stdout by default

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -169,6 +169,7 @@ var defaultTemplate = `
   /{,usr/}bin/stat ixr,
   /{,usr/}bin/stdbuf ixr,
   /{,usr/}bin/stty ixr,
+  /{,usr/}bin/systemd-cat ixr,
   /{,usr/}bin/tac ixr,
   /{,usr/}bin/tail ixr,
   /{,usr/}bin/tar ixr,
@@ -220,6 +221,8 @@ var defaultTemplate = `
   # systemd native journal API (see sd_journal_print(4)). This should be in
   # AppArmor's base abstraction, but until it is, include here.
   /run/systemd/journal/socket w,
+  /run/systemd/journal/stdout rw, # 'r' shouldn't be needed, but journald
+                                  # doesn't leak anything so allow
 
   # snapctl and its requirements
   /usr/bin/snapctl ixr,


### PR DESCRIPTION
This is to address no log output when snaps are run inside lxd (https://forum.snapcraft.io/t/snaps-daemons-have-no-log-when-running-in-lxc/328) but it also allows snaps to use systemd-cat to connect a program's stdout to the journal.