### PR TITLE
tests/upgrade: force install core snap from beta for debian

### DIFF
--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -18,6 +18,13 @@ execute: |
 
     prevsnapdver=$(snap --version|grep "snapd ")
 
+    if [[ "$SPREAD_SYSTEM" = debian-* ]] ; then
+        # For debian we install the latest core snap from beta instead
+        # from stable as stable and candidate are broken at the moment.
+        # FIXME: drop this again once 2.25 landed in stable.
+        snap install --beta core
+    fi
+
     echo Install sanity check snaps with it
     snap install test-snapd-tools
     snap install test-snapd-auto-aliases


### PR DESCRIPTION
Until 2.25 lands in candidate/stable we have to force install the
core snap from beta to get necessary bug fixes which prevent the
core configure hook from running successfully on installation.