### PR TITLE
update 'Get in touch' links to Rocket and forums

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ If you have found an issue with the application, please [file a bug](https://bug
 
 ## Get in touch
 
-We're friendly! Talk to us on [IRC](https://webchat.freenode.net/?channels=snappy)
-or on [our mailing list](https://lists.snapcraft.io/mailman/listinfo/snapcraft).
+We're friendly! Talk to us on [Rocket Chat](https://rocket.ubuntu.com/channel/snapcraft) 
+or on [our forums](https://forum.snapcraft.io/).
 
 Get news and stay up to date on [Twitter](https://twitter.com/snapcraftio),
 [Google+](https://plus.google.com/+SnapcraftIo) or

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ If you have found an issue with the application, please [file a bug](https://bug
 
 ## Get in touch
 
-We're friendly! Talk to us on [Rocket Chat](https://rocket.ubuntu.com/channel/snapcraft) 
+We're friendly! Talk to us on 
+[IRC](https://webchat.freenode.net/?channels=snappy),
+[Rocket Chat](https://rocket.ubuntu.com/channel/snappy),
 or on [our forums](https://forum.snapcraft.io/).
 
 Get news and stay up to date on [Twitter](https://twitter.com/snapcraftio),


### PR DESCRIPTION
Previously the links in the 'Get in touch' section pointed to IRC and the mailing list but now Rocket and the forums are used, this commit updates the links to the new mediums of communication.

See my merged PR for the snapcraft repository [here](https://github.com/snapcore/snapcraft/pull/1268). I should've merged it into the snapd repository earlier so sorry about that.