### PR TITLE
overlord/ifacestate: don't spam logs with harmless auto-connect messages

### DIFF
--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -361,7 +361,7 @@ func (m *InterfaceManager) autoConnect(task *state.Task, snapName string, blackl
 		key := connRef.ID()
 		if _, ok := conns[key]; ok {
 			// Suggested connection already exist so don't clobber it.
-			task.Logf("cannot auto connect %s to %s: (plug auto-connection), existing connection state %q in the way", connRef.PlugRef, connRef.SlotRef, key)
+			// NOTE: we don't log anything here as this is a normal and common condition.
 			continue
 		}
 		if err := m.repo.Connect(connRef); err != nil {
@@ -394,7 +394,7 @@ func (m *InterfaceManager) autoConnect(task *state.Task, snapName string, blackl
 		key := connRef.ID()
 		if _, ok := conns[key]; ok {
 			// Suggested connection already exist so don't clobber it.
-			task.Logf("cannot auto connect %s to %s: (slot auto-connection), existing connection state %q in the way", connRef.PlugRef, connRef.SlotRef, key)
+			// NOTE: we don't log anything here as this is a normal and common condition.
 			continue
 		}
 		if err := m.repo.Connect(connRef); err != nil {


### PR DESCRIPTION
This patch removes the message that was logged when auto-connect
"failed" because the same connection was already in place. This is not a
failure in any way and should not be logged.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>