### PR TITLE
snapstate: improve the error message when classic confinement is not supported

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -125,12 +125,14 @@ func SupportsClassicConfinement() bool {
 		return true
 	}
 
-	// distros with a non-default /snap location may still be good if
-	// there is a symlink in place
-	fi, err := os.Lstat(defaultSnapMountDir)
+	// distros with a non-default /snap location may still be good
+	// if there is a symlink in place that links from the
+	// defaultSnapMountDir (/snap) to the distro specific mount dir
+	smd := filepath.Join(GlobalRootDir, defaultSnapMountDir)
+	fi, err := os.Lstat(smd)
 	if err == nil && fi.Mode()&os.ModeSymlink != 0 {
-		if target, err := filepath.EvalSymlinks(defaultSnapMountDir); err == nil {
-			if target == defaultSnapMountDir {
+		if target, err := filepath.EvalSymlinks(smd); err == nil {
+			if target == SnapMountDir {
 				return true
 			}
 		}

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -121,7 +121,22 @@ func StripRootDir(dir string) string {
 
 // SupportsClassicConfinement returns true if the current directory layout supports classic confinement.
 func SupportsClassicConfinement() bool {
-	return SnapMountDir == defaultSnapMountDir
+	if SnapMountDir == defaultSnapMountDir {
+		return true
+	}
+
+	// distros with a non-default /snap location may still be good if
+	// there is a symlink in place
+	fi, err := os.Lstat(defaultSnapMountDir)
+	if err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		if target, err := filepath.EvalSymlinks(defaultSnapMountDir); err == nil {
+			if target == defaultSnapMountDir {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // SetRootDir allows settings a new global root directory, this is useful

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -54,9 +54,9 @@ func (s *DirsTestSuite) TestClassicConfinementSupport(c *C) {
 	reset := release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
 	defer reset()
 	dirs.SetRootDir("/")
-	c.Assert(dirs.SupportsClassicConfinement(), Equals, true)
+	c.Check(dirs.SupportsClassicConfinement(), Equals, true)
 	dirs.SetRootDir("/alt")
-	c.Assert(dirs.SupportsClassicConfinement(), Equals, false)
+	c.Check(dirs.SupportsClassicConfinement(), Equals, false)
 }
 
 func (s *DirsTestSuite) TestClassicConfinementSupportOnSpecificDistributions(c *C) {

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -20,6 +20,8 @@
 package dirs_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -55,8 +57,24 @@ func (s *DirsTestSuite) TestClassicConfinementSupport(c *C) {
 	defer reset()
 	dirs.SetRootDir("/")
 	c.Check(dirs.SupportsClassicConfinement(), Equals, true)
+
 	dirs.SetRootDir("/alt")
+	defer dirs.SetRootDir("/")
 	c.Check(dirs.SupportsClassicConfinement(), Equals, false)
+}
+
+func (s *DirsTestSuite) TestClassicConfinementSymlinkWorkaround(c *C) {
+	restore := release.MockReleaseInfo(&release.OS{ID: "fedora"})
+	defer restore()
+
+	altRoot := c.MkDir()
+	dirs.SetRootDir(altRoot)
+	defer dirs.SetRootDir("/")
+	c.Check(dirs.SupportsClassicConfinement(), Equals, false)
+	d := filepath.Join(altRoot, "/var/lib/snapd/snap")
+	os.MkdirAll(d, 0755)
+	os.Symlink(d, filepath.Join(altRoot, "snap"))
+	c.Check(dirs.SupportsClassicConfinement(), Equals, true)
 }
 
 func (s *DirsTestSuite) TestClassicConfinementSupportOnSpecificDistributions(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -64,7 +64,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		if !release.OnClassic {
 			return nil, fmt.Errorf("classic confinement is only supported on classic systems")
 		} else if !dirs.SupportsClassicConfinement() {
-			return nil, fmt.Errorf("classic confinement is not yet supported on your distribution")
+			return nil, fmt.Errorf("Your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from %s to /snap", dirs.SnapMountDir)
 		}
 	}
 	if !snapst.HasCurrent() { // install?

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -64,7 +64,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		if !release.OnClassic {
 			return nil, fmt.Errorf("classic confinement is only supported on classic systems")
 		} else if !dirs.SupportsClassicConfinement() {
-			return nil, fmt.Errorf(i18n.G("classic confinement requires snaps under /snap or symlink from %s to /snap"), dirs.SnapMountDir)
+			return nil, fmt.Errorf(i18n.G("classic confinement requires snaps under /snap or symlink from /snap to %s"), dirs.SnapMountDir)
 		}
 	}
 	if !snapst.HasCurrent() { // install?

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -64,7 +64,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		if !release.OnClassic {
 			return nil, fmt.Errorf("classic confinement is only supported on classic systems")
 		} else if !dirs.SupportsClassicConfinement() {
-			return nil, fmt.Errorf("Your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from %s to /snap", dirs.SnapMountDir)
+			return nil, fmt.Errorf(i18n.G("your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from %s to /snap"), dirs.SnapMountDir)
 		}
 	}
 	if !snapst.HasCurrent() { // install?

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -64,7 +64,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		if !release.OnClassic {
 			return nil, fmt.Errorf("classic confinement is only supported on classic systems")
 		} else if !dirs.SupportsClassicConfinement() {
-			return nil, fmt.Errorf(i18n.G("your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from %s to /snap"), dirs.SnapMountDir)
+			return nil, fmt.Errorf(i18n.G("classic confinement requires snaps under /snap or symlink from %s to /snap"), dirs.SnapMountDir)
 		}
 	}
 	if !snapst.HasCurrent() { // install?

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -350,7 +350,7 @@ func (s *snapmgrTestSuite) TestInstallFailsWhenClassicSnapsAreNotSupported(c *C)
 
 	_, err := snapstate.Install(s.state, "some-snap", "channel-for-classic", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
 	c.Assert(err, Not(IsNil))
-	c.Assert(err, DeepEquals, fmt.Errorf("classic confinement requires snaps under /snap or symlink from /snap to %s"))
+	c.Assert(err, DeepEquals, fmt.Errorf("classic confinement requires snaps under /snap or symlink from /snap to /var/lib/snapd/snap"))
 }
 
 func (s *snapmgrTestSuite) TestInstallTasks(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -350,7 +350,7 @@ func (s *snapmgrTestSuite) TestInstallFailsWhenClassicSnapsAreNotSupported(c *C)
 
 	_, err := snapstate.Install(s.state, "some-snap", "channel-for-classic", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
 	c.Assert(err, Not(IsNil))
-	c.Assert(err, DeepEquals, fmt.Errorf("classic confinement is not yet supported on your distribution"))
+	c.Assert(err, DeepEquals, fmt.Errorf("your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from /var/lib/snapd/snap to /snap"))
 }
 
 func (s *snapmgrTestSuite) TestInstallTasks(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -350,7 +350,7 @@ func (s *snapmgrTestSuite) TestInstallFailsWhenClassicSnapsAreNotSupported(c *C)
 
 	_, err := snapstate.Install(s.state, "some-snap", "channel-for-classic", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
 	c.Assert(err, Not(IsNil))
-	c.Assert(err, DeepEquals, fmt.Errorf("your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from /var/lib/snapd/snap to /snap"))
+	c.Assert(err, DeepEquals, fmt.Errorf("classic confinement requires snaps under /snap or symlink from /snap to %s"))
 }
 
 func (s *snapmgrTestSuite) TestInstallTasks(c *C) {

--- a/tests/main/classic-confinement-not-supported/task.yaml
+++ b/tests/main/classic-confinement-not-supported/task.yaml
@@ -26,13 +26,13 @@ execute: |
     echo "Check that the classic snap is not installable even with --classic"
     EXPECTED_TEXT="cannot install snap file: classic confinement is only supported on classic systems"
     if [[ "$SPREAD_SYSTEM" = fedora-* ]]; then
-        EXPECTED_TEXT="classic confinement is not yet supported on your distribution"
+        EXPECTED_TEXT="your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from /var/lib/snapd/snap to /snap"
     fi
     str_to_one_line "$( snap install --dangerous --classic "${CLASSIC_SNAP}_1.0_all.snap" 2>&1 && exit 1 || true )" | MATCH "$EXPECTED_TEXT"
 
     echo "Not from the store either"
     EXPECTED_TEXT="snap \"$CLASSIC_SNAP\" requires classic confinement which is only available on classic systems"
     if [[ "$SPREAD_SYSTEM" = fedora-* ]]; then
-        EXPECTED_TEXT="cannot install \"$CLASSIC_SNAP\": classic confinement is not yet supported on your distribution"
+        EXPECTED_TEXT="cannot install \"$CLASSIC_SNAP\": your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from /var/lib/snapd/snap to /snap"
     fi
     str_to_one_line "$( snap install --classic "$CLASSIC_SNAP" 2>&1 && exit 1 || true )" | MATCH "$EXPECTED_TEXT"

--- a/tests/main/classic-confinement-not-supported/task.yaml
+++ b/tests/main/classic-confinement-not-supported/task.yaml
@@ -26,13 +26,13 @@ execute: |
     echo "Check that the classic snap is not installable even with --classic"
     EXPECTED_TEXT="cannot install snap file: classic confinement is only supported on classic systems"
     if [[ "$SPREAD_SYSTEM" = fedora-* ]]; then
-        EXPECTED_TEXT="your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from /var/lib/snapd/snap to /snap"
+        EXPECTED_TEXT="classic confinement requires snaps under /snap or symlink from /snap to /var/lib/snapd/snap"
     fi
     str_to_one_line "$( snap install --dangerous --classic "${CLASSIC_SNAP}_1.0_all.snap" 2>&1 && exit 1 || true )" | MATCH "$EXPECTED_TEXT"
 
     echo "Not from the store either"
     EXPECTED_TEXT="snap \"$CLASSIC_SNAP\" requires classic confinement which is only available on classic systems"
     if [[ "$SPREAD_SYSTEM" = fedora-* ]]; then
-        EXPECTED_TEXT="cannot install \"$CLASSIC_SNAP\": your distribution choose a directory layout incompatible with classic confinement. You can fix this yourself by setting a symlink from /var/lib/snapd/snap to /snap"
+        EXPECTED_TEXT="cannot install \"$CLASSIC_SNAP\": classic confinement requires snaps under /snap or symlink from /snap to /var/lib/snapd/snap"
     fi
     str_to_one_line "$( snap install --classic "$CLASSIC_SNAP" 2>&1 && exit 1 || true )" | MATCH "$EXPECTED_TEXT"


### PR DESCRIPTION
Also allow to workaround a different layout from classic via a
symlink.

This is a RFC branch, I will update tests and add new tests *if* there is agreement on the idea. We talked about it during the last sprint that it would be nice to give people who use a different layout than /snap for snaps a way out to still use classic confined snaps. This branch tries to accomplish this via a better error message and also by supporting a symlink from $otherSnapMountDir to /snap.