### PR TITLE
tests: fix for rng-tools service not restarting

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -219,8 +219,9 @@ EOF
         echo "HRNGDEVICE=/dev/urandom" > /etc/default/rng-tools
         /etc/init.d/rng-tools restart
 
-        mkdir -p /etc/systemd/system/rng-tools.service.d/
-        cat <<EOF > /etc/systemd/system/rng-tools.service.d/local.conf
+        if systemctl list-units | MATCH "rng-tools.service"; then
+            mkdir -p /etc/systemd/system/rng-tools.service.d/
+            cat <<EOF > /etc/systemd/system/rng-tools.service.d/local.conf
 [Service]
 Restart=always
 RestartSec=2
@@ -229,6 +230,7 @@ PIDFile=/var/run/rngd.pid
 EOF
         systemctl daemon-reload
         systemctl restart rng-tools.service
+        fi
     fi
 
     disable_kernel_rate_limiting

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -225,8 +225,10 @@ EOF
 Restart=always
 RestartSec=2
 RemainAfterExit=no
+PIDFile=/var/run/rngd.pid
 EOF
         systemctl daemon-reload
+        systemctl restart rng-tools.service
     fi
 
     disable_kernel_rate_limiting


### PR DESCRIPTION
As the rng-tools is a forking systemd service, it needs to know which is the
forked process to restart the service successfully.

This change is adding the information in the service unit configuration
to make sure when /usr/sbin/rngd is not running for any reason, then the systemd 
service unit is restarted automatically.

This fix eliminates the lack of entropy issue in 32 bits virtual machines.

ERROR:
https://travis-ci.org/snapcore/snapd/builds/248441911