### PR TITLE
tests: disable create-key test on ppc64el for artful (expect not working)

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -308,7 +308,7 @@ suites:
     tests/completion/:
         summary: completion tests
 
-        # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
+        # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
         systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
 
         prepare: |

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -2,7 +2,7 @@ summary: Check different completions
 
 systems:
     - -ubuntu-core-16-*
-    # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
+    # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
     - -ubuntu-*-ppc64el
 
 prepare: |

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for snap create-key
 # ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-core-16-*, -ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
     . "$TESTSLIB/mkpinentry.sh"

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -1,5 +1,5 @@
 summary: Checks for snap create-key
-# ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
+# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |

--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -1,7 +1,7 @@
 summary: Check that find works with private snaps.
 
-# ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
-systems: [-ubuntu-16.04-ppc64el, -ubuntu-16.10-ppc64el, -ubuntu-17.04-ppc64el]
+# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
+systems: [-ubuntu-*-ppc64el]
 
 details: |
     These tests rely on the existence of a snap in the remote store set to private.

--- a/tests/main/login/task.yaml
+++ b/tests/main/login/task.yaml
@@ -1,6 +1,6 @@
 summary: Checks for snap login
 
-# ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
+# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 restore: |

--- a/tests/main/security-devpts/task.yaml
+++ b/tests/main/security-devpts/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that the basic devpts security rules are in place.
 
-# ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
+# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |

--- a/tests/main/security-private-tmp/task.yaml
+++ b/tests/main/security-private-tmp/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that the security rules for private tmp are in place.
 
-# ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
+# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 environment:

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -1,6 +1,6 @@
 summary: Run snap sign to sign a model assertion
 
-# ppc64el disabled because of https://github.com/snapcore/snapd/issues/2502
+# ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |


### PR DESCRIPTION
This fixes an autopkgtest failure in artful.