### PR TITLE
tests: fix for upgrade test when it is repeated

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -284,7 +284,7 @@ restore: |
     fi
 
     rm -f $SPREAD_PATH/snapd-state.tar.gz
-    rm -rf $GOPATH/*
+    rm -rf ${GOPATH%%:*}/*
 
 suites:
     tests/main/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -284,6 +284,7 @@ restore: |
     fi
 
     rm -f $SPREAD_PATH/snapd-state.tar.gz
+    rm -rf $GOPATH/*
 
 suites:
     tests/main/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -368,13 +368,13 @@ suites:
                 echo "skip upgrade tests while talking to the staging store"
                 exit 0
             fi
-            apt-get purge -y snapd
         restore-each: |
             if [ "$REMOTE_STORE" = staging ]; then
                 echo "skip upgrade tests while talking to the staging store"
                 exit 0
             fi
             $TESTSLIB/reset.sh
+            apt-get purge -y snapd
 
     tests/unit/:
         summary: Suite to run unit tests (non-go and different go runtimes)

--- a/tests/main/snap-on-non-shared-root/task.yaml
+++ b/tests/main/snap-on-non-shared-root/task.yaml
@@ -22,12 +22,12 @@ execute: |
     test-snapd-tools.echo hello
 
     echo "Ensure we have a shared mount of $SNAPMOUNTDIR"
-    cat /proc/self/mountinfo |MATCH "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]*"
+    cat /proc/self/mountinfo |MATCH "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]"
 
     echo "Run it again for good measure"
     test-snapd-tools.echo hello
     echo "... and ensure we do not mount $SNAPMOUNTDIR again"
-    n=$(cat /proc/self/mountinfo |grep "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]*"|wc -l)
+    n=$(cat /proc/self/mountinfo |grep "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]"|wc -l)
     if [ "$n" -ne 1 ]; then
         echo "Incorrect extra $SNAPMOUNTDIR bind mounts created"
         exit 1

--- a/tests/main/snap-on-non-shared-root/task.yaml
+++ b/tests/main/snap-on-non-shared-root/task.yaml
@@ -22,12 +22,12 @@ execute: |
     test-snapd-tools.echo hello
 
     echo "Ensure we have a shared mount of $SNAPMOUNTDIR"
-    cat /proc/self/mountinfo |MATCH "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:1"
+    cat /proc/self/mountinfo |MATCH "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]*"
 
     echo "Run it again for good measure"
     test-snapd-tools.echo hello
     echo "... and ensure we do not mount $SNAPMOUNTDIR again"
-    n=$(cat /proc/self/mountinfo |grep "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:1"|wc -l)
+    n=$(cat /proc/self/mountinfo |grep "$SNAPMOUNTDIR $SNAPMOUNTDIR.*shared:[0-9]*"|wc -l)
     if [ "$n" -ne 1 ]; then
         echo "Incorrect extra $SNAPMOUNTDIR bind mounts created"
         exit 1


### PR DESCRIPTION
When the upgrade test is repeated using -repeat option, it is failing  due to snapd it is not being purged for each task.
    
    It is happening that the prev version is the same than the new one:
    + prevsnapdver='snapd   1337.2.26.3'
    + snapdver='snapd   1337.2.26.3'
    + '[' 'snapd   1337.2.26.3' '!=' 'snapd   1337.2.26.3' ']'
