### PR TITLE
tests: pull from urandom when real entropy is not enough

### DIFF
--- a/tests/lib/entropy.sh
+++ b/tests/lib/entropy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+generate_entropy() {
+	# Regenerate entropy when the level is under the entropy used by ubuntu-core (700)
+	if [ $# -gt 0 ] && [ "$1" = "--force" ] || [ $(sysctl --values kernel.random.entropy_avail || echo 0) -gt 700 ]; then
+		echo "HRNGDEVICE=/dev/urandom" > /etc/default/rng-tools
+		/etc/init.d/rng-tools restart
+	fi
+}

--- a/tests/lib/entropy.sh
+++ b/tests/lib/entropy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-generate_entropy() {
+feed_kernel_entropy_pool() {
 	# Regenerate entropy when the level is under the entropy used by ubuntu-core (700)
 	if [ $# -gt 0 ] && [ "$1" = "--force" ] || [ $(sysctl --values kernel.random.entropy_avail || echo 0) -gt 700 ]; then
 		echo "HRNGDEVICE=/dev/urandom" > /etc/default/rng-tools

--- a/tests/lib/entropy.sh
+++ b/tests/lib/entropy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 feed_kernel_entropy_pool() {
-	# Regenerate entropy when the level is under the entropy used by ubuntu-core (700)
+	# Feed the kernel entropy pool when the level is under 700 (level used by ubuntu-core)
 	if [ $# -gt 0 ] && [ "$1" = "--force" ] || [ $(sysctl --values kernel.random.entropy_avail || echo 0) -gt 700 ]; then
 		echo "HRNGDEVICE=/dev/urandom" > /etc/default/rng-tools
 		/etc/init.d/rng-tools restart

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -8,6 +8,8 @@ set -eux
 . "$TESTSLIB/snaps.sh"
 # shellcheck source=tests/lib/pkgdb.sh
 . "$TESTSLIB/pkgdb.sh"
+# shellcheck source=tests/lib/entropy.sh
+. "$TESTSLIB/entropy.sh"
 
 disable_kernel_rate_limiting() {
     # kernel rate limiting hinders debugging security policy so turn it off
@@ -216,8 +218,7 @@ EOF
         # Improve entropy for the whole system quite a lot to get fast
         # key generation during our test cycles
         apt-get install -y -q rng-tools
-        echo "HRNGDEVICE=/dev/urandom" > /etc/default/rng-tools
-        /etc/init.d/rng-tools restart
+        generate_entropy --force
     fi
 
     disable_kernel_rate_limiting

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -218,7 +218,7 @@ EOF
         # Improve entropy for the whole system quite a lot to get fast
         # key generation during our test cycles
         apt-get install -y -q rng-tools
-        generate_entropy --force
+        feed_kernel_entropy_pool --force
     fi
 
     disable_kernel_rate_limiting

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -13,6 +13,8 @@ prepare: |
     snap install test-snapd-tools
     "$TESTSLIB"/mkpinentry.sh
     expect -d -f key.exp0
+    . "$TESTSLIB"/entropy.sh
+    generate_entropy
 
 restore: |
     rm testdir/foo.snap bar.snap

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -12,9 +12,9 @@ prepare: |
     snap install core
     snap install test-snapd-tools
     "$TESTSLIB"/mkpinentry.sh
-    expect -d -f key.exp0
     . "$TESTSLIB"/entropy.sh
-    generate_entropy
+    feed_kernel_entropy_pool
+    expect -d -f key.exp0
 
 restore: |
     rm testdir/foo.snap bar.snap

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -4,6 +4,8 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
     "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/entropy.sh
+    generate_entropy
 
 debug: |
     sysctl kernel.random.entropy_avail || true

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -5,7 +5,7 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 prepare: |
     "$TESTSLIB"/mkpinentry.sh
     . "$TESTSLIB"/entropy.sh
-    generate_entropy
+    feed_kernel_entropy_pool
 
 debug: |
     sysctl kernel.random.entropy_avail || true

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -5,6 +5,8 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
     "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/entropy.sh
+    generate_entropy
 
 debug: |
     sysctl kernel.random.entropy_avail || true

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -6,7 +6,7 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 prepare: |
     "$TESTSLIB"/mkpinentry.sh
     . "$TESTSLIB"/entropy.sh
-    generate_entropy
+    feed_kernel_entropy_pool
 
 debug: |
     sysctl kernel.random.entropy_avail || true


### PR DESCRIPTION
This is needed to prevent a timeout in the create-key command due to
lack of entropy. This scenario is produced sporadically when there is a
segfault produced by rngd.

This is the error which is affecting:
Jun 10 01:39:19 ubuntu kernel: [  911.509447] rngd[3001]: segfault at
805f000 ip 0804ac3e sp bfaaa4dc error 6 in rngd[8048000+5000]

Error: 
https://travis-ci.org/snapcore/snapd/builds/241031225
More info:
https://forum.snapcraft.io/t/error-creating-key/964/6