### PR TITLE
cmd/snap-confine: don't share /etc/nsswitch from host

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -325,7 +325,9 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		//  - https://bugs.launchpad.net/snap-confine/+bug/1580018
 		//  - https://bugzilla.opensuse.org/show_bug.cgi?id=1028568
 		const char *dirs_from_core[] =
-		    { "/etc/alternatives", "/etc/ssl", NULL };
+		    { "/etc/alternatives", "/etc/ssl", "/etc/nsswitch.conf",
+			NULL
+		};
 		for (const char **dirs = dirs_from_core; *dirs != NULL; dirs++) {
 			const char *dir = *dirs;
 			if (access(dir, F_OK) == 0) {

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -164,10 +164,12 @@
     # /etc/alternatives (classic)
     mount options=(rw bind) @SNAP_MOUNT_DIR@/{,ubuntu-}core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
     mount options=(rw bind) @SNAP_MOUNT_DIR@/{,ubuntu-}core/*/etc/ssl/ -> /tmp/snap.rootfs_*/etc/ssl/,
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/{,ubuntu-}core/*/etc/nsswitch.conf -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
     # /etc/alternatives (core)
     mount options=(rw bind) /etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/alternatives/,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/ssl/,
+    mount options=(rw slave) -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
     # the /snap directory
     mount options=(rw rbind) @SNAP_MOUNT_DIR@/ -> /tmp/snap.rootfs_*/snap/,
     mount options=(rw rslave) -> /tmp/snap.rootfs_*/snap/,


### PR DESCRIPTION
This patch corrects name resolution errors on Arch where host's
/etc/nsswitch.conf contains references to modules not present in the
core snap. This is again one of the bugs originating from sharing all of
/etc blindly and then undoing the damage but for now it is easier to add
an exception than to undo this.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>