### PR TITLE
tests: installing snapd for nested test suite

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -516,7 +516,7 @@ suites:
         prepare: |
             . $TESTSLIB/pkgdb.sh
             distro_update_package_db
-            distro_install_package qemu genisoimage sshpass
+            distro_install_package snapd qemu genisoimage sshpass
             snap install --classic --beta ubuntu-image
         restore: |
             . $TESTSLIB/pkgdb.sh


### PR DESCRIPTION
snapd is needed to be installed in the prepare of the nested test suite.
Currently the nightly tests are failing because it is not finding the
snap command.

Before it was being installed, but at some point there was a regression
which was not detected. 

Error:
https://travis-ci.org/snapcore/spread-cron/builds/262070615