### PR TITLE
tests: fix timeout issue for test refresh core with hanging …

### DIFF
--- a/tests/main/refresh-core-with-hanging-configure-hook/task.yaml
+++ b/tests/main/refresh-core-with-hanging-configure-hook/task.yaml
@@ -10,14 +10,12 @@ restore:
     rm -rf squashfs-root
     rm -f $BROKEN_CORE_SNAP
 
-kill-timeout: 2m
-
 execute: |
     snap list | awk "/^core / {print(\$3)}" > prevBoot
     
     echo "Breaking the configure hook of the core snap to hang forever"
     unsquashfs /var/lib/snapd/snaps/core_$(cat prevBoot).snap
-    printf '#!/bin/sh\necho ithangs\nsleep 9999\n' > squashfs-root/meta/hooks/configure
+    printf '#!/bin/sh\necho ithangs\nsleep 60\n' > squashfs-root/meta/hooks/configure
     chmod 755 squashfs-root/meta/hooks/configure
 
     . $TESTSLIB/snaps.sh


### PR DESCRIPTION
This flaky test is failing in the autopkgtests execution. The failure is
caused because sometimes it is taking to much to generate the broken
core snap and the test is reaching the kill-timeout defined in 2
minutes.
The change makes the configure hangs during 60 seconds (enough time out
purpose). Then the kill time out is removed, avoiding any time out
issue.

ERROR:
https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac
/autopkgtest-xenial-snappy-dev-
image/xenial/i386/s/snapd/20170626_145348_a40d4@/log.gz