### PR TITLE
tests/lib: generalize RPM build support

### DIFF
--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -104,7 +104,7 @@ build_rpm() {
       -ba \
       $packaging_path/snapd.spec
 
-    cp $rpm_dir/RPMS/$arch/snapd*.rpm $GOPATH
+    cp $rpm_dir/RPMS/$arch/snap*.rpm $GOPATH
 }
 
 download_from_published(){

--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -99,15 +99,15 @@ build_rpm() {
 
     # And now build our binary package
     rpmbuild \
-      --with testkeys \
-      --nocheck \
-      -ba \
-      $packaging_path/snapd.spec
+        --with testkeys \
+        --nocheck \
+        -ba \
+        $packaging_path/snapd.spec
 
     cp $rpm_dir/RPMS/$arch/snap*.rpm $GOPATH
     if [[ "$SPREAD_SYSTEM" = fedora-* ]]; then
-      # On Fedora we have an additional package for SELinux
-      cp $rpm_dir/RPMS/noarch/snap*.rpm $GOPATH
+        # On Fedora we have an additional package for SELinux
+        cp $rpm_dir/RPMS/noarch/snap*.rpm $GOPATH
     fi
 }
 

--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -54,15 +54,13 @@ build_rpm() {
     archive_name=snapd-$version.tar.gz
     archive_compression=z
     extra_tar_args=
-    rpm_dir=
+    rpm_dir=$(rpm --eval "%_topdir")
 
     case "$SPREAD_SYSTEM" in
         fedora-*)
             extra_tar_args="$extra_tar_args --exclude=vendor/"
-            rpm_dir=$HOME/rpmbuild
             ;;
         opensuse-*)
-            rpm_dir=/usr/src/packages
             archive_name=snapd_$version.vendor.tar.xz
             archive_compression=J
             ;;
@@ -83,8 +81,10 @@ build_rpm() {
     # Cleanup all artifacts from previous builds
     rm -rf $rpm_dir/BUILD/*
 
-    # Install all necessary build dependencies
+    # Build our source package
     rpmbuild --with testkeys --nocheck -bs $packaging_path/snapd.spec
+
+    # .. and we need all necessary build dependencies available
     deps=()
     n=0
     IFS=$'\n'
@@ -97,7 +97,7 @@ build_rpm() {
     done
     distro_install_package "${deps[@]}"
 
-    # And now build our package
+    # And now build our binary package
     rpmbuild \
       --with testkeys \
       --nocheck \

--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -105,6 +105,10 @@ build_rpm() {
       $packaging_path/snapd.spec
 
     cp $rpm_dir/RPMS/$arch/snap*.rpm $GOPATH
+    if [[ "$SPREAD_SYSTEM" = fedora-* ]]; then
+      # On Fedora we have an additional package for SELinux
+      cp $rpm_dir/RPMS/noarch/snap*.rpm $GOPATH
+    fi
 }
 
 download_from_published(){

--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -82,7 +82,7 @@ build_rpm() {
     rm -rf $rpm_dir/BUILD/*
 
     # Build our source package
-    rpmbuild --with testkeys --nocheck -bs $packaging_path/snapd.spec
+    rpmbuild --with testkeys -bs $packaging_path/snapd.spec
 
     # .. and we need all necessary build dependencies available
     deps=()


### PR DESCRIPTION
We had two independent functions before to build the RPM for Fedora and openSUSE. This PR combines both into a single function which uses rpmbuild.