### PR TITLE
many: mount squashfs as read-only

### DIFF
--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -84,7 +84,7 @@ Description=Mount unit for foo
 What=/var/lib/snapd/snaps/foo_13.snap
 Where=/snap/foo/13
 Type=squashfs
-Options=nodev
+Options=nodev,ro
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -438,11 +438,14 @@ func MountUnitPath(baseDir string) string {
 
 func (s *systemd) WriteMountUnitFile(name, what, where, fstype string) (string, error) {
 	options := []string{"nodev"}
+	if fstype == "squashfs" {
+		options = append(options, "ro")
+	}
 	if osutil.IsDirectory(what) {
 		options = append(options, "bind")
 		fstype = "none"
 	} else if fstype == "squashfs" && useFuse() {
-		options = append(options, []string{"ro", "allow_other"}...)
+		options = append(options, "allow_other")
 		fstype = "fuse.squashfuse"
 	}
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -300,7 +300,7 @@ Description=Mount unit for foo
 What=%s
 Where=/apps/foo/1.0
 Type=squashfs
-Options=nodev
+Options=nodev,ro
 
 [Install]
 WantedBy=multi-user.target
@@ -323,7 +323,7 @@ Description=Mount unit for foodir
 What=%s
 Where=/apps/foo/1.0
 Type=none
-Options=nodev,bind
+Options=nodev,ro,bind
 
 [Install]
 WantedBy=multi-user.target
@@ -419,7 +419,7 @@ Description=Mount unit for foo
 What=%s
 Where=/apps/foo/1.0
 Type=squashfs
-Options=nodev
+Options=nodev,ro
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is a cosmetic change because they are read only in general but
it helps to cure my nerves whenever I see "rw" next to one.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>