### PR TITLE
fix locations of xdg-open files

### DIFF
--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -85,8 +85,8 @@ const unity7ConnectedPlugAppArmor = `
 # only in environments supporting dbus-send (eg, X11). In the future once
 # snappy's xdg-open supports all snaps images, this access may move to another
 # interface.
-/usr/local/bin/xdg-open ixr,
-/usr/local/share/applications/{,*} r,
+/usr/bin/xdg-open ixr,
+/usr/share/applications/{,*} r,
 /usr/bin/dbus-send ixr,
 dbus (send)
     bus=session


### PR DESCRIPTION
when we moved xdg-open in the core snap from /usr/local to proper locations under /usr the unty7 interface did not get updated to the new paths which results in an apparmor denial when apps try to use xdg-open