### PR TITLE
tests: wait for the docker socket to be listening

### DIFF
--- a/tests/nightly/docker/task.yaml
+++ b/tests/nightly/docker/task.yaml
@@ -19,6 +19,9 @@ debug: |
     dmesg
 
 execute: |
+    # wait for the socket to be listening
+    while ! printf "GET /" | nc -U -q 1 /var/run/docker.sock; do sleep 1; done
+
     echo "Check that docker info and run basically work"
     docker info
 


### PR DESCRIPTION
The docker test is failing with https://travis-ci.org/snapcore/spread-cron/builds/228574717#L411 sometimes the service is not yet up when we issue `docker info`. These changes make the test wait until the socket is listening.