### PR TITLE
vendor: refresh everything

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -7,40 +7,46 @@
 			"revision": ""
 		},
 		{
-			"checksumSHA1": "f4UJKXymPS31lDRMfsmPA4PvwVw=",
+			"checksumSHA1": "t8CsjyFayB7tH16Th46OH2zL09I=",
 			"path": "github.com/cheggaaa/pb",
-			"revision": "6e9d17711bb763b26b68b3931d47f24c1323abab",
-			"revisionTime": "2016-08-12T10:57:48Z"
+			"revision": "f6ccf2184de4dd34495277e38dc19b6e7fbe0ea2",
+			"revisionTime": "2017-05-08T13:24:47Z"
 		},
 		{
-			"checksumSHA1": "ab0MZfSfbTzqPQ1lVEJWpzZ5PJM=",
+			"checksumSHA1": "RBwpnMpfQt7Jo7YWrRph0Vwe+f0=",
 			"path": "github.com/coreos/go-systemd/activation",
-			"revision": "f743bc15d6bddd23662280b4ad20f7c874cdd5ad",
-			"revisionTime": "2014-05-03T19:37:39Z"
+			"revision": "1f9909e51b2dab2487c26d64c8f2e7e580e4c9f5",
+			"revisionTime": "2017-03-24T09:58:19Z"
 		},
 		{
-			"checksumSHA1": "iIUYZyoanCQQTUaWsu8b+iOSPt4=",
+			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
 			"path": "github.com/gorilla/context",
-			"revision": "1c83b3eabd45b6d76072b66b746c20815fb2872d",
-			"revisionTime": "2015-08-20T05:12:45Z"
+			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
+			"revisionTime": "2016-08-17T18:46:32Z"
 		},
 		{
-			"checksumSHA1": "8jXj6IMkk1B0LdIYgVG5Vn01/NU=",
+			"checksumSHA1": "zmCk+lgIeiOf0Ng9aFP9aFy8ksE=",
 			"path": "github.com/gorilla/mux",
-			"revision": "ee1815431e497d3850809578c93ab6705f1a19f7",
-			"revisionTime": "2015-08-20T05:15:06Z"
+			"revision": "4c1c3952b7d9d0a061a3fa7b36fd373ba0398ebc",
+			"revisionTime": "2017-04-27T04:12:50Z"
 		},
 		{
-			"checksumSHA1": "Fsff4Yngdyqbq9ulSyTT4LGrxck=",
+			"checksumSHA1": "HyzJVpU83/duL9rjkQ4fGE0cw5Q=",
 			"path": "github.com/jessevdk/go-flags",
-			"revision": "6b9493b3cb60367edd942144879646604089e3f7",
-			"revisionTime": "2016-02-27T09:34:14Z"
+			"revision": "460c7bb0abd6e927f2767cadc91aa6ef776a98b4",
+			"revisionTime": "2017-02-12T22:02:46Z"
 		},
 		{
-			"checksumSHA1": "bzUdFxQ29mPK0lwgFVcF0GFN74Q=",
+			"checksumSHA1": "cJE7dphDlam/i7PhnsyosNWtbd4=",
+			"path": "github.com/mattn/go-runewidth",
+			"revision": "97311d9f7767e3d6f422ea06661bc2c7a19e8a5d",
+			"revisionTime": "2017-05-10T07:48:58Z"
+		},
+		{
+			"checksumSHA1": "yoGLTr9p4sWhF3iZfPCD3xW8Gxs=",
 			"path": "github.com/mvo5/goconfigparser",
-			"revision": "26426272dda20cc76aa1fa44286dc743d2972fe8",
-			"revisionTime": "2015-02-12T09:37:50Z"
+			"revision": "efba97014b80c1d34ead4f3bbafc5d8effe4d2b0",
+			"revisionTime": "2016-03-24T20:09:42Z"
 		},
 		{
 			"checksumSHA1": "c1zgLuM2b+2vguxwz+XVMXPnXOY=",
@@ -55,47 +61,53 @@
 			"revisionTime": "2017-05-16T08:01:36Z"
 		},
 		{
-			"checksumSHA1": "lG6diF/yE9cGgQIKRAlsaeYAjO4=",
+			"checksumSHA1": "nV76VgoCpwa+JjK/tSyu5jCj8HQ=",
 			"path": "github.com/ojii/gettext.go",
-			"revision": "95289a7e0ac17c76737a5ceca3c9471c0adf70c7",
-			"revisionTime": "2016-07-14T06:47:45Z"
+			"revision": "b6dae1d7af8a8441285e42661565760b530a8a57",
+			"revisionTime": "2017-01-20T06:14:37Z"
 		},
 		{
 			"checksumSHA1": "j5FytTwC2nAqSrDR7V7O7E4cHKM=",
 			"path": "github.com/ojii/gettext.go/pluralforms",
-			"revision": "95289a7e0ac17c76737a5ceca3c9471c0adf70c7",
-			"revisionTime": "2016-07-14T06:47:45Z"
+			"revision": "b6dae1d7af8a8441285e42661565760b530a8a57",
+			"revisionTime": "2017-01-20T06:14:37Z"
 		},
 		{
-			"checksumSHA1": "E28iXtNf9DZVsymruqAnTFGNNnE=",
+			"checksumSHA1": "SDg94ADPbqVe/rvNRQjb1TfszYE=",
 			"path": "golang.org/x/crypto",
-			"revision": "351dc6a5bf92a5f2ae22fadeee08eb6a45aa2d93",
-			"revisionTime": "2016-08-24T13:50:57Z",
+			"revision": "0fe963104e9d1877082f8fb38f816fcd97eb1d10",
+			"revisionTime": "2017-05-16T11:44:04Z",
 			"tree": true
 		},
 		{
-			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
+			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
 			"path": "golang.org/x/net/context",
-			"revision": "6250b412798208e6c90b03b7c4f226de5aa299e2",
-			"revisionTime": "2016-08-24T22:20:41Z"
+			"revision": "34057069f4ab13dc4433c68d368737ebeafcccdc",
+			"revisionTime": "2017-05-09T19:22:37Z"
 		},
 		{
 			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
 			"path": "golang.org/x/net/context/ctxhttp",
-			"revision": "6250b412798208e6c90b03b7c4f226de5aa299e2",
-			"revisionTime": "2016-08-24T22:20:41Z"
+			"revision": "34057069f4ab13dc4433c68d368737ebeafcccdc",
+			"revisionTime": "2017-05-09T19:22:37Z"
 		},
 		{
-			"checksumSHA1": "XeOje6FklwIZfFMTgE583al/ZDo=",
+			"checksumSHA1": "5VxR5SMHHsE7QM8kwrc8ZckU0TU=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "1e99a4f9d247b28c670884b9a8d6801f39a47b77",
+			"revisionTime": "2017-05-14T19:20:32Z"
+		},
+		{
+			"checksumSHA1": "CEFTYXtWmgSh+3Ik1NmDaJcz4E0=",
 			"path": "gopkg.in/check.v1",
-			"revision": "64131543e7896d5bcc6bd5a76287eb75ea96c673",
-			"revisionTime": "2014-10-24T13:38:53Z"
+			"revision": "20d25e2804050c1cd24a7eea1e7a6447dd0e74ec",
+			"revisionTime": "2016-12-08T18:13:25Z"
 		},
 		{
-			"checksumSHA1": "mWrTCVjXPLevlqKUqpzSoEM3tu8=",
+			"checksumSHA1": "WzfnlKptKzOkZMhyPRoMmUy5lm0=",
 			"path": "gopkg.in/macaroon.v1",
-			"revision": "ab3940c6c16510a850e1c2dd628b919f0f3f1464",
-			"revisionTime": "2015-01-21T11:42:31Z"
+			"revision": "d8fd13e6951f2ce46f0964a58149cf2f103cac9a",
+			"revisionTime": "2016-06-09T13:57:32Z"
 		},
 		{
 			"checksumSHA1": "YsB2DChSV9HxdzHaKATllAUKWSI=",
@@ -122,16 +134,16 @@
 			"revisionTime": "2016-12-08T15:16:19Z"
 		},
 		{
-			"checksumSHA1": "hiOUviIMDKo7y918uBiEhfJyOkk=",
+			"checksumSHA1": "O9E8G234qCcPA7f7srGpnawDmMs=",
 			"path": "gopkg.in/tylerb/graceful.v1",
-			"revision": "50a48b6e73fcc75b45e22c05b79629a67c79e938",
-			"revisionTime": "2016-08-29T01:00:30Z"
+			"revision": "4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb",
+			"revisionTime": "2017-02-01T19:58:55Z"
 		},
 		{
-			"checksumSHA1": "TXfll3dCoaPKSntwHO0yR8eZ4JY=",
+			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "49c95bdc21843256fb6c4e0d370a05f24a0bf213",
-			"revisionTime": "2015-02-24T22:57:58Z"
+			"revision": "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b",
+			"revisionTime": "2017-04-07T17:21:22Z"
 		}
 	],
 	"rootPath": "github.com/snapcore/snapd"


### PR DESCRIPTION
This patch refreshes all of the vendorized dependencies to their latest
versions. This patch should be landed only after careful review.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>