### PR TITLE
snap-confine: ensure snap-confine waits some seconds for seccomp security profilese

### DIFF
--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -73,7 +73,7 @@ execute: |
     # from the old test_noprofile
     rm -f ${PROFILE}.bin
     echo "Ensure the code cannot not run due to missing filter"
-    if test-snapd-tools.echo hello; then
+    if SNAP_CONFINE_MAX_PROFILE_WAIT=3 test-snapd-tools.echo hello; then
         echo "filtering broken: program should have failed to run"
         exit 1
     fi
@@ -111,4 +111,11 @@ execute: |
         exit 1
     fi
 
-    
+    echo "Ensure snap-confine waits for security profiles to appear"
+    rm -f ${PROFILE}.bin
+    cat >"${PROFILE}.src" <<EOF
+    @unrestricted
+    EOF
+    ( (sleep 3; $SNAP_SECCOMP compile ${PROFILE}.src ${PROFILE}.bin) &)
+    echo "Ensure the code still runs"
+    test-snapd-tools.echo hello | MATCH hello


### PR DESCRIPTION
On a refresh from the old snapd (pre-seccomp-bpf) to the new snapd
that uses the /var/lib/snapd/seccomp/bpf/*.bin code there is a race
condition on startup. When snapd starts it will create the new
security profiles. However all snap services (daemons) start in
parallel with snapd. So when a snap service like e.g. network-manager
runs it may not have a security profile yet. To fix this, snap-confine
will wait up to 120s for the security profiles to appear.