### PR TITLE
interfaces: add summary to each interface

### DIFF
--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const accountControlSummary = `allows managing non-system user accounts`
+
 const accountControlDescription = `
 The account-control interface allows connected plugs to create, modify and
 delete non-system users as well as to change account passwords.
@@ -68,6 +70,7 @@ socket AF_NETLINK - NETLINK_AUDIT
 func init() {
 	registerIface(&commonInterface{
 		name:                  "account-control",
+		summary:               accountControlSummary,
 		description:           accountControlDescription,
 		connectedPlugAppArmor: accountControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  accountControlConnectedPlugSecComp,

--- a/interfaces/builtin/alsa.go
+++ b/interfaces/builtin/alsa.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const alsaSummary = `allows access to raw ALSA devices`
+
 const alsaDescription = `
 The alsa interface allows connected plugs to access raw ALSA devices.
 
@@ -40,6 +42,7 @@ const alsaConnectedPlugAppArmor = `
 func init() {
 	registerIface(&commonInterface{
 		name:                  "alsa",
+		summary:               alsaSummary,
 		description:           alsaDescription,
 		connectedPlugAppArmor: alsaConnectedPlugAppArmor,
 		reservedForOS:         true,

--- a/interfaces/builtin/autopilot.go
+++ b/interfaces/builtin/autopilot.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const autopilotIntrospectionSummary = `allows introspection of application user interface`
+
 const autopilotIntrospectionPlugAppArmor = `
 # Description: Allows an application to be introspected and export its ui
 # status over DBus
@@ -54,7 +56,8 @@ sendto
 
 func init() {
 	registerIface(&commonInterface{
-		name: "autopilot-introspection",
+		name:                  "autopilot-introspection",
+		summary:               autopilotIntrospectionSummary,
 		connectedPlugAppArmor: autopilotIntrospectionPlugAppArmor,
 		connectedPlugSecComp:  autopilotIntrospectionPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/avahi_observe.go
+++ b/interfaces/builtin/avahi_observe.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const avahiObserveSummary = `allows discovering local domains, hostnames and services`
+
 const avahiObserveConnectedPlugAppArmor = `
 # Description: allows domain browsing, service browsing and service resolving
 
@@ -113,7 +115,8 @@ dbus (receive)
 
 func init() {
 	registerIface(&commonInterface{
-		name: "avahi-observe",
+		name:                  "avahi-observe",
+		summary:               avahiObserveSummary,
 		connectedPlugAppArmor: avahiObserveConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const bluetoothControlSummary = `allows managing the kernel bluetooth stack`
+
 const bluetoothControlConnectedPlugAppArmor = `
 # Description: Allow managing the kernel side Bluetooth stack. Reserved
 # because this gives privileged access to the system.
@@ -48,7 +50,8 @@ bind
 
 func init() {
 	registerIface(&commonInterface{
-		name: "bluetooth-control",
+		name:                  "bluetooth-control",
+		summary:               bluetoothControlSummary,
 		connectedPlugAppArmor: bluetoothControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  bluetoothControlConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const bluezSummary = `allows operating as the bluez service`
+
 const bluezPermanentSlotAppArmor = `
 # Description: Allow operating as the bluez service. This gives privileged
 # access to the system.
@@ -185,6 +187,12 @@ type bluezInterface struct{}
 
 func (iface *bluezInterface) Name() string {
 	return "bluez"
+}
+
+func (iface *bluezInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: bluezSummary,
+	}
 }
 
 func (iface *bluezInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
+const boolFileSummary = `allows access to specific file with bool semantics`
+
 // boolFileInterface is the type of all the bool-file interfaces.
 type boolFileInterface struct{}
 
@@ -39,6 +41,12 @@ func (iface *boolFileInterface) String() string {
 // Name returns the name of the bool-file interface.
 func (iface *boolFileInterface) Name() string {
 	return "bool-file"
+}
+
+func (iface *boolFileInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: boolFileSummary,
+	}
 }
 
 var boolFileGPIOValuePattern = regexp.MustCompile(

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const browserSupportSummary = `allows access to various APIs needed by modern web browsers`
+
 const browserSupportConnectedPlugAppArmor = `
 # Description: Can access various APIs needed by modern browsers (eg, Google
 # Chrome/Chromium and Mozilla) and file paths they expect. This interface is
@@ -240,6 +242,12 @@ type browserSupportInterface struct{}
 
 func (iface *browserSupportInterface) Name() string {
 	return "browser-support"
+}
+
+func (iface *browserSupportInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: browserSupportSummary,
+	}
 }
 
 func (iface *browserSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const cameraSummary = `allows access to all cameras`
+
 const cameraConnectedPlugAppArmor = `
 # Until we have proper device assignment, allow access to all cameras
 /dev/video[0-9]* rw,
@@ -32,7 +34,8 @@ const cameraConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "camera",
+		name:                  "camera",
+		summary:               cameraSummary,
 		connectedPlugAppArmor: cameraConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/classic_support.go
+++ b/interfaces/builtin/classic_support.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const classicSupportSummary = `special permissions for the classic snap`
+
 const classicSupportPlugAppArmor = `
 # Description: permissions to use classic dimension. This policy is
 # intentionally not restricted. This gives device ownership to
@@ -102,7 +104,8 @@ umount2
 
 func init() {
 	registerIface(&commonInterface{
-		name: "classic-support",
+		name:                  "classic-support",
+		summary:               classicSupportSummary,
 		connectedPlugAppArmor: classicSupportPlugAppArmor,
 		connectedPlugSecComp:  classicSupportPlugSecComp,
 	})

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -37,8 +37,11 @@ type evalSymlinksFn func(string) (string, error)
 var evalSymlinks = filepath.EvalSymlinks
 
 type commonInterface struct {
-	name                   string
-	description            string
+	name             string
+	summary          string
+	description      string
+	documentationURL string
+
 	connectedPlugAppArmor  string
 	connectedPlugSecComp   string
 	reservedForOS          bool
@@ -58,7 +61,9 @@ func (iface *commonInterface) Name() string {
 // MetaData returns various meta-data about this interface.
 func (iface *commonInterface) MetaData() interfaces.MetaData {
 	return interfaces.MetaData{
-		Description: iface.description,
+		Description:      iface.description,
+		Summary:          iface.summary,
+		DocumentationURL: iface.documentationURL,
 	}
 }
 

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -31,11 +31,19 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+const contentSummary = `allows sharing code and data with other snaps`
+
 // contentInterface allows sharing content between snaps
 type contentInterface struct{}
 
 func (iface *contentInterface) Name() string {
 	return "content"
+}
+
+func (iface *contentInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: contentSummary,
+	}
 }
 
 func cleanSubPath(path string) bool {

--- a/interfaces/builtin/core_support.go
+++ b/interfaces/builtin/core_support.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const coreSupportSummary = `special permissions for the core snap`
+
 const coreSupportConnectedPlugAppArmor = `
 # Description: Can control all aspects of systemd via the systemctl command,
 # update rsyslog configuration, update systemd-timesyncd configuration and
@@ -76,7 +78,8 @@ owner /boot/uboot/config.txt.tmp rwk,
 
 func init() {
 	registerIface(&commonInterface{
-		name: "core-support",
+		name:    "core-support",
+		summary: coreSupportSummary,
 		// NOTE: core-support implicitly contains the rules from network-bind.
 		connectedPlugAppArmor: coreSupportConnectedPlugAppArmor + networkBindConnectedPlugAppArmor,
 		connectedPlugSecComp:  "" + networkBindConnectedPlugSecComp,

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const cupsControlSummary = `allows access to the CUPS control socket`
+
 const cupsControlConnectedPlugAppArmor = `
 # Description: Can access cups control socket. This is restricted because it provides
 # privileged access to configure printing.
@@ -28,7 +30,8 @@ const cupsControlConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "cups-control",
+		name:                  "cups-control",
+		summary:               cupsControlSummary,
 		connectedPlugAppArmor: cupsControlConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -31,6 +31,8 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
+const dbusSummary = `allows owning a specifc name on DBus`
+
 const dbusPermanentSlotAppArmor = `
 # Description: Allow owning a name on DBus public bus
 
@@ -189,6 +191,12 @@ type dbusInterface struct{}
 
 func (iface *dbusInterface) Name() string {
 	return "dbus"
+}
+
+func (iface *dbusInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: dbusSummary,
+	}
 }
 
 // Obtain yaml-specified bus well-known name

--- a/interfaces/builtin/dcdbas_control.go
+++ b/interfaces/builtin/dcdbas_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const dcdbasControlSummary = `allows access to Dell Systems Management Base Driver`
+
 // https://www.kernel.org/doc/Documentation/dcdbas.txt
 const dcdbasControlConnectedPlugAppArmor = `
 # Description: This interface allows communication with Dell Systems Management Base Driver
@@ -43,7 +45,8 @@ const dcdbasControlConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "dcdbas-control",
+		name:                  "dcdbas-control",
+		summary:               dcdbasControlSummary,
 		connectedPlugAppArmor: dcdbasControlConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const dockerSummary = `allows access to Docker socket`
+
 const dockerConnectedPlugAppArmor = `
 # Description: allow access to the Docker daemon socket. This gives privileged
 # access to the system via Docker's socket API.
@@ -47,6 +49,12 @@ type dockerInterface struct{}
 
 func (iface *dockerInterface) Name() string {
 	return "docker"
+}
+
+func (iface *dockerInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: dockerSummary,
+	}
 }
 
 func (iface *dockerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const dockerSupportSummary = `allows operating as the Docker daemon`
+
 const dockerSupportConnectedPlugAppArmor = `
 # Description: allow operating as the Docker daemon. This policy is
 # intentionally not restrictive and is here to help guard against programming
@@ -524,6 +526,12 @@ type dockerSupportInterface struct{}
 
 func (iface *dockerSupportInterface) Name() string {
 	return "docker-support"
+}
+
+func (iface *dockerSupportInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: dockerSupportSummary,
+	}
 }
 
 func (iface *dockerSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const firewallControlSummary = `allows control over network firewall`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/firewall-control
 const firewallControlConnectedPlugAppArmor = `
 # Description: Can configure firewall. This is restricted because it gives
@@ -121,7 +123,8 @@ var firewallControlConnectedPlugKmod = []string{
 
 func init() {
 	registerIface(&commonInterface{
-		name: "firewall-control",
+		name:                     "firewall-control",
+		summary:                  firewallControlSummary,
 		connectedPlugAppArmor:    firewallControlConnectedPlugAppArmor,
 		connectedPlugSecComp:     firewallControlConnectedPlugSecComp,
 		connectedPlugKModModules: firewallControlConnectedPlugKmod,

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const framebufferSummary = `allows access to universal framebuffer devices`
+
 const framebufferConnectedPlugAppArmor = `
 # Description: Allow reading and writing to the universal framebuffer (/dev/fb*) which
 # gives privileged access to the console framebuffer.
@@ -41,6 +43,12 @@ type framebufferInterface struct{}
 // Getter for the name of the physical-memory-control interface
 func (iface *framebufferInterface) Name() string {
 	return "framebuffer"
+}
+
+func (iface *framebufferInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: framebufferSummary,
+	}
 }
 
 func (iface *framebufferInterface) String() string {

--- a/interfaces/builtin/fuse_support.go
+++ b/interfaces/builtin/fuse_support.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const fuseSupportSummary = `allows access to the FUSE file system`
+
 const fuseSupportConnectedPlugSecComp = `
 # Description: Can run a FUSE filesystem. Unprivileged fuse mounts are
 # not supported at this time.
@@ -71,7 +73,8 @@ deny /etc/fuse.conf r,
 
 func init() {
 	registerIface(&commonInterface{
-		name: "fuse-support",
+		name:                  "fuse-support",
+		summary:               fuseSupportSummary,
 		connectedPlugAppArmor: fuseSupportConnectedPlugAppArmor,
 		connectedPlugSecComp:  fuseSupportConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const fwupdSummary = `allows operating as the fwupd service`
+
 const fwupdPermanentSlotAppArmor = `
 # Description: Allow operating as the fwupd service. This gives privileged
 # access to the system.
@@ -187,6 +189,12 @@ type fwupdInterface struct{}
 // Name of the fwupdInterface
 func (iface *fwupdInterface) Name() string {
 	return "fwupd"
+}
+
+func (iface *fwupdInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: fwupdSummary,
+	}
 }
 
 func (iface *fwupdInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/systemd"
 )
 
+const gpioSummary = `allows access to specifc GPIO pin`
+
 var gpioSysfsGpioBase = "/sys/class/gpio/gpio"
 var gpioSysfsExport = "/sys/class/gpio/export"
 
@@ -41,6 +43,12 @@ func (iface *gpioInterface) String() string {
 // Name of the gpioInterface
 func (iface *gpioInterface) Name() string {
 	return "gpio"
+}
+
+func (iface *gpioInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: gpioSummary,
+	}
 }
 
 // SanitizeSlot checks the slot definition is valid

--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const gsettingsSummary = `allows access to any gsettings item of current user`
+
 const gsettingsConnectedPlugAppArmor = `
 # Description: Can access global gsettings of the user's session. Restricted
 # because this gives privileged access to sensitive information stored in
@@ -37,7 +39,8 @@ dbus (receive, send)
 
 func init() {
 	registerIface(&commonInterface{
-		name: "gsettings",
+		name:                  "gsettings",
+		summary:               gsettingsSummary,
 		connectedPlugAppArmor: gsettingsConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const hardwareObserveSummary = `allows reading information about system hardware`
+
 const hardwareObserveConnectedPlugAppArmor = `
 # Description: This interface allows for getting hardware information
 # from the system. This is reserved because it allows reading potentially
@@ -81,7 +83,8 @@ socket AF_NETLINK - NETLINK_GENERIC
 
 func init() {
 	registerIface(&commonInterface{
-		name: "hardware-observe",
+		name:                  "hardware-observe",
+		summary:               hardwareObserveSummary,
 		connectedPlugAppArmor: hardwareObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  hardwareObserveConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/hardware_random_control.go
+++ b/interfaces/builtin/hardware_random_control.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+const hardwareRandomControlSummary = `allows control over the hardware random number generator`
+
 const hardwareRandomControlConnectedPlugAppArmor = `
 # Description: allow direct access to the hardware random number generator
 # device. Usually, the default access to /dev/random is sufficient, but this
@@ -50,6 +52,12 @@ type hardwareRandomControlInterface struct{}
 // Getter for the name of the physical-memory-control interface
 func (iface *hardwareRandomControlInterface) Name() string {
 	return "hardware-random-control"
+}
+
+func (iface *hardwareRandomControlInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: hardwareRandomControlSummary,
+	}
 }
 
 // Check validity of the defined slot

--- a/interfaces/builtin/hardware_random_observe.go
+++ b/interfaces/builtin/hardware_random_observe.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+const hardwareRandomObserveSummary = `allows reading from hardware random number generator`
+
 const hardwareRandomObserveConnectedPlugAppArmor = `
 # Description: allow direct read-only access to the hardware random number
 # generator device. In addition allow observing the available and
@@ -45,6 +47,12 @@ type hardwareRandomObserveInterface struct{}
 // Getter for the name of the physical-memory-control interface
 func (iface *hardwareRandomObserveInterface) Name() string {
 	return "hardware-random-observe"
+}
+
+func (iface *hardwareRandomObserveInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: hardwareRandomObserveSummary,
+	}
 }
 
 // Check validity of the defined slot

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -30,12 +30,20 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const hidrawSummary = `allows access to specific hidraw device`
+
 // hidrawInterface is the type for hidraw interfaces.
 type hidrawInterface struct{}
 
 // Name of the hidraw interface.
 func (iface *hidrawInterface) Name() string {
 	return "hidraw"
+}
+
+func (iface *hidrawInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: hidrawSummary,
+	}
 }
 
 func (iface *hidrawInterface) String() string {

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const homeSummary = `allows access to non-hidden files in the home directory`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/home
 const homeConnectedPlugAppArmor = `
 # Description: Can access non-hidden files in user's $HOME. This is restricted
@@ -46,7 +48,8 @@ owner /run/user/[0-9]*/gvfs/*/**  w,
 
 func init() {
 	registerIface(&commonInterface{
-		name: "home",
+		name:                  "home",
+		summary:               homeSummary,
 		connectedPlugAppArmor: homeConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -30,12 +30,20 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const i2cSummary = `allows access to specific I2C controller`
+
 // The type for i2c interface
 type i2cInterface struct{}
 
 // Getter for the name of the i2c interface
 func (iface *i2cInterface) Name() string {
 	return "i2c"
+}
+
+func (iface *i2cInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: i2cSummary,
+	}
 }
 
 func (iface *i2cInterface) String() string {

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -30,6 +30,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const iioSummary = `allows access to a specific IIO device`
+
 const iioConnectedPlugAppArmor = `
 # Description: Give access to a specific IIO device on the system.
 
@@ -44,6 +46,12 @@ type iioInterface struct{}
 // Getter for the name of the iio interface
 func (iface *iioInterface) Name() string {
 	return "iio"
+}
+
+func (iface *iioInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: iioSummary,
+	}
 }
 
 func (iface *iioInterface) String() string {

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const ioPortsControlSummary = `allows access to all I/O ports`
+
 const ioPortsControlConnectedPlugAppArmor = `
 # Description: Allow write access to all I/O ports.
 # See 'man 4 mem' for details.
@@ -53,6 +55,12 @@ type iioPortsControlInterface struct{}
 // Getter for the name of the io-ports-control interface
 func (iface *iioPortsControlInterface) Name() string {
 	return "io-ports-control"
+}
+
+func (iface *iioPortsControlInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: ioPortsControlSummary,
+	}
 }
 
 func (iface *iioPortsControlInterface) String() string {

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+const joystickSummary = `allows access to joystick devices`
+
 const joystickConnectedPlugAppArmor = `
 # Description: Allow reading and writing to joystick devices (/dev/input/js*).
 
@@ -42,6 +44,12 @@ type joystickInterface struct{}
 // Name returns the name of the joystick interface.
 func (iface *joystickInterface) Name() string {
 	return "joystick"
+}
+
+func (iface *joystickInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: joystickSummary,
+	}
 }
 
 // String returns the name of the joystick interface.

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const kernelModuleControlSummary = `allows insertion, removal and querying of kernel modules`
+
 const kernelModuleControlConnectedPlugAppArmor = `
 # Description: Allow insertion, removal and querying of modules.
 
@@ -47,7 +49,8 @@ delete_module
 
 func init() {
 	registerIface(&commonInterface{
-		name: "kernel-module-control",
+		name:                  "kernel-module-control",
+		summary:               kernelModuleControlSummary,
 		connectedPlugAppArmor: kernelModuleControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  kernelModuleControlConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/kubernetes_support.go
+++ b/interfaces/builtin/kubernetes_support.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const kubernetesSupportSummary = `allows operating as the Kubernetes service`
+
 const kubernetesSupportConnectedPlugAppArmor = `
 # Description: can use kubernetes to control Docker containers. This interface
 # is restricted because it gives wide ranging access to the host and other
@@ -70,7 +72,8 @@ var kubernetesSupportConnectedPlugKmod = []string{`llc`, `stp`}
 
 func init() {
 	registerIface(&commonInterface{
-		name: "kubernetes-support",
+		name:                     "kubernetes-support",
+		summary:                  kubernetesSupportSummary,
 		connectedPlugAppArmor:    kubernetesSupportConnectedPlugAppArmor,
 		connectedPlugKModModules: kubernetesSupportConnectedPlugKmod,
 		reservedForOS:            true,

--- a/interfaces/builtin/libvirt.go
+++ b/interfaces/builtin/libvirt.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const libvirtSummary = `allows access to libvirt service`
+
 const libvirtConnectedPlugAppArmor = `
 /run/libvirt/libvirt-sock rw,
 /etc/libvirt/* r,
@@ -32,7 +34,8 @@ accept4
 
 func init() {
 	registerIface(&commonInterface{
-		name: "libvirt",
+		name:                  "libvirt",
+		summary:               libvirtSummary,
 		connectedPlugAppArmor: libvirtConnectedPlugAppArmor,
 		connectedPlugSecComp:  libvirtConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/locale_control.go
+++ b/interfaces/builtin/locale_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const localeControlSummary = `allows control over system locale`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/locale-control
 const localeControlConnectedPlugAppArmor = `
 # Description: Can manage locales directly separate from 'config ubuntu-core'.
@@ -29,7 +31,8 @@ const localeControlConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "locale-control",
+		name:                  "locale-control",
+		summary:               localeControlSummary,
 		connectedPlugAppArmor: localeControlConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/dbus"
 )
 
+const locationControlSummary = `allows operating as the location service`
+
 const locationControlPermanentSlotAppArmor = `
 # Description: Allow operating as the location service. This gives privileged
 # access to the system.
@@ -194,6 +196,12 @@ type locationControlInterface struct{}
 
 func (iface *locationControlInterface) Name() string {
 	return "location-control"
+}
+
+func (iface *locationControlInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: locationControlSummary,
+	}
 }
 
 func (iface *locationControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/dbus"
 )
 
+const locationObserveSummary = `allows access to the current physical location`
+
 const locationObservePermanentSlotAppArmor = `
 # Description: Allow operating as the location service. This gives privileged
 # access to the system.
@@ -248,6 +250,12 @@ type locationObserveInterface struct{}
 
 func (iface *locationObserveInterface) Name() string {
 	return "location-observe"
+}
+
+func (iface *locationObserveInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: locationObserveSummary,
+	}
 }
 
 func (iface *locationObserveInterface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/log_observe.go
+++ b/interfaces/builtin/log_observe.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const logObserveSummary = `allows read access to system logs`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/log-observe
 const logObserveConnectedPlugAppArmor = `
 # Description: Can read system logs and set kernel log rate-limiting
@@ -53,7 +55,8 @@ capability dac_override,
 
 func init() {
 	registerIface(&commonInterface{
-		name: "log-observe",
+		name:                  "log-observe",
+		summary:               logObserveSummary,
 		connectedPlugAppArmor: logObserveConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const lxdSummary = `allows access to the LXD socket`
+
 const lxdConnectedPlugAppArmor = `
 # Description: allow access to the LXD daemon socket. This gives privileged
 # access to the system via LXD's socket API.
@@ -46,6 +48,12 @@ type lxdInterface struct{}
 
 func (iface *lxdInterface) Name() string {
 	return "lxd"
+}
+
+func (iface *lxdInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: lxdSummary,
+	}
 }
 
 func (iface *lxdInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -25,6 +25,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const lxdSupportSummary = `allows operating as the LXD service`
+
 const lxdSupportConnectedPlugAppArmor = `
 # Description: Can change to any apparmor profile (including unconfined) thus
 # giving access to all resources of the system so LXD may manage what to give
@@ -43,6 +45,12 @@ type lxdSupportInterface struct{}
 
 func (iface *lxdSupportInterface) Name() string {
 	return "lxd-support"
+}
+
+func (iface *lxdSupportInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: lxdSupportSummary,
+	}
 }
 
 func (iface *lxdSupportInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/maliit.go
+++ b/interfaces/builtin/maliit.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const maliitSummary = `allows operating as the Maliit service`
+
 const maliitPermanentSlotAppArmor = `
 # Description: Allow operating as a maliit server.
 # Communication with maliit happens in the following stages:
@@ -117,6 +119,12 @@ type maliitInterface struct{}
 
 func (iface *maliitInterface) Name() string {
 	return "maliit"
+}
+
+func (iface *maliitInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: maliitSummary,
+	}
 }
 
 func (iface *maliitInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/media_hub.go
+++ b/interfaces/builtin/media_hub.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const mediaHubSummary = `allows operating as the media-hub service`
+
 const mediaHubPermanentSlotAppArmor = `
 # Description: Allow operating as the the media-hub service.
 
@@ -148,6 +150,12 @@ type mediaHubInterface struct{}
 
 func (iface *mediaHubInterface) Name() string {
 	return "media-hub"
+}
+
+func (iface *mediaHubInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: mediaHubSummary,
+	}
 }
 
 func (iface *mediaHubInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const mirSummary = `allows operating as the Mir server`
+
 const mirPermanentSlotAppArmor = `
 # Description: Allow operating as the Mir server. This gives privileged access
 # to the system.
@@ -81,6 +83,12 @@ type mirInterface struct{}
 
 func (iface *mirInterface) Name() string {
 	return "mir"
+}
+
+func (iface *mirInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: mirSummary,
+	}
 }
 
 func (iface *mirInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -30,6 +30,8 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
+const modemManagerSummary = `allows operating as the ModemManager service`
+
 const modemManagerPermanentSlotAppArmor = `
 # Description: Allow operating as the ModemManager service. This gives
 # privileged access to the system.
@@ -1160,6 +1162,12 @@ type modemManagerInterface struct{}
 
 func (iface *modemManagerInterface) Name() string {
 	return "modem-manager"
+}
+
+func (iface *modemManagerInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: modemManagerSummary,
+	}
 }
 
 func (iface *modemManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const mountObserveSummary = `allows reading mount table and quota information`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/mount-observe
 const mountObserveConnectedPlugAppArmor = `
 # Description: Can query system mount and disk quota information. This is
@@ -54,7 +56,8 @@ quotactl Q_XGETQSTAT - - -
 
 func init() {
 	registerIface(&commonInterface{
-		name: "mount-observe",
+		name:                  "mount-observe",
+		summary:               mountObserveSummary,
 		connectedPlugAppArmor: mountObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  mountObserveConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -29,6 +29,8 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
+const mprisSummary = `allows operating as an MPRIS player`
+
 const mprisPermanentSlotAppArmor = `
 # Description: Allow operating as an MPRIS player.
 
@@ -142,6 +144,12 @@ type mprisInterface struct{}
 
 func (iface *mprisInterface) Name() string {
 	return "mpris"
+}
+
+func (iface *mprisInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: mprisSummary,
+	}
 }
 
 func (iface *mprisInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/netlink_audit.go
+++ b/interfaces/builtin/netlink_audit.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const netlinkAuditSummary = `allows access to kernel audit system through netlink`
+
 const netlinkAuditConnectedPlugSecComp = `
 # Description: Can use netlink to read/write to kernel audit system.
 bind
@@ -28,6 +30,7 @@ socket AF_NETLINK - NETLINK_AUDIT
 func init() {
 	registerIface(&commonInterface{
 		name:                 "netlink-audit",
+		summary:              netlinkAuditSummary,
 		connectedPlugSecComp: netlinkAuditConnectedPlugSecComp,
 		reservedForOS:        true,
 	})

--- a/interfaces/builtin/netlink_connector.go
+++ b/interfaces/builtin/netlink_connector.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const netlinkConnectorSummary = `allows communication through the kernel netlink connector`
+
 const netlinkConnectorConnectedPlugSecComp = `
 # Description: Can use netlink to communicate with kernel connector. Because
 # NETLINK_CONNECTOR is not finely mediated and app-specific, use of this
@@ -31,6 +33,7 @@ socket AF_NETLINK - NETLINK_CONNECTOR
 func init() {
 	registerIface(&commonInterface{
 		name:                 "netlink-connector",
+		summary:              netlinkConnectorSummary,
 		connectedPlugSecComp: netlinkConnectorConnectedPlugSecComp,
 		reservedForOS:        true,
 	})

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const networkSummary = `allows access to the network`
+
 const networkDescription = `
 The network interface allows connected plugs to access the network as a client.
 
@@ -51,6 +53,7 @@ socket AF_NETLINK - NETLINK_ROUTE
 func init() {
 	registerIface(&commonInterface{
 		name:                  "network",
+		summary:               networkSummary,
 		description:           networkDescription,
 		connectedPlugAppArmor: networkConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkConnectedPlugSecComp,

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const networkBindSummary = `allows operating as a network service`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network-bind
 const networkBindConnectedPlugAppArmor = `
 # Description: Can access the network as a server.
@@ -67,7 +69,8 @@ socket AF_NETLINK - NETLINK_ROUTE
 
 func init() {
 	registerIface(&commonInterface{
-		name: "network-bind",
+		name:                  "network-bind",
+		summary:               networkBindSummary,
 		connectedPlugAppArmor: networkBindConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkBindConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const networkControlSummary = `allows configuring networking and network namespaces`
+
 const networkControlConnectedPlugAppArmor = `
 # Description: Can configure networking and network namespaces via the standard
 # 'ip netns' command (man ip-netns(8)). This interface is restricted because it
@@ -208,7 +210,8 @@ socket AF_NETLINK - NETLINK_GENERIC
 
 func init() {
 	registerIface(&commonInterface{
-		name: "network-control",
+		name:                  "network-control",
+		summary:               networkControlSummary,
 		connectedPlugAppArmor: networkControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkControlConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -29,6 +29,8 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
+const networkManagerSummary = `allows operating as the NetworkManager service`
+
 const networkManagerPermanentSlotAppArmor = `
 # Description: Allow operating as the NetworkManager service. This gives
 # privileged access to the system.
@@ -375,6 +377,12 @@ type networkManagerInterface struct{}
 
 func (iface *networkManagerInterface) Name() string {
 	return "network-manager"
+}
+
+func (iface *networkManagerInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: networkManagerSummary,
+	}
 }
 
 func (iface *networkManagerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const networkObserveSummary = `allows querying network status`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/network-observe
 const networkObserveConnectedPlugAppArmor = `
 # Description: Can query network status information. This is restricted because
@@ -113,7 +115,8 @@ socket AF_NETLINK - NETLINK_GENERIC
 
 func init() {
 	registerIface(&commonInterface{
-		name: "network-observe",
+		name:                  "network-observe",
+		summary:               networkObserveSummary,
 		connectedPlugAppArmor: networkObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  networkObserveConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/network_setup_control.go
+++ b/interfaces/builtin/network_setup_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const networkSetupControlSummary = `allows access to netplan configuration`
+
 const networkSetupControlConnectedPlugAppArmor = `
 # Description: Can read/write netplan configuration files
 
@@ -28,7 +30,8 @@ const networkSetupControlConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "network-setup-control",
+		name:                  "network-setup-control",
+		summary:               networkSetupControlSummary,
 		connectedPlugAppArmor: networkSetupControlConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/network_setup_observe.go
+++ b/interfaces/builtin/network_setup_observe.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const networkSetupObserveSummary = `allows read access to netplan configuration`
+
 const networkSetupObserveConnectedPlugAppArmor = `
 # Description: Can read netplan configuration files
 
@@ -28,7 +30,8 @@ const networkSetupObserveConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "network-setup-observe",
+		name:                  "network-setup-observe",
+		summary:               networkSetupObserveSummary,
 		connectedPlugAppArmor: networkSetupObserveConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/dbus"
 )
 
+const networkStatusSummary = `allows operating as the NetworkingStatus service`
+
 const networkStatusPermanentSlotAppArmor = `
 # Description: Allow owning the NetworkingStatus bus name on the system bus
 
@@ -94,6 +96,12 @@ type networkStatusInterface struct{}
 
 func (iface *networkStatusInterface) Name() string {
 	return "network-status"
+}
+
+func (iface *networkStatusInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: networkStatusSummary,
+	}
 }
 
 func (iface *networkStatusInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -30,6 +30,8 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
+const ofonoSummary = `allows operating as the ofono service`
+
 const ofonoPermanentSlotAppArmor = `
 # Description: Allow operating as the ofono service. This gives privileged
 # access to the system.
@@ -261,6 +263,12 @@ type ofonoInterface struct{}
 
 func (iface *ofonoInterface) Name() string {
 	return "ofono"
+}
+
+func (iface *ofonoInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: ofonoSummary,
+	}
 }
 
 func (iface *ofonoInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/online_accounts_service.go
+++ b/interfaces/builtin/online_accounts_service.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const onlineAccountsServiceSummary = `allows operating as the Online Accounts service`
+
 const onlineAccountsServicePermanentSlotAppArmor = `
 # Description: Allow operating as the Online Accounts service.
 
@@ -92,6 +94,12 @@ type onlineAccountsServiceInterface struct{}
 
 func (iface *onlineAccountsServiceInterface) Name() string {
 	return "online-accounts-service"
+}
+
+func (iface *onlineAccountsServiceInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: onlineAccountsServiceSummary,
+	}
 }
 
 func (iface *onlineAccountsServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const openglSummary = `allows access to OpenGL stack`
+
 const openglConnectedPlugAppArmor = `
 # Description: Can access opengl.
 
@@ -56,7 +58,8 @@ const openglConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "opengl",
+		name:                  "opengl",
+		summary:               openglSummary,
 		connectedPlugAppArmor: openglConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/openvswitch.go
+++ b/interfaces/builtin/openvswitch.go
@@ -19,13 +19,16 @@
 
 package builtin
 
+const openvswitchSummary = `allows access to the openvswitch socket`
+
 const openvswitchConnectedPlugAppArmor = `
 /run/openvswitch/db.sock rw,
 `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "openvswitch",
+		name:                  "openvswitch",
+		summary:               openvswitchSummary,
 		connectedPlugAppArmor: openvswitchConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/openvswitch_support.go
+++ b/interfaces/builtin/openvswitch_support.go
@@ -19,11 +19,14 @@
 
 package builtin
 
+const openvswitchSupportSummary = `allows operating as the openvswitch service`
+
 var openvswitchSupportConnectedPlugKmod = []string{`openvswitch`}
 
 func init() {
 	registerIface(&commonInterface{
-		name: "openvswitch-support",
+		name:                     "openvswitch-support",
+		summary:                  openvswitchSummary,
 		connectedPlugKModModules: openvswitchSupportConnectedPlugKmod,
 		reservedForOS:            true,
 	})

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const opticalDriveSummary = `allows read access to optical drives`
+
 const opticalDriveConnectedPlugAppArmor = `
 /dev/sr[0-9]* r,
 /dev/scd[0-9]* r,
@@ -26,7 +28,8 @@ const opticalDriveConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "optical-drive",
+		name:                  "optical-drive",
+		summary:               opticalDriveSummary,
 		connectedPlugAppArmor: opticalDriveConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const physicalMemoryControlSummary = `allows write access to all physical memory`
+
 const physicalMemoryControlConnectedPlugAppArmor = `
 # Description: With kernels with STRICT_DEVMEM=n, write access to all physical
 # memory.
@@ -45,6 +47,12 @@ type physicalMemoryControlInterface struct{}
 // Getter for the name of the physical-memory-control interface
 func (iface *physicalMemoryControlInterface) Name() string {
 	return "physical-memory-control"
+}
+
+func (iface *physicalMemoryControlInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: physicalMemoryControlSummary,
+	}
 }
 
 func (iface *physicalMemoryControlInterface) String() string {

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const physicalMemoryObserveSummary = `allows read access to all physical memory`
+
 const physicalMemoryObserveConnectedPlugAppArmor = `
 # Description: With kernels with STRICT_DEVMEM=n, read-only access to all physical
 # memory. With STRICT_DEVMEM=y, allow reading /dev/mem for read-only
@@ -45,6 +47,12 @@ func (iface *physicalMemoryObserveInterface) Name() string {
 
 func (iface *physicalMemoryObserveInterface) String() string {
 	return iface.Name()
+}
+
+func (iface *physicalMemoryObserveInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: physicalMemoryObserveSummary,
+	}
 }
 
 // Check validity of the defined slot

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -25,6 +25,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/kmod"
 )
 
+const pppSummary = `allows operating as the ppp service`
+
 const pppConnectedPlugAppArmor = `
 # Description: Allow operating ppp daemon. This gives privileged access to the
 # ppp daemon.
@@ -53,6 +55,12 @@ type pppInterface struct{}
 
 func (iface *pppInterface) Name() string {
 	return "ppp"
+}
+
+func (iface *pppInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: pppSummary,
+	}
 }
 
 func (iface *pppInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const processControlSummary = `allows controlling other processes`
+
 const processControlConnectedPlugAppArmor = `
 # Description: This interface allows for controlling other processes via
 # signals and nice. This is reserved because it grants privileged access to
@@ -48,7 +50,8 @@ sched_setscheduler
 
 func init() {
 	registerIface(&commonInterface{
-		name: "process-control",
+		name:                  "process-control",
+		summary:               processControlSummary,
 		connectedPlugAppArmor: processControlConnectedPlugAppArmor,
 		connectedPlugSecComp:  processControlConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -26,6 +26,8 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
+const pulseaudioSummary = `allows operating as or interacting with the pulseaudio service`
+
 const pulseaudioConnectedPlugAppArmor = `
 /{run,dev}/shm/pulse-shm-* mrwk,
 
@@ -115,6 +117,12 @@ type pulseAudioInterface struct{}
 
 func (iface *pulseAudioInterface) Name() string {
 	return "pulseaudio"
+}
+
+func (iface *pulseAudioInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: pulseaudioSummary,
+	}
 }
 
 func (iface *pulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const rawusbSummary = `allows raw access to all USB devices`
+
 const rawusbConnectedPlugAppArmor = `
 # Description: Allow raw access to all connected USB devices.
 # This gives privileged access to the system.
@@ -37,7 +39,8 @@ const rawusbConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "raw-usb",
+		name:                  "raw-usb",
+		summary:               rawusbSummary,
 		connectedPlugAppArmor: rawusbConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/removable_media.go
+++ b/interfaces/builtin/removable_media.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const removableMediaSummary = `allows access to mounted removable storage`
+
 const removableMediaConnectedPlugAppArmor = `
 # Description: Can access removable storage filesystems
 
@@ -29,7 +31,8 @@ const removableMediaConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "removable-media",
+		name:                  "removable-media",
+		summary:               removableMediaSummary,
 		connectedPlugAppArmor: removableMediaConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const screenInhibitControlSummary = `allows inhibiting the screen saver`
+
 const screenInhibitControlConnectedPlugAppArmor = `
 # Description: Can inhibit and uninhibit screen savers in desktop sessions.
 #include <abstractions/dbus-session-strict>
@@ -65,7 +67,8 @@ dbus (send)
 
 func init() {
 	registerIface(&commonInterface{
-		name: "screen-inhibit-control",
+		name:                  "screen-inhibit-control",
+		summary:               screenInhibitControlSummary,
 		connectedPlugAppArmor: screenInhibitControlConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -30,12 +30,20 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const serialPortSummary = `allows accessing a specific serial port`
+
 // serialPortInterface is the type for serial port interfaces.
 type serialPortInterface struct{}
 
 // Name of the serial-port interface.
 func (iface *serialPortInterface) Name() string {
 	return "serial-port"
+}
+
+func (iface *serialPortInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: serialPortSummary,
+	}
 }
 
 func (iface *serialPortInterface) String() string {

--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const shutdownSummary = `allows shutting down or rebooting the system`
+
 const shutdownConnectedPlugAppArmor = `
 # Description: Can reboot, power-off and halt the system.
 
@@ -56,7 +58,8 @@ dbus (send)
 
 func init() {
 	registerIface(&commonInterface{
-		name: "shutdown",
+		name:                  "shutdown",
+		summary:               shutdownSummary,
 		connectedPlugAppArmor: shutdownConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const snapdControlSummary = `allows communicating with snapd`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/snapd-control
 const snapdControlConnectedPlugAppArmor = `
 # Description: Can manage snaps via snapd.
@@ -28,7 +30,8 @@ const snapdControlConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "snapd-control",
+		name:                  "snapd-control",
+		summary:               snapdControlSummary,
 		connectedPlugAppArmor: snapdControlConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/storage_framework_service.go
+++ b/interfaces/builtin/storage_framework_service.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const storageFrameworkServiceSummary = `allows operating as or interacting with the Storage Framework`
+
 const storageFrameworkServicePermanentSlotAppArmor = `
 # Description: Allow use of aa_is_enabled()
 
@@ -105,6 +107,12 @@ type storageFrameworkServiceInterface struct{}
 
 func (iface *storageFrameworkServiceInterface) Name() string {
 	return "storage-framework-service"
+}
+
+func (iface *storageFrameworkServiceInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: storageFrameworkServiceSummary,
+	}
 }
 
 func (iface *storageFrameworkServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const systemObserveSummary = `allows observing all processes and drivers`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/system-observe
 const systemObserveConnectedPlugAppArmor = `
 # Description: Can query system status information. This is restricted because
@@ -88,7 +90,8 @@ const systemObserveConnectedPlugSecComp = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "system-observe",
+		name:                  "system-observe",
+		summary:               systemObserveSummary,
 		connectedPlugAppArmor: systemObserveConnectedPlugAppArmor,
 		connectedPlugSecComp:  systemObserveConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/system_trace.go
+++ b/interfaces/builtin/system_trace.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const systemTraceSummary = `allows using kernel tracing facilities`
+
 const systemTraceConnectedPlugAppArmor = `
 # Description: Can use kernel tracing facilities. This is restricted because it
 # gives privileged access to all processes on the system and should only be
@@ -53,7 +55,8 @@ perf_event_open
 
 func init() {
 	registerIface(&commonInterface{
-		name: "system-trace",
+		name:                  "system-trace",
+		summary:               systemTraceSummary,
 		connectedPlugAppArmor: systemTraceConnectedPlugAppArmor,
 		connectedPlugSecComp:  systemTraceConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/builtin/thumbnailer_service.go
+++ b/interfaces/builtin/thumbnailer_service.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
+const thumbnailerServiceSummary = `allows operating as or interacting with the Thumbnailer service`
+
 const thumbnailerServicePermanentSlotAppArmor = `
 # Description: Allow use of aa_query_label API. This
 # discloses the AppArmor policy for all processes.
@@ -90,6 +92,12 @@ type thumbnailerServiceInterface struct{}
 
 func (iface *thumbnailerServiceInterface) Name() string {
 	return "thumbnailer-service"
+}
+
+func (iface *thumbnailerServiceInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: thumbnailerServiceSummary,
+	}
 }
 
 func (iface *thumbnailerServiceInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const timeControlSummary = `allows setting system date and time`
+
 const timeControlConnectedPlugAppArmor = `
 # Description: Can set time and date via systemd' timedated D-Bus interface.
 # Can read all properties of /org/freedesktop/timedate1 D-Bus object; see
@@ -96,6 +98,12 @@ type timeControlInterface struct{}
 // Getter for the name of the rtc interface
 func (iface *timeControlInterface) Name() string {
 	return "time-control"
+}
+
+func (iface *timeControlInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: timeControlSummary,
+	}
 }
 
 func (iface *timeControlInterface) String() string {

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const timeserverControlSummary = `allows setting system time synchronization servers`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/timeserver-control
 const timeserverControlConnectedPlugAppArmor = `
 # Description: Can manage timeservers directly separate from config ubuntu-core.
@@ -72,7 +74,8 @@ dbus (receive)
 
 func init() {
 	registerIface(&commonInterface{
-		name: "timeserver-control",
+		name:                  "timeserver-control",
+		summary:               timeserverControlSummary,
 		connectedPlugAppArmor: timeserverControlConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const timezoneControlSummary = `allows setting system timezone`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/timezone-control
 const timezoneControlConnectedPlugAppArmor = `
 # Description: Can manage timezones directly separate from 'config ubuntu-core'.
@@ -74,7 +76,8 @@ dbus (receive)
 
 func init() {
 	registerIface(&commonInterface{
-		name: "timezone-control",
+		name:                  "timezone-control",
+		summary:               timezoneControlSummary,
 		connectedPlugAppArmor: timezoneControlConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/tpm.go
+++ b/interfaces/builtin/tpm.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const tpmSummary = `allows access to the Trusted Platform Module device`
+
 const tpmConnectedPlugAppArmor = `
 # Description: for those who need to talk to the system TPM chip over /dev/tpm0
 
@@ -27,7 +29,8 @@ const tpmConnectedPlugAppArmor = `
 
 func init() {
 	registerIface(&commonInterface{
-		name: "tpm",
+		name:                  "tpm",
+		summary:               tpmSummary,
 		connectedPlugAppArmor: tpmConnectedPlugAppArmor,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 )
 
+const ubuntuDownloadManagerSummary = `allows operating as or interacting with the Ubuntu download manager`
+
 /* The methods: allowGSMDownload, createMmsDownload, exit and setDefaultThrottle
    are deliberately left out of this profile due to their privileged nature. */
 const downloadConnectedPlugAppArmor = `
@@ -189,6 +191,12 @@ type ubuntuDownloadManagerInterface struct{}
 
 func (iface *ubuntuDownloadManagerInterface) Name() string {
 	return "ubuntu-download-manager"
+}
+
+func (iface *ubuntuDownloadManagerInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: ubuntuDownloadManagerSummary,
+	}
 }
 
 func (iface *ubuntuDownloadManagerInterface) String() string {

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -29,6 +29,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const udisks2Summary = `allows operating as or interacting with the UDisks2 service`
+
 const udisks2PermanentSlotAppArmor = `
 # Description: Allow operating as the udisks2. This gives privileged access to
 # the system.
@@ -346,6 +348,12 @@ type udisks2Interface struct{}
 
 func (iface *udisks2Interface) Name() string {
 	return "udisks2"
+}
+
+func (iface *udisks2Interface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: udisks2Summary,
+	}
 }
 
 func (iface *udisks2Interface) DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/uhid.go
+++ b/interfaces/builtin/uhid.go
@@ -27,6 +27,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/udev"
 )
 
+const uhidSummary = `allows control over UHID devices`
+
 const uhidConnectedPlugAppArmor = `
 # Description: Allows accessing the UHID to create kernel
 # hid devices from user-space.
@@ -39,6 +41,12 @@ type uhidInterface struct{}
 
 func (iface *uhidInterface) Name() string {
 	return "uhid"
+}
+
+func (iface *uhidInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: uhidSummary,
+	}
 }
 
 func (iface *uhidInterface) String() string {

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -29,6 +29,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+const unity7Summary = `allows interacting with Unity 7 services`
+
 const unity7ConnectedPlugAppArmor = `
 # Description: Can access Unity7. Note, Unity 7 runs on X and requires access
 # to various DBus services and this environment does not prevent eavesdropping
@@ -514,6 +516,12 @@ type unity7Interface struct{}
 
 func (iface *unity7Interface) Name() string {
 	return "unity7"
+}
+
+func (iface *unity7Interface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: unity7Summary,
+	}
 }
 
 func (iface *unity7Interface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -28,6 +28,8 @@ import (
 	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
+const unity8Summary = `allows operating as or interacting with Unity 8`
+
 const unity8ConnectedPlugAppArmor = `
 # Description: Can access unity8 desktop services
 
@@ -86,6 +88,12 @@ type unity8Interface struct{}
 
 func (iface *unity8Interface) Name() string {
 	return "unity8"
+}
+
+func (iface *unity8Interface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: unity8Summary,
+	}
 }
 
 func (iface *unity8Interface) String() string {

--- a/interfaces/builtin/unity8_calendar.go
+++ b/interfaces/builtin/unity8_calendar.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const unity8CalendarSummary = `allows operating as or interacting with the Unity 8 Calendar Service`
+
 const unity8CalendarPermanentSlotAppArmor = `
 # Description: Allow operating as the EDS service. This gives privileged access
 # to the system.
@@ -136,7 +138,8 @@ dbus (receive, send)
 
 func init() {
 	registerIface(&unity8PimCommonInterface{
-		name: "unity8-calendar",
+		name:                  "unity8-calendar",
+		summary:               unity8CalendarSummary,
 		permanentSlotAppArmor: unity8CalendarPermanentSlotAppArmor,
 		connectedSlotAppArmor: unity8CalendarConnectedSlotAppArmor,
 		connectedPlugAppArmor: unity8CalendarConnectedPlugAppArmor,

--- a/interfaces/builtin/unity8_contacts.go
+++ b/interfaces/builtin/unity8_contacts.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const unity8ContactsSummary = `allows operating as or interacting with the Unity 8 Contacts Service`
+
 const unity8ContactsPermanentSlotAppArmor = `
 # Description: Allow operating as the EDS service. This gives privileged access
 # to the system.
@@ -173,7 +175,8 @@ dbus (receive, send)
 
 func init() {
 	registerIface(&unity8PimCommonInterface{
-		name: "unity8-contacts",
+		name:                  "unity8-contacts",
+		summary:               unity8ContactsSummary,
 		permanentSlotAppArmor: unity8ContactsPermanentSlotAppArmor,
 		connectedSlotAppArmor: unity8ContactsConnectedSlotAppArmor,
 		connectedPlugAppArmor: unity8ContactsConnectedPlugAppArmor,

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -105,6 +105,7 @@ shutdown
 
 type unity8PimCommonInterface struct {
 	name                  string
+	summary               string
 	permanentSlotAppArmor string
 	connectedSlotAppArmor string
 	connectedPlugAppArmor string
@@ -112,6 +113,12 @@ type unity8PimCommonInterface struct {
 
 func (iface *unity8PimCommonInterface) Name() string {
 	return iface.name
+}
+
+func (iface *unity8PimCommonInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: iface.summary,
+	}
 }
 
 func (iface *unity8PimCommonInterface) DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error {

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -31,6 +31,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+const upowerObserveSummary = `allows operating as or reading from the UPower service`
+
 const upowerObservePermanentSlotAppArmor = `
 # Description: Allow operating as the UPower service.
 
@@ -207,6 +209,12 @@ type upowerObserveInterface struct{}
 
 func (iface *upowerObserveInterface) Name() string {
 	return "upower-observe"
+}
+
+func (iface *upowerObserveInterface) MetaData() interfaces.MetaData {
+	return interfaces.MetaData{
+		Summary: upowerObserveSummary,
+	}
 }
 
 func (iface *upowerObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -19,6 +19,8 @@
 
 package builtin
 
+const x11Summary = `allows interacting with the X11 server`
+
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/x
 const x11ConnectedPlugAppArmor = `
 # Description: Can access the X server. Restricted because X does not prevent
@@ -46,7 +48,8 @@ shutdown
 
 func init() {
 	registerIface(&commonInterface{
-		name: "x11",
+		name:                  "x11",
+		summary:               x11Summary,
 		connectedPlugAppArmor: x11ConnectedPlugAppArmor,
 		connectedPlugSecComp:  x11ConnectedPlugSecComp,
 		reservedForOS:         true,

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -130,8 +130,15 @@ type Interface interface {
 }
 
 // MetaData describes various meta-data of a given interface.
+//
+// The Summary must be a one-line string of length suitable for listing views.
+// The Description must describe the purpose of the interface in non-technical
+// terms. The DocumentationURL can point to website (e.g. a forum thread) that
+// goes into more depth and documents the interface in detail.
 type MetaData struct {
-	Description string `json:"description,omitempty"`
+	Summary          string `json:"summary,omitempty"`
+	Description      string `json:"description,omitempty"`
+	DocumentationURL string `json:"documentation-url,omitempty"`
 }
 
 // ifaceMetaData returns the meta-data of the given interface.


### PR DESCRIPTION
This branch adds summary to all 91 interfaces currently known by snapd. The
actual text is expected to change and is an invitation to suggestions and
re-wordings.
