### PR TITLE
tests: fix refresh tests not stopping fake store for fedora

### DIFF
--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -31,12 +31,16 @@ restore: |
 
     . $TESTSLIB/store.sh
     teardown_fake_store $BLOB_DIR
+    rm -rf $BLOB_DIR
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
     fi
+
+    echo "Sanity check for the fake store"
+    snap refresh 2>&1 | MATCH "All snaps up to date"
 
     echo "When the store is configured to make them refreshable"
     . $TESTSLIB/files.sh

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -34,12 +34,16 @@ restore: |
 
     . $TESTSLIB/store.sh
     teardown_fake_store $BLOB_DIR
+    rm -rf $BLOB_DIR
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
     fi
+
+    echo "Sanity check for the fake store"
+    snap refresh 2>&1 | MATCH "All snaps up to date."
 
     echo "When the store is configured to make them refreshable"
     . $TESTSLIB/files.sh
@@ -48,7 +52,6 @@ execute: |
     wait_for_file $BLOB_DIR/test-snapd-tools*fake1*.snap 4 .5
     init_fake_refreshes test-snapd-python-webserver $BLOB_DIR
     wait_for_file $BLOB_DIR/test-snapd-python-webserver*fake1*.snap 4 .5
-
 
     echo "And a refresh is performed"
     snap refresh

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -52,11 +52,9 @@ prepare: |
 restore: |
     rm -f stderr.out
     if [ "$STORE_TYPE" = "fake" ]; then
-        case "$SPREAD_SYSTEM" in
-            ubuntu-core-*|fedora-*)
-                exit
-                ;;
-        esac
+        if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
+            exit
+        fi
         if [ "$TRUST_TEST_KEYS" = "false" ]; then
             echo "This test needs test keys to be trusted"
             exit


### PR DESCRIPTION
Removing code to avoid stopping the fake store for fedora in refresh
task and adding sanity check before set the refresh

Error:
https://travis-ci.org/snapcore/snapd/builds/257633119