### PR TITLE
tests: speedup prepare statement part 1

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -187,9 +187,8 @@ EOF
         systemctl stop snapd.{service,socket}
         systemctl daemon-reload
         escaped_snap_mount_dir="$(systemd-escape --path "$SNAPMOUNTDIR")"
-        mounts="$(systemctl list-unit-files --full | grep "^$escaped_snap_mount_dir[-.].*\.mount" | cut -f1 -d ' ')"
-        services="$(systemctl list-unit-files --full | grep "^$escaped_snap_mount_dir[-.].*\.service" | cut -f1 -d ' ')"
-        for unit in $services $mounts; do
+        units="$(systemctl list-unit-files --full | grep -e "^$escaped_snap_mount_dir[-.].*\.mount" -e "^$escaped_snap_mount_dir[-.].*\.service" | cut -f1 -d ' ')"
+        for unit in $units; do
             systemctl stop "$unit"
         done
         snapd_env="/etc/environment /etc/systemd/system/snapd.service.d /etc/systemd/system/snapd.socket.d"
@@ -201,7 +200,7 @@ EOF
         if [[ "$SPREAD_SYSTEM" = ubuntu-14.04-* ]] && mount | grep -q "$core"; then
             umount "$core" || true
         fi
-        for unit in $mounts $services; do
+        for unit in $units; do
             systemctl start "$unit"
         done
         systemctl start snapd.socket

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -28,13 +28,13 @@ execute: |
     iptables -I OUTPUT -m owner --uid-owner $(id -u test) -j REJECT -p tcp --reject-with tcp-reset
 
     echo "Check that we retried"
-    for i in $(seq 10); do
-        if [ cat snap-download.log | MATCH "Retrying.*\.snap, attempt 2" ]; then
+    for i in $(seq 20); do
+        if MATCH "Retrying.*\.snap, attempt 2" < snap-download.log; then
             break
         fi
-        sleep 1
+        sleep .5
     done
-    cat snap-download.log | MATCH "Retrying.*\.snap, attempt 2"
+    MATCH "Retrying.*\.snap, attempt 2" < snap-download.log
 
     # Note that the download will not be successful because of the nature of
     # the netfilter testbed. When snap download retries the next attempt will


### PR DESCRIPTION
This change is proposing a simple change to save about 200 ms for every
test by changing how service units are get. Also is reducing some time
in the econnreset test.