### PR TITLE
cmd: rework reexec detection

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -140,9 +140,32 @@ func InternalToolPath(tool string) string {
 	return filepath.Join(filepath.Dir(exe), tool)
 }
 
+// mustUnsetenv will os.Unsetenv the for or panic if it cannot do that
+func mustUnsetenv(key string) {
+	if err := os.Unsetenv(key); err != nil {
+		panic(fmt.Sprintf("cannot unset %s: %s", key, err))
+	}
+}
+
 // ExecInCoreSnap makes sure you're executing the binary that ships in
 // the core snap.
 func ExecInCoreSnap() {
+	// Which executable are we?
+	exe, err := os.Readlink(selfExe)
+	if err != nil {
+		return
+	}
+
+	// Special case for snapd re-execing from 2.21. In this
+	// version of snap/snapd we did set SNAP_REEXEC=0 when we
+	// re-execed. In this case we need to unset the reExecKey to
+	// ensure that subsequent run of snap/snapd (e.g. when using
+	// classic confinement) will *not* prevented from re-execing.
+	if strings.HasPrefix(exe, dirs.SnapMountDir) && !osutil.GetenvBool(reExecKey, true) {
+		mustUnsetenv(reExecKey)
+		return
+	}
+
 	// If we are asked not to re-execute use distribution packages. This is
 	// "spiritual" re-exec so use the same environment variable to decide.
 	if !osutil.GetenvBool(reExecKey, true) {
@@ -152,20 +175,12 @@ func ExecInCoreSnap() {
 
 	// Did we already re-exec?
 	if osutil.GetenvBool("SNAP_DID_REEXEC") {
-		if err := os.Unsetenv("SNAP_DID_REEXEC"); err != nil {
-			panic(fmt.Sprintf("cannot unset SNAP_DID_REEXEC: %s", err))
-		}
+		mustUnsetenv("SNAP_DID_REEXEC")
 		return
 	}
 
 	// If the distribution doesn't support re-exec or run-from-core then don't do it.
 	if !distroSupportsReExec() {
-		return
-	}
-
-	// Which executable are we?
-	exe, err := os.Readlink(selfExe)
-	if err != nil {
 		return
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -174,8 +174,7 @@ func ExecInCoreSnap() {
 	}
 
 	// Did we already re-exec?
-	if osutil.GetenvBool("SNAP_DID_REEXEC") {
-		mustUnsetenv("SNAP_DID_REEXEC")
+	if strings.HasPrefix(exe, dirs.SnapMountDir) {
 		return
 	}
 
@@ -201,6 +200,7 @@ func ExecInCoreSnap() {
 	}
 
 	logger.Debugf("restarting into %q", full)
+	// we keep this for e.g. the errtracker
 	env := append(os.Environ(), "SNAP_DID_REEXEC=1")
 	panic(syscallExec(full, os.Args, env))
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -153,6 +153,7 @@ func ExecInCoreSnap() {
 	// Which executable are we?
 	exe, err := os.Readlink(selfExe)
 	if err != nil {
+		logger.Noticef("cannot read /proc/self/exe: %v", err)
 		return
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -20,8 +20,8 @@
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -127,7 +127,7 @@ func InternalToolPath(tool string) string {
 
 	// ensure we never use this helper from anything but
 	if !strings.HasSuffix(exe, "/snapd") && !strings.HasSuffix(exe, ".test") {
-		panic(fmt.Sprintf("InternalToolPath can only be used from snapd, got: %s", exe))
+		log.Panicf("InternalToolPath can only be used from snapd, got: %s", exe)
 	}
 
 	if !strings.HasPrefix(exe, dirs.SnapMountDir) {
@@ -143,7 +143,7 @@ func InternalToolPath(tool string) string {
 // mustUnsetenv will os.Unsetenv the for or panic if it cannot do that
 func mustUnsetenv(key string) {
 	if err := os.Unsetenv(key); err != nil {
-		panic(fmt.Sprintf("cannot unset %s: %s", key, err))
+		log.Panicf("cannot unset %s: %s", key, err)
 	}
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -286,10 +286,9 @@ func (s *cmdSuite) TestExecInCoreSnapBailsNoDistroSupport(c *C) {
 }
 
 func (s *cmdSuite) TestExecInCoreSnapNoDouble(c *C) {
-	defer s.mockReExecFor(c, s.newCore, "potato")()
-
-	os.Setenv("SNAP_DID_REEXEC", "1")
-	defer os.Unsetenv("SNAP_DID_REEXEC")
+	selfExe := filepath.Join(s.fakeroot, "proc/self/exe")
+	err := os.Symlink(filepath.Join(s.fakeroot, "/snap/core/42/usr/lib/snapd"), selfExe)
+	c.Assert(err, IsNil)
 
 	cmd.ExecInCoreSnap()
 	c.Check(s.execCalled, Equals, 0)

--- a/tests/lib/snaps/test-snapd-classic-confinement/bin/recurse
+++ b/tests/lib/snaps/test-snapd-classic-confinement/bin/recurse
@@ -1,0 +1,6 @@
+#!/bin/sh
+N="${1:-0}"
+echo "recurse: $N"
+if [ "$N" -gt 0 ]; then
+	exec /snap/bin/test-snapd-classic-confinement.recurse $(( N - 1 ))
+fi

--- a/tests/lib/snaps/test-snapd-classic-confinement/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-classic-confinement/meta/snap.yaml
@@ -4,3 +4,5 @@ confinement: classic
 apps:
     test-snapd-classic-confinement:
         command: bin/classic-confinement
+    recurse:
+        command: bin/recurse

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -11,6 +11,7 @@ execute: |
         exit 0
     fi
     . "$TESTSLIB/pkgdb.sh"
+    . "$TESTSLIB/snaps.sh"
 
     echo Install previous version...
     dpkg -l snapd snap-confine || true
@@ -27,6 +28,7 @@ execute: |
     echo Install sanity check snaps with it
     snap install test-snapd-tools
     snap install test-snapd-auto-aliases
+    install_local_classic test-snapd-classic-confinement
 
     echo Sanity check installs
     test-snapd-tools.echo Hello | grep Hello
@@ -47,6 +49,7 @@ execute: |
     snap list | grep test-snapd-tools
     test-snapd-tools.echo Hello | grep Hello
     test-snapd-tools.env | grep SNAP_NAME=test-snapd-tools
+    test-snapd-classic-confinement.recurse 5
 
     # only test if confinement works and we actually have apparmor available
     # FIXME: this will be converted to a better check once we added the


### PR DESCRIPTION
This reworked the detection if we already re-execed or not. The logic is simply to check if the /proc/self/exe points inside the /snap/* directory. If that is the case we did already re-exec and there is no need to do anything further.

This also contains the bugfix when re-execing from snapd 2.21 which used to set `SNAP_REEXEC=0`.

