### PR TITLE
cmd/snap-confine: re-enable re-assciate fix for CE

### DIFF
--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -138,15 +138,7 @@ int main(int argc, char **argv)
 			 * snap-specific namespace, has a predictable PID and is long
 			 * lived.
 			 */
-#if 0
-			// FIXME: this was reverted as requested by jdstrand because the
-			// corresponding fix in the kernel was reverted as well. It should
-			// be re-enabled with an upcoming kernel package that contains all
-			// of the apparmor fixes.
-			//
-			// https://github.com/snapcore/snapd/pull/2624#issuecomment-288732682
 			sc_reassociate_with_pid1_mount_ns();
-#endif
 
 			// Do global initialization:
 			int global_lock_fd = sc_lock_global();


### PR DESCRIPTION
This patch re-enables the re-associate fix that was previously commented
out. Just the code is enabled as the test relies on a kernel that is not
available yet (but it is used by CE projects already).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>