### PR TITLE
httputil,store: extract retry code to httputil, reorg usages

### DIFF
--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -57,7 +57,7 @@ func ShouldRetryHttpResponse(attempt *retry.Attempt, resp *http.Response) bool {
 	if !attempt.More() {
 		return false
 	}
-	return resp.StatusCode >= 500
+	return resp.StatusCode >= http.StatusInternalServerError
 }
 
 func ShouldRetryError(attempt *retry.Attempt, err error) bool {

--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -17,7 +17,7 @@
  *
  */
 
-package store
+package httputil
 
 import (
 	"fmt"
@@ -35,16 +35,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-// the LimitTime should be slightly more than 3 times of our http.Client
-// Timeout value
-var defaultRetryStrategy = retry.LimitCount(5, retry.LimitTime(33*time.Second,
-	retry.Exponential{
-		Initial: 100 * time.Millisecond,
-		Factor:  2.5,
-	},
-))
-
-func maybeLogRetryAttempt(url string, attempt *retry.Attempt, startTime time.Time) {
+func MaybeLogRetryAttempt(url string, attempt *retry.Attempt, startTime time.Time) {
 	if osutil.GetenvBool("SNAPD_DEBUG") || attempt.Count() > 1 {
 		logger.Debugf("Retrying %s, attempt %d, elapsed time=%v", url, attempt.Count(), time.Since(startTime))
 	}
@@ -62,14 +53,14 @@ func maybeLogRetrySummary(startTime time.Time, url string, attempt *retry.Attemp
 	}
 }
 
-func shouldRetryHttpResponse(attempt *retry.Attempt, resp *http.Response) bool {
+func ShouldRetryHttpResponse(attempt *retry.Attempt, resp *http.Response) bool {
 	if !attempt.More() {
 		return false
 	}
-	return resp.StatusCode == 500 || resp.StatusCode == 502 || resp.StatusCode == 503 || resp.StatusCode == 504
+	return resp.StatusCode >= 500
 }
 
-func shouldRetryError(attempt *retry.Attempt, err error) bool {
+func ShouldRetryError(attempt *retry.Attempt, err error) bool {
 	if !attempt.More() {
 		return false
 	}
@@ -92,6 +83,10 @@ func shouldRetryError(attempt *retry.Attempt, err error) bool {
 				return true
 			}
 		}
+		if opNetErr, ok := opErr.Err.(net.Error); ok {
+			// TODO: some DNS errors? just log for now
+			logger.Debugf("Not retrying: %#v", opNetErr)
+		}
 	}
 
 	if err == io.ErrUnexpectedEOF || err == io.EOF {
@@ -100,4 +95,41 @@ func shouldRetryError(attempt *retry.Attempt, err error) bool {
 	}
 
 	return false
+}
+
+// RetryRequest calls doRequest and read the response body in a retry loop using the given retryStrategy.
+func RetryRequest(endpoint string, doRequest func() (*http.Response, error), readResponseBody func(resp *http.Response) error, retryStrategy retry.Strategy) (resp *http.Response, err error) {
+	var attempt *retry.Attempt
+	startTime := time.Now()
+	for attempt = retry.Start(retryStrategy, nil); attempt.Next(); {
+		MaybeLogRetryAttempt(endpoint, attempt, startTime)
+
+		resp, err = doRequest()
+		if err != nil {
+			if ShouldRetryError(attempt, err) {
+				continue
+			}
+			break
+		}
+
+		if ShouldRetryHttpResponse(attempt, resp) {
+			resp.Body.Close()
+			continue
+		} else {
+			err := readResponseBody(resp)
+			resp.Body.Close()
+			if err != nil {
+				if ShouldRetryError(attempt, err) {
+					continue
+				} else {
+					return nil, err
+				}
+			}
+		}
+		// break out from retry loop
+		break
+	}
+	maybeLogRetrySummary(startTime, endpoint, attempt, resp, err)
+
+	return resp, err
 }

--- a/httputil/retry_test.go
+++ b/httputil/retry_test.go
@@ -21,6 +21,7 @@ package httputil_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -415,20 +416,14 @@ func (s *retrySuite) TestRetryRequestFailOnDNS(c *C) {
 		return cli.Get(url)
 	}
 
-	failure := false
 	var got interface{}
 	readResponseBody := func(resp *http.Response) error {
-		failure = false
-		if resp.StatusCode != 200 {
-			failure = true
-			return nil
+		if resp.StatusCode >= 500 {
+			return fmt.Errorf("proxy error")
 		}
 		return json.NewDecoder(resp.Body).Decode(&got)
 	}
 
 	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
 	c.Assert(err, NotNil)
-
-	c.Check(failure, Equals, false)
-	c.Assert(n, Equals, 1)
 }

--- a/httputil/retry_test.go
+++ b/httputil/retry_test.go
@@ -1,0 +1,434 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package httputil_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/retry.v1"
+
+	"github.com/snapcore/snapd/httputil"
+)
+
+type retrySuite struct{}
+
+var _ = Suite(&retrySuite{})
+
+func (s *retrySuite) SetUpTest(c *C) {
+}
+
+func (s *retrySuite) TearDownTest(c *C) {
+}
+
+var testRetryStrategy = retry.LimitCount(5, retry.LimitTime(1*time.Second,
+	retry.Exponential{
+		Initial: 1 * time.Millisecond,
+		Factor:  1,
+	},
+))
+
+func (s *retrySuite) TestRetryRequestOnEOF(c *C) {
+	n := 0
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		if n < 4 {
+			io.WriteString(w, "{")
+			mockServer.CloseClientConnections()
+			return
+		}
+		io.WriteString(w, `{"ok": true}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	cli := httputil.NewHTTPClient(nil)
+
+	doRequest := func() (*http.Response, error) {
+		return cli.Get(mockServer.URL)
+	}
+
+	failure := false
+	var got interface{}
+	readResponseBody := func(resp *http.Response) error {
+		failure = false
+		if resp.StatusCode != 200 {
+			failure = true
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(&got)
+	}
+
+	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, IsNil)
+
+	c.Assert(failure, Equals, false)
+	c.Check(got, DeepEquals, map[string]interface{}{"ok": true})
+	c.Assert(n, Equals, 4)
+}
+
+func (s *retrySuite) TestRetryRequestFailWithEOF(c *C) {
+	n := 0
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		io.WriteString(w, "{")
+		mockServer.CloseClientConnections()
+		return
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	cli := httputil.NewHTTPClient(nil)
+
+	doRequest := func() (*http.Response, error) {
+		return cli.Get(mockServer.URL)
+	}
+
+	failure := false
+	var got interface{}
+	readResponseBody := func(resp *http.Response) error {
+		failure = false
+		if resp.StatusCode != 200 {
+			failure = true
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(&got)
+	}
+
+	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, `^Get http://127.0.0.1:.*?: EOF$`)
+
+	c.Check(failure, Equals, false)
+	c.Assert(n, Equals, 5)
+}
+
+func (s *retrySuite) TestRetryRequestOn500(c *C) {
+	n := 0
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		if n < 4 {
+			w.WriteHeader(500)
+			return
+		}
+		io.WriteString(w, `{"ok": true}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	cli := httputil.NewHTTPClient(nil)
+
+	doRequest := func() (*http.Response, error) {
+		return cli.Get(mockServer.URL)
+	}
+
+	failure := false
+	var got interface{}
+	readResponseBody := func(resp *http.Response) error {
+		failure = false
+		if resp.StatusCode != 200 {
+			failure = true
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(&got)
+	}
+
+	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, IsNil)
+
+	c.Assert(failure, Equals, false)
+	c.Check(got, DeepEquals, map[string]interface{}{"ok": true})
+	c.Assert(n, Equals, 4)
+}
+
+func (s *retrySuite) TestRetryRequestFailOn500(c *C) {
+	n := 0
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		w.WriteHeader(500)
+		return
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	cli := httputil.NewHTTPClient(nil)
+
+	doRequest := func() (*http.Response, error) {
+		return cli.Get(mockServer.URL)
+	}
+
+	failure := false
+	var got interface{}
+	readResponseBody := func(resp *http.Response) error {
+		failure = false
+		if resp.StatusCode != 200 {
+			failure = true
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(&got)
+	}
+
+	resp, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, 500)
+
+	c.Check(failure, Equals, true)
+	c.Assert(n, Equals, 5)
+}
+
+func (s *retrySuite) TestRetryRequestUnexpectedEOFHandling(c *C) {
+	permanentlyBrokenSrvCalls := 0
+	somewhatBrokenSrvCalls := 0
+
+	mockPermanentlyBrokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		permanentlyBrokenSrvCalls++
+		w.Header().Add("Content-Length", "1000")
+	}))
+	c.Assert(mockPermanentlyBrokenServer, NotNil)
+	defer mockPermanentlyBrokenServer.Close()
+
+	mockSomewhatBrokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		somewhatBrokenSrvCalls++
+		if somewhatBrokenSrvCalls > 3 {
+			io.WriteString(w, `{"ok": true}`)
+			return
+		}
+		w.Header().Add("Content-Length", "1000")
+	}))
+	c.Assert(mockSomewhatBrokenServer, NotNil)
+	defer mockSomewhatBrokenServer.Close()
+
+	cli := httputil.NewHTTPClient(nil)
+
+	url := ""
+	doRequest := func() (*http.Response, error) {
+		return cli.Get(url)
+	}
+
+	failure := false
+	var got interface{}
+	readResponseBody := func(resp *http.Response) error {
+		failure = false
+		if resp.StatusCode != 200 {
+			failure = true
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(&got)
+	}
+
+	// Check that we really recognize unexpected EOF error by failing on all retries
+	url = mockPermanentlyBrokenServer.URL
+	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, NotNil)
+	c.Assert(err, Equals, io.ErrUnexpectedEOF)
+	c.Assert(err, ErrorMatches, "unexpected EOF")
+	// check that we exhausted all retries (as defined by mocked retry strategy)
+	c.Assert(permanentlyBrokenSrvCalls, Equals, 5)
+	c.Check(failure, Equals, false)
+	c.Check(got, Equals, nil)
+
+	url = mockSomewhatBrokenServer.URL
+	failure = false
+	got = nil
+	// Check that we retry on unexpected EOF and eventually succeed
+	_, err = httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, IsNil)
+	// check that we retried 4 times
+	c.Check(failure, Equals, false)
+	c.Check(got, DeepEquals, map[string]interface{}{"ok": true})
+	c.Assert(somewhatBrokenSrvCalls, Equals, 4)
+}
+
+func (s *retrySuite) TestRetryRequestFailOnReadResponseBody(c *C) {
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "<bad>")
+		return
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	cli := httputil.NewHTTPClient(nil)
+
+	doRequest := func() (*http.Response, error) {
+		return cli.Get(mockServer.URL)
+	}
+
+	failure := false
+	var got interface{}
+	readResponseBody := func(resp *http.Response) error {
+		failure = false
+		if resp.StatusCode != 200 {
+			failure = true
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(&got)
+	}
+
+	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, ErrorMatches, `invalid character '<' looking for beginning of value`)
+	c.Check(failure, Equals, false)
+}
+
+func (s *retrySuite) TestRetryRequestReadResponseBodyFailure(c *C) {
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		io.WriteString(w, `{"error": true}`)
+		return
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	cli := httputil.NewHTTPClient(nil)
+
+	doRequest := func() (*http.Response, error) {
+		return cli.Get(mockServer.URL)
+	}
+
+	failure := false
+	var got interface{}
+	readResponseBody := func(resp *http.Response) error {
+		failure = false
+		if resp.StatusCode != 200 {
+			failure = true
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(&got)
+	}
+
+	resp, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, IsNil)
+	c.Check(failure, Equals, true)
+	c.Check(resp.StatusCode, Equals, 404)
+}
+
+func (s *retrySuite) TestRetryRequestTimeoutHandling(c *C) {
+	permanentlyBrokenSrvCalls := 0
+	somewhatBrokenSrvCalls := 0
+
+	finished := make(chan struct{})
+
+	mockPermanentlyBrokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		permanentlyBrokenSrvCalls++
+		<-finished
+	}))
+	c.Assert(mockPermanentlyBrokenServer, NotNil)
+	defer mockPermanentlyBrokenServer.Close()
+
+	mockSomewhatBrokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		somewhatBrokenSrvCalls++
+		if somewhatBrokenSrvCalls > 2 {
+			io.WriteString(w, `{"ok": true}`)
+			return
+		}
+		<-finished
+	}))
+	c.Assert(mockSomewhatBrokenServer, NotNil)
+	defer mockSomewhatBrokenServer.Close()
+
+	defer close(finished)
+
+	cli := httputil.NewHTTPClient(&httputil.ClientOpts{
+		Timeout: 50 * time.Millisecond,
+	})
+
+	url := ""
+	doRequest := func() (*http.Response, error) {
+		return cli.Get(url)
+	}
+
+	failure := false
+	var got interface{}
+	readResponseBody := func(resp *http.Response) error {
+		failure = false
+		if resp.StatusCode != 200 {
+			failure = true
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(&got)
+	}
+
+	// Check that we really recognize unexpected EOF error by failing on all retries
+	url = mockPermanentlyBrokenServer.URL
+	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `.*Client.Timeout.*`)
+	// check that we exhausted all retries (as defined by mocked retry strategy)
+	c.Assert(permanentlyBrokenSrvCalls, Equals, 5)
+	c.Check(failure, Equals, false)
+	c.Check(got, Equals, nil)
+
+	url = mockSomewhatBrokenServer.URL
+	failure = false
+	got = nil
+	// Check that we retry on unexpected EOF and eventually succeed
+	_, err = httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, IsNil)
+	// check that we retried 4 times
+	c.Check(failure, Equals, false)
+	c.Check(got, DeepEquals, map[string]interface{}{"ok": true})
+	c.Assert(somewhatBrokenSrvCalls, Equals, 3)
+}
+
+func (s *retrySuite) TestRetryRequestFailOnDNS(c *C) {
+	// TODO: retry some types of DNS errors?
+
+	url := "http://nonexistingserver909123.com/"
+
+	cli := httputil.NewHTTPClient(nil)
+
+	n := 0
+	doRequest := func() (*http.Response, error) {
+		n++
+		return cli.Get(url)
+	}
+
+	failure := false
+	var got interface{}
+	readResponseBody := func(resp *http.Response) error {
+		failure = false
+		if resp.StatusCode != 200 {
+			failure = true
+			return nil
+		}
+		return json.NewDecoder(resp.Body).Decode(&got)
+	}
+
+	_, err := httputil.RetryRequest("endp", doRequest, readResponseBody, testRetryStrategy)
+	c.Assert(err, NotNil)
+
+	c.Check(failure, Equals, false)
+	c.Assert(n, Equals, 1)
+}

--- a/store/auth.go
+++ b/store/auth.go
@@ -26,10 +26,8 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"gopkg.in/macaroon.v1"
-	"gopkg.in/retry.v1"
 
 	"github.com/snapcore/snapd/httputil"
 )
@@ -107,27 +105,15 @@ func loginCaveatID(m *macaroon.Macaroon) (string, error) {
 
 // retryPostRequestDecodeJSON calls retryPostRequest and decodes the response into either success or failure.
 func retryPostRequestDecodeJSON(endpoint string, headers map[string]string, data []byte, success interface{}, failure interface{}) (resp *http.Response, err error) {
-	return retryPostRequest(endpoint, headers, data, func(ok bool, resp *http.Response) error {
-		result := success
-		if !ok {
-			result = failure
-		}
-		if result != nil {
-			return json.NewDecoder(resp.Body).Decode(result)
-		}
-		return nil
+	return retryPostRequest(endpoint, headers, data, func(resp *http.Response) error {
+		return decodeJSONBody(resp, success, failure)
 	})
 }
 
 // retryPostRequest calls doRequest and decodes the response in a retry loop.
-func retryPostRequest(endpoint string, headers map[string]string, data []byte, decode func(ok bool, resp *http.Response) error) (resp *http.Response, err error) {
-	var attempt *retry.Attempt
-	startTime := time.Now()
-	for attempt = retry.Start(defaultRetryStrategy, nil); attempt.Next(); {
-		maybeLogRetryAttempt(endpoint, attempt, startTime)
-
-		var req *http.Request
-		req, err = http.NewRequest("POST", endpoint, bytes.NewBuffer(data))
+func retryPostRequest(endpoint string, headers map[string]string, data []byte, readResponseBody func(resp *http.Response) error) (*http.Response, error) {
+	return httputil.RetryRequest(endpoint, func() (*http.Response, error) {
+		req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(data))
 		if err != nil {
 			return nil, err
 		}
@@ -135,40 +121,8 @@ func retryPostRequest(endpoint string, headers map[string]string, data []byte, d
 			req.Header.Set(k, v)
 		}
 
-		resp, err = httpClient.Do(req)
-		if err != nil {
-			if shouldRetryError(attempt, err) {
-				continue
-			}
-			break
-		}
-
-		if shouldRetryHttpResponse(attempt, resp) {
-			resp.Body.Close()
-			continue
-		} else {
-			ok := (resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated)
-			// always decode on success; decode failures only if body is not empty
-			if !ok && resp.ContentLength == 0 {
-				resp.Body.Close()
-				break
-			}
-			err = decode(ok, resp)
-			resp.Body.Close()
-			if err != nil {
-				if shouldRetryError(attempt, err) {
-					continue
-				} else {
-					return nil, err
-				}
-			}
-		}
-		// break out from retry loop
-		break
-	}
-	maybeLogRetrySummary(startTime, endpoint, attempt, resp, err)
-
-	return resp, err
+		return httpClient.Do(req)
+	}, readResponseBody, defaultRetryStrategy)
 }
 
 // requestStoreMacaroon requests a macaroon for accessing package data from the ubuntu store.
@@ -341,8 +295,8 @@ func requestDeviceSession(serialAssertion, sessionRequest, previousSession strin
 		headers["X-Device-Authorization"] = fmt.Sprintf(`Macaroon root="%s"`, previousSession)
 	}
 
-	_, err = retryPostRequest(MyAppsDeviceSessionAPI, headers, deviceJSONData, func(ok bool, resp *http.Response) error {
-		if ok {
+	_, err = retryPostRequest(MyAppsDeviceSessionAPI, headers, deviceJSONData, func(resp *http.Response) error {
+		if resp.StatusCode == 200 || resp.StatusCode == 202 {
 			return json.NewDecoder(resp.Body).Decode(&responseData)
 		}
 		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 1e6)) // do our best to read the body

--- a/store/store.go
+++ b/store/store.go
@@ -658,9 +658,9 @@ func decodeJSONBody(resp *http.Response, success interface{}, failure interface{
 }
 
 // retryRequestDecodeJSON calls retryRequest and decodes the response into either success or failure.
-func (s *Store) retryRequestDecodeJSON(reqOptions *requestOptions, user *auth.UserState, success interface{}, failure interface{}) (resp *http.Response, err error) {
+func (s *Store) retryRequestDecodeJSON(ctx context.Context, reqOptions *requestOptions, user *auth.UserState, success interface{}, failure interface{}) (resp *http.Response, err error) {
 	return httputil.RetryRequest(reqOptions.URL.String(), func() (*http.Response, error) {
-		return s.doRequest(context.TODO(), s.client, reqOptions, user)
+		return s.doRequest(ctx, s.client, reqOptions, user)
 	}, func(resp *http.Response) error {
 		return decodeJSONBody(resp, success, failure)
 	}, defaultRetryStrategy)
@@ -851,7 +851,7 @@ func (s *Store) decorateOrders(snaps []*snap.Info, user *auth.UserState) error {
 		Accept: jsonContentType,
 	}
 	var result ordersResult
-	resp, err := s.retryRequestDecodeJSON(reqOptions, user, &result, nil)
+	resp, err := s.retryRequestDecodeJSON(context.TODO(), reqOptions, user, &result, nil)
 	if err != nil {
 		return err
 	}
@@ -933,7 +933,7 @@ func (s *Store) SnapInfo(snapSpec SnapSpec, user *auth.UserState) (*snap.Info, e
 	}
 
 	var remote *snapDetails
-	resp, err := s.retryRequestDecodeJSON(reqOptions, user, &remote, nil)
+	resp, err := s.retryRequestDecodeJSON(context.TODO(), reqOptions, user, &remote, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,7 +1026,7 @@ func (s *Store) Find(search *Search, user *auth.UserState) ([]*snap.Info, error)
 	}
 
 	var searchData searchResults
-	resp, err := s.retryRequestDecodeJSON(reqOptions, user, &searchData, nil)
+	resp, err := s.retryRequestDecodeJSON(context.TODO(), reqOptions, user, &searchData, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1069,7 +1069,7 @@ func (s *Store) Sections(user *auth.UserState) ([]string, error) {
 	}
 
 	var sectionData sectionResults
-	resp, err := s.retryRequestDecodeJSON(reqOptions, user, &sectionData, nil)
+	resp, err := s.retryRequestDecodeJSON(context.TODO(), reqOptions, user, &sectionData, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1171,7 +1171,7 @@ func (s *Store) refreshForCandidates(currentSnaps []*currentSnapJSON, user *auth
 	}
 
 	var updateData searchResults
-	resp, err := s.retryRequestDecodeJSON(reqOptions, user, &updateData, nil)
+	resp, err := s.retryRequestDecodeJSON(context.TODO(), reqOptions, user, &updateData, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1714,7 +1714,7 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 
 	var orderDetails order
 	var errorInfo storeErrors
-	resp, err := s.retryRequestDecodeJSON(reqOptions, user, &orderDetails, &errorInfo)
+	resp, err := s.retryRequestDecodeJSON(context.TODO(), reqOptions, user, &orderDetails, &errorInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -1767,7 +1767,7 @@ func (s *Store) ReadyToBuy(user *auth.UserState) error {
 
 	var customer storeCustomer
 	var errors storeErrors
-	resp, err := s.retryRequestDecodeJSON(reqOptions, user, &customer, &errors)
+	resp, err := s.retryRequestDecodeJSON(context.TODO(), reqOptions, user, &customer, &errors)
 	if err != nil {
 		return err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -221,9 +221,8 @@ func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(dirs.SnapMountDir, 0755), IsNil)
 
-	oldSnapdDebug := os.Getenv("SNAPD_DEBUG")
 	os.Setenv("SNAPD_DEBUG", "1")
-	t.AddCleanup(func() { os.Setenv("SNAPD_DEBUG", oldSnapdDebug) })
+	t.AddCleanup(func() { os.Unsetenv("SNAPD_DEBUG") })
 
 	t.logbuf = bytes.NewBuffer(nil)
 	l, err := logger.New(t.logbuf, logger.DefaultFlags)

--- a/store/userinfo_test.go
+++ b/store/userinfo_test.go
@@ -20,6 +20,7 @@
 package store
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -29,6 +30,7 @@ import (
 	"gopkg.in/check.v1"
 	"gopkg.in/retry.v1"
 
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -51,6 +53,10 @@ var mockServerJSON = `{
 }`
 
 func (t *userInfoSuite) SetUpTest(c *check.C) {
+	l, err := logger.New(&bytes.Buffer{}, logger.DefaultFlags)
+	c.Assert(err, check.IsNil)
+	logger.SetLogger(l)
+
 	MockDefaultRetryStrategy(&t.BaseTest, retry.LimitCount(6, retry.LimitTime(1*time.Second,
 		retry.Exponential{
 			Initial: 1 * time.Millisecond,


### PR DESCRIPTION
This extracts the retry code in store to httputil so that it can reused outside of store, it reorgs and generalises some of its details.