### PR TITLE
interfaces/network: workaround Go's need for NETLINK_ROUTE with 'net'. LP: #1689536

### DIFF
--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -36,6 +36,12 @@ const networkConnectedPlugSecComp = `
 # Description: Can access the network as a client.
 bind
 shutdown
+
+# FIXME: ARM needs this with some common functions in golang's 'net' library.
+# While this should remain in network-bind, network-control and
+# network-observe, for series 16 also have it here to not break existing snaps.
+# Future snapd series may remove this in the future. LP: #1689536
+socket AF_NETLINK - NETLINK_ROUTE
 `
 
 // NewNetworkInterface returns a new "network" interface.

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -37,7 +37,7 @@ const networkConnectedPlugSecComp = `
 bind
 shutdown
 
-# FIXME: ARM needs this with some common functions in golang's 'net' library.
+# FIXME: some kernels require this with common functions in go's 'net' library.
 # While this should remain in network-bind, network-control and
 # network-observe, for series 16 also have it here to not break existing snaps.
 # Future snapd series may remove this in the future. LP: #1689536


### PR DESCRIPTION
https://bugs.launchpad.net/snapd/+bug/1689536

This should be in 2.26 point release.

It looks like with 4.4 kernels, these go calls require NETLINK_ROUTE:

- net.Interfaces()
- net.InterfaceAddrs()

Curiously, NETLINK_ROUTE is not needed for these on 4.10 x86 kernel. Technically, these two calls are in the domain of 'network-observe', 'network-bind' and 'network-control' and not 'network'.

For series 16 I think we should add this to 'network' to not break existing applications on ARM that only plugs 'network', in part because both network and network-bind are autoconnected and there is therefore no appreciable difference security-wise wrt install time interface connections.

For series 18 (or whenever we start having different policy), we can consider removing NETLINK_ROUTE from the 'network' policy since that is more correct.