### PR TITLE
snap-confine: move rm_rf_tmp to test-utils.

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -103,6 +103,8 @@ libsnap_confine_private_unit_tests_SOURCES = \
 	libsnap-confine-private/secure-getenv-test.c \
 	libsnap-confine-private/snap-test.c \
 	libsnap-confine-private/string-utils-test.c \
+	libsnap-confine-private/test-utils.c \
+	libsnap-confine-private/test-utils-test.c \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
 	libsnap-confine-private/unit-tests.h \
@@ -286,6 +288,7 @@ snap-confine/snap-confine-debug$(EXEEXT): LIBS += -Wl,-Bstatic $(snap_confine_sn
 if WITH_UNIT_TESTS
 noinst_PROGRAMS += snap-confine/unit-tests
 snap_confine_unit_tests_SOURCES = \
+	libsnap-confine-private/test-utils.c \
 	libsnap-confine-private/unit-tests-main.c \
 	libsnap-confine-private/unit-tests.c \
 	libsnap-confine-private/unit-tests.h \

--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -19,6 +19,7 @@
 #include "locking.c"
 
 #include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/test-utils.h"
 
 #include <errno.h>
 
@@ -29,57 +30,6 @@
 static void sc_set_lock_dir(const char *dir)
 {
 	sc_lock_dir = dir;
-}
-
-// Shell-out to "rm -rf -- $dir" as long as $dir is in /tmp.
-static void rm_rf_tmp(const char *dir)
-{
-	// Sanity check, don't remove anything that's not in the temporary
-	// directory. This is here to prevent unintended data loss.
-	if (!g_str_has_prefix(dir, "/tmp/"))
-		die("refusing to remove: %s", dir);
-	const gchar *working_directory = NULL;
-	gchar **argv = NULL;
-	gchar **envp = NULL;
-	GSpawnFlags flags = G_SPAWN_SEARCH_PATH;
-	GSpawnChildSetupFunc child_setup = NULL;
-	gpointer user_data = NULL;
-	gchar **standard_output = NULL;
-	gchar **standard_error = NULL;
-	gint exit_status = 0;
-	GError *error = NULL;
-
-	argv = calloc(5, sizeof *argv);
-	if (argv == NULL)
-		die("cannot allocate command argument array");
-	argv[0] = g_strdup("rm");
-	if (argv[0] == NULL)
-		die("cannot allocate memory");
-	argv[1] = g_strdup("-rf");
-	if (argv[1] == NULL)
-		die("cannot allocate memory");
-	argv[2] = g_strdup("--");
-	if (argv[2] == NULL)
-		die("cannot allocate memory");
-	argv[3] = g_strdup(dir);
-	if (argv[3] == NULL)
-		die("cannot allocate memory");
-	argv[4] = NULL;
-	g_assert_true(g_spawn_sync
-		      (working_directory, argv, envp, flags, child_setup,
-		       user_data, standard_output, standard_error, &exit_status,
-		       &error));
-	g_assert_true(g_spawn_check_exit_status(exit_status, NULL));
-	if (error != NULL) {
-		g_test_message("cannot remove temporary directory: %s\n",
-			       error->message);
-		g_error_free(error);
-	}
-	g_free(argv[0]);
-	g_free(argv[1]);
-	g_free(argv[2]);
-	g_free(argv[3]);
-	g_free(argv);
 }
 
 // Use temporary directory for locking.

--- a/cmd/libsnap-confine-private/test-utils-test.c
+++ b/cmd/libsnap-confine-private/test-utils-test.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "test-utils.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <glib.h>
+
+// Check that rm_rf_tmp doesn't remove things outside of /tmp
+static void test_rm_rf_tmp()
+{
+	if (access("/nonexistent", F_OK) == 0) {
+		g_test_message
+		    ("/nonexistent exists but this test doesn't want it to");
+		g_test_fail();
+		return;
+	}
+	if (g_test_subprocess()) {
+		rm_rf_tmp("/nonexistent");
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+}
+
+static void __attribute__ ((constructor)) init()
+{
+	g_test_add_func("/test-utils/rm_rf_tmp", test_rm_rf_tmp);
+}

--- a/cmd/libsnap-confine-private/test-utils.c
+++ b/cmd/libsnap-confine-private/test-utils.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "test-utils.h"
+
+#include "error.h"
+#include "utils.h"
+
+#include <glib.h>
+
+void rm_rf_tmp(const char *dir)
+{
+	// Sanity check, don't remove anything that's not in the temporary
+	// directory. This is here to prevent unintended data loss.
+	if (!g_str_has_prefix(dir, "/tmp/"))
+		die("refusing to remove: %s", dir);
+	const gchar *working_directory = NULL;
+	gchar **argv = NULL;
+	gchar **envp = NULL;
+	GSpawnFlags flags = G_SPAWN_SEARCH_PATH;
+	GSpawnChildSetupFunc child_setup = NULL;
+	gpointer user_data = NULL;
+	gchar **standard_output = NULL;
+	gchar **standard_error = NULL;
+	gint exit_status = 0;
+	GError *error = NULL;
+
+	argv = calloc(5, sizeof *argv);
+	if (argv == NULL)
+		die("cannot allocate command argument array");
+	argv[0] = g_strdup("rm");
+	if (argv[0] == NULL)
+		die("cannot allocate memory");
+	argv[1] = g_strdup("-rf");
+	if (argv[1] == NULL)
+		die("cannot allocate memory");
+	argv[2] = g_strdup("--");
+	if (argv[2] == NULL)
+		die("cannot allocate memory");
+	argv[3] = g_strdup(dir);
+	if (argv[3] == NULL)
+		die("cannot allocate memory");
+	argv[4] = NULL;
+	g_assert_true(g_spawn_sync
+		      (working_directory, argv, envp, flags, child_setup,
+		       user_data, standard_output, standard_error, &exit_status,
+		       &error));
+	g_assert_true(g_spawn_check_exit_status(exit_status, NULL));
+	if (error != NULL) {
+		g_test_message("cannot remove temporary directory: %s\n",
+			       error->message);
+		g_error_free(error);
+	}
+	g_free(argv[0]);
+	g_free(argv[1]);
+	g_free(argv[2]);
+	g_free(argv[3]);
+	g_free(argv);
+}

--- a/cmd/libsnap-confine-private/test-utils.h
+++ b/cmd/libsnap-confine-private/test-utils.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SNAP_CONFINE_TEST_UTILS_H
+#define SNAP_CONFINE_TEST_UTILS_H
+
+/**
+ * Shell-out to "rm -rf -- $dir" as long as $dir is in /tmp.
+ */
+void rm_rf_tmp(const char *dir);
+
+#endif

--- a/cmd/snap-confine/ns-support-test.c
+++ b/cmd/snap-confine/ns-support-test.c
@@ -19,6 +19,7 @@
 #include "ns-support.c"
 
 #include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/test-utils.h"
 
 #include <errno.h>
 #include <linux/magic.h>	// for NSFS_MAGIC
@@ -32,74 +33,6 @@
 static void sc_set_ns_dir(const char *dir)
 {
 	sc_ns_dir = dir;
-}
-
-// Shell-out to "rm -rf -- $dir" as long as $dir is in /tmp.
-static void rm_rf_tmp(const char *dir)
-{
-	// Sanity check, don't remove anything that's not in the temporary
-	// directory. This is here to prevent unintended data loss.
-	if (!g_str_has_prefix(dir, "/tmp/"))
-		die("refusing to remove: %s", dir);
-	const gchar *working_directory = NULL;
-	gchar **argv = NULL;
-	gchar **envp = NULL;
-	GSpawnFlags flags = G_SPAWN_SEARCH_PATH;
-	GSpawnChildSetupFunc child_setup = NULL;
-	gpointer user_data = NULL;
-	gchar **standard_output = NULL;
-	gchar **standard_error = NULL;
-	gint exit_status = 0;
-	GError *error = NULL;
-
-	argv = calloc(5, sizeof *argv);
-	if (argv == NULL)
-		die("cannot allocate command argument array");
-	argv[0] = g_strdup("rm");
-	if (argv[0] == NULL)
-		die("cannot allocate memory");
-	argv[1] = g_strdup("-rf");
-	if (argv[1] == NULL)
-		die("cannot allocate memory");
-	argv[2] = g_strdup("--");
-	if (argv[2] == NULL)
-		die("cannot allocate memory");
-	argv[3] = g_strdup(dir);
-	if (argv[3] == NULL)
-		die("cannot allocate memory");
-	argv[4] = NULL;
-	g_assert_true(g_spawn_sync
-		      (working_directory, argv, envp, flags, child_setup,
-		       user_data, standard_output, standard_error, &exit_status,
-		       &error));
-	g_assert_true(g_spawn_check_exit_status(exit_status, NULL));
-	if (error != NULL) {
-		g_test_message("cannot remove temporary directory: %s\n",
-			       error->message);
-		g_error_free(error);
-	}
-	g_free(argv[0]);
-	g_free(argv[1]);
-	g_free(argv[2]);
-	g_free(argv[3]);
-	g_free(argv);
-}
-
-// Check that rm_rf_tmp doesn't remove things outside of /tmp
-static void test_rm_rf_tmp()
-{
-	if (access("/nonexistent", F_OK) == 0) {
-		g_test_message
-		    ("/nonexistent exists but this test doesn't want it to");
-		g_test_fail();
-		return;
-	}
-	if (g_test_subprocess()) {
-		rm_rf_tmp("/nonexistent");
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
 }
 
 // Use temporary directory for namespace groups.
@@ -267,7 +200,6 @@ static void test_nsfs_fs_id()
 
 static void __attribute__ ((constructor)) init()
 {
-	g_test_add_func("/internal/rm_rf_tmp", test_rm_rf_tmp);
 	g_test_add_func("/ns/sc_alloc_ns_group", test_sc_alloc_ns_group);
 	g_test_add_func("/ns/sc_open_ns_group", test_sc_open_ns_group);
 	g_test_add_func("/ns/sc_open_ns_group/graceful",


### PR DESCRIPTION
Introduce test-utils and move rm_rf_tmp utility functions into it. Removed duplicated rm_rf_tmp code from two existing tests. No new code, just moving existing code around.