### PR TITLE
tests: tweak time for econnreset test a bit more

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -7,7 +7,7 @@ execute: |
     su -c "/usr/bin/env SNAPD_DEBUG=1 snap download core 2>snap-download.log" test &
     echo "Wait until it actually got some data for the snap"
     while ! grep -q "Retrying.*download-snap/.*\.snap, attempt 1" snap-download.log; do
-        sleep 2
+        sleep 1
     done
     echo "Force sending a RST packages"
     iptables -I OUTPUT -m owner --uid-owner $(id -u test) -j REJECT -p tcp --reject-with tcp-reset

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -7,9 +7,10 @@ execute: |
     su -c "/usr/bin/env SNAPD_DEBUG=1 snap download core 2>snap-download.log" test &
     echo "Wait until it actually got some data for the snap"
     while ! grep -q "Retrying.*download-snap/.*\.snap, attempt 1" snap-download.log; do
-        sleep 1
+        sleep 0.2
     done
     echo "Force sending a RST packages"
+    sleep 1
     iptables -I OUTPUT -m owner --uid-owner $(id -u test) -j REJECT -p tcp --reject-with tcp-reset
     echo "Check that we retried"
     for i in $(seq 10); do

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -4,13 +4,13 @@ restore: |
     iptables -D OUTPUT -m owner --uid-owner $(id -u test) -j REJECT  -p tcp --reject-with tcp-reset
 execute: |
     echo "Downloading a large snap in the background"
-    su -c "/usr/bin/env SNAPD_DEBUG=1 snap download core 2>snap-download.log" test &
+    su -c "/usr/bin/env SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &
     echo "Wait until it actually got some data for the snap"
     while ! grep -q "Retrying.*download-snap/.*\.snap, attempt 1" snap-download.log; do
-        sleep 0.2
+        sleep 1
     done
-    echo "Force sending a RST packages"
-    sleep 2
+    echo "Wait a little bit for the download to start, then force sending a RST package"
+    sleep 3
     iptables -I OUTPUT -m owner --uid-owner $(id -u test) -j REJECT -p tcp --reject-with tcp-reset
     echo "Check that we retried"
     for i in $(seq 10); do

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -10,7 +10,7 @@ execute: |
         sleep 0.2
     done
     echo "Force sending a RST packages"
-    sleep 1
+    sleep 2
     iptables -I OUTPUT -m owner --uid-owner $(id -u test) -j REJECT -p tcp --reject-with tcp-reset
     echo "Check that we retried"
     for i in $(seq 10); do


### PR DESCRIPTION
@pedronis points to https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-zesty-snappy-dev-image/zesty/amd64/s/snapd/20170426_092408_9dd14@/log.gz where the econnreset test fails.

This test tweaks it by moving to a much bigger snap