### PR TITLE
snap-seccomp: skip socket() tests on systems that use socketcall() instead of socket()

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	main "github.com/snapcore/snapd/cmd/snap-seccomp"
+	"github.com/snapcore/snapd/release"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -189,6 +190,21 @@ func (s *snapSeccompSuite) SetUpSuite(c *C) {
 	bpf.VmEndianness = nativeEndian()
 }
 
+func systemUsesSocketcall() bool {
+	// We need to skip the tests on trusty/i386 and trusty/s390x as
+	// those are using the socketcall syscall instead of the real
+	// socket syscall.
+	//
+	// See also:
+	// https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1576066
+	if release.ReleaseInfo.VersionID == "14.04" {
+		if arch.UbuntuArchitecture() == "i386" || arch.UbuntuArchitecture() == "s390x" {
+			return true
+		}
+	}
+	return false
+}
+
 // TestCompile iterates over a range of textual seccomp whitelist rules and
 // mocked kernel syscall input. For each rule, the test consists of compiling
 // the rule into a bpf program and then running that program on a virtual bpf
@@ -303,6 +319,11 @@ func (s *snapSeccompSuite) TestCompile(c *C) {
 		{"ioctl - TIOCSTI", "ioctl;native;-,TIOCSTI", main.SeccompRetAllow},
 		{"ioctl - TIOCSTI", "ioctl;native;-,99", main.SeccompRetKill},
 	} {
+		// skip socket tests if the system uses socketcall instead
+		// of socket
+		if strings.Contains(t.seccompWhitelist, "socket") && systemUsesSocketcall() {
+			continue
+		}
 		simulateBpf(c, t.seccompWhitelist, t.bpfInput, t.expected)
 	}
 }
@@ -386,6 +407,13 @@ func (s *snapSeccompSuite) TestCompileBadInput(c *C) {
 
 // ported from test_restrictions_working_args_socket
 func (s *snapSeccompSuite) TestRestrictionsWorkingArgsSocket(c *C) {
+	// skip socket tests if the system uses socketcall instead
+	// of socket
+	if systemUsesSocketcall() {
+		c.Skip("cannot run when socketcall() is used")
+		return
+	}
+
 	for _, pre := range []string{"AF", "PF"} {
 		for _, i := range []string{"UNIX", "LOCAL", "INET", "INET6", "IPX", "NETLINK", "X25", "AX25", "ATMPVC", "APPLETALK", "PACKET", "ALG", "CAN", "BRIDGE", "NETROM", "ROSE", "NETBEUI", "SECURITY", "KEY", "ASH", "ECONET", "SNA", "IRDA", "PPPOX", "WANPIPE", "BLUETOOTH", "RDS", "LLC", "TIPC", "IUCV", "RXRPC", "ISDN", "PHONET", "IEEE802154", "CAIF", "NFC", "VSOCK", "MPLS", "IB"} {
 			seccompWhitelist := fmt.Sprintf("socket %s_%s", pre, i)


### PR DESCRIPTION
On such systems, the bpf generated will only contain socketcall()
(which ironically can't be filtered anyway). Our test input will
generate socket() calls so this can not work.

Fortunately all modern systems have moved to use socket() - only
14.04/{i386,s390x} are still affected.