### PR TITLE
interfaces/browser-support: deny read on squashfs backing files and LVM vg names

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -128,6 +128,7 @@ owner @{PROC}/@{pid}/fd/[0-9]* w,
 # since these contain the names of snaps. Chromium operates fine without the
 # access so just block it.
 deny /sys/devices/virtual/block/loop[0-9]*/loop/backing_file r,
+deny /sys/devices/virtual/block/dm-[0-9]*/dm/name r,
 
 # networking
 /run/udev/data/n[0-9]* r,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -124,6 +124,11 @@ owner @{PROC}/@{pid}/fd/[0-9]* w,
 /sys/devices/**/product r,
 /sys/devices/**/serial r,
 
+# Chromium content api tries to read these. It is an information disclosure
+# since these contain the names of snaps. Chromium operates fine without the
+# access so just block it.
+deny /sys/devices/virtual/block/loop[0-9]*/loop/backing_file r,
+
 # networking
 /run/udev/data/n[0-9]* r,
 /run/udev/data/+bluetooth:hci[0-9]* r,


### PR DESCRIPTION
Chromium content api when the sandbox is enabled tries to access virtual/block/loop[0-9]*/loop/backing_file in sysfs, but it operates fine without them. These files correspond to the squashfs mounts for snaps and allowing the access constitutes an information leak since the snap would be able to enumerate the mounted snaps. Similarly, it will try to enumerate the names of LVM volume groups. These are rather esoteric accesses and with the existing policy, only the udisks2 permanent slot policy allows the accesses via a glob rule. The udisks2 snap does not plug browser-support and any slot implementation of udisks2 should not either (*especially* not with 'allow-sandbox: true').