### PR TITLE
store: fix panic error in auth

### DIFF
--- a/store/auth.go
+++ b/store/auth.go
@@ -126,7 +126,8 @@ func retryPostRequest(endpoint string, headers map[string]string, data []byte, d
 	for attempt = retry.Start(defaultRetryStrategy, nil); attempt.Next(); {
 		maybeLogRetryAttempt(endpoint, attempt, startTime)
 
-		req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(data))
+		var req *http.Request
+		req, err = http.NewRequest("POST", endpoint, bytes.NewBuffer(data))
 		if err != nil {
 			return nil, err
 		}

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -290,6 +290,13 @@ func (s *authTestSuite) TestRequestStoreDeviceNonce(c *C) {
 	c.Assert(nonce, Equals, "the-nonce")
 }
 
+func (s *authTestSuite) TestRequestStoreDeviceNonceFailureOnDNS(c *C) {
+	MyAppsDeviceNonceAPI = "http://nonexistingserver121321.com/identity/api/v1/nonces"
+	_, err := requestStoreDeviceNonce()
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `cannot get nonce from store.*`)
+}
+
 func (s *authTestSuite) TestRequestStoreDeviceNonceEmptyResponse(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, mockStoreReturnNoNonce)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2946,6 +2946,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshUnauthorised(c
 
 func (t *remoteRepoTestSuite) TestListRefreshFailOnDNS(c *C) {
 	bulkURI, err := url.Parse("http://nonexistingserver909123.com/updates/")
+	c.Assert(err, IsNil)
 	cfg := Config{
 		BulkURI: bulkURI,
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2960,7 +2960,8 @@ func (t *remoteRepoTestSuite) TestListRefreshFailOnDNS(c *C) {
 		Revision: snap.R(24),
 		Epoch:    "0",
 	}}, nil)
-	c.Assert(err, ErrorMatches, `Post http://nonexistingserver909123.com/updates/: dial tcp: lookup nonexistingserver909123.com on .*: no such host`)
+	// the error differs depending on whether a proxy is in use (e.g. on travis), so don't inspect error message
+	c.Assert(err, NotNil)
 }
 
 func (t *remoteRepoTestSuite) TestListRefresh500(c *C) {


### PR DESCRIPTION
Fix panic on DNS error in auth, caused by shadowing of err. Added a couple extra tests. Store requests do not have this bug, only auth.