### PR TITLE
cmd: mark arch as non-reexecing distro

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,7 +66,7 @@ func distroSupportsReExec() bool {
 		return false
 	}
 	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "opensuse", "suse", "poky":
+	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch":
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return false
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -145,7 +145,7 @@ func (s *cmdSuite) TestNonClassicDistroNoSupportsReExec(c *C) {
 	// no distro supports re-exec when not on classic :-)
 	for _, id := range []string{
 		"fedora", "centos", "rhel", "opensuse", "suse", "poky",
-		"debian", "ubuntu",
+		"debian", "ubuntu", "arch",
 	} {
 		restore = release.MockReleaseInfo(&release.OS{ID: id})
 		defer restore()


### PR DESCRIPTION
Arch doesn't re-execute because snap-confine has incompatible snap mount
directory compiled in and we cannot use the binary from core. This can
be fixed by building a communication channel from snapd to snap-confine
but earlier attempts were stuck on design.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>