### PR TITLE
overlord/snapstate: Enable() was ignoring the flags from the snap's state, resulting in losing "devmode" on disable/enable. This fixes that.

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -897,6 +897,7 @@ func Enable(st *state.State, name string) (*state.TaskSet, error) {
 
 	snapsup := &SnapSetup{
 		SideInfo: snapst.CurrentSideInfo(),
+		Flags:    snapst.Flags.ForSnapSetup(),
 	}
 
 	prepareSnap := st.NewTask("prepare-snap", fmt.Sprintf(i18n.G("Prepare snap %q (%s)"), snapsup.Name(), snapst.Current))

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4061,11 +4061,19 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
+	flags := snapstate.Flags{
+		DevMode:  true,
+		JailMode: true,
+		Classic:  true,
+		TryMode:  true,
+		Required: true,
+	}
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{&si},
 		Current:  si.Revision,
 		Active:   false,
 		Channel:  "edge",
+		Flags:    flags,
 	})
 
 	chg := s.state.NewChange("enable", "enable a snap")
@@ -4107,6 +4115,7 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 	var snapst snapstate.SnapState
 	err = snapstate.Get(s.state, "some-snap", &snapst)
 	c.Assert(err, IsNil)
+	c.Check(snapst.Flags, DeepEquals, flags)
 
 	c.Assert(snapst.Active, Equals, true)
 	info, err := snapst.CurrentInfo()

--- a/tests/regression/lp-1667385/task.yaml
+++ b/tests/regression/lp-1667385/task.yaml
@@ -1,0 +1,17 @@
+summary: Regression check for https://bugs.launchpad.net/snappy/+bug/1667385
+systems: [ubuntu-*]
+details: |
+  When disabling and then enabling a snap, the flags saved in state
+  (e.g. from when the user installed it) should be preserved.
+environment:
+  FLAG/jailmode: jailmode
+  FLAG/devmode: devmode
+  SNAP: test-snapd-devmode
+prepare: |
+  snap install --edge --$FLAG $SNAP
+execute: |
+  # sanity check
+  snap list $SNAP | MATCH $FLAG$
+  snap disable $SNAP
+  snap enable $SNAP
+  snap list $SNAP | MATCH $FLAG$


### PR DESCRIPTION
This is [lp:1667385](https://bugs.launchpad.net/snappy/+bug/1667385).