### PR TITLE
errtracker: include bits of snap-confine apparmor profile (#3421)

### DIFF
--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -46,6 +46,8 @@ func Test(t *testing.T) { TestingT(t) }
 
 type ErrtrackerTestSuite struct {
 	testutil.BaseTest
+
+	snapConfineProfile string
 }
 
 var _ = Suite(&ErrtrackerTestSuite{})
@@ -56,12 +58,19 @@ var falsePath = osutil.LookPathDefault("false", "/bin/false")
 func (s *ErrtrackerTestSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
-	p := filepath.Join(c.MkDir(), "machine-id")
+	d := c.MkDir()
+	p := filepath.Join(d, "machine-id")
 	err := ioutil.WriteFile(p, []byte("bbb1a6a5bcdb418380056a2d759c3f7c"), 0644)
 	c.Assert(err, IsNil)
 	s.AddCleanup(errtracker.MockMachineIDPath(p))
 	s.AddCleanup(errtracker.MockHostSnapd(truePath))
 	s.AddCleanup(errtracker.MockCoreSnapd(falsePath))
+
+	p = filepath.Join(d, "usr.lib.snapd.snap-confine.real")
+	err = ioutil.WriteFile(p, []byte("# fake profile of snap-confine"), 0644)
+	c.Assert(err, IsNil)
+	s.AddCleanup(errtracker.MockSnapConfineApparmorProfile(p))
+	s.snapConfineProfile = p
 }
 
 func (s *ErrtrackerTestSuite) TestReport(c *C) {
@@ -70,6 +79,9 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 	hostBuildID, err := osutil.ReadBuildID(truePath)
 	c.Assert(err, IsNil)
 	coreBuildID, err := osutil.ReadBuildID(falsePath)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(s.snapConfineProfile+".dpkg-new", []byte{0}, 0644)
 	c.Assert(err, IsNil)
 
 	prev := errtracker.SnapdVersion
@@ -107,6 +119,9 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 				"ErrorMessage":       "failed to do stuff",
 				"DuplicateSignature": "[failed to do stuff]",
 				"Architecture":       arch.UbuntuArchitecture(),
+
+				"SnapConfineAppArmorProfileCurrentMD5Sum": "7a7aa5f21063170c1991b84eb8d86de1",
+				"SnapConfineAppArmorProfileDpkgNewMD5Sum": "93b885adfe0da089cdf634904fd59f71",
 			})
 			fmt.Fprintf(w, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 		case 1:

--- a/errtracker/export_test.go
+++ b/errtracker/export_test.go
@@ -62,3 +62,11 @@ func MockTimeNow(f func() time.Time) (restorer func()) {
 		timeNow = old
 	}
 }
+
+func MockSnapConfineApparmorProfile(path string) (restorer func()) {
+	old := snapConfineProfile
+	snapConfineProfile = path
+	return func() {
+		snapConfineProfile = old
+	}
+}


### PR DESCRIPTION
This patch extends the error report with information about the used
snap-confine apparmor profile (as expressed by the text of the file) as
well as hint of partial dpkg update.

Partial or failed updates can leave the old (previous) apparmor profile
of snap-confine around (since it is tagged as a conffile) and
subsequently cause any snap execution to fail with access to
"/run/snapd/lock" directory.

To test the theory we will now measure the hashes of the current and any
.dpkg-new versions of the apparmor profile of snap-confine and attach
them to the report.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>