### PR TITLE
tests: prefer ipv4 over ipv6

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -254,7 +254,13 @@ prepare: |
     fi
 
     # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
-    echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf
+    cat <<EOF > /etc/gai.conf
+    precedence  ::1/128       50
+    precedence  ::/0          40
+    precedence  2002::/16     30
+    precedence ::/96          20
+    precedence ::ffff:0:0/96 100
+    EOD
 
     # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
     # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)

--- a/spread.yaml
+++ b/spread.yaml
@@ -253,9 +253,8 @@ prepare: |
         exit 1
     fi
 
-    # apt update is hanging on security.ubuntu.com with IPv6.
-    sysctl -w net.ipv6.conf.all.disable_ipv6=1
-    trap "sysctl -w net.ipv6.conf.all.disable_ipv6=0" EXIT
+    # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
+    echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf
 
     # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
     # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)
@@ -429,9 +428,6 @@ suites:
         kill-timeout: 2h
         manual: true
         prepare: |
-            # apt update is hanging on security.ubuntu.com with IPv6.
-            sysctl -w net.ipv6.conf.all.disable_ipv6=1
-            trap "sysctl -w net.ipv6.conf.all.disable_ipv6=0" EXIT
             apt update && apt install -y snapd qemu genisoimage sshpass
         restore: |
             apt remove -y qemu genisoimage sshpass

--- a/spread.yaml
+++ b/spread.yaml
@@ -260,7 +260,7 @@ prepare: |
     precedence  2002::/16     30
     precedence ::/96          20
     precedence ::ffff:0:0/96 100
-    EOD
+    EOF
 
     # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
     # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)

--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -16,8 +16,6 @@ details: |
 
 prepare: |
     echo "Given libvirt and qemu are installed"
-    sysctl -w net.ipv6.conf.all.disable_ipv6=1
-    trap "sysctl -w net.ipv6.conf.all.disable_ipv6=0" EXIT
     apt install -y libvirt-bin qemu
     # add test user to the libvirtd group
     adduser test libvirtd


### PR DESCRIPTION
apt update is hanging on security.ubuntu.com with IPv6, we are also getting timeouts on other apt operations that might be related to the same problem.

Instead of disabling it and enabling after concrete apt calls, with these changes we give weight to IPv4 over IPv6 at the prepare stage of the suite and this setting is kept during the whole execution.