### PR TITLE
interfaces/builtin: reduce duplication and remove cruft in Sanitize{Plug,Slot}

### DIFF
--- a/interfaces/builtin/account_control_test.go
+++ b/interfaces/builtin/account_control_test.go
@@ -73,19 +73,18 @@ func (s *AccountControlSuite) TestName(c *C) {
 }
 
 func (s *AccountControlSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "account-control",
 		Interface: "account-control",
-	}})
-	c.Assert(err, ErrorMatches, "account-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"account-control slots are reserved for the operating system snap")
 }
 
 func (s *AccountControlSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *AccountControlSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/account_control_test.go
+++ b/interfaces/builtin/account_control_test.go
@@ -88,13 +88,6 @@ func (s *AccountControlSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *AccountControlSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "account-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "account-control"`)
-}
-
 func (s *AccountControlSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/account_control_test.go
+++ b/interfaces/builtin/account_control_test.go
@@ -80,7 +80,7 @@ func (s *AccountControlSuite) TestSanitizeSlot(c *C) {
 		Interface: "account-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"account-control slots are reserved for the operating system snap")
+		"account-control slots are reserved for the core snap")
 }
 
 func (s *AccountControlSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -80,13 +80,6 @@ func (s *AlsaInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *AlsaInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "alsa"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "alsa"`)
-}
-
 func (s *AlsaInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -65,19 +65,18 @@ func (s *AlsaInterfaceSuite) TestName(c *C) {
 }
 
 func (s *AlsaInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "alsa",
 		Interface: "alsa",
-	}})
-	c.Assert(err, ErrorMatches, "alsa slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"alsa slots are reserved for the operating system snap")
 }
 
 func (s *AlsaInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *AlsaInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -72,7 +72,7 @@ func (s *AlsaInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "alsa",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"alsa slots are reserved for the operating system snap")
+		"alsa slots are reserved for the core snap")
 }
 
 func (s *AlsaInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/autopilot_test.go
+++ b/interfaces/builtin/autopilot_test.go
@@ -73,7 +73,7 @@ func (s *AutopilotInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "autopilot-introspection",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"autopilot-introspection slots are reserved for the operating system snap")
+		"autopilot-introspection slots are reserved for the core snap")
 }
 
 func (s *AutopilotInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/autopilot_test.go
+++ b/interfaces/builtin/autopilot_test.go
@@ -66,19 +66,18 @@ func (s *AutopilotInterfaceSuite) TestName(c *C) {
 }
 
 func (s *AutopilotInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "autopilot-introspection",
 		Interface: "autopilot-introspection",
-	}})
-	c.Assert(err, ErrorMatches, "autopilot-introspection slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"autopilot-introspection slots are reserved for the operating system snap")
 }
 
 func (s *AutopilotInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *AutopilotInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/autopilot_test.go
+++ b/interfaces/builtin/autopilot_test.go
@@ -81,13 +81,6 @@ func (s *AutopilotInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *AutopilotInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "autopilot-introspection"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "autopilot-introspection"`)
-}
-
 func (s *AutopilotInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -71,7 +71,7 @@ func (s *AvahiObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "avahi-observe",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"avahi-observe slots are reserved for the operating system snap")
+		"avahi-observe slots are reserved for the core snap")
 }
 
 func (s *AvahiObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -79,13 +79,6 @@ func (s *AvahiObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *AvahiObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "avahi-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "avahi-observe"`)
-}
-
 func (s *AvahiObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -64,19 +64,18 @@ func (s *AvahiObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *AvahiObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "avahi-observe",
 		Interface: "avahi-observe",
-	}})
-	c.Assert(err, ErrorMatches, "avahi-observe slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"avahi-observe slots are reserved for the operating system snap")
 }
 
 func (s *AvahiObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *AvahiObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -72,19 +72,18 @@ func (s *BluetoothControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *BluetoothControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "bluetooth-control",
 		Interface: "bluetooth-control",
-	}})
-	c.Assert(err, ErrorMatches, "bluetooth-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"bluetooth-control slots are reserved for the operating system snap")
 }
 
 func (s *BluetoothControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *BluetoothControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -87,13 +87,6 @@ func (s *BluetoothControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *BluetoothControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "bluetooth-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "bluetooth-control"`)
-}
-
 func (s *BluetoothControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/bluetooth_control_test.go
+++ b/interfaces/builtin/bluetooth_control_test.go
@@ -79,7 +79,7 @@ func (s *BluetoothControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "bluetooth-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"bluetooth-control slots are reserved for the operating system snap")
+		"bluetooth-control slots are reserved for the core snap")
 }
 
 func (s *BluetoothControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -237,10 +237,12 @@ func (iface *bluezInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 }
 
 func (iface *bluezInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *bluezInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -236,14 +236,6 @@ func (iface *bluezInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 	return nil
 }
 
-func (iface *bluezInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *bluezInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *bluezInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -237,12 +237,10 @@ func (iface *bluezInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 }
 
 func (iface *bluezInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *bluezInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -71,9 +71,7 @@ var boolFileAllowedPathPatterns = []*regexp.Regexp{
 // SanitizeSlot checks and possibly modifies a slot.
 // Valid "bool-file" slots must contain the attribute "path".
 func (iface *boolFileInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	path, ok := slot.Attrs["path"].(string)
 	if !ok || path == "" {
 		return fmt.Errorf("bool-file must contain the path attribute")
@@ -89,9 +87,7 @@ func (iface *boolFileInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *boolFileInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	// NOTE: currently we don't check anything on the plug side.
 	return nil
 }

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -84,11 +84,6 @@ func (iface *boolFileInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return fmt.Errorf("bool-file can only point at LED brightness or GPIO value")
 }
 
-// SanitizePlug checks and possibly modifies a plug.
-func (iface *boolFileInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *boolFileInterface) AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error {
 	gpioSnippet := `
 /sys/class/gpio/export rw,

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -71,7 +71,6 @@ var boolFileAllowedPathPatterns = []*regexp.Regexp{
 // SanitizeSlot checks and possibly modifies a slot.
 // Valid "bool-file" slots must contain the attribute "path".
 func (iface *boolFileInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	path, ok := slot.Attrs["path"].(string)
 	if !ok || path == "" {
 		return fmt.Errorf("bool-file must contain the path attribute")
@@ -87,8 +86,6 @@ func (iface *boolFileInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *boolFileInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
-	// NOTE: currently we don't check anything on the plug side.
 	return nil
 }
 

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -121,17 +121,11 @@ func (s *BoolFileInterfaceSuite) TestSanitizeSlot(c *C) {
 	err = s.iface.SanitizeSlot(s.badPathSlot)
 	c.Assert(err, ErrorMatches,
 		"bool-file can only point at LED brightness or GPIO value")
-	// It is impossible to use "bool-file" interface to sanitize slots with other interfaces.
-	c.Assert(func() { s.iface.SanitizeSlot(s.badInterfaceSlot) }, PanicMatches,
-		`slot is not of interface "bool-file"`)
 }
 
 func (s *BoolFileInterfaceSuite) TestSanitizePlug(c *C) {
 	err := s.iface.SanitizePlug(s.plug)
 	c.Assert(err, IsNil)
-	// It is impossible to use "bool-file" interface to sanitize plugs of different interface.
-	c.Assert(func() { s.iface.SanitizePlug(s.badInterfacePlug) }, PanicMatches,
-		`plug is not of interface "bool-file"`)
 }
 
 func (s *BoolFileInterfaceSuite) TestPlugSnippetHandlesSymlinkErrors(c *C) {

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -105,27 +105,21 @@ func (s *BoolFileInterfaceSuite) TestName(c *C) {
 
 func (s *BoolFileInterfaceSuite) TestSanitizeSlot(c *C) {
 	// Both LED and GPIO slots are accepted
-	err := s.iface.SanitizeSlot(s.ledSlot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(s.gpioSlot)
-	c.Assert(err, IsNil)
+	c.Assert(s.ledSlot.Sanitize(s.iface), IsNil)
+	c.Assert(s.gpioSlot.Sanitize(s.iface), IsNil)
 	// Slots without the "path" attribute are rejected.
-	err = s.iface.SanitizeSlot(s.missingPathSlot)
-	c.Assert(err, ErrorMatches,
+	c.Assert(s.missingPathSlot.Sanitize(s.iface), ErrorMatches,
 		"bool-file must contain the path attribute")
 	// Slots without the "path" attribute are rejected.
-	err = s.iface.SanitizeSlot(s.parentDirPathSlot)
-	c.Assert(err, ErrorMatches,
+	c.Assert(s.parentDirPathSlot.Sanitize(s.iface), ErrorMatches,
 		"bool-file can only point at LED brightness or GPIO value")
 	// Slots with incorrect value of the "path" attribute are rejected.
-	err = s.iface.SanitizeSlot(s.badPathSlot)
-	c.Assert(err, ErrorMatches,
+	c.Assert(s.badPathSlot.Sanitize(s.iface), ErrorMatches,
 		"bool-file can only point at LED brightness or GPIO value")
 }
 
 func (s *BoolFileInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *BoolFileInterfaceSuite) TestPlugSnippetHandlesSymlinkErrors(c *C) {

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -264,13 +264,12 @@ func (iface *browserSupportInterface) MetaData() interfaces.MetaData {
 }
 
 func (iface *browserSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 
 func (iface *browserSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 
 	// It's fine if allow-sandbox isn't specified, but it it is,
 	// it needs to be bool

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -264,13 +264,10 @@ func (iface *browserSupportInterface) MetaData() interfaces.MetaData {
 }
 
 func (iface *browserSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 
 func (iface *browserSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
-
 	// It's fine if allow-sandbox isn't specified, but it it is,
 	// it needs to be bool
 	if v, ok := plug.Attrs["allow-sandbox"]; ok {

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -263,10 +263,6 @@ func (iface *browserSupportInterface) MetaData() interfaces.MetaData {
 	}
 }
 
-func (iface *browserSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *browserSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
 	// It's fine if allow-sandbox isn't specified, but it it is,
 	// it needs to be bool

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -188,11 +188,6 @@ apps:
 	c.Assert(secCompSnippet, testutil.Contains, `chroot`)
 }
 
-func (s *BrowserSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "browser-support"`)
-}
-
 func (s *BrowserSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/browser_support_test.go
+++ b/interfaces/builtin/browser_support_test.go
@@ -66,13 +66,11 @@ func (s *BrowserSupportInterfaceSuite) TestName(c *C) {
 }
 
 func (s *BrowserSupportInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *BrowserSupportInterfaceSuite) TestSanitizePlugNoAttrib(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *BrowserSupportInterfaceSuite) TestSanitizePlugWithAttrib(c *C) {
@@ -83,10 +81,8 @@ plugs:
   allow-sandbox: true
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
-
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["browser-support"]}
-	err := s.iface.SanitizePlug(plug)
-	c.Assert(err, IsNil)
+	c.Assert(plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *BrowserSupportInterfaceSuite) TestSanitizePlugWithBadAttrib(c *C) {
@@ -97,11 +93,9 @@ plugs:
   allow-sandbox: bad
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
-
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["browser-support"]}
-	err := s.iface.SanitizePlug(plug)
-	c.Assert(err, Not(IsNil))
-	c.Assert(err, ErrorMatches, "browser-support plug requires bool with 'allow-sandbox'")
+	c.Assert(plug.Sanitize(s.iface), ErrorMatches,
+		"browser-support plug requires bool with 'allow-sandbox'")
 }
 
 func (s *BrowserSupportInterfaceSuite) TestConnectedPlugSnippetWithoutAttrib(c *C) {

--- a/interfaces/builtin/classic_support_test.go
+++ b/interfaces/builtin/classic_support_test.go
@@ -75,13 +75,6 @@ func (s *ClassicSupportInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *ClassicSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "classic-support"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "classic-support"`)
-}
-
 func (s *ClassicSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/classic_support_test.go
+++ b/interfaces/builtin/classic_support_test.go
@@ -66,13 +66,11 @@ func (s *ClassicSupportInterfaceSuite) TestName(c *C) {
 }
 
 func (s *ClassicSupportInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *ClassicSupportInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *ClassicSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -20,14 +20,12 @@
 package builtin
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/snap"
 )
 
 type evalSymlinksFn func(string) (string, error)
@@ -82,20 +80,16 @@ func (iface *commonInterface) MetaData() interfaces.MetaData {
 // If the reservedForOS flag is set then only slots on core snap
 // are allowed.
 func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
-	if iface.reservedForOS && slot.Snap.Type != snap.TypeOS {
-		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.name)
+	ensureSlotIfaceMatch(iface, slot)
+	if iface.reservedForOS {
+		return sanitizeSlotReservedForOS(iface, slot)
 	}
 	return nil
 }
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *commonInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	// NOTE: currently we don't check anything on the plug side.
 	return nil
 }

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -86,12 +86,6 @@ func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-// SanitizePlug checks and possibly modifies a plug.
-func (iface *commonInterface) SanitizePlug(plug *interfaces.Plug) error {
-	// NOTE: currently we don't check anything on the plug side.
-	return nil
-}
-
 func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	if iface.connectedPlugAppArmor != "" {
 		spec.AddSnippet(iface.connectedPlugAppArmor)

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -80,7 +80,6 @@ func (iface *commonInterface) MetaData() interfaces.MetaData {
 // If the reservedForOS flag is set then only slots on core snap
 // are allowed.
 func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	if iface.reservedForOS {
 		return sanitizeSlotReservedForOS(iface, slot)
 	}
@@ -89,7 +88,6 @@ func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *commonInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	// NOTE: currently we don't check anything on the plug side.
 	return nil
 }

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -69,9 +69,6 @@ func cleanSubPath(path string) bool {
 }
 
 func (iface *contentInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
 	content, ok := slot.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
 		// content defaults to "slot" name if unspecified
@@ -98,9 +95,6 @@ func (iface *contentInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 func (iface *contentInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
 	content, ok := plug.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
 		if plug.Attrs == nil {

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -59,8 +59,7 @@ slots:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
-	err := s.iface.SanitizeSlot(slot)
-	c.Assert(err, IsNil)
+	c.Assert(slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *ContentSuite) TestSanitizeSlotContentLabelDefault(c *C) {
@@ -74,8 +73,7 @@ slots:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
-	err := s.iface.SanitizeSlot(slot)
-	c.Assert(err, IsNil)
+	c.Assert(slot.Sanitize(s.iface), IsNil)
 	c.Assert(slot.Attrs["content"], Equals, slot.Name)
 }
 
@@ -89,8 +87,7 @@ slots:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
-	err := s.iface.SanitizeSlot(slot)
-	c.Assert(err, ErrorMatches, "read or write path must be set")
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "read or write path must be set")
 }
 
 func (s *ContentSuite) TestSanitizeSlotEmptyPaths(c *C) {
@@ -105,8 +102,7 @@ slots:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
-	err := s.iface.SanitizeSlot(slot)
-	c.Assert(err, ErrorMatches, "read or write path must be set")
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "read or write path must be set")
 }
 
 func (s *ContentSuite) TestSanitizeSlotHasRelativePath(c *C) {
@@ -120,8 +116,7 @@ slots:
 	for _, rw := range []string{"read: [../foo]", "write: [../bar]"} {
 		info := snaptest.MockInfo(c, mockSnapYaml+"  "+rw, nil)
 		slot := &interfaces.Slot{SlotInfo: info.Slots["content-slot"]}
-		err := s.iface.SanitizeSlot(slot)
-		c.Assert(err, ErrorMatches, "content interface path is not clean:.*")
+		c.Assert(slot.Sanitize(s.iface), ErrorMatches, "content interface path is not clean:.*")
 	}
 }
 
@@ -136,8 +131,7 @@ plugs:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["content-plug"]}
-	err := s.iface.SanitizePlug(plug)
-	c.Assert(err, IsNil)
+	c.Assert(plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *ContentSuite) TestSanitizePlugContentLabelDefault(c *C) {
@@ -150,8 +144,7 @@ plugs:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["content-plug"]}
-	err := s.iface.SanitizePlug(plug)
-	c.Assert(err, IsNil)
+	c.Assert(plug.Sanitize(s.iface), IsNil)
 	c.Assert(plug.Attrs["content"], Equals, plug.Name)
 }
 
@@ -165,8 +158,7 @@ plugs:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["content-plug"]}
-	err := s.iface.SanitizePlug(plug)
-	c.Assert(err, ErrorMatches, "content plug must contain target path")
+	c.Assert(plug.Sanitize(s.iface), ErrorMatches, "content plug must contain target path")
 }
 
 func (s *ContentSuite) TestSanitizePlugSimpleTargetRelative(c *C) {
@@ -180,8 +172,7 @@ plugs:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["content-plug"]}
-	err := s.iface.SanitizePlug(plug)
-	c.Assert(err, ErrorMatches, "content interface target path is not clean:.*")
+	c.Assert(plug.Sanitize(s.iface), ErrorMatches, "content interface target path is not clean:.*")
 }
 
 func (s *ContentSuite) TestSanitizePlugNilAttrMap(c *C) {
@@ -194,8 +185,7 @@ apps:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["content"]}
-	err := s.iface.SanitizePlug(plug)
-	c.Assert(err, ErrorMatches, "content plug must contain target path")
+	c.Assert(plug.Sanitize(s.iface), ErrorMatches, "content plug must contain target path")
 }
 
 func (s *ContentSuite) TestResolveSpecialVariable(c *C) {

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -64,19 +64,18 @@ func (s *CoreSupportInterfaceSuite) TestName(c *C) {
 }
 
 func (s *CoreSupportInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "core-support",
 		Interface: "core-support",
-	}})
-	c.Assert(err, ErrorMatches, "core-support slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"core-support slots are reserved for the operating system snap")
 }
 
 func (s *CoreSupportInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *CoreSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -71,7 +71,7 @@ func (s *CoreSupportInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "core-support",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"core-support slots are reserved for the operating system snap")
+		"core-support slots are reserved for the core snap")
 }
 
 func (s *CoreSupportInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/core_support_test.go
+++ b/interfaces/builtin/core_support_test.go
@@ -79,13 +79,6 @@ func (s *CoreSupportInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *CoreSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "core-support"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "core-support"`)
-}
-
 func (s *CoreSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -404,19 +404,13 @@ func (iface *dbusInterface) AppArmorConnectedSlot(spec *apparmor.Specification, 
 }
 
 func (iface *dbusInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-
+	ensurePlugIfaceMatch(iface, plug)
 	_, _, err := iface.getAttribs(plug.Attrs)
 	return err
 }
 
 func (iface *dbusInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
+	ensureSlotIfaceMatch(iface, slot)
 	_, _, err := iface.getAttribs(slot.Attrs)
 	return err
 }

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -404,13 +404,11 @@ func (iface *dbusInterface) AppArmorConnectedSlot(spec *apparmor.Specification, 
 }
 
 func (iface *dbusInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	_, _, err := iface.getAttribs(plug.Attrs)
 	return err
 }
 
 func (iface *dbusInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	_, _, err := iface.getAttribs(slot.Attrs)
 	return err
 }

--- a/interfaces/builtin/dbus_test.go
+++ b/interfaces/builtin/dbus_test.go
@@ -138,8 +138,7 @@ slots:
 	c.Assert(err, IsNil)
 
 	slot := &interfaces.Slot{SlotInfo: info.Slots["dbus-slot"]}
-	err = s.iface.SanitizeSlot(slot)
-	c.Assert(err, IsNil)
+	c.Assert(slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestValidSystemBusName(c *C) {
@@ -156,8 +155,7 @@ slots:
 	c.Assert(err, IsNil)
 
 	slot := &interfaces.Slot{SlotInfo: info.Slots["dbus-slot"]}
-	err = s.iface.SanitizeSlot(slot)
-	c.Assert(err, IsNil)
+	c.Assert(slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestValidFullBusName(c *C) {
@@ -174,8 +172,7 @@ slots:
 	c.Assert(err, IsNil)
 
 	slot := &interfaces.Slot{SlotInfo: info.Slots["dbus-slot"]}
-	err = s.iface.SanitizeSlot(slot)
-	c.Assert(err, IsNil)
+	c.Assert(slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestNonexistentBusName(c *C) {
@@ -192,9 +189,7 @@ slots:
 	c.Assert(err, IsNil)
 
 	slot := &interfaces.Slot{SlotInfo: info.Slots["dbus-slot"]}
-	err = s.iface.SanitizeSlot(slot)
-	c.Assert(err, Not(IsNil))
-	c.Assert(err, ErrorMatches, "bus 'nonexistent' must be one of 'session' or 'system'")
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "bus 'nonexistent' must be one of 'session' or 'system'")
 }
 
 // If this test is failing, be sure to verify the AppArmor rules for binding to
@@ -213,9 +208,7 @@ slots:
 	c.Assert(err, IsNil)
 
 	slot := &interfaces.Slot{SlotInfo: info.Slots["dbus-slot"]}
-	err = s.iface.SanitizeSlot(slot)
-	c.Assert(err, Not(IsNil))
-	c.Assert(err, ErrorMatches, "DBus bus name must not end with -NUMBER")
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "DBus bus name must not end with -NUMBER")
 }
 
 func (s *DbusInterfaceSuite) TestSanitizeSlotSystem(c *C) {
@@ -232,8 +225,7 @@ slots:
 	c.Assert(err, IsNil)
 
 	slot := &interfaces.Slot{SlotInfo: info.Slots["dbus-slot"]}
-	err = s.iface.SanitizeSlot(slot)
-	c.Assert(err, IsNil)
+	c.Assert(slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestSanitizeSlotSession(c *C) {
@@ -250,8 +242,7 @@ slots:
 	c.Assert(err, IsNil)
 
 	slot := &interfaces.Slot{SlotInfo: info.Slots["dbus-slot"]}
-	err = s.iface.SanitizeSlot(slot)
-	c.Assert(err, IsNil)
+	c.Assert(slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestSanitizePlugSystem(c *C) {
@@ -268,8 +259,7 @@ plugs:
 	c.Assert(err, IsNil)
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["dbus-plug"]}
-	err = s.iface.SanitizePlug(plug)
-	c.Assert(err, IsNil)
+	c.Assert(plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestSanitizePlugSession(c *C) {
@@ -286,8 +276,7 @@ plugs:
 	c.Assert(err, IsNil)
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["dbus-plug"]}
-	err = s.iface.SanitizePlug(plug)
-	c.Assert(err, IsNil)
+	c.Assert(plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestPermanentSlotAppArmorSession(c *C) {

--- a/interfaces/builtin/dcdbas_control_test.go
+++ b/interfaces/builtin/dcdbas_control_test.go
@@ -78,13 +78,6 @@ func (s *DcdbasControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *DcdbasControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "dcdbas-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "dcdbas-control"`)
-}
-
 func (s *DcdbasControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/dcdbas_control_test.go
+++ b/interfaces/builtin/dcdbas_control_test.go
@@ -63,19 +63,18 @@ func (s *DcdbasControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *DcdbasControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "dcdbas-control",
 		Interface: "dcdbas-control",
-	}})
-	c.Assert(err, ErrorMatches, "dcdbas-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"dcdbas-control slots are reserved for the operating system snap")
 }
 
 func (s *DcdbasControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *DcdbasControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/dcdbas_control_test.go
+++ b/interfaces/builtin/dcdbas_control_test.go
@@ -70,7 +70,7 @@ func (s *DcdbasControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "dcdbas-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"dcdbas-control slots are reserved for the operating system snap")
+		"dcdbas-control slots are reserved for the core snap")
 }
 
 func (s *DcdbasControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -74,12 +74,10 @@ func (iface *dockerInterface) SecCompConnectedPlug(spec *seccomp.Specification, 
 }
 
 func (iface *dockerInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *dockerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -73,14 +73,6 @@ func (iface *dockerInterface) SecCompConnectedPlug(spec *seccomp.Specification, 
 	return nil
 }
 
-func (iface *dockerInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *dockerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *dockerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -20,8 +20,6 @@
 package builtin
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -76,16 +74,12 @@ func (iface *dockerInterface) SecCompConnectedPlug(spec *seccomp.Specification, 
 }
 
 func (iface *dockerInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *dockerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -571,10 +571,6 @@ func (iface *dockerSupportInterface) SecCompConnectedPlug(spec *seccomp.Specific
 	return nil
 }
 
-func (iface *dockerSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *dockerSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
 	if v, ok := plug.Attrs["privileged-containers"]; ok {
 		if _, ok = v.(bool); !ok {

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -572,12 +572,10 @@ func (iface *dockerSupportInterface) SecCompConnectedPlug(spec *seccomp.Specific
 }
 
 func (iface *dockerSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 
 func (iface *dockerSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	if v, ok := plug.Attrs["privileged-containers"]; ok {
 		if _, ok = v.(bool); !ok {
 			return fmt.Errorf("docker-support plug requires bool with 'privileged-containers'")

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -572,16 +572,12 @@ func (iface *dockerSupportInterface) SecCompConnectedPlug(spec *seccomp.Specific
 }
 
 func (iface *dockerSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 
 func (iface *dockerSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	if v, ok := plug.Attrs["privileged-containers"]; ok {
 		if _, ok = v.(bool); !ok {
 			return fmt.Errorf("docker-support plug requires bool with 'privileged-containers'")

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -96,13 +96,11 @@ func (s *DockerSupportInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 }
 
 func (s *DockerSupportInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *DockerSupportInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *DockerSupportInterfaceSuite) TestSanitizePlugWithPrivilegedTrue(c *C) {
@@ -123,8 +121,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["privileged"]}
-	err = s.iface.SanitizePlug(plug)
-	c.Assert(err, IsNil)
+	c.Assert(plug.Sanitize(s.iface), IsNil)
 
 	apparmorSpec := &apparmor.Specification{}
 	err = apparmorSpec.AddConnectedPlug(s.iface, plug, nil, s.slot, nil)
@@ -157,8 +154,7 @@ apps:
 	c.Assert(err, IsNil)
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["privileged"]}
-	err = s.iface.SanitizePlug(plug)
-	c.Assert(err, IsNil)
+	c.Assert(plug.Sanitize(s.iface), IsNil)
 
 	apparmorSpec := &apparmor.Specification{}
 	err = apparmorSpec.AddConnectedPlug(s.iface, plug, nil, s.slot, nil)
@@ -186,9 +182,7 @@ plugs:
 	c.Assert(err, IsNil)
 
 	plug := &interfaces.Plug{PlugInfo: info.Plugs["privileged"]}
-	err = s.iface.SanitizePlug(plug)
-	c.Assert(err, Not(IsNil))
-	c.Assert(err, ErrorMatches, "docker-support plug requires bool with 'privileged-containers'")
+	c.Assert(plug.Sanitize(s.iface), ErrorMatches, "docker-support plug requires bool with 'privileged-containers'")
 }
 
 func (s *DockerSupportInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/docker_test.go
+++ b/interfaces/builtin/docker_test.go
@@ -82,13 +82,11 @@ func (s *DockerInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 }
 
 func (s *DockerInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *DockerInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *DockerInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -28,8 +28,6 @@ import (
 var (
 	RegisterIface                     = registerIface
 	ResolveSpecialVariable            = resolveSpecialVariable
-	EnsureSlotIfaceMatch              = ensureSlotIfaceMatch
-	EnsurePlugIfaceMatch              = ensurePlugIfaceMatch
 	SanitizeSlotReservedForOS         = sanitizeSlotReservedForOS
 	SanitizeSlotReservedForOSOrGadget = sanitizeSlotReservedForOSOrGadget
 	SanitizeSlotReservedForOSOrApp    = sanitizeSlotReservedForOSOrApp

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -26,8 +26,13 @@ import (
 )
 
 var (
-	RegisterIface          = registerIface
-	ResolveSpecialVariable = resolveSpecialVariable
+	RegisterIface                     = registerIface
+	ResolveSpecialVariable            = resolveSpecialVariable
+	EnsureSlotIfaceMatch              = ensureSlotIfaceMatch
+	EnsurePlugIfaceMatch              = ensurePlugIfaceMatch
+	SanitizeSlotReservedForOS         = sanitizeSlotReservedForOS
+	SanitizeSlotReservedForOSOrGadget = sanitizeSlotReservedForOSOrGadget
+	SanitizeSlotReservedForOSOrApp    = sanitizeSlotReservedForOSOrApp
 )
 
 func MprisGetName(iface interfaces.Interface, attribs map[string]interface{}) (string, error) {

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -82,13 +82,6 @@ func (s *FirewallControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *FirewallControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "firewall-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "firewall-control"`)
-}
-
 func (s *FirewallControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -74,7 +74,7 @@ func (s *FirewallControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "firewall-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"firewall-control slots are reserved for the operating system snap")
+		"firewall-control slots are reserved for the core snap")
 }
 
 func (s *FirewallControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -67,19 +67,18 @@ func (s *FirewallControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *FirewallControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "firewall-control",
 		Interface: "firewall-control",
-	}})
-	c.Assert(err, ErrorMatches, "firewall-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"firewall-control slots are reserved for the operating system snap")
 }
 
 func (s *FirewallControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *FirewallControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -66,13 +66,11 @@ func (iface *framebufferInterface) String() string {
 
 // Check validity of the defined slot
 func (iface *framebufferInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *framebufferInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	// Currently nothing is checked on the plug side
 	return nil
 }

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -20,8 +20,6 @@
 package builtin
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
@@ -68,24 +66,13 @@ func (iface *framebufferInterface) String() string {
 
 // Check validity of the defined slot
 func (iface *framebufferInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Does it have right type?
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// Creation of the slot of this type
-	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
-		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
-	}
-	return nil
+	ensureSlotIfaceMatch(iface, slot)
+	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *framebufferInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	// Currently nothing is checked on the plug side
 	return nil
 }

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -69,12 +69,6 @@ func (iface *framebufferInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-// Checks and possibly modifies a plug
-func (iface *framebufferInterface) SanitizePlug(plug *interfaces.Plug) error {
-	// Currently nothing is checked on the plug side
-	return nil
-}
-
 func (iface *framebufferInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(framebufferConnectedPlugAppArmor)
 	return nil

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -74,7 +74,7 @@ func (s *FramebufferInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "framebuffer",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"framebuffer slots are reserved for the operating system snap")
+		"framebuffer slots are reserved for the core snap")
 }
 
 func (s *FramebufferInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -74,7 +74,7 @@ func (s *FramebufferInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "framebuffer",
 		Interface: "framebuffer",
 	}})
-	c.Assert(err, ErrorMatches, "framebuffer slots only allowed on core snap")
+	c.Assert(err, ErrorMatches, "framebuffer slots are reserved for the operating system snap")
 }
 
 func (s *FramebufferInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -67,19 +67,18 @@ func (s *FramebufferInterfaceSuite) TestName(c *C) {
 }
 
 func (s *FramebufferInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "framebuffer",
 		Interface: "framebuffer",
-	}})
-	c.Assert(err, ErrorMatches, "framebuffer slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"framebuffer slots are reserved for the operating system snap")
 }
 
 func (s *FramebufferInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *FramebufferInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -82,13 +82,6 @@ func (s *FramebufferInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *FramebufferInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "framebuffer"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "framebuffer"`)
-}
-
 func (s *FramebufferInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	expectedSnippet1 := `
 # Description: Allow reading and writing to the universal framebuffer (/dev/fb*) which

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -73,7 +73,7 @@ func (s *FuseSupportInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "fuse-support",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"fuse-support slots are reserved for the operating system snap")
+		"fuse-support slots are reserved for the core snap")
 }
 
 func (s *FuseSupportInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -66,19 +66,18 @@ func (s *FuseSupportInterfaceSuite) TestName(c *C) {
 }
 
 func (s *FuseSupportInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "fuse-support",
 		Interface: "fuse-support",
-	}})
-	c.Assert(err, ErrorMatches, "fuse-support slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"fuse-support slots are reserved for the operating system snap")
 }
 
 func (s *FuseSupportInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *FuseSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -81,13 +81,6 @@ func (s *FuseSupportInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *FuseSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "fuse-support"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "fuse-support"`)
-}
-
 func (s *FuseSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -246,11 +246,13 @@ func (iface *fwupdInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 
 // SanitizePlug checks the plug definition is valid
 func (iface *fwupdInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 // SanitizeSlot checks the slot definition is valid
 func (iface *fwupdInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -246,13 +246,11 @@ func (iface *fwupdInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 
 // SanitizePlug checks the plug definition is valid
 func (iface *fwupdInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 // SanitizeSlot checks the slot definition is valid
 func (iface *fwupdInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -244,16 +244,6 @@ func (iface *fwupdInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 	return nil
 }
 
-// SanitizePlug checks the plug definition is valid
-func (iface *fwupdInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-// SanitizeSlot checks the slot definition is valid
-func (iface *fwupdInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *fwupdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -63,7 +63,6 @@ func (iface *gpioInterface) MetaData() interfaces.MetaData {
 
 // SanitizeSlot checks the slot definition is valid
 func (iface *gpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
 		return err
 	}
@@ -85,7 +84,6 @@ func (iface *gpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // SanitizePlug checks the plug definition is valid
 func (iface *gpioInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -63,14 +63,9 @@ func (iface *gpioInterface) MetaData() interfaces.MetaData {
 
 // SanitizeSlot checks the slot definition is valid
 func (iface *gpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Paranoid check this right interface type
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// We will only allow creation of this type of slot by a gadget or OS snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
-		return fmt.Errorf("gpio slots only allowed on gadget or core snaps")
+	ensureSlotIfaceMatch(iface, slot)
+	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
+		return err
 	}
 
 	// Must have a GPIO number
@@ -90,12 +85,7 @@ func (iface *gpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // SanitizePlug checks the plug definition is valid
 func (iface *gpioInterface) SanitizePlug(plug *interfaces.Plug) error {
-	// Make sure right interface type
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-
-	// Plug is good
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -82,11 +82,6 @@ func (iface *gpioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-// SanitizePlug checks the plug definition is valid
-func (iface *gpioInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *gpioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	path := fmt.Sprint(gpioSysfsGpioBase, slot.Attrs["number"])
 	// Entries in /sys/class/gpio for single GPIO's are just symlinks

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -117,7 +117,7 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotOsSnap(c *C) {
 func (s *GpioInterfaceSuite) TestSanitizeSlotAppSnap(c *C) {
 	// gpio slot not accepted on app snap
 	c.Assert(s.appGpioSlot.Sanitize(s.iface), ErrorMatches,
-		"gpio slots are reserved for the operating system and gadget snaps")
+		"gpio slots are reserved for the core and gadget snaps")
 }
 
 func (s *GpioInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -108,9 +108,6 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotGadgetSnap(c *C) {
 	// slots with number attribute that isnt a number
 	err = s.iface.SanitizeSlot(s.gadgetBadNumberSlot)
 	c.Assert(err, ErrorMatches, "gpio slot number attribute must be an int")
-
-	// Must be right interface type
-	c.Assert(func() { s.iface.SanitizeSlot(s.gadgetBadInterfaceSlot) }, PanicMatches, `slot is not of interface "gpio"`)
 }
 
 func (s *GpioInterfaceSuite) TestSanitizeSlotOsSnap(c *C) {
@@ -128,9 +125,6 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotAppSnap(c *C) {
 func (s *GpioInterfaceSuite) TestSanitizePlug(c *C) {
 	err := s.iface.SanitizePlug(s.gadgetPlug)
 	c.Assert(err, IsNil)
-
-	// It is impossible to use "bool-file" interface to sanitize plugs of different interface.
-	c.Assert(func() { s.iface.SanitizePlug(s.gadgetBadInterfacePlug) }, PanicMatches, `plug is not of interface "gpio"`)
 }
 
 func (s *GpioInterfaceSuite) TestSystemdConnectedSlot(c *C) {

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -122,7 +122,7 @@ func (s *GpioInterfaceSuite) TestSanitizeSlotOsSnap(c *C) {
 func (s *GpioInterfaceSuite) TestSanitizeSlotAppSnap(c *C) {
 	// gpio slot not accepted on app snap
 	err := s.iface.SanitizeSlot(s.appGpioSlot)
-	c.Assert(err, ErrorMatches, "gpio slots only allowed on gadget or core snaps")
+	c.Assert(err, ErrorMatches, "gpio slots are reserved for the operating system and gadget snaps")
 }
 
 func (s *GpioInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -98,33 +98,30 @@ func (s *GpioInterfaceSuite) TestName(c *C) {
 
 func (s *GpioInterfaceSuite) TestSanitizeSlotGadgetSnap(c *C) {
 	// gpio slot on gadget accepeted
-	err := s.iface.SanitizeSlot(s.gadgetGpioSlot)
-	c.Assert(err, IsNil)
+	c.Assert(s.gadgetGpioSlot.Sanitize(s.iface), IsNil)
 
 	// slots without number attribute are rejected
-	err = s.iface.SanitizeSlot(s.gadgetMissingNumberSlot)
-	c.Assert(err, ErrorMatches, "gpio slot must have a number attribute")
+	c.Assert(s.gadgetMissingNumberSlot.Sanitize(s.iface), ErrorMatches,
+		"gpio slot must have a number attribute")
 
 	// slots with number attribute that isnt a number
-	err = s.iface.SanitizeSlot(s.gadgetBadNumberSlot)
-	c.Assert(err, ErrorMatches, "gpio slot number attribute must be an int")
+	c.Assert(s.gadgetBadNumberSlot.Sanitize(s.iface), ErrorMatches,
+		"gpio slot number attribute must be an int")
 }
 
 func (s *GpioInterfaceSuite) TestSanitizeSlotOsSnap(c *C) {
 	// gpio slot on OS accepeted
-	err := s.iface.SanitizeSlot(s.osGpioSlot)
-	c.Assert(err, IsNil)
+	c.Assert(s.osGpioSlot.Sanitize(s.iface), IsNil)
 }
 
 func (s *GpioInterfaceSuite) TestSanitizeSlotAppSnap(c *C) {
 	// gpio slot not accepted on app snap
-	err := s.iface.SanitizeSlot(s.appGpioSlot)
-	c.Assert(err, ErrorMatches, "gpio slots are reserved for the operating system and gadget snaps")
+	c.Assert(s.appGpioSlot.Sanitize(s.iface), ErrorMatches,
+		"gpio slots are reserved for the operating system and gadget snaps")
 }
 
 func (s *GpioInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.gadgetPlug)
-	c.Assert(err, IsNil)
+	c.Assert(s.gadgetPlug.Sanitize(s.iface), IsNil)
 }
 
 func (s *GpioInterfaceSuite) TestSystemdConnectedSlot(c *C) {

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -81,13 +81,6 @@ func (s *GreengrassSupportInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *GreengrassSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "greengrass-support"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "greengrass-support"`)
-}
-
 func (s *GreengrassSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	seccompSpec := &seccomp.Specification{}
 	err := seccompSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -66,19 +66,18 @@ func (s *GreengrassSupportInterfaceSuite) TestName(c *C) {
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "greengrass-support",
 		Interface: "greengrass-support",
-	}})
-	c.Assert(err, ErrorMatches, "greengrass-support slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"greengrass-support slots are reserved for the operating system snap")
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/greengrass_support_test.go
+++ b/interfaces/builtin/greengrass_support_test.go
@@ -73,7 +73,7 @@ func (s *GreengrassSupportInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "greengrass-support",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"greengrass-support slots are reserved for the operating system snap")
+		"greengrass-support slots are reserved for the core snap")
 }
 
 func (s *GreengrassSupportInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/gsettings_test.go
+++ b/interfaces/builtin/gsettings_test.go
@@ -81,13 +81,6 @@ func (s *GsettingsInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *GsettingsInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "gsettings"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "gsettings"`)
-}
-
 func (s *GsettingsInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/gsettings_test.go
+++ b/interfaces/builtin/gsettings_test.go
@@ -73,7 +73,7 @@ func (s *GsettingsInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "gsettings",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"gsettings slots are reserved for the operating system snap")
+		"gsettings slots are reserved for the core snap")
 }
 
 func (s *GsettingsInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/gsettings_test.go
+++ b/interfaces/builtin/gsettings_test.go
@@ -66,19 +66,18 @@ func (s *GsettingsInterfaceSuite) TestName(c *C) {
 }
 
 func (s *GsettingsInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "gsettings",
 		Interface: "gsettings",
-	}})
-	c.Assert(err, ErrorMatches, "gsettings slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"gsettings slots are reserved for the operating system snap")
 }
 
 func (s *GsettingsInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *GsettingsInterfaceSuite) TestConnectedPlugSnippet(c *C) {

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -73,7 +73,7 @@ func (s *HardwareObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "hardware-observe",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"hardware-observe slots are reserved for the operating system snap")
+		"hardware-observe slots are reserved for the core snap")
 }
 
 func (s *HardwareObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -66,19 +66,18 @@ func (s *HardwareObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *HardwareObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "hardware-observe",
 		Interface: "hardware-observe",
-	}})
-	c.Assert(err, ErrorMatches, "hardware-observe slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"hardware-observe slots are reserved for the operating system snap")
 }
 
 func (s *HardwareObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -81,13 +81,6 @@ func (s *HardwareObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *HardwareObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "hardware-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "hardware-observe"`)
-}
-
 func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/hardware_random_control.go
+++ b/interfaces/builtin/hardware_random_control.go
@@ -75,11 +75,6 @@ func (iface *hardwareRandomControlInterface) SanitizeSlot(slot *interfaces.Slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-// Checks and possibly modifies a plug
-func (iface *hardwareRandomControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *hardwareRandomControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(hardwareRandomControlConnectedPlugAppArmor)
 	return nil

--- a/interfaces/builtin/hardware_random_control.go
+++ b/interfaces/builtin/hardware_random_control.go
@@ -25,7 +25,6 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
-	"github.com/snapcore/snapd/snap"
 )
 
 const hardwareRandomControlSummary = `allows control over the hardware random number generator`
@@ -73,22 +72,13 @@ func (iface *hardwareRandomControlInterface) MetaData() interfaces.MetaData {
 
 // Check validity of the defined slot
 func (iface *hardwareRandomControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Does it have right type?
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
-	if slot.Snap.Type != snap.TypeOS {
-		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
-	}
-	return nil
+	ensureSlotIfaceMatch(iface, slot)
+	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *hardwareRandomControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
-	// Currently nothing is checked on the plug side
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/hardware_random_control.go
+++ b/interfaces/builtin/hardware_random_control.go
@@ -72,13 +72,11 @@ func (iface *hardwareRandomControlInterface) MetaData() interfaces.MetaData {
 
 // Check validity of the defined slot
 func (iface *hardwareRandomControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *hardwareRandomControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/hardware_random_control_test.go
+++ b/interfaces/builtin/hardware_random_control_test.go
@@ -67,19 +67,18 @@ func (s *HardwareRandomControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *HardwareRandomControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "hardware-random-control",
 		Interface: "hardware-random-control",
-	}})
-	c.Assert(err, ErrorMatches, "hardware-random-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"hardware-random-control slots are reserved for the operating system snap")
 }
 
 func (s *HardwareRandomControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *HardwareRandomControlInterfaceSuite) TestAppArmorSpec(c *C) {

--- a/interfaces/builtin/hardware_random_control_test.go
+++ b/interfaces/builtin/hardware_random_control_test.go
@@ -82,13 +82,6 @@ func (s *HardwareRandomControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *HardwareRandomControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "hardware-random-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "hardware-random-control"`)
-}
-
 func (s *HardwareRandomControlInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)

--- a/interfaces/builtin/hardware_random_control_test.go
+++ b/interfaces/builtin/hardware_random_control_test.go
@@ -74,7 +74,7 @@ func (s *HardwareRandomControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "hardware-random-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"hardware-random-control slots are reserved for the operating system snap")
+		"hardware-random-control slots are reserved for the core snap")
 }
 
 func (s *HardwareRandomControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/hardware_random_observe.go
+++ b/interfaces/builtin/hardware_random_observe.go
@@ -25,7 +25,6 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/udev"
-	"github.com/snapcore/snapd/snap"
 )
 
 const hardwareRandomObserveSummary = `allows reading from hardware random number generator`
@@ -68,20 +67,11 @@ func (iface *hardwareRandomObserveInterface) MetaData() interfaces.MetaData {
 
 // Check validity of the defined slot
 func (iface *hardwareRandomObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
-	if slot.Snap.Type != snap.TypeOS {
-		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
-	}
-	return nil
+	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *hardwareRandomObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
 	// Currently nothing is checked on the plug side
 	return nil
 }

--- a/interfaces/builtin/hardware_random_observe.go
+++ b/interfaces/builtin/hardware_random_observe.go
@@ -70,12 +70,6 @@ func (iface *hardwareRandomObserveInterface) SanitizeSlot(slot *interfaces.Slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-// Checks and possibly modifies a plug
-func (iface *hardwareRandomObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	// Currently nothing is checked on the plug side
-	return nil
-}
-
 func (iface *hardwareRandomObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(hardwareRandomObserveConnectedPlugAppArmor)
 	return nil

--- a/interfaces/builtin/hardware_random_observe_test.go
+++ b/interfaces/builtin/hardware_random_observe_test.go
@@ -74,7 +74,7 @@ func (s *HardwareRandomObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "hardware-random-observe",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"hardware-random-observe slots are reserved for the operating system snap")
+		"hardware-random-observe slots are reserved for the core snap")
 }
 
 func (s *HardwareRandomObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/hardware_random_observe_test.go
+++ b/interfaces/builtin/hardware_random_observe_test.go
@@ -67,19 +67,18 @@ func (s *HardwareRandomObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *HardwareRandomObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "hardware-random-observe",
 		Interface: "hardware-random-observe",
-	}})
-	c.Assert(err, ErrorMatches, "hardware-random-observe slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"hardware-random-observe slots are reserved for the operating system snap")
 }
 
 func (s *HardwareRandomObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *HardwareRandomObserveInterfaceSuite) TestAppArmorSpec(c *C) {

--- a/interfaces/builtin/hardware_random_observe_test.go
+++ b/interfaces/builtin/hardware_random_observe_test.go
@@ -82,13 +82,6 @@ func (s *HardwareRandomObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *HardwareRandomObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "hardware-random-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "hardware-random-observe"`)
-}
-
 func (s *HardwareRandomObserveInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -71,14 +71,9 @@ var hidrawUDevSymlinkPattern = regexp.MustCompile("^/dev/hidraw-[a-z0-9]+$")
 
 // SanitizeSlot checks validity of the defined slot
 func (iface *hidrawInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Check slot is of right type
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// We will only allow creation of this type of slot by a gadget or OS snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
-		return fmt.Errorf("hidraw slots only allowed on gadget or core snaps")
+	ensureSlotIfaceMatch(iface, slot)
+	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
+		return err
 	}
 
 	// Check slot has a path attribute identify hidraw device
@@ -124,9 +119,7 @@ func (iface *hidrawInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *hidrawInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	// NOTE: currently we don't check anything on the plug side.
 	return nil
 }

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -71,7 +71,6 @@ var hidrawUDevSymlinkPattern = regexp.MustCompile("^/dev/hidraw-[a-z0-9]+$")
 
 // SanitizeSlot checks validity of the defined slot
 func (iface *hidrawInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
 		return err
 	}
@@ -119,7 +118,6 @@ func (iface *hidrawInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *hidrawInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	// NOTE: currently we don't check anything on the plug side.
 	return nil
 }

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -116,12 +116,6 @@ func (iface *hidrawInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-// SanitizePlug checks and possibly modifies a plug.
-func (iface *hidrawInterface) SanitizePlug(plug *interfaces.Plug) error {
-	// NOTE: currently we don't check anything on the plug side.
-	return nil
-}
-
 func (iface *hidrawInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
 	usbVendor, vOk := slot.Attrs["usb-vendor"].(int64)
 	if !vOk {

--- a/interfaces/builtin/hidraw_test.go
+++ b/interfaces/builtin/hidraw_test.go
@@ -167,9 +167,6 @@ func (s *HidrawInterfaceSuite) TestSanitizeBadCoreSnapSlots(c *C) {
 		err := s.iface.SanitizeSlot(slot)
 		c.Assert(err, ErrorMatches, "hidraw path attribute must be a valid device node")
 	}
-
-	// It is impossible to use "bool-file" interface to sanitize slots with other interfaces.
-	c.Assert(func() { s.iface.SanitizeSlot(s.badInterfaceSlot) }, PanicMatches, `slot is not of interface "hidraw"`)
 }
 
 func (s *HidrawInterfaceSuite) TestSanitizeGadgetSnapSlots(c *C) {

--- a/interfaces/builtin/hidraw_test.go
+++ b/interfaces/builtin/hidraw_test.go
@@ -152,40 +152,29 @@ func (s *HidrawInterfaceSuite) TestName(c *C) {
 
 func (s *HidrawInterfaceSuite) TestSanitizeCoreSnapSlots(c *C) {
 	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2} {
-		err := s.iface.SanitizeSlot(slot)
-		c.Assert(err, IsNil)
+		c.Assert(slot.Sanitize(s.iface), IsNil)
 	}
 }
 
 func (s *HidrawInterfaceSuite) TestSanitizeBadCoreSnapSlots(c *C) {
 	// Slots without the "path" attribute are rejected.
-	err := s.iface.SanitizeSlot(s.missingPathSlot)
-	c.Assert(err, ErrorMatches, `hidraw slots must have a path attribute`)
+	c.Assert(s.missingPathSlot.Sanitize(s.iface), ErrorMatches, `hidraw slots must have a path attribute`)
 
 	// Slots with incorrect value of the "path" attribute are rejected.
 	for _, slot := range []*interfaces.Slot{s.badPathSlot1, s.badPathSlot2, s.badPathSlot3} {
-		err := s.iface.SanitizeSlot(slot)
-		c.Assert(err, ErrorMatches, "hidraw path attribute must be a valid device node")
+		c.Assert(slot.Sanitize(s.iface), ErrorMatches, "hidraw path attribute must be a valid device node")
 	}
 }
 
 func (s *HidrawInterfaceSuite) TestSanitizeGadgetSnapSlots(c *C) {
-	err := s.iface.SanitizeSlot(s.testUDev1)
-	c.Assert(err, IsNil)
-
-	err = s.iface.SanitizeSlot(s.testUDev2)
-	c.Assert(err, IsNil)
+	c.Assert(s.testUDev1.Sanitize(s.iface), IsNil)
+	c.Assert(s.testUDev2.Sanitize(s.iface), IsNil)
 }
 
 func (s *HidrawInterfaceSuite) TestSanitizeBadGadgetSnapSlots(c *C) {
-	err := s.iface.SanitizeSlot(s.testUDevBadValue1)
-	c.Assert(err, ErrorMatches, "hidraw usb-vendor attribute not valid: -1")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue2)
-	c.Assert(err, ErrorMatches, "hidraw usb-product attribute not valid: 65536")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue3)
-	c.Assert(err, ErrorMatches, "hidraw path attribute specifies invalid symlink location")
+	c.Assert(s.testUDevBadValue1.Sanitize(s.iface), ErrorMatches, "hidraw usb-vendor attribute not valid: -1")
+	c.Assert(s.testUDevBadValue2.Sanitize(s.iface), ErrorMatches, "hidraw usb-product attribute not valid: 65536")
+	c.Assert(s.testUDevBadValue3.Sanitize(s.iface), ErrorMatches, "hidraw path attribute specifies invalid symlink location")
 }
 
 func (s *HidrawInterfaceSuite) TestPermanentSlotUDevSnippets(c *C) {

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -71,7 +71,7 @@ func (s *HomeInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "home",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"home slots are reserved for the operating system snap")
+		"home slots are reserved for the core snap")
 }
 
 func (s *HomeInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -64,19 +64,18 @@ func (s *HomeInterfaceSuite) TestName(c *C) {
 }
 
 func (s *HomeInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "home",
 		Interface: "home",
-	}})
-	c.Assert(err, ErrorMatches, "home slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"home slots are reserved for the operating system snap")
 }
 
 func (s *HomeInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *HomeInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -79,13 +79,6 @@ func (s *HomeInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *HomeInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "home"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "home"`)
-}
-
 func (s *HomeInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -67,7 +67,6 @@ var i2cControlDeviceNodePattern = regexp.MustCompile("^/dev/i2c-[0-9]+$")
 
 // Check validity of the defined slot
 func (iface *i2cInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
 		return err
 	}
@@ -89,7 +88,6 @@ func (iface *i2cInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // Checks and possibly modifies a plug
 func (iface *i2cInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -67,15 +67,9 @@ var i2cControlDeviceNodePattern = regexp.MustCompile("^/dev/i2c-[0-9]+$")
 
 // Check validity of the defined slot
 func (iface *i2cInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Does it have right type?
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// Creation of the slot of this type
-	// is allowed only by a gadget snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
-		return fmt.Errorf("%s slots only allowed on gadget or core snaps", iface.Name())
+	ensureSlotIfaceMatch(iface, slot)
+	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
+		return err
 	}
 
 	// Validate the path
@@ -95,10 +89,7 @@ func (iface *i2cInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // Checks and possibly modifies a plug
 func (iface *i2cInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-	// Currently nothing is checked on the plug side
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -86,11 +86,6 @@ func (iface *i2cInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-// Checks and possibly modifies a plug
-func (iface *i2cInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *i2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	path, pathOk := slot.Attrs["path"].(string)
 	if !pathOk {

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -176,8 +176,6 @@ func (s *I2cInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
 
 	err = s.iface.SanitizeSlot(s.testUDevBadValue7)
 	c.Assert(err, ErrorMatches, "i2c slot must have a path attribute")
-
-	c.Assert(func() { s.iface.SanitizeSlot(s.testUDevBadInterface1) }, PanicMatches, `slot is not of interface "i2c"`)
 }
 
 func (s *I2cInterfaceSuite) TestConnectedPlugUDevSnippets(c *C) {

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -138,44 +138,23 @@ func (s *I2cInterfaceSuite) TestName(c *C) {
 }
 
 func (s *I2cInterfaceSuite) TestSanitizeCoreSnapSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.testSlot1)
-	c.Assert(err, IsNil)
+	c.Assert(s.testSlot1.Sanitize(s.iface), IsNil)
 }
 
 func (s *I2cInterfaceSuite) TestSanitizeGadgetSnapSlot(c *C) {
-
-	err := s.iface.SanitizeSlot(s.testUDev1)
-	c.Assert(err, IsNil)
-
-	err = s.iface.SanitizeSlot(s.testUDev2)
-	c.Assert(err, IsNil)
-
-	err = s.iface.SanitizeSlot(s.testUDev3)
-	c.Assert(err, IsNil)
+	c.Assert(s.testUDev1.Sanitize(s.iface), IsNil)
+	c.Assert(s.testUDev2.Sanitize(s.iface), IsNil)
+	c.Assert(s.testUDev3.Sanitize(s.iface), IsNil)
 }
 
 func (s *I2cInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
-
-	err := s.iface.SanitizeSlot(s.testUDevBadValue1)
-	c.Assert(err, ErrorMatches, "i2c path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue2)
-	c.Assert(err, ErrorMatches, "i2c path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue3)
-	c.Assert(err, ErrorMatches, "i2c path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue4)
-	c.Assert(err, ErrorMatches, "i2c path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue5)
-	c.Assert(err, ErrorMatches, "i2c path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue6)
-	c.Assert(err, ErrorMatches, "i2c slot must have a path attribute")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue7)
-	c.Assert(err, ErrorMatches, "i2c slot must have a path attribute")
+	c.Assert(s.testUDevBadValue1.Sanitize(s.iface), ErrorMatches, "i2c path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue2.Sanitize(s.iface), ErrorMatches, "i2c path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue3.Sanitize(s.iface), ErrorMatches, "i2c path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue4.Sanitize(s.iface), ErrorMatches, "i2c path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue5.Sanitize(s.iface), ErrorMatches, "i2c path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue6.Sanitize(s.iface), ErrorMatches, "i2c slot must have a path attribute")
+	c.Assert(s.testUDevBadValue7.Sanitize(s.iface), ErrorMatches, "i2c slot must have a path attribute")
 }
 
 func (s *I2cInterfaceSuite) TestConnectedPlugUDevSnippets(c *C) {

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -94,11 +94,6 @@ func (iface *iioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-// Checks and possibly modifies a plug
-func (iface *iioInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *iioInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	path, pathOk := slot.Attrs["path"].(string)
 	if !pathOk {

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -75,15 +75,9 @@ var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio:device[0-9]+$")
 
 // Check validity of the defined slot
 func (iface *iioInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Does it have right type?
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// Creation of the slot of this type
-	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
-		return fmt.Errorf("%s slots only allowed on gadget or core snaps", iface.Name())
+	ensureSlotIfaceMatch(iface, slot)
+	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
+		return err
 	}
 
 	// Validate the path
@@ -103,10 +97,7 @@ func (iface *iioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // Checks and possibly modifies a plug
 func (iface *iioInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-	// Currently nothing is checked on the plug side
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -75,7 +75,6 @@ var iioControlDeviceNodePattern = regexp.MustCompile("^/dev/iio:device[0-9]+$")
 
 // Check validity of the defined slot
 func (iface *iioInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
 		return err
 	}
@@ -97,7 +96,6 @@ func (iface *iioInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // Checks and possibly modifies a plug
 func (iface *iioInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -143,30 +143,14 @@ func (s *IioInterfaceSuite) TestName(c *C) {
 }
 
 func (s *IioInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
-
-	err := s.iface.SanitizeSlot(s.testUDevBadValue1)
-	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue2)
-	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue3)
-	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue4)
-	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue5)
-	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue6)
-	c.Assert(err, ErrorMatches, "iio path attribute must be a valid device node")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue7)
-	c.Assert(err, ErrorMatches, "iio slot must have a path attribute")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue8)
-	c.Assert(err, ErrorMatches, "iio slot must have a path attribute")
+	c.Assert(s.testUDevBadValue1.Sanitize(s.iface), ErrorMatches, "iio path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue2.Sanitize(s.iface), ErrorMatches, "iio path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue3.Sanitize(s.iface), ErrorMatches, "iio path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue4.Sanitize(s.iface), ErrorMatches, "iio path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue5.Sanitize(s.iface), ErrorMatches, "iio path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue6.Sanitize(s.iface), ErrorMatches, "iio path attribute must be a valid device node")
+	c.Assert(s.testUDevBadValue7.Sanitize(s.iface), ErrorMatches, "iio slot must have a path attribute")
+	c.Assert(s.testUDevBadValue8.Sanitize(s.iface), ErrorMatches, "iio slot must have a path attribute")
 }
 
 func (s *IioInterfaceSuite) TestConnectedPlugUDevSnippets(c *C) {

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -167,8 +167,6 @@ func (s *IioInterfaceSuite) TestSanitizeBadGadgetSnapSlot(c *C) {
 
 	err = s.iface.SanitizeSlot(s.testUDevBadValue8)
 	c.Assert(err, ErrorMatches, "iio slot must have a path attribute")
-
-	c.Assert(func() { s.iface.SanitizeSlot(s.testUDevBadInterface1) }, PanicMatches, `slot is not of interface "iio"`)
 }
 
 func (s *IioInterfaceSuite) TestConnectedPlugUDevSnippets(c *C) {

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -83,11 +83,6 @@ func (iface *ioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error 
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-// Checks and possibly modifies a plug
-func (iface *ioPortsControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *ioPortsControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(ioPortsControlConnectedPlugAppArmor)
 	return nil

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -80,25 +80,13 @@ func (iface *ioPortsControlInterface) String() string {
 
 // Check validity of the defined slot
 func (iface *ioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Does it have right type?
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// Creation of the slot of this type
-	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
-		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
-	}
-	return nil
+	ensureSlotIfaceMatch(iface, slot)
+	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *ioPortsControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-	// Currently nothing is checked on the plug side
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -80,13 +80,11 @@ func (iface *ioPortsControlInterface) String() string {
 
 // Check validity of the defined slot
 func (iface *ioPortsControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *ioPortsControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -69,19 +69,18 @@ func (s *ioPortsControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *ioPortsControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "io-ports-control",
 		Interface: "io-ports-control",
-	}})
-	c.Assert(err, ErrorMatches, "io-ports-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"io-ports-control slots are reserved for the operating system snap")
 }
 
 func (s *ioPortsControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *ioPortsControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -76,7 +76,7 @@ func (s *ioPortsControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "io-ports-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"io-ports-control slots are reserved for the operating system snap")
+		"io-ports-control slots are reserved for the core snap")
 }
 
 func (s *ioPortsControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -84,13 +84,6 @@ func (s *ioPortsControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *ioPortsControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "io-ports-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "io-ports-control"`)
-}
-
 func (s *ioPortsControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	expectedSnippet1 := `
 # Description: Allow write access to all I/O ports.

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -76,7 +76,7 @@ func (s *ioPortsControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "io-ports-control",
 		Interface: "io-ports-control",
 	}})
-	c.Assert(err, ErrorMatches, "io-ports-control slots only allowed on core snap")
+	c.Assert(err, ErrorMatches, "io-ports-control slots are reserved for the operating system snap")
 }
 
 func (s *ioPortsControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -70,11 +70,6 @@ func (iface *joystickInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-// SanitizePlug checks and possibly modifies a plug.
-func (iface *joystickInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 // AppArmorConnectedPlug adds the necessary appamor snippet to the spec that
 // allows access to joystick devices.
 func (iface *joystickInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -67,13 +67,11 @@ func (iface *joystickInterface) String() string {
 
 // SanitizeSlot checks the validity of the defined slot.
 func (iface *joystickInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *joystickInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -20,11 +20,8 @@
 package builtin
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
-	"github.com/snapcore/snapd/snap"
 )
 
 const joystickSummary = `allows access to joystick devices`
@@ -70,26 +67,13 @@ func (iface *joystickInterface) String() string {
 
 // SanitizeSlot checks the validity of the defined slot.
 func (iface *joystickInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Does it have right type?
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// The snap implementing this slot must be an os snap.
-	if !(slot.Snap.Type == snap.TypeOS) {
-		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
-	}
-
-	return nil
+	ensureSlotIfaceMatch(iface, slot)
+	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *joystickInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-
-	// Currently nothing is checked on the plug side
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -74,7 +74,7 @@ func (s *JoystickInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "joystick",
 		Interface: "joystick",
 	}})
-	c.Assert(err, ErrorMatches, "joystick slots only allowed on core snap")
+	c.Assert(err, ErrorMatches, "joystick slots are reserved for the operating system snap")
 }
 
 func (s *JoystickInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -67,19 +67,18 @@ func (s *JoystickInterfaceSuite) TestName(c *C) {
 }
 
 func (s *JoystickInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "joystick",
 		Interface: "joystick",
-	}})
-	c.Assert(err, ErrorMatches, "joystick slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"joystick slots are reserved for the operating system snap")
 }
 
 func (s *JoystickInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *JoystickInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -74,7 +74,7 @@ func (s *JoystickInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "joystick",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"joystick slots are reserved for the operating system snap")
+		"joystick slots are reserved for the core snap")
 }
 
 func (s *JoystickInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -82,13 +82,6 @@ func (s *JoystickInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *JoystickInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "joystick"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "joystick"`)
-}
-
 func (s *JoystickInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	expectedSnippet := `
 # Description: Allow reading and writing to joystick devices (/dev/input/js*).

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -81,13 +81,6 @@ func (s *KernelModuleControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *KernelModuleControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "kernel-module-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "kernel-module-control"`)
-}
-
 func (s *KernelModuleControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -73,7 +73,7 @@ func (s *KernelModuleControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "kernel-module-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"kernel-module-control slots are reserved for the operating system snap")
+		"kernel-module-control slots are reserved for the core snap")
 }
 
 func (s *KernelModuleControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -66,19 +66,18 @@ func (s *KernelModuleControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *KernelModuleControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "kernel-module-control",
 		Interface: "kernel-module-control",
-	}})
-	c.Assert(err, ErrorMatches, "kernel-module-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"kernel-module-control slots are reserved for the operating system snap")
 }
 
 func (s *KernelModuleControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *KernelModuleControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -81,13 +81,6 @@ func (s *KubernetesSupportInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *KubernetesSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "kubernetes-support"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "kubernetes-support"`)
-}
-
 func (s *KubernetesSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	kmodSpec := &kmod.Specification{}
 	err := kmodSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -66,19 +66,18 @@ func (s *KubernetesSupportInterfaceSuite) TestName(c *C) {
 }
 
 func (s *KubernetesSupportInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "kubernetes-support",
 		Interface: "kubernetes-support",
-	}})
-	c.Assert(err, ErrorMatches, "kubernetes-support slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"kubernetes-support slots are reserved for the operating system snap")
 }
 
 func (s *KubernetesSupportInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *KubernetesSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/kubernetes_support_test.go
+++ b/interfaces/builtin/kubernetes_support_test.go
@@ -73,7 +73,7 @@ func (s *KubernetesSupportInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "kubernetes-support",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"kubernetes-support slots are reserved for the operating system snap")
+		"kubernetes-support slots are reserved for the core snap")
 }
 
 func (s *KubernetesSupportInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/libvirt_test.go
+++ b/interfaces/builtin/libvirt_test.go
@@ -57,13 +57,11 @@ func (s *LibvirtInterfaceSuite) TestName(c *C) {
 }
 
 func (s *LibvirtInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, ErrorMatches, ".*libvirt slots are reserved for the operating system snap.*")
+	c.Assert(s.slot.Sanitize(s.iface), ErrorMatches, ".*libvirt slots are reserved for the operating system snap.*")
 }
 
 func (s *LibvirtInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *LibvirtInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/libvirt_test.go
+++ b/interfaces/builtin/libvirt_test.go
@@ -57,7 +57,7 @@ func (s *LibvirtInterfaceSuite) TestName(c *C) {
 }
 
 func (s *LibvirtInterfaceSuite) TestSanitizeSlot(c *C) {
-	c.Assert(s.slot.Sanitize(s.iface), ErrorMatches, ".*libvirt slots are reserved for the operating system snap.*")
+	c.Assert(s.slot.Sanitize(s.iface), ErrorMatches, ".*libvirt slots are reserved for the core snap.*")
 }
 
 func (s *LibvirtInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -64,19 +64,18 @@ func (s *LocaleControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *LocaleControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "locale-control",
 		Interface: "locale-control",
-	}})
-	c.Assert(err, ErrorMatches, "locale-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"locale-control slots are reserved for the operating system snap")
 }
 
 func (s *LocaleControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *LocaleControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -71,7 +71,7 @@ func (s *LocaleControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "locale-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"locale-control slots are reserved for the operating system snap")
+		"locale-control slots are reserved for the core snap")
 }
 
 func (s *LocaleControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/locale_control_test.go
+++ b/interfaces/builtin/locale_control_test.go
@@ -79,13 +79,6 @@ func (s *LocaleControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *LocaleControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "locale-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "locale-control"`)
-}
-
 func (s *LocaleControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -246,10 +246,12 @@ func (iface *locationControlInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 }
 
 func (iface *locationControlInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *locationControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -246,12 +246,10 @@ func (iface *locationControlInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 }
 
 func (iface *locationControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *locationControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -245,14 +245,6 @@ func (iface *locationControlInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 	return nil
 }
 
-func (iface *locationControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *locationControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *locationControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -299,14 +299,6 @@ func (iface *locationObserveInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 	return nil
 }
 
-func (iface *locationObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *locationObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *locationObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -300,12 +300,10 @@ func (iface *locationObserveInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 }
 
 func (iface *locationObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *locationObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -300,10 +300,12 @@ func (iface *locationObserveInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 }
 
 func (iface *locationObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *locationObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -79,13 +79,6 @@ func (s *LogObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *LogObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "log-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "log-observe"`)
-}
-
 func (s *LogObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -64,19 +64,18 @@ func (s *LogObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *LogObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "log-observe",
 		Interface: "log-observe",
-	}})
-	c.Assert(err, ErrorMatches, "log-observe slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"log-observe slots are reserved for the operating system snap")
 }
 
 func (s *LogObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *LogObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/log_observe_test.go
+++ b/interfaces/builtin/log_observe_test.go
@@ -71,7 +71,7 @@ func (s *LogObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "log-observe",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"log-observe slots are reserved for the operating system snap")
+		"log-observe slots are reserved for the core snap")
 }
 
 func (s *LogObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -72,14 +72,6 @@ func (iface *lxdInterface) SecCompConnectedPlug(spec *seccomp.Specification, plu
 	return nil
 }
 
-func (iface *lxdInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *lxdInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *lxdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -73,12 +73,10 @@ func (iface *lxdInterface) SecCompConnectedPlug(spec *seccomp.Specification, plu
 }
 
 func (iface *lxdInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *lxdInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -20,8 +20,6 @@
 package builtin
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -75,16 +73,12 @@ func (iface *lxdInterface) SecCompConnectedPlug(spec *seccomp.Specification, plu
 }
 
 func (iface *lxdInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *lxdInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -82,12 +82,10 @@ func (iface *lxdSupportInterface) SecCompConnectedPlug(spec *seccomp.Specificati
 }
 
 func (iface *lxdSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *lxdSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -82,10 +82,12 @@ func (iface *lxdSupportInterface) SecCompConnectedPlug(spec *seccomp.Specificati
 }
 
 func (iface *lxdSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *lxdSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -81,14 +81,6 @@ func (iface *lxdSupportInterface) SecCompConnectedPlug(spec *seccomp.Specificati
 	return nil
 }
 
-func (iface *lxdSupportInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *lxdSupportInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *lxdSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -66,13 +66,11 @@ func (s *LxdSupportInterfaceSuite) TestName(c *C) {
 }
 
 func (s *LxdSupportInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *LxdSupportInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *LxdSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/lxd_test.go
+++ b/interfaces/builtin/lxd_test.go
@@ -68,13 +68,11 @@ func (s *LxdInterfaceSuite) TestName(c *C) {
 }
 
 func (s *LxdInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *LxdInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *LxdInterfaceSuite) TestConnectedPlugSnippetAppArmor(c *C) {

--- a/interfaces/builtin/maliit.go
+++ b/interfaces/builtin/maliit.go
@@ -163,12 +163,10 @@ func (iface *maliitInterface) AppArmorConnectedSlot(spec *apparmor.Specification
 }
 
 func (iface *maliitInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *maliitInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/maliit.go
+++ b/interfaces/builtin/maliit.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -163,17 +162,13 @@ func (iface *maliitInterface) AppArmorConnectedSlot(spec *apparmor.Specification
 	return nil
 }
 
-func (iface *maliitInterface) SanitizePlug(slot *interfaces.Plug) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
+func (iface *maliitInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *maliitInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/maliit.go
+++ b/interfaces/builtin/maliit.go
@@ -162,14 +162,6 @@ func (iface *maliitInterface) AppArmorConnectedSlot(spec *apparmor.Specification
 	return nil
 }
 
-func (iface *maliitInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *maliitInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *maliitInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/media_hub.go
+++ b/interfaces/builtin/media_hub.go
@@ -194,10 +194,12 @@ func (iface *mediaHubInterface) SecCompPermanentSlot(spec *seccomp.Specification
 }
 
 func (iface *mediaHubInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *mediaHubInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/media_hub.go
+++ b/interfaces/builtin/media_hub.go
@@ -193,14 +193,6 @@ func (iface *mediaHubInterface) SecCompPermanentSlot(spec *seccomp.Specification
 	return nil
 }
 
-func (iface *mediaHubInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *mediaHubInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *mediaHubInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/media_hub.go
+++ b/interfaces/builtin/media_hub.go
@@ -194,12 +194,10 @@ func (iface *mediaHubInterface) SecCompPermanentSlot(spec *seccomp.Specification
 }
 
 func (iface *mediaHubInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *mediaHubInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -131,10 +131,12 @@ func (iface *mirInterface) SecCompPermanentSlot(spec *seccomp.Specification, slo
 }
 
 func (iface *mirInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *mirInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -130,14 +130,6 @@ func (iface *mirInterface) SecCompPermanentSlot(spec *seccomp.Specification, slo
 	return nil
 }
 
-func (iface *mirInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *mirInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *mirInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -131,12 +131,10 @@ func (iface *mirInterface) SecCompPermanentSlot(spec *seccomp.Specification, slo
 }
 
 func (iface *mirInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *mirInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1227,14 +1227,6 @@ func (iface *modemManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifica
 	return nil
 }
 
-func (iface *modemManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *modemManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *modemManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1228,12 +1228,10 @@ func (iface *modemManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifica
 }
 
 func (iface *modemManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *modemManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1228,10 +1228,12 @@ func (iface *modemManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifica
 }
 
 func (iface *modemManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *modemManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -70,7 +70,7 @@ func (s *MountObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "mount-observe",
 		Interface: "mount-observe",
 	}}
-	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "mount-observe slots are reserved for the operating system snap")
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "mount-observe slots are reserved for the core snap")
 }
 
 func (s *MountObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -79,13 +79,6 @@ func (s *MountObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *MountObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "mount-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "mount-observe"`)
-}
-
 func (s *MountObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/mount_observe_test.go
+++ b/interfaces/builtin/mount_observe_test.go
@@ -64,19 +64,17 @@ func (s *MountObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *MountObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "mount-observe",
 		Interface: "mount-observe",
-	}})
-	c.Assert(err, ErrorMatches, "mount-observe slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "mount-observe slots are reserved for the operating system snap")
 }
 
 func (s *MountObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *MountObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -220,10 +220,6 @@ func (iface *mprisInterface) getName(attribs map[string]interface{}) (string, er
 	return mprisName, nil
 }
 
-func (iface *mprisInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *mprisInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	_, err := iface.getName(slot.Attrs)
 	return err

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -221,12 +221,10 @@ func (iface *mprisInterface) getName(attribs map[string]interface{}) (string, er
 }
 
 func (iface *mprisInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *mprisInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	_, err := iface.getName(slot.Attrs)
 	return err
 }

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -220,15 +220,13 @@ func (iface *mprisInterface) getName(attribs map[string]interface{}) (string, er
 	return mprisName, nil
 }
 
-func (iface *mprisInterface) SanitizePlug(slot *interfaces.Plug) error {
+func (iface *mprisInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *mprisInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
+	ensureSlotIfaceMatch(iface, slot)
 	_, err := iface.getName(slot.Attrs)
 	return err
 }

--- a/interfaces/builtin/netlink_audit_test.go
+++ b/interfaces/builtin/netlink_audit_test.go
@@ -72,7 +72,7 @@ func (s *NetlinkAuditInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "netlink-audit",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"netlink-audit slots are reserved for the operating system snap")
+		"netlink-audit slots are reserved for the core snap")
 }
 
 func (s *NetlinkAuditInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/netlink_audit_test.go
+++ b/interfaces/builtin/netlink_audit_test.go
@@ -80,13 +80,6 @@ func (s *NetlinkAuditInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *NetlinkAuditInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "netlink-audit"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "netlink-audit"`)
-}
-
 func (s *NetlinkAuditInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	seccompSpec := &seccomp.Specification{}
 	err := seccompSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)

--- a/interfaces/builtin/netlink_audit_test.go
+++ b/interfaces/builtin/netlink_audit_test.go
@@ -65,19 +65,18 @@ func (s *NetlinkAuditInterfaceSuite) TestName(c *C) {
 }
 
 func (s *NetlinkAuditInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "netlink-audit",
 		Interface: "netlink-audit",
-	}})
-	c.Assert(err, ErrorMatches, "netlink-audit slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"netlink-audit slots are reserved for the operating system snap")
 }
 
 func (s *NetlinkAuditInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *NetlinkAuditInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/netlink_connector_test.go
+++ b/interfaces/builtin/netlink_connector_test.go
@@ -72,7 +72,7 @@ func (s *NetlinkConnectorInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "netlink-connector",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"netlink-connector slots are reserved for the operating system snap")
+		"netlink-connector slots are reserved for the core snap")
 }
 
 func (s *NetlinkConnectorInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/netlink_connector_test.go
+++ b/interfaces/builtin/netlink_connector_test.go
@@ -65,19 +65,18 @@ func (s *NetlinkConnectorInterfaceSuite) TestName(c *C) {
 }
 
 func (s *NetlinkConnectorInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "netlink-connector",
 		Interface: "netlink-connector",
-	}})
-	c.Assert(err, ErrorMatches, "netlink-connector slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"netlink-connector slots are reserved for the operating system snap")
 }
 
 func (s *NetlinkConnectorInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *NetlinkConnectorInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/netlink_connector_test.go
+++ b/interfaces/builtin/netlink_connector_test.go
@@ -80,13 +80,6 @@ func (s *NetlinkConnectorInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *NetlinkConnectorInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "netlink-connector"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "netlink-connector"`)
-}
-
 func (s *NetlinkConnectorInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	seccompSpec := &seccomp.Specification{}
 	err := seccompSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -80,13 +80,6 @@ func (s *NetworkBindInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *NetworkBindInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "network-bind"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "network-bind"`)
-}
-
 func (s *NetworkBindInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -72,7 +72,7 @@ func (s *NetworkBindInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "network-bind",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"network-bind slots are reserved for the operating system snap")
+		"network-bind slots are reserved for the core snap")
 }
 
 func (s *NetworkBindInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/network_bind_test.go
+++ b/interfaces/builtin/network_bind_test.go
@@ -65,19 +65,18 @@ func (s *NetworkBindInterfaceSuite) TestName(c *C) {
 }
 
 func (s *NetworkBindInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "network-bind",
 		Interface: "network-bind",
-	}})
-	c.Assert(err, ErrorMatches, "network-bind slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"network-bind slots are reserved for the operating system snap")
 }
 
 func (s *NetworkBindInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *NetworkBindInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -81,13 +81,6 @@ func (s *NetworkControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *NetworkControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "network-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "network-control"`)
-}
-
 func (s *NetworkControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -73,7 +73,7 @@ func (s *NetworkControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "network-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"network-control slots are reserved for the operating system snap")
+		"network-control slots are reserved for the core snap")
 }
 
 func (s *NetworkControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -66,19 +66,18 @@ func (s *NetworkControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *NetworkControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "network-control",
 		Interface: "network-control",
-	}})
-	c.Assert(err, ErrorMatches, "network-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"network-control slots are reserved for the operating system snap")
 }
 
 func (s *NetworkControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *NetworkControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -441,14 +441,6 @@ func (iface *networkManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifi
 	return nil
 }
 
-func (iface *networkManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *networkManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *networkManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -442,10 +442,12 @@ func (iface *networkManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifi
 }
 
 func (iface *networkManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *networkManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -442,12 +442,10 @@ func (iface *networkManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifi
 }
 
 func (iface *networkManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *networkManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -66,19 +66,18 @@ func (s *NetworkObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *NetworkObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "network-observe",
 		Interface: "network-observe",
-	}})
-	c.Assert(err, ErrorMatches, "network-observe slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"network-observe slots are reserved for the operating system snap")
 }
 
 func (s *NetworkObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *NetworkObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -73,7 +73,7 @@ func (s *NetworkObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "network-observe",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"network-observe slots are reserved for the operating system snap")
+		"network-observe slots are reserved for the core snap")
 }
 
 func (s *NetworkObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/network_observe_test.go
+++ b/interfaces/builtin/network_observe_test.go
@@ -81,13 +81,6 @@ func (s *NetworkObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *NetworkObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "network-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "network-observe"`)
-}
-
 func (s *NetworkObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/network_setup_control_test.go
+++ b/interfaces/builtin/network_setup_control_test.go
@@ -78,13 +78,6 @@ func (s *NetworkSetupControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *NetworkSetupControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "network-setup-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "network-setup-control"`)
-}
-
 func (s *NetworkSetupControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/network_setup_control_test.go
+++ b/interfaces/builtin/network_setup_control_test.go
@@ -63,19 +63,18 @@ func (s *NetworkSetupControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *NetworkSetupControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "network-setup-control",
 		Interface: "network-setup-control",
-	}})
-	c.Assert(err, ErrorMatches, "network-setup-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"network-setup-control slots are reserved for the operating system snap")
 }
 
 func (s *NetworkSetupControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *NetworkSetupControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/network_setup_control_test.go
+++ b/interfaces/builtin/network_setup_control_test.go
@@ -70,7 +70,7 @@ func (s *NetworkSetupControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "network-setup-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"network-setup-control slots are reserved for the operating system snap")
+		"network-setup-control slots are reserved for the core snap")
 }
 
 func (s *NetworkSetupControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -64,19 +64,18 @@ func (s *NetworkSetupObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *NetworkSetupObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "network-setup-observe",
 		Interface: "network-setup-observe",
-	}})
-	c.Assert(err, ErrorMatches, "network-setup-observe slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"network-setup-observe slots are reserved for the operating system snap")
 }
 
 func (s *NetworkSetupObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *NetworkSetupObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -79,13 +79,6 @@ func (s *NetworkSetupObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *NetworkSetupObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "network-setup-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "network-setup-observe"`)
-}
-
 func (s *NetworkSetupObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/network_setup_observe_test.go
+++ b/interfaces/builtin/network_setup_observe_test.go
@@ -71,7 +71,7 @@ func (s *NetworkSetupObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "network-setup-observe",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"network-setup-observe slots are reserved for the operating system snap")
+		"network-setup-observe slots are reserved for the core snap")
 }
 
 func (s *NetworkSetupObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -136,14 +136,6 @@ func (iface *networkStatusInterface) DBusPermanentSlot(spec *dbus.Specification,
 	return nil
 }
 
-func (iface *networkStatusInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *networkStatusInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *networkStatusInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -138,16 +137,12 @@ func (iface *networkStatusInterface) DBusPermanentSlot(spec *dbus.Specification,
 }
 
 func (iface *networkStatusInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *networkStatusInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -137,12 +137,10 @@ func (iface *networkStatusInterface) DBusPermanentSlot(spec *dbus.Specification,
 }
 
 func (iface *networkStatusInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *networkStatusInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/network_status_test.go
+++ b/interfaces/builtin/network_status_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/dbus"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -65,13 +64,6 @@ apps:
 
 func (s *NetworkStatusSuite) TestName(c *C) {
 	c.Check(s.iface.Name(), Equals, "network-status")
-}
-
-func (s *NetworkStatusSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Check(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "network-status"`)
-	c.Check(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "network-status"`)
 }
 
 func (s *NetworkStatusSuite) TestAppArmorConnectedPlug(c *C) {

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -73,7 +73,7 @@ func (s *NetworkInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "network",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"network slots are reserved for the operating system snap")
+		"network slots are reserved for the core snap")
 }
 
 func (s *NetworkInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -81,13 +81,6 @@ func (s *NetworkInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *NetworkInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "network"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "network"`)
-}
-
 func (s *NetworkInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/network_test.go
+++ b/interfaces/builtin/network_test.go
@@ -66,19 +66,18 @@ func (s *NetworkInterfaceSuite) TestName(c *C) {
 }
 
 func (s *NetworkInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "network",
 		Interface: "network",
-	}})
-	c.Assert(err, ErrorMatches, "network slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"network slots are reserved for the operating system snap")
 }
 
 func (s *NetworkInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *NetworkInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -324,10 +324,12 @@ func (iface *ofonoInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 }
 
 func (iface *ofonoInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *ofonoInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -324,12 +324,10 @@ func (iface *ofonoInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 }
 
 func (iface *ofonoInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *ofonoInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -323,14 +323,6 @@ func (iface *ofonoInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 	return nil
 }
 
-func (iface *ofonoInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *ofonoInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *ofonoInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/online_accounts_service.go
+++ b/interfaces/builtin/online_accounts_service.go
@@ -135,12 +135,10 @@ func (iface *onlineAccountsServiceInterface) SecCompPermanentSlot(spec *seccomp.
 }
 
 func (iface *onlineAccountsServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *onlineAccountsServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/online_accounts_service.go
+++ b/interfaces/builtin/online_accounts_service.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -136,16 +135,12 @@ func (iface *onlineAccountsServiceInterface) SecCompPermanentSlot(spec *seccomp.
 }
 
 func (iface *onlineAccountsServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *onlineAccountsServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/online_accounts_service.go
+++ b/interfaces/builtin/online_accounts_service.go
@@ -134,14 +134,6 @@ func (iface *onlineAccountsServiceInterface) SecCompPermanentSlot(spec *seccomp.
 	return nil
 }
 
-func (iface *onlineAccountsServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *onlineAccountsServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *onlineAccountsServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/online_accounts_service_test.go
+++ b/interfaces/builtin/online_accounts_service_test.go
@@ -70,8 +70,8 @@ func (s *OnlineAccountsServiceInterfaceSuite) TestName(c *C) {
 }
 
 func (s *OnlineAccountsServiceInterfaceSuite) TestSanitize(c *C) {
-	c.Assert(s.iface.SanitizePlug(s.plug), IsNil)
-	c.Assert(s.iface.SanitizeSlot(s.slot), IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *OnlineAccountsServiceInterfaceSuite) TestAppArmorConnectedPlug(c *C) {

--- a/interfaces/builtin/online_accounts_service_test.go
+++ b/interfaces/builtin/online_accounts_service_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -73,13 +72,6 @@ func (s *OnlineAccountsServiceInterfaceSuite) TestName(c *C) {
 func (s *OnlineAccountsServiceInterfaceSuite) TestSanitize(c *C) {
 	c.Assert(s.iface.SanitizePlug(s.plug), IsNil)
 	c.Assert(s.iface.SanitizeSlot(s.slot), IsNil)
-}
-
-func (s *OnlineAccountsServiceInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "online-accounts-service"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "online-accounts-service"`)
 }
 
 func (s *OnlineAccountsServiceInterfaceSuite) TestAppArmorConnectedPlug(c *C) {

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -82,13 +82,6 @@ func (s *OpenglInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *OpenglInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "opengl"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "opengl"`)
-}
-
 func (s *OpenglInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	expectedSnippet := `
 # Description: Can access opengl.

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -74,7 +74,7 @@ func (s *OpenglInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "opengl",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"opengl slots are reserved for the operating system snap")
+		"opengl slots are reserved for the core snap")
 }
 
 func (s *OpenglInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -67,19 +67,18 @@ func (s *OpenglInterfaceSuite) TestName(c *C) {
 }
 
 func (s *OpenglInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "opengl",
 		Interface: "opengl",
-	}})
-	c.Assert(err, ErrorMatches, "opengl slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"opengl slots are reserved for the operating system snap")
 }
 
 func (s *OpenglInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *OpenglInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/openvswitch_support_test.go
+++ b/interfaces/builtin/openvswitch_support_test.go
@@ -86,7 +86,7 @@ func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "openvswitch-support",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"openvswitch-support slots are reserved for the operating system snap")
+		"openvswitch-support slots are reserved for the core snap")
 }
 
 func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/openvswitch_support_test.go
+++ b/interfaces/builtin/openvswitch_support_test.go
@@ -79,19 +79,18 @@ func (s *OpenvSwitchSupportInterfaceSuite) TestName(c *C) {
 }
 
 func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "openvswitch-support",
 		Interface: "openvswitch-support",
-	}})
-	c.Assert(err, ErrorMatches, "openvswitch-support slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"openvswitch-support slots are reserved for the operating system snap")
 }
 
 func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *OpenvSwitchSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/openvswitch_support_test.go
+++ b/interfaces/builtin/openvswitch_support_test.go
@@ -94,13 +94,6 @@ func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *OpenvSwitchSupportInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "openvswitch-support"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "openvswitch-support"`)
-}
-
 func (s *OpenvSwitchSupportInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	spec := &kmod.Specification{}
 	err := spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)

--- a/interfaces/builtin/openvswitch_test.go
+++ b/interfaces/builtin/openvswitch_test.go
@@ -64,19 +64,18 @@ func (s *OpenvSwitchInterfaceSuite) TestName(c *C) {
 }
 
 func (s *OpenvSwitchInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "openvswitch",
 		Interface: "openvswitch",
-	}})
-	c.Assert(err, ErrorMatches, "openvswitch slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"openvswitch slots are reserved for the operating system snap")
 }
 
 func (s *OpenvSwitchInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *OpenvSwitchInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/openvswitch_test.go
+++ b/interfaces/builtin/openvswitch_test.go
@@ -71,7 +71,7 @@ func (s *OpenvSwitchInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "openvswitch",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"openvswitch slots are reserved for the operating system snap")
+		"openvswitch slots are reserved for the core snap")
 }
 
 func (s *OpenvSwitchInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/openvswitch_test.go
+++ b/interfaces/builtin/openvswitch_test.go
@@ -79,13 +79,6 @@ func (s *OpenvSwitchInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *OpenvSwitchInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "openvswitch"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "openvswitch"`)
-}
-
 func (s *OpenvSwitchInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)

--- a/interfaces/builtin/password_manager_service_test.go
+++ b/interfaces/builtin/password_manager_service_test.go
@@ -71,7 +71,7 @@ func (s *passwordManagerServiceInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "password-manager-service",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"password-manager-service slots are reserved for the operating system snap")
+		"password-manager-service slots are reserved for the core snap")
 }
 
 func (s *passwordManagerServiceInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/password_manager_service_test.go
+++ b/interfaces/builtin/password_manager_service_test.go
@@ -64,19 +64,18 @@ func (s *passwordManagerServiceInterfaceSuite) TestName(c *C) {
 }
 
 func (s *passwordManagerServiceInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "password-manager-service",
 		Interface: "password-manager-service",
-	}})
-	c.Assert(err, ErrorMatches, "password-manager-service slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"password-manager-service slots are reserved for the operating system snap")
 }
 
 func (s *passwordManagerServiceInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *passwordManagerServiceInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/password_manager_service_test.go
+++ b/interfaces/builtin/password_manager_service_test.go
@@ -79,13 +79,6 @@ func (s *passwordManagerServiceInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *passwordManagerServiceInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "password-manager-service"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "password-manager-service"`)
-}
-
 func (s *passwordManagerServiceInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -75,11 +75,6 @@ func (iface *physicalMemoryControlInterface) SanitizeSlot(slot *interfaces.Slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-// Checks and possibly modifies a plug
-func (iface *physicalMemoryControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *physicalMemoryControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(physicalMemoryControlConnectedPlugAppArmor)
 	return nil

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -72,13 +72,11 @@ func (iface *physicalMemoryControlInterface) String() string {
 
 // Check validity of the defined slot
 func (iface *physicalMemoryControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *physicalMemoryControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -72,25 +72,13 @@ func (iface *physicalMemoryControlInterface) String() string {
 
 // Check validity of the defined slot
 func (iface *physicalMemoryControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Does it have right type?
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// Creation of the slot of this type
-	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
-		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
-	}
-	return nil
+	ensureSlotIfaceMatch(iface, slot)
+	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *physicalMemoryControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-	// Currently nothing is checked on the plug side
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -75,7 +75,7 @@ func (s *PhysicalMemoryControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "physical-memory-control",
 		Interface: "physical-memory-control",
 	}})
-	c.Assert(err, ErrorMatches, "physical-memory-control slots only allowed on core snap")
+	c.Assert(err, ErrorMatches, "physical-memory-control slots are reserved for the operating system snap")
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -75,7 +75,7 @@ func (s *PhysicalMemoryControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "physical-memory-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"physical-memory-control slots are reserved for the operating system snap")
+		"physical-memory-control slots are reserved for the core snap")
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -68,19 +68,18 @@ func (s *PhysicalMemoryControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "physical-memory-control",
 		Interface: "physical-memory-control",
-	}})
-	c.Assert(err, ErrorMatches, "physical-memory-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"physical-memory-control slots are reserved for the operating system snap")
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -83,13 +83,6 @@ func (s *PhysicalMemoryControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *PhysicalMemoryControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "physical-memory-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "physical-memory-control"`)
-}
-
 func (s *PhysicalMemoryControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	expectedSnippet1 := `
 # Description: With kernels with STRICT_DEVMEM=n, write access to all physical

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -68,13 +68,11 @@ func (iface *physicalMemoryObserveInterface) MetaData() interfaces.MetaData {
 
 // Check validity of the defined slot
 func (iface *physicalMemoryObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *physicalMemoryObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -71,11 +71,6 @@ func (iface *physicalMemoryObserveInterface) SanitizeSlot(slot *interfaces.Slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-// Checks and possibly modifies a plug
-func (iface *physicalMemoryObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *physicalMemoryObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(physicalMemoryObserveConnectedPlugAppArmor)
 	return nil

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -68,25 +68,13 @@ func (iface *physicalMemoryObserveInterface) MetaData() interfaces.MetaData {
 
 // Check validity of the defined slot
 func (iface *physicalMemoryObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Does it have right type?
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// Creation of the slot of this type
-	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
-		return fmt.Errorf("%s slots only allowed on core snap", iface.Name())
-	}
-	return nil
+	ensureSlotIfaceMatch(iface, slot)
+	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *physicalMemoryObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-	// Currently nothing is checked on the plug side
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -76,7 +76,7 @@ func (s *PhysicalMemoryObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "physical-memory-observe",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"physical-memory-observe slots are reserved for the operating system snap")
+		"physical-memory-observe slots are reserved for the core snap")
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -76,7 +76,7 @@ func (s *PhysicalMemoryObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "physical-memory-observe",
 		Interface: "physical-memory-observe",
 	}})
-	c.Assert(err, ErrorMatches, "physical-memory-observe slots only allowed on core snap")
+	c.Assert(err, ErrorMatches, "physical-memory-observe slots are reserved for the operating system snap")
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -84,13 +84,6 @@ func (s *PhysicalMemoryObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *PhysicalMemoryObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "physical-memory-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "physical-memory-observe"`)
-}
-
 func (s *PhysicalMemoryObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	expectedSnippet1 := `
 # Description: With kernels with STRICT_DEVMEM=n, read-only access to all physical

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -69,19 +69,18 @@ func (s *PhysicalMemoryObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "physical-memory-observe",
 		Interface: "physical-memory-observe",
-	}})
-	c.Assert(err, ErrorMatches, "physical-memory-observe slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"physical-memory-observe slots are reserved for the operating system snap")
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -84,10 +84,12 @@ func (iface *pppInterface) KModConnectedPlug(spec *kmod.Specification, plug *int
 }
 
 func (iface *pppInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *pppInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -84,12 +84,10 @@ func (iface *pppInterface) KModConnectedPlug(spec *kmod.Specification, plug *int
 }
 
 func (iface *pppInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *pppInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -83,14 +83,6 @@ func (iface *pppInterface) KModConnectedPlug(spec *kmod.Specification, plug *int
 	return spec.AddModule(pppConnectedPlugKmod)
 }
 
-func (iface *pppInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *pppInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *pppInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -81,13 +81,6 @@ func (s *ProcessControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *ProcessControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "process-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "process-control"`)
-}
-
 func (s *ProcessControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -73,7 +73,7 @@ func (s *ProcessControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "process-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"process-control slots are reserved for the operating system snap")
+		"process-control slots are reserved for the core snap")
 }
 
 func (s *ProcessControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/process_control_test.go
+++ b/interfaces/builtin/process_control_test.go
@@ -66,19 +66,18 @@ func (s *ProcessControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *ProcessControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "process-control",
 		Interface: "process-control",
-	}})
-	c.Assert(err, ErrorMatches, "process-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"process-control slots are reserved for the operating system snap")
 }
 
 func (s *ProcessControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *ProcessControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -161,12 +161,10 @@ func (iface *pulseAudioInterface) SecCompPermanentSlot(spec *seccomp.Specificati
 }
 
 func (iface *pulseAudioInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *pulseAudioInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -160,11 +160,13 @@ func (iface *pulseAudioInterface) SecCompPermanentSlot(spec *seccomp.Specificati
 	return nil
 }
 
-func (iface *pulseAudioInterface) SanitizePlug(slot *interfaces.Plug) error {
+func (iface *pulseAudioInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *pulseAudioInterface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -160,14 +160,6 @@ func (iface *pulseAudioInterface) SecCompPermanentSlot(spec *seccomp.Specificati
 	return nil
 }
 
-func (iface *pulseAudioInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *pulseAudioInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *pulseAudioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/pulseaudio_test.go
+++ b/interfaces/builtin/pulseaudio_test.go
@@ -82,12 +82,12 @@ func (s *PulseAudioInterfaceSuite) TestName(c *C) {
 }
 
 func (s *PulseAudioInterfaceSuite) TestSanitizeSlot(c *C) {
-	c.Assert(s.iface.SanitizeSlot(s.coreSlot), IsNil)
-	c.Assert(s.iface.SanitizeSlot(s.classicSlot), IsNil)
+	c.Assert(s.coreSlot.Sanitize(s.iface), IsNil)
+	c.Assert(s.classicSlot.Sanitize(s.iface), IsNil)
 }
 
 func (s *PulseAudioInterfaceSuite) TestSanitizePlug(c *C) {
-	c.Assert(s.iface.SanitizePlug(s.plug), IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *PulseAudioInterfaceSuite) TestSecCompOnClassic(c *C) {

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -71,7 +71,7 @@ func (s *RawUsbSuite) TestSanitizeSlot(c *C) {
 		Interface: "raw-usb",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"raw-usb slots are reserved for the operating system snap")
+		"raw-usb slots are reserved for the core snap")
 }
 
 func (s *RawUsbSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -64,19 +64,18 @@ func (s *RawUsbSuite) TestName(c *C) {
 }
 
 func (s *RawUsbSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "raw-usb",
 		Interface: "raw-usb",
-	}})
-	c.Assert(err, ErrorMatches, "raw-usb slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"raw-usb slots are reserved for the operating system snap")
 }
 
 func (s *RawUsbSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *RawUsbSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -79,13 +79,6 @@ func (s *RawUsbSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *RawUsbSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "raw-usb"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "raw-usb"`)
-}
-
 func (s *RawUsbSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -78,13 +78,6 @@ func (s *RemovableMediaInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *RemovableMediaInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "removable-media"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "removable-media"`)
-}
-
 func (s *RemovableMediaInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -63,19 +63,18 @@ func (s *RemovableMediaInterfaceSuite) TestName(c *C) {
 }
 
 func (s *RemovableMediaInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "removable-media",
 		Interface: "removable-media",
-	}})
-	c.Assert(err, ErrorMatches, "removable-media slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"removable-media slots are reserved for the operating system snap")
 }
 
 func (s *RemovableMediaInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *RemovableMediaInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -70,7 +70,7 @@ func (s *RemovableMediaInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "removable-media",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"removable-media slots are reserved for the operating system snap")
+		"removable-media slots are reserved for the core snap")
 }
 
 func (s *RemovableMediaInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -71,7 +71,7 @@ func (s *ScreenInhibitControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "screen-inhibit-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"screen-inhibit-control slots are reserved for the operating system snap")
+		"screen-inhibit-control slots are reserved for the core snap")
 }
 
 func (s *ScreenInhibitControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -79,13 +79,6 @@ func (s *ScreenInhibitControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *ScreenInhibitControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "screen-inhibit-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "screen-inhibit-control"`)
-}
-
 func (s *ScreenInhibitControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/screen_inhibit_control_test.go
+++ b/interfaces/builtin/screen_inhibit_control_test.go
@@ -64,19 +64,18 @@ func (s *ScreenInhibitControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *ScreenInhibitControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "screen-inhibit-control",
 		Interface: "screen-inhibit-control",
-	}})
-	c.Assert(err, ErrorMatches, "screen-inhibit-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"screen-inhibit-control slots are reserved for the operating system snap")
 }
 
 func (s *ScreenInhibitControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *ScreenInhibitControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -77,14 +77,9 @@ var serialUDevSymlinkPattern = regexp.MustCompile("^/dev/serial-port-[a-z0-9]+$"
 
 // SanitizeSlot checks validity of the defined slot
 func (iface *serialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Check slot is of right type
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// We will only allow creation of this type of slot by a gadget or OS snap
-	if !(slot.Snap.Type == "gadget" || slot.Snap.Type == "os") {
-		return fmt.Errorf("serial-port slots only allowed on gadget or core snaps")
+	ensureSlotIfaceMatch(iface, slot)
+	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
+		return err
 	}
 
 	// Check slot has a path attribute identify serial device
@@ -130,10 +125,7 @@ func (iface *serialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *serialPortInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-	// NOTE: currently we don't check anything on the plug side.
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -77,7 +77,6 @@ var serialUDevSymlinkPattern = regexp.MustCompile("^/dev/serial-port-[a-z0-9]+$"
 
 // SanitizeSlot checks validity of the defined slot
 func (iface *serialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
 		return err
 	}
@@ -125,7 +124,6 @@ func (iface *serialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
 
 // SanitizePlug checks and possibly modifies a plug.
 func (iface *serialPortInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -122,11 +122,6 @@ func (iface *serialPortInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-// SanitizePlug checks and possibly modifies a plug.
-func (iface *serialPortInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *serialPortInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
 	usbVendor, vOk := slot.Attrs["usb-vendor"].(int64)
 	if !vOk {

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -227,9 +227,6 @@ func (s *SerialPortInterfaceSuite) TestSanitizeBadCoreSnapSlots(c *C) {
 		err := s.iface.SanitizeSlot(slot)
 		c.Assert(err, ErrorMatches, "serial-port path attribute must be a valid device node")
 	}
-
-	// It is impossible to use "bool-file" interface to sanitize slots with other interfaces.
-	c.Assert(func() { s.iface.SanitizeSlot(s.badInterfaceSlot) }, PanicMatches, `slot is not of interface "serial-port"`)
 }
 
 func (s *SerialPortInterfaceSuite) TestSanitizeGadgetSnapSlots(c *C) {

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -212,40 +212,29 @@ func (s *SerialPortInterfaceSuite) TestName(c *C) {
 
 func (s *SerialPortInterfaceSuite) TestSanitizeCoreSnapSlots(c *C) {
 	for _, slot := range []*interfaces.Slot{s.testSlot1, s.testSlot2, s.testSlot3, s.testSlot4, s.testSlot5, s.testSlot6, s.testSlot7} {
-		err := s.iface.SanitizeSlot(slot)
-		c.Assert(err, IsNil)
+		c.Assert(slot.Sanitize(s.iface), IsNil)
 	}
 }
 
 func (s *SerialPortInterfaceSuite) TestSanitizeBadCoreSnapSlots(c *C) {
 	// Slots without the "path" attribute are rejected.
-	err := s.iface.SanitizeSlot(s.missingPathSlot)
-	c.Assert(err, ErrorMatches, `serial-port slot must have a path attribute`)
+	c.Assert(s.missingPathSlot.Sanitize(s.iface), ErrorMatches, `serial-port slot must have a path attribute`)
 
 	// Slots with incorrect value of the "path" attribute are rejected.
 	for _, slot := range []*interfaces.Slot{s.badPathSlot1, s.badPathSlot2, s.badPathSlot3, s.badPathSlot4, s.badPathSlot5, s.badPathSlot6, s.badPathSlot7, s.badPathSlot8, s.badPathSlot9, s.badPathSlot10} {
-		err := s.iface.SanitizeSlot(slot)
-		c.Assert(err, ErrorMatches, "serial-port path attribute must be a valid device node")
+		c.Assert(slot.Sanitize(s.iface), ErrorMatches, "serial-port path attribute must be a valid device node")
 	}
 }
 
 func (s *SerialPortInterfaceSuite) TestSanitizeGadgetSnapSlots(c *C) {
-	err := s.iface.SanitizeSlot(s.testUDev1)
-	c.Assert(err, IsNil)
-
-	err = s.iface.SanitizeSlot(s.testUDev2)
-	c.Assert(err, IsNil)
+	c.Assert(s.testUDev1.Sanitize(s.iface), IsNil)
+	c.Assert(s.testUDev2.Sanitize(s.iface), IsNil)
 }
 
 func (s *SerialPortInterfaceSuite) TestSanitizeBadGadgetSnapSlots(c *C) {
-	err := s.iface.SanitizeSlot(s.testUDevBadValue1)
-	c.Assert(err, ErrorMatches, "serial-port usb-vendor attribute not valid: -1")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue2)
-	c.Assert(err, ErrorMatches, "serial-port usb-product attribute not valid: 65536")
-
-	err = s.iface.SanitizeSlot(s.testUDevBadValue3)
-	c.Assert(err, ErrorMatches, "serial-port path attribute specifies invalid symlink location")
+	c.Assert(s.testUDevBadValue1.Sanitize(s.iface), ErrorMatches, "serial-port usb-vendor attribute not valid: -1")
+	c.Assert(s.testUDevBadValue2.Sanitize(s.iface), ErrorMatches, "serial-port usb-product attribute not valid: 65536")
+	c.Assert(s.testUDevBadValue3.Sanitize(s.iface), ErrorMatches, "serial-port path attribute specifies invalid symlink location")
 }
 
 func (s *SerialPortInterfaceSuite) TestPermanentSlotUDevSnippets(c *C) {

--- a/interfaces/builtin/shutdown_test.go
+++ b/interfaces/builtin/shutdown_test.go
@@ -63,19 +63,17 @@ func (s *ShutdownInterfaceSuite) TestName(c *C) {
 }
 
 func (s *ShutdownInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "shutdown",
 		Interface: "shutdown",
-	}})
-	c.Assert(err, ErrorMatches, "shutdown slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "shutdown slots are reserved for the operating system snap")
 }
 
 func (s *ShutdownInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *ShutdownInterfaceSuite) TestConnectedPlugSnippet(c *C) {

--- a/interfaces/builtin/shutdown_test.go
+++ b/interfaces/builtin/shutdown_test.go
@@ -69,7 +69,7 @@ func (s *ShutdownInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "shutdown",
 		Interface: "shutdown",
 	}}
-	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "shutdown slots are reserved for the operating system snap")
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "shutdown slots are reserved for the core snap")
 }
 
 func (s *ShutdownInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/shutdown_test.go
+++ b/interfaces/builtin/shutdown_test.go
@@ -78,13 +78,6 @@ func (s *ShutdownInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *ShutdownInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "shutdown"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "shutdown"`)
-}
-
 func (s *ShutdownInterfaceSuite) TestConnectedPlugSnippet(c *C) {
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -78,13 +78,6 @@ func (s *SnapdControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *SnapdControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "snapd-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "snapd-control"`)
-}
-
 func (s *SnapdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -70,7 +70,7 @@ func (s *SnapdControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "snapd-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"snapd-control slots are reserved for the operating system snap")
+		"snapd-control slots are reserved for the core snap")
 }
 
 func (s *SnapdControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -63,19 +63,18 @@ func (s *SnapdControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *SnapdControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "snapd-control",
 		Interface: "snapd-control",
-	}})
-	c.Assert(err, ErrorMatches, "snapd-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"snapd-control slots are reserved for the operating system snap")
 }
 
 func (s *SnapdControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *SnapdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/storage_framework_service.go
+++ b/interfaces/builtin/storage_framework_service.go
@@ -153,12 +153,10 @@ func (iface *storageFrameworkServiceInterface) SecCompPermanentSlot(spec *seccom
 }
 
 func (iface *storageFrameworkServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *storageFrameworkServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/storage_framework_service.go
+++ b/interfaces/builtin/storage_framework_service.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -154,16 +153,12 @@ func (iface *storageFrameworkServiceInterface) SecCompPermanentSlot(spec *seccom
 }
 
 func (iface *storageFrameworkServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *storageFrameworkServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/storage_framework_service.go
+++ b/interfaces/builtin/storage_framework_service.go
@@ -152,14 +152,6 @@ func (iface *storageFrameworkServiceInterface) SecCompPermanentSlot(spec *seccom
 	return nil
 }
 
-func (iface *storageFrameworkServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *storageFrameworkServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *storageFrameworkServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/storage_framework_service_test.go
+++ b/interfaces/builtin/storage_framework_service_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -66,13 +65,6 @@ apps:
 
 func (s *StorageFrameworkServiceInterfaceSuite) TestName(c *C) {
 	c.Check(s.iface.Name(), Equals, "storage-framework-service")
-}
-
-func (s *StorageFrameworkServiceInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Check(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "storage-framework-service"`)
-	c.Check(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "storage-framework-service"`)
 }
 
 func (s *StorageFrameworkServiceInterfaceSuite) TestAppArmorConnectedPlug(c *C) {

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -73,7 +73,7 @@ func (s *SystemObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "system-observe",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"system-observe slots are reserved for the operating system snap")
+		"system-observe slots are reserved for the core snap")
 }
 
 func (s *SystemObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -66,19 +66,18 @@ func (s *SystemObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *SystemObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "system-observe",
 		Interface: "system-observe",
-	}})
-	c.Assert(err, ErrorMatches, "system-observe slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"system-observe slots are reserved for the operating system snap")
 }
 
 func (s *SystemObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *SystemObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/system_observe_test.go
+++ b/interfaces/builtin/system_observe_test.go
@@ -81,13 +81,6 @@ func (s *SystemObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *SystemObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "system-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "system-observe"`)
-}
-
 func (s *SystemObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -79,13 +79,6 @@ func (s *SystemTraceInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *SystemTraceInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "system-trace"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "system-trace"`)
-}
-
 func (s *SystemTraceInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -64,19 +64,17 @@ func (s *SystemTraceInterfaceSuite) TestName(c *C) {
 }
 
 func (s *SystemTraceInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "system-trace",
 		Interface: "system-trace",
-	}})
-	c.Assert(err, ErrorMatches, "system-trace slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "system-trace slots are reserved for the operating system snap")
 }
 
 func (s *SystemTraceInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *SystemTraceInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/system_trace_test.go
+++ b/interfaces/builtin/system_trace_test.go
@@ -70,7 +70,7 @@ func (s *SystemTraceInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "system-trace",
 		Interface: "system-trace",
 	}}
-	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "system-trace slots are reserved for the operating system snap")
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "system-trace slots are reserved for the core snap")
 }
 
 func (s *SystemTraceInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/thumbnailer_service.go
+++ b/interfaces/builtin/thumbnailer_service.go
@@ -136,14 +136,6 @@ func (iface *thumbnailerServiceInterface) AppArmorConnectedSlot(spec *apparmor.S
 	return nil
 }
 
-func (iface *thumbnailerServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *thumbnailerServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *thumbnailerServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
 	return true
 }

--- a/interfaces/builtin/thumbnailer_service.go
+++ b/interfaces/builtin/thumbnailer_service.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -138,16 +137,12 @@ func (iface *thumbnailerServiceInterface) AppArmorConnectedSlot(spec *apparmor.S
 }
 
 func (iface *thumbnailerServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *thumbnailerServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/thumbnailer_service.go
+++ b/interfaces/builtin/thumbnailer_service.go
@@ -137,12 +137,10 @@ func (iface *thumbnailerServiceInterface) AppArmorConnectedSlot(spec *apparmor.S
 }
 
 func (iface *thumbnailerServiceInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *thumbnailerServiceInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/thumbnailer_service_test.go
+++ b/interfaces/builtin/thumbnailer_service_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
-	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -77,13 +76,6 @@ apps:
 
 func (s *ThumbnailerServiceInterfaceSuite) TestName(c *C) {
 	c.Check(s.iface.Name(), Equals, "thumbnailer-service")
-}
-
-func (s *ThumbnailerServiceInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Check(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "thumbnailer-service"`)
-	c.Check(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "thumbnailer-service"`)
 }
 
 func (s *ThumbnailerServiceInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -126,11 +126,6 @@ func (iface *timeControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-// Checks and possibly modifies a plug
-func (iface *timeControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *timeControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(timeControlConnectedPlugAppArmor)
 	return nil

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -123,13 +123,11 @@ func (iface *timeControlInterface) String() string {
 
 // Check validity of the defined slot
 func (iface *timeControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *timeControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -123,25 +123,13 @@ func (iface *timeControlInterface) String() string {
 
 // Check validity of the defined slot
 func (iface *timeControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// Does it have right type?
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
-	// Creation of the slot of this type
-	// is allowed only by a gadget or os snap
-	if !(slot.Snap.Type == "os") {
-		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
-	}
-	return nil
+	ensureSlotIfaceMatch(iface, slot)
+	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 // Checks and possibly modifies a plug
 func (iface *timeControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-	// Currently nothing is checked on the plug side
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -72,7 +72,7 @@ func (s *TimeControlTestInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "time-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"time-control slots are reserved for the operating system snap")
+		"time-control slots are reserved for the core snap")
 }
 
 func (s *TimeControlTestInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -65,19 +65,18 @@ func (s *TimeControlTestInterfaceSuite) TestName(c *C) {
 }
 
 func (s *TimeControlTestInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "time-control",
 		Interface: "time-control",
-	}})
-	c.Assert(err, ErrorMatches, "time-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"time-control slots are reserved for the operating system snap")
 }
 
 func (s *TimeControlTestInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *TimeControlTestInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -80,13 +80,6 @@ func (s *TimeControlTestInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *TimeControlTestInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "time-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "time-control"`)
-}
-
 func (s *TimeControlTestInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	expectedUDevSnippet := `KERNEL=="/dev/rtc0", TAG+="snap_client-snap_app-accessing-time-control"`
 

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -64,19 +64,18 @@ func (s *TimeserverControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *TimeserverControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "timeserver-control",
 		Interface: "timeserver-control",
-	}})
-	c.Assert(err, ErrorMatches, "timeserver-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"timeserver-control slots are reserved for the operating system snap")
 }
 
 func (s *TimeserverControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *TimeserverControlInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -79,13 +79,6 @@ func (s *TimeserverControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *TimeserverControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "timeserver-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "timeserver-control"`)
-}
-
 func (s *TimeserverControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/timeserver_control_test.go
+++ b/interfaces/builtin/timeserver_control_test.go
@@ -71,7 +71,7 @@ func (s *TimeserverControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "timeserver-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"timeserver-control slots are reserved for the operating system snap")
+		"timeserver-control slots are reserved for the core snap")
 }
 
 func (s *TimeserverControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -79,13 +79,6 @@ func (s *TimezoneControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *TimezoneControlInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "timezone-control"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "timezone-control"`)
-}
-
 func (s *TimezoneControlInterfaceSuite) TestConnectedPlug(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -71,7 +71,7 @@ func (s *TimezoneControlInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "timezone-control",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"timezone-control slots are reserved for the operating system snap")
+		"timezone-control slots are reserved for the core snap")
 }
 
 func (s *TimezoneControlInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/timezone_control_test.go
+++ b/interfaces/builtin/timezone_control_test.go
@@ -64,19 +64,18 @@ func (s *TimezoneControlInterfaceSuite) TestName(c *C) {
 }
 
 func (s *TimezoneControlInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "timezone-control",
 		Interface: "timezone-control",
-	}})
-	c.Assert(err, ErrorMatches, "timezone-control slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"timezone-control slots are reserved for the operating system snap")
 }
 
 func (s *TimezoneControlInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *TimezoneControlInterfaceSuite) TestConnectedPlug(c *C) {

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -71,7 +71,7 @@ func (s *TpmInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "tpm",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"tpm slots are reserved for the operating system snap")
+		"tpm slots are reserved for the core snap")
 }
 
 func (s *TpmInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -64,19 +64,18 @@ func (s *TpmInterfaceSuite) TestName(c *C) {
 }
 
 func (s *TpmInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "tpm",
 		Interface: "tpm",
-	}})
-	c.Assert(err, ErrorMatches, "tpm slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"tpm slots are reserved for the operating system snap")
 }
 
 func (s *TpmInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *TpmInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -79,13 +79,6 @@ func (s *TpmInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *TpmInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "tpm"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "tpm"`)
-}
-
 func (s *TpmInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -236,12 +236,10 @@ func (iface *ubuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmo
 }
 
 func (iface *ubuntuDownloadManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *ubuntuDownloadManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -236,17 +235,13 @@ func (iface *ubuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmo
 	return nil
 }
 
-func (iface *ubuntuDownloadManagerInterface) SanitizePlug(slot *interfaces.Plug) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
+func (iface *ubuntuDownloadManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *ubuntuDownloadManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -235,14 +235,6 @@ func (iface *ubuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmo
 	return nil
 }
 
-func (iface *ubuntuDownloadManagerInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *ubuntuDownloadManagerInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *ubuntuDownloadManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/ubuntu_download_manager_test.go
+++ b/interfaces/builtin/ubuntu_download_manager_test.go
@@ -79,13 +79,6 @@ func (s *UbuntuDownloadManagerInterfaceSuite) TestSanitizeSlot(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *UbuntuDownloadManagerInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "ubuntu-download-manager"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "ubuntu-download-manager"`)
-}
-
 func (s *UbuntuDownloadManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/ubuntu_download_manager_test.go
+++ b/interfaces/builtin/ubuntu_download_manager_test.go
@@ -64,19 +64,17 @@ func (s *UbuntuDownloadManagerInterfaceSuite) TestName(c *C) {
 }
 
 func (s *UbuntuDownloadManagerInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *UbuntuDownloadManagerInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "ubuntu-download-manager",
 		Interface: "ubuntu-download-manager",
-	}})
-	c.Assert(err, IsNil)
+	}}
+	c.Assert(slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *UbuntuDownloadManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -407,12 +407,10 @@ func (iface *udisks2Interface) SecCompPermanentSlot(spec *seccomp.Specification,
 }
 
 func (iface *udisks2Interface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *udisks2Interface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -406,11 +406,13 @@ func (iface *udisks2Interface) SecCompPermanentSlot(spec *seccomp.Specification,
 	return nil
 }
 
-func (iface *udisks2Interface) SanitizePlug(slot *interfaces.Plug) error {
+func (iface *udisks2Interface) SanitizePlug(plug *interfaces.Plug) error {
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *udisks2Interface) SanitizeSlot(slot *interfaces.Slot) error {
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -406,14 +406,6 @@ func (iface *udisks2Interface) SecCompPermanentSlot(spec *seccomp.Specification,
 	return nil
 }
 
-func (iface *udisks2Interface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *udisks2Interface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *udisks2Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -71,8 +71,7 @@ func (s *UDisks2InterfaceSuite) TestName(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 // The label glob when all apps are bound to the udisks2 slot

--- a/interfaces/builtin/uhid.go
+++ b/interfaces/builtin/uhid.go
@@ -66,20 +66,13 @@ func (iface *uhidInterface) String() string {
 
 // Check the validity of the slot
 func (iface *uhidInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	// First check the type
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
-
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 
 // Check and possibly modify a plug
 func (iface *uhidInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface))
-	}
-	// Currently nothing is checked on the plug side
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/uhid.go
+++ b/interfaces/builtin/uhid.go
@@ -66,13 +66,11 @@ func (iface *uhidInterface) String() string {
 
 // Check the validity of the slot
 func (iface *uhidInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 
 // Check and possibly modify a plug
 func (iface *uhidInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 

--- a/interfaces/builtin/uhid.go
+++ b/interfaces/builtin/uhid.go
@@ -64,16 +64,6 @@ func (iface *uhidInterface) String() string {
 	return iface.Name()
 }
 
-// Check the validity of the slot
-func (iface *uhidInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
-// Check and possibly modify a plug
-func (iface *uhidInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *uhidInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(uhidConnectedPlugAppArmor)
 	return nil

--- a/interfaces/builtin/uhid_test.go
+++ b/interfaces/builtin/uhid_test.go
@@ -68,13 +68,11 @@ func (s *UhidInterfaceSuite) TestName(c *C) {
 }
 
 func (s *UhidInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *UhidInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *UhidInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -20,13 +20,11 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/snap"
 )
 
 const unity7Summary = `allows interacting with Unity 7 services`
@@ -570,24 +568,13 @@ func (iface *unity7Interface) SecCompConnectedPlug(spec *seccomp.Specification, 
 }
 
 func (iface *unity7Interface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
-
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *unity7Interface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
-
-	// Creation of the slot of this type is allowed only by the os snap
-	if !(slot.Snap.Type == snap.TypeOS) {
-		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
-	}
-
-	return nil
+	ensureSlotIfaceMatch(iface, slot)
+	return sanitizeSlotReservedForOS(iface, slot)
 }
 
 func (iface *unity7Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -567,10 +567,6 @@ func (iface *unity7Interface) SecCompConnectedPlug(spec *seccomp.Specification, 
 	return nil
 }
 
-func (iface *unity7Interface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *unity7Interface) SanitizeSlot(slot *interfaces.Slot) error {
 	return sanitizeSlotReservedForOS(iface, slot)
 }

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -568,12 +568,10 @@ func (iface *unity7Interface) SecCompConnectedPlug(spec *seccomp.Specification, 
 }
 
 func (iface *unity7Interface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *unity7Interface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -66,19 +66,18 @@ func (s *Unity7InterfaceSuite) TestName(c *C) {
 }
 
 func (s *Unity7InterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "unity7",
 		Interface: "unity7",
-	}})
-	c.Assert(err, ErrorMatches, "unity7 slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"unity7 slots are reserved for the operating system snap")
 }
 
 func (s *Unity7InterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -81,13 +81,6 @@ func (s *Unity7InterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *Unity7InterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other-snap"}}) },
-		PanicMatches, `slot is not of interface "unity7"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other-snap"}}) },
-		PanicMatches, `plug is not of interface "unity7"`)
-}
-
 func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -73,7 +73,7 @@ func (s *Unity7InterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "unity7",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"unity7 slots are reserved for the operating system snap")
+		"unity7 slots are reserved for the core snap")
 }
 
 func (s *Unity7InterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -128,12 +128,10 @@ func (iface *unity8Interface) SecCompConnectedPlug(spec *seccomp.Specification, 
 }
 
 func (iface *unity8Interface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *unity8Interface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -127,14 +127,6 @@ func (iface *unity8Interface) SecCompConnectedPlug(spec *seccomp.Specification, 
 	return nil
 }
 
-func (iface *unity8Interface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *unity8Interface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *unity8Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -129,16 +128,12 @@ func (iface *unity8Interface) SecCompConnectedPlug(spec *seccomp.Specification, 
 }
 
 func (iface *unity8Interface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *unity8Interface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/unity8_calendar_test.go
+++ b/interfaces/builtin/unity8_calendar_test.go
@@ -78,8 +78,7 @@ func (s *Unity8CalendarInterfaceSuite) TestName(c *C) {
 }
 
 func (s *Unity8CalendarInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *Unity8CalendarInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/unity8_calendar_test.go
+++ b/interfaces/builtin/unity8_calendar_test.go
@@ -82,13 +82,6 @@ func (s *Unity8CalendarInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *Unity8CalendarInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "unity8-calendar"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "unity8-calendar"`)
-}
-
 func (s *Unity8CalendarInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/unity8_contacts_test.go
+++ b/interfaces/builtin/unity8_contacts_test.go
@@ -79,8 +79,7 @@ func (s *Unity8ContactsInterfaceSuite) TestName(c *C) {
 }
 
 func (s *Unity8ContactsInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *Unity8ContactsInterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/builtin/unity8_contacts_test.go
+++ b/interfaces/builtin/unity8_contacts_test.go
@@ -83,13 +83,6 @@ func (s *Unity8ContactsInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *Unity8ContactsInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "unity8-contacts"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "unity8-contacts"`)
-}
-
 func (s *Unity8ContactsInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -165,12 +165,10 @@ func (iface *unity8PimCommonInterface) SecCompPermanentSlot(spec *seccomp.Specif
 }
 
 func (iface *unity8PimCommonInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *unity8PimCommonInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -166,17 +165,12 @@ func (iface *unity8PimCommonInterface) SecCompPermanentSlot(spec *seccomp.Specif
 }
 
 func (iface *unity8PimCommonInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface \"%s\"", iface.Name()))
-	}
-
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *unity8PimCommonInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface \"%s\"", iface.Name()))
-	}
+	ensureSlotIfaceMatch(iface, slot)
 	return nil
 }
 

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -164,14 +164,6 @@ func (iface *unity8PimCommonInterface) SecCompPermanentSlot(spec *seccomp.Specif
 	return nil
 }
 
-func (iface *unity8PimCommonInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
-func (iface *unity8PimCommonInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return nil
-}
-
 func (iface *unity8PimCommonInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
 	// allow what declarations allowed
 	return true

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -262,10 +262,6 @@ func (iface *upowerObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specif
 	return nil
 }
 
-func (iface *upowerObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *upowerObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return sanitizeSlotReservedForOSOrApp(iface, slot)
 }

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -263,12 +263,10 @@ func (iface *upowerObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specif
 }
 
 func (iface *upowerObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *upowerObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	ensureSlotIfaceMatch(iface, slot)
 	return sanitizeSlotReservedForOSOrApp(iface, slot)
 }
 

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -28,7 +27,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/snap"
 )
 
 const upowerObserveSummary = `allows operating as or reading from the UPower service`
@@ -265,20 +263,13 @@ func (iface *upowerObserveInterface) AppArmorConnectedSlot(spec *apparmor.Specif
 }
 
 func (iface *upowerObserveInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
+	ensurePlugIfaceMatch(iface, plug)
 	return nil
 }
 
 func (iface *upowerObserveInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
-	if slot.Snap.Type != snap.TypeApp && slot.Snap.Type != snap.TypeOS {
-		return fmt.Errorf("%s slots are reserved for the operating system or application snaps", iface.Name())
-	}
-	return nil
+	ensureSlotIfaceMatch(iface, slot)
+	return sanitizeSlotReservedForOSOrApp(iface, slot)
 }
 
 func (iface *upowerObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -90,7 +90,7 @@ func (s *UPowerObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Name:      "upower-observe",
 		Interface: "upower-observe",
 	}})
-	c.Assert(err, ErrorMatches, "upower-observe slots are reserved for the operating system or application snaps")
+	c.Assert(err, ErrorMatches, "upower-observe slots are reserved for the operating system and app snaps")
 }
 
 func (s *UPowerObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -83,19 +83,18 @@ func (s *UPowerObserveInterfaceSuite) TestName(c *C) {
 }
 
 func (s *UPowerObserveInterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.coreSlot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.coreSlot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "upower-observe",
 		Interface: "upower-observe",
-	}})
-	c.Assert(err, ErrorMatches, "upower-observe slots are reserved for the operating system and app snaps")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"upower-observe slots are reserved for the operating system and app snaps")
 }
 
 func (s *UPowerObserveInterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 // The label glob when all apps are bound to the ofono slot

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -90,7 +90,7 @@ func (s *UPowerObserveInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "upower-observe",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"upower-observe slots are reserved for the operating system and app snaps")
+		"upower-observe slots are reserved for the core and app snaps")
 }
 
 func (s *UPowerObserveInterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -98,13 +98,6 @@ func (s *UPowerObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *UPowerObserveInterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "upower-observe"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "upower-observe"`)
-}
-
 // The label glob when all apps are bound to the ofono slot
 func (s *UPowerObserveInterfaceSuite) TestConnectedPlugSnippetUsesSlotLabelAll(c *C) {
 	app1 := &snap.AppInfo{Name: "app1"}

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -95,7 +95,7 @@ func udevSnapSecurityName(snapName string, appName string) string {
 // sanitizeSlotReservedForOS checks if slot is of type os.
 func sanitizeSlotReservedForOS(iface interfaces.Interface, slot *interfaces.Slot) error {
 	if slot.Snap.Type != snap.TypeOS {
-		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
+		return fmt.Errorf("%s slots are reserved for the core snap", iface.Name())
 	}
 	return nil
 }
@@ -103,7 +103,7 @@ func sanitizeSlotReservedForOS(iface interfaces.Interface, slot *interfaces.Slot
 // sanitizeSlotReservedForOSOrGadget checks if the slot is of type os or gadget.
 func sanitizeSlotReservedForOSOrGadget(iface interfaces.Interface, slot *interfaces.Slot) error {
 	if slot.Snap.Type != snap.TypeOS && slot.Snap.Type != snap.TypeGadget {
-		return fmt.Errorf("%s slots are reserved for the operating system and gadget snaps", iface.Name())
+		return fmt.Errorf("%s slots are reserved for the core and gadget snaps", iface.Name())
 	}
 	return nil
 }
@@ -111,7 +111,7 @@ func sanitizeSlotReservedForOSOrGadget(iface interfaces.Interface, slot *interfa
 // sanitizeSlotReservedForOSOrApp checks if the slot is of type os or app.
 func sanitizeSlotReservedForOSOrApp(iface interfaces.Interface, slot *interfaces.Slot) error {
 	if slot.Snap.Type != snap.TypeOS && slot.Snap.Type != snap.TypeApp {
-		return fmt.Errorf("%s slots are reserved for the operating system and app snaps", iface.Name())
+		return fmt.Errorf("%s slots are reserved for the core and app snaps", iface.Name())
 	}
 	return nil
 }

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -92,18 +92,6 @@ func udevSnapSecurityName(snapName string, appName string) string {
 	return fmt.Sprintf(`snap_%s_%s`, snapName, appName)
 }
 
-func ensureSlotIfaceMatch(iface interfaces.Interface, slot *interfaces.Slot) {
-	if iface.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
-	}
-}
-
-func ensurePlugIfaceMatch(iface interfaces.Interface, plug *interfaces.Plug) {
-	if iface.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
-	}
-}
-
 // sanitizeSlotReservedForOS checks if slot is of type os.
 func sanitizeSlotReservedForOS(iface interfaces.Interface, slot *interfaces.Slot) error {
 	if slot.Snap.Type != snap.TypeOS {

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -91,3 +91,39 @@ func udevUsbDeviceSnippet(subsystem string, usbVendor int64, usbProduct int64, k
 func udevSnapSecurityName(snapName string, appName string) string {
 	return fmt.Sprintf(`snap_%s_%s`, snapName, appName)
 }
+
+func ensureSlotIfaceMatch(iface interfaces.Interface, slot *interfaces.Slot) {
+	if iface.Name() != slot.Interface {
+		panic(fmt.Sprintf("slot is not of interface %q", iface.Name()))
+	}
+}
+
+func ensurePlugIfaceMatch(iface interfaces.Interface, plug *interfaces.Plug) {
+	if iface.Name() != plug.Interface {
+		panic(fmt.Sprintf("plug is not of interface %q", iface.Name()))
+	}
+}
+
+// sanitizeSlotReservedForOS checks if slot is of type os.
+func sanitizeSlotReservedForOS(iface interfaces.Interface, slot *interfaces.Slot) error {
+	if slot.Snap.Type != snap.TypeOS {
+		return fmt.Errorf("%s slots are reserved for the operating system snap", iface.Name())
+	}
+	return nil
+}
+
+// sanitizeSlotReservedForOSOrGadget checks if the slot is of type os or gadget.
+func sanitizeSlotReservedForOSOrGadget(iface interfaces.Interface, slot *interfaces.Slot) error {
+	if slot.Snap.Type != snap.TypeOS && slot.Snap.Type != snap.TypeGadget {
+		return fmt.Errorf("%s slots are reserved for the operating system and gadget snaps", iface.Name())
+	}
+	return nil
+}
+
+// sanitizeSlotReservedForOSOrApp checks if the slot is of type os or app.
+func sanitizeSlotReservedForOSOrApp(iface interfaces.Interface, slot *interfaces.Slot) error {
+	if slot.Snap.Type != snap.TypeOS && slot.Snap.Type != snap.TypeApp {
+		return fmt.Errorf("%s slots are reserved for the operating system and app snaps", iface.Name())
+	}
+	return nil
+}

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -43,21 +43,21 @@ var _ = Suite(&utilsSuite{
 })
 
 func (s *utilsSuite) TestSanitizeSlotReservedForOS(c *C) {
-	errmsg := "iface slots are reserved for the operating system snap"
+	errmsg := "iface slots are reserved for the core snap"
 	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotOS), IsNil)
 	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotApp), ErrorMatches, errmsg)
 	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotGadget), ErrorMatches, errmsg)
 }
 
 func (s *utilsSuite) TestSanitizeSlotReservedForOSOrGadget(c *C) {
-	errmsg := "iface slots are reserved for the operating system and gadget snaps"
+	errmsg := "iface slots are reserved for the core and gadget snaps"
 	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotOS), IsNil)
 	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotApp), ErrorMatches, errmsg)
 	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotGadget), IsNil)
 }
 
 func (s *utilsSuite) TestSanitizeSlotReservedForOSOrApp(c *C) {
-	errmsg := "iface slots are reserved for the operating system and app snaps"
+	errmsg := "iface slots are reserved for the core and app snaps"
 	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotOS), IsNil)
 	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotApp), IsNil)
 	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotGadget), ErrorMatches, errmsg)

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -42,20 +42,6 @@ var _ = Suite(&utilsSuite{
 	slotGadget: &interfaces.Slot{SlotInfo: &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeGadget}}},
 })
 
-func (s *utilsSuite) TestEnsureSlotIfaceMatch(c *C) {
-	slotIface := &interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "iface"}}
-	slotOther := &interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}
-	builtin.EnsureSlotIfaceMatch(s.iface, slotIface)
-	c.Assert(func() { builtin.EnsureSlotIfaceMatch(s.iface, slotOther) }, PanicMatches, `slot is not of interface "iface"`)
-}
-
-func (s *utilsSuite) TestEnsurePlugIfaceMatch(c *C) {
-	plugIface := &interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "iface"}}
-	plugOther := &interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}
-	builtin.EnsurePlugIfaceMatch(s.iface, plugIface)
-	c.Assert(func() { builtin.EnsurePlugIfaceMatch(s.iface, plugOther) }, PanicMatches, `plug is not of interface "iface"`)
-}
-
 func (s *utilsSuite) TestSanitizeSlotReservedForOS(c *C) {
 	errmsg := "iface slots are reserved for the operating system snap"
 	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotOS), IsNil)

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/snap"
+)
+
+type utilsSuite struct {
+	iface      interfaces.Interface
+	slotOS     *interfaces.Slot
+	slotApp    *interfaces.Slot
+	slotGadget *interfaces.Slot
+}
+
+var _ = Suite(&utilsSuite{
+	iface:      &ifacetest.TestInterface{InterfaceName: "iface"},
+	slotOS:     &interfaces.Slot{SlotInfo: &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeOS}}},
+	slotApp:    &interfaces.Slot{SlotInfo: &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeApp}}},
+	slotGadget: &interfaces.Slot{SlotInfo: &snap.SlotInfo{Snap: &snap.Info{Type: snap.TypeGadget}}},
+})
+
+func (s *utilsSuite) TestEnsureSlotIfaceMatch(c *C) {
+	slotIface := &interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "iface"}}
+	slotOther := &interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}
+	builtin.EnsureSlotIfaceMatch(s.iface, slotIface)
+	c.Assert(func() { builtin.EnsureSlotIfaceMatch(s.iface, slotOther) }, PanicMatches, `slot is not of interface "iface"`)
+}
+
+func (s *utilsSuite) TestEnsurePlugIfaceMatch(c *C) {
+	plugIface := &interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "iface"}}
+	plugOther := &interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}
+	builtin.EnsurePlugIfaceMatch(s.iface, plugIface)
+	c.Assert(func() { builtin.EnsurePlugIfaceMatch(s.iface, plugOther) }, PanicMatches, `plug is not of interface "iface"`)
+}
+
+func (s *utilsSuite) TestSanitizeSlotReservedForOS(c *C) {
+	errmsg := "iface slots are reserved for the operating system snap"
+	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotOS), IsNil)
+	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotApp), ErrorMatches, errmsg)
+	c.Assert(builtin.SanitizeSlotReservedForOS(s.iface, s.slotGadget), ErrorMatches, errmsg)
+}
+
+func (s *utilsSuite) TestSanitizeSlotReservedForOSOrGadget(c *C) {
+	errmsg := "iface slots are reserved for the operating system and gadget snaps"
+	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotOS), IsNil)
+	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotApp), ErrorMatches, errmsg)
+	c.Assert(builtin.SanitizeSlotReservedForOSOrGadget(s.iface, s.slotGadget), IsNil)
+}
+
+func (s *utilsSuite) TestSanitizeSlotReservedForOSOrApp(c *C) {
+	errmsg := "iface slots are reserved for the operating system and app snaps"
+	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotOS), IsNil)
+	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotApp), IsNil)
+	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotGadget), ErrorMatches, errmsg)
+}

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -73,7 +73,7 @@ func (s *X11InterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "x11",
 	}}
 	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"x11 slots are reserved for the operating system snap")
+		"x11 slots are reserved for the core snap")
 }
 
 func (s *X11InterfaceSuite) TestSanitizePlug(c *C) {

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -81,13 +81,6 @@ func (s *X11InterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *X11InterfaceSuite) TestSanitizeIncorrectInterface(c *C) {
-	c.Assert(func() { s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{Interface: "other"}}) },
-		PanicMatches, `slot is not of interface "x11"`)
-	c.Assert(func() { s.iface.SanitizePlug(&interfaces.Plug{PlugInfo: &snap.PlugInfo{Interface: "other"}}) },
-		PanicMatches, `plug is not of interface "x11"`)
-}
-
 func (s *X11InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -66,19 +66,18 @@ func (s *X11InterfaceSuite) TestName(c *C) {
 }
 
 func (s *X11InterfaceSuite) TestSanitizeSlot(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
-	err = s.iface.SanitizeSlot(&interfaces.Slot{SlotInfo: &snap.SlotInfo{
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "x11",
 		Interface: "x11",
-	}})
-	c.Assert(err, ErrorMatches, "x11 slots are reserved for the operating system snap")
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"x11 slots are reserved for the operating system snap")
 }
 
 func (s *X11InterfaceSuite) TestSanitizePlug(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 func (s *X11InterfaceSuite) TestUsedSecuritySystems(c *C) {

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -38,6 +38,22 @@ func (plug *Plug) Ref() PlugRef {
 	return PlugRef{Snap: plug.Snap.Name(), Name: plug.Name}
 }
 
+// Sanitize plug with a given snapd interface.
+func (plug *Plug) Sanitize(iface Interface) error {
+	if iface.Name() != plug.Interface {
+		return fmt.Errorf("cannot sanitize plug %q (interface %q) using interface %q",
+			plug.Ref(), plug.Interface, iface.Name())
+	}
+	type sanitizer interface {
+		SanitizePlug(plug *Plug) error
+	}
+	var err error
+	if iface, ok := iface.(sanitizer); ok {
+		err = iface.SanitizePlug(plug)
+	}
+	return err
+}
+
 // PlugRef is a reference to a plug.
 type PlugRef struct {
 	Snap string `json:"snap"`
@@ -58,6 +74,22 @@ type Slot struct {
 // Ref returns reference to a slot
 func (slot *Slot) Ref() SlotRef {
 	return SlotRef{Snap: slot.Snap.Name(), Name: slot.Name}
+}
+
+// Sanitize slot with a given snapd interface.
+func (slot *Slot) Sanitize(iface Interface) error {
+	if iface.Name() != slot.Interface {
+		return fmt.Errorf("cannot sanitize slot %q (interface %q) using interface %q",
+			slot.Ref(), slot.Interface, iface.Name())
+	}
+	type sanitizer interface {
+		SanitizeSlot(slot *Slot) error
+	}
+	var err error
+	if iface, ok := iface.(sanitizer); ok {
+		err = iface.SanitizeSlot(slot)
+	}
+	return err
 }
 
 // SlotRef is a reference to a slot.

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -44,11 +44,8 @@ func (plug *Plug) Sanitize(iface Interface) error {
 		return fmt.Errorf("cannot sanitize plug %q (interface %q) using interface %q",
 			plug.Ref(), plug.Interface, iface.Name())
 	}
-	type sanitizer interface {
-		SanitizePlug(plug *Plug) error
-	}
 	var err error
-	if iface, ok := iface.(sanitizer); ok {
+	if iface, ok := iface.(PlugSanitizer); ok {
 		err = iface.SanitizePlug(plug)
 	}
 	return err
@@ -82,11 +79,8 @@ func (slot *Slot) Sanitize(iface Interface) error {
 		return fmt.Errorf("cannot sanitize slot %q (interface %q) using interface %q",
 			slot.Ref(), slot.Interface, iface.Name())
 	}
-	type sanitizer interface {
-		SanitizeSlot(slot *Slot) error
-	}
 	var err error
-	if iface, ok := iface.(sanitizer); ok {
+	if iface, ok := iface.(SlotSanitizer); ok {
 		err = iface.SanitizeSlot(slot)
 	}
 	return err
@@ -160,6 +154,16 @@ type Interface interface {
 	// unambiguous connection candidate and declaration-based checks
 	// allow.
 	AutoConnect(plug *Plug, slot *Slot) bool
+}
+
+// PlugSanitizer describes an interface that can sanitize plug instances.
+type PlugSanitizer interface {
+	SanitizePlug(plug *Plug) error
+}
+
+// SlotSanitizer describes an interface that can sanitize slot instances.
+type SlotSanitizer interface {
+	SanitizeSlot(slot *Slot) error
 }
 
 // StaticInfo describes various static-info of a given interface.

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -146,12 +146,6 @@ type Interface interface {
 	// Unique and public name of this interface.
 	Name() string
 
-	// SanitizePlug checks if a plug is correct, altering if necessary.
-	SanitizePlug(plug *Plug) error
-
-	// SanitizeSlot checks if a slot is correct, altering if necessary.
-	SanitizeSlot(slot *Slot) error
-
 	// AutoConnect returns whether plug and slot should be
 	// implicitly auto-connected assuming they will be an
 	// unambiguous connection candidate and declaration-based checks

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -156,12 +156,12 @@ type Interface interface {
 	AutoConnect(plug *Plug, slot *Slot) bool
 }
 
-// PlugSanitizer describes an interface that can sanitize plug instances.
+// PlugSanitizer can be implemented by Interfaces that have reasons to sanitize their plugs.
 type PlugSanitizer interface {
 	SanitizePlug(plug *Plug) error
 }
 
-// SlotSanitizer describes an interface that can sanitize slot instances.
+// SlotSanitizer can be implemented by Interfaces that have reasons to sanitize their slots.
 type SlotSanitizer interface {
 	SanitizeSlot(slot *Slot) error
 }

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -20,12 +20,15 @@
 package interfaces_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
 	. "github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 func Test(t *testing.T) {
@@ -176,4 +179,44 @@ func (s *CoreSuite) TestParseConnRef(c *C) {
 	c.Assert(err, ErrorMatches, `malformed connection identifier: ".*"`)
 	_, err = ParseConnRef("snap:plug snap:slot:garbage")
 	c.Assert(err, ErrorMatches, `malformed connection identifier: ".*"`)
+}
+
+func (s *CoreSuite) TestSanitizePlug(c *C) {
+	info := snaptest.MockInfo(c, `
+name: snap
+plugs:
+  plug:
+    interface: iface
+`, nil)
+	plug := &Plug{PlugInfo: info.Plugs["plug"]}
+	c.Assert(plug.Sanitize(&ifacetest.TestInterface{
+		InterfaceName: "iface",
+	}), IsNil)
+	c.Assert(plug.Sanitize(&ifacetest.TestInterface{
+		InterfaceName:        "iface",
+		SanitizePlugCallback: func(plug *Plug) error { return fmt.Errorf("broken") },
+	}), ErrorMatches, "broken")
+	c.Assert(plug.Sanitize(&ifacetest.TestInterface{
+		InterfaceName: "other",
+	}), ErrorMatches, `cannot sanitize plug "snap:plug" \(interface "iface"\) using interface "other"`)
+}
+
+func (s *CoreSuite) TestSanitizeSlot(c *C) {
+	info := snaptest.MockInfo(c, `
+name: snap
+slots:
+  slot:
+    interface: iface
+`, nil)
+	slot := &Slot{SlotInfo: info.Slots["slot"]}
+	c.Assert(slot.Sanitize(&ifacetest.TestInterface{
+		InterfaceName: "iface",
+	}), IsNil)
+	c.Assert(slot.Sanitize(&ifacetest.TestInterface{
+		InterfaceName:        "iface",
+		SanitizeSlotCallback: func(slot *Slot) error { return fmt.Errorf("broken") },
+	}), ErrorMatches, "broken")
+	c.Assert(slot.Sanitize(&ifacetest.TestInterface{
+		InterfaceName: "other",
+	}), ErrorMatches, `cannot sanitize slot "snap:slot" \(interface "iface"\) using interface "other"`)
 }

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -20,8 +20,6 @@
 package ifacetest
 
 import (
-	"fmt"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/dbus"
@@ -116,9 +114,6 @@ func (t *TestInterface) Name() string {
 
 // SanitizePlug checks and possibly modifies a plug.
 func (t *TestInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if t.Name() != plug.Interface {
-		panic(fmt.Sprintf("plug is not of interface %q", t))
-	}
 	if t.SanitizePlugCallback != nil {
 		return t.SanitizePlugCallback(plug)
 	}
@@ -127,9 +122,6 @@ func (t *TestInterface) SanitizePlug(plug *interfaces.Plug) error {
 
 // SanitizeSlot checks and possibly modifies a slot.
 func (t *TestInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	if t.Name() != slot.Interface {
-		panic(fmt.Sprintf("slot is not of interface %q", t))
-	}
 	if t.SanitizeSlotCallback != nil {
 		return t.SanitizeSlotCallback(slot)
 	}

--- a/interfaces/ifacetest/testiface_test.go
+++ b/interfaces/ifacetest/testiface_test.go
@@ -86,8 +86,7 @@ func (s *TestInterfaceSuite) TestValidateSlotError(c *C) {
 
 // TestInterface doesn't do any sanitization by default
 func (s *TestInterfaceSuite) TestSanitizePlugOK(c *C) {
-	err := s.iface.SanitizePlug(s.plug)
-	c.Assert(err, IsNil)
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
 // TestInterface has provisions to customize sanitization
@@ -98,26 +97,12 @@ func (s *TestInterfaceSuite) TestSanitizePlugError(c *C) {
 			return fmt.Errorf("sanitize plug failed")
 		},
 	}
-	err := iface.SanitizePlug(s.plug)
-	c.Assert(err, ErrorMatches, "sanitize plug failed")
-}
-
-// TestInterface sanitization still checks for interface identity
-func (s *TestInterfaceSuite) TestSanitizePlugWrongInterface(c *C) {
-	plug := &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "snap"},
-			Name:      "name",
-			Interface: "other-interface",
-		},
-	}
-	c.Assert(func() { s.iface.SanitizePlug(plug) }, Panics, "plug is not of interface \"test\"")
+	c.Assert(s.plug.Sanitize(iface), ErrorMatches, "sanitize plug failed")
 }
 
 // TestInterface doesn't do any sanitization by default
 func (s *TestInterfaceSuite) TestSanitizeSlotOK(c *C) {
-	err := s.iface.SanitizeSlot(s.slot)
-	c.Assert(err, IsNil)
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
 }
 
 // TestInterface has provisions to customize sanitization
@@ -128,20 +113,7 @@ func (s *TestInterfaceSuite) TestSanitizeSlotError(c *C) {
 			return fmt.Errorf("sanitize slot failed")
 		},
 	}
-	err := iface.SanitizeSlot(s.slot)
-	c.Assert(err, ErrorMatches, "sanitize slot failed")
-}
-
-// TestInterface sanitization still checks for interface identity
-func (s *TestInterfaceSuite) TestSanitizeSlotWrongInterface(c *C) {
-	slot := &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "snap"},
-			Name:      "name",
-			Interface: "interface",
-		},
-	}
-	c.Assert(func() { s.iface.SanitizeSlot(slot) }, Panics, "slot is not of interface \"test\"")
+	c.Assert(s.slot.Sanitize(iface), ErrorMatches, "sanitize slot failed")
 }
 
 // TestInterface hands out empty plug security snippets

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -539,7 +539,8 @@ func (s *baseDeclSuite) TestSlotInstallation(c *C) {
 				c.Check(err, NotNil, comm)
 			}
 			if compareWithSanitize {
-				sanitizeErr := iface.SanitizeSlot(&interfaces.Slot{SlotInfo: slotInfo})
+				slot := &interfaces.Slot{SlotInfo: slotInfo}
+				sanitizeErr := slot.Sanitize(iface)
 				if err == nil {
 					c.Check(sanitizeErr, IsNil, comm)
 				} else {

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -154,7 +154,7 @@ func (r *Repository) AddPlug(plug *Plug) error {
 		return fmt.Errorf("cannot add plug, interface %q is not known", plug.Interface)
 	}
 	// Reject plug that don't pass interface-specific sanitization
-	if err := i.SanitizePlug(plug); err != nil {
+	if err := plug.Sanitize(i); err != nil {
 		return fmt.Errorf("cannot add plug: %v", err)
 	}
 	if _, ok := r.plugs[snapName][plug.Name]; ok {
@@ -253,7 +253,7 @@ func (r *Repository) AddSlot(slot *Slot) error {
 	if i == nil {
 		return fmt.Errorf("cannot add slot, interface %q is not known", slot.Interface)
 	}
-	if err := i.SanitizeSlot(slot); err != nil {
+	if err := slot.Sanitize(i); err != nil {
 		return fmt.Errorf("cannot add slot: %v", err)
 	}
 	if _, ok := r.slots[snapName][slot.Name]; ok {
@@ -783,7 +783,7 @@ func (r *Repository) AddSnap(snapInfo *snap.Info) error {
 			continue
 		}
 		plug := &Plug{PlugInfo: plugInfo}
-		if err := iface.SanitizePlug(plug); err != nil {
+		if err := plug.Sanitize(iface); err != nil {
 			bad.issues[plugName] = err.Error()
 			continue
 		}
@@ -805,7 +805,7 @@ func (r *Repository) AddSnap(snapInfo *snap.Info) error {
 			continue
 		}
 		slot := &Slot{SlotInfo: slotInfo}
-		if err := iface.SanitizeSlot(slot); err != nil {
+		if err := slot.Sanitize(iface); err != nil {
 			bad.issues[slotName] = err.Error()
 			continue
 		}


### PR DESCRIPTION
This branch unifies how Sanitize{Plug,Slot} are implemented across all of the interfaces.
This removes a lot of copy-pasted code and adds some missing calls in other copy-pasted code.
Lastly, because all of the error messages are in a small set of four functions, there is much more
uniformity in how error messages look like.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>