### PR TITLE
tests: fix for econnreset test checking that the download already started

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -22,7 +22,7 @@ execute: |
         [ grep -q "Retrying.*\.snap, attempt 2" snap-download.log ] && break
         sleep 1
     done
-    MATCH "Retrying.*\.snap, attempt 2" snap-download.log
+    cat snap-download.log | MATCH "Retrying.*\.snap, attempt 2"
     # Note that the download will not be successful because of the nature of
     # the netfilter testbed. When snap download retries the next attempt will
     # end up with a "connection refused" error, something we do not retry

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -23,6 +23,7 @@ execute: |
         sleep 1
     done
     cat snap-download.log | MATCH "Retrying.*\.snap, attempt 2"
+
     # Note that the download will not be successful because of the nature of
     # the netfilter testbed. When snap download retries the next attempt will
     # end up with a "connection refused" error, something we do not retry

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -9,17 +9,25 @@ execute: |
     echo "Wait until the download started and downloaded more than 1 MB"
     partial=test-snapd-huge_1.snap.partial
     for i in $(seq 20); do
-        [ -f $partial ] && [ $(wc -c <"$partial") -gt 1048576 ] && break
+        if [ -f "$partial" ] && [ $(stat -c%s "$partial") -gt $(( 1024 * 1024 )) ]; then
+            break
+        fi
         sleep .5
     done
-    [ ! -f $partial ] || [ $(wc -c <"$partial") -eq 0 ] && exit 1
+
+    if [ ! -f "$partial" ] || [ $(stat -c%s "$partial") -eq 0 ]; then
+        echo "Partial file $partial did not start downloading, test broken"
+        exit 1
+    fi
 
     echo "Block the download using iptables"
     iptables -I OUTPUT -m owner --uid-owner $(id -u test) -j REJECT -p tcp --reject-with tcp-reset
 
     echo "Check that we retried"
     for i in $(seq 10); do
-        [ grep -q "Retrying.*\.snap, attempt 2" snap-download.log ] && break
+        if [ cat snap-download.log | MATCH "Retrying.*\.snap, attempt 2" ]; then
+            break
+        fi
         sleep 1
     done
     cat snap-download.log | MATCH "Retrying.*\.snap, attempt 2"

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -5,21 +5,24 @@ restore: |
 execute: |
     echo "Downloading a large snap in the background"
     su -c "/usr/bin/env SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &
-    echo "Wait until it actually got some data for the snap"
-    while ! grep -q "Retrying.*download-snap/.*\.snap, attempt 1" snap-download.log; do
-        sleep 1
+
+    echo "Wait until the download started and downloaded more than 1 MB"
+    partial=test-snapd-huge_1.snap.partial
+    for i in $(seq 20); do
+        [ -f $partial ] && [ $(wc -c <"$partial") -gt 1048576 ] && break
+        sleep .5
     done
-    echo "Wait a little bit for the download to start, then force sending a RST package"
-    sleep 3
+    [ ! -f $partial ] || [ $(wc -c <"$partial") -eq 0 ] && exit 1
+
+    echo "Block the download using iptables"
     iptables -I OUTPUT -m owner --uid-owner $(id -u test) -j REJECT -p tcp --reject-with tcp-reset
+
     echo "Check that we retried"
     for i in $(seq 10); do
-        if grep -q "Retrying.*\.snap, attempt 2" snap-download.log; then
-            break
-        fi
+        [ grep -q "Retrying.*\.snap, attempt 2" snap-download.log ] && break
         sleep 1
     done
-    cat snap-download.log | MATCH "Retrying.*\.snap, attempt 2"
+    MATCH "Retrying.*\.snap, attempt 2" snap-download.log
     # Note that the download will not be successful because of the nature of
     # the netfilter testbed. When snap download retries the next attempt will
     # end up with a "connection refused" error, something we do not retry


### PR DESCRIPTION
This change makes the test to wait until the download started by
checking the download file size and then if the download already started
the iptables rule is applied.

ERROR:
https://travis-ci.org/snapcore/snapd/builds/237470126