### PR TITLE
snap/snapenv: always expect /snap for $SNAP

### DIFF
--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -121,7 +121,7 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 		env := snapEnv(info)
 		c.Check(env, DeepEquals, map[string]string{
 			"HOME":              fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
-			"SNAP":              fmt.Sprintf("%s/snapname/42", dirs.SnapMountDir),
+			"SNAP":              fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
 			"SNAP_ARCH":         arch.UbuntuArchitecture(),
 			"SNAP_COMMON":       "/var/snap/snapname/common",
 			"SNAP_DATA":         "/var/snap/snapname/42",


### PR DESCRIPTION
On the "inside" of the snap execution environment we can always(1) rely on
the /snap directory to be present. On distributions where the /snap
directory on the host is redirected to /var/lib/snapd/snap this fact
should not leak into the runtime environment.

This was already done correctly but one of the tests was stale.

(1): Snaps with classic confinement don't work there anyway so that's a
non-issue.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>