### PR TITLE
interfaces: move seecomp profiles to /var/lib/snapd/seccomp/profiles-v2/

### DIFF
--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -95,7 +95,7 @@ struct sc_map_list {
 	int count;
 };
 
-static char *filter_profile_dir = "/var/lib/snapd/seccomp/profiles/";
+static char *filter_profile_dir = "/var/lib/snapd/seccomp/profiles-v2/";
 static struct hsearch_data sc_map_htab;
 static struct sc_map_list sc_map_entries;
 

--- a/cmd/snap-confine/seccomp-support.h
+++ b/cmd/snap-confine/seccomp-support.h
@@ -23,7 +23,7 @@
  * Prepare seccomp profile associated with the security tag.
  *
  * This function loads the seccomp profile from
- * /var/lib/snapd/seccomp/profiles/$SECURITY_TAG and stores it into
+ * /var/lib/snapd/seccomp/profiles-v2/$SECURITY_TAG and stores it into
  * scmp_filter_ctx object.
  *
  * The object is returned to the caller and can be made effective with a call

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -89,7 +89,7 @@
     # change_profile unsafe /** -> **,
 
     # reading seccomp filters
-    /{tmp/snap.rootfs_*/,}var/lib/snapd/seccomp/profiles/* r,
+    /{tmp/snap.rootfs_*/,}var/lib/snapd/seccomp/profiles-v2/* r,
 
     # reading mount profiles
     /{tmp/snap.rootfs_*/,}var/lib/snapd/mount/*.fstab r,

--- a/cmd/snap-confine/snap-confine.rst
+++ b/cmd/snap-confine/snap-confine.rst
@@ -47,7 +47,7 @@ extensive dbus mediation. Refer to apparmor documentation for more details.
 Seccomp profiles
 ----------------
 
-`snap-confine` looks for the `/var/lib/snapd/seccomp/profiles/$SECURITY_TAG`
+`snap-confine` looks for the `/var/lib/snapd/seccomp/profiles-v2/$SECURITY_TAG`
 file. This file is **mandatory** and `snap-confine` will refuse to run without
 it.
 
@@ -129,7 +129,7 @@ FILES
 
 	Description of the mount profile.
 
-`/var/lib/snapd/seccomp/profiles/*`:
+`/var/lib/snapd/seccomp/profiles-v2/*`:
 
 	Description of the seccomp profile.
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -137,7 +137,7 @@ func SetRootDir(rootdir string) {
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	AppArmorCacheDir = filepath.Join(rootdir, "/var/cache/apparmor")
 	SnapAppArmorAdditionalDir = filepath.Join(rootdir, snappyDir, "apparmor", "additional")
-	SnapSeccompDir = filepath.Join(rootdir, snappyDir, "seccomp", "profiles")
+	SnapSeccompDir = filepath.Join(rootdir, snappyDir, "seccomp", "profiles-v2")
 	SnapMountPolicyDir = filepath.Join(rootdir, snappyDir, "mount")
 	SnapMetaDir = filepath.Join(rootdir, snappyDir, "meta")
 	SnapBlobDir = filepath.Join(rootdir, snappyDir, "snaps")

--- a/packaging/fedora/snap-mgmt.sh
+++ b/packaging/fedora/snap-mgmt.sh
@@ -88,7 +88,7 @@ if [ "$1" = "purge" ]; then
 
     echo "Removing leftover snap shared state data"
     rm -rf /var/lib/snapd/desktop/applications/*
-    rm -rf /var/lib/snapd/seccomp/profiles/*
+    rm -rf /var/lib/snapd/seccomp/profiles*/*
     rm -rf /var/lib/snapd/device/*
     rm -rf /var/lib/snapd/assertions/*
 

--- a/tests/regression/lp-1641885/task.yaml
+++ b/tests/regression/lp-1641885/task.yaml
@@ -18,11 +18,11 @@ execute: |
     echo "Ensure that the apparmor profile doesn't use the complain mode"
     grep attach_disconnected /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode | MATCH -v complain
     echo "Ensure that the seccomp profile doesn't use the complain mode"
-    MATCH -v '@complain' < /var/lib/snapd/seccomp/profiles/snap.test-snapd-devmode.test-snapd-devmode
+    MATCH -v '@complain' < /var/lib/snapd/seccomp/profiles-v2/snap.test-snapd-devmode.test-snapd-devmode
 restore: |
     rm -f ./test-snapd-devmode_1.0_all.snap
 debug: |
     echo "Apparmor profile (first 30 lines)"
     head -n 30 /var/lib/snapd/apparmor/profiles/snap.test-snapd-devmode.test-snapd-devmode || true
     echo "Seccomp profile (first 30 lines)"
-    head -n 30 /var/lib/snapd/seccomp/profiles/snap.test-snapd-devmode.test-snapd-devmode || true
+    head -n 30 /var/lib/snapd/seccomp/profiles-v2/snap.test-snapd-devmode.test-snapd-devmode || true


### PR DESCRIPTION
This is an alternative approach to deal with https://forum.snapcraft.io/t/snapd-2-25-blocked-because-of-revert-race-condition/722/5 - it should unblock 2.25/2.26 for stable promotion.

In a nutshell there is the problem that when moving from 2.24 to 2.25 and revert back snap services will not startup correctly because when snapd rewrites the seccomp profile the snap service is already started and because the profile is not something that snap-confine from 2.24 understands the daemon will have failed, https://github.com/snapcore/snapd/pull/3348 can reproduce it.

I think we also need to make the format more robust while we do this profile dir switch to avoid that we need to do it everytime we break the format. Either we simply ignore lines that cannot be parsedd. Which should be ok (unless I miss something) - its a whitelist, so if we add anything in there that is skipped worst case is that snap-confine does not understand it and will not add it. So no security issue. E.g. `mknod - |S_IFREG -` would simply be skipped. Alternatively we could add a magic marker when new syntax gets added, like: `syntax: 2` and snap-confine simply stops parsing when it encounters a "syntax: N" line that is bigger than the N it supports.