### PR TITLE
cmd: make rst2man optional

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -187,9 +187,11 @@ all_tests = \
     snap-confine/tests/test_whitelist
 
 libexec_PROGRAMS += snap-confine/snap-confine
+if HAVE_RST2MAN
 dist_man_MANS += snap-confine/snap-confine.5
 CLEANFILES += snap-confine/snap-confine.5
 EXTRA_DIST += snap-confine/snap-confine.rst
+endif
 EXTRA_DIST += snap-confine/snap-confine.apparmor.in
 EXTRA_DIST += $(all_tests) snap-confine/tests/common.sh
 if SECCOMP
@@ -307,9 +309,11 @@ snap-confine/unit-tests$(EXEEXT): $(snap_confine_unit_tests_OBJECTS) $(snap_conf
 snap-confine/unit-tests$(EXEEXT): LIBS += -Wl,-Bstatic $(snap_confine_unit_tests_STATIC) -Wl,-Bdynamic -pthread
 endif  # WITH_UNIT_TESTS
 
+if HAVE_RST2MAN
 snap-confine/%.5: snap-confine/%.rst
 	mkdir -p snap-confine
 	$(HAVE_RST2MAN) $^ > $@
+endif
 
 snap-confine/snap-confine.apparmor: snap-confine/snap-confine.apparmor.in Makefile
 	sed -e 's,[@]LIBEXECDIR[@],$(libexecdir),g' -e 's,[@]SNAP_MOUNT_DIR[@],$(SNAP_MOUNT_DIR),' <$< >$@
@@ -372,9 +376,11 @@ install-exec-local::
 ##
 
 libexec_PROGRAMS += snap-discard-ns/snap-discard-ns
+if HAVE_RST2MAN
 dist_man_MANS += snap-discard-ns/snap-discard-ns.5
 CLEANFILES += snap-discard-ns/snap-discard-ns.5
 EXTRA_DIST += snap-discard-ns/snap-discard-ns.rst
+endif
 
 snap_discard_ns_snap_discard_ns_SOURCES = \
 	snap-confine/ns-support.c \
@@ -409,9 +415,11 @@ snap-discard-ns/snap-discard-ns$(EXEEXT): $(snap_discard_ns_snap_discard_ns_OBJE
 
 snap-discard-ns/snap-discard-ns$(EXEEXT): LIBS += -Wl,-Bstatic $(snap_discard_ns_snap_discard_ns_STATIC) -Wl,-Bdynamic -pthread
 
+if HAVE_RST2MAN
 snap-discard-ns/%.5: snap-discard-ns/%.rst
 	mkdir -p snap-discard-ns
 	$(HAVE_RST2MAN) $^ > $@
+endif
 
 ##
 ## system-shutdown

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -190,8 +190,8 @@ libexec_PROGRAMS += snap-confine/snap-confine
 if HAVE_RST2MAN
 dist_man_MANS += snap-confine/snap-confine.5
 CLEANFILES += snap-confine/snap-confine.5
-EXTRA_DIST += snap-confine/snap-confine.rst
 endif
+EXTRA_DIST += snap-confine/snap-confine.rst
 EXTRA_DIST += snap-confine/snap-confine.apparmor.in
 EXTRA_DIST += $(all_tests) snap-confine/tests/common.sh
 if SECCOMP
@@ -379,8 +379,8 @@ libexec_PROGRAMS += snap-discard-ns/snap-discard-ns
 if HAVE_RST2MAN
 dist_man_MANS += snap-discard-ns/snap-discard-ns.5
 CLEANFILES += snap-discard-ns/snap-discard-ns.5
-EXTRA_DIST += snap-discard-ns/snap-discard-ns.rst
 endif
+EXTRA_DIST += snap-discard-ns/snap-discard-ns.rst
 
 snap_discard_ns_snap_discard_ns_SOURCES = \
 	snap-confine/ns-support.c \

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -175,7 +175,8 @@ AS_IF([test "x$enable_caps_over_setuid" = "xyes"], [
         [Use capabilities rather than setuid bit])])
 
 AC_PATH_PROGS([HAVE_RST2MAN],[rst2man rst2man.py])
-AS_IF([test "x$HAVE_RST2MAN" = "x"], [AC_MSG_ERROR(["cannot find the rst2man tool, install python-docutils or similar"])])
+AS_IF([test "x$HAVE_RST2MAN" = "x"], [AC_MSG_WARN(["cannot find the rst2man tool, install python-docutils or similar"])])
+AM_CONDITIONAL([HAVE_RST2MAN], [test "x${HAVE_RST2MAN}" != "x"])
 
 AC_PATH_PROG([HAVE_SHELLCHECK],[shellcheck])
 AM_CONDITIONAL([HAVE_SHELLCHECK], [test "x${HAVE_SHELLCHECK}" != "x"])


### PR DESCRIPTION
Not every distribution as rst2man available or needs man pages packaged like Yocto. This disables all man page generation when rst2man isn't found on the build system.