### PR TITLE
tests/lib: introduce pkgdb helper library

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -304,7 +304,9 @@ suites:
         restore: |
             $TESTSLIB/reset.sh --store
             if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then
-                apt-get purge -y snapd
+                . $TESTSLIB/pkgdb.sh
+                distro_purge_package snapd
+                distro_purge_package snap-confine
             fi
 
     tests/completion/:

--- a/tests/lib/apt.sh
+++ b/tests/lib/apt.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 
-apt_install_local() {
-    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
-        # relying on dpkg as apt(-get) does not support installation from local files in trusty.
-        dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
-        apt-get -f install -y
-    else
-        apt install -y "$@"
-    fi
-}
+. $TESTSLIB/pkgdb.sh
 
 install_build_snapd(){
     if [ "$SRU_VALIDATION" = "1" ]; then
@@ -20,6 +12,7 @@ install_build_snapd(){
         mv sources.list.back /etc/apt/sources.list
         apt update
     else
-        apt_install_local ${GOPATH}/snapd_*.deb
+        packages="${GOPATH}/snapd_*.deb"
+        distro_install_local_package $packages
     fi
 }

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -109,3 +109,15 @@ distro_update_package_db() {
             ;;
     esac
 }
+
+distro_clean_package_cache() {
+    case "$SPREAD_SYSTEM" in
+        ubuntu-*|debian-*)
+            quiet apt-get clean
+            ;;
+        *)
+            echo "ERROR: Unsupported distribution $SPREAD_SYSTEM"
+            exit 1
+            ;;
+    esac
+}

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -29,6 +29,18 @@ distro_name_package() {
 }
 
 distro_install_local_package() {
+    allow_downgrades=false
+    while [ -n "$1" ]; do
+        case "$1" in
+            --allow-downgrades)
+                allow_downgrades=true
+                shift
+                ;;
+            *)
+                break
+        esac
+    done
+
     case "$SPREAD_SYSTEM" in
         ubuntu-*)
             ;&
@@ -38,7 +50,11 @@ distro_install_local_package() {
                 dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
                 apt-get -f install -y
             else
-                apt install -y "$@"
+                flags="-y"
+                if [ "$allow_downgrades" = "true" ]; then
+                    flags="$flags --allow-downgrades"
+                fi
+                apt install $flags "$@"
             fi
             ;;
         *)

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -4,7 +4,7 @@
 
 debian_name_package() {
     case "$1" in
-        xdelta3|curl|python3-yaml)
+        xdelta3|curl|python3-yaml|kpartx|busybox-static)
             echo "$1"
             ;;
     esac

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -36,18 +36,17 @@ distro_install_local_package() {
     done
 
     case "$SPREAD_SYSTEM" in
-        ubuntu-*|debian-*)
-            if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
-                # relying on dpkg as apt(-get) does not support installation from local files in trusty.
-                dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
-                apt-get -f install -y
-            else
-                flags="-y"
-                if [ "$allow_downgrades" = "true" ]; then
-                    flags="$flags --allow-downgrades"
-                fi
-                apt install $flags "$@"
+        ubuntu-14.04-*|debian-*)
+            # relying on dpkg as apt(-get) does not support installation from local files in trusty.
+            dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
+            apt-get -f install -y
+            ;;
+        ubuntu-*)
+            flags="-y"
+            if [ "$allow_downgrades" = "true" ]; then
+                flags="$flags --allow-downgrades"
             fi
+            apt install $flags "$@"
             ;;
         *)
             echo "ERROR: Unsupported distribution $SPREAD_SYSTEM"

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -1,28 +1,22 @@
 #!/bin/bash
 
-. $TESTSLIB/quiet.sh
+. "$TESTSLIB/quiet.sh"
 
 debian_name_package() {
     case "$1" in
-        xdelta3)
-            ;&
-        curl)
-            ;&
-        python3-yaml)
-            echo $1
+        xdelta3|curl|python3-yaml)
+            echo "$1"
             ;;
     esac
 }
 
 distro_name_package() {
     case "$SPREAD_SYSTEM" in
-        ubuntu-*)
-            ;&
-        debian-*)
-            debian_name_package $1
+        ubuntu-*|debian-*)
+            debian_name_package "$1"
             ;;
         *)
-            echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+            echo "ERROR: Unsupported distribution $SPREAD_SYSTEM"
             exit 1
             ;;
     esac
@@ -42,9 +36,7 @@ distro_install_local_package() {
     done
 
     case "$SPREAD_SYSTEM" in
-        ubuntu-*)
-            ;&
-        debian-*)
+        ubuntu-*|debian-*)
             if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
                 # relying on dpkg as apt(-get) does not support installation from local files in trusty.
                 dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
@@ -54,11 +46,11 @@ distro_install_local_package() {
                 if [ "$allow_downgrades" = "true" ]; then
                     flags="$flags --allow-downgrades"
                 fi
-                apt install $flags "$@"
+                apt install "$flags" "$@"
             fi
             ;;
         *)
-            echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+            echo "ERROR: Unsupported distribution $SPREAD_SYSTEM"
             exit 1
             ;;
     esac
@@ -66,7 +58,7 @@ distro_install_local_package() {
 
 distro_install_package() {
     for pkg in "$@" ; do
-        package_name=$(distro_name_package $pkg)
+        package_name=$(distro_name_package "$pkg")
         # When we could not find a different package name for the distribution
         # we're running on we try the package name given as last attempt
         if [ -z "$package_name" ]; then
@@ -74,13 +66,11 @@ distro_install_package() {
         fi
 
         case "$SPREAD_SYSTEM" in
-            ubuntu-*)
-                ;&
-            debian-*)
-                apt-get install -y $package_name
+            ubuntu-*|debian-*)
+                apt-get install -y "$package_name"
                 ;;
             *)
-                echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+                echo "ERROR: Unsupported distribution $SPREAD_SYSTEM"
                 exit 1
                 ;;
         esac
@@ -89,7 +79,7 @@ distro_install_package() {
 
 distro_purge_package() {
     for pkg in "$@" ; do
-        package_name=$(distro_name_package $pkg)
+        package_name=$(distro_name_package "$pkg")
         # When we could not find a different package name for the distribution
         # we're running on we try the package name given as last attempt
         if [ -z "$package_name" ]; then
@@ -97,13 +87,11 @@ distro_purge_package() {
         fi
 
         case "$SPREAD_SYSTEM" in
-            ubuntu-*)
-                ;&
-            debian-*)
-                quiet apt-get remove -y --purge -y $package_name
+            ubuntu-*|debian-*)
+                quiet apt-get remove -y --purge -y "$package_name"
                 ;;
             *)
-                echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+                echo "ERROR: Unsupported distribution $SPREAD_SYSTEM"
                 exit 1
                 ;;
         esac
@@ -112,13 +100,11 @@ distro_purge_package() {
 
 distro_update_package_db() {
     case "$SPREAD_SYSTEM" in
-        ubuntu-*)
-            ;&
-        debian-*)
+        ubuntu-*|debian-*)
             quiet apt-get update
             ;;
         *)
-            echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+            echo "ERROR: Unsupported distribution $SPREAD_SYSTEM"
             exit 1
             ;;
     esac

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -46,7 +46,7 @@ distro_install_local_package() {
                 if [ "$allow_downgrades" = "true" ]; then
                     flags="$flags --allow-downgrades"
                 fi
-                apt install "$flags" "$@"
+                apt install $flags "$@"
             fi
             ;;
         *)

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+. $TESTSLIB/quiet.sh
+
+debian_name_package() {
+    case "$1" in
+        xdelta3)
+            ;&
+        curl)
+            ;&
+        python3-yaml)
+            echo $1
+            ;;
+    esac
+}
+
+distro_name_package() {
+    case "$SPREAD_SYSTEM" in
+        ubuntu-*)
+            ;&
+        debian-*)
+            debian_name_package $1
+            ;;
+        *)
+            echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+            exit 1
+            ;;
+    esac
+}
+
+distro_install_local_package() {
+    case "$SPREAD_SYSTEM" in
+        ubuntu-*)
+            ;&
+        debian-*)
+            if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
+                # relying on dpkg as apt(-get) does not support installation from local files in trusty.
+                dpkg -i --force-depends --auto-deconfigure --force-depends-version "$@"
+                apt-get -f install -y
+            else
+                apt install -y "$@"
+            fi
+            ;;
+        *)
+            echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+            exit 1
+            ;;
+    esac
+}
+
+distro_install_package() {
+    for pkg in "$@" ; do
+        package_name=$(distro_name_package $pkg)
+        # When we could not find a different package name for the distribution
+        # we're running on we try the package name given as last attempt
+        if [ -z "$package_name" ]; then
+            package_name="$pkg"
+        fi
+
+        case "$SPREAD_SYSTEM" in
+            ubuntu-*)
+                ;&
+            debian-*)
+                apt-get install -y $package_name
+                ;;
+            *)
+                echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+                exit 1
+                ;;
+        esac
+    done
+}
+
+distro_purge_package() {
+    for pkg in "$@" ; do
+        package_name=$(distro_name_package $pkg)
+        # When we could not find a different package name for the distribution
+        # we're running on we try the package name given as last attempt
+        if [ -z "$package_name" ]; then
+            package_name="$pkg"
+        fi
+
+        case "$SPREAD_SYSTEM" in
+            ubuntu-*)
+                ;&
+            debian-*)
+                quiet apt-get remove -y --purge -y $package_name
+                ;;
+            *)
+                echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+                exit 1
+                ;;
+        esac
+    done
+}
+
+distro_update_package_db() {
+    case "$SPREAD_SYSTEM" in
+        ubuntu-*)
+            ;&
+        debian-*)
+            quiet apt-get update
+            ;;
+        *)
+            echo "ERROR: Unsupported distribution '$SPREAD_SYSTEM'"
+            exit 1
+            ;;
+    esac
+}

--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -97,7 +97,9 @@ fi
 
 create_test_user
 
-quiet apt-get update
+. "$TESTSLIB/pkgdb.sh"
+
+distro_update_package_db
 
 if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
     if [ ! -d packaging/ubuntu-14.04 ]; then
@@ -119,17 +121,14 @@ if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
     quiet apt-get install -y --force-yes apparmor libapparmor1 seccomp libseccomp2 systemd cgroup-lite util-linux
 fi
 
-quiet apt-get purge -y snapd
+distro_purge_package snapd
 # utilities
 # XXX: build-essential seems to be required. Otherwise package build
 # fails with unmet dependency on "build-essential:native"
-quiet apt-get install -y build-essential curl devscripts expect gdebi-core jq rng-tools git
+distro_install_package build-essential curl devscripts expect gdebi-core jq rng-tools git netcat-openbsd
 
 # in 16.04: apt build-dep -y ./
 quiet apt-get install -y $(gdebi --quiet --apt-line ./debian/control)
-
-# Necessary tools for our test setup
-quiet apt-get install -y netcat-openbsd
 
 # update vendoring
 if [ "$(which govendor)" = "" ]; then

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -167,9 +167,9 @@ EOF
 
 setup_reflash_magic() {
         # install the stuff we need
-        apt-get install -y kpartx busybox-static
-        apt_install_local ${GOPATH}/snapd_*.deb
-        apt-get clean
+        distro_install_package kpartx busybox-static
+        distro_install_local_package ${GOPATH}/snapd_*.deb
+        distro_clean_package_cache
 
         snap install --${CORE_CHANNEL} core
 

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -38,7 +38,7 @@ execute: |
     echo Do upgrade
     # allow-downgrades prevents errors when new versions hit the archive, for instance,
     # trying to install 2.11ubuntu1 over 2.11+0.16.04
-    distro_install_local_package --allow-downgrades ${GOPATH}/snapd.deb
+    distro_install_local_package --allow-downgrades ${GOPATH}/snapd*.deb
 
     snapdver=$(snap --version|grep "snapd ")
     [ "$snapdver" != "$prevsnapdver" ]

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -38,14 +38,7 @@ execute: |
     echo Do upgrade
     # allow-downgrades prevents errors when new versions hit the archive, for instance,
     # trying to install 2.11ubuntu1 over 2.11+0.16.04
-    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
-        # apt_install_local uses dpkg directly which happily downgrades
-        apt_install_local ${GOPATH}/snapd*.deb
-    else
-        # not using apt_install_local here as this will not have
-        # --allow-downgrades
-        apt install -y --allow-downgrades ${GOPATH}/snapd*.deb
-    fi
+    distro_install_local_package --allow-downgrades ${GOPATH}/snapd.deb
 
     snapdver=$(snap --version|grep "snapd ")
     [ "$snapdver" != "$prevsnapdver" ]


### PR DESCRIPTION
All functions in the pkdb library will abstract different packaging
functions so that we have a common way to install/remove/update
packages in a distribution independent way.

This is required for later changes to add support for other distros
like Fedora or openSUSE.

The new helper functions are not used everywhere yet but follow up
changes will introduce their use everywhere so that everything is
abstracted through pkgdb functions.