### PR TITLE
wrappers: don't convert between []byte and string needlessly.

### DIFF
--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -126,7 +126,8 @@ Icon=${SNAP}/meep
 Name=foo
 Icon=%s/foo/12/meep
 
-# the empty line above is fine`, dirs.SnapMountDir))
+# the empty line above is fine
+`, dirs.SnapMountDir))
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExec(c *C) {
@@ -145,7 +146,8 @@ Exec=baz
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
-Name=foo`)
+Name=foo
+`)
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExecPrefix(c *C) {
@@ -164,7 +166,8 @@ Exec=snap.app.evil.evil
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
-Name=foo`)
+Name=foo
+`)
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExecOk(c *C) {
@@ -184,7 +187,8 @@ Exec=snap.app %U
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 Name=foo
-Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app %%U`, dirs.SnapMountDir))
+Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app %%U
+`, dirs.SnapMountDir))
 }
 
 // we do not support TryExec (even if its a valid line), this test ensures
@@ -205,7 +209,8 @@ TryExec=snap.app %U
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
-Name=foo`)
+Name=foo
+`)
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeWorthWithI18n(c *C) {
@@ -226,15 +231,16 @@ Name=foo
 GenericName=bar
 GenericName[de]=einsehrlangeszusammengesetzteswort
 GenericName[tlh_TLH]=Qapla'
-GenericName[ca@valencia]=Hola!`)
+GenericName[ca@valencia]=Hola!
+`)
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeDesktopActionsOk(c *C) {
 	snap := &snap.Info{}
-	desktopContent := []byte(`[Desktop Action is-ok]`)
+	desktopContent := []byte("[Desktop Action is-ok]\n")
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(string(e), Equals, `[Desktop Action is-ok]`)
+	c.Assert(string(e), Equals, string(desktopContent))
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeDesktopFileAyatana(c *C) {
@@ -251,7 +257,8 @@ TargetEnvironment=Unity
 
 [Private Shortcut Group]
 Name=Private Mode
-TargetEnvironment=Unity`)
+TargetEnvironment=Unity
+`)
 
 	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, string(desktopContent))
@@ -302,6 +309,6 @@ func (s *sanitizeDesktopFileSuite) TestLangLang(c *C) {
 		{"Icon[xx]=bar", false},
 	}
 	for _, t := range langs {
-		c.Assert(wrappers.IsValidDesktopFileLine(t.line), Equals, t.isValid)
+		c.Assert(wrappers.IsValidDesktopFileLine([]byte(t.line)), Equals, t.isValid)
 	}
 }

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -50,9 +50,9 @@ func serviceStopTimeout(app *snap.AppInfo) time.Duration {
 	return time.Duration(tout)
 }
 
-func generateSnapServiceFile(app *snap.AppInfo) (string, error) {
+func generateSnapServiceFile(app *snap.AppInfo) ([]byte, error) {
 	if err := snap.ValidateApp(app); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	return genServiceFile(app), nil
@@ -96,7 +96,7 @@ func AddSnapServices(s *snap.Info, inter interacter) error {
 		}
 		svcFilePath := app.ServiceFile()
 		os.MkdirAll(filepath.Dir(svcFilePath), 0755)
-		if err := osutil.AtomicWriteFile(svcFilePath, []byte(content), 0644, 0); err != nil {
+		if err := osutil.AtomicWriteFile(svcFilePath, content, 0644, 0); err != nil {
 			return err
 		}
 	}
@@ -168,7 +168,7 @@ func RemoveSnapServices(s *snap.Info, inter interacter) error {
 	return nil
 }
 
-func genServiceFile(appInfo *snap.AppInfo) string {
+func genServiceFile(appInfo *snap.AppInfo) []byte {
 	serviceTemplate := `[Unit]
 # Auto-generated, DO NOT EDIT
 Description=Service for snap application {{.App.Snap.Name}}.{{.App.Name}}
@@ -247,5 +247,5 @@ WantedBy={{.ServicesTarget}}
 		logger.Panicf("Unable to execute template: %v", err)
 	}
 
-	return templateOut.String()
+	return templateOut.Bytes()
 }

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -106,7 +106,7 @@ apps:
 
 	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
 	c.Assert(err, IsNil)
-	c.Check(generatedWrapper, Equals, expectedAppService)
+	c.Check(string(generatedWrapper), Equals, expectedAppService)
 }
 
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileRestart(c *C) {
@@ -124,8 +124,9 @@ apps:
 		info.Revision = snap.R(44)
 		app := info.Apps["app"]
 
-		wrapperText, err := wrappers.GenerateSnapServiceFile(app)
+		generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
 		c.Assert(err, IsNil)
+		wrapperText := string(generatedWrapper)
 		if cond == systemd.RestartNever {
 			c.Check(wrapperText, Matches,
 				`(?ms).*^Restart=no$.*`, Commentf(name))
@@ -154,7 +155,7 @@ func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileTypeForking(c *C) {
 
 	generatedWrapper, err := wrappers.GenerateSnapServiceFile(service)
 	c.Assert(err, IsNil)
-	c.Assert(generatedWrapper, Equals, expectedTypeForkingWrapper)
+	c.Assert(string(generatedWrapper), Equals, expectedTypeForkingWrapper)
 }
 
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileIllegalChars(c *C) {
@@ -198,10 +199,10 @@ apps:
 	info.Revision = snap.R(44)
 	app := info.Apps["app"]
 
-	wrapperText, err := wrappers.GenerateSnapServiceFile(app)
+	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
 	c.Assert(err, IsNil)
 
-	c.Assert(wrapperText, Equals, expectedDbusService)
+	c.Assert(string(generatedWrapper), Equals, expectedDbusService)
 }
 
 func (s *servicesWrapperGenSuite) TestGenOneshotServiceFile(c *C) {
@@ -221,8 +222,8 @@ apps:
 
 	app := info.Apps["app"]
 
-	wrapperText, err := wrappers.GenerateSnapServiceFile(app)
+	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
 	c.Assert(err, IsNil)
 
-	c.Assert(wrapperText, Equals, expectedOneshotService)
+	c.Assert(string(generatedWrapper), Equals, expectedOneshotService)
 }


### PR DESCRIPTION
A bit of a drive-by branch, this one. `wrappers` was being a bit messy: the helper functions created the files' contents as `[]byte`, returned them as strings, only to have them converted back to `[]byte` to write them out. Easy enough to fix 90% of that (left `rewriteExecLine` alone because it'd get messy, but it's doable later if we want).