### PR TITLE
interfaces/mount: write current fstab files with mode 0644

### DIFF
--- a/interfaces/mount/profile.go
+++ b/interfaces/mount/profile.go
@@ -57,7 +57,7 @@ func (p *Profile) Save(fname string) error {
 	if _, err := p.WriteTo(&buf); err != nil {
 		return err
 	}
-	return osutil.AtomicWriteFile(fname, buf.Bytes(), 0600, osutil.AtomicWriteFlags(0))
+	return osutil.AtomicWriteFile(fname, buf.Bytes(), 0644, osutil.AtomicWriteFlags(0))
 }
 
 // ReadProfile reads and parses a mount profile.

--- a/interfaces/mount/profile_test.go
+++ b/interfaces/mount/profile_test.go
@@ -22,6 +22,7 @@ package mount_test
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -67,6 +68,11 @@ func (s *profileSuite) TestSaveProfile1(c *C) {
 	}
 	err := p.Save(fname)
 	c.Assert(err, IsNil)
+
+	stat, err := os.Stat(fname)
+	c.Assert(err, IsNil)
+	c.Assert(stat.Mode().Perm(), Equals, os.FileMode(0644))
+
 	data, err := ioutil.ReadFile(fname)
 	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals, "name-1 dir-1 type-1 options-1 1 1\n")


### PR DESCRIPTION
The files are not secret in any way and it is sufficient to make
them read-only for everyone else.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>