### PR TITLE
store: change main store host to api.snapcraft.io

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -255,7 +255,9 @@ func useStaging() bool {
 
 func apiURL() string {
 	// FIXME: this will become a store-url assertion
-	// backward-compatibility: this used to be "Click Package Index"
+	// XXX: Deprecated but present for backward-compatibility: this used
+	// to be "Click Package Index".  Remove this once people have got
+	// used to SNAPPY_FORCE_API_URL instead.
 	if u := os.Getenv("SNAPPY_FORCE_CPI_URL"); u != "" && strings.HasSuffix(u, "api/v1/") {
 		return u[:len(u)-len("api/v1/")]
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -259,7 +259,7 @@ func apiURL() string {
 	// to be "Click Package Index".  Remove this once people have got
 	// used to SNAPPY_FORCE_API_URL instead.
 	if u := os.Getenv("SNAPPY_FORCE_CPI_URL"); u != "" && strings.HasSuffix(u, "api/v1/") {
-		return u[:len(u)-len("api/v1/")]
+		return strings.TrimSuffix(u, "api/v1/")
 	}
 	if u := os.Getenv("SNAPPY_FORCE_API_URL"); u != "" {
 		return u

--- a/store/store.go
+++ b/store/store.go
@@ -256,17 +256,17 @@ func useStaging() bool {
 func apiURL() string {
 	// FIXME: this will become a store-url assertion
 	// backward-compatibility: this used to be "Click Package Index"
-	if u := os.Getenv("SNAPPY_FORCE_CPI_URL"); u != "" && strings.HasSuffix(u, "v1/") {
-		return u[:len(u)-len("v1/")]
+	if u := os.Getenv("SNAPPY_FORCE_CPI_URL"); u != "" && strings.HasSuffix(u, "api/v1/") {
+		return u[:len(u)-len("api/v1/")]
 	}
 	if u := os.Getenv("SNAPPY_FORCE_API_URL"); u != "" {
 		return u
 	}
 	if useStaging() {
-		return "https://api.staging.snapcraft.io/api/"
+		return "https://api.staging.snapcraft.io/"
 	}
 
-	return "https://api.snapcraft.io/api/"
+	return "https://api.snapcraft.io/"
 }
 
 func authLocation() string {
@@ -315,18 +315,18 @@ func init() {
 		panic(err)
 	}
 
-	defaultConfig.SearchURI, err = storeBaseURI.Parse("v1/snaps/search")
+	defaultConfig.SearchURI, err = storeBaseURI.Parse("api/v1/snaps/search")
 	if err != nil {
 		panic(err)
 	}
 
 	// slash at the end because snap name is appended to this with .Parse(snapName)
-	defaultConfig.DetailsURI, err = storeBaseURI.Parse("v1/snaps/details/")
+	defaultConfig.DetailsURI, err = storeBaseURI.Parse("api/v1/snaps/details/")
 	if err != nil {
 		panic(err)
 	}
 
-	defaultConfig.BulkURI, err = storeBaseURI.Parse("v1/snaps/metadata")
+	defaultConfig.BulkURI, err = storeBaseURI.Parse("api/v1/snaps/metadata")
 	if err != nil {
 		panic(err)
 	}
@@ -351,7 +351,7 @@ func init() {
 		panic(err)
 	}
 
-	defaultConfig.SectionsURI, err = storeBaseURI.Parse("v1/snaps/sections")
+	defaultConfig.SectionsURI, err = storeBaseURI.Parse("api/v1/snaps/sections")
 	if err != nil {
 		panic(err)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -253,16 +253,20 @@ func useStaging() bool {
 	return osutil.GetenvBool("SNAPPY_USE_STAGING_STORE")
 }
 
-func cpiURL() string {
+func apiURL() string {
 	// FIXME: this will become a store-url assertion
-	if u := os.Getenv("SNAPPY_FORCE_CPI_URL"); u != "" {
+	// backward-compatibility: this used to be "Click Package Index"
+	if u := os.Getenv("SNAPPY_FORCE_CPI_URL"); u != "" && strings.HasSuffix(u, "v1/") {
+		return u[:len(u)-len("v1/")]
+	}
+	if u := os.Getenv("SNAPPY_FORCE_API_URL"); u != "" {
 		return u
 	}
 	if useStaging() {
-		return "https://search.apps.staging.ubuntu.com/api/v1/"
+		return "https://api.staging.snapcraft.io/api/"
 	}
 
-	return "https://search.apps.ubuntu.com/api/v1/"
+	return "https://api.snapcraft.io/api/"
 }
 
 func authLocation() string {
@@ -306,23 +310,23 @@ func DefaultConfig() *Config {
 }
 
 func init() {
-	storeBaseURI, err := url.Parse(cpiURL())
+	storeBaseURI, err := url.Parse(apiURL())
 	if err != nil {
 		panic(err)
 	}
 
-	defaultConfig.SearchURI, err = storeBaseURI.Parse("snaps/search")
+	defaultConfig.SearchURI, err = storeBaseURI.Parse("v1/snaps/search")
 	if err != nil {
 		panic(err)
 	}
 
 	// slash at the end because snap name is appended to this with .Parse(snapName)
-	defaultConfig.DetailsURI, err = storeBaseURI.Parse("snaps/details/")
+	defaultConfig.DetailsURI, err = storeBaseURI.Parse("v1/snaps/details/")
 	if err != nil {
 		panic(err)
 	}
 
-	defaultConfig.BulkURI, err = storeBaseURI.Parse("snaps/metadata")
+	defaultConfig.BulkURI, err = storeBaseURI.Parse("v1/snaps/metadata")
 	if err != nil {
 		panic(err)
 	}
@@ -347,7 +351,7 @@ func init() {
 		panic(err)
 	}
 
-	defaultConfig.SectionsURI, err = storeBaseURI.Parse("snaps/sections")
+	defaultConfig.SectionsURI, err = storeBaseURI.Parse("v1/snaps/sections")
 	if err != nil {
 		panic(err)
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1527,7 +1527,7 @@ const (
 
 /* acquired via
 
-http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha3_384,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,screenshot_urls,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
+http --pretty=format --print b https://api.snapcraft.io/api/v1/snaps/details/hello-world X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha3_384,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,screenshot_urls,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
 
 on 2016-07-03. Then, by hand:
  * set prices to {"EUR": 0.99, "USD": 1.23}.
@@ -1539,15 +1539,8 @@ the http snap instead).
 */
 const MockDetailsJSON = `{
     "_links": {
-        "curies": [
-            {
-                "href": "https://wiki.ubuntu.com/AppStore/Interfaces/ClickPackageIndex#reltype_{rel}",
-                "name": "clickindex",
-                "templated": true
-            }
-        ],
         "self": {
-            "href": "https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cprivate%2Cconfinement&channel=edge"
+            "href": "https://api.snapcraft.io/api/v1/snaps/details/hello-world?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cprivate%2Cconfinement&channel=edge"
         }
     },
     "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap",
@@ -1625,15 +1618,8 @@ const MockDetailsJSON = `{
 // FIXME: this can go once the store always provides a channel_map_list
 const MockDetailsJSONnoChannelMapList = `{
     "_links": {
-        "curies": [
-            {
-                "href": "https://wiki.ubuntu.com/AppStore/Interfaces/ClickPackageIndex#reltype_{rel}",
-                "name": "clickindex",
-                "templated": true
-            }
-        ],
         "self": {
-            "href": "https://search.apps.ubuntu.com/api/v1/snaps/details/hello-world?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cprivate%2Cconfinement&channel=edge"
+            "href": "https://api.snapcraft.io/api/v1/snaps/details/hello-world?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha3_384%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Cdeveloper_id%2Cprivate%2Cconfinement&channel=edge"
         }
     },
     "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap",
@@ -2139,7 +2125,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsOopses(c *C) {
 /*
 acquired via
 
-http --pretty=format --print b https://search.apps.ubuntu.com/api/v1/snaps/details/no:such:package X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha512,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
+http --pretty=format --print b https://api.snapcraft.io/api/v1/snaps/details/no:such:package X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha512,summary,description,binary_filesize,download_url,icon_url,last_updated,package_name,prices,publisher,ratings_average,revision,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
 
 on 2016-07-03
 
@@ -2195,18 +2181,13 @@ func (t *remoteRepoTestSuite) TestStructFields(c *C) {
 }
 
 /* acquired via:
-curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://search.apps.ubuntu.com/api/v1/search?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&q=hello' | python -m json.tool | xsel -b
+curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://api.snapcraft.io/api/v1/snaps/search?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&q=hello' | python -m json.tool | xsel -b
 Screenshot URLS set manually.
 */
 const MockSearchJSON = `{
     "_embedded": {
         "clickindex:package": [
             {
-                "_links": {
-                    "self": {
-                        "href": "https://search.apps.ubuntu.com/api/v1/package/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ"
-                    }
-                },
                 "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_25.snap",
                 "architecture": [
                     "all"
@@ -2235,21 +2216,14 @@ const MockSearchJSON = `{
         ]
     },
     "_links": {
-        "curies": [
-            {
-                "href": "https://wiki.ubuntu.com/AppStore/Interfaces/ClickPackageIndex#reltype_{rel}",
-                "name": "clickindex",
-                "templated": true
-            }
-        ],
         "first": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
+            "href": "https://api.snapcraft.io/api/v1/snaps/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
         },
         "last": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
+            "href": "https://api.snapcraft.io/api/v1/snaps/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
         },
         "self": {
-            "href": "https://search.apps.ubuntu.com/api/v1/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
+            "href": "https://api.snapcraft.io/api/v1/snaps/search?q=hello&fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&page=1"
         }
     }
 }
@@ -2322,7 +2296,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindQueries(c *C) {
 }
 
 /* acquired via:
-curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://search.apps.ubuntu.com/api/v1/snaps/sections'
+curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://api.snapcraft.io/api/v1/snaps/sections'
 */
 const MockSectionsJSON = `{
   "_embedded": {
@@ -2336,16 +2310,8 @@ const MockSectionsJSON = `{
     ]
   }, 
   "_links": {
-    "curies": [
-      {
-        "href": "https://search.apps.ubuntu.com/docs/#reltype-{rel}", 
-        "name": "clickindex", 
-        "templated": true, 
-        "type": "text/html"
-      }
-    ], 
     "self": {
-      "href": "http://search.apps.ubuntu.com/api/v1/snaps/sections"
+      "href": "http://api.snapcraft.io/api/v1/snaps/sections"
     }
   }
 }
@@ -2673,18 +2639,13 @@ func (t *remoteRepoTestSuite) TestCurrentSnapNilLocalRevisionNoID(c *C) {
 
 /* acquired via:
 (against production "hello-world")
-$ curl -s --data-binary '{"snaps":[{"snap_id":"buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ","channel":"stable","revision":25,"epoch":"0","confinement":"strict"}],"fields":["anon_download_url","architecture","channel","download_sha512","summary","description","binary_filesize","download_url","icon_url","last_updated","package_name","prices","publisher","ratings_average","revision","snap_id","support_url","title","content","version","origin","developer_id","private","confinement"]}'  -H 'content-type: application/json' -H 'X-Ubuntu-Release: 16' -H 'X-Ubuntu-Wire-Protocol: 1' -H "accept: application/hal+json" https://search.apps.ubuntu.com/api/v1/snaps/metadata | python3 -m json.tool --sort-keys | xsel -b
+$ curl -s --data-binary '{"snaps":[{"snap_id":"buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ","channel":"stable","revision":25,"epoch":"0","confinement":"strict"}],"fields":["anon_download_url","architecture","channel","download_sha512","summary","description","binary_filesize","download_url","icon_url","last_updated","package_name","prices","publisher","ratings_average","revision","snap_id","support_url","title","content","version","origin","developer_id","private","confinement"]}'  -H 'content-type: application/json' -H 'X-Ubuntu-Release: 16' -H 'X-Ubuntu-Wire-Protocol: 1' -H "accept: application/hal+json" https://api.snapcraft.io/api/v1/snaps/metadata | python3 -m json.tool --sort-keys | xsel -b
 */
 var MockUpdatesJSON = `
 {
     "_embedded": {
         "clickindex:package": [
             {
-                "_links": {
-                    "self": {
-                        "href": "https://search.apps.ubuntu.com/api/v1/package/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ"
-                    }
-                },
                 "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_26.snap",
                 "architecture": [
                     "all"
@@ -2710,15 +2671,6 @@ var MockUpdatesJSON = `
                 "support_url": "mailto:snappy-devel@lists.ubuntu.com",
                 "title": "hello-world",
                 "version": "6.1"
-            }
-        ]
-    },
-    "_links": {
-        "curies": [
-            {
-                "href": "https://wiki.ubuntu.com/AppStore/Interfaces/ClickPackageIndex#reltype_{rel}",
-                "name": "clickindex",
-                "templated": true
             }
         ]
     }
@@ -3405,11 +3357,6 @@ var MockUpdatesWithDeltasJSON = `
     "_embedded": {
         "clickindex:package": [
             {
-                "_links": {
-                    "self": {
-                        "href": "https://search.apps.ubuntu.com/api/v1/package/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ"
-                    }
-                },
                 "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_26.snap",
                 "architecture": [
                     "all"
@@ -3452,15 +3399,6 @@ var MockUpdatesWithDeltasJSON = `
                     "anon_download_url": "https://public.apps.ubuntu.com/anon/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_25_26_xdelta3.delta",
                     "download_url": "https://public.apps.ubuntu.com/download-snap/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_25_26_xdelta3.delta"
                 }]
-            }
-        ]
-    },
-    "_links": {
-        "curies": [
-            {
-                "href": "https://wiki.ubuntu.com/AppStore/Interfaces/ClickPackageIndex#reltype_{rel}",
-                "name": "clickindex",
-                "templated": true
             }
         ]
     }
@@ -3669,11 +3607,11 @@ func (t *remoteRepoTestSuite) TestStructFieldsSurvivesNoTag(c *C) {
 
 func (t *remoteRepoTestSuite) TestCpiURLDependsOnEnviron(c *C) {
 	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
-	before := cpiURL()
+	before := apiURL()
 
 	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", "1"), IsNil)
 	defer os.Setenv("SNAPPY_USE_STAGING_STORE", "")
-	after := cpiURL()
+	after := apiURL()
 
 	c.Check(before, Not(Equals), after)
 }
@@ -3723,8 +3661,8 @@ func (t *remoteRepoTestSuite) TestMyAppsURLDependsOnEnviron(c *C) {
 }
 
 func (t *remoteRepoTestSuite) TestDefaultConfig(c *C) {
-	c.Check(strings.HasPrefix(defaultConfig.SearchURI.String(), "https://search.apps.ubuntu.com/api/v1/snaps/search"), Equals, true)
-	c.Check(strings.HasPrefix(defaultConfig.BulkURI.String(), "https://search.apps.ubuntu.com/api/v1/snaps/metadata"), Equals, true)
+	c.Check(strings.HasPrefix(defaultConfig.SearchURI.String(), "https://api.snapcraft.io/api/v1/snaps/search"), Equals, true)
+	c.Check(strings.HasPrefix(defaultConfig.BulkURI.String(), "https://api.snapcraft.io/api/v1/snaps/metadata"), Equals, true)
 	c.Check(defaultConfig.AssertionsURI.String(), Equals, "https://assertions.ubuntu.com/v1/assertions/")
 }
 

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -94,9 +94,9 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 	}
 
 	mux.HandleFunc("/", rootEndpoint)
-	mux.HandleFunc("/v1/snaps/search", store.searchEndpoint)
-	mux.HandleFunc("/v1/snaps/details/", store.detailsEndpoint)
-	mux.HandleFunc("/v1/snaps/metadata", store.bulkEndpoint)
+	mux.HandleFunc("/api/v1/snaps/search", store.searchEndpoint)
+	mux.HandleFunc("/api/v1/snaps/details/", store.detailsEndpoint)
+	mux.HandleFunc("/api/v1/snaps/metadata", store.bulkEndpoint)
 	mux.Handle("/download/", http.StripPrefix("/download/", http.FileServer(http.Dir(topDir))))
 	mux.HandleFunc("/assertions/", store.assertionsEndpoint)
 
@@ -251,7 +251,7 @@ func (s *Store) searchEndpoint(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Store) detailsEndpoint(w http.ResponseWriter, req *http.Request) {
-	pkg := strings.TrimPrefix(req.URL.Path, "/v1/snaps/details/")
+	pkg := strings.TrimPrefix(req.URL.Path, "/api/v1/snaps/details/")
 	if pkg == req.URL.Path {
 		panic("how?")
 	}

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -94,9 +94,9 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 	}
 
 	mux.HandleFunc("/", rootEndpoint)
-	mux.HandleFunc("/search", store.searchEndpoint)
-	mux.HandleFunc("/snaps/details/", store.detailsEndpoint)
-	mux.HandleFunc("/snaps/metadata", store.bulkEndpoint)
+	mux.HandleFunc("/v1/snaps/search", store.searchEndpoint)
+	mux.HandleFunc("/v1/snaps/details/", store.detailsEndpoint)
+	mux.HandleFunc("/v1/snaps/metadata", store.bulkEndpoint)
 	mux.Handle("/download/", http.StripPrefix("/download/", http.FileServer(http.Dir(topDir))))
 	mux.HandleFunc("/assertions/", store.assertionsEndpoint)
 
@@ -251,7 +251,7 @@ func (s *Store) searchEndpoint(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Store) detailsEndpoint(w http.ResponseWriter, req *http.Request) {
-	pkg := strings.TrimPrefix(req.URL.Path, "/snaps/details/")
+	pkg := strings.TrimPrefix(req.URL.Path, "/v1/snaps/details/")
 	if pkg == req.URL.Path {
 		panic("how?")
 	}

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -104,7 +104,7 @@ func (s *storeTestSuite) TestTrivialGetWorks(c *C) {
 }
 
 func (s *storeTestSuite) TestSearchEndpoint(c *C) {
-	resp, err := s.StoreGet("/v1/snaps/search")
+	resp, err := s.StoreGet("/api/v1/snaps/search")
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -119,7 +119,7 @@ func (s *storeTestSuite) TestDetailsEndpointWithAssertions(c *C) {
 	snapFn := s.makeTestSnap(c, "name: foo\nversion: 7")
 	s.makeAssertions(c, snapFn, "foo", "xidididididididididididididididid", "foo-devel", "foo-devel-id", 77)
 
-	resp, err := s.StoreGet(`/v1/snaps/details/foo`)
+	resp, err := s.StoreGet(`/api/v1/snaps/details/foo`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -143,7 +143,7 @@ func (s *storeTestSuite) TestDetailsEndpointWithAssertions(c *C) {
 
 func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 	snapFn := s.makeTestSnap(c, "name: foo\nversion: 1")
-	resp, err := s.StoreGet(`/v1/snaps/details/foo`)
+	resp, err := s.StoreGet(`/api/v1/snaps/details/foo`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -169,7 +169,7 @@ func (s *storeTestSuite) TestBulkEndpoint(c *C) {
 	snapFn := s.makeTestSnap(c, "name: test-snapd-tools\nversion: 1")
 
 	// note that we send the test-snapd-tools snapID here
-	resp, err := s.StorePostJSON("/v1/snaps/metadata", []byte(`{
+	resp, err := s.StorePostJSON("/api/v1/snaps/metadata", []byte(`{
 "snaps": [{"snap_id":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw","channel":"stable","revision":1}]
 }`))
 	c.Assert(err, IsNil)
@@ -201,7 +201,7 @@ func (s *storeTestSuite) TestBulkEndpointWithAssertions(c *C) {
 	snapFn := s.makeTestSnap(c, "name: foo\nversion: 10")
 	s.makeAssertions(c, snapFn, "foo", "xidididididididididididididididid", "foo-devel", "foo-devel-id", 99)
 
-	resp, err := s.StorePostJSON("/v1/snaps/metadata", []byte(`{
+	resp, err := s.StorePostJSON("/api/v1/snaps/metadata", []byte(`{
 "snaps": [{"snap_id":"xidididididididididididididididid","channel":"stable","revision":1}]
 }`))
 	c.Assert(err, IsNil)

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -104,7 +104,7 @@ func (s *storeTestSuite) TestTrivialGetWorks(c *C) {
 }
 
 func (s *storeTestSuite) TestSearchEndpoint(c *C) {
-	resp, err := s.StoreGet("/search")
+	resp, err := s.StoreGet("/v1/snaps/search")
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -119,7 +119,7 @@ func (s *storeTestSuite) TestDetailsEndpointWithAssertions(c *C) {
 	snapFn := s.makeTestSnap(c, "name: foo\nversion: 7")
 	s.makeAssertions(c, snapFn, "foo", "xidididididididididididididididid", "foo-devel", "foo-devel-id", 77)
 
-	resp, err := s.StoreGet(`/snaps/details/foo`)
+	resp, err := s.StoreGet(`/v1/snaps/details/foo`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -143,7 +143,7 @@ func (s *storeTestSuite) TestDetailsEndpointWithAssertions(c *C) {
 
 func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 	snapFn := s.makeTestSnap(c, "name: foo\nversion: 1")
-	resp, err := s.StoreGet(`/snaps/details/foo`)
+	resp, err := s.StoreGet(`/v1/snaps/details/foo`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -169,7 +169,7 @@ func (s *storeTestSuite) TestBulkEndpoint(c *C) {
 	snapFn := s.makeTestSnap(c, "name: test-snapd-tools\nversion: 1")
 
 	// note that we send the test-snapd-tools snapID here
-	resp, err := s.StorePostJSON("/snaps/metadata", []byte(`{
+	resp, err := s.StorePostJSON("/v1/snaps/metadata", []byte(`{
 "snaps": [{"snap_id":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw","channel":"stable","revision":1}]
 }`))
 	c.Assert(err, IsNil)
@@ -201,7 +201,7 @@ func (s *storeTestSuite) TestBulkEndpointWithAssertions(c *C) {
 	snapFn := s.makeTestSnap(c, "name: foo\nversion: 10")
 	s.makeAssertions(c, snapFn, "foo", "xidididididididididididididididid", "foo-devel", "foo-devel-id", 99)
 
-	resp, err := s.StorePostJSON("/snaps/metadata", []byte(`{
+	resp, err := s.StorePostJSON("/v1/snaps/metadata", []byte(`{
 "snaps": [{"snap_id":"xidididididididididididididididid","channel":"stable","revision":1}]
 }`))
 	c.Assert(err, IsNil)

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -49,7 +49,7 @@ setup_fake_store(){
     systemd_create_and_start_unit fakestore "$(which fakestore) -start -dir $top_dir -addr localhost:11028 -https-proxy=${https_proxy} -http-proxy=${http_proxy} -assert-fallback" "SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
 
     echo "And snapd is configured to use the controlled store"
-    _configure_store_backends "SNAPPY_FORCE_CPI_URL=http://localhost:11028" "SNAPPY_FORCE_SAS_URL=http://localhost:11028 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
+    _configure_store_backends "SNAPPY_FORCE_API_URL=http://localhost:11028" "SNAPPY_FORCE_SAS_URL=http://localhost:11028 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
 }
 
 teardown_fake_store(){


### PR DESCRIPTION
As part of the enterprise store project, the store is moving over to
having a single api.snapcraft.io host which should eventually be the
front door for all queries from devices; this will make it much easier
to put something like an edge proxy in place, because only one URL will
need to be overridden.

At the moment, api.snapcraft.io only provides the non-legacy endpoints
that used to be part of Click Package Index, but it will soon be
expanded to provide others as well.  This shifts snapd over to the new
host name.  The older endpoints will of course be maintained for as long
as is necessary.

I've dropped the trailing `api/v1/` from the URL, since we'll probably
have a `v2/` at some point but that may be on an endpoint-by-endpoint
basis, so it doesn't make sense to pin all of snapd's API calls to the
same version.

The preferred way to set an alternate store API URL is now
`SNAPPY_FORCE_API_URL=https://api.example.org/`.
`SNAPPY_USE_STAGING_STORE=1` still works as an abbreviated way to point
at staging.