### PR TITLE
interfaces/wayland: add wayland interface

### DIFF
--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const waylandSummary = `allows access to compositors supporting wayland protocol`
+
+const waylandBaseDeclarationSlots = `
+  wayland:
+    allow-installation:
+      slot-snap-type:
+        - core
+`
+
+const waylandConnectedPlugAppArmor = `
+# Description: Can access compositors supporting the wayland protocol
+
+# Allow access to the wayland compsitor server socket
+owner /run/user/*/wayland-[0-9]* rw,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "wayland",
+		summary:               waylandSummary,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  waylandBaseDeclarationSlots,
+		connectedPlugAppArmor: waylandConnectedPlugAppArmor,
+		reservedForOS:         true,
+	})
+}

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -26,38 +26,34 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type WaylandInterfaceSuite struct {
-	iface interfaces.Interface
-	slot  *interfaces.Slot
-	plug  *interfaces.Plug
+	iface    interfaces.Interface
+	coreSlot *interfaces.Slot
+	plug     *interfaces.Plug
 }
-
-const waylandMockPlugSnapInfoYaml = `name: other
-version: 1.0
-apps:
- app2:
-  command: foo
-  plugs: [wayland]
-`
 
 var _ = Suite(&WaylandInterfaceSuite{
 	iface: builtin.MustInterface("wayland"),
 })
 
+const waylandConsumerYaml = `name: consumer
+apps:
+ app:
+  plugs: [wayland]
+`
+
+const waylandCoreYaml = `name: core
+type: os
+slots:
+  wayland:
+`
+
 func (s *WaylandInterfaceSuite) SetUpTest(c *C) {
-	s.slot = &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
-			Name:      "wayland",
-			Interface: "wayland",
-		},
-	}
-	plugSnap := snaptest.MockInfo(c, waylandMockPlugSnapInfoYaml, nil)
-	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["wayland"]}
+	s.plug = MockPlug(c, waylandConsumerYaml, nil, "wayland")
+	s.coreSlot = MockSlot(c, waylandCoreYaml, nil, "wayland")
 }
 
 func (s *WaylandInterfaceSuite) TestName(c *C) {
@@ -65,7 +61,8 @@ func (s *WaylandInterfaceSuite) TestName(c *C) {
 }
 
 func (s *WaylandInterfaceSuite) TestSanitizeSlot(c *C) {
-	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	c.Assert(s.coreSlot.Sanitize(s.iface), IsNil)
+	// wayland slot currently only used with core
 	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "wayland",
@@ -79,13 +76,25 @@ func (s *WaylandInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
-func (s *WaylandInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	// connected plugs have a non-nil security snippet for apparmor
-	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
-	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `owner /run/user/*/wayland-[0-9]* rw,`)
+func (s *WaylandInterfaceSuite) TestAppArmorSpec(c *C) {
+	// connected plug to core slot
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.coreSlot, nil), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/*/wayland-[0-9]* rw,")
+
+	// connected plug to core slot
+	spec = &apparmor.Specification{}
+	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, nil, s.coreSlot, nil), IsNil)
+	c.Assert(spec.SecurityTags(), HasLen, 0)
+}
+
+func (s *WaylandInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to compositors supporting wayland protocol`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "wayland")
 }
 
 func (s *WaylandInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -1,0 +1,93 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type WaylandInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+const waylandMockPlugSnapInfoYaml = `name: other
+version: 1.0
+apps:
+ app2:
+  command: foo
+  plugs: [wayland]
+`
+
+var _ = Suite(&WaylandInterfaceSuite{
+	iface: builtin.MustInterface("wayland"),
+})
+
+func (s *WaylandInterfaceSuite) SetUpTest(c *C) {
+	s.slot = &interfaces.Slot{
+		SlotInfo: &snap.SlotInfo{
+			Snap:      &snap.Info{SuggestedName: "core", Type: snap.TypeOS},
+			Name:      "wayland",
+			Interface: "wayland",
+		},
+	}
+	plugSnap := snaptest.MockInfo(c, waylandMockPlugSnapInfoYaml, nil)
+	s.plug = &interfaces.Plug{PlugInfo: plugSnap.Plugs["wayland"]}
+}
+
+func (s *WaylandInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "wayland")
+}
+
+func (s *WaylandInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "wayland",
+		Interface: "wayland",
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"wayland slots are reserved for the core snap")
+}
+
+func (s *WaylandInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
+}
+
+func (s *WaylandInterfaceSuite) TestUsedSecuritySystems(c *C) {
+	// connected plugs have a non-nil security snippet for apparmor
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, `owner /run/user/*/wayland-[0-9]* rw,`)
+}
+
+func (s *WaylandInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -155,6 +155,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		"unity7":                  true,
 		"unity8":                  true,
 		"upower-observe":          true,
+		"wayland":                 true,
 		"x11":                     true,
 	}
 


### PR DESCRIPTION
This implicit classic interface is very simple-- add an AppArmor rule for `owner /run/user/*/wayland-[0-9]* rw,` and have the base declaration allow anyone to autoconnect to it.

The previous investigative PR tried to undo snapd's setting of XDG_RUNTIME_DIR, but [this is no longer required](https://forum.snapcraft.io/t/wayland-dconf-and-xdg-runtime-dir/186/10). Because we aren't changing XDG_RUNTIME_DIR, there is no risk in breaking existing clients, but clients won't be able to find the wayland server socket [without a little help](https://github.com/ubuntu/snapcraft-desktop-helpers/pull/68). The help given is similar to what the desktop part is doing for dconf and thus acceptable for now, IMO.

Future iterations of the interface might build upon the [portals](https://forum.snapcraft.io/t/xdg-desktop-portal-proof-of-concept-demo/1027) work and be part of the [per-user mounts that is being discussed](https://forum.snapcraft.io/t/ubuntu-desktop-team-priorities/1397/2). This PR does not introduce complications for that work.