### PR TITLE
cmd/hotfix: add hotfix tool

### DIFF
--- a/cmd/snapd-hotfix-tool/hotfixes/1.hotfix
+++ b/cmd/snapd-hotfix-tool/hotfixes/1.hotfix
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+do_describe() {
+	cat << EOF
+core revision 1968 contained a snapd that would load snap-update-ns from the
+distribution and not from the core snap, at that time the released (classic)
+package of snapd has a no-op snap-update-ns that always fails.
+
+As a work-around, copy the update-ns tool from the core snap and overwrite
+the system package.
+EOF
+}
+
+do_apply() {
+	sudo cp -a /snap/core/current/usr/lib/snapd/snap-update-ns /usr/lib/snapd/snap-update-ns
+}
+
+is_eligible() {
+	# Only certain distributions are eligible for repair.
+	. /etc/os-release
+	case "$ID" in
+		ubuntu-core)
+			# Not applicable to core systems.
+			return 1
+			;;
+		fedora|centos|opensuse|suse)
+			# Not applicable to systems that do not re-execute.
+			return 1
+			;;
+	esac
+
+	# Only certain core revisions are eligible for repair.
+	case "$(readlink /snap/core/current)" in
+		1968)
+			# This corresponds to snapd 2.26.3+201705171658.git.78e21 on amd64
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+is_necessary() {
+	if cmp --quiet /snap/core/current/usr/lib/snapd/snap-update-ns /usr/lib/snapd/snap-update-ns; then
+		return 1
+	else
+		return 0
+	fi
+}

--- a/cmd/snapd-hotfix-tool/snapd-hotfix-tool
+++ b/cmd/snapd-hotfix-tool/snapd-hotfix-tool
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+hotfix_id="$1"
+
+if [ -z "$hotfix_id" ]; then
+	echo "usage: snapd-hotfix-tool HOTFIX-ID"
+	exit 1
+fi
+
+if [ ! -f "hotfixes/$hotfix_id.hotfix" ]; then
+	echo "snapd-hotfix-tool: invalid hotfix identifier: $hotfix_id" >&2
+	exit 1
+fi
+
+echo "snapd-hotfix-tool, hotfix identifier $hotfix_id"
+
+. ./hotfixes/"$hotfix_id".hotfix
+
+echo
+do_describe
+echo
+
+echo "Attempting hotfix:"
+if is_eligible; then
+	echo " - the system is eligible"
+	if is_necessary; then
+		echo " - hotfix is necessary"
+		if do_apply; then
+			echo " - hotfix successful!"
+		else
+			echo " - hotfix failed, please report this on forum.snapcraft.io"
+			exit 1
+		fi
+	else
+		echo " - hotfix is *not* necessary (already performed)"
+	fi
+else
+	echo " - the system is *not* eligible for this hotfix"
+fi


### PR DESCRIPTION
The hotfix tool is intended to help people that are tracking edge and
get into funny state that is hard to recover manually (e.g. by
refreshing to another core revision) but can still be fixed
automatically.

Along with the simple tool we also add the first hotfix, the one that is
affecting people on the core revision 1968, where core refresh fails
with "snap-update-ns" errors.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>