### PR TITLE
errtracker: try multiple paths to read machine-id

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -72,17 +72,13 @@ func readMachineID() ([]byte, error) {
 	for _, id := range machineIDs {
 		machineID, err = ioutil.ReadFile(id)
 		if err == nil {
-			break
+			return bytes.TrimSpace(machineID), nil
 		} else if !os.IsNotExist(err) {
-			logger.Noticef("cannot find %s: %s", id, err)
+			logger.Noticef("cannot read %s: %s", id, err)
 		}
 	}
 
-	if len(machineID) == 0 {
-		return nil, fmt.Errorf("cannot report: no suitable machine id file found")
-	}
-
-	return bytes.TrimSpace(machineID), nil
+	return nil, fmt.Errorf("cannot report: no suitable machine id file found")
 }
 
 func Report(snap, errMsg, dupSig string, extra map[string]string) (string, error) {

--- a/errtracker/export_test.go
+++ b/errtracker/export_test.go
@@ -31,11 +31,11 @@ func MockCrashDbURL(url string) (restorer func()) {
 	}
 }
 
-func MockMachineIDPath(path string) (restorer func()) {
-	old := machineID
-	machineID = path
+func MockMachineIDPaths(paths []string) (restorer func()) {
+	old := machineIDs
+	machineIDs = paths
 	return func() {
-		machineID = old
+		machineIDs = old
 	}
 }
 


### PR DESCRIPTION
The machine-id file is at different locations depending on how the system
is setup. On Fedora for example /var/lib/dbus/machine-id doesn't exist
but we have /etc/machine-id. See
https://www.freedesktop.org/software/systemd/man/machine-id.html for a
few more details.