### PR TITLE
tests: show available entropy on error

### DIFF
--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -19,10 +19,7 @@ restore: |
     rmdir testdir
 
 debug: |
-    if [ -f /proc/sys/kernel/random/entropy_avail ]; then
-        echo "Available entropy:"
-        cat /proc/sys/kernel/random/entropy_avail
-    fi
+    sysctl kernel.random.entropy_avail || true
 
 execute: |
     for i in *.exp; do

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -18,6 +18,12 @@ restore: |
     rm testdir/foo.snap bar.snap
     rmdir testdir
 
+debug: |
+    if [ -f /proc/sys/kernel/random/entropy_avail ]; then
+        echo "Available entropy:"
+        cat /proc/sys/kernel/random/entropy_avail
+    fi
+
 execute: |
     for i in *.exp; do
         echo $i

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -6,10 +6,7 @@ prepare: |
     "$TESTSLIB"/mkpinentry.sh
 
 debug: |
-    if [ -f /proc/sys/kernel/random/entropy_avail ]; then
-        echo "Available entropy:"
-        cat /proc/sys/kernel/random/entropy_avail
-    fi
+    sysctl kernel.random.entropy_avail || true
 
 execute: |
     echo "Checking passphrase mismatch error"

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -5,6 +5,12 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 prepare: |
     "$TESTSLIB"/mkpinentry.sh
 
+debug: |
+    if [ -f /proc/sys/kernel/random/entropy_avail ]; then
+        echo "Available entropy:"
+        cat /proc/sys/kernel/random/entropy_avail
+    fi
+
 execute: |
     echo "Checking passphrase mismatch error"
     expect -d -f passphrase_mismatch.exp

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -6,6 +6,12 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 prepare: |
     "$TESTSLIB"/mkpinentry.sh
 
+debug: |
+    if [ -f /proc/sys/kernel/random/entropy_avail ]; then
+        echo "Available entropy:"
+        cat /proc/sys/kernel/random/entropy_avail
+    fi
+
 execute: |
     echo "Creating a new key without a password"
     expect -f create-key.exp

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -7,10 +7,7 @@ prepare: |
     "$TESTSLIB"/mkpinentry.sh
 
 debug: |
-    if [ -f /proc/sys/kernel/random/entropy_avail ]; then
-        echo "Available entropy:"
-        cat /proc/sys/kernel/random/entropy_avail
-    fi
+    sysctl kernel.random.entropy_avail || true
 
 execute: |
     echo "Creating a new key without a password"


### PR DESCRIPTION
The tests that call `snap create-key` are eventually falling with a timeout, we managed to partially mitigate this problem by installing rng-tools and pointing it to use `/dev/urandom` as described here https://forum.snapcraft.io/t/snap-create-key-timeouts/359, this worked fine and reduced the frequency of the timeouts but we are still getting some of them (so far only reported on ubuntu-16.04-32).

These changes will let us confirm if a low entropy comes together with the current timeout error.