### PR TITLE
osutil: allow building on ppc64 (not LE)

### DIFF
--- a/osutil/chattr_64.go
+++ b/osutil/chattr_64.go
@@ -1,5 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-// +build arm64 amd64 ppc64le s390x
+// +build arm64 amd64 ppc64le ppc64 s390x
 
 /*
  * Copyright (C) 2016 Canonical Ltd


### PR DESCRIPTION
This fixes building on Fedora PPC64 (big endian mode). The actual IOCTL
values were OK but were not available due to the selection of the golang
build tags. This patch just adds ppc64 to the list of architectures to
build on.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>