### PR TITLE
tests: fix for  upgrade test on fedora

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -195,6 +195,7 @@ distro_purge_package() {
                 ;;
             fedora-*)
                 dnf -y -q remove "$package_name"
+                dnf -q clean all
                 ;;
             opensuse-*)
                 zypper -q remove -y "$package_name"


### PR DESCRIPTION
The test if failing due to it is not uninstalling properly snap-confine
on fedora. The fix ensure the packages clean up when using dnf after a
remove.

Error:
https://travis-ci.org/snapcore/snapd/builds/262723163

To reproduce the error run:
spread -v -debug -reuse -seed=1502280823
linode:fedora-25-64:tests/regression/ linode:fedora-25-64:tests/upgrade/