### PR TITLE
tests: fix for create-key task to avoid rng-tools service ramains alive

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -223,7 +223,8 @@ EOF
         cat <<EOF > /etc/systemd/system/rng-tools.service.d/local.conf
 [Service]
 Restart=always
-RestartSec=5
+RestartSec=2
+RemainAfterExit=no
 EOF
         systemctl daemon-reload
     fi


### PR DESCRIPTION
The idea of this fix is to stop the rng-tools service once the forked
rng-tools process is dead. It will prevent the service keep running and
the restart is not done.