### PR TITLE
errtracker: include bits of snap-confine apparmor profile

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -21,6 +21,7 @@ package errtracker
 
 import (
 	"bytes"
+	"crypto/md5"
 	"crypto/sha512"
 	"fmt"
 	"io/ioutil"
@@ -53,6 +54,8 @@ var (
 	mockedHostSnapd = ""
 	mockedCoreSnapd = ""
 
+	snapConfineProfile = "/etc/apparmor.d/usr.lib.snapd.snap-confine.real"
+
 	timeNow = time.Now
 )
 
@@ -77,6 +80,15 @@ func readMachineID() ([]byte, error) {
 	}
 
 	return nil, fmt.Errorf("cannot report: no suitable machine id file found")
+}
+
+func snapConfineProfileDigest(suffix string) string {
+	profileText, err := ioutil.ReadFile(snapConfineProfile + suffix)
+	if err != nil {
+		return ""
+	}
+	// NOTE: uses md5sum for easier comparison against dpkg meta-data
+	return fmt.Sprintf("%x", md5.Sum(profileText))
 }
 
 func Report(snap, errMsg, dupSig string, extra map[string]string) (string, error) {
@@ -122,6 +134,9 @@ func Report(snap, errMsg, dupSig string, extra map[string]string) (string, error
 		"KernelVersion":      release.KernelVersion(),
 		"ErrorMessage":       errMsg,
 		"DuplicateSignature": dupSig,
+
+		"SnapConfineAppArmorProfileCurrentMD5Sum": snapConfineProfileDigest(""),
+		"SnapConfineAppArmorProfileDpkgNewMD5Sum": snapConfineProfileDigest(".dpkg-new"),
 	}
 	for k, v := range extra {
 		// only set if empty

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -47,6 +47,8 @@ func Test(t *testing.T) { TestingT(t) }
 
 type ErrtrackerTestSuite struct {
 	testutil.BaseTest
+
+	snapConfineProfile string
 }
 
 var _ = Suite(&ErrtrackerTestSuite{})
@@ -57,12 +59,19 @@ var falsePath = osutil.LookPathDefault("false", "/bin/false")
 func (s *ErrtrackerTestSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	p := filepath.Join(c.MkDir(), "machine-id")
+	d := c.MkDir()
+	p := filepath.Join(d, "machine-id")
 	err := ioutil.WriteFile(p, []byte("bbb1a6a5bcdb418380056a2d759c3f7c"), 0644)
 	c.Assert(err, IsNil)
 	s.AddCleanup(errtracker.MockMachineIDPaths([]string{p}))
 	s.AddCleanup(errtracker.MockHostSnapd(truePath))
 	s.AddCleanup(errtracker.MockCoreSnapd(falsePath))
+
+	p = filepath.Join(d, "usr.lib.snapd.snap-confine.real")
+	err = ioutil.WriteFile(p, []byte("# fake profile of snap-confine"), 0644)
+	c.Assert(err, IsNil)
+	s.AddCleanup(errtracker.MockSnapConfineApparmorProfile(p))
+	s.snapConfineProfile = p
 }
 
 func (s *ErrtrackerTestSuite) TestReport(c *C) {
@@ -71,6 +80,9 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 	hostBuildID, err := osutil.ReadBuildID(truePath)
 	c.Assert(err, IsNil)
 	coreBuildID, err := osutil.ReadBuildID(falsePath)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(s.snapConfineProfile+".dpkg-new", []byte{0}, 0644)
 	c.Assert(err, IsNil)
 
 	prev := errtracker.SnapdVersion
@@ -108,6 +120,9 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 				"ErrorMessage":       "failed to do stuff",
 				"DuplicateSignature": "[failed to do stuff]",
 				"Architecture":       arch.UbuntuArchitecture(),
+
+				"SnapConfineAppArmorProfileCurrentMD5Sum": "7a7aa5f21063170c1991b84eb8d86de1",
+				"SnapConfineAppArmorProfileDpkgNewMD5Sum": "93b885adfe0da089cdf634904fd59f71",
 			})
 			fmt.Fprintf(w, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 		case 1:

--- a/errtracker/export_test.go
+++ b/errtracker/export_test.go
@@ -62,3 +62,11 @@ func MockTimeNow(f func() time.Time) (restorer func()) {
 		timeNow = old
 	}
 }
+
+func MockSnapConfineApparmorProfile(path string) (restorer func()) {
+	old := snapConfineProfile
+	snapConfineProfile = path
+	return func() {
+		snapConfineProfile = old
+	}
+}


### PR DESCRIPTION
This patch extends the error report with information about the used
snap-confine apparmor profile (as expressed by the text of the file) as
well as hint of partial dpkg update.

Partial or failed updates can leave the old (previous) apparmor profile
of snap-confine around (since it is tagged as a conffile) and
subsequently cause any snap execution to fail with access to
"/run/snapd/lock" directory.
    
To test the theory we will now measure the hashes of the current and any
.dpkg-new versions of the apparmor profile of snap-confine and attach
them to the report.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>