### PR TITLE
cmd/snap: snap find only searches stable

### DIFF
--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -32,7 +32,7 @@ import (
 
 var shortFindHelp = i18n.G("Finds packages to install")
 var longFindHelp = i18n.G(`
-The find command queries the store for available packages.
+The find command queries the store for available packages in the stable channel.
 `)
 
 func getPrice(prices map[string]float64, currency string) (float64, string, error) {


### PR DESCRIPTION
Note in the help (and thus the man page) that snap find only searches the stable channel; https://snapcraft.io/docs/core/usage makes this clear, but the man page doesn't mention it, which is confusing (because snaps that are only in the beta channel appear to not exist at all).