### PR TITLE
overlord/devicestate, store: update device auth endpoints URLs

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -207,15 +207,15 @@ func (s *deviceMgrSuite) mockServer(c *C) *httptest.Server {
 	count := 0
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/identity/api/v1/request-id":
+		case "/api/v1/snaps/auth/request-id":
 			w.WriteHeader(200)
 			c.Check(r.Header.Get("User-Agent"), Equals, expectedUserAgent)
 			io.WriteString(w, fmt.Sprintf(`{"request-id": "%s"}`, s.reqID))
 
-		case "/identity/api/v1/serial":
+		case "/api/v1/snaps/auth/serial":
 			c.Check(r.Header.Get("X-Extra-Header"), Equals, "extra")
 			fallthrough
-		case "/identity/api/v1/devices":
+		case "/api/v1/snaps/auth/devices":
 			c.Check(r.Header.Get("User-Agent"), Equals, expectedUserAgent)
 
 			mu.Lock()
@@ -303,11 +303,11 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappy(c *C) {
 	mockServer := s.mockServer(c)
 	defer mockServer.Close()
 
-	mockRequestIDURL := mockServer.URL + "/identity/api/v1/request-id"
+	mockRequestIDURL := mockServer.URL + "/api/v1/snaps/auth/request-id"
 	r2 := devicestate.MockRequestIDURL(mockRequestIDURL)
 	defer r2()
 
-	mockSerialRequestURL := mockServer.URL + "/identity/api/v1/devices"
+	mockSerialRequestURL := mockServer.URL + "/api/v1/snaps/auth/devices"
 	r3 := devicestate.MockSerialRequestURL(mockSerialRequestURL)
 	defer r3()
 
@@ -374,11 +374,11 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterAddSerial(c *C) {
 	mockServer := s.mockServer(c)
 	defer mockServer.Close()
 
-	mockRequestIDURL := mockServer.URL + "/identity/api/v1/request-id"
+	mockRequestIDURL := mockServer.URL + "/api/v1/snaps/auth/request-id"
 	restore := devicestate.MockRequestIDURL(mockRequestIDURL)
 	defer restore()
 
-	mockSerialRequestURL := mockServer.URL + "/identity/api/v1/devices"
+	mockSerialRequestURL := mockServer.URL + "/api/v1/snaps/auth/devices"
 	restore = devicestate.MockSerialRequestURL(mockSerialRequestURL)
 	defer restore()
 
@@ -443,11 +443,11 @@ func (s *deviceMgrSuite) TestDoRequestSerialIdempotentAfterGotSerial(c *C) {
 	mockServer := s.mockServer(c)
 	defer mockServer.Close()
 
-	mockRequestIDURL := mockServer.URL + "/identity/api/v1/request-id"
+	mockRequestIDURL := mockServer.URL + "/api/v1/snaps/auth/request-id"
 	restore := devicestate.MockRequestIDURL(mockRequestIDURL)
 	defer restore()
 
-	mockSerialRequestURL := mockServer.URL + "/identity/api/v1/devices"
+	mockSerialRequestURL := mockServer.URL + "/api/v1/snaps/auth/devices"
 	restore = devicestate.MockSerialRequestURL(mockSerialRequestURL)
 	defer restore()
 
@@ -513,11 +513,11 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationPollHappy(c *C) {
 	mockServer := s.mockServer(c)
 	defer mockServer.Close()
 
-	mockRequestIDURL := mockServer.URL + "/identity/api/v1/request-id"
+	mockRequestIDURL := mockServer.URL + "/api/v1/snaps/auth/request-id"
 	r2 := devicestate.MockRequestIDURL(mockRequestIDURL)
 	defer r2()
 
-	mockSerialRequestURL := mockServer.URL + "/identity/api/v1/devices"
+	mockSerialRequestURL := mockServer.URL + "/api/v1/snaps/auth/devices"
 	r3 := devicestate.MockSerialRequestURL(mockSerialRequestURL)
 	defer r3()
 
@@ -593,7 +593,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyPrepareDeviceHook(c *C) 
 		c.Assert(ctx.HookName(), Equals, "prepare-device")
 
 		// snapctl set the registration params
-		_, _, err := ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("device-service.url=%q", mockServer.URL+"/identity/api/v1/")})
+		_, _, err := ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("device-service.url=%q", mockServer.URL+"/api/v1/snaps/auth/")})
 		c.Assert(err, IsNil)
 
 		h, err := json.Marshal(map[string]string{
@@ -691,11 +691,11 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationErrorBackoff(c *C) {
 	mockServer := s.mockServer(c)
 	defer mockServer.Close()
 
-	mockRequestIDURL := mockServer.URL + "/identity/api/v1/request-id"
+	mockRequestIDURL := mockServer.URL + "/api/v1/snaps/auth/request-id"
 	r2 := devicestate.MockRequestIDURL(mockRequestIDURL)
 	defer r2()
 
-	mockSerialRequestURL := mockServer.URL + "/identity/api/v1/devices"
+	mockSerialRequestURL := mockServer.URL + "/api/v1/snaps/auth/devices"
 	r3 := devicestate.MockSerialRequestURL(mockSerialRequestURL)
 	defer r3()
 

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -54,9 +54,9 @@ func useStaging() bool {
 
 func deviceAPIBaseURL() string {
 	if useStaging() {
-		return "https://myapps.developer.staging.ubuntu.com/identity/api/v1/"
+		return "https://api.staging.snapcraft.io/api/v1/snaps/auth/"
 	}
-	return "https://myapps.developer.ubuntu.com/identity/api/v1/"
+	return "https://api.snapcraft.io/api/v1/snaps/auth/"
 }
 
 var (

--- a/store/auth.go
+++ b/store/auth.go
@@ -33,14 +33,15 @@ import (
 )
 
 var (
-	myappsAPIBase = myappsURL()
+	baseAPIURL = apiURL()
+	// DeviceNonceAPI points to endpoint to get a nonce
+	DeviceNonceAPI = baseAPIURL.String() + "api/v1/snaps/auth/nonces"
+	// DeviceSessionAPI points to endpoint to get a device session
+	DeviceSessionAPI = baseAPIURL.String() + "api/v1/snaps/auth/sessions"
+	myappsAPIBase    = myappsURL()
 	// MyAppsMacaroonACLAPI points to MyApps endpoint to get a ACL macaroon
 	MyAppsMacaroonACLAPI = myappsAPIBase + "dev/api/acl/"
-	// MyAppsDeviceNonceAPI points to MyApps endpoint to get a nonce
-	MyAppsDeviceNonceAPI = myappsAPIBase + "identity/api/v1/nonces"
-	// MyAppsDeviceSessionAPI points to MyApps endpoint to get a device session
-	MyAppsDeviceSessionAPI = myappsAPIBase + "identity/api/v1/sessions"
-	ubuntuoneAPIBase       = authURL()
+	ubuntuoneAPIBase     = authURL()
 	// UbuntuoneLocation is the Ubuntuone location as defined in the store macaroon
 	UbuntuoneLocation = authLocation()
 	// UbuntuoneDischargeAPI points to SSO endpoint to discharge a macaroon
@@ -252,7 +253,7 @@ func requestStoreDeviceNonce() (string, error) {
 		"User-Agent": httputil.UserAgent(),
 		"Accept":     "application/json",
 	}
-	resp, err := retryPostRequestDecodeJSON(MyAppsDeviceNonceAPI, headers, nil, &responseData, nil)
+	resp, err := retryPostRequestDecodeJSON(DeviceNonceAPI, headers, nil, &responseData, nil)
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
@@ -295,7 +296,7 @@ func requestDeviceSession(serialAssertion, sessionRequest, previousSession strin
 		headers["X-Device-Authorization"] = fmt.Sprintf(`Macaroon root="%s"`, previousSession)
 	}
 
-	_, err = retryPostRequest(MyAppsDeviceSessionAPI, headers, deviceJSONData, func(resp *http.Response) error {
+	_, err = retryPostRequest(DeviceSessionAPI, headers, deviceJSONData, func(resp *http.Response) error {
 		if resp.StatusCode == 200 || resp.StatusCode == 202 {
 			return json.NewDecoder(resp.Body).Decode(&responseData)
 		}

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -283,7 +283,7 @@ func (s *authTestSuite) TestRequestStoreDeviceNonce(c *C) {
 		io.WriteString(w, mockStoreReturnNonce)
 	}))
 	defer mockServer.Close()
-	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
+	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
 	nonce, err := requestStoreDeviceNonce()
 	c.Assert(err, IsNil)
@@ -301,7 +301,7 @@ func (s *authTestSuite) TestRequestStoreDeviceNonceRetry500(c *C) {
 		}
 	}))
 	defer mockServer.Close()
-	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
+	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
 	nonce, err := requestStoreDeviceNonce()
 	c.Assert(err, IsNil)
@@ -316,7 +316,7 @@ func (s *authTestSuite) TestRequestStoreDeviceNonce500(c *C) {
 		w.WriteHeader(500)
 	}))
 	defer mockServer.Close()
-	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
+	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
 	_, err := requestStoreDeviceNonce()
 	c.Assert(err, NotNil)
@@ -325,7 +325,7 @@ func (s *authTestSuite) TestRequestStoreDeviceNonce500(c *C) {
 }
 
 func (s *authTestSuite) TestRequestStoreDeviceNonceFailureOnDNS(c *C) {
-	MyAppsDeviceNonceAPI = "http://nonexistingserver121321.com/identity/api/v1/nonces"
+	DeviceNonceAPI = "http://nonexistingserver121321.com/api/v1/snaps/auth/nonces"
 	_, err := requestStoreDeviceNonce()
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot get nonce from store.*`)
@@ -336,7 +336,7 @@ func (s *authTestSuite) TestRequestStoreDeviceNonceEmptyResponse(c *C) {
 		io.WriteString(w, mockStoreReturnNoNonce)
 	}))
 	defer mockServer.Close()
-	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
+	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
 	nonce, err := requestStoreDeviceNonce()
 	c.Assert(err, ErrorMatches, "cannot get nonce from store: empty nonce returned")
@@ -350,7 +350,7 @@ func (s *authTestSuite) TestRequestStoreDeviceNonceError(c *C) {
 		n++
 	}))
 	defer mockServer.Close()
-	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
+	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
 	nonce, err := requestStoreDeviceNonce()
 	c.Assert(err, ErrorMatches, "cannot get nonce from store: store server returned status 500")
@@ -368,7 +368,7 @@ func (s *authTestSuite) TestRequestDeviceSession(c *C) {
 		io.WriteString(w, mockStoreReturnMacaroon)
 	}))
 	defer mockServer.Close()
-	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
 	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "")
 	c.Assert(err, IsNil)
@@ -385,7 +385,7 @@ func (s *authTestSuite) TestRequestDeviceSessionWithPreviousSession(c *C) {
 		io.WriteString(w, mockStoreReturnMacaroon)
 	}))
 	defer mockServer.Close()
-	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
 	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "previous-session")
 	c.Assert(err, IsNil)
@@ -397,7 +397,7 @@ func (s *authTestSuite) TestRequestDeviceSessionMissingData(c *C) {
 		io.WriteString(w, mockStoreReturnNoMacaroon)
 	}))
 	defer mockServer.Close()
-	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
 	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "")
 	c.Assert(err, ErrorMatches, "cannot get device session from store: empty session returned")
@@ -412,7 +412,7 @@ func (s *authTestSuite) TestRequestDeviceSessionError(c *C) {
 		n++
 	}))
 	defer mockServer.Close()
-	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
 	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "")
 	c.Assert(err, ErrorMatches, `cannot get device session from store: store server returned status 500 and body "error body"`)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1440,9 +1440,9 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 				c.Check(authorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
 				io.WriteString(w, "response-data")
 			}
-		case "/identity/api/v1/nonces":
+		case "/api/v1/auth/nonces":
 			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
-		case "/identity/api/v1/sessions":
+		case "/api/v1/auth/sessions":
 			authorization := r.Header.Get("X-Device-Authorization")
 			if authorization == "" {
 				io.WriteString(w, `{"macaroon": "expired-session-macaroon"}`)
@@ -1459,8 +1459,8 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	MyAppsDeviceNonceAPI = mockServer.URL + "/identity/api/v1/nonces"
-	MyAppsDeviceSessionAPI = mockServer.URL + "/identity/api/v1/sessions"
+	DeviceNonceAPI = mockServer.URL + "/api/v1/auth/nonces"
+	DeviceSessionAPI = mockServer.URL + "/api/v1/auth/sessions"
 
 	// make sure device session is not set
 	t.device.SessionMacaroon = ""


### PR DESCRIPTION
Updates device registration/authentication URLs to point to api.snapcraft.io. Right now myApps endpoints are already proxying requests to the these new endpoints.

This is part of the process looking to serve store endpoints under api.snapcraft.io, and also to migrate device registration/authentication to a new service.