### PR TITLE
many: `os` ➯ `core` snap type

### DIFF
--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -106,7 +106,7 @@ func SetNextBoot(s *snap.Info) error {
 	if release.OnClassic {
 		return nil
 	}
-	if s.Type != snap.TypeOS && s.Type != snap.TypeKernel {
+	if s.Type != snap.TypeCore && s.Type != snap.TypeKernel {
 		return nil
 	}
 
@@ -117,7 +117,7 @@ func SetNextBoot(s *snap.Info) error {
 
 	var nextBoot, goodBoot string
 	switch s.Type {
-	case snap.TypeOS:
+	case snap.TypeCore:
 		nextBoot = "snap_try_core"
 		goodBoot = "snap_core"
 	case snap.TypeKernel:
@@ -144,7 +144,7 @@ func SetNextBoot(s *snap.Info) error {
 
 // KernelOrOsRebootRequired returns whether a reboot is required to swith to the given OS or kernel snap.
 func KernelOrOsRebootRequired(s *snap.Info) bool {
-	if s.Type != snap.TypeKernel && s.Type != snap.TypeOS {
+	if s.Type != snap.TypeKernel && s.Type != snap.TypeCore {
 		return false
 	}
 
@@ -159,7 +159,7 @@ func KernelOrOsRebootRequired(s *snap.Info) bool {
 	case snap.TypeKernel:
 		nextBoot = "snap_try_kernel"
 		goodBoot = "snap_kernel"
-	case snap.TypeOS:
+	case snap.TypeCore:
 		nextBoot = "snap_try_core"
 		goodBoot = "snap_core"
 	}

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -164,7 +164,7 @@ func (s *kernelOSSuite) TestSetNextBootForCore(c *C) {
 	defer restore()
 
 	info := &snap.Info{}
-	info.Type = snap.TypeOS
+	info.Type = snap.TypeCore
 	info.RealName = "core"
 	info.Revision = snap.R(100)
 

--- a/client/packages.go
+++ b/client/packages.go
@@ -87,7 +87,7 @@ const (
 	TypeApp    = "app"
 	TypeKernel = "kernel"
 	TypeGadget = "gadget"
-	TypeOS     = "os"
+	TypeCore   = "core"
 
 	StrictConfinement  = "strict"
 	DevModeConfinement = "devmode"

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -80,13 +80,8 @@ func maybePrintPrice(w io.Writer, snap *client.Snap, resInfo *client.ResultInfo)
 }
 
 func maybePrintType(w io.Writer, t string) {
-	// XXX: using literals here until we reshuffle snap & client properly
-	// (and os->core rename happens, etc)
-	switch t {
-	case "", "app", "application":
+	if t == "" || t == client.TypeApp {
 		return
-	case "os":
-		t = "core"
 	}
 
 	fmt.Fprintf(w, "type:\t%s\n", t)

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -52,6 +52,7 @@ func formatPrice(val float64, currency string) string {
 // snap, in order to present a brief summary of it.
 type Notes struct {
 	Price    string
+	SnapType snap.Type
 	Private  bool
 	DevMode  bool
 	JailMode bool
@@ -68,37 +69,40 @@ func NotesFromChannelSnapInfo(ref *snap.ChannelSnapInfo) *Notes {
 	}
 }
 
-func NotesFromRemote(snap *client.Snap, resInfo *client.ResultInfo) *Notes {
+func NotesFromRemote(snp *client.Snap, resInfo *client.ResultInfo) *Notes {
 	notes := &Notes{
-		Private: snap.Private,
-		DevMode: snap.Confinement == client.DevModeConfinement,
-		Classic: snap.Confinement == client.ClassicConfinement,
+		Private:  snp.Private,
+		DevMode:  snp.Confinement == client.DevModeConfinement,
+		Classic:  snp.Confinement == client.ClassicConfinement,
+		SnapType: snap.Type(snp.Type),
 	}
 	if resInfo != nil {
-		notes.Price = getPriceString(snap.Prices, resInfo.SuggestedCurrency, snap.Status)
+		notes.Price = getPriceString(snp.Prices, resInfo.SuggestedCurrency, snp.Status)
 	}
 
 	return notes
 }
 
-func NotesFromLocal(snap *client.Snap) *Notes {
+func NotesFromLocal(snp *client.Snap) *Notes {
 	return &Notes{
-		Private:  snap.Private,
-		DevMode:  snap.DevMode,
-		Classic:  !snap.JailMode && (snap.Confinement == client.ClassicConfinement),
-		JailMode: snap.JailMode,
-		TryMode:  snap.TryMode,
-		Disabled: snap.Status != client.StatusActive,
-		Broken:   snap.Broken != "",
+		SnapType: snap.Type(snp.Type),
+		Private:  snp.Private,
+		DevMode:  snp.DevMode,
+		Classic:  !snp.JailMode && (snp.Confinement == client.ClassicConfinement),
+		JailMode: snp.JailMode,
+		TryMode:  snp.TryMode,
+		Disabled: snp.Status != client.StatusActive,
+		Broken:   snp.Broken != "",
 	}
 }
 
 func NotesFromInfo(info *snap.Info) *Notes {
 	return &Notes{
-		Private: info.Private,
-		DevMode: info.Confinement == client.DevModeConfinement,
-		Classic: info.Confinement == client.ClassicConfinement,
-		Broken:  info.Broken != "",
+		SnapType: info.Type,
+		Private:  info.Private,
+		DevMode:  info.Confinement == client.DevModeConfinement,
+		Classic:  info.Confinement == client.ClassicConfinement,
+		Broken:   info.Broken != "",
 	}
 }
 
@@ -108,6 +112,14 @@ func (n *Notes) String() string {
 	}
 	var ns []string
 
+	switch n.SnapType {
+	case "", snap.TypeApp:
+		// nothing
+	case snap.TypeOS:
+		ns = append(ns, "core")
+	default:
+		ns = append(ns, string(n.SnapType))
+	}
 	if n.Disabled {
 		// TRANSLATORS: if possible, a single short word
 		ns = append(ns, i18n.G("disabled"))

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -115,8 +115,6 @@ func (n *Notes) String() string {
 	switch n.SnapType {
 	case "", snap.TypeApp:
 		// nothing
-	case snap.TypeOS:
-		ns = append(ns, "core")
 	default:
 		ns = append(ns, string(n.SnapType))
 	}

--- a/cmd/snap/notes_test.go
+++ b/cmd/snap/notes_test.go
@@ -32,6 +32,7 @@ var _ = check.Suite(&notesSuite{})
 
 func (notesSuite) TestNoNotes(c *check.C) {
 	c.Check((&snap.Notes{}).String(), check.Equals, "-")
+	c.Check((&snap.Notes{SnapType: client.TypeApp}).String(), check.Equals, "-")
 }
 
 func (notesSuite) TestNotesPrice(c *check.C) {
@@ -80,10 +81,6 @@ func (notesSuite) TestNotesBroken(c *check.C) {
 	c.Check((&snap.Notes{
 		Broken: true,
 	}).String(), check.Equals, "broken")
-}
-
-func (notesSuite) TestNotesNothing(c *check.C) {
-	c.Check((&snap.Notes{}).String(), check.Equals, "-")
 }
 
 func (notesSuite) TestNotesTwo(c *check.C) {

--- a/image/image.go
+++ b/image/image.go
@@ -374,7 +374,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 		}
 
 		// kernel/os are required for booting
-		if typ == snap.TypeKernel || typ == snap.TypeOS {
+		if typ == snap.TypeKernel || typ == snap.TypeCore {
 			dst := filepath.Join(dirs.SnapBlobDir, filepath.Base(fn))
 			if err := osutil.CopyFile(fn, dst, 0); err != nil {
 				return err
@@ -466,7 +466,7 @@ func setBootvars(downloadedSnapsInfo map[string]*snap.Info) error {
 
 		info := downloadedSnapsInfo[fn]
 		switch info.Type {
-		case snap.TypeOS:
+		case snap.TypeCore:
 			bootvar = "snap_core"
 		case snap.TypeKernel:
 			bootvar = "snap_kernel"

--- a/interfaces/builtin/account_control_test.go
+++ b/interfaces/builtin/account_control_test.go
@@ -52,7 +52,7 @@ apps:
 func (s *AccountControlSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "account-control",
 			Interface: "account-control",
 			Apps: map[string]*snap.AppInfo{

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "alsa",
 			Interface: "alsa",
 		},

--- a/interfaces/builtin/autopilot_test.go
+++ b/interfaces/builtin/autopilot_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&AutopilotInterfaceSuite{
 func (s *AutopilotInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "autopilot-introspection",
 			Interface: "autopilot-introspection",
 		},

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "avahi-observe",
 			Interface: "avahi-observe",
 		},

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&BluetoothControlInterfaceSuite{
 func (s *BluetoothControlInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "bluetooth-control",
 			Interface: "bluetooth-control",
 			Apps: map[string]*snap.AppInfo{

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&BrowserSupportInterfaceSuite{
 func (s *BrowserSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "browser-support",
 			Interface: "browser-support",
 		},

--- a/interfaces/builtin/classic_support_test.go
+++ b/interfaces/builtin/classic_support_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&ClassicSupportInterfaceSuite{
 func (s *ClassicSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "classic-support",
 			Interface: "classic-support",
 		},

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -85,7 +85,7 @@ func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
-	if iface.reservedForOS && slot.Snap.Type != snap.TypeOS {
+	if iface.reservedForOS && slot.Snap.Type != snap.TypeCore {
 		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.name)
 	}
 	return nil

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -49,7 +49,7 @@ hooks:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "core-support",
 			Interface: "core-support",
 		},

--- a/interfaces/builtin/dcdbas_control_test.go
+++ b/interfaces/builtin/dcdbas_control_test.go
@@ -50,7 +50,7 @@ apps:
 `, nil)
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "dcdbas-control",
 			Interface: "dcdbas-control",
 		},

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -54,7 +54,7 @@ func (s *DockerSupportInterfaceSuite) SetUpTest(c *C) {
 		SlotInfo: &snap.SlotInfo{
 			Snap: &snap.Info{
 				SuggestedName: "core",
-				Type:          snap.TypeOS},
+				Type:          snap.TypeCore},
 			Name:      "docker-support",
 			Interface: "docker-support",
 		},

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -53,7 +53,7 @@ var _ = Suite(&FirewallControlInterfaceSuite{
 func (s *FirewallControlInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "firewall-control",
 			Interface: "firewall-control",
 		},

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
 )
 
 const framebufferSummary = `allows access to universal framebuffer devices`
@@ -66,7 +67,7 @@ func (iface *framebufferInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 	// Creation of the slot of this type
 	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
 	}
 	return nil

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&FuseSupportInterfaceSuite{
 func (s *FuseSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "fuse-support",
 			Interface: "fuse-support",
 		},

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/systemd"
+	"github.com/snapcore/snapd/snap"
 )
 
 const gpioSummary = `allows access to specifc GPIO pin`
@@ -59,7 +60,7 @@ func (iface *gpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 
 	// We will only allow creation of this type of slot by a gadget or OS snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeGadget || slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("gpio slots only allowed on gadget or core snaps")
 	}
 

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&GreengrassSupportInterfaceSuite{
 func (s *GreengrassSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "greengrass-support",
 			Interface: "greengrass-support",
 		},

--- a/interfaces/builtin/gsettings_test.go
+++ b/interfaces/builtin/gsettings_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&GsettingsInterfaceSuite{
 func (s *GsettingsInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "gsettings",
 			Interface: "gsettings",
 		},

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&HardwareObserveInterfaceSuite{
 func (s *HardwareObserveInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "hardware-observe",
 			Interface: "hardware-observe",
 		},

--- a/interfaces/builtin/hardware_random_control.go
+++ b/interfaces/builtin/hardware_random_control.go
@@ -68,7 +68,7 @@ func (iface *hardwareRandomControlInterface) SanitizeSlot(slot *interfaces.Slot)
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
-	if slot.Snap.Type != snap.TypeOS {
+	if slot.Snap.Type != snap.TypeCore {
 		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
 	}
 	return nil

--- a/interfaces/builtin/hardware_random_observe.go
+++ b/interfaces/builtin/hardware_random_observe.go
@@ -62,7 +62,7 @@ func (iface *hardwareRandomObserveInterface) SanitizeSlot(slot *interfaces.Slot)
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
-	if slot.Snap.Type != snap.TypeOS {
+	if slot.Snap.Type != snap.TypeCore {
 		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
 	}
 	return nil

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
 )
 
 const hidrawSummary = `allows access to specific hidraw device`
@@ -67,7 +68,7 @@ func (iface *hidrawInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 
 	// We will only allow creation of this type of slot by a gadget or OS snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeGadget || slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("hidraw slots only allowed on gadget or core snaps")
 	}
 

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "home",
 			Interface: "home",
 		},

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
 )
 
 const i2cSummary = `allows access to specific I2C controller`
@@ -64,7 +65,7 @@ func (iface *i2cInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 	// Creation of the slot of this type
 	// is allowed only by a gadget snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeGadget || slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("%s slots only allowed on gadget or core snaps", iface.Name())
 	}
 

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
 )
 
 const iioSummary = `allows access to a specific IIO device`
@@ -72,7 +73,7 @@ func (iface *iioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 	// Creation of the slot of this type
 	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeGadget || slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("%s slots only allowed on gadget or core snaps", iface.Name())
 	}
 

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
 )
 
 const ioPortsControlSummary = `allows access to all I/O ports`
@@ -78,7 +79,7 @@ func (iface *iioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error
 
 	// Creation of the slot of this type
 	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
 	}
 	return nil

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -67,7 +67,7 @@ func (iface *joystickInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 
 	// The snap implementing this slot must be an os snap.
-	if !(slot.Snap.Type == snap.TypeOS) {
+	if !(slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
 	}
 

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&KernelModuleControlInterfaceSuite{
 func (s *KernelModuleControlInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "kernel-module-control",
 			Interface: "kernel-module-control",
 		},

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&KubernetesSupportInterfaceSuite{
 func (s *KubernetesSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "kubernetes-support",
 			Interface: "kubernetes-support",
 		},

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -52,7 +52,7 @@ apps:
 	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["locale-control"]}
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "locale-control",
 			Interface: "locale-control",
 		},

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "log-observe",
 			Interface: "log-observe",
 		},

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&LxdSupportInterfaceSuite{
 func (s *LxdSupportInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "lxd-support",
 			Interface: "lxd-support",
 		},

--- a/interfaces/builtin/lxd_test.go
+++ b/interfaces/builtin/lxd_test.go
@@ -40,7 +40,7 @@ var _ = Suite(&LxdInterfaceSuite{
 	iface: builtin.MustInterface("lxd"),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "lxd",
 			Interface: "lxd",
 		},

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "mount-observe",
 			Interface: "mount-observe",
 		},

--- a/interfaces/builtin/netlink_audit_test.go
+++ b/interfaces/builtin/netlink_audit_test.go
@@ -51,7 +51,7 @@ var _ = Suite(&NetlinkAuditInterfaceSuite{
 func (s *NetlinkAuditInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "netlink-audit",
 			Interface: "netlink-audit",
 		},

--- a/interfaces/builtin/netlink_connector_test.go
+++ b/interfaces/builtin/netlink_connector_test.go
@@ -51,7 +51,7 @@ var _ = Suite(&NetlinkConnectorInterfaceSuite{
 func (s *NetlinkConnectorInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "netlink-connector",
 			Interface: "netlink-connector",
 		},

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&NetworkBindInterfaceSuite{
 func (s *NetworkBindInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "network-bind",
 			Interface: "network-bind",
 		},

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&NetworkControlInterfaceSuite{
 func (s *NetworkControlInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "network-control",
 			Interface: "network-control",
 		},

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&NetworkObserveInterfaceSuite{
 func (s *NetworkObserveInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "network-observe",
 			Interface: "network-observe",
 		},

--- a/interfaces/builtin/network_setup_control_test.go
+++ b/interfaces/builtin/network_setup_control_test.go
@@ -50,7 +50,7 @@ apps:
 `, nil)
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "network-setup-control",
 			Interface: "network-setup-control",
 		},

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "network-setup-observe",
 			Interface: "network-setup-observe",
 		},

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&NetworkInterfaceSuite{
 func (s *NetworkInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "network",
 			Interface: "network",
 		},

--- a/interfaces/builtin/openvswitch_support_test.go
+++ b/interfaces/builtin/openvswitch_support_test.go
@@ -39,7 +39,7 @@ var _ = Suite(&OpenvSwitchSupportInterfaceSuite{
 	iface: builtin.MustInterface("openvswitch-support"),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "openvswitch-support",
 			Interface: "openvswitch-support",
 		},

--- a/interfaces/builtin/openvswitch_test.go
+++ b/interfaces/builtin/openvswitch_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "openvswitch",
 			Interface: "openvswitch",
 		},

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
 )
 
 const physicalMemoryControlSummary = `allows write access to all physical memory`
@@ -70,7 +71,7 @@ func (iface *physicalMemoryControlInterface) SanitizeSlot(slot *interfaces.Slot)
 
 	// Creation of the slot of this type
 	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
 	}
 	return nil

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
 )
 
 const physicalMemoryObserveSummary = `allows read access to all physical memory`
@@ -66,7 +67,7 @@ func (iface *physicalMemoryObserveInterface) SanitizeSlot(slot *interfaces.Slot)
 
 	// Creation of the slot of this type
 	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
 	}
 	return nil

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&ProcessControlInterfaceSuite{
 func (s *ProcessControlInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "process-control",
 			Interface: "process-control",
 		},

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "raw-usb",
 			Interface: "raw-usb",
 		},

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -50,7 +50,7 @@ apps:
 `, nil)
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "removable-media",
 			Interface: "removable-media",
 		},

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "screen-inhibit-control",
 			Interface: "screen-inhibit-control",
 		},

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
 )
 
 const serialPortSummary = `allows accessing a specific serial port`
@@ -73,7 +74,7 @@ func (iface *serialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 
 	// We will only allow creation of this type of slot by a gadget or OS snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeGadget || slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("serial-port slots only allowed on gadget or core snaps")
 	}
 

--- a/interfaces/builtin/shutdown_test.go
+++ b/interfaces/builtin/shutdown_test.go
@@ -51,7 +51,7 @@ apps:
 	s.plug = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["shutdown"]}
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "shutdown",
 			Interface: "shutdown",
 		},

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -50,7 +50,7 @@ apps:
 `, nil)
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "snapd-control",
 			Interface: "snapd-control",
 		},

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&SystemObserveInterfaceSuite{
 func (s *SystemObserveInterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "system-observe",
 			Interface: "system-observe",
 		},

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "system-trace",
 			Interface: "system-trace",
 		},

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
 )
 
 const timeControlSummary = `allows setting system date and time`
@@ -121,7 +122,7 @@ func (iface *timeControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 	// Creation of the slot of this type
 	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
+	if !(slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
 	}
 	return nil

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -41,7 +41,7 @@ var _ = Suite(&TimeControlTestInterfaceSuite{
 	iface: builtin.MustInterface("time-control"),
 	slot: &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "time-control",
 			Interface: "time-control",
 		},

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "timeserver-control",
 			Interface: "timeserver-control",
 		},

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "timezone-control",
 			Interface: "timezone-control",
 		},

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -50,7 +50,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "tpm",
 			Interface: "tpm",
 		},

--- a/interfaces/builtin/ubuntu_download_manager_test.go
+++ b/interfaces/builtin/ubuntu_download_manager_test.go
@@ -52,7 +52,7 @@ apps:
 	s.plug = &interfaces.Plug{PlugInfo: snapInfo.Plugs["ubuntu-download-manager"]}
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "ubuntu-download-manager",
 			Interface: "ubuntu-download-manager",
 		},

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -562,7 +562,7 @@ func (iface *unity7Interface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 
 	// Creation of the slot of this type is allowed only by the os snap
-	if !(slot.Snap.Type == snap.TypeOS) {
+	if !(slot.Snap.Type == snap.TypeCore) {
 		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
 	}
 

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -52,7 +52,7 @@ apps:
 func (s *Unity7InterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "unity7",
 			Interface: "unity7",
 		},

--- a/interfaces/builtin/unity8_calendar_test.go
+++ b/interfaces/builtin/unity8_calendar_test.go
@@ -60,7 +60,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "unity8-calendar",
 			Interface: "unity8-calendar",
 		},

--- a/interfaces/builtin/unity8_contacts_test.go
+++ b/interfaces/builtin/unity8_contacts_test.go
@@ -61,7 +61,7 @@ apps:
 `
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "unity8-contacts",
 			Interface: "unity8-contacts",
 		},

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -264,7 +264,7 @@ func (iface *upowerObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
 	}
-	if slot.Snap.Type != snap.TypeApp && slot.Snap.Type != snap.TypeOS {
+	if slot.Snap.Type != snap.TypeApp && slot.Snap.Type != snap.TypeCore {
 		return fmt.Errorf("%s slots are reserved for the operating system or application snaps", iface.Name())
 	}
 	return nil

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -52,7 +52,7 @@ var _ = Suite(&X11InterfaceSuite{
 func (s *X11InterfaceSuite) SetUpTest(c *C) {
 	s.slot = &interfaces.Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "x11",
 			Interface: "x11",
 		},

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -504,7 +504,7 @@ var (
 	}
 
 	snapTypeMap = map[string]snap.Type{
-		"core":   snap.TypeOS,
+		"core":   snap.TypeCore,
 		"app":    snap.TypeApp,
 		"kernel": snap.TypeKernel,
 		"gadget": snap.TypeGadget,

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -35,9 +35,6 @@ func checkSnapType(snapType snap.Type, types []string) error {
 		return nil
 	}
 	s := string(snapType)
-	if s == "os" { // we use "core" in the assertions
-		s = "core"
-	}
 	for _, t := range types {
 		if t == s {
 			return nil

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1232,7 +1232,7 @@ func (s *RepositorySuite) TestConnectedFindsConnections(c *C) {
 func (s *RepositorySuite) TestConnectedFindsCoreSnap(c *C) {
 	slot := &Slot{
 		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeCore},
 			Name:      "slot",
 			Interface: "interface",
 		},
@@ -1818,7 +1818,7 @@ func (s *RepositorySuite) TestAutoConnectContentInterfaceSimple(c *C) {
 
 func (s *RepositorySuite) TestAutoConnectContentInterfaceOSWorksCorrectly(c *C) {
 	repo, _, slotSnap := makeContentConnectionTestSnaps(c, "mylib", "otherlib")
-	slotSnap.Type = snap.TypeOS
+	slotSnap.Type = snap.TypeCore
 
 	candidateSlots := repo.AutoConnectCandidateSlots("content-plug-snap", "imported-content", contentPolicyCheck)
 	c.Check(candidateSlots, HasLen, 0)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -274,7 +274,7 @@ func (s *deviceMgrSuite) setupGadget(c *C, snapYaml string, snapContents string)
 	}
 	snaptest.MockSnap(c, snapYaml, snapContents, sideInfoGadget)
 	snapstate.Set(s.state, "gadget", &snapstate.SnapState{
-		SnapType: "gadget",
+		SnapType: string(snap.TypeGadget),
 		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfoGadget},
 		Current:  sideInfoGadget.Revision,
@@ -288,7 +288,7 @@ func (s *deviceMgrSuite) setupCore(c *C, name, snapYaml string, snapContents str
 	}
 	snaptest.MockSnap(c, snapYaml, snapContents, sideInfoCore)
 	snapstate.Set(s.state, name, &snapstate.SnapState{
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfoCore},
 		Current:  sideInfoCore.Revision,
@@ -1015,7 +1015,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkBootloaderHappy(c *C) {
 	defer s.state.Unlock()
 	siCore1 := &snap.SideInfo{RealName: "core", Revision: snap.R(1)}
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 		Active:   true,
 		Sequence: []*snap.SideInfo{siCore1},
 		Current:  siCore1.Revision,
@@ -1047,7 +1047,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkUpdateBootRevisionsHappy(c
 	defer s.state.Unlock()
 	siKernel1 := &snap.SideInfo{RealName: "kernel", Revision: snap.R(1)}
 	snapstate.Set(s.state, "kernel", &snapstate.SnapState{
-		SnapType: "kernel",
+		SnapType: string(snap.TypeKernel),
 		Active:   true,
 		Sequence: []*snap.SideInfo{siKernel1},
 		Current:  siKernel1.Revision,
@@ -1056,7 +1056,7 @@ func (s *deviceMgrSuite) TestDeviceManagerEnsureBootOkUpdateBootRevisionsHappy(c
 	siCore1 := &snap.SideInfo{RealName: "core", Revision: snap.R(1)}
 	siCore2 := &snap.SideInfo{RealName: "core", Revision: snap.R(2)}
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 		Active:   true,
 		Sequence: []*snap.SideInfo{siCore1, siCore2},
 		Current:  siCore2.Revision,

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -93,7 +93,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 		return err
 	}
 	if corePhase2 {
-		if snapInfo.Type != snap.TypeOS {
+		if snapInfo.Type != snap.TypeCore {
 			// not core, nothing to do
 			return nil
 		}
@@ -107,7 +107,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 			// TODO: double check that we really rebooted
 			// otherwise this could be just a spurious restart
 			// of snapd
-			name, rev, err := snapstate.CurrentBootNameAndRevision(snap.TypeOS)
+			name, rev, err := snapstate.CurrentBootNameAndRevision(snap.TypeCore)
 			if err == snapstate.ErrBootNameAndRevisionAgain {
 				return &state.Retry{After: 5 * time.Second}
 			}

--- a/overlord/ifacestate/implicit.go
+++ b/overlord/ifacestate/implicit.go
@@ -33,7 +33,7 @@ import (
 // It is assumed that slots have names matching the interface name. Existing
 // slots are not changed, only missing slots are added.
 func addImplicitSlots(snapInfo *snap.Info) {
-	if snapInfo.Type != snap.TypeOS {
+	if snapInfo.Type != snap.TypeCore {
 		return
 	}
 	// Ask each interface if it wants to be implcitly added.

--- a/overlord/patch/patch1_test.go
+++ b/overlord/patch/patch1_test.go
@@ -122,7 +122,7 @@ func (s *patch1Suite) TestPatch1(c *C) {
 		cur  snap.Revision
 	}{
 		{"foo", snap.TypeApp, snap.R(22)},
-		{"core", snap.TypeOS, snap.R(111)},
+		{"core", snap.TypeCore, snap.R(111)},
 		{"borken", snap.TypeApp, snap.R(-2)},
 		{"wip", "", snap.R(0)},
 	}
@@ -131,7 +131,7 @@ func (s *patch1Suite) TestPatch1(c *C) {
 		var snapst snapstate.SnapState
 		err := snapstate.Get(st, exp.name, &snapst)
 		c.Assert(err, IsNil)
-		c.Check(snap.Type(snapst.SnapType), Equals, exp.typ)
+		c.Check(snapst.SnapType, Equals, string(exp.typ))
 		c.Check(snapst.Current, Equals, exp.cur)
 	}
 
@@ -151,7 +151,7 @@ func (s *patch1Suite) readType(name string, rev snap.Revision) (snap.Type, error
 		return snap.TypeGadget, nil
 	}
 	if name == "core" {
-		return snap.TypeOS, nil
+		return snap.TypeCore, nil
 	}
 
 	return snap.TypeApp, nil

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -124,7 +124,7 @@ func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 
 	typ := snap.TypeApp
 	if spec.Name == "some-core" {
-		typ = snap.TypeOS
+		typ = snap.TypeCore
 	}
 
 	info := &snap.Info{
@@ -340,7 +340,7 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 	case "gadget":
 		info.Type = snap.TypeGadget
 	case "core":
-		info.Type = snap.TypeOS
+		info.Type = snap.TypeCore
 	case "services-snap":
 		var err error
 		info, err = snap.InfoFromSnapYaml([]byte(`name: services-snap

--- a/overlord/snapstate/booted.go
+++ b/overlord/snapstate/booted.go
@@ -130,7 +130,7 @@ func CurrentBootNameAndRevision(typ snap.Type) (name string, revision snap.Revis
 	case snap.TypeKernel:
 		kind = "kernel"
 		bootVar = "snap_kernel"
-	case snap.TypeOS:
+	case snap.TypeCore:
 		kind = "core"
 		bootVar = "snap_core"
 	default:

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -95,7 +95,7 @@ func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
 	snaptest.MockSnap(c, "name: core\ntype: os\nversion: 1", "", osSI1)
 	snaptest.MockSnap(c, "name: core\ntype: os\nversion: 2", "", osSI2)
 	snapstate.Set(st, "core", &snapstate.SnapState{
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 		Active:   true,
 		Sequence: []*snap.SideInfo{osSI1, osSI2},
 		Current:  snap.R(2),
@@ -104,7 +104,7 @@ func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
 	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 1", "", kernelSI1)
 	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 2", "", kernelSI2)
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
-		SnapType: "kernel",
+		SnapType: string(snap.TypeKernel),
 		Active:   true,
 		Sequence: []*snap.SideInfo{kernelSI1, kernelSI2},
 		Current:  snap.R(2),
@@ -212,7 +212,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	// have a kernel
 	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 2", "", kernelSI2)
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
-		SnapType: "kernel",
+		SnapType: string(snap.TypeKernel),
 		Active:   true,
 		Sequence: []*snap.SideInfo{kernelSI2},
 		Current:  snap.R(2),
@@ -221,7 +221,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	// put core into the state but add no files on disk
 	// will break in the tasks
 	snapstate.Set(st, "core", &snapstate.SnapState{
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 		Active:   true,
 		Sequence: []*snap.SideInfo{osSI1, osSI2},
 		Current:  snap.R(2),
@@ -256,7 +256,7 @@ func (bs *bootedSuite) TestNameAndRevnoFromSnapInvalidFormat(c *C) {
 }
 
 func (bs *bootedSuite) TestCurrentBootNameAndRevision(c *C) {
-	name, revision, err := snapstate.CurrentBootNameAndRevision(snap.TypeOS)
+	name, revision, err := snapstate.CurrentBootNameAndRevision(snap.TypeCore)
 	c.Check(err, IsNil)
 	c.Check(name, Equals, "core")
 	c.Check(revision, Equals, snap.R(2))

--- a/overlord/snapstate/check_snap.go
+++ b/overlord/snapstate/check_snap.go
@@ -227,7 +227,7 @@ func MockCheckSnapCallbacks(checks []CheckSnapCallback) (restore func()) {
 }
 
 func checkCoreName(st *state.State, snapInfo, curInfo *snap.Info, flags Flags) error {
-	if snapInfo.Type != snap.TypeOS {
+	if snapInfo.Type != snap.TypeCore {
 		// not a relevant check
 		return nil
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -611,7 +611,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 // snap with info if it's a core or kernel snap.
 func maybeRestart(t *state.Task, info *snap.Info) {
 	st := t.State()
-	if release.OnClassic && info.Type == snap.TypeOS {
+	if release.OnClassic && info.Type == snap.TypeCore {
 		t.Logf("Requested daemon restart.")
 		st.RequestRestart(state.RestartDaemon)
 	}

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -242,7 +242,7 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessCoreRestarts(c *C) {
 
 	typ, err := snapst.Type()
 	c.Check(err, IsNil)
-	c.Check(typ, Equals, snap.TypeOS)
+	c.Check(typ, Equals, snap.TypeCore)
 
 	c.Check(t.Status(), Equals, state.DoneStatus)
 	c.Check(s.stateBackend.restartRequested, Equals, state.RestartDaemon)
@@ -356,7 +356,7 @@ func (s *linkSnapSuite) TestDoUndoUnlinkCurrentSnapCore(c *C) {
 		Sequence: []*snap.SideInfo{si1},
 		Current:  si1.Revision,
 		Active:   true,
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 	t := s.state.NewTask("unlink-current-snap", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{

--- a/overlord/snapstate/handlers_mount_test.go
+++ b/overlord/snapstate/handlers_mount_test.go
@@ -110,7 +110,7 @@ func (s *mountSnapSuite) TestDoUndoMountSnap(c *C) {
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Sequence: []*snap.SideInfo{si1},
 		Current:  si1.Revision,
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 
 	t := s.state.NewTask("mount-snap", "test")
@@ -148,7 +148,7 @@ func (s *mountSnapSuite) TestDoUndoMountSnap(c *C) {
 		{
 			op:    "undo-setup-snap",
 			name:  filepath.Join(dirs.StripRootDir(dirs.SnapMountDir), "core/2"),
-			stype: "os",
+			stype: snap.TypeCore,
 		},
 	})
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -52,7 +52,7 @@ const (
 )
 
 func needsMaybeCore(typ snap.Type) int {
-	if typ == snap.TypeOS {
+	if typ == snap.TypeCore {
 		return maybeCore
 	}
 	return 0
@@ -1008,7 +1008,7 @@ func Disable(st *state.State, name string) (*state.TaskSet, error) {
 
 // canDisable verifies that a snap can be deactivated.
 func canDisable(si *snap.Info) bool {
-	for _, importantSnapType := range []snap.Type{snap.TypeGadget, snap.TypeKernel, snap.TypeOS} {
+	for _, importantSnapType := range []snap.Type{snap.TypeGadget, snap.TypeKernel, snap.TypeCore} {
 		if importantSnapType == si.Type {
 			return false
 		}
@@ -1048,13 +1048,13 @@ func canRemove(si *snap.Info, snapst *SnapState, removeAll bool) bool {
 	//
 	// Once the ubuntu-core -> core transition has landed for some
 	// time we can remove the two lines below.
-	if si.Name() == "ubuntu-core" && si.Type == snap.TypeOS {
+	if si.Name() == "ubuntu-core" && si.Type == snap.TypeCore {
 		return true
 	}
 
 	// You never want to remove a kernel or OS. Do not remove their
 	// last revision left.
-	if si.Type == snap.TypeKernel || si.Type == snap.TypeOS {
+	if si.Type == snap.TypeKernel || si.Type == snap.TypeCore {
 		return false
 	}
 
@@ -1513,7 +1513,7 @@ func KernelInfo(st *state.State) (*snap.Info, error) {
 // from ubuntu-core to core we can simplify this again
 // and make it the same as the above "KernelInfo".
 func CoreInfo(st *state.State) (*snap.Info, error) {
-	res, err := infosForTypes(st, snap.TypeOS)
+	res, err := infosForTypes(st, snap.TypeCore)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -916,7 +916,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksCoreSetsIgnoreOnConfigure(c *C) {
 		Channel:  "edge",
 		Sequence: []*snap.SideInfo{{RealName: "core", SnapID: "core-snap-id", Revision: snap.R(7)}},
 		Current:  snap.R(7),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 
 	oldConfigure := snapstate.Configure
@@ -4839,7 +4839,7 @@ func (s *snapmgrQuerySuite) TestTypeInfo(c *C) {
 		},
 		{
 			snapName: "core",
-			snapType: snap.TypeOS,
+			snapType: snap.TypeCore,
 			getInfo:  snapstate.CoreInfo,
 		},
 		{
@@ -4914,7 +4914,7 @@ func (s *snapmgrQuerySuite) TestTypeInfoCore(c *C) {
 			}
 			snaptest.MockSnap(c, fmt.Sprintf("name: %q\ntype: os\nversion: %q\n", snapName, snapName), "", sideInfo)
 			snapstate.Set(st, snapName, &snapstate.SnapState{
-				SnapType: string(snap.TypeOS),
+				SnapType: string(snap.TypeCore),
 				Active:   true,
 				Sequence: []*snap.SideInfo{sideInfo},
 				Current:  sideInfo.Revision,
@@ -4927,7 +4927,7 @@ func (s *snapmgrQuerySuite) TestTypeInfoCore(c *C) {
 		} else {
 			c.Assert(info, NotNil)
 			c.Check(info.Name(), Equals, t.expectedSnap, Commentf("(%d) test %q %v", testNr, t.expectedSnap, t.snapNames))
-			c.Check(info.Type, Equals, snap.TypeOS)
+			c.Check(info.Type, Equals, snap.TypeCore)
 		}
 	}
 }
@@ -5229,7 +5229,7 @@ func (s *canRemoveSuite) TestLastGadgetsAreNotOK(c *C) {
 
 func (s *canRemoveSuite) TestLastOSAndKernelAreNotOK(c *C) {
 	os := &snap.Info{
-		Type: snap.TypeOS,
+		Type: snap.TypeCore,
 	}
 	os.RealName = "os"
 	kernel := &snap.Info{
@@ -5978,7 +5978,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasksNoUbuntuCore(c *C) {
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "corecore", SnapID: "core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 
 	_, err := snapstate.TransitionCore(s.state, "ubuntu-core", "core")
@@ -6009,7 +6009,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasks(c *C) {
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 
 	tsl, err := snapstate.TransitionCore(s.state, "ubuntu-core", "core")
@@ -6032,13 +6032,13 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasksWithUbuntuCoreAndCore(c *C) {
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 
 	tsl, err := snapstate.TransitionCore(s.state, "ubuntu-core", "core")
@@ -6059,7 +6059,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 
 	chg := s.state.NewChange("transition-ubuntu-core", "...")
@@ -6173,7 +6173,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 		{
 			op:    "remove-snap-files",
 			name:  filepath.Join(dirs.StripRootDir(dirs.SnapMountDir), "ubuntu-core/1"),
-			stype: "os",
+			stype: snap.TypeCore,
 		},
 		{
 			op:   "discard-namespace",
@@ -6201,13 +6201,13 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "core", SnapID: "core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 
 	chg := s.state.NewChange("transition-ubuntu-core", "...")
@@ -6260,7 +6260,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 		{
 			op:    "remove-snap-files",
 			name:  filepath.Join(dirs.StripRootDir(dirs.SnapMountDir), "ubuntu-core/1"),
-			stype: "os",
+			stype: snap.TypeCore,
 		},
 		{
 			op:   "discard-namespace",
@@ -6285,7 +6285,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreStartsAutomatically(c *C) {
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "corecore", SnapID: "core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 
 	s.state.Unlock()
@@ -6305,7 +6305,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreTimeLimitWorks(c *C) {
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "corecore", SnapID: "core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 
 	// tried 3h ago, no retry
@@ -6340,7 +6340,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreNoOtherChanges(c *C) {
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "corecore", SnapID: "core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 	})
 	chg := s.state.NewChange("unrelated-change", "unfinished change blocks core transition")
 	chg.SetStatus(state.DoStatus)
@@ -6400,7 +6400,7 @@ func (s *snapmgrTestSuite) checkForceDevModeCleanupRuns(c *C, name string, shoul
 			SnapID:   "id-id-id",
 			Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 		Flags:    snapstate.Flags{DevMode: true},
 	})
 
@@ -6454,7 +6454,7 @@ func (s *snapmgrTestSuite) TestForceDevModeCleanupSkipsNonForcedOS(c *C) {
 			SnapID:   "id-id-id",
 			Revision: snap.R(1)}},
 		Current:  snap.R(1),
-		SnapType: "os",
+		SnapType: string(snap.TypeCore),
 		Flags:    snapstate.Flags{DevMode: true},
 	})
 
@@ -6645,7 +6645,7 @@ func (s *canDisableSuite) TestCanDisable(c *C) {
 		{snap.TypeApp, true},
 		{snap.TypeGadget, false},
 		{snap.TypeKernel, false},
-		{snap.TypeOS, false},
+		{snap.TypeCore, false},
 	} {
 		info := &snap.Info{Type: tt.typ}
 		c.Check(snapstate.CanDisable(info), Equals, tt.canDisable)

--- a/snap/broken.go
+++ b/snap/broken.go
@@ -70,7 +70,7 @@ func GuessAppsForBroken(info *Info) map[string]*AppInfo {
 // was not validated before.  To avoid a flag day and any potential issues,
 // transparently rename the two clashing plugs by appending the "-plug" suffix.
 func (info *Info) renameClashingCorePlugs() {
-	if info.Name() == "core" && info.Type == TypeOS {
+	if info.Name() == "core" && info.Type == TypeCore {
 		for _, plugName := range []string{"network-bind", "core-support"} {
 			info.renamePlug(plugName, plugName+"-plug")
 		}

--- a/snap/types_test.go
+++ b/snap/types_test.go
@@ -46,7 +46,7 @@ func (s *typeSuite) TestJsonMarshalTypes(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "\"gadget\"")
 
-	out, err = json.Marshal(TypeOS)
+	out, err = json.Marshal(TypeCore)
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "\"os\"")
 
@@ -72,7 +72,7 @@ func (s *typeSuite) TestJsonUnmarshalTypes(c *C) {
 
 	err = json.Unmarshal([]byte("\"os\""), &st)
 	c.Assert(err, IsNil)
-	c.Check(st, Equals, TypeOS)
+	c.Check(st, Equals, TypeCore)
 
 	err = json.Unmarshal([]byte("\"kernel\""), &st)
 	c.Assert(err, IsNil)
@@ -97,9 +97,9 @@ func (s *typeSuite) TestYamlMarshalTypes(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(string(out), Equals, "gadget\n")
 
-	out, err = yaml.Marshal(TypeOS)
+	out, err = yaml.Marshal(TypeCore)
 	c.Assert(err, IsNil)
-	c.Check(string(out), Equals, "os\n")
+	c.Check(string(out), Equals, "core\n")
 
 	out, err = yaml.Marshal(TypeKernel)
 	c.Assert(err, IsNil)
@@ -121,9 +121,13 @@ func (s *typeSuite) TestYamlUnmarshalTypes(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(st, Equals, TypeGadget)
 
+	err = yaml.Unmarshal([]byte("core"), &st)
+	c.Assert(err, IsNil)
+	c.Check(st, Equals, TypeCore)
+
 	err = yaml.Unmarshal([]byte("os"), &st)
 	c.Assert(err, IsNil)
-	c.Check(st, Equals, TypeOS)
+	c.Check(st, Equals, TypeCore)
 
 	err = yaml.Unmarshal([]byte("kernel"), &st)
 	c.Assert(err, IsNil)

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -12,9 +12,9 @@ execute: |
     # *current* edge also has .git. and a hash snippet, so add an optional .git.[0-9a-f]+ to the already optional timestamp
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
-        expected='^core .* [0-9]{2}-[0-9.]+(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +core *$'
     else
-        expected='^core .* [0-9]{2}-[0-9.]+(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +- *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +core *$'
     fi
     snap list | MATCH "$expected"
 


### PR DESCRIPTION
This switches everything so it's a core snap type, not an os snap type. Includes a client-visible change, but confirmed with gnome-software that they don't key off of this anywhere. Also includes backwards compatibility so that we still understand type:os, and still serialises type:core as type:os so we don't need a flag day.
