### PR TITLE
cmd/snap-confine: don't fail on pre 3.8 kernel

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -120,6 +120,14 @@ void sc_reassociate_with_pid1_mount_ns()
 	char init_buf[128], self_buf[128];
 	memset(init_buf, 0, sizeof init_buf);
 	if (readlinkat(init_mnt_fd, "", init_buf, sizeof init_buf) < 0) {
+		if (errno == ENOENT) {
+			// According to namespaces(7) on a pre 3.8 kernel the namespace
+			// files are hardlinks, not sylinks. If that happens readlinkat
+			// fails with ENOENT. As a quick workaround for this special-case
+			// functionality, just bail out and do nothing without raising an
+			// error.
+			return;
+		}
 		die("cannot perform readlinkat() on the mount namespace file "
 		    "descriptor of the init process");
 	}


### PR DESCRIPTION
This patch neuters the reassociate-with-pid-1-namespace feature
on a pre 3.8 kernel. This will allow people to experiment with older
kernels while a more proper solution is put in place.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>