### PR TITLE
cmd/snap-confine: various small fixes and tweaks to seccomp support code

### DIFF
--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -75,7 +75,7 @@ static void validate_bpfpath_is_safe(const char *path)
 	// '/'
 	size_t checked_path_size = strlen(path) + 1;
 	char *checked_path __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
-	checked_path = malloc(checked_path_size);
+	checked_path = calloc(checked_path_size, 1);
 	if (checked_path == NULL) {
 		die("cannot allocate memory for checked_path");
 	}

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -128,7 +128,13 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	int max_wait = 120;
 	const char *MAX_PROFILE_WAIT = getenv("SNAP_CONFINE_MAX_PROFILE_WAIT");
 	if (MAX_PROFILE_WAIT != NULL) {
-		int env_max_wait = atoi(MAX_PROFILE_WAIT);
+		char *endptr = NULL;
+		errno = 0;
+		long env_max_wait = strtol(MAX_PROFILE_WAIT, &endptr, 10);
+		if (errno != 0 || MAX_PROFILE_WAIT == endptr || *endptr != '\0'
+		    || env_max_wait <= 0) {
+			die("SNAP_CONFINE_MAX_PROFILE_WAIT invalid");
+		}
 		max_wait = env_max_wait > 0 ? env_max_wait : max_wait;
 	}
 	for (int i = 0; i < max_wait; ++i) {

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -19,6 +19,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/prctl.h>
@@ -105,7 +106,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 {
 	debug("loading bpf program for security tag %s", filter_profile);
 
-	char profile_path[512];	// arbitrary path name limit
+	char profile_path[PATH_MAX];
 	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin",
 			 filter_profile_dir, filter_profile);
 

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -120,9 +120,8 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 		int env_max_wait = atoi(MAX_PROFILE_WAIT);
 		max_wait = env_max_wait > 0 ? env_max_wait : max_wait;
 	}
-	struct stat buf;
-	for (int i = 0; i < max_wait; i++) {
-		if (stat(profile_path, &buf) == 0) {
+	for (int i = 0; i < max_wait; ++i) {
+		if (access(profile_path, F_OK) == 0) {
 			break;
 		}
 		sleep(1);

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -73,7 +73,7 @@ static void validate_bpfpath_is_safe(const char *path)
 	}
 	// allocate a string large enough to hold path, and initialize it to
 	// '/'
-	size_t checked_path_size = sizeof(char) * strlen(path) + 1;
+	size_t checked_path_size = strlen(path) + 1;
 	char *checked_path __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
 	checked_path = malloc(checked_path_size);
 	if (checked_path == NULL) {

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -77,7 +77,7 @@ static void validate_bpfpath_is_safe(const char *path)
 	char *checked_path __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
 	checked_path = malloc(checked_path_size);
 	if (checked_path == NULL) {
-		die("Out of memory creating checked_path");
+		die("cannot allocate memory for checked_path");
 	}
 
 	checked_path[0] = '/';

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -153,16 +153,17 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	// set 'size' to 1 to get bytes transferred
 	size_t num_read = fread(bpf, 1, sizeof(bpf), fp);
 	if (ferror(fp) != 0) {
-		die("cannot fread() %s", profile_path);
+		die("cannot read seccomp profile %s", profile_path);
 	} else if (feof(fp) == 0) {
-		die("profile %s exceeds %zu bytes", profile_path, sizeof(bpf));
+		die("seccomp profile %s exceeds %zu bytes", profile_path,
+		    sizeof(bpf));
 	}
 	fclose(fp);
 	debug("read %zu bytes from %s", num_read, profile_path);
 
 	uid_t real_uid, effective_uid, saved_uid;
-	if (getresuid(&real_uid, &effective_uid, &saved_uid) != 0) {
-		die("could not find user IDs");
+	if (getresuid(&real_uid, &effective_uid, &saved_uid) < 0) {
+		die("cannot call getresuid");
 	}
 	// If we can, raise privileges so that we can load the BPF into the
 	// kernel via 'prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, ...)'.

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -115,10 +115,11 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	// snapd so for such snaps, the profiles may not be generated
 	// yet
 	int max_wait = 120;
-	if (getenv("SNAP_CONFINE_MAX_PROFILE_WAIT") != 0)
-		if (atoi(getenv("SNAP_CONFINE_MAX_PROFILE_WAIT")) > 0)
-			max_wait =
-			    atoi(getenv("SNAP_CONFINE_MAX_PROFILE_WAIT"));
+	const char *MAX_PROFILE_WAIT = getenv("SNAP_CONFINE_MAX_PROFILE_WAIT");
+	if (MAX_PROFILE_WAIT != NULL) {
+		int env_max_wait = atoi(MAX_PROFILE_WAIT);
+		max_wait = env_max_wait > 0 ? env_max_wait : max_wait;
+	}
 	struct stat buf;
 	for (int i = 0; i < max_wait; i++) {
 		if (stat(profile_path, &buf) == 0) {

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -34,7 +34,7 @@
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 
-static char *filter_profile_dir = "/var/lib/snapd/seccomp/bpf/";
+static const char *filter_profile_dir = "/var/lib/snapd/seccomp/bpf/";
 
 // MAX_BPF_SIZE is an arbitrary limit.
 const int MAX_BPF_SIZE = 32 * 1024;

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -66,6 +66,9 @@ static void validate_bpfpath_is_safe(const char *path)
 	}
 	// strtok_r() modifies its first argument, so work on a copy
 	char *tokenized = strdup(path);
+	if (tokenized == NULL) {
+		die("cannot allocate memory for copy of path");
+	}
 
 	// allocate a string large enough to hold path, and initialize it to
 	// '/'
@@ -89,6 +92,9 @@ static void validate_bpfpath_is_safe(const char *path)
 	char *buf_token = strtok_r(tokenized, "/", &buf_saveptr);
 	while (buf_token != NULL) {
 		char *prev = strdup(checked_path);	// needed by vsnprintf in sc_must_snprintf
+		if (prev == NULL) {
+			die("cannot allocate memory for copy of checked_path");
+		}
 		// append '<buf_token>' if checked_path is '/', otherwise '/<buf_token>'
 		if (strlen(checked_path) == 1) {
 			sc_must_snprintf(checked_path, checked_path_size,

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -190,9 +190,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 		.filter = (struct sock_filter *)bpf,
 	};
 	if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog)) {
-		perror
-		    ("prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, ...) failed");
-		die("aborting");
+		die("cannot apply seccomp profile");
 	}
 	// drop privileges again
 	debug("dropping privileges after loading seccomp profile");

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -188,7 +188,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 		.len = num_read / sizeof(struct sock_filter),
 		.filter = (struct sock_filter *)bpf,
 	};
-	if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog)) {
+	if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog) != 0) {
 		die("cannot apply seccomp profile");
 	}
 	// drop privileges again

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -125,7 +125,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	// a service snap (e.g. network-manager) starts in parallel with
 	// snapd so for such snaps, the profiles may not be generated
 	// yet
-	int max_wait = 120;
+	long max_wait = 120;
 	const char *MAX_PROFILE_WAIT = getenv("SNAP_CONFINE_MAX_PROFILE_WAIT");
 	if (MAX_PROFILE_WAIT != NULL) {
 		char *endptr = NULL;
@@ -137,7 +137,10 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 		}
 		max_wait = env_max_wait > 0 ? env_max_wait : max_wait;
 	}
-	for (int i = 0; i < max_wait; ++i) {
+	if (max_wait > 3600) {
+		max_wait = 3600;
+	}
+	for (long i = 0; i < max_wait; ++i) {
 		if (access(profile_path, F_OK) == 0) {
 			break;
 		}

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -84,7 +84,7 @@ execute: |
         echo "test-snapd-tools.echo should fail with invalid seccomp profile"
         exit 1
     fi
-    echo $output | MATCH "prctl.*Invalid argument"
+    echo $output | MATCH "cannot apply seccomp profile: Invalid argument"
 
     echo "Add huge snapd.test-snapd-tools.bin to ensure size limit works"
     dd if=/dev/zero of=${PROFILE}.bin count=50 bs=1M


### PR DESCRIPTION
This branch is a result of top-to-bottom read and tweak of seccomp support code.
There are several fixes for missing NULL checks, simplifications to memory management,
consistency tweaks for error messages, for error checks and for const correctness.