### PR TITLE
tests: download core and ubuntu-core at most once

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -38,6 +38,7 @@ environment:
     NO_PROXY: "127.0.0.1"
     NEW_CORE_CHANNEL: "$(HOST: echo $SPREAD_NEW_CORE_CHANNEL)"
     SRU_VALIDATION: "$(HOST: echo ${SPREAD_SRU_VALIDATION:-0})"
+    PRE_CACHE_SNAPS: core ubuntu-core test-snapd-tools
 
 backends:
     linode:

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -166,7 +166,7 @@ EOF
                 # There is a bug in snapd where partial file must be a proper
                 # prefix of the full file or we make a wrong request to the
                 # store.
-                truncate --size=$(expr $(stat $snap_file.partial -c %s) - 1) $snap_file.partial
+                truncate --size=-1 $snap_file.partial
                 mv $snap_file.partial /var/lib/snapd/snaps/
             done
             set +x

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -152,6 +152,26 @@ EOF
 
     # Snapshot the state including core.
     if [ ! -f "$SPREAD_PATH/snapd-state.tar.gz" ]; then
+        # Pre-cache a few heavy snaps so that they can be installed by tests
+        # quickly. This relies on a behavior of snapd where .partial files are
+        # used for resuming downloads.
+        (
+            set -x
+            cd /tmp
+            for snap_name in ${PRE_CACHE_SNAPS:-}; do
+                snap download $snap_name
+            done
+            for snap_file in *.snap; do
+                mv $snap_file $snap_file.partial
+                # There is a bug in snapd where partial file must be a proper
+                # prefix of the full file or we make a wrong request to the
+                # store.
+                truncate --size=$(expr $(stat $snap_file.partial -c %s) - 1) $snap_file.partial
+                mv $snap_file.partial /var/lib/snapd/snaps/
+            done
+            set +x
+        )
+
         ! snap list | grep core || exit 1
         # use parameterized core channel (defaults to edge) instead
         # of a fixed one and close to stable in order to detect defects


### PR DESCRIPTION
This patch relies on snapd's ability to resume partial downloads.  In
the one-off preparation phase we download a set of snaps, chop off the
last byte and move them to /var/lib/snapd/snaps adding the .partial
suffix to enable the download beavior. Each test that needs to pull in
one of those two fill then take advantage of the existing file and will
do minimal network traffic required to achieve this.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>