### PR TITLE
tests: extend kernel-module-control interface test

### DIFF
--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -32,7 +32,7 @@ mksnap_fast() {
 install_generic_consumer() {
     local INTERFACE_NAME="$1"
     cp -ar $TESTSLIB/snaps/generic-consumer .
-    sed -i "s/<interface-name>/$INTERFACE_NAME/" generic-consumer/meta/snap.yaml
+    sed "s/@INTERFACE@/$INTERFACE_NAME/" generic-consumer/meta/snap.yaml.in > generic-consumer/meta/snap.yaml
     snapbuild generic-consumer generic-consumer
     snap install --dangerous generic-consumer/*.snap
     rm -rf generic-consumer

--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -20,11 +20,20 @@ install_local_devmode() {
 mksnap_fast() {
     dir="$1"
     snap="$2"
-    
+
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         # trusty does not support  -Xcompression-level 1
         mksquashfs "$dir" "$snap" -comp gzip
     else
         mksquashfs "$dir" "$snap" -comp gzip -Xcompression-level 1
     fi
+}
+
+install_generic_consumer() {
+    local INTERFACE_NAME="$1"
+    cp -ar $TESTSLIB/snaps/generic-consumer .
+    sed -i "s/<interface-name>/$INTERFACE_NAME/" generic-consumer/meta/snap.yaml
+    snapbuild generic-consumer generic-consumer
+    snap install --dangerous generic-consumer/*.snap
+    rm -rf generic-consumer
 }

--- a/tests/lib/snaps/generic-consumer/bin/cmd
+++ b/tests/lib/snaps/generic-consumer/bin/cmd
@@ -1,0 +1,5 @@
+#!/bin/sh
+command="$1"
+shift
+
+"$command" "$@"

--- a/tests/lib/snaps/generic-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/generic-consumer/meta/snap.yaml
@@ -1,0 +1,6 @@
+name: generic-consumer
+version: 1.0
+apps:
+    cmd:
+        command: bin/cmd
+        plugs: [<interface-name>]

--- a/tests/lib/snaps/generic-consumer/meta/snap.yaml.in
+++ b/tests/lib/snaps/generic-consumer/meta/snap.yaml.in
@@ -3,4 +3,4 @@ version: 1.0
 apps:
     cmd:
         command: bin/cmd
-        plugs: [<interface-name>]
+        plugs: [@INTERFACE@]

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -18,9 +18,11 @@ details: |
 prepare: |
     echo "Given a snap declaring a plug on the kernel-module-control interface is installed"
     snap install --edge test-snapd-kernel-module-control-consumer
+    . $TESTSLIB/snaps.sh
+    install_generic_consumer kernel-module-control
 
 restore: |
-    rm -f list.error remove.error
+    rm -f *.error
     if lsmod | MATCH binfmt_misc && ! -f module_present; then
         rmmod binfmt_misc
     elif [ -f module_present ]; then
@@ -35,7 +37,7 @@ debug: |
     lsmod
 
 execute: |
-    CONNECTED_PATTERN=":kernel-module-control +test-snapd-kernel-module-control-consumer"
+    CONNECTED_PATTERN=":kernel-module-control +.*test-snapd-kernel-module-control-consumer"
     DISCONNECTED_PATTERN="\- +test-snapd-kernel-module-control-consumer:kernel-module-control"
 
     echo "The plug is disconnected by default"
@@ -45,7 +47,9 @@ execute: |
 
     echo "When the plug is connected"
     snap connect test-snapd-kernel-module-control-consumer:kernel-module-control
+    snap connect generic-consumer:kernel-module-control
     snap interfaces | MATCH "$CONNECTED_PATTERN"
+
 
     echo "Then the snap is able to list the existing modules"
     [ $(su -l -c "test-snapd-kernel-module-control-consumer.lsmod" test | wc -l) -gt 2 ]
@@ -65,6 +69,16 @@ execute: |
     lsmod | MATCH -v binfmt_misc
     test-snapd-kernel-module-control-consumer.insmod /lib/modules/$(uname -r)/kernel/fs/binfmt_misc.ko
 
+    echo "And the snap is able to read /sys/module"
+    generic-consumer.cmd ls /sys/module | MATCH binfmt_misc
+
+    echo "And the snap is not able to write to /sys/module"
+    if su -l -c "generic-consumer.cmd touch /sys/module/test 2>${PWD}/touch.error" test; then
+        echo "Expected permission error writing to /sys/module"
+        exit 1
+    fi
+    cat touch.error | MATCH "Permission denied"
+
     echo "And the snap is able to remove a module"
     test-snapd-kernel-module-control-consumer.rmmod binfmt_misc
     lsmod | MATCH -v binfmt_misc
@@ -73,6 +87,7 @@ execute: |
 
     echo "When the plug is disconnected"
     snap disconnect test-snapd-kernel-module-control-consumer:kernel-module-control
+    snap disconnect generic-consumer:kernel-module-control
     snap interfaces | MATCH "$DISCONNECTED_PATTERN"
 
     echo "Then the snap is not able to list modules"
@@ -98,3 +113,17 @@ execute: |
         exit 1
     fi
     cat remove.error | MATCH "Permission denied"
+
+    echo "And the snap is not able to read /sys/module"
+    if su -l -c "generic-consumer.cmd ls /sys/module 2>${PWD}/read.error" test; then
+        echo "Expected permission error reading /sys/module with disconnected plug"
+        exit 1
+    fi
+    cat read.error | MATCH "Permission denied"
+
+    echo "And the snap is not able to write to /sys/module"
+    if su -l -c "generic-consumer.cmd touch /sys/module/test 2>${PWD}/touch.error" test; then
+        echo "Expected permission error writing to /sys/module"
+        exit 1
+    fi
+    cat touch.error | MATCH "Permission denied"


### PR DESCRIPTION
Now the kernel-module-control interface test covers the rule to read `/sys/module`. 

These changes also introduce a `generic-consumer` snap, it declares a plug on a variable interface, which is replaced by an actual value before building the snap, and ships a simple app which just executes the given command. We can use this snap to replace simple test snap in other interface tests that just define a plug and a command to be executed with the plug connected or disconnected, like `tests/lib/snaps/network-control-consumer` or `tests/lib/snaps/log-observe-consumer`. Other interface tests can be refactored to be able to use the generic-consumer.