### PR TITLE
tests: add retry mechanism for snap install command

### DIFF
--- a/tests/lib/retry.sh
+++ b/tests/lib/retry.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+snap_install() {
+    local PARAMS=$@
+    local CONDITIONS='timeout \| connection refused'
+    local RETRIES=2
+    local SLEEP=2
+
+    local ITER=0
+    until [ $ITER -gt $RETRIES ]; do
+        ERROR=$(snap install $PARAMS 2>&1> /dev/null)
+        if [ -z "$ERROR" ]; then 
+            break
+        elif [[ $( echo $ERROR | grep -c "$CONDITIONS") -ge 1 ]]; then
+            ITER=$[$ITER+1]
+            sleep $SLEEP
+            echo $ERROR >&2
+            if [ $ITER -le $RETRIES ]; then
+                echo "Retrying install $ITER" >&2
+            fi
+        else
+            echo $ERROR >&2
+            break
+        fi
+    done
+}

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -17,11 +17,13 @@ details: |
     list and deletion.
 
 prepare: |
+    . $TESTSLIB/retry.sh
+
     echo "Given openvswitch is installed"
     apt install -y --no-install-recommends openvswitch-switch
 
     echo "And a snap declaring a plug on the openvswitch interface is installed"
-    snap install --edge test-snapd-openvswitch-consumer
+    snap_install --edge test-snapd-openvswitch-consumer
 
     echo "And a tap interface is defined"
     ip tuntap add tap1 mode tap


### PR DESCRIPTION
This change fixes 2 possible connection errors during the snap install
process: timeout and connection refused.