### PR TITLE
tests: fix for snapd-reexec test cheking for restart info on debug log

### DIFF
--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -26,8 +26,8 @@ execute: |
     fi
 
     echo "Ensure we re-exec by default"
-    snap list
-    journalctl | MATCH "DEBUG: restarting into"
+    /usr/bin/env SNAPD_DEBUG=1 snap list 2> debug.log
+    cat debug.log | MATCH "DEBUG: restarting into"
 
     . $TESTSLIB/dirs.sh
 

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -26,8 +26,7 @@ execute: |
     fi
 
     echo "Ensure we re-exec by default"
-    /usr/bin/env SNAPD_DEBUG=1 snap list 2> debug.log
-    cat debug.log | MATCH "DEBUG: restarting into"
+    /usr/bin/env SNAPD_DEBUG=1 snap list 2>&1 | MATCH "DEBUG: restarting into"
 
     . $TESTSLIB/dirs.sh
 


### PR DESCRIPTION
This change is to check the restart info a the debug log instaed of
checking that in the journalctl that sometimes does not log any data.

The prevoius check is not enough to validate the restart has been done
because journalctl used to show log information which already contains
the string "DEBUG: restarting into".

Error:
https://travis-ci.org/snapcore/snapd/builds/235819260
https://travis-ci.org/snapcore/snapd/builds/238737010