### PR TITLE
overlord,store: send model assertion when setting up device sessions

### DIFF
--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -357,7 +357,7 @@ type AuthContext interface {
 
 	StoreID(fallback string) (string, error)
 
-	DeviceSessionRequest(nonce string) (devSessionRequest []byte, model []byte, serial []byte, err error)
+	DeviceSessionRequest(nonce string) (devSessionRequest []byte, serial []byte, model []byte, err error)
 }
 
 // authContext helps keeping track of auth data in the state and exposing it.
@@ -448,17 +448,17 @@ func (ac *authContext) StoreID(fallback string) (string, error) {
 	return fallback, nil
 }
 
-// DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the encoded device model and serial assertions. It returns ErrNoSerial if the device serial is not yet initialized.
-func (ac *authContext) DeviceSessionRequest(nonce string) (deviceSessionRequest []byte, model []byte, serial []byte, err error) {
+// DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the encoded device serial and model assertions. It returns ErrNoSerial if the device serial is not yet initialized.
+func (ac *authContext) DeviceSessionRequest(nonce string) (deviceSessionRequest []byte, serial []byte, model []byte, err error) {
 	if ac.deviceAsserts == nil {
 		return nil, nil, nil, ErrNoSerial
 	}
-	req, mod, ser, err := ac.deviceAsserts.DeviceSessionRequest(nonce)
+	req, ser, mod, err := ac.deviceAsserts.DeviceSessionRequest(nonce)
 	if err == state.ErrNoState {
 		return nil, nil, nil, ErrNoSerial
 	}
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return asserts.Encode(req), asserts.Encode(mod), asserts.Encode(ser), nil
+	return asserts.Encode(req), asserts.Encode(ser), asserts.Encode(mod), nil
 }

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -338,8 +338,8 @@ type DeviceAssertions interface {
 	// Serial returns the device serial assertion.
 	Serial() (*asserts.Serial, error)
 
-	// DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the device model and serial assertions.
-	DeviceSessionRequest(nonce string) (*asserts.DeviceSessionRequest, *asserts.Model, *asserts.Serial, error)
+	// DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the device serial and model assertions.
+	DeviceSessionRequest(nonce string) (*asserts.DeviceSessionRequest, *asserts.Serial, *asserts.Model, error)
 }
 
 var (

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -367,19 +367,24 @@ func (m *DeviceManager) Serial() (*asserts.Serial, error) {
 	return Serial(m.state)
 }
 
-// DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the device serial assertion.
-func (m *DeviceManager) DeviceSessionRequest(nonce string) (*asserts.DeviceSessionRequest, *asserts.Serial, error) {
+// DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the device model and serial assertions.
+func (m *DeviceManager) DeviceSessionRequest(nonce string) (*asserts.DeviceSessionRequest, *asserts.Model, *asserts.Serial, error) {
 	m.state.Lock()
 	defer m.state.Unlock()
 
+	model, err := Model(m.state)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	serial, err := Serial(m.state)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	privKey, err := m.keyPair()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	a, err := asserts.SignWithoutAuthority(asserts.DeviceSessionRequestType, map[string]interface{}{
@@ -390,9 +395,9 @@ func (m *DeviceManager) DeviceSessionRequest(nonce string) (*asserts.DeviceSessi
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
 	}, nil, privKey)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return a.(*asserts.DeviceSessionRequest), serial, err
+	return a.(*asserts.DeviceSessionRequest), model, serial, err
 
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -367,8 +367,8 @@ func (m *DeviceManager) Serial() (*asserts.Serial, error) {
 	return Serial(m.state)
 }
 
-// DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the device model and serial assertions.
-func (m *DeviceManager) DeviceSessionRequest(nonce string) (*asserts.DeviceSessionRequest, *asserts.Model, *asserts.Serial, error) {
+// DeviceSessionRequest produces a device-session-request with the given nonce, it also returns the device serial and model assertions.
+func (m *DeviceManager) DeviceSessionRequest(nonce string) (*asserts.DeviceSessionRequest, *asserts.Serial, *asserts.Model, error) {
 	m.state.Lock()
 	defer m.state.Unlock()
 
@@ -398,6 +398,6 @@ func (m *DeviceManager) DeviceSessionRequest(nonce string) (*asserts.DeviceSessi
 		return nil, nil, nil, err
 	}
 
-	return a.(*asserts.DeviceSessionRequest), model, serial, err
+	return a.(*asserts.DeviceSessionRequest), serial, model, err
 
 }

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -929,10 +929,12 @@ func (s *deviceMgrSuite) TestDeviceAssertionsDeviceSessionRequest(c *C) {
 	s.mgr.KeypairManager().Put(devKey)
 	s.state.Unlock()
 
-	sessReq, model, serial, err := s.mgr.DeviceSessionRequest("NONCE-1")
+	sessReq, serial, model, err := s.mgr.DeviceSessionRequest("NONCE-1")
 	c.Assert(err, IsNil)
 
 	c.Check(model.Model(), Equals, "pc")
+
+	c.Check(serial.Model(), Equals, "pc")
 	c.Check(serial.Serial(), Equals, "8989")
 
 	// correctly signed with device key

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -1815,7 +1815,7 @@ func (s *authContextSetupSuite) TestDeviceSessionRequest(c *C) {
 	})
 
 	st.Unlock()
-	req, encModel, encSerial, err := s.ac.DeviceSessionRequest("NONCE")
+	req, encSerial, encModel, err := s.ac.DeviceSessionRequest("NONCE")
 	st.Lock()
 	c.Assert(err, IsNil)
 	c.Check(bytes.HasPrefix(req, []byte("type: device-session-request\n")), Equals, true)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1794,11 +1794,13 @@ func (s *authContextSetupSuite) TestDeviceSessionRequest(c *C) {
 	defer st.Unlock()
 
 	st.Unlock()
-	_, _, err := s.ac.DeviceSessionRequest("NONCE")
+	_, _, _, err := s.ac.DeviceSessionRequest("NONCE")
 	st.Lock()
 	c.Check(err, Equals, auth.ErrNoSerial)
 
-	// setup serial and key in system state
+	// setup model, serial and key in system state
+	err = assertstate.Add(st, s.model)
+	c.Assert(err, IsNil)
 	err = assertstate.Add(st, s.serial)
 	c.Assert(err, IsNil)
 	kpMgr, err := asserts.OpenFSKeypairManager(dirs.SnapDeviceDir)
@@ -1813,9 +1815,10 @@ func (s *authContextSetupSuite) TestDeviceSessionRequest(c *C) {
 	})
 
 	st.Unlock()
-	req, encSerial, err := s.ac.DeviceSessionRequest("NONCE")
+	req, encModel, encSerial, err := s.ac.DeviceSessionRequest("NONCE")
 	st.Lock()
 	c.Assert(err, IsNil)
 	c.Check(bytes.HasPrefix(req, []byte("type: device-session-request\n")), Equals, true)
+	c.Check(encModel, DeepEquals, asserts.Encode(s.model))
 	c.Check(encSerial, DeepEquals, asserts.Encode(s.serial))
 }

--- a/store/auth.go
+++ b/store/auth.go
@@ -270,10 +270,11 @@ func requestStoreDeviceNonce() (string, error) {
 }
 
 // requestDeviceSession requests a device session macaroon from the store.
-func requestDeviceSession(serialAssertion, sessionRequest, previousSession string) (string, error) {
+func requestDeviceSession(modelAssertion, serialAssertion, sessionRequest, previousSession string) (string, error) {
 	const errorPrefix = "cannot get device session from store: "
 
 	data := map[string]string{
+		"model-assertion":        modelAssertion,
 		"serial-assertion":       serialAssertion,
 		"device-session-request": sessionRequest,
 	}

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2016 Canonical Ltd
+ * Copyright (C) 2014-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -362,7 +362,7 @@ func (s *authTestSuite) TestRequestDeviceSession(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		jsonReq, err := ioutil.ReadAll(r.Body)
 		c.Assert(err, IsNil)
-		c.Check(string(jsonReq), Equals, `{"device-session-request":"session-request","serial-assertion":"serial-assertion"}`)
+		c.Check(string(jsonReq), Equals, `{"device-session-request":"session-request","model-assertion":"model-assertion","serial-assertion":"serial-assertion"}`)
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, "")
 
 		io.WriteString(w, mockStoreReturnMacaroon)
@@ -370,7 +370,7 @@ func (s *authTestSuite) TestRequestDeviceSession(c *C) {
 	defer mockServer.Close()
 	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
-	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "")
+	macaroon, err := requestDeviceSession("model-assertion", "serial-assertion", "session-request", "")
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
@@ -379,7 +379,7 @@ func (s *authTestSuite) TestRequestDeviceSessionWithPreviousSession(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		jsonReq, err := ioutil.ReadAll(r.Body)
 		c.Assert(err, IsNil)
-		c.Check(string(jsonReq), Equals, `{"device-session-request":"session-request","serial-assertion":"serial-assertion"}`)
+		c.Check(string(jsonReq), Equals, `{"device-session-request":"session-request","model-assertion":"model-assertion","serial-assertion":"serial-assertion"}`)
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="previous-session"`)
 
 		io.WriteString(w, mockStoreReturnMacaroon)
@@ -387,7 +387,7 @@ func (s *authTestSuite) TestRequestDeviceSessionWithPreviousSession(c *C) {
 	defer mockServer.Close()
 	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
-	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "previous-session")
+	macaroon, err := requestDeviceSession("model-assertion", "serial-assertion", "session-request", "previous-session")
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
@@ -399,7 +399,7 @@ func (s *authTestSuite) TestRequestDeviceSessionMissingData(c *C) {
 	defer mockServer.Close()
 	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
-	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "")
+	macaroon, err := requestDeviceSession("model-assertion", "serial-assertion", "session-request", "")
 	c.Assert(err, ErrorMatches, "cannot get device session from store: empty session returned")
 	c.Assert(macaroon, Equals, "")
 }
@@ -414,7 +414,7 @@ func (s *authTestSuite) TestRequestDeviceSessionError(c *C) {
 	defer mockServer.Close()
 	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
-	macaroon, err := requestDeviceSession("serial-assertion", "session-request", "")
+	macaroon, err := requestDeviceSession("model-assertion", "serial-assertion", "session-request", "")
 	c.Assert(err, ErrorMatches, `cannot get device session from store: store server returned status 500 and body "error body"`)
 	c.Assert(n, Equals, 5)
 	c.Assert(macaroon, Equals, "")

--- a/store/store.go
+++ b/store/store.go
@@ -620,12 +620,12 @@ func (s *Store) refreshDeviceSession(device *auth.DeviceState) error {
 		return err
 	}
 
-	sessionRequest, serialAssertion, err := s.authContext.DeviceSessionRequest(nonce)
+	sessionRequest, modelAssertion, serialAssertion, err := s.authContext.DeviceSessionRequest(nonce)
 	if err != nil {
 		return err
 	}
 
-	session, err := requestDeviceSession(string(serialAssertion), string(sessionRequest), device.SessionMacaroon)
+	session, err := requestDeviceSession(string(modelAssertion), string(serialAssertion), string(sessionRequest), device.SessionMacaroon)
 	if err != nil {
 		return err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -620,7 +620,7 @@ func (s *Store) refreshDeviceSession(device *auth.DeviceState) error {
 		return err
 	}
 
-	sessionRequest, modelAssertion, serialAssertion, err := s.authContext.DeviceSessionRequest(nonce)
+	sessionRequest, serialAssertion, modelAssertion, err := s.authContext.DeviceSessionRequest(nonce)
 	if err != nil {
 		return err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -148,6 +148,20 @@ type remoteRepoTestSuite struct {
 var _ = Suite(&remoteRepoTestSuite{})
 
 const (
+	exModel = `type: model
+authority-id: my-brand
+series: 16
+brand-id: my-brand
+model: baz-3000
+architecture: armhf
+gadget: gadget
+kernel: kernel
+store: my-brand-store-id
+timestamp: 2016-08-20T13:00:00Z
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw=`
+
 	exSerial = `type: serial
 authority-id: my-brand
 brand-id: my-brand
@@ -219,18 +233,23 @@ func (ac *testAuthContext) StoreID(fallback string) (string, error) {
 	return fallback, nil
 }
 
-func (ac *testAuthContext) DeviceSessionRequest(nonce string) ([]byte, []byte, error) {
+func (ac *testAuthContext) DeviceSessionRequest(nonce string) ([]byte, []byte, []byte, error) {
+	model, err := asserts.Decode([]byte(exModel))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	serial, err := asserts.Decode([]byte(exSerial))
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	sessReq, err := asserts.Decode([]byte(strings.Replace(exDeviceSessionRequest, "@NONCE@", nonce, 1)))
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return asserts.Encode(sessReq.(*asserts.DeviceSessionRequest)), asserts.Encode(serial.(*asserts.Serial)), nil
+	return asserts.Encode(sessReq.(*asserts.DeviceSessionRequest)), asserts.Encode(model.(*asserts.Model)), asserts.Encode(serial.(*asserts.Serial)), nil
 }
 
 func makeTestMacaroon() (*macaroon.Macaroon, error) {


### PR DESCRIPTION
When requesting (or refreshing) a device session, pass the model assertion (besides serial and session request). Store ID will be set in the session macaroon, if defined in the assertion.