### PR TITLE
many: aliases v2 cleanups

### DIFF
--- a/cmd/snap/cmd_alias.go
+++ b/cmd/snap/cmd_alias.go
@@ -71,13 +71,14 @@ func (x *cmdAlias) Execute(args []string) error {
 	}
 
 	chg, err := wait(cli, id)
-	if err == nil {
-		if err := showAliasChanges(chg); err != nil {
-			return err
-		}
+	if err != nil {
+		return err
+	}
+	if err := showAliasChanges(chg); err != nil {
+		return err
 	}
 
-	return err
+	return nil
 }
 
 type changedAlias struct {

--- a/cmd/snap/cmd_prefer.go
+++ b/cmd/snap/cmd_prefer.go
@@ -58,11 +58,12 @@ func (x *cmdPrefer) Execute(args []string) error {
 	}
 
 	chg, err := wait(cli, id)
-	if err == nil {
-		if err := showAliasChanges(chg); err != nil {
-			return err
-		}
+	if err != nil {
+		return err
+	}
+	if err := showAliasChanges(chg); err != nil {
+		return err
 	}
 
-	return err
+	return nil
 }

--- a/cmd/snap/cmd_unalias.go
+++ b/cmd/snap/cmd_unalias.go
@@ -56,11 +56,12 @@ func (x *cmdUnalias) Execute(args []string) error {
 	}
 
 	chg, err := wait(cli, id)
-	if err == nil {
-		if err := showAliasChanges(chg); err != nil {
-			return err
-		}
+	if err != nil {
+		return err
+	}
+	if err := showAliasChanges(chg); err != nil {
+		return err
 	}
 
-	return err
+	return nil
 }

--- a/daemon/api_mock_test.go
+++ b/daemon/api_mock_test.go
@@ -121,7 +121,5 @@ name: alias-snap
 version: 1
 apps:
  app:
-  aliases: [alias1]
  app2:
-  aliases: [alias2]
 `

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -340,7 +340,7 @@ func AutoAliases(s *state.State, info *snap.Info) (map[string]string, error) {
 	}
 	res := make(map[string]string, len(oldAutoAliases))
 	for _, alias := range oldAutoAliases {
-		app := info.Aliases[alias]
+		app := info.LegacyAliases[alias]
 		if app == nil {
 			// not a known alias anymore or yet, skip
 			continue

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1144,8 +1144,11 @@ apps:
 
 func (ms *mgrsSuite) TestHappyRemoteInstallAutoAliases(c *C) {
 	ms.prereqSnapAssertions(c, map[string]interface{}{
-		"snap-name":    "foo",
-		"auto-aliases": []interface{}{"app1", "app2"},
+		"snap-name": "foo",
+		"aliases": []interface{}{
+			map[string]interface{}{"name": "app1", "target": "app1"},
+			map[string]interface{}{"name": "app2", "target": "app2"},
+		},
 	})
 
 	snapYamlContent := `name: foo
@@ -1153,10 +1156,8 @@ version: @VERSION@
 apps:
  app1:
   command: bin/app1
-  aliases: [app1]
  app2:
   command: bin/app2
-  aliases: [app2]
 `
 
 	ver := "1.0"
@@ -1206,8 +1207,10 @@ apps:
 
 func (ms *mgrsSuite) TestHappyRemoteInstallAndUpdateAutoAliases(c *C) {
 	ms.prereqSnapAssertions(c, map[string]interface{}{
-		"snap-name":    "foo",
-		"auto-aliases": []interface{}{"app1"},
+		"snap-name": "foo",
+		"aliases": []interface{}{
+			map[string]interface{}{"name": "app1", "target": "app1"},
+		},
 	})
 
 	fooYaml := `name: foo
@@ -1215,10 +1218,8 @@ version: @VERSION@
 apps:
  app1:
   command: bin/app1
-  aliases: [app1]
  app2:
   command: bin/app2
-  aliases: [app2]
 `
 
 	fooPath, _ := ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
@@ -1262,9 +1263,11 @@ apps:
 	c.Check(dest, Equals, "foo.app1")
 
 	ms.prereqSnapAssertions(c, map[string]interface{}{
-		"snap-name":    "foo",
-		"auto-aliases": []interface{}{"app2"},
-		"revision":     "1",
+		"snap-name": "foo",
+		"aliases": []interface{}{
+			map[string]interface{}{"name": "app2", "target": "app2"},
+		},
+		"revision": "1",
 	})
 
 	// new foo version/revision
@@ -1309,8 +1312,10 @@ apps:
 
 func (ms *mgrsSuite) TestHappyOrthogonalRefreshAutoAliases(c *C) {
 	ms.prereqSnapAssertions(c, map[string]interface{}{
-		"snap-name":    "foo",
-		"auto-aliases": []interface{}{"app1"},
+		"snap-name": "foo",
+		"aliases": []interface{}{
+			map[string]interface{}{"name": "app1", "target": "app1"},
+		},
 	}, map[string]interface{}{
 		"snap-name": "bar",
 	})
@@ -1320,10 +1325,8 @@ version: @VERSION@
 apps:
  app1:
   command: bin/app1
-  aliases: [app1]
  app2:
   command: bin/app2
-  aliases: [app2]
 `
 
 	barYaml := `name: bar
@@ -1331,10 +1334,8 @@ version: @VERSION@
 apps:
  app1:
   command: bin/app1
-  aliases: [app1]
  app3:
   command: bin/app3
-  aliases: [app3]
 `
 
 	fooPath, _ := ms.makeStoreTestSnap(c, strings.Replace(fooYaml, "@VERSION@", "1.0", -1), "10")
@@ -1394,18 +1395,23 @@ apps:
 		"app1": {Auto: "app1"},
 	})
 
-	// foo gets a new version/revision and a change of auto-aliases
+	// foo gets a new version/revision and a change of automatic aliases
 	// bar gets only the latter
 	// app1 is transferred from foo to bar
 	// UpdateMany after a snap-declaration refresh handles all of this
 	ms.prereqSnapAssertions(c, map[string]interface{}{
-		"snap-name":    "foo",
-		"auto-aliases": []interface{}{"app2"},
-		"revision":     "1",
+		"snap-name": "foo",
+		"aliases": []interface{}{
+			map[string]interface{}{"name": "app2", "target": "app2"},
+		},
+		"revision": "1",
 	}, map[string]interface{}{
-		"snap-name":    "bar",
-		"auto-aliases": []interface{}{"app1", "app3"},
-		"revision":     "1",
+		"snap-name": "bar",
+		"aliases": []interface{}{
+			map[string]interface{}{"name": "app1", "target": "app1"},
+			map[string]interface{}{"name": "app3", "target": "app3"},
+		},
+		"revision": "1",
 	})
 
 	// new foo version/revision

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -88,6 +88,14 @@ func (at *AliasTarget) Effective(autoDisabled bool) string {
 
 */
 
+// autoDisabled options and doApply
+const (
+	autoDis = true
+	autoEn  = false
+
+	doApply = false
+)
+
 // applyAliasesChange applies the necessary changes to aliases on disk
 // to go from prevAliases consindering the automatic aliases flag
 // (prevAutoDisabled) to newAliases considering newAutoDisabled for
@@ -505,7 +513,7 @@ func (m *SnapManager) ensureAliasesV2() error {
 
 	for snapName, snapst := range withAliases {
 		if !snapst.AliasesPending {
-			_, _, err := applyAliasesChange(snapName, true, nil, false, snapst.Aliases, m.backend, false)
+			_, _, err := applyAliasesChange(snapName, autoDis, nil, autoEn, snapst.Aliases, m.backend, doApply)
 			if err != nil {
 				// try to clean up and disable
 				logger.Noticef("cannot create automatic aliases for %q: %v", snapName, err)

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -136,12 +136,11 @@ func applyAliasesChange(snapName string, prevAutoDisabled bool, prevAliases map[
 // AutoAliases allows to hook support for retrieving the automatic aliases of a snap.
 var AutoAliases func(st *state.State, info *snap.Info) (map[string]string, error)
 
-// autoAliasesDeltaV2 compares the automatic aliases with the current snap
+// autoAliasesDelta compares the automatic aliases with the current snap
 // declaration for the installed snaps with the given names (or all if
 // names is empty) and returns changed and dropped auto-aliases by
 // snap name.
-// TODO: temporary name
-func autoAliasesDeltaV2(st *state.State, names []string) (changed map[string][]string, dropped map[string][]string, err error) {
+func autoAliasesDelta(st *state.State, names []string) (changed map[string][]string, dropped map[string][]string, err error) {
 	var snapStates map[string]*SnapState
 	if len(names) == 0 {
 		var err error

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -143,7 +143,7 @@ func (s *snapmgrTestSuite) TestApplyAliasesChangeMulti(c *C) {
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 }
 
-func (s *snapmgrTestSuite) TestAutoAliasesDeltaV2(c *C) {
+func (s *snapmgrTestSuite) TestAutoAliasesDelta(c *C) {
 	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
 		c.Check(info.Name(), Equals, "alias-snap")
 		return map[string]string{
@@ -172,7 +172,7 @@ func (s *snapmgrTestSuite) TestAutoAliasesDeltaV2(c *C) {
 		},
 	})
 
-	changed, dropped, err := snapstate.AutoAliasesDeltaV2(s.state, []string{"alias-snap"})
+	changed, dropped, err := snapstate.AutoAliasesDelta(s.state, []string{"alias-snap"})
 	c.Assert(err, IsNil)
 
 	c.Check(changed, HasLen, 1)
@@ -185,7 +185,7 @@ func (s *snapmgrTestSuite) TestAutoAliasesDeltaV2(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestAutoAliasesDeltaV2All(c *C) {
+func (s *snapmgrTestSuite) TestAutoAliasesDeltaAll(c *C) {
 	seen := make(map[string]bool)
 	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
 		seen[info.Name()] = true
@@ -218,7 +218,7 @@ func (s *snapmgrTestSuite) TestAutoAliasesDeltaV2All(c *C) {
 		Active:  true,
 	})
 
-	changed, dropped, err := snapstate.AutoAliasesDeltaV2(s.state, nil)
+	changed, dropped, err := snapstate.AutoAliasesDelta(s.state, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(changed, HasLen, 1)
@@ -234,7 +234,7 @@ func (s *snapmgrTestSuite) TestAutoAliasesDeltaV2All(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestAutoAliasesDeltaV2OverManual(c *C) {
+func (s *snapmgrTestSuite) TestAutoAliasesDeltaOverManual(c *C) {
 	snapstate.AutoAliases = func(st *state.State, info *snap.Info) (map[string]string, error) {
 		c.Check(info.Name(), Equals, "alias-snap")
 		return map[string]string{
@@ -257,7 +257,7 @@ func (s *snapmgrTestSuite) TestAutoAliasesDeltaV2OverManual(c *C) {
 		},
 	})
 
-	changed, dropped, err := snapstate.AutoAliasesDeltaV2(s.state, []string{"alias-snap"})
+	changed, dropped, err := snapstate.AutoAliasesDelta(s.state, []string{"alias-snap"})
 	c.Assert(err, IsNil)
 
 	c.Check(changed, HasLen, 1)

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -111,7 +111,7 @@ func PreviousSideInfo(snapst *SnapState) *snap.SideInfo {
 // aliases v2
 var (
 	ApplyAliasesChange    = applyAliasesChange
-	AutoAliasesDeltaV2    = autoAliasesDeltaV2
+	AutoAliasesDelta      = autoAliasesDelta
 	RefreshAliases        = refreshAliases
 	CheckAliasesConflicts = checkAliasesConflicts
 	DisableAliases        = disableAliases

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -940,7 +940,7 @@ func (m *SnapManager) doSetupAliases(t *state.Task, _ *tomb.Tomb) error {
 	snapName := snapsup.Name()
 	curAliases := snapst.Aliases
 
-	_, _, err = applyAliasesChange(snapName, true, nil, snapst.AutoAliasesDisabled, curAliases, m.backend, false)
+	_, _, err = applyAliasesChange(snapName, autoDis, nil, snapst.AutoAliasesDisabled, curAliases, m.backend, doApply)
 	if err != nil {
 		return err
 	}
@@ -976,7 +976,7 @@ func (m *SnapManager) doRefreshAliases(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if !snapst.AliasesPending {
-		if _, _, err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend, false); err != nil {
+		if _, _, err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend, doApply); err != nil {
 			return err
 		}
 	}
@@ -1029,7 +1029,7 @@ func (m *SnapManager) undoRefreshAliases(t *state.Task, _ *tomb.Tomb) error {
 
 	if !snapst.AliasesPending {
 		curAliases := snapst.Aliases
-		if _, _, err := applyAliasesChange(snapName, curAutoDisabled, curAliases, autoDisabled, oldAliases, m.backend, false); err != nil {
+		if _, _, err := applyAliasesChange(snapName, curAutoDisabled, curAliases, autoDisabled, oldAliases, m.backend, doApply); err != nil {
 			return err
 		}
 	}
@@ -1087,7 +1087,7 @@ func (m *SnapManager) undoRefreshAliases(t *state.Task, _ *tomb.Tomb) error {
 		}
 		newSnapSt := newSnapStates[otherSnap]
 		if !otherSnapState.AliasesPending {
-			if _, _, err := applyAliasesChange(otherSnap, otherSnapState.AutoAliasesDisabled, otherSnapState.Aliases, newSnapSt.AutoAliasesDisabled, newSnapSt.Aliases, m.backend, false); err != nil {
+			if _, _, err := applyAliasesChange(otherSnap, otherSnapState.AutoAliasesDisabled, otherSnapState.Aliases, newSnapSt.AutoAliasesDisabled, newSnapSt.Aliases, m.backend, doApply); err != nil {
 				return err
 			}
 		}
@@ -1123,7 +1123,7 @@ func (m *SnapManager) doPruneAutoAliases(t *state.Task, _ *tomb.Tomb) error {
 	newAliases := pruneAutoAliases(curAliases, which)
 
 	if !snapst.AliasesPending {
-		if _, _, err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend, false); err != nil {
+		if _, _, err := applyAliasesChange(snapName, autoDisabled, curAliases, autoDisabled, newAliases, m.backend, doApply); err != nil {
 			return err
 		}
 	}
@@ -1240,7 +1240,7 @@ func (m *SnapManager) doDisableAliases(t *state.Task, _ *tomb.Tomb) error {
 	oldAliases := snapst.Aliases
 	newAliases, _ := disableAliases(oldAliases)
 
-	added, removed, err := applyAliasesChange(snapName, oldAutoDisabled, oldAliases, true, newAliases, m.backend, snapst.AliasesPending)
+	added, removed, err := applyAliasesChange(snapName, oldAutoDisabled, oldAliases, autoDis, newAliases, m.backend, snapst.AliasesPending)
 	if err != nil {
 		return err
 	}
@@ -1318,7 +1318,7 @@ func (m *SnapManager) doPreferAliases(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	curAliases := snapst.Aliases
-	aliasConflicts, err := checkAliasesConflicts(st, snapName, false, curAliases, nil)
+	aliasConflicts, err := checkAliasesConflicts(st, snapName, autoEn, curAliases, nil)
 	conflErr, isConflErr := err.(*AliasConflictError)
 	if err != nil && !isConflErr {
 		return err
@@ -1341,7 +1341,7 @@ func (m *SnapManager) doPreferAliases(t *state.Task, _ *tomb.Tomb) error {
 
 		otherAliases, disabledManual := disableAliases(otherSnapState.Aliases)
 
-		added, removed, err := applyAliasesChange(otherSnap, otherSnapState.AutoAliasesDisabled, otherSnapState.Aliases, true, otherAliases, m.backend, otherSnapState.AliasesPending)
+		added, removed, err := applyAliasesChange(otherSnap, otherSnapState.AutoAliasesDisabled, otherSnapState.Aliases, autoDis, otherAliases, m.backend, otherSnapState.AliasesPending)
 		if err != nil {
 			return err
 		}
@@ -1362,7 +1362,7 @@ func (m *SnapManager) doPreferAliases(t *state.Task, _ *tomb.Tomb) error {
 		otherSnapStates[otherSnap] = &otherSnapState
 	}
 
-	added, removed, err := applyAliasesChange(snapName, true, curAliases, false, curAliases, m.backend, snapst.AliasesPending)
+	added, removed, err := applyAliasesChange(snapName, autoDis, curAliases, autoEn, curAliases, m.backend, snapst.AliasesPending)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -876,7 +876,7 @@ aliases v2 implementation uses the following tasks:
 
 */
 
-func (m *SnapManager) doSetAutoAliasesV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doSetAutoAliases(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -909,7 +909,7 @@ func (m *SnapManager) doSetAutoAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) doRemoveAliasesV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doRemoveAliases(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -929,7 +929,7 @@ func (m *SnapManager) doRemoveAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) doSetupAliasesV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doSetupAliases(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -950,7 +950,7 @@ func (m *SnapManager) doSetupAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) doRefreshAliasesV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doRefreshAliases(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -987,7 +987,7 @@ func (m *SnapManager) doRefreshAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) undoRefreshAliasesV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) undoRefreshAliases(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1103,7 +1103,7 @@ func (m *SnapManager) undoRefreshAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) doPruneAutoAliasesV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doPruneAutoAliases(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1177,7 +1177,7 @@ func aliasesTrace(t *state.Task, added, removed []*backend.Alias) error {
 	return nil
 }
 
-func (m *SnapManager) doAliasV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doAlias(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1226,7 +1226,7 @@ func (m *SnapManager) doAliasV2(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) doDisableAliasesV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doDisableAliases(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1256,7 +1256,7 @@ func (m *SnapManager) doDisableAliasesV2(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func (m *SnapManager) doUnaliasV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doUnalias(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1302,7 +1302,7 @@ type otherDisabledAliases struct {
 	Manual map[string]string `json:"manual,omitempty"`
 }
 
-func (m *SnapManager) doPreferAliasesV2(t *state.Task, _ *tomb.Tomb) error {
+func (m *SnapManager) doPreferAliases(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()

--- a/overlord/snapstate/handlers_aliasesv2_test.go
+++ b/overlord/snapstate/handlers_aliasesv2_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-func (s *snapmgrTestSuite) TestDoSetAutoAliasesV2(c *C) {
+func (s *snapmgrTestSuite) TestDoSetAutoAliases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -84,7 +84,7 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesV2(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoSetAutoAliasesV2FirstInstall(c *C) {
+func (s *snapmgrTestSuite) TestDoSetAutoAliasesFirstInstall(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -134,7 +134,7 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesV2FirstInstall(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesV2(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoSetAutoAliases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -195,7 +195,7 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesV2(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoSetAutoAliasesV2Conflict(c *C) {
+func (s *snapmgrTestSuite) TestDoSetAutoAliasesConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -251,7 +251,7 @@ func (s *snapmgrTestSuite) TestDoSetAutoAliasesV2Conflict(c *C) {
 	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias4" for "alias-snap", already enabled for "other-snap".*`)
 }
 
-func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesV2Conflict(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -348,7 +348,7 @@ func (s *snapmgrTestSuite) TestDoUndoSetAutoAliasesV2Conflict(c *C) {
 	c.Check(t.Log()[0], Matches, `.* ERROR cannot reinstate alias state because of conflicts, disabling: cannot enable alias "alias3" for "alias-snap", already enabled for "other-snap".*`)
 }
 
-func (s *snapmgrTestSuite) TestDoSetupAliasesV2(c *C) {
+func (s *snapmgrTestSuite) TestDoSetupAliases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -398,7 +398,7 @@ func (s *snapmgrTestSuite) TestDoSetupAliasesV2(c *C) {
 	c.Check(snapst.AliasesPending, Equals, false)
 }
 
-func (s *snapmgrTestSuite) TestDoUndoSetupAliasesV2(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoSetupAliases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -458,7 +458,7 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesV2(c *C) {
 	c.Check(snapst.AliasesPending, Equals, true)
 }
 
-func (s *snapmgrTestSuite) TestDoSetupAliasesV2Auto(c *C) {
+func (s *snapmgrTestSuite) TestDoSetupAliasesAuto(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -508,7 +508,7 @@ func (s *snapmgrTestSuite) TestDoSetupAliasesV2Auto(c *C) {
 	c.Check(snapst.AliasesPending, Equals, false)
 }
 
-func (s *snapmgrTestSuite) TestDoUndoSetupAliasesV2Auto(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAuto(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -568,7 +568,7 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesV2Auto(c *C) {
 	c.Check(snapst.AliasesPending, Equals, true)
 }
 
-func (s *snapmgrTestSuite) TestDoSetupAliasesV2Nothing(c *C) {
+func (s *snapmgrTestSuite) TestDoSetupAliasesNothing(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -614,7 +614,7 @@ func (s *snapmgrTestSuite) TestDoSetupAliasesV2Nothing(c *C) {
 	c.Check(snapst.AliasesPending, Equals, false)
 }
 
-func (s *snapmgrTestSuite) TestDoUndoSetupAliasesV2Nothing(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoSetupAliasesNothing(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -668,7 +668,7 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesV2Nothing(c *C) {
 	c.Check(snapst.AliasesPending, Equals, true)
 }
 
-func (s *snapmgrTestSuite) TestDoPruneAutoAliasesV2Auto(c *C) {
+func (s *snapmgrTestSuite) TestDoPruneAutoAliasesAuto(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -725,7 +725,7 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesV2Auto(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoPruneAutoAliasesV2AutoPending(c *C) {
+func (s *snapmgrTestSuite) TestDoPruneAutoAliasesAutoPending(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -772,7 +772,7 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesV2AutoPending(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoPruneAutoAliasesV2ManualAndDisabled(c *C) {
+func (s *snapmgrTestSuite) TestDoPruneAutoAliasesManualAndDisabled(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -829,7 +829,7 @@ func (s *snapmgrTestSuite) TestDoPruneAutoAliasesV2ManualAndDisabled(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoRefreshAliasesV2(c *C) {
+func (s *snapmgrTestSuite) TestDoRefreshAliases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -902,7 +902,7 @@ func (s *snapmgrTestSuite) TestDoRefreshAliasesV2(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesV2(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoRefreshAliases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -992,7 +992,7 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesV2(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesV2FromEmpty(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesFromEmpty(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1067,7 +1067,7 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesV2FromEmpty(c *C) {
 	c.Check(snapst.Aliases, HasLen, 0)
 }
 
-func (s *snapmgrTestSuite) TestDoRefreshAliasesV2Pending(c *C) {
+func (s *snapmgrTestSuite) TestDoRefreshAliasesPending(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1126,7 +1126,7 @@ func (s *snapmgrTestSuite) TestDoRefreshAliasesV2Pending(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesV2Pending(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesPending(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1191,7 +1191,7 @@ func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesV2Pending(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoRefreshAliasesV2Conflict(c *C) {
+func (s *snapmgrTestSuite) TestDoRefreshAliasesConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1245,7 +1245,7 @@ func (s *snapmgrTestSuite) TestDoRefreshAliasesV2Conflict(c *C) {
 	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot enable alias "alias4" for "alias-snap", already enabled for "other-snap".*`)
 }
 
-func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesV2Conflict(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoRefreshAliasesConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1442,7 +1442,7 @@ func (s *snapmgrTestSuite) TestDoUndoDisableAliases(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoPreferAliasesV2(c *C) {
+func (s *snapmgrTestSuite) TestDoPreferAliases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1566,7 +1566,7 @@ func (s *snapmgrTestSuite) TestDoPreferAliasesV2(c *C) {
 	c.Check(trace.Removed, HasLen, 4)
 }
 
-func (s *snapmgrTestSuite) TestDoUndoPreferAliasesV2(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoPreferAliases(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -1690,7 +1690,7 @@ func (s *snapmgrTestSuite) TestDoUndoPreferAliasesV2(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) TestDoUndoPreferAliasesV2Conflict(c *C) {
+func (s *snapmgrTestSuite) TestDoUndoPreferAliasesConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -330,15 +330,15 @@ func Manager(st *state.State) (*SnapManager, error) {
 	// alias related
 	// FIXME: drop the task entirely after a while
 	runner.AddHandler("clear-aliases", func(*state.Task, *tomb.Tomb) error { return nil }, nil)
-	runner.AddHandler("set-auto-aliases", m.doSetAutoAliasesV2, m.undoRefreshAliasesV2)
-	runner.AddHandler("setup-aliases", m.doSetupAliasesV2, m.doRemoveAliasesV2)
-	runner.AddHandler("refresh-aliases", m.doRefreshAliasesV2, m.undoRefreshAliasesV2)
-	runner.AddHandler("prune-auto-aliases", m.doPruneAutoAliasesV2, m.undoRefreshAliasesV2)
-	runner.AddHandler("remove-aliases", m.doRemoveAliasesV2, m.doSetupAliasesV2)
-	runner.AddHandler("alias", m.doAliasV2, m.undoRefreshAliasesV2)
-	runner.AddHandler("unalias", m.doUnaliasV2, m.undoRefreshAliasesV2)
-	runner.AddHandler("disable-aliases", m.doDisableAliasesV2, m.undoRefreshAliasesV2)
-	runner.AddHandler("prefer-aliases", m.doPreferAliasesV2, m.undoRefreshAliasesV2)
+	runner.AddHandler("set-auto-aliases", m.doSetAutoAliases, m.undoRefreshAliases)
+	runner.AddHandler("setup-aliases", m.doSetupAliases, m.doRemoveAliases)
+	runner.AddHandler("refresh-aliases", m.doRefreshAliases, m.undoRefreshAliases)
+	runner.AddHandler("prune-auto-aliases", m.doPruneAutoAliases, m.undoRefreshAliases)
+	runner.AddHandler("remove-aliases", m.doRemoveAliases, m.doSetupAliases)
+	runner.AddHandler("alias", m.doAlias, m.undoRefreshAliases)
+	runner.AddHandler("unalias", m.doUnalias, m.undoRefreshAliases)
+	runner.AddHandler("disable-aliases", m.doDisableAliases, m.undoRefreshAliases)
+	runner.AddHandler("prefer-aliases", m.doPreferAliases, m.undoRefreshAliases)
 
 	// control serialisation
 	runner.SetBlocked(m.blockedTask)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -663,7 +663,7 @@ func applyAutoAliasesDelta(st *state.State, delta map[string][]string, op string
 }
 
 func autoAliasesUpdate(st *state.State, names []string, updates []*snap.Info) (changed map[string][]string, mustPrune map[string][]string, transferTargets map[string]bool, err error) {
-	changed, dropped, err := autoAliasesDeltaV2(st, nil)
+	changed, dropped, err := autoAliasesDelta(st, nil)
 	if err != nil {
 		if len(names) != 0 {
 			// not "refresh all", error

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -2197,7 +2197,7 @@ func (s *snapmgrTestSuite) TestUpdateManyAutoAliasesScenarios(c *C) {
 		updates, tts, err := snapstate.UpdateMany(s.state, scenario.names, s.user.ID)
 		c.Check(err, IsNil)
 
-		_, dropped, err := snapstate.AutoAliasesDeltaV2(s.state, []string{"some-snap", "other-snap"})
+		_, dropped, err := snapstate.AutoAliasesDelta(s.state, []string{"some-snap", "other-snap"})
 		c.Assert(err, IsNil)
 
 		j := 0
@@ -2343,7 +2343,7 @@ func (s *snapmgrTestSuite) TestUpdateOneAutoAliasesScenarios(c *C) {
 
 		ts, err := snapstate.Update(s.state, scenario.names[0], "", snap.R(0), s.user.ID, snapstate.Flags{})
 		c.Assert(err, IsNil)
-		_, dropped, err := snapstate.AutoAliasesDeltaV2(s.state, []string{"some-snap", "other-snap"})
+		_, dropped, err := snapstate.AutoAliasesDelta(s.state, []string{"some-snap", "other-snap"})
 		c.Assert(err, IsNil)
 
 		j := 0

--- a/snap/info.go
+++ b/snap/info.go
@@ -145,7 +145,7 @@ type Info struct {
 	Epoch            string
 	Confinement      ConfinementType
 	Apps             map[string]*AppInfo
-	Aliases          map[string]*AppInfo
+	LegacyAliases    map[string]*AppInfo // FIXME: eventually drop this
 	Hooks            map[string]*HookInfo
 	Plugs            map[string]*PlugInfo
 	Slots            map[string]*SlotInfo
@@ -362,9 +362,9 @@ type SlotInfo struct {
 type AppInfo struct {
 	Snap *Info
 
-	Name    string
-	Aliases []string
-	Command string
+	Name          string
+	LegacyAliases []string // FIXME: eventually drop this
+	Command       string
 
 	Daemon          string
 	StopTimeout     timeout.Timeout

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -160,7 +160,7 @@ func infoSkeletonFromSnapYaml(y snapYaml) *Info {
 		Epoch:               epoch,
 		Confinement:         confinement,
 		Apps:                make(map[string]*AppInfo),
-		Aliases:             make(map[string]*AppInfo),
+		LegacyAliases:       make(map[string]*AppInfo),
 		Hooks:               make(map[string]*HookInfo),
 		Plugs:               make(map[string]*PlugInfo),
 		Slots:               make(map[string]*SlotInfo),
@@ -223,7 +223,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 		app := &AppInfo{
 			Snap:            snap,
 			Name:            appName,
-			Aliases:         yApp.Aliases,
+			LegacyAliases:   yApp.Aliases,
 			Command:         yApp.Command,
 			Daemon:          yApp.Daemon,
 			StopTimeout:     yApp.StopTimeout,
@@ -241,11 +241,11 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			app.Slots = make(map[string]*SlotInfo)
 		}
 		snap.Apps[appName] = app
-		for _, alias := range app.Aliases {
-			if snap.Aliases[alias] != nil {
-				return fmt.Errorf("cannot set %q as alias for both %q and %q", alias, snap.Aliases[alias].Name, appName)
+		for _, alias := range app.LegacyAliases {
+			if snap.LegacyAliases[alias] != nil {
+				return fmt.Errorf("cannot set %q as alias for both %q and %q", alias, snap.LegacyAliases[alias].Name, appName)
 			}
-			snap.Aliases[alias] = app
+			snap.LegacyAliases[alias] = app
 		}
 		// Bind all plugs/slots listed in this app
 		for _, plugName := range yApp.PlugNames {

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1403,10 +1403,10 @@ apps:
 	info, err := snap.InfoFromSnapYaml(y)
 	c.Assert(err, IsNil)
 
-	c.Check(info.Apps["foo"].Aliases, DeepEquals, []string{"foo"})
-	c.Check(info.Apps["bar"].Aliases, DeepEquals, []string{"bar", "bar1"})
+	c.Check(info.Apps["foo"].LegacyAliases, DeepEquals, []string{"foo"})
+	c.Check(info.Apps["bar"].LegacyAliases, DeepEquals, []string{"bar", "bar1"})
 
-	c.Check(info.Aliases, DeepEquals, map[string]*snap.AppInfo{
+	c.Check(info.LegacyAliases, DeepEquals, map[string]*snap.AppInfo{
 		"foo":  info.Apps["foo"],
 		"bar":  info.Apps["bar"],
 		"bar1": info.Apps["bar"],

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -96,7 +96,7 @@ func Validate(info *Info) error {
 	}
 
 	// validate aliases
-	for alias, app := range info.Aliases {
+	for alias, app := range info.LegacyAliases {
 		if !validAlias.MatchString(alias) {
 			return fmt.Errorf("cannot have %q as alias name for app %q - use only letters, digits, dash, underscore and dot characters", alias, app.Name)
 		}


### PR DESCRIPTION
* linearize some error handling as per feedback to #3220 
* move away non-legacy tests completely from using auto-aliases in snap-declaration and declaring aliases in snaps
* drop V2 suffix from most aliases functions
* rename Aliases to LegacyAliases on *Info, to be dropped soon
* as asked by mvo introduce some bool constants for when passing immediate autoDisabled values to applyAliasesChange or checkAliasesConflicts
