### PR TITLE
snap: add support for parsing snap layout section

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -195,13 +195,13 @@ type Info struct {
 type Layout struct {
 	Snap *Info
 
-	Path    string `json:"path"`
-	Bind    string `json:"bind,omitempty"`
-	Type    string `json:"type,omitempty"`
-	User    string `json:"user,omitempty"`
-	Group   string `json:"group,omitempty"`
-	Mode    int    `json:"mode,omitempty"`
-	Symlink string `json:"symlink,omitempty"`
+	Path    string      `json:"path"`
+	Bind    string      `json:"bind,omitempty"`
+	Type    string      `json:"type,omitempty"`
+	User    string      `json:"user,omitempty"`
+	Group   string      `json:"group,omitempty"`
+	Mode    os.FileMode `json:"mode,omitempty"`
+	Symlink string      `json:"symlink,omitempty"`
 }
 
 // ChannelSnapInfo is the minimum information that can be used to clearly

--- a/snap/info.go
+++ b/snap/info.go
@@ -187,6 +187,21 @@ type Info struct {
 
 	// The ordered list of tracks that contain channels
 	Tracks []string
+
+	Layout map[string]*Layout
+}
+
+// Layout describes a single element of the layout section.
+type Layout struct {
+	Snap *Info
+
+	Path    string `json:"path"`
+	Bind    string `json:"bind,omitempty"`
+	Type    string `json:"type,omitempty"`
+	User    string `json:"user,omitempty"`
+	Group   string `json:"group,omitempty"`
+	Mode    int    `json:"mode,omitempty"`
+	Symlink string `json:"symlink,omitempty"`
 }
 
 // ChannelSnapInfo is the minimum information that can be used to clearly

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -138,7 +138,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 		for path, l := range y.Layout {
 			var mode os.FileMode = 0755
 			if l.Mode != "" {
-				m, err := strconv.ParseInt(l.Mode, 8, 32)
+				m, err := strconv.ParseUint(l.Mode, 8, 32)
 				if err != nil {
 					return nil, err
 				}

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -21,6 +21,7 @@ package snap
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -135,13 +136,13 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 	if y.Layout != nil {
 		snap.Layout = make(map[string]*Layout, len(y.Layout))
 		for path, l := range y.Layout {
-			mode := 0755
+			var mode os.FileMode = 0755
 			if l.Mode != "" {
 				m, err := strconv.ParseInt(l.Mode, 8, 32)
 				if err != nil {
 					return nil, err
 				}
-				mode = int(m)
+				mode = os.FileMode(m)
 			}
 			user := "root"
 			if l.User != "" {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -710,3 +710,46 @@ apps:
 	c.Check(info.Apps["app1"].IsService(), Equals, false)
 	c.Check(info.Apps["app1"].IsService(), Equals, false)
 }
+
+func (s *infoSuite) TestLayoutParsing(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`name: layout-demo
+layout:
+  /usr:
+    bind: $SNAP/usr
+  /mytmp:
+    type: tmpfs
+    user: nobody
+    group: nobody
+    mode: 1777
+  /mylink:
+    symlink: /link/target
+`))
+	c.Assert(err, IsNil)
+
+	layout := info.Layout
+	c.Assert(layout, NotNil)
+	c.Check(layout["/usr"], DeepEquals, &snap.Layout{
+		Snap:  info,
+		Path:  "/usr",
+		User:  "root",
+		Group: "root",
+		Mode:  0755,
+		Bind:  "$SNAP/usr",
+	})
+	c.Check(layout["/mytmp"], DeepEquals, &snap.Layout{
+		Snap:  info,
+		Path:  "/mytmp",
+		Type:  "tmpfs",
+		User:  "nobody",
+		Group: "nobody",
+		Mode:  01777,
+	})
+	c.Check(layout["/mylink"], DeepEquals, &snap.Layout{
+		Snap:    info,
+		Path:    "/mylink",
+		User:    "root",
+		Group:   "root",
+		Mode:    0755,
+		Symlink: "/link/target",
+	})
+}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -21,6 +21,7 @@ package snap
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -242,7 +243,7 @@ func ValidateLayout(li *Layout) error {
 		return fmt.Errorf("cannot accept group %q for %q", li.Group, li.Path)
 	}
 	// "at most" 0777 permissions are allowed.
-	if li.Mode & ^0777 != 0 {
+	if li.Mode&^os.FileMode(0777) != 0 {
 		return fmt.Errorf("cannot accept mode %#0o for %q", li.Mode, li.Path)
 	}
 	return nil

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -202,6 +202,7 @@ func ValidatePathVariables(path string) error {
 	return nil
 }
 
+// ValidateLayout ensures that the given layout contains only valid subset of constructs.
 func ValidateLayout(li *Layout) error {
 	// The path is used to identify the layout below so validate it first.
 	if li.Path == "" {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -311,3 +311,46 @@ func (s *ValidateSuite) TestValidateAlias(c *C) {
 		c.Assert(err, ErrorMatches, `invalid alias name: ".*"`)
 	}
 }
+
+func (s *ValidateSuite) TestValidateLayout(c *C) {
+	// Several invalid layouts.
+	c.Check(ValidateLayout(&Layout{}),
+		ErrorMatches, "cannot accept layout with empty path")
+	c.Check(ValidateLayout(&Layout{Path: "/foo"}),
+		ErrorMatches, `cannot determine layout for "/foo"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "/bar", Type: "tmpfs"}),
+		ErrorMatches, `cannot accept conflicting layout for "/foo"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "/bar", Symlink: "/froz"}),
+		ErrorMatches, `cannot accept conflicting layout for "/foo"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Symlink: "/froz"}),
+		ErrorMatches, `cannot accept conflicting layout for "/foo"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "ext4"}),
+		ErrorMatches, `cannot accept filesystem "ext4" for "/foo"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo/bar", Type: "tmpfs", User: "foo"}),
+		ErrorMatches, `cannot accept user "foo" for "/foo/bar"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo/bar", Type: "tmpfs", Group: "foo"}),
+		ErrorMatches, `cannot accept group "foo" for "/foo/bar"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Mode: 01755}),
+		ErrorMatches, `cannot accept mode 01755 for "/foo"`)
+	c.Check(ValidateLayout(&Layout{Path: "$FOO", Type: "tmpfs"}),
+		ErrorMatches, `cannot accept layout of "\$FOO": reference to unknown variable "\$FOO"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "$BAR"}),
+		ErrorMatches, `cannot accept layout of "/foo": reference to unknown variable "\$BAR"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo", Symlink: "$BAR"}),
+		ErrorMatches, `cannot accept layout of "/foo": reference to unknown variable "\$BAR"`)
+	// Several valid layouts.
+	c.Check(ValidateLayout(&Layout{Path: "/tmp", Type: "tmpfs"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/usr", Bind: "$SNAP/usr"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/var", Bind: "$SNAP_DATA/var"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/var", Bind: "$SNAP_COMMON/var"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/etc/foo.conf", Symlink: "$SNAP_DATA/etc/foo.conf"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", User: "nobody"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", User: "root"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", Group: "nobody"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", Group: "root"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", Mode: 0655}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/usr", Symlink: "$SNAP/usr"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/var", Symlink: "$SNAP_DATA/var"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/var", Symlink: "$SNAP_COMMON/var"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "$SNAP/data", Symlink: "$SNAP_DATA"}), IsNil)
+}


### PR DESCRIPTION
The layout section defines the "shape" of the runtime mount namespace
of a given snap. Layout is entirely optional and is empty by default.

Tree kind of layout entries can be defind:
 - bind mounts, designated by the presence of the "bind" field
 - tmpfs mounts, designated by the "type" field of "tmpfs"
 - symlinks, designated by the presence of the "symlink" field

In addition, all kinds can use the "user", "group" and "mode" fields
to define the ownership and permissions of any parent directories that
may need to be created. At present those are limited to "root", "nobody"
and at most "0755" permissions.

Any path designators can expand the following environment variables:
$SNAP, $SNAP_DATA and $SNAP_COMMON.

Forum: https://forum.snapcraft.io/t/feature-snap-layouts/1471
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>