### PR TITLE
tests/main/snap-info: don't use named parameter for print statement

### DIFF
--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -4,7 +4,7 @@ import sys
 import yaml
 
 def die(s):
-    print(s, file=sys.stderr)
+    print(s, sys.stderr)
     sys.exit(1)
 
 def equals(name, s1, s2):


### PR DESCRIPTION
This doesn't work well with older python versions on other distributions.