### PR TITLE
interfaces: add common support for udev

### DIFF
--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -20,8 +20,53 @@
 package builtin
 
 import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/testutil"
 )
+
+type commonIfaceSuite struct{}
+
+var _ = Suite(&commonIfaceSuite{})
+
+func (s *commonIfaceSuite) TestUDevSpec(c *C) {
+	plug := MockPlug(c, `
+name: consumer
+apps:
+  app-a:
+    plugs: [common]
+  app-b:
+  app-c:
+    plugs: [common]
+`, nil, "common")
+	slot := MockSlot(c, `
+name: producer
+slots:
+  common:
+`, nil, "common")
+
+	// common interface can define connected plug udev rules
+	iface := &commonInterface{
+		name:              "common",
+		connectedPlugUDev: `KERNEL="foo", TAG+="###SLOT_SECURITY_TAGS###"`,
+	}
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(iface, plug, nil, slot, nil), IsNil)
+	c.Assert(spec.Snippets(), DeepEquals, []string{
+		`KERNEL="foo", TAG+="snap_consumer_app-a"`,
+		// NOTE: app-b is unaffected as it doesn't have a plug reference.
+		`KERNEL="foo", TAG+="snap_consumer_app-c"`,
+	})
+
+	// connected plug udev rules are optional
+	iface = &commonInterface{
+		name: "common",
+	}
+	spec = &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(iface, plug, nil, slot, nil), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 0)
+}
 
 // MockEvalSymlinks replaces the path/filepath.EvalSymlinks function used inside the caps package.
 func MockEvalSymlinks(test *testutil.BaseTest, fn func(string) (string, error)) {

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -22,7 +22,11 @@ package builtin
 import (
 	"fmt"
 
+	. "gopkg.in/check.v1"
+
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 var (
@@ -55,4 +59,20 @@ func MustInterface(name string) interfaces.Interface {
 		return iface
 	}
 	panic(fmt.Errorf("cannot find interface with name %q", name))
+}
+
+func MockPlug(c *C, yaml string, si *snap.SideInfo, plugName string) *interfaces.Plug {
+	info := snaptest.MockInfo(c, yaml, si)
+	if plugInfo, ok := info.Plugs[plugName]; ok {
+		return &interfaces.Plug{PlugInfo: plugInfo}
+	}
+	panic(fmt.Sprintf("cannot find plug %q in snap %q", plugName, info.Name()))
+}
+
+func MockSlot(c *C, yaml string, si *snap.SideInfo, slotName string) *interfaces.Slot {
+	info := snaptest.MockInfo(c, yaml, si)
+	if slotInfo, ok := info.Slots[slotName]; ok {
+		return &interfaces.Slot{SlotInfo: slotInfo}
+	}
+	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.Name()))
 }


### PR DESCRIPTION
Many interfaces will need to support udev-based device tagging. To
counter the explosion of custom interface types the common interface can
be grown to support per-app udev tags.

There's also some helper for testing, placed in export_test.go, since
common_test is not using builtin_test package. I'll clean that up
separately.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>