### PR TITLE
interfaces: covert framebuffer to commonInterface

### DIFF
--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -19,12 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/apparmor"
-	"github.com/snapcore/snapd/interfaces/udev"
-)
-
 const framebufferSummary = `allows access to universal framebuffer devices`
 
 const framebufferBaseDeclarationSlots = `
@@ -43,56 +37,21 @@ const framebufferConnectedPlugAppArmor = `
 /run/udev/data/c29:[0-9]* r,
 `
 
-// The type for physical-memory-control interface
-type framebufferInterface struct{}
-
-// Getter for the name of the physical-memory-control interface
-func (iface *framebufferInterface) Name() string {
-	return "framebuffer"
-}
-
-func (iface *framebufferInterface) StaticInfo() interfaces.StaticInfo {
-	return interfaces.StaticInfo{
-		Summary:              framebufferSummary,
-		ImplicitOnCore:       true,
-		ImplicitOnClassic:    true,
-		BaseDeclarationSlots: framebufferBaseDeclarationSlots,
-	}
-}
-
-func (iface *framebufferInterface) String() string {
-	return iface.Name()
-}
-
-// Check validity of the defined slot
-func (iface *framebufferInterface) SanitizeSlot(slot *interfaces.Slot) error {
-	return sanitizeSlotReservedForOS(iface, slot)
-}
-
-func (iface *framebufferInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
-	spec.AddSnippet(framebufferConnectedPlugAppArmor)
-	return nil
-}
-
-func (iface *framebufferInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
-	// This will fix access denied of opengl interface when it's used with
-	// framebuffer interface in the same snap.
-	// https://bugs.launchpad.net/snapd/+bug/1675738
-	// TODO: we are not doing this due to the bug and we'll be reintroducing
-	// the udev tagging soon.
-	//const udevRule = `KERNEL=="fb[0-9]*", TAG+="%s"`
-	//for appName := range plug.Apps {
-	//	tag := udevSnapSecurityName(plug.Snap.Name(), appName)
-	//	spec.AddSnippet(fmt.Sprintf(udevRule, tag))
-	//}
-	return nil
-}
-
-func (iface *framebufferInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
-	// Allow what is allowed in the declarations
-	return true
-}
+// This will fix access denied of opengl interface when it's used with
+// framebuffer interface in the same snap.
+// https://bugs.launchpad.net/snapd/+bug/1675738
+// TODO: we are not doing this due to the bug and we'll be reintroducing
+// the udev tagging soon.
+// const framebufferUDevConnectedPlug = `KERNEL=="fb[0-9]*", TAG+="###SLOT_SECURITY_TAGS###"`
 
 func init() {
-	registerIface(&framebufferInterface{})
+	registerIface(&commonInterface{
+		name:                  "framebuffer",
+		summary:               framebufferSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  framebufferBaseDeclarationSlots,
+		connectedPlugAppArmor: framebufferConnectedPlugAppArmor,
+		reservedForOS:         true,
+	})
 }


### PR DESCRIPTION
It used to be commonInterface but then changed to a custom one so that
udev snippets could be handled. Then those snippets were disabled
because of the bug with udev tagging breaking interfaces not using it
properly. Since this is all being fixed and udev taggning is supported
by commonInterface let's simplify this code.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>