### PR TITLE
tests: use dnf --refresh install to avert stale cache

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -167,7 +167,7 @@ distro_install_package() {
                 quiet apt-get install $APT_FLAGS -y "$package_name"
                 ;;
             fedora-*)
-                dnf -q -y install $DNF_FLAGS "$package_name"
+                dnf -q -y --refresh install $DNF_FLAGS "$package_name"
                 ;;
             opensuse-*)
                 zypper -q install -y $ZYPPER_FLAGS "$package_name"


### PR DESCRIPTION
While our package abstraction helper for spread tests does call dnf
makecache evidence in test failures shows that something is not quite
right and we fail to install packages that have since, in the archive,
been upgraded to a new revision and we attempt to install the old
version oblivious to that fact.

Neal Gompa suggested that we use the --refresh option on dnf install to
always ensure that the package cache is updated if it is out of date.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>