### PR TITLE
daemon,overlord/auth: store from model assertion wins

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -268,11 +268,6 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		},
 	}
 
-	// TODO: set the store-id here from the model information
-	if storeID := os.Getenv("UBUNTU_STORE_ID"); storeID != "" {
-		m["store"] = storeID
-	}
-
 	return SyncResponse(m, nil)
 }
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4868,7 +4868,7 @@ func (s *postCreateUserSuite) TestUsersHasUser(c *check.C) {
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 
-func (s *postCreateUserSuite) TestSysinfoIsManaged(c *check.C) {
+func (s *postCreateUserSuite) TestSysInfoIsManaged(c *check.C) {
 	st := s.d.overlord.State()
 	st.Lock()
 	_, err := auth.NewUser(st, "someuser", "mymail@test.com", "macaroon", []string{"discharge"})

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -421,22 +421,27 @@ func (ac *authContext) UpdateUserAuth(user *UserState, newDischarges []string) (
 	return cur, nil
 }
 
+// StoreID returns the store set in the model assertion, if mod != nil,
+// or the override from the UBUNTU_STORE_ID envvar.
+func StoreID(mod *asserts.Model) string {
+	if mod != nil {
+		return mod.Store()
+	}
+	return os.Getenv("UBUNTU_STORE_ID")
+}
+
 // StoreID returns the store id according to system state or
 // the fallback one if the state has none set (yet).
 func (ac *authContext) StoreID(fallback string) (string, error) {
-	storeID := os.Getenv("UBUNTU_STORE_ID")
-	if storeID != "" {
-		return storeID, nil
-	}
+	var mod *asserts.Model
 	if ac.deviceAsserts != nil {
-		mod, err := ac.deviceAsserts.Model()
+		var err error
+		mod, err = ac.deviceAsserts.Model()
 		if err != nil && err != state.ErrNoState {
 			return "", err
 		}
-		if err == nil {
-			storeID = mod.Store()
-		}
 	}
+	storeID := StoreID(mod)
 	if storeID != "" {
 		return storeID, nil
 	}


### PR DESCRIPTION
* store from model assertion wins, no point allowing overriding
* also don't return the store id at all from system-info, the endpoint less privileged than snap known atm, it's been mostly empty anyway so far in 16