### PR TITLE
cmd: fix re-exec bug when starting from snapd 2.21

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -140,9 +140,32 @@ func InternalToolPath(tool string) string {
 	return filepath.Join(filepath.Dir(exe), tool)
 }
 
+// mustUnsetenv will os.Unsetenv the for or panic if it cannot do that
+func mustUnsetenv(key string) {
+	if err := os.Unsetenv(key); err != nil {
+		panic(fmt.Sprintf("cannot unset %s: %s", key, err))
+	}
+}
+
 // ExecInCoreSnap makes sure you're executing the binary that ships in
 // the core snap.
 func ExecInCoreSnap() {
+	// Which executable are we?
+	exe, err := os.Readlink(selfExe)
+	if err != nil {
+		return
+	}
+
+	// Special case for snapd re-execing from 2.21. In this
+	// version of snap/snapd we did set SNAP_REEXEC=0 when we
+	// re-execed. In this case we need to unset the reExecKey to
+	// ensure that subsequent run of snap/snapd (e.g. when using
+	// classic confinement) will *not* prevented from re-execing.
+	if strings.HasPrefix(exe, dirs.SnapMountDir) && !osutil.GetenvBool(reExecKey, true) {
+		mustUnsetenv(reExecKey)
+		return
+	}
+
 	// If we are asked not to re-execute use distribution packages. This is
 	// "spiritual" re-exec so use the same environment variable to decide.
 	if !osutil.GetenvBool(reExecKey, true) {
@@ -152,20 +175,12 @@ func ExecInCoreSnap() {
 
 	// Did we already re-exec?
 	if osutil.GetenvBool("SNAP_DID_REEXEC") {
-		if err := os.Unsetenv("SNAP_DID_REEXEC"); err != nil {
-			panic(fmt.Sprintf("cannot unset SNAP_DID_REEXEC: %s", err))
-		}
+		mustUnsetenv("SNAP_DID_REEXEC")
 		return
 	}
 
 	// If the distribution doesn't support re-exec or run-from-core then don't do it.
 	if !distroSupportsReExec() {
-		return
-	}
-
-	// Which executable are we?
-	exe, err := os.Readlink(selfExe)
-	if err != nil {
 		return
 	}
 

--- a/tests/lib/snaps/test-snapd-classic-confinement/bin/recurse
+++ b/tests/lib/snaps/test-snapd-classic-confinement/bin/recurse
@@ -1,0 +1,6 @@
+#!/bin/sh
+N="${1:-0}"
+echo "recurse: $N"
+if [ "$N" -gt 0 ]; then
+	exec /snap/bin/test-snapd-classic-confinement.recurse $(( N - 1 ))
+fi

--- a/tests/lib/snaps/test-snapd-classic-confinement/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-classic-confinement/meta/snap.yaml
@@ -4,3 +4,5 @@ confinement: classic
 apps:
     test-snapd-classic-confinement:
         command: bin/classic-confinement
+    recurse:
+        command: bin/recurse

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -11,6 +11,7 @@ execute: |
         exit 0
     fi
     . "$TESTSLIB/apt.sh"
+    . "$TESTSLIB/snaps.sh"
 
     echo Install previous version...
     dpkg -l snapd snap-confine || true
@@ -27,6 +28,7 @@ execute: |
     echo Install sanity check snaps with it
     snap install test-snapd-tools
     snap install test-snapd-auto-aliases
+    install_local_classic test-snapd-classic-confinement
 
     echo Sanity check installs
     test-snapd-tools.echo Hello | grep Hello
@@ -54,6 +56,7 @@ execute: |
     snap list | grep test-snapd-tools
     test-snapd-tools.echo Hello | grep Hello
     test-snapd-tools.env | grep SNAP_NAME=test-snapd-tools
+    test-snapd-classic-confinement.recurse 5
 
     # only test if confinement works and we actually have apparmor available
     # FIXME: this will be converted to a better check once we added the


### PR DESCRIPTION
We need to special case the env handling for snapd re-execing
from 2.21. In this version of snap/snapd we did set SNAP_REEXEC=0
when we re-execed.

In this case we need to unset the reExecKey to ensure that subsequent
run of snap/snapd (e.g. when using classic confinement) will *not*
prevented from re-execing.

This will also need to be cherry-picked for master.