### PR TITLE
tests: fix failing tests (snap core version, syslog changes)

### DIFF
--- a/tests/lib/snaps/log-observe-consumer/bin/consumer
+++ b/tests/lib/snaps/log-observe-consumer/bin/consumer
@@ -5,7 +5,7 @@ import sys
 
 def run():
   try:
-    subprocess.check_output("tail -n 10 /var/log/syslog", shell=True)
+    subprocess.check_output("journalctl -n 10", shell=True)
     print("ok")
   except Exception as e:
     print("error accessing log")

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -12,7 +12,7 @@ execute: |
     # *current* edge also has .git. and a hash snippet, so add an optional .git.[0-9a-f]+ to the already optional timestamp
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
-        expected='^core .* [0-9]{2}-[0-9.]+(\+[0-9]+(\.git\.[0-9a-f]+)?)? +[0-9]+ +- *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(\+[0-9]+(\.git\.[0-9a-f]+)?)? +x[0-9]+ +- *$'
     else
         expected='^core .* [0-9]{2}-[0-9.]+(\+[0-9]+(\.git\.[0-9a-f]+)?)? +[0-9]+ +canonical +- *$'
     fi

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -7,11 +7,14 @@ prepare: |
 execute: |
 
     echo "List prints core snap version"
+    # most core versions should be like "16-2", so [0-9]{2}-[0-9.]+
+    # but edge will have a timestamp in there, "16.2+201701010932", so add an optional \+[0-9]+ to the end
+    # *current* edge also has .git. and a hash snippet, so add an optional .git.[0-9a-f]+ to the already optional timestamp
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
-        expected="^core .* [0-9]{2}-[0-9.]+  +x[0-9]+ +- *$"
+        expected='^core .* [0-9]{2}-[0-9.]+(\+[0-9]+(\.git\.[0-9a-f]+)?)? +[0-9]+ +- *$'
     else
-        expected="^core .* [0-9]{2}-[0-9.]+ +[0-9]+ +canonical +- *$"
+        expected='^core .* [0-9]{2}-[0-9.]+(\+[0-9]+(\.git\.[0-9a-f]+)?)? +[0-9]+ +canonical +- *$'
     fi
     snap list | MATCH "$expected"
 


### PR DESCRIPTION
This branch fixes `tests/main/listing` to match what the core snap version currently is. It also fixes `tests/lib/snaps/log-observe-consumer` as syslog might not be there #3327