### PR TITLE
errtracker: report if snapd did re-execute itself

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -71,6 +71,13 @@ func snapConfineProfileDigest(suffix string) string {
 	return fmt.Sprintf("%x", md5.Sum(profileText))
 }
 
+func didSnapdReExec() string {
+	if osutil.GetenvBool("SNAP_DID_REEXEC") {
+		return "yes"
+	}
+	return "no"
+}
+
 func Report(snap, errMsg, dupSig string, extra map[string]string) (string, error) {
 	if CrashDbURLBase == "" {
 		return "", nil
@@ -117,6 +124,8 @@ func Report(snap, errMsg, dupSig string, extra map[string]string) (string, error
 
 		"SnapConfineAppArmorProfileCurrentMD5Sum": snapConfineProfileDigest(""),
 		"SnapConfineAppArmorProfileDpkgNewMD5Sum": snapConfineProfileDigest(".dpkg-new"),
+
+		"DidSnapdReExec": didSnapdReExec(),
 	}
 	for k, v := range extra {
 		// only set if empty

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -65,6 +65,7 @@ func (s *ErrtrackerTestSuite) SetUpTest(c *C) {
 	s.AddCleanup(errtracker.MockMachineIDPath(p))
 	s.AddCleanup(errtracker.MockHostSnapd(truePath))
 	s.AddCleanup(errtracker.MockCoreSnapd(falsePath))
+	s.AddCleanup(errtracker.MockReExec(true))
 
 	p = filepath.Join(d, "usr.lib.snapd.snap-confine.real")
 	err = ioutil.WriteFile(p, []byte("# fake profile of snap-confine"), 0644)
@@ -122,6 +123,8 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 
 				"SnapConfineAppArmorProfileCurrentMD5Sum": "7a7aa5f21063170c1991b84eb8d86de1",
 				"SnapConfineAppArmorProfileDpkgNewMD5Sum": "93b885adfe0da089cdf634904fd59f71",
+
+				"DidSnapdReExec": "yes",
 			})
 			fmt.Fprintf(w, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 		case 1:

--- a/errtracker/export_test.go
+++ b/errtracker/export_test.go
@@ -20,7 +20,10 @@
 package errtracker
 
 import (
+	"os"
 	"time"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
 func MockCrashDbURL(url string) (restorer func()) {
@@ -68,5 +71,21 @@ func MockSnapConfineApparmorProfile(path string) (restorer func()) {
 	snapConfineProfile = path
 	return func() {
 		snapConfineProfile = old
+	}
+}
+
+func MockReExec(didReExec bool) (restorer func()) {
+	old := osutil.GetenvBool("SNAP_DID_REEXEC")
+	if didReExec {
+		os.Setenv("SNAP_DID_REEXEC", "1")
+	} else {
+		os.Unsetenv("SNAP_DID_REEXEC")
+	}
+	return func() {
+		if old {
+			os.Setenv("SNAP_DID_REEXEC", "1")
+		} else {
+			os.Unsetenv("SNAP_DID_REEXEC")
+		}
 	}
 }


### PR DESCRIPTION
Re-execution affects which internal tools and which snapd is used.
while the current error report shows us hashes of both distribution
and core snapd we always need to guess which one is being used
by inspecting the version string. This makes it more obvious.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>