### PR TITLE
interfaces/builtin: discard empty Validate{Plug,Slot}

### DIFF
--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -151,14 +151,6 @@ func (iface *boolFileInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) 
 	return true
 }
 
-func (iface *boolFileInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
-	return nil
-}
-
-func (iface *boolFileInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&boolFileInterface{})
 }

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -308,14 +308,6 @@ func (iface *browserSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.
 	return true
 }
 
-func (iface *browserSupportInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
-	return nil
-}
-
-func (iface *browserSupportInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&browserSupportInterface{})
 }

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -232,14 +232,6 @@ func (iface *contentInterface) MountConnectedPlug(spec *mount.Specification, plu
 	return nil
 }
 
-func (iface *contentInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
-	return nil
-}
-
-func (iface *contentInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&contentInterface{})
 }

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -426,14 +426,6 @@ func (iface *dbusInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool
 	return true
 }
 
-func (iface *dbusInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
-	return nil
-}
-
-func (iface *dbusInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&dbusInterface{})
 }

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -595,10 +595,6 @@ func (iface *dockerSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.S
 	return true
 }
 
-func (iface *dockerSupportInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&dockerSupportInterface{})
 }

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -134,10 +134,6 @@ func (iface *gpioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool
 	return true
 }
 
-func (iface *gpioInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&gpioInterface{})
 }

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -198,10 +198,6 @@ func (iface *hidrawInterface) hasUsbAttrs(slot *interfaces.Slot) bool {
 	return false
 }
 
-func (iface *hidrawInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&hidrawInterface{})
 }

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -133,10 +133,6 @@ func (iface *i2cInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool 
 	return true
 }
 
-func (iface *i2cInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&i2cInterface{})
 }

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -149,10 +149,6 @@ func (iface *iioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool 
 	return true
 }
 
-func (iface *iioInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&iioInterface{})
 }

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -238,14 +238,6 @@ func (iface *mprisInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) boo
 	return true
 }
 
-func (iface *mprisInterface) ValidatePlug(plug *interfaces.Plug, attrs map[string]interface{}) error {
-	return nil
-}
-
-func (iface *mprisInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&mprisInterface{})
 }

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -204,10 +204,6 @@ func (iface *serialPortInterface) hasUsbAttrs(slot *interfaces.Slot) bool {
 	return false
 }
 
-func (iface *serialPortInterface) ValidateSlot(slot *interfaces.Slot, attrs map[string]interface{}) error {
-	return nil
-}
-
 func init() {
 	registerIface(&serialPortInterface{})
 }


### PR DESCRIPTION
The validate methods used to be mandatory but they are entirely optional
now and can be safely discarded.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>