### PR TITLE
interfaces: allow snaps to use the timedatectl utility

### DIFF
--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -66,6 +66,12 @@ dbus (receive)
     member=PropertiesChanged
     peer=(label=unconfined),
 
+# As the core snap ships the timedatectl utility we can also allow
+# clients to use it now that they have access to the relevant
+# D-Bus methods for setting the time via timedatectl's set-time and
+# set-local-rtc commands.
+/usr/bin/timedatectl{,.real} ixr,
+
 # Allow write access to system real-time clock
 # See 'man 4 rtc' for details.
 

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -62,6 +62,12 @@ dbus (receive)
     interface=org.freedesktop.DBus.Properties
     member=PropertiesChanged
     peer=(label=unconfined),
+
+# As the core snap ships the timedatectl utility we can also allow
+# clients to use it now that they have access to the relevant
+# D-Bus method for controlling network time synchronization via
+# timedatectl's set-ntp command.
+/usr/bin/timedatectl{,.real} ixr,
 `
 
 func init() {

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -32,6 +32,7 @@ const timezoneControlConnectedPlugAppArmor = `
 /usr/share/zoneinfo/**    r,
 /etc/{,writable/}timezone rw,
 /etc/{,writable/}localtime rw,
+/etc/{,writable/}localtime.tmp rw, # Required for the timedatectl wrapper (LP: #1650688)
 
 # Introspection of org.freedesktop.timedate1
 dbus (send)
@@ -63,6 +64,12 @@ dbus (receive)
     interface=org.freedesktop.DBus.Properties
     member=PropertiesChanged
     peer=(label=unconfined),
+
+# As the core snap ships the timedatectl utility we can also allow
+# clients to use it now that they have access to the relevant
+# D-Bus method for setting the timezone via timedatectl's set-timezone
+# command.
+/usr/bin/timedatectl{,.real} ixr,
 `
 
 func init() {

--- a/tests/lib/snaps/time-control-consumer/bin/timedatectl
+++ b/tests/lib/snaps/time-control-consumer/bin/timedatectl
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/timedatectl "$@"

--- a/tests/lib/snaps/time-control-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/time-control-consumer/meta/snap.yaml
@@ -10,3 +10,6 @@ apps:
   write:
     command: bin/write
     plugs: [time-control]
+  timedatectl:
+    command: bin/timedatectl
+    plugs: [time-control]

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -32,3 +32,7 @@ execute: |
     # Read/write access should be possible
     test -n "`$SNAPMOUNTDIR/bin/time-control-consumer.read`"
     $SNAPMOUNTDIR/bin/time-control-consumer.write
+
+    # Read/write access should be possible
+    test -n "`$SNAPMOUNTDIR/bin/time-control-consumer.timedatectl status`"
+    $SNAPMOUNTDIR/bin/time-control-consumer.timedatectl set-local-rtc no


### PR DESCRIPTION
Allows access to the timedatectl utility via the time-control, timezone-control, and timeserver-control interfaces. This was discussed in the following forum topic:

https://forum.snapcraft.io/t/managing-time-date-and-timezone-in-ubuntu-core/408/