### PR TITLE
interfaces: fix broken master after merging the storage_framework_services branch

### DIFF
--- a/interfaces/builtin/storage_framework_service.go
+++ b/interfaces/builtin/storage_framework_service.go
@@ -107,16 +107,7 @@ func (iface *StorageFrameworkServiceInterface) Name() string {
 	return "storage-framework-service"
 }
 
-func (iface *StorageFrameworkServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
-	snippet := storageFrameworkServiceConnectedPlugAppArmor
-	old := "###SLOT_SECURITY_TAGS###"
-	new := slotAppLabelExpr(slot)
-	snippet = strings.Replace(snippet, old, new, -1)
-	spec.AddSnippet(snippet)
-	return nil
-}
-
-func (iface *StorageFrameworkServiceInterface) ApparmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+func (iface *StorageFrameworkServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	snippet := storageFrameworkServiceConnectedPlugAppArmor
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
@@ -130,7 +121,7 @@ func (iface *StorageFrameworkServiceInterface) AppArmorPermanentSlot(spec *appar
 	return nil
 }
 
-func (iface *StorageFrameworkServiceInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+func (iface *StorageFrameworkServiceInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	snippet := storageFrameworkServiceConnectedSlotAppArmor
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)

--- a/interfaces/builtin/storage_framework_service_test.go
+++ b/interfaces/builtin/storage_framework_service_test.go
@@ -77,14 +77,14 @@ func (s *StorageFrameworkServiceInterfaceSuite) TestSanitizeIncorrectInterface(c
 
 func (s *StorageFrameworkServiceInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
 	spec := &apparmor.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.client.app"})
 	c.Assert(spec.SnippetForTag("snap.client.app"), testutil.Contains, `interface=com.canonical.StorageFramework.Registry`)
 }
 
 func (s *StorageFrameworkServiceInterfaceSuite) TestAppArmorConnectedSlot(c *C) {
 	spec := &apparmor.Specification{}
-	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.storage-framework-service.app"})
 	c.Assert(spec.SnippetForTag("snap.storage-framework-service.app"), testutil.Contains, `interface=com.canonical.StorageFramework`)
 }


### PR DESCRIPTION
The storage-framework-services branch was apparently not fully up-to-date with the latest changes in the interfaces code :/ 