### PR TITLE
tests: copy .real profile as .real

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -31,9 +31,9 @@ update_core_snap_for_classic_reexec() {
     cp -a /usr/lib/snapd/snap-discard-ns squashfs-root/usr/lib/snapd/
     cp -a /usr/lib/snapd/snap-confine squashfs-root/usr/lib/snapd/
     if [ -e /etc/apparmor.d/usr.lib.snapd.snap-confine.real ]; then
-        cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine.real squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine
+        cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine.real squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine.real
     else
-        cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine      squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine
+        cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine      squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine.real
     fi
     # also add snap/snapd because we re-exec by default and want to test
     # this version


### PR DESCRIPTION
The snap-confine apparmor profile comes in two flavours, one plain one and one
with the `.real` suffix appended. The one suffixed `.real` takes precedence at
runtime. During preparation of the test execution environment we copy one or
the other into the unpacked core snap. At runtime snap uses the profile present
in the core snap as a template for creating a new profile that is specific to
the revision of the core.

There was a bug where we would copy one or the other flavour of the file into
the unpacked core snap but without the `.real` suffix. The core snap always
contains the file with the .real suffix so this didn't have any effect.

This patch corrects this.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>