### PR TITLE
interfaces: disable "mknod |N" in the default seccomp template again

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -209,14 +209,17 @@ mlockall
 mmap
 mmap2
 
+# FIXME: commented out because of:
+# https://forum.snapcraft.io/t/snapd-2-25-blocked-because-of-possible-revert-race-condition
+#
 # Allow mknod for regular files, pipes and sockets (and not block or char
 # devices)
-mknod - |S_IFREG -
-mknodat - - |S_IFREG -
-mknod - |S_IFIFO -
-mknodat - - |S_IFIFO -
-mknod - |S_IFSOCK -
-mknodat - - |S_IFSOCK -
+#mknod - |S_IFREG -
+#mknodat - - |S_IFREG -
+#mknod - |S_IFIFO -
+#mknodat - - |S_IFIFO -
+#mknod - |S_IFSOCK -
+#mknodat - - |S_IFSOCK -
 
 modify_ldt
 mprotect


### PR DESCRIPTION
This partially reverts a previous commit to allow mknod/mknodat
for regular files, pipes and sockets (and not block or char
devices).

The reason for the revert is described in:
https://forum.snapcraft.io/t/snapd-2-25-blocked-because-of-possible-revert-race-condition

In a nutshell there is a race-condition when doing the following:
$ snap refresh core; snap install daemon; snap revert core; reboot

when the system reboots the seccomp profile will contain symbols
(the |N syntax) that snap-confine from the old core does not
understands. Snapd will rewrite the seccomp profile on startup,
however there is no gurantee currently that this rewrite will
happen before the installed software "daemon" starts which makes
this racy and we see real bugs because of this.

So we revert the new syntax for now to unblock 2.25+ and work
on a plan to properly fix this.