### PR TITLE
make /etc/localtime writable in timezone_control

### DIFF
--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -35,6 +35,7 @@ const timezoneControlConnectedPlugAppArmor = `
 /usr/share/zoneinfo/      r,
 /usr/share/zoneinfo/**    r,
 /etc/{,writable/}timezone rw,
+/etc/{,writable/}localtime rw,
 
 # Introspection of org.freedesktop.timedate1
 dbus (send)


### PR DESCRIPTION
the timezone_control interface only allows changing /etc/timezone and /etc/writable/timezone. systemd-timedated also updated the link of /etc/localtime and /etc/writable/localtime ... allow access to this file too (https://bugs.launchpad.net/snappy/+bug/1650688)