### PR TITLE
snap-seccomp: add secondary arch for unrestricted snaps as well

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -616,6 +616,9 @@ func compile(content []byte, out string) error {
 			if err != nil {
 				return fmt.Errorf("cannot create seccomp filter: %s", err)
 			}
+			if err := addSecondaryArches(secFilter); err != nil {
+				return err
+			}
 			break
 		}
 


### PR DESCRIPTION
When creating a @unrestricted filter we need to whitelist all
architectures or e.g. i386 apps on amd64 will fail.