### PR TITLE
interfaces: enable access to bridge settings

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -143,6 +143,9 @@ capability setuid,
 /dev/tun[0-9]{,[0-9]*} rw,
 /dev/tap[0-9]{,[0-9]*} rw,
 
+# access to bridge sysfs interfaces for bridge settings
+/sys/devices/virtual/net/*/bridge/* rw,
+
 # Network namespaces via 'ip netns'. In order to create network namespaces
 # that persist outside of the process and be entered (eg, via
 # 'ip netns exec ...') the ip command uses mount namespaces such that


### PR DESCRIPTION
Update network-control to allow access to bridge sysfs interfaces for bridge settings.

Personally, our snap only needs rw access to forward_delay, stp_state, and multicast_snooping but it seems reasonable to enable access to all of the interfaces.

Full list of interfaces: http://paste.ubuntu.com/25012845/