### PR TITLE
interfaces/greengrass-support: adjust accesses now that have working …

### DIFF
--- a/interfaces/builtin/greengrass_support.go
+++ b/interfaces/builtin/greengrass_support.go
@@ -86,7 +86,7 @@ capability dac_read_search,
 capability sys_admin,
 capability dac_override,  # for various overlayfs accesses
 
-owner @{PROC}/[0-9]*/mountinfo r,
+@{PROC}/[0-9]*/mountinfo r,
 @{PROC}/filesystems r,
 
 # setup the overlay so we may pivot_root into it
@@ -128,11 +128,12 @@ mount options=(rw, bind) /dev/null -> /proc/sched_debug,
 mount options=(rw, bind) /dev/null -> /proc/timer_stats,
 
 # perform the pivot_root into the overlay
-pivot_root oldroot=/var/snap/greengrass/x1/rootfs/.pivot_root*/ /var/snap/greengrass/*/rootfs/,
+pivot_root oldroot=/var/snap/greengrass/@{SNAP_REVISION}/rootfs/.pivot_root*/ /var/snap/greengrass/*/rootfs/,
 mount options=(rw, rprivate) -> /.pivot_root*/,
 umount /.pivot_root*/,
 owner /.pivot_root*/ w,
 mount options=(rw, rprivate) -> /,
+mount options=(ro, remount, rbind) -> /,
 
 # allow tearing down the overlay
 umount /var/snap/@{SNAP_NAME}/**,


### PR DESCRIPTION
…snap

- don't use owner match with @{PROC}/[0-9]*/mountinfo
- use @{SNAP_REVISION} with pivot_root rule
- allow 'ro, remount, rbind' on / for pivot_root in overlay