### PR TITLE
snap: do not always quote the snap info summary

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/asserts"
@@ -121,7 +123,7 @@ func tryDirect(w io.Writer, path string, verbose bool) bool {
 	}
 	fmt.Fprintf(w, "path:\t%q\n", path)
 	fmt.Fprintf(w, "name:\t%s\n", info.Name())
-	fmt.Fprintf(w, "summary:\t%q\n", info.Summary())
+	fmt.Fprintf(w, "summary:\t%s\n", formatSummary(info.Summary()))
 
 	var notes *Notes
 	if verbose {
@@ -237,6 +239,14 @@ func displayChannels(w io.Writer, remote *client.Snap) {
 	}
 }
 
+func formatSummary(raw string) string {
+	s, err := yaml.Marshal(raw)
+	if err != nil {
+		return fmt.Sprintf("cannot marshal summary: %s", err)
+	}
+	return strings.TrimSpace(string(s))
+}
+
 func (x *infoCmd) Execute([]string) error {
 	cli := Client()
 
@@ -265,7 +275,7 @@ func (x *infoCmd) Execute([]string) error {
 		noneOK = false
 
 		fmt.Fprintf(w, "name:\t%s\n", both.Name)
-		fmt.Fprintf(w, "summary:\t%q\n", both.Summary)
+		fmt.Fprintf(w, "summary:\t%s\n", formatSummary(both.Summary))
 		// TODO: have publisher; use publisher here,
 		// and additionally print developer if publisher != developer
 		fmt.Fprintf(w, "publisher:\t%s\n", both.Developer)

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -49,10 +49,73 @@ func (s *SnapSuite) TestInfoPriced(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"info", "hello"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `name:      hello
-summary:   "GNU Hello, the \"hello world\" snap"
+	c.Check(s.Stdout(), check.Equals, `name:      hello
+summary:   GNU Hello, the "hello world" snap
 publisher: canonical
 price:     1.99GBP
+description: |
+  GNU hello prints a friendly greeting. This is part of the snapcraft tour at
+  https://snapcraft.io/
+snap-id: mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+const mockInfoJSON = `
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": [
+    {
+      "channel": "stable",
+      "confinement": "strict",
+      "description": "GNU hello prints a friendly greeting. This is part of the snapcraft tour at https://snapcraft.io/",
+      "developer": "canonical",
+      "download-size": 65536,
+      "icon": "",
+      "id": "mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6",
+      "name": "hello",
+      "private": false,
+      "resource": "/v2/snaps/hello",
+      "revision": "1",
+      "status": "available",
+      "summary": "The GNU Hello snap",
+      "type": "app",
+      "version": "2.10"
+    }
+  ],
+  "sources": [
+    "store"
+  ],
+  "suggested-currency": "GBP"
+}
+`
+
+func (s *SnapSuite) TestInfoUnquoted(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/find")
+			fmt.Fprintln(w, mockInfoJSON)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
+			fmt.Fprintln(w, "{}")
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d (%v)", n+1, r)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser().ParseArgs([]string{"info", "hello"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, `name:      hello
+summary:   The GNU Hello snap
+publisher: canonical
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
   https://snapcraft.io/


### PR DESCRIPTION
Most of the time the summary of a snap does not need quoting. So
instead of always quoting, use goyaml to only quote when it is
really needed.

