### PR TITLE
snap-confine: validate SNAP_NAME against security tag

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -63,6 +63,7 @@ static void test_verify_security_tag()
 	g_assert_false(verify_security_tag("snap.name.app..", "name"));
 
 	// Test names that are both good, but snap name doesn't match security tag
+	g_assert_false(verify_security_tag("snap.foo.hook.bar", "fo"));
 	g_assert_false(verify_security_tag("snap.foo.hook.bar", "fooo"));
 	g_assert_false(verify_security_tag("snap.foo.hook.bar", "snap"));
 	g_assert_false(verify_security_tag("snap.foo.hook.bar", "bar"));

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -33,8 +33,6 @@ static void test_verify_security_tag()
 
 	// Now, test the names we know are bad
 	g_assert_false(verify_security_tag
-		       ("snap.foo.hook.bar", "nonmatchingname"));
-	g_assert_false(verify_security_tag
 		       ("pkg-foo.bar.0binary-bar+baz", "bar"));
 	g_assert_false(verify_security_tag("pkg-foo_bar_1.1", ""));
 	g_assert_false(verify_security_tag("appname/..", ""));
@@ -63,6 +61,11 @@ static void test_verify_security_tag()
 	g_assert_false(verify_security_tag("snap..name.app", ".name"));
 	g_assert_false(verify_security_tag("snap.name..app", "name."));
 	g_assert_false(verify_security_tag("snap.name.app..", "name"));
+
+	// Test names that are both good, but snap name doesn't match security tag
+	g_assert_false(verify_security_tag("snap.foo.hook.bar", "fooo"));
+	g_assert_false(verify_security_tag("snap.foo.hook.bar", "snap"));
+	g_assert_false(verify_security_tag("snap.foo.hook.bar", "bar"));
 }
 
 static void test_sc_snap_name_validate()

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -23,42 +23,46 @@
 static void test_verify_security_tag()
 {
 	// First, test the names we know are good
-	g_assert_true(verify_security_tag("snap.name.app"));
+	g_assert_true(verify_security_tag("snap.name.app", "name"));
 	g_assert_true(verify_security_tag
-		      ("snap.network-manager.NetworkManager"));
-	g_assert_true(verify_security_tag("snap.f00.bar-baz1"));
-	g_assert_true(verify_security_tag("snap.foo.hook.bar"));
-	g_assert_true(verify_security_tag("snap.foo.hook.bar-baz"));
+		      ("snap.network-manager.NetworkManager",
+		       "network-manager"));
+	g_assert_true(verify_security_tag("snap.f00.bar-baz1", "f00"));
+	g_assert_true(verify_security_tag("snap.foo.hook.bar", "foo"));
+	g_assert_true(verify_security_tag("snap.foo.hook.bar-baz", "foo"));
 
 	// Now, test the names we know are bad
-	g_assert_false(verify_security_tag("pkg-foo.bar.0binary-bar+baz"));
-	g_assert_false(verify_security_tag("pkg-foo_bar_1.1"));
-	g_assert_false(verify_security_tag("appname/.."));
-	g_assert_false(verify_security_tag("snap"));
-	g_assert_false(verify_security_tag("snap."));
-	g_assert_false(verify_security_tag("snap.name"));
-	g_assert_false(verify_security_tag("snap.name."));
-	g_assert_false(verify_security_tag("snap.name.app."));
-	g_assert_false(verify_security_tag("snap.name.hook."));
-	g_assert_false(verify_security_tag("snap!name.app"));
-	g_assert_false(verify_security_tag("snap.-name.app"));
-	g_assert_false(verify_security_tag("snap.name!app"));
-	g_assert_false(verify_security_tag("snap.name.-app"));
-	g_assert_false(verify_security_tag("snap.name.app!hook.foo"));
-	g_assert_false(verify_security_tag("snap.name.app.hook!foo"));
-	g_assert_false(verify_security_tag("snap.name.app.hook.-foo"));
-	g_assert_false(verify_security_tag("snap.name.app.hook.f00"));
-	g_assert_false(verify_security_tag("sna.pname.app"));
-	g_assert_false(verify_security_tag("snap.n@me.app"));
-	g_assert_false(verify_security_tag("SNAP.name.app"));
-	g_assert_false(verify_security_tag("snap.Name.app"));
-	g_assert_false(verify_security_tag("snap.0name.app"));
-	g_assert_false(verify_security_tag("snap.-name.app"));
-	g_assert_false(verify_security_tag("snap.name.@app"));
-	g_assert_false(verify_security_tag(".name.app"));
-	g_assert_false(verify_security_tag("snap..name.app"));
-	g_assert_false(verify_security_tag("snap.name..app"));
-	g_assert_false(verify_security_tag("snap.name.app.."));
+	g_assert_false(verify_security_tag
+		       ("snap.foo.hook.bar", "nonmatchingname"));
+	g_assert_false(verify_security_tag
+		       ("pkg-foo.bar.0binary-bar+baz", "bar"));
+	g_assert_false(verify_security_tag("pkg-foo_bar_1.1", ""));
+	g_assert_false(verify_security_tag("appname/..", ""));
+	g_assert_false(verify_security_tag("snap", ""));
+	g_assert_false(verify_security_tag("snap.", ""));
+	g_assert_false(verify_security_tag("snap.name", "name"));
+	g_assert_false(verify_security_tag("snap.name.", "name"));
+	g_assert_false(verify_security_tag("snap.name.app.", "name"));
+	g_assert_false(verify_security_tag("snap.name.hook.", "name"));
+	g_assert_false(verify_security_tag("snap!name.app", "!name"));
+	g_assert_false(verify_security_tag("snap.-name.app", "-name"));
+	g_assert_false(verify_security_tag("snap.name!app", "name!"));
+	g_assert_false(verify_security_tag("snap.name.-app", "name"));
+	g_assert_false(verify_security_tag("snap.name.app!hook.foo", "name"));
+	g_assert_false(verify_security_tag("snap.name.app.hook!foo", "name"));
+	g_assert_false(verify_security_tag("snap.name.app.hook.-foo", "name"));
+	g_assert_false(verify_security_tag("snap.name.app.hook.f00", "name"));
+	g_assert_false(verify_security_tag("sna.pname.app", "pname"));
+	g_assert_false(verify_security_tag("snap.n@me.app", "n@me"));
+	g_assert_false(verify_security_tag("SNAP.name.app", "name"));
+	g_assert_false(verify_security_tag("snap.Name.app", "Name"));
+	g_assert_false(verify_security_tag("snap.0name.app", "0name"));
+	g_assert_false(verify_security_tag("snap.-name.app", "-name"));
+	g_assert_false(verify_security_tag("snap.name.@app", "name"));
+	g_assert_false(verify_security_tag(".name.app", "name"));
+	g_assert_false(verify_security_tag("snap..name.app", ".name"));
+	g_assert_false(verify_security_tag("snap.name..app", "name."));
+	g_assert_false(verify_security_tag("snap.name.app..", "name"));
 }
 
 static void test_sc_snap_name_validate()

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -35,14 +35,15 @@ bool verify_security_tag(const char *security_tag, const char *snap_name)
 	if (regcomp(&re, whitelist_re, REG_EXTENDED) != 0)
 		die("can not compile regex %s", whitelist_re);
 
-	// first capture is the entire string, second is the name we care about
+	// first capture is for verifying the full security tag, second capture
+	// for verifying the snap_name is correct for this security tag
 	regmatch_t matches[2];
 	int status =
 	    regexec(&re, security_tag, sizeof matches / sizeof *matches,
 		    matches, 0);
 	regfree(&re);
 
-	// make sure that snap name was captured by 2nd match group
+	// Fail if no match or if snap name wasn't captured in the 2nd match group
 	if (status != 0 || matches[1].rm_so < 0) {
 		return false;
 	}

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -45,10 +45,11 @@ bool verify_security_tag(const char *security_tag, const char *snap_name)
 	// first capture is the entire string, second is the name we care about
 	regmatch_t matches[2];
 	int status =
-	    regexec(&re, security_tag, sizeof(matches) / sizeof(regmatch_t),
+	    regexec(&re, security_tag, sizeof matches / sizeof *matches,
 		    matches, 0);
 	regfree(&re);
 
+  // make sure that snap name was captured by 2nd match group
 	if (status != 0 || matches[1].rm_so < 0) {
 		return false;
 	}

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -29,13 +29,6 @@
 
 bool verify_security_tag(const char *security_tag, const char *snap_name)
 {
-	// The executable name is of form:
-	// snap.<name>.(<appname>|hook.<hookname>)
-	// - <name> must start with lowercase letter, then may contain
-	//   lowercase alphanumerics and '-'; it must match snap_name
-	// - <appname> may contain alphanumerics and '-'
-	// - <hookname must start with a lowercase letter, then may
-	//   contain lowercase letters and '-'
 	const char *whitelist_re =
 	    "^snap\\.([a-z](-?[a-z0-9])*)\\.([a-zA-Z0-9](-?[a-zA-Z0-9])*|hook\\.[a-z](-?[a-z])*)$";
 	regex_t re;
@@ -49,7 +42,7 @@ bool verify_security_tag(const char *security_tag, const char *snap_name)
 		    matches, 0);
 	regfree(&re);
 
-  // make sure that snap name was captured by 2nd match group
+	// make sure that snap name was captured by 2nd match group
 	if (status != 0 || matches[1].rm_so < 0) {
 		return false;
 	}

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -47,8 +47,9 @@ bool verify_security_tag(const char *security_tag, const char *snap_name)
 		return false;
 	}
 
-	return strncmp(security_tag + matches[1].rm_so, snap_name,
-		       matches[1].rm_eo - matches[1].rm_so) == 0;
+	size_t len = matches[1].rm_eo - matches[1].rm_so;
+	return len == strlen(snap_name)
+	    && strncmp(security_tag + matches[1].rm_so, snap_name, len) == 0;
 }
 
 bool sc_is_hook_security_tag(const char *security_tag)

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -43,6 +43,17 @@ enum {
  **/
 void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp);
 
+/**
+ * Validate security tag against strict naming requirements and snap name.
+ *
+ *  The executable name is of form:
+ *   snap.<name>.(<appname>|hook.<hookname>)
+ *  - <name> must start with lowercase letter, then may contain
+ *   lowercase alphanumerics and '-'; it must match snap_name
+ *  - <appname> may contain alphanumerics and '-'
+ *  - <hookname must start with a lowercase letter, then may
+ *   contain lowercase letters and '-'
+ **/
 bool verify_security_tag(const char *security_tag, const char *snap_name);
 
 bool sc_is_hook_security_tag(const char *security_tag);

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -43,7 +43,7 @@ enum {
  **/
 void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp);
 
-bool verify_security_tag(const char *security_tag);
+bool verify_security_tag(const char *security_tag, const char *snap_name);
 
 bool sc_is_hook_security_tag(const char *security_tag);
 

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -54,21 +54,23 @@ int main(int argc, char **argv)
 		printf("%s %s\n", PACKAGE, PACKAGE_VERSION);
 		return 0;
 	}
-	// Collect and validate the security tag and a few other things passed on
-	// command line.
-	const char *security_tag = sc_args_security_tag(args);
-	if (!verify_security_tag(security_tag)) {
-		die("security tag %s not allowed", security_tag);
-	}
-	const char *executable = sc_args_executable(args);
-	const char *base_snap_name = sc_args_base_snap(args) ? : "core";
-	bool classic_confinement = sc_args_is_classic_confinement(args);
 
 	const char *snap_name = getenv("SNAP_NAME");
 	if (snap_name == NULL) {
 		die("SNAP_NAME is not set");
 	}
 	sc_snap_name_validate(snap_name, NULL);
+
+	// Collect and validate the security tag and a few other things passed on
+	// command line.
+	const char *security_tag = sc_args_security_tag(args);
+	if (!verify_security_tag(security_tag, snap_name)) {
+		die("security tag %s not allowed", security_tag);
+	}
+	const char *executable = sc_args_executable(args);
+	const char *base_snap_name = sc_args_base_snap(args) ? : "core";
+	bool classic_confinement = sc_args_is_classic_confinement(args);
+
 	sc_snap_name_validate(base_snap_name, NULL);
 
 	debug("security tag: %s", security_tag);

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -97,10 +97,6 @@ int snappy_udev_init(const char *security_tag, struct snappy_udev *udev_s)
 	debug("%s", __func__);
 	int rc = 0;
 
-	// extra paranoia
-	if (!verify_security_tag(security_tag))
-		die("security tag %s not allowed", security_tag);
-
 	udev_s->tagname[0] = '\0';
 	udev_s->tagname_len = 0;
 	// TAG+="snap_<security tag>" (udev doesn't like '.' in the tag name)
@@ -157,9 +153,6 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 		NULL,
 	};
 
-	// extra paranoia
-	if (!verify_security_tag(security_tag))
-		die("security tag %s not allowed", security_tag);
 	if (udev_s == NULL)
 		die("snappy_udev is NULL");
 	if (udev_s->udev == NULL)


### PR DESCRIPTION
Make sure SNAP_NAME env variable matches the name from security tag.