### PR TITLE
store: orders API now checks if customer is ready

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1666,7 +1666,7 @@ type storeErrors struct {
 	Errors []*storeError `json:"error_list"`
 }
 
-func (s *storeErrors) ErrorCode() string {
+func (s *storeErrors) Code() string {
 	if len(s.Errors) == 0 {
 		return ""
 	}
@@ -1741,7 +1741,7 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 		return buyOptionError(fmt.Sprintf("bad request: %v", errorInfo.Error()))
 	case 403:
 		// Customer account not set up for purchases.
-		switch errorInfo.ErrorCode() {
+		switch errorInfo.Code() {
 		case "no-payment-methods":
 			return nil, ErrNoPaymentMethods
 		case "tos-not-accepted":

--- a/store/store.go
+++ b/store/store.go
@@ -1666,11 +1666,18 @@ type storeErrors struct {
 	Errors []*storeError `json:"error_list"`
 }
 
+func (s *storeErrors) ErrorCode() string {
+	if len(s.Errors) == 0 {
+		return ""
+	}
+	return s.Errors[0].Code
+}
+
 func (s *storeErrors) Error() string {
 	if len(s.Errors) == 0 {
 		return "internal error: empty store error used as an actual error"
 	}
-	return "store reported an error: " + s.Errors[0].Error()
+	return s.Errors[0].Error()
 }
 
 func buyOptionError(message string) (*BuyResult, error) {
@@ -1691,12 +1698,6 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 	}
 	if user == nil {
 		return nil, ErrUnauthenticated
-	}
-
-	// FIXME Would really rather not to do this, and have the same meaningful errors from the POST to order.
-	err := s.ReadyToBuy(user)
-	if err != nil {
-		return nil, err
 	}
 
 	instruction := orderInstruction{
@@ -1738,9 +1739,18 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 	case 400:
 		// Invalid price was specified, etc.
 		return buyOptionError(fmt.Sprintf("bad request: %v", errorInfo.Error()))
+	case 403:
+		// Customer account not set up for purchases.
+		switch errorInfo.ErrorCode() {
+		case "no-payment-methods":
+			return nil, ErrNoPaymentMethods
+		case "tos-not-accepted":
+			return nil, ErrTOSNotAccepted
+		}
+		return buyOptionError(fmt.Sprintf("permission denied: %v", errorInfo.Error()))
 	case 404:
-		// Likely because snap ID doesn't exist.
-		return buyOptionError("server says not found (snap got removed?)")
+		// Likely because customer account or snap ID doesn't exist.
+		return buyOptionError(fmt.Sprintf("server says not found: %v", errorInfo.Error()))
 	case 402: // Payment Required
 		// Payment failed for some reason.
 		return nil, ErrPaymentDeclined

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -4155,7 +4155,7 @@ var buyTests = []struct {
 		buyErrorCode:      "invalid-field",
 		buyErrorMessage:   "invalid price specified",
 		price:             5.99,
-		expectedError:     "cannot buy snap: bad request: store reported an error: invalid price specified",
+		expectedError:     "cannot buy snap: bad request: invalid price specified",
 	},
 	{
 		// failure due to unknown snap ID
@@ -4163,11 +4163,11 @@ var buyTests = []struct {
 		expectedInput:     `{"snap_id":"invalid snap ID","amount":"0.99","currency":"EUR"}`,
 		buyStatus:         404,
 		buyErrorCode:      "not-found",
-		buyErrorMessage:   "Not found",
+		buyErrorMessage:   "Snap package not found",
 		snapID:            "invalid snap ID",
 		price:             0.99,
 		currency:          "EUR",
-		expectedError:     "cannot buy snap: server says not found (snap got removed?)",
+		expectedError:     "cannot buy snap: server says not found: Snap package not found",
 	},
 	{
 		// failure due to "Purchase failed"
@@ -4177,6 +4177,24 @@ var buyTests = []struct {
 		buyErrorCode:      "request-failed",
 		buyErrorMessage:   "Purchase failed",
 		expectedError:     "payment declined",
+	},
+	{
+		// failure due to no payment methods
+		suggestedCurrency: "USD",
+		expectedInput:     `{"snap_id":"` + helloWorldSnapID + `","amount":"1.23","currency":"USD"}`,
+		buyStatus:         403,
+		buyErrorCode:      "no-payment-methods",
+		buyErrorMessage:   "No payment methods associated with your account.",
+		expectedError:     "no payment methods",
+	},
+	{
+		// failure due to terms of service not accepted
+		suggestedCurrency: "USD",
+		expectedInput:     `{"snap_id":"` + helloWorldSnapID + `","amount":"1.23","currency":"USD"}`,
+		buyStatus:         403,
+		buyErrorCode:      "tos-not-accepted",
+		buyErrorMessage:   "You must accept the latest terms of service first.",
+		expectedError:     "terms of service not accepted",
 	},
 }
 
@@ -4490,7 +4508,7 @@ var readyToBuyTests = []struct {
 		},
 		Test: func(c *C, err error) {
 			c.Assert(err, NotNil)
-			c.Check(err.Error(), Equals, `store reported an error: message 1`)
+			c.Check(err.Error(), Equals, `message 1`)
 		},
 		NumOfCalls: 5,
 	},


### PR DESCRIPTION
The store's orders endpoint now checks that the customer exists, has a
payment method, and has accepted the terms of service, so `store.Buy` no
longer needs to make a separate request to confirm this.

I removed "store reported an error: " from `storeErrors.Error`, because
"cannot buy snap: server says not found: store reported an error: Snap
package not found" was getting a bit excessive.