### PR TITLE
interfaces/builtin: make all interfaces private

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const accountControlConnectedPlugAppArmor = `
 # Allow creating, modifying and deleting non-system users and account password.
 /{,usr/}sbin/chpasswd ixr,
@@ -63,16 +59,11 @@ bind
 socket AF_NETLINK - NETLINK_AUDIT
 `
 
-// Interface which allows to handle the user accounts.
-func NewAccountControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "account-control",
 		connectedPlugAppArmor: accountControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  accountControlConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewAccountControlInterface())
+	})
 }

--- a/interfaces/builtin/account_control_test.go
+++ b/interfaces/builtin/account_control_test.go
@@ -37,7 +37,9 @@ type AccountControlSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&AccountControlSuite{})
+var _ = Suite(&AccountControlSuite{
+	iface: builtin.MustInterface("account-control"),
+})
 
 const accountCtlMockPlugSnapInfo = `name: other
 version: 1.0
@@ -48,7 +50,6 @@ apps:
 `
 
 func (s *AccountControlSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewAccountControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/alsa.go
+++ b/interfaces/builtin/alsa.go
@@ -19,8 +19,6 @@
 
 package builtin
 
-import "github.com/snapcore/snapd/interfaces"
-
 const alsaConnectedPlugAppArmor = `
 # Description: Allow access to raw ALSA devices.
 
@@ -33,14 +31,10 @@ const alsaConnectedPlugAppArmor = `
 /var/lib/alsa/{,*}         r,
 `
 
-func NewAlsaInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "alsa",
 		connectedPlugAppArmor: alsaConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewAlsaInterface())
+	})
 }

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -36,7 +36,9 @@ type AlsaInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&AlsaInterfaceSuite{})
+var _ = Suite(&AlsaInterfaceSuite{
+	iface: builtin.MustInterface("alsa"),
+})
 
 func (s *AlsaInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [alsa]
 `
-	s.iface = builtin.NewAlsaInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
@@ -56,6 +57,7 @@ apps:
 	}
 	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
 	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["alsa"]}
+	c.Assert(s.iface, NotNil)
 }
 
 func (s *AlsaInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/autopilot.go
+++ b/interfaces/builtin/autopilot.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const autopilotIntrospectionPlugAppArmor = `
 # Description: Allows an application to be introspected and export its ui
 # status over DBus
@@ -56,17 +52,11 @@ sendmsg
 sendto
 `
 
-// NewAutopilotIntrospectionInterface returns a new "autopilot-introspection"
-// interface.
-func NewAutopilotIntrospectionInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "autopilot-introspection",
 		connectedPlugAppArmor: autopilotIntrospectionPlugAppArmor,
 		connectedPlugSecComp:  autopilotIntrospectionPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewAutopilotIntrospectionInterface())
+	})
 }

--- a/interfaces/builtin/autopilot_test.go
+++ b/interfaces/builtin/autopilot_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [autopilot-introspection]
 `
 
-var _ = Suite(&AutopilotInterfaceSuite{})
+var _ = Suite(&AutopilotInterfaceSuite{
+	iface: builtin.MustInterface("autopilot-introspection"),
+})
 
 func (s *AutopilotInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewAutopilotIntrospectionInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/avahi_observe.go
+++ b/interfaces/builtin/avahi_observe.go
@@ -19,8 +19,6 @@
 
 package builtin
 
-import "github.com/snapcore/snapd/interfaces"
-
 const avahiObserveConnectedPlugAppArmor = `
 # Description: allows domain browsing, service browsing and service resolving
 
@@ -113,14 +111,10 @@ dbus (receive)
     peer=(label=unconfined),
 `
 
-func NewAvahiObserveInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "avahi-observe",
 		connectedPlugAppArmor: avahiObserveConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewAvahiObserveInterface())
+	})
 }

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -36,7 +36,9 @@ type AvahiObserveInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&AvahiObserveInterfaceSuite{})
+var _ = Suite(&AvahiObserveInterfaceSuite{
+	iface: builtin.MustInterface("avahi-observe"),
+})
 
 func (s *AvahiObserveInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [avahi-observe]
 `
-	s.iface = builtin.NewAvahiObserveInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const bluetoothControlConnectedPlugAppArmor = `
 # Description: Allow managing the kernel side Bluetooth stack. Reserved
 # because this gives privileged access to the system.
@@ -50,15 +46,11 @@ const bluetoothControlConnectedPlugSecComp = `
 bind
 `
 
-func NewBluetoothControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "bluetooth-control",
 		connectedPlugAppArmor: bluetoothControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  bluetoothControlConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewBluetoothControlInterface())
+	})
 }

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [bluetooth-control]
 `
 
-var _ = Suite(&BluetoothControlInterfaceSuite{})
+var _ = Suite(&BluetoothControlInterfaceSuite{
+	iface: builtin.MustInterface("bluetooth-control"),
+})
 
 func (s *BluetoothControlInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewBluetoothControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -181,18 +181,18 @@ const bluezPermanentSlotDBus = `
 </policy>
 `
 
-type BluezInterface struct{}
+type bluezInterface struct{}
 
-func (iface *BluezInterface) Name() string {
+func (iface *bluezInterface) Name() string {
 	return "bluez"
 }
 
-func (iface *BluezInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *bluezInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(bluezPermanentSlotDBus)
 	return nil
 }
 
-func (iface *BluezInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *bluezInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(bluezConnectedPlugAppArmor, old, new, -1)
@@ -200,7 +200,7 @@ func (iface *BluezInterface) AppArmorConnectedPlug(spec *apparmor.Specification,
 	return nil
 }
 
-func (iface *BluezInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *bluezInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(bluezConnectedSlotAppArmor, old, new, -1)
@@ -208,29 +208,29 @@ func (iface *BluezInterface) AppArmorConnectedSlot(spec *apparmor.Specification,
 	return nil
 }
 
-func (iface *BluezInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *bluezInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(bluezPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *BluezInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *bluezInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(bluezPermanentSlotSecComp)
 	return nil
 }
 
-func (iface *BluezInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *bluezInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *BluezInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *bluezInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *BluezInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *bluezInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&BluezInterface{})
+	registerIface(&bluezInterface{})
 }

--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -38,7 +38,9 @@ type BluezInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&BluezInterfaceSuite{})
+var _ = Suite(&BluezInterfaceSuite{
+	iface: builtin.MustInterface("bluez"),
+})
 
 const bluezMockPlugSnapInfoYaml = `name: other
 version: 1.0
@@ -56,7 +58,6 @@ apps:
 `
 
 func (s *BluezInterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.BluezInterface{}
 	slotSnap := snaptest.MockInfo(c, bluezMockSlotSnapInfoYaml, nil)
 	s.slot = &interfaces.Slot{SlotInfo: slotSnap.Slots["bluez"]}
 	plugSnap := snaptest.MockInfo(c, bluezMockPlugSnapInfoYaml, nil)

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -28,16 +28,16 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
-// BoolFileInterface is the type of all the bool-file interfaces.
-type BoolFileInterface struct{}
+// boolFileInterface is the type of all the bool-file interfaces.
+type boolFileInterface struct{}
 
 // String returns the same value as Name().
-func (iface *BoolFileInterface) String() string {
+func (iface *boolFileInterface) String() string {
 	return iface.Name()
 }
 
 // Name returns the name of the bool-file interface.
-func (iface *BoolFileInterface) Name() string {
+func (iface *boolFileInterface) Name() string {
 	return "bool-file"
 }
 
@@ -52,7 +52,7 @@ var boolFileAllowedPathPatterns = []*regexp.Regexp{
 
 // SanitizeSlot checks and possibly modifies a slot.
 // Valid "bool-file" slots must contain the attribute "path".
-func (iface *BoolFileInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *boolFileInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
 	}
@@ -70,7 +70,7 @@ func (iface *BoolFileInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // SanitizePlug checks and possibly modifies a plug.
-func (iface *BoolFileInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *boolFileInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -78,7 +78,7 @@ func (iface *BoolFileInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *BoolFileInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *boolFileInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	gpioSnippet := `
 /sys/class/gpio/export rw,
 /sys/class/gpio/unexport rw,
@@ -91,7 +91,7 @@ func (iface *BoolFileInterface) AppArmorPermanentSlot(spec *apparmor.Specificati
 	return nil
 }
 
-func (iface *BoolFileInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *boolFileInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	// Allow write and lock on the file designated by the path.
 	// Dereference symbolic links to file path handed out to apparmor since
 	// sysfs is full of symlinks and apparmor requires uses real path for
@@ -104,7 +104,7 @@ func (iface *BoolFileInterface) AppArmorConnectedPlug(spec *apparmor.Specificati
 	return nil
 }
 
-func (iface *BoolFileInterface) dereferencedPath(slot *interfaces.Slot) (string, error) {
+func (iface *boolFileInterface) dereferencedPath(slot *interfaces.Slot) (string, error) {
 	if path, ok := slot.Attrs["path"].(string); ok {
 		path, err := evalSymlinks(path)
 		if err != nil {
@@ -116,7 +116,7 @@ func (iface *BoolFileInterface) dereferencedPath(slot *interfaces.Slot) (string,
 }
 
 // isGPIO checks if a given bool-file slot refers to a GPIO pin.
-func (iface *BoolFileInterface) isGPIO(slot *interfaces.Slot) bool {
+func (iface *boolFileInterface) isGPIO(slot *interfaces.Slot) bool {
 	if path, ok := slot.Attrs["path"].(string); ok {
 		path = filepath.Clean(path)
 		return boolFileGPIOValuePattern.MatchString(path)
@@ -129,18 +129,18 @@ func (iface *BoolFileInterface) isGPIO(slot *interfaces.Slot) bool {
 // candidate and declaration-based checks allow.
 //
 // By default we allow what declarations allowed.
-func (iface *BoolFileInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *boolFileInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }
 
-func (iface *BoolFileInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
+func (iface *boolFileInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
 	return nil
 }
 
-func (iface *BoolFileInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *boolFileInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&BoolFileInterface{})
+	registerIface(&boolFileInterface{})
 }

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -54,7 +54,7 @@ type BoolFileInterfaceSuite struct {
 }
 
 var _ = Suite(&BoolFileInterfaceSuite{
-	iface: &builtin.BoolFileInterface{},
+	iface: builtin.MustInterface("bool-file"),
 })
 
 func (s *BoolFileInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -236,17 +236,17 @@ unshare
 quotactl
 `
 
-type BrowserSupportInterface struct{}
+type browserSupportInterface struct{}
 
-func (iface *BrowserSupportInterface) Name() string {
+func (iface *browserSupportInterface) Name() string {
 	return "browser-support"
 }
 
-func (iface *BrowserSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *browserSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *BrowserSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *browserSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
@@ -262,7 +262,7 @@ func (iface *BrowserSupportInterface) SanitizePlug(plug *interfaces.Plug) error 
 	return nil
 }
 
-func (iface *BrowserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *browserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	allowSandbox, _ := plug.Attrs["allow-sandbox"].(bool)
 	spec.AddSnippet(browserSupportConnectedPlugAppArmor)
 	if allowSandbox {
@@ -273,7 +273,7 @@ func (iface *BrowserSupportInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 	return nil
 }
 
-func (iface *BrowserSupportInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *browserSupportInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	allowSandbox, _ := plug.Attrs["allow-sandbox"].(bool)
 	snippet := browserSupportConnectedPlugSecComp
 	if allowSandbox {
@@ -283,18 +283,18 @@ func (iface *BrowserSupportInterface) SecCompConnectedPlug(spec *seccomp.Specifi
 	return nil
 }
 
-func (iface *BrowserSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *browserSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }
 
-func (iface *BrowserSupportInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
+func (iface *browserSupportInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
 	return nil
 }
 
-func (iface *BrowserSupportInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *browserSupportInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&BrowserSupportInterface{})
+	registerIface(&browserSupportInterface{})
 }

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [browser-support]
 `
 
-var _ = Suite(&BrowserSupportInterfaceSuite{})
+var _ = Suite(&BrowserSupportInterfaceSuite{
+	iface: builtin.MustInterface("browser-support"),
+})
 
 func (s *BrowserSupportInterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.BrowserSupportInterface{}
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const cameraConnectedPlugAppArmor = `
 # Until we have proper device assignment, allow access to all cameras
 /dev/video[0-9]* rw,
@@ -34,15 +30,10 @@ const cameraConnectedPlugAppArmor = `
 /run/udev/data/c81:[0-9]* r, # video4linux (/dev/video*, etc)
 `
 
-// NewCameraInterface returns a new "camera" interface.
-func NewCameraInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "camera",
 		connectedPlugAppArmor: cameraConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewCameraInterface())
+	})
 }

--- a/interfaces/builtin/classic_support.go
+++ b/interfaces/builtin/classic_support.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const classicSupportPlugAppArmor = `
 # Description: permissions to use classic dimension. This policy is
 # intentionally not restricted. This gives device ownership to
@@ -104,14 +100,10 @@ umount
 umount2
 `
 
-func NewClassicSupportInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "classic-support",
 		connectedPlugAppArmor: classicSupportPlugAppArmor,
 		connectedPlugSecComp:  classicSupportPlugSecComp,
-	}
-}
-
-func init() {
-	registerIface(NewClassicSupportInterface())
+	})
 }

--- a/interfaces/builtin/classic_support_test.go
+++ b/interfaces/builtin/classic_support_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [classic-support]
 `
 
-var _ = Suite(&ClassicSupportInterfaceSuite{})
+var _ = Suite(&ClassicSupportInterfaceSuite{
+	iface: builtin.MustInterface("classic-support"),
+})
 
 func (s *ClassicSupportInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewClassicSupportInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -31,10 +31,10 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// ContentInterface allows sharing content between snaps
-type ContentInterface struct{}
+// contentInterface allows sharing content between snaps
+type contentInterface struct{}
 
-func (iface *ContentInterface) Name() string {
+func (iface *contentInterface) Name() string {
 	return "content"
 }
 
@@ -42,7 +42,7 @@ func cleanSubPath(path string) bool {
 	return filepath.Clean(path) == path && path != ".." && !strings.HasPrefix(path, "../")
 }
 
-func (iface *ContentInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *contentInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
 	}
@@ -71,7 +71,7 @@ func (iface *ContentInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *ContentInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *contentInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -96,7 +96,7 @@ func (iface *ContentInterface) SanitizePlug(plug *interfaces.Plug) error {
 
 // path is an internal helper that extract the "read" and "write" attribute
 // of the slot
-func (iface *ContentInterface) path(slot *interfaces.Slot, name string) []string {
+func (iface *contentInterface) path(slot *interfaces.Slot, name string) []string {
 	if name != "read" && name != "write" {
 		panic("internal error, path can only be used with read/write")
 	}
@@ -145,7 +145,7 @@ func mountEntry(plug *interfaces.Plug, slot *interfaces.Slot, relSrc string, ext
 	}
 }
 
-func (iface *ContentInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	contentSnippet := bytes.NewBuffer(nil)
 	writePaths := iface.path(slot, "write")
 	if len(writePaths) > 0 {
@@ -179,14 +179,14 @@ func (iface *ContentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 	return nil
 }
 
-func (iface *ContentInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (iface *contentInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 // Interactions with the mount backend.
 
-func (iface *ContentInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *contentInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	for _, r := range iface.path(slot, "read") {
 		err := spec.AddMountEntry(mountEntry(plug, slot, r, "ro"))
 		if err != nil {
@@ -202,14 +202,14 @@ func (iface *ContentInterface) MountConnectedPlug(spec *mount.Specification, plu
 	return nil
 }
 
-func (iface *ContentInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
+func (iface *contentInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
 	return nil
 }
 
-func (iface *ContentInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *contentInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&ContentInterface{})
+	registerIface(&contentInterface{})
 }

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -32,11 +32,11 @@ import (
 )
 
 type ContentSuite struct {
-	iface *builtin.ContentInterface
+	iface interfaces.Interface
 }
 
 var _ = Suite(&ContentSuite{
-	iface: &builtin.ContentInterface{},
+	iface: builtin.MustInterface("content"),
 })
 
 func (s *ContentSuite) TestName(c *C) {
@@ -224,7 +224,7 @@ slots:
 	slot := &interfaces.Slot{SlotInfo: producerInfo.Slots["content"]}
 
 	spec := &mount.Specification{}
-	c.Assert(s.iface.MountConnectedPlug(spec, plug, nil, slot, nil), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, plug, nil, slot, nil), IsNil)
 	expectedMnt := []mount.Entry{{
 		Name:    "/snap/producer/5/export",
 		Dir:     "/snap/consumer/7/import",
@@ -255,7 +255,7 @@ slots:
 	slot := &interfaces.Slot{SlotInfo: producerInfo.Slots["content"]}
 
 	spec := &mount.Specification{}
-	c.Assert(s.iface.MountConnectedPlug(spec, plug, nil, slot, nil), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, plug, nil, slot, nil), IsNil)
 	expectedMnt := []mount.Entry{{
 		Name:    "/snap/producer/5/export",
 		Dir:     "/snap/consumer/7/import",
@@ -298,7 +298,7 @@ slots:
 	slot := &interfaces.Slot{SlotInfo: producerInfo.Slots["content"]}
 
 	spec := &mount.Specification{}
-	c.Assert(s.iface.MountConnectedPlug(spec, plug, nil, slot, nil), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, plug, nil, slot, nil), IsNil)
 	expectedMnt := []mount.Entry{{
 		Name:    "/var/snap/producer/5/export",
 		Dir:     "/var/snap/consumer/7/import",
@@ -343,7 +343,7 @@ slots:
 	slot := &interfaces.Slot{SlotInfo: producerInfo.Slots["content"]}
 
 	spec := &mount.Specification{}
-	c.Assert(s.iface.MountConnectedPlug(spec, plug, nil, slot, nil), IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, plug, nil, slot, nil), IsNil)
 	expectedMnt := []mount.Entry{{
 		Name:    "/var/snap/producer/common/export",
 		Dir:     "/var/snap/consumer/common/import",

--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const coreSupportConnectedPlugAppArmor = `
 # Description: Can control all aspects of systemd via the systemctl command,
 # update rsyslog configuration, update systemd-timesyncd configuration and
@@ -78,17 +74,12 @@ owner /boot/uboot/config.txt rwk,
 owner /boot/uboot/config.txt.tmp rwk,
 `
 
-// NewShutdownInterface returns a new "shutdown" interface.
-func NewCoreSupportInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "core-support",
-		// NOTE: cure-support implicitly contains the rules from network-bind.
+		// NOTE: core-support implicitly contains the rules from network-bind.
 		connectedPlugAppArmor: coreSupportConnectedPlugAppArmor + networkBindConnectedPlugAppArmor,
 		connectedPlugSecComp:  "" + networkBindConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewCoreSupportInterface())
+	})
 }

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -36,7 +36,9 @@ type CoreSupportInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&CoreSupportInterfaceSuite{})
+var _ = Suite(&CoreSupportInterfaceSuite{
+	iface: builtin.MustInterface("core-support"),
+})
 
 func (s *CoreSupportInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfo = `name: other
@@ -45,7 +47,6 @@ hooks:
  prepare-device:
      plugs: [core-support]
 `
-	s.iface = builtin.NewCoreSupportInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -19,8 +19,6 @@
 
 package builtin
 
-import "github.com/snapcore/snapd/interfaces"
-
 const cupsControlConnectedPlugAppArmor = `
 # Description: Can access cups control socket. This is restricted because it provides
 # privileged access to configure printing.
@@ -28,15 +26,10 @@ const cupsControlConnectedPlugAppArmor = `
 #include <abstractions/cups-client>
 `
 
-// NewCupsControlInterface returns a new "cups" interface.
-func NewCupsControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "cups-control",
 		connectedPlugAppArmor: cupsControlConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewCupsControlInterface())
+	})
 }

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -185,14 +185,14 @@ dbus (receive, send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
-type DbusInterface struct{}
+type dbusInterface struct{}
 
-func (iface *DbusInterface) Name() string {
+func (iface *dbusInterface) Name() string {
 	return "dbus"
 }
 
 // Obtain yaml-specified bus well-known name
-func (iface *DbusInterface) getAttribs(attribs map[string]interface{}) (string, string, error) {
+func (iface *dbusInterface) getAttribs(attribs map[string]interface{}) (string, string, error) {
 	// bus attribute
 	bus, ok := attribs["bus"].(string)
 	if !ok {
@@ -272,7 +272,7 @@ func getAppArmorSnippet(policy string, bus string, name string) string {
 	return snippet
 }
 
-func (iface *DbusInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *dbusInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	bus, name, err := iface.getAttribs(plug.Attrs)
 	if err != nil {
 		return err
@@ -309,7 +309,7 @@ func (iface *DbusInterface) AppArmorConnectedPlug(spec *apparmor.Specification, 
 	return nil
 }
 
-func (iface *DbusInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *dbusInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	bus, name, err := iface.getAttribs(slot.Attrs)
 	if err != nil {
 		return err
@@ -326,7 +326,7 @@ func (iface *DbusInterface) DBusPermanentSlot(spec *dbus.Specification, slot *in
 	return nil
 }
 
-func (iface *DbusInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *dbusInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	bus, name, err := iface.getAttribs(slot.Attrs)
 	if err != nil {
 		return err
@@ -353,7 +353,7 @@ func (iface *DbusInterface) AppArmorPermanentSlot(spec *apparmor.Specification, 
 	return nil
 }
 
-func (iface *DbusInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *dbusInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	bus, name, err := iface.getAttribs(slot.Attrs)
 	if err != nil {
 		return err
@@ -383,7 +383,7 @@ func (iface *DbusInterface) AppArmorConnectedSlot(spec *apparmor.Specification, 
 	return nil
 }
 
-func (iface *DbusInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *dbusInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -392,7 +392,7 @@ func (iface *DbusInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return err
 }
 
-func (iface *DbusInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *dbusInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
 	}
@@ -401,19 +401,19 @@ func (iface *DbusInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return err
 }
 
-func (iface *DbusInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *dbusInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
-func (iface *DbusInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
+func (iface *dbusInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
 	return nil
 }
 
-func (iface *DbusInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *dbusInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&DbusInterface{})
+	registerIface(&dbusInterface{})
 }

--- a/interfaces/builtin/dbus_test.go
+++ b/interfaces/builtin/dbus_test.go
@@ -50,7 +50,7 @@ type DbusInterfaceSuite struct {
 }
 
 var _ = Suite(&DbusInterfaceSuite{
-	iface: &builtin.DbusInterface{},
+	iface: builtin.MustInterface("dbus"),
 })
 
 func (s *DbusInterfaceSuite) SetUpSuite(c *C) {
@@ -316,10 +316,9 @@ func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSession(c *C) {
 func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSessionNative(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
-	iface := &builtin.DbusInterface{}
 
 	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddPermanentSlot(iface, s.sessionSlot)
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.sessionSlot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-provider"})
 
@@ -330,10 +329,9 @@ func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSessionNative(c *C) {
 func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSessionClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
-	iface := &builtin.DbusInterface{}
 
 	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddPermanentSlot(iface, s.sessionSlot)
+	err := apparmorSpec.AddPermanentSlot(s.iface, s.sessionSlot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-provider"})
 
@@ -382,10 +380,8 @@ func (s *DbusInterfaceSuite) TestPermanentSlotDBusSystem(c *C) {
 }
 
 func (s *DbusInterfaceSuite) TestConnectedSlotAppArmorSession(c *C) {
-	iface := &builtin.DbusInterface{}
-
 	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedSlot(iface, s.connectedSessionPlug, nil, s.connectedSessionSlot, nil)
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.connectedSessionPlug, nil, s.connectedSessionSlot, nil)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-consumer", "snap.test-dbus.test-session-provider", "snap.test-dbus.test-system-consumer", "snap.test-dbus.test-system-provider"})
 	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-session-provider")
@@ -404,10 +400,8 @@ func (s *DbusInterfaceSuite) TestConnectedSlotAppArmorSession(c *C) {
 }
 
 func (s *DbusInterfaceSuite) TestConnectedSlotAppArmorSystem(c *C) {
-	iface := &builtin.DbusInterface{}
-
 	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedSlot(iface, s.connectedSystemPlug, nil, s.connectedSystemSlot, nil)
+	err := apparmorSpec.AddConnectedSlot(s.iface, s.connectedSystemPlug, nil, s.connectedSystemSlot, nil)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-consumer", "snap.test-dbus.test-session-provider", "snap.test-dbus.test-system-consumer", "snap.test-dbus.test-system-provider"})
 	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-session-provider")
@@ -426,10 +420,8 @@ func (s *DbusInterfaceSuite) TestConnectedSlotAppArmorSystem(c *C) {
 }
 
 func (s *DbusInterfaceSuite) TestConnectedPlugAppArmorSession(c *C) {
-	iface := &builtin.DbusInterface{}
-
 	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(iface, s.connectedSessionPlug, nil, s.connectedSessionSlot, nil)
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.connectedSessionPlug, nil, s.connectedSessionSlot, nil)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-consumer", "snap.test-dbus.test-session-provider", "snap.test-dbus.test-system-consumer", "snap.test-dbus.test-system-provider"})
 	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-session-consumer")
@@ -453,10 +445,8 @@ func (s *DbusInterfaceSuite) TestConnectedPlugAppArmorSession(c *C) {
 }
 
 func (s *DbusInterfaceSuite) TestConnectedPlugAppArmorSystem(c *C) {
-	iface := &builtin.DbusInterface{}
-
 	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(iface, s.connectedSystemPlug, nil, s.connectedSystemSlot, nil)
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.connectedSystemPlug, nil, s.connectedSystemSlot, nil)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.test-dbus.test-session-consumer", "snap.test-dbus.test-session-provider", "snap.test-dbus.test-system-consumer", "snap.test-dbus.test-system-provider"})
 	snippet := apparmorSpec.SnippetForTag("snap.test-dbus.test-session-consumer")

--- a/interfaces/builtin/dcdbas_control.go
+++ b/interfaces/builtin/dcdbas_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // https://www.kernel.org/doc/Documentation/dcdbas.txt
 const dcdbasControlConnectedPlugAppArmor = `
 # Description: This interface allows communication with Dell Systems Management Base Driver
@@ -45,15 +41,10 @@ const dcdbasControlConnectedPlugAppArmor = `
 /sys/devices/platform/dcdbas/host_control_on_shutdown rw,
 `
 
-// NewHardwareObserveInterface returns a new "dcdbas-control" interface.
-func NewDcdbasControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "dcdbas-control",
 		connectedPlugAppArmor: dcdbasControlConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewDcdbasControlInterface())
+	})
 }

--- a/interfaces/builtin/dcdbas_control_test.go
+++ b/interfaces/builtin/dcdbas_control_test.go
@@ -36,7 +36,9 @@ type DcdbasControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&DcdbasControlInterfaceSuite{})
+var _ = Suite(&DcdbasControlInterfaceSuite{
+	iface: builtin.MustInterface("dcdbas-control"),
+})
 
 func (s *DcdbasControlInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
@@ -46,7 +48,6 @@ apps:
     command: foo
     plugs: [dcdbas-control]
 `, nil)
-	s.iface = builtin.NewDcdbasControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -43,41 +43,41 @@ bind
 socket AF_NETLINK - NETLINK_GENERIC
 `
 
-type DockerInterface struct{}
+type dockerInterface struct{}
 
-func (iface *DockerInterface) Name() string {
+func (iface *dockerInterface) Name() string {
 	return "docker"
 }
 
-func (iface *DockerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *dockerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(dockerConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *DockerInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *dockerInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(dockerConnectedPlugSecComp)
 	return nil
 }
 
-func (iface *DockerInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *dockerInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *DockerInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *dockerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *DockerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *dockerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&DockerInterface{})
+	registerIface(&dockerInterface{})
 }

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -520,13 +520,13 @@ const dockerSupportPrivilegedSecComp = `
 @unrestricted
 `
 
-type DockerSupportInterface struct{}
+type dockerSupportInterface struct{}
 
-func (iface *DockerSupportInterface) Name() string {
+func (iface *dockerSupportInterface) Name() string {
 	return "docker-support"
 }
 
-func (iface *DockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	privileged, _ := plug.Attrs["privileged-containers"].(bool)
 	spec.AddSnippet(dockerSupportConnectedPlugAppArmor)
 	if privileged {
@@ -535,7 +535,7 @@ func (iface *DockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	return nil
 }
 
-func (iface *DockerSupportInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *dockerSupportInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	privileged, _ := plug.Attrs["privileged-containers"].(bool)
 	snippet := dockerSupportConnectedPlugSecComp
 	if privileged {
@@ -545,14 +545,14 @@ func (iface *DockerSupportInterface) SecCompConnectedPlug(spec *seccomp.Specific
 	return nil
 }
 
-func (iface *DockerSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *dockerSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *DockerSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *dockerSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
@@ -564,15 +564,15 @@ func (iface *DockerSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *DockerSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *dockerSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
-func (iface *DockerSupportInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
+func (iface *dockerSupportInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&DockerSupportInterface{})
+	registerIface(&dockerSupportInterface{})
 }

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [docker-support]
 `
 
-var _ = Suite(&DockerSupportInterfaceSuite{})
+var _ = Suite(&DockerSupportInterfaceSuite{
+	iface: builtin.MustInterface("docker-support"),
+})
 
 func (s *DockerSupportInterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.DockerSupportInterface{}
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap: &snap.Info{

--- a/interfaces/builtin/docker_test.go
+++ b/interfaces/builtin/docker_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [docker]
 `
 
-var _ = Suite(&DockerInterfaceSuite{})
+var _ = Suite(&DockerInterfaceSuite{
+	iface: builtin.MustInterface("docker"),
+})
 
 func (s *DockerInterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.DockerInterface{}
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap: &snap.Info{

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -19,8 +19,25 @@
 
 package builtin
 
-func MprisGetName(iface *MprisInterface, attribs map[string]interface{}) (string, error) {
-	return iface.getName(attribs)
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+func MprisGetName(iface interfaces.Interface, attribs map[string]interface{}) (string, error) {
+	return iface.(*mprisInterface).getName(attribs)
 }
 
 var ResolveSpecialVariable = resolveSpecialVariable
+
+// MustInterface returns the interface with the given name or panicks.
+func MustInterface(name string) interfaces.Interface {
+	for _, iface := range allInterfaces {
+		if iface.Name() == name {
+			return iface
+		}
+	}
+	panic(fmt.Errorf("cannot find interface with name %q", name))
+
+}

--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/firewall-control
 const firewallControlConnectedPlugAppArmor = `
 # Description: Can configure firewall. This is restricted because it gives
@@ -120,19 +116,15 @@ var firewallControlConnectedPlugKmod = []string{
 	"arp_tables",
 	"br_netfilter",
 	"ip6table_filter",
-	"iptable_filter"}
+	"iptable_filter",
+}
 
-// NewFirewallControlInterface returns a new "firewall-control" interface.
-func NewFirewallControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "firewall-control",
 		connectedPlugAppArmor:    firewallControlConnectedPlugAppArmor,
 		connectedPlugSecComp:     firewallControlConnectedPlugSecComp,
 		connectedPlugKModModules: firewallControlConnectedPlugKmod,
 		reservedForOS:            true,
-	}
-}
-
-func init() {
-	registerIface(NewFirewallControlInterface())
+	})
 }

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -46,10 +46,11 @@ apps:
   plugs: [firewall-control]
 `
 
-var _ = Suite(&FirewallControlInterfaceSuite{})
+var _ = Suite(&FirewallControlInterfaceSuite{
+	iface: builtin.MustInterface("firewall-control"),
+})
 
 func (s *FirewallControlInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewFirewallControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -36,19 +36,19 @@ const framebufferConnectedPlugAppArmor = `
 `
 
 // The type for physical-memory-control interface
-type FramebufferInterface struct{}
+type framebufferInterface struct{}
 
 // Getter for the name of the physical-memory-control interface
-func (iface *FramebufferInterface) Name() string {
+func (iface *framebufferInterface) Name() string {
 	return "framebuffer"
 }
 
-func (iface *FramebufferInterface) String() string {
+func (iface *framebufferInterface) String() string {
 	return iface.Name()
 }
 
 // Check validity of the defined slot
-func (iface *FramebufferInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *framebufferInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -63,7 +63,7 @@ func (iface *FramebufferInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // Checks and possibly modifies a plug
-func (iface *FramebufferInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *framebufferInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -71,12 +71,12 @@ func (iface *FramebufferInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *FramebufferInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *framebufferInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(framebufferConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *FramebufferInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *framebufferInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	// This will fix access denied of opengl interface when it's used with
 	// framebuffer interface in the same snap.
 	// https://bugs.launchpad.net/snapd/+bug/1675738
@@ -90,11 +90,11 @@ func (iface *FramebufferInterface) UDevConnectedPlug(spec *udev.Specification, p
 	return nil
 }
 
-func (iface *FramebufferInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *framebufferInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
 func init() {
-	registerIface(&FramebufferInterface{})
+	registerIface(&framebufferInterface{})
 }

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -37,7 +37,7 @@ type FramebufferInterfaceSuite struct {
 }
 
 var _ = Suite(&FramebufferInterfaceSuite{
-	iface: &builtin.FramebufferInterface{},
+	iface: builtin.MustInterface("framebuffer"),
 })
 
 func (s *FramebufferInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/fuse_support.go
+++ b/interfaces/builtin/fuse_support.go
@@ -19,8 +19,6 @@
 
 package builtin
 
-import "github.com/snapcore/snapd/interfaces"
-
 const fuseSupportConnectedPlugSecComp = `
 # Description: Can run a FUSE filesystem. Unprivileged fuse mounts are
 # not supported at this time.
@@ -71,16 +69,11 @@ deny /etc/fuse.conf r,
 #/{,usr/}bin/fusermount ixr,
 `
 
-// NewFuseControlInterface returns a new "fuse-support" interface.
-func NewFuseSupportInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "fuse-support",
 		connectedPlugAppArmor: fuseSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:  fuseSupportConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewFuseSupportInterface())
+	})
 }

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [fuse-support]
 `
 
-var _ = Suite(&FuseSupportInterfaceSuite{})
+var _ = Suite(&FuseSupportInterfaceSuite{
+	iface: builtin.MustInterface("fuse-support"),
+})
 
 func (s *FuseSupportInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewFuseSupportInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -181,20 +181,20 @@ const fwupdConnectedPlugSecComp = `
 bind
 `
 
-// FwupdInterface type
-type FwupdInterface struct{}
+// fwupdInterface type
+type fwupdInterface struct{}
 
-// Name of the FwupdInterface
-func (iface *FwupdInterface) Name() string {
+// Name of the fwupdInterface
+func (iface *fwupdInterface) Name() string {
 	return "fwupd"
 }
 
-func (iface *FwupdInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *fwupdInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(fwupdPermanentSlotDBus)
 	return nil
 }
 
-func (iface *FwupdInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *fwupdInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(fwupdConnectedPlugAppArmor, old, new, -1)
@@ -202,13 +202,13 @@ func (iface *FwupdInterface) AppArmorConnectedPlug(spec *apparmor.Specification,
 	return nil
 }
 
-func (iface *FwupdInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *fwupdInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(fwupdPermanentSlotAppArmor)
 	return nil
 
 }
 
-func (iface *FwupdInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *fwupdInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(fwupdConnectedSlotAppArmor, old, new, -1)
@@ -216,31 +216,31 @@ func (iface *FwupdInterface) AppArmorConnectedSlot(spec *apparmor.Specification,
 	return nil
 }
 
-func (iface *FwupdInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *fwupdInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(fwupdConnectedPlugSecComp)
 	return nil
 }
 
-func (iface *FwupdInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *fwupdInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(fwupdPermanentSlotSecComp)
 	return nil
 }
 
 // SanitizePlug checks the plug definition is valid
-func (iface *FwupdInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *fwupdInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
 // SanitizeSlot checks the slot definition is valid
-func (iface *FwupdInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *fwupdInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *FwupdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *fwupdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&FwupdInterface{})
+	registerIface(&fwupdInterface{})
 }

--- a/interfaces/builtin/fwupd_test.go
+++ b/interfaces/builtin/fwupd_test.go
@@ -54,10 +54,11 @@ apps:
   slots: [fwupd]
 `
 
-var _ = Suite(&FwupdInterfaceSuite{})
+var _ = Suite(&FwupdInterfaceSuite{
+	iface: builtin.MustInterface("fwupd"),
+})
 
 func (s *FwupdInterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.FwupdInterface{}
 	slotSnap := snaptest.MockInfo(c, mockSlotSnapInfoYaml, nil)
 	plugSnap := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
 	s.slot = &interfaces.Slot{SlotInfo: slotSnap.Slots["fwupd"]}

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -30,21 +30,21 @@ import (
 var gpioSysfsGpioBase = "/sys/class/gpio/gpio"
 var gpioSysfsExport = "/sys/class/gpio/export"
 
-// GpioInterface type
-type GpioInterface struct{}
+// gpioInterface type
+type gpioInterface struct{}
 
 // String returns the same value as Name().
-func (iface *GpioInterface) String() string {
+func (iface *gpioInterface) String() string {
 	return iface.Name()
 }
 
-// Name of the GpioInterface
-func (iface *GpioInterface) Name() string {
+// Name of the gpioInterface
+func (iface *gpioInterface) Name() string {
 	return "gpio"
 }
 
 // SanitizeSlot checks the slot definition is valid
-func (iface *GpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *gpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Paranoid check this right interface type
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -71,7 +71,7 @@ func (iface *GpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // SanitizePlug checks the plug definition is valid
-func (iface *GpioInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *gpioInterface) SanitizePlug(plug *interfaces.Plug) error {
 	// Make sure right interface type
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
@@ -81,7 +81,7 @@ func (iface *GpioInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *GpioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *gpioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	path := fmt.Sprint(gpioSysfsGpioBase, slot.Attrs["number"])
 	// Entries in /sys/class/gpio for single GPIO's are just symlinks
 	// to their correct device part in the sysfs tree. Given AppArmor
@@ -96,7 +96,7 @@ func (iface *GpioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, 
 
 }
 
-func (iface *GpioInterface) SystemdConnectedSlot(spec *systemd.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *gpioInterface) SystemdConnectedSlot(spec *systemd.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	gpioNum, ok := slot.Attrs["number"].(int64)
 	if !ok {
 		return fmt.Errorf("gpio slot has invalid number attribute: %q", slot.Attrs["number"])
@@ -111,15 +111,15 @@ func (iface *GpioInterface) SystemdConnectedSlot(spec *systemd.Specification, pl
 	return spec.AddService(serviceName, service)
 }
 
-func (iface *GpioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *gpioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
-func (iface *GpioInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *gpioInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&GpioInterface{})
+	registerIface(&gpioInterface{})
 }

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -42,7 +42,7 @@ type GpioInterfaceSuite struct {
 }
 
 var _ = Suite(&GpioInterfaceSuite{
-	iface: &builtin.GpioInterface{},
+	iface: builtin.MustInterface("gpio"),
 })
 
 func (s *GpioInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const gsettingsConnectedPlugAppArmor = `
 # Description: Can access global gsettings of the user's session. Restricted
 # because this gives privileged access to sensitive information stored in
@@ -39,15 +35,10 @@ dbus (receive, send)
     peer=(label=unconfined),
 `
 
-// NewGsettingsInterface returns a new "gsettings" interface.
-func NewGsettingsInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "gsettings",
 		connectedPlugAppArmor: gsettingsConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewGsettingsInterface())
+	})
 }

--- a/interfaces/builtin/gsettings_test.go
+++ b/interfaces/builtin/gsettings_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [gsettings]
 `
 
-var _ = Suite(&GsettingsInterfaceSuite{})
+var _ = Suite(&GsettingsInterfaceSuite{
+	iface: builtin.MustInterface("gsettings"),
+})
 
 func (s *GsettingsInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewGsettingsInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const hardwareObserveConnectedPlugAppArmor = `
 # Description: This interface allows for getting hardware information
 # from the system. This is reserved because it allows reading potentially
@@ -83,16 +79,11 @@ iopl
 socket AF_NETLINK - NETLINK_GENERIC
 `
 
-// NewHardwareObserveInterface returns a new "hardware-observe" interface.
-func NewHardwareObserveInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "hardware-observe",
 		connectedPlugAppArmor: hardwareObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  hardwareObserveConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewHardwareObserveInterface())
+	})
 }

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [hardware-observe]
 `
 
-var _ = Suite(&HardwareObserveInterfaceSuite{})
+var _ = Suite(&HardwareObserveInterfaceSuite{
+	iface: builtin.MustInterface("hardware-observe"),
+})
 
 func (s *HardwareObserveInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewHardwareObserveInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/hardware_random_control.go
+++ b/interfaces/builtin/hardware_random_control.go
@@ -45,15 +45,15 @@ const hardwareRandomControlConnectedPlugAppArmor = `
 `
 
 // The type for physical-memory-control interface
-type HardwareRandomControlInterface struct{}
+type hardwareRandomControlInterface struct{}
 
 // Getter for the name of the physical-memory-control interface
-func (iface *HardwareRandomControlInterface) Name() string {
+func (iface *hardwareRandomControlInterface) Name() string {
 	return "hardware-random-control"
 }
 
 // Check validity of the defined slot
-func (iface *HardwareRandomControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *hardwareRandomControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
@@ -65,7 +65,7 @@ func (iface *HardwareRandomControlInterface) SanitizeSlot(slot *interfaces.Slot)
 }
 
 // Checks and possibly modifies a plug
-func (iface *HardwareRandomControlInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *hardwareRandomControlInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
@@ -73,12 +73,12 @@ func (iface *HardwareRandomControlInterface) SanitizePlug(plug *interfaces.Plug)
 	return nil
 }
 
-func (iface *HardwareRandomControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *hardwareRandomControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(hardwareRandomControlConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *HardwareRandomControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *hardwareRandomControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const udevRule = `KERNEL=="hwrng", TAG+="%s"`
 	for appName := range plug.Apps {
 		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
@@ -87,11 +87,11 @@ func (iface *HardwareRandomControlInterface) UDevConnectedPlug(spec *udev.Specif
 	return nil
 }
 
-func (iface *HardwareRandomControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *hardwareRandomControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
 func init() {
-	registerIface(&HardwareRandomControlInterface{})
+	registerIface(&hardwareRandomControlInterface{})
 }

--- a/interfaces/builtin/hardware_random_control_test.go
+++ b/interfaces/builtin/hardware_random_control_test.go
@@ -38,7 +38,7 @@ type HardwareRandomControlInterfaceSuite struct {
 }
 
 var _ = Suite(&HardwareRandomControlInterfaceSuite{
-	iface: &builtin.HardwareRandomControlInterface{},
+	iface: builtin.MustInterface("hardware-random-control"),
 })
 
 func (s *HardwareRandomControlInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/hardware_random_observe.go
+++ b/interfaces/builtin/hardware_random_observe.go
@@ -40,15 +40,15 @@ const hardwareRandomObserveConnectedPlugAppArmor = `
 `
 
 // The type for physical-memory-control interface
-type HardwareRandomObserveInterface struct{}
+type hardwareRandomObserveInterface struct{}
 
 // Getter for the name of the physical-memory-control interface
-func (iface *HardwareRandomObserveInterface) Name() string {
+func (iface *hardwareRandomObserveInterface) Name() string {
 	return "hardware-random-observe"
 }
 
 // Check validity of the defined slot
-func (iface *HardwareRandomObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *hardwareRandomObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
@@ -59,7 +59,7 @@ func (iface *HardwareRandomObserveInterface) SanitizeSlot(slot *interfaces.Slot)
 }
 
 // Checks and possibly modifies a plug
-func (iface *HardwareRandomObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *hardwareRandomObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
@@ -67,12 +67,12 @@ func (iface *HardwareRandomObserveInterface) SanitizePlug(plug *interfaces.Plug)
 	return nil
 }
 
-func (iface *HardwareRandomObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *hardwareRandomObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(hardwareRandomObserveConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *HardwareRandomObserveInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *hardwareRandomObserveInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const udevRule = `KERNEL=="hwrng", TAG+="%s"`
 	for appName := range plug.Apps {
 		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
@@ -81,11 +81,11 @@ func (iface *HardwareRandomObserveInterface) UDevConnectedPlug(spec *udev.Specif
 	return nil
 }
 
-func (iface *HardwareRandomObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *hardwareRandomObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
 func init() {
-	registerIface(&HardwareRandomObserveInterface{})
+	registerIface(&hardwareRandomObserveInterface{})
 }

--- a/interfaces/builtin/hardware_random_observe_test.go
+++ b/interfaces/builtin/hardware_random_observe_test.go
@@ -38,7 +38,7 @@ type HardwareRandomObserveInterfaceSuite struct {
 }
 
 var _ = Suite(&HardwareRandomObserveInterfaceSuite{
-	iface: &builtin.HardwareRandomObserveInterface{},
+	iface: builtin.MustInterface("hardware-random-observe"),
 })
 
 func (s *HardwareRandomObserveInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -30,15 +30,15 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
-// HidrawInterface is the type for hidraw interfaces.
-type HidrawInterface struct{}
+// hidrawInterface is the type for hidraw interfaces.
+type hidrawInterface struct{}
 
 // Name of the hidraw interface.
-func (iface *HidrawInterface) Name() string {
+func (iface *hidrawInterface) Name() string {
 	return "hidraw"
 }
 
-func (iface *HidrawInterface) String() string {
+func (iface *hidrawInterface) String() string {
 	return iface.Name()
 }
 
@@ -52,7 +52,7 @@ var hidrawDeviceNodePattern = regexp.MustCompile("^/dev/hidraw[0-9]{1,3}$")
 var hidrawUDevSymlinkPattern = regexp.MustCompile("^/dev/hidraw-[a-z0-9]+$")
 
 // SanitizeSlot checks validity of the defined slot
-func (iface *HidrawInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *hidrawInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Check slot is of right type
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -105,7 +105,7 @@ func (iface *HidrawInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // SanitizePlug checks and possibly modifies a plug.
-func (iface *HidrawInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *hidrawInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -113,7 +113,7 @@ func (iface *HidrawInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *HidrawInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
+func (iface *hidrawInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
 	usbVendor, vOk := slot.Attrs["usb-vendor"].(int64)
 	if !vOk {
 		return nil
@@ -130,7 +130,7 @@ func (iface *HidrawInterface) UDevPermanentSlot(spec *udev.Specification, slot *
 	return nil
 }
 
-func (iface *HidrawInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *hidrawInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	if iface.hasUsbAttrs(slot) {
 		// This apparmor rule must match hidrawDeviceNodePattern
 		// UDev tagging and device cgroups will restrict down to the specific device
@@ -149,7 +149,7 @@ func (iface *HidrawInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 
 }
 
-func (iface *HidrawInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *hidrawInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	usbVendor, vOk := slot.Attrs["usb-vendor"].(int64)
 	if !vOk {
 		return nil
@@ -165,12 +165,12 @@ func (iface *HidrawInterface) UDevConnectedPlug(spec *udev.Specification, plug *
 	return nil
 }
 
-func (iface *HidrawInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *hidrawInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
-func (iface *HidrawInterface) hasUsbAttrs(slot *interfaces.Slot) bool {
+func (iface *hidrawInterface) hasUsbAttrs(slot *interfaces.Slot) bool {
 	if _, ok := slot.Attrs["usb-vendor"]; ok {
 		return true
 	}
@@ -180,10 +180,10 @@ func (iface *HidrawInterface) hasUsbAttrs(slot *interfaces.Slot) bool {
 	return false
 }
 
-func (iface *HidrawInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *hidrawInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&HidrawInterface{})
+	registerIface(&hidrawInterface{})
 }

--- a/interfaces/builtin/hidraw_test.go
+++ b/interfaces/builtin/hidraw_test.go
@@ -56,7 +56,7 @@ type HidrawInterfaceSuite struct {
 }
 
 var _ = Suite(&HidrawInterfaceSuite{
-	iface: &builtin.HidrawInterface{},
+	iface: builtin.MustInterface("hidraw"),
 })
 
 func (s *HidrawInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/home
 const homeConnectedPlugAppArmor = `
 # Description: Can access non-hidden files in user's $HOME. This is restricted
@@ -48,15 +44,10 @@ owner /run/user/[0-9]*/gvfs/{,**} r,
 owner /run/user/[0-9]*/gvfs/*/**  w,
 `
 
-// NewHomeInterface returns a new "home" interface.
-func NewHomeInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "home",
 		connectedPlugAppArmor: homeConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewHomeInterface())
+	})
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -36,7 +36,9 @@ type HomeInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&HomeInterfaceSuite{})
+var _ = Suite(&HomeInterfaceSuite{
+	iface: builtin.MustInterface("home"),
+})
 
 func (s *HomeInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfo = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [home]
 `
-	s.iface = builtin.NewHomeInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -31,14 +31,14 @@ import (
 )
 
 // The type for i2c interface
-type I2cInterface struct{}
+type i2cInterface struct{}
 
 // Getter for the name of the i2c interface
-func (iface *I2cInterface) Name() string {
+func (iface *i2cInterface) Name() string {
 	return "i2c"
 }
 
-func (iface *I2cInterface) String() string {
+func (iface *i2cInterface) String() string {
 	return iface.Name()
 }
 
@@ -48,7 +48,7 @@ func (iface *I2cInterface) String() string {
 var i2cControlDeviceNodePattern = regexp.MustCompile("^/dev/i2c-[0-9]+$")
 
 // Check validity of the defined slot
-func (iface *I2cInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *i2cInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -76,7 +76,7 @@ func (iface *I2cInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // Checks and possibly modifies a plug
-func (iface *I2cInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *i2cInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -84,7 +84,7 @@ func (iface *I2cInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *I2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *i2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	path, pathOk := slot.Attrs["path"].(string)
 	if !pathOk {
 		return nil
@@ -96,7 +96,7 @@ func (iface *I2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	return nil
 }
 
-func (iface *I2cInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *i2cInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	path, pathOk := slot.Attrs["path"].(string)
 	if !pathOk {
 		return nil
@@ -110,15 +110,15 @@ func (iface *I2cInterface) UDevConnectedPlug(spec *udev.Specification, plug *int
 	return nil
 }
 
-func (iface *I2cInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *i2cInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
-func (iface *I2cInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *i2cInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&I2cInterface{})
+	registerIface(&i2cInterface{})
 }

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -55,7 +55,7 @@ type I2cInterfaceSuite struct {
 }
 
 var _ = Suite(&I2cInterfaceSuite{
-	iface: &builtin.I2cInterface{},
+	iface: builtin.MustInterface("i2c"),
 })
 
 func (s *I2cInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -39,14 +39,14 @@ const iioConnectedPlugAppArmor = `
 `
 
 // The type for iio interface
-type IioInterface struct{}
+type iioInterface struct{}
 
 // Getter for the name of the iio interface
-func (iface *IioInterface) Name() string {
+func (iface *iioInterface) Name() string {
 	return "iio"
 }
 
-func (iface *IioInterface) String() string {
+func (iface *iioInterface) String() string {
 	return iface.Name()
 }
 
@@ -56,7 +56,7 @@ func (iface *IioInterface) String() string {
 var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio:device[0-9]+$")
 
 // Check validity of the defined slot
-func (iface *IioInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *iioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -84,7 +84,7 @@ func (iface *IioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // Checks and possibly modifies a plug
-func (iface *IioInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *iioInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -92,7 +92,7 @@ func (iface *IioInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *IioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *iioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	path, pathOk := slot.Attrs["path"].(string)
 	if !pathOk {
 		return nil
@@ -112,7 +112,7 @@ func (iface *IioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	return nil
 }
 
-func (iface *IioInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *iioInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	path, pathOk := slot.Attrs["path"].(string)
 	if !pathOk {
 		return nil
@@ -126,15 +126,15 @@ func (iface *IioInterface) UDevConnectedPlug(spec *udev.Specification, plug *int
 	return nil
 }
 
-func (iface *IioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *iioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
-func (iface *IioInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *iioInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&IioInterface{})
+	registerIface(&iioInterface{})
 }

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -56,7 +56,7 @@ type IioInterfaceSuite struct {
 }
 
 var _ = Suite(&IioInterfaceSuite{
-	iface: &builtin.IioInterface{},
+	iface: builtin.MustInterface("iio"),
 })
 
 func (s *IioInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -48,19 +48,19 @@ iopl
 `
 
 // The type for io-ports-control interface
-type IioPortsControlInterface struct{}
+type iioPortsControlInterface struct{}
 
 // Getter for the name of the io-ports-control interface
-func (iface *IioPortsControlInterface) Name() string {
+func (iface *iioPortsControlInterface) Name() string {
 	return "io-ports-control"
 }
 
-func (iface *IioPortsControlInterface) String() string {
+func (iface *iioPortsControlInterface) String() string {
 	return iface.Name()
 }
 
 // Check validity of the defined slot
-func (iface *IioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *iioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -75,7 +75,7 @@ func (iface *IioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error
 }
 
 // Checks and possibly modifies a plug
-func (iface *IioPortsControlInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *iioPortsControlInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -83,12 +83,12 @@ func (iface *IioPortsControlInterface) SanitizePlug(plug *interfaces.Plug) error
 	return nil
 }
 
-func (iface *IioPortsControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *iioPortsControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(ioPortsControlConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *IioPortsControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *iioPortsControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const udevRule = `KERNEL=="port", TAG+="%s"`
 	for appName := range plug.Apps {
 		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
@@ -97,16 +97,16 @@ func (iface *IioPortsControlInterface) UDevConnectedPlug(spec *udev.Specificatio
 	return nil
 }
 
-func (iface *IioPortsControlInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *iioPortsControlInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(ioPortsControlConnectedPlugSecComp)
 	return nil
 }
 
-func (iface *IioPortsControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *iioPortsControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
 func init() {
-	registerIface(&IioPortsControlInterface{})
+	registerIface(&iioPortsControlInterface{})
 }

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -39,7 +39,7 @@ type IioPortsControlInterfaceSuite struct {
 }
 
 var _ = Suite(&IioPortsControlInterfaceSuite{
-	iface: &builtin.IioPortsControlInterface{},
+	iface: builtin.MustInterface("io-ports-control"),
 })
 
 func (s *IioPortsControlInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -36,21 +36,21 @@ const joystickConnectedPlugAppArmor = `
 /run/udev/data/c13:{[0-9],[12][0-9],3[01]} r,
 `
 
-// JoystickInterface is the type for joystick interface
-type JoystickInterface struct{}
+// joystickInterface is the type for joystick interface
+type joystickInterface struct{}
 
 // Name returns the name of the joystick interface.
-func (iface *JoystickInterface) Name() string {
+func (iface *joystickInterface) Name() string {
 	return "joystick"
 }
 
 // String returns the name of the joystick interface.
-func (iface *JoystickInterface) String() string {
+func (iface *joystickInterface) String() string {
 	return iface.Name()
 }
 
 // SanitizeSlot checks the validity of the defined slot.
-func (iface *JoystickInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *joystickInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -65,7 +65,7 @@ func (iface *JoystickInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // SanitizePlug checks and possibly modifies a plug.
-func (iface *JoystickInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *joystickInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -76,13 +76,13 @@ func (iface *JoystickInterface) SanitizePlug(plug *interfaces.Plug) error {
 
 // AppArmorConnectedPlug adds the necessary appamor snippet to the spec that
 // allows access to joystick devices.
-func (iface *JoystickInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *joystickInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(joystickConnectedPlugAppArmor)
 	return nil
 }
 
 // TODO: This interface needs to use udev tagging, see LP: #1675738.
-// func (iface *JoystickInterface) UdevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+// func (iface *joystickInterface) UdevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 // 	const udevRule = `KERNEL=="js[0-9]*", TAG+="%s"`
 // 	for appName := range plug.Apps {
 // 		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
@@ -92,10 +92,10 @@ func (iface *JoystickInterface) AppArmorConnectedPlug(spec *apparmor.Specificati
 // }
 
 // AutoConnect returns true in order to allow what's in the declarations.
-func (iface *JoystickInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *joystickInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }
 
 func init() {
-	registerIface(&JoystickInterface{})
+	registerIface(&joystickInterface{})
 }

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -37,7 +37,7 @@ type JoystickInterfaceSuite struct {
 }
 
 var _ = Suite(&JoystickInterfaceSuite{
-	iface: &builtin.JoystickInterface{},
+	iface: builtin.MustInterface("joystick"),
 })
 
 func (s *JoystickInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const kernelModuleControlConnectedPlugAppArmor = `
 # Description: Allow insertion, removal and querying of modules.
 
@@ -49,16 +45,11 @@ finit_module
 delete_module
 `
 
-// NewKernelModuleControlInterface returns a new "kernel-module" interface.
-func NewKernelModuleControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "kernel-module-control",
 		connectedPlugAppArmor: kernelModuleControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  kernelModuleControlConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewKernelModuleControlInterface())
+	})
 }

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [kernel-module-control]
 `
 
-var _ = Suite(&KernelModuleControlInterfaceSuite{})
+var _ = Suite(&KernelModuleControlInterfaceSuite{
+	iface: builtin.MustInterface("kernel-module-control"),
+})
 
 func (s *KernelModuleControlInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewKernelModuleControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const kubernetesSupportConnectedPlugAppArmor = `
 # Description: can use kubernetes to control Docker containers. This interface
 # is restricted because it gives wide ranging access to the host and other
@@ -72,16 +68,11 @@ ptrace (read, trace) peer=unconfined,
 
 var kubernetesSupportConnectedPlugKmod = []string{`llc`, `stp`}
 
-// NewKubernetesSupportInterface returns a new "openvswitch-support" interface.
-func NewKubernetesSupportInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "kubernetes-support",
 		connectedPlugAppArmor:    kubernetesSupportConnectedPlugAppArmor,
 		connectedPlugKModModules: kubernetesSupportConnectedPlugKmod,
 		reservedForOS:            true,
-	}
-}
-
-func init() {
-	registerIface(NewKubernetesSupportInterface())
+	})
 }

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [kubernetes-support]
 `
 
-var _ = Suite(&KubernetesSupportInterfaceSuite{})
+var _ = Suite(&KubernetesSupportInterfaceSuite{
+	iface: builtin.MustInterface("kubernetes-support"),
+})
 
 func (s *KubernetesSupportInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewKubernetesSupportInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -19,8 +19,6 @@
 
 package builtin
 
-import "github.com/snapcore/snapd/interfaces"
-
 const libvirtConnectedPlugAppArmor = `
 /run/libvirt/libvirt-sock rw,
 /etc/libvirt/* r,
@@ -32,15 +30,11 @@ accept
 accept4
 `
 
-func NewLibvirtInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "libvirt",
 		connectedPlugAppArmor: libvirtConnectedPlugAppArmor,
 		connectedPlugSecComp:  libvirtConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewLibvirtInterface())
+	})
 }

--- a/interfaces/builtin/libvirt_test.go
+++ b/interfaces/builtin/libvirt_test.go
@@ -35,7 +35,7 @@ type LibvirtInterfaceSuite struct {
 }
 
 var _ = Suite(&LibvirtInterfaceSuite{
-	iface: builtin.NewLibvirtInterface(),
+	iface: builtin.MustInterface("libvirt"),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "libvirt"},

--- a/interfaces/builtin/locale_control.go
+++ b/interfaces/builtin/locale_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/locale-control
 const localeControlConnectedPlugAppArmor = `
 # Description: Can manage locales directly separate from 'config ubuntu-core'.
@@ -31,15 +27,10 @@ const localeControlConnectedPlugAppArmor = `
 /etc/default/locale rw,
 `
 
-// NewLocaleControlInterface returns a new "locale-control" interface.
-func NewLocaleControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "locale-control",
 		connectedPlugAppArmor: localeControlConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewLocaleControlInterface())
+	})
 }

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -36,7 +36,9 @@ type LocaleControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&LocaleControlInterfaceSuite{})
+var _ = Suite(&LocaleControlInterfaceSuite{
+	iface: builtin.MustInterface("locale-control"),
+})
 
 func (s *LocaleControlInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [locale-control]
 `
-	s.iface = builtin.NewLocaleControlInterface()
 	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
 	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["locale-control"]}
 	s.slot = &interfaces.Slot{

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -190,13 +190,13 @@ const locationControlConnectedPlugDBus = `
 </policy>
 `
 
-type LocationControlInterface struct{}
+type locationControlInterface struct{}
 
-func (iface *LocationControlInterface) Name() string {
+func (iface *locationControlInterface) Name() string {
 	return "location-control"
 }
 
-func (iface *LocationControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *locationControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(locationControlConnectedPlugAppArmor, old, new, -1)
@@ -204,22 +204,22 @@ func (iface *LocationControlInterface) AppArmorConnectedPlug(spec *apparmor.Spec
 	return nil
 }
 
-func (iface *LocationControlInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *locationControlInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(locationControlConnectedPlugDBus)
 	return nil
 }
 
-func (iface *LocationControlInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *locationControlInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(locationControlPermanentSlotDBus)
 	return nil
 }
 
-func (iface *LocationControlInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *locationControlInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(locationControlPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *LocationControlInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *locationControlInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(locationControlConnectedSlotAppArmor, old, new, -1)
@@ -227,19 +227,19 @@ func (iface *LocationControlInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 	return nil
 }
 
-func (iface *LocationControlInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *locationControlInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *LocationControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *locationControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *LocationControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *locationControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&LocationControlInterface{})
+	registerIface(&locationControlInterface{})
 }

--- a/interfaces/builtin/location_control_test.go
+++ b/interfaces/builtin/location_control_test.go
@@ -36,7 +36,9 @@ type LocationControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&LocationControlInterfaceSuite{})
+var _ = Suite(&LocationControlInterfaceSuite{
+	iface: builtin.MustInterface("location-control"),
+})
 
 func (s *LocationControlInterfaceSuite) SetUpTest(c *C) {
 	var plugSnapInfoYaml = `name: location-consumer
@@ -59,7 +61,6 @@ apps:
   command: foo
   slots: [location]
 `
-	s.iface = &builtin.LocationControlInterface{}
 	snapInfo := snaptest.MockInfo(c, plugSnapInfoYaml, nil)
 	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["location-client"]}
 	snapInfo = snaptest.MockInfo(c, slotSnapInfoYaml, nil)

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -244,23 +244,23 @@ const locationObserveConnectedPlugDBus = `
 </policy>
 `
 
-type LocationObserveInterface struct{}
+type locationObserveInterface struct{}
 
-func (iface *LocationObserveInterface) Name() string {
+func (iface *locationObserveInterface) Name() string {
 	return "location-observe"
 }
 
-func (iface *LocationObserveInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *locationObserveInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(locationObserveConnectedPlugDBus)
 	return nil
 }
 
-func (iface *LocationObserveInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *locationObserveInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(locationObservePermanentSlotDBus)
 	return nil
 }
 
-func (iface *LocationObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *locationObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(locationObserveConnectedPlugAppArmor, old, new, -1)
@@ -268,12 +268,12 @@ func (iface *LocationObserveInterface) AppArmorConnectedPlug(spec *apparmor.Spec
 	return nil
 }
 
-func (iface *LocationObserveInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *locationObserveInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(locationObservePermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *LocationObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *locationObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(locationObserveConnectedSlotAppArmor, old, new, -1)
@@ -281,19 +281,19 @@ func (iface *LocationObserveInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 	return nil
 }
 
-func (iface *LocationObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *locationObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *LocationObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *locationObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *LocationObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *locationObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&LocationObserveInterface{})
+	registerIface(&locationObserveInterface{})
 }

--- a/interfaces/builtin/location_observe_test.go
+++ b/interfaces/builtin/location_observe_test.go
@@ -36,7 +36,9 @@ type LocationObserveInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&LocationObserveInterfaceSuite{})
+var _ = Suite(&LocationObserveInterfaceSuite{
+	iface: builtin.MustInterface("location-observe"),
+})
 
 func (s *LocationObserveInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -53,7 +55,6 @@ apps:
   command: foo
   slots: [location-observe]
 `
-	s.iface = &builtin.LocationObserveInterface{}
 	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
 	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["location-observe"]}
 	snapInfo = snaptest.MockInfo(c, mockSlotSnapInfoYaml, nil)

--- a/interfaces/builtin/log_observe.go
+++ b/interfaces/builtin/log_observe.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/log-observe
 const logObserveConnectedPlugAppArmor = `
 # Description: Can read system logs and set kernel log rate-limiting
@@ -46,15 +42,10 @@ const logObserveConnectedPlugAppArmor = `
 capability dac_override,
 `
 
-// NewLogObserveInterface returns a new "log-observe" interface.
-func NewLogObserveInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "log-observe",
 		connectedPlugAppArmor: logObserveConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewLogObserveInterface())
+	})
 }

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -36,7 +36,9 @@ type LogObserveInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&LogObserveInterfaceSuite{})
+var _ = Suite(&LogObserveInterfaceSuite{
+	iface: builtin.MustInterface("log-observe"),
+})
 
 func (s *LogObserveInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [log-observe]
 `
-	s.iface = builtin.NewLogObserveInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -42,41 +42,41 @@ shutdown
 socket AF_NETLINK - NETLINK_GENERIC
 `
 
-type LxdInterface struct{}
+type lxdInterface struct{}
 
-func (iface *LxdInterface) Name() string {
+func (iface *lxdInterface) Name() string {
 	return "lxd"
 }
 
-func (iface *LxdInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *lxdInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(lxdConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *LxdInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *lxdInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(lxdConnectedPlugSecComp)
 	return nil
 }
 
-func (iface *LxdInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *lxdInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *LxdInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *lxdInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *LxdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *lxdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&LxdInterface{})
+	registerIface(&lxdInterface{})
 }

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -39,35 +39,35 @@ const lxdSupportConnectedPlugSecComp = `
 @unrestricted
 `
 
-type LxdSupportInterface struct{}
+type lxdSupportInterface struct{}
 
-func (iface *LxdSupportInterface) Name() string {
+func (iface *lxdSupportInterface) Name() string {
 	return "lxd-support"
 }
 
-func (iface *LxdSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *lxdSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(lxdSupportConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *LxdSupportInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *lxdSupportInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(lxdSupportConnectedPlugSecComp)
 	return nil
 }
 
-func (iface *LxdSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *lxdSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *LxdSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *lxdSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *LxdSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *lxdSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&LxdSupportInterface{})
+	registerIface(&lxdSupportInterface{})
 }

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [lxd-support]
 `
 
-var _ = Suite(&LxdSupportInterfaceSuite{})
+var _ = Suite(&LxdSupportInterfaceSuite{
+	iface: builtin.MustInterface("lxd-support"),
+})
 
 func (s *LxdSupportInterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.LxdSupportInterface{}
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/lxd_test.go
+++ b/interfaces/builtin/lxd_test.go
@@ -37,7 +37,7 @@ type LxdInterfaceSuite struct {
 }
 
 var _ = Suite(&LxdInterfaceSuite{
-	iface: &builtin.LxdInterface{},
+	iface: builtin.MustInterface("lxd"),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/maliit.go
+++ b/interfaces/builtin/maliit.go
@@ -113,13 +113,13 @@ accept
 accept4
 `
 
-type MaliitInterface struct{}
+type maliitInterface struct{}
 
-func (iface *MaliitInterface) Name() string {
+func (iface *maliitInterface) Name() string {
 	return "maliit"
 }
 
-func (iface *MaliitInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *maliitInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(maliitConnectedPlugAppArmor, old, new, -1)
@@ -127,17 +127,17 @@ func (iface *MaliitInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 	return nil
 }
 
-func (iface *MaliitInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *maliitInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(maliitPermanentSlotSecComp)
 	return nil
 }
 
-func (iface *MaliitInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *maliitInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(maliitPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *MaliitInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *maliitInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(maliitConnectedSlotAppArmor, old, new, -1)
@@ -145,25 +145,25 @@ func (iface *MaliitInterface) AppArmorConnectedSlot(spec *apparmor.Specification
 	return nil
 }
 
-func (iface *MaliitInterface) SanitizePlug(slot *interfaces.Plug) error {
+func (iface *maliitInterface) SanitizePlug(slot *interfaces.Plug) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
 	return nil
 }
 
-func (iface *MaliitInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *maliitInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
 	}
 	return nil
 }
 
-func (iface *MaliitInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *maliitInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&MaliitInterface{})
+	registerIface(&maliitInterface{})
 }

--- a/interfaces/builtin/maliit_test.go
+++ b/interfaces/builtin/maliit_test.go
@@ -38,7 +38,9 @@ type MaliitInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&MaliitInterfaceSuite{})
+var _ = Suite(&MaliitInterfaceSuite{
+	iface: builtin.MustInterface("maliit"),
+})
 
 func (s *MaliitInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfoYaml = `name: other
@@ -55,7 +57,6 @@ apps:
   command: foo
   slots: [maliit]
 `
-	s.iface = &builtin.MaliitInterface{}
 	slotSnap := snaptest.MockInfo(c, mockCoreSlotSnapInfoYaml, nil)
 	s.slot = &interfaces.Slot{SlotInfo: slotSnap.Slots["maliit"]}
 	plugSnap := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)

--- a/interfaces/builtin/media_hub.go
+++ b/interfaces/builtin/media_hub.go
@@ -144,49 +144,49 @@ const mediaHubPermanentSlotSecComp = `
 bind
 `
 
-type MediaHubInterface struct{}
+type mediaHubInterface struct{}
 
-func (iface *MediaHubInterface) Name() string {
+func (iface *mediaHubInterface) Name() string {
 	return "media-hub"
 }
 
-func (iface *MediaHubInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *mediaHubInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	spec.AddSnippet(strings.Replace(mediaHubConnectedPlugAppArmor, old, new, -1))
 	return nil
 }
 
-func (iface *MediaHubInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *mediaHubInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(mediaHubPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *MediaHubInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *mediaHubInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	spec.AddSnippet(strings.Replace(mediaHubConnectedSlotAppArmor, old, new, -1))
 	return nil
 }
 
-func (iface *MediaHubInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *mediaHubInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(mediaHubPermanentSlotSecComp)
 	return nil
 }
 
-func (iface *MediaHubInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *mediaHubInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *MediaHubInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *mediaHubInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *MediaHubInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *mediaHubInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&MediaHubInterface{})
+	registerIface(&mediaHubInterface{})
 }

--- a/interfaces/builtin/media_hub_test.go
+++ b/interfaces/builtin/media_hub_test.go
@@ -38,7 +38,9 @@ type MediaHubInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&MediaHubInterfaceSuite{})
+var _ = Suite(&MediaHubInterfaceSuite{
+	iface: builtin.MustInterface("media-hub"),
+})
 
 func (s *MediaHubInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -58,7 +60,6 @@ apps:
   command: foo
   slots: [media-hub]
 `
-	s.iface = &builtin.MediaHubInterface{}
 	snapInfo := snaptest.MockInfo(c, mockSlotSnapInfoYaml, nil)
 	s.slot = &interfaces.Slot{SlotInfo: snapInfo.Slots["media-hub"]}
 	snapInfo = snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -77,13 +77,13 @@ unix (receive, send) type=seqpacket addr=none peer=(label=###SLOT_SECURITY_TAGS#
 /run/user/[0-9]*/mir_socket rw,
 `
 
-type MirInterface struct{}
+type mirInterface struct{}
 
-func (iface *MirInterface) Name() string {
+func (iface *mirInterface) Name() string {
 	return "mir"
 }
 
-func (iface *MirInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *mirInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(mirConnectedPlugAppArmor, old, new, -1)
@@ -91,7 +91,7 @@ func (iface *MirInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 	return nil
 }
 
-func (iface *MirInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *mirInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(mirConnectedSlotAppArmor, old, new, -1)
@@ -99,28 +99,28 @@ func (iface *MirInterface) AppArmorConnectedSlot(spec *apparmor.Specification, p
 	return nil
 }
 
-func (iface *MirInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *mirInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(mirPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *MirInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *mirInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(mirPermanentSlotSecComp)
 	return nil
 }
 
-func (iface *MirInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *mirInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *MirInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *mirInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *MirInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *mirInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }
 
 func init() {
-	registerIface(&MirInterface{})
+	registerIface(&mirInterface{})
 }

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -37,7 +37,9 @@ type MirInterfaceSuite struct {
 	plug        *interfaces.Plug
 }
 
-var _ = Suite(&MirInterfaceSuite{})
+var _ = Suite(&MirInterfaceSuite{
+	iface: builtin.MustInterface("mir"),
+})
 
 func (s *MirInterfaceSuite) SetUpTest(c *C) {
 	// a pulseaudio slot on the core snap (as automatically added on classic)
@@ -64,7 +66,6 @@ apps:
   command: foo
   plugs: [mir]
 `
-	s.iface = &builtin.MirInterface{}
 	// mir snap with mir-server slot on an core/all-snap install.
 	snapInfo := snaptest.MockInfo(c, mirMockSlotSnapInfoYaml, nil)
 	s.coreSlot = &interfaces.Slot{SlotInfo: snapInfo.Slots["mir"]}

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1156,13 +1156,13 @@ KERNEL=="cdc-wdm*", SUBSYSTEM=="usbmisc", ENV{ID_MM_CANDIDATE}="1"
 LABEL="mm_candidate_end"
 `
 
-type ModemManagerInterface struct{}
+type modemManagerInterface struct{}
 
-func (iface *ModemManagerInterface) Name() string {
+func (iface *modemManagerInterface) Name() string {
 	return "modem-manager"
 }
 
-func (iface *ModemManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *modemManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	spec.AddSnippet(strings.Replace(modemManagerConnectedPlugAppArmor, old, new, -1))
@@ -1173,27 +1173,27 @@ func (iface *ModemManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specifi
 	return nil
 }
 
-func (iface *ModemManagerInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *modemManagerInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(modemManagerConnectedPlugDBus)
 	return nil
 }
 
-func (iface *ModemManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *modemManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(modemManagerPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *ModemManagerInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *modemManagerInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(modemManagerPermanentSlotDBus)
 	return nil
 }
 
-func (iface *ModemManagerInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
+func (iface *modemManagerInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(modemManagerPermanentSlotUDev)
 	return nil
 }
 
-func (iface *ModemManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *modemManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(modemManagerConnectedSlotAppArmor, old, new, -1)
@@ -1201,24 +1201,24 @@ func (iface *ModemManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specifi
 	return nil
 }
 
-func (iface *ModemManagerInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *modemManagerInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(modemManagerPermanentSlotSecComp)
 	return nil
 }
 
-func (iface *ModemManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *modemManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *ModemManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *modemManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *ModemManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *modemManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&ModemManagerInterface{})
+	registerIface(&modemManagerInterface{})
 }

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -60,10 +60,11 @@ apps:
    - modem-manager
 `
 
-var _ = Suite(&ModemManagerInterfaceSuite{})
+var _ = Suite(&ModemManagerInterfaceSuite{
+	iface: builtin.MustInterface("modem-manager"),
+})
 
 func (s *ModemManagerInterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.ModemManagerInterface{}
 	s.plug = &interfaces.Plug{
 		PlugInfo: &snap.PlugInfo{
 			Snap:      &snap.Info{SuggestedName: "modem-manager"},

--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/mount-observe
 const mountObserveConnectedPlugAppArmor = `
 # Description: Can query system mount and disk quota information. This is
@@ -56,16 +52,11 @@ quotactl Q_XGETQUOTA - - -
 quotactl Q_XGETQSTAT - - -
 `
 
-// NewMountObserveInterface returns a new "mount-observe" interface.
-func NewMountObserveInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "mount-observe",
 		connectedPlugAppArmor: mountObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  mountObserveConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewMountObserveInterface())
+	})
 }

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -36,7 +36,9 @@ type MountObserveInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&MountObserveInterfaceSuite{})
+var _ = Suite(&MountObserveInterfaceSuite{
+	iface: builtin.MustInterface("mount-observe"),
+})
 
 func (s *MountObserveInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [mount-observe]
 `
-	s.iface = builtin.NewMountObserveInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -138,20 +138,20 @@ dbus (send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
-type MprisInterface struct{}
+type mprisInterface struct{}
 
-func (iface *MprisInterface) Name() string {
+func (iface *mprisInterface) Name() string {
 	return "mpris"
 }
 
-func (iface *MprisInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *mprisInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	spec.AddSnippet(strings.Replace(mprisConnectedPlugAppArmor, old, new, -1))
 	return nil
 }
 
-func (iface *MprisInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *mprisInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	name, err := iface.getName(slot.Attrs)
 	if err != nil {
 		return err
@@ -168,14 +168,14 @@ func (iface *MprisInterface) AppArmorPermanentSlot(spec *apparmor.Specification,
 	return nil
 }
 
-func (iface *MprisInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *mprisInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	spec.AddSnippet(strings.Replace(mprisConnectedSlotAppArmor, old, new, -1))
 	return nil
 }
 
-func (iface *MprisInterface) getName(attribs map[string]interface{}) (string, error) {
+func (iface *mprisInterface) getName(attribs map[string]interface{}) (string, error) {
 	// default to snap name if 'name' attribute not set
 	mprisName := "@{SNAP_NAME}"
 	for attr := range attribs {
@@ -200,11 +200,11 @@ func (iface *MprisInterface) getName(attribs map[string]interface{}) (string, er
 	return mprisName, nil
 }
 
-func (iface *MprisInterface) SanitizePlug(slot *interfaces.Plug) error {
+func (iface *mprisInterface) SanitizePlug(slot *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *MprisInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *mprisInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
 	}
@@ -213,19 +213,19 @@ func (iface *MprisInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return err
 }
 
-func (iface *MprisInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *mprisInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
-func (iface *MprisInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
+func (iface *mprisInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
 	return nil
 }
 
-func (iface *MprisInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *mprisInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&MprisInterface{})
+	registerIface(&mprisInterface{})
 }

--- a/interfaces/builtin/mpris_test.go
+++ b/interfaces/builtin/mpris_test.go
@@ -37,7 +37,9 @@ type MprisInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&MprisInterfaceSuite{})
+var _ = Suite(&MprisInterfaceSuite{
+	iface: builtin.MustInterface("mpris"),
+})
 
 func (s *MprisInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -55,7 +57,6 @@ apps:
   slots: [mpris]
 `
 
-	s.iface = &builtin.MprisInterface{}
 	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
 	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["mpris"]}
 	snapInfo = snaptest.MockInfo(c, mockSlotSnapInfoYaml, nil)
@@ -76,8 +77,7 @@ slots:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
-	iface := &builtin.MprisInterface{}
-	name, err := builtin.MprisGetName(iface, slot.Attrs)
+	name, err := builtin.MprisGetName(s.iface, slot.Attrs)
 	c.Assert(err, IsNil)
 	c.Assert(name, Equals, "foo")
 }
@@ -91,8 +91,7 @@ slots:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
-	iface := &builtin.MprisInterface{}
-	name, err := builtin.MprisGetName(iface, slot.Attrs)
+	name, err := builtin.MprisGetName(s.iface, slot.Attrs)
 	c.Assert(err, IsNil)
 	c.Assert(name, Equals, "@{SNAP_NAME}")
 }
@@ -106,8 +105,7 @@ slots:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
-	iface := &builtin.MprisInterface{}
-	name, err := builtin.MprisGetName(iface, slot.Attrs)
+	name, err := builtin.MprisGetName(s.iface, slot.Attrs)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "invalid name element: \"foo.bar\"")
 	c.Assert(name, Equals, "")
@@ -124,8 +122,7 @@ slots:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
-	iface := &builtin.MprisInterface{}
-	name, err := builtin.MprisGetName(iface, slot.Attrs)
+	name, err := builtin.MprisGetName(s.iface, slot.Attrs)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, `name element \[foo\] is not a string`)
 	c.Assert(name, Equals, "")
@@ -141,8 +138,7 @@ slots:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["mpris-slot"]}
-	iface := &builtin.MprisInterface{}
-	name, err := builtin.MprisGetName(iface, slot.Attrs)
+	name, err := builtin.MprisGetName(s.iface, slot.Attrs)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, "unknown attribute 'unknown'")
 	c.Assert(name, Equals, "")

--- a/interfaces/builtin/netlink_audit.go
+++ b/interfaces/builtin/netlink_audit.go
@@ -19,25 +19,16 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const netlinkAuditConnectedPlugSecComp = `
 # Description: Can use netlink to read/write to kernel audit system.
 bind
 socket AF_NETLINK - NETLINK_AUDIT
 `
 
-// NewNetlinkAuditInterface returns a new "netlink-audit" interface.
-func NewNetlinkAuditInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name:                 "netlink-audit",
 		connectedPlugSecComp: netlinkAuditConnectedPlugSecComp,
 		reservedForOS:        true,
-	}
-}
-
-func init() {
-	registerIface(NewNetlinkAuditInterface())
+	})
 }

--- a/interfaces/builtin/netlink_audit_test.go
+++ b/interfaces/builtin/netlink_audit_test.go
@@ -44,10 +44,11 @@ apps:
   plugs: [netlink-audit]
 `
 
-var _ = Suite(&NetlinkAuditInterfaceSuite{})
+var _ = Suite(&NetlinkAuditInterfaceSuite{
+	iface: builtin.MustInterface("netlink-audit"),
+})
 
 func (s *NetlinkAuditInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewNetlinkAuditInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/netlink_connector.go
+++ b/interfaces/builtin/netlink_connector.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const netlinkConnectorConnectedPlugSecComp = `
 # Description: Can use netlink to communicate with kernel connector. Because
 # NETLINK_CONNECTOR is not finely mediated and app-specific, use of this
@@ -32,15 +28,10 @@ bind
 socket AF_NETLINK - NETLINK_CONNECTOR
 `
 
-// NewNetlinkConnectorInterface returns a new "netlink-connector" interface.
-func NewNetlinkConnectorInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name:                 "netlink-connector",
 		connectedPlugSecComp: netlinkConnectorConnectedPlugSecComp,
 		reservedForOS:        true,
-	}
-}
-
-func init() {
-	registerIface(NewNetlinkConnectorInterface())
+	})
 }

--- a/interfaces/builtin/netlink_connector_test.go
+++ b/interfaces/builtin/netlink_connector_test.go
@@ -44,10 +44,11 @@ apps:
   plugs: [netlink-connector]
 `
 
-var _ = Suite(&NetlinkConnectorInterfaceSuite{})
+var _ = Suite(&NetlinkConnectorInterfaceSuite{
+	iface: builtin.MustInterface("netlink-connector"),
+})
 
 func (s *NetlinkConnectorInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewNetlinkConnectorInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -19,8 +19,6 @@
 
 package builtin
 
-import "github.com/snapcore/snapd/interfaces"
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network
 const networkConnectedPlugAppArmor = `
 # Description: Can access the network as a client.
@@ -44,16 +42,11 @@ shutdown
 socket AF_NETLINK - NETLINK_ROUTE
 `
 
-// NewNetworkInterface returns a new "network" interface.
-func NewNetworkInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "network",
 		connectedPlugAppArmor: networkConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewNetworkInterface())
+	})
 }

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network-bind
 const networkBindConnectedPlugAppArmor = `
 # Description: Can access the network as a server.
@@ -69,16 +65,11 @@ shutdown
 socket AF_NETLINK - NETLINK_ROUTE
 `
 
-// NewNetworkBindInterface returns a new "network-bind" interface.
-func NewNetworkBindInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "network-bind",
 		connectedPlugAppArmor: networkBindConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkBindConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewNetworkBindInterface())
+	})
 }

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [network-bind]
 `
 
-var _ = Suite(&NetworkBindInterfaceSuite{})
+var _ = Suite(&NetworkBindInterfaceSuite{
+	iface: builtin.MustInterface("network-bind"),
+})
 
 func (s *NetworkBindInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewNetworkBindInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const networkControlConnectedPlugAppArmor = `
 # Description: Can configure networking and network namespaces via the standard
 # 'ip netns' command (man ip-netns(8)). This interface is restricted because it
@@ -210,16 +206,11 @@ socket AF_NETLINK - NETLINK_RDMA
 socket AF_NETLINK - NETLINK_GENERIC
 `
 
-// NewNetworkControlInterface returns a new "network-control" interface.
-func NewNetworkControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "network-control",
 		connectedPlugAppArmor: networkControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkControlConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewNetworkControlInterface())
+	})
 }

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [network-control]
 `
 
-var _ = Suite(&NetworkControlInterfaceSuite{})
+var _ = Suite(&NetworkControlInterfaceSuite{
+	iface: builtin.MustInterface("network-control"),
+})
 
 func (s *NetworkControlInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewNetworkControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -371,13 +371,13 @@ const networkManagerPermanentSlotDBus = `
 <limit name="max_match_rules_per_connection">2048</limit>
 `
 
-type NetworkManagerInterface struct{}
+type networkManagerInterface struct{}
 
-func (iface *NetworkManagerInterface) Name() string {
+func (iface *networkManagerInterface) Name() string {
 	return "network-manager"
 }
 
-func (iface *NetworkManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *networkManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	var new string
 	if release.OnClassic {
@@ -392,7 +392,7 @@ func (iface *NetworkManagerInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 	return nil
 }
 
-func (iface *NetworkManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *networkManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(networkManagerConnectedSlotAppArmor, old, new, -1)
@@ -400,34 +400,34 @@ func (iface *NetworkManagerInterface) AppArmorConnectedSlot(spec *apparmor.Speci
 	return nil
 }
 
-func (iface *NetworkManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *networkManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(networkManagerPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *NetworkManagerInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *networkManagerInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(networkManagerPermanentSlotDBus)
 	return nil
 }
 
-func (iface *NetworkManagerInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *networkManagerInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(networkManagerPermanentSlotSecComp)
 	return nil
 }
 
-func (iface *NetworkManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *networkManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *NetworkManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *networkManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *NetworkManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *networkManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&NetworkManagerInterface{})
+	registerIface(&networkManagerInterface{})
 }

--- a/interfaces/builtin/network_manager_test.go
+++ b/interfaces/builtin/network_manager_test.go
@@ -58,10 +58,11 @@ apps:
   slots: [network-manager]
 `
 
-var _ = Suite(&NetworkManagerInterfaceSuite{})
+var _ = Suite(&NetworkManagerInterfaceSuite{
+	iface: builtin.MustInterface("network-manager"),
+})
 
 func (s *NetworkManagerInterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.NetworkManagerInterface{}
 	plugSnap := snaptest.MockInfo(c, netmgrMockPlugSnapInfoYaml, nil)
 	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["network-manager"]}
 

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network-observe
 const networkObserveConnectedPlugAppArmor = `
 # Description: Can query network status information. This is restricted because
@@ -115,16 +111,11 @@ socket AF_NETLINK - NETLINK_ROUTE
 socket AF_NETLINK - NETLINK_GENERIC
 `
 
-// NewNetworkObserveInterface returns a new "network-observe" interface.
-func NewNetworkObserveInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "network-observe",
 		connectedPlugAppArmor: networkObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkObserveConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewNetworkObserveInterface())
+	})
 }

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [network-observe]
 `
 
-var _ = Suite(&NetworkObserveInterfaceSuite{})
+var _ = Suite(&NetworkObserveInterfaceSuite{
+	iface: builtin.MustInterface("network-observe"),
+})
 
 func (s *NetworkObserveInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewNetworkObserveInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const networkSetupControlConnectedPlugAppArmor = `
 # Description: Can read/write netplan configuration files
 
@@ -30,15 +26,10 @@ const networkSetupControlConnectedPlugAppArmor = `
 /etc/network/{,**} rw,
 `
 
-// NewNetworkSetupControlInterface returns a new "network-setup-control" interface.
-func NewNetworkSetupControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "network-setup-control",
 		connectedPlugAppArmor: networkSetupControlConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewNetworkSetupControlInterface())
+	})
 }

--- a/interfaces/builtin/network_setup_control_test.go
+++ b/interfaces/builtin/network_setup_control_test.go
@@ -36,7 +36,9 @@ type NetworkSetupControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&NetworkSetupControlInterfaceSuite{})
+var _ = Suite(&NetworkSetupControlInterfaceSuite{
+	iface: builtin.MustInterface("network-setup-control"),
+})
 
 func (s *NetworkSetupControlInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
@@ -46,7 +48,6 @@ apps:
     command: foo
     plugs: [network-setup-control]
 `, nil)
-	s.iface = builtin.NewNetworkSetupControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/network_setup_observe.go
+++ b/interfaces/builtin/network_setup_observe.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const networkSetupObserveConnectedPlugAppArmor = `
 # Description: Can read netplan configuration files
 
@@ -30,15 +26,10 @@ const networkSetupObserveConnectedPlugAppArmor = `
 /etc/network/{,**} r,
 `
 
-// NewNetworkSetupObserveInterface returns a new "network-setup-observe" interface.
-func NewNetworkSetupObserveInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "network-setup-observe",
 		connectedPlugAppArmor: networkSetupObserveConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewNetworkSetupObserveInterface())
+	})
 }

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -36,7 +36,9 @@ type NetworkSetupObserveInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&NetworkSetupObserveInterfaceSuite{})
+var _ = Suite(&NetworkSetupObserveInterfaceSuite{
+	iface: builtin.MustInterface("network-setup-observe"),
+})
 
 func (s *NetworkSetupObserveInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [network-setup-observe]
 `
-	s.iface = builtin.NewNetworkSetupObserveInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -90,55 +90,55 @@ const networkStatusPermanentSlotDBus = `
 <limit name="max_match_rules_per_connection">2048</limit>
 `
 
-type NetworkStatusInterface struct{}
+type networkStatusInterface struct{}
 
-func (iface *NetworkStatusInterface) Name() string {
+func (iface *networkStatusInterface) Name() string {
 	return "network-status"
 }
 
-func (iface *NetworkStatusInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *networkStatusInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const old = "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	spec.AddSnippet(strings.Replace(networkStatusConnectedPlugAppArmor, old, new, -1))
 	return nil
 }
 
-func (iface *NetworkStatusInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *networkStatusInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const old = "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	spec.AddSnippet(strings.Replace(networkStatusConnectedSlotAppArmor, old, new, -1))
 	return nil
 }
 
-func (iface *NetworkStatusInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *networkStatusInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(networkStatusPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *NetworkStatusInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *networkStatusInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(networkStatusPermanentSlotDBus)
 	return nil
 }
 
-func (iface *NetworkStatusInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *networkStatusInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *NetworkStatusInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *networkStatusInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *NetworkStatusInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *networkStatusInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&NetworkStatusInterface{})
+	registerIface(&networkStatusInterface{})
 }

--- a/interfaces/builtin/network_status_test.go
+++ b/interfaces/builtin/network_status_test.go
@@ -38,7 +38,7 @@ type NetworkStatusSuite struct {
 }
 
 var _ = Suite(&NetworkStatusSuite{
-	iface: &builtin.NetworkStatusInterface{},
+	iface: builtin.MustInterface("network-status"),
 })
 
 func (s *NetworkStatusSuite) SetUpSuite(c *C) {

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [network]
 `
 
-var _ = Suite(&NetworkInterfaceSuite{})
+var _ = Suite(&NetworkInterfaceSuite{
+	iface: builtin.MustInterface("network"),
+})
 
 func (s *NetworkInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewNetworkInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -257,13 +257,13 @@ ATTRS{idVendor}=="1c9e", ATTRS{idProduct}=="9605", ENV{ID_USB_INTERFACE_NUM}=="0
 LABEL="ofono_speedup_end"
 `
 
-type OfonoInterface struct{}
+type ofonoInterface struct{}
 
-func (iface *OfonoInterface) Name() string {
+func (iface *ofonoInterface) Name() string {
 	return "ofono"
 }
 
-func (iface *OfonoInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *ofonoInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	spec.AddSnippet(strings.Replace(ofonoConnectedPlugAppArmor, old, new, -1))
@@ -275,46 +275,46 @@ func (iface *OfonoInterface) AppArmorConnectedPlug(spec *apparmor.Specification,
 
 }
 
-func (iface *OfonoInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *ofonoInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(ofonoPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *OfonoInterface) DBusPermanentSlot(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
+func (iface *ofonoInterface) DBusPermanentSlot(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error {
 	spec.AddSnippet(ofonoPermanentSlotDBus)
 	return nil
 }
 
-func (iface *OfonoInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
+func (iface *ofonoInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(ofonoPermanentSlotUDev)
 	return nil
 }
 
-func (iface *OfonoInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *ofonoInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	spec.AddSnippet(strings.Replace(ofonoConnectedSlotAppArmor, old, new, -1))
 	return nil
 }
 
-func (iface *OfonoInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *ofonoInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(ofonoPermanentSlotSecComp)
 	return nil
 }
 
-func (iface *OfonoInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *ofonoInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *OfonoInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *ofonoInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *OfonoInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *ofonoInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&OfonoInterface{})
+	registerIface(&ofonoInterface{})
 }

--- a/interfaces/builtin/ofono_test.go
+++ b/interfaces/builtin/ofono_test.go
@@ -38,7 +38,9 @@ type OfonoInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&OfonoInterfaceSuite{})
+var _ = Suite(&OfonoInterfaceSuite{
+	iface: builtin.MustInterface("ofono"),
+})
 
 func (s *OfonoInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -58,7 +60,6 @@ apps:
   command: foo
   slots: [ofono]
 `
-	s.iface = &builtin.OfonoInterface{}
 	snapInfo := snaptest.MockInfo(c, mockSlotSnapInfoYaml, nil)
 	s.slot = &interfaces.Slot{SlotInfo: snapInfo.Slots["ofono"]}
 	snapInfo = snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)

--- a/interfaces/builtin/online_accounts_service.go
+++ b/interfaces/builtin/online_accounts_service.go
@@ -88,54 +88,54 @@ listen
 shutdown
 `
 
-type OnlineAccountsServiceInterface struct{}
+type onlineAccountsServiceInterface struct{}
 
-func (iface *OnlineAccountsServiceInterface) Name() string {
+func (iface *onlineAccountsServiceInterface) Name() string {
 	return "online-accounts-service"
 }
 
-func (iface *OnlineAccountsServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *onlineAccountsServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	spec.AddSnippet(strings.Replace(onlineAccountsServiceConnectedPlugAppArmor, old, new, -1))
 	return nil
 }
 
-func (iface *OnlineAccountsServiceInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *onlineAccountsServiceInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	spec.AddSnippet(strings.Replace(onlineAccountsServiceConnectedSlotAppArmor, old, new, -1))
 	return nil
 }
 
-func (iface *OnlineAccountsServiceInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *onlineAccountsServiceInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(onlineAccountsServicePermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *OnlineAccountsServiceInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *onlineAccountsServiceInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(onlineAccountsServicePermanentSlotSecComp)
 	return nil
 }
 
-func (iface *OnlineAccountsServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *onlineAccountsServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *OnlineAccountsServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *onlineAccountsServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *OnlineAccountsServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (iface *onlineAccountsServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	return true
 }
 
 func init() {
-	registerIface(&OnlineAccountsServiceInterface{})
+	registerIface(&onlineAccountsServiceInterface{})
 }

--- a/interfaces/builtin/online_accounts_service_test.go
+++ b/interfaces/builtin/online_accounts_service_test.go
@@ -38,7 +38,7 @@ type OnlineAccountsServiceInterfaceSuite struct {
 }
 
 var _ = Suite(&OnlineAccountsServiceInterfaceSuite{
-	iface: &builtin.OnlineAccountsServiceInterface{},
+	iface: builtin.MustInterface("online-accounts-service"),
 })
 
 func (s *OnlineAccountsServiceInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const openglConnectedPlugAppArmor = `
 # Description: Can access opengl.
 
@@ -58,15 +54,10 @@ const openglConnectedPlugAppArmor = `
   /run/udev/data/c226:[0-9]* r,  # 226 drm
 `
 
-// NewOpenglInterface returns a new "opengl" interface.
-func NewOpenglInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "opengl",
 		connectedPlugAppArmor: openglConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewOpenglInterface())
+	})
 }

--- a/interfaces/builtin/openvswitch.go
+++ b/interfaces/builtin/openvswitch.go
@@ -19,20 +19,14 @@
 
 package builtin
 
-import "github.com/snapcore/snapd/interfaces"
-
 const openvswitchConnectedPlugAppArmor = `
 /run/openvswitch/db.sock rw,
 `
 
-func NewOpenvSwitchInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "openvswitch",
 		connectedPlugAppArmor: openvswitchConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewOpenvSwitchInterface())
+	})
 }

--- a/interfaces/builtin/openvswitch_support.go
+++ b/interfaces/builtin/openvswitch_support.go
@@ -19,21 +19,12 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 var openvswitchSupportConnectedPlugKmod = []string{`openvswitch`}
 
-// NewOpenvSwitchSupportInterface returns a new "openvswitch-support" interface.
-func NewOpenvSwitchSupportInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "openvswitch-support",
 		connectedPlugKModModules: openvswitchSupportConnectedPlugKmod,
 		reservedForOS:            true,
-	}
-}
-
-func init() {
-	registerIface(NewOpenvSwitchSupportInterface())
+	})
 }

--- a/interfaces/builtin/openvswitch_support_test.go
+++ b/interfaces/builtin/openvswitch_support_test.go
@@ -36,7 +36,7 @@ type OpenvSwitchSupportInterfaceSuite struct {
 }
 
 var _ = Suite(&OpenvSwitchSupportInterfaceSuite{
-	iface: builtin.NewOpenvSwitchSupportInterface(),
+	iface: builtin.MustInterface("openvswitch-support"),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/openvswitch_test.go
+++ b/interfaces/builtin/openvswitch_test.go
@@ -36,7 +36,9 @@ type OpenvSwitchInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&OpenvSwitchInterfaceSuite{})
+var _ = Suite(&OpenvSwitchInterfaceSuite{
+	iface: builtin.MustInterface("openvswitch"),
+})
 
 func (s *OpenvSwitchInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [openvswitch]
 `
-	s.iface = builtin.NewOpenvSwitchInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -19,24 +19,15 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const opticalDriveConnectedPlugAppArmor = `
 /dev/sr[0-9]* r,
 /dev/scd[0-9]* r,
 `
 
-// NewOpticalDriveInterface returns a new "optical-drive" interface.
-func NewOpticalDriveInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "optical-drive",
 		connectedPlugAppArmor: opticalDriveConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewOpticalDriveInterface())
+	})
 }

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -40,19 +40,19 @@ capability sys_rawio,
 `
 
 // The type for physical-memory-control interface
-type PhysicalMemoryControlInterface struct{}
+type physicalMemoryControlInterface struct{}
 
 // Getter for the name of the physical-memory-control interface
-func (iface *PhysicalMemoryControlInterface) Name() string {
+func (iface *physicalMemoryControlInterface) Name() string {
 	return "physical-memory-control"
 }
 
-func (iface *PhysicalMemoryControlInterface) String() string {
+func (iface *physicalMemoryControlInterface) String() string {
 	return iface.Name()
 }
 
 // Check validity of the defined slot
-func (iface *PhysicalMemoryControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *physicalMemoryControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -67,7 +67,7 @@ func (iface *PhysicalMemoryControlInterface) SanitizeSlot(slot *interfaces.Slot)
 }
 
 // Checks and possibly modifies a plug
-func (iface *PhysicalMemoryControlInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *physicalMemoryControlInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -75,12 +75,12 @@ func (iface *PhysicalMemoryControlInterface) SanitizePlug(plug *interfaces.Plug)
 	return nil
 }
 
-func (iface *PhysicalMemoryControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *physicalMemoryControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(physicalMemoryControlConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *PhysicalMemoryControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *physicalMemoryControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const udevRule = `KERNEL=="mem", TAG+="%s"`
 	for appName := range plug.Apps {
 		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
@@ -89,11 +89,11 @@ func (iface *PhysicalMemoryControlInterface) UDevConnectedPlug(spec *udev.Specif
 	return nil
 }
 
-func (iface *PhysicalMemoryControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *physicalMemoryControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
 func init() {
-	registerIface(&PhysicalMemoryControlInterface{})
+	registerIface(&physicalMemoryControlInterface{})
 }

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -38,7 +38,7 @@ type PhysicalMemoryControlInterfaceSuite struct {
 }
 
 var _ = Suite(&PhysicalMemoryControlInterfaceSuite{
-	iface: &builtin.PhysicalMemoryControlInterface{},
+	iface: builtin.MustInterface("physical-memory-control"),
 })
 
 func (s *PhysicalMemoryControlInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -36,19 +36,19 @@ const physicalMemoryObserveConnectedPlugAppArmor = `
 `
 
 // The type for physical-memory-observe interface
-type PhysicalMemoryObserveInterface struct{}
+type physicalMemoryObserveInterface struct{}
 
 // Getter for the name of the physical-memory-observe interface
-func (iface *PhysicalMemoryObserveInterface) Name() string {
+func (iface *physicalMemoryObserveInterface) Name() string {
 	return "physical-memory-observe"
 }
 
-func (iface *PhysicalMemoryObserveInterface) String() string {
+func (iface *physicalMemoryObserveInterface) String() string {
 	return iface.Name()
 }
 
 // Check validity of the defined slot
-func (iface *PhysicalMemoryObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *physicalMemoryObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -63,7 +63,7 @@ func (iface *PhysicalMemoryObserveInterface) SanitizeSlot(slot *interfaces.Slot)
 }
 
 // Checks and possibly modifies a plug
-func (iface *PhysicalMemoryObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *physicalMemoryObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -71,12 +71,12 @@ func (iface *PhysicalMemoryObserveInterface) SanitizePlug(plug *interfaces.Plug)
 	return nil
 }
 
-func (iface *PhysicalMemoryObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *physicalMemoryObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(physicalMemoryObserveConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *PhysicalMemoryObserveInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *physicalMemoryObserveInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const udevRule = `KERNEL=="mem", TAG+="%s"`
 	for appName := range plug.Apps {
 		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
@@ -85,11 +85,11 @@ func (iface *PhysicalMemoryObserveInterface) UDevConnectedPlug(spec *udev.Specif
 	return nil
 }
 
-func (iface *PhysicalMemoryObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *physicalMemoryObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
 func init() {
-	registerIface(&PhysicalMemoryObserveInterface{})
+	registerIface(&physicalMemoryObserveInterface{})
 }

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -39,7 +39,7 @@ type PhysicalMemoryObserveInterfaceSuite struct {
 }
 
 var _ = Suite(&PhysicalMemoryObserveInterfaceSuite{
-	iface: &builtin.PhysicalMemoryObserveInterface{},
+	iface: builtin.MustInterface("physical-memory-observe"),
 })
 
 func (s *PhysicalMemoryObserveInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -49,34 +49,34 @@ capability setuid,
 // in many cases ppp_generic is statically linked into the kernel (CONFIG_PPP=y)
 const pppConnectedPlugKmod = "ppp_generic"
 
-type PppInterface struct{}
+type pppInterface struct{}
 
-func (iface *PppInterface) Name() string {
+func (iface *pppInterface) Name() string {
 	return "ppp"
 }
 
-func (iface *PppInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *pppInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(pppConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *PppInterface) KModConnectedPlug(spec *kmod.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *pppInterface) KModConnectedPlug(spec *kmod.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	return spec.AddModule(pppConnectedPlugKmod)
 }
 
-func (iface *PppInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *pppInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *PppInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *pppInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *PppInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *pppInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&PppInterface{})
+	registerIface(&pppInterface{})
 }

--- a/interfaces/builtin/ppp_test.go
+++ b/interfaces/builtin/ppp_test.go
@@ -38,7 +38,9 @@ type PppInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&PppInterfaceSuite{})
+var _ = Suite(&PppInterfaceSuite{
+	iface: builtin.MustInterface("ppp"),
+})
 
 func (s *PppInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfo = `name: other
@@ -56,8 +58,6 @@ apps:
   command: foo
   slots: [ppp]
 `
-
-	s.iface = &builtin.PppInterface{}
 	slotSnap := snaptest.MockInfo(c, mockPlugSnapInfo, nil)
 	s.slot = &interfaces.Slot{SlotInfo: slotSnap.Slots["ppp"]}
 

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const processControlConnectedPlugAppArmor = `
 # Description: This interface allows for controlling other processes via
 # signals and nice. This is reserved because it grants privileged access to
@@ -50,16 +46,11 @@ sched_setparam
 sched_setscheduler
 `
 
-// NewProcessControlInterface returns a new "process-control" interface.
-func NewProcessControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "process-control",
 		connectedPlugAppArmor: processControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  processControlConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewProcessControlInterface())
+	})
 }

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [process-control]
 `
 
-var _ = Suite(&ProcessControlInterfaceSuite{})
+var _ = Suite(&ProcessControlInterfaceSuite{
+	iface: builtin.MustInterface("process-control"),
+})
 
 func (s *ProcessControlInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewProcessControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -111,13 +111,13 @@ setgroups32
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
-type PulseAudioInterface struct{}
+type pulseAudioInterface struct{}
 
-func (iface *PulseAudioInterface) Name() string {
+func (iface *pulseAudioInterface) Name() string {
 	return "pulseaudio"
 }
 
-func (iface *PulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *pulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(pulseaudioConnectedPlugAppArmor)
 	if release.OnClassic {
 		spec.AddSnippet(pulseaudioConnectedPlugAppArmorDesktop)
@@ -125,33 +125,33 @@ func (iface *PulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 	return nil
 }
 
-func (iface *PulseAudioInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *pulseAudioInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(pulseaudioPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *PulseAudioInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *pulseAudioInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(pulseaudioConnectedPlugSecComp)
 	return nil
 }
 
-func (iface *PulseAudioInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *pulseAudioInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(pulseaudioPermanentSlotSecComp)
 	return nil
 }
 
-func (iface *PulseAudioInterface) SanitizePlug(slot *interfaces.Plug) error {
+func (iface *pulseAudioInterface) SanitizePlug(slot *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *PulseAudioInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *pulseAudioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *PulseAudioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *pulseAudioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }
 
 func init() {
-	registerIface(&PulseAudioInterface{})
+	registerIface(&pulseAudioInterface{})
 }

--- a/interfaces/builtin/pulseaudio_test.go
+++ b/interfaces/builtin/pulseaudio_test.go
@@ -37,7 +37,7 @@ type PulseAudioInterfaceSuite struct {
 }
 
 var _ = Suite(&PulseAudioInterfaceSuite{
-	iface: &builtin.PulseAudioInterface{},
+	iface: builtin.MustInterface("pulseaudio"),
 })
 
 const pulseaudioMockPlugSnapInfoYaml = `name: other

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const rawusbConnectedPlugAppArmor = `
 # Description: Allow raw access to all connected USB devices.
 # This gives privileged access to the system.
@@ -39,15 +35,10 @@ const rawusbConnectedPlugAppArmor = `
 /run/udev/data/+usb:* r,
 `
 
-// Transitional interface which allows access to all usb devices.
-func NewRawUsbInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "raw-usb",
 		connectedPlugAppArmor: rawusbConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewRawUsbInterface())
+	})
 }

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -36,7 +36,9 @@ type RawUsbSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&RawUsbSuite{})
+var _ = Suite(&RawUsbSuite{
+	iface: builtin.MustInterface("raw-usb"),
+})
 
 func (s *RawUsbSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfo = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [raw-usb]
 `
-	s.iface = builtin.NewRawUsbInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/removable_media.go
+++ b/interfaces/builtin/removable_media.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const removableMediaConnectedPlugAppArmor = `
 # Description: Can access removable storage filesystems
 
@@ -31,15 +27,10 @@ const removableMediaConnectedPlugAppArmor = `
 /{,run/}media/*/** rw,
 `
 
-// NewRemovableMediaInterface returns a new "removable-media" interface.
-func NewRemovableMediaInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "removable-media",
 		connectedPlugAppArmor: removableMediaConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewRemovableMediaInterface())
+	})
 }

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -36,7 +36,9 @@ type RemovableMediaInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&RemovableMediaInterfaceSuite{})
+var _ = Suite(&RemovableMediaInterfaceSuite{
+	iface: builtin.MustInterface("removable-media"),
+})
 
 func (s *RemovableMediaInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
@@ -46,7 +48,6 @@ apps:
     command: foo
     plugs: [removable-media]
 `, nil)
-	s.iface = builtin.NewRemovableMediaInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const screenInhibitControlConnectedPlugAppArmor = `
 # Description: Can inhibit and uninhibit screen savers in desktop sessions.
 #include <abstractions/dbus-session-strict>
@@ -67,15 +63,10 @@ dbus (send)
     peer=(label=unconfined),
 `
 
-// NewScreenInhibitControlInterface returns a new "screen-inhibit-control" interface.
-func NewScreenInhibitControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "screen-inhibit-control",
 		connectedPlugAppArmor: screenInhibitControlConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewScreenInhibitControlInterface())
+	})
 }

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -36,7 +36,9 @@ type ScreenInhibitControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&ScreenInhibitControlInterfaceSuite{})
+var _ = Suite(&ScreenInhibitControlInterfaceSuite{
+	iface: builtin.MustInterface("screen-inhibit-control"),
+})
 
 func (s *ScreenInhibitControlInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [screen-inhibit-control]
 `
-	s.iface = builtin.NewScreenInhibitControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -30,15 +30,15 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
-// SerialPortInterface is the type for serial port interfaces.
-type SerialPortInterface struct{}
+// serialPortInterface is the type for serial port interfaces.
+type serialPortInterface struct{}
 
 // Name of the serial-port interface.
-func (iface *SerialPortInterface) Name() string {
+func (iface *serialPortInterface) Name() string {
 	return "serial-port"
 }
 
-func (iface *SerialPortInterface) String() string {
+func (iface *serialPortInterface) String() string {
 	return iface.Name()
 }
 
@@ -58,7 +58,7 @@ var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(USB|ACM|AMA|XRUSB|S|
 var serialUDevSymlinkPattern = regexp.MustCompile("^/dev/serial-port-[a-z0-9]+$")
 
 // SanitizeSlot checks validity of the defined slot
-func (iface *SerialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *serialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Check slot is of right type
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -111,7 +111,7 @@ func (iface *SerialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // SanitizePlug checks and possibly modifies a plug.
-func (iface *SerialPortInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *serialPortInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -119,7 +119,7 @@ func (iface *SerialPortInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *SerialPortInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
+func (iface *serialPortInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
 	usbVendor, vOk := slot.Attrs["usb-vendor"].(int64)
 	if !vOk {
 		return nil
@@ -136,7 +136,7 @@ func (iface *SerialPortInterface) UDevPermanentSlot(spec *udev.Specification, sl
 	return nil
 }
 
-func (iface *SerialPortInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *serialPortInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	if iface.hasUsbAttrs(slot) {
 		// This apparmor rule is an approximation of serialDeviceNodePattern
 		// (AARE is different than regex, so we must approximate).
@@ -155,7 +155,7 @@ func (iface *SerialPortInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 	return nil
 }
 
-func (iface *SerialPortInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *serialPortInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	usbVendor, vOk := slot.Attrs["usb-vendor"].(int64)
 	if !vOk {
 		return nil
@@ -171,12 +171,12 @@ func (iface *SerialPortInterface) UDevConnectedPlug(spec *udev.Specification, pl
 	return nil
 }
 
-func (iface *SerialPortInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *serialPortInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
-func (iface *SerialPortInterface) hasUsbAttrs(slot *interfaces.Slot) bool {
+func (iface *serialPortInterface) hasUsbAttrs(slot *interfaces.Slot) bool {
 	if _, ok := slot.Attrs["usb-vendor"]; ok {
 		return true
 	}
@@ -186,10 +186,10 @@ func (iface *SerialPortInterface) hasUsbAttrs(slot *interfaces.Slot) bool {
 	return false
 }
 
-func (iface *SerialPortInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
+func (iface *serialPortInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
 	return nil
 }
 
 func init() {
-	registerIface(&SerialPortInterface{})
+	registerIface(&serialPortInterface{})
 }

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -68,7 +68,7 @@ type SerialPortInterfaceSuite struct {
 }
 
 var _ = Suite(&SerialPortInterfaceSuite{
-	iface: &builtin.SerialPortInterface{},
+	iface: builtin.MustInterface("serial-port"),
 })
 
 func (s *SerialPortInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const shutdownConnectedPlugAppArmor = `
 # Description: Can reboot, power-off and halt the system.
 
@@ -58,15 +54,10 @@ dbus (send)
     peer=(label=unconfined),
 `
 
-// NewShutdownInterface returns a new "shutdown" interface.
-func NewShutdownInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "shutdown",
 		connectedPlugAppArmor: shutdownConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewShutdownInterface())
+	})
 }

--- a/interfaces/builtin/shutdown_test.go
+++ b/interfaces/builtin/shutdown_test.go
@@ -36,7 +36,9 @@ type ShutdownInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&ShutdownInterfaceSuite{})
+var _ = Suite(&ShutdownInterfaceSuite{
+	iface: builtin.MustInterface("shutdown"),
+})
 
 func (s *ShutdownInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
@@ -47,7 +49,6 @@ apps:
     plugs: [shutdown]
 `, nil)
 	s.plug = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["shutdown"]}
-	s.iface = builtin.NewShutdownInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/snapd-control
 const snapdControlConnectedPlugAppArmor = `
 # Description: Can manage snaps via snapd.
@@ -30,15 +26,10 @@ const snapdControlConnectedPlugAppArmor = `
 /run/snapd.socket rw,
 `
 
-// NewSnapdControlInterface returns a new "snapd-control" interface.
-func NewSnapdControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "snapd-control",
 		connectedPlugAppArmor: snapdControlConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewSnapdControlInterface())
+	})
 }

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -36,7 +36,9 @@ type SnapdControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&SnapdControlInterfaceSuite{})
+var _ = Suite(&SnapdControlInterfaceSuite{
+	iface: builtin.MustInterface("snapd-control"),
+})
 
 func (s *SnapdControlInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
@@ -46,7 +48,6 @@ apps:
     command: foo
     plugs: [snapd-control]
 `, nil)
-	s.iface = builtin.NewSnapdControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/storage_framework_service.go
+++ b/interfaces/builtin/storage_framework_service.go
@@ -101,13 +101,13 @@ const storageFrameworkServicePermanentSlotSecComp = `
 bind
 `
 
-type StorageFrameworkServiceInterface struct{}
+type storageFrameworkServiceInterface struct{}
 
-func (iface *StorageFrameworkServiceInterface) Name() string {
+func (iface *storageFrameworkServiceInterface) Name() string {
 	return "storage-framework-service"
 }
 
-func (iface *StorageFrameworkServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *storageFrameworkServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	snippet := storageFrameworkServiceConnectedPlugAppArmor
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
@@ -116,12 +116,12 @@ func (iface *StorageFrameworkServiceInterface) AppArmorConnectedPlug(spec *appar
 	return nil
 }
 
-func (iface *StorageFrameworkServiceInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *storageFrameworkServiceInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(storageFrameworkServicePermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *StorageFrameworkServiceInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *storageFrameworkServiceInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	snippet := storageFrameworkServiceConnectedSlotAppArmor
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
@@ -130,29 +130,29 @@ func (iface *StorageFrameworkServiceInterface) AppArmorConnectedSlot(spec *appar
 	return nil
 }
 
-func (iface *StorageFrameworkServiceInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *storageFrameworkServiceInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(storageFrameworkServicePermanentSlotSecComp)
 	return nil
 }
 
-func (iface *StorageFrameworkServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *storageFrameworkServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *StorageFrameworkServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *storageFrameworkServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *StorageFrameworkServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (iface *storageFrameworkServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	return true
 }
 
 func init() {
-	registerIface(&StorageFrameworkServiceInterface{})
+	registerIface(&storageFrameworkServiceInterface{})
 }

--- a/interfaces/builtin/storage_framework_service_test.go
+++ b/interfaces/builtin/storage_framework_service_test.go
@@ -38,7 +38,7 @@ type StorageFrameworkServiceInterfaceSuite struct {
 }
 
 var _ = Suite(&StorageFrameworkServiceInterfaceSuite{
-	iface: &builtin.StorageFrameworkServiceInterface{},
+	iface: builtin.MustInterface("storage-framework-service"),
 })
 
 func (s *StorageFrameworkServiceInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/system-observe
 const systemObserveConnectedPlugAppArmor = `
 # Description: Can query system status information. This is restricted because
@@ -90,16 +86,11 @@ const systemObserveConnectedPlugSecComp = `
 #@deny ptrace
 `
 
-// NewSystemObserveInterface returns a new "system-observe" interface.
-func NewSystemObserveInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "system-observe",
 		connectedPlugAppArmor: systemObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  systemObserveConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewSystemObserveInterface())
+	})
 }

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [system-observe]
 `
 
-var _ = Suite(&SystemObserveInterfaceSuite{})
+var _ = Suite(&SystemObserveInterfaceSuite{
+	iface: builtin.MustInterface("system-observe"),
+})
 
 func (s *SystemObserveInterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewSystemObserveInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/system_trace.go
+++ b/interfaces/builtin/system_trace.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const systemTraceConnectedPlugAppArmor = `
 # Description: Can use kernel tracing facilities. This is restricted because it
 # gives privileged access to all processes on the system and should only be
@@ -55,16 +51,11 @@ bpf
 perf_event_open
 `
 
-// NewSystemTraceInterface returns a new "system-trace" interface.
-func NewSystemTraceInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "system-trace",
 		connectedPlugAppArmor: systemTraceConnectedPlugAppArmor,
 		connectedPlugSecComp:  systemTraceConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewSystemTraceInterface())
+	})
 }

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -36,7 +36,9 @@ type SystemTraceInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&SystemTraceInterfaceSuite{})
+var _ = Suite(&SystemTraceInterfaceSuite{
+	iface: builtin.MustInterface("system-trace"),
+})
 
 func (s *SystemTraceInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfo = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [system-trace]
 `
-	s.iface = builtin.NewSystemTraceInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/thumbnailer_service.go
+++ b/interfaces/builtin/thumbnailer_service.go
@@ -86,13 +86,13 @@ dbus (send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
-type ThumbnailerServiceInterface struct{}
+type thumbnailerServiceInterface struct{}
 
-func (iface *ThumbnailerServiceInterface) Name() string {
+func (iface *thumbnailerServiceInterface) Name() string {
 	return "thumbnailer-service"
 }
 
-func (iface *ThumbnailerServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *thumbnailerServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	snippet := thumbnailerServiceConnectedPlugAppArmor
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
@@ -101,12 +101,12 @@ func (iface *ThumbnailerServiceInterface) AppArmorConnectedPlug(spec *apparmor.S
 	return nil
 }
 
-func (iface *ThumbnailerServiceInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *thumbnailerServiceInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(thumbnailerServicePermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *ThumbnailerServiceInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *thumbnailerServiceInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	snippet := thumbnailerServiceConnectedSlotAppArmor
 	old := "###PLUG_SNAP_NAME###"
 	new := plug.Snap.Name()
@@ -119,24 +119,24 @@ func (iface *ThumbnailerServiceInterface) AppArmorConnectedSlot(spec *apparmor.S
 	return nil
 }
 
-func (iface *ThumbnailerServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *thumbnailerServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *ThumbnailerServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *thumbnailerServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *ThumbnailerServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (iface *thumbnailerServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	return true
 }
 
 func init() {
-	registerIface(&ThumbnailerServiceInterface{})
+	registerIface(&thumbnailerServiceInterface{})
 }

--- a/interfaces/builtin/thumbnailer_service_test.go
+++ b/interfaces/builtin/thumbnailer_service_test.go
@@ -37,7 +37,9 @@ type ThumbnailerServiceInterfaceSuite struct {
 	plug        *interfaces.Plug
 }
 
-var _ = Suite(&ThumbnailerServiceInterfaceSuite{})
+var _ = Suite(&ThumbnailerServiceInterfaceSuite{
+	iface: builtin.MustInterface("thumbnailer-service"),
+})
 
 func (s *ThumbnailerServiceInterfaceSuite) SetUpTest(c *C) {
 	// a thumbnailer slot on a thumbnailer snap
@@ -62,7 +64,6 @@ apps:
   command: foo
   plugs: [thumbnailer-service]
 `
-	s.iface = &builtin.ThumbnailerServiceInterface{}
 	// thumbnailer-service snap with thumbnailer-service slot on an core/all-snap install.
 	snapInfo := snaptest.MockInfo(c, thumbnailerServiceMockCoreSlotSnapInfoYaml, nil)
 	s.coreSlot = &interfaces.Slot{SlotInfo: snapInfo.Slots["thumbnailer-service"]}

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -85,19 +85,19 @@ capability sys_time,
 `
 
 // The type for the rtc interface
-type TimeControlInterface struct{}
+type timeControlInterface struct{}
 
 // Getter for the name of the rtc interface
-func (iface *TimeControlInterface) Name() string {
+func (iface *timeControlInterface) Name() string {
 	return "time-control"
 }
 
-func (iface *TimeControlInterface) String() string {
+func (iface *timeControlInterface) String() string {
 	return iface.Name()
 }
 
 // Check validity of the defined slot
-func (iface *TimeControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *timeControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -112,7 +112,7 @@ func (iface *TimeControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // Checks and possibly modifies a plug
-func (iface *TimeControlInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *timeControlInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -120,12 +120,12 @@ func (iface *TimeControlInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *TimeControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *timeControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(timeControlConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *TimeControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *timeControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const udevRule = `KERNEL=="/dev/rtc0", TAG+="%s"`
 	for appName := range plug.Apps {
 		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
@@ -134,11 +134,11 @@ func (iface *TimeControlInterface) UDevConnectedPlug(spec *udev.Specification, p
 	return nil
 }
 
-func (iface *TimeControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *timeControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
 func init() {
-	registerIface(&TimeControlInterface{})
+	registerIface(&timeControlInterface{})
 }

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -38,7 +38,7 @@ type TimeControlTestInterfaceSuite struct {
 }
 
 var _ = Suite(&TimeControlTestInterfaceSuite{
-	iface: &builtin.TimeControlInterface{},
+	iface: builtin.MustInterface("time-control"),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/timeserver-control
 const timeserverControlConnectedPlugAppArmor = `
 # Description: Can manage timeservers directly separate from config ubuntu-core.
@@ -68,15 +64,10 @@ dbus (receive)
     peer=(label=unconfined),
 `
 
-// NewTimeserverControlInterface returns a new "timeserver-control" interface.
-func NewTimeserverControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "timeserver-control",
 		connectedPlugAppArmor: timeserverControlConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewTimeserverControlInterface())
+	})
 }

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -36,7 +36,9 @@ type TimeserverControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&TimeserverControlInterfaceSuite{})
+var _ = Suite(&TimeserverControlInterfaceSuite{
+	iface: builtin.MustInterface("timeserver-control"),
+})
 
 func (s *TimeserverControlInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [timeserver-control]
 `
-	s.iface = builtin.NewTimeserverControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/timezone-control
 const timezoneControlConnectedPlugAppArmor = `
 # Description: Can manage timezones directly separate from 'config ubuntu-core'.
@@ -68,15 +64,10 @@ dbus (receive)
     peer=(label=unconfined),
 `
 
-// NewTimezoneControlInterface returns a new "timezone-control" interface.
-func NewTimezoneControlInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "timezone-control",
 		connectedPlugAppArmor: timezoneControlConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewTimezoneControlInterface())
+	})
 }

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -36,7 +36,9 @@ type TimezoneControlInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&TimezoneControlInterfaceSuite{})
+var _ = Suite(&TimezoneControlInterfaceSuite{
+	iface: builtin.MustInterface("timezone-control"),
+})
 
 func (s *TimezoneControlInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [timezone-control]
 `
-	s.iface = builtin.NewTimezoneControlInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/tpm.go
+++ b/interfaces/builtin/tpm.go
@@ -19,22 +19,16 @@
 
 package builtin
 
-import "github.com/snapcore/snapd/interfaces"
-
 const tpmConnectedPlugAppArmor = `
 # Description: for those who need to talk to the system TPM chip over /dev/tpm0
 
 /dev/tpm0 rw,
 `
 
-func NewTpmInterface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "tpm",
 		connectedPlugAppArmor: tpmConnectedPlugAppArmor,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewTpmInterface())
+	})
 }

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -36,7 +36,9 @@ type TpmInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&TpmInterfaceSuite{})
+var _ = Suite(&TpmInterfaceSuite{
+	iface: builtin.MustInterface("tpm"),
+})
 
 func (s *TpmInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [tpm]
 `
-	s.iface = builtin.NewTpmInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -185,17 +185,17 @@ owner @{HOME}/snap/###PLUG_NAME###/common/Downloads/    rw,
 owner @{HOME}/snap/###PLUG_NAME###/common/Downloads/**  rwk,
 `
 
-type UbuntuDownloadManagerInterface struct{}
+type ubuntuDownloadManagerInterface struct{}
 
-func (iface *UbuntuDownloadManagerInterface) Name() string {
+func (iface *ubuntuDownloadManagerInterface) Name() string {
 	return "ubuntu-download-manager"
 }
 
-func (iface *UbuntuDownloadManagerInterface) String() string {
+func (iface *ubuntuDownloadManagerInterface) String() string {
 	return iface.Name()
 }
 
-func (iface *UbuntuDownloadManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *ubuntuDownloadManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(downloadConnectedPlugAppArmor, old, new, -1)
@@ -203,12 +203,12 @@ func (iface *UbuntuDownloadManagerInterface) AppArmorConnectedPlug(spec *apparmo
 	return nil
 }
 
-func (iface *UbuntuDownloadManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *ubuntuDownloadManagerInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(downloadPermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *UbuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *ubuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(downloadConnectedSlotAppArmor, old, new, -1)
@@ -219,25 +219,25 @@ func (iface *UbuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmo
 	return nil
 }
 
-func (iface *UbuntuDownloadManagerInterface) SanitizePlug(slot *interfaces.Plug) error {
+func (iface *ubuntuDownloadManagerInterface) SanitizePlug(slot *interfaces.Plug) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
 	return nil
 }
 
-func (iface *UbuntuDownloadManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *ubuntuDownloadManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
 	}
 	return nil
 }
 
-func (iface *UbuntuDownloadManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *ubuntuDownloadManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&UbuntuDownloadManagerInterface{})
+	registerIface(&ubuntuDownloadManagerInterface{})
 }

--- a/interfaces/builtin/ubuntu_download_manager_test.go
+++ b/interfaces/builtin/ubuntu_download_manager_test.go
@@ -36,7 +36,9 @@ type UbuntuDownloadManagerInterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&UbuntuDownloadManagerInterfaceSuite{})
+var _ = Suite(&UbuntuDownloadManagerInterfaceSuite{
+	iface: builtin.MustInterface("ubuntu-download-manager"),
+})
 
 func (s *UbuntuDownloadManagerInterfaceSuite) SetUpTest(c *C) {
 	var mockPlugSnapInfoYaml = `name: other
@@ -46,7 +48,6 @@ apps:
   command: foo
   plugs: [ubuntu-download-manager]
 `
-	s.iface = &builtin.UbuntuDownloadManagerInterface{}
 	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
 	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["ubuntu-download-manager"]}
 	s.slot = &interfaces.Slot{

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -342,23 +342,23 @@ KERNEL=="sr*", ENV{ID_VENDOR}=="SanDisk", ENV{ID_MODEL}=="Cruzer", ENV{ID_FS_LAB
 ENV{ID_PART_TABLE_TYPE}=="dos", ENV{ID_PART_ENTRY_TYPE}=="0x0", ENV{ID_PART_ENTRY_NUMBER}=="1", ENV{ID_FS_TYPE}=="iso9660|udf", ENV{UDISKS_IGNORE}="0"
 `
 
-type UDisks2Interface struct{}
+type udisks2Interface struct{}
 
-func (iface *UDisks2Interface) Name() string {
+func (iface *udisks2Interface) Name() string {
 	return "udisks2"
 }
 
-func (iface *UDisks2Interface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *udisks2Interface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(udisks2ConnectedPlugDBus)
 	return nil
 }
 
-func (iface *UDisks2Interface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *udisks2Interface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(udisks2PermanentSlotDBus)
 	return nil
 }
 
-func (iface *UDisks2Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *udisks2Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	snippet := strings.Replace(udisks2ConnectedPlugAppArmor, old, new, -1)
@@ -366,17 +366,17 @@ func (iface *UDisks2Interface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 	return nil
 }
 
-func (iface *UDisks2Interface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *udisks2Interface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(udisks2PermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *UDisks2Interface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
+func (iface *udisks2Interface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(udisks2PermanentSlotUDev)
 	return nil
 }
 
-func (iface *UDisks2Interface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *udisks2Interface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(udisks2ConnectedSlotAppArmor, old, new, -1)
@@ -384,24 +384,24 @@ func (iface *UDisks2Interface) AppArmorConnectedSlot(spec *apparmor.Specificatio
 	return nil
 }
 
-func (iface *UDisks2Interface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *udisks2Interface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(udisks2PermanentSlotSecComp)
 	return nil
 }
 
-func (iface *UDisks2Interface) SanitizePlug(slot *interfaces.Plug) error {
+func (iface *udisks2Interface) SanitizePlug(slot *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *UDisks2Interface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *udisks2Interface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *UDisks2Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *udisks2Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&UDisks2Interface{})
+	registerIface(&udisks2Interface{})
 }

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -55,10 +55,11 @@ apps:
   slots: [udisks2]
 `
 
-var _ = Suite(&UDisks2InterfaceSuite{})
+var _ = Suite(&UDisks2InterfaceSuite{
+	iface: builtin.MustInterface("udisks2"),
+})
 
 func (s *UDisks2InterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.UDisks2Interface{}
 	slotSnap := snaptest.MockInfo(c, udisks2mockSlotSnapInfoYaml, nil)
 	plugSnap := snaptest.MockInfo(c, udisks2mockPlugSnapInfoYaml, nil)
 	s.slot = &interfaces.Slot{SlotInfo: slotSnap.Slots["udisks2"]}

--- a/interfaces/builtin/uhid.go
+++ b/interfaces/builtin/uhid.go
@@ -35,18 +35,18 @@ const uhidConnectedPlugAppArmor = `
   /dev/uhid rw,
 `
 
-type UhidInterface struct{}
+type uhidInterface struct{}
 
-func (iface *UhidInterface) Name() string {
+func (iface *uhidInterface) Name() string {
 	return "uhid"
 }
 
-func (iface *UhidInterface) String() string {
+func (iface *uhidInterface) String() string {
 	return iface.Name()
 }
 
 // Check the validity of the slot
-func (iface *UhidInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *uhidInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// First check the type
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -56,7 +56,7 @@ func (iface *UhidInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 // Check and possibly modify a plug
-func (iface *UhidInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *uhidInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -64,12 +64,12 @@ func (iface *UhidInterface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *UhidInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *uhidInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(uhidConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *UhidInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *uhidInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const udevRule = `KERNEL=="uhid", TAG+="%s"`
 	for appName := range plug.Apps {
 		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
@@ -78,11 +78,11 @@ func (iface *UhidInterface) UDevConnectedPlug(spec *udev.Specification, plug *in
 	return nil
 }
 
-func (iface *UhidInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *uhidInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declaration
 	return true
 }
 
 func init() {
-	registerIface(&UhidInterface{})
+	registerIface(&uhidInterface{})
 }

--- a/interfaces/builtin/uhid_test.go
+++ b/interfaces/builtin/uhid_test.go
@@ -32,13 +32,12 @@ import (
 
 type UhidInterfaceSuite struct {
 	iface interfaces.Interface
-
-	slot *interfaces.Slot
-	plug *interfaces.Plug
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
 }
 
 var _ = Suite(&UhidInterfaceSuite{
-	iface: &builtin.UhidInterface{},
+	iface: builtin.MustInterface("uhid"),
 })
 
 func (s *UhidInterfaceSuite) SetUpTest(c *C) {

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -510,13 +510,13 @@ const unity7ConnectedPlugSeccomp = `
 shutdown
 `
 
-type Unity7Interface struct{}
+type unity7Interface struct{}
 
-func (iface *Unity7Interface) Name() string {
+func (iface *unity7Interface) Name() string {
 	return "unity7"
 }
 
-func (iface *Unity7Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *unity7Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	// Unity7 will take the desktop filename and convert all '-' (and '.',
 	// but we don't care about that here because the rule above already
 	// does that) to '_'. Since we know that the desktop filename starts
@@ -528,12 +528,12 @@ func (iface *Unity7Interface) AppArmorConnectedPlug(spec *apparmor.Specification
 	return nil
 }
 
-func (iface *Unity7Interface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *unity7Interface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(unity7ConnectedPlugSeccomp)
 	return nil
 }
 
-func (iface *Unity7Interface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *unity7Interface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
@@ -541,7 +541,7 @@ func (iface *Unity7Interface) SanitizePlug(plug *interfaces.Plug) error {
 	return nil
 }
 
-func (iface *Unity7Interface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *unity7Interface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
@@ -554,11 +554,11 @@ func (iface *Unity7Interface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *Unity7Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *unity7Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&Unity7Interface{})
+	registerIface(&unity7Interface{})
 }

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -37,7 +37,9 @@ type Unity7InterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&Unity7InterfaceSuite{})
+var _ = Suite(&Unity7InterfaceSuite{
+	iface: builtin.MustInterface("unity7"),
+})
 
 const unity7mockPlugSnapInfoYaml = `name: other-snap
 version: 1.0
@@ -48,7 +50,6 @@ apps:
 `
 
 func (s *Unity7InterfaceSuite) SetUpTest(c *C) {
-	s.iface = &builtin.Unity7Interface{}
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -82,17 +82,17 @@ const unity8ConnectedPlugSecComp = `
 shutdown
 `
 
-type Unity8Interface struct{}
+type unity8Interface struct{}
 
-func (iface *Unity8Interface) Name() string {
+func (iface *unity8Interface) Name() string {
 	return "unity8"
 }
 
-func (iface *Unity8Interface) String() string {
+func (iface *unity8Interface) String() string {
 	return iface.Name()
 }
 
-func (iface *Unity8Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *unity8Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	oldTags := "###SLOT_SECURITY_TAGS###"
 	newTags := slotAppLabelExpr(slot)
 	snippet := strings.Replace(unity8ConnectedPlugAppArmor, oldTags, newTags, -1)
@@ -100,30 +100,30 @@ func (iface *Unity8Interface) AppArmorConnectedPlug(spec *apparmor.Specification
 	return nil
 }
 
-func (iface *Unity8Interface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *unity8Interface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(unity8ConnectedPlugSecComp)
 	return nil
 }
 
-func (iface *Unity8Interface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *unity8Interface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
 	}
 	return nil
 }
 
-func (iface *Unity8Interface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *unity8Interface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
 	}
 	return nil
 }
 
-func (iface *Unity8Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *unity8Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&Unity8Interface{})
+	registerIface(&unity8Interface{})
 }

--- a/interfaces/builtin/unity8_calendar.go
+++ b/interfaces/builtin/unity8_calendar.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const unity8CalendarPermanentSlotAppArmor = `
 # Description: Allow operating as the EDS service. This gives privileged access
 # to the system.
@@ -138,16 +134,11 @@ dbus (receive, send)
 	peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
-// NewUnity8CalendarInterface returns a new "untiy8-calendar" interface.
-func NewUnity8CalendarInterface() interfaces.Interface {
-	return &unity8PimCommonInterface{
+func init() {
+	registerIface(&unity8PimCommonInterface{
 		name: "unity8-calendar",
 		permanentSlotAppArmor: unity8CalendarPermanentSlotAppArmor,
 		connectedSlotAppArmor: unity8CalendarConnectedSlotAppArmor,
 		connectedPlugAppArmor: unity8CalendarConnectedPlugAppArmor,
-	}
-}
-
-func init() {
-	registerIface(NewUnity8CalendarInterface())
+	})
 }

--- a/interfaces/builtin/unity8_calendar_test.go
+++ b/interfaces/builtin/unity8_calendar_test.go
@@ -39,7 +39,9 @@ type Unity8CalendarInterfaceSuite struct {
 	plug     *interfaces.Plug
 }
 
-var _ = Suite(&Unity8CalendarInterfaceSuite{})
+var _ = Suite(&Unity8CalendarInterfaceSuite{
+	iface: builtin.MustInterface("unity8-calendar"),
+})
 
 func (s *Unity8CalendarInterfaceSuite) SetUpTest(c *C) {
 	const mockCoreSlotInfoYaml = `name: unity8-calendar
@@ -56,7 +58,6 @@ apps:
   command: foo
   plugs: [unity8-calendar]
 `
-	s.iface = builtin.NewUnity8CalendarInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/unity8_contacts.go
+++ b/interfaces/builtin/unity8_contacts.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 const unity8ContactsPermanentSlotAppArmor = `
 # Description: Allow operating as the EDS service. This gives privileged access
 # to the system.
@@ -175,16 +171,11 @@ dbus (receive, send)
 	peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
-// NewUnity8ContactsInterface returns a new "unity8-contacts" interface.
-func NewUnity8ContactsInterface() interfaces.Interface {
-	return &unity8PimCommonInterface{
+func init() {
+	registerIface(&unity8PimCommonInterface{
 		name: "unity8-contacts",
 		permanentSlotAppArmor: unity8ContactsPermanentSlotAppArmor,
 		connectedSlotAppArmor: unity8ContactsConnectedSlotAppArmor,
 		connectedPlugAppArmor: unity8ContactsConnectedPlugAppArmor,
-	}
-}
-
-func init() {
-	registerIface(NewUnity8ContactsInterface())
+	})
 }

--- a/interfaces/builtin/unity8_contacts_test.go
+++ b/interfaces/builtin/unity8_contacts_test.go
@@ -39,7 +39,9 @@ type Unity8ContactsInterfaceSuite struct {
 	plug     *interfaces.Plug
 }
 
-var _ = Suite(&Unity8ContactsInterfaceSuite{})
+var _ = Suite(&Unity8ContactsInterfaceSuite{
+	iface: builtin.MustInterface("unity8-contacts"),
+})
 
 func (s *Unity8ContactsInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfo = `name: other
@@ -57,7 +59,6 @@ apps:
   command: foo
   slots: [unity8-contacts]
 `
-	s.iface = builtin.NewUnity8ContactsInterface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},

--- a/interfaces/builtin/unity8_test.go
+++ b/interfaces/builtin/unity8_test.go
@@ -42,9 +42,9 @@ type unity8InterfaceSuite struct {
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&unity8InterfaceSuite{})
-
-var _ = Suite(&FirewallControlInterfaceSuite{})
+var _ = Suite(&unity8InterfaceSuite{
+	iface: builtin.MustInterface("unity8"),
+})
 
 func createMockFooPlug(c *C, content string) *interfaces.Plug {
 	info := snaptest.MockSnap(c, content, "", &snap.SideInfo{Revision: snap.R(3)})
@@ -76,7 +76,6 @@ apps:
   plugs: [unity8]
 `
 	dirs.SetRootDir(c.MkDir())
-	s.iface = &builtin.Unity8Interface{}
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "unity8-session"},

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -203,13 +203,13 @@ dbus (send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
-type UpowerObserveInterface struct{}
+type upowerObserveInterface struct{}
 
-func (iface *UpowerObserveInterface) Name() string {
+func (iface *upowerObserveInterface) Name() string {
 	return "upower-observe"
 }
 
-func (iface *UpowerObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *upowerObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
 	if release.OnClassic {
@@ -221,22 +221,22 @@ func (iface *UpowerObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	return nil
 }
 
-func (iface *UpowerObserveInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
+func (iface *upowerObserveInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(upowerObservePermanentSlotAppArmor)
 	return nil
 }
 
-func (iface *UpowerObserveInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
+func (iface *upowerObserveInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(upowerObservePermanentSlotSeccomp)
 	return nil
 }
 
-func (iface *UpowerObserveInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
+func (iface *upowerObserveInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(upowerObservePermanentSlotDBus)
 	return nil
 }
 
-func (iface *UpowerObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *upowerObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	old := "###PLUG_SECURITY_TAGS###"
 	new := plugAppLabelExpr(plug)
 	snippet := strings.Replace(upowerObserveConnectedSlotAppArmor, old, new, -1)
@@ -244,14 +244,14 @@ func (iface *UpowerObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specif
 	return nil
 }
 
-func (iface *UpowerObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *upowerObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
 	}
 	return nil
 }
 
-func (iface *UpowerObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *upowerObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
@@ -261,11 +261,11 @@ func (iface *UpowerObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-func (iface *UpowerObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *upowerObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true
 }
 
 func init() {
-	registerIface(&UpowerObserveInterface{})
+	registerIface(&upowerObserveInterface{})
 }

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -39,7 +39,9 @@ type UPowerObserveInterfaceSuite struct {
 	plug        *interfaces.Plug
 }
 
-var _ = Suite(&UPowerObserveInterfaceSuite{})
+var _ = Suite(&UPowerObserveInterfaceSuite{
+	iface: builtin.MustInterface("upower-observe"),
+})
 
 func (s *UPowerObserveInterfaceSuite) SetUpTest(c *C) {
 	const mockPlugSnapInfoYaml = `name: other
@@ -65,7 +67,6 @@ apps:
   command: foo
   slots: [upower-observe]
 `
-	s.iface = &builtin.UpowerObserveInterface{}
 	// upower snap with upower-server slot on an core/all-snap install.
 	snapInfo := snaptest.MockInfo(c, upowerMockSlotSnapInfoYaml, nil)
 	s.coreSlot = &interfaces.Slot{SlotInfo: snapInfo.Slots["upower-observe"]}

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -19,10 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-)
-
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/x
 const x11ConnectedPlugAppArmor = `
 # Description: Can access the X server. Restricted because X does not prevent
@@ -48,16 +44,11 @@ const x11ConnectedPlugSecComp = `
 shutdown
 `
 
-// NewX11Interface returns a new "x11" interface.
-func NewX11Interface() interfaces.Interface {
-	return &commonInterface{
+func init() {
+	registerIface(&commonInterface{
 		name: "x11",
 		connectedPlugAppArmor: x11ConnectedPlugAppArmor,
 		connectedPlugSecComp:  x11ConnectedPlugSecComp,
 		reservedForOS:         true,
-	}
-}
-
-func init() {
-	registerIface(NewX11Interface())
+	})
 }

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -45,10 +45,11 @@ apps:
   plugs: [x11]
 `
 
-var _ = Suite(&X11InterfaceSuite{})
+var _ = Suite(&X11InterfaceSuite{
+	iface: builtin.MustInterface("x11"),
+})
 
 func (s *X11InterfaceSuite) SetUpTest(c *C) {
-	s.iface = builtin.NewX11Interface()
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
 			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},


### PR DESCRIPTION
The rest of snapd doesn't need to access interface types, all that is
requires is the builtin.Interfaces function, that returns the list of
all known interfaces.

This patch makes interfaces private, adds a helper for testing, that
returns interface by name. Some tests were changed to use `s.iface`
rather than trying to construct the interface object needlessly. Some
tests were changed to use `spec.AddConnectedPlug` rather than
`iface.MountConnectedPlug` so that the interface test code does not need
to know the real interface type.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>