### PR TITLE
tests/main/manpages: install missing man package

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -8,6 +8,9 @@ debian_name_package() {
         xdelta3|curl|python3-yaml|kpartx|busybox-static)
             echo "$1"
             ;;
+        man)
+            echo "man-db"
+            ;;
         *)
             echo $1
             ;;

--- a/tests/main/manpages/task.yaml
+++ b/tests/main/manpages/task.yaml
@@ -1,6 +1,12 @@
 summary: the essential manual pages are installed by the native package
 # core systems don't ship man or manual pages
 systems: [-ubuntu-core-16-*]
+prepare: |
+    . "$TESTSLIB/pkgdb.sh"
+    distro_install_package man
+restore: |
+    . "$TESTSLIB/pkgdb.sh"
+    distro_purge_package man
 execute: |
     for manpage in snap snap-confine snap-discard-ns; do
         if ! man --what $manpage; then


### PR DESCRIPTION
Man isn't installed on all our Linode images by default so better explicitly install it.