### PR TITLE
tests: store /etc/systemd/system/snap-*core*.mount in snapd-state.tar.gz

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -459,7 +459,7 @@ prepare_all_snap() {
         fi
 
         systemctl stop snapd.service snapd.socket
-        tar czf "$SPREAD_PATH/snapd-state.tar.gz" /var/lib/snapd $BOOT
+        tar czf "$SPREAD_PATH/snapd-state.tar.gz" /var/lib/snapd $BOOT /etc/systemd/system/snap-*core*.mount
         systemctl start snapd.socket
     fi
 


### PR DESCRIPTION
Without those files mount units from the base image may go missing.
We have the same code in the prepare for classic, when it was added
it was not added to core as well. This commit fixes this.