### PR TITLE
overlord/hookstate: remove unused Context.timeout

### DIFF
--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -38,7 +38,6 @@ type Context struct {
 	setup   *HookSetup
 	id      string
 	handler Handler
-	timeout time.Duration
 
 	cache  map[interface{}]interface{}
 	onDone []func() error


### PR DESCRIPTION
The hookstate.Context has an unused timeout field that is not used anywhere in the code.
This patch just removes it.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>