### PR TITLE
cmd: fix broken double re-executiong from snapd 2.21

### DIFF
--- a/tests/lib/snaps/test-snapd-classic-confinement/bin/recurse
+++ b/tests/lib/snaps/test-snapd-classic-confinement/bin/recurse
@@ -1,0 +1,6 @@
+#!/bin/sh
+N="${1:-0}"
+echo "recurse: $N"
+if [ "$N" -gt 0 ]; then
+	exec /snap/bin/test-snapd-classic-confinement.recurse $(( N - 1 ))
+fi

--- a/tests/lib/snaps/test-snapd-classic-confinement/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-classic-confinement/meta/snap.yaml
@@ -4,3 +4,5 @@ confinement: classic
 apps:
     test-snapd-classic-confinement:
         command: bin/classic-confinement
+    recurse:
+        command: bin/recurse

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -20,7 +20,7 @@ execute: |
 
     echo "Ensure we re-exec by default"
     snap list
-    journalctl | MATCH "DEBUG: restarting into"
+    journalctl | MATCH "DEBUG: restarting from .* into .*"
 
     echo "Ensure snap-confine from the core snap is run"
     # do not use "strace -f" for unknown reasons that hangs

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -26,7 +26,7 @@ execute: |
     fi
 
     echo "Ensure we re-exec by default"
-    /usr/bin/env SNAPD_DEBUG=1 snap list 2>&1 | MATCH "DEBUG: restarting into"
+    /usr/bin/env SNAPD_DEBUG=1 snap list 2>&1 | MATCH "DEBUG: restarting from .* into .*"
 
     . $TESTSLIB/dirs.sh
 

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -11,6 +11,7 @@ execute: |
         exit 0
     fi
     . "$TESTSLIB/pkgdb.sh"
+    . "$TESTSLIB/snaps.sh"
 
     echo Install previous version...
     dpkg -l snapd snap-confine || true
@@ -27,6 +28,7 @@ execute: |
     echo Install sanity check snaps with it
     snap install test-snapd-tools
     snap install test-snapd-auto-aliases
+    install_local_classic test-snapd-classic-confinement
 
     echo Sanity check installs
     test-snapd-tools.echo Hello | grep Hello
@@ -47,6 +49,7 @@ execute: |
     snap list | grep test-snapd-tools
     test-snapd-tools.echo Hello | grep Hello
     test-snapd-tools.env | grep SNAP_NAME=test-snapd-tools
+    test-snapd-classic-confinement.recurse 5
 
     # only test if confinement works and we actually have apparmor available
     # FIXME: this will be converted to a better check once we added the


### PR DESCRIPTION
This patch fixes a bug where the snap command from distribution package
containing snapd 2.21 will misbehave when re-executing for the second
time in the context of a snap using classic confinement.

In 2.21 snapd used one variable SNAP_REEXEC to indicate that re-exec has
occured. Upon reexecution we would set SNAP_REEXEC=0 to say that we
don't need to reexecute anymore. Future versions of snapd split that
into SNAP_REEXEC (preference) and SNAP_DID_REEXEC (fact).

A re-executing 2.21 snapd will thus set the *preference* respected by
future version of snap that will no longer re-execute. In the case of a
classically confined snap that runs snap applications itself this will
cause the snap to misbehave as 2.26.13-installed /usr/bin/snap will no
longer put certain configuration files that 2.21 not-reexecuting
/usr/bin/snap (and thus snap-exec and snap-confine) expects.

To work around that, when we ditch the environment variable and instead
rely on /proc/self/exe symlink to tell us if we're running from the core
snap already (or not) and also if the target executable is the same one
as the one executing.

In addition we unset SNAP_REEXEC if we did re-execute and SNAP_REEXEC is
equal to 0. That value means "don't reexec" so but since we have
re-executed it must have been set by an old version of snapd and thus it
can be safely removed.

Forum: https://forum.snapcraft.io/t/snapd-2-26-9-and-conjure-up-no-longer-work/1348/
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>