### PR TITLE
adjust Nice and oom_score levels for snapd

### DIFF
--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -3,6 +3,8 @@ Description=Snappy daemon
 Requires=snapd.socket
 
 [Service]
+Nice=-5
+OOMScoreAdjust=-900
 ExecStart=@libexecdir@/snapd/snapd
 EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
 Restart=always


### PR DESCRIPTION
- set nice level to -5 so the scheduler will use a higher priority for snapd under heavy load
- use an oom score of -900 for snapd (same as the system dbus) to make sure OOM conditions do kill it late