### PR TITLE
tests: prevent quoting error on opensuse

### DIFF
--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -244,8 +244,9 @@ fakestore_tags=
 if [ "$REMOTE_STORE" = staging ]; then
     fakestore_tags="-tags withstagingkeys"
 fi
-# shellcheck disable=SC2086
-go get $fakestore_tags ./tests/lib/fakestore/cmd/fakestore
+
+# eval to prevent expansion errors on opensuse (the variable keeps quotes)
+eval "go get $fakestore_tags ./tests/lib/fakestore/cmd/fakestore"
 
 # Build additional utilities we need for testing
 go get ./tests/lib/fakedevicesvc


### PR DESCRIPTION
When running the suite against staging we are getting this error on opensuse:
```
go get '-tags withstagingkeys' ./tests/lib/fakestore/cmd/fakestore
flag provided but not defined: -tags withstagingkeys
```
The variable `fakestore_tags` gets expanded into `'-tags withstagingkeys'` instead of `-tags withstagingkeys`, double quoting the whole command and evaluating it fixes the problem.