### PR TITLE
interfaces: add password-manager-service implicit interface

### DIFF
--- a/interfaces/builtin/basedeclaration.go
+++ b/interfaces/builtin/basedeclaration.go
@@ -509,6 +509,11 @@ slots:
     allow-installation:
       slot-snap-type:
         - core
+  password-manager-service:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
   physical-memory-control:
     allow-installation:
       slot-snap-type:

--- a/interfaces/builtin/password_manager_service.go
+++ b/interfaces/builtin/password_manager_service.go
@@ -1,0 +1,52 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const passwordManagerServiceSummary = `allows interacting with the Password Manager Service`
+
+const passwordManagerServiceConnectedPlugAppArmor = `
+# Description: Allow access to the registry and storage framework services.
+
+#include <abstractions/dbus-session-strict>
+
+dbus (send)
+    bus=session
+    path=/org/freedesktop/secrets
+    interface=org.freedesktop.DBus.Properties
+    member="{Get,GetAll,PropertiesChanged}"
+    peer=(label=unconfined),
+
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.Secret.*
+    path=/org/freedesktop/secrets{,/**}
+    peer=(label=unconfined),
+
+
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "password-manager-service",
+		summary:               passwordManagerServiceSummary,
+		connectedPlugAppArmor: passwordManagerServiceConnectedPlugAppArmor,
+		reservedForOS:         true,
+	})
+}

--- a/interfaces/builtin/password_manager_service.go
+++ b/interfaces/builtin/password_manager_service.go
@@ -38,8 +38,6 @@ dbus (receive, send)
     interface=org.freedesktop.Secret.*
     path=/org/freedesktop/secrets{,/**}
     peer=(label=unconfined),
-
-
 `
 
 func init() {

--- a/interfaces/builtin/password_manager_service_test.go
+++ b/interfaces/builtin/password_manager_service_test.go
@@ -1,0 +1,100 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type passwordManagerServiceInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&passwordManagerServiceInterfaceSuite{
+	iface: builtin.MustInterface("password-manager-service"),
+})
+
+func (s *passwordManagerServiceInterfaceSuite) SetUpTest(c *C) {
+	var mockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [password-manager-service]
+`
+	s.slot = &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Name:      "password-manager-service",
+			Interface: "password-manager-service",
+		},
+	}
+	snapInfo := snaptest.MockInfo(c, mockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["password-manager-service"]}
+}
+
+func (s *passwordManagerServiceInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "password-manager-service")
+}
+
+func (s *passwordManagerServiceInterfaceSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "password-manager-service",
+		Interface: "password-manager-service",
+	}})
+	c.Assert(err, ErrorMatches, "password-manager-service slots are reserved for the operating system snap")
+}
+
+func (s *passwordManagerServiceInterfaceSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *passwordManagerServiceInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "password-manager-service"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "password-manager-service"`)
+}
+
+func (s *passwordManagerServiceInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "interface= org.freedesktop.Secret")
+}
+
+func (s *passwordManagerServiceInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/password_manager_service_test.go
+++ b/interfaces/builtin/password_manager_service_test.go
@@ -92,7 +92,7 @@ func (s *passwordManagerServiceInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
-	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "interface= org.freedesktop.Secret")
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, "interface=org.freedesktop.Secret")
 }
 
 func (s *passwordManagerServiceInterfaceSuite) TestInterfaces(c *C) {

--- a/snap/implicit.go
+++ b/snap/implicit.go
@@ -89,6 +89,7 @@ var implicitClassicSlots = []string{
 	"ofono",
 	"openvswitch",
 	"optical-drive",
+	"password-manager-service",
 	"pulseaudio",
 	"screen-inhibit-control",
 	"unity7",

--- a/tests/lib/snaps/test-snapd-password-manager-service-consumer/bin/secret-tool
+++ b/tests/lib/snaps/test-snapd-password-manager-service-consumer/bin/secret-tool
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+"$SNAP"/usr/bin/secret-tool "$@"

--- a/tests/lib/snaps/test-snapd-password-manager-service-consumer/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-password-manager-service-consumer/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: test-snapd-password-manager-consumer
+version: 1.0
+summary: Basic snap declaring a plug on the password-manager-service interface
+description: Basic snap declaring a plug on the password-manager-service interface
+grade: stable
+confinement: strict
+
+apps:
+    secret-tool:
+        command: bin/secret-tool
+        plugs: [password-manager-service]
+
+parts:
+    libsecret-tools:
+        plugin: dump
+        stage-packages:
+            - libsecret-tools
+        source: .
+        prime:
+            - bin/
+            - usr/

--- a/tests/main/interfaces-password-manager-service/task.yaml
+++ b/tests/main/interfaces-password-manager-service/task.yaml
@@ -4,12 +4,16 @@ systems:
     - -ubuntu-core-16-*
 
 prepare: |
+    . $TESTSLIB/pkgdb.sh
     echo "Ensure we have a working gnome-keyring"
-    apt-get install -y --no-install-recommends gnome-keyring dbus-x11
+    distro_install_package gnome-keyring dbus-x11
     snap install --edge test-snapd-password-manager-consumer
 
 restore: |
-    apt-get purge -y --auto-remove gnome-keyring dbus-x11
+    . $TESTSLIB/pkgdb.sh
+    distro_auto_remove_packages gnome-keyring dbus-x11
+    kill $(cat dbus-launch.pid)
+    rm -f  dbus-launch.pid
 
 execute: |
     CONNECTED_PATTERN=":password-manager-service +test-snapd-password-manager-consumer"
@@ -17,9 +21,9 @@ execute: |
 
     echo "Ensure things run"
     eval $(dbus-launch --sh-syntax)
-    eval $(printf ubuntu|gnome-keyring-daemon --login)
+    eval $(printf password|gnome-keyring-daemon --login)
     eval $(gnome-keyring-daemon --start)
-    
+    echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid
 
     echo "Then it is not shown as connected"
     snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
@@ -48,4 +52,5 @@ execute: |
         echo "Expected error with plug disconnected"
         exit 1
     fi
+
 

--- a/tests/main/interfaces-password-manager-service/task.yaml
+++ b/tests/main/interfaces-password-manager-service/task.yaml
@@ -1,0 +1,51 @@
+summary: Ensure that the password-manager-service interface works
+
+systems:
+    - -ubuntu-core-16-*
+
+prepare: |
+    echo "Ensure we have a working gnome-keyring"
+    apt-get install -y --no-install-recommends gnome-keyring
+    snap install --edge test-snapd-password-manager-consumer
+
+restore: |
+    apt-get purge -y --auto-remove gnome-keyring
+
+execute: |
+    CONNECTED_PATTERN=":password-manager-service +test-snapd-password-manager-consumer"
+    DISCONNECTED_PATTERN="(?s).*?\n- +test-snapd-password-manager-consumer:password-manager-service"
+
+    echo "Ensure things run"
+    eval $(dbus-launch --sh-syntax)
+    eval $(printf ubuntu|gnome-keyring-daemon --login)
+    eval $(gnome-keyring-daemon --start)
+    
+
+    echo "Then it is not shown as connected"
+    snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
+
+    echo "===================================="
+
+    echo "When the plug is connected"
+    snap connect test-snapd-password-manager-consumer:password-manager-service
+    snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
+
+    echo "Then the snap command is able use the libsecret service"
+    test-snapd-password-manager-consumer.secret-tool clear foo bar
+
+    if [ "$(snap debug confinement)" = none ] ; then
+        exit 0
+    fi
+
+    echo "===================================="
+
+    echo "When the plug is disconnected"
+    snap disconnect test-snapd-password-manager-consumer:password-manager-service
+    snap interfaces | grep -Pzq "$DISCONNECTED_PATTERN"
+
+    echo "Then the snap command is not able to use the secret-tool"
+    if test-snapd-password-manager-consumer.secret-tool clear foo bar; then
+        echo "Expected error with plug disconnected"
+        exit 1
+    fi
+

--- a/tests/main/interfaces-password-manager-service/task.yaml
+++ b/tests/main/interfaces-password-manager-service/task.yaml
@@ -5,11 +5,11 @@ systems:
 
 prepare: |
     echo "Ensure we have a working gnome-keyring"
-    apt-get install -y --no-install-recommends gnome-keyring
+    apt-get install -y --no-install-recommends gnome-keyring dbus-x11
     snap install --edge test-snapd-password-manager-consumer
 
 restore: |
-    apt-get purge -y --auto-remove gnome-keyring
+    apt-get purge -y --auto-remove gnome-keyring dbus-x11
 
 execute: |
     CONNECTED_PATTERN=":password-manager-service +test-snapd-password-manager-consumer"


### PR DESCRIPTION
A careful review from the security team is appreciated here. Also this was only tested with the `secret-tool` so far, no real world application yet.

LP: #1653769