### PR TITLE
packaging/{opensuse,fedora}: allow package build with testkeys included

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -331,12 +331,9 @@ export GOPATH=$(pwd):%{gopath}
 export GOPATH=$(pwd):$(pwd)/Godeps/_workspace:%{gopath}
 %endif
 
-# We have to build snapd first to prevent the build from
-# building various things from the tree without additional
-# set tags.
 GOFLAGS=
 %if 0%{?with_test_keys}
-GOFLAGS="-tags withtestkeys"
+GOFLAGS="$GOFLAGS -tags withtestkeys"
 %endif
 
 # We have to build snapd first to prevent the build from

--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -133,6 +133,12 @@ export CXXFLAGS
 # so we we have to invoke `go install` here manually.
 export GOPATH=%{_builddir}/go:%{_libdir}/go/contrib
 export GOBIN=%{_builddir}/go/bin
+# Options used are the same as the %gobuild macro does but as it
+# doesn't allow us to amend new flags we have to repeat them here:
+# -s: tell long running tests to shorten their build time
+# -v: be verbose
+# -p 4: allow parallel execution of tests
+# -x: print commands
 go install -s -v -p 4 -x -tags withtestkeys github.com/snapcore/snapd/cmd/snapd
 %else
 %gobuild cmd/snapd


### PR DESCRIPTION
Special build with test keys enabled is necessary for a few spread tests.