### PR TITLE
tests/main/completion: source from /usr/share/bash-completion

### DIFF
--- a/tests/completion/lib.exp0
+++ b/tests/completion/lib.exp0
@@ -66,5 +66,5 @@ proc brexit {} {
 # tests to fail.
 spawn env -u PS1 bash --norc -i
 next
-send ". /etc/bash_completion; . ../../../data/completion/snap\n"
+send ". /usr/share/bash-completion/bash_completion; . ../../../data/completion/snap\n"
 next


### PR DESCRIPTION
/etc/bash_completion does not exist on all distributions but
/usr/share/bash-completion does we so we can use this instead
in the test case to let it pass everywhere.