### PR TITLE
tests: fixes for executions using the staging store

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -4,7 +4,7 @@ restore: |
     iptables -D OUTPUT -m owner --uid-owner $(id -u test) -j REJECT  -p tcp --reject-with tcp-reset
 execute: |
     echo "Downloading a large snap in the background"
-    su -c "/usr/bin/env SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &
+    su -c "/usr/bin/env SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &
     echo "Wait until it actually got some data for the snap"
     while ! grep -q "Retrying.*download-snap/.*\.snap, attempt 1" snap-download.log; do
         sleep 1

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -4,7 +4,7 @@ restore: |
     iptables -D OUTPUT -m owner --uid-owner $(id -u test) -j REJECT  -p tcp --reject-with tcp-reset
 execute: |
     echo "Downloading a large snap in the background"
-    su -c "/usr/bin/env SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &
+    su -c "/usr/bin/env SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &
     echo "Wait until it actually got some data for the snap"
     while ! grep -q "Retrying.*download-snap/.*\.snap, attempt 1" snap-download.log; do
         sleep 1

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -17,7 +17,7 @@ details: |
 
 prepare: |
     echo "Given a snap declaring a plug on the kernel-module-control interface is installed"
-    snap install --edge test-snapd-kernel-module-control-consumer
+    snap install --edge test-snapd-kernel-module-consumer
     . $TESTSLIB/snaps.sh
     install_generic_consumer kernel-module-control
 
@@ -37,8 +37,8 @@ debug: |
     lsmod
 
 execute: |
-    CONNECTED_PATTERN=":kernel-module-control +.*test-snapd-kernel-module-control-consumer"
-    DISCONNECTED_PATTERN="\- +test-snapd-kernel-module-control-consumer:kernel-module-control"
+    CONNECTED_PATTERN=":kernel-module-control +.*test-snapd-kernel-module-consumer"
+    DISCONNECTED_PATTERN="\- +test-snapd-kernel-module-consumer:kernel-module-control"
 
     echo "The plug is disconnected by default"
     snap interfaces | MATCH "$DISCONNECTED_PATTERN"
@@ -46,13 +46,13 @@ execute: |
     echo "==================================="
 
     echo "When the plug is connected"
-    snap connect test-snapd-kernel-module-control-consumer:kernel-module-control
+    snap connect test-snapd-kernel-module-consumer:kernel-module-control
     snap connect generic-consumer:kernel-module-control
     snap interfaces | MATCH "$CONNECTED_PATTERN"
 
 
     echo "Then the snap is able to list the existing modules"
-    [ $(su -l -c "test-snapd-kernel-module-control-consumer.lsmod" test | wc -l) -gt 2 ]
+    [ $(su -l -c "test-snapd-kernel-module-consumer.lsmod" test | wc -l) -gt 2 ]
 
     echo "And the snap is able to insert a module"
     if lsmod | MATCH binfmt_misc; then
@@ -67,7 +67,7 @@ execute: |
         fi
     fi
     lsmod | MATCH -v binfmt_misc
-    test-snapd-kernel-module-control-consumer.insmod /lib/modules/$(uname -r)/kernel/fs/binfmt_misc.ko
+    test-snapd-kernel-module-consumer.insmod /lib/modules/$(uname -r)/kernel/fs/binfmt_misc.ko
 
     echo "And the snap is able to read /sys/module"
     generic-consumer.cmd ls /sys/module | MATCH binfmt_misc
@@ -80,25 +80,25 @@ execute: |
     cat touch.error | MATCH "Permission denied"
 
     echo "And the snap is able to remove a module"
-    test-snapd-kernel-module-control-consumer.rmmod binfmt_misc
+    test-snapd-kernel-module-consumer.rmmod binfmt_misc
     lsmod | MATCH -v binfmt_misc
 
     echo "==================================="
 
     echo "When the plug is disconnected"
-    snap disconnect test-snapd-kernel-module-control-consumer:kernel-module-control
+    snap disconnect test-snapd-kernel-module-consumer:kernel-module-control
     snap disconnect generic-consumer:kernel-module-control
     snap interfaces | MATCH "$DISCONNECTED_PATTERN"
 
     echo "Then the snap is not able to list modules"
-    if su -l -c "test-snapd-kernel-module-control-consumer.lsmod 2>${PWD}/list.error" test; then
+    if su -l -c "test-snapd-kernel-module-consumer.lsmod 2>${PWD}/list.error" test; then
         echo "Expected permission error listing modules with disconnected plug"
         exit 1
     fi
     cat list.error | MATCH "Permission denied"
 
     echo "And the snap is not able to insert a module"
-    if test-snapd-kernel-module-control-consumer.insmod /lib/modules/$(uname -r)/kernel/fs/binfmt_misc.ko; then
+    if test-snapd-kernel-module-consumer.insmod /lib/modules/$(uname -r)/kernel/fs/binfmt_misc.ko; then
         echo "Expected permission error inserting module with disconnected plug"
         exit 1
     fi
@@ -108,7 +108,7 @@ execute: |
     lsmod | MATCH -v binfmt_misc
     insmod /lib/modules/$(uname -r)/kernel/fs/binfmt_misc.ko
     lsmod | MATCH binfmt_misc
-    if test-snapd-kernel-module-control-consumer.rmmod binfmt_misc 2>${PWD}/remove.error; then
+    if test-snapd-kernel-module-consumer.rmmod binfmt_misc 2>${PWD}/remove.error; then
         echo "Expected permission error removing module with disconnected plug"
         exit 1
     fi

--- a/tests/main/xauth-migration/task.yaml
+++ b/tests/main/xauth-migration/task.yaml
@@ -13,17 +13,17 @@ description: |
     inside `snap run`.
 
 execute: |
-    snap install hello-world
+    snap install test-snapd-tools
 
     ensure_xauth_path() {
         export XAUTHORITY="$1"
         # Get rid of things to ensure a clean test bed
-        rm -f /var/snap/hello-world/common/xauth-content /run/user/0/.Xauthority
-        snap run --shell hello-world <<'EOF'
-    echo $XAUTHORITY > /var/snap/hello-world/common/xauth-content
+        rm -f /var/snap/test-snapd-tools/common/xauth-content /run/user/0/.Xauthority
+        snap run --shell test-snapd-tools.sh <<'EOF'
+    echo $XAUTHORITY > /var/snap/test-snapd-tools/common/xauth-content
     exit
     EOF
-        env_path="$(cat /var/snap/hello-world/common/xauth-content)"
+        env_path="$(cat /var/snap/test-snapd-tools/common/xauth-content)"
         test "$env_path" = "$2" || exit 1
         test "$(sh256sum $env_path)" = "$(sh256sum $1)"
         unset XAUTHORITY


### PR DESCRIPTION
The fixes include:
* Download test-snapf-huge from staging
* Use a test snap with a shorter name (there's a 40 character limit on the name, you can't upload new snaps with names bigger than that, but also can't update snaps already in the store with names that big).
* Use test-snapd-tools instead of hello-world