### PR TITLE
tests: make main/help run on opensuse and fedora again

### DIFF
--- a/tests/main/help/task.yaml
+++ b/tests/main/help/task.yaml
@@ -1,4 +1,5 @@
 summary: Check commands help
+systems: [+fedora-*, +opensuse-*]
 environment:
     CMD/abort: abort
     CMD/changes: changes


### PR DESCRIPTION
This _will fail_ because we've not kept the spec files up to date.

I know nothing about spec files, and I don't intend to learn.... who can fix this? Please fix this.