### PR TITLE
tests: specify the auto-refreshable snap being tested

### DIFF
--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -8,7 +8,7 @@ restore: |
         snap set core refresh.schedule="$(date +%a --date=2days)@12:00-14:00"
         snap set core refresh.disabled=true
     fi
-    
+
 execute: |
     echo "Install a snap from stable"
     snap install test-snapd-tools
@@ -17,7 +17,7 @@ execute: |
         snap set core refresh.schedule="0:00-23:59"
         snap set core refresh.disabled=false
     fi
-    
+
     systemctl stop snapd.{service,socket}
     echo "Modify the snap to track the edge channel"
     jq '.data.snaps["test-snapd-tools"].channel = "edge"' /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
@@ -29,7 +29,7 @@ execute: |
 
     echo "wait for auto-refresh to happen"
     for i in $(seq 120); do
-        if snap changes|grep -q "Done.*Auto-refresh snap"; then
+        if snap changes|grep -q "Done.*Auto-refresh snap \"test-snapd-tools\""; then
             break
         fi
         echo "Doing something that triggers ensure"
@@ -40,7 +40,6 @@ execute: |
 
     echo "Ensure our snap got updated"
     snap list|MATCH "test-snapd-tools +[0-9]+\.[0-9]+\+fake1"
-    
+
     echo "Ensure refresh.last is set"
     jq ".data[\"last-refresh\"]" /var/lib/snapd/state.json | MATCH $(date +%Y)
-


### PR DESCRIPTION
In one of the validation scenarios run on the external backend, when we execute the test suite on the latest stable image after refreshing core to the target channel, it is possible that other snaps, like kernel, are auto refreshed before the suite is executed. Specifying the snap used in the change message prevents eventual errors on `tests/main/auto-refresh`.