### PR TITLE
logger (& many more, to accommodate): drop explicit syslog.

### DIFF
--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -85,7 +85,7 @@ func (s *SnapSuite) TestAutoImportAssertsHappy(c *C) {
 	restore = snap.MockMountInfoPath(makeMockMountInfo(c, content))
 	defer restore()
 
-	l, err := logger.NewConsoleLog(s.stderr, 0)
+	l, err := logger.New(s.stderr, 0)
 	c.Assert(err, IsNil)
 	logger.SetLogger(l)
 
@@ -190,7 +190,7 @@ func (s *SnapSuite) TestAutoImportIntoSpool(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("")
 
-	l, err := logger.NewConsoleLog(s.stderr, 0)
+	l, err := logger.New(s.stderr, 0)
 	c.Assert(err, IsNil)
 	logger.SetLogger(l)
 
@@ -266,7 +266,7 @@ func (s *SnapSuite) TestAutoImportFromSpoolHappy(c *C) {
 	err = ioutil.WriteFile(fakeAssertsFn, fakeAssertData, 0644)
 	c.Assert(err, IsNil)
 
-	l, err := logger.NewConsoleLog(s.stderr, 0)
+	l, err := logger.New(s.stderr, 0)
 	c.Assert(err, IsNil)
 	logger.SetLogger(l)
 
@@ -290,7 +290,7 @@ func (s *SnapSuite) TestAutoImportIntoSpoolUnhappyTooBig(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("")
 
-	l, err := logger.NewConsoleLog(s.stderr, 0)
+	l, err := logger.New(s.stderr, 0)
 	c.Assert(err, IsNil)
 	logger.SetLogger(l)
 

--- a/httputil/logger_test.go
+++ b/httputil/logger_test.go
@@ -51,7 +51,7 @@ func (loggerSuite) TearDownTest(c *check.C) {
 func (s *loggerSuite) SetUpTest(c *check.C) {
 	os.Setenv("SNAPD_DEBUG", "true")
 	s.logbuf = bytes.NewBuffer(nil)
-	l, err := logger.NewConsoleLog(s.logbuf, logger.DefaultFlags)
+	l, err := logger.New(s.logbuf, logger.DefaultFlags)
 	c.Assert(err, check.IsNil)
 	logger.SetLogger(l)
 }

--- a/logger/export_test.go
+++ b/logger/export_test.go
@@ -1,0 +1,27 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014,2015,2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package logger
+
+func GetLogger() Logger {
+	lock.Lock()
+	defer lock.Unlock()
+
+	return logger
+}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4384,7 +4384,7 @@ func (s *snapmgrTestSuite) TestEnsureRefreshRefusesWeekdaySchedules(c *C) {
 	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
 
 	logbuf := bytes.NewBuffer(nil)
-	l, err := logger.NewConsoleLog(logbuf, logger.DefaultFlags)
+	l, err := logger.New(logbuf, logger.DefaultFlags)
 	c.Assert(err, IsNil)
 	logger.SetLogger(l)
 	defer logger.SetLogger(logger.NullLogger)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -226,7 +226,7 @@ func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 	t.AddCleanup(func() { os.Setenv("SNAPD_DEBUG", oldSnapdDebug) })
 
 	t.logbuf = bytes.NewBuffer(nil)
-	l, err := logger.NewConsoleLog(t.logbuf, logger.DefaultFlags)
+	l, err := logger.New(t.logbuf, logger.DefaultFlags)
 	c.Assert(err, IsNil)
 	logger.SetLogger(l)
 


### PR DESCRIPTION
logger.ConsoleLog printed to standard output and to syslog, an idea
which has proven to be at least partly misguided: snapd's logs would
typically be duplicated as systemd logs the output already. snap only
rarely logged anything relevant to syslog. Aditionally, syslog was
always written to (even for DEBUG), which has been deemed a misfeature.

This drops logger.ConsoleLog and introudces logger.Log (constructor
goes from logger.NewConsoleLog to logger.New); the new type has no
connection with syslog.