### PR TITLE
interfaces: fix copy-pasted iio vs io in io-ports-control

### DIFF
--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -58,14 +58,14 @@ iopl
 `
 
 // The type for io-ports-control interface
-type iioPortsControlInterface struct{}
+type ioPortsControlInterface struct{}
 
 // Getter for the name of the io-ports-control interface
-func (iface *iioPortsControlInterface) Name() string {
+func (iface *ioPortsControlInterface) Name() string {
 	return "io-ports-control"
 }
 
-func (iface *iioPortsControlInterface) MetaData() interfaces.MetaData {
+func (iface *ioPortsControlInterface) MetaData() interfaces.MetaData {
 	return interfaces.MetaData{
 		Summary:              ioPortsControlSummary,
 		ImplicitOnCore:       true,
@@ -74,12 +74,12 @@ func (iface *iioPortsControlInterface) MetaData() interfaces.MetaData {
 	}
 }
 
-func (iface *iioPortsControlInterface) String() string {
+func (iface *ioPortsControlInterface) String() string {
 	return iface.Name()
 }
 
 // Check validity of the defined slot
-func (iface *iioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
+func (iface *ioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	// Does it have right type?
 	if iface.Name() != slot.Interface {
 		panic(fmt.Sprintf("slot is not of interface %q", iface))
@@ -94,7 +94,7 @@ func (iface *iioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error
 }
 
 // Checks and possibly modifies a plug
-func (iface *iioPortsControlInterface) SanitizePlug(plug *interfaces.Plug) error {
+func (iface *ioPortsControlInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if iface.Name() != plug.Interface {
 		panic(fmt.Sprintf("plug is not of interface %q", iface))
 	}
@@ -102,12 +102,12 @@ func (iface *iioPortsControlInterface) SanitizePlug(plug *interfaces.Plug) error
 	return nil
 }
 
-func (iface *iioPortsControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *ioPortsControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(ioPortsControlConnectedPlugAppArmor)
 	return nil
 }
 
-func (iface *iioPortsControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *ioPortsControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	const udevRule = `KERNEL=="port", TAG+="%s"`
 	for appName := range plug.Apps {
 		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
@@ -116,16 +116,16 @@ func (iface *iioPortsControlInterface) UDevConnectedPlug(spec *udev.Specificatio
 	return nil
 }
 
-func (iface *iioPortsControlInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
+func (iface *ioPortsControlInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(ioPortsControlConnectedPlugSecComp)
 	return nil
 }
 
-func (iface *iioPortsControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *ioPortsControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// Allow what is allowed in the declarations
 	return true
 }
 
 func init() {
-	registerIface(&iioPortsControlInterface{})
+	registerIface(&ioPortsControlInterface{})
 }

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -32,17 +32,17 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-type IioPortsControlInterfaceSuite struct {
+type ioPortsControlInterfaceSuite struct {
 	iface interfaces.Interface
 	slot  *interfaces.Slot
 	plug  *interfaces.Plug
 }
 
-var _ = Suite(&IioPortsControlInterfaceSuite{
+var _ = Suite(&ioPortsControlInterfaceSuite{
 	iface: builtin.MustInterface("io-ports-control"),
 })
 
-func (s *IioPortsControlInterfaceSuite) SetUpTest(c *C) {
+func (s *ioPortsControlInterfaceSuite) SetUpTest(c *C) {
 	// Mock for OS Snap
 	osSnapInfo := snaptest.MockInfo(c, `
 name: ubuntu-core
@@ -64,11 +64,11 @@ apps:
 	s.plug = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["io-ports-control"]}
 }
 
-func (s *IioPortsControlInterfaceSuite) TestName(c *C) {
+func (s *ioPortsControlInterfaceSuite) TestName(c *C) {
 	c.Assert(s.iface.Name(), Equals, "io-ports-control")
 }
 
-func (s *IioPortsControlInterfaceSuite) TestSanitizeSlot(c *C) {
+func (s *ioPortsControlInterfaceSuite) TestSanitizeSlot(c *C) {
 	err := s.iface.SanitizeSlot(s.slot)
 	c.Assert(err, IsNil)
 	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
@@ -79,19 +79,19 @@ func (s *IioPortsControlInterfaceSuite) TestSanitizeSlot(c *C) {
 	c.Assert(err, ErrorMatches, "io-ports-control slots only allowed on core snap")
 }
 
-func (s *IioPortsControlInterfaceSuite) TestSanitizePlug(c *C) {
+func (s *ioPortsControlInterfaceSuite) TestSanitizePlug(c *C) {
 	err := s.iface.SanitizePlug(s.plug)
 	c.Assert(err, IsNil)
 }
 
-func (s *IioPortsControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
+func (s *ioPortsControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
 	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
 		PanicMatches, `slot is not of interface "io-ports-control"`)
 	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
 		PanicMatches, `plug is not of interface "io-ports-control"`)
 }
 
-func (s *IioPortsControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
+func (s *ioPortsControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	expectedSnippet1 := `
 # Description: Allow write access to all I/O ports.
 # See 'man 4 mem' for details.
@@ -116,7 +116,7 @@ capability sys_rawio, # required by iopl
 	c.Assert(snippet, Equals, expectedSnippet3)
 }
 
-func (s *IioPortsControlInterfaceSuite) TestConnectedPlugPolicySecComp(c *C) {
+func (s *ioPortsControlInterfaceSuite) TestConnectedPlugPolicySecComp(c *C) {
 	expectedSnippet2 := `
 # Description: Allow changes to the I/O port permissions and
 # privilege level of the calling process.  In addition to granting
@@ -134,6 +134,6 @@ iopl
 	c.Check(seccompSpec.SnippetForTag("snap.client-snap.app-accessing-io-ports"), Equals, expectedSnippet2)
 }
 
-func (s *IioPortsControlInterfaceSuite) TestInterfaces(c *C) {
+func (s *ioPortsControlInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
 }


### PR DESCRIPTION
The io-ports-control interface is unrelated to iio but has some
(probably) copy-pasted definitions. This patch just replaces iio with io
in the affected file.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>