### PR TITLE
Improve the test for physical memory control and observe interface.

### DIFF
--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -28,7 +28,6 @@ import (
 
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -42,26 +41,21 @@ var _ = Suite(&PhysicalMemoryObserveInterfaceSuite{
 	iface: builtin.MustInterface("physical-memory-observe"),
 })
 
-func (s *PhysicalMemoryObserveInterfaceSuite) SetUpTest(c *C) {
-	// Mock for OS Snap
-	osSnapInfo := snaptest.MockInfo(c, `
-name: ubuntu-core
+const physicalMemoryObserveConsumerYaml = `name: consumer
+apps:
+ app:
+  plugs: [physical-memory-observe]
+`
+
+const physicalMemoryObserveCoreYaml = `name: core
 type: os
 slots:
-  test-physical-memory:
-    interface: physical-memory-observe
-`, nil)
-	s.slot = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["test-physical-memory"]}
+  physical-memory-observe:
+`
 
-	// Snap Consumers
-	consumingSnapInfo := snaptest.MockInfo(c, `
-name: client-snap
-apps:
-  app-accessing-physical-memory:
-    command: foo
-    plugs: [physical-memory-observe]
-`, nil)
-	s.plug = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["physical-memory-observe"]}
+func (s *PhysicalMemoryObserveInterfaceSuite) SetUpTest(c *C) {
+	s.plug = MockPlug(c, physicalMemoryObserveConsumerYaml, nil, "physical-memory-observe")
+	s.slot = MockSlot(c, physicalMemoryObserveCoreYaml, nil, "physical-memory-observe")
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestName(c *C) {
@@ -83,29 +77,36 @@ func (s *PhysicalMemoryObserveInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
-func (s *PhysicalMemoryObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	expectedSnippet1 := `
+func (s *PhysicalMemoryObserveInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, `
 # Description: With kernels with STRICT_DEVMEM=n, read-only access to all physical
 # memory. With STRICT_DEVMEM=y, allow reading /dev/mem for read-only
 # access to architecture-specific subset of the physical address (eg, PCI,
 # space, BIOS code and data regions on x86, etc).
 /dev/mem r,
-`
-	expectedSnippet2 := `KERNEL=="mem", TAG+="snap_client-snap_app-accessing-physical-memory"`
+`)
+}
 
-	// connected plugs have a non-nil security snippet for apparmor
-	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-physical-memory"})
-	aasnippet := apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-physical-memory")
-	c.Assert(aasnippet, Equals, expectedSnippet1, Commentf("\nexpected:\n%s\nfound:\n%s", expectedSnippet1, aasnippet))
-
+func (s *PhysicalMemoryObserveInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 1)
-	snippet := spec.Snippets()[0]
-	c.Assert(snippet, DeepEquals, expectedSnippet2)
+	c.Assert(spec.Snippets()[0], DeepEquals, `KERNEL=="mem", TAG+="snap_consumer_app"`)
+}
+
+func (s *PhysicalMemoryObserveInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows read access to all physical memory`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "physical-memory-observe")
+}
+
+func (s *PhysicalMemoryObserveInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plug, s.slot), Equals, true)
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
* Utilize MockPlug/MockSlot to setup slot and plug.
* Test security backend specs one by one(TestAppArmorSpec, TestUDevSpec))