### PR TITLE
interfaces/many, cmd/snap-confine: miscellaneous policy updates (#3634)

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -177,7 +177,7 @@
     mount options=(rw bind) /tmp/snap.rootfs_*/var/lib/snapd/hostfs/ -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
     mount options=(rw private) -> /tmp/snap.rootfs_*/var/lib/snapd/hostfs/,
     pivot_root,
-    # cleanup 
+    # cleanup
     umount /var/lib/snapd/hostfs/tmp/snap.rootfs_*/,
     umount /var/lib/snapd/hostfs/sys/,
     umount /var/lib/snapd/hostfs/dev/,
@@ -283,6 +283,14 @@
     mount options=(ro rbind) /snap/{,ubuntu-}core/*/var/lib/** -> /var/lib/**,
     umount /var/lib/snapd/,
     mount options=(move) /tmp/snapd.quirks_*/ -> /var/lib/snapd/,
+    # On classic systems with a setuid root snap-confine when run by non-root
+    # user, the mimic_dir is created with the gid of the calling user (ie,
+    # not '0') so when setting the permissions (chmod) of the mimicked
+    # directory to that of the reference directory, a CAP_FSETID is triggered.
+    # snap-confine sets the directory up correctly, so simply silence the
+    # denial since we don't want to grant the capability as a whole to
+    # snap-confine.
+    deny capability fsetid,
 
     # support for the LXD quirk
     mount options=(rw rbind nodev nosuid noexec) /var/lib/snapd/hostfs/var/lib/lxd/ -> /var/lib/lxd/,

--- a/interfaces/builtin/alsa.go
+++ b/interfaces/builtin/alsa.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -45,6 +45,10 @@ const alsaConnectedPlugAppArmor = `
 
 # Allow access to the alsa state dir
 /var/lib/alsa/{,*}         r,
+
+# Allow access to alsa /proc entries
+@{PROC}/asound/   r,
+@{PROC}/asound/** rw,
 `
 
 func init() {

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -38,6 +38,8 @@ const cameraConnectedPlugAppArmor = `
 /sys/devices/pci**/usb*/**/idVendor r,
 /sys/devices/pci**/usb*/**/idProduct r,
 /run/udev/data/c81:[0-9]* r, # video4linux (/dev/video*, etc)
+/sys/class/video4linux/ r,
+/sys/devices/pci**/usb*/**/video4linux/** r,
 `
 
 func init() {

--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -36,6 +36,25 @@ const firewallControlConnectedPlugAppArmor = `
 
 #include <abstractions/nameservice>
 
+# systemd-resolved (not yet included in nameservice abstraction)
+#
+# Allow access to the safe members of the systemd-resolved D-Bus API:
+#
+#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#
+# This API may be used directly over the D-Bus system bus or it may be used
+# indirectly via the nss-resolve plugin:
+#
+#   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
+#
+#include <abstractions/dbus-strict>
+dbus send
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="Resolve{Address,Hostname,Record,Service}"
+     peer=(name="org.freedesktop.resolve1"),
+
 capability net_admin,
 
 /{,usr/}{,s}bin/iptables{,-save,-restore} ixr,

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -110,6 +110,24 @@ const fwupdConnectedPlugAppArmor = `
   # DBus accesses
   #include <abstractions/dbus-strict>
 
+  # systemd-resolved (not yet included in nameservice abstraction)
+  #
+  # Allow access to the safe members of the systemd-resolved D-Bus API:
+  #
+  #   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+  #
+  # This API may be used directly over the D-Bus system bus or it may be used
+  # indirectly via the nss-resolve plugin:
+  #
+  #   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
+  #
+  dbus send
+       bus=system
+       path="/org/freedesktop/resolve1"
+       interface="org.freedesktop.resolve1.Manager"
+       member="Resolve{Address,Hostname,Record,Service}"
+       peer=(name="org.freedesktop.resolve1"),
+
   # Allow access to fwupd service
   dbus (receive, send)
       bus=system

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -73,6 +73,24 @@ include <abstractions/nameservice>
 # DBus accesses
 include <abstractions/dbus-strict>
 
+# systemd-resolved (not yet included in nameservice abstraction)
+#
+# Allow access to the safe members of the systemd-resolved D-Bus API:
+#
+#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#
+# This API may be used directly over the D-Bus system bus or it may be used
+# indirectly via the nss-resolve plugin:
+#
+#   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
+#
+dbus send
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="Resolve{Address,Hostname,Record,Service}"
+     peer=(name="org.freedesktop.resolve1"),
+
 dbus (send)
    bus=system
    path=/org/freedesktop/DBus

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -38,6 +38,26 @@ The core snap provides the slot that is shared by all the snaps.
 const networkConnectedPlugAppArmor = `
 # Description: Can access the network as a client.
 #include <abstractions/nameservice>
+
+# systemd-resolved (not yet included in nameservice abstraction)
+#
+# Allow access to the safe members of the systemd-resolved D-Bus API:
+#
+#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#
+# This API may be used directly over the D-Bus system bus or it may be used
+# indirectly via the nss-resolve plugin:
+#
+#   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
+#
+#include <abstractions/dbus-strict>
+dbus send
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="Resolve{Address,Hostname,Record,Service}"
+     peer=(name="org.freedesktop.resolve1"),
+
 #include <abstractions/ssl_certs>
 
 @{PROC}/sys/net/core/somaxconn r,

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -32,6 +32,26 @@ const networkBindBaseDeclarationSlots = `
 const networkBindConnectedPlugAppArmor = `
 # Description: Can access the network as a server.
 #include <abstractions/nameservice>
+
+# systemd-resolved (not yet included in nameservice abstraction)
+#
+# Allow access to the safe members of the systemd-resolved D-Bus API:
+#
+#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#
+# This API may be used directly over the D-Bus system bus or it may be used
+# indirectly via the nss-resolve plugin:
+#
+#   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
+#
+#include <abstractions/dbus-strict>
+dbus send
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="Resolve{Address,Hostname,Record,Service}"
+     peer=(name="org.freedesktop.resolve1"),
+
 #include <abstractions/ssl_certs>
 
 # These probably shouldn't be something that apps should use, but this offers

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -36,6 +36,26 @@ const networkControlConnectedPlugAppArmor = `
 # trusted apps.
 
 #include <abstractions/nameservice>
+
+# systemd-resolved (not yet included in nameservice abstraction)
+#
+# Allow access to the safe members of the systemd-resolved D-Bus API:
+#
+#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#
+# This API may be used directly over the D-Bus system bus or it may be used
+# indirectly via the nss-resolve plugin:
+#
+#   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
+#
+#include <abstractions/dbus-strict>
+dbus send
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="Resolve{Address,Hostname,Record,Service}"
+     peer=(name="org.freedesktop.resolve1"),
+
 #include <abstractions/ssl_certs>
 
 capability net_admin,
@@ -102,6 +122,9 @@ network sna,
 /{,usr/}{,s}bin/wpa_supplicant ixr,
 
 /dev/rfkill rw,
+/sys/class/rfkill/ r,
+/sys/devices/{pci[0-9]*,platform,virtual}/**/rfkill[0-9]*/{,**} r,
+/sys/devices/{pci[0-9]*,platform,virtual}/**/rfkill[0-9]*/state w,
 
 # arp
 network netlink dgram,

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -122,6 +122,24 @@ deny ptrace (trace) peer=###PLUG_SECURITY_TAGS###,
 # DBus accesses
 #include <abstractions/dbus-strict>
 
+# systemd-resolved (not yet included in nameservice abstraction)
+#
+# Allow access to the safe members of the systemd-resolved D-Bus API:
+#
+#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#
+# This API may be used directly over the D-Bus system bus or it may be used
+# indirectly via the nss-resolve plugin:
+#
+#   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
+#
+dbus send
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="Resolve{Address,Hostname,Record,Service}"
+     peer=(name="org.freedesktop.resolve1"),
+
 dbus (send)
    bus=system
    path=/org/freedesktop/DBus

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -41,6 +41,26 @@ const networkObserveConnectedPlugAppArmor = `
 #capability net_admin,
 
 #include <abstractions/nameservice>
+
+# systemd-resolved (not yet included in nameservice abstraction)
+#
+# Allow access to the safe members of the systemd-resolved D-Bus API:
+#
+#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#
+# This API may be used directly over the D-Bus system bus or it may be used
+# indirectly via the nss-resolve plugin:
+#
+#   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
+#
+#include <abstractions/dbus-strict>
+dbus send
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="Resolve{Address,Hostname,Record,Service}"
+     peer=(name="org.freedesktop.resolve1"),
+
 #include <abstractions/ssl_certs>
 
 @{PROC}/@{pid}/net/ r,

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -92,6 +92,24 @@ include <abstractions/nameservice>
 # DBus accesses
 include <abstractions/dbus-strict>
 
+# systemd-resolved (not yet included in nameservice abstraction)
+#
+# Allow access to the safe members of the systemd-resolved D-Bus API:
+#
+#   https://www.freedesktop.org/wiki/Software/systemd/resolved/
+#
+# This API may be used directly over the D-Bus system bus or it may be used
+# indirectly via the nss-resolve plugin:
+#
+#   https://www.freedesktop.org/software/systemd/man/nss-resolve.html
+#
+dbus send
+     bus=system
+     path="/org/freedesktop/resolve1"
+     interface="org.freedesktop.resolve1.Manager"
+     member="Resolve{Address,Hostname,Record,Service}"
+     peer=(name="org.freedesktop.resolve1"),
+
 dbus (send)
     bus=system
     path=/org/freedesktop/DBus

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -29,6 +29,7 @@ const opticalDriveBaseDeclarationSlots = `
 `
 
 const opticalDriveConnectedPlugAppArmor = `
+# Allow read access to optical drives
 /dev/sr[0-9]* r,
 /dev/scd[0-9]* r,
 @{PROC}/sys/dev/cdrom/info r,


### PR DESCRIPTION
* interfaces/many: for interfaces using nameservice abstraction, allow resolved

The AppArmor nameservice abstraction does not yet include access to
systemd-resolved, but certain distributions like Ubuntu configure nsswitch.conf
to use it. On these systems, name resolution via resolved will be denied.
Adjust all interfaces that include the nameservice abstraction to allow
resolved. Organizationally, any interfaces without DBus rules put this under
the nameservice include and interfaces with DBus rules put this under the
'DBus accesses' section (ie, below the dbus-strict include).

References: https://lists.ubuntu.com/archives/apparmor/2016-October/010130.html

* interfaces/alsa: allow rw access to /proc/asound

* interfaces/optical-drive: add comment in apparmor policy

* interfaces/camera: allow read access to video4linux sysfs entries

* cmd/snap-confine: silence harmless fsetid denial

* interfaces/network-control: allow reading rfkill sysfs entries

* interfaces/network-control: also allow writing to rfkill state file