### PR TITLE
tests: add out-of-the-box test suite

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -227,26 +227,28 @@ exclude:
     - "*.a"
 
 prepare-each: |
-    # systemd on 14.04 does not know about --rotate or --vacuum-time.
-    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
-        journalctl --rotate
-        sleep .1
-        journalctl --vacuum-time=1ms
-    else
-        # Force a log rotation with small size
-        sed -i.bak s/#SystemMaxUse=/SystemMaxUse=1K/g /etc/systemd/journald.conf
-        systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
+    if [ ${SKIP_SETUP:-} != "yes" ]; then
+        # systemd on 14.04 does not know about --rotate or --vacuum-time.
+        if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
+            journalctl --rotate
+            sleep .1
+            journalctl --vacuum-time=1ms
+        else
+            # Force a log rotation with small size
+            sed -i.bak s/#SystemMaxUse=/SystemMaxUse=1K/g /etc/systemd/journald.conf
+            systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
 
-        # Restore the initial configuration and rotate logs
-        mv /etc/systemd/journald.conf.bak /etc/systemd/journald.conf
-        systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
+            # Restore the initial configuration and rotate logs
+            mv /etc/systemd/journald.conf.bak /etc/systemd/journald.conf
+            systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
 
-        # Remove rotated journal logs
-        systemctl stop systemd-journald.service
-        find /run/log/journal/ -name "*@*.journal" -delete
-        systemctl start systemd-journald.service
+            # Remove rotated journal logs
+            systemctl stop systemd-journald.service
+            find /run/log/journal/ -name "*@*.journal" -delete
+            systemctl start systemd-journald.service
+        fi
+        dmesg -c > /dev/null
     fi
-    dmesg -c > /dev/null
 
 debug-each: |
     echo '# journal messages for snapd'
@@ -282,11 +284,13 @@ repack: |
 kill-timeout: 20m
 
 prepare: |
-    # check if running inside a container, the testsuite will not
-    # work in such an environment
-    if systemd-detect-virt -c; then
-        echo "Tests cannot run inside a container"
-        exit 1
+    if [ ${SKIP_SETUP:-} != "yes" ]; then
+        # check if running inside a container, the testsuite will not
+        # work in such an environment
+        if systemd-detect-virt -c; then
+            echo "Tests cannot run inside a container"
+            exit 1
+        fi
     fi
 
     # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
@@ -328,8 +332,9 @@ prepare: |
         find $DELTA_PREFIX -mindepth 1 -maxdepth 1 -exec mv {} . \;
         rmdir $DELTA_PREFIX
     fi
-
-    . "$TESTSLIB/prepare-project.sh"
+    if [ ${SKIP_SETUP:-} != "yes" ]; then
+        . "$TESTSLIB/prepare-project.sh"
+    fi
 
 restore: |
     if [ "$SPREAD_BACKEND" = external ]; then
@@ -340,8 +345,10 @@ restore: |
         fi
     fi
 
-    rm -f $SPREAD_PATH/snapd-state.tar.gz
-    rm -rf ${GOPATH%%:*}/*
+    if [ ${SKIP_SETUP:-} != "yes" ]; then
+        rm -f $SPREAD_PATH/snapd-state.tar.gz
+        rm -rf ${GOPATH%%:*}/*
+    fi
 
 suites:
     tests/main/:
@@ -515,5 +522,42 @@ suites:
         restore: |
             apt remove -y qemu genisoimage sshpass
             snap remove ubuntu-image
+
+    tests/ootb/:
+        summary: Out-of-the-box experience on specific distributions
+        systems: [-ubuntu-core-*]
+        environment:
+            SKIP_SETUP: yes
+        manual: true
+        prepare-each: |
+            case "$SPREAD_SYSTEM" in
+                debian-*|ubuntu-*)
+                    apt-get update
+                    apt-get install -y snapd
+                    ;;
+                fedora-*)
+                    dnf install snapd -y
+                    ;;
+                opensuse-42.2*)
+                    zypper --non-interactive addrepo -f "http://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_42.2/" snappy
+                    zypper --non-interactive --gpg-auto-import-keys refresh
+                    zypper --non-interactive install -y snapd
+                    systemctl enable --now snapd.{socket,service}
+                    ;;
+            esac
+        restore-each: |
+            case "$SPREAD_SYSTEM" in
+                debian-*|ubuntu-*)
+                    apt-get remove --purge -y snapd
+                    apt-get autoremove --purge -y
+                    ;;
+                fedora-*)
+                    dnf remove snapd -y
+                    ;;
+                opensuse-*)
+                    zypper --non-interactive remove -y snapd
+                    zypper --non-interactive removerepo snappy
+                    ;;
+            esac
 
 # vim:ts=4:sw=4:et

--- a/tests/ootb/install-1st-snap-and-core/task.yaml
+++ b/tests/ootb/install-1st-snap-and-core/task.yaml
@@ -1,0 +1,10 @@
+summary: Install first snap and core in one go
+# This test is disabled on Debian for now because it uncovers a bug.
+# https://forum.snapcraft.io/t/snapd-out-of-the-box-experience-debian-9
+systems: [-debian-*]
+details: |
+    This test installs a simple snap along with the core, in one go.
+    This is how many users will get their first snapd experience.
+execute: |
+    snap install test-snapd-tools
+    snap run test-snapd-tools.success

--- a/tests/ootb/install-just-core/task.yaml
+++ b/tests/ootb/install-just-core/task.yaml
@@ -1,0 +1,7 @@
+summary: Install just the core snap.
+details: |
+    This test installs the core snap by itself. This triggers many processes,
+    including re-execution and possibly profile migration.
+execute: |
+    snap install core
+    snap version | MATCH -v unknown


### PR DESCRIPTION
This patch adds out-of-the-box test suite that tests how snapd behaves
out-of-the box, for regular users. There is no elaborate setup, no
package building involved. The test is juts installing snapd from the
repository (enabling a 3rd party repository in case of openSUSE) and
installs a simple snap.

The point of this test is to catch errors out in the wild, such as the
recently discovered hang (still) affecting Debian 9. For that purpose
the tests are specificall as close to what people would really do as
possible.

The suite is marked as manual and should be invoked nightly as a canary
test, to ensure we're doing okay.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>