### PR TITLE
store: talk to api.snapcraft.io for purchases

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -169,6 +169,7 @@ type Config struct {
 	BulkURI        *url.URL
 	AssertionsURI  *url.URL
 	OrdersURI      *url.URL
+	BuyURI         *url.URL
 	CustomersMeURI *url.URL
 	SectionsURI    *url.URL
 
@@ -189,6 +190,7 @@ type Store struct {
 	bulkURI        *url.URL
 	assertionsURI  *url.URL
 	ordersURI      *url.URL
+	buyURI         *url.URL
 	customersMeURI *url.URL
 	sectionsURI    *url.URL
 
@@ -338,11 +340,6 @@ func init() {
 		panic(err)
 	}
 
-	myappsBaseURI, err := url.Parse(myappsURL())
-	if err != nil {
-		panic(err)
-	}
-
 	// XXX: Repeating "api/" here is cumbersome, but the next generation
 	// of store APIs will probably drop that prefix (since it now
 	// duplicates the hostname), and we may want to switch to v2 APIs
@@ -352,12 +349,12 @@ func init() {
 	// slash at the end because snap name is appended to this with .Parse(snapName)
 	defaultConfig.DetailsURI = urlJoin(storeBaseURI, "api/v1/snaps/details/")
 	defaultConfig.BulkURI = urlJoin(storeBaseURI, "api/v1/snaps/metadata")
+	defaultConfig.OrdersURI = urlJoin(storeBaseURI, "api/v1/snaps/purchases/orders")
+	defaultConfig.BuyURI = urlJoin(storeBaseURI, "api/v1/snaps/purchases/buy")
+	defaultConfig.CustomersMeURI = urlJoin(storeBaseURI, "api/v1/snaps/purchases/customers/me")
 	defaultConfig.SectionsURI = urlJoin(storeBaseURI, "api/v1/snaps/sections")
 
 	defaultConfig.AssertionsURI = urlJoin(assertsBaseURI, "assertions/")
-
-	defaultConfig.OrdersURI = urlJoin(myappsBaseURI, "purchases/v1/orders")
-	defaultConfig.CustomersMeURI = urlJoin(myappsBaseURI, "purchases/v1/customers/me")
 }
 
 type searchResults struct {
@@ -440,6 +437,7 @@ func New(cfg *Config, authContext auth.AuthContext) *Store {
 		bulkURI:         cfg.BulkURI,
 		assertionsURI:   cfg.AssertionsURI,
 		ordersURI:       cfg.OrdersURI,
+		buyURI:          cfg.BuyURI,
 		customersMeURI:  cfg.CustomersMeURI,
 		sectionsURI:     sectionsURI,
 		series:          series,
@@ -1719,7 +1717,7 @@ func (s *Store) Buy(options *BuyOptions, user *auth.UserState) (*BuyResult, erro
 
 	reqOptions := &requestOptions{
 		Method:      "POST",
-		URL:         s.ordersURI,
+		URL:         s.buyURI,
 		Accept:      jsonContentType,
 		ContentType: jsonContentType,
 		Data:        jsonData,

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3979,8 +3979,9 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersAllFree(c *C) {
 	c.Check(requestRecieved, Equals, false)
 }
 
-const ordersPath = "/purchases/v1/orders"
-const customersMePath = "/purchases/v1/customers/me"
+const ordersPath = "/api/v1/snaps/purchases/orders"
+const buyPath = "/api/v1/snaps/purchases/buy"
+const customersMePath = "/api/v1/snaps/purchases/customers/me"
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersSingle(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4207,7 +4208,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuy500(c *C) {
 
 	detailsURI, err := url.Parse(mockServer.URL)
 	c.Assert(err, IsNil)
-	ordersURI, err := url.Parse(mockPurchasesServer.URL + ordersPath)
+	buyURI, err := url.Parse(mockPurchasesServer.URL + buyPath)
 	c.Assert(err, IsNil)
 	customersMeURI, err := url.Parse(mockPurchasesServer.URL + customersMePath)
 	c.Assert(err, IsNil)
@@ -4216,7 +4217,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuy500(c *C) {
 	cfg := Config{
 		CustomersMeURI: customersMeURI,
 		DetailsURI:     detailsURI,
-		OrdersURI:      ordersURI,
+		BuyURI:         buyURI,
 	}
 	repo := New(&cfg, authContext)
 	c.Assert(repo, NotNil)
@@ -4269,7 +4270,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuy(c *C) {
 				c.Check(r.Header.Get("Authorization"), Equals, t.expectedAuthorization(c, t.user))
 				c.Check(r.Header.Get("Accept"), Equals, jsonContentType)
 				c.Check(r.Header.Get("Content-Type"), Equals, jsonContentType)
-				c.Check(r.URL.Path, Equals, ordersPath)
+				c.Check(r.URL.Path, Equals, buyPath)
 				jsonReq, err := ioutil.ReadAll(r.Body)
 				c.Assert(err, IsNil)
 				c.Check(string(jsonReq), Equals, test.expectedInput)
@@ -4301,14 +4302,14 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuy(c *C) {
 		c.Assert(err, IsNil)
 		ordersURI, err := url.Parse(mockPurchasesServer.URL + ordersPath)
 		c.Assert(err, IsNil)
-		customersMeURI, err := url.Parse(mockPurchasesServer.URL + customersMePath)
+		buyURI, err := url.Parse(mockPurchasesServer.URL + buyPath)
 		c.Assert(err, IsNil)
 
 		authContext := &testAuthContext{c: c, device: t.device, user: t.user}
 		cfg := Config{
-			CustomersMeURI: customersMeURI,
-			DetailsURI:     detailsURI,
-			OrdersURI:      ordersURI,
+			DetailsURI: detailsURI,
+			OrdersURI:  ordersURI,
+			BuyURI:     buyURI,
 		}
 		repo := New(&cfg, authContext)
 		c.Assert(repo, NotNil)


### PR DESCRIPTION
api.snapcraft.io now has proxy endpoints for the purchases requests
needed by snapd, so we can use that to get us closer to consolidating
snapd's store requests onto a single device gateway.

The buy URL is now separate from orders just because that was a bit
easier to implement on the store side.