### PR TITLE
tests: fix for test interfaces-openvswitch

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -159,20 +159,7 @@ if [ "$SPREAD" = 1 ]; then
     export PATH=$TMP_SPREAD:$PATH
     ( cd $TMP_SPREAD && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
-    spread -v linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
-    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v linode:
 
     # cleanup the debian-ubuntu-14.04
     rm -rf debian-ubuntu-14.04

--- a/run-checks
+++ b/run-checks
@@ -157,6 +157,9 @@ if [ "$SPREAD" = 1 ]; then
     addtrap "rm -rf \"$TMP_SPREAD\""
 
     export PATH=$TMP_SPREAD:$PATH
+    ( cd $TMP_SPREAD && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
+
+    rm spread
     ( cd $TMP_SPREAD && curl -s -O http://people.canonical.com/~sjcazzol/snappy/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
     spread -v -repeat 20 linode:tests/main/interfaces-openvswitch

--- a/run-checks
+++ b/run-checks
@@ -159,7 +159,7 @@ if [ "$SPREAD" = 1 ]; then
     export PATH=$TMP_SPREAD:$PATH
     ( cd $TMP_SPREAD && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
-    rm spread
+    rm $TMP_SPREAD/spread
     ( cd $TMP_SPREAD && curl -s -O http://people.canonical.com/~sjcazzol/snappy/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
     spread -v -repeat 20 linode:tests/main/interfaces-openvswitch

--- a/run-checks
+++ b/run-checks
@@ -159,10 +159,20 @@ if [ "$SPREAD" = 1 ]; then
     export PATH=$TMP_SPREAD:$PATH
     ( cd $TMP_SPREAD && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
-    rm $TMP_SPREAD/spread
-    ( cd $TMP_SPREAD && curl -s -O http://people.canonical.com/~sjcazzol/snappy/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
-
-    spread -v -repeat 20 linode:tests/main/interfaces-openvswitch
+    spread -v linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
+    spread -v -reuse linode:tests/main/interfaces-openvswitch
 
     # cleanup the debian-ubuntu-14.04
     rm -rf debian-ubuntu-14.04

--- a/run-checks
+++ b/run-checks
@@ -157,9 +157,9 @@ if [ "$SPREAD" = 1 ]; then
     addtrap "rm -rf \"$TMP_SPREAD\""
 
     export PATH=$TMP_SPREAD:$PATH
-    ( cd $TMP_SPREAD && curl -s -O https://niemeyer.s3.amazonaws.com/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
+    ( cd $TMP_SPREAD && curl -s -O http://people.canonical.com/~sjcazzol/snappy/spread-amd64.tar.gz && tar xzvf spread-amd64.tar.gz )
 
-    spread -v linode:
+    spread -v -repeat 20 linode:tests/main/interfaces-openvswitch
 
     # cleanup the debian-ubuntu-14.04
     rm -rf debian-ubuntu-14.04

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -47,6 +47,8 @@ debug: |
     tail -n100 /var/log/syslog || echo "failed"
     echo "------------------------------"
     ifconfig || echo failed
+    echo "------------------------------"
+    journalctl -xu openvswitch.service || echo "failed"
     echo "=============================="
 
 execute: |

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -37,7 +37,7 @@ restore: |
 
 debug: |
     echo "=============================="
-    echo "Custom debug information"
+    echo " Custom debug information "
     echo "=============================="
     systemctl status openvswitch-switch.service || echo "failed"
     echo "------------------------------"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -37,17 +37,17 @@ restore: |
 
 debug: |
     echo "Custom debug info"
-    echo "==================================="
+    echo "=============================="
     systemctl status openvswitch-switch.service || echo failed
     echo "-----------------------------------"
     ls -al /etc/openvswitch || echo failed
-    echo "-----------------------------------"
+    echo "------------------------------"
     tail -n100 /var/log/dpkg.log || echo failed
-    echo "-----------------------------------"
+    echo "------------------------------"
     tail -n100 /var/log/syslog || echo failed
-    echo "-----------------------------------"
+    echo "------------------------------"
     ifconfig || echo failed
-    echo "==================================="
+    echo "=============================="
 
 execute: |
     CONNECTED_PATTERN=":openvswitch +test-snapd-openvswitch-consumer"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -15,11 +15,11 @@ details: |
     list and deletion.
 
 prepare: |
-    echo "Given openvswitch is installed"
-    apt install -y --no-install-recommends openvswitch-switch
-
-    echo "And a snap declaring a plug on the openvswitch interface is installed"
+    echo "Install a snap declaring a plug on the openvswitch interface is installed"
     snap install --edge test-snapd-openvswitch-consumer
+
+    echo "Install openvswitch"
+    apt install -y --no-install-recommends openvswitch-switch
 
     echo "And a tap interface is defined"
     ip tuntap add tap1 mode tap

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -49,6 +49,12 @@ debug: |
     ifconfig || echo failed
     echo "------------------------------"
     journalctl -xu openvswitch.service || echo "failed"
+    echo "------------------------------"
+    tail -n100 /var/log/openvswitch/ovsdb-server.log || echo "failed"
+    echo "------------------------------"
+    tail -n100 /var/log/openvswitch/ovs-vswitchd.log || echo "failed"
+    echo "------------------------------"
+    ls -al /var/run/openvswitch || echo "failed"
     echo "=============================="
 
 execute: |

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -35,6 +35,14 @@ restore: |
 
     ip link delete tap1 || true
 
+debug: |
+    systemctl status openvswitch-switch.service
+    ls -al /etc/openvswitch
+    tail -n100 /var/log/dpkg.log
+    tail -n100 /var/log/syslog
+    systemctl list-unit-files
+    ifconfig
+
 execute: |
     CONNECTED_PATTERN=":openvswitch +test-snapd-openvswitch-consumer"
     DISCONNECTED_PATTERN="\- +test-snapd-openvswitch-consumer:openvswitch"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -36,11 +36,14 @@ restore: |
     ip link delete tap1 || true
 
 debug: |
+    echo "Custom debug info"
+    echo "==================================="
     systemctl status openvswitch-switch.service
     ls -al /etc/openvswitch
     tail -n100 /var/log/dpkg.log
     tail -n100 /var/log/syslog
     ifconfig
+    echo "==================================="
 
 execute: |
     CONNECTED_PATTERN=":openvswitch +test-snapd-openvswitch-consumer"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -39,9 +39,13 @@ debug: |
     echo "Custom debug info"
     echo "==================================="
     systemctl status openvswitch-switch.service
+    echo "-----------------------------------"
     ls -al /etc/openvswitch
+    echo "-----------------------------------"
     tail -n100 /var/log/dpkg.log
+    echo "-----------------------------------"
     tail -n100 /var/log/syslog
+    echo "-----------------------------------"
     ifconfig
     echo "==================================="
 

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -37,7 +37,7 @@ restore: |
 
 debug: |
     echo "=============================="
-    echo " Custom debug information "
+    echo "Custom debug information"
     echo "=============================="
     systemctl status openvswitch-switch.service || echo "failed"
     echo "------------------------------"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -38,13 +38,13 @@ restore: |
 debug: |
     echo "Custom debug info"
     echo "=============================="
-    systemctl status openvswitch-switch.service || echo failed
+    systemctl status openvswitch-switch.service || echo "failed"
     echo "-----------------------------------"
-    ls -al /etc/openvswitch || echo failed
+    ls -al /etc/openvswitch || echo "failed"
     echo "------------------------------"
-    tail -n100 /var/log/dpkg.log || echo failed
+    tail -n100 /var/log/dpkg.log || echo "failed"
     echo "------------------------------"
-    tail -n100 /var/log/syslog || echo failed
+    tail -n100 /var/log/syslog || echo "failed"
     echo "------------------------------"
     ifconfig || echo failed
     echo "=============================="

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -35,29 +35,6 @@ restore: |
 
     ip link delete tap1 || true
 
-debug: |
-    echo "=============================="
-    echo "Custom debug information"
-    echo "=============================="
-    systemctl status openvswitch-switch.service || echo "failed"
-    echo "------------------------------"
-    ls -al /etc/openvswitch || echo "failed"
-    echo "------------------------------"
-    tail -n100 /var/log/dpkg.log || echo "failed"
-    echo "------------------------------"
-    tail -n100 /var/log/syslog || echo "failed"
-    echo "------------------------------"
-    ifconfig || echo failed
-    echo "------------------------------"
-    journalctl -xu openvswitch.service || echo "failed"
-    echo "------------------------------"
-    tail -n100 /var/log/openvswitch/ovsdb-server.log || echo "failed"
-    echo "------------------------------"
-    tail -n100 /var/log/openvswitch/ovs-vswitchd.log || echo "failed"
-    echo "------------------------------"
-    ls -al /var/run/openvswitch || echo "failed"
-    echo "=============================="
-
 execute: |
     CONNECTED_PATTERN=":openvswitch +test-snapd-openvswitch-consumer"
     DISCONNECTED_PATTERN="\- +test-snapd-openvswitch-consumer:openvswitch"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -3,6 +3,8 @@ summary: Ensure that the openvswitch interface works.
 systems:
     - -ubuntu-core-*
 
+manual: true
+
 details: |
     The openvswitch interface allows to task to the openvswitch socket (rw mode).
 
@@ -18,11 +20,11 @@ prepare: |
     # Note that the order of the installs is to avoid a timeout issue on the 
     # openvswitch-switch package setup
 
-    echo "Install a snap declaring a plug on the openvswitch interface"
-    snap install --edge test-snapd-openvswitch-consumer
-
     echo "Install openvswitch"
     apt install -y --no-install-recommends openvswitch-switch
+
+    echo "Install a snap declaring a plug on the openvswitch interface"
+    snap install --edge test-snapd-openvswitch-consumer
 
     echo "And a tap interface is defined"
     ip tuntap add tap1 mode tap

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -15,7 +15,7 @@ details: |
     list and deletion.
 
 prepare: |
-    echo "Install a snap declaring a plug on the openvswitch interface is installed"
+    echo "Install a snap declaring a plug on the openvswitch interface"
     snap install --edge test-snapd-openvswitch-consumer
 
     echo "Install openvswitch"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -40,7 +40,7 @@ debug: |
     echo "Custom debug information"
     echo "=============================="
     systemctl status openvswitch-switch.service || echo "failed"
-    echo "-----------------------------------"
+    echo "------------------------------"
     ls -al /etc/openvswitch || echo "failed"
     echo "------------------------------"
     tail -n100 /var/log/dpkg.log || echo "failed"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -40,7 +40,6 @@ debug: |
     ls -al /etc/openvswitch
     tail -n100 /var/log/dpkg.log
     tail -n100 /var/log/syslog
-    systemctl list-unit-files
     ifconfig
 
 execute: |

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -38,15 +38,15 @@ restore: |
 debug: |
     echo "Custom debug info"
     echo "==================================="
-    systemctl status openvswitch-switch.service
+    systemctl status openvswitch-switch.service || echo failed
     echo "-----------------------------------"
-    ls -al /etc/openvswitch
+    ls -al /etc/openvswitch || echo failed
     echo "-----------------------------------"
-    tail -n100 /var/log/dpkg.log
+    tail -n100 /var/log/dpkg.log || echo failed
     echo "-----------------------------------"
-    tail -n100 /var/log/syslog
+    tail -n100 /var/log/syslog || echo failed
     echo "-----------------------------------"
-    ifconfig
+    ifconfig || echo failed
     echo "==================================="
 
 execute: |

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -36,6 +36,7 @@ restore: |
     ip link delete tap1 || true
 
 debug: |
+    echo "=============================="
     echo "Custom debug info"
     echo "=============================="
     systemctl status openvswitch-switch.service || echo "failed"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -37,7 +37,7 @@ restore: |
 
 debug: |
     echo "=============================="
-    echo "Custom debug info"
+    echo "Custom debug information"
     echo "=============================="
     systemctl status openvswitch-switch.service || echo "failed"
     echo "-----------------------------------"

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -15,6 +15,9 @@ details: |
     list and deletion.
 
 prepare: |
+    # Note that the order of the installs is to avoid a timeout issue on the 
+    # openvswitch-switch package setup
+
     echo "Install a snap declaring a plug on the openvswitch interface"
     snap install --edge test-snapd-openvswitch-consumer
 


### PR DESCRIPTION
The issue seem to be a timing issue, and to fix that the idea is to move forward the apt installation from the reset done in the prepare-each.

There was a bug similar to this one which was caused becaues of a file lock. The debug information is not giving us so much information of the real problem, just that a timeout was reached after create the internal db, and because of that the service failed to be started. 

The fix has been tested in CI 7 times and it was not reproduced anymore. 

The root cause of this error seems to be this https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858418  

ERROR with debug info:
https://travis-ci.org/snapcore/snapd/builds/238102172