### PR TITLE
tests: shellcheck improvements for tests/main tasks - first set of tests

### DIFF
--- a/tests/main/abort/task.yaml
+++ b/tests/main/abort/task.yaml
@@ -4,7 +4,7 @@ environment:
     SNAP_NAME: test-snapd-tools
 
 execute: |
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB/dirs.sh"
 
     echo "Abort with invalid id"
     if snap abort 10000000; then
@@ -16,27 +16,27 @@ execute: |
 
     echo "Abort with valid id - error"
     subdirPath="$SNAPMOUNTDIR/$SNAP_NAME/current/foo"
-    mkdir -p $subdirPath
-    . $TESTSLIB/snaps.sh
-    if install_local $SNAP_NAME; then
+    mkdir -p "$subdirPath"
+    . "$TESTSLIB/snaps.sh"
+    if install_local "$SNAP_NAME"; then
         echo "install should fail when the target directory exists"
         exit 1
     fi
     idPattern="\d+(?= +Error.*?Install \"$SNAP_NAME\" snap)"
-    id=$(echo "$(snap changes)" | grep -Pzo "$idPattern")
-    if snap abort $id; then
+    id=$(snap changes | grep -Pzo "$idPattern")
+    if snap abort "$id"; then
         echo "abort with valid failed id should fail"
         exit 1
     fi
-    rm -rf $subdirPath
+    rm -rf "$subdirPath"
 
     echo "===================================="
 
     echo "Abort with valid id - done"
-    install_local $SNAP_NAME
+    install_local "$SNAP_NAME"
     idPattern="\d+(?= +Done.*?Install \"$SNAP_NAME\" snap)"
-    id=$(echo "$(snap changes)" | grep -Pzo "$idPattern")
-    if snap abort $id; then
+    id=$(snap changes | grep -Pzo "$idPattern")
+    if snap abort "$id"; then
         echo "abort with valid done id should fail"
         exit 1
     fi

--- a/tests/main/ack/task.yaml
+++ b/tests/main/ack/task.yaml
@@ -6,7 +6,7 @@ execute: |
         exit
     fi
     echo "Ack the test store key in case"
-    snap ack $TESTSLIB/assertions/testrootorg-store.account-key
+    snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
 
     ALICE_ID=BGLTY1rcRKQQMbt9B407lDH38lbCW3wg
 

--- a/tests/main/alias/task.yaml
+++ b/tests/main/alias/task.yaml
@@ -1,11 +1,11 @@
 summary: Check snap alias and snap unalias
 
 prepare: |
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB/snaps.sh"
     install_local aliases
 
 execute: |
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB/dirs.sh"
 
     echo "Sanity check"
     aliases.cmd1|MATCH "ok command 1"
@@ -16,8 +16,8 @@ execute: |
     snap alias aliases.cmd2 alias2
 
     echo "Test the aliases"
-    test -h $SNAPMOUNTDIR/bin/alias1
-    test -h $SNAPMOUNTDIR/bin/alias2
+    test -h "$SNAPMOUNTDIR/bin/alias1"
+    test -h "$SNAPMOUNTDIR/bin/alias2"
     alias1|MATCH "ok command 1"
     alias2|MATCH "ok command 2"
 
@@ -30,7 +30,7 @@ execute: |
 
     echo "One still works, one is not there"
     alias1|MATCH "ok command 1"
-    test ! -e $SNAPMOUNTDIR/bin/alias2
+    test ! -e "$SNAPMOUNTDIR/bin/alias2"
     alias2 2>&1|MATCH "alias2: command not found"
 
     echo "Check listing again"
@@ -41,7 +41,7 @@ execute: |
     snap unalias aliases|MATCH ".*- aliases.cmd1 as alias1*"
 
     echo "Alias is gone"
-    test ! -e $SNAPMOUNTDIR/bin/alias1
+    test ! -e "$SNAPMOUNTDIR/bin/alias1"
     alias1 2>&1|MATCH "alias1: command not found"
     ! snap aliases|MATCH "aliases.cmd1 +alias1"
 
@@ -51,5 +51,5 @@ execute: |
 
     echo "Removing the snap should remove the aliases"
     snap remove aliases
-    test ! -e $SNAPMOUNTDIR/bin/alias1
-    test ! -e $SNAPMOUNTDIR/bin/alias2
+    test ! -e "$SNAPMOUNTDIR/bin/alias1"
+    test ! -e "$SNAPMOUNTDIR/bin/alias2"

--- a/tests/main/auto-aliases/task.yaml
+++ b/tests/main/auto-aliases/task.yaml
@@ -1,13 +1,13 @@
 summary: Check auto-aliases mechanism
 execute: |
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB/dirs.sh"
 
     echo "Install the snap with auto-aliases"
     snap install test-snapd-auto-aliases
 
     echo "Test the auto-aliases"
-    test -h $SNAPMOUNTDIR/bin/test_snapd_wellknown1
-    test -h $SNAPMOUNTDIR/bin/test_snapd_wellknown2
+    test -h "$SNAPMOUNTDIR/bin/test_snapd_wellknown1"
+    test -h "$SNAPMOUNTDIR/bin/test_snapd_wellknown2"
     test_snapd_wellknown1|MATCH "ok wellknown 1"
     test_snapd_wellknown2|MATCH "ok wellknown 2"
 
@@ -17,21 +17,21 @@ execute: |
 
     echo "Removing the snap should remove the aliases"
     snap remove test-snapd-auto-aliases
-    test ! -e $SNAPMOUNTDIR/bin/test_snapd_wellknown1
-    test ! -e $SNAPMOUNTDIR/bin/test_snapd_wellknown2
+    test ! -e "$SNAPMOUNTDIR/bin/test_snapd_wellknown1"
+    test ! -e "$SNAPMOUNTDIR/bin/test_snapd_wellknown2"
     ! snap aliases|MATCH "test-snapd-auto-aliases.wellknown1 +test_snapd_wellknown1"
     ! snap aliases|MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2"
 
     echo "Installing the snap with --unaliased doesn't create the aliases"
     snap install --unaliased test-snapd-auto-aliases
-    test ! -e $SNAPMOUNTDIR/bin/test_snapd_wellknown1
-    test ! -e $SNAPMOUNTDIR/bin/test_snapd_wellknown2
+    test ! -e "$SNAPMOUNTDIR/bin/test_snapd_wellknown1"
+    test ! -e "$SNAPMOUNTDIR/bin/test_snapd_wellknown2"
     snap aliases|MATCH "test-snapd-auto-aliases.wellknown1 +test_snapd_wellknown1 +disabled"
     snap aliases|MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2 +disabled"
 
     echo "snap prefer will enable them after the fact"
     snap prefer test-snapd-auto-aliases
-    test -h $SNAPMOUNTDIR/bin/test_snapd_wellknown1
-    test -h $SNAPMOUNTDIR/bin/test_snapd_wellknown2
+    test -h "$SNAPMOUNTDIR/bin/test_snapd_wellknown1"
+    test -h "$SNAPMOUNTDIR/bin/test_snapd_wellknown2"
     snap aliases|MATCH "test-snapd-auto-aliases.wellknown1 +test_snapd_wellknown1 +-"
     snap aliases|MATCH "test-snapd-auto-aliases.wellknown2 +test_snapd_wellknown2 +-"

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -4,14 +4,14 @@ prepare: |
     snap install --devmode jq
 
 restore: |
-    . $TESTSLIB/dirs.sh
-    if [ -e $SNAPMOUNTDIR/core/current/meta/hooks/configure ]; then
+    . "$TESTSLIB/dirs.sh"
+    if [ -e "$SNAPMOUNTDIR/core/current/meta/hooks/configure" ]; then
         snap set core refresh.schedule="$(date +%a --date=2days)@12:00-14:00"
         snap set core refresh.disabled=true
     fi
 
 execute: |
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB/dirs.sh"
 
     echo "Auto refresh information is shown"
     output=$(snap refresh --time)
@@ -22,7 +22,7 @@ execute: |
     echo "Install a snap from stable"
     snap install test-snapd-tools
     snap list | MATCH 'test-snapd-tools +[0-9]+\.[0-9]+'
-    if [ -e $SNAPMOUNTDIR/core/current/meta/hooks/configure ]; then
+    if [ -e "$SNAPMOUNTDIR/core/current/meta/hooks/configure" ]; then
         snap set core refresh.schedule="0:00-23:59"
         snap set core refresh.disabled=false
     fi
@@ -37,7 +37,7 @@ execute: |
     systemctl start snapd.{service,socket}
 
     echo "wait for auto-refresh to happen"
-    for i in $(seq 120); do
+    for _ in $(seq 120); do
         if snap changes|grep -q "Done.*Auto-refresh snap \"test-snapd-tools\""; then
             break
         fi
@@ -50,4 +50,4 @@ execute: |
     snap list|MATCH "test-snapd-tools +[0-9]+\.[0-9]+\+fake1"
 
     echo "Ensure refresh.last is set"
-    jq ".data[\"last-refresh\"]" /var/lib/snapd/state.json | MATCH $(date +%Y)
+    jq ".data[\"last-refresh\"]" /var/lib/snapd/state.json | MATCH "$(date +%Y)"

--- a/tests/main/classic-confinement/task.yaml
+++ b/tests/main/classic-confinement/task.yaml
@@ -4,44 +4,44 @@ environment:
     CLASSIC_SNAP: test-snapd-classic-confinement
 
 prepare: |
-    . $TESTSLIB/snaps.sh
+    . "$TESTSLIB/snaps.sh"
     snapbuild "$TESTSLIB/snaps/$CLASSIC_SNAP/" .
 
 execute: |
     echo "Check that classic snaps work only with --classic"
-    if snap install --dangerous ${CLASSIC_SNAP}_1.0_all.snap; then
+    if snap install --dangerous "${CLASSIC_SNAP}_1.0_all.snap"; then
         echo "snap install needs --classic to install local snaps with classic confinment"
         exit 1
     fi
 
-    if snap install $CLASSIC_SNAP; then
+    if snap install "$CLASSIC_SNAP"; then
         echo "snap install needs --classic to install remote snaps with classic confinment"
         exit 1
     fi
 
     if [[ "$SPREAD_SYSTEM" =~ core ]]; then
         echo "Check that the classic snap is not installable even with --classic"
-        ( snap install --dangerous --classic ${CLASSIC_SNAP}_1.0_all.snap 2>&1 && exit 1 || true ) | MATCH $'cannot install snap file: classic confinement is only supported on classic\n *systems'
+        ( snap install --dangerous --classic "${CLASSIC_SNAP}_1.0_all.snap" 2>&1 && exit 1 || true ) | MATCH $'cannot install snap file: classic confinement is only supported on classic\n *systems'
         echo "Not from the store either"
-        ( snap install --classic $CLASSIC_SNAP 2>&1 && exit 1 || true ) | MATCH "requires classic confinement"
+        ( snap install --classic "$CLASSIC_SNAP" 2>&1 && exit 1 || true ) | MATCH "requires classic confinement"
 
         exit 0
     fi
     echo "Check that the classic snap works (it skips the entire sandbox)"
-    snap install --dangerous --classic ${CLASSIC_SNAP}_1.0_all.snap
+    snap install --dangerous --classic "${CLASSIC_SNAP}_1.0_all.snap"
     touch /tmp/lala
-    $CLASSIC_SNAP | MATCH lala
-    snap remove $CLASSIC_SNAP
+    "$CLASSIC_SNAP" | MATCH lala
+    snap remove "$CLASSIC_SNAP"
 
     echo "Check that we can install classic confinement snaps from the store"
-    snap install --classic $CLASSIC_SNAP
+    snap install --classic "$CLASSIC_SNAP"
     snap list | MATCH "$CLASSIC_SNAP .*1.0 .*classic"
-    snap info  $CLASSIC_SNAP|MATCH "installed:.* 1.0 .*classic"
-    $CLASSIC_SNAP | MATCH lala
+    snap info "$CLASSIC_SNAP"|MATCH "installed:.* 1.0 .*classic"
+    "$CLASSIC_SNAP" | MATCH lala
 
     echo "Snap refresh from the store also works (2.0 is in beta, 1.0 in stable)"
-    snap refresh --beta $CLASSIC_SNAP
+    snap refresh --beta "$CLASSIC_SNAP"
     snap list | MATCH "$CLASSIC_SNAP .*2.0 .*classic"
-    snap info  $CLASSIC_SNAP|MATCH "installed:.* 2.0 .*classic"
-    $CLASSIC_SNAP | MATCH lala
+    snap info "$CLASSIC_SNAP"|MATCH "installed:.* 2.0 .*classic"
+    "$CLASSIC_SNAP" | MATCH lala
 

--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -8,15 +8,15 @@ prepare: |
         echo "This test needs test keys to be trusted"
         exit
     fi
-    . $TESTSLIB/systemd.sh
+    . "$TESTSLIB/systemd.sh"
 
-    snapbuild $TESTSLIB/snaps/classic-gadget .
-    snap download --$CORE_CHANNEL core
+    snapbuild "$TESTSLIB/snaps/classic-gadget" .
+    snap download "--$CORE_CHANNEL" core
 
-    $TESTSLIB/reset.sh --keep-stopped
-    mkdir -p $SEED_DIR/snaps
-    mkdir -p $SEED_DIR/assertions
-    cat > $SEED_DIR/seed.yaml <<EOF
+    "$TESTSLIB/reset.sh" --keep-stopped
+    mkdir -p "$SEED_DIR/snaps"
+    mkdir -p "$SEED_DIR/assertions"
+    cat > "$SEED_DIR/seed.yaml" <<EOF
     snaps:
       - name: core
         channel: $CORE_CHANNEL
@@ -26,15 +26,15 @@ prepare: |
         file: classic-gadget.snap
     EOF
 
-    echo Copy the needed assertions to /var/lib/snapd/
-    cp core_*.assert $SEED_DIR/assertions
-    cp $TESTSLIB/assertions/developer1.account $SEED_DIR/assertions
-    cp $TESTSLIB/assertions/developer1.account-key $SEED_DIR/assertions
-    cp $TESTSLIB/assertions/developer1-my-classic-w-gadget.model $SEED_DIR/assertions
-    cp $TESTSLIB/assertions/testrootorg-store.account-key $SEED_DIR/assertions
-    echo Copy the needed snaps to $SEED_DIR/snaps
-    cp ./core_*.snap $SEED_DIR/snaps/core.snap
-    cp ./classic-gadget_1.0_all.snap $SEED_DIR/snaps/classic-gadget.snap
+    echo "Copy the needed assertions to /var/lib/snapd/"
+    cp core_*.assert "$SEED_DIR/assertions"
+    cp "$TESTSLIB/assertions/developer1.account" "$SEED_DIR/assertions"
+    cp "$TESTSLIB/assertions/developer1.account-key" "$SEED_DIR/assertions"
+    cp "$TESTSLIB/assertions/developer1-my-classic-w-gadget.model" "$SEED_DIR/assertions"
+    cp "$TESTSLIB/assertions/testrootorg-store.account-key" "$SEED_DIR/assertions"
+    echo "Copy the needed snaps to $SEED_DIR/snaps"
+    cp ./core_*.snap "$SEED_DIR/snaps/core.snap"
+    cp ./classic-gadget_1.0_all.snap "$SEED_DIR/snaps/classic-gadget.snap"
     # start fake device svc
     systemd_create_and_start_unit fakedevicesvc "$(which fakedevicesvc) localhost:11029"
 restore: |
@@ -42,13 +42,13 @@ restore: |
         echo "This test needs test keys to be trusted"
         exit
     fi
-    . $TESTSLIB/systemd.sh
+    . "$TESTSLIB/systemd.sh"
     systemctl stop snapd.service snapd.socket
     systemd_stop_and_destroy_unit fakedevicesvc
 
-    rm -r $SEED_DIR
-    rm -f *.snap
-    rm -f *.assert
+    rm -r "$SEED_DIR"
+    rm -f -- *.snap
+    rm -f -- *.assert
     systemctl start snapd.socket snapd.service
 kill-timeout: 3m
 execute: |

--- a/tests/main/classic-firstboot/task.yaml
+++ b/tests/main/classic-firstboot/task.yaml
@@ -8,13 +8,13 @@ prepare: |
         exit
     fi
 
-    snapbuild $TESTSLIB/snaps/basic .
-    snap download --$CORE_CHANNEL core
+    snapbuild "$TESTSLIB/snaps/basic" .
+    snap download "--$CORE_CHANNEL" core
 
-    $TESTSLIB/reset.sh --keep-stopped
-    mkdir -p $SEED_DIR/snaps
-    mkdir -p $SEED_DIR/assertions
-    cat > $SEED_DIR/seed.yaml <<EOF
+    "$TESTSLIB/reset.sh" --keep-stopped
+    mkdir -p "$SEED_DIR/snaps"
+    mkdir -p "$SEED_DIR/assertions"
+    cat > "$SEED_DIR/seed.yaml" <<EOF
     snaps:
       - name: core
         channel: $CORE_CHANNEL
@@ -25,23 +25,23 @@ prepare: |
     EOF
 
     echo Copy the needed assertions to /var/lib/snapd/
-    cp core_*.assert $SEED_DIR/assertions
-    cp $TESTSLIB/assertions/developer1.account $SEED_DIR/assertions
-    cp $TESTSLIB/assertions/developer1.account-key $SEED_DIR/assertions
-    cp $TESTSLIB/assertions/developer1-my-classic.model $SEED_DIR/assertions
-    cp $TESTSLIB/assertions/testrootorg-store.account-key $SEED_DIR/assertions
-    echo Copy the needed snaps to $SEED_DIR/snaps
-    cp ./core_*.snap $SEED_DIR/snaps/core.snap
-    cp ./basic_1.0_all.snap $SEED_DIR/snaps/basic.snap
+    cp core_*.assert "$SEED_DIR/assertions"
+    cp "$TESTSLIB/assertions/developer1.account" "$SEED_DIR/assertions"
+    cp "$TESTSLIB/assertions/developer1.account-key" "$SEED_DIR/assertions"
+    cp "$TESTSLIB/assertions/developer1-my-classic.model" "$SEED_DIR/assertions"
+    cp "$TESTSLIB/assertions/testrootorg-store.account-key" "$SEED_DIR/assertions"
+    echo "Copy the needed snaps to $SEED_DIR/snaps"
+    cp ./core_*.snap "$SEED_DIR/snaps/core.snap"
+    cp ./basic_1.0_all.snap "$SEED_DIR/snaps/basic.snap"
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
     fi
 
-    rm -r $SEED_DIR
-    rm -f *.snap
-    rm -f *.assert
+    rm -r "$SEED_DIR"
+    rm -f -- *.snap
+    rm -f -- *.assert
     systemctl start snapd.socket snapd.service
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -55,7 +55,7 @@ execute: |
     systemctl start snapd.socket snapd.service
 
     echo "Wait for Seed change to be finished"
-    for i in `seq 120`; do
+    for _ in $(seq 120); do
         if snap list 2>/dev/null |grep -q -E "^basic" ; then
             break
         fi
@@ -63,10 +63,10 @@ execute: |
     done
 
     echo "Verifying the imported assertions"
-    if ! snap known model|MATCH "model: my-classic" ; then
+    if ! snap known model | MATCH "model: my-classic" ; then
         echo "Model assertion was not imported on firstboot"
         exit 1
     fi
 
-    snap list|MATCH "^basic"
-    test -f $SEED_DIR/snaps/basic.snap
+    snap list | MATCH "^basic"
+    test -f "$SEED_DIR/snaps/basic.snap"

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -16,7 +16,9 @@ execute: |
     wait_for_service() {
         local service_name="$1"
         local state="${2:-active}"
-        while ! systemctl show -p ActiveState $service_name | grep -q "ActiveState=$state"; do systemctl status $service_name || true; sleep 1; done
+        while ! systemctl show -p ActiveState "$service_name" | grep -q "ActiveState=$state"; do 
+            systemctl status "$service_name" || true; sleep 1; 
+        done
     }
     curl() {
         local url="$1"
@@ -38,12 +40,12 @@ execute: |
     # current time to prevent the ubuntu-core transition before the test snap is
     # installed
     systemctl stop snapd.{service,socket}
-    now=$(date --utc -Ins)
-    cat /var/lib/snapd/state.json | jq -c '. + {data: (.data + {"ubuntu-core-transition-last-retry-time": "'"$now"'"})}' > state.json.new
+    now="$(date --utc -Ins)"
+    jq -c '. + {data: (.data + {"ubuntu-core-transition-last-retry-time": "'"$now"'"})}' < /var/lib/snapd/state.json > state.json.new
     mv state.json.new /var/lib/snapd/state.json
     systemctl start snapd.{service,socket}
 
-    snap download --${CORE_CHANNEL} ubuntu-core
+    snap download "--${CORE_CHANNEL}" ubuntu-core
     snap ack ./ubuntu-core_*.assert
     snap install ./ubuntu-core_*.snap
 
@@ -57,17 +59,17 @@ execute: |
 
     # restore ubuntu-core-transition-last-retry-time to its previous value and restart the daemon
     systemctl stop snapd.{service,socket}
-    cat /var/lib/snapd/state.json | jq -c 'del(.["data"]["ubuntu-core-transition-last-retry-time"])' > state.json.new
+    jq -c 'del(.["data"]["ubuntu-core-transition-last-retry-time"])' < /var/lib/snapd/state.json > state.json.new
     mv state.json.new /var/lib/snapd/state.json
     systemctl start snapd.{service,socket}
 
     echo "Ensure transition is triggered"
     snap debug ensure-state-soon
 
-    . $TESTSLIB/changes.sh
+    . "$TESTSLIB/changes.sh"
     while ! snap changes|grep ".*Done.*Transition ubuntu-core to core"; do
         snap changes
-        snap change $(change_id "Transition ubuntu-core to core")||true
+        snap change "$(change_id 'Transition ubuntu-core to core')" || true
         sleep 1
     done
 


### PR DESCRIPTION
Shellcheck improvements for the scripts on tests/main from abort to
classic-ubuntu-core-transition tasks