### PR TITLE
tests: adding extra worker for fedora

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -62,7 +62,7 @@ backends:
                 kernel: GRUB 2
                 workers: 4
             - fedora-25-64:
-                workers: 2
+                workers: 3
             - opensuse-42.2-64:
                 workers: 2
     qemu:


### PR DESCRIPTION
Based on some error executing tests on linode, we identified that it is
needed an extra worker for fedora. The fedora execution is taking about
15 minutes more then the rest of the systems and in some cases it is
making the whole test suite fail because there are some tasks that are
not be completed as it happened in the build attached.

https://travis-
ci.org/snapcore/snapd/builds/263077039?utm_source=github_status&utm_medium=notification