### PR TITLE
many: stop "snap refresh $x --channel invalid" from working.

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -102,6 +102,13 @@ func (s *apiBaseSuite) Find(search *store.Search, user *auth.UserState) ([]*snap
 	return s.rsnaps, s.err
 }
 
+func (s *apiBaseSuite) LookupRefresh(snap *store.RefreshCandidate, user *auth.UserState) (*snap.Info, error) {
+	s.refreshCandidates = []*store.RefreshCandidate{snap}
+	s.user = user
+
+	return s.rsnaps[0], s.err
+}
+
 func (s *apiBaseSuite) ListRefresh(snaps []*store.RefreshCandidate, user *auth.UserState) ([]*snap.Info, error) {
 	s.refreshCandidates = snaps
 	s.user = user

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -92,6 +92,10 @@ func (sto *fakeStore) Find(*store.Search, *auth.UserState) ([]*snap.Info, error)
 	panic("fakeStore.Find not expected")
 }
 
+func (sto *fakeStore) LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info, error) {
+	panic("fakeStore.LookupRefresh not expected")
+}
+
 func (sto *fakeStore) ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error) {
 	panic("fakeStore.ListRefresh not expected")
 }

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -105,6 +105,10 @@ func (sto *fakeStore) Find(*store.Search, *auth.UserState) ([]*snap.Info, error)
 	panic("fakeStore.Find not expected")
 }
 
+func (sto *fakeStore) LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info, error) {
+	panic("fakeStore.LookupRefresh not expected")
+}
+
 func (sto *fakeStore) ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error) {
 	panic("fakeStore.ListRefresh not expected")
 }

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -34,6 +34,7 @@ import (
 type StoreService interface {
 	SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
 	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
+	LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info, error)
 	ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error)
 	Sections(user *auth.UserState) ([]string, error)
 	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -781,7 +781,7 @@ func Update(st *state.State, name, channel string, revision snap.Revision, userI
 	var updates []*snap.Info
 	info, infoErr := infoForUpdate(st, &snapst, name, channel, revision, userID, flags)
 	if infoErr != nil {
-		if _, ok := infoErr.(*snap.NoUpdateAvailableError); !ok {
+		if !snap.IsNoUpdateAvailableError(infoErr) {
 			return nil, infoErr
 		}
 		// there may be some new auto-aliases

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -851,7 +851,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksPropagatesErrors(c *C) {
 	})
 
 	_, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `cannot get refresh information for snap "some-snap": failing as requested`)
+	c.Assert(err, ErrorMatches, `failing as requested`)
 }
 
 func (s *snapmgrTestSuite) TestUpdateTasks(c *C) {

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -59,16 +59,9 @@ func updateInfo(st *state.State, snapst *SnapState, channel string, userID int) 
 
 	theStore := Store(st)
 	st.Unlock() // calls to the store should be done without holding the state lock
-	res, err := theStore.ListRefresh([]*store.RefreshCandidate{refreshCand}, user)
+	res, err := theStore.LookupRefresh(refreshCand, user)
 	st.Lock()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get refresh information for snap %q: %s", curInfo.Name(), err)
-	}
-	if len(res) == 0 {
-		return nil, &snap.NoUpdateAvailableError{Snap: curInfo.Name()}
-	}
-
-	return res[0], nil
+	return res, err
 }
 
 func snapInfo(st *state.State, name, channel string, revision snap.Revision, userID int) (*snap.Info, error) {

--- a/store/errors.go
+++ b/store/errors.go
@@ -58,6 +58,9 @@ var (
 
 	// ErrPaymentDeclined is returned when the user's payment method was declined by the upstream payment provider.
 	ErrPaymentDeclined = errors.New("payment declined")
+
+	// ErrLocalSnap is returned when an operation that only applies to snaps that come from a store was attempted on a local snap.
+	ErrLocalSnap = errors.New("the given snap does not come from the store")
 )
 
 // ErrDownload represents a download error

--- a/store/errors.go
+++ b/store/errors.go
@@ -60,7 +60,7 @@ var (
 	ErrPaymentDeclined = errors.New("payment declined")
 
 	// ErrLocalSnap is returned when an operation that only applies to snaps that come from a store was attempted on a local snap.
-	ErrLocalSnap = errors.New("the given snap does not come from the store")
+	ErrLocalSnap = errors.New("cannot perform operation on local snap")
 )
 
 // ErrDownload represents a download error

--- a/store/store.go
+++ b/store/store.go
@@ -1129,7 +1129,7 @@ type RefreshCandidate struct {
 }
 
 // the exact bits that we need to send to the store
-type currentSnapJson struct {
+type currentSnapJSON struct {
 	SnapID      string `json:"snap_id"`
 	Channel     string `json:"channel"`
 	Revision    int    `json:"revision,omitempty"`
@@ -1138,11 +1138,11 @@ type currentSnapJson struct {
 }
 
 type metadataWrapper struct {
-	Snaps  []*currentSnapJson `json:"snaps"`
+	Snaps  []*currentSnapJSON `json:"snaps"`
 	Fields []string           `json:"fields"`
 }
 
-func currentSnap(cs *RefreshCandidate) *currentSnapJson {
+func currentSnap(cs *RefreshCandidate) *currentSnapJSON {
 	revision := cs.Revision.N
 	if !cs.Revision.Store() {
 		revision = 0
@@ -1158,7 +1158,7 @@ func currentSnap(cs *RefreshCandidate) *currentSnapJson {
 		channel = "stable"
 	}
 
-	return &currentSnapJson{
+	return &currentSnapJSON{
 		SnapID:   cs.SnapID,
 		Channel:  channel,
 		Epoch:    cs.Epoch,
@@ -1167,7 +1167,7 @@ func currentSnap(cs *RefreshCandidate) *currentSnapJson {
 	}
 }
 
-func (s *Store) checkCandidates(currentSnaps []*currentSnapJson, user *auth.UserState) ([]snapDetails, error) {
+func (s *Store) checkCandidates(currentSnaps []*currentSnapJSON, user *auth.UserState) ([]snapDetails, error) {
 	// build input for the updates endpoint
 	jsonData, err := json.Marshal(metadataWrapper{
 		Snaps:  currentSnaps,
@@ -1213,7 +1213,7 @@ func (s *Store) LookupRefresh(installed *RefreshCandidate, user *auth.UserState)
 		return nil, ErrLocalSnap
 	}
 
-	latest, err := s.checkCandidates([]*currentSnapJson{cur}, user)
+	latest, err := s.checkCandidates([]*currentSnapJSON{cur}, user)
 	if err != nil {
 		return nil, err
 	}
@@ -1235,7 +1235,7 @@ func (s *Store) LookupRefresh(installed *RefreshCandidate, user *auth.UserState)
 func (s *Store) ListRefresh(installed []*RefreshCandidate, user *auth.UserState) (snaps []*snap.Info, err error) {
 
 	candidateMap := map[string]*RefreshCandidate{}
-	currentSnaps := make([]*currentSnapJson, 0, len(installed))
+	currentSnaps := make([]*currentSnapJSON, 0, len(installed))
 	for _, cs := range installed {
 		cur := currentSnap(cs)
 		if cur == nil {

--- a/store/store.go
+++ b/store/store.go
@@ -1170,7 +1170,7 @@ func currentSnap(cs *RefreshCandidate) *currentSnapJSON {
 	}
 }
 
-// query the store for the information about currently-offered revisions of snaps
+// query the store for the information about currently offered revisions of snaps
 func (s *Store) refreshForCandidates(currentSnaps []*currentSnapJSON, user *auth.UserState) ([]*snapDetails, error) {
 	// build input for the updates endpoint
 	jsonData, err := json.Marshal(metadataWrapper{

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3294,18 +3294,18 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) 
 	c.Assert(n, Equals, 1)
 }
 
-func (t *remoteRepoTestSuite) TestIsActuallyUpdateWorks(c *C) {
-	c.Check(isActuallyUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("1")}), Equals, true)
+func (t *remoteRepoTestSuite) TestAcceptableUpdateWorks(c *C) {
+	c.Check(acceptableUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("1")}), Equals, true)
 }
-func (t *remoteRepoTestSuite) TestIsActuallyUpdateSkipsCurrent(c *C) {
-	c.Check(isActuallyUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("42")}), Equals, false)
+func (t *remoteRepoTestSuite) TestAcceptableUpdateSkipsCurrent(c *C) {
+	c.Check(acceptableUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("42")}), Equals, false)
 }
-func (t *remoteRepoTestSuite) TestIsActuallyUpdateSkipsBlocked(c *C) {
-	c.Check(isActuallyUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("1"), Block: []snap.Revision{snap.R("42")}}), Equals, false)
+func (t *remoteRepoTestSuite) TestAcceptableUpdateSkipsBlocked(c *C) {
+	c.Check(acceptableUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("1"), Block: []snap.Revision{snap.R("42")}}), Equals, false)
 }
-func (t *remoteRepoTestSuite) TestIsActuallyUpdateSkipsBoth(c *C) {
+func (t *remoteRepoTestSuite) TestAcceptableUpdateSkipsBoth(c *C) {
 	// belts-and-suspenders
-	c.Check(isActuallyUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("42"), Block: []snap.Revision{snap.R("42")}}), Equals, false)
+	c.Check(acceptableUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("42"), Block: []snap.Revision{snap.R("42")}}), Equals, false)
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c *C) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2611,6 +2611,67 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindAuthFailed(c *C) {
 	c.Check(snaps[0].MustBuy, Equals, true)
 }
 
+func (t *remoteRepoTestSuite) TestCurrentSnap(c *C) {
+	cand := &RefreshCandidate{
+		SnapID:   helloWorldSnapID,
+		Channel:  "stable",
+		Revision: snap.R(1),
+		Epoch:    "1",
+	}
+	cs := currentSnap(cand)
+	c.Assert(cs, NotNil)
+	c.Check(cs.SnapID, Equals, cand.SnapID)
+	c.Check(cs.Channel, Equals, cand.Channel)
+	c.Check(cs.Epoch, Equals, cand.Epoch)
+	c.Check(cs.Revision, Equals, cand.Revision.N)
+	c.Check(t.logbuf.String(), Equals, "")
+}
+
+func (t *remoteRepoTestSuite) TestCurrentSnapNoChannel(c *C) {
+	cand := &RefreshCandidate{
+		SnapID:   helloWorldSnapID,
+		Revision: snap.R(1),
+		Epoch:    "1",
+	}
+	cs := currentSnap(cand)
+	c.Assert(cs, NotNil)
+	c.Check(cs.SnapID, Equals, cand.SnapID)
+	c.Check(cs.Channel, Equals, "stable")
+	c.Check(cs.Epoch, Equals, cand.Epoch)
+	c.Check(cs.Revision, Equals, cand.Revision.N)
+	c.Check(t.logbuf.String(), Equals, "")
+}
+
+func (t *remoteRepoTestSuite) TestCurrentSnapNilNoID(c *C) {
+	cand := &RefreshCandidate{
+		SnapID:   "",
+		Revision: snap.R(1),
+	}
+	cs := currentSnap(cand)
+	c.Assert(cs, IsNil)
+	c.Check(t.logbuf.String(), Matches, "(?m).* an empty SnapID but a store revision!")
+}
+
+func (t *remoteRepoTestSuite) TestCurrentSnapNilLocalRevision(c *C) {
+	cand := &RefreshCandidate{
+		SnapID:   helloWorldSnapID,
+		Revision: snap.R("x1"),
+	}
+	cs := currentSnap(cand)
+	c.Assert(cs, IsNil)
+	c.Check(t.logbuf.String(), Matches, "(?m).* a non-empty SnapID but a non-store revision!")
+}
+
+func (t *remoteRepoTestSuite) TestCurrentSnapNilLocalRevisionNoID(c *C) {
+	cand := &RefreshCandidate{
+		SnapID:   "",
+		Revision: snap.R("x1"),
+	}
+	cs := currentSnap(cand)
+	c.Assert(cs, IsNil)
+	c.Check(t.logbuf.String(), Equals, "")
+}
+
 /* acquired via:
 (against production "hello-world")
 $ curl -s --data-binary '{"snaps":[{"snap_id":"buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ","channel":"stable","revision":25,"epoch":"0","confinement":"strict"}],"fields":["anon_download_url","architecture","channel","download_sha512","summary","description","binary_filesize","download_url","icon_url","last_updated","package_name","prices","publisher","ratings_average","revision","snap_id","support_url","title","content","version","origin","developer_id","private","confinement"]}'  -H 'content-type: application/json' -H 'X-Ubuntu-Release: 16' -H 'X-Ubuntu-Wire-Protocol: 1' -H "accept: application/hal+json" https://search.apps.ubuntu.com/api/v1/snaps/metadata | python3 -m json.tool --sort-keys | xsel -b
@@ -2664,6 +2725,219 @@ var MockUpdatesJSON = `
     }
 }
 `
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var resp struct {
+			Snaps  []map[string]interface{} `json:"snaps"`
+			Fields []string                 `json:"fields"`
+		}
+
+		err = json.Unmarshal(jsonReq, &resp)
+		c.Assert(err, IsNil)
+
+		c.Assert(resp.Snaps, HasLen, 1)
+		c.Assert(resp.Snaps[0], DeepEquals, map[string]interface{}{
+			"snap_id":     helloWorldSnapID,
+			"channel":     "stable",
+			"revision":    float64(1),
+			"epoch":       "0",
+			"confinement": "",
+		})
+		c.Assert(resp.Fields, DeepEquals, detailFields)
+
+		io.WriteString(w, MockUpdatesJSON)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	bulkURI, err := url.Parse(mockServer.URL + "/updates/")
+	c.Assert(err, IsNil)
+	cfg := Config{
+		BulkURI: bulkURI,
+	}
+	authContext := &testAuthContext{c: c, device: t.device}
+	repo := New(&cfg, authContext)
+	c.Assert(repo, NotNil)
+
+	results, err := repo.refreshForCandidates([]*currentSnapJSON{
+		{
+			SnapID:   helloWorldSnapID,
+			Channel:  "stable",
+			Revision: 1,
+			Epoch:    "0",
+		},
+	}, nil)
+
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name, Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, 26)
+	c.Assert(results[0].Version, Equals, "6.1")
+	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
+	c.Assert(results[0].DeveloperID, Equals, helloWorldDeveloperID)
+	c.Assert(results[0].Deltas, HasLen, 0)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesRetriesOnEOF(c *C) {
+	n := 0
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		if n < 4 {
+			io.WriteString(w, "{")
+			mockServer.CloseClientConnections()
+			return
+		}
+		var resp struct {
+			Snaps  []map[string]interface{} `json:"snaps"`
+			Fields []string                 `json:"fields"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&resp)
+		c.Assert(err, IsNil)
+		c.Assert(resp.Snaps, HasLen, 1)
+		io.WriteString(w, MockUpdatesJSON)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	bulkURI, err := url.Parse(mockServer.URL + "/updates/")
+	c.Assert(err, IsNil)
+	cfg := Config{
+		BulkURI: bulkURI,
+	}
+	authContext := &testAuthContext{c: c, device: t.device}
+	repo := New(&cfg, authContext)
+	c.Assert(repo, NotNil)
+
+	results, err := repo.refreshForCandidates([]*currentSnapJSON{{
+		SnapID:   helloWorldSnapID,
+		Channel:  "stable",
+		Revision: 1,
+		Epoch:    "0",
+	}}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 4)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name, Equals, "hello-world")
+}
+
+func mockRFC(newRFC func(*Store, []*currentSnapJSON, *auth.UserState) ([]*snapDetails, error)) func() {
+	oldRFC := refreshForCandidates
+	refreshForCandidates = newRFC
+	return func() {
+		refreshForCandidates = oldRFC
+	}
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
+	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+		c.Check(currentSnaps, DeepEquals, []*currentSnapJSON{{
+			SnapID:   helloWorldSnapID,
+			Channel:  "stable",
+			Revision: 1,
+			Epoch:    "0",
+		}})
+		return []*snapDetails{{
+			Name:        "hello-world",
+			Revision:    26,
+			Version:     "6.1",
+			SnapID:      helloWorldSnapID,
+			DeveloperID: helloWorldDeveloperID,
+		}}, nil
+	})()
+
+	repo := New(nil, &testAuthContext{c: c, device: t.device})
+	c.Assert(repo, NotNil)
+
+	result, err := repo.LookupRefresh(&RefreshCandidate{
+		SnapID:   helloWorldSnapID,
+		Channel:  "stable",
+		Revision: snap.R(1),
+		Epoch:    "0",
+	}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(result.Name(), Equals, "hello-world")
+	c.Assert(result.Revision, Equals, snap.R(26))
+	c.Assert(result.Version, Equals, "6.1")
+	c.Assert(result.SnapID, Equals, helloWorldSnapID)
+	c.Assert(result.PublisherID, Equals, helloWorldDeveloperID)
+	c.Assert(result.Deltas, HasLen, 0)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c *C) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+		panic("unexpected call to refreshForCandidates")
+	})()
+
+	repo := New(nil, &testAuthContext{c: c, device: t.device})
+	c.Assert(repo, NotNil)
+
+	result, err := repo.LookupRefresh(&RefreshCandidate{
+		Revision: snap.R("x1"),
+	}, nil)
+	c.Assert(result, IsNil)
+	c.Check(err, Equals, ErrLocalSnap)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *C) {
+	anError := errors.New("ouchie")
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+		return nil, anError
+	})()
+
+	repo := New(nil, &testAuthContext{c: c, device: t.device})
+	c.Assert(repo, NotNil)
+
+	result, err := repo.LookupRefresh(&RefreshCandidate{
+		SnapID:   helloWorldDeveloperID,
+		Revision: snap.R(1),
+	}, nil)
+	c.Assert(result, IsNil)
+	c.Check(err, Equals, anError)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyResponse(c *C) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+		return nil, nil
+	})()
+
+	repo := New(nil, &testAuthContext{c: c, device: t.device})
+	c.Assert(repo, NotNil)
+
+	result, err := repo.LookupRefresh(&RefreshCandidate{
+		SnapID:   helloWorldDeveloperID,
+		Revision: snap.R(1),
+	}, nil)
+	c.Assert(result, IsNil)
+	c.Check(err, Equals, ErrSnapNotFound)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshNoUpdate(c *C) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+		return []*snapDetails{{
+			SnapID:   helloWorldDeveloperID,
+			Revision: 1,
+		}}, nil
+	})()
+
+	repo := New(nil, &testAuthContext{c: c, device: t.device})
+	c.Assert(repo, NotNil)
+
+	result, err := repo.LookupRefresh(&RefreshCandidate{
+		SnapID:   helloWorldDeveloperID,
+		Revision: snap.R(1),
+	}, nil)
+	c.Assert(result, IsNil)
+	c.Check(err, FitsTypeOf, &snap.NoUpdateAvailableError{})
+}
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2854,13 +3128,12 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 		repo := New(&cfg, authContext)
 		c.Assert(repo, NotNil)
 
-		_, err = repo.ListRefresh([]*RefreshCandidate{{
+		_, err = repo.refreshForCandidates([]*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
-			Revision: snap.R(1),
+			Revision: 1,
 			Epoch:    "0",
-		},
-		}, nil)
+		}}, nil)
 		return err
 	}
 
@@ -2879,7 +3152,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 	c.Assert(somewhatBrokenSrvCalls, Equals, 4)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshEOF(c *C) {
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2901,10 +3174,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshEOF(c *C) {
 	repo := New(&cfg, authContext)
 	c.Assert(repo, NotNil)
 
-	_, err = repo.ListRefresh([]*RefreshCandidate{{
+	_, err = repo.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
-		Revision: snap.R(1),
+		Revision: 1,
 		Epoch:    "0",
 	}}, nil)
 	c.Assert(err, NotNil)
@@ -2912,7 +3185,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshEOF(c *C) {
 	c.Assert(n, Equals, 5)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshUnauthorised(c *C) {
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesUnauthorised(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -2934,17 +3207,17 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshUnauthorised(c
 	repo := New(&cfg, authContext)
 	c.Assert(repo, NotNil)
 
-	_, err = repo.ListRefresh([]*RefreshCandidate{{
+	_, err = repo.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
-		Revision: snap.R(24),
+		Revision: 24,
 		Epoch:    "0",
 	}}, nil)
 	c.Assert(n, Equals, 1)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 401 via POST to "http://.*?/updates/"`)
 }
 
-func (t *remoteRepoTestSuite) TestListRefreshFailOnDNS(c *C) {
+func (t *remoteRepoTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
 	bulkURI, err := url.Parse("http://nonexistingserver909123.com/updates/")
 	c.Assert(err, IsNil)
 	cfg := Config{
@@ -2954,17 +3227,17 @@ func (t *remoteRepoTestSuite) TestListRefreshFailOnDNS(c *C) {
 	repo := New(&cfg, authContext)
 	c.Assert(repo, NotNil)
 
-	_, err = repo.ListRefresh([]*RefreshCandidate{{
+	_, err = repo.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
-		Revision: snap.R(24),
+		Revision: 24,
 		Epoch:    "0",
 	}}, nil)
 	// the error differs depending on whether a proxy is in use (e.g. on travis), so don't inspect error message
 	c.Assert(err, NotNil)
 }
 
-func (t *remoteRepoTestSuite) TestListRefresh500(c *C) {
+func (t *remoteRepoTestSuite) TestRefreshForCandidates500(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -2982,17 +3255,17 @@ func (t *remoteRepoTestSuite) TestListRefresh500(c *C) {
 	repo := New(&cfg, authContext)
 	c.Assert(repo, NotNil)
 
-	_, err = repo.ListRefresh([]*RefreshCandidate{{
+	_, err = repo.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
-		Revision: snap.R(24),
+		Revision: 24,
 		Epoch:    "0",
 	}}, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/updates/"`)
 	c.Assert(n, Equals, 5)
 }
 
-func (t *remoteRepoTestSuite) TestListRefresh500DurationExceeded(c *C) {
+func (t *remoteRepoTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -3011,14 +3284,28 @@ func (t *remoteRepoTestSuite) TestListRefresh500DurationExceeded(c *C) {
 	repo := New(&cfg, authContext)
 	c.Assert(repo, NotNil)
 
-	_, err = repo.ListRefresh([]*RefreshCandidate{{
+	_, err = repo.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
-		Revision: snap.R(24),
+		Revision: 24,
 		Epoch:    "0",
 	}}, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/updates/"`)
 	c.Assert(n, Equals, 1)
+}
+
+func (t *remoteRepoTestSuite) TestIsActuallyUpdateWorks(c *C) {
+	c.Check(isActuallyUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("1")}), Equals, true)
+}
+func (t *remoteRepoTestSuite) TestIsActuallyUpdateSkipsCurrent(c *C) {
+	c.Check(isActuallyUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("42")}), Equals, false)
+}
+func (t *remoteRepoTestSuite) TestIsActuallyUpdateSkipsBlocked(c *C) {
+	c.Check(isActuallyUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("1"), Block: []snap.Revision{snap.R("42")}}), Equals, false)
+}
+func (t *remoteRepoTestSuite) TestIsActuallyUpdateSkipsBoth(c *C) {
+	// belts-and-suspenders
+	c.Check(isActuallyUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("42"), Block: []snap.Revision{snap.R("42")}}), Equals, false)
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c *C) {
@@ -3205,10 +3492,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOn
 		repo := New(&cfg, nil)
 		c.Assert(repo, NotNil)
 
-		repo.ListRefresh([]*RefreshCandidate{{
+		repo.refreshForCandidates([]*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
-			Revision: snap.R(24),
+			Revision: 1,
 			Epoch:    "0",
 		}}, nil)
 	}
@@ -3348,15 +3635,9 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c 
 		err = json.Unmarshal(jsonReq, &resp)
 		c.Assert(err, IsNil)
 
-		c.Assert(resp.Snaps, HasLen, 1)
-		c.Assert(resp.Snaps[0], DeepEquals, map[string]interface{}{
-			"snap_id":     helloWorldSnapID,
-			"channel":     "stable",
-			"epoch":       "0",
-			"confinement": "",
-		})
-
-		io.WriteString(w, MockUpdatesJSON)
+		// XXX actually why hit the network here
+		c.Assert(resp.Snaps, HasLen, 0)
+		io.WriteString(w, `{}`)
 	}))
 
 	c.Assert(mockServer, NotNil)

--- a/tests/regression/lp-1693042/task.yaml
+++ b/tests/regression/lp-1693042/task.yaml
@@ -1,0 +1,14 @@
+summary: Regression check for https://bugs.launchpad.net/snapd/+bug/1693042
+details: |
+  When attempting to refresh to a bogus channel, detect it and fail.
+execute: |
+  # sanity check
+  snap list core
+
+  out=$(! snap refresh core --channel bogus 2>&1- 1>- )
+  revno=$( snap info core | awk '/^installed:/{print $3}' )
+  if [[ "$revno" =~ x[0-9]+ ]]; then
+      MATCH "cannot refresh local snap" <<< "$out"
+  else
+      MATCH not.found <<< "$out"
+  fi


### PR DESCRIPTION
This splits LookupRefrsh out of store's ListRefresh, and makes
snapstate's Update use the new one. The difference is that
LookupRefresh can tell the difference between "this snap does not
exist [in the channel you asked about]" and "there are no updates for
this snap"; ListRefresh confounds the two situations, leading to some
hilarity.

Also includes some incidental refactoring of ListRefresh in order to
avoid DRY.