### PR TITLE
tests: mark interfaces-openvswitch as manual due to prepare errors

### DIFF
--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -14,6 +14,9 @@ details: |
     are carried through the socket, in this test we exercise bridge and port creation,
     list and deletion.
 
+# marking as manual due to errors during prepare
+manual: true
+
 prepare: |
     echo "Given openvswitch is installed"
     apt install -y --no-install-recommends openvswitch-switch


### PR DESCRIPTION
We are still getting eventual errors on `tests/main/interfaces-openvswitch`, like http://paste.ubuntu.com/24856387/