### PR TITLE
vendor,partition: fix panics from uenv

### DIFF
--- a/partition/uboot.go
+++ b/partition/uboot.go
@@ -58,7 +58,7 @@ func (u *uboot) envFile() string {
 }
 
 func (u *uboot) SetBootVars(values map[string]string) error {
-	env, err := uenv.Open(u.envFile())
+	env, err := uenv.OpenWithFlags(u.envFile(), uenv.OpenBestEffort)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (u *uboot) SetBootVars(values map[string]string) error {
 func (u *uboot) GetBootVars(names ...string) (map[string]string, error) {
 	out := map[string]string{}
 
-	env, err := uenv.Open(u.envFile())
+	env, err := uenv.OpenWithFlags(u.envFile(), uenv.OpenBestEffort)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -49,16 +49,16 @@
 			"revisionTime": "2015-02-12T09:37:50Z"
 		},
 		{
-			"checksumSHA1": "VV5OVESr0GIy7mRuCjpve1U4/zM=",
+			"checksumSHA1": "c1zgLuM2b+2vguxwz+XVMXPnXOY=",
 			"path": "github.com/mvo5/uboot-go",
-			"revision": "361f6ebcbb54f389d15dc9faefa000e996ba3e37",
-			"revisionTime": "2015-07-22T06:53:40Z"
+			"revision": "256976a42706934b027729183e3a5af2ae646502",
+			"revisionTime": "2017-05-16T08:01:36Z"
 		},
 		{
-			"checksumSHA1": "33255TmqBPhD+hcO4kzuzyJc23o=",
+			"checksumSHA1": "tZT9rWgTJ61Y5VdqSCF9B3404mU=",
 			"path": "github.com/mvo5/uboot-go/uenv",
-			"revision": "361f6ebcbb54f389d15dc9faefa000e996ba3e37",
-			"revisionTime": "2015-07-22T06:53:40Z"
+			"revision": "256976a42706934b027729183e3a5af2ae646502",
+			"revisionTime": "2017-05-16T08:01:36Z"
 		},
 		{
 			"checksumSHA1": "lG6diF/yE9cGgQIKRAlsaeYAjO4=",


### PR DESCRIPTION
This branch aims to fix an error reported by @fgimenez during testing on raspberry pi 2/3.

The relevant part of the panic is:
```
May 15 14:51:13 localhost snapd[1207]: panic: runtime error: index out of range
May 15 14:51:13 localhost snapd[1207]: goroutine 29 [running]:
May 15 14:51:13 localhost snapd[1207]: panic(0x55471de8, 0x34ade010)
May 15 14:51:13 localhost snapd[1207]: #011/usr/lib/go-1.6/src/runtime/panic.go:481 +0x370
May 15 14:51:13 localhost snapd[1207]: github.com/snapcore/snapd/vendor/github.com/mvo5/uboot-go/uenv.parseData(0x34dfc005, 0x1fffb, 0x3fdfb, 0x7913abd9)
May 15 14:51:13 localhost snapd[1207]: #011/build/snapd-EbqrYA/snapd-2.26.1/_build/src/github.com/snapcore/snapd/vendor/github.com/mvo5/uboot-go/uenv/env.go:95 +0x230
May 15 14:51:13 localhost snapd[1207]: github.com/snapcore/snapd/vendor/github.com/mvo5/uboot-go/uenv.Open(0x34c158e0, 0x15, 0x0, 0x0, 0x0)
May 15 14:51:13 localhost snapd[1207]: #011/build/snapd-EbqrYA/snapd-2.26.1/_build/src/github.com/snapcore/snapd/vendor/github.com/mvo5/uboot-go/uenv/env.go:80 +0x3c0
May 15 14:51:13 localhost snapd[1207]: github.com/snapcore/snapd/partition.(*uboot).GetBootVars(0x557bac6c, 0x34c36298, 0x1, 0x1, 0x34dd7d01, 0x0, 0x0)
May 15 14:51:13 localhost snapd[1207]: #011/build/snapd-EbqrYA/snapd-2.26.1/_build/src/github.com/snapcore/snapd/partition/uboot.go:86 +0x80
May 15 14:51:13 localhost snapd[1207]: github.com/snapcore/snapd/boot.SetNextBoot(0x34cb4000, 0x0, 0x0)
```

While we don't have the uenv data from the affected devices we suspect this was a data corruption issue and uenv could no longer parse the existing config. In the revision we were using prior to this branch this would cause uenv to panic.

This branch pulls in changes that landed in uboot-go master since last sync, as well as two new improvements that are aimed directly at the issue we discovered https://github.com/mvo5/uboot-go/pull/2 and https://github.com/mvo5/uboot-go/pull/3

The vendor sync is coupled with a small change that makes us use best-effort parser that kindly ignores malformed data without panicking or returning an error. This should hopefully improve reliability in face of certain kinds of data corruption.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>