### PR TITLE
tests: allow 16-X.Y.Z version of core snap

### DIFF
--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -9,9 +9,9 @@ execute: |
     echo "List prints core snap version"
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
-        expected="^core +.*? +(\d{2}\-\d+) + x\d+ +- *"
+        expected="^core +.*? +([0-9]{2}-[0-9.]+) + x\d+ +- *"
     else
-        expected="^core +.*? +(\d{2}\-\d+) + \d+ +canonical +- *"
+        expected="^core +.*? +([0-9]{2}-[0-9.]+) + \d+ +canonical +- *"
     fi
     snap list | grep -Pq "$expected"
 


### PR DESCRIPTION
Thanks to the new feature in snapcraft, the core snap now includes the
series (16) and the version of snapd (say, 2.26.1) combined with a dash.
One test was too strict with the allowed value so let's make it more
flexible.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>