### PR TITLE
daemon: make snapd a "Type=notify" daemon and notify when startup is done

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -24,12 +24,14 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/errtracker"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/systemd"
 )
 
 func init() {
@@ -51,6 +53,7 @@ func main() {
 }
 
 func run() error {
+	t0 := time.Now().Truncate(time.Millisecond)
 	httputil.SetUserAgentFromVersion(cmd.Version)
 
 	d, err := daemon.New()
@@ -64,6 +67,10 @@ func run() error {
 
 	d.Start()
 
+	// notify systemd that we are ready
+	systemd.SdNotify("READY=1")
+	logger.Debugf("activation done in %v", time.Now().Truncate(time.Millisecond).Sub(t0))
+
 	ch := make(chan os.Signal)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	select {
@@ -73,5 +80,6 @@ func run() error {
 		// something called Stop()
 	}
 
+	systemd.SdNotify("STOPPING=1")
 	return d.Stop()
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -219,7 +219,6 @@ func getListener(socketPath string, listenerMap map[string]net.Listener) (net.Li
 // Init sets up the Daemon's internal workings.
 // Don't call more than once.
 func (d *Daemon) Init() error {
-	t0 := time.Now()
 	listeners, err := activation.Listeners(false)
 	if err != nil {
 		return err
@@ -250,7 +249,6 @@ func (d *Daemon) Init() error {
 
 	d.addRoutes()
 
-	logger.Debugf("init done in %s", time.Now().Sub(t0))
 	logger.Noticef("started %v.", httputil.UserAgent())
 
 	return nil

--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -8,6 +8,7 @@ OOMScoreAdjust=-900
 ExecStart=@libexecdir@/snapd/snapd
 EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
 Restart=always
+Type=notify
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -38,3 +38,9 @@ func MockStopDelays(checkDelay, notifyDelay time.Duration) func() {
 		stopNotifyDelay = oldNotifyDelay
 	}
 }
+
+func MockOsGetenv(f func(string) string) func() {
+	oldOsGetenv := osGetenv
+	osGetenv = f
+	return func() { osGetenv = oldOsGetenv }
+}

--- a/systemd/sdnotify.go
+++ b/systemd/sdnotify.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package systemd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+// SdNotify sends the given state string notification to systemd.
+//
+// inspired by libsystemd/sd-daemon/sd-daemon.c from the systemd source
+func SdNotify(notifyState string) error {
+	if notifyState == "" {
+		return fmt.Errorf("cannot use empty notify state")
+	}
+
+	notifySocket := os.Getenv("NOTIFY_SOCKET")
+	if notifySocket == "" {
+		return fmt.Errorf("cannot find NOTIFY_SOCKET environment")
+	}
+	if !strings.HasPrefix(notifySocket, "@") && !strings.HasPrefix(notifySocket, "/") {
+		return fmt.Errorf("cannot use NOTIFY_SOCKET %q", notifySocket)
+	}
+
+	raddr := &net.UnixAddr{
+		Name: notifySocket,
+		Net:  "unixgram",
+	}
+	conn, err := net.DialUnix("unixgram", nil, raddr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(notifyState))
+	return err
+}

--- a/systemd/sdnotify.go
+++ b/systemd/sdnotify.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 )
 
+var osGetenv = os.Getenv
+
 // SdNotify sends the given state string notification to systemd.
 //
 // inspired by libsystemd/sd-daemon/sd-daemon.c from the systemd source
@@ -34,7 +36,7 @@ func SdNotify(notifyState string) error {
 		return fmt.Errorf("cannot use empty notify state")
 	}
 
-	notifySocket := os.Getenv("NOTIFY_SOCKET")
+	notifySocket := osGetenv("NOTIFY_SOCKET")
 	if notifySocket == "" {
 		return fmt.Errorf("cannot find NOTIFY_SOCKET environment")
 	}

--- a/systemd/sdnotify_test.go
+++ b/systemd/sdnotify_test.go
@@ -53,12 +53,17 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWrongNotifySocket(c *C) {
 }
 
 func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
+	fakeEnv := map[string]string{}
+	restore := systemd.MockOsGetenv(func(k string) string {
+		return fakeEnv[k]
+	})
+	defer restore()
+
 	for _, sockPath := range []string{
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
-		os.Setenv("NOTIFY_SOCKET", sockPath)
-		defer os.Unsetenv(sockPath)
+		fakeEnv["NOTIFY_SOCKET"] = sockPath
 
 		conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
 			Name: sockPath,

--- a/systemd/sdnotify_test.go
+++ b/systemd/sdnotify_test.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package systemd_test
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/systemd"
+)
+
+type sdNotifyTestSuite struct{}
+
+var _ = Suite(&sdNotifyTestSuite{})
+
+func (sd *sdNotifyTestSuite) TestSdNotifyMissingNotifyState(c *C) {
+	c.Check(systemd.SdNotify(""), ErrorMatches, "cannot use empty notify state")
+}
+
+func (sd *sdNotifyTestSuite) TestSdNotifyWrongNotifySocket(c *C) {
+	for _, t := range []struct {
+		env    string
+		errStr string
+	}{
+		{"", "cannot find NOTIFY_SOCKET environment"},
+		{"xxx", `cannot use NOTIFY_SOCKET "xxx"`},
+	} {
+		os.Setenv("NOTIFY_SOCKET", t.env)
+		defer os.Unsetenv("NOTIFY_SOCKET")
+
+		c.Check(systemd.SdNotify("something"), ErrorMatches, t.errStr)
+	}
+}
+
+func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
+	for _, sockPath := range []string{
+		filepath.Join(c.MkDir(), "socket"),
+		"@socket",
+	} {
+		os.Setenv("NOTIFY_SOCKET", sockPath)
+		defer os.Unsetenv(sockPath)
+
+		conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
+			Name: sockPath,
+			Net:  "unixgram",
+		})
+		c.Assert(err, IsNil)
+		defer conn.Close()
+
+		ch := make(chan string)
+		go func() {
+			var buf [128]byte
+			n, err := conn.Read(buf[:])
+			c.Assert(err, IsNil)
+			ch <- string(buf[:n])
+		}()
+
+		err = systemd.SdNotify("something")
+		c.Assert(err, IsNil)
+		c.Check(<-ch, Equals, "something")
+	}
+}

--- a/tests/main/snapd-notify/task.yaml
+++ b/tests/main/snapd-notify/task.yaml
@@ -1,0 +1,5 @@
+summary: Ensure snapd notify feature is working
+
+execute: |
+    systemctl status snapd.service | MATCH "Active: active"
+    journalctl -u snapd | MATCH "activation done in"


### PR DESCRIPTION
This way we can notify systemd only after our initialization is
complete. It also moves some timing code which was less useful
in daemon.Init() (as it is not doing much) and much more useful
around daemon.New() where the security profiles are re-generated.

It will also allow us later to order snap services to run after snapd itself 
started up.