### PR TITLE
interfaces: revert "interfaces: re-add reverted ioctl and quotactl

### DIFF
--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -47,11 +47,13 @@ const mountObserveConnectedPlugSecComp = `
 # restricted because it gives privileged read access to mount arguments and
 # should only be used with trusted apps.
 
-quotactl Q_GETQUOTA - - -
-quotactl Q_GETINFO - - -
-quotactl Q_GETFMT - - -
-quotactl Q_XGETQUOTA - - -
-quotactl Q_XGETQSTAT - - -
+# FIXME: restore quotactl with parameter filtering once snap-confine can read
+# this syntax. See LP:#1662489 for context.
+#quotactl Q_GETQUOTA - - -
+#quotactl Q_GETINFO - - -
+#quotactl Q_GETFMT - - -
+#quotactl Q_XGETQUOTA - - -
+#quotactl Q_XGETQSTAT - - -
 `
 
 func init() {

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -165,7 +165,10 @@ inotify_rm_watch
 
 # TIOCSTI allows for faking input (man tty_ioctl)
 # TODO: this should be scaled back even more
-ioctl - !TIOCSTI
+#ioctl - !TIOCSTI
+# FIXME: replace this with the filter of TIOCSTI once snap-confine can read this syntax
+# See LP:#1662489 for context.
+ioctl
 
 io_cancel
 io_destroy


### PR DESCRIPTION
(revert 21bc6b9f)"

This reverts commit 82311cfd14c44d8d8b9b7a0339e30deb1fb0ea59.

The reason for the revert is described in:
https://forum.snapcraft.io/t/snapd-2-25-blocked-because-of-revert-race-condition/722