### PR TITLE
store: do not resume a download when we already have the whole thing

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1359,7 +1359,22 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 		url = downloadInfo.DownloadURL
 	}
 
-	err = download(ctx, name, downloadInfo.Sha3_384, url, user, s, w, resume, pbar)
+	if downloadInfo.Size == 0 || resume < downloadInfo.Size {
+		err = download(ctx, name, downloadInfo.Sha3_384, url, user, s, w, resume, pbar)
+	} else if downloadInfo.Sha3_384 != "" {
+		// we're done! check the hash though
+		h := crypto.SHA3_384.New()
+		if _, err := w.Seek(0, os.SEEK_SET); err != nil {
+			return err
+		}
+		if _, err := io.Copy(h, w); err != nil {
+			return err
+		}
+		actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
+		if downloadInfo.Sha3_384 != actualSha3 {
+			err = HashError{name, actualSha3, downloadInfo.Sha3_384}
+		}
+	}
 	// If hashsum is incorrect retry once
 	if _, ok := err.(HashError); ok {
 		logger.Debugf("Hashsum error on download: %v", err.Error())

--- a/store/store.go
+++ b/store/store.go
@@ -1361,7 +1361,7 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 
 	if downloadInfo.Size == 0 || resume < downloadInfo.Size {
 		err = download(ctx, name, downloadInfo.Sha3_384, url, user, s, w, resume, pbar)
-	} else if downloadInfo.Sha3_384 != "" {
+	} else {
 		// we're done! check the hash though
 		h := crypto.SHA3_384.New()
 		if _, err := w.Seek(0, os.SEEK_SET); err != nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -355,10 +355,10 @@ func (t *remoteRepoTestSuite) expectedAuthorization(c *C, user *auth.UserState) 
 }
 
 func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
-
+	expectedContent := []byte("I was downloaded")
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		c.Check(url, Equals, "anon-url")
-		w.Write([]byte("I was downloaded"))
+		w.Write(expectedContent)
 		return nil
 	}
 
@@ -366,6 +366,7 @@ func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 	snap.RealName = "foo"
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
+	snap.Size = int64(len(expectedContent))
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
 	err := t.store.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, nil)
@@ -374,16 +375,18 @@ func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 
 	content, err := ioutil.ReadFile(path)
 	c.Assert(err, IsNil)
-	c.Assert(string(content), Equals, "I was downloaded")
+	c.Assert(string(content), Equals, string(expectedContent))
 }
 
 func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 	partialContentStr := "partial content "
+	missingContentStr := "was downloaded"
+	expectedContentStr := partialContentStr + missingContentStr
 
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		c.Check(resume, Equals, int64(len(partialContentStr)))
 		c.Check(url, Equals, "anon-url")
-		w.Write([]byte("was downloaded"))
+		w.Write([]byte(missingContentStr))
 		return nil
 	}
 
@@ -392,6 +395,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
 	snap.Sha3_384 = "abcdabcd"
+	snap.Size = int64(len(expectedContentStr))
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
 	err := ioutil.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
@@ -402,7 +406,31 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 
 	content, err := ioutil.ReadFile(targetFn)
 	c.Assert(err, IsNil)
-	c.Assert(string(content), Equals, partialContentStr+"was downloaded")
+	c.Assert(string(content), Equals, expectedContentStr)
+}
+
+func (t *remoteRepoTestSuite) TestResumeOfCompleted(c *C) {
+	expectedContentStr := "nothing downloaded"
+
+	download = nil
+
+	snap := &snap.Info{}
+	snap.RealName = "foo"
+	snap.AnonDownloadURL = "anon-url"
+	snap.DownloadURL = "AUTH-URL"
+	snap.Sha3_384 = ""
+	snap.Size = int64(len(expectedContentStr))
+
+	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
+	err := ioutil.WriteFile(targetFn+".partial", []byte(expectedContentStr), 0644)
+	c.Assert(err, IsNil)
+
+	err = t.store.Download(context.TODO(), "foo", targetFn, &snap.DownloadInfo, nil, nil)
+	c.Assert(err, IsNil)
+
+	content, err := ioutil.ReadFile(targetFn)
+	c.Assert(err, IsNil)
+	c.Assert(string(content), Equals, expectedContentStr)
 }
 
 func (t *remoteRepoTestSuite) TestDownloadEOFHandlesResumeHashCorrectly(c *C) {
@@ -437,6 +465,7 @@ func (t *remoteRepoTestSuite) TestDownloadEOFHandlesResumeHashCorrectly(c *C) {
 	snap.AnonDownloadURL = mockServer.URL
 	snap.DownloadURL = "AUTH-URL"
 	snap.Sha3_384 = fmt.Sprintf("%x", h.Sum(nil))
+	snap.Size = 50000
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
 	err := t.store.Download(context.TODO(), "foo", targetFn, &snap.DownloadInfo, nil, nil)
@@ -484,6 +513,7 @@ func (t *remoteRepoTestSuite) TestDownloadRetryHashErrorIsFullyRetried(c *C) {
 	snap.AnonDownloadURL = mockServer.URL
 	snap.DownloadURL = "AUTH-URL"
 	snap.Sha3_384 = fmt.Sprintf("%x", h.Sum(nil))
+	snap.Size = 50000
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
 	err := t.store.Download(context.TODO(), "foo", targetFn, &snap.DownloadInfo, nil, nil)
@@ -494,6 +524,45 @@ func (t *remoteRepoTestSuite) TestDownloadRetryHashErrorIsFullyRetried(c *C) {
 	c.Assert(content, DeepEquals, buf)
 
 	c.Assert(t.logbuf.String(), Matches, "(?s).*Retrying .* attempt 2, .*")
+}
+
+func (t *remoteRepoTestSuite) TestResumeOfCompletedRetriedOnHashFailure(c *C) {
+	var mockServer *httptest.Server
+
+	// our mock download content
+	buf := make([]byte, 50000)
+	badbuf := make([]byte, 50000)
+	for i := range buf {
+		buf[i] = 'x'
+		badbuf[i] = 'y'
+	}
+	h := crypto.SHA3_384.New()
+	io.Copy(h, bytes.NewBuffer(buf))
+
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(buf)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	snap := &snap.Info{}
+	snap.RealName = "foo"
+	snap.AnonDownloadURL = mockServer.URL
+	snap.DownloadURL = "AUTH-URL"
+	snap.Sha3_384 = fmt.Sprintf("%x", h.Sum(nil))
+	snap.Size = 50000
+
+	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
+	c.Assert(ioutil.WriteFile(targetFn+".partial", badbuf, 0644), IsNil)
+	err := t.store.Download(context.TODO(), "foo", targetFn, &snap.DownloadInfo, nil, nil)
+	c.Assert(err, IsNil)
+
+	content, err := ioutil.ReadFile(targetFn)
+	c.Assert(err, IsNil)
+	c.Assert(content, DeepEquals, buf)
+
+	c.Assert(t.logbuf.String(), Matches, "(?s).*sha3-384 mismatch.*")
 }
 
 func (t *remoteRepoTestSuite) TestDownloadRetryHashErrorIsFullyRetriedOnlyOnce(c *C) {
@@ -513,6 +582,7 @@ func (t *remoteRepoTestSuite) TestDownloadRetryHashErrorIsFullyRetriedOnlyOnce(c
 	snap.AnonDownloadURL = mockServer.URL
 	snap.DownloadURL = "AUTH-URL"
 	snap.Sha3_384 = "invalid-hash"
+	snap.Size = int64(len("something invalid"))
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
 	err := t.store.Download(context.TODO(), "foo", targetFn, &snap.DownloadInfo, nil, nil)
@@ -524,6 +594,7 @@ func (t *remoteRepoTestSuite) TestDownloadRetryHashErrorIsFullyRetriedOnlyOnce(c
 }
 
 func (t *remoteRepoTestSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {
+	expectedContentStr := "file was downloaded from scratch"
 	partialContentStr := "partial content "
 
 	n := 0
@@ -534,7 +605,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {
 			c.Check(resume, Equals, int64(len(partialContentStr)))
 			return HashError{"foo", "1234", "5678"}
 		}
-		w.Write([]byte("file was downloaded from scratch"))
+		w.Write([]byte(expectedContentStr))
 		return nil
 	}
 
@@ -543,6 +614,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
 	snap.Sha3_384 = ""
+	snap.Size = int64(len(expectedContentStr))
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
 	err := ioutil.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
@@ -554,7 +626,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {
 
 	content, err := ioutil.ReadFile(targetFn)
 	c.Assert(err, IsNil)
-	c.Assert(string(content), Equals, "file was downloaded from scratch")
+	c.Assert(string(content), Equals, expectedContentStr)
 }
 
 func (t *remoteRepoTestSuite) TestDownloadRangeRequestFailOnHashError(c *C) {
@@ -571,6 +643,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequestFailOnHashError(c *C) {
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
 	snap.Sha3_384 = ""
+	snap.Size = int64(len(partialContentStr) + 1)
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")
 	err := ioutil.WriteFile(targetFn+".partial", []byte(partialContentStr), 0644)
@@ -583,12 +656,13 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequestFailOnHashError(c *C) {
 }
 
 func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
+	expectedContent := []byte("I was downloaded")
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		// check user is pass and auth url is used
 		c.Check(user, Equals, t.user)
 		c.Check(url, Equals, "AUTH-URL")
 
-		w.Write([]byte("I was downloaded"))
+		w.Write(expectedContent)
 		return nil
 	}
 
@@ -596,6 +670,7 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 	snap.RealName = "foo"
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
+	snap.Size = int64(len(expectedContent))
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
 	err := t.store.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, t.user)
@@ -604,15 +679,16 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 
 	content, err := ioutil.ReadFile(path)
 	c.Assert(err, IsNil)
-	c.Assert(string(content), Equals, "I was downloaded")
+	c.Assert(string(content), Equals, string(expectedContent))
 }
 
 func (t *remoteRepoTestSuite) TestAuthenticatedDeviceDoesNotUseAnonURL(c *C) {
+	expectedContent := []byte("I was downloaded")
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		// check auth url is used
 		c.Check(url, Equals, "AUTH-URL")
 
-		w.Write([]byte("I was downloaded"))
+		w.Write(expectedContent)
 		return nil
 	}
 
@@ -620,6 +696,7 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDeviceDoesNotUseAnonURL(c *C) {
 	snap.RealName = "foo"
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
+	snap.Size = int64(len(expectedContent))
 
 	authContext := &testAuthContext{c: c, device: t.device}
 	repo := New(&Config{}, authContext)
@@ -632,14 +709,15 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDeviceDoesNotUseAnonURL(c *C) {
 
 	content, err := ioutil.ReadFile(path)
 	c.Assert(err, IsNil)
-	c.Assert(string(content), Equals, "I was downloaded")
+	c.Assert(string(content), Equals, string(expectedContent))
 }
 
 func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
+	expectedContentStr := "I was downloaded"
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		c.Check(url, Equals, "anon-url")
 
-		w.Write([]byte("I was downloaded"))
+		w.Write([]byte(expectedContentStr))
 		return nil
 	}
 
@@ -647,6 +725,7 @@ func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
 	snap.RealName = "foo"
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
+	snap.Size = int64(len(expectedContentStr))
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
 	err := t.store.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, t.localUser)
@@ -655,7 +734,7 @@ func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
 
 	content, err := ioutil.ReadFile(path)
 	c.Assert(err, IsNil)
-	c.Assert(string(content), Equals, "I was downloaded")
+	c.Assert(string(content), Equals, expectedContentStr)
 }
 
 func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
@@ -669,6 +748,7 @@ func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
 	snap.RealName = "foo"
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
+	snap.Size = 1
 	// simulate a failed download
 	path := filepath.Join(c.MkDir(), "downloaded-file")
 	err := t.store.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, nil)
@@ -691,6 +771,7 @@ func (t *remoteRepoTestSuite) TestDownloadSyncFails(c *C) {
 	snap.RealName = "foo"
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
+	snap.Size = int64(len("sync will fail"))
 
 	// simulate a failed sync
 	path := filepath.Join(c.MkDir(), "downloaded-file")
@@ -1032,6 +1113,7 @@ func (t *remoteRepoTestSuite) TestDownloadWithDelta(c *C) {
 	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
 
 	for _, testCase := range deltaTests {
+		testCase.info.Size = int64(len(testCase.expectedContent))
 		downloadIndex := 0
 		download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 			if testCase.downloads[downloadIndex].error {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -36,6 +36,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/crypto/sha3"
 	"golang.org/x/net/context"
 	. "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v1"
@@ -418,7 +419,7 @@ func (t *remoteRepoTestSuite) TestResumeOfCompleted(c *C) {
 	snap.RealName = "foo"
 	snap.AnonDownloadURL = "anon-url"
 	snap.DownloadURL = "AUTH-URL"
-	snap.Sha3_384 = ""
+	snap.Sha3_384 = fmt.Sprintf("%x", sha3.Sum384([]byte(expectedContentStr)))
 	snap.Size = int64(len(expectedContentStr))
 
 	targetFn := filepath.Join(c.MkDir(), "foo_1.0_all.snap")


### PR DESCRIPTION
Without this a .partial file that has been completely downloaded still
triggers a request to the server (which will then come back with a
416).

This lets you drop a .snap in /var/lib/snapd/snaps as a .partial,
which could be used to speed up tests. It'll still be checksummed
(twice), but it won't hit the network for the download unless the
store says it's got a delta.

Doing the same thing for delta downloads is left as an exercise to the
reader.