### PR TITLE
release: remove default from VERSION_ID

### DIFF
--- a/release/release.go
+++ b/release/release.go
@@ -76,7 +76,6 @@ var (
 func readOSRelease() OS {
 	// TODO: separate this out into its own thing maybe (if made more general)
 	osRelease := OS{
-		VersionID: "unknown",
 		// from os-release(5): If not set, defaults to "ID=linux".
 		ID: "linux",
 	}

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -98,7 +98,7 @@ func (s *ReleaseTestSuite) TestReadOSReleaseNotFound(c *C) {
 	defer reset()
 
 	os := release.ReadOSRelease()
-	c.Assert(os, DeepEquals, release.OS{ID: "linux", VersionID: "unknown"})
+	c.Assert(os, DeepEquals, release.OS{ID: "linux"})
 }
 
 func (s *ReleaseTestSuite) TestOnClassic(c *C) {


### PR DESCRIPTION
According to os-release(5) there is no default value for this field so
we should not provide one. This also removes the unexpected "unknown"
element from "snap version" on rolling releases, such as Arch.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>