### PR TITLE
tests: create ramdisk if it's not present

### DIFF
--- a/tests/lib/ramdisk.sh
+++ b/tests/lib/ramdisk.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+setup_ramdisk(){
+    if [ ! -e /dev/ram0 ]; then
+        mknod -m 660 /dev/ram0 b 1 0
+        chown root.disk /dev/ram0
+    fi
+}

--- a/tests/lib/ramdisk.sh
+++ b/tests/lib/ramdisk.sh
@@ -3,5 +3,15 @@ setup_ramdisk(){
     if [ ! -e /dev/ram0 ]; then
         mknod -m 660 /dev/ram0 b 1 0
         chown root.disk /dev/ram0
+        # wait for all udev events to be handled, sometimes we are getting an error:
+        #
+        # $ dmsetup -v --noudevsync --noudevrules create dm-ram0 --table '0 131072 linear /dev/ram0 0'
+        # device-mapper: reload ioctl on dm-ram0 failed: Device or resource busy
+        #
+        # and in syslog:
+        #
+        # Jun 28 09:18:34 localhost kernel: [   36.434220] device-mapper: table: 252:0: linear: Device lookup failed
+        # Jun 28 09:18:34 localhost kernel: [   36.434686] device-mapper: ioctl: error adding target to table
+        udevadm settle
     fi
 }

--- a/tests/lib/ramdisk.sh
+++ b/tests/lib/ramdisk.sh
@@ -3,15 +3,5 @@ setup_ramdisk(){
     if [ ! -e /dev/ram0 ]; then
         mknod -m 660 /dev/ram0 b 1 0
         chown root.disk /dev/ram0
-        # wait for all udev events to be handled, sometimes we are getting an error:
-        #
-        # $ dmsetup -v --noudevsync --noudevrules create dm-ram0 --table '0 131072 linear /dev/ram0 0'
-        # device-mapper: reload ioctl on dm-ram0 failed: Device or resource busy
-        #
-        # and in syslog:
-        #
-        # Jun 28 09:18:34 localhost kernel: [   36.434220] device-mapper: table: 252:0: linear: Device lookup failed
-        # Jun 28 09:18:34 localhost kernel: [   36.434686] device-mapper: ioctl: error adding target to table
-        udevadm settle
     fi
 }

--- a/tests/main/snap-auto-import-asserts-spools/task.yaml
+++ b/tests/main/snap-auto-import-asserts-spools/task.yaml
@@ -19,6 +19,7 @@ prepare: |
     mkfs.vfat /dev/ram0
     mount /dev/ram0 /mnt
     cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
+    sync
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/snap-auto-import-asserts-spools/task.yaml
+++ b/tests/main/snap-auto-import-asserts-spools/task.yaml
@@ -14,6 +14,8 @@ prepare: |
             exit 1
     fi
     echo "Create a ramdisk with the testrootorg-store.account-key assertion"
+    . "$TESTSLIB/ramdisk.sh"
+    setup_ramdisk
     mkfs.vfat /dev/ram0
     mount /dev/ram0 /mnt
     cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert

--- a/tests/main/snap-auto-import-asserts/task.yaml
+++ b/tests/main/snap-auto-import-asserts/task.yaml
@@ -19,6 +19,7 @@ prepare: |
     mkfs.vfat /dev/ram0
     mount /dev/ram0 /mnt
     cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
+    sync
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/snap-auto-import-asserts/task.yaml
+++ b/tests/main/snap-auto-import-asserts/task.yaml
@@ -14,6 +14,8 @@ prepare: |
             exit 1
     fi
     echo "Create a ramdisk with the testrootorg-store.account-key assertion"
+    . "$TESTSLIB/ramdisk.sh"
+    setup_ramdisk
     mkfs.vfat /dev/ram0
     mount /dev/ram0 /mnt
     cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -22,6 +22,7 @@ prepare: |
     mkfs.vfat /dev/ram0
     mount /dev/ram0 /mnt
     cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
+    sync
     umount /mnt
     echo "Create new block device to trigger auto-import mount"
     # wait for all udev events to be handled, sometimes we are getting an error:

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -24,6 +24,16 @@ prepare: |
     cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
     umount /mnt
     echo "Create new block device to trigger auto-import mount"
+    # wait for all udev events to be handled, sometimes we are getting an error:
+    #
+    # $ dmsetup -v --noudevsync --noudevrules create dm-ram0 --table '0 131072 linear /dev/ram0 0'
+    # device-mapper: reload ioctl on dm-ram0 failed: Device or resource busy
+    #
+    # and in syslog:
+    #
+    # Jun 28 09:18:34 localhost kernel: [   36.434220] device-mapper: table: 252:0: linear: Device lookup failed
+    # Jun 28 09:18:34 localhost kernel: [   36.434686] device-mapper: ioctl: error adding target to table
+    udevadm settle
     dmsetup -v --noudevsync --noudevrules create dm-ram0 --table "0 $(blockdev --getsize /dev/ram0) linear /dev/ram0 0"
 
 restore: |

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -24,13 +24,7 @@ prepare: |
     cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
     umount /mnt
     echo "Create new block device to trigger auto-import mount"
-    for i in $(seq 5); do
-        if dmsetup -v --noudevsync --noudevrules create dm-ram0 --table "0 $(blockdev --getsize /dev/ram0) linear /dev/ram0 0"; then
-            break
-        else
-            sleep 1
-        fi
-    done
+    dmsetup -v --noudevsync --noudevrules create dm-ram0 --table "0 $(blockdev --getsize /dev/ram0) linear /dev/ram0 0"
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/snap-auto-mount/task.yaml
+++ b/tests/main/snap-auto-mount/task.yaml
@@ -17,13 +17,20 @@ prepare: |
             exit 1
     fi
     echo "Create a ramdisk with the testrootorg-store.account-key assertion"
+    . "$TESTSLIB/ramdisk.sh"
+    setup_ramdisk
     mkfs.vfat /dev/ram0
     mount /dev/ram0 /mnt
     cp $TESTSLIB/assertions/testrootorg-store.account-key /mnt/auto-import.assert
     umount /mnt
-
     echo "Create new block device to trigger auto-import mount"
-    dmsetup -v --noudevsync --noudevrules create dm-ram0 --table "0 $(blockdev --getsize /dev/ram0) linear /dev/ram0 0"
+    for i in $(seq 5); do
+        if dmsetup -v --noudevsync --noudevrules create dm-ram0 --table "0 $(blockdev --getsize /dev/ram0) linear /dev/ram0 0"; then
+            break
+        else
+            sleep 1
+        fi
+    done
 
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then


### PR DESCRIPTION
Recent kernel snaps don't ship ramdisks, which we are using in some tests, with these changes we create them if needed. 