### PR TITLE
wrappers, overlord/snapstate/backend: make link-snap clean up on failure.

### DIFF
--- a/overlord/snapstate/backend/link.go
+++ b/overlord/snapstate/backend/link.go
@@ -89,10 +89,13 @@ func generateWrappers(s *snap.Info) error {
 	}
 	// add the daemons from the snap.yaml
 	if err := wrappers.AddSnapServices(s, &progress.NullProgress{}); err != nil {
+		wrappers.RemoveSnapBinaries(s)
 		return err
 	}
 	// add the desktop files
 	if err := wrappers.AddSnapDesktopFiles(s); err != nil {
+		wrappers.RemoveSnapServices(s, &progress.NullProgress{})
+		wrappers.RemoveSnapBinaries(s)
 		return err
 	}
 

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -81,3 +81,19 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 
 	c.Check(osutil.FileExists(link), Equals, false)
 }
+
+func (s *binariesTestSuite) TestAddSnapBinariesCleansUpOnFailure(c *C) {
+	link := filepath.Join(dirs.SnapBinariesDir, "hello-snap.hello")
+	c.Assert(osutil.FileExists(link), Equals, false)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.SnapBinariesDir, "hello-snap.bye", "potato"), 0755), IsNil)
+
+	info := snaptest.MockSnap(c, packageHello+`
+ bye:
+  command: bin/bye
+`, contentsHello, &snap.SideInfo{Revision: snap.R(11)})
+
+	err := wrappers.AddSnapBinaries(info)
+	c.Assert(err, NotNil)
+
+	c.Check(osutil.FileExists(link), Equals, false)
+}

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -171,7 +171,18 @@ func updateDesktopDatabase(desktopFiles []string) error {
 }
 
 // AddSnapDesktopFiles puts in place the desktop files for the applications from the snap.
-func AddSnapDesktopFiles(s *snap.Info) error {
+func AddSnapDesktopFiles(s *snap.Info) (err error) {
+	var created []string
+	defer func() {
+		if err == nil {
+			return
+		}
+
+		for _, fn := range created {
+			os.Remove(fn)
+		}
+	}()
+
 	if err := os.MkdirAll(dirs.SnapDesktopFilesDir, 0755); err != nil {
 		return err
 	}
@@ -194,6 +205,7 @@ func AddSnapDesktopFiles(s *snap.Info) error {
 		if err := osutil.AtomicWriteFile(installedDesktopFileName, content, 0755, 0); err != nil {
 			return err
 		}
+		created = append(created, installedDesktopFileName)
 	}
 
 	// updates mime info etc

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -106,6 +106,31 @@ func (s *desktopSuite) TestRemovePackageDesktopFiles(c *C) {
 	})
 }
 
+func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
+	mockDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar1.desktop")
+	c.Assert(osutil.FileExists(mockDesktopFilePath), Equals, false)
+
+	err := os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop", "potato"), 0755)
+	c.Assert(err, IsNil)
+
+	info := snaptest.MockSnap(c, desktopAppYaml, desktopContents, &snap.SideInfo{Revision: snap.R(11)})
+
+	// generate .desktop file in the package baseDir
+	baseDir := info.MountDir()
+	err = os.MkdirAll(filepath.Join(baseDir, "meta", "gui"), 0755)
+	c.Assert(err, IsNil)
+
+	err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar1.desktop"), mockDesktopFile, 0644)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(baseDir, "meta", "gui", "foobar2.desktop"), mockDesktopFile, 0644)
+	c.Assert(err, IsNil)
+
+	err = wrappers.AddSnapDesktopFiles(info)
+	c.Check(err, NotNil)
+	c.Check(osutil.FileExists(mockDesktopFilePath), Equals, false)
+	c.Check(s.mockUpdateDesktopDatabase.Calls(), HasLen, 0)
+}
+
 // sanitize
 
 type sanitizeDesktopFileSuite struct{}

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -101,15 +101,35 @@ func StartServices(apps []*snap.AppInfo, inter interacter) (err error) {
 }
 
 // AddSnapServices adds service units for the applications from the snap which are services.
-func AddSnapServices(s *snap.Info, inter interacter) error {
+func AddSnapServices(s *snap.Info, inter interacter) (err error) {
 	sysd := systemd.New(dirs.GlobalRootDir, inter)
-	nservices := 0
+	var written []string
+	var enabled []string
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, s := range enabled {
+			if e := sysd.Disable(s); e != nil {
+				inter.Notify(fmt.Sprintf("while trying to disable %s due to previous failure: %v", s, e))
+			}
+		}
+		for _, s := range written {
+			if e := os.Remove(s); e != nil {
+				inter.Notify(fmt.Sprintf("while trying to remove %s due to previous failure: %v", s, e))
+			}
+		}
+		if len(written) > 0 {
+			if e := sysd.DaemonReload(); e != nil {
+				inter.Notify(fmt.Sprintf("while trying to perform systemd daemon-reload due to previous failure: %v", e))
+			}
+		}
+	}()
 
 	for _, app := range s.Apps {
 		if !app.IsService() {
 			continue
 		}
-		nservices++
 		// Generate service file
 		content, err := generateSnapServiceFile(app)
 		if err != nil {
@@ -120,12 +140,15 @@ func AddSnapServices(s *snap.Info, inter interacter) error {
 		if err := osutil.AtomicWriteFile(svcFilePath, content, 0644, 0); err != nil {
 			return err
 		}
-		if err := sysd.Enable(app.ServiceName()); err != nil {
+		written = append(written, svcFilePath)
+		svcName := app.ServiceName()
+		if err := sysd.Enable(svcName); err != nil {
 			return err
 		}
+		enabled = append(enabled, svcName)
 	}
 
-	if nservices > 0 {
+	if len(enabled) > 0 {
 		if err := sysd.DaemonReload(); err != nil {
 			return err
 		}


### PR DESCRIPTION
The `link-snap` task involves multiple steps, each of which can fail. While our state machine deals well with undoing the tasks that led up to a failure, each individual task is assumed to be boolean: it either fails, or it succeeds, in its entirety. This means that each handler needs to clean up after itself when it fails. We're not very good at doing this, and in particular `link-snap` can leave behind a lot of artifacts when it fails. This fixes that.

For simplicity I've propagated the requirement for cleaning up behind oneself into the `wrappers` helper lib. This way each layer involved only needs to know about cleaning up the steps visible at that layer.