### PR TITLE
tests: move static and unit tests to spread task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,4 @@ install:
   - sudo apt-get install -qq gnupg1 || sudo apt-get install -qq gnupg
 
 script:
-    - ./run-checks --static || travis_terminate 1
-    - ./run-checks --unit || travis_terminate 1
     - ./run-checks --spread

--- a/spread.yaml
+++ b/spread.yaml
@@ -382,6 +382,13 @@ suites:
         environment:
             # env vars required for coverage reporting from a spread task
             TRAVIS_BUILD_NUMBER: "$(HOST: echo $TRAVIS_BUILD_NUMBER)"
+            TRAVIS_BRANCH: "$(HOST: echo $TRAVIS_BRANCH)"
+            TRAVIS_COMMIT: "$(HOST: echo $TRAVIS_COMMIT)"
+            TRAVIS_JOB_NUMBER: "$(HOST: echo $TRAVIS_JOB_NUMBER)"
+            TRAVIS_PULL_REQUEST: "$(HOST: echo $TRAVIS_PULL_REQUEST)"
+            TRAVIS_JOB_ID: "$(HOST: echo $TRAVIS_JOB_ID)"
+            TRAVIS_REPO_SLUG: "$(HOST: echo $TRAVIS_REPO_SLUG)"
+            TRAVIS_TAG: "$(HOST: echo $TRAVIS_TAG)"
             COVERMODE: "$(HOST: echo $COVERMODE)"
 
         prepare: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -379,6 +379,11 @@ suites:
     tests/unit/:
         summary: Suite to run unit tests (non-go and different go runtimes)
         systems: [-ubuntu-core-16-*]
+        environment:
+            # env vars required for coverage reporting from a spread task
+            TRAVIS_BUILD_NUMBER: "$(HOST: echo $TRAVIS_BUILD_NUMBER)"
+            COVERMODE: "$(HOST: echo $COVERMODE)"
+
         prepare: |
             . $TESTSLIB/prepare.sh
             prepare_classic

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -14,5 +14,5 @@ execute: |
     rm -r /tmp/static-unit-tests/src/github.com/snapcore/snapd/vendor/*/
     rm -rf /tmp/static-unit-tests/src/github.com/snapcore/snapd/cmd/{autom4te.cache,configure,test-driver,config.status,config.guess,config.sub,config.h.in,compile,install-sh,depcomp,build,missing,aclocal.m4,Makefile,Makefile.in}
 
-    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && /usr/bin/env GOPATH=/tmp/static-unit-tests ./run-checks --static" test
-    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && /usr/bin/env GOPATH=/tmp/static-unit-tests ./run-checks --unit" test
+    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && GOPATH=/tmp/static-unit-tests ./run-checks --static" test
+    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER COVERMODE=$COVERMODE GOPATH=/tmp/static-unit-tests ./run-checks --unit" test

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -24,5 +24,7 @@ execute: |
                                                                          TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG \
                                                                          TRAVIS_TAG=$TRAVIS_TAG \
                                                                          COVERMODE=$COVERMODE \
+                                                                         TRAVIS=true \
+                                                                         CI=true \
                                                                          GOPATH=/tmp/static-unit-tests \
                                                                          ./run-checks --unit" test

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -15,4 +15,14 @@ execute: |
     rm -rf /tmp/static-unit-tests/src/github.com/snapcore/snapd/cmd/{autom4te.cache,configure,test-driver,config.status,config.guess,config.sub,config.h.in,compile,install-sh,depcomp,build,missing,aclocal.m4,Makefile,Makefile.in}
 
     su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && GOPATH=/tmp/static-unit-tests ./run-checks --static" test
-    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER COVERMODE=$COVERMODE GOPATH=/tmp/static-unit-tests ./run-checks --unit" test
+    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER \
+                                                                         TRAVIS_BRANCH=$TRAVIS_BRANCH \
+                                                                         TRAVIS_COMMIT=$TRAVIS_COMMIT \
+                                                                         TRAVIS_JOB_NUMBER=$TRAVIS_JOB_NUMBER \
+                                                                         TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST \
+                                                                         TRAVIS_JOB_ID=$TRAVIS_JOB_ID \
+                                                                         TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG \
+                                                                         TRAVIS_TAG=$TRAVIS_TAG \
+                                                                         COVERMODE=$COVERMODE \
+                                                                         GOPATH=/tmp/static-unit-tests \
+                                                                         ./run-checks --unit" test

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -1,0 +1,18 @@
+summary: Run project static and unit tests
+
+systems: [ubuntu-16.04-64]
+
+restore: |
+    rm -rf /tmp/static-unit-tests
+
+execute: |
+    mkdir -p /tmp/static-unit-tests/src/github.com/snapcore
+    cp -ar $PROJECT_PATH /tmp/static-unit-tests/src/github.com/snapcore
+    chown -R test:12345 /tmp/static-unit-tests
+
+    # remove leftovers
+    rm -r /tmp/static-unit-tests/src/github.com/snapcore/snapd/vendor/*/
+    rm -rf /tmp/static-unit-tests/src/github.com/snapcore/snapd/cmd/{autom4te.cache,configure,test-driver,config.status,config.guess,config.sub,config.h.in,compile,install-sh,depcomp,build,missing,aclocal.m4,Makefile,Makefile.in}
+
+    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && /usr/bin/env GOPATH=/tmp/static-unit-tests ./run-checks --static" test
+    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && /usr/bin/env GOPATH=/tmp/static-unit-tests ./run-checks --unit" test

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -15,16 +15,17 @@ execute: |
     rm -rf /tmp/static-unit-tests/src/github.com/snapcore/snapd/cmd/{autom4te.cache,configure,test-driver,config.status,config.guess,config.sub,config.h.in,compile,install-sh,depcomp,build,missing,aclocal.m4,Makefile,Makefile.in}
 
     su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && GOPATH=/tmp/static-unit-tests ./run-checks --static" test
-    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER \
-                                                                         TRAVIS_BRANCH=$TRAVIS_BRANCH \
-                                                                         TRAVIS_COMMIT=$TRAVIS_COMMIT \
-                                                                         TRAVIS_JOB_NUMBER=$TRAVIS_JOB_NUMBER \
-                                                                         TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST \
-                                                                         TRAVIS_JOB_ID=$TRAVIS_JOB_ID \
-                                                                         TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG \
-                                                                         TRAVIS_TAG=$TRAVIS_TAG \
-                                                                         COVERMODE=$COVERMODE \
-                                                                         TRAVIS=true \
-                                                                         CI=true \
-                                                                         GOPATH=/tmp/static-unit-tests \
-                                                                         ./run-checks --unit" test
+    su -l -c "cd /tmp/static-unit-tests/src/github.com/snapcore/snapd && \
+        TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER \
+        TRAVIS_BRANCH=$TRAVIS_BRANCH \
+        TRAVIS_COMMIT=$TRAVIS_COMMIT \
+        TRAVIS_JOB_NUMBER=$TRAVIS_JOB_NUMBER \
+        TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST \
+        TRAVIS_JOB_ID=$TRAVIS_JOB_ID \
+        TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG \
+        TRAVIS_TAG=$TRAVIS_TAG \
+        COVERMODE=$COVERMODE \
+        TRAVIS=true \
+        CI=true \
+        GOPATH=/tmp/static-unit-tests \
+        ./run-checks --unit" test


### PR DESCRIPTION
With these changes, the static and unit tests are moved to a spread task instead of being executed always as the first steps of each build, so that we can get the benefits of spread parallelization (more about the rationale here https://forum.snapcraft.io/t/move-initial-checks-into-their-own-spread-task/771).

The `TRAVIS_BUILD_NUMBER` and `COVERMODE` are passed from the host to the testbed so that they are available while running the spread task, according to https://github.com/snapcore/snapd/blob/master/run-checks#L148 they are needed for reporting coverage metrics properly.