### PR TITLE
cmd/snap-repair:  start of Runner, implement first pass of Peek and Fetch

### DIFF
--- a/cmd/snap-repair/export_test.go
+++ b/cmd/snap-repair/export_test.go
@@ -19,8 +19,20 @@
 
 package main
 
+import (
+	"gopkg.in/retry.v1"
+)
+
 var (
 	Parser    = parser
 	ParseArgs = parseArgs
 	Run       = run
 )
+
+func MockFetchRetryStrategy(strategy retry.Strategy) (restore func()) {
+	originalFetchRetryStrategy := fetchRetryStrategy
+	fetchRetryStrategy = strategy
+	return func() {
+		fetchRetryStrategy = originalFetchRetryStrategy
+	}
+}

--- a/cmd/snap-repair/export_test.go
+++ b/cmd/snap-repair/export_test.go
@@ -36,3 +36,11 @@ func MockFetchRetryStrategy(strategy retry.Strategy) (restore func()) {
 		fetchRetryStrategy = originalFetchRetryStrategy
 	}
 }
+
+func MockPeekRetryStrategy(strategy retry.Strategy) (restore func()) {
+	originalPeekRetryStrategy := peekRetryStrategy
+	peekRetryStrategy = strategy
+	return func() {
+		peekRetryStrategy = originalPeekRetryStrategy
+	}
+}

--- a/cmd/snap-repair/export_test.go
+++ b/cmd/snap-repair/export_test.go
@@ -44,3 +44,11 @@ func MockPeekRetryStrategy(strategy retry.Strategy) (restore func()) {
 		peekRetryStrategy = originalPeekRetryStrategy
 	}
 }
+
+func MockMaxRepairScriptSize(maxSize int) (restore func()) {
+	originalMaxSize := maxRepairScriptSize
+	maxRepairScriptSize = maxSize
+	return func() {
+		maxRepairScriptSize = originalMaxSize
+	}
+}

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -1,0 +1,122 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"gopkg.in/retry.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/httputil"
+)
+
+// Runner implements fetching, tracking and running repairs.
+type Runner struct {
+	URL string
+	cli *http.Client
+}
+
+// NewRunner returns a Runner.
+func NewRunner() *Runner {
+	// TODO: pass TLSConfig with lower-bounded time
+	opts := httputil.ClientOpts{
+		Timeout:    15 * time.Second,
+		MayLogBody: false,
+	}
+	cli := httputil.NewHTTPClient(&opts)
+	return &Runner{
+		cli: cli,
+	}
+}
+
+var (
+	fetchRetryStrategy = retry.LimitCount(10, retry.LimitTime(1*time.Minute,
+		retry.Exponential{
+			Initial: 100 * time.Millisecond,
+			Factor:  2.5,
+		},
+	))
+)
+
+var ErrRepairNotFound = errors.New("repair not found")
+
+// Fetch retrieves a stream with the repair with the given ids and any auxiliary assertions.
+func (run *Runner) Fetch(brandID, repairID string) (r []asserts.Assertion, err error) {
+	// TODO: BaseURL
+	url := fmt.Sprintf(run.URL, brandID, repairID)
+
+	resp, err := httputil.RetryRequest(url, func() (*http.Response, error) {
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/x.ubuntu.assertion")
+		return run.cli.Do(req)
+	}, func(resp *http.Response) error {
+		if resp.StatusCode == 200 {
+			// decode assertions
+			// TODO: use a decoder that can accept large repair bodies
+			dec := asserts.NewDecoder(resp.Body)
+			for {
+				a, err := dec.Decode()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return err
+				}
+				r = append(r, a)
+			}
+			if len(r) == 0 {
+				return io.ErrUnexpectedEOF
+			}
+		}
+		return nil
+	}, fetchRetryStrategy)
+
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		// ok
+	case 404:
+		return nil, ErrRepairNotFound
+	default:
+		return nil, fmt.Errorf("cannot fetch repair, unexpected status %d", resp.StatusCode)
+	}
+
+	repair, ok := r[0].(*asserts.Repair)
+	if !ok {
+		return nil, fmt.Errorf("cannot fetch repair, unexpected first assertion %q", r[0].Type().Name)
+	}
+
+	if repair.BrandID() != brandID || repair.RepairID() != repairID {
+		return nil, fmt.Errorf("cannot fetch repair, id mismatch %s/%s != %s/%s", repair.BrandID(), repair.RepairID(), brandID, repairID)
+	}
+
+	return r, nil
+}

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -1,0 +1,240 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/retry.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	repair "github.com/snapcore/snapd/cmd/snap-repair"
+)
+
+var (
+	testKey = `type: account-key
+authority-id: canonical
+account-id: canonical
+name: repair
+public-key-sha3-384: KPIl7M4vQ9d4AUjkoU41TGAwtOMLc_bWUCeW8AvdRWD4_xcP60Oo4ABsFNo6BtXj
+since: 2015-11-16T15:04:00Z
+body-length: 149
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AcZrBFaFwYABAvCX5A8dTcdLdhdiuy2YRHO5CAfM5InQefkKOhNMUq2yfi3Sk6trUHxskhZkPnm4
+NKx2yRr332q7AJXQHLX+DrZ29ycyoQ2NQGO3eAfQ0hjAAQFYBF8SSh5SutPu5XCVABEBAAE=
+
+AXNpZw==
+`
+
+	testRepair = `type: repair
+authority-id: canonical
+brand-id: canonical
+repair-id: 2
+architectures:
+  - amd64
+  - arm64
+series:
+  - 16
+timestamp: 2017-03-30T12:22:16Z
+body-length: 7
+sign-key-sha3-384: KPIl7M4vQ9d4AUjkoU41TGAwtOMLc_bWUCeW8AvdRWD4_xcP60Oo4ABsFNo6BtXj
+
+script
+
+
+AXNpZw==
+`
+)
+
+func (r *repairSuite) TestFetchJustRepair(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
+		c.Check(r.URL.Path, Equals, "/repairs/canonical/2")
+		io.WriteString(w, testRepair)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	runner := repair.NewRunner()
+	runner.URL = mockServer.URL + "/repairs/%s/%s"
+
+	a, err := runner.Fetch("canonical", "2")
+	c.Assert(err, IsNil)
+	c.Check(a, HasLen, 1)
+	_, ok := a[0].(*asserts.Repair)
+	c.Check(ok, Equals, true)
+}
+
+var (
+	testRetryStrategy = retry.LimitCount(5, retry.LimitTime(1*time.Second,
+		retry.Exponential{
+			Initial: 1 * time.Millisecond,
+			Factor:  1,
+		},
+	))
+)
+
+func (r *repairSuite) TestFetch500(c *C) {
+	restore := repair.MockFetchRetryStrategy(testRetryStrategy)
+	defer restore()
+
+	n := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		w.WriteHeader(500)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	runner := repair.NewRunner()
+	runner.URL = mockServer.URL + "/repairs/%s/%s"
+
+	_, err := runner.Fetch("canonical", "2")
+	c.Assert(err, ErrorMatches, "cannot fetch repair, unexpected status 500")
+	c.Assert(n, Equals, 5)
+}
+
+func (r *repairSuite) TestFetchEmpty(c *C) {
+	restore := repair.MockFetchRetryStrategy(testRetryStrategy)
+	defer restore()
+
+	n := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		w.WriteHeader(200)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	runner := repair.NewRunner()
+	runner.URL = mockServer.URL + "/repairs/%s/%s"
+
+	_, err := runner.Fetch("canonical", "2")
+	c.Assert(err, Equals, io.ErrUnexpectedEOF)
+	c.Assert(n, Equals, 5)
+}
+
+func (r *repairSuite) TestFetchBroken(c *C) {
+	restore := repair.MockFetchRetryStrategy(testRetryStrategy)
+	defer restore()
+
+	n := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		w.WriteHeader(200)
+		io.WriteString(w, "xyz:")
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	runner := repair.NewRunner()
+	runner.URL = mockServer.URL + "/repairs/%s/%s"
+
+	_, err := runner.Fetch("canonical", "2")
+	c.Assert(err, Equals, io.ErrUnexpectedEOF)
+	c.Assert(n, Equals, 5)
+}
+
+func (r *repairSuite) TestFetchNotFound(c *C) {
+	restore := repair.MockFetchRetryStrategy(testRetryStrategy)
+	defer restore()
+
+	n := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		w.WriteHeader(404)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	runner := repair.NewRunner()
+	runner.URL = mockServer.URL + "/repairs/%s/%s"
+
+	_, err := runner.Fetch("canonical", "2")
+	c.Assert(err, Equals, repair.ErrRepairNotFound)
+	c.Assert(n, Equals, 1)
+}
+
+func (r *repairSuite) TestFetchIdMismatch(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
+		io.WriteString(w, testRepair)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	runner := repair.NewRunner()
+	runner.URL = mockServer.URL + "/repairs/%s/%s"
+
+	_, err := runner.Fetch("canonical", "4")
+	c.Assert(err, ErrorMatches, `cannot fetch repair, id mismatch canonical/2 != canonical/4`)
+}
+
+func (r *repairSuite) TestFetchWrongFirstType(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
+		c.Check(r.URL.Path, Equals, "/repairs/canonical/2")
+		io.WriteString(w, testKey)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	runner := repair.NewRunner()
+	runner.URL = mockServer.URL + "/repairs/%s/%s"
+
+	_, err := runner.Fetch("canonical", "2")
+	c.Assert(err, ErrorMatches, `cannot fetch repair, unexpected first assertion "account-key"`)
+}
+
+func (r *repairSuite) TestFetchRepairPlusKey(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
+		c.Check(r.URL.Path, Equals, "/repairs/canonical/2")
+		io.WriteString(w, testRepair)
+		io.WriteString(w, "\n")
+		io.WriteString(w, testKey)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	runner := repair.NewRunner()
+	runner.URL = mockServer.URL + "/repairs/%s/%s"
+
+	a, err := runner.Fetch("canonical", "2")
+	c.Assert(err, IsNil)
+	c.Check(a, HasLen, 2)
+	_, ok := a[0].(*asserts.Repair)
+	c.Check(ok, Equals, true)
+	_, ok = a[1].(*asserts.AccountKey)
+	c.Check(ok, Equals, true)
+}

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -68,6 +69,14 @@ AXNpZw==
 `
 )
 
+func MustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
 func (r *repairSuite) TestFetchJustRepair(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
@@ -79,7 +88,7 @@ func (r *repairSuite) TestFetchJustRepair(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.URL = mockServer.URL + "/repairs/%s/%s"
+	runner.BaseURL = MustParseURL(mockServer.URL)
 
 	a, err := runner.Fetch("canonical", "2")
 	c.Assert(err, IsNil)
@@ -111,7 +120,7 @@ func (r *repairSuite) TestFetch500(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.URL = mockServer.URL + "/repairs/%s/%s"
+	runner.BaseURL = MustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, ErrorMatches, "cannot fetch repair, unexpected status 500")
@@ -132,7 +141,7 @@ func (r *repairSuite) TestFetchEmpty(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.URL = mockServer.URL + "/repairs/%s/%s"
+	runner.BaseURL = MustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, Equals, io.ErrUnexpectedEOF)
@@ -154,7 +163,7 @@ func (r *repairSuite) TestFetchBroken(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.URL = mockServer.URL + "/repairs/%s/%s"
+	runner.BaseURL = MustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, Equals, io.ErrUnexpectedEOF)
@@ -175,7 +184,7 @@ func (r *repairSuite) TestFetchNotFound(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.URL = mockServer.URL + "/repairs/%s/%s"
+	runner.BaseURL = MustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, Equals, repair.ErrRepairNotFound)
@@ -192,7 +201,7 @@ func (r *repairSuite) TestFetchIdMismatch(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.URL = mockServer.URL + "/repairs/%s/%s"
+	runner.BaseURL = MustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "4")
 	c.Assert(err, ErrorMatches, `cannot fetch repair, id mismatch canonical/2 != canonical/4`)
@@ -209,7 +218,7 @@ func (r *repairSuite) TestFetchWrongFirstType(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.URL = mockServer.URL + "/repairs/%s/%s"
+	runner.BaseURL = MustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, ErrorMatches, `cannot fetch repair, unexpected first assertion "account-key"`)
@@ -228,7 +237,7 @@ func (r *repairSuite) TestFetchRepairPlusKey(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.URL = mockServer.URL + "/repairs/%s/%s"
+	runner.BaseURL = MustParseURL(mockServer.URL)
 
 	a, err := runner.Fetch("canonical", "2")
 	c.Assert(err, IsNil)

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -73,7 +73,7 @@ AXNpZw==
 {"architectures":["amd64","arm64"],"authority-id":"canonical","body-length":"7","brand-id":"canonical","models":["xyz/frobinator"],"repair-id":"2","series":["16"],"sign-key-sha3-384":"KPIl7M4vQ9d4AUjkoU41TGAwtOMLc_bWUCeW8AvdRWD4_xcP60Oo4ABsFNo6BtXj","timestamp":"2017-03-30T12:22:16Z","type":"repair"}}`
 )
 
-func MustParseURL(s string) *url.URL {
+func mustParseURL(s string) *url.URL {
 	u, err := url.Parse(s)
 	if err != nil {
 		panic(err)
@@ -92,7 +92,7 @@ func (r *repairSuite) TestFetchJustRepair(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	a, err := runner.Fetch("canonical", "2")
 	c.Assert(err, IsNil)
@@ -124,7 +124,7 @@ func (r *repairSuite) TestFetch500(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, ErrorMatches, "cannot fetch repair, unexpected status 500")
@@ -145,7 +145,7 @@ func (r *repairSuite) TestFetchEmpty(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, Equals, io.ErrUnexpectedEOF)
@@ -167,7 +167,7 @@ func (r *repairSuite) TestFetchBroken(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, Equals, io.ErrUnexpectedEOF)
@@ -188,7 +188,7 @@ func (r *repairSuite) TestFetchNotFound(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, Equals, repair.ErrRepairNotFound)
@@ -205,7 +205,7 @@ func (r *repairSuite) TestFetchIdMismatch(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "4")
 	c.Assert(err, ErrorMatches, `cannot fetch repair, id mismatch canonical/2 != canonical/4`)
@@ -222,7 +222,7 @@ func (r *repairSuite) TestFetchWrongFirstType(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Fetch("canonical", "2")
 	c.Assert(err, ErrorMatches, `cannot fetch repair, unexpected first assertion "account-key"`)
@@ -241,7 +241,7 @@ func (r *repairSuite) TestFetchRepairPlusKey(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	a, err := runner.Fetch("canonical", "2")
 	c.Assert(err, IsNil)
@@ -263,7 +263,7 @@ func (r *repairSuite) TestPeek(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	h, err := runner.Peek("canonical", "2")
 	c.Assert(err, IsNil)
@@ -286,7 +286,7 @@ func (r *repairSuite) TestPeek500(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Peek("canonical", "2")
 	c.Assert(err, ErrorMatches, "cannot peek repair headers, unexpected status 500")
@@ -308,7 +308,7 @@ func (r *repairSuite) TestPeekInvalid(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Peek("canonical", "2")
 	c.Assert(err, Equals, io.ErrUnexpectedEOF)
@@ -326,7 +326,7 @@ func (r *repairSuite) TestPeekNotFound(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Peek("canonical", "2")
 	c.Assert(err, Equals, repair.ErrRepairNotFound)
@@ -343,7 +343,7 @@ func (r *repairSuite) TestPeekIdMismatch(c *C) {
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
-	runner.BaseURL = MustParseURL(mockServer.URL)
+	runner.BaseURL = mustParseURL(mockServer.URL)
 
 	_, err := runner.Peek("canonical", "4")
 	c.Assert(err, ErrorMatches, `cannot peek repair headers, id mismatch canonical/2 != canonical/4`)


### PR DESCRIPTION
left TODO for later branches: 
 * use a time for TLS cert checks with a lower bound
 * wrapping logic to decide when to fallback to HTTP