### PR TITLE
asserts: simplify and adjust repair assertion definition

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -58,7 +58,7 @@ func (at *AssertionType) MaxSupportedFormat() int {
 var (
 	AccountType         = &AssertionType{"account", []string{"account-id"}, assembleAccount, 0}
 	AccountKeyType      = &AssertionType{"account-key", []string{"public-key-sha3-384"}, assembleAccountKey, 0}
-	RepairType          = &AssertionType{"repair", []string{"brand-id", "repair-id", "arch"}, assembleRepair, 0}
+	RepairType          = &AssertionType{"repair", []string{"brand-id", "repair-id"}, assembleRepair, 0}
 	ModelType           = &AssertionType{"model", []string{"series", "brand-id", "model"}, assembleModel, 0}
 	SerialType          = &AssertionType{"serial", []string{"brand-id", "model", "serial"}, assembleSerial, 0}
 	BaseDeclarationType = &AssertionType{"base-declaration", []string{"series"}, assembleBaseDeclaration, 0}

--- a/asserts/repair.go
+++ b/asserts/repair.go
@@ -28,42 +28,42 @@ import (
 type Repair struct {
 	assertionBase
 
-	series []string
-	models []string
+	series        []string
+	architectures []string
+	models        []string
 }
 
 // BrandID returns the brand identifier that signed this assertion.
-func (em *Repair) BrandID() string {
-	return em.HeaderString("brand-id")
+func (r *Repair) BrandID() string {
+	return r.HeaderString("brand-id")
 }
 
 // RepairID returns the "id" of the repair. It should be a short string
 // that follows a convention like "REPAIR-123". Similar to a CVE there
 // should be a public place to look up details about the repair-id
 // (e.g. the snapcraft forum).
-func (em *Repair) RepairID() string {
-	return em.HeaderString("repair-id")
+func (r *Repair) RepairID() string {
+	return r.HeaderString("repair-id")
 }
 
-// Arch returns the architecture that this assertions applies to.
-// If the architecture is "all" it means it applies to all architecutres.
-func (em *Repair) Arch() string {
-	return em.HeaderString("arch")
+// Architectures returns the architectures that this assertions applies to.
+func (r *Repair) Architectures() []string {
+	return r.architectures
 }
 
 // Series returns the series that this assertion is valid for.
-func (em *Repair) Series() []string {
-	return em.series
+func (r *Repair) Series() []string {
+	return r.series
 }
 
 // Models returns the models that this assertion is valid for.
 // It is a list of "brand-id/model-name" strings.
-func (em *Repair) Models() []string {
-	return em.models
+func (r *Repair) Models() []string {
+	return r.models
 }
 
 // Implement further consistency checks.
-func (em *Repair) checkConsistency(db RODatabase, acck *AccountKey) error {
+func (r *Repair) checkConsistency(db RODatabase, acck *AccountKey) error {
 	// Do the cross-checks when this assertion is actually used,
 	// i.e. in the future repair code
 
@@ -73,15 +73,16 @@ func (em *Repair) checkConsistency(db RODatabase, acck *AccountKey) error {
 // sanity
 var _ consistencyChecker = (*Repair)(nil)
 
-// the repair-id can either be:
-// - repair-$ID
-// - $brand-$ID
-// - $brand_$model-$ID
-var validRepairID = regexp.MustCompile("^.*-[0-9]+$")
+// the repair-id can for now be a sequential number starting with 1
+var validRepairID = regexp.MustCompile("^[1-9][0-9]*$")
 
 func assembleRepair(assert assertionBase) (Assertion, error) {
 	err := checkAuthorityMatchesBrand(&assert)
 	if err != nil {
+		return nil, err
+	}
+
+	if _, err = checkStringMatchesWhat(assert.headers, "repair-id", "header", validRepairID); err != nil {
 		return nil, err
 	}
 
@@ -93,13 +94,15 @@ func assembleRepair(assert assertionBase) (Assertion, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err = checkStringMatchesWhat(assert.headers, "repair-id", "header", validRepairID); err != nil {
+	architectures, err := checkStringList(assert.headers, "architectures")
+	if err != nil {
 		return nil, err
 	}
 
 	return &Repair{
 		assertionBase: assert,
 		series:        series,
+		architectures: architectures,
 		models:        models,
 	}, nil
 }

--- a/asserts/repair_test.go
+++ b/asserts/repair_test.go
@@ -64,8 +64,10 @@ HupVphQllzGfYvPrkQAAAAAAAAAAAAAAAACAN3dTp9TNACgAAA==
 var repairExample = fmt.Sprintf("type: repair\n"+
 	"authority-id: acme\n"+
 	"brand-id: acme\n"+
-	"arch: all\n"+
-	"repair-id: repair-42\n"+
+	"architectures:\n"+
+	"  - amd64\n"+
+	"  - arm64\n"+
+	"repair-id: 42\n"+
 	"series:\n"+
 	"  - 16\n"+
 	"MODELSLINE\n"+
@@ -75,21 +77,21 @@ var repairExample = fmt.Sprintf("type: repair\n"+
 	script+"\n\n"+
 	"AXNpZw==", len(script))
 
-func (em *repairSuite) SetUpTest(c *C) {
-	em.modelsLine = "models:\n  - acme/frobinator\n"
-	em.repairStr = strings.Replace(repairExample, "MODELSLINE\n", em.modelsLine, 1)
-	em.repairStr = strings.Replace(em.repairStr, "SCRIPT\n", script, 1)
+func (s *repairSuite) SetUpTest(c *C) {
+	s.modelsLine = "models:\n  - acme/frobinator\n"
+	s.repairStr = strings.Replace(repairExample, "MODELSLINE\n", s.modelsLine, 1)
+	s.repairStr = strings.Replace(s.repairStr, "SCRIPT\n", script, 1)
 }
 
-func (em *repairSuite) TestDecodeOK(c *C) {
-	a, err := asserts.Decode([]byte(em.repairStr))
+func (s *repairSuite) TestDecodeOK(c *C) {
+	a, err := asserts.Decode([]byte(s.repairStr))
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.RepairType)
 	repair := a.(*asserts.Repair)
 	c.Check(repair.BrandID(), Equals, "acme")
-	c.Check(repair.RepairID(), Equals, "repair-42")
-	c.Check(repair.Arch(), Equals, "all")
+	c.Check(repair.RepairID(), Equals, "42")
 	c.Check(repair.Series(), DeepEquals, []string{"16"})
+	c.Check(repair.Architectures(), DeepEquals, []string{"amd64", "arm64"})
 	c.Check(repair.Models(), DeepEquals, []string{"acme/frobinator"})
 	c.Check(string(repair.Body()), Equals, script)
 }
@@ -98,26 +100,27 @@ const (
 	repairErrPrefix = "assertion repair: "
 )
 
-func (em *repairSuite) TestDecodeInvalid(c *C) {
+func (s *repairSuite) TestDecodeInvalid(c *C) {
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"series:\n  - 16\n", "series: \n", `"series" header must be a list of strings`},
 		{"series:\n  - 16\n", "series: something\n", `"series" header must be a list of strings`},
+		{"architectures:\n  - amd64\n  - arm64\n", "architectures: foo\n", `"architectures" header must be a list of strings`},
 		{"models:\n  - acme/frobinator\n", "models: \n", `"models" header must be a list of strings`},
 		{"models:\n  - acme/frobinator\n", "models: something\n", `"models" header must be a list of strings`},
-		{"repair-id: repair-42\n", "repair-id: no-suffix-number\n", `"repair-id" header contains invalid characters: "no-suffix-number"`},
+		{"repair-id: 42\n", "repair-id: no-number\n", `"repair-id" header contains invalid characters: "no-number"`},
 		{"brand-id: acme\n", "brand-id: brand-id-not-eq-authority-id\n", `authority-id and brand-id must match, repair assertions are expected to be signed by the brand: "acme" != "brand-id-not-eq-authority-id"`},
 	}
 
 	for _, test := range invalidTests {
-		invalid := strings.Replace(em.repairStr, test.original, test.invalid, 1)
+		invalid := strings.Replace(s.repairStr, test.original, test.invalid, 1)
 		_, err := asserts.Decode([]byte(invalid))
 		c.Check(err, ErrorMatches, repairErrPrefix+test.expectedErr)
 	}
 }
 
 // FIXME: move to a different layer later
-func (em *repairSuite) TestRepairCanEmbeddScripts(c *C) {
-	a, err := asserts.Decode([]byte(em.repairStr))
+func (s *repairSuite) TestRepairCanEmbeddScripts(c *C) {
+	a, err := asserts.Decode([]byte(s.repairStr))
 	c.Assert(err, IsNil)
 	c.Check(a.Type(), Equals, asserts.RepairType)
 	repair := a.(*asserts.Repair)

--- a/asserts/repair_test.go
+++ b/asserts/repair_test.go
@@ -108,6 +108,8 @@ func (s *repairSuite) TestDecodeInvalid(c *C) {
 		{"models:\n  - acme/frobinator\n", "models: \n", `"models" header must be a list of strings`},
 		{"models:\n  - acme/frobinator\n", "models: something\n", `"models" header must be a list of strings`},
 		{"repair-id: 42\n", "repair-id: no-number\n", `"repair-id" header contains invalid characters: "no-number"`},
+		{"repair-id: 42\n", "repair-id: 0\n", `"repair-id" header contains invalid characters: "0"`},
+		{"repair-id: 42\n", "repair-id: 01\n", `"repair-id" header contains invalid characters: "01"`},
 		{"brand-id: acme\n", "brand-id: brand-id-not-eq-authority-id\n", `authority-id and brand-id must match, repair assertions are expected to be signed by the brand: "acme" != "brand-id-not-eq-authority-id"`},
 	}
 


### PR DESCRIPTION
This simplifies things further:

* architectures is an optional list like series and models
* repair-id is a sequential number for now starting with 1