### PR TITLE
overlord: rely on more conservative ensure interval

### DIFF
--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -358,7 +358,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeOutsideEnsure(c *C) 
 }
 
 func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
-	restoreIntv := overlord.MockPruneInterval(20*time.Millisecond, 100*time.Millisecond, 100*time.Millisecond)
+	restoreIntv := overlord.MockPruneInterval(200*time.Millisecond, 1000*time.Millisecond, 1000*time.Millisecond)
 	defer restoreIntv()
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
@@ -378,7 +378,7 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 	cycles := -1
 	waitForPrune := func(_ *state.State) error {
 		if cycles == -1 {
-			if time.Since(t0) > 100*time.Millisecond {
+			if time.Since(t0) > 1000*time.Millisecond {
 				cycles = 2 // wait a couple more loop cycles
 			}
 			return nil
@@ -419,7 +419,7 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 }
 
 func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
-	restoreIntv := overlord.MockPruneInterval(10*time.Millisecond, 100*time.Millisecond, 1*time.Hour)
+	restoreIntv := overlord.MockPruneInterval(100*time.Millisecond, 1000*time.Millisecond, 1*time.Hour)
 	defer restoreIntv()
 	o, err := overlord.New()
 	c.Assert(err, IsNil)
@@ -443,7 +443,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	o.Loop()
 
 	// ensure the first change is pruned
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	st.Lock()
 	c.Check(st.Changes(), HasLen, 1)
 	st.Unlock()
@@ -452,7 +452,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	st.Lock()
 	chg2.SetStatus(state.DoneStatus)
 	st.Unlock()
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	st.Lock()
 	c.Check(st.Changes(), HasLen, 0)
 	st.Unlock()


### PR DESCRIPTION
On openSUSE tumbleweed running Linux 4.11.8 and golang 1.8.3 the
observed latency between subsequent calls to Ensure in
overlordSuite.EnsureLoopPrune is on the order of ~500ms versus ~50ms on
of the same binary running on top of Ubuntu Artful with Linux 4.11.0 and
golang 1.8.1. This makes the test fail as the sequence of evens it
widely different and things just don't happen in time.

As a workaround, before the root issue is understood better, use a more
conservative prune interval of 200ms (up from 20ms) which makes this test
pass each time.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>