### PR TITLE
systemd: add snapd.core-fixup.service unit

### DIFF
--- a/data/systemd/Makefile
+++ b/data/systemd/Makefile
@@ -34,6 +34,7 @@ all: ${SYSTEMD_UNITS}
 
 install: $(SYSTEMD_UNITS)
 	install -D -m 0644 -t ${DESTDIR}/${SYSTEMDSYSTEMUNITDIR} $^
+	install -D -m 0755 -t ${DESTDIR}/${LIBEXECDIR}/snapd snapd.core-fixup.sh
 
 clean:
 	rm -f ${SYSTEMD_UNITS_GENERATED}

--- a/data/systemd/snapd.core-fixup.service.in
+++ b/data/systemd/snapd.core-fixup.service.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=Automatically repair incorrect owner/permissons on core devices
+Before=snapd.service
+ConditionPathExists=/writable/system-data
+ConditionPathExists=!/var/lib/snapd/device/ownership-change.after
+Documentation=man:snap(1)
+
+[Service]
+Type=oneshot
+ExecStart=@libexecdir@/snapd/snapd.core-fixup.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+

--- a/data/systemd/snapd.core-fixup.service.in
+++ b/data/systemd/snapd.core-fixup.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Automatically repair incorrect owner/permissons on core devices
+Description=Automatically repair incorrect owner/permissions on core devices
 Before=snapd.service
 ConditionPathExists=/writable/system-data
 ConditionPathExists=!/var/lib/snapd/device/ownership-change.after

--- a/data/systemd/snapd.core-fixup.sh
+++ b/data/systemd/snapd.core-fixup.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -e
+
+if ! grep -q "ID=ubuntu-core" /etc/os-release; then
+    # this code is only relevant on ubuntu-core devices
+    #
+    # this script will only run via systemd if /writable/system-data
+    # exists however we still add this check here in case people run
+    # it manually
+    exit 0
+fi
+
+# store important data in case we need it later
+if [ ! -f /var/lib/snapd/device/ownership-change.before ]; then
+    mkdir -p /var/lib/snapd/device
+    find /etc/cloud /var/lib/cloud /var/lib/snapd -printf '%M %U %G %p\n' > /var/lib/snapd/device/ownership-change.before.tmp || true
+    find  /writable/system-data /writable/system-data/var /writable/system-data/var/lib /writable/system-data/boot /writable/system-data/etc -maxdepth 0 -printf '%M %U %G %p\n' >> /var/lib/snapd/device/ownership-change.before.tmp || true
+    mv /var/lib/snapd/device/ownership-change.before.tmp /var/lib/snapd/device/ownership-change.before
+fi
+    
+# cleanup read/write files and directories (CVE-2017-10600)
+for i in /etc/cloud /var/lib/cloud /var/lib/snapd ; do
+  # restore ownership to root:root
+  find "$i" \( -type f -o -type d -o -type l \) -a \( \! -uid 0 -o \! -gid 0 \) -print0 | \
+    xargs -0 --no-run-if-empty chown -c --no-dereference root:root -- || true
+done
+
+# cleanup a few /writable directories without descending
+for i in /writable/system-data /writable/system-data/var /writable/system-data/var/lib /writable/system-data/boot /writable/system-data/etc ; do
+  # restore ownership to root:root
+  find "$i" -maxdepth 0 \( \! -uid 0 -o \! -gid 0 -o -type l \) -print0 | \
+    xargs -0 --no-run-if-empty chown -c --no-dereference root:root -- || true
+done
+
+# store permissions after manipulation, this is also used as the stamp file
+# for the systemd service to ensure it is only run once
+find /etc/cloud /var/lib/cloud /var/lib/snapd -printf '%M %U %G %p\n' > /var/lib/snapd/device/ownership-change.after.tmp
+find  /writable/system-data /writable/system-data/var /writable/system-data/var/lib /writable/system-data/boot /writable/system-data/etc -maxdepth 0 -printf '%M %U %G %p\n' >> /var/lib/snapd/device/ownership-change.after.tmp
+mv /var/lib/snapd/device/ownership-change.after.tmp /var/lib/snapd/device/ownership-change.after

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -161,6 +161,9 @@ override_dh_systemd_enable:
 	dh_systemd_enable \
 		-psnapd \
 		data/systemd/snapd.system-shutdown.service
+	dh_systemd_enable \
+		-psnapd \
+		data/systemd/snapd.core-fixup.service
 
 override_dh_systemd_start:
 	# we want to start the auto-update timer
@@ -183,6 +186,9 @@ override_dh_systemd_start:
 	dh_systemd_start \
 		-psnapd \
 		data/systemd/snapd.autoimport.service
+	dh_systemd_start \
+		-psnapd \
+		data/systemd/snapd.core-fixup.service
 
 override_dh_install:
 	# we do not need this in the package, its just needed during build


### PR DESCRIPTION
On some Ubuntu Core devices the ubuntu-image program may create directories that are owned by the uid that ran ubuntu-image instead of the uid root. There is a fix coming in ubuntu-image for this and this branch will fix existing systems.