### PR TITLE
overlord/snapstate: avoid creating command aliases for daemons 

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -332,6 +332,8 @@ apps:
   cmd3:
   cmd4:
   cmd5:
+  cmddaemon:
+    daemon: simple
 `))
 		if err != nil {
 			panic(err)

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -27,6 +27,11 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+// IsService returns whether app represents a daemon/service.
+func IsService(app *snap.AppInfo) bool {
+	return app.Daemon != ""
+}
+
 // AddSnapBinaries writes the wrapper binaries for the applications from the snap which aren't services.
 func AddSnapBinaries(s *snap.Info) error {
 	if err := os.MkdirAll(dirs.SnapBinariesDir, 0755); err != nil {
@@ -34,7 +39,7 @@ func AddSnapBinaries(s *snap.Info) error {
 	}
 
 	for _, app := range s.Apps {
-		if app.Daemon != "" {
+		if IsService(app) {
 			continue
 		}
 


### PR DESCRIPTION
We have plans to do something about daemons/services as well but for now avoid creating confusion, spurious symlinks.