### PR TITLE
daemon, client, cmd/snap: implement snap start/stop/restart

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -166,7 +166,7 @@ type StartOptions struct {
 // Start services.
 //
 // It takes a list of names that can be snaps, of which all their
-// services are startped, or snap.service which are individual
+// services are started, or snap.service which are individual
 // services to start; it shouldn't be empty.
 func (client *Client) Start(names []string, opts StartOptions) (changeID string, err error) {
 	if len(names) == 0 {
@@ -214,7 +214,8 @@ func (client *Client) Stop(names []string, opts StopOptions) (changeID string, e
 
 // RestartOptions represent the different options of the Restart call.
 type RestartOptions struct {
-	// Reload the services, if possible, instead of restarting.
+	// Reload the services, if possible (i.e. if the App has a
+	// ReloadCommand, invoque it), instead of restarting.
 	Reload bool `json:"reload,omitempty"`
 }
 
@@ -222,7 +223,8 @@ type RestartOptions struct {
 //
 // It takes a list of names that can be snaps, of which all their
 // services are restarted, or snap.service which are individual
-// services to restart; it shouldn't be empty.
+// services to restart; it shouldn't be empty. If the service is not
+// running, starts it.
 func (client *Client) Restart(names []string, opts RestartOptions) (changeID string, err error) {
 	if len(names) == 0 {
 		return "", ErrNoNames

--- a/client/apps.go
+++ b/client/apps.go
@@ -23,6 +23,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -141,4 +142,99 @@ func (client *Client) Logs(names []string, opts LogOptions) (<-chan Log, error) 
 	}()
 
 	return ch, nil
+}
+
+// ErrNoNames is returned by Start, Stop, or Restart, when the given
+// list of things on which to operate is empty.
+var ErrNoNames = errors.New(`"names" must not be empty`)
+
+type appInstruction struct {
+	Action string   `json:"action"`
+	Names  []string `json:"names"`
+	StartOptions
+	StopOptions
+	RestartOptions
+}
+
+// StartOptions represent the different options of the Start call.
+type StartOptions struct {
+	// Enable, as well as starting, the listed services. A
+	// disabled service does not start on boot.
+	Enable bool `json:"enable,omitempty"`
+}
+
+// Start services.
+//
+// It takes a list of names that can be snaps, of which all their
+// services are startped, or snap.service which are individual
+// services to start; it shouldn't be empty.
+func (client *Client) Start(names []string, opts StartOptions) (changeID string, err error) {
+	if len(names) == 0 {
+		return "", ErrNoNames
+	}
+
+	buf, err := json.Marshal(appInstruction{
+		Action:       "start",
+		Names:        names,
+		StartOptions: opts,
+	})
+	if err != nil {
+		return "", err
+	}
+	return client.doAsync("POST", "/v2/apps", nil, nil, bytes.NewReader(buf))
+}
+
+// StopOptions represent the different options of the Stop call.
+type StopOptions struct {
+	// Disable, as well as stopping, the listed services. A
+	// service that is not disabled starts on boot.
+	Disable bool `json:"disable,omitempty"`
+}
+
+// Stop services.
+//
+// It takes a list of names that can be snaps, of which all their
+// services are stopped, or snap.service which are individual
+// services to stop; it shouldn't be empty.
+func (client *Client) Stop(names []string, opts StopOptions) (changeID string, err error) {
+	if len(names) == 0 {
+		return "", ErrNoNames
+	}
+
+	buf, err := json.Marshal(appInstruction{
+		Action:      "stop",
+		Names:       names,
+		StopOptions: opts,
+	})
+	if err != nil {
+		return "", err
+	}
+	return client.doAsync("POST", "/v2/apps", nil, nil, bytes.NewReader(buf))
+}
+
+// RestartOptions represent the different options of the Restart call.
+type RestartOptions struct {
+	// Reload the services, if possible, instead of restarting.
+	Reload bool `json:"reload,omitempty"`
+}
+
+// Restart services.
+//
+// It takes a list of names that can be snaps, of which all their
+// services are restarted, or snap.service which are individual
+// services to restart; it shouldn't be empty.
+func (client *Client) Restart(names []string, opts RestartOptions) (changeID string, err error) {
+	if len(names) == 0 {
+		return "", ErrNoNames
+	}
+
+	buf, err := json.Marshal(appInstruction{
+		Action:         "restart",
+		Names:          names,
+		RestartOptions: opts,
+	})
+	if err != nil {
+		return "", err
+	}
+	return client.doAsync("POST", "/v2/apps", nil, nil, bytes.NewReader(buf))
 }

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -191,13 +191,13 @@ func (cs *clientSuite) TestClientLogsOpts(c *check.C) {
 func (cs *clientSuite) TestClientServiceStart(c *check.C) {
 	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
 
-	type tT struct {
+	type scenario struct {
 		names   []string
 		opts    client.StartOptions
 		comment check.CommentInterface
 	}
 
-	var scs []tT
+	var scenarios []scenario
 
 	for _, names := range [][]string{
 		nil, {},
@@ -208,7 +208,7 @@ func (cs *clientSuite) TestClientServiceStart(c *check.C) {
 			{true},
 			{false},
 		} {
-			scs = append(scs, tT{
+			scenarios = append(scenarios, scenario{
 				names:   names,
 				opts:    opts,
 				comment: check.Commentf("{%q; %#v}", names, opts),
@@ -216,7 +216,7 @@ func (cs *clientSuite) TestClientServiceStart(c *check.C) {
 		}
 	}
 
-	for _, sc := range scs {
+	for _, sc := range scenarios {
 		id, err := cs.cli.Start(sc.names, sc.opts)
 		if len(sc.names) == 0 {
 			c.Check(id, check.Equals, "", sc.comment)

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -187,3 +187,186 @@ func (cs *clientSuite) TestClientLogsOpts(c *check.C) {
 		}
 	}
 }
+
+func (cs *clientSuite) TestClientServiceStart(c *check.C) {
+	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
+
+	type tT struct {
+		names   []string
+		opts    client.StartOptions
+		comment check.CommentInterface
+	}
+
+	var scs []tT
+
+	for _, names := range [][]string{
+		nil, {},
+		{"foo"},
+		{"foo", "bar", "baz"},
+	} {
+		for _, opts := range []client.StartOptions{
+			{true},
+			{false},
+		} {
+			scs = append(scs, tT{
+				names:   names,
+				opts:    opts,
+				comment: check.Commentf("{%q; %#v}", names, opts),
+			})
+		}
+	}
+
+	for _, sc := range scs {
+		id, err := cs.cli.Start(sc.names, sc.opts)
+		if len(sc.names) == 0 {
+			c.Check(id, check.Equals, "", sc.comment)
+			c.Check(err, check.Equals, client.ErrNoNames, sc.comment)
+			c.Check(cs.req, check.IsNil, sc.comment) // i.e. the request was never done
+		} else {
+			c.Assert(err, check.IsNil, sc.comment)
+			c.Check(id, check.Equals, "24", sc.comment)
+			c.Check(cs.req.URL.Path, check.Equals, "/v2/apps", sc.comment)
+			c.Check(cs.req.Method, check.Equals, "POST", sc.comment)
+			c.Check(cs.req.URL.Query(), check.HasLen, 0, sc.comment)
+
+			inames := make([]interface{}, len(sc.names))
+			for i, name := range sc.names {
+				inames[i] = interface{}(name)
+			}
+
+			var reqOp map[string]interface{}
+			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, sc.comment)
+			if sc.opts.Enable {
+				c.Check(len(reqOp), check.Equals, 3, sc.comment)
+				c.Check(reqOp["enable"], check.Equals, true, sc.comment)
+			} else {
+				c.Check(len(reqOp), check.Equals, 2, sc.comment)
+				c.Check(reqOp["enable"], check.IsNil, sc.comment)
+			}
+			c.Check(reqOp["action"], check.Equals, "start", sc.comment)
+			c.Check(reqOp["names"], check.DeepEquals, inames, sc.comment)
+		}
+	}
+}
+
+func (cs *clientSuite) TestClientServiceStop(c *check.C) {
+	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
+
+	type tT struct {
+		names   []string
+		opts    client.StopOptions
+		comment check.CommentInterface
+	}
+
+	var scs []tT
+
+	for _, names := range [][]string{
+		nil, {},
+		{"foo"},
+		{"foo", "bar", "baz"},
+	} {
+		for _, opts := range []client.StopOptions{
+			{true},
+			{false},
+		} {
+			scs = append(scs, tT{
+				names:   names,
+				opts:    opts,
+				comment: check.Commentf("{%q; %#v}", names, opts),
+			})
+		}
+	}
+
+	for _, sc := range scs {
+		id, err := cs.cli.Stop(sc.names, sc.opts)
+		if len(sc.names) == 0 {
+			c.Check(id, check.Equals, "", sc.comment)
+			c.Check(err, check.Equals, client.ErrNoNames, sc.comment)
+			c.Check(cs.req, check.IsNil, sc.comment) // i.e. the request was never done
+		} else {
+			c.Assert(err, check.IsNil, sc.comment)
+			c.Check(id, check.Equals, "24", sc.comment)
+			c.Check(cs.req.URL.Path, check.Equals, "/v2/apps", sc.comment)
+			c.Check(cs.req.Method, check.Equals, "POST", sc.comment)
+			c.Check(cs.req.URL.Query(), check.HasLen, 0, sc.comment)
+
+			inames := make([]interface{}, len(sc.names))
+			for i, name := range sc.names {
+				inames[i] = interface{}(name)
+			}
+
+			var reqOp map[string]interface{}
+			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, sc.comment)
+			if sc.opts.Disable {
+				c.Check(len(reqOp), check.Equals, 3, sc.comment)
+				c.Check(reqOp["disable"], check.Equals, true, sc.comment)
+			} else {
+				c.Check(len(reqOp), check.Equals, 2, sc.comment)
+				c.Check(reqOp["disable"], check.IsNil, sc.comment)
+			}
+			c.Check(reqOp["action"], check.Equals, "stop", sc.comment)
+			c.Check(reqOp["names"], check.DeepEquals, inames, sc.comment)
+		}
+	}
+}
+
+func (cs *clientSuite) TestClientServiceRestart(c *check.C) {
+	cs.rsp = `{"type": "async", "status-code": 202, "change": "24"}`
+
+	type tT struct {
+		names   []string
+		opts    client.RestartOptions
+		comment check.CommentInterface
+	}
+
+	var scs []tT
+
+	for _, names := range [][]string{
+		nil, {},
+		{"foo"},
+		{"foo", "bar", "baz"},
+	} {
+		for _, opts := range []client.RestartOptions{
+			{true},
+			{false},
+		} {
+			scs = append(scs, tT{
+				names:   names,
+				opts:    opts,
+				comment: check.Commentf("{%q; %#v}", names, opts),
+			})
+		}
+	}
+
+	for _, sc := range scs {
+		id, err := cs.cli.Restart(sc.names, sc.opts)
+		if len(sc.names) == 0 {
+			c.Check(id, check.Equals, "", sc.comment)
+			c.Check(err, check.Equals, client.ErrNoNames, sc.comment)
+			c.Check(cs.req, check.IsNil, sc.comment) // i.e. the request was never done
+		} else {
+			c.Assert(err, check.IsNil, sc.comment)
+			c.Check(id, check.Equals, "24", sc.comment)
+			c.Check(cs.req.URL.Path, check.Equals, "/v2/apps", sc.comment)
+			c.Check(cs.req.Method, check.Equals, "POST", sc.comment)
+			c.Check(cs.req.URL.Query(), check.HasLen, 0, sc.comment)
+
+			inames := make([]interface{}, len(sc.names))
+			for i, name := range sc.names {
+				inames[i] = interface{}(name)
+			}
+
+			var reqOp map[string]interface{}
+			c.Assert(json.NewDecoder(cs.req.Body).Decode(&reqOp), check.IsNil, sc.comment)
+			if sc.opts.Reload {
+				c.Check(len(reqOp), check.Equals, 3, sc.comment)
+				c.Check(reqOp["reload"], check.Equals, true, sc.comment)
+			} else {
+				c.Check(len(reqOp), check.Equals, 2, sc.comment)
+				c.Check(reqOp["reload"], check.IsNil, sc.comment)
+			}
+			c.Check(reqOp["action"], check.Equals, "restart", sc.comment)
+			c.Check(reqOp["names"], check.DeepEquals, inames, sc.comment)
+		}
+	}
+}

--- a/cmd/snap/cmd_services_test.go
+++ b/cmd/snap/cmd_services_test.go
@@ -1,0 +1,173 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/client"
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+type appOpSuite struct {
+	BaseSnapSuite
+
+	restoreAll func()
+}
+
+var _ = check.Suite(&appOpSuite{})
+
+func (s *appOpSuite) SetUpTest(c *check.C) {
+	s.BaseSnapSuite.SetUpTest(c)
+
+	restoreClientRetry := client.MockDoRetry(time.Millisecond, 10*time.Millisecond)
+	restorePollTime := snap.MockPollTime(time.Millisecond)
+	s.restoreAll = func() {
+		restoreClientRetry()
+		restorePollTime()
+	}
+}
+
+func (s *appOpSuite) TearDownTest(c *check.C) {
+	s.restoreAll()
+	s.BaseSnapSuite.TearDownTest(c)
+}
+
+func (s *appOpSuite) expectedBody(op string, names []string, extra []string) map[string]interface{} {
+	inames := make([]interface{}, len(names))
+	for i, name := range names {
+		inames[i] = name
+	}
+	expectedBody := map[string]interface{}{
+		"action": op,
+		"names":  inames,
+	}
+	for _, x := range extra {
+		expectedBody[x] = true
+	}
+	return expectedBody
+}
+
+func (s *appOpSuite) args(op string, names []string, extra []string, noWait bool) []string {
+	args := []string{op}
+	if noWait {
+		args = append(args, "--no-wait")
+	}
+	for _, x := range extra {
+		args = append(args, "--"+x)
+	}
+	for _, name := range names {
+		args = append(args, name)
+	}
+	return args
+}
+
+func (s *appOpSuite) testOpNoArgs(c *check.C, op string) {
+	s.RedirectClientToTestServer(nil)
+	_, err := snap.Parser().ParseArgs([]string{op})
+	c.Assert(err, check.ErrorMatches, `.* required argument .* not provided`)
+}
+
+func (s *appOpSuite) testOpErrorResponse(c *check.C, op string, names []string, extra []string, noWait bool) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "POST")
+			c.Check(r.URL.Path, check.Equals, "/v2/apps")
+			c.Check(r.URL.Query(), check.HasLen, 0)
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, s.expectedBody(op, names, extra))
+			w.WriteHeader(400)
+			fmt.Fprintln(w, `{"type": "error", "result": {"message": "error"}, "status-code": 400}`)
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+		}
+
+		n++
+	})
+
+	_, err := snap.Parser().ParseArgs(s.args(op, names, extra, noWait))
+	c.Assert(err, check.ErrorMatches, "error")
+	c.Check(n, check.Equals, 1)
+}
+
+func (s *appOpSuite) testOp(c *check.C, op, summary string, names []string, extra []string, noWait bool) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.URL.Path, check.Equals, "/v2/apps")
+			c.Check(r.URL.Query(), check.HasLen, 0)
+			c.Check(DecodedRequestBody(c, r), check.DeepEquals, s.expectedBody(op, names, extra))
+			c.Check(r.Method, check.Equals, "POST")
+			w.WriteHeader(202)
+			fmt.Fprintln(w, `{"type":"async", "change": "42", "status-code": 202}`)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"status": "Doing"}}`)
+		case 2:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/changes/42")
+			fmt.Fprintln(w, `{"type": "sync", "result": {"ready": true, "status": "Done"}}`)
+		default:
+			c.Fatalf("expected to get 2 requests, now on %d", n+1)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser().ParseArgs(s.args(op, names, extra, noWait))
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+	c.Check(s.Stderr(), check.Equals, "")
+	expectedN := 3
+	if noWait {
+		summary = "42"
+		expectedN = 1
+	}
+	c.Check(s.Stdout(), check.Equals, summary+"\n")
+	// ensure that the fake server api was actually hit
+	c.Check(n, check.Equals, expectedN)
+}
+
+func (s *appOpSuite) TestAppOps(c *check.C) {
+	extras := []string{"enable", "disable", "reload"}
+	summaries := []string{"Started.", "Stopped.", "Restarted."}
+	for i, op := range []string{"start", "stop", "restart"} {
+		s.testOpNoArgs(c, op)
+		for _, extra := range [][]string{nil, {extras[i]}} {
+			for _, noWait := range []bool{false, true} {
+				for _, names := range [][]string{
+					{"foo"},
+					{"foo", "bar"},
+					{"foo", "bar.baz"},
+				} {
+					s.testOpErrorResponse(c, op, names, extra, noWait)
+					s.testOp(c, op, summaries[i], names, extra, noWait)
+					s.stdout.Reset()
+				}
+			}
+		}
+	}
+}

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -100,6 +100,12 @@ func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (stri
 		// arch/channel/revision. Surface that here somehow!
 
 		msg = i18n.G("snap %q not found")
+		if snapName == "" {
+			errValStr, ok := err.Value.(string)
+			if ok && errValStr != "" {
+				snapName = errValStr
+			}
+		}
 		if opts != nil {
 			if opts.Revision != "" {
 				// TRANSLATORS: %%q will become a %q for the snap name; %q is whatever foo the user used for --revision=foo

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2696,13 +2696,17 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("unknown action %q", inst.Action)
 	}
 
-	snapNames := make(map[string]bool, len(appInfos))
+	snapNames := make([]string, 0, len(appInfos))
+	lastName := ""
 	names := make([]string, len(appInfos))
 	for i, svc := range appInfos {
 		argv = append(argv, svc.ServiceName())
 		snapName := svc.Snap.Name()
 		names[i] = snapName + "." + svc.Name
-		snapNames[snapName] = true
+		if snapName != lastName {
+			snapNames = append(snapNames, snapName)
+			lastName = snapName
+		}
 	}
 
 	desc := fmt.Sprintf("%s of %v", inst.Action, names)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -50,6 +50,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/cmdstate"
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -146,6 +147,7 @@ var (
 		Path:   "/v2/apps",
 		UserOK: true,
 		GET:    getAppsInfo,
+		POST:   postApps,
 	}
 
 	logsCmd = &Command{
@@ -478,7 +480,7 @@ func getSnapInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	about, err := localSnapInfo(c.d.overlord.State(), name)
 	if err != nil {
 		if err == errNoSnap {
-			return SnapNotFound(err)
+			return SnapNotFound(name, err)
 		}
 
 		return InternalError("%v", err)
@@ -630,7 +632,7 @@ func findOne(c *Command, r *http.Request, user *auth.UserState, name string) Res
 	snapInfo, err := theStore.SnapInfo(spec, user)
 	if err != nil {
 		if err == store.ErrSnapNotFound {
-			return SnapNotFound(err)
+			return SnapNotFound(name, err)
 		}
 		return InternalError("%v", err)
 	}
@@ -1128,7 +1130,7 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 
 	switch err {
 	case store.ErrSnapNotFound:
-		return SnapNotFound(err)
+		return SnapNotFound(inst.Snaps[0], err)
 	case store.ErrNoUpdateAvailable:
 		kind = errorKindSnapNoUpdateAvailable
 	case store.ErrLocalSnap:
@@ -1508,7 +1510,7 @@ func iconGet(st *state.State, name string) Response {
 	about, err := localSnapInfo(st, name)
 	if err != nil {
 		if err == errNoSnap {
-			return SnapNotFound(err)
+			return SnapNotFound(name, err)
 		}
 		return InternalError("%v", err)
 	}
@@ -1590,7 +1592,7 @@ func setSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 	var snapst snapstate.SnapState
 	if err := snapstate.Get(st, snapName, &snapst); err != nil {
 		if err == state.ErrNoState {
-			return SnapNotFound(err)
+			return SnapNotFound(snapName, err)
 		} else {
 			return InternalError("%v", err)
 		}
@@ -2636,4 +2638,74 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 		ReadCloser: reader,
 		follow:     follow,
 	}
+}
+
+type appInstruction struct {
+	Action string   `json:"action"`
+	Names  []string `json:"names"`
+	client.StartOptions
+	client.StopOptions
+	client.RestartOptions
+}
+
+func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
+	var inst appInstruction
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&inst); err != nil {
+		return BadRequest("cannot decode request body into service operation: %v", err)
+	}
+	if len(inst.Names) == 0 {
+		// on POST, don't allow empty to mean all
+		return BadRequest("cannot perform operation on services without a list of services to operate on")
+	}
+
+	st := c.d.overlord.State()
+	appInfos, rsp := appInfosFor(st, inst.Names, appInfoOptions{service: true})
+	if rsp != nil {
+		return rsp
+	}
+	if len(appInfos) == 0 {
+		// can't happen: appInfosFor with a non-empty list of services
+		// shouldn't ever return an empty appInfos with no error response
+		return InternalError("no services found")
+	}
+
+	argv := make([]string, 2, 3+len(appInfos))
+	argv[0] = "systemctl"
+	argv[1] = inst.Action
+
+	switch inst.Action {
+	case "start":
+		if inst.Enable {
+			argv[1] = "enable"
+			argv = append(argv, "--now")
+		}
+	case "stop":
+		if inst.Disable {
+			argv[1] = "disable"
+			argv = append(argv, "--now")
+		}
+	case "restart":
+		if inst.Reload {
+			argv[1] = "try-reload-or-restart"
+		}
+	default:
+		return BadRequest("unknown action %q", inst.Action)
+	}
+
+	names := make([]string, len(appInfos))
+	for i, svc := range appInfos {
+		argv = append(argv, svc.ServiceName())
+		names[i] = svc.Snap.Name() + "." + svc.Name
+	}
+
+	desc := fmt.Sprintf("%s of %v", inst.Action, names)
+
+	st.Lock()
+	defer st.Unlock()
+	ts := cmdstate.Exec(st, desc, argv)
+	chg := st.NewChange("exec", desc)
+	chg.AddAll(ts)
+	st.EnsureBefore(0)
+	return AsyncResponse(nil, &Meta{Change: chg.ID()})
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2675,8 +2675,8 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 	// an option. That's a maximum of 3+len(appInfos).
 	argv := make([]string, 2, 3+len(appInfos))
 	argv[0] = "systemctl"
-	argv[1] = inst.Action
 
+	argv[1] = inst.Action
 	switch inst.Action {
 	case "start":
 		if inst.Enable {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6249,7 +6249,7 @@ func (s *appSuite) TestPosetAppsRestart(c *check.C) {
 func (s *appSuite) TestPosetAppsReload(c *check.C) {
 	inst := appInstruction{Action: "restart", Names: []string{"snap-a.svc2"}}
 	inst.Reload = true
-	args := []string{"systemctl", "try-reload-or-restart", "snap.snap-a.svc2.service"}
+	args := []string{"systemctl", "reload-or-restart", "snap.snap-a.svc2.service"}
 	s.testPostApps(c, inst, args)
 }
 
@@ -6332,7 +6332,7 @@ func (s *appSuite) TestPostAppsConflict(c *check.C) {
 	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "start", "names": ["snap-a.svc1"]}`))
 	c.Assert(err, check.IsNil)
 	rsp := postApps(appsCmd, req, nil).(*resp)
-	c.Check(rsp.Status, check.Equals, 409)
+	c.Check(rsp.Status, check.Equals, 500)
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `snap "snap-a" has changes in progress`)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6214,57 +6214,57 @@ func (s *appSuite) testPostApps(c *check.C, inst appInstruction, systemctlCall [
 
 func (s *appSuite) TestPostAppsStartOne(c *check.C) {
 	inst := appInstruction{Action: "start", Names: []string{"snap-a.svc2"}}
-	args := []string{"systemctl", "start", "snap.snap-a.svc2.service"}
-	s.testPostApps(c, inst, args)
+	expected := []string{"systemctl", "start", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, expected)
 }
 
 func (s *appSuite) TestPostAppsStartTwo(c *check.C) {
 	inst := appInstruction{Action: "start", Names: []string{"snap-a"}}
-	args := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service"}
-	chg := s.testPostApps(c, inst, args)
+	expected := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service"}
+	chg := s.testPostApps(c, inst, expected)
 	// check the summary expands the snap into actual apps
 	c.Check(chg.Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2]")
 }
 
 func (s *appSuite) TestPostAppsStartThree(c *check.C) {
 	inst := appInstruction{Action: "start", Names: []string{"snap-a", "snap-b"}}
-	args := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service", "snap.snap-b.svc3.service"}
-	chg := s.testPostApps(c, inst, args)
+	expected := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service", "snap.snap-b.svc3.service"}
+	chg := s.testPostApps(c, inst, expected)
 	// check the summary expands the snap into actual apps
 	c.Check(chg.Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2 snap-b.svc3]")
 }
 
 func (s *appSuite) TestPosetAppsStop(c *check.C) {
 	inst := appInstruction{Action: "stop", Names: []string{"snap-a.svc2"}}
-	args := []string{"systemctl", "stop", "snap.snap-a.svc2.service"}
-	s.testPostApps(c, inst, args)
+	expected := []string{"systemctl", "stop", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, expected)
 }
 
 func (s *appSuite) TestPosetAppsRestart(c *check.C) {
 	inst := appInstruction{Action: "restart", Names: []string{"snap-a.svc2"}}
-	args := []string{"systemctl", "restart", "snap.snap-a.svc2.service"}
-	s.testPostApps(c, inst, args)
+	expected := []string{"systemctl", "restart", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, expected)
 }
 
 func (s *appSuite) TestPosetAppsReload(c *check.C) {
 	inst := appInstruction{Action: "restart", Names: []string{"snap-a.svc2"}}
 	inst.Reload = true
-	args := []string{"systemctl", "reload-or-restart", "snap.snap-a.svc2.service"}
-	s.testPostApps(c, inst, args)
+	expected := []string{"systemctl", "reload-or-restart", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, expected)
 }
 
 func (s *appSuite) TestPosetAppsEnableNow(c *check.C) {
 	inst := appInstruction{Action: "start", Names: []string{"snap-a.svc2"}}
 	inst.Enable = true
-	args := []string{"systemctl", "enable", "--now", "snap.snap-a.svc2.service"}
-	s.testPostApps(c, inst, args)
+	expected := []string{"systemctl", "enable", "--now", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, expected)
 }
 
 func (s *appSuite) TestPosetAppsDisableNow(c *check.C) {
 	inst := appInstruction{Action: "stop", Names: []string{"snap-a.svc2"}}
 	inst.Disable = true
-	args := []string{"systemctl", "disable", "--now", "snap.snap-a.svc2.service"}
-	s.testPostApps(c, inst, args)
+	expected := []string{"systemctl", "disable", "--now", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, expected)
 }
 
 func (s *appSuite) TestPostAppsBadJSON(c *check.C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2555,7 +2555,9 @@ func (s *apiSuite) TestSetConfBadSnap(c *check.C) {
 		"status":      "Not Found",
 		"result": map[string]interface{}{
 			"message": "no state entry for key",
-			"kind":    "snap-not-found"},
+			"kind":    "snap-not-found",
+			"value":   "config-snap",
+		},
 		"type": "error"})
 }
 
@@ -6184,4 +6186,128 @@ func (s *appSuite) TestLogsSad(c *check.C) {
 	rsp := getLogs(logsCmd, req, nil).(*resp)
 	c.Assert(rsp.Status, check.Equals, 500)
 	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+}
+
+func (s *appSuite) testPostApps(c *check.C, inst appInstruction, systemctlCall []string) *state.Change {
+	postBody, err := json.Marshal(inst)
+	c.Assert(err, check.IsNil)
+
+	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBuffer(postBody))
+	c.Assert(err, check.IsNil)
+
+	rsp := postApps(appsCmd, req, nil).(*resp)
+	c.Assert(rsp.Status, check.Equals, 202)
+	c.Assert(rsp.Type, check.Equals, ResponseTypeAsync)
+	c.Check(rsp.Change, check.Matches, `[0-9]+`)
+
+	st := s.d.overlord.State()
+	st.Lock()
+	chg := st.Change(rsp.Change)
+	c.Assert(chg, check.NotNil)
+	c.Check(chg.Tasks(), check.HasLen, 1)
+	st.Unlock()
+	<-chg.Ready()
+
+	c.Check(s.cmd.Calls(), check.DeepEquals, [][]string{systemctlCall})
+	return chg
+}
+
+func (s *appSuite) TestPostAppsStartOne(c *check.C) {
+	inst := appInstruction{Action: "start", Names: []string{"snap-a.svc2"}}
+	args := []string{"systemctl", "start", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, args)
+}
+
+func (s *appSuite) TestPostAppsStartTwo(c *check.C) {
+	inst := appInstruction{Action: "start", Names: []string{"snap-a"}}
+	args := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service"}
+	chg := s.testPostApps(c, inst, args)
+	// check the summary expands the snap into actual apps
+	c.Check(chg.Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2]")
+}
+
+func (s *appSuite) TestPostAppsStartThree(c *check.C) {
+	inst := appInstruction{Action: "start", Names: []string{"snap-a", "snap-b"}}
+	args := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service", "snap.snap-b.svc3.service"}
+	chg := s.testPostApps(c, inst, args)
+	// check the summary expands the snap into actual apps
+	c.Check(chg.Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2 snap-b.svc3]")
+}
+
+func (s *appSuite) TestPosetAppsStop(c *check.C) {
+	inst := appInstruction{Action: "stop", Names: []string{"snap-a.svc2"}}
+	args := []string{"systemctl", "stop", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, args)
+}
+
+func (s *appSuite) TestPosetAppsRestart(c *check.C) {
+	inst := appInstruction{Action: "restart", Names: []string{"snap-a.svc2"}}
+	args := []string{"systemctl", "restart", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, args)
+}
+
+func (s *appSuite) TestPosetAppsReload(c *check.C) {
+	inst := appInstruction{Action: "restart", Names: []string{"snap-a.svc2"}}
+	inst.Reload = true
+	args := []string{"systemctl", "try-reload-or-restart", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, args)
+}
+
+func (s *appSuite) TestPosetAppsEnableNow(c *check.C) {
+	inst := appInstruction{Action: "start", Names: []string{"snap-a.svc2"}}
+	inst.Enable = true
+	args := []string{"systemctl", "enable", "--now", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, args)
+}
+
+func (s *appSuite) TestPosetAppsDisableNow(c *check.C) {
+	inst := appInstruction{Action: "stop", Names: []string{"snap-a.svc2"}}
+	inst.Disable = true
+	args := []string{"systemctl", "disable", "--now", "snap.snap-a.svc2.service"}
+	s.testPostApps(c, inst, args)
+}
+
+func (s *appSuite) TestPostAppsBadJSON(c *check.C) {
+	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`'junk`))
+	c.Assert(err, check.IsNil)
+	rsp := postApps(aliasesCmd, req, nil).(*resp)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Message, check.Matches, ".*cannot decode request body.*")
+}
+
+func (s *appSuite) TestPostAppsBadOp(c *check.C) {
+	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"random": "json"}`))
+	c.Assert(err, check.IsNil)
+	rsp := postApps(aliasesCmd, req, nil).(*resp)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Message, check.Matches, ".*cannot perform operation on services without a list of services.*")
+}
+
+func (s *appSuite) TestPostAppsBadSnap(c *check.C) {
+	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "stop", "names": ["snap-c"]}`))
+	c.Assert(err, check.IsNil)
+	rsp := postApps(aliasesCmd, req, nil).(*resp)
+	c.Check(rsp.Status, check.Equals, 404)
+	c.Check(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `snap "snap-c" has no services`)
+}
+
+func (s *appSuite) TestPostAppsBadApp(c *check.C) {
+	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "stop", "names": ["snap-a.what"]}`))
+	c.Assert(err, check.IsNil)
+	rsp := postApps(aliasesCmd, req, nil).(*resp)
+	c.Check(rsp.Status, check.Equals, 404)
+	c.Check(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `snap "snap-a" has no service "what"`)
+}
+
+func (s *appSuite) TestPostAppsBadAction(c *check.C) {
+	req, err := http.NewRequest("POST", "/v2/apps", bytes.NewBufferString(`{"action": "discombobulate", "names": ["snap-a.svc1"]}`))
+	c.Assert(err, check.IsNil)
+	rsp := postApps(aliasesCmd, req, nil).(*resp)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `unknown action "discombobulate"`)
 }

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -319,12 +319,13 @@ var (
 
 // SnapNotFound is an error responder used when an operation is
 // requested on a snap that doesn't exist.
-func SnapNotFound(err error) Response {
+func SnapNotFound(snapName string, err error) Response {
 	return &resp{
 		Type: ResponseTypeError,
 		Result: &errorResult{
 			Message: err.Error(),
 			Kind:    errorKindSnapNotFound,
+			Value:   snapName,
 		},
 		Status: 404,
 	}

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -269,7 +269,7 @@ func appInfosFor(st *state.State, names []string, opts appInfoOptions) ([]*snap.
 	for k := range requested {
 		if !found[k] {
 			if snapNames[k] {
-				return nil, SnapNotFound(fmt.Errorf("snap %q not found", k))
+				return nil, SnapNotFound(k, fmt.Errorf("snap %q not found", k))
 			} else {
 				snap, app := splitAppName(k)
 				return nil, AppNotFound("snap %q has no %s %q", snap, opts, app)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -299,13 +299,13 @@ func getPlugAndSlotRefs(task *state.Task) (*interfaces.PlugRef, *interfaces.Slot
 	return &plugRef, &slotRef, nil
 }
 
-// CheckChangeConflictMulti ensures that for the given snapNames no other
+// CheckChangeConflictMany ensures that for the given snapNames no other
 // changes that alters the snaps (like remove, install, refresh) are in
 // progress. If a conflict is detected an error is returned.
 //
 // It's like CheckChangeConflict, but for multiple snaps, and does not
 // check snapst.
-func CheckChangeConflictMulti(st *state.State, snapNames map[string]bool, checkConflictPredicate func(taskKind string) bool) error {
+func CheckChangeConflictMany(st *state.State, snapNames map[string]bool, checkConflictPredicate func(taskKind string) bool) error {
 	for _, chg := range st.Changes() {
 		if chg.Status().Ready() {
 			continue
@@ -354,7 +354,7 @@ func CheckChangeConflictMulti(st *state.State, snapNames map[string]bool, checkC
 // progress. It also ensures that snapst (if not nil) did not get
 // modified. If a conflict is detected an error is returned.
 func CheckChangeConflict(st *state.State, snapName string, checkConflictPredicate func(taskKind string) bool, snapst *SnapState) error {
-	if err := CheckChangeConflictMulti(st, map[string]bool{snapName: true}, checkConflictPredicate); err != nil {
+	if err := CheckChangeConflictMany(st, map[string]bool{snapName: true}, checkConflictPredicate); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -6808,20 +6808,20 @@ func (s *snapmgrTestSuite) TestConflictMany(c *C) {
 	}
 
 	// things that should be ok:
-	for _, m := range []map[string]bool{
+	for _, m := range [][]string{
 		{}, //nothing
-		{"c-snap": true},
-		{"c-snap": true, "d-snap": true, "e-snap": true, "f-snap": true},
+		{"c-snap"},
+		{"c-snap", "d-snap", "e-snap", "f-snap"},
 	} {
 		c.Check(snapstate.CheckChangeConflictMany(s.state, m, nil), IsNil)
 	}
 
 	// things that should not be ok:
-	for _, m := range []map[string]bool{
-		{"a-snap": true},
-		{"a-snap": true, "b-snap": true},
-		{"a-snap": true, "c-snap": true},
-		{"b-snap": true, "c-snap": true},
+	for _, m := range [][]string{
+		{"a-snap"},
+		{"a-snap", "b-snap"},
+		{"a-snap", "c-snap"},
+		{"b-snap", "c-snap"},
 	} {
 		c.Check(snapstate.CheckChangeConflictMany(s.state, m, nil), ErrorMatches, `snap "[^"]*" has changes in progress`)
 	}


### PR DESCRIPTION
This implements:

 * snap start [--enable] foo[.bar]...
 * snap stop [--disable] foo[.bar]...
 * snap restart [--reload] foo[.bar]...

Also it improves error messages for app-related commands by including
the snap name as the value of the snap-not-found error kind response.