### PR TITLE
add interfaces-shutdown-introspection spread test

### DIFF
--- a/tests/lib/snaps/shutdown-introspection-consumer/bin/consumer
+++ b/tests/lib/snaps/shutdown-introspection-consumer/bin/consumer
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+dbus-send --system --print-reply --dest=org.freedesktop.login1 \
+        /org/freedesktop/login1 \
+        org.freedesktop.DBus.Introspectable.Introspect

--- a/tests/lib/snaps/shutdown-introspection-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/shutdown-introspection-consumer/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: shutdown-introspection-consumer
+version: 1.0
+summary: Basic shutdown consumer snap for introspecting org.freedesktop.login1
+description: A basic snap declaring a plug on shutdown for DBus introspection
+
+apps:
+    shutdown-introspection-consumer:
+        command: bin/consumer
+        plugs: [shutdown, unity7]

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -3,7 +3,8 @@ summary: Ensures that introspection of login1 of the shutdown interface works.
 systems:
     # No confinement (AppArmor, Seccomp) available on these systems
     - -debian-*
-    # unity7 implicit slot (used to access dbus-send), not available on core
+    # unity7 implicit classic slot needed (used to access dbus-send) not
+    # available on core
     - -ubuntu-core-*
 
 details: |
@@ -20,7 +21,7 @@ restore: |
 
 execute: |
     CONNECTED_PATTERN=":shutdown +shutdown-introspection-consumer"
-    DISCONNECTED_PATTERN="(?s).*?\n- +shutdown-introspection-consumer:shutdown"
+    DISCONNECTED_PATTERN="\- +shutdown-introspection-consumer:shutdown"
 
     echo "Then the plug is shown as disconnected"
     snap interfaces | MATCH "$DISCONNECTED_PATTERN"

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -11,15 +11,14 @@ details: |
     A snap declaring the shutdown plug is defined, its command just calls
     the Introspect method on org.freedesktop.login1.
 
-prepare: |
-    echo "Given a snap declaring a plug on the shutdown interface is installed"
-    snapbuild $TESTSLIB/snaps/shutdown-introspection-consumer .
-    snap install --dangerous shutdown-introspection-consumer_1.0_all.snap
-
 restore: |
     rm -f shutdown-introspection-consumer_1.0_all.snap
 
 execute: |
+    echo "Given a snap declaring a plug on the shutdown interface is installed"
+    . $TESTSLIB/snaps.sh
+    install_local shutdown-introspection-consumer
+
     CONNECTED_PATTERN=":shutdown +shutdown-introspection-consumer"
     DISCONNECTED_PATTERN="\- +shutdown-introspection-consumer:shutdown"
 

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -23,23 +23,23 @@ execute: |
     DISCONNECTED_PATTERN="(?s).*?\n- +shutdown-introspection-consumer:shutdown"
 
     echo "Then the plug is shown as disconnected"
-    snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
+    snap interfaces | MATCH "$DISCONNECTED_PATTERN"
 
     echo "==========================================="
 
     echo "When the plug is connected"
     snap connect shutdown-introspection-consumer:shutdown
-    snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
+    snap interfaces | MATCH "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to get introspect org.freedesktop.login1"
     expected="<interface name=\"org.freedesktop.login1.Manager\">"
-    su -l -c "shutdown-introspection-consumer" test | grep -Pq "$expected"
+    su -l -c "shutdown-introspection-consumer" test | MATCH"$expected"
 
     echo "==========================================="
 
     echo "When the plug is disconnected"
     snap disconnect shutdown-introspection-consumer:shutdown
-    snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
+    snap interfaces | MATCH "$DISCONNECTED_PATTERN"
 
     echo "Then the snap is not able to get system information"
     if su -l -c "shutdown-introspection-consumer" test; then

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -1,0 +1,48 @@
+summary: Ensures that introspection of login1 of the shutdown interface works.
+
+systems:
+    # No confinement (AppArmor, Seccomp) available on these systems
+    - -debian-*
+    # unity7 implicit slot (used to access dbus-send), not available on core
+    - -ubuntu-core-*
+
+details: |
+    A snap declaring the shutdown plug is defined, its command just calls
+    the Introspect method on org.freedesktop.login1.
+
+prepare: |
+    echo "Given a snap declaring a plug on the shutdown interface is installed"
+    snapbuild $TESTSLIB/snaps/shutdown-introspection-consumer .
+    snap install --dangerous shutdown-introspection-consumer_1.0_all.snap
+
+restore: |
+    rm -f shutdown-introspection-consumer_1.0_all.snap
+
+execute: |
+    CONNECTED_PATTERN=":shutdown +shutdown-introspection-consumer"
+    DISCONNECTED_PATTERN="(?s).*?\n- +shutdown-introspection-consumer:shutdown"
+
+    echo "Then the plug is shown as disconnected"
+    snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
+
+    echo "==========================================="
+
+    echo "When the plug is connected"
+    snap connect shutdown-introspection-consumer:shutdown
+    snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
+
+    echo "Then the snap is able to get introspect org.freedesktop.login1"
+    expected="<interface name=\"org.freedesktop.login1.Manager\">"
+    su -l -c "shutdown-introspection-consumer" test | grep -Pq "$expected"
+
+    echo "==========================================="
+
+    echo "When the plug is disconnected"
+    snap disconnect shutdown-introspection-consumer:shutdown
+    snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
+
+    echo "Then the snap is not able to get system information"
+    if su -l -c "shutdown-introspection-consumer" test; then
+        echo "Expected error with plug disconnected"
+        exit 1
+    fi

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -33,7 +33,7 @@ execute: |
 
     echo "Then the snap is able to get introspect org.freedesktop.login1"
     expected="<interface name=\"org.freedesktop.login1.Manager\">"
-    su -l -c "shutdown-introspection-consumer" test | MATCH"$expected"
+    su -l -c "shutdown-introspection-consumer" test | MATCH "$expected"
 
     echo "==========================================="
 

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -11,9 +11,6 @@ details: |
     A snap declaring the shutdown plug is defined, its command just calls
     the Introspect method on org.freedesktop.login1.
 
-restore: |
-    rm -f shutdown-introspection-consumer_1.0_all.snap
-
 execute: |
     echo "Given a snap declaring a plug on the shutdown interface is installed"
     . $TESTSLIB/snaps.sh


### PR DESCRIPTION
As a follow-on to https://github.com/snapcore/snapd/pull/3266, add interfaces-shutdown-introspection spread test. This can only be run on classic since the PR uses an internal snap and dbus-send and only the unity7 implicit classic interface allows use of dbus-send. If this is deemed a problem, we could create a snap in the store or adjust the security policy to allow dbus-send. Since this test is only about showing that introspection works at all anywhere (the introspection rules add in PR#3266 will be the same regardless of target OS), 'classic ubuntu' counts as 'anywhere' and I therefore feel this test is fine as is.

Test based on existing interfaces-system-observe test.