### PR TITLE
docs: add PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,2 @@
-Thanks for helping us make a better Snapd!
-
-Checklist:
-
-- Have you signed the contributor licence agreement?
-  https://www.ubuntu.com/legal/contributors
-
-- Have you read our contribution guide?
-  [CONTRIBUTING.md](CONTRIBUTING.md)
+Thanks for helping us make a better snapd!
+Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](CONTRIBUTING.md)?

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Thanks for helping us make a better Snapd!
+
+Checklist:
+
+- Have you signed the contributor licence agreement?
+  https://www.ubuntu.com/legal/contributors
+
+- Have you read our contribution guide?
+  [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
A bit of an RFC.

Our friends at snapcraft use a PULL_REQUEST_TEMPLATE - this will be automatically appear in the "write" area of a PR. I like this over the small "have you read the "the guidelines for contributing" that we currently have, shows more information. However the downside maybe that now we need to delete some text when the core team members create PRs.