### PR TITLE
packaging/fedora: sync packaging from Fedora Dist-Git

### DIFF
--- a/packaging/fedora/snap-mgmt.sh
+++ b/packaging/fedora/snap-mgmt.sh
@@ -8,7 +8,7 @@
 set -e
 
 SNAP_MOUNT_DIR="/var/lib/snapd/snap"
-SNAP_UNIT_PREFIX="var-lib-snapd-snap"
+SNAP_UNIT_PREFIX="$(systemd-escape -p ${SNAP_MOUNT_DIR})"
 
 systemctl_stop() {
     unit="$1"
@@ -21,7 +21,7 @@ systemctl_stop() {
 if [ "$1" = "purge" ]; then
     # undo any bind mount to ${SNAP_MOUNT_DIR} that resulted from LP:#1668659
     if grep -q "${SNAP_MOUNT_DIR} ${SNAP_MOUNT_DIR}" /proc/self/mountinfo; then
-        umount -l ${SNAP_MOUNT_DIR} || true
+        umount -l "${SNAP_MOUNT_DIR}" || true
     fi
 
     mounts=$(systemctl list-unit-files --full | grep "^${SNAP_UNIT_PREFIX}[-.].*\.mount" | cut -f1 -d ' ')
@@ -43,16 +43,16 @@ if [ "$1" = "purge" ]; then
         if [ -n "$snap" ]; then
             echo "Removing snap $snap"
             # aliases
-            if [ -d ${SNAP_MOUNT_DIR}/bin ]; then
-                find ${SNAP_MOUNT_DIR}/bin -maxdepth 1 -lname "$snap" -delete
-                find ${SNAP_MOUNT_DIR}/bin -maxdepth 1 -lname "$snap.*" -delete
+            if [ -d "${SNAP_MOUNT_DIR}/bin" ]; then
+                find "${SNAP_MOUNT_DIR}/bin" -maxdepth 1 -lname "$snap" -delete
+                find "${SNAP_MOUNT_DIR}/bin" -maxdepth 1 -lname "$snap.*" -delete
             fi
             # generated binaries
             rm -f "${SNAP_MOUNT_DIR}/bin/$snap"
             rm -f "${SNAP_MOUNT_DIR}/bin/$snap".*
             # snap mount dir
             umount -l "${SNAP_MOUNT_DIR}/$snap/$rev" 2> /dev/null || true
-            rm -rf "${SNAP_MOUNT_DIR:?}/$snap/$rev"
+            rm -rf "${SNAP_MOUNT_DIR}/$snap/$rev"
             rm -f "${SNAP_MOUNT_DIR}/$snap/current"
             # snap data dir
             rm -rf "/var/snap/$snap/$rev"
@@ -83,10 +83,11 @@ if [ "$1" = "purge" ]; then
     rm -rf /var/lib/snapd/snaps/*
 
     echo "Final directory cleanup"
-    rm -rf "${SNAP_MOUNT_DIR:?}"/*
+    rm -rf "${SNAP_MOUNT_DIR}"/*
     rm -rf /var/snap/*
 
     echo "Removing leftover snap shared state data"
+    rm -rf /var/lib/snapd/desktop/applications/*
     rm -rf /var/lib/snapd/seccomp/profiles/*
     rm -rf /var/lib/snapd/device/*
     rm -rf /var/lib/snapd/assertions/*

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -361,6 +361,7 @@ install -d -p %{buildroot}%{_sysconfdir}/profile.d
 install -d -p %{buildroot}%{_sysconfdir}/sysconfig
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/assertions
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/desktop/applications
+install -d -p %{buildroot}%{_sharedstatedir}/snapd/device
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/hostfs
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/mount
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/seccomp/profiles
@@ -504,6 +505,7 @@ popd
 %dir %{_sharedstatedir}/snapd/assertions
 %dir %{_sharedstatedir}/snapd/desktop
 %dir %{_sharedstatedir}/snapd/desktop/applications
+%dir %{_sharedstatedir}/snapd/device
 %dir %{_sharedstatedir}/snapd/hostfs
 %dir %{_sharedstatedir}/snapd/mount
 %dir %{_sharedstatedir}/snapd/seccomp
@@ -592,6 +594,9 @@ fi
 
 
 %changelog
+* Thu May 25 2017 Neal Gompa <ngompa13@gmail.com> - 2.26.3-3
+- Cover even more stuff for proper erasure on final uninstall (RH#1444422)
+
 * Sun May 21 2017 Neal Gompa <ngompa13@gmail.com> - 2.26.3-2
 - Fix error in script for removing Snappy content (RH#1444422)
 - Adjust changelog bug references to be specific on origin


### PR DESCRIPTION
Pull in changes from the Fedora Dist-Git repository for snapd into the local copy of Fedora packaging.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>