### PR TITLE
configstate: return error if patch is invalid

### DIFF
--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -70,7 +70,9 @@ func (h *configureHandler) Before() error {
 	var patch map[string]interface{}
 	if err := h.context.Get("patch", &patch); err == nil {
 		for key, value := range patch {
-			tr.Set(h.context.SnapName(), key, value)
+			if err := tr.Set(h.context.SnapName(), key, value); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -36,6 +36,13 @@ execute: |
         exit 1
     fi
 
+    echo "Test that an invalid key results in an error"
+    if obtained=$(snap set snapctl-hooks invalid_key=value 2>&1); then
+        echo "Expected usage of an invalid key to result in an error"
+        exit 1
+    fi
+    [[ "$obtained" == *"invalid option name"* ]]
+
     echo "Install should fail altogether as it has a broken hook"
     if obtained=$(snap install --dangerous failing-config-hooks_1.0_all.snap 2>&1); then
         echo "Expected install of snap with broken configure hook to fail"


### PR DESCRIPTION
`snap set` silently ignores invalid keys/values by not checking if the transaction successfully sets them. This PR fixes LP: [#1689396](https://bugs.launchpad.net/snapd/+bug/1689396) by checking, and if they weren't successfully set, returning an error.