### PR TITLE
interfaces/builtin: silence ptrace denial for network-manager

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -103,8 +103,9 @@ network packet,
 
 #include <abstractions/nameservice>
 
-# Explicitly deny ptrace. This doesn't influence any NetworkManager
-# functionality but silences AppArmor denials in the system log.
+# Explicitly deny plugging snaps from ptracing the slot to silence noisy
+# denials. Neither the NetworkManager service nor nmcli require ptrace
+# trace for full functionality.
 deny ptrace (trace) peer=###PLUG_SECURITY_TAGS###,
 
 # DBus accesses

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -103,6 +103,10 @@ network packet,
 
 #include <abstractions/nameservice>
 
+# Explicitly deny ptrace. This doesn't influence any NetworkManager
+# functionality but silences AppArmor denials in the system log.
+deny ptrace (trace) peer=###PLUG_SECURITY_TAGS###,
+
 # DBus accesses
 #include <abstractions/dbus-strict>
 


### PR DESCRIPTION
Adding this was recommended by @jdstrand on https://forum.snapcraft.io/t/use-of-nmcli-from-inside-a-snap/822/13 to silence the ptrace denials we still get with the network-manager interface. Adding this explicit denial does not affect the NetworkManager functionality.