### PR TITLE
tests: ensure travis fails early if static checks fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ install:
   - sudo apt-get install -qq gnupg1 || sudo apt-get install -qq gnupg
 
 script:
-    - ./run-checks --static
+    - ./run-checks --static || travis_terminate 1
     - ./run-checks --spread


### PR DESCRIPTION
Travis does not run the script section of itself with `set -e` so we need to manually do that (see https://github.com/travis-ci/travis-ci/issues/1066)

Includes a static failure to test that this really works. I will remove that once I got confirmation :)