### PR TITLE
overlord/snapstate: have an explicit code path last-refresh unset/zero => immediately refresh try

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -499,8 +499,13 @@ func (m *SnapManager) ensureRefreshes() error {
 	// compute next refresh attempt time (if needed)
 	if m.nextRefresh.IsZero() {
 		// store attempts in memory so that we can backoff
-		delta := timeutil.Next(refreshSchedule, lastRefresh)
-		m.nextRefresh = time.Now().Add(delta)
+		if !lastRefresh.IsZero() {
+			delta := timeutil.Next(refreshSchedule, lastRefresh)
+			m.nextRefresh = time.Now().Add(delta)
+		} else {
+			// immediate
+			m.nextRefresh = time.Now()
+		}
 		logger.Debugf("Next refresh scheduled for %s.", m.nextRefresh)
 	}
 
@@ -512,7 +517,7 @@ func (m *SnapManager) ensureRefreshes() error {
 	}
 
 	// do refresh attempt (if needed)
-	if m.nextRefresh.Before(time.Now()) {
+	if !m.nextRefresh.After(time.Now()) {
 		err = m.launchAutoRefresh()
 		// clear nextRefresh only if the refresh worked. There is
 		// still the lastRefreshAttempt rate limit so things will


### PR DESCRIPTION
This makes that a clear explicit policy decision, also timeutil.Next is relatively slow when given zero-Time starting-point.