### PR TITLE
store: talk to api.snapcraft.io for assertions

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -289,11 +289,7 @@ func assertsURL() string {
 	if u := os.Getenv("SNAPPY_FORCE_SAS_URL"); u != "" {
 		return u
 	}
-	if useStaging() {
-		return "https://assertions.staging.ubuntu.com/v1/"
-	}
-
-	return "https://assertions.ubuntu.com/v1/"
+	return apiURL() + "api/v1/snaps/"
 }
 
 func myappsURL() string {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3665,7 +3665,7 @@ func (t *remoteRepoTestSuite) TestMyAppsURLDependsOnEnviron(c *C) {
 func (t *remoteRepoTestSuite) TestDefaultConfig(c *C) {
 	c.Check(strings.HasPrefix(defaultConfig.SearchURI.String(), "https://api.snapcraft.io/api/v1/snaps/search"), Equals, true)
 	c.Check(strings.HasPrefix(defaultConfig.BulkURI.String(), "https://api.snapcraft.io/api/v1/snaps/metadata"), Equals, true)
-	c.Check(defaultConfig.AssertionsURI.String(), Equals, "https://assertions.ubuntu.com/v1/assertions/")
+	c.Check(defaultConfig.AssertionsURI.String(), Equals, "https://api.snapcraft.io/api/v1/snaps/assertions/")
 }
 
 func (t *remoteRepoTestSuite) TestNew(c *C) {

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -98,7 +98,7 @@ func NewStore(topDir, addr string, assertFallback bool) *Store {
 	mux.HandleFunc("/api/v1/snaps/details/", store.detailsEndpoint)
 	mux.HandleFunc("/api/v1/snaps/metadata", store.bulkEndpoint)
 	mux.Handle("/download/", http.StripPrefix("/download/", http.FileServer(http.Dir(topDir))))
-	mux.HandleFunc("/assertions/", store.assertionsEndpoint)
+	mux.HandleFunc("/api/v1/snaps/assertions/", store.assertionsEndpoint)
 
 	return store
 }
@@ -495,7 +495,7 @@ func (s *Store) retrieveAssertion(bs asserts.Backstore, assertType *asserts.Asse
 }
 
 func (s *Store) assertionsEndpoint(w http.ResponseWriter, req *http.Request) {
-	assertPath := strings.TrimPrefix(req.URL.Path, "/assertions/")
+	assertPath := strings.TrimPrefix(req.URL.Path, "/api/v1/snaps/assertions/")
 
 	bs, err := s.collectAssertions()
 	if err != nil {

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -345,7 +345,7 @@ AXNpZw=`
 
 func (s *storeTestSuite) TestAssertionsEndpointPreloaded(c *C) {
 	// something preloaded
-	resp, err := s.StoreGet(`/assertions/account/testrootorg`)
+	resp, err := s.StoreGet(`/api/v1/snaps/assertions/account/testrootorg`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -366,7 +366,7 @@ func (s *storeTestSuite) TestAssertionsEndpointFromAssertsDir(c *C) {
 	err = ioutil.WriteFile(filepath.Join(s.store.assertDir, "foo_36.snap-revision"), []byte(exampleSnapRev), 0655)
 	c.Assert(err, IsNil)
 
-	resp, err := s.StoreGet(`/assertions/snap-revision/` + rev.SnapSHA3_384())
+	resp, err := s.StoreGet(`/api/v1/snaps/assertions/snap-revision/` + rev.SnapSHA3_384())
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -378,7 +378,7 @@ func (s *storeTestSuite) TestAssertionsEndpointFromAssertsDir(c *C) {
 
 func (s *storeTestSuite) TestAssertionsEndpointNotFound(c *C) {
 	// something not found
-	resp, err := s.StoreGet(`/assertions/account/not-an-account-id`)
+	resp, err := s.StoreGet(`/api/v1/snaps/assertions/account/not-an-account-id`)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -49,7 +49,7 @@ setup_fake_store(){
     systemd_create_and_start_unit fakestore "$(which fakestore) -start -dir $top_dir -addr localhost:11028 -https-proxy=${https_proxy} -http-proxy=${http_proxy} -assert-fallback" "SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
 
     echo "And snapd is configured to use the controlled store"
-    _configure_store_backends "SNAPPY_FORCE_API_URL=http://localhost:11028" "SNAPPY_FORCE_SAS_URL=http://localhost:11028 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
+    _configure_store_backends "SNAPPY_FORCE_API_URL=http://localhost:11028" "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
 }
 
 teardown_fake_store(){

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -36,7 +36,7 @@ execute: |
     cp $TESTSLIB/assertions/developer1.account $STORE_DIR/asserts
     cp $TESTSLIB/assertions/developer1.account-key $STORE_DIR/asserts
     # have snap use the fakestore for assertions
-    export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
+    export SNAPPY_FORCE_API_URL=http://$STORE_ADDR
 
     echo Running prepare-image
     su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --extra-snaps snapweb $TESTSLIB/assertions/developer1-pc.model $ROOT" test


### PR DESCRIPTION
api.snapcraft.io now has a proxy endpoint for the assertions query
needed by snapd, so we can use that to reduce the number of configured
store hostnames.

SNAPPY_FORCE_SAS_URL still exists separately, because I expect it to be
useful for developers working on assertions to be able to point snapd at
a separate snap-assertions-service deployment without having to set up a
snapdevicegw instance as well.