### PR TITLE
tests: set ownership of $PROJECT_PATH for the external backend

### DIFF
--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -82,6 +82,7 @@ if [ "$SPREAD_BACKEND" = external ]; then
        systemctl disable --now snapd.refresh.timer
        snap set core refresh.disabled=true
    fi
+   chown test.test -R $PROJECT_PATH
    exit 0
 fi
 


### PR DESCRIPTION
Until now we didn't have any test executed by the external backend (testbeds are already running ubuntu-core systems) that tried to write to directories under `$PROJECT_PATH` as a non-root user, like in [1]. These tests are passing on linode and qemu backends for ubuntu-core systems because during the suite preparation we create the test user and chown the required files to be owned by it, here [2]. We need to do the same for the external backend, where the test user is created before the suite begins to execute.

[1] https://github.com/snapcore/snapd/blob/master/tests/main/econnreset/task.yaml#L7
[2] https://github.com/snapcore/snapd/blob/master/tests/lib/prepare-project.sh#L23