### PR TITLE
tests: enable regression and completion suites for opensuse

### DIFF
--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -121,7 +121,7 @@ export CXXFLAGS
 # apparmor kernel available in SUSE and Debian. The generated apparmor profiles
 # cannot be loaded into a vanilla kernel. As a temporary measure we just switch
 # it all off.
-%configure --disable-apparmor --libexecdir=/usr/lib/snapd
+%configure --disable-apparmor --libexecdir=%{_libexecdir}/snapd
 
 %build
 # Build golang executables
@@ -164,15 +164,15 @@ make %{?_smp_mflags} -C cmd check
 # Install all the go stuff
 %goinstall
 # TODO: instead of removing it move this to a dedicated golang package
-rm -rf %{buildroot}/usr/lib64/go
-rm -rf %{buildroot}/usr/lib/go
+rm -rf %{buildroot}%{_libexecdir}64/go
+rm -rf %{buildroot}%{_libexecdir}/go
 find %{buildroot}
-# Move snapd, snap-exec, snap-seccomp and snap-update-ns into /usr/lib/snapd
-install -m 755 -d %{buildroot}/usr/lib/snapd
-mv %{buildroot}/usr/bin/snapd %{buildroot}/usr/lib/snapd/snapd
-mv %{buildroot}/usr/bin/snap-exec %{buildroot}/usr/lib/snapd/snap-exec
-mv %{buildroot}/usr/bin/snap-update-ns %{buildroot}/usr/lib/snapd/snap-update-ns
-mv %{buildroot}/usr/bin/snap-seccomp %{buildroot}/usr/lib/snapd/snap-seccomp
+# Move snapd, snap-exec, snap-seccomp and snap-update-ns into %{_libexecdir}/snapd
+install -m 755 -d %{buildroot}%{_libexecdir}/snapd
+mv %{buildroot}/usr/bin/snapd %{buildroot}%{_libexecdir}/snapd/snapd
+mv %{buildroot}/usr/bin/snap-exec %{buildroot}%{_libexecdir}/snapd/snap-exec
+mv %{buildroot}/usr/bin/snap-update-ns %{buildroot}%{_libexecdir}/snapd/snap-update-ns
+mv %{buildroot}/usr/bin/snap-seccomp %{buildroot}%{_libexecdir}/snapd/snap-seccomp
 # Install profile.d-based PATH integration for /snap/bin
 install -m 755 -d %{buildroot}/etc/profile.d/
 install -m 644 etc/profile.d/apps-bin-path.sh %{buildroot}/etc/profile.d/snapd.sh
@@ -195,7 +195,7 @@ rm -f %{?buildroot}/usr/bin/ubuntu-core-launcher
 # NOTE: we don't want to ship system-shutdown helper, it is just a helper on
 # ubuntu-core systems that exclusively use snaps. It is used during the
 # shutdown process and thus can be left out of the distribution package.
-rm -f %{?buildroot}/usr/lib/snapd/system-shutdown
+rm -f %{?buildroot}%{_libexecdir}/snapd/system-shutdown
 # Install the directories that snapd creates by itself so that they can be a part of the package
 install -d %buildroot/var/lib/snapd/{assertions,desktop/applications,device,hostfs,mount,apparmor/profiles,seccomp/bpf,snaps}
 install -d %buildroot/snap/bin
@@ -211,25 +211,27 @@ for s in snapd.autoimport.service snapd.system-shutdown.service snap-repair.time
     rm -f %buildroot/%{_unitdir}/$s
 done
 # Remove snappy core specific scripts
-rm -f %buildroot/usr/lib/snapd/snapd.core-fixup.sh
+rm -f %buildroot%{_libexecdir}/snapd/snapd.core-fixup.sh
 
 # See https://en.opensuse.org/openSUSE:Packaging_checks#suse-missing-rclink for details
 install -d %{buildroot}/usr/sbin
 ln -sf %{_sbindir}/service %{buildroot}/%{_sbindir}/rcsnapd
 ln -sf %{_sbindir}/service %{buildroot}/%{_sbindir}/rcsnapd.refresh
 # Install the "info" data file with snapd version
-install -m 644 -D data/info %{buildroot}/usr/lib/snapd/info
+install -m 644 -D data/info %{buildroot}%{_libexecdir}/snapd/info
 # Install bash completion for "snap"
 install -m 644 -D data/completion/snap %{buildroot}/usr/share/bash-completion/completions/snap
+install -m 644 -D data/completion/complete.sh %{buildroot}%{_libexecdir}/snapd
+install -m 644 -D data/completion/etelpmoc.sh %{buildroot}%{_libexecdir}/snapd
 
 %verifyscript
-%verify_permissions -e /usr/lib/snapd/snap-confine
+%verify_permissions -e %{_libexecdir}/snapd/snap-confine
 
 %pre
 %service_add_pre %{systemd_services_list}
 
 %post
-%set_permissions /usr/lib/snapd/snap-confine
+%set_permissions %{_libexecdir}/snapd/snap-confine
 %service_add_post %{systemd_services_list}
 case ":$PATH:" in
     *:/snap/bin:*)
@@ -253,7 +255,7 @@ esac
 %dir %attr(0000,root,root) /var/lib/snapd/void
 %dir /snap
 %dir /snap/bin
-%dir /usr/lib/snapd
+%dir %{_libexecdir}/snapd
 %dir /var/lib/snapd
 %dir /var/lib/snapd/apparmor
 %dir /var/lib/snapd/apparmor/profiles
@@ -266,7 +268,7 @@ esac
 %dir /var/lib/snapd/seccomp
 %dir /var/lib/snapd/seccomp/bpf
 %dir /var/lib/snapd/snaps
-%verify(not user group mode) %attr(04755,root,root) /usr/lib/snapd/snap-confine
+%verify(not user group mode) %attr(04755,root,root) %{_libexecdir}/snapd/snap-confine
 %{_mandir}/man5/snap-confine.5.gz
 %{_mandir}/man5/snap-discard-ns.5.gz
 %{_udevrulesdir}/80-snappy-assign.rules
@@ -278,14 +280,16 @@ esac
 /usr/bin/snapctl
 /usr/sbin/rcsnapd
 /usr/sbin/rcsnapd.refresh
-/usr/lib/snapd/info
-/usr/lib/snapd/snap-discard-ns
-/usr/lib/snapd/snap-update-ns
-/usr/lib/snapd/snap-exec
-/usr/lib/snapd/snap-seccomp
-/usr/lib/snapd/snapd
-/usr/lib/udev/snappy-app-dev
+%{_libexecdir}/snapd/info
+%{_libexecdir}/snapd/snap-discard-ns
+%{_libexecdir}/snapd/snap-update-ns
+%{_libexecdir}/snapd/snap-exec
+%{_libexecdir}/snapd/snap-seccomp
+%{_libexecdir}/snapd/snapd
+%{_libexecdir}/udev/snappy-app-dev
 /usr/share/bash-completion/completions/snap
+%{_libexecdir}/snapd/complete.sh
+%{_libexecdir}/snapd/etelpmoc.sh
 %{_mandir}/man1/snap.1.gz
 
 %changelog

--- a/spread.yaml
+++ b/spread.yaml
@@ -373,13 +373,8 @@ suites:
 
     tests/completion/:
         summary: completion tests
-
         # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
-        # Test cases are not yet ported to Fedora/openSUSE that is why
-        # we keep them disabled. A later PR will enable most tests and
-        # drop this blacklist.
-        systems: [-ubuntu-core-*, -ubuntu-*-ppc64el, -opensuse-*]
-
+        systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
         prepare: |
             . $TESTSLIB/prepare.sh
             prepare_classic
@@ -409,10 +404,6 @@ suites:
 
     tests/regression/:
         summary: Regression tests for snapd
-        # Test cases are not yet ported to Fedora/openSUSE that is why
-        # we keep them disabled. A later PR will enable most tests and
-        # drop this blacklist.
-        systems: [-opensuse-*]
         prepare: |
             . $TESTSLIB/prepare.sh
             if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
@@ -431,8 +422,8 @@ suites:
 
     tests/upgrade/:
         summary: Tests for snapd upgrade
-        # Test cases are not yet ported to Fedora/openSUSE that is why
-        # we keep them disabled. A later PR will enable most tests and
+        # Test cases are not yet ported to openSUSE that is why we keep
+        # it disabled. A later PR will enable most tests and
         # drop this blacklist.
         systems: [-ubuntu-core-16-*, -opensuse-*]
         restore: |

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -43,7 +43,6 @@ restore: |
 
 debug: |
     systemctl status cups || true
-    journalctl -u cups || true
 
 execute: |
     CONNECTED_PATTERN=":cups-control +test-snapd-cups-control-consumer"

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -43,6 +43,7 @@ restore: |
 
 debug: |
     systemctl status cups || true
+    journalctl -u cups || true
 
 execute: |
     CONNECTED_PATTERN=":cups-control +test-snapd-cups-control-consumer"


### PR DESCRIPTION
Enabling two test suites for opensuse. 
Also it is included a minor change in the opensuse specs to use %{_libexecdir} instead of /usr/lib.
Upgrade test suite is still disabled because there is not snapd avaiblable to install it with zypper yet.