### PR TITLE
DO NOT REVIEW - tests: try to reproduce error preparing ubuntu core

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -46,24 +46,24 @@ backends:
         systems:
             - ubuntu-14.04-64:
                 kernel: GRUB 2
-                workers: 4
+                workers: 0
             - ubuntu-16.04-64:
                 kernel: GRUB 2
-                workers: 4
+                workers: 0
             - ubuntu-16.04-32:
                 kernel: GRUB 2
-                workers: 4
+                workers: 0
             - ubuntu-core-16-64:
                 kernel: Direct Disk
                 image: ubuntu-16.04-64
-                workers: 4
+                workers: 20
             - debian-unstable-64:
                 kernel: GRUB 2
-                workers: 4
+                workers: 0
             - fedora-25-64:
-                workers: 1
+                workers: 0
             - opensuse-42.2-64:
-                workers: 1
+                workers: 0
     qemu:
         systems:
             - ubuntu-14.04-32:
@@ -279,7 +279,7 @@ repack: |
         tar c current.delta >&4
     fi
 
-kill-timeout: 20m
+kill-timeout: 40m
 
 prepare: |
     # check if running inside a container, the testsuite will not
@@ -370,6 +370,7 @@ suites:
                     distro_purge_package snap-confine
                 fi
             fi
+            sleep 1800
 
     tests/completion/:
         summary: completion tests

--- a/spread.yaml
+++ b/spread.yaml
@@ -370,7 +370,7 @@ suites:
                     distro_purge_package snap-confine
                 fi
             fi
-            sleep 1800
+            sleep 1200
 
     tests/completion/:
         summary: completion tests


### PR DESCRIPTION
This change is gonna be used to reproduce error that occurs after
prepare ubuntu core and where there is a timeout trying to reboot the
os.

Please, dont review it, it will be closed as soon the error can be
reproduced.

This is an example of the error