### PR TITLE
asserts,overlord/assertstate: auto refresh account-keys

### DIFF
--- a/asserts/account_key_test.go
+++ b/asserts/account_key_test.go
@@ -326,12 +326,14 @@ func (aks *accountKeySuite) TestAccountKeyCheckUntrustedAuthority(c *C) {
 	storeDB := assertstest.NewSigningDB("canonical", trustedKey)
 	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 
+	since := time.Now()
+	until := since.AddDate(1, 0, 0)
 	headers := map[string]interface{}{
 		"account-id":          "acc-id1",
 		"name":                "default",
 		"public-key-sha3-384": aks.keyID,
-		"since":               aks.since.Format(time.RFC3339),
-		"until":               aks.until.Format(time.RFC3339),
+		"since":               since.Format(time.RFC3339),
+		"until":               until.Format(time.RFC3339),
 	}
 	accKey, err := otherDB.Sign(asserts.AccountKeyType, headers, []byte(aks.pubKeyBody), "")
 	c.Assert(err, IsNil)

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -538,6 +538,9 @@ func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey
 		// (e.g. account-key-request)
 		return nil
 	}
+	// TODO: when to stop accepting/using keys that are expired since long?
+	// should there be a point at which obsolete === revoked?
+
 	var timestamp time.Time
 	check := false
 	if tstamped, ok := assert.(timestamped); ok {
@@ -580,7 +583,6 @@ func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, roDB ROData
 // checkers used by Database if none are specified in the
 // DatabaseConfig.Checkers.
 var DefaultCheckers = []Checker{
-	CheckSigningKeyIsNotExpired,
 	CheckSignature,
 	CheckTimestampVsSigningKeyValidity,
 	CheckCrossConsistency,

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -729,6 +729,8 @@ func (safs *signAddFindSuite) TestFindFindsTrustedAccountKeys(c *C) {
 
 	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]interface{}{
 		"authority-id": "canonical",
+		"since":        time.Now().UTC().Format(time.RFC3339),
+		"until":        time.Now().AddDate(5, 0, 0).UTC().Format(time.RFC3339),
 	}, pk1.PublicKey(), safs.signingKeyID)
 
 	err := safs.db.Add(acct1)
@@ -760,6 +762,8 @@ func (safs *signAddFindSuite) TestFindTrusted(c *C) {
 
 	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]interface{}{
 		"authority-id": "canonical",
+		"since":        time.Now().UTC().Format(time.RFC3339),
+		"until":        time.Now().AddDate(5, 0, 0).UTC().Format(time.RFC3339),
 	}, pk1.PublicKey(), safs.signingKeyID)
 
 	err := safs.db.Add(acct1)
@@ -818,6 +822,8 @@ func (safs *signAddFindSuite) TestFindManyTrusted(c *C) {
 
 	acct1Key := assertstest.NewAccountKey(safs.signingDB, acct1, map[string]interface{}{
 		"authority-id": "canonical",
+		"since":        time.Now().UTC().Format(time.RFC3339),
+		"until":        time.Now().AddDate(5, 0, 0).UTC().Format(time.RFC3339),
 	}, pk1.PublicKey(), safs.signingKeyID)
 
 	err = db.Add(acct1)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -238,6 +238,7 @@ func (chks *checkSuite) TestCheckExpiredPubKey(c *C) {
 	cfg := &asserts.DatabaseConfig{
 		Backstore: chks.bs,
 		Trusted:   []asserts.Assertion{asserts.ExpiredAccountKeyForTest("canonical", trustedKey.PublicKey())},
+		Checkers:  []asserts.Checker{asserts.CheckSigningKeyIsNotExpired},
 	}
 	db, err := asserts.OpenDatabase(cfg)
 	c.Assert(err, IsNil)

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -79,7 +79,7 @@ func makeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, validYea
 }
 
 func BootstrapAccountKeyForTest(authorityID string, pubKey PublicKey) *AccountKey {
-	return makeAccountKeyForTest(authorityID, pubKey, 9999)
+	return makeAccountKeyForTest(authorityID, pubKey, 2999)
 }
 
 func ExpiredAccountKeyForTest(authorityID string, pubKey PublicKey) *AccountKey {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -620,7 +620,10 @@ func setup3rdPartySigning(c *C, username string, storeDB *assertstest.SigningDB,
 	acct := assertstest.NewAccount(storeDB, username, map[string]interface{}{
 		"account-id": username,
 	}, "")
-	accKey := assertstest.NewAccountKey(storeDB, acct, nil, privKey.PublicKey(), "")
+	accKey := assertstest.NewAccountKey(storeDB, acct, map[string]interface{}{
+		"since": time.Now().UTC().Format(time.RFC3339),
+		"until": time.Now().AddDate(10, 0, 0).UTC().Format(time.RFC3339),
+	}, privKey.PublicKey(), "")
 
 	err := checkDB.Add(acct)
 	c.Assert(err, IsNil)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -833,6 +833,7 @@ var (
 	snapstateRevertToRevision  = snapstate.RevertToRevision
 
 	assertstateRefreshSnapDeclarations = assertstate.RefreshSnapDeclarations
+	assertstateAutoRefreshAssertions   = assertstate.AutoRefreshAssertions
 )
 
 func ensureStateSoonImpl(st *state.State) {
@@ -905,7 +906,13 @@ func modeFlags(devMode, jailMode, classic bool) (snapstate.Flags, error) {
 
 func snapUpdateMany(inst *snapInstruction, st *state.State) (msg string, updated []string, tasksets []*state.TaskSet, err error) {
 	// we need refreshed snap-declarations to enforce refresh-control as best as we can, this also ensures that snap-declarations and their prerequisite assertions are updated regularly
-	if err := assertstateRefreshSnapDeclarations(st, inst.userID); err != nil {
+	// for refresh all we go a step further and refresh all assertions
+	// as scheduled auto refreshes do
+	refreshAssertions := assertstateRefreshSnapDeclarations
+	if len(inst.Snaps) == 0 {
+		refreshAssertions = assertstateAutoRefreshAssertions
+	}
+	if err := refreshAssertions(st, inst.userID); err != nil {
 		return "", nil, nil, err
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4847,7 +4847,13 @@ func (s *postCreateUserSuite) makeSystemUsers(c *check.C, systemUsers []map[stri
 	assertAdd(st, model)
 
 	for _, suMap := range systemUsers {
-		su, err := signers[suMap["authority-id"].(string)].Sign(asserts.SystemUserType, suMap, nil, "")
+		headers := make(map[string]interface{})
+		for k, v := range suMap {
+			headers[k] = v
+		}
+		headers["since"] = time.Now().Format(time.RFC3339)
+		headers["until"] = time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339)
+		su, err := signers[suMap["authority-id"].(string)].Sign(asserts.SystemUserType, headers, nil, "")
 		c.Assert(err, check.IsNil)
 		su = su.(*asserts.SystemUser)
 		// now add system-user assertion to the system
@@ -4872,8 +4878,6 @@ var goodUser = map[string]interface{}{
 	"name":         "Boring Guy",
 	"username":     "guy",
 	"password":     "$6$salt$hash",
-	"since":        time.Now().Format(time.RFC3339),
-	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
 var partnerUser = map[string]interface{}{
@@ -4885,8 +4889,6 @@ var partnerUser = map[string]interface{}{
 	"name":         "Partner Guy",
 	"username":     "partnerguy",
 	"password":     "$6$salt$hash",
-	"since":        time.Now().Format(time.RFC3339),
-	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
 var badUser = map[string]interface{}{
@@ -4899,8 +4901,6 @@ var badUser = map[string]interface{}{
 	"name":         "Random Gal",
 	"username":     "gal",
 	"password":     "$6$salt$hash",
-	"since":        time.Now().Format(time.RFC3339),
-	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
 var unknownUser = map[string]interface{}{

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -55,6 +55,7 @@ type assertMgrSuite struct {
 
 	storeSigning *assertstest.StoreStack
 	dev1Acct     *asserts.Account
+	dev1AcctKey  *asserts.AccountKey
 	dev1Signing  *assertstest.SigningDB
 
 	restore func()
@@ -134,8 +135,8 @@ func (s *assertMgrSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// developer signing
-	dev1AcctKey := assertstest.NewAccountKey(s.storeSigning, s.dev1Acct, nil, dev1PrivKey.PublicKey(), "")
-	err = s.storeSigning.Add(dev1AcctKey)
+	s.dev1AcctKey = assertstest.NewAccountKey(s.storeSigning, s.dev1Acct, nil, dev1PrivKey.PublicKey(), "")
+	err = s.storeSigning.Add(s.dev1AcctKey)
 	c.Assert(err, IsNil)
 
 	s.dev1Signing = assertstest.NewSigningDB(s.dev1Acct.AccountID(), dev1PrivKey)
@@ -1141,4 +1142,61 @@ func (s *assertMgrSuite) TestPublisher(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(acct.AccountID(), Equals, s.dev1Acct.AccountID())
 	c.Check(acct.Username(), Equals, "developer1")
+}
+
+func (s *assertMgrSuite) TestAutoRefresh(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapDeclFoo := s.snapDecl(c, "foo", nil)
+	s.stateFromDecl(snapDeclFoo, snap.R(7))
+
+	// previous state
+	err := assertstate.Add(s.state, s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, s.dev1Acct)
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, snapDeclFoo)
+	c.Assert(err, IsNil)
+	// also another account-key
+	err = assertstate.Add(s.state, s.dev1AcctKey)
+	c.Assert(err, IsNil)
+
+	// one changed snap-decl
+	headers := map[string]interface{}{
+		"series":       "16",
+		"snap-id":      "foo-id",
+		"snap-name":    "fo-o",
+		"publisher-id": s.dev1Acct.AccountID(),
+		"timestamp":    time.Now().Format(time.RFC3339),
+		"revision":     "1",
+	}
+	snapDeclFoo1, err := s.storeSigning.Sign(asserts.SnapDeclarationType, headers, nil, "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(snapDeclFoo1)
+	c.Assert(err, IsNil)
+	// changed key
+	headers = s.dev1AcctKey.Headers()
+	headers["revision"] = "1"
+	headers["until"] = s.dev1AcctKey.Since().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	dev1AcctKeyRev1, err := s.storeSigning.Sign(asserts.AccountKeyType, headers, s.dev1AcctKey.Body(), "")
+	c.Assert(err, IsNil)
+	err = s.storeSigning.Add(dev1AcctKeyRev1)
+	c.Assert(err, IsNil)
+
+	err = assertstate.AutoRefreshAssertions(s.state, 0)
+	c.Assert(err, IsNil)
+
+	a, err := assertstate.DB(s.state).Find(asserts.SnapDeclarationType, map[string]string{
+		"series":  "16",
+		"snap-id": "foo-id",
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.SnapDeclaration).SnapName(), Equals, "fo-o")
+
+	a, err = assertstate.DB(s.state).Find(asserts.AccountKeyType, map[string]string{
+		"public-key-sha3-384": s.dev1AcctKey.PublicKeyID(),
+	})
+	c.Assert(err, IsNil)
+	c.Check(a.(*asserts.AccountKey).Until(), Not(Equals), time.Time{})
 }


### PR DESCRIPTION
This branch does two things:

* adds auto refresh of account-keys which could have since been changed to expire, or be revoked

* reviews the checks around key validity, considering also "since" headers on one hand and making
  sure that keys are within the  validity of their signing keys

the last commit here is something to discuss, we might want to keep thing as is for now until we can do overall better