### PR TITLE
cmd/snap-repair: recover brand/model from /var/lib/snapd/seed/assertions checking signatures and brand account

### DIFF
--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -303,11 +303,12 @@ func trustedBackstore(trusted []asserts.Assertion) asserts.Backstore {
 }
 
 func checkAuthorityID(a asserts.Assertion, trusted asserts.Backstore) error {
-	switch a.Type() {
-	case asserts.AccountKeyType, asserts.AccountType:
-	default:
+	assertType := a.Type()
+	if assertType != asserts.AccountKeyType && assertType != asserts.AccountType {
 		return nil
 	}
+	// check that account and account-key assertions are signed by
+	// a trusted authority
 	acctID := a.AuthorityID()
 	_, err := trusted.Get(asserts.AccountType, []string{acctID}, asserts.AccountType.MaxSupportedFormat())
 	if err != nil && err != asserts.ErrNotFound {

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -372,20 +372,20 @@ func verifySignatures(a asserts.Assertion, workBS asserts.Backstore, trusted ass
 		}
 		seen[u] = true
 		signKey := []string{a.SignKeyID()}
-		key, err := workBS.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
+		key, err := trusted.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
 		if err != nil && err != asserts.ErrNotFound {
 			return err
 		}
-		if err == asserts.ErrNotFound {
-			key, err = trusted.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
+		if err == nil {
+			bottom = true
+		} else {
+			key, err = workBS.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
 			if err != nil && err != asserts.ErrNotFound {
 				return err
 			}
 			if err == asserts.ErrNotFound {
 				return fmt.Errorf("cannot find public key %q", signKey[0])
 			}
-			bottom = true
-		} else {
 			if err := checkAuthorityID(key, trusted); err != nil {
 				return err
 			}

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -35,6 +36,7 @@ import (
 	"gopkg.in/retry.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
@@ -285,9 +287,113 @@ func (run *Runner) initState() error {
 	}
 	// best-effort remove old
 	os.Remove(dirs.SnapRepairStateFile)
-	// TODO: init Device
+	if err := run.initDeviceInfo(); err != nil {
+		return err
+	}
 	run.stateModified = true
 	return run.SaveState()
+}
+
+func trustedBackstore(trusted []asserts.Assertion) asserts.Backstore {
+	trustedBS := asserts.NewMemoryBackstore()
+	for _, t := range trusted {
+		trustedBS.Put(t.Type(), t)
+	}
+	return trustedBS
+}
+
+func verifySignatures(a asserts.Assertion, workBS asserts.Backstore, trustedKeys asserts.Backstore) error {
+	acctKeyMaxSuppFormat := asserts.AccountKeyType.MaxSupportedFormat()
+
+	seen := make(map[string]bool)
+	bottom := false
+	for !bottom {
+		u := a.Ref().Unique()
+		if seen[u] {
+			return fmt.Errorf("circular assertions")
+		}
+		seen[u] = true
+		signKey := []string{a.SignKeyID()}
+		key, err := workBS.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
+		if err != nil && err != asserts.ErrNotFound {
+			return err
+		}
+		if err == asserts.ErrNotFound {
+			key, err = trustedKeys.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
+			if err != nil && err != asserts.ErrNotFound {
+				return err
+			}
+			if err == asserts.ErrNotFound {
+				return fmt.Errorf("cannot find public key %q", signKey[0])
+			}
+			bottom = true
+		}
+		if err := asserts.CheckSignature(a, key.(*asserts.AccountKey), nil, time.Time{}); err != nil {
+			return err
+		}
+		a = key
+	}
+	return nil
+}
+
+func (run *Runner) initDeviceInfo() error {
+	const errPrefix = "cannot set device information: "
+
+	workBS := asserts.NewMemoryBackstore()
+	assertSeedDir := filepath.Join(dirs.SnapSeedDir, "assertions")
+	dc, err := ioutil.ReadDir(assertSeedDir)
+	if err != nil {
+		return err
+	}
+	var model *asserts.Model
+	for _, fi := range dc {
+		fn := filepath.Join(assertSeedDir, fi.Name())
+		f, err := os.Open(fn)
+		if err != nil {
+			// best effort
+			continue
+		}
+		dec := asserts.NewDecoder(f)
+		for {
+			a, err := dec.Decode()
+			if err != nil {
+				// best effort
+				break
+			}
+			switch a.Type() {
+			case asserts.ModelType:
+				if model != nil {
+					return fmt.Errorf(errPrefix + "multiple models in seed assertions")
+				}
+				model = a.(*asserts.Model)
+			case asserts.AccountType, asserts.AccountKeyType:
+				workBS.Put(a.Type(), a)
+			}
+		}
+	}
+	if model == nil {
+		return fmt.Errorf(errPrefix + "no model assertion in seed data")
+	}
+	trustedBS := trustedBackstore(sysdb.Trusted())
+	if err := verifySignatures(model, workBS, trustedBS); err != nil {
+		return fmt.Errorf(errPrefix+"%v", err)
+	}
+	acctPK := []string{model.BrandID()}
+	acctMaxSupFormat := asserts.AccountType.MaxSupportedFormat()
+	acct, err := trustedBS.Get(asserts.AccountType, acctPK, acctMaxSupFormat)
+	if err != nil {
+		var err error
+		acct, err = workBS.Get(asserts.AccountType, acctPK, acctMaxSupFormat)
+		if err != nil {
+			return fmt.Errorf(errPrefix + "no brand account assertion in seed data")
+		}
+	}
+	if err := verifySignatures(acct, workBS, trustedBS); err != nil {
+		return fmt.Errorf(errPrefix+"%v", err)
+	}
+	run.state.Device.Brand = model.BrandID()
+	run.state.Device.Model = model.Model()
+	return nil
 }
 
 // LoadState loads the repairs' state from disk, and (re)initializes it if it's missing or corrupted.

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -61,10 +61,7 @@ type runnerSuite struct {
 var _ = Suite(&runnerSuite{})
 
 func (s *runnerSuite) SetUpSuite(c *C) {
-	rootPrivKey, _ := assertstest.GenerateKey(1024)
-	storePrivKey, _ := assertstest.GenerateKey(752)
-
-	s.storeSigning = assertstest.NewStoreStack("canonical", rootPrivKey, storePrivKey)
+	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
 
 	brandPrivKey, _ := assertstest.GenerateKey(752)
 


### PR DESCRIPTION
This adds code to initialise snap-repair state with brand/model recovered from /var/lib/snapd/seed/assertions.

Some helper introduced here can likely be reused when we will need to verify the signatures of the repairs themselves. 