### PR TITLE
tests: update listing test to the core version number schema

### DIFF
--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -12,9 +12,9 @@ execute: |
     # *current* edge also has .git. and a hash snippet, so add an optional .git.[0-9a-f]+ to the already optional timestamp
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
-        expected='^core .* [0-9]{2}-[0-9.]+(\+[0-9]+(\.git\.[0-9a-f]+)?)? +x[0-9]+ +- *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(\.git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- *$'
     else
-        expected='^core .* [0-9]{2}-[0-9.]+(\+[0-9]+(\.git\.[0-9a-f]+)?)? +[0-9]+ +canonical +- *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(\.git[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +- *$'
     fi
     snap list | MATCH "$expected"
 

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -12,9 +12,9 @@ execute: |
     # *current* edge also has .git. and a hash snippet, so add an optional .git.[0-9a-f]+ to the already optional timestamp
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
-        expected='^core .* [0-9]{2}-[0-9.]+(\.git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- *$'
     else
-        expected='^core .* [0-9]{2}-[0-9.]+(\.git[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +- *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +- *$'
     fi
     snap list | MATCH "$expected"
 


### PR DESCRIPTION
The version number schema for core will follow what
mkversions.sh is doing. This means that our versions
will look like this:

    16-2 (old format)
    16-2.26.3 (stable release)
    16-2.26.3+git201.f89261c (edge release)

Hopefully this is stable from now on.