### PR TITLE
tests: add linode-sru backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -189,6 +189,27 @@ backends:
                 username: test
                 password: ubuntu
 
+    linode-sru:
+        type: linode
+        key: "$(HOST: echo $SPREAD_LINODE_KEY)"
+        halt-timeout: 2h
+        systems:
+            - ubuntu-14.04-64:
+                kernel: GRUB 2
+                workers: 2
+            - ubuntu-16.04-64:
+                kernel: GRUB 2
+                workers: 2
+            - ubuntu-16.10-64:
+                kernel: GRUB 2
+                workers: 2
+            - ubuntu-17.04-64:
+                kernel: GRUB 2
+                workers: 2
+            - ubuntu-17.10-64:
+                kernel: GRUB 2
+                workers: 2
+
 path: /home/gopath/src/github.com/snapcore/snapd
 
 exclude:


### PR DESCRIPTION
This will allow us to run SRU validation tests entirely automated on linode, the current linode backend is missing most of the required systems for the validation.