### PR TITLE
tests: fail early in the spread suite if trying to run it inside a container

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -220,6 +220,13 @@ repack: |
     fi
 
 prepare: |
+    # check if running inside an lxc/lxd container, the testsuite will not
+    # work in such an environment
+    if env|grep -q 'container=lxc'; then
+        echo "Tests cannot run inside an lxc/lxd/docker environment"
+        exit 1
+    fi
+
     # apt update is hanging on security.ubuntu.com with IPv6.
     sysctl -w net.ipv6.conf.all.disable_ipv6=1
     trap "sysctl -w net.ipv6.conf.all.disable_ipv6=0" EXIT

--- a/spread.yaml
+++ b/spread.yaml
@@ -220,10 +220,10 @@ repack: |
     fi
 
 prepare: |
-    # check if running inside an lxc/lxd container, the testsuite will not
+    # check if running inside a container, the testsuite will not
     # work in such an environment
-    if env|grep -q 'container=lxc'; then
-        echo "Tests cannot run inside an lxc/lxd/docker environment"
+    if systemd-detect-virt -c; then
+        echo "Tests cannot run inside a container"
         exit 1
     fi
 


### PR DESCRIPTION
The testsuite needs to run in a full environment (virtual or real),
it will not work inside a container so fail early instead of
generating hard to read error messages like:
```
- Mount snap "core" (1580) ([start snap-core-1580.mount] failed with
exit status 1: Job for snap-core-1580.mount failed.
```
