### PR TITLE
add broadcom-asic-control interface

### DIFF
--- a/interfaces/builtin/broadcom-asic-control.go
+++ b/interfaces/builtin/broadcom-asic-control.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const broadcomAsicControlSummary = `allows using the broadcom-asic kernel module`
+
+const broadcomAsicControlDescription = `
+The broadcom-asic-control interfaces allows connected plugs to read and sometimes
+write files required to use the broadcom asic kernel module.`
+
+const broadcomAsicControlBaseDeclarationSlots = `
+  broadcom-asic-control:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+const broadcomAsicControlConnectedPlugAppArmor = `
+# Description: Allow access to broadcom asic kernel module.
+
+/sys/module/linux_kernel_bde/initstate r,
+/sys/module/linux_user_bde/initstate r,
+/sys/module/linux_kernel_bde/holders/ r,
+/sys/module/linux_user_bde/holders/ r,
+/sys/module/linux_user_bde/holders/** r,
+/sys/module/linux_user_bde/refcnt r,
+/sys/module/linux_bcm_knet/initstate r,
+/sys/module/linux_bcm_knet/holders/ r,
+/sys/module/linux_bcm_knet/refcnt r,
+/dev/linux-user-bde rw,
+/dev/linux-kernel-bde rw,
+/dev/linux-bcm-knet wr,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "broadcom-asic-control",
+		summary:               broadcomAsicControlSummary,
+		description:           broadcomAsicControlDescription,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  broadcomAsicControlBaseDeclarationSlots,
+		connectedPlugAppArmor: broadcomAsicControlConnectedPlugAppArmor,
+		reservedForOS:         true,
+	})
+}

--- a/interfaces/builtin/broadcom-asic-control_test.go
+++ b/interfaces/builtin/broadcom-asic-control_test.go
@@ -1,0 +1,109 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type BroadcomAsicControlSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&BroadcomAsicControlSuite{
+	iface: builtin.MustInterface("broadcom-asic-control"),
+})
+
+const broadcomCtlMockPlugSnapInfo = `name: other
+version: 1.0
+apps:
+ app2:
+  command: foo
+  plugs: [broadcom-asic-control]
+`
+
+func (s *BroadcomAsicControlSuite) SetUpTest(c *C) {
+	s.slot = &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Name:      "broadcom-asic-control",
+			Interface: "broadcom-asic-control",
+			Apps: map[string]*snap.AppInfo{
+				"app1": {
+					Snap: &snap.Info{
+						SuggestedName: "core",
+					},
+					Name: "app1"}},
+		},
+	}
+
+	plugSnap := snaptest.MockInfo(c, broadcomCtlMockPlugSnapInfo, nil)
+	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["broadcom-asic-control"]}
+}
+
+func (s *BroadcomAsicControlSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "broadcom-asic-control")
+}
+
+func (s *BroadcomAsicControlSuite) TestSanitizeSlot(c *C) {
+	err := s.iface.SanitizeSlot(s.slot)
+	c.Assert(err, IsNil)
+	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "broadcom-asic-control",
+		Interface: "broadcom-asic-control",
+	}})
+	c.Assert(err, ErrorMatches, "broadcom-asic-control slots are reserved for the operating system snap")
+}
+
+func (s *BroadcomAsicControlSuite) TestSanitizePlug(c *C) {
+	err := s.iface.SanitizePlug(s.plug)
+	c.Assert(err, IsNil)
+}
+
+func (s *BroadcomAsicControlSuite) TestSanitizeIncorrectInterface(c *C) {
+	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
+		PanicMatches, `slot is not of interface "broadcom-asic-control"`)
+	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
+		PanicMatches, `plug is not of interface "broadcom-asic-control"`)
+}
+
+func (s *BroadcomAsicControlSuite) TestUsedSecuritySystems(c *C) {
+	expectedAppArmorLine := "/sys/module/linux_kernel_bde/initstate r,"
+	// connected plugs have a non-nil security snippet for apparmor
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, expectedAppArmorLine)
+}
+
+func (s *BroadcomAsicControlSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}


### PR DESCRIPTION
provide an apparmor snippet that grants access to the files associated with the broadcom asic kernel module. 