### PR TITLE
systemd: refactor service ops to also be exposed more directly

### DIFF
--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -85,7 +85,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementO
 		}
 		// If we have a new service here which isn't started yet the restart
 		// operation will start it.
-		if err := systemd.Restart(service, 10*time.Second); err != nil {
+		if err := systemd.RestartAndWait(service, 10*time.Second); err != nil {
 			logger.Noticef("cannot restart service %q: %s", service, err)
 		}
 	}
@@ -102,7 +102,7 @@ func (b *Backend) Remove(snapName string) error {
 		if err := systemd.Disable(service); err != nil {
 			logger.Noticef("cannot disable service %q: %s", service, err)
 		}
-		if err := systemd.Stop(service, 5*time.Second); err != nil {
+		if err := systemd.StopAndWait(service, 5*time.Second); err != nil {
 			logger.Noticef("cannot stop service %q: %s", service, err)
 		}
 	}
@@ -148,7 +148,7 @@ func disableRemovedServices(systemd sysd.Systemd, dir, glob string, content map[
 			if err := systemd.Disable(service); err != nil {
 				logger.Noticef("cannot disable service %q: %s", service, err)
 			}
-			if err := systemd.Stop(service, 5*time.Second); err != nil {
+			if err := systemd.StopAndWait(service, 5*time.Second); err != nil {
 				logger.Noticef("cannot stop service %q: %s", service, err)
 			}
 		}

--- a/osutil/chdir_test.go
+++ b/osutil/chdir_test.go
@@ -17,13 +17,15 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"fmt"
 	"os"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
 type ChdirTestSuite struct{}
@@ -36,7 +38,7 @@ func (ts *ChdirTestSuite) TestChdir(c *C) {
 	cwd, err := os.Getwd()
 	c.Assert(err, IsNil)
 	c.Assert(cwd, Not(Equals), tmpdir)
-	ChDir(tmpdir, func() error {
+	osutil.ChDir(tmpdir, func() error {
 		cwd, err := os.Getwd()
 		c.Assert(err, IsNil)
 		c.Assert(cwd, Equals, tmpdir)
@@ -45,14 +47,14 @@ func (ts *ChdirTestSuite) TestChdir(c *C) {
 }
 
 func (ts *ChdirTestSuite) TestChdirErrorNoDir(c *C) {
-	err := ChDir("random-dir-that-does-not-exist", func() error {
+	err := osutil.ChDir("random-dir-that-does-not-exist", func() error {
 		return nil
 	})
 	c.Assert(err, ErrorMatches, "chdir .*: no such file or directory")
 }
 
 func (ts *ChdirTestSuite) TestChdirErrorFromFunc(c *C) {
-	err := ChDir("/", func() error {
+	err := osutil.ChDir("/", func() error {
 		return fmt.Errorf("meep")
 	})
 	c.Assert(err, ErrorMatches, "meep")

--- a/osutil/cp.go
+++ b/osutil/cp.go
@@ -46,7 +46,7 @@ var (
 	copyfile = doCopyFile
 )
 
-type fileish interface {
+type Fileish interface {
 	Close() error
 	Sync() error
 	Fd() uintptr
@@ -55,7 +55,7 @@ type fileish interface {
 	Write([]byte) (int, error)
 }
 
-func doOpenFile(name string, flag int, perm os.FileMode) (fileish, error) {
+func doOpenFile(name string, flag int, perm os.FileMode) (Fileish, error) {
 	return os.OpenFile(name, flag, perm)
 }
 

--- a/osutil/cp_linux.go
+++ b/osutil/cp_linux.go
@@ -28,7 +28,7 @@ const maxint = int64(^uint(0) >> 1)
 
 var maxcp = maxint // overridden in testing
 
-func doCopyFile(fin, fout fileish, fi os.FileInfo) error {
+func doCopyFile(fin, fout Fileish, fi os.FileInfo) error {
 	size := fi.Size()
 	var offset int64
 	for offset < size {

--- a/osutil/cp_linux_test.go
+++ b/osutil/cp_linux_test.go
@@ -17,20 +17,21 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"io/ioutil"
 	"os"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
 func (s *cpSuite) TestCpMulti(c *C) {
-	maxcp = 2
-	defer func() { maxcp = maxint }()
+	defer osutil.MockMaxCp(2)()
 
-	c.Check(CopyFile(s.f1, s.f2, CopyFlagDefault), IsNil)
+	c.Check(osutil.CopyFile(s.f1, s.f2, osutil.CopyFlagDefault), IsNil)
 	bs, err := ioutil.ReadFile(s.f2)
 	c.Check(err, IsNil)
 	c.Check(bs, DeepEquals, s.data)
@@ -42,5 +43,5 @@ func (s *cpSuite) TestDoCpErr(c *C) {
 	st, err := f1.Stat()
 	c.Assert(err, IsNil)
 	// force an error by asking it to write to a readonly stream
-	c.Check(doCopyFile(f1, os.Stdin, st), NotNil)
+	c.Check(osutil.DoCopyFile(f1, os.Stdin, st), NotNil)
 }

--- a/osutil/exitcode_test.go
+++ b/osutil/exitcode_test.go
@@ -17,13 +17,15 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"os"
 	"os/exec"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
 type ExitCodeTestSuite struct{}
@@ -38,19 +40,19 @@ func (ts *ExitCodeTestSuite) TestExitCode(c *C) {
 	cmd = exec.Command("false")
 	err = cmd.Run()
 	c.Assert(err, NotNil)
-	e, err := ExitCode(err)
+	e, err := osutil.ExitCode(err)
 	c.Assert(err, IsNil)
 	c.Assert(e, Equals, 1)
 
 	cmd = exec.Command("sh", "-c", "exit 7")
 	err = cmd.Run()
-	e, err = ExitCode(err)
+	e, err = osutil.ExitCode(err)
 	c.Assert(err, IsNil)
 	c.Assert(e, Equals, 7)
 
 	// ensure that non exec.ExitError values give a error
 	_, err = os.Stat("/random/file/that/is/not/there")
 	c.Assert(err, NotNil)
-	_, err = ExitCode(err)
+	_, err = osutil.ExitCode(err)
 	c.Assert(err, NotNil)
 }

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -20,6 +20,8 @@
 package osutil
 
 import (
+	"os"
+	"os/exec"
 	"os/user"
 )
 
@@ -49,4 +51,31 @@ func MockMountInfoPath(mockMountInfoPath string) func() {
 	mountInfoPath = mockMountInfoPath
 
 	return func() { mountInfoPath = realMountInfoPath }
+}
+
+func MockCmpBufSize(newBufsz int) func() {
+	bufsz = newBufsz
+	return func() { bufsz = defaultBufsz }
+}
+
+func MockOpenfile(mock func(name string, flag int, perm os.FileMode) (Fileish, error)) func() {
+	openfile = mock
+	return func() { openfile = doOpenFile }
+}
+
+func MockCopyfile(mock func(fin, fout Fileish, fi os.FileInfo) error) func() {
+	copyfile = mock
+	return func() { copyfile = doCopyFile }
+}
+
+func MockMaxCp(newMax int64) func() {
+	maxcp = newMax
+	return func() { maxcp = maxint }
+}
+
+var DoCopyFile = doCopyFile
+
+func MockLookPath(mock func(name string) (string, error)) func() {
+	lookPath = mock
+	return func() { lookPath = exec.LookPath }
 }

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"io/ioutil"
@@ -25,9 +25,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/snapcore/snapd/strutil"
-
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/strutil"
 )
 
 type AtomicWriteTestSuite struct{}
@@ -38,7 +39,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFile(c *C) {
 	tmpdir := c.MkDir()
 
 	p := filepath.Join(tmpdir, "foo")
-	err := AtomicWriteFile(p, []byte("canary"), 0644, 0)
+	err := osutil.AtomicWriteFile(p, []byte("canary"), 0644, 0)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(p)
@@ -55,7 +56,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFilePermissions(c *C) {
 	tmpdir := c.MkDir()
 
 	p := filepath.Join(tmpdir, "foo")
-	err := AtomicWriteFile(p, []byte(""), 0600, 0)
+	err := osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
 	c.Assert(err, IsNil)
 
 	st, err := os.Stat(p)
@@ -67,7 +68,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwrite(c *C) {
 	tmpdir := c.MkDir()
 	p := filepath.Join(tmpdir, "foo")
 	c.Assert(ioutil.WriteFile(p, []byte("hello"), 0644), IsNil)
-	c.Assert(AtomicWriteFile(p, []byte("hi"), 0600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0), IsNil)
 
 	content, err := ioutil.ReadFile(p)
 	c.Assert(err, IsNil)
@@ -84,7 +85,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	err := AtomicWriteFile(p, []byte("hi"), 0600, 0)
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0)
 	c.Assert(err, NotNil)
 }
 
@@ -98,7 +99,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAbsoluteSymlinks(c *C) {
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	err := AtomicWriteFile(p, []byte("hi"), 0600, AtomicWriteFollow)
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(p)
@@ -117,7 +118,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteAbsoluteSymlink(c *C
 	defer os.Chmod(rodir, 0700)
 
 	c.Assert(ioutil.WriteFile(s, []byte("hello"), 0644), IsNil)
-	c.Assert(AtomicWriteFile(p, []byte("hi"), 0600, AtomicWriteFollow), IsNil)
+	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow), IsNil)
 
 	content, err := ioutil.ReadFile(p)
 	c.Assert(err, IsNil)
@@ -133,7 +134,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileRelativeSymlinks(c *C) {
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	err := AtomicWriteFile(p, []byte("hi"), 0600, AtomicWriteFollow)
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(p)
@@ -152,7 +153,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteRelativeSymlink(c *C
 	defer os.Chmod(rodir, 0700)
 
 	c.Assert(ioutil.WriteFile(s, []byte("hello"), 0644), IsNil)
-	c.Assert(AtomicWriteFile(p, []byte("hi"), 0600, AtomicWriteFollow), IsNil)
+	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow), IsNil)
 
 	content, err := ioutil.ReadFile(p)
 	c.Assert(err, IsNil)
@@ -171,6 +172,6 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) 
 	err := ioutil.WriteFile(p+"."+expectedRandomness, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
-	err = AtomicWriteFile(p, []byte(""), 0600, 0)
+	err = osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
 	c.Assert(err, ErrorMatches, "open .*: file exists")
 }

--- a/osutil/osutil_test.go
+++ b/osutil/osutil_test.go
@@ -1,3 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package osutil_test
 
 import (

--- a/osutil/outputerr_test.go
+++ b/osutil/outputerr_test.go
@@ -17,12 +17,14 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"fmt"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
 type outputErrSuite struct{}
@@ -32,14 +34,14 @@ var _ = Suite(&outputErrSuite{})
 func (ts *outputErrSuite) TestOutputErrOutputWithoutNewlines(c *C) {
 	output := "test output"
 	err := fmt.Errorf("test error")
-	formattedErr := OutputErr([]byte(output), err)
+	formattedErr := osutil.OutputErr([]byte(output), err)
 	c.Check(formattedErr, ErrorMatches, output)
 }
 
 func (ts *outputErrSuite) TestOutputErrOutputWithNewlines(c *C) {
 	output := "output line1\noutput line2"
 	err := fmt.Errorf("test error")
-	formattedErr := OutputErr([]byte(output), err)
+	formattedErr := osutil.OutputErr([]byte(output), err)
 	c.Check(formattedErr.Error(), Equals, `
 -----
 output line1
@@ -49,6 +51,6 @@ output line2
 
 func (ts *outputErrSuite) TestOutputErrNoOutput(c *C) {
 	err := fmt.Errorf("test error")
-	formattedErr := OutputErr([]byte{}, err)
+	formattedErr := osutil.OutputErr([]byte{}, err)
 	c.Check(formattedErr, Equals, err)
 }

--- a/osutil/stat_test.go
+++ b/osutil/stat_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
 	"fmt"
@@ -26,6 +26,8 @@ import (
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
 )
 
 type StatTestSuite struct{}
@@ -33,7 +35,7 @@ type StatTestSuite struct{}
 var _ = Suite(&StatTestSuite{})
 
 func (ts *StatTestSuite) TestFileDoesNotExist(c *C) {
-	c.Assert(FileExists("/i-do-not-exist"), Equals, false)
+	c.Assert(osutil.FileExists("/i-do-not-exist"), Equals, false)
 }
 
 func (ts *StatTestSuite) TestFileExistsSimple(c *C) {
@@ -41,7 +43,7 @@ func (ts *StatTestSuite) TestFileExistsSimple(c *C) {
 	err := ioutil.WriteFile(fname, []byte(fname), 0644)
 	c.Assert(err, IsNil)
 
-	c.Assert(FileExists(fname), Equals, true)
+	c.Assert(osutil.FileExists(fname), Equals, true)
 }
 
 func (ts *StatTestSuite) TestFileExistsExistsOddPermissions(c *C) {
@@ -49,11 +51,11 @@ func (ts *StatTestSuite) TestFileExistsExistsOddPermissions(c *C) {
 	err := ioutil.WriteFile(fname, []byte(fname), 0100)
 	c.Assert(err, IsNil)
 
-	c.Assert(FileExists(fname), Equals, true)
+	c.Assert(osutil.FileExists(fname), Equals, true)
 }
 
 func (ts *StatTestSuite) TestIsDirectoryDoesNotExist(c *C) {
-	c.Assert(IsDirectory("/i-do-not-exist"), Equals, false)
+	c.Assert(osutil.IsDirectory("/i-do-not-exist"), Equals, false)
 }
 
 func (ts *StatTestSuite) TestIsDirectorySimple(c *C) {
@@ -61,7 +63,7 @@ func (ts *StatTestSuite) TestIsDirectorySimple(c *C) {
 	err := os.Mkdir(dname, 0700)
 	c.Assert(err, IsNil)
 
-	c.Assert(IsDirectory(dname), Equals, true)
+	c.Assert(osutil.IsDirectory(dname), Equals, true)
 }
 
 func (ts *StatTestSuite) TestIsSymlink(c *C) {
@@ -69,11 +71,11 @@ func (ts *StatTestSuite) TestIsSymlink(c *C) {
 	err := os.Symlink("/", sname)
 	c.Assert(err, IsNil)
 
-	c.Assert(IsSymlink(sname), Equals, true)
+	c.Assert(osutil.IsSymlink(sname), Equals, true)
 }
 
 func (ts *StatTestSuite) TestIsSymlinkNoSymlink(c *C) {
-	c.Assert(IsSymlink(c.MkDir()), Equals, false)
+	c.Assert(osutil.IsSymlink(c.MkDir()), Equals, false)
 }
 
 func (ts *StatTestSuite) TestExecutableExists(c *C) {
@@ -81,22 +83,22 @@ func (ts *StatTestSuite) TestExecutableExists(c *C) {
 	defer os.Setenv("PATH", oldPath)
 	d := c.MkDir()
 	os.Setenv("PATH", d)
-	c.Check(ExecutableExists("xyzzy"), Equals, false)
+	c.Check(osutil.ExecutableExists("xyzzy"), Equals, false)
 
 	fname := filepath.Join(d, "xyzzy")
 	c.Assert(ioutil.WriteFile(fname, []byte{}, 0644), IsNil)
-	c.Check(ExecutableExists("xyzzy"), Equals, false)
+	c.Check(osutil.ExecutableExists("xyzzy"), Equals, false)
 
 	c.Assert(os.Chmod(fname, 0755), IsNil)
-	c.Check(ExecutableExists("xyzzy"), Equals, true)
+	c.Check(osutil.ExecutableExists("xyzzy"), Equals, true)
 }
 
 func (s *StatTestSuite) TestLookPathDefaultGivesCorrectPath(c *C) {
-	lookPath = func(name string) (string, error) { return "/bin/true", nil }
-	c.Assert(LookPathDefault("true", "/bin/foo"), Equals, "/bin/true")
+	defer osutil.MockLookPath(func(name string) (string, error) { return "/bin/true", nil })()
+	c.Assert(osutil.LookPathDefault("true", "/bin/foo"), Equals, "/bin/true")
 }
 
 func (s *StatTestSuite) TestLookPathDefaultReturnsDefaultWhenNotFound(c *C) {
-	lookPath = func(name string) (string, error) { return "", fmt.Errorf("Not found") }
-	c.Assert(LookPathDefault("bar", "/bin/bla"), Equals, "/bin/bla")
+	defer osutil.MockLookPath(func(name string) (string, error) { return "", fmt.Errorf("Not found") })()
+	c.Assert(osutil.LookPathDefault("bar", "/bin/bla"), Equals, "/bin/bla")
 }

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -72,7 +72,7 @@ func removeMountUnit(baseDir string, meter progress.Meter) error {
 				return osutil.OutputErr(output, err)
 			}
 
-			if err := sysd.Stop(filepath.Base(unit), time.Duration(1*time.Second)); err != nil {
+			if err := sysd.StopAndWait(filepath.Base(unit), time.Duration(1*time.Second)); err != nil {
 				return err
 			}
 		}

--- a/testutil/systemd.go
+++ b/testutil/systemd.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testutil
+
+import (
+	"time"
+
+	"github.com/snapcore/snapd/systemd"
+)
+
+func MockSystemd(string, systemd.Notifier) systemd.Systemd {
+	return SystemdInstance
+}
+
+type Systemd struct {
+	Ops       [][]string
+	Err       error
+	SvcStatus *systemd.ServiceStatus
+	LogList   []systemd.Log
+}
+
+var _ systemd.Systemd = (*Systemd)(nil)
+
+var SystemdInstance *Systemd
+
+func ResetSystemd() {
+	SystemdInstance = &Systemd{}
+}
+
+func (s *Systemd) add(op string, args []string) error {
+	opArgs := make([]string, len(args)+1)
+	opArgs[0] = op
+	copy(opArgs[1:], args)
+	s.Ops = append(s.Ops, opArgs)
+	return s.Err
+}
+
+func (s *Systemd) DaemonReload() error                 { return s.add("daemon-reload", nil) }
+func (s *Systemd) Enable(services ...string) error     { return s.add("enable", services) }
+func (s *Systemd) EnableNow(services ...string) error  { return s.add("enable-now", services) }
+func (s *Systemd) Disable(services ...string) error    { return s.add("disable", services) }
+func (s *Systemd) DisableNow(services ...string) error { return s.add("disable-now", services) }
+func (s *Systemd) Start(services ...string) error      { return s.add("start", services) }
+func (s *Systemd) Stop(services ...string) error       { return s.add("stop", services) }
+func (s *Systemd) Restart(services ...string) error    { return s.add("restart", services) }
+func (s *Systemd) Reload(services ...string) error     { return s.add("reload", services) }
+func (s *Systemd) Kill(service, signal string) error   { return s.add("kill", []string{service, signal}) }
+func (s *Systemd) Logs(services []string) ([]systemd.Log, error) {
+	err := s.add("logs", services)
+	return s.LogList, err
+}
+func (s *Systemd) Status(service string) (string, error) {
+	err := s.add("status", []string{service})
+	return s.SvcStatus.String(), err
+}
+func (s *Systemd) ServiceStatus(service string) (*systemd.ServiceStatus, error) {
+	err := s.add("service-status", []string{service})
+	return s.SvcStatus, err
+}
+func (s *Systemd) StopAndWait(service string, timeout time.Duration) error {
+	return s.add("stop-and-wait", []string{service, timeout.String()})
+}
+func (s *Systemd) RestartAndWait(service string, timeout time.Duration) error {
+	return s.add("restart-and-wait", []string{service, timeout.String()})
+}
+func (s *Systemd) WriteMountUnitFile(name, what, where, fstype string) (string, error) {
+	panic("not implemented")
+}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -61,7 +61,7 @@ func generateSnapServiceFile(app *snap.AppInfo) ([]byte, error) {
 func stopService(sysd systemd.Systemd, app *snap.AppInfo, inter interacter) error {
 	serviceName := app.ServiceName()
 	tout := serviceStopTimeout(app)
-	if err := sysd.Stop(serviceName, tout); err != nil {
+	if err := sysd.StopAndWait(serviceName, tout); err != nil {
 		if !systemd.IsTimeout(err) {
 			return err
 		}
@@ -150,7 +150,6 @@ func StopServices(apps []*snap.AppInfo, inter interacter) error {
 	}
 
 	return nil
-
 }
 
 // RemoveSnapServices disables and removes service units for the applications from the snap which are services.


### PR DESCRIPTION
This has a small knock-on effect on some clients of the systemd
package because of a rename from Stop and Restart to StopAndWait and
RestartAndWait respectively, otherwise it works in the same way. Now
exposed also are EnableNow/DisableNow for the enable-and-start and
stop-and-disable variants of enable/disable, as well as Reload, and
direct Start and Restart which don't wait for things to actually stop.

Also, added some integrationy tests while in there to improve coverage a little.