### PR TITLE
interfaces: add minimal seccomp resolver to avoid backward compatiblity issues

### DIFF
--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -93,6 +94,12 @@ func (s *MountObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "/etc/fstab")
+
+	seccompSpec := &seccomp.Specification{}
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Assert(seccompSpec.SnippetForTag("snap.other.app"), testutil.Contains, "quotactl Q_GETQUOTA - - -\n")
 }
 
 func (s *MountObserveInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -36,6 +36,8 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
@@ -123,6 +125,12 @@ func addContent(securityTag string, opts interfaces.ConfinementOptions, snippetF
 	if opts.DevMode && !opts.JailMode {
 		// NOTE: This is understood by snap-confine
 		buffer.WriteString("@complain\n")
+	}
+
+	for sym, val := range seccompSymbolTable {
+		// FIXME: resolve this only once
+		defaultTemplate = bytes.Replace(defaultTemplate, []byte(sym), []byte(strconv.Itoa(val)), -1)
+		snippetForTag = strings.Replace(snippetForTag, sym, strconv.Itoa(val), -1)
 	}
 
 	buffer.Write(defaultTemplate)

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -20,6 +20,7 @@
 package seccomp_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -186,7 +187,7 @@ func (s *backendSuite) TestRealCanResolveS(c *C) {
 	profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.smbd")
 	data, err := ioutil.ReadFile(profile)
 	c.Assert(err, IsNil)
-	c.Check(string(data), Equals, "quotactl 8388615 - - -\n")
+	c.Check(string(data), Equals, fmt.Sprintf("%d 8388615 - - -\n", seccomp.SeccompSymbolTable["quotactl"]))
 }
 
 type combineSnippetsScenario struct {

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -176,6 +176,19 @@ func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 	}
 }
 
+func (s *backendSuite) TestRealCanResolveS(c *C) {
+	snapInfo := snaptest.MockInfo(c, ifacetest.SambaYamlV1, nil)
+	restore := seccomp.MockTemplate([]byte("quotactl Q_GETQUOTA - - -\n"))
+	defer restore()
+
+	err := s.Backend.Setup(snapInfo, interfaces.ConfinementOptions{}, s.Repo)
+	c.Assert(err, IsNil)
+	profile := filepath.Join(dirs.SnapSeccompDir, "snap.samba.smbd")
+	data, err := ioutil.ReadFile(profile)
+	c.Assert(err, IsNil)
+	c.Check(string(data), Equals, "quotactl 8388615 - - -\n")
+}
+
 type combineSnippetsScenario struct {
 	opts    interfaces.ConfinementOptions
 	snippet string

--- a/interfaces/seccomp/const.go
+++ b/interfaces/seccomp/const.go
@@ -32,21 +32,23 @@
 // This directory is hard-coded in ubuntu-core-launcher.
 package seccomp
 
-// #include<linux/quota.h>
-// #include<linux/dqblk_xfs.h>
-// #include<asm-generic/ioctls.h>
-import "C"
+import "syscall"
 
+// we could use cgo here to get the flags, but because we try to avoid cgo
+// this table is added manually
 var seccompSymbolTable = map[string]int{
 	// from linux/quota.h:72
-	"Q_SYNC":      C.Q_SYNC,
-	"Q_GETFMT":    C.Q_GETFMT,
-	"Q_GETINFO":   C.Q_GETINFO,
-	"Q_SETINFO":   C.Q_SETINFO,
-	"Q_GETQUOTA":  C.Q_GETQUOTA,
-	"Q_SETQUOTA":  C.Q_SETQUOTA,
-	"Q_XGETQUOTA": C.Q_XGETQUOTA,
-	"Q_XGETQSTAT": C.Q_XGETQSTAT,
+	"Q_SYNC":     0x800001,
+	"Q_GETFMT":   0x800004,
+	"Q_GETINFO":  0x800005,
+	"Q_SETINFO":  0x800006,
+	"Q_GETQUOTA": 0x800007,
+	"Q_SETQUOTA": 0x800008,
+	// from linux/dqblk_xfs.h
+	"Q_XGETQUOTA": 0x5803,
+	"Q_XGETQSTAT": 0x5805,
 
-	"TIOCSTI": C.TIOCSTI,
+	"TIOCSTI": syscall.TIOCSTI,
+
+	"quotactl": syscall.SYS_QUOTACTL,
 }

--- a/interfaces/seccomp/const.go
+++ b/interfaces/seccomp/const.go
@@ -1,0 +1,52 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package seccomp implements integration between snappy and
+// ubuntu-core-launcher around seccomp.
+//
+// Snappy creates so-called seccomp profiles for each application (for each
+// snap) present in the system.  Upon each execution of ubuntu-core-launcher,
+// the profile is read and "compiled" to an eBPF program and injected into the
+// kernel for the duration of the execution of the process.
+//
+// There is no binary cache for seccomp, each time the launcher starts an
+// application the profile is parsed and re-compiled.
+//
+// The actual profiles are stored in /var/lib/snappy/seccomp/profiles.
+// This directory is hard-coded in ubuntu-core-launcher.
+package seccomp
+
+// #include<linux/quota.h>
+// #include<linux/dqblk_xfs.h>
+// #include<asm-generic/ioctls.h>
+import "C"
+
+var seccompSymbolTable = map[string]int{
+	// from linux/quota.h:72
+	"Q_SYNC":      C.Q_SYNC,
+	"Q_GETFMT":    C.Q_GETFMT,
+	"Q_GETINFO":   C.Q_GETINFO,
+	"Q_SETINFO":   C.Q_SETINFO,
+	"Q_GETQUOTA":  C.Q_GETQUOTA,
+	"Q_SETQUOTA":  C.Q_SETQUOTA,
+	"Q_XGETQUOTA": C.Q_XGETQUOTA,
+	"Q_XGETQSTAT": C.Q_XGETQSTAT,
+
+	"TIOCSTI": C.TIOCSTI,
+}

--- a/interfaces/seccomp/export_test.go
+++ b/interfaces/seccomp/export_test.go
@@ -28,3 +28,5 @@ func MockTemplate(fakeTemplate []byte) (restore func()) {
 	defaultTemplate = fakeTemplate
 	return func() { defaultTemplate = orig }
 }
+
+var SeccompSymbolTable = seccompSymbolTable


### PR DESCRIPTION
This solves the problem that we have newer seccomp symbols in snapd 2.25 than in 2.24. This is a minimal approach to resolve those symbols before writing the seccomp profile out. This way snap-confine only sees numbers instead of symbolic names and the profiles is fully compatible with the old snap-confine.

*If* we decide to go with this approach to unblock 2.25/2.26 I will go over the debdiff of 2.24 -> 2.25 to double check that really all new seccomp symbols are added this way and also cleanup the code and add more tests.