### PR TITLE
vendor: update go-flags to address crash in "snap debug"

### DIFF
--- a/cmd/snap/cmd_interfaces_test.go
+++ b/cmd/snap/cmd_interfaces_test.go
@@ -62,7 +62,8 @@ Help Options:
       -i=                          Constrain listing to specific interfaces
 
 [interfaces command arguments]
-  <snap>:<slot or plug>:           Constrain listing to a specific snap or snap:name
+  <snap>:<slot or plug>:           Constrain listing to a specific snap or
+                                   snap:name
 `
 	rest, err := Parser().ParseArgs([]string{"interfaces", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -31,10 +31,10 @@
 			"revisionTime": "2015-08-20T05:15:06Z"
 		},
 		{
-			"checksumSHA1": "Fsff4Yngdyqbq9ulSyTT4LGrxck=",
+			"checksumSHA1": "Ihm00CfTHuuTYXgXJkgH7TFP0L4=",
 			"path": "github.com/jessevdk/go-flags",
-			"revision": "6b9493b3cb60367edd942144879646604089e3f7",
-			"revisionTime": "2016-02-27T09:34:14Z"
+			"revision": "96dc06278ce32a0e9d957d590bb987c81ee66407",
+			"revisionTime": "2017-07-20T12:40:56Z"
 		},
 		{
 			"checksumSHA1": "bzUdFxQ29mPK0lwgFVcF0GFN74Q=",


### PR DESCRIPTION
This fixes a panic that happens when a subcommand parser is empty and
gets interrogated for command hints on parsing error. This affected us
in the past where "snap debug" had nothing registered.

Forum: https://forum.snapcraft.io/t/small-issue-with-snap-debug-confinement/
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>