### PR TITLE
interfaces/misc: updates for unity7/x11 (LP: #1663221), browser-support, network-control (LP: #1679295) and mount-observe

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -134,7 +134,9 @@ owner @{PROC}/@{pid}/fd/[0-9]* w,
 /sys/devices/**/descriptors r,
 /sys/devices/**/manufacturer r,
 /sys/devices/**/product r,
+/sys/devices/**/revision r,
 /sys/devices/**/serial r,
+/sys/devices/system/node/node[0-9]*/meminfo r,
 
 # Chromium content api tries to read these. It is an information disclosure
 # since these contain the names of snaps. Chromium operates fine without the

--- a/interfaces/builtin/mount_observe.go
+++ b/interfaces/builtin/mount_observe.go
@@ -42,6 +42,7 @@ const mountObserveConnectedPlugAppArmor = `
 owner @{PROC}/@{pid}/mounts r,
 owner @{PROC}/@{pid}/mountinfo r,
 owner @{PROC}/@{pid}/mountstats r,
+/sys/devices/*/block/{,**} r,
 
 @{PROC}/swaps r,
 

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -89,7 +89,7 @@ network sna,
 
 # For advanced wireless configuration
 /sys/kernel/debug/ieee80211/ r,
-/sys/kernel/debug/ieee80211/** r,
+/sys/kernel/debug/ieee80211/** rw,
 
 # read netfilter module parameters
 /sys/module/nf_*/                r,

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -87,6 +87,10 @@ network sna,
 @{PROC}/sys/net/netfilter/** rw,
 @{PROC}/sys/net/nf_conntrack_max rw,
 
+# For advanced wireless configuration
+/sys/kernel/debug/ieee80211/ r,
+/sys/kernel/debug/ieee80211/** r,
+
 # read netfilter module parameters
 /sys/module/nf_*/                r,
 /sys/module/nf_*/parameters/{,*} r,

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -543,6 +543,7 @@ shutdown
 
 # Needed by QtSystems on X to detect mouse and keyboard
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
+bind
 `
 
 type unity7Interface struct{}

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -195,7 +195,7 @@ dbus send
 
 # Needed by QtSystems on X to detect mouse and keyboard. Note, the 'netlink
 # raw' rule is not finely mediated by apparmor so we mediate with seccomp arg
-# filtering, below.
+# filtering.
 network netlink raw,
 /run/udev/data/c13:[0-9]* r,
 /run/udev/data/+input:* r,

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -193,6 +193,12 @@ dbus send
     member=GetAll
     peer=(label=unconfined),
 
+# Needed by QtSystems on X to detect mouse and keyboard. Note, the 'netlink
+# raw' rule is not finely mediated by apparmor so we mediate with seccomp arg
+# filtering, below.
+network netlink raw,
+/run/udev/data/c13:[0-9]* r,
+/run/udev/data/+input:* r,
 
 # subset of freedesktop.org
 /usr/share/mime/**                   r,
@@ -534,6 +540,9 @@ const unity7ConnectedPlugSeccomp = `
 
 # X
 shutdown
+
+# Needed by QtSystems on X to detect mouse and keyboard
+socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
 type unity7Interface struct{}

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -28,7 +28,6 @@ const x11BaseDeclarationSlots = `
         - core
 `
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/x
 const x11ConnectedPlugAppArmor = `
 # Description: Can access the X server. Restricted because X does not prevent
 # eavesdropping or apps interfering with one another.
@@ -43,14 +42,23 @@ const x11ConnectedPlugAppArmor = `
 # in the XAUTHORITY environment variable, that "snap run" creates on
 # startup.
 owner /run/user/[0-9]*/.Xauthority r,
+
+# Needed by QtSystems on X to detect mouse and keyboard. Note, the 'netlink
+# raw' rule is not finely mediated by apparmor so we mediate with seccomp arg
+# filtering, below.
+network netlink raw,
+/run/udev/data/c13:[0-9]* r,
+/run/udev/data/+input:* r,
 `
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/x
 const x11ConnectedPlugSecComp = `
 # Description: Can access the X server. Restricted because X does not prevent
 # eavesdropping or apps interfering with one another.
 
 shutdown
+
+# Needed by QtSystems on X to detect mouse and keyboard
+socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
 func init() {

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -59,6 +59,7 @@ shutdown
 
 # Needed by QtSystems on X to detect mouse and keyboard
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
+bind
 `
 
 func init() {

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -45,7 +45,7 @@ owner /run/user/[0-9]*/.Xauthority r,
 
 # Needed by QtSystems on X to detect mouse and keyboard. Note, the 'netlink
 # raw' rule is not finely mediated by apparmor so we mediate with seccomp arg
-# filtering, below.
+# filtering.
 network netlink raw,
 /run/udev/data/c13:[0-9]* r,
 /run/udev/data/+input:* r,


### PR DESCRIPTION
- interfaces/unity7,x11: update for NETLINK_KOBJECT_UEVENT (LP: #1663221)
- interfaces/browser-support: update sysfs reads for newer browser versions
- interfaces/network-control: rw for ieee80211 advanced wireless (LP: #1679295)
- interfaces/mount-observe: allow read on sysfs entries for block devices