### PR TITLE
tests: bump kill-timeout and remove quiet call on build

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -242,6 +242,8 @@ repack: |
         tar c current.delta >&4
     fi
 
+kill-timeout: 20m
+
 prepare: |
     # check if running inside a container, the testsuite will not
     # work in such an environment

--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -27,7 +27,7 @@ build_deb(){
     # Use fake version to ensure we are always bigger than anything else
     dch --newversion "1337.$(dpkg-parsechangelog --show-field Version)" "testing build"
 
-    quiet su -l -c "cd $PWD && DEB_BUILD_OPTIONS='nocheck testkeys' dpkg-buildpackage -tc -b -Zgzip" test
+    su -l -c "cd $PWD && DEB_BUILD_OPTIONS='nocheck testkeys' dpkg-buildpackage -tc -b -Zgzip" test
     # put our debs to a safe place
     cp ../*.deb $GOPATH
 }


### PR DESCRIPTION
We are seeing timeouts at the prepare stage, like this:
```
++ quiet su -l -c 'cd /home/gopath/src/github.com/snapcore/snapd && DEB_BUILD_OPTIONS='\''nocheck testkeys'\'' dpkg-buildpackage -tc -b -Zgzip' test
<kill-timeout reached>
```
These changes increase the `kill-timeout` at the project level from 15m to 20m. They also remove a `quiet`  call to get more info about where the execution is getting stuck.