### PR TITLE
arch: the kernel architecutre name is armv7l instead of armv7

### DIFF
--- a/arch/arch.go
+++ b/arch/arch.go
@@ -110,7 +110,7 @@ func ubuntuArchFromKernelArch(utsMachine string) string {
 		// kernel  ubuntu
 		"i686":    "i386",
 		"x86_64":  "amd64",
-		"armv7":   "armhf",
+		"armv7l":  "armhf",
 		"aarch64": "arm64",
 		"ppc64le": "ppc64el",
 		"s390x":   "s390x",


### PR DESCRIPTION
We currently have build failures in the PPA because the arm kernel name is armv7l instead of armv7.