### PR TITLE
tests: restore interfaces-account-control properly

### DIFF
--- a/tests/main/interfaces-account-control/task.yaml
+++ b/tests/main/interfaces-account-control/task.yaml
@@ -4,6 +4,8 @@ details: |
     This test makes sure that a snap using the account-control interface
     can handle the user accounts properly.
 
+systems: [ubuntu-core-16-64]
+
 prepare: |
     echo "Given a snap declaring a plug on account-control is installed"
     . $TESTSLIB/snaps.sh
@@ -12,7 +14,11 @@ prepare: |
     echo "And the account-control plug is connected"
     snap connect account-control-consumer:account-control
 
-systems: [ubuntu-core-16-64]
+restore: |
+    echo "Ensure alice is gone from the system"
+    for f in /var/lib/extrausers/*; do
+        sed -i '/^alice:/d' $f
+    done
 
 execute: |
     . $TESTSLIB/dirs.sh


### PR DESCRIPTION
When the test for interfaces-account-control runs twice it will
fail because the newly created "alice" user is not cleaned up.

Add the missing restore step for this.