### PR TITLE
cmd/snap-discard-ns: remove current profile when cleaning up

### DIFF
--- a/tests/main/snap-discard-ns/task.yaml
+++ b/tests/main/snap-discard-ns/task.yaml
@@ -1,0 +1,23 @@
+summary: test that snap-discard-ns works as expected
+details: |
+    The internal command snap-discard-ns discards (unmounts) the
+    /run/snapd/ns/$SNAP_NAME.mnt file and removes the current mount profile
+    /run/snapd/ns/snap.$SNAP_NAME.fstab. The profile removal is optional and it
+    is not an error if it doesn't exist.
+prepare: |
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-tools
+execute: |
+    echo "We can discard the namespace before a snap app runs without errors"
+    /usr/lib/snapd/snap-discard-ns test-snapd-tools
+
+    test-snapd-tools.success
+
+    echo "We can discard the namespace after a snap app runs without errors"
+    /usr/lib/snapd/snap-discard-ns test-snapd-tools
+
+    echo "We can fake a current mount profile and see that it is removed too"
+    test-snapd-tools.success
+    touch /run/snapd/ns/snap.test-snapd-tools.fstab
+    /usr/lib/snapd/snap-discard-ns test-snapd-tools
+    test ! -e /run/snapd/ns/snap.test-snapd-tools.fstab


### PR DESCRIPTION
This patch changes snap-discard-ns to remove the current mount profile
when discarding the mount namespace. This will be done in anticipation
of update-ns landing everywhere. Since we ignore ENOENT the change is
harmless.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>