### PR TITLE
gitignore: ignore more build artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ po/snappy.pot
 cmd/decode-mount-opts/decode-mount-opts
 cmd/libsnap-confine-private/unit-tests
 cmd/snap-confine/snap-confine
+cmd/snap-confine/snap-confine-debug
 cmd/snap-confine/snap-confine.apparmor
 cmd/snap-confine/unit-tests
 cmd/snap-discard-ns/snap-discard-ns
@@ -32,6 +33,7 @@ cmd/*/*.[1-9]
 
 # auto-generated systemd units
 data/systemd/*.service
+data/info
 
 # test-driver
 *.log


### PR DESCRIPTION
Those files are made during the build but are reported by run-checks as
unknown junk. We can fix this by just marking them as ignored.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>