### PR TITLE
cmd/snap-confine: set _FILE_OFFSET_BITS to 64

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -19,6 +19,7 @@
 
 package main
 
+//#cgo CFLAGS: -D_FILE_OFFSET_BITS=64
 //#cgo pkg-config: --static --cflags libseccomp
 //#cgo LDFLAGS: -Wl,-Bstatic -lseccomp -Wl,-Bdynamic
 //


### PR DESCRIPTION
This fixes build issues on some 32bit systems which previously choked on
xfs header files and size of some structures.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>