### PR TITLE
many: show alias changes on snap alias/unalias (aliases v2)

### DIFF
--- a/cmd/snap/cmd_alias.go
+++ b/cmd/snap/cmd_alias.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"text/tabwriter"
 
 	"github.com/jessevdk/go-flags"
@@ -80,8 +81,9 @@ func (x *cmdAlias) Execute(args []string) error {
 }
 
 type changedAlias struct {
-	Name   string `json:"name"`
-	Target string `json:"target"`
+	Snap  string `json:"snap"`
+	App   string `json:"app"`
+	Alias string `json"alias"`
 }
 
 func showAliasChanges(chg *client.Change) error {
@@ -94,17 +96,18 @@ func showAliasChanges(chg *client.Change) error {
 	}
 	w := tabwriter.NewWriter(Stdout, 2, 2, 1, ' ', 0)
 	if len(added) != 0 {
-		fmt.Fprintf(w, i18n.G("Added:\n"))
-		for _, ta := range added {
-			fmt.Fprintf(w, "\t- %s => %s\n", ta.Name, ta.Target)
-		}
+		printChangedAliases(w, i18n.G("Added"), added)
 	}
 	if len(removed) != 0 {
-		fmt.Fprintf(w, i18n.G("Removed:\n"))
-		for _, ta := range removed {
-			fmt.Fprintf(w, "\t- %s => %s\n", ta.Name, ta.Target)
-		}
+		printChangedAliases(w, i18n.G("Removed"), removed)
 	}
 	w.Flush()
 	return nil
+}
+
+func printChangedAliases(w io.Writer, label string, changed []*changedAlias) {
+	fmt.Fprintf(w, "%s:\n", label)
+	for _, a := range changed {
+		fmt.Fprintf(w, "\t- %s => %s\n", a.Alias, snap.JoinSnapApp(a.Snap, a.App))
+	}
 }

--- a/cmd/snap/cmd_alias.go
+++ b/cmd/snap/cmd_alias.go
@@ -83,7 +83,7 @@ func (x *cmdAlias) Execute(args []string) error {
 type changedAlias struct {
 	Snap  string `json:"snap"`
 	App   string `json:"app"`
-	Alias string `json"alias"`
+	Alias string `json:"alias"`
 }
 
 func showAliasChanges(chg *client.Change) error {

--- a/cmd/snap/cmd_alias_test.go
+++ b/cmd/snap/cmd_alias_test.go
@@ -62,7 +62,7 @@ func (s *SnapSuite) TestAlias(c *C) {
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")
-			fmt.Fprintln(w, `{"type":"sync", "result":{"ready": true, "status": "Done"}}`)
+			fmt.Fprintln(w, `{"type":"sync", "result":{"ready": true, "status": "Done", "data": {"aliases-added": [{"name": "alias1", "target": "alias-snap.cmd1"}]}}}`)
 		default:
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
@@ -70,4 +70,9 @@ func (s *SnapSuite) TestAlias(c *C) {
 	rest, err := Parser().ParseArgs([]string{"alias", "alias-snap.cmd1", "alias1"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
+	c.Assert(s.Stdout(), Equals, ""+
+		"Added:\n"+
+		"  - alias1 => alias-snap.cmd1\n",
+	)
+	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/snap/cmd_alias_test.go
+++ b/cmd/snap/cmd_alias_test.go
@@ -62,7 +62,7 @@ func (s *SnapSuite) TestAlias(c *C) {
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")
-			fmt.Fprintln(w, `{"type":"sync", "result":{"ready": true, "status": "Done", "data": {"aliases-added": [{"name": "alias1", "target": "alias-snap.cmd1"}]}}}`)
+			fmt.Fprintln(w, `{"type":"sync", "result":{"ready": true, "status": "Done", "data": {"aliases-added": [{"alias": "alias1", "snap": "alias-snap", "app": "cmd1"}]}}}`)
 		default:
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}

--- a/cmd/snap/cmd_unalias.go
+++ b/cmd/snap/cmd_unalias.go
@@ -55,6 +55,12 @@ func (x *cmdUnalias) Execute(args []string) error {
 		return err
 	}
 
-	_, err = wait(cli, id)
+	chg, err := wait(cli, id)
+	if err == nil {
+		if err := showAliasChanges(chg); err != nil {
+			return err
+		}
+	}
+
 	return err
 }

--- a/cmd/snap/cmd_unalias_test.go
+++ b/cmd/snap/cmd_unalias_test.go
@@ -58,7 +58,7 @@ func (s *SnapSuite) TestUnalias(c *C) {
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")
-			fmt.Fprintln(w, `{"type":"sync", "result":{"ready": true, "status": "Done"}}`)
+			fmt.Fprintln(w, `{"type":"sync", "result":{"ready": true, "status": "Done", "data": {"aliases-removed": [{"name": "alias1", "target": "alias-snap.cmd1"}]}}}`)
 		default:
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
@@ -66,4 +66,9 @@ func (s *SnapSuite) TestUnalias(c *C) {
 	rest, err := Parser().ParseArgs([]string{"unalias", "alias1"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
+	c.Assert(s.Stdout(), Equals, ""+
+		"Removed:\n"+
+		"  - alias1 => alias-snap.cmd1\n",
+	)
+	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/snap/cmd_unalias_test.go
+++ b/cmd/snap/cmd_unalias_test.go
@@ -58,7 +58,7 @@ func (s *SnapSuite) TestUnalias(c *C) {
 			fmt.Fprintln(w, `{"type":"async", "status-code": 202, "change": "zzz"}`)
 		case "/v2/changes/zzz":
 			c.Check(r.Method, Equals, "GET")
-			fmt.Fprintln(w, `{"type":"sync", "result":{"ready": true, "status": "Done", "data": {"aliases-removed": [{"name": "alias1", "target": "alias-snap.cmd1"}]}}}`)
+			fmt.Fprintln(w, `{"type":"sync", "result":{"ready": true, "status": "Done", "data": {"aliases-removed": [{"alias": "alias1", "snap": "foo", "app": "foo"}]}}}`)
 		default:
 			c.Fatalf("unexpected path %q", r.URL.Path)
 		}
@@ -68,7 +68,7 @@ func (s *SnapSuite) TestUnalias(c *C) {
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, ""+
 		"Removed:\n"+
-		"  - alias1 => alias-snap.cmd1\n",
+		"  - alias1 => foo\n",
 	)
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -88,14 +88,6 @@ func (at *AliasTarget) Effective(autoDisabled bool) string {
 
 */
 
-// TODO: helper from snap
-func composeTarget(snapName, targetApp string) string {
-	if targetApp == snapName {
-		return targetApp
-	}
-	return fmt.Sprintf("%s.%s", snapName, targetApp)
-}
-
 // applyAliasesChange applies the necessary changes to aliases on disk
 // to go from prevAliases consindering the automatic aliases flag
 // (prevAutoDisabled) to newAliases considering newAutoDisabled for
@@ -109,7 +101,7 @@ func applyAliasesChange(snapName string, prevAutoDisabled bool, prevAliases map[
 		if effTgt := prevTargets.Effective(prevAutoDisabled); effTgt != "" {
 			remove = append(remove, &backend.Alias{
 				Name:   alias,
-				Target: composeTarget(snapName, effTgt),
+				Target: snap.JoinSnapApp(snapName, effTgt),
 			})
 		}
 	}
@@ -123,13 +115,13 @@ func applyAliasesChange(snapName string, prevAutoDisabled bool, prevAliases map[
 		if prevTgt != "" {
 			remove = append(remove, &backend.Alias{
 				Name:   alias,
-				Target: composeTarget(snapName, prevTgt),
+				Target: snap.JoinSnapApp(snapName, prevTgt),
 			})
 		}
 		if newTgt != "" {
 			add = append(add, &backend.Alias{
 				Name:   alias,
-				Target: composeTarget(snapName, newTgt),
+				Target: snap.JoinSnapApp(snapName, newTgt),
 			})
 		}
 	}

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -100,7 +100,7 @@ func composeTarget(snapName, targetApp string) string {
 // to go from prevAliases consindering the automatic aliases flag
 // (prevAutoDisabled) to newAliases considering newAutoDisabled for
 // snapName. It assumes that conflicts have already been checked.
-func applyAliasesChange(st *state.State, snapName string, prevAutoDisabled bool, prevAliases map[string]*AliasTarget, newAutoDisabled bool, newAliases map[string]*AliasTarget, be managerBackend) error {
+func applyAliasesChange(snapName string, prevAutoDisabled bool, prevAliases map[string]*AliasTarget, newAutoDisabled bool, newAliases map[string]*AliasTarget, be managerBackend) error {
 	var add, remove []*backend.Alias
 	for alias, prevTargets := range prevAliases {
 		if _, ok := newAliases[alias]; ok {
@@ -475,7 +475,7 @@ func (m *SnapManager) ensureAliasesV2() error {
 
 	for snapName, snapst := range withAliases {
 		if !snapst.AliasesPending {
-			err := applyAliasesChange(m.state, snapName, true, nil, false, snapst.Aliases, m.backend)
+			err := applyAliasesChange(snapName, true, nil, false, snapst.Aliases, m.backend)
 			if err != nil {
 				// try to clean up and disable
 				logger.Noticef("cannot create automatic aliases for %q: %v", snapName, err)

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -100,8 +100,7 @@ func composeTarget(snapName, targetApp string) string {
 // to go from prevAliases consindering the automatic aliases flag
 // (prevAutoDisabled) to newAliases considering newAutoDisabled for
 // snapName. It assumes that conflicts have already been checked.
-func applyAliasesChange(snapName string, prevAutoDisabled bool, prevAliases map[string]*AliasTarget, newAutoDisabled bool, newAliases map[string]*AliasTarget, be managerBackend) error {
-	var add, remove []*backend.Alias
+func applyAliasesChange(snapName string, prevAutoDisabled bool, prevAliases map[string]*AliasTarget, newAutoDisabled bool, newAliases map[string]*AliasTarget, be managerBackend, dryRun bool) (add, remove []*backend.Alias, err error) {
 	for alias, prevTargets := range prevAliases {
 		if _, ok := newAliases[alias]; ok {
 			continue
@@ -134,11 +133,12 @@ func applyAliasesChange(snapName string, prevAutoDisabled bool, prevAliases map[
 			})
 		}
 	}
-	err := be.UpdateAliases(add, remove)
-	if err != nil {
-		return err
+	if !dryRun {
+		if err := be.UpdateAliases(add, remove); err != nil {
+			return nil, nil, err
+		}
 	}
-	return nil
+	return add, remove, nil
 }
 
 // AutoAliases allows to hook support for retrieving the automatic aliases of a snap.
@@ -475,7 +475,7 @@ func (m *SnapManager) ensureAliasesV2() error {
 
 	for snapName, snapst := range withAliases {
 		if !snapst.AliasesPending {
-			err := applyAliasesChange(snapName, true, nil, false, snapst.Aliases, m.backend)
+			_, _, err := applyAliasesChange(snapName, true, nil, false, snapst.Aliases, m.backend, false)
 			if err != nil {
 				// try to clean up and disable
 				logger.Noticef("cannot create automatic aliases for %q: %v", snapName, err)

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -495,7 +495,7 @@ func (s *snapmgrTestSuite) TestAliasTasks(c *C) {
 type changedAlias struct {
 	Snap  string `json:"snap"`
 	App   string `json:"app"`
-	Alias string `json"alias"`
+	Alias string `json:"alias"`
 }
 
 type traceData struct {

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -492,9 +492,15 @@ func (s *snapmgrTestSuite) TestAliasTasks(c *C) {
 	})
 }
 
+type changedAlias struct {
+	Snap  string `json:"snap"`
+	App   string `json:"app"`
+	Alias string `json"alias"`
+}
+
 type traceData struct {
-	Added   []*backend.Alias `json:"aliases-added,omitempty"`
-	Removed []*backend.Alias `json:"aliases-removed,omitempty"`
+	Added   []*changedAlias `json:"aliases-added,omitempty"`
+	Removed []*changedAlias `json:"aliases-removed,omitempty"`
 }
 
 func (s *snapmgrTestSuite) TestAliasRunThrough(c *C) {
@@ -520,11 +526,10 @@ func (s *snapmgrTestSuite) TestAliasRunThrough(c *C) {
 	s.state.Lock()
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
-	added := []*backend.Alias{{"alias1", "alias-snap.cmd1"}}
 	expected := fakeOps{
 		{
 			op:      "update-aliases",
-			aliases: added,
+			aliases: []*backend.Alias{{"alias1", "alias-snap.cmd1"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -545,7 +550,7 @@ func (s *snapmgrTestSuite) TestAliasRunThrough(c *C) {
 	err = chg.Get("api-data", &trace)
 	c.Assert(err, IsNil)
 	c.Check(trace, DeepEquals, traceData{
-		Added: added,
+		Added: []*changedAlias{{Snap: "alias-snap", App: "cmd1", Alias: "alias1"}},
 	})
 }
 
@@ -846,11 +851,10 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasRunThrough(c *C) {
 	s.state.Lock()
 
 	c.Assert(chg.Status(), Equals, state.DoneStatus, Commentf("%v", chg.Err()))
-	removed := []*backend.Alias{{"alias1", "alias-snap.cmd5"}}
 	expected := fakeOps{
 		{
 			op:        "update-aliases",
-			rmAliases: removed,
+			rmAliases: []*backend.Alias{{"alias1", "alias-snap.cmd5"}},
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -869,7 +873,7 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasRunThrough(c *C) {
 	err = chg.Get("api-data", &trace)
 	c.Assert(err, IsNil)
 	c.Check(trace, DeepEquals, traceData{
-		Removed: removed,
+		Removed: []*changedAlias{{Snap: "alias-snap", App: "cmd5", Alias: "alias1"}},
 	})
 }
 

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -41,9 +41,6 @@ func target(at *snapstate.AliasTarget) string {
 }
 
 func (s *snapmgrTestSuite) TestApplyAliasesChange(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	auto1 := &snapstate.AliasTarget{
 		Auto: "cmd1",
 	}
@@ -91,7 +88,7 @@ func (s *snapmgrTestSuite) TestApplyAliasesChange(c *C) {
 			newAliases["myalias"] = scenario.newTarget
 		}
 
-		err := snapstate.ApplyAliasesChange(s.state, "alias-snap1", scenario.autoDisabled, prevAliases, scenario.newAutoDisabled, newAliases, s.fakeBackend)
+		err := snapstate.ApplyAliasesChange("alias-snap1", scenario.autoDisabled, prevAliases, scenario.newAutoDisabled, newAliases, s.fakeBackend)
 		c.Assert(err, IsNil)
 
 		var add, rm []*backend.Alias
@@ -120,9 +117,6 @@ func (s *snapmgrTestSuite) TestApplyAliasesChange(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestApplyAliasesChangeMulti(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	prevAliases := map[string]*snapstate.AliasTarget{
 		"myalias0": {Auto: "cmd0"},
 	}
@@ -130,7 +124,7 @@ func (s *snapmgrTestSuite) TestApplyAliasesChangeMulti(c *C) {
 		"myalias1": {Auto: "alias-snap1"},
 	}
 
-	err := snapstate.ApplyAliasesChange(s.state, "alias-snap1", false, prevAliases, false, newAliases, s.fakeBackend)
+	err := snapstate.ApplyAliasesChange("alias-snap1", false, prevAliases, false, newAliases, s.fakeBackend)
 	c.Assert(err, IsNil)
 
 	expected := fakeOps{

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -903,7 +904,7 @@ func (m *SnapManager) doSetupAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	snapName := snapsup.Name()
 	curAliases := snapst.Aliases
 
-	err = applyAliasesChange(snapName, true, nil, snapst.AutoAliasesDisabled, curAliases, m.backend)
+	_, _, err = applyAliasesChange(snapName, true, nil, snapst.AutoAliasesDisabled, curAliases, m.backend, false)
 	if err != nil {
 		return err
 	}
@@ -941,7 +942,7 @@ func (m *SnapManager) doRefreshAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if !snapst.AliasesPending {
-		if err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend); err != nil {
+		if _, _, err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend, false); err != nil {
 			return err
 		}
 	}
@@ -989,7 +990,7 @@ func (m *SnapManager) undoRefreshAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 
 	if !snapst.AliasesPending {
 		curAliases := snapst.Aliases
-		if err := applyAliasesChange(snapName, curAutoDisabled, curAliases, autoDisabled, oldAliases, m.backend); err != nil {
+		if _, _, err := applyAliasesChange(snapName, curAutoDisabled, curAliases, autoDisabled, oldAliases, m.backend, false); err != nil {
 			return err
 		}
 	}
@@ -1020,7 +1021,7 @@ func (m *SnapManager) doPruneAutoAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	newAliases := pruneAutoAliases(curAliases, which)
 
 	if !snapst.AliasesPending {
-		if err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend); err != nil {
+		if _, _, err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend, false); err != nil {
 			return err
 		}
 	}
@@ -1028,6 +1029,33 @@ func (m *SnapManager) doPruneAutoAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	t.Set("old-aliases-v2", curAliases)
 	snapst.Aliases = newAliases
 	Set(st, snapName, snapst)
+	return nil
+}
+
+func aliasesTrace(t *state.Task, added, removed []*backend.Alias) error {
+	chg := t.Change()
+	var data map[string]interface{}
+	err := chg.Get("api-data", &data)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	if len(data) == 0 {
+		data = make(map[string]interface{})
+	}
+
+	curAdded, _ := data["aliases-added"].([]interface{})
+	for _, a := range added {
+		curAdded = append(curAdded, a)
+	}
+	data["aliases-added"] = curAdded
+
+	curRemoved, _ := data["aliases-removed"].([]interface{})
+	for _, a := range removed {
+		curRemoved = append(curRemoved, a)
+	}
+	data["aliases-removed"] = curRemoved
+
+	chg.Set("api-data", data)
 	return nil
 }
 
@@ -1066,10 +1094,12 @@ func (m *SnapManager) doAliasV2(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	if !snapst.AliasesPending {
-		if err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend); err != nil {
-			return err
-		}
+	added, removed, err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend, snapst.AliasesPending)
+	if err != nil {
+		return err
+	}
+	if err := aliasesTrace(t, added, removed); err != nil {
+		return err
 	}
 
 	t.Set("old-aliases-v2", curAliases)
@@ -1092,10 +1122,12 @@ func (m *SnapManager) doDisableAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	oldAliases := snapst.Aliases
 	newAliases := disableAliases(oldAliases)
 
-	if !snapst.AliasesPending {
-		if err := applyAliasesChange(snapName, oldAutoDisabled, oldAliases, true, newAliases, m.backend); err != nil {
-			return err
-		}
+	added, removed, err := applyAliasesChange(snapName, oldAutoDisabled, oldAliases, true, newAliases, m.backend, snapst.AliasesPending)
+	if err != nil {
+		return err
+	}
+	if err := aliasesTrace(t, added, removed); err != nil {
+		return err
 	}
 
 	t.Set("old-auto-aliases-disabled", oldAutoDisabled)
@@ -1128,10 +1160,12 @@ func (m *SnapManager) doUnaliasV2(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	if !snapst.AliasesPending {
-		if err := applyAliasesChange(snapName, autoDisabled, oldAliases, autoDisabled, newAliases, m.backend); err != nil {
-			return err
-		}
+	added, removed, err := applyAliasesChange(snapName, autoDisabled, oldAliases, autoDisabled, newAliases, m.backend, snapst.AliasesPending)
+	if err != nil {
+		return err
+	}
+	if err := aliasesTrace(t, added, removed); err != nil {
+		return err
 	}
 
 	t.Set("old-aliases-v2", oldAliases)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -903,7 +903,7 @@ func (m *SnapManager) doSetupAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	snapName := snapsup.Name()
 	curAliases := snapst.Aliases
 
-	err = applyAliasesChange(st, snapName, true, nil, snapst.AutoAliasesDisabled, curAliases, m.backend)
+	err = applyAliasesChange(snapName, true, nil, snapst.AutoAliasesDisabled, curAliases, m.backend)
 	if err != nil {
 		return err
 	}
@@ -941,7 +941,7 @@ func (m *SnapManager) doRefreshAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if !snapst.AliasesPending {
-		if err := applyAliasesChange(st, snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend); err != nil {
+		if err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend); err != nil {
 			return err
 		}
 	}
@@ -989,7 +989,7 @@ func (m *SnapManager) undoRefreshAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 
 	if !snapst.AliasesPending {
 		curAliases := snapst.Aliases
-		if err := applyAliasesChange(st, snapName, curAutoDisabled, curAliases, autoDisabled, oldAliases, m.backend); err != nil {
+		if err := applyAliasesChange(snapName, curAutoDisabled, curAliases, autoDisabled, oldAliases, m.backend); err != nil {
 			return err
 		}
 	}
@@ -1020,7 +1020,7 @@ func (m *SnapManager) doPruneAutoAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	newAliases := pruneAutoAliases(curAliases, which)
 
 	if !snapst.AliasesPending {
-		if err := applyAliasesChange(st, snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend); err != nil {
+		if err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend); err != nil {
 			return err
 		}
 	}
@@ -1067,7 +1067,7 @@ func (m *SnapManager) doAliasV2(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if !snapst.AliasesPending {
-		if err := applyAliasesChange(st, snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend); err != nil {
+		if err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend); err != nil {
 			return err
 		}
 	}
@@ -1093,7 +1093,7 @@ func (m *SnapManager) doDisableAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	newAliases := disableAliases(oldAliases)
 
 	if !snapst.AliasesPending {
-		if err := applyAliasesChange(st, snapName, oldAutoDisabled, oldAliases, true, newAliases, m.backend); err != nil {
+		if err := applyAliasesChange(snapName, oldAutoDisabled, oldAliases, true, newAliases, m.backend); err != nil {
 			return err
 		}
 	}
@@ -1129,7 +1129,7 @@ func (m *SnapManager) doUnaliasV2(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if !snapst.AliasesPending {
-		if err := applyAliasesChange(st, snapName, autoDisabled, oldAliases, autoDisabled, newAliases, m.backend); err != nil {
+		if err := applyAliasesChange(snapName, autoDisabled, oldAliases, autoDisabled, newAliases, m.backend); err != nil {
 			return err
 		}
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1035,7 +1035,7 @@ func (m *SnapManager) doPruneAutoAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 type changedAlias struct {
 	Snap  string `json:"snap"`
 	App   string `json:"app"`
-	Alias string `json"alias"`
+	Alias string `json:"alias"`
 }
 
 func aliasesTrace(t *state.Task, added, removed []*backend.Alias) error {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -1032,6 +1032,12 @@ func (m *SnapManager) doPruneAutoAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
+type changedAlias struct {
+	Snap  string `json:"snap"`
+	App   string `json:"app"`
+	Alias string `json"alias"`
+}
+
 func aliasesTrace(t *state.Task, added, removed []*backend.Alias) error {
 	chg := t.Change()
 	var data map[string]interface{}
@@ -1045,13 +1051,23 @@ func aliasesTrace(t *state.Task, added, removed []*backend.Alias) error {
 
 	curAdded, _ := data["aliases-added"].([]interface{})
 	for _, a := range added {
-		curAdded = append(curAdded, a)
+		snap, app := snap.SplitSnapApp(a.Target)
+		curAdded = append(curAdded, &changedAlias{
+			Snap:  snap,
+			App:   app,
+			Alias: a.Name,
+		})
 	}
 	data["aliases-added"] = curAdded
 
 	curRemoved, _ := data["aliases-removed"].([]interface{})
 	for _, a := range removed {
-		curRemoved = append(curRemoved, a)
+		snap, app := snap.SplitSnapApp(a.Target)
+		curRemoved = append(curRemoved, &changedAlias{
+			Snap:  snap,
+			App:   app,
+			Alias: a.Name,
+		})
 	}
 	data["aliases-removed"] = curRemoved
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -587,3 +587,13 @@ func SplitSnapApp(snapApp string) (snap, app string) {
 	}
 	return l[0], l[1]
 }
+
+// JoinSnapApp produces a full application wrapper name from the
+// `snap` and the `app` part. It also deals with the special
+// case of snapName == appName.
+func JoinSnapApp(snap, app string) string {
+	if snap == app {
+		return app
+	}
+	return fmt.Sprintf("%s.%s", snap, app)
+}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -346,6 +346,22 @@ func (s *infoSuite) TestSplitSnapApp(c *C) {
 	}
 }
 
+func (s *infoSuite) TestJoinSnapApp(c *C) {
+	for _, t := range []struct {
+		in  []string
+		out string
+	}{
+		// normal cases
+		{[]string{"foo", "bar"}, "foo.bar"},
+		{[]string{"foo", "bar-baz"}, "foo.bar-baz"},
+		// special case, snapName == appName
+		{[]string{"foo", "foo"}, "foo"},
+	} {
+		snapApp := snap.JoinSnapApp(t.in[0], t.in[1])
+		c.Check(snapApp, Equals, t.out)
+	}
+}
+
 func ExampleSpltiSnapApp() {
 	fmt.Println(snap.SplitSnapApp("hello-world.env"))
 	// Output: hello-world env

--- a/tests/main/alias/task.yaml
+++ b/tests/main/alias/task.yaml
@@ -10,7 +10,7 @@ execute: |
     aliases.cmd2|MATCH "ok command 2"
 
     echo "Create manual aliases"
-    snap alias aliases.cmd1 alias1
+    snap alias aliases.cmd1 alias1|MATCH ".*- alias1 => aliases.cmd1.*"
     snap alias aliases.cmd2 alias2
 
     echo "Test the aliases"
@@ -20,7 +20,7 @@ execute: |
     alias2|MATCH "ok command 2"
 
     echo "Disable one manual alias"
-    snap unalias alias2
+    snap unalias alias2|MATCH ".*- alias2 => aliases.cmd2.*"
 
     echo "One still works, one is not there"
     alias1|MATCH "ok command 1"
@@ -28,7 +28,7 @@ execute: |
     alias2 2>&1|MATCH "alias2: command not found"
 
     echo "Disable all aliases"
-    snap unalias aliases
+    snap unalias aliases|MATCH ".*- alias1 => aliases.cmd1.*"
 
     echo "Alias is gone"
     test ! -e /snap/bin/alias1


### PR DESCRIPTION
This produces on snap alias / snap unalias an output like:

    Added:
       - alias1 => snap.app
       ...
    Removed:
       - alias2 => snap.app
       ...

as originally discussed, can be applied in a follow up to prefer as well.