### PR TITLE
cmd,interfaces/mount: run snap-update-ns and snap-discard-ns from core if possible

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"syscall"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
@@ -36,7 +37,7 @@ import (
 // will attempt to re-exec itself from inside an ubuntu-core snap
 // present on the system. If not present in the environ it's assumed
 // to be set to 1 (do re-exec); that is: set it to 0 to disable.
-const key = "SNAP_REEXEC"
+const reExecKey = "SNAP_REEXEC"
 
 // newCore is the place to look for the core snap; everything in this
 // location will be new enough to re-exec into.
@@ -46,37 +47,111 @@ const newCore = "/snap/core/current"
 // newer than minOldRevno will be ok to re-exec into.
 const oldCore = "/snap/ubuntu-core/current"
 
+// distroSupportsReExec returns true if the distribution we are running on can use re-exec.
+//
+// This is true by default except for a "core/all" snap system where it makes
+// no sense and in certain distributions that we don't want to enable re-exec
+// yet because of missing validation or other issues.
+func distroSupportsReExec() bool {
+	if !release.OnClassic {
+		return false
+	}
+	switch release.ReleaseInfo.ID {
+	case "fedora", "centos", "rhel", "opensuse", "suse", "poky":
+		return false
+	}
+	return true
+}
+
+// coreSupportsReExec returns true if the given core snap should be used as re-exec target.
+//
+// Ensure we do not use older version of snapd, look for info file and ignore
+// version of core that do not yet have it.
+func coreSupportsReExec(corePath string) bool {
+	fullInfo := filepath.Join(corePath, "/usr/lib/snapd/info")
+	if !osutil.FileExists(fullInfo) {
+		return false
+	}
+	content, err := ioutil.ReadFile(fullInfo)
+	if err != nil {
+		logger.Noticef("cannot read info file %q: %s", fullInfo, err)
+		return false
+	}
+	ver := regexp.MustCompile("(?m)^VERSION=(.*)$").FindStringSubmatch(string(content))
+	if len(ver) != 2 {
+		logger.Noticef("cannot find version information in %q", content)
+		return false
+	}
+	// > 0 means our Version is bigger than the version of snapd in core
+	res, err := strutil.VersionCompare(Version, ver[1])
+	if err != nil {
+		return false
+	}
+	return res <= 0
+}
+
+// InternalToolPath returns the path of the internal snapd tool.
+//
+// The return value is either the path of the tool in the current distribution
+// or in the core snap (or the ubuntu-core snap). This handles spiritual
+// "re-exec" where we run the tool from the core snap if the environment allows
+// us to do so.
+func InternalToolPath(tool string) string {
+	distroTool := filepath.Join(dirs.DistroLibExecDir, tool)
+
+	// If we are asked not to re-execute use distribution packages. This is
+	// "spiritual" re-exec so use the same environment variable to decide.
+	if !osutil.GetenvBool(reExecKey, true) {
+		return distroTool
+	}
+
+	// If the distribution doesn't support re-exec or run-from-core then don't do it.
+	if !distroSupportsReExec() {
+		return distroTool
+	}
+
+	// Is the tool we are after present in the core snap?
+	corePath := newCore
+	coreTool := filepath.Join(newCore, "/usr/lib/snapd", tool)
+	if !osutil.FileExists(coreTool) {
+		corePath = oldCore
+		coreTool = filepath.Join(oldCore, "/usr/lib/snapd", tool)
+	}
+
+	// If the core snap doesn't support re-exec or run-from-core then don't do it.
+	if !coreSupportsReExec(corePath) {
+		return distroTool
+	}
+
+	return coreTool
+}
+
 // ExecInCoreSnap makes sure you're executing the binary that ships in
 // the core snap.
 func ExecInCoreSnap() {
-	if !release.OnClassic {
-		// you're already the real deal, natch
+	// If we are asked not to re-execute use distribution packages. This is
+	// "spiritual" re-exec so use the same environment variable to decide.
+	if !osutil.GetenvBool(reExecKey, true) {
 		return
 	}
 
-	// should we re-exec? no option in the environment means yes
-	if !osutil.GetenvBool(key, true) {
-		logger.Debugf("re-exec disabled by user")
-		return
-	}
-
-	// can we re-exec? some distributions will need extra work before re-exec really works.
-	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "opensuse", "suse", "poky":
-		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
-		return
-	}
-
-	// did we already re-exec?
+	// Did we already re-exec?
 	if osutil.GetenvBool("SNAP_DID_REEXEC") {
 		return
 	}
 
+	// If the distribution doesn't support re-exec or run-from-core then don't do it.
+	if !distroSupportsReExec() {
+		return
+	}
+
+	// Which executable are we?
 	exe, err := os.Readlink("/proc/self/exe")
 	if err != nil {
 		return
 	}
 
+	// Is this executable in the core snap too?
 	corePath := newCore
 	full := filepath.Join(newCore, exe)
 	if !osutil.FileExists(full) {
@@ -87,36 +162,12 @@ func ExecInCoreSnap() {
 		}
 	}
 
-	// ensure we do not re-exec into an older version of snapd, look
-	// for info file and ignore version of core that do not yet have
-	// it
-	fullInfo := filepath.Join(corePath, "/usr/lib/snapd/info")
-	if !osutil.FileExists(fullInfo) {
-		logger.Debugf("not restarting into %q (no version info): older than %q (%s)", full, exe, Version)
-		return
-	}
-	content, err := ioutil.ReadFile(fullInfo)
-	if err != nil {
-		logger.Noticef("cannot read info file %q: %s", fullInfo, err)
-		return
-	}
-	ver := regexp.MustCompile("(?m)^VERSION=(.*)$").FindStringSubmatch(string(content))
-	if len(ver) != 2 {
-		logger.Noticef("cannot find version information in %q", content)
-	}
-	// > 0 means our Version is bigger than the version of snapd in core
-	res, err := strutil.VersionCompare(Version, ver[1])
-	if err != nil {
-		logger.Debugf("cannot version compare %q and %q: %s", Version, ver[1], res)
-		return
-	}
-	if res > 0 {
-		logger.Debugf("not restarting into %q (%s): older than %q (%s)", full, ver, exe, Version)
+	// If the core snap doesn't support re-exec or run-from-core then don't do it.
+	if !coreSupportsReExec(corePath) {
 		return
 	}
 
 	logger.Debugf("restarting into %q", full)
-
 	env := append(os.Environ(), "SNAP_DID_REEXEC=1")
 	panic(syscall.Exec(full, os.Args, env))
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/cmd"
+	"github.com/snapcore/snapd/release"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -30,3 +33,22 @@ func Test(t *testing.T) { TestingT(t) }
 type cmdSuite struct{}
 
 var _ = Suite(&cmdSuite{})
+
+func (s *cmdSuite) TestDistroSupportsReExec(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// Some distributions don't support re-execution yet.
+	for _, id := range []string{"fedora", "centos", "rhel", "opensuse", "suse", "poky"} {
+		restore = release.MockReleaseInfo(&release.OS{ID: id})
+		defer restore()
+		c.Assert(cmd.DistroSupportsReExec(), Equals, false, Commentf("ID: %q", id))
+	}
+
+	// While others do.
+	for _, id := range []string{"debian", "ubuntu"} {
+		restore = release.MockReleaseInfo(&release.OS{ID: id})
+		defer restore()
+		c.Assert(cmd.DistroSupportsReExec(), Equals, true, Commentf("ID: %q", id))
+	}
+}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,32 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmd_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type cmdSuite struct{}
+
+var _ = Suite(&cmdSuite{})

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -1,0 +1,24 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package cmd
+
+var (
+	DistroSupportsReExec = distroSupportsReExec
+)

--- a/interfaces/mount/ns.go
+++ b/interfaces/mount/ns.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 )
@@ -38,7 +39,7 @@ func mountNsPath(snapName string) string {
 func runNamespaceTool(toolName, snapName string) ([]byte, error) {
 	mntFile := mountNsPath(snapName)
 	if osutil.FileExists(mntFile) {
-		toolPath := filepath.Join(dirs.DistroLibExecDir, toolName)
+		toolPath := cmd.InternalToolPath(toolName)
 		cmd := exec.Command(toolPath, snapName)
 		output, err := cmd.CombinedOutput()
 		return output, err

--- a/interfaces/mount/ns_test.go
+++ b/interfaces/mount/ns_test.go
@@ -28,24 +28,23 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type nsSuite struct {
-	oldDistroLibExecDir string
+	testutil.BaseTest
 }
 
 var _ = Suite(&nsSuite{})
 
 func (s *nsSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
-	// Mock enough bits so that we can observe calls to snap-discard-ns
-	s.oldDistroLibExecDir = dirs.DistroLibExecDir
-}
-
-func (s *nsSuite) TearDownTest(c *C) {
-	dirs.SetRootDir("")
-	dirs.DistroLibExecDir = s.oldDistroLibExecDir
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+	s.AddCleanup(release.MockOnClassic(true))
+	// Anything that just gives us no-reexec.
+	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "fedora"}))
 }
 
 func (s *nsSuite) TestDiscardNamespaceMnt(c *C) {

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -35,7 +35,7 @@ execute: |
     mount --bind /tmp/old-info /snap/core/current/usr/lib/snapd/info
     systemctl start snapd.service snapd.socket
     snap list
-    journalctl | MATCH "not restarting into.*older than"
+    journalctl | MATCH "core snap \(at .*\) is older \(.*\) than distribution package"
 
     echo "Revert back to normal"
     systemctl stop snapd.service snapd.socket


### PR DESCRIPTION
This patch fixes "re-exec" of the two aforementioned tools by adding a new helper `cmd.InternalToolPath` and using it in the right spot. I will follow up with a change to use the same
helper for `snap-confine`