### PR TITLE
interfaces/builtin: sync connected slot and permanent slot snippet

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -106,7 +106,6 @@ dbus (send)
     bus=system
     path=/org/freedesktop/UDisks2/**
     interface=org.freedesktop.DBus.Properties
-    member=PropertiesChanged
     peer=(label=###PLUG_SECURITY_TAGS###),
 
 dbus (receive, send)


### PR DESCRIPTION
The connected plug snippet allows sending any method call from
a connected plug to the service but the corresponding snippet for
the slot denied receiving anything other than PropertiesChanged.

See https://forum.snapcraft.io/t/udisks2-interface-doesnt-allow-to-use-dbus-properties-interface/902
for more details.