### PR TITLE
cmd/snap-confine: add support for --base snap

### DIFF
--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -31,7 +31,7 @@
  * The function will also try to preserve the current working directory but if
  * this is impossible it will chdir to SC_VOID_DIR.
  **/
-void sc_populate_mount_ns(const char *snap_name);
+void sc_populate_mount_ns(const char *base_snap_name, const char *snap_name);
 
 /**
  * Ensure that / or /snap is mounted with the SHARED option. 

--- a/cmd/snap-confine/snap-confine-args.h
+++ b/cmd/snap-confine/snap-confine-args.h
@@ -113,4 +113,12 @@ const char *sc_args_security_tag(struct sc_args *args);
  **/
 const char *sc_args_executable(struct sc_args *args);
 
+/**
+ * Get the name of the base snap to use.
+ *
+ * The return value must not be freed(). It is bound to the lifetime of
+ * the argument parser.
+ **/
+const char *sc_args_base_snap(struct sc_args *args);
+
 #endif

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -103,7 +103,7 @@
     mount options=(rw bind) /tmp/snap.rootfs_*/ -> /tmp/snap.rootfs_*/,
     mount options=(rw unbindable) -> /tmp/snap.rootfs_*/,
     # the next line is for classic system
-    mount options=(rw rbind) @SNAP_MOUNT_DIR@/{,ubuntu-}core/*/ -> /tmp/snap.rootfs_*/,
+    mount options=(rw rbind) @SNAP_MOUNT_DIR@/*/*/ -> /tmp/snap.rootfs_*/,
     # the next line is for core system
     mount options=(rw rbind) / -> /tmp/snap.rootfs_*/,
     # all of the constructed rootfs is a rslave

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -60,6 +60,7 @@ int main(int argc, char **argv)
 		die("security tag %s not allowed", security_tag);
 	}
 	const char *executable = sc_args_executable(args);
+	const char *base_snap_name = sc_args_base_snap(args) ? : "core";
 	bool classic_confinement = sc_args_is_classic_confinement(args);
 
 	const char *snap_name = getenv("SNAP_NAME");
@@ -67,11 +68,13 @@ int main(int argc, char **argv)
 		die("SNAP_NAME is not set");
 	}
 	sc_snap_name_validate(snap_name, NULL);
+	sc_snap_name_validate(base_snap_name, NULL);
 
 	debug("security tag: %s", security_tag);
 	debug("executable:   %s", executable);
 	debug("confinement:  %s",
 	      classic_confinement ? "classic" : "non-classic");
+	debug("base snap:    %s", base_snap_name);
 
 	// Who are we?
 	uid_t real_uid = getuid();
@@ -148,7 +151,7 @@ int main(int argc, char **argv)
 			group = sc_open_ns_group(snap_name, 0);
 			sc_create_or_join_ns_group(group, &apparmor);
 			if (sc_should_populate_ns_group(group)) {
-				sc_populate_mount_ns(snap_name);
+				sc_populate_mount_ns(base_snap_name, snap_name);
 				sc_preserve_populated_ns_group(group);
 			}
 			sc_close_ns_group(group);


### PR DESCRIPTION
This branch allows snap-confine to run against a different base snap. By default we use "core"
but each invocation can now select an alternate base. This is not wired to "snap run" yet but will
allow other team members to experiment with the implementation of base snaps. In addition the
current implementation is limited to classic systems. On core systems we don't pivot_root and that
has to change before base snaps are fully operational.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
 