### PR TITLE
many: remove interface meta-data from list of connections

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -62,8 +62,6 @@ type SlotRef struct {
 type Interfaces struct {
 	Plugs []Plug `json:"plugs"`
 	Slots []Slot `json:"slots"`
-
-	MetaData map[string]InterfaceMetaData `json:"meta-data"`
 }
 
 // InterfaceMetaData contains meta-data about a given interface type.

--- a/client/interfaces_test.go
+++ b/client/interfaces_test.go
@@ -58,12 +58,7 @@ func (cs *clientSuite) TestClientInterfaces(c *check.C) {
 						{"snap": "canonical-pi2", "plug": "pin-13"}
 					]
 				}
-			],
-			"meta-data": {
-				"bool-file": {
-					"description": "The bool-file interface allows access to a specific file that contains values 0 or 1"
-				}
-			}
+			]
 		}
 	}`
 	interfaces, err := cs.cli.Interfaces()
@@ -95,11 +90,6 @@ func (cs *clientSuite) TestClientInterfaces(c *check.C) {
 						Name: "pin-13",
 					},
 				},
-			},
-		},
-		MetaData: map[string]client.InterfaceMetaData{
-			"bool-file": {
-				Description: "The bool-file interface allows access to a specific file that contains values 0 or 1",
 			},
 		},
 	})

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -77,6 +77,7 @@ func (x *cmdInterfaces) Execute(args []string) error {
 		return fmt.Errorf(i18n.G("no interfaces found"))
 	}
 	w := tabWriter()
+	defer w.Flush()
 	fmt.Fprintln(w, i18n.G("Slot\tPlug"))
 	for _, slot := range ifaces.Slots {
 		if wanted := x.Positionals.Query.Snap; wanted != "" {
@@ -132,15 +133,6 @@ func (x *cmdInterfaces) Execute(args []string) error {
 		// Display visual indicator for disconnected plugs.
 		if len(plug.Connections) == 0 {
 			fmt.Fprintf(w, "-\t%s:%s\n", plug.Snap, plug.Name)
-		}
-	}
-	w.Flush()
-	// Display interface description if a single interface was requested via -i
-	// and we have meta-data for that interface and the meta-data contains an
-	// actual description.
-	if x.Interface != "" {
-		if md, ok := ifaces.MetaData[x.Interface]; ok && md.Description != "" {
-			fmt.Fprintf(Stdout, "\n%s\n", fill(md.Description, 0))
 		}
 	}
 	return nil

--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -573,59 +573,6 @@ func (s *SnapSuite) TestInterfacesOfSpecificType(c *C) {
 	c.Assert(s.Stderr(), Equals, "")
 }
 
-func (s *SnapSuite) TestInterfacesOfSpecificTypeWithMetaData(c *C) {
-	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.Method, Equals, "GET")
-		c.Check(r.URL.Path, Equals, "/v2/interfaces")
-		body, err := ioutil.ReadAll(r.Body)
-		c.Check(err, IsNil)
-		c.Check(body, DeepEquals, []byte{})
-		EncodeResponseBody(c, w, map[string]interface{}{
-			"type": "sync",
-			"result": client.Interfaces{
-				Slots: []client.Slot{
-					{
-						Snap:      "cheese",
-						Name:      "photo-trigger",
-						Interface: "bool-file",
-						Label:     "Photo trigger",
-					},
-					{
-						Snap:      "wake-up-alarm",
-						Name:      "toggle",
-						Interface: "bool-file",
-						Label:     "Alarm toggle",
-					},
-					{
-						Snap:      "wake-up-alarm",
-						Name:      "snooze",
-						Interface: "bool-file",
-						Label:     "Alarm snooze",
-					},
-				},
-				MetaData: map[string]client.InterfaceMetaData{
-					"bool-file": {
-						Description: "The bool-file interface allows access to a specific file that contains values 0 or 1",
-					},
-				},
-			},
-		})
-	})
-	rest, err := Parser().ParseArgs([]string{"interfaces", "-i", "bool-file"})
-	c.Assert(err, IsNil)
-	c.Assert(rest, DeepEquals, []string{})
-	expectedStdout := "" +
-		"Slot                  Plug\n" +
-		"cheese:photo-trigger  -\n" +
-		"wake-up-alarm:toggle  -\n" +
-		"wake-up-alarm:snooze  -\n" +
-		"\n" +
-		"The bool-file interface allows access to a specific file that contains values 0\n" +
-		"or 1\n"
-	c.Assert(s.Stdout(), Equals, expectedStdout)
-	c.Assert(s.Stderr(), Equals, "")
-}
-
 func (s *SnapSuite) TestInterfacesCompletion(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -3235,9 +3235,6 @@ func (s *apiSuite) TestInterfaces(c *check.C) {
 					},
 				},
 			},
-			"meta-data": map[string]interface{}{
-				"test": map[string]interface{}{},
-			},
 		},
 		"status":      "OK",
 		"status-code": 200.0,

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -75,8 +75,6 @@ func (ref SlotRef) String() string {
 type Interfaces struct {
 	Plugs []*Plug `json:"plugs"`
 	Slots []*Slot `json:"slots"`
-
-	MetaData map[string]MetaData `json:"meta-data"`
 }
 
 // ConnRef holds information about plug and slot reference that form a particular connection.

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -641,7 +641,6 @@ func (r *Repository) Interfaces() *Interfaces {
 
 	ifaces := &Interfaces{}
 	// Copy and flatten plugs and slots
-	seenIfaces := make(map[Interface]bool)
 	for _, plugs := range r.plugs {
 		for _, plug := range plugs {
 			p := &Plug{
@@ -650,7 +649,6 @@ func (r *Repository) Interfaces() *Interfaces {
 			}
 			sort.Sort(bySlotRef(p.Connections))
 			ifaces.Plugs = append(ifaces.Plugs, p)
-			seenIfaces[r.ifaces[plug.Interface]] = true
 		}
 	}
 	for _, slots := range r.slots {
@@ -661,13 +659,6 @@ func (r *Repository) Interfaces() *Interfaces {
 			}
 			sort.Sort(byPlugRef(s.Connections))
 			ifaces.Slots = append(ifaces.Slots, s)
-			seenIfaces[r.ifaces[slot.Interface]] = true
-		}
-	}
-	if len(seenIfaces) > 0 {
-		ifaces.MetaData = make(map[string]MetaData, len(seenIfaces))
-		for iface := range seenIfaces {
-			ifaces.MetaData[iface.Name()] = ifaceMetaData(iface)
 		}
 	}
 	sort.Sort(byPlugSnapAndName(ifaces.Plugs))

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1103,7 +1103,6 @@ func (s *RepositorySuite) TestConnectSucceedsWhenIdenticalConnectExists(c *C) {
 			SlotInfo:    s.slot.SlotInfo,
 			Connections: []PlugRef{{Snap: s.plug.Snap.Name(), Name: s.plug.Name}},
 		}},
-		MetaData: map[string]MetaData{"interface": {}},
 	})
 }
 
@@ -1183,9 +1182,8 @@ func (s *RepositorySuite) TestDisconnectSucceeds(c *C) {
 	err := s.testRepo.Disconnect(s.plug.Snap.Name(), s.plug.Name, s.slot.Snap.Name(), s.slot.Name)
 	c.Assert(err, IsNil)
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
-		Plugs:    []*Plug{{PlugInfo: s.plug.PlugInfo}},
-		Slots:    []*Slot{{SlotInfo: s.slot.SlotInfo}},
-		MetaData: map[string]MetaData{"interface": {}},
+		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
 	})
 }
 
@@ -1260,9 +1258,8 @@ func (s *RepositorySuite) TestDisconnectAll(c *C) {
 	conns := []ConnRef{{PlugRef: s.plug.Ref(), SlotRef: s.slot.Ref()}}
 	s.testRepo.DisconnectAll(conns)
 	c.Assert(s.testRepo.Interfaces(), DeepEquals, &Interfaces{
-		Plugs:    []*Plug{{PlugInfo: s.plug.PlugInfo}},
-		Slots:    []*Slot{{SlotInfo: s.slot.SlotInfo}},
-		MetaData: map[string]MetaData{"interface": {}},
+		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
 	})
 }
 
@@ -1287,16 +1284,14 @@ func (s *RepositorySuite) TestInterfacesSmokeTest(c *C) {
 			SlotInfo:    s.slot.SlotInfo,
 			Connections: []PlugRef{{Snap: s.plug.Snap.Name(), Name: s.plug.Name}},
 		}},
-		MetaData: map[string]MetaData{"interface": {}},
 	})
 	// After disconnecting the connections become empty
 	err = s.testRepo.Disconnect(s.plug.Snap.Name(), s.plug.Name, s.slot.Snap.Name(), s.slot.Name)
 	c.Assert(err, IsNil)
 	ifaces = s.testRepo.Interfaces()
 	c.Assert(ifaces, DeepEquals, &Interfaces{
-		Plugs:    []*Plug{{PlugInfo: s.plug.PlugInfo}},
-		Slots:    []*Slot{{SlotInfo: s.slot.SlotInfo}},
-		MetaData: map[string]MetaData{"interface": {}},
+		Plugs: []*Plug{{PlugInfo: s.plug.PlugInfo}},
+		Slots: []*Slot{{SlotInfo: s.slot.SlotInfo}},
 	})
 }
 


### PR DESCRIPTION
This eradicates the ill-placed meta-data from all the places.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>