### PR TITLE
many: expose service status in 'snap info'

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -72,6 +72,7 @@ type AppInfo struct {
 	*ServiceInfo `json:",omitempty"`
 }
 
+// IsService returns true if the application is a background daemon.
 func (a *AppInfo) IsService() bool {
 	if a == nil {
 		return false

--- a/client/packages.go
+++ b/client/packages.go
@@ -87,7 +87,10 @@ func (a *AppInfo) IsService() bool {
 }
 
 type ServiceInfo struct {
-	Daemon string `json:"daemon"`
+	Daemon          string `json:"daemon"`
+	ServiceFileName string `json:"service-file-name"`
+	Enabled         bool   `json:"enabled"`
+	Active          bool   `json:"active"`
 }
 
 type Screenshot struct {

--- a/client/packages.go
+++ b/client/packages.go
@@ -67,7 +67,26 @@ type Snap struct {
 }
 
 type AppInfo struct {
-	Name   string `json:"name"`
+	Name         string `json:"name"`
+	DesktopFile  string `json:"desktop-file,omitempty"`
+	*ServiceInfo `json:",omitempty"`
+}
+
+func (a *AppInfo) IsService() bool {
+	if a == nil {
+		return false
+	}
+	if a.ServiceInfo == nil {
+		return false
+	}
+	if a.ServiceInfo.Daemon == "" {
+		return false
+	}
+
+	return true
+}
+
+type ServiceInfo struct {
 	Daemon string `json:"daemon"`
 }
 

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -20,6 +20,7 @@
 package client_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"time"
@@ -223,4 +224,34 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 			{URL: "http://example.com/shot2.png"},
 		},
 	})
+}
+
+func (cs *clientSuite) TestAppInfoNilNotService(c *check.C) {
+	var app *client.AppInfo
+	c.Check(app.IsService(), check.Equals, false)
+}
+
+func (cs *clientSuite) TestAppInfoNoDaemonNotService(c *check.C) {
+	var app *client.AppInfo
+	c.Assert(json.Unmarshal([]byte(`{"name": "hello"}`), &app), check.IsNil)
+	c.Check(app.Name, check.Equals, "hello")
+	c.Check(app.ServiceInfo, check.IsNil)
+	c.Check(app.IsService(), check.Equals, false)
+}
+
+func (cs *clientSuite) TestAppInfoEmptyDaemonNotService(c *check.C) {
+	var app *client.AppInfo
+	c.Assert(json.Unmarshal([]byte(`{"name": "hello", "daemon": ""}`), &app), check.IsNil)
+	c.Check(app.Name, check.Equals, "hello")
+	c.Check(app.ServiceInfo, check.NotNil)
+	c.Check(app.IsService(), check.Equals, false)
+}
+
+func (cs *clientSuite) TestAppInfoDaemonIsService(c *check.C) {
+	var app *client.AppInfo
+
+	c.Assert(json.Unmarshal([]byte(`{"name": "hello", "daemon": "x"}`), &app), check.IsNil)
+	c.Check(app.Name, check.Equals, "hello")
+	c.Check(app.ServiceInfo, check.NotNil)
+	c.Check(app.IsService(), check.Equals, true)
 }

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -226,6 +226,32 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 	})
 }
 
+func (cs *clientSuite) TestAppInfoNoServiceNoDaemon(c *check.C) {
+	buf, err := json.MarshalIndent(client.AppInfo{Name: "hello"}, "\t", "\t")
+	c.Assert(err, check.IsNil)
+	c.Check(string(buf), check.Equals, `{
+		"name": "hello"
+	}`)
+}
+
+func (cs *clientSuite) TestAppInfoServiceDaemon(c *check.C) {
+	si := &client.ServiceInfo{
+		Daemon:          "daemon",
+		ServiceFileName: "filename",
+		Enabled:         true,
+		Active:          false,
+	}
+	buf, err := json.MarshalIndent(client.AppInfo{Name: "hello", ServiceInfo: si}, "\t", "\t")
+	c.Assert(err, check.IsNil)
+	c.Check(string(buf), check.Equals, `{
+		"name": "hello",
+		"daemon": "daemon",
+		"service-file-name": "filename",
+		"enabled": true,
+		"active": false
+	}`)
+}
+
 func (cs *clientSuite) TestAppInfoNilNotService(c *check.C) {
 	var app *client.AppInfo
 	c.Check(app.IsService(), check.Equals, false)

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -200,6 +200,40 @@ func maybePrintCommands(w io.Writer, snapName string, allApps []client.AppInfo, 
 	}
 }
 
+func maybePrintServices(w io.Writer, snapName string, allApps []client.AppInfo, n int) {
+	if len(allApps) == 0 {
+		return
+	}
+
+	services := make([]string, 0, len(allApps))
+	for _, app := range allApps {
+		if !app.IsService() {
+			continue
+		}
+
+		var active, enabled string
+		if app.Active {
+			active = "active"
+		} else {
+			active = "inactive"
+		}
+		if app.Enabled {
+			enabled = "enabled"
+		} else {
+			enabled = "disabled"
+		}
+		services = append(services, fmt.Sprintf("  %s:\t%s, %s, %s", snap.JoinSnapApp(snapName, app.Name), app.Daemon, enabled, active))
+	}
+	if len(services) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "services:\n")
+	for _, svc := range services {
+		fmt.Fprintln(w, svc)
+	}
+}
+
 // displayChannels displays channels and tracks in the right order
 func displayChannels(w io.Writer, remote *client.Snap) {
 	// \t\t\t so we get "installed" lined up with "channels"
@@ -279,6 +313,7 @@ func (x *infoCmd) Execute([]string) error {
 		maybePrintType(w, both.Type)
 		maybePrintID(w, both)
 		maybePrintCommands(w, snapName, both.Apps, termWidth)
+		maybePrintServices(w, snapName, both.Apps, termWidth)
 
 		if x.Verbose {
 			fmt.Fprintln(w, "notes:\t")

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -183,7 +183,7 @@ func maybePrintCommands(w io.Writer, snapName string, allApps []client.AppInfo, 
 
 	commands := make([]string, 0, len(allApps))
 	for _, app := range allApps {
-		if app.Daemon != "" {
+		if app.IsService() {
 			continue
 		}
 

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -36,6 +36,8 @@ var (
 	Wait               = wait
 	ResolveApp         = resolveApp
 	IsReexeced         = isReexeced
+	MaybePrintServices = maybePrintServices
+	MaybePrintCommands = maybePrintCommands
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -84,10 +84,10 @@ type apiBaseSuite struct {
 	storeSigning      *assertstest.StoreStack
 	restoreRelease    func()
 	trustedRestorer   func()
-	origSysctlcmd     func(...string) ([]byte, error)
-	sysctlargses      [][]string
-	sysctlbuf         []byte
-	sysctlerr         error
+	origSysctlCmd     func(...string) ([]byte, error)
+	sysctlArgses      [][]string
+	sysctlBuf         []byte
+	sysctlErr         error
 }
 
 func (s *apiBaseSuite) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
@@ -158,19 +158,19 @@ func (s *apiBaseSuite) SetUpSuite(c *check.C) {
 	s.restoreRelease = release.MockForcedDevmode(false)
 
 	snapstate.CanAutoRefresh = nil
-	s.origSysctlcmd = systemd.SystemctlCmd
+	s.origSysctlCmd = systemd.SystemctlCmd
 	systemd.SystemctlCmd = s.systemctl
 }
 
 func (s *apiBaseSuite) TearDownSuite(c *check.C) {
 	muxVars = nil
 	s.restoreRelease()
-	systemd.SystemctlCmd = s.origSysctlcmd
+	systemd.SystemctlCmd = s.origSysctlCmd
 }
 
 func (s *apiBaseSuite) systemctl(args ...string) ([]byte, error) {
-	s.sysctlargses = append(s.sysctlargses, args)
-	return s.sysctlbuf, s.sysctlerr
+	s.sysctlArgses = append(s.sysctlArgses, args)
+	return s.sysctlBuf, s.sysctlErr
 }
 
 var (
@@ -179,7 +179,7 @@ var (
 )
 
 func (s *apiBaseSuite) SetUpTest(c *check.C) {
-	s.sysctlargses = nil
+	s.sysctlArgses = nil
 	dirs.SetRootDir(c.MkDir())
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, check.IsNil)
@@ -392,7 +392,7 @@ apps:
     daemon: simple
 `)
 	df := s.mkInstalledDesktopFile(c, "foo_cmd.desktop", "[Desktop]\nExec=foo.cmd %U")
-	s.sysctlbuf = []byte("Type=simple\nId=snap.foo.svc.service\nActiveState=fumbling\nUnitFileState=enabled\n")
+	s.sysctlBuf = []byte("Type=simple\nId=snap.foo.svc.service\nActiveState=fumbling\nUnitFileState=enabled\n")
 
 	req, err := http.NewRequest("GET", "/v2/snaps/foo", nil)
 	c.Assert(err, check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
 	"github.com/snapcore/snapd/asserts/sysdb"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
@@ -407,7 +408,7 @@ func (s *apiSuite) TestSnapInfoOneIntegration(c *check.C) {
 			"jailmode":         false,
 			"confinement":      snap.StrictConfinement,
 			"trymode":          false,
-			"apps": []appJSON{
+			"apps": []*client.AppInfo{
 				{Name: "cmd", DesktopFile: df},
 				// no desktop file
 				{Name: "cmd2"},

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -180,6 +180,8 @@ func mapLocal(about aboutSnap) map[string]interface{} {
 	}
 	sort.Strings(appNames)
 	apps := make([]*client.AppInfo, len(localSnap.Apps))
+	// TODO: pass in an actual notifier here instead of nil
+	//       (Status doesn't _need_ it, but benefits from it)
 	sysd := systemd.New(dirs.GlobalRootDir, nil)
 	for i, appName := range appNames {
 		app := localSnap.Apps[appName]
@@ -189,7 +191,7 @@ func mapLocal(about aboutSnap) map[string]interface{} {
 		}
 
 		if app.IsService() {
-			// todo: look into making a single call to Status for all services
+			// TODO: look into making a single call to Status for all services
 			sts, err := sysd.Status(app.ServiceName())
 			if err == nil && len(sts) == 1 {
 				apps[i].ServiceInfo = sts[0]

--- a/snap/info.go
+++ b/snap/info.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/strutil"
-	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timeout"
 )
 
@@ -406,7 +405,7 @@ type AppInfo struct {
 	StopCommand     string
 	ReloadCommand   string
 	PostStopCommand string
-	RestartCond     systemd.RestartCondition
+	RestartCond     RestartCondition
 	Completer       string
 
 	// TODO: this should go away once we have more plumbing and can change

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -27,7 +27,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/strutil"
-	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timeout"
 )
 
@@ -64,9 +63,9 @@ type appYaml struct {
 	StopTimeout     timeout.Timeout `yaml:"stop-timeout,omitempty"`
 	Completer       string          `yaml:"completer,omitempty"`
 
-	RestartCond systemd.RestartCondition `yaml:"restart-condition,omitempty"`
-	SlotNames   []string                 `yaml:"slots,omitempty"`
-	PlugNames   []string                 `yaml:"plugs,omitempty"`
+	RestartCond RestartCondition `yaml:"restart-condition,omitempty"`
+	SlotNames   []string         `yaml:"slots,omitempty"`
+	PlugNames   []string         `yaml:"plugs,omitempty"`
 
 	BusName string `yaml:"bus-name,omitempty"`
 

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
-	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timeout"
 )
 
@@ -1344,7 +1343,7 @@ apps:
 			Name:            "svc",
 			Command:         "svc1",
 			Daemon:          "forking",
-			RestartCond:     systemd.RestartOnAbnormal,
+			RestartCond:     snap.RestartOnAbnormal,
 			StopTimeout:     timeout.Timeout(25 * time.Second),
 			StopCommand:     "stop-cmd",
 			PostStopCommand: "post-stop-cmd",

--- a/snap/restartcond.go
+++ b/snap/restartcond.go
@@ -1,0 +1,75 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap
+
+import (
+	"errors"
+)
+
+// RestartCondition encapsulates the different systemd 'restart' options
+type RestartCondition string
+
+// These are the supported restart conditions
+const (
+	RestartNever      RestartCondition = "never"
+	RestartOnSuccess  RestartCondition = "on-success"
+	RestartOnFailure  RestartCondition = "on-failure"
+	RestartOnAbnormal RestartCondition = "on-abnormal"
+	RestartOnAbort    RestartCondition = "on-abort"
+	RestartAlways     RestartCondition = "always"
+)
+
+var RestartMap = map[string]RestartCondition{
+	"no":          RestartNever,
+	"never":       RestartNever,
+	"on-success":  RestartOnSuccess,
+	"on-failure":  RestartOnFailure,
+	"on-abnormal": RestartOnAbnormal,
+	"on-abort":    RestartOnAbort,
+	"always":      RestartAlways,
+}
+
+// ErrUnknownRestartCondition is returned when trying to unmarshal an unknown restart condition
+var ErrUnknownRestartCondition = errors.New("invalid restart condition")
+
+func (rc RestartCondition) String() string {
+	if rc == "never" {
+		return "no"
+	}
+	return string(rc)
+}
+
+// UnmarshalYAML so RestartCondition implements yaml's Unmarshaler interface
+func (rc *RestartCondition) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var v string
+
+	if err := unmarshal(&v); err != nil {
+		return err
+	}
+
+	nrc, ok := RestartMap[v]
+	if !ok {
+		return ErrUnknownRestartCondition
+	}
+
+	*rc = nrc
+
+	return nil
+}

--- a/snap/restartcond_test.go
+++ b/snap/restartcond_test.go
@@ -31,12 +31,12 @@ type restartcondSuite struct{}
 var _ = Suite(&restartcondSuite{})
 
 func (*restartcondSuite) TestRestartCondUnmarshal(c *C) {
-	for cond := range snap.RestartMap {
-		bs := []byte(cond)
+	for name, cond := range snap.RestartMap {
+		bs := []byte(name)
 		var rc snap.RestartCondition
 
 		c.Check(yaml.Unmarshal(bs, &rc), IsNil)
-		c.Check(rc, Equals, snap.RestartMap[cond], Commentf(cond))
+		c.Check(rc, Equals, cond, Commentf(name))
 	}
 }
 

--- a/snap/restartcond_test.go
+++ b/snap/restartcond_test.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap_test
+
+import (
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+type restartcondSuite struct{}
+
+var _ = Suite(&restartcondSuite{})
+
+func (*restartcondSuite) TestRestartCondUnmarshal(c *C) {
+	for cond := range snap.RestartMap {
+		bs := []byte(cond)
+		var rc snap.RestartCondition
+
+		c.Check(yaml.Unmarshal(bs, &rc), IsNil)
+		c.Check(rc, Equals, snap.RestartMap[cond], Commentf(cond))
+	}
+}
+
+func (restartcondSuite) TestRestartCondString(c *C) {
+	for name, cond := range snap.RestartMap {
+		if name == "never" {
+			c.Check(cond.String(), Equals, "no")
+		} else {
+			c.Check(cond.String(), Equals, name, Commentf(name))
+		}
+	}
+}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -20,7 +20,6 @@
 package systemd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -99,53 +98,6 @@ type Systemd interface {
 
 // A Log is a single entry in the systemd journal
 type Log map[string]string
-
-// RestartCondition encapsulates the different systemd 'restart' options
-type RestartCondition string
-
-// These are the supported restart conditions
-const (
-	RestartNever      RestartCondition = "never"
-	RestartOnSuccess  RestartCondition = "on-success"
-	RestartOnFailure  RestartCondition = "on-failure"
-	RestartOnAbnormal RestartCondition = "on-abnormal"
-	RestartOnAbort    RestartCondition = "on-abort"
-	RestartAlways     RestartCondition = "always"
-)
-
-var RestartMap = map[string]RestartCondition{
-	"never":       RestartNever,
-	"on-success":  RestartOnSuccess,
-	"on-failure":  RestartOnFailure,
-	"on-abnormal": RestartOnAbnormal,
-	"on-abort":    RestartOnAbort,
-	"always":      RestartAlways,
-}
-
-// ErrUnknownRestartCondition is returned when trying to unmarshal an unknown restart condition
-var ErrUnknownRestartCondition = errors.New("invalid restart condition")
-
-func (rc RestartCondition) String() string {
-	return string(rc)
-}
-
-// UnmarshalYAML so RestartCondition implements yaml's Unmarshaler interface
-func (rc *RestartCondition) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var v string
-
-	if err := unmarshal(&v); err != nil {
-		return err
-	}
-
-	nrc, ok := RestartMap[v]
-	if !ok {
-		return ErrUnknownRestartCondition
-	}
-
-	*rc = nrc
-
-	return nil
-}
 
 const (
 	// the default target for systemd units that we generate

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -162,9 +162,10 @@ type ServiceStatus struct {
 }
 
 func (s *systemd) Status(serviceNames ...string) ([]*ServiceStatus, error) {
+	expected := []string{"Id", "Type", "ActiveState", "UnitFileState"}
 	cmd := make([]string, len(serviceNames)+2)
 	cmd[0] = "show"
-	cmd[1] = "--property=Id,ActiveState,UnitFileState"
+	cmd[1] = "--property=" + strings.Join(expected, ",")
 	copy(cmd[2:], serviceNames)
 	bs, err := SystemctlCmd(cmd...)
 	if err != nil {
@@ -173,19 +174,14 @@ func (s *systemd) Status(serviceNames ...string) ([]*ServiceStatus, error) {
 
 	sts := make([]*ServiceStatus, 0, len(serviceNames))
 	cur := &ServiceStatus{}
-	expected := map[string]bool{
-		"Id":            true,
-		"Type":          true,
-		"ActiveState":   true,
-		"UnitFileState": true,
-	}
+	seen := map[string]bool{}
 
 	for _, bs := range statusregex.FindAllSubmatch(bs, -1) {
 		if len(bs[0]) == 0 {
 			// systemctl separates data pertaining to particular services by an empty line
 			missing := make([]string, 0, len(expected))
-			for k, v := range expected {
-				if v {
+			for _, k := range expected {
+				if !seen[k] {
 					missing = append(missing, k)
 				}
 			}
@@ -202,12 +198,7 @@ func (s *systemd) Status(serviceNames ...string) ([]*ServiceStatus, error) {
 			}
 
 			cur = &ServiceStatus{}
-			expected = map[string]bool{
-				"Id":            true,
-				"Type":          true,
-				"ActiveState":   true,
-				"UnitFileState": true,
-			}
+			seen = map[string]bool{}
 			continue
 		}
 		if len(bs[3]) > 0 {
@@ -215,13 +206,6 @@ func (s *systemd) Status(serviceNames ...string) ([]*ServiceStatus, error) {
 		}
 		k := string(bs[1])
 		v := string(bs[2])
-		if b, ok := expected[k]; b {
-			expected[k] = false
-		} else if ok {
-			return nil, fmt.Errorf("cannot get service status: duplicate field %q in ‘systemctl show’ output", k)
-		} else {
-			return nil, fmt.Errorf("cannot get service status: unexpected field %q in ‘systemctl show’ output", k)
-		}
 
 		if v == "" {
 			return nil, fmt.Errorf("cannot get service status: empty field %q in ‘systemctl show’ output", k)
@@ -238,7 +222,14 @@ func (s *systemd) Status(serviceNames ...string) ([]*ServiceStatus, error) {
 		case "UnitFileState":
 			// "static" means it can't be disabled
 			cur.Enabled = v == "enabled" || v == "static"
+		default:
+			return nil, fmt.Errorf("cannot get service status: unexpected field %q in ‘systemctl show’ output", k)
 		}
+
+		if seen[k] {
+			return nil, fmt.Errorf("cannot get service status: duplicate field %q in ‘systemctl show’ output", k)
+		}
+		seen[k] = true
 	}
 
 	if len(sts) != len(serviceNames) {

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -205,6 +205,7 @@ UnitFileState=disabled
 		},
 	})
 	c.Check(s.rep.msgs, IsNil)
+	c.Assert(s.argses, DeepEquals, [][]string{{"show", "--property=Id,Type,ActiveState,UnitFileState", "foo.service", "bar.service", "baz.service"}})
 }
 
 func (s *SystemdTestSuite) TestStatusBadNumberOfValues(c *C) {

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
@@ -358,22 +357,6 @@ Options=nodev,ro,bind
 [Install]
 WantedBy=multi-user.target
 `, snapDir))
-}
-
-func (s *SystemdTestSuite) TestRestartCondUnmarshal(c *C) {
-	for cond := range RestartMap {
-		bs := []byte(cond)
-		var rc RestartCondition
-
-		c.Check(yaml.Unmarshal(bs, &rc), IsNil)
-		c.Check(rc, Equals, RestartMap[cond], Commentf(cond))
-	}
-}
-
-func (s *SystemdTestSuite) TestRestartCondString(c *C) {
-	for name, cond := range RestartMap {
-		c.Check(cond.String(), Equals, name, Commentf(name))
-	}
 }
 
 func (s *SystemdTestSuite) TestFuseInContainer(c *C) {

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -216,14 +216,9 @@ WantedBy={{.ServicesTarget}}
 	var templateOut bytes.Buffer
 	t := template.Must(template.New("service-wrapper").Parse(serviceTemplate))
 
-	var restartCond string
-	if appInfo.RestartCond == systemd.RestartNever {
-		restartCond = "no"
-	} else {
-		restartCond = appInfo.RestartCond.String()
-	}
+	restartCond := appInfo.RestartCond.String()
 	if restartCond == "" {
-		restartCond = systemd.RestartOnFailure.String()
+		restartCond = snap.RestartOnFailure.String()
 	}
 
 	var remain string

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/timeout"
 	"github.com/snapcore/snapd/wrappers"
 )
@@ -125,7 +124,7 @@ apps:
     app:
         restart-condition: %s
 `
-	for name, cond := range systemd.RestartMap {
+	for name, cond := range snap.RestartMap {
 		yamlText := fmt.Sprintf(yamlTextTemplate, cond)
 
 		info, err := snap.InfoFromSnapYaml([]byte(yamlText))
@@ -136,7 +135,7 @@ apps:
 		generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
 		c.Assert(err, IsNil)
 		wrapperText := string(generatedWrapper)
-		if cond == systemd.RestartNever {
+		if cond == snap.RestartNever {
 			c.Check(wrapperText, Matches,
 				`(?ms).*^Restart=no$.*`, Commentf(name))
 		} else {


### PR DESCRIPTION
This is actually preparatory work for the services branch, but it makes sense on its own.

Actually, each commit makes sense on its own I think, but this way it's a nice bundle.
