### PR TITLE
tests: clean journalctl logs on trusty

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -200,21 +200,22 @@ exclude:
     - "*.a"
 
 prepare-each: |
-    # systemd on 14.04 does not know about --rotate
-    # or --vacuum-time.
-    # TODO: Find a way to clean out systemd logs on
-    # systemd 204.
+    # systemd on 14.04 does not know about --rotate or --vacuum-time.
     if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
         journalctl --rotate
         sleep .1
         journalctl --vacuum-time=1ms
     else
+        # Force a log rotation with small size
         sed -i.bak s/#SystemMaxUse=/SystemMaxUse=1K/g /etc/systemd/journald.conf
         systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
         mv /etc/systemd/journald.conf.bak /etc/systemd/journald.conf
         systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
+
+        #Remove rotated journal logs
+        systemctl stop systemd-journald.service
         find /run/log/journal/ -name *@*.journal | xargs rm
-        sudo systemctl restart systemd-journald.service
+        systemctl start systemd-journald.service
     fi
     dmesg -c > /dev/null
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -209,10 +209,12 @@ prepare-each: |
         # Force a log rotation with small size
         sed -i.bak s/#SystemMaxUse=/SystemMaxUse=1K/g /etc/systemd/journald.conf
         systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
+
+        # Restore the initial configuration and rotate logs
         mv /etc/systemd/journald.conf.bak /etc/systemd/journald.conf
         systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
 
-        #Remove rotated journal logs
+        # Remove rotated journal logs
         systemctl stop systemd-journald.service
         find /run/log/journal/ -name "*@*.journal" -delete
         systemctl start systemd-journald.service

--- a/spread.yaml
+++ b/spread.yaml
@@ -214,7 +214,7 @@ prepare-each: |
 
         #Remove rotated journal logs
         systemctl stop systemd-journald.service
-        find /run/log/journal/ -name *@*.journal | xargs rm
+        find /run/log/journal/ -name "*@*.journal" -delete
         systemctl start systemd-journald.service
     fi
     dmesg -c > /dev/null

--- a/spread.yaml
+++ b/spread.yaml
@@ -208,6 +208,13 @@ prepare-each: |
         journalctl --rotate
         sleep .1
         journalctl --vacuum-time=1ms
+    else
+        sed -i.bak s/#SystemMaxUse=/SystemMaxUse=1K/g /etc/systemd/journald.conf
+        systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
+        mv /etc/systemd/journald.conf.bak /etc/systemd/journald.conf
+        systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
+        find /run/log/journal/ -name *@*.journal | xargs rm
+        sudo systemctl restart systemd-journald.service
     fi
     dmesg -c > /dev/null
 


### PR DESCRIPTION
This is a way to reduce the size of the journalctl logs on ubuntu 14.04.
This is needed to improve the quality of the tests bacause some of them are using journalctl to check that the actions are done.
I also will help to make more readable the logs when a test fail.