### PR TITLE
debian: unify built_using between the 14.04 and 16.04 packaging branch

### DIFF
--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -44,7 +44,32 @@ ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
 	TAGS=-tags withtestkeys
 endif
 
-BUILT_USING_PACKAGES= libcap-dev libapparmor-dev libseccomp-dev
+BUILT_USING_PACKAGES=
+# export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+# DPKG_EXPORT_BUILDFLAGS = 1
+# include /usr/share/dpkg/buildflags.mk
+
+# Currently, we enable confinement for Ubuntu only, not for derivatives,
+# because derivatives may have different kernels that don't support all the
+# required confinement features and we don't to mislead anyone about the
+# security of the system.  Discuss a proper approach to this for downstreams
+# if and when they approach us
+ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
+    # On Ubuntu 16.04 we need to produce a build that can be used on wide
+    # variety of systems. As such we prefer static linking over dynamic linking
+    # for stability, predicability and easy of deployment. We need to link some
+    # things dynamically though: udev has no stable IPC protocol between
+    # libudev and udevd so we need to link with it dynamically.
+    VENDOR_ARGS=--enable-nvidia-ubuntu --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp
+    BUILT_USING_PACKAGES=libcap-dev libapparmor-dev libseccomp-dev
+else
+ifeq ($(shell dpkg-vendor --query Vendor),Debian)
+    VENDOR_ARGS=--disable-apparmor --disable-seccomp
+    BUILT_USING_PACKAGES=libcap-dev
+else
+    VENDOR_ARGS=--disable-apparmor
+endif
+endif
 BUILT_USING=$(shell dpkg-query -f '$${source:Package} (= $${source:Version}), ' -W $(BUILT_USING_PACKAGES))
 
 # export DEB_BUILD_MAINT_OPTIONS = hardening=+all


### PR DESCRIPTION
This is purely to keep the diff between the 14.04 and 16.04 packaging smaller. Kudos to Andy Whitcroft.