### PR TITLE
overlord: populate interface label with summary

### DIFF
--- a/overlord/ifacestate/implicit.go
+++ b/overlord/ifacestate/implicit.go
@@ -42,15 +42,16 @@ func addImplicitSlots(snapInfo *snap.Info) {
 		if (release.OnClassic && md.ImplicitOnClassic) || (!release.OnClassic && md.ImplicitOnCore) {
 			ifaceName := iface.Name()
 			if _, ok := snapInfo.Slots[ifaceName]; !ok {
-				snapInfo.Slots[ifaceName] = makeImplicitSlot(snapInfo, ifaceName)
+				snapInfo.Slots[ifaceName] = makeImplicitSlot(snapInfo, ifaceName, md.Summary)
 			}
 		}
 	}
 }
 
-func makeImplicitSlot(snapInfo *snap.Info, ifaceName string) *snap.SlotInfo {
+func makeImplicitSlot(snapInfo *snap.Info, ifaceName string, ifaceLabel string) *snap.SlotInfo {
 	return &snap.SlotInfo{
 		Name:      ifaceName,
+		Label:     ifaceLabel,
 		Snap:      snapInfo,
 		Interface: ifaceName,
 	}


### PR DESCRIPTION
Currently the `/v2/interfaces` API has a _label_ field for plugs and slots. I haven't seen any of these being set for any snaps that I can find. (My original patch was to add a Label() method before I saw there was existing metadata).

This patch sets the label for the built-in slots in the core snap (which can't have labels set manually by a developer). It uses the _summary_ field from the interface metadata, however I'm not sure if this is the correct method.

- Interfaces have a _summary_ and _description_ - should we be exposing these on the API instead / as well as _label_?
- Is the _summary_ appropriate here? What is the intention of this information?
- What form is _summary_ in? The current strings appear to be of the form "allow X". What audience are they intended for? The current form is a sentence fragment, so may not be useful for displaying in a UI.
- Are these fields going to be translatable in the future?