### PR TITLE
store, daemon, client, cmd/snap: handle PASSWORD_POLICY_ERROR

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -333,6 +333,7 @@ const (
 	ErrorKindTermsNotAccepted  = "terms-not-accepted"
 	ErrorKindNoPaymentMethods  = "no-payment-methods"
 	ErrorKindPaymentDeclined   = "payment-declined"
+	ErrorKindPasswordPolicy    = "password-policy"
 
 	ErrorKindSnapAlreadyInstalled   = "snap-already-installed"
 	ErrorKindSnapNotInstalled       = "snap-not-installed"

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -130,9 +130,6 @@ If you understand and want to proceed repeat the command including --classic.
 			// TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 			msg = fmt.Sprintf(i18n.G(`%s (try with sudo)`), err.Message)
 		}
-	case client.ErrorKindPasswordPolicy:
-		usesSnapName = false
-		msg = err.Message
 	case client.ErrorKindSnapNotInstalled, client.ErrorKindNoUpdateAvailable:
 		isError = false
 		usesSnapName = false

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -77,9 +77,17 @@ func fill(para string) string {
 	// 3 is the %v\n, which will be present in any locale
 	indent := len(errorPrefix) - 3
 	var buf bytes.Buffer
-	doc.ToText(&buf, para, strings.Repeat(" ", indent), "", width)
+	doc.ToText(&buf, para, strings.Repeat(" ", indent), "", width-indent)
 
 	return strings.TrimSpace(buf.String())
+}
+
+type filledError struct {
+	error
+}
+
+func (e filledError) Error() string {
+	return fill(e.error.Error())
 }
 
 func clientErrorToCmdMessage(snapName string, err *client.Error) (string, error) {
@@ -122,6 +130,9 @@ If you understand and want to proceed repeat the command including --classic.
 			// TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 			msg = fmt.Sprintf(i18n.G(`%s (try with sudo)`), err.Message)
 		}
+	case client.ErrorKindPasswordPolicy:
+		usesSnapName = false
+		msg = err.Message
 	case client.ErrorKindSnapNotInstalled, client.ErrorKindNoUpdateAvailable:
 		isError = false
 		usesSnapName = false

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"unicode"
@@ -314,14 +313,14 @@ func run() error {
 				return fmt.Errorf(i18n.G(`unknown command %q, see "snap --help"`), os.Args[1])
 			}
 		}
-		if e, ok := err.(*client.Error); ok && e.Kind == client.ErrorKindLoginRequired {
-			u, _ := user.Current()
-			if u != nil && u.Username == "root" {
-				return fmt.Errorf(i18n.G(`%s (see "snap login --help")`), e.Message)
+		if e, ok := err.(*client.Error); ok {
+			msg, err := clientErrorToCmdMessage("", e)
+			if err != nil {
+				return err
 			}
 
-			// TRANSLATORS: %s will be a message along the lines of "login required"
-			return fmt.Errorf(i18n.G(`%s (try with sudo)`), e.Message)
+			fmt.Fprintf(Stderr, msg)
+			return nil
 		}
 	}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -345,7 +345,8 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 			Status: http.StatusUnauthorized,
 		}, nil)
 	default:
-		if err, ok := err.(store.ErrInvalidAuthData); ok {
+		switch err := err.(type) {
+		case store.ErrInvalidAuthData:
 			return SyncResponse(&resp{
 				Type: ResponseTypeError,
 				Result: &errorResult{
@@ -354,6 +355,16 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 					Value:   err,
 				},
 				Status: http.StatusBadRequest,
+			}, nil)
+		case store.ErrPasswordPolicy:
+			return SyncResponse(&resp{
+				Type: ResponseTypeError,
+				Result: &errorResult{
+					Message: err.Error(),
+					Kind:    errorKindPasswordPolicy,
+					Value:   err,
+				},
+				Status: http.StatusUnauthorized,
 			}, nil)
 		}
 		return Unauthorized(err.Error())

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -124,6 +124,7 @@ const (
 	errorKindTermsNotAccepted  = errorKind("terms-not-accepted")
 	errorKindNoPaymentMethods  = errorKind("no-payment-methods")
 	errorKindPaymentDeclined   = errorKind("payment-declined")
+	errorKindPasswordPolicy    = errorKind("password-policy")
 
 	errorKindSnapAlreadyInstalled  = errorKind("snap-already-installed")
 	errorKindSnapNotInstalled      = errorKind("snap-not-installed")

--- a/store/auth.go
+++ b/store/auth.go
@@ -51,22 +51,23 @@ var (
 	UbuntuoneRefreshDischargeAPI = ubuntuoneAPIBase + "/tokens/refresh"
 )
 
-// a stringish is something that can be a []string or a string
-// like the values of the "extra" documents in error responses
-type stringish []string
+// a stringList is something that can be deserialized from a JSON
+// []string or a string, like the values of the "extra" documents in
+// error responses
+type stringList []string
 
-func (sish *stringish) UnmarshalJSON(bs []byte) error {
+func (sish *stringList) UnmarshalJSON(bs []byte) error {
 	var ss []string
 	e1 := json.Unmarshal(bs, &ss)
 	if e1 == nil {
-		*sish = stringish(ss)
+		*sish = stringList(ss)
 		return nil
 	}
 
 	var s string
 	e2 := json.Unmarshal(bs, &s)
 	if e2 == nil {
-		*sish = stringish([]string{s})
+		*sish = stringList([]string{s})
 		return nil
 	}
 
@@ -74,9 +75,9 @@ func (sish *stringish) UnmarshalJSON(bs []byte) error {
 }
 
 type ssoMsg struct {
-	Code    string               `json:"code"`
-	Message string               `json:"message"`
-	Extra   map[string]stringish `json:"extra"`
+	Code    string                `json:"code"`
+	Message string                `json:"message"`
+	Extra   map[string]stringList `json:"extra"`
 }
 
 // returns true if the http status code is in the "success" range (2xx)

--- a/store/auth.go
+++ b/store/auth.go
@@ -51,10 +51,32 @@ var (
 	UbuntuoneRefreshDischargeAPI = ubuntuoneAPIBase + "/tokens/refresh"
 )
 
+// a stringish is something that can be a []string or a string
+// like the values of the "extra" documents in error responses
+type stringish []string
+
+func (sish *stringish) UnmarshalJSON(bs []byte) error {
+	var ss []string
+	e1 := json.Unmarshal(bs, &ss)
+	if e1 == nil {
+		*sish = stringish(ss)
+		return nil
+	}
+
+	var s string
+	e2 := json.Unmarshal(bs, &s)
+	if e2 == nil {
+		*sish = stringish([]string{s})
+		return nil
+	}
+
+	return e1
+}
+
 type ssoMsg struct {
-	Code    string              `json:"code"`
-	Message string              `json:"message"`
-	Extra   map[string][]string `json:"extra"`
+	Code    string               `json:"code"`
+	Message string               `json:"message"`
+	Extra   map[string]stringish `json:"extra"`
 }
 
 // returns true if the http status code is in the "success" range (2xx)
@@ -220,6 +242,8 @@ func requestDischargeMacaroon(endpoint string, data map[string]string) (string, 
 			return "", Err2faFailed
 		case "INVALID_DATA":
 			return "", ErrInvalidAuthData(msg.Extra)
+		case "PASSWORD_POLICY_ERROR":
+			return "", ErrPasswordPolicy(msg.Extra)
 		}
 
 		if msg.Message != "" {

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -380,11 +380,11 @@ func (s *authTestSuite) TestRequestDeviceSessionError(c *C) {
 }
 
 func (s *authTestSuite) TestStringish(c *C) {
-	var x stringish
+	var x stringList
 
 	c.Check(json.Unmarshal([]byte(`"hello"`), &x), IsNil)
-	c.Check(x, DeepEquals, stringish([]string{"hello"}))
+	c.Check(x, DeepEquals, stringList([]string{"hello"}))
 
 	c.Check(json.Unmarshal([]byte(`["hello", "world"]`), &x), IsNil)
-	c.Check(x, DeepEquals, stringish([]string{"hello", "world"}))
+	c.Check(x, DeepEquals, stringList([]string{"hello", "world"}))
 }

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -20,6 +20,7 @@
 package store
 
 import (
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -376,4 +377,14 @@ func (s *authTestSuite) TestRequestDeviceSessionError(c *C) {
 	c.Assert(err, ErrorMatches, `cannot get device session from store: store server returned status 500 and body "error body"`)
 	c.Assert(n, Equals, 5)
 	c.Assert(macaroon, Equals, "")
+}
+
+func (s *authTestSuite) TestStringish(c *C) {
+	var x stringish
+
+	c.Check(json.Unmarshal([]byte(`"hello"`), &x), IsNil)
+	c.Check(x, DeepEquals, stringish([]string{"hello"}))
+
+	c.Check(json.Unmarshal([]byte(`["hello", "world"]`), &x), IsNil)
+	c.Check(x, DeepEquals, stringish([]string{"hello", "world"}))
 }

--- a/store/errors.go
+++ b/store/errors.go
@@ -70,7 +70,7 @@ func (e *ErrDownload) Error() string {
 	return fmt.Sprintf("received an unexpected http response code (%v) when trying to download %s", e.Code, e.URL)
 }
 
-type ErrPasswordPolicy map[string]stringish
+type ErrPasswordPolicy map[string]stringList
 
 func (e ErrPasswordPolicy) Error() string {
 	var msg string
@@ -90,7 +90,7 @@ func (e ErrPasswordPolicy) Error() string {
 }
 
 // ErrInvalidAuthData signals that the authentication data didn't pass validation.
-type ErrInvalidAuthData map[string]stringish
+type ErrInvalidAuthData map[string]stringList
 
 func (e ErrInvalidAuthData) Error() string {
 	var es []string

--- a/store/errors.go
+++ b/store/errors.go
@@ -70,8 +70,27 @@ func (e *ErrDownload) Error() string {
 	return fmt.Sprintf("received an unexpected http response code (%v) when trying to download %s", e.Code, e.URL)
 }
 
+type ErrPasswordPolicy map[string]stringish
+
+func (e ErrPasswordPolicy) Error() string {
+	var msg string
+
+	if reason, ok := e["reason"]; ok && len(reason) == 1 {
+		msg = reason[0]
+		if location, ok := e["location"]; ok && len(location) == 1 {
+			msg += "\nTo address this, go to: " + location[0] + "\n"
+		}
+	} else {
+		for k, vs := range e {
+			msg += fmt.Sprintf("%s: %s\n", k, strings.Join(vs, "  "))
+		}
+	}
+
+	return msg
+}
+
 // ErrInvalidAuthData signals that the authentication data didn't pass validation.
-type ErrInvalidAuthData map[string][]string
+type ErrInvalidAuthData map[string]stringish
 
 func (e ErrInvalidAuthData) Error() string {
 	var es []string

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -24,7 +24,8 @@ execute: |
     snap install $SNAP_NAME --devmode | grep -Pzq "$expected"
 
     echo "Install devmode snap without devmode option"
-    ( snap install --channel beta $DEVMODE_SNAP 2>&1 && exit 1 || true ) | MATCH 'repeat the command including --devmode'
+    expected="repeat the command including --devmode"
+    ( snap install --channel beta $DEVMODE_SNAP 2>&1 && exit 1 || true ) | MATCH -z "${expected// /[[:space:]]+}"
 
     echo "Install devmode snap from stable"
     expected="snap not found"

--- a/tests/main/login/unsuccessful_login.exp
+++ b/tests/main/login/unsuccessful_login.exp
@@ -6,7 +6,7 @@ expect "Password of "
 send "wrong-password\n"
 
 expect {
-    "not correct" {
+    -re "not\[ \n\r\]*correct" {
         exit 0
     } default {
         exit 1


### PR DESCRIPTION
We had the wrong type for SSO errors. This was usually fine, because the most common errors either have no `extra` field, or the `extra` field fits in a `map[string][]string`. But sometimes, and in particular for `PASSWORD_POLICY_ERROR`, it's a `map[string]string`. This made the user-visible error you'd get as a result of `PASSWORD_POLICY_ERROR` to be unintelligible and unhelpful (a json decode error).

Additionally, `PASSWORD_POLICY_ERROR` is rather different from other errors that have an `extra` field; in these, there is a long, detailed explanation of the cause of the error together with a URL the user needs to go to to address the issue. With this branch this is surfaced appropriately; for example (and the case that triggered this branch),

```
$ sudo snap login jlenton+test@gmail.com
Password of "jlenton+test@gmail.com": 
error: Recently, there was a security breach on another website unrelated to
       Ubuntu One. Ubuntu One was not affected and is not connected in any way
       with this incident, but the password you're trying to use would put your
       Ubuntu One account at risk because you're using the same email and
       password that was breached elsewhere.

       To make sure your account is kept safe, you will need to use a different
       password for this account.

       To address this, go to: https://login.ubuntu.com/
```