### PR TITLE
cmd/snap: correct devmode note for anomalous state

### DIFF
--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -84,7 +84,7 @@ func NotesFromRemote(snap *client.Snap, resInfo *client.ResultInfo) *Notes {
 func NotesFromLocal(snap *client.Snap) *Notes {
 	return &Notes{
 		Private:  snap.Private,
-		DevMode:  !snap.JailMode && (snap.DevMode || snap.Confinement == client.DevModeConfinement),
+		DevMode:  snap.DevMode,
 		Classic:  !snap.JailMode && (snap.Confinement == client.ClassicConfinement),
 		JailMode: snap.JailMode,
 		TryMode:  snap.TryMode,

--- a/cmd/snap/notes_test.go
+++ b/cmd/snap/notes_test.go
@@ -22,6 +22,7 @@ package main_test
 import (
 	"gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/client"
 	snap "github.com/snapcore/snapd/cmd/snap"
 )
 
@@ -90,4 +91,10 @@ func (notesSuite) TestNotesTwo(c *check.C) {
 		DevMode: true,
 		Broken:  true,
 	}).String(), check.Matches, "(devmode,broken|broken,devmode)")
+}
+
+func (notesSuite) TestNotesFromLocal(c *check.C) {
+	// Check that DevMode note is derived from DevMode flag, not DevModeConfinement type.
+	c.Check(snap.NotesFromLocal(&client.Snap{DevMode: true}).DevMode, check.Equals, true)
+	c.Check(snap.NotesFromLocal(&client.Snap{Confinement: client.DevModeConfinement}).DevMode, check.Equals, false)
 }


### PR DESCRIPTION
Past versions of snapd had a bug where snapd would lose the various
flags (like devmode) as a result of disable/enable operations.
In such state a snap would behave as if it was installed in jailmode
(the devmode flag was *not* set and confinement was strict) but the
output of "snap list" would still show it as devmode.

The cause of this is that in absence of the devmode flag we would look
at confinement type (what the snap declares the confinement should be).
This discrepancy between how the snap operates (strict) and how we show
it (devmode) can cause unwanted confusion. While we want to show an
useful "corrupted state" message later on we should not complicate how
the devmode note is computed. This patch makes us derive the devmode
note directly from the devmode flag.

Forum: https://forum.snapcraft.io/t/anomalous-snap-list-devmode-flag/699
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>