### PR TITLE
interfaces: partly revert aace15ab53 to unbreak core reverts

### DIFF
--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -417,44 +417,47 @@ sigwaitinfo
 # domains via 'network' rules. We won't allow bare 'network' AppArmor rules, so
 # we can allow 'socket' for all domains except AF_NETLINK and let AppArmor
 # handle the rest.
-socket AF_UNIX
-socket AF_LOCAL
-socket AF_INET
-socket AF_INET6
-socket AF_IPX
-socket AF_X25
-socket AF_AX25
-socket AF_ATMPVC
-socket AF_APPLETALK
-socket AF_PACKET
-socket AF_ALG
-socket AF_CAN
-socket AF_BRIDGE
-socket AF_NETROM
-socket AF_ROSE
-socket AF_NETBEUI
-socket AF_SECURITY
-socket AF_KEY
-socket AF_ASH
-socket AF_ECONET
-socket AF_SNA
-socket AF_IRDA
-socket AF_PPPOX
-socket AF_WANPIPE
-socket AF_BLUETOOTH
-socket AF_RDS
-socket AF_LLC
-socket AF_TIPC
-socket AF_IUCV
-socket AF_RXRPC
-socket AF_ISDN
-socket AF_PHONET
-socket AF_IEEE802154
-socket AF_CAIF
-socket AF_NFC
-socket AF_VSOCK
-socket AF_MPLS
-socket AF_IB
+socket
+# FIXME: uncomment below (and remove the line above) once we can add
+#        symbols to seccomp again
+#socket AF_UNIX
+#socket AF_LOCAL
+#socket AF_INET
+#socket AF_INET6
+#socket AF_IPX
+#socket AF_X25
+#socket AF_AX25
+#socket AF_ATMPVC
+#socket AF_APPLETALK
+#socket AF_PACKET
+#socket AF_ALG
+#socket AF_CAN
+#socket AF_BRIDGE
+#socket AF_NETROM
+#socket AF_ROSE
+#socket AF_NETBEUI
+#socket AF_SECURITY
+#socket AF_KEY
+#socket AF_ASH
+#socket AF_ECONET
+#socket AF_SNA
+#socket AF_IRDA
+#socket AF_PPPOX
+#socket AF_WANPIPE
+#socket AF_BLUETOOTH
+#socket AF_RDS
+#socket AF_LLC
+#socket AF_TIPC
+#socket AF_IUCV
+#socket AF_RXRPC
+#socket AF_ISDN
+#socket AF_PHONET
+#socket AF_IEEE802154
+#socket AF_CAIF
+#socket AF_NFC
+#socket AF_VSOCK
+#socket AF_MPLS
+#socket AF_IB
 
 # For AF_NETLINK, we'll use a combination of AppArmor coarse mediation and
 # seccomp arg filtering of netlink families.


### PR DESCRIPTION
Another partial revert of new symbols for seccomp to unblock 2.26 and to work-around the core revert startup race condition.