### PR TITLE
interfaces/snapd-control: also allow use of /usr/bin/snap

### DIFF
--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -21,11 +21,15 @@ package builtin
 
 const snapdControlSummary = `allows communicating with snapd`
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/snapd-control
 const snapdControlConnectedPlugAppArmor = `
 # Description: Can manage snaps via snapd.
 
 /run/snapd.socket rw,
+
+# allow snaps to use the snap command to talk to snapd over the above snapd
+# socket. (Currently requires 'sudo su -l ...' if running under sudo on the
+# command line)
+/usr/bin/snap ixr,
 `
 
 func init() {


### PR DESCRIPTION
It got me thinking that while we provide access to /run/snapd.socket which gives the whole of the rest API to the snap, we don't allow use of /usr/bin/snap, which would be handy for shell scripts, etc. This PR adds /usr/bin/snap using an 'ixr' rule, which means that 'snap' can use the rest API but nothing outside of what would normally be allowed (ie, no additional permissions so things like 'snap run' don't work). This is, in terms of security, equivalent to a snap that plugs 'snapd-control' shipping its own tools for using the socket.

The main benefit of this PR is that snaps that `plugs: [ snapd-control ]` don't have to worry about shipping 'snap' and having it become out of date or incompatible. The downside is UX because (in part) 'snap' looks for `/home/<user>/.snap/auth.json` under `sudo` (even `sudo -H -i`) and users would need to use 'sudo su -l ...' to make 'snap' look in `/root/.snap/auth.json` when invoking 'snap' under sudo. While the security surface of applying this PR is unchanged, we may not want to expose 'snap' in core because it isn't designed to be used in this manner. Another potential consideration is that exceedingly few snaps are allowed to use 'snapd-control' and so this downside shouldn't be a big issue in practice.

Other reviewers-- sending this up for @niemeyer's review, please don't commit unless he explicitly approves it.