### PR TITLE
overlord/snapstate/backend: some copydata improvements

### DIFF
--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -40,6 +40,9 @@ func (b Backend) CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter)
 
 	if oldSnap == nil {
 		return os.MkdirAll(newSnap.DataDir(), 0755)
+	} else if oldSnap.Revision == newSnap.Revision {
+		// nothing to do
+		return nil
 	}
 
 	return copySnapData(oldSnap, newSnap)
@@ -47,6 +50,10 @@ func (b Backend) CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter)
 
 // UndoCopySnapData removes the copy that may have been done for newInfo snap of oldInfo snap data and also the data directories that may have been created for newInfo snap.
 func (b Backend) UndoCopySnapData(newInfo *snap.Info, oldInfo *snap.Info, meter progress.Meter) error {
+	if oldInfo != nil && oldInfo.Revision == newInfo.Revision {
+		// nothing to do
+		return nil
+	}
 	err1 := b.RemoveSnapData(newInfo)
 	if err1 != nil {
 		logger.Noticef("Cannot remove data directories for %q: %v", newInfo.Name(), err1)

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -226,6 +226,7 @@ func copySnapDataDirectory(oldPath, newPath string) (err error) {
 				// try to fix that; hope for the best
 				if e := untrash(newPath); e != nil {
 					// oh noes
+					// TODO: issue a warning to the user that data was lost
 					msg += fmt.Sprintf("; and when trying to restore the old data directory: %v", e)
 				}
 


### PR DESCRIPTION
The state machinery needs that every handler either succeeds or fails
entirely. Currently copy-snap-data has a few half-failure modes; this
addresses that.

In particular, copying data has multiple steps that can fail
independently. This makes it so that when one of them fails, the
previous ones are cleaned up (undone), and anything that had been
trashed in the same operation is brought back from the trash.

This is easy to check, currently: simply

    snap refresh <some snap> --revision=<the current revision it's on>

and you'll see the operation fail, but also you'll notice that if the
snap had data dirs they're gone, moved to .old. This PR also enables
this operation to succeed, by explicitly checking for it in both
directions.