### PR TITLE
tests: fix nightly suite

### DIFF
--- a/tests/nested/extra-snaps-assertions/task.yaml
+++ b/tests/nested/extra-snaps-assertions/task.yaml
@@ -3,9 +3,16 @@ summary: create ubuntu-core image and execute the suite in a nested qemu instanc
 systems: [ubuntu-16.04-64, ubuntu-16.04-32]
 
 prepare: |
+    # FIXME: until https://github.com/snapcore/snapd/pull/3263 is available from
+    # the archive we need to build snapd from branch so that it can be used by
+    # ubuntu-image
+    apt remove -y --purge snapd
+
     . $TESTSLIB/prepare.sh
     prepare_classic
     prepare_each_classic
+
+    snap install --classic --beta ubuntu-image
 
     # determine arch related vars
     case "$NESTED_ARCH" in
@@ -23,14 +30,13 @@ prepare: |
 
     # create ubuntu-core image
     mkdir -p /tmp/work-dir
-    # bind mount the snap binary installed from the package built with the branch to the binary used by ubuntu-image
-    mount -o bind /usr/bin/snap /snap/ubuntu-image/current/bin/snap
 
     snap download core
 
     /snap/bin/ubuntu-image --image-size 3G $TESTSLIB/assertions/nested-${NESTED_ARCH}.model --channel $CORE_CHANNEL --output ubuntu-core.img --extra-snaps core_*.snap
     mv ubuntu-core.img /tmp/work-dir
 
+    . $TESTSLIB/nested.sh
     create_assertions_disk
 
     . $TESTSLIB/systemd.sh

--- a/tests/nested/extra-snaps-assertions/task.yaml
+++ b/tests/nested/extra-snaps-assertions/task.yaml
@@ -6,8 +6,6 @@ prepare: |
     # FIXME: until https://github.com/snapcore/snapd/pull/3263 is available from
     # the archive we need to build snapd from branch so that it can be used by
     # ubuntu-image
-    apt remove -y --purge snapd
-
     . $TESTSLIB/prepare.sh
     prepare_classic
     prepare_each_classic


### PR DESCRIPTION
We are getting errors like https://travis-ci.org/snapcore/spread-cron/builds/243085406#L545, now there's an additional check on prepare for core not being installed at the suite start and it makes some of the nested tests to fail.

In these changes there's an update to the way we use ubuntu-image too, it no longer embeds the snap binary (uses the one in the host thanks to the classic confinement), so we don't need to bind mount it.