### PR TITLE
debian: update debian/tests/control to use isolation-machine

### DIFF
--- a/packaging/ubuntu-16.04/tests/control
+++ b/packaging/ubuntu-16.04/tests/control
@@ -1,5 +1,5 @@
 Tests: integrationtests
-Restrictions: allow-stderr, isolation-container, rw-build-tree, needs-root, breaks-testbed
+Restrictions: allow-stderr, rw-build-tree, needs-root, breaks-testbed, isolation-machine
 Depends: @builddeps@,
          bzr,
          ca-certificates,


### PR DESCRIPTION
We used to have isolation-container but now we test more and
a container is no longer good enough.