### PR TITLE
cmd/snap-confine: write current mount profile.

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -177,27 +177,36 @@ static void sc_setup_mount_profiles(const char *snap_name)
 {
 	debug("%s: %s", __FUNCTION__, snap_name);
 
-	FILE *f __attribute__ ((cleanup(sc_cleanup_endmntent))) = NULL;
-	const char *mount_profile_dir = "/var/lib/snapd/mount";
-
+	FILE *desired __attribute__ ((cleanup(sc_cleanup_endmntent))) = NULL;
+	FILE *current __attribute__ ((cleanup(sc_cleanup_endmntent))) = NULL;
 	char profile_path[PATH_MAX];
-	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/snap.%s.fstab",
-			 mount_profile_dir, snap_name);
 
-	debug("opening mount profile %s", profile_path);
-	f = setmntent(profile_path, "r");
-	// it is ok for the file to not exist
-	if (f == NULL && errno == ENOENT) {
-		debug("mount profile %s doesn't exist, ignoring", profile_path);
+	sc_must_snprintf(profile_path, sizeof(profile_path),
+			 "/run/snapd/ns/snap.%s.fstab", snap_name);
+	debug("opening current mount profile %s", profile_path);
+	current = setmntent(profile_path, "w");
+	if (current == NULL) {
+		die("cannot open current mount profile: %s", profile_path);
+	}
+
+	sc_must_snprintf(profile_path, sizeof(profile_path),
+			 "/var/lib/snapd/mount/snap.%s.fstab", snap_name);
+	debug("opening desired mount profile %s", profile_path);
+	desired = setmntent(profile_path, "r");
+	if (desired == NULL && errno == ENOENT) {
+		// It is ok for the desired profile to not exist. Note that in this
+		// case we also "update" the current profile as we already opened and
+		// truncated it above.
+		debug("desired mount profile %s doesn't exist, ignoring",
+		      profile_path);
 		return;
 	}
-	// however any other error is a real error
-	if (f == NULL) {
-		die("cannot open %s", profile_path);
+	if (desired == NULL) {
+		die("cannot open desired mount profile: %s", profile_path);
 	}
 
 	struct mntent *m = NULL;
-	while ((m = getmntent(f)) != NULL) {
+	while ((m = getmntent(desired)) != NULL) {
 		debug("read mount entry\n"
 		      "\tmnt_fsname: %s\n"
 		      "\tmnt_dir: %s\n"
@@ -219,6 +228,9 @@ static void sc_setup_mount_profiles(const char *snap_name)
 			flags &= ~MS_RDONLY;
 		}
 		sc_do_mount(m->mnt_fsname, m->mnt_dir, NULL, flags, NULL);
+		if (addmntent(current, m) != 0) {	// NOTE: returns 1 on error.
+			die("cannot append entry to the current mount profile");
+		}
 	}
 }
 

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -292,6 +292,7 @@
     /run/snapd/ns/ rw,
     /run/snapd/ns/*.lock rwk,
     /run/snapd/ns/*.mnt rw,
+    /run/snapd/ns/*.fstab rw,
     ptrace (read, readby, tracedby) peer=@LIBEXECDIR@/snap-confine//mount-namespace-capture-helper,
     @{PROC}/*/mountinfo r,
     capability sys_chroot,

--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -28,6 +28,9 @@ execute: |
     echo "And we can use the shared content"
     test-snapd-content-plug.content-plug | grep "Some shared content"
 
+    echo "And the current mount profile is the same as the desired mount profile"
+    diff -u /run/snapd/ns/snap.test-snapd-content-plug.fstab /var/lib/snapd/mount/snap.test-snapd-content-plug.fstab
+
     echo "============================================"
 
     echo "When the plug is disconnected"


### PR DESCRIPTION
This patch makes snap confine write the current mount profile whenver
the desired mount profile is being processed. The current mount profile
is stored in /run/snapd/ns/ and is going to be processed by
snap-update-ns.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>