### PR TITLE
interfaces: move base declaration to the policy sub-package

### DIFF
--- a/interfaces/policy/basedeclaration.go
+++ b/interfaces/policy/basedeclaration.go
@@ -17,7 +17,7 @@
  *
  */
 
-package builtin
+package policy
 
 import (
 	"fmt"

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package builtin_test
+package policy_test
 
 import (
 	"fmt"


### PR DESCRIPTION
The base declaration is becoming de-centralized and as a part of that it
will be composed of out of small pieces.

To make this possible the policy package needs to be able to enumerate
interfaces reliably and the best way to make that possible is to move it
to a separate pacakge and then call the public builtin.Interfaces
function.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>