### PR TITLE
debian: add missing  Type=notify in 14.04 packaging

### DIFF
--- a/packaging/ubuntu-14.04/snapd.service
+++ b/packaging/ubuntu-14.04/snapd.service
@@ -6,6 +6,7 @@ Requires=snapd.socket
 ExecStart=/usr/lib/snapd/snapd
 EnvironmentFile=/etc/environment
 Restart=always
+Type=notify
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The 14.04 branch is not using data/systemd, instead it has its own copy of the systemd file. Why is not quite clear I investigate that now. As a quick fix this ensures that 14.04 works the same as 16.04+