### PR TITLE
Use RFC3339 time format for refresh times.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -378,8 +378,8 @@ type OSRelease struct {
 
 type RefreshInfo struct {
 	Schedule string `json:"schedule"`
-	Last     string `json:"last"`
-	Next     string `json:"next"`
+	Last     string `json:"last,omitempty"`
+	Next     string `json:"next,omitempty"`
 }
 
 // SysInfo holds system information

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -645,8 +645,16 @@ func (x *cmdRefresh) showRefreshTimes() error {
 	}
 
 	fmt.Fprintf(Stdout, "schedule: %s\n", sysinfo.Refresh.Schedule)
-	fmt.Fprintf(Stdout, "last: %s\n", sysinfo.Refresh.Last)
-	fmt.Fprintf(Stdout, "next: %s\n", sysinfo.Refresh.Next)
+	if sysinfo.Refresh.Last != "" {
+		fmt.Fprintf(Stdout, "last: %s\n", sysinfo.Refresh.Last)
+	} else {
+		fmt.Fprintf(Stdout, "last: n/a\n")
+	}
+	if sysinfo.Refresh.Next != "" {
+		fmt.Fprintf(Stdout, "next: %s\n", sysinfo.Refresh.Next)
+	} else {
+		fmt.Fprintf(Stdout, "next: n/a\n")
+	}
 	return nil
 }
 

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -545,7 +545,7 @@ func (s *SnapSuite) TestRefreshTime(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/system-info")
-			fmt.Fprintln(w, `{"type": "sync", "status-code": 200, "result": {"refresh": {"schedule": "00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59", "last": "2017-04-25 17:35:00 +0200 CEST", "next": "2017-04-26 00:58:00 +0200 CEST"}}}`)
+			fmt.Fprintln(w, `{"type": "sync", "status-code": 200, "result": {"refresh": {"schedule": "00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59", "last": "2017-04-25T17:35:00+0200", "next": "2017-04-26T00:58:00+0200"}}}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -556,8 +556,8 @@ func (s *SnapSuite) TestRefreshTime(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `schedule: 00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59
-last: 2017-04-25 17:35:00 +0200 CEST
-next: 2017-04-26 00:58:00 +0200 CEST
+last: 2017-04-25T17:35:00+0200
+next: 2017-04-26T00:58:00+0200
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -261,10 +261,10 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 			"snap-mount-dir": dirs.SnapMountDir,
 			"snap-bin-dir":   dirs.SnapBinariesDir,
 		},
-		"refresh": map[string]interface{}{
-			"schedule": refreshScheduleStr,
-			"last":     formatRefreshTime(lastRefresh),
-			"next":     formatRefreshTime(nextRefresh),
+		"refresh": client.RefreshInfo{
+			Schedule: refreshScheduleStr,
+			Last:     formatRefreshTime(lastRefresh),
+			Next:     formatRefreshTime(nextRefresh),
 		},
 	}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -232,9 +232,9 @@ func tbd(c *Command, r *http.Request, user *auth.UserState) Response {
 
 func formatRefreshTime(t time.Time) string {
 	if t.IsZero() {
-		return "n/a"
+		return ""
 	}
-	return fmt.Sprintf("%s", t.Truncate(time.Minute))
+	return fmt.Sprintf("%s", t.Truncate(time.Minute).Format(time.RFC3339))
 }
 
 func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -586,8 +586,6 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 		},
 		"refresh": map[string]interface{}{
 			"schedule": "",
-			"last":     "",
-			"next":     "",
 		},
 	}
 	var rsp resp

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -586,8 +586,8 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 		},
 		"refresh": map[string]interface{}{
 			"schedule": "",
-			"last":     "n/a",
-			"next":     "n/a",
+			"last":     "",
+			"next":     "",
 		},
 	}
 	var rsp resp


### PR DESCRIPTION
Use a consistent time format matching the existing code.
Also return "" for empty times and convert to "n/a" in the client.