### PR TITLE
tests: extend find-private test to cover more cases

### DIFF
--- a/tests/main/find-private/task.yaml
+++ b/tests/main/find-private/task.yaml
@@ -28,6 +28,21 @@ execute: |
         echo "And the user has logged in"
         expect -f successful_login.exp
 
-        echo "Then a private snap belonging to that user shows up in the find results"
-        snap find test-snapd-private --private | MATCH "test-snapd-private +[0-9]+\.[0-9]+"
+        echo "Then a private snap belonging to that user shows up in the find results and nothing else"
+        result=$(snap find test-snapd-private2 --private)
+        echo "$result" | MATCH "test-snapd-private2 +[0-9]+\.[0-9]+"
+        echo "$result" | MATCH -v "test-snapd-private +[0-9]+\.[0-9]+"
+        echo "$result" | MATCH -v "test-snapd-public +[0-9]+\.[0-9]+"
+
+        echo "And searching for private snaps shows all of them and anything else"
+        result=$(snap find --private)
+        echo "$result" | MATCH "test-snapd-private2 +[0-9]+\.[0-9]+"
+        echo "$result" | MATCH "test-snapd-private +[0-9]+\.[0-9]+"
+        echo "$result" | MATCH -v "test-snapd-public +[0-9]+\.[0-9]+"
+
+        echo "And searching for public snaps does not show private ones"
+        result=$(snap find test-snapd)
+        echo "$result" | MATCH -v "test-snapd-private2 +[0-9]+\.[0-9]+"
+        echo "$result" | MATCH -v "test-snapd-private +[0-9]+\.[0-9]+"
+        echo "$result" | MATCH "test-snapd-public +[0-9]+\.[0-9]+"
     fi


### PR DESCRIPTION
There are additional cases not covered by the test which are behaving wrongly, for instance when searching for all the private snaps, public and private snaps are shown together. These changes make sure that each search returns the right results. 