### PR TITLE
tests: add snap-confine privilege test

### DIFF
--- a/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-sh/meta/snap.yaml
@@ -1,0 +1,6 @@
+name: test-snapd-sh
+summary: A no-strings-attached, no-fuss shell for writing tests
+version: 1.0
+apps:
+    test-snapd-sh:
+        command: ../../../bin/sh

--- a/tests/main/snap-confine-privs/task.yaml
+++ b/tests/main/snap-confine-privs/task.yaml
@@ -1,8 +1,8 @@
 summary: ensure that snap-confine handles group and user privileges correctly
 details: |
     The openSUSE security team has made a remark about a particular part of
-    snap-confine's UID/GID handling. The code there was, we believe, correct
-    but this test is here to demonstrate that and ensure it never regresses.
+    snap-confine's UID/GID handling. The code there was correct but this test
+    is here to demonstrate that and ensure it never regresses.
 
     Security review https://bugzilla.opensuse.org/show_bug.cgi?id=986050
 # This test is not executed on a core system simply because of the hassle of

--- a/tests/main/snap-confine-privs/task.yaml
+++ b/tests/main/snap-confine-privs/task.yaml
@@ -47,14 +47,17 @@ execute: |
     su -l -c "sudo $P/uids-and-gids-setgid" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
 
     echo "Running as regular user under snap-confine"
-    # This is the same as the two above but it goes through snap-confine as well.
-    # Note that we have to quote the $ sign below as there are two shell expansions done.
-    su -l -c "test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=12345 sgid=12345'
-    su -l -c "test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=12345 euid=0     suid=0     rgid=12345 egid=12345 sgid=12345'
-    su -l -c "test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=0     sgid=0    '
+    # This is the same as the two above but it goes through snap-confine as
+    # well. Note that we have to quote the $ sign below as there are two shell
+    # expansions done. Note that we are using "snap run test-snapd-sh" in order
+    # to ensure that we can start the progam even if su/sudo's secure PATH does
+    # not contain the snap bin directory.
+    su -l -c "snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=12345 sgid=12345'
+    su -l -c "snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=12345 euid=0     suid=0     rgid=12345 egid=12345 sgid=12345'
+    su -l -c "snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=0     sgid=0    '
 
     echo "Running as regular user, uder snap-conifne under sudo"
     # This is the same one as the previous one but also using sudo.
-    su -l -c "sudo test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
-    su -l -c "sudo test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
-    su -l -c "sudo test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo snap run test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '

--- a/tests/main/snap-confine-privs/task.yaml
+++ b/tests/main/snap-confine-privs/task.yaml
@@ -1,0 +1,60 @@
+summary: ensure that snap-confine handles group and user privileges correctly
+details: |
+    The openSUSE security team has made a remark about a particular part of
+    snap-confine's UID/GID handling. The code there was, we believe, correct
+    but this test is here to demonstrate that and ensure it never regresses.
+
+    Security review https://bugzilla.opensuse.org/show_bug.cgi?id=986050
+# This test is not executed on a core system simply because of the hassle of
+# building the support C program. In the future it might be improved with the
+# use of the classic snap where we just use classic to build the helper.
+systems: [-ubuntu-core-16-*]
+environment:
+    # This is used to abbreviate some of the paths below.
+    P: /var/snap/test-snapd-sh/common
+prepare: |
+    echo "Install a helper snap (for confinement testing)"
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-sh
+
+    echo "Compile and prepare the support program"
+    # Because we use the snap data directory we don't need to clean it up
+    # manually as all snaps and their data are reset after each test.
+    gcc -Wall -Wextra -Werror ./uids-and-gids.c -o $P/uids-and-gids
+    cp $P/uids-and-gids $P/uids-and-gids-setuid
+    chown root $P/uids-and-gids-setuid
+    chmod 4755 $P/uids-and-gids-setuid
+    cp $P/uids-and-gids $P/uids-and-gids-setgid
+    chgrp root $P/uids-and-gids-setgid
+    chmod 2755 $P/uids-and-gids-setgid
+execute: |
+    echo "The test executables files have the expected mode and ownership"
+    ls -l $P | MATCH -- '-rwxr-xr-x 1 root root [0-9]+ [A-Z][a-z]+ +[0-9]+ [0-9]+:[0-9]+ uids-and-gids'
+    ls -l $P | MATCH -- '-rwxr-sr-x 1 root root [0-9]+ [A-Z][a-z]+ +[0-9]+ [0-9]+:[0-9]+ uids-and-gids-setgid'
+    ls -l $P | MATCH -- '-rwsr-xr-x 1 root root [0-9]+ [A-Z][a-z]+ +[0-9]+ [0-9]+:[0-9]+ uids-and-gids-setuid'
+
+    echo "Running as regular user"
+    # Spread runs all tests as root so we're using su to switch to the "test" user.
+    # The "test" user inside the spread suite is guaranteed to have UID/GID of 12345.
+    su -l -c $P/uids-and-gids        test        | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=12345 sgid=12345'
+    su -l -c $P/uids-and-gids-setuid test        | MATCH 'ruid=12345 euid=0     suid=0     rgid=12345 egid=12345 sgid=12345'
+    su -l -c $P/uids-and-gids-setgid test        | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=0     sgid=0    '
+
+    echo "Running as regular user via sudo"
+    # This is same as above except that we're also using sudo
+    su -l -c "sudo $P/uids-and-gids"        test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo $P/uids-and-gids-setuid" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo $P/uids-and-gids-setgid" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+
+    echo "Running as regular user under snap-confine"
+    # This is the same as the two above but it goes through snap-confine as well.
+    # Note that we have to quote the $ sign below as there are two shell expansions done.
+    su -l -c "test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=12345 sgid=12345'
+    su -l -c "test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=12345 euid=0     suid=0     rgid=12345 egid=12345 sgid=12345'
+    su -l -c "test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=12345 euid=12345 suid=12345 rgid=12345 egid=0     sgid=0    '
+
+    echo "Running as regular user, uder snap-conifne under sudo"
+    # This is the same one as the previous one but also using sudo.
+    su -l -c "sudo test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids'"        test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setuid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '
+    su -l -c "sudo test-snapd-sh -c '\$SNAP_COMMON/uids-and-gids-setgid'" test | MATCH 'ruid=0     euid=0     suid=0     rgid=0     egid=0     sgid=0    '

--- a/tests/main/snap-confine-privs/uids-and-gids.c
+++ b/tests/main/snap-confine-privs/uids-and-gids.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #define _GNU_SOURCE
 #include <errno.h>
 #include <grp.h>

--- a/tests/main/snap-confine-privs/uids-and-gids.c
+++ b/tests/main/snap-confine-privs/uids-and-gids.c
@@ -1,0 +1,24 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <grp.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(int argc __attribute__((unused)), char* argv[] __attribute__((unused)))
+{
+    uid_t ruid, euid, suid;
+    gid_t rgid, egid, sgid;
+    if (getresuid(&ruid, &euid, &suid) < 0) {
+        perror("cannot call getresuid");
+        exit(1);
+    }
+    if (getresgid(&rgid, &egid, &sgid) < 0) {
+        perror("cannot call getresgid");
+        exit(1);
+    }
+    printf("ruid=%-5d euid=%-5d suid=%-5d rgid=%-5d egid=%-5d sgid=%-5d\n", ruid, euid, suid, rgid, egid, sgid);
+    return 0;
+}


### PR DESCRIPTION
This test ensures that snap confine correctly drops privileges (user and
group identifiers) in various scenarios involving sudo and regular users.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>