### PR TITLE
tests: fix for upgrade test when it is repeated

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -367,13 +367,13 @@ suites:
                 echo "skip upgrade tests while talking to the staging store"
                 exit 0
             fi
-            apt-get purge -y snapd
         restore-each: |
             if [ "$REMOTE_STORE" = staging ]; then
                 echo "skip upgrade tests while talking to the staging store"
                 exit 0
             fi
             $TESTSLIB/reset.sh
+            apt-get purge -y snapd
 
     tests/unit/:
         summary: Suite to run unit tests (non-go and different go runtimes)


### PR DESCRIPTION
When the upgrade test is repeated using -repeat option, it is failing
due to snapd it is not being purged for each task.

It is happening that the prev version is the same than the new one:
+ prevsnapdver='snapd   1337.2.26.3'
+ snapdver='snapd   1337.2.26.3'
+ '[' 'snapd   1337.2.26.3' '!=' 'snapd   1337.2.26.3' ']'