### PR TITLE
update to version of golang.org/x/crypto currently in Debian unstable

### DIFF
--- a/packaging/ubuntu-14.04/rules
+++ b/packaging/ubuntu-14.04/rules
@@ -5,7 +5,7 @@
 export DH_OPTIONS
 export DH_GOPKG := github.com/snapcore/snapd
 #export DEB_BUILD_OPTIONS=nocheck
-export DH_GOLANG_EXCLUDES=tests
+export DH_GOLANG_EXCLUDES=tests vendor
 export DH_GOLANG_GO_GENERATE=1
 
 export PATH:=${PATH}:${CURDIR}

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -5,7 +5,7 @@
 export DH_OPTIONS
 export DH_GOPKG := github.com/snapcore/snapd
 #export DEB_BUILD_OPTIONS=nocheck
-export DH_GOLANG_EXCLUDES=tests
+export DH_GOLANG_EXCLUDES=tests vendor
 export DH_GOLANG_GO_GENERATE=1
 
 export PATH:=${PATH}:${CURDIR}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -86,7 +86,7 @@
 			"revisionTime": "2016-08-24T22:20:41Z"
 		},
 		{
-			"checksumSHA1": "tyXdQ4OdVQelQdsil6fXUtKKIRw=",
+			"checksumSHA1": "K3C9lD5XgLfXd25MtZe3Uw5BRoA=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "35ef4487ce0a1ea5d4b616ffe71e34febe723695",
 			"revisionTime": "2017-07-27T13:28:57Z"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -67,10 +67,10 @@
 			"revisionTime": "2016-07-14T06:47:45Z"
 		},
 		{
-			"checksumSHA1": "E28iXtNf9DZVsymruqAnTFGNNnE=",
+			"checksumSHA1": "cpFToKOs95/Aob2g0juVXnN7Hb4=",
 			"path": "golang.org/x/crypto",
-			"revision": "351dc6a5bf92a5f2ae22fadeee08eb6a45aa2d93",
-			"revisionTime": "2016-08-24T13:50:57Z",
+			"revision": "5ef0053f77724838734b6945dd364d3847e5de1d",
+			"revisionTime": "2017-06-29T04:06:47Z",
 			"tree": true
 		},
 		{
@@ -84,6 +84,12 @@
 			"path": "golang.org/x/net/context/ctxhttp",
 			"revision": "6250b412798208e6c90b03b7c4f226de5aa299e2",
 			"revisionTime": "2016-08-24T22:20:41Z"
+		},
+		{
+			"checksumSHA1": "tyXdQ4OdVQelQdsil6fXUtKKIRw=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "35ef4487ce0a1ea5d4b616ffe71e34febe723695",
+			"revisionTime": "2017-07-27T13:28:57Z"
 		},
 		{
 			"checksumSHA1": "XeOje6FklwIZfFMTgE583al/ZDo=",


### PR DESCRIPTION
This pulls in a new dependency, golang.org/x/sys, which I have also pinned to
the version currently in Debian unstable.