### PR TITLE
tests: remove additional setup for docker on core

### DIFF
--- a/tests/nightly/docker/task.yaml
+++ b/tests/nightly/docker/task.yaml
@@ -19,12 +19,6 @@ debug: |
     dmesg
 
 execute: |
-    # we need additional setup in core systems
-    if [[ "$SPREAD_SYSTEM" == ubuntu-core-* ]]; then
-        snap connect docker:account-control :account-control
-        snap disable docker && snap enable  docker
-    fi
-
     # wait for the socket to be listening
     while ! printf "GET /" | nc -U -q 1 /var/run/docker.sock; do sleep 1; done
 


### PR DESCRIPTION
The docker snap no longer ships an account-control plug, the new revision works fine on core systems without needing it.