### PR TITLE
tests: fix interfaces-cups-control test

### DIFF
--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -38,7 +38,6 @@ prepare: |
         fi
     fi
 
-
 restore: |
     rm -rf $HOME/PDF $TEST_FILE print.error
 

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -30,8 +30,12 @@ prepare: |
         if ! systemctl is-enabled cups ; then
             # We can't use --now as this isn't supported by all distributions
             systemctl enable cups
-            systemctl start cups
         fi
+    fi
+
+    echo "Starting cups service in case it is not active"
+    if ! systemctl is-active cups; then
+        systemctl start cups
     fi
 
 restore: |

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -41,6 +41,9 @@ prepare: |
 restore: |
     rm -rf $HOME/PDF $TEST_FILE print.error
 
+debug: |
+    systemctl status cups || true
+
 execute: |
     CONNECTED_PATTERN=":cups-control +test-snapd-cups-control-consumer"
     DISCONNECTED_PATTERN="(?s).*?\n- +test-snapd-cups-control-consumer:cups-control"

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -27,16 +27,17 @@ prepare: |
     if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
         # Not all distributions are starting the cups service directly after
         # the package was installed.
+        echo "Enabling cups service in case it is not enabled"
         if ! systemctl is-enabled cups ; then
             # We can't use --now as this isn't supported by all distributions
             systemctl enable cups
         fi
+        echo "Starting cups service in case it is not active"
+        if ! systemctl is-active cups; then
+            systemctl start cups
+        fi
     fi
 
-    echo "Starting cups service in case it is not active"
-    if ! systemctl is-active cups; then
-        systemctl start cups
-    fi
 
 restore: |
     rm -rf $HOME/PDF $TEST_FILE print.error


### PR DESCRIPTION
This is happening that sometimes the cups service is not active, and it
is making the snap test-snapd-cups-control-consumer.lpr fails to print
showing the error "lpr: Error - scheduler not responding".

Error:
https://travis-ci.org/snapcore/snapd/builds/262634569