### PR TITLE
ifacestate: only re-generate all security profiles if the system-key changes

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -58,7 +58,8 @@ var (
 	SnapTrustedAccountKey string
 	SnapAssertsSpoolDir   string
 
-	SnapStateFile string
+	SnapStateFile     string
+	SnapSystemKeyFile string
 
 	SnapBinariesDir     string
 	SnapServicesDir     string
@@ -154,6 +155,7 @@ func SetRootDir(rootdir string) {
 	SnapAssertsSpoolDir = filepath.Join(rootdir, "run/snapd/auto-import")
 
 	SnapStateFile = filepath.Join(rootdir, snappyDir, "state.json")
+	SnapSystemKeyFile = filepath.Join(rootdir, snappyDir, "system-key")
 
 	SnapSeedDir = filepath.Join(rootdir, snappyDir, "seed")
 	SnapDeviceDir = filepath.Join(rootdir, snappyDir, "device")

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+// systemKey describes the environment for which security profiles
+// have been generated. It is useful to compare if the current
+// running system is similar enough to the generated profiles or
+// if the profiles need to be re-generated to match the new system.
+type systemKey struct {
+	BuildID          string   `yaml:"build-id"`
+	ApparmorFeatures []string `yaml:"apparmor-features"`
+}
+
+var mySystemKey systemKey
+
+func init() {
+	// add build-id
+	buildID, err := osutil.MyBuildID()
+	if err != nil {
+		buildID = "unknown"
+	}
+	mySystemKey.BuildID = buildID
+
+	// add apparmor-feature, note that ioutil.ReadDir() is already sorted
+	if dentries, err := ioutil.ReadDir("/sys/kernel/security/apparmor/features"); err == nil {
+		mySystemKey.ApparmorFeatures = make([]string, len(dentries))
+		for i, f := range dentries {
+			mySystemKey.ApparmorFeatures[i] = f.Name()
+		}
+	}
+}
+
+// SystemKey outputs a string that identifies what security profiles
+// environment this snapd is using. Security profiles that were generated
+// with a different Systemkey should be re-generated.
+func SystemKey() string {
+	sk, err := yaml.Marshal(mySystemKey)
+	if err != nil {
+		panic(err)
+	}
+	return string(sk)
+}

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -39,7 +39,6 @@ type systemKey struct {
 var mySystemKey systemKey
 
 func init() {
-	// add build-id
 	buildID, err := osutil.MyBuildID()
 	if err != nil {
 		buildID = "unknown"

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -73,6 +73,7 @@ func SystemKey() string {
 func MockSystemKey(s string) func() {
 	realMySystemKey := mySystemKey
 
+	mySystemKey = systemKey{}
 	err := yaml.Unmarshal([]byte(s), &mySystemKey)
 	if err != nil {
 		panic(err)

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -41,7 +41,7 @@ var mySystemKey systemKey
 func init() {
 	buildID, err := osutil.MyBuildID()
 	if err != nil {
-		buildID = "unknown"
+		buildID = ""
 	}
 	mySystemKey.BuildID = buildID
 
@@ -58,9 +58,24 @@ func init() {
 // environment this snapd is using. Security profiles that were generated
 // with a different Systemkey should be re-generated.
 func SystemKey() string {
+	// special case: unknown build-ids always trigger a rebuild
+	if mySystemKey.BuildID == "" {
+		return ""
+	}
+
 	sk, err := yaml.Marshal(mySystemKey)
 	if err != nil {
 		panic(err)
 	}
 	return string(sk)
+}
+
+func MockSystemKey(s string) func() {
+	realMySystemKey := mySystemKey
+
+	err := yaml.Unmarshal([]byte(s), &mySystemKey)
+	if err != nil {
+		panic(err)
+	}
+	return func() { mySystemKey = realMySystemKey }
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -1,0 +1,36 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+type systemKeySuite struct{}
+
+var _ = Suite(&systemKeySuite{})
+
+func (ts *systemKeySuite) TestInterfaceDigest(c *C) {
+	systemKey := interfaces.SystemKey()
+	c.Check(systemKey, Matches, "(?sm)^build-id: (unknown|[a-z0-9]+)$")
+	c.Check(systemKey, Matches, "(?sm).*apparmor-features:")
+}

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -30,7 +30,13 @@ type systemKeySuite struct{}
 var _ = Suite(&systemKeySuite{})
 
 func (ts *systemKeySuite) TestInterfaceDigest(c *C) {
+	interfaces.MockSystemKey(`build-id: 7a94e9736c091b3984bd63f5aebfc883c4d859e0
+apparmor-features:
+- caps
+- dbus
+`)
+
 	systemKey := interfaces.SystemKey()
-	c.Check(systemKey, Matches, "(?sm)^build-id: (unknown|[a-z0-9]+)$")
+	c.Check(systemKey, Matches, "(?sm)^build-id: [a-z0-9]+$")
 	c.Check(systemKey, Matches, "(?sm).*apparmor-features:")
 }

--- a/osutil/buildid.go
+++ b/osutil/buildid.go
@@ -27,6 +27,8 @@ import (
 	"os"
 )
 
+var osReadlink = os.Readlink
+
 // ErrNoBuildID is returned when an executable does not contain a Build-ID
 var ErrNoBuildID = errors.New("executable does not contain a build ID")
 
@@ -98,4 +100,14 @@ func ReadBuildID(fname string) (string, error) {
 		return hex.EncodeToString(noteData), nil
 	}
 	return "", ErrNoBuildID
+}
+
+// MyBuildID return the build-id of the currently running executable
+func MyBuildID() (string, error) {
+	exe, err := osReadlink("/proc/self/exe")
+	if err != nil {
+		return "", err
+	}
+
+	return ReadBuildID(exe)
 }

--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -86,3 +86,14 @@ func (s *buildIDSuite) TestReadBuildIDmd5(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(id, Equals, buildID(c, md5Truth))
 }
+
+func (s *buildIDSuite) TestMyBuildID(c *C) {
+	restore := osutil.MockOsReadlink(func(string) (string, error) {
+		return truePath, nil
+	})
+	defer restore()
+
+	id, err := osutil.MyBuildID()
+	c.Assert(err, IsNil)
+	c.Check(id, Equals, buildID(c, truePath))
+}

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -50,3 +50,10 @@ func MockMountInfoPath(mockMountInfoPath string) func() {
 
 	return func() { mountInfoPath = realMountInfoPath }
 }
+
+func MockOsReadlink(f func(string) (string, error)) func() {
+	realOsReadlink := osReadlink
+	osReadlink = f
+
+	return func() { osReadlink = realOsReadlink }
+}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -122,14 +122,7 @@ func (m *InterfaceManager) profilesNeedRegeneration() bool {
 	return onDiskSystemKey != interfaces.SystemKey()
 }
 
-// regenerateAllSecurityProfiles will regenerate the security profiles
-// for apparmor and seccomp. This is needed because:
-// - for seccomp we may have "terms" on disk that the current snap-confine
-//   does not understand (e.g. in a rollback scenario). a refresh ensures
-//   we have a profile that matches what snap-confine understand
-// - for apparmor the kernel 4.4.0-65.86 has an incompatible apparmor
-//   change that breaks existing profiles for installed snaps. With a
-//   refresh those get fixed.
+// regenerateAllSecurityProfiles will regenerate all security profiles.
 func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 	// Get all the security backends
 	securityBackends := m.repo.Backends()
@@ -158,13 +151,6 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 
 		// For each backend:
 		for _, backend := range securityBackends {
-			// The issue this is attempting to fix is only
-			// affecting seccomp/apparmor so limit the work just to
-			// this backend.
-			shouldRefresh := (backend.Name() == interfaces.SecuritySecComp || backend.Name() == interfaces.SecurityAppArmor)
-			if !shouldRefresh {
-				continue
-			}
 			// Refresh security of this snap and backend
 			if err := backend.Setup(snapInfo, opts, m.repo); err != nil {
 				// Let's log this but carry on

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -21,14 +21,18 @@ package ifacestate
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/policy"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -54,8 +58,10 @@ func (m *InterfaceManager) initialize(extraInterfaces []interfaces.Interface, ex
 	if err := m.reloadConnections(""); err != nil {
 		return err
 	}
-	if err := m.regenerateAllSecurityProfiles(); err != nil {
-		return err
+	if m.profilesNeedRegeneration() {
+		if err := m.regenerateAllSecurityProfiles(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -100,6 +106,20 @@ func (m *InterfaceManager) addSnaps() error {
 		}
 	}
 	return nil
+}
+
+func (m *InterfaceManager) profilesNeedRegeneration() bool {
+	raw, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
+	if os.IsNotExist(err) {
+		return true
+	}
+	if err != nil {
+		logger.Noticef("cannot read system-key file: %s", err)
+		return true
+	}
+
+	onDiskSystemKey := string(raw)
+	return onDiskSystemKey != interfaces.SystemKey()
 }
 
 // regenerateAllSecurityProfiles will regenerate the security profiles
@@ -154,7 +174,8 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 		}
 	}
 
-	return nil
+	sk := interfaces.SystemKey()
+	return osutil.AtomicWriteFile(dirs.SnapSystemKeyFile, []byte(sk), 0644, 0)
 }
 
 // renameCorePlugConnection renames one connection from "core-support" plug to

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -110,17 +110,9 @@ func (m *InterfaceManager) addSnaps() error {
 
 func (m *InterfaceManager) profilesNeedRegeneration() bool {
 	currentSystemKey := interfaces.SystemKey()
-	if currentSystemKey == "" {
-		logger.Noticef("no system key, forcing re-generation of security profiles")
-		return true
-	}
-
 	onDiskSystemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
-	if os.IsNotExist(err) {
-		return true
-	}
-	if err != nil {
-		logger.Noticef("cannot read system-key file: %s", err)
+	if currentSystemKey == "" || os.IsNotExist(err) {
+		logger.Noticef("no system key, forcing re-generation of security profiles")
 		return true
 	}
 

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -109,7 +109,13 @@ func (m *InterfaceManager) addSnaps() error {
 }
 
 func (m *InterfaceManager) profilesNeedRegeneration() bool {
-	raw, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
+	currentSystemKey := interfaces.SystemKey()
+	if currentSystemKey == "" {
+		logger.Noticef("no system key, forcing re-generation of security profiles")
+		return true
+	}
+
+	onDiskSystemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
 	if os.IsNotExist(err) {
 		return true
 	}
@@ -118,8 +124,7 @@ func (m *InterfaceManager) profilesNeedRegeneration() bool {
 		return true
 	}
 
-	onDiskSystemKey := string(raw)
-	return onDiskSystemKey != interfaces.SystemKey()
+	return string(onDiskSystemKey) != currentSystemKey
 }
 
 // regenerateAllSecurityProfiles will regenerate all security profiles.

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -118,6 +118,10 @@ func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {
 		c.Assert(err, IsNil)
 		mgr.AddForeignTaskHandlers()
 		s.privateMgr = mgr
+
+		// ensure the re-generation of security profiles did not
+		// confuse the tests
+		s.secBackend.SetupCalls = nil
 	}
 	return s.privateMgr
 }

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2113,5 +2113,5 @@ func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKey
 	_ = s.manager(c)
 	stat2, err := os.Stat(dirs.SnapSystemKeyFile)
 	c.Assert(err, IsNil)
-	c.Check(stat, DeepEquals, stat2)
+	c.Check(stat.ModTime(), DeepEquals, stat2.ModTime())
 }

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2092,6 +2092,9 @@ func (s *interfaceManagerSuite) TestAutoConnectDuringCoreTransition(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKeyFile(c *C) {
+	restore := interfaces.MockSystemKey("build-id: something")
+	defer restore()
+
 	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	c.Assert(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)

--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -91,6 +91,7 @@ endif
 	dh_clean
 	# XXX: hacky
 	$(MAKE) -C cmd distclean || true
+	$(MAKE) -C data/systemd clean
 
 override_dh_auto_build:
 	# usually done via `go generate` but that is not supported on powerpc

--- a/packaging/ubuntu-14.04/snapd.service
+++ b/packaging/ubuntu-14.04/snapd.service
@@ -6,6 +6,7 @@ Requires=snapd.socket
 ExecStart=/usr/lib/snapd/snapd
 EnvironmentFile=/etc/environment
 Restart=always
+Type=notify
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -98,6 +98,7 @@ endif
 	dh_clean
 	# XXX: hacky
 	$(MAKE) -C cmd distclean || true
+	$(MAKE) -C data/systemd clean
 
 override_dh_auto_build:
 	# usually done via `go generate` but that is not supported on powerpc

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -193,7 +193,15 @@ EOF
             systemctl stop "$unit"
         done
         snapd_env="/etc/environment /etc/systemd/system/snapd.service.d /etc/systemd/system/snapd.socket.d"
-        tar czf "$SPREAD_PATH"/snapd-state.tar.gz /var/lib/snapd "$SNAPMOUNTDIR" /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount /etc/apparmor.d/*snap-confine* $snapd_env
+
+        # on apparmor systems we need to store the auto-generated profiles
+        # as well
+        etc_apparmor_d=""
+        if [ -d /etc/apparmor.d ]; then
+            etc_apparmor_d=/etc/apparmor.d/*snap-confine*
+        fi
+
+        tar czf "$SPREAD_PATH"/snapd-state.tar.gz /var/lib/snapd "$SNAPMOUNTDIR" /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount $etc_apparmor_d $snapd_env
         systemctl daemon-reload # Workaround for http://paste.ubuntu.com/17735820/
         core="$(readlink -f "$SNAPMOUNTDIR/core/current")"
         # on 14.04 it is possible that the core snap is still mounted at this point, unmount

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -193,7 +193,7 @@ EOF
             systemctl stop "$unit"
         done
         snapd_env="/etc/environment /etc/systemd/system/snapd.service.d /etc/systemd/system/snapd.socket.d"
-        tar czf "$SPREAD_PATH"/snapd-state.tar.gz /var/lib/snapd "$SNAPMOUNTDIR" /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount $snapd_env
+        tar czf "$SPREAD_PATH"/snapd-state.tar.gz /var/lib/snapd "$SNAPMOUNTDIR" /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount /etc/apparmor.d/*snap-confine* $snapd_env
         systemctl daemon-reload # Workaround for http://paste.ubuntu.com/17735820/
         core="$(readlink -f "$SNAPMOUNTDIR/core/current")"
         # on 14.04 it is possible that the core snap is still mounted at this point, unmount

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -1,0 +1,31 @@
+summary: Ensure security profile re-generation works with system-key
+
+execute: |
+    restart_snapd() {
+        systemctl restart snapd.service
+        while "$(systemctl show -pActiveState snapd.service)" != "active"; do
+            systemctl show -pActiveState snapd.service
+            sleep 1
+        done
+    }
+
+    echo "Ensure a valid system-key file is on-disk"
+    cat /var/lib/snapd/system-key | MATCH "build-id: [0-9a-z]+"
+    buf="$(stat /var/lib/snapd/system-key)"
+
+    echo "Ensure that the system-key is not rewritten if system-key is unchanged"
+    restart_snapd
+    buf2="$(stat /var/lib/snapd/system-key)"
+    if [ "$buf" != "$buf2" ]; then
+        echo "system-key got rewriten: $buf != buf2, test broken"
+        exit 1
+    fi
+
+    echo "Ensure that the system-key is rewritten if system-key changes"
+    printf "something: new\n" >> /var/lib/snapd/system-key
+    restart_snapd
+    buf3="$(stat /var/lib/snapd/system-key)"
+    if [ "$buf" = "$buf3" ]; then
+        echo "system-key *not* rewriten: $buf3 unchanged, test broken"
+        exit 1
+    fi

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -2,8 +2,14 @@ summary: Ensure security profile re-generation works with system-key
 
 execute: |
     restart_snapd() {
-        systemctl restart snapd.service
-        while "$(systemctl show -pActiveState snapd.service)" != "active"; do
+        systemctl stop snapd.service
+        while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=inactive" ]; do
+            systemctl show -pActiveState snapd.service
+            sleep 1
+        done
+
+        systemctl start snapd.service
+        while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=active" ]; do
             systemctl show -pActiveState snapd.service
             sleep 1
         done
@@ -12,6 +18,7 @@ execute: |
     echo "Ensure a valid system-key file is on-disk"
     cat /var/lib/snapd/system-key | MATCH "build-id: [0-9a-z]+"
     buf="$(stat /var/lib/snapd/system-key)"
+    system_key_content="$(cat /var/lib/snapd/system-key)"
 
     echo "Ensure that the system-key is not rewritten if system-key is unchanged"
     restart_snapd
@@ -24,8 +31,7 @@ execute: |
     echo "Ensure that the system-key is rewritten if system-key changes"
     printf "something: new\n" >> /var/lib/snapd/system-key
     restart_snapd
-    buf3="$(stat /var/lib/snapd/system-key)"
-    if [ "$buf" = "$buf3" ]; then
-        echo "system-key *not* rewriten: $buf3 unchanged, test broken"
+    if grep "something: new" /var/lib/snapd/system-key; then
+        echo "system-key *not* rewriten test broken"
         exit 1
     fi


### PR DESCRIPTION
Based on https://github.com/snapcore/snapd/pull/3456

This branch uses the interfaces.SystemKey() to only re-generate the security profile if the system-key actually changes.

I.e. if snapd is not changed and the kernel apparmor capabilities have not changed there is no need to re-generate the security profiles because nothing relevant on the system has changed.