### PR TITLE
tests: fix snap create-key by restarting automatically rng-tools

### DIFF
--- a/tests/lib/entropy.sh
+++ b/tests/lib/entropy.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-feed_kernel_entropy_pool() {
-	# Feed the kernel entropy pool when the level is under 700 (level used by ubuntu-core)
-	if [ $# -gt 0 ] && [ "$1" = "--force" ] || [ $(sysctl --values kernel.random.entropy_avail || echo 0) -gt 700 ]; then
-		echo "HRNGDEVICE=/dev/urandom" > /etc/default/rng-tools
-		/etc/init.d/rng-tools restart
-	fi
-}

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -219,7 +219,11 @@ EOF
         echo "HRNGDEVICE=/dev/urandom" > /etc/default/rng-tools
         /etc/init.d/rng-tools restart
 
-        find /run/systemd -type f -name 'rng-tools.service' -exec sed -i 's/^Restart=no/Restart=always/g' {} \;
+        mkdir -p /etc/systemd/system/rng-tools.service.d/
+        cat <<EOF > /etc/systemd/system/rng-tools.service.d/local.conf
+[Service]
+Restart=always
+EOF
         systemctl daemon-reload
     fi
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -8,8 +8,6 @@ set -eux
 . "$TESTSLIB/snaps.sh"
 # shellcheck source=tests/lib/pkgdb.sh
 . "$TESTSLIB/pkgdb.sh"
-# shellcheck source=tests/lib/entropy.sh
-. "$TESTSLIB/entropy.sh"
 
 disable_kernel_rate_limiting() {
     # kernel rate limiting hinders debugging security policy so turn it off

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -218,7 +218,11 @@ EOF
         # Improve entropy for the whole system quite a lot to get fast
         # key generation during our test cycles
         apt-get install -y -q rng-tools
-        feed_kernel_entropy_pool --force
+        echo "HRNGDEVICE=/dev/urandom" > /etc/default/rng-tools
+        /etc/init.d/rng-tools restart
+
+        find /run/systemd -type f -name 'rng-tools.service' -exec sed -i 's/^Restart=no/Restart=always/g' {} \;
+        systemctl daemon-reload
     fi
 
     disable_kernel_rate_limiting

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -12,8 +12,6 @@ prepare: |
     snap install core
     snap install test-snapd-tools
     "$TESTSLIB"/mkpinentry.sh
-    . "$TESTSLIB"/entropy.sh
-    feed_kernel_entropy_pool
     expect -d -f key.exp0
 
 restore: |

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -4,8 +4,6 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
     "$TESTSLIB"/mkpinentry.sh
-    . "$TESTSLIB"/entropy.sh
-    feed_kernel_entropy_pool
 
 debug: |
     sysctl kernel.random.entropy_avail || true

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -5,8 +5,6 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
     "$TESTSLIB"/mkpinentry.sh
-    . "$TESTSLIB"/entropy.sh
-    feed_kernel_entropy_pool
 
 debug: |
     sysctl kernel.random.entropy_avail || true


### PR DESCRIPTION
This change is to deal with unexpected segfault logged by the kernel.

Through this change rng-tools will restart automatically after a crash,
so en entropy will stay high allowing the snap create-key to finish.

This is the error which is affecting:
Jun 10 01:39:19 ubuntu kernel: [ 911.509447] rngd[3001]: segfault at
805f000 ip 0804ac3e sp bfaaa4dc error 6 in rngd[8048000+5000]

Log:
https://travis-ci.org/snapcore/snapd/builds/241031225

More info:
https://forum.snapcraft.io/t/error-creating-key/964/6