### PR TITLE
interfaces: convert broadcom-asic-control to common iface

### DIFF
--- a/interfaces/builtin/broadcom_asic_control.go
+++ b/interfaces/builtin/broadcom_asic_control.go
@@ -19,15 +19,6 @@
 
 package builtin
 
-import (
-	"strings"
-
-	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/apparmor"
-	"github.com/snapcore/snapd/interfaces/kmod"
-	"github.com/snapcore/snapd/interfaces/udev"
-)
-
 const broadcomAsicControlSummary = `allows using the broadcom-asic kernel module`
 
 const broadcomAsicControlBaseDeclarationSlots = `
@@ -37,6 +28,7 @@ const broadcomAsicControlBaseDeclarationSlots = `
         - core
     deny-auto-connection: true
 `
+
 const broadcomAsicControlConnectedPlugAppArmor = `
 # Description: Allow access to broadcom asic kernel module.
 
@@ -64,58 +56,16 @@ var broadcomAsicControlConnectedPlugKMod = []string{
 	"linux-bcm-knet",
 }
 
-// The type for broadcom-asic-control interface
-type broadcomAsicControlInterface struct{}
-
-// Getter for the name of the broadcom-asic-control interface
-func (iface *broadcomAsicControlInterface) Name() string {
-	return "broadcom-asic-control"
-}
-
-func (iface *broadcomAsicControlInterface) StaticInfo() interfaces.StaticInfo {
-	return interfaces.StaticInfo{
-		Summary:              broadcomAsicControlSummary,
-		ImplicitOnCore:       true,
-		ImplicitOnClassic:    true,
-		BaseDeclarationSlots: broadcomAsicControlBaseDeclarationSlots,
-	}
-}
-
-// Check validity of the defined slot
-func (iface *broadcomAsicControlInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return sanitizeSlotReservedForOS(iface, slot)
-}
-
-func (iface *broadcomAsicControlInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
-	spec.AddSnippet(broadcomAsicControlConnectedPlugAppArmor)
-	return nil
-}
-
-func (iface *broadcomAsicControlInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
-	old := "###SLOT_SECURITY_TAGS###"
-	for appName := range plug.Apps {
-		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
-		snippet := strings.Replace(broadcomAsicControlConnectedPlugUDev, old, tag, -1)
-		spec.AddSnippet(snippet)
-	}
-	return nil
-}
-
-func (iface *broadcomAsicControlInterface) KModConnectedPlug(spec *kmod.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
-	for _, kmod := range broadcomAsicControlConnectedPlugKMod {
-		if err := spec.AddModule(kmod); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (iface *broadcomAsicControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
-	// Allow what is allowed in the declarations; see https://github.com/snapcore/snapd/blob/master/interfaces/policy/basedeclaration.go
-	// for more details.
-	return true
-}
-
 func init() {
-	registerIface(&broadcomAsicControlInterface{})
+	registerIface(&commonInterface{
+		name:                     "broadcom-asic-control",
+		summary:                  broadcomAsicControlSummary,
+		implicitOnCore:           true,
+		implicitOnClassic:        true,
+		reservedForOS:            true,
+		baseDeclarationSlots:     broadcomAsicControlBaseDeclarationSlots,
+		connectedPlugAppArmor:    broadcomAsicControlConnectedPlugAppArmor,
+		connectedPlugKModModules: broadcomAsicControlConnectedPlugKMod,
+		connectedPlugUDev:        broadcomAsicControlConnectedPlugUDev,
+	})
 }


### PR DESCRIPTION
This patch uses the improved common interface to cut the amount of
boilerplate code that needs to exist in the builtin interfaces packae.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>