### PR TITLE
cmd,client,daemon: expose "force devmode" in sysinfo

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -392,7 +392,8 @@ type SysInfo struct {
 
 	KernelVersion string `json:"kernel-version,omitempty"`
 
-	Refresh RefreshInfo `json:"refresh,omitempty"`
+	Refresh     RefreshInfo `json:"refresh,omitempty"`
+	Confinement string      `json:"confinement"`
 }
 
 func (rsp *response) err() error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -200,7 +200,8 @@ func (cs *clientSuite) TestClientSysInfo(c *C) {
                      {"series": "16",
                       "version": "2",
                       "os-release": {"id": "ubuntu", "version-id": "16.04"},
-                      "on-classic": true}}`
+                      "on-classic": true,
+                      "confinement": "strict"}}`
 	sysInfo, err := cs.cli.SysInfo()
 	c.Check(err, IsNil)
 	c.Check(sysInfo, DeepEquals, &client.SysInfo{
@@ -210,7 +211,8 @@ func (cs *clientSuite) TestClientSysInfo(c *C) {
 			ID:        "ubuntu",
 			VersionID: "16.04",
 		},
-		OnClassic: true,
+		OnClassic:   true,
+		Confinement: "strict",
 	})
 }
 

--- a/cmd/snap/cmd_confinement.go
+++ b/cmd/snap/cmd_confinement.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/release"
 
 	"fmt"
 
@@ -45,16 +44,11 @@ func (cmd cmdConfinement) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	// NOTE: Right now we don't have a good way to differentiate if we
-	// only have partial confinement (ala AppArmor disabled and Seccomp
-	// enabled) or no confinement at all. Once we have a better system
-	// in place how we can dynamically retrieve these information from
-	// snapd we will use this here.
-	if !release.ReleaseInfo.ForceDevMode() {
-		fmt.Printf("strict\n")
-	} else {
-		fmt.Printf("none\n")
+	cli := Client()
+	sysInfo, err := cli.SysInfo()
+	if err != nil {
+		return err
 	}
-
+	fmt.Fprintf(Stdout, "%s\n", sysInfo.Confinement)
 	return nil
 }

--- a/cmd/snap/cmd_confinement_test.go
+++ b/cmd/snap/cmd_confinement_test.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+
+	. "gopkg.in/check.v1"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+func (s *SnapSuite) TestConfinement(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "sync", "result": {"confinement": "strict"}}`)
+	})
+	_, err := snap.Parser().ParseArgs([]string{"debug", "confinement"})
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Equals, "strict\n")
+	c.Assert(s.Stderr(), Equals, "")
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -267,6 +267,16 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 			Next:     formatRefreshTime(nextRefresh),
 		},
 	}
+	// NOTE: Right now we don't have a good way to differentiate if we
+	// only have partial confinement (ala AppArmor disabled and Seccomp
+	// enabled) or no confinement at all. Once we have a better system
+	// in place how we can dynamically retrieve these information from
+	// snapd we will use this here.
+	if release.ReleaseInfo.ForceDevMode() {
+		m["confinement"] = "none"
+	} else {
+		m["confinement"] = "strict"
+	}
 
 	return SyncResponse(m, nil)
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -273,7 +273,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	// in place how we can dynamically retrieve these information from
 	// snapd we will use this here.
 	if release.ReleaseInfo.ForceDevMode() {
-		m["confinement"] = "none"
+		m["confinement"] = "partial"
 	} else {
 		m["confinement"] = "strict"
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -568,6 +568,9 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	defer restore()
 	restore = release.MockOnClassic(true)
 	defer restore()
+	restore = release.MockForcedDevmode(true)
+	defer restore()
+
 	sysInfoCmd.GET(sysInfoCmd, nil, nil).ServeHTTP(rec, nil)
 	c.Check(rec.Code, check.Equals, 200)
 	c.Check(rec.HeaderMap.Get("Content-Type"), check.Equals, "application/json")
@@ -588,6 +591,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 		"refresh": map[string]interface{}{
 			"schedule": "",
 		},
+		"confinement": "none",
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -591,7 +591,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 		"refresh": map[string]interface{}{
 			"schedule": "",
 		},
-		"confinement": "none",
+		"confinement": "partial",
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -17,7 +17,7 @@ execute: |
     run_install --classic
     $SNAPMOUNTDIR/bin/test-snapd-hello-classic | MATCH 'Hello Classic!'
 
-    if [ "$(snap debug confinement)" = none ]; then
+    if [ "$(snap debug confinement)" = partial ]; then
         exit 0
     fi
 

--- a/tests/main/debug-confinement/task.yaml
+++ b/tests/main/debug-confinement/task.yaml
@@ -1,7 +1,7 @@
 summary: Verify confinement is correctly reported
 
 execute: |
-    expected=none
+    expected=partial
     case "$SPREAD_SYSTEM" in
     ubuntu-*)
         expected=strict

--- a/tests/main/interfaces-alsa/task.yaml
+++ b/tests/main/interfaces-alsa/task.yaml
@@ -51,7 +51,7 @@ execute: |
     # TODO: extend test to check /var/lib/alsa with plug connected when
     # https://bugs.launchpad.net/snapd/+bug/1694281 is fixed
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         echo "Do not execute checks with disconnected plug on systems where confinement doesn't work"
         exit 0
     fi

--- a/tests/main/interfaces-content-empty-content-attr/task.yaml
+++ b/tests/main/interfaces-content-empty-content-attr/task.yaml
@@ -20,7 +20,7 @@ execute: |
     echo "And we can use the shared content"
     test-snapd-content-plug-empty-content-attr.content-plug | grep "Some shared content"
 
-    if [ "$(snap debug confinement)" = none ]; then
+    if [ "$(snap debug confinement)" = partial ]; then
         exit 0
     fi
 

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -60,7 +60,7 @@ execute: |
     test-snapd-cups-control-consumer.lpr $TEST_FILE
     while ! test -e $HOME/PDF/test_file*.pdf; do sleep 1; done
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 

--- a/tests/main/interfaces-dbus/task.yaml
+++ b/tests/main/interfaces-dbus/task.yaml
@@ -72,7 +72,7 @@ execute: |
     echo "And plug is disconnected by default"
     snap interfaces | MATCH "$DISCONNECTED_PATTERN"
 
-    if [ "$(snap debug confinement)" = none ]; then
+    if [ "$(snap debug confinement)" = partial ]; then
         exit 0
     fi
 

--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -69,7 +69,7 @@ execute: |
     echo "Then the service listening on localhost is no longer accessible through the destination IP in the rule"
     ! nc -w 2 "$DESTINATION_IP" "$PORT" < $REQUEST_FILE
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 

--- a/tests/main/interfaces-hardware-observe/task.yaml
+++ b/tests/main/interfaces-hardware-observe/task.yaml
@@ -32,7 +32,7 @@ execute: |
     echo "Then the snap is able to read hardware information"
     hardware-observe-consumer.consumer
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 

--- a/tests/main/interfaces-home/task.yaml
+++ b/tests/main/interfaces-home/task.yaml
@@ -119,7 +119,7 @@ execute: |
 
     echo "============================================"
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -79,7 +79,7 @@ execute: |
     test-snapd-kernel-module-consumer.rmmod binfmt_misc
     lsmod | MATCH -v binfmt_misc
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 

--- a/tests/main/interfaces-log-observe/task.yaml
+++ b/tests/main/interfaces-log-observe/task.yaml
@@ -51,7 +51,7 @@ execute: |
     echo "Then the snap is able to access the system logs"
     log-observe-consumer | grep -Pqz "ok\n"
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -62,7 +62,7 @@ execute: |
     echo "Then the service is accessible by a client"
     nc -w 2 -q 2 localhost "$PORT" < $REQUEST_FILE | grep -Pqz "ok\n"
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -75,7 +75,7 @@ execute: |
     test-snapd-openvswitch-consumer.ovs-vsctl del-br br0
     ovs-vsctl list-br | MATCH -v br0
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 

--- a/tests/main/interfaces-process-control/task.yaml
+++ b/tests/main/interfaces-process-control/task.yaml
@@ -39,7 +39,7 @@ execute: |
     process-control-consumer.signal "SIGTERM" $pid
     ! ps ax | grep -Pq "^ *$pid"
 
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -38,7 +38,7 @@ execute: |
     snap disconnect shutdown-introspection-consumer:shutdown
     snap interfaces | MATCH "$DISCONNECTED_PATTERN"
 
-    if [ "$(snap debug confinement)" = none ]; then
+    if [ "$(snap debug confinement)" = partial ]; then
         exit
     fi
 

--- a/tests/main/security-apparmor/task.yaml
+++ b/tests/main/security-apparmor/task.yaml
@@ -5,7 +5,7 @@ prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
 execute: |
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
     echo "Then an unconfined action should succeed"

--- a/tests/main/security-profiles/task.yaml
+++ b/tests/main/security-profiles/task.yaml
@@ -6,7 +6,7 @@ restore: |
     rm basic-hooks_1.0_all.snap
 
 execute: |
-    if [ "$(snap debug confinement)" = none ] ; then
+    if [ "$(snap debug confinement)" = partial ] ; then
         exit 0
     fi
 


### PR DESCRIPTION
The GNOME software center would like to show appopriate icons if a snap
application is confined and while each snap shows its confinement
information the whole system may be unable to offer effective
confinement. This patch adds a "confinement" key to the sysinfo
interface and switches the existing "snap debug confinement" command to
use it, rather than implement the logic in the client.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>