### PR TITLE
tests: fix ipv6 disable for ubuntu-core

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -278,7 +278,6 @@ prepare: |
     precedence ::/96          20
     precedence ::ffff:0:0/96 100
     EOF
-    fi
     if ! mv gai.conf /etc/gai.conf; then
         # not writable, disable ipv6 through sysctl
         sysctl -w net.ipv6.conf.all.disable_ipv6=1

--- a/spread.yaml
+++ b/spread.yaml
@@ -271,13 +271,19 @@ prepare: |
     fi
 
     # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
-    cat <<EOF > /etc/gai.conf
+    cat <<EOF > gai.conf
     precedence  ::1/128       50
     precedence  ::/0          40
     precedence  2002::/16     30
     precedence ::/96          20
     precedence ::ffff:0:0/96 100
     EOF
+    fi
+    if ! mv gai.conf /etc/gai.conf; then
+        # not writable, disable ipv6 through sysctl
+        sysctl -w net.ipv6.conf.all.disable_ipv6=1
+        rm -f gai.conf
+    fi
 
     # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
     # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)


### PR DESCRIPTION
`/etc/gai.conf` is not writable on ubuntu-core, for those systems disable ipv6