### PR TITLE
tests: remove unneeded check for re-exec in InternalToolPath()

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -115,12 +115,6 @@ func coreSupportsReExec(corePath string) bool {
 func InternalToolPath(tool string) string {
 	distroTool := filepath.Join(dirs.DistroLibExecDir, tool)
 
-	// mostly useful for tests
-	if !osutil.GetenvBool(reExecKey, true) {
-		logger.Debugf("re-exec disabled by user")
-		return distroTool
-	}
-
 	// find the internal path relative to the running snapd, this
 	// ensure we don't rely on the state of the system (like
 	// having a valid "current" symlink).

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -20,6 +20,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -125,8 +126,8 @@ func InternalToolPath(tool string) string {
 	}
 
 	// ensure we never use this helper from anything but
-	if !strings.HasSuffix(exe, "/snapd") {
-		panic("InternalToolPath can only be used from snapd")
+	if !strings.HasSuffix(exe, "/snapd") && !strings.HasSuffix(exe, ".test") {
+		panic(fmt.Sprintf("InternalToolPath can only be used from snapd, got: %s", exe))
 	}
 
 	if !strings.HasPrefix(exe, dirs.SnapMountDir) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -217,7 +217,12 @@ func (s *cmdSuite) TestInternalToolPathWithReexec(c *C) {
 }
 
 func (s *cmdSuite) TestInternalToolPathFromIncorrectHelper(c *C) {
-	c.Check(func() { cmd.InternalToolPath("potato") }, PanicMatches, "InternalToolPath can only be used from snapd")
+	restore := cmd.MockOsReadlink(func(string) (string, error) {
+		return "/usr/bin/potato", nil
+	})
+	defer restore()
+
+	c.Check(func() { cmd.InternalToolPath("potato") }, PanicMatches, "InternalToolPath can only be used from snapd, got: /usr/bin/potato")
 }
 
 func (s *cmdSuite) TestExecInCoreSnap(c *C) {

--- a/interfaces/mount/ns_test.go
+++ b/interfaces/mount/ns_test.go
@@ -45,9 +45,6 @@ func (s *nsSuite) SetUpTest(c *C) {
 	s.AddCleanup(release.MockOnClassic(true))
 	// Anything that just gives us no-reexec.
 	s.AddCleanup(release.MockReleaseInfo(&release.OS{ID: "fedora"}))
-
-	os.Setenv("SNAP_REEXEC", "0")
-	s.AddCleanup(func() { os.Unsetenv("SNAP_REEXEC") })
 }
 
 func (s *nsSuite) TestDiscardNamespaceMnt(c *C) {

--- a/tests/main/interfaces-avahi-observe/task.yaml
+++ b/tests/main/interfaces-avahi-observe/task.yaml
@@ -16,7 +16,7 @@ prepare: |
         restart avahi-daemon
     else
         systemctl daemon-reload
-        systemctl restart avahi-daemon.{service,socket}
+        systemctl restart avahi-daemon.{socket,service}
     fi
 
 restore: |

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -19,10 +19,9 @@ execute: |
     prevsnapdver=$(snap --version|grep "snapd ")
 
     if [[ "$SPREAD_SYSTEM" = debian-* ]] ; then
-        # For debian we install the latest core snap from beta instead
-        # from stable as stable and candidate are broken at the moment.
-        # FIXME: drop this again once 2.25 landed in stable.
-        snap install --beta core
+        # For debian we install the latest core snap independently until
+        # the bug fix is on stable once 2.27 landed
+        snap install core
     fi
 
     echo Install sanity check snaps with it


### PR DESCRIPTION
This should fix the debian-unstable-64 upgrade scenario test.