### PR TITLE
snap-seccomp: deal with mknod on aarch64 in the seccomp tests

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -99,6 +99,10 @@ func parseBpfInput(s string) (*main.SeccompData, error) {
 			sc = 359 /* see src/arch-x86.c socket */
 		} else if sc == -101 && scmpArch == seccomp.ArchS390X {
 			sc = 359 /* see src/arch-s390x.c socket */
+		} else if sc == -10165 && scmpArch == seccomp.ArchARM64 {
+			// -10165 is mknod on aarch64 and it is translated
+			// to mknodat. for our simulation -10165 is fine
+			// though
 		} else {
 			panic(fmt.Sprintf("cannot resolve syscall %v for arch %v, got %v", l[0], l[1], sc))
 		}


### PR DESCRIPTION
There is no mknod on aarch64, libseccomp returns a negative syscall
-10165 here. This is fine for our test purposes though, so whitelist
that in our testing code.