### PR TITLE
tests: fix how package lists are updated for opensuse and fedora

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -203,7 +203,7 @@ distro_update_package_db() {
             quiet apt-get update
             ;;
         fedora-*)
-            dnf -q check-update
+            dnf -q makecache
             ;;
         opensuse-*)
             zypper -q refresh

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -203,10 +203,10 @@ distro_update_package_db() {
             quiet apt-get update
             ;;
         fedora-*)
-            dnf -y -q upgrade
+            dnf -q check-update
             ;;
         opensuse-*)
-            zypper -q update -y
+            zypper -q refresh
             ;;
         *)
             echo "ERROR: Unsupported distribution $SPREAD_SYSTEM"


### PR DESCRIPTION
The current update packages list implementations for opensuse and fedora
are upgrading all the packages installed, making the test suite setup
much slower than the ubuntu/debian.