### PR TITLE
assserts,overlord/assertstate: test we don't accept chains of assertions founded on a self-signed key coming externally

### DIFF
--- a/asserts/fetcher.go
+++ b/asserts/fetcher.go
@@ -74,7 +74,7 @@ func (f *fetcher) chase(ref *Ref, a Assertion) error {
 	case fetchSaved:
 		return nil // nothing to do
 	case fetchRetrieved:
-		return fmt.Errorf("internal error: circular assertions are not expected: %s", ref)
+		return fmt.Errorf("circular assertions are not expected: %s", ref)
 	}
 	if a == nil {
 		retrieved, err := f.retrieve(ref)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -315,7 +315,7 @@ func (s *assertMgrSuite) TestBatchCommitRefusesSelfSignedKey(c *C) {
 
 	// this must fail
 	err = batch.Commit(s.state)
-	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `circular assertions are not expected:.*`)
 }
 
 func (s *assertMgrSuite) TestBatchAddUnsupported(c *C) {

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -276,6 +276,48 @@ func (s *assertMgrSuite) TestBatchAddStreamReturnsEffectivelyAddedRefs(c *C) {
 	c.Check(devAcct.(*asserts.Account).Username(), Equals, "developer1")
 }
 
+func (s *assertMgrSuite) TestBatchCommitRefusesSelfSignedKey(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	aKey, _ := assertstest.GenerateKey(752)
+	aSignDB := assertstest.NewSigningDB("can0nical", aKey)
+
+	aKeyEncoded, err := asserts.EncodePublicKey(aKey.PublicKey())
+	c.Assert(err, IsNil)
+
+	headers := map[string]interface{}{
+		"authority-id":        "can0nical",
+		"account-id":          "can0nical",
+		"public-key-sha3-384": aKey.PublicKey().ID(),
+		"name":                "default",
+		"since":               time.Now().UTC().Format(time.RFC3339),
+	}
+	acctKey, err := aSignDB.Sign(asserts.AccountKeyType, headers, aKeyEncoded, "")
+	c.Assert(err, IsNil)
+
+	headers = map[string]interface{}{
+		"authority-id": "can0nical",
+		"brand-id":     "can0nical",
+		"repair-id":    "2",
+		"timestamp":    time.Now().UTC().Format(time.RFC3339),
+	}
+	repair, err := aSignDB.Sign(asserts.RepairType, headers, []byte("#script"), "")
+	c.Assert(err, IsNil)
+
+	batch := assertstate.NewBatch()
+
+	err = batch.Add(repair)
+	c.Assert(err, IsNil)
+
+	err = batch.Add(acctKey)
+	c.Assert(err, IsNil)
+
+	// this must fail
+	err = batch.Commit(s.state)
+	c.Assert(err, NotNil)
+}
+
 func (s *assertMgrSuite) TestBatchAddUnsupported(c *C) {
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 111)
 	defer restore()


### PR DESCRIPTION
This is as per design and expected. But so far we had no tests testing for this explicitly.