### PR TITLE
tests: fix spread flaky tests linode

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -284,7 +284,7 @@ restore: |
     fi
 
     rm -f $SPREAD_PATH/snapd-state.tar.gz
-    rm -rf $GOPATH/*
+    rm -rf ${GOPATH%%:*}/*
 
 suites:
     tests/main/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -284,6 +284,7 @@ restore: |
     fi
 
     rm -f $SPREAD_PATH/snapd-state.tar.gz
+    rm -rf $GOPATH/*
 
 suites:
     tests/main/:

--- a/tests/main/snap-on-non-shared-root/task.yaml
+++ b/tests/main/snap-on-non-shared-root/task.yaml
@@ -22,12 +22,12 @@ execute: |
     test-snapd-tools.echo hello
 
     echo "Ensure we have a shared mount of $SNAPMOUNTDIR"
-    cat /proc/self/mountinfo |MATCH "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]*"
+    cat /proc/self/mountinfo |MATCH "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]"
 
     echo "Run it again for good measure"
     test-snapd-tools.echo hello
     echo "... and ensure we do not mount $SNAPMOUNTDIR again"
-    n=$(cat /proc/self/mountinfo |grep "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]*"|wc -l)
+    n=$(cat /proc/self/mountinfo |grep "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]"|wc -l)
     if [ "$n" -ne 1 ]; then
         echo "Incorrect extra $SNAPMOUNTDIR bind mounts created"
         exit 1

--- a/tests/main/snap-on-non-shared-root/task.yaml
+++ b/tests/main/snap-on-non-shared-root/task.yaml
@@ -22,12 +22,12 @@ execute: |
     test-snapd-tools.echo hello
 
     echo "Ensure we have a shared mount of $SNAPMOUNTDIR"
-    cat /proc/self/mountinfo |MATCH "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:1"
+    cat /proc/self/mountinfo |MATCH "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]*"
 
     echo "Run it again for good measure"
     test-snapd-tools.echo hello
     echo "... and ensure we do not mount $SNAPMOUNTDIR again"
-    n=$(cat /proc/self/mountinfo |grep "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:1"|wc -l)
+    n=$(cat /proc/self/mountinfo |grep "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]*"|wc -l)
     if [ "$n" -ne 1 ]; then
         echo "Incorrect extra $SNAPMOUNTDIR bind mounts created"
         exit 1


### PR DESCRIPTION
This change contains a fix for 2 spread tests:
    - linode:ubuntu-14.04-64:tests/main/debs-have-built-using
    - linode:ubuntu-14.04-64:tests/main/snap-on-non-shared-root
