### PR TITLE
wrappers: service start/stop were inconsistent

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -454,9 +454,14 @@ func (app *AppInfo) LauncherPostStopCommand() string {
 	return app.launcherCommand("--command=post-stop")
 }
 
+// Servicename returns the systemd service name for the daemon app.
+func (app *AppInfo) ServiceName() string {
+	return app.SecurityTag() + ".service"
+}
+
 // ServiceFile returns the systemd service file path for the daemon app.
 func (app *AppInfo) ServiceFile() string {
-	return filepath.Join(dirs.SnapServicesDir, app.SecurityTag()+".service")
+	return filepath.Join(dirs.SnapServicesDir, app.ServiceName())
 }
 
 // ServiceSocketFile returns the systemd socket file path for the daemon app.

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -60,22 +60,12 @@ func generateSnapServiceFile(app *snap.AppInfo) ([]byte, error) {
 
 // StartSnapServices starts service units for the applications from the snap which are services.
 func StartSnapServices(s *snap.Info, inter interacter) error {
+	sysd := systemd.New(dirs.GlobalRootDir, inter)
 	for _, app := range s.Apps {
 		if app.Daemon == "" {
 			continue
 		}
-		// daemon-reload and enable plus start
-		serviceName := filepath.Base(app.ServiceFile())
-		sysd := systemd.New(dirs.GlobalRootDir, inter)
-		if err := sysd.DaemonReload(); err != nil {
-			return err
-		}
-
-		if err := sysd.Enable(serviceName); err != nil {
-			return err
-		}
-
-		if err := sysd.Start(serviceName); err != nil {
+		if err := sysd.Start(app.ServiceName()); err != nil {
 			return err
 		}
 	}
@@ -85,10 +75,14 @@ func StartSnapServices(s *snap.Info, inter interacter) error {
 
 // AddSnapServices adds service units for the applications from the snap which are services.
 func AddSnapServices(s *snap.Info, inter interacter) error {
+	sysd := systemd.New(dirs.GlobalRootDir, inter)
+	nservices := 0
+
 	for _, app := range s.Apps {
 		if app.Daemon == "" {
 			continue
 		}
+		nservices++
 		// Generate service file
 		content, err := generateSnapServiceFile(app)
 		if err != nil {
@@ -97,6 +91,15 @@ func AddSnapServices(s *snap.Info, inter interacter) error {
 		svcFilePath := app.ServiceFile()
 		os.MkdirAll(filepath.Dir(svcFilePath), 0755)
 		if err := osutil.AtomicWriteFile(svcFilePath, content, 0644, 0); err != nil {
+			return err
+		}
+		if err := sysd.Enable(app.ServiceName()); err != nil {
+			return err
+		}
+	}
+
+	if nservices > 0 {
+		if err := sysd.DaemonReload(); err != nil {
 			return err
 		}
 	}
@@ -135,7 +138,6 @@ func StopSnapServices(s *snap.Info, inter interacter) error {
 // RemoveSnapServices disables and removes service units for the applications from the snap which are services.
 func RemoveSnapServices(s *snap.Info, inter interacter) error {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
-
 	nservices := 0
 
 	for _, app := range s.Apps {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -67,11 +67,15 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 	}
 
 	info := snaptest.MockSnap(c, packageHello, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	err := wrappers.AddSnapServices(info, nil)
 	c.Assert(err, IsNil)
+	c.Check(sysdLog, DeepEquals, [][]string{
+		{"--root", dirs.GlobalRootDir, "enable", filepath.Base(svcFile)},
+		{"daemon-reload"},
+	})
 
-	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 	content, err := ioutil.ReadFile(svcFile)
 	c.Assert(err, IsNil)
 
@@ -154,8 +158,5 @@ func (s *servicesTestSuite) TestStartSnapServices(c *C) {
 	err := wrappers.StartSnapServices(info, nil)
 	c.Assert(err, IsNil)
 
-	c.Assert(sysdLog, HasLen, 3)
-	c.Check(sysdLog[0], DeepEquals, []string{"daemon-reload"})
-	c.Check(sysdLog[1], DeepEquals, []string{"--root", dirs.GlobalRootDir, "enable", filepath.Base(svcFile)})
-	c.Check(sysdLog[2], DeepEquals, []string{"start", filepath.Base(svcFile)})
+	c.Assert(sysdLog, DeepEquals, [][]string{{"start", filepath.Base(svcFile)}})
 }


### PR DESCRIPTION
service start and stop (and add/remove) were rather inconsistent in that start enabled, but remove disabled; add wrote the service files, but start called daemon-reload.

I've changed them so add/remove are the ones enabling/disabling, as well as calling daemon-reload (daemon-reload is only needed when a service file is changed), leaving start/stop to just start/stop.