### PR TITLE
many: model and expose interface meta-data.

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -62,6 +62,13 @@ type SlotRef struct {
 type Interfaces struct {
 	Plugs []Plug `json:"plugs"`
 	Slots []Slot `json:"slots"`
+
+	MetaData map[string]InterfaceMetaData `json:"meta-data"`
+}
+
+// InterfaceMetaData contains meta-data about a given interface type.
+type InterfaceMetaData struct {
+	Description string `json:"description,omitempty"`
 }
 
 // InterfaceAction represents an action performed on the interface system.

--- a/client/interfaces_test.go
+++ b/client/interfaces_test.go
@@ -58,7 +58,12 @@ func (cs *clientSuite) TestClientInterfaces(c *check.C) {
 						{"snap": "canonical-pi2", "plug": "pin-13"}
 					]
 				}
-			]
+			],
+			"meta-data": {
+				"bool-file": {
+					"description": "The bool-file interface allows access to a specific file that contains values 0 or 1"
+				}
+			}
 		}
 	}`
 	interfaces, err := cs.cli.Interfaces()
@@ -90,6 +95,11 @@ func (cs *clientSuite) TestClientInterfaces(c *check.C) {
 						Name: "pin-13",
 					},
 				},
+			},
+		},
+		MetaData: map[string]client.InterfaceMetaData{
+			"bool-file": {
+				Description: "The bool-file interface allows access to a specific file that contains values 0 or 1",
 			},
 		},
 	})

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -70,69 +70,78 @@ func (x *cmdInterfaces) Execute(args []string) error {
 	}
 
 	ifaces, err := Client().Interfaces()
-	if err == nil {
-		if len(ifaces.Plugs) == 0 && len(ifaces.Slots) == 0 {
-			return fmt.Errorf(i18n.G("no interfaces found"))
+	if err != nil {
+		return err
+	}
+	if len(ifaces.Plugs) == 0 && len(ifaces.Slots) == 0 {
+		return fmt.Errorf(i18n.G("no interfaces found"))
+	}
+	w := tabWriter()
+	fmt.Fprintln(w, i18n.G("Slot\tPlug"))
+	for _, slot := range ifaces.Slots {
+		if wanted := x.Positionals.Query.Snap; wanted != "" {
+			ok := wanted == slot.Snap
+			for i := 0; i < len(slot.Connections) && !ok; i++ {
+				ok = wanted == slot.Connections[i].Snap
+			}
+			if !ok {
+				continue
+			}
 		}
-		w := tabWriter()
-		fmt.Fprintln(w, i18n.G("Slot\tPlug"))
-		defer w.Flush()
-		for _, slot := range ifaces.Slots {
-			if wanted := x.Positionals.Query.Snap; wanted != "" {
-				ok := wanted == slot.Snap
-				for i := 0; i < len(slot.Connections) && !ok; i++ {
-					ok = wanted == slot.Connections[i].Snap
-				}
-				if !ok {
-					continue
-				}
+		if x.Positionals.Query.Name != "" && x.Positionals.Query.Name != slot.Name {
+			continue
+		}
+		if x.Interface != "" && slot.Interface != x.Interface {
+			continue
+		}
+		// The OS snap is special and enable abbreviated
+		// display syntax on the slot-side of the connection.
+		if slot.Snap == "core" || slot.Snap == "ubuntu-core" {
+			fmt.Fprintf(w, ":%s\t", slot.Name)
+		} else {
+			fmt.Fprintf(w, "%s:%s\t", slot.Snap, slot.Name)
+		}
+		for i := 0; i < len(slot.Connections); i++ {
+			if i > 0 {
+				fmt.Fprint(w, ",")
 			}
-			if x.Positionals.Query.Name != "" && x.Positionals.Query.Name != slot.Name {
-				continue
-			}
-			if x.Interface != "" && slot.Interface != x.Interface {
-				continue
-			}
-			// The OS snap is special and enable abbreviated
-			// display syntax on the slot-side of the connection.
-			if slot.Snap == "core" || slot.Snap == "ubuntu-core" {
-				fmt.Fprintf(w, ":%s\t", slot.Name)
+			if slot.Connections[i].Name != slot.Name {
+				fmt.Fprintf(w, "%s:%s", slot.Connections[i].Snap, slot.Connections[i].Name)
 			} else {
-				fmt.Fprintf(w, "%s:%s\t", slot.Snap, slot.Name)
+				fmt.Fprintf(w, "%s", slot.Connections[i].Snap)
 			}
-			for i := 0; i < len(slot.Connections); i++ {
-				if i > 0 {
-					fmt.Fprint(w, ",")
-				}
-				if slot.Connections[i].Name != slot.Name {
-					fmt.Fprintf(w, "%s:%s", slot.Connections[i].Snap, slot.Connections[i].Name)
-				} else {
-					fmt.Fprintf(w, "%s", slot.Connections[i].Snap)
-				}
-			}
-			// Display visual indicator for disconnected slots
-			if len(slot.Connections) == 0 {
-				fmt.Fprint(w, "-")
-			}
-			fmt.Fprintf(w, "\n")
 		}
-		// Plugs are treated differently. Since the loop above already printed each connected
-		// plug, the loop below focuses on printing just the disconnected plugs.
-		for _, plug := range ifaces.Plugs {
-			if x.Positionals.Query.Snap != "" && x.Positionals.Query.Snap != plug.Snap {
-				continue
-			}
-			if x.Positionals.Query.Name != "" && x.Positionals.Query.Name != plug.Name {
-				continue
-			}
-			if x.Interface != "" && plug.Interface != x.Interface {
-				continue
-			}
-			// Display visual indicator for disconnected plugs.
-			if len(plug.Connections) == 0 {
-				fmt.Fprintf(w, "-\t%s:%s\n", plug.Snap, plug.Name)
-			}
+		// Display visual indicator for disconnected slots
+		if len(slot.Connections) == 0 {
+			fmt.Fprint(w, "-")
+		}
+		fmt.Fprintf(w, "\n")
+	}
+	// Plugs are treated differently. Since the loop above already printed each connected
+	// plug, the loop below focuses on printing just the disconnected plugs.
+	for _, plug := range ifaces.Plugs {
+		if x.Positionals.Query.Snap != "" && x.Positionals.Query.Snap != plug.Snap {
+			continue
+		}
+		if x.Positionals.Query.Name != "" && x.Positionals.Query.Name != plug.Name {
+			continue
+		}
+		if x.Interface != "" && plug.Interface != x.Interface {
+			continue
+		}
+		// Display visual indicator for disconnected plugs.
+		if len(plug.Connections) == 0 {
+			fmt.Fprintf(w, "-\t%s:%s\n", plug.Snap, plug.Name)
 		}
 	}
-	return err
+	w.Flush()
+	// Display interface description if a single interface was requested via -i
+	// and we have meta-data for that interface and the meta-data contains an
+	// actual description.
+	if x.Interface != "" {
+		if md, ok := ifaces.MetaData[x.Interface]; ok && md.Description != "" {
+			fmt.Fprintf(Stdout, "\n%s\n", fill(md.Description, 0))
+		}
+	}
+	return nil
 }

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -61,7 +61,7 @@ func termSize() (width, height int) {
 	return width, height
 }
 
-func fill(para string) string {
+func fill(para string, indent int) string {
 	width, _ := termSize()
 
 	if width > 100 {
@@ -74,20 +74,10 @@ func fill(para string) string {
 	// work just for this.
 	width--
 
-	// 3 is the %v\n, which will be present in any locale
-	indent := len(errorPrefix) - 3
 	var buf bytes.Buffer
 	doc.ToText(&buf, para, strings.Repeat(" ", indent), "", width-indent)
 
 	return strings.TrimSpace(buf.String())
-}
-
-type filledError struct {
-	error
-}
-
-func (e filledError) Error() string {
-	return fill(e.error.Error())
 }
 
 func clientErrorToCmdMessage(snapName string, err *client.Error) (string, error) {
@@ -142,7 +132,8 @@ If you understand and want to proceed repeat the command including --classic.
 	if usesSnapName {
 		msg = fmt.Sprintf(msg, snapName)
 	}
-	msg = fill(msg)
+	// 3 is the %v\n, which will be present in any locale
+	msg = fill(msg, len(errorPrefix)-3)
 	if isError {
 		return "", errors.New(msg)
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3235,6 +3235,9 @@ func (s *apiSuite) TestInterfaces(c *check.C) {
 					},
 				},
 			},
+			"meta-data": map[string]interface{}{
+				"test": map[string]interface{}{},
+			},
 		},
 		"status":      "OK",
 		"status-code": 200.0,

--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -19,8 +19,14 @@
 
 package builtin
 
+const accountControlDescription = `
+The account-control interface allows connected plugs to create, modify and
+delete non-system users as well as to change account passwords.
+
+The core snap provides the slot that is shared by all the snaps.
+`
+
 const accountControlConnectedPlugAppArmor = `
-# Allow creating, modifying and deleting non-system users and account password.
 /{,usr/}sbin/chpasswd ixr,
 /{,usr/}sbin/user{add,del} ixr,
 
@@ -61,7 +67,8 @@ socket AF_NETLINK - NETLINK_AUDIT
 
 func init() {
 	registerIface(&commonInterface{
-		name: "account-control",
+		name:                  "account-control",
+		description:           accountControlDescription,
 		connectedPlugAppArmor: accountControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  accountControlConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/alsa.go
+++ b/interfaces/builtin/alsa.go
@@ -19,6 +19,12 @@
 
 package builtin
 
+const alsaDescription = `
+The alsa interface allows connected plugs to access raw ALSA devices.
+
+The core snap provides the slot that is shared by all the snaps.
+`
+
 const alsaConnectedPlugAppArmor = `
 # Description: Allow access to raw ALSA devices.
 
@@ -33,7 +39,8 @@ const alsaConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "alsa",
+		name:                  "alsa",
+		description:           alsaDescription,
 		connectedPlugAppArmor: alsaConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -38,6 +38,7 @@ var evalSymlinks = filepath.EvalSymlinks
 
 type commonInterface struct {
 	name                   string
+	description            string
 	connectedPlugAppArmor  string
 	connectedPlugSecComp   string
 	reservedForOS          bool
@@ -52,6 +53,13 @@ type commonInterface struct {
 // Name returns the interface name.
 func (iface *commonInterface) Name() string {
 	return iface.name
+}
+
+// MetaData returns variou meta-data about this interface.
+func (iface *commonInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Description: iface.description,
+	}
 }
 
 // SanitizeSlot checks and possibly modifies a slot.

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -55,7 +55,7 @@ func (iface *commonInterface) Name() string {
 	return iface.name
 }
 
-// MetaData returns variou meta-data about this interface.
+// MetaData returns various meta-data about this interface.
 func (iface *commonInterface) MetaData() interfaces.MetaData {
 	return interfaces.MetaData{
 		Description: iface.description,

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -19,6 +19,12 @@
 
 package builtin
 
+const networkDescription = `
+The network interface allows connected plugs to access the network as a client.
+
+The core snap provides the slot that is shared by all the snaps.
+`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network
 const networkConnectedPlugAppArmor = `
 # Description: Can access the network as a client.
@@ -44,7 +50,8 @@ socket AF_NETLINK - NETLINK_ROUTE
 
 func init() {
 	registerIface(&commonInterface{
-		name: "network",
+		name:                  "network",
+		description:           networkDescription,
 		connectedPlugAppArmor: networkConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -71,10 +71,12 @@ func (ref SlotRef) String() string {
 	return fmt.Sprintf("%s:%s", ref.Snap, ref.Name)
 }
 
-// Interfaces holds information about a list of plugs and slots, and their connections.
+// Interfaces holds information about a list of plugs and slots, their connections and known interfaces.
 type Interfaces struct {
 	Plugs []*Plug `json:"plugs"`
 	Slots []*Slot `json:"slots"`
+
+	MetaData map[string]MetaData `json:"meta-data"`
 }
 
 // ConnRef holds information about plug and slot reference that form a particular connection.
@@ -125,6 +127,22 @@ type Interface interface {
 	// unambiguous connection candidate and declaration-based checks
 	// allow.
 	AutoConnect(plug *Plug, slot *Slot) bool
+}
+
+// MetaData describes various meta-data of a given interface.
+type MetaData struct {
+	Description string `json:"description,omitempty"`
+}
+
+// ifaceMetaData returns the meta-data of the given interface.
+func ifaceMetaData(iface Interface) (md MetaData) {
+	type metaDataProvider interface {
+		MetaData() MetaData
+	}
+	if iface, ok := iface.(metaDataProvider); ok {
+		md = iface.MetaData()
+	}
+	return md
 }
 
 // Specification describes interactions between backends and interfaces.

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -71,7 +71,7 @@ func (ref SlotRef) String() string {
 	return fmt.Sprintf("%s:%s", ref.Snap, ref.Name)
 }
 
-// Interfaces holds information about a list of plugs and slots, their connections and known interfaces.
+// Interfaces holds information about a list of plugs and slots, their connections and interface meta-data.
 type Interfaces struct {
 	Plugs []*Plug `json:"plugs"`
 	Slots []*Slot `json:"slots"`

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -641,6 +641,7 @@ func (r *Repository) Interfaces() *Interfaces {
 
 	ifaces := &Interfaces{}
 	// Copy and flatten plugs and slots
+	seenIfaces := make(map[Interface]bool)
 	for _, plugs := range r.plugs {
 		for _, plug := range plugs {
 			p := &Plug{
@@ -649,6 +650,7 @@ func (r *Repository) Interfaces() *Interfaces {
 			}
 			sort.Sort(bySlotRef(p.Connections))
 			ifaces.Plugs = append(ifaces.Plugs, p)
+			seenIfaces[r.ifaces[plug.Interface]] = true
 		}
 	}
 	for _, slots := range r.slots {
@@ -659,6 +661,13 @@ func (r *Repository) Interfaces() *Interfaces {
 			}
 			sort.Sort(byPlugRef(s.Connections))
 			ifaces.Slots = append(ifaces.Slots, s)
+			seenIfaces[r.ifaces[slot.Interface]] = true
+		}
+	}
+	if len(seenIfaces) > 0 {
+		ifaces.MetaData = make(map[string]MetaData, len(seenIfaces))
+		for iface := range seenIfaces {
+			ifaces.MetaData[iface.Name()] = ifaceMetaData(iface)
 		}
 	}
 	sort.Sort(byPlugSnapAndName(ifaces.Plugs))

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1103,6 +1103,7 @@ func (s *RepositorySuite) TestConnectSucceedsWhenIdenticalConnectExists(c *C) {
 			SlotInfo:    s.slot.SlotInfo,
 			Connections: []PlugRef{{Snap: s.plug.Snap.Name(), Name: s.plug.Name}},
 		}},
+		MetaData: map[string]MetaData{"interface": {}},
 	})
 }
 
@@ -1182,8 +1183,9 @@ func (s *RepositorySuite) TestDisconnectSucceeds(c *C) {
 	err := s.testRepo.Disconnect(s.plug.Snap.Name(), s.plug.Name, s.slot.Snap.Name(), s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
-		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
-		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
+		Plugs:    []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots:    []*Slot{{SlotInfo: s.slot.SlotInfo}},
+		MetaData: map[string]MetaData{"interface": {}},
 	})
 }
 
@@ -1258,8 +1260,9 @@ func (s *RepositorySuite) TestDisconnectAll(c *C) {
 	conns := []ConnRef{{PlugRef: s.plug.Ref(), SlotRef: s.slot.Ref()}}
 	s.testRepo.DisconnectAll(conns)
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
-		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
-		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
+		Plugs:    []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots:    []*Slot{{SlotInfo: s.slot.SlotInfo}},
+		MetaData: map[string]MetaData{"interface": {}},
 	})
 }
 
@@ -1284,14 +1287,16 @@ func (s *RepositorySuite) TestInterfacesSmokeTest(c *C) {
 			SlotInfo:    s.slot.SlotInfo,
 			Connections: []PlugRef{{Snap: s.plug.Snap.Name(), Name: s.plug.Name}},
 		}},
+		MetaData: map[string]MetaData{"interface": {}},
 	})
 	// After disconnecting the connections become empty
 	err = s.testRepo.Disconnect(s.plug.Snap.Name(), s.plug.Name, s.slot.Snap.Name(), s.slot.Name)
 	c.Assert(err, IsNil)
 	ifaces = s.testRepo.Interfaces()
 	c.Assert(ifaces, DeepEquals, &Interfaces{
-		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
-		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
+		Plugs:    []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots:    []*Slot{{SlotInfo: s.slot.SlotInfo}},
+		MetaData: map[string]MetaData{"interface": {}},
 	})
 }
 


### PR DESCRIPTION
This branch adds a new, optional, method that any snapd interface can
implement. The new method allows returning a structure with various
meta-data about the interface. For now only the Description field is
present.

This could be used for constructing various useful flows, like giving
interfaces proper descriptions, documentations URLs, information when it
was first added, possibly even static descriptions of desired
one-to-many connection semantics for slots.

In this experimental patch the common interface is extended to convey
the meta-data, a few interfaces are patched to document themselves and
the daemon and client APIs are extended to carry this information. The
command "snap interfaces -i IFACE" will now display the description of
the interface if one is available (try with network).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>