### PR TITLE
tests: the new ubuntu-image snap needs classic confinement, adjust tests

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -174,7 +174,7 @@ setup_reflash_magic() {
         snap install --${CORE_CHANNEL} core
 
         # install ubuntu-image
-        snap install --devmode --edge ubuntu-image
+        snap install --classic --edge ubuntu-image
 
         # needs to be under /home because ubuntu-device-flash
         # uses snap-confine and that will hide parts of the hostfs


### PR DESCRIPTION
Right now all tests are broken because ubuntu-image can not be installed anymore. It used to be a regular snap and it is now a classic snap.