### PR TITLE
tests: fix snapd-notify when it takes more time to restart

### DIFF
--- a/tests/main/snapd-notify/task.yaml
+++ b/tests/main/snapd-notify/task.yaml
@@ -1,5 +1,13 @@
 summary: Ensure snapd notify feature is working
 
 execute: |
-    systemctl status snapd.service | MATCH "Active: active"
-    journalctl -u snapd | MATCH "activation done in"
+    for _ in $(seq 5); do
+      if systemctl status snapd.service | MATCH "Active: active"; then
+          journalctl -u snapd | MATCH "activation done in"
+          exit
+      fi
+      sleep 1
+    done
+
+    echo "Snapd service status not active"
+    exit 1


### PR DESCRIPTION
This change is to fix the error that happens when the snapd service takes about
3 seconds to start. The idea is to retry during 5 seconds to deal with
those scenarios.

ERROR:
https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac
/autopkgtest-xenial-snappy-dev-
image/xenial/ppc64el/s/snapd/20170621_210428_ee428@/log.gz