### PR TITLE
interfaces/mount: keep track of kept mount entries

### DIFF
--- a/interfaces/mount/change.go
+++ b/interfaces/mount/change.go
@@ -31,6 +31,8 @@ import (
 type Action string
 
 const (
+	// Keep indicates that a given mount entry should be kept as-is.
+	Keep Action = "keep"
 	// Mount represents an action that results in mounting something somewhere.
 	Mount Action = "mount"
 	// Unmount represents an action that results in unmounting something from somewhere.
@@ -135,7 +137,9 @@ func NeededChanges(currentProfile, desiredProfile *Profile) []Change {
 
 	// Unmount entries not reused in reverse to handle children before their parent.
 	for i := len(current) - 1; i >= 0; i-- {
-		if !reuse[current[i].Dir] {
+		if reuse[current[i].Dir] {
+			changes = append(changes, Change{Action: Keep, Entry: current[i]})
+		} else {
 			changes = append(changes, Change{Action: Unmount, Entry: current[i]})
 		}
 	}

--- a/interfaces/mount/change_test.go
+++ b/interfaces/mount/change_test.go
@@ -50,7 +50,9 @@ func (s *changeSuite) TestNeededChangesNoChange(c *C) {
 	current := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
 	desired := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
 	changes := mount.NeededChanges(current, desired)
-	c.Assert(changes, IsNil)
+	c.Assert(changes, DeepEquals, []mount.Change{
+		{Entry: mount.Entry{Dir: "/common/stuf"}, Action: mount.Keep},
+	})
 }
 
 // When the content interface is connected we should mount the new entry.
@@ -115,6 +117,7 @@ func (s *changeSuite) TestNeededChangesChangedParentSameChild(c *C) {
 	}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
+		{Entry: mount.Entry{Dir: "/common/unrelated"}, Action: mount.Keep},
 		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: mount.Unmount},
 		{Entry: mount.Entry{Dir: "/common/stuf", Name: "/dev/sda1"}, Action: mount.Unmount},
 		{Entry: mount.Entry{Dir: "/common/stuf", Name: "/dev/sda2"}, Action: mount.Mount},
@@ -136,7 +139,9 @@ func (s *changeSuite) TestNeededChangesSameParentChangedChild(c *C) {
 	}}
 	changes := mount.NeededChanges(current, desired)
 	c.Assert(changes, DeepEquals, []mount.Change{
+		{Entry: mount.Entry{Dir: "/common/unrelated"}, Action: mount.Keep},
 		{Entry: mount.Entry{Dir: "/common/stuf/extra", Name: "/dev/sda1"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/common/stuf"}, Action: mount.Keep},
 		{Entry: mount.Entry{Dir: "/common/stuf/extra", Name: "/dev/sda2"}, Action: mount.Mount},
 	})
 }
@@ -163,6 +168,7 @@ func (s *changeSuite) TestNeededChangesSmartEntryComparison(c *C) {
 		{Entry: mount.Entry{Dir: "/a/b/c"}, Action: mount.Unmount},
 		{Entry: mount.Entry{Dir: "/a/b", Name: "/dev/sda1"}, Action: mount.Unmount},
 		{Entry: mount.Entry{Dir: "/a/b-1/3"}, Action: mount.Unmount},
+		{Entry: mount.Entry{Dir: "/a/b-1"}, Action: mount.Keep},
 
 		{Entry: mount.Entry{Dir: "/a/b", Name: "/dev/sda2"}, Action: mount.Mount},
 		{Entry: mount.Entry{Dir: "/a/b/c"}, Action: mount.Mount},


### PR DESCRIPTION
This assists in computing the effective current profile as all
the kept and mounted things are in in.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>