### PR TITLE
wrappers: add SyslogIdentifier to the service unit files.

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -199,6 +199,7 @@ X-Snappy=yes
 
 [Service]
 ExecStart={{.App.LauncherCommand}}
+SyslogIdentifier={{.App.Snap.Name}}.{{.App.Name}}
 Restart={{.Restart}}
 WorkingDirectory={{.App.Snap.DataDir}}
 {{if .App.StopCommand}}ExecStop={{.App.LauncherStopCommand}}{{end}}

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -48,6 +48,7 @@ X-Snappy=yes
 
 [Service]
 ExecStart=/usr/bin/snap run snap.app
+SyslogIdentifier=snap.app
 Restart=%s
 WorkingDirectory=/var/snap/snap/44
 ExecStop=/usr/bin/snap run --command=stop snap.app
@@ -81,6 +82,7 @@ X-Snappy=yes
 
 [Service]
 ExecStart=/usr/bin/snap run xkcd-webserver
+SyslogIdentifier=xkcd-webserver.xkcd-webserver
 Restart=on-failure
 WorkingDirectory=/var/snap/xkcd-webserver/44
 ExecStop=/usr/bin/snap run --command=stop xkcd-webserver


### PR DESCRIPTION
This way a syslog entry for snap logs will list the snap app, not the
executable (which is always “snap”).