### PR TITLE
tests: restart rng-tools services after few seconds

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -223,6 +223,7 @@ EOF
         cat <<EOF > /etc/systemd/system/rng-tools.service.d/local.conf
 [Service]
 Restart=always
+RestartSec=5
 EOF
         systemctl daemon-reload
     fi

--- a/tests/main/completion/key.exp0
+++ b/tests/main/completion/key.exp0
@@ -3,7 +3,9 @@ source lib.exp0
 # create a key doesn't complete
 chat "snap create-key \t\t" "snap create-key ??$"
 chat "\r" "Passphrase:"
+sleep .5
 chat "pass\r" "Confirm passphrase:"
+sleep .5
 send "pass\r"
 
 # this can take a while

--- a/tests/main/create-key/passphrase_mismatch.exp
+++ b/tests/main/create-key/passphrase_mismatch.exp
@@ -1,9 +1,11 @@
 spawn snap create-key
 
 expect "Passphrase: "
+sleep .5
 send "one\n"
 
 expect "Confirm passphrase: "
+sleep .5
 send "two\n"
 
 expect {

--- a/tests/main/create-key/successful_default.exp
+++ b/tests/main/create-key/successful_default.exp
@@ -3,9 +3,11 @@ set timeout 60
 spawn snap create-key
 
 expect "Passphrase: "
+sleep .5
 send "pass\n"
 
 expect "Confirm passphrase: "
+sleep .5
 send "pass\n"
 
 set status [wait]

--- a/tests/main/create-key/successful_non_default.exp
+++ b/tests/main/create-key/successful_non_default.exp
@@ -3,9 +3,11 @@ set timeout 60
 spawn snap create-key another
 
 expect "Passphrase: "
+sleep .5
 send "pass\n"
 
 expect "Confirm passphrase: "
+sleep .5
 send "pass\n"
 
 set status [wait]

--- a/tests/main/snap-sign/create-key.exp
+++ b/tests/main/snap-sign/create-key.exp
@@ -1,9 +1,11 @@
 spawn snap create-key
 
 expect "Passphrase: "
+sleep .5
 send "pass\n"
 
 expect "Confirm passphrase: "
+sleep .5
 send "pass\n"
 
 set status [wait]


### PR DESCRIPTION
Sometimes the service is not starting properly when it is restarted
inmediatly after the segfault. To deal with that it is recommended to
wait few seconds after the service is down to restart it.

Error:
https://travis-ci.org/snapcore/snapd/builds/244673127#L3493