### PR TITLE
Unity7 interface grows gtk2/3 settings and user's specific ini

### DIFF
--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -195,9 +195,9 @@ owner @{HOME}/.local/share/mime/**   r,
 owner @{HOME}/.config/user-dirs.dirs r,
 
 # gtk settings
-owner @{HOME}/.config/gtk-2.0/gtkfilechooser.ini w,
-owner @{HOME}/.config/gtk-3.0/bookmarks w,
-owner @{HOME}/.config/gtk-3.0/settings.ini w,
+owner @{HOME}/.config/gtk-2.0/gtkfilechooser.ini r,
+owner @{HOME}/.config/gtk-3.0/bookmarks r,
+owner @{HOME}/.config/gtk-3.0/settings.ini r,
 
 # accessibility
 #include <abstractions/dbus-accessibility-strict>

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -194,6 +194,11 @@ dbus send
 owner @{HOME}/.local/share/mime/**   r,
 owner @{HOME}/.config/user-dirs.dirs r,
 
+# gtk settings
+owner @{HOME}/.config/gtk-2.0/gtkfilechooser.ini w,
+owner @{HOME}/.config/gtk-3.0/bookmarks w,
+owner @{HOME}/.config/gtk-3.0/settings.ini w,
+
 # accessibility
 #include <abstractions/dbus-accessibility-strict>
 dbus (send)

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -194,10 +194,11 @@ dbus send
 owner @{HOME}/.local/share/mime/**   r,
 owner @{HOME}/.config/user-dirs.dirs r,
 
-# gtk settings
+# gtk settings (subset of gnome abstraction)
 owner @{HOME}/.config/gtk-2.0/gtkfilechooser.ini r,
-owner @{HOME}/.config/gtk-3.0/bookmarks r,
 owner @{HOME}/.config/gtk-3.0/settings.ini r,
+# Note: this leaks directory names that wouldn't otherwise be known to the snap
+owner @{HOME}/.config/gtk-3.0/bookmarks r,
 
 # accessibility
 #include <abstractions/dbus-accessibility-strict>


### PR DESCRIPTION
Those files, global to user session, are needed to be accessible to access
advanced gtk user settings which aren't available in gsettings, like dark
theme variant, specific bookmarks pinning and file chooser settings.