### PR TITLE
packaging: have Ubuntu snapd package recommend squashfuse

### DIFF
--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -28,6 +28,7 @@ Build-Depends: autoconf,
                python3,
                python3-docutils,
                python3-markdown,
+               squashfuse,
                squashfs-tools,
                udev,
                xfslibs-dev

--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -28,7 +28,6 @@ Build-Depends: autoconf,
                python3,
                python3-docutils,
                python3-markdown,
-               squashfuse,
                squashfs-tools,
                udev,
                xfslibs-dev
@@ -71,6 +70,7 @@ Depends: adduser,
          util-linux (>=2.20.1-5.1ubuntu20.9),
          ${misc:Depends},
          ${shlibs:Depends}
+Recommends: squashfuse
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23~14.04)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23~14.04)
 Conflicts: snap (<< 2013-11-29-1ubuntu1)

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -28,7 +28,6 @@ Build-Depends: autoconf,
                python3,
                python3-docutils,
                python3-markdown,
-               squashfuse,
                squashfs-tools,
                udev,
                xfslibs-dev
@@ -65,6 +64,7 @@ Depends: adduser,
          systemd,
          ${misc:Depends},
          ${shlibs:Depends}
+Recommends: squashfuse
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22)
 Conflicts: snap (<< 2013-11-29-1ubuntu1)

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -28,6 +28,7 @@ Build-Depends: autoconf,
                python3,
                python3-docutils,
                python3-markdown,
+               squashfuse,
                squashfs-tools,
                udev,
                xfslibs-dev


### PR DESCRIPTION
Snaps don't work properly inside of LXD containers without squashfuse.  This package has been approved for an MIR, but needs the snapd package to depend/recommend it to pull it into Main.  See: https://bugs.launchpad.net/ubuntu/+source/squashfuse/+bug/1628289