### PR TITLE
wrappers: symlink completion snippets when symlinking binaries

### DIFF
--- a/data/completion/complete.sh
+++ b/data/completion/complete.sh
@@ -104,15 +104,19 @@ _complete_from_snap() {
 # this file can be sourced directly as e.g. /usr/lib/snapd/complete.sh, or via
 # a symlink from /usr/share/bash-completion/completions/. In the first case we
 # want to load the default loader; in the second, the specific one.
-if [[ "${BASH_SOURCE[0]}" =~ /complete\.sh$ ]]; then
+#
+if [[ "${BASH_SOURCE[0]}" =~ ^/usr/share/bash-completion/completions/ ]]; then
+    complete -F _complete_from_snap "$1"
+else
 
     # _complete_from_snap_maybe calls _complete_from_snap if the command is in
     # bin/snap, and otherwise does bash-completion's _completion_loader (which is
     # what -D would've done before).
     type -t _complete_from_snap_maybe > /dev/null ||
     _complete_from_snap_maybe() {
+        local etel=snap/core/current/usr/lib/snapd/etelpmoc.sh
         # catch /snap/bin and /var/lib/snapd/snap/bin
-        if [[ "$(which "$1")" =~ /snap/bin/ && ( -e /var/lib/snapd/snap/core/current/usr/lib/snapd/etelpmoc.sh || -e /snap/core/current/usr/lib/snapd/etelpmoc.sh ) ]]; then
+        if [[ "$(which "$1")" =~ /snap/bin/ && ( -e "/var/lib/snapd/$etel" || -e "/$etel" ) ]]; then
             complete -F _complete_from_snap "$1"
             return 124
         fi
@@ -121,8 +125,5 @@ if [[ "${BASH_SOURCE[0]}" =~ /complete\.sh$ ]]; then
     }
 
     complete -D -F _complete_from_snap_maybe
-
-else
-    complete -F _complete_from_snap "$1"
 fi
 

--- a/data/completion/complete.sh
+++ b/data/completion/complete.sh
@@ -36,6 +36,7 @@
 #    from 'etelpmoc.sh', validates the results and puts the validated results
 #    into the bash completion environment variables
 # 8. bash displays the results to the user
+type -t _complete_from_snap > /dev/null ||
 _complete_from_snap() {
     {
         # De-serialize the output of 'snap run --command=complete ...' into the format
@@ -100,17 +101,28 @@ _complete_from_snap() {
 
 }
 
-# _complete_from_snap_maybe calls _complete_from_snap if the command is in
-# bin/snap, and otherwise does bash-completion's _completion_loader (which is
-# what -D would've done before).
-_complete_from_snap_maybe() {
-    # catch /snap/bin and /var/lib/snapd/snap/bin
-    if [[ "$(which "$1")" =~ /snap/bin/ && ( -e /var/lib/snapd/snap/core/current/usr/lib/snapd/etelpmoc.sh || -e /snap/core/current/usr/lib/snapd/etelpmoc.sh ) ]]; then
-        _complete_from_snap "$1"
-        return $?
-    fi
-    # fallback to the old -D
-    _completion_loader "$1"
-}
+# this file can be sourced directly as e.g. /usr/lib/snapd/complete.sh, or via
+# a symlink from /usr/share/bash-completion/completions/. In the first case we
+# want to load the default loader; in the second, the specific one.
+if [[ "${BASH_SOURCE[0]}" =~ /complete\.sh$ ]]; then
 
-complete -D -F _complete_from_snap_maybe
+    # _complete_from_snap_maybe calls _complete_from_snap if the command is in
+    # bin/snap, and otherwise does bash-completion's _completion_loader (which is
+    # what -D would've done before).
+    type -t _complete_from_snap_maybe > /dev/null ||
+    _complete_from_snap_maybe() {
+        # catch /snap/bin and /var/lib/snapd/snap/bin
+        if [[ "$(which "$1")" =~ /snap/bin/ && ( -e /var/lib/snapd/snap/core/current/usr/lib/snapd/etelpmoc.sh || -e /snap/core/current/usr/lib/snapd/etelpmoc.sh ) ]]; then
+            complete -F _complete_from_snap "$1"
+            return 124
+        fi
+        # fallback to the old -D
+        _completion_loader "$1"
+    }
+
+    complete -D -F _complete_from_snap_maybe
+
+else
+    complete -F _complete_from_snap "$1"
+fi
+

--- a/data/completion/snap
+++ b/data/completion/snap
@@ -14,7 +14,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-_complete() {
+_complete_snap() {
     # TODO: add support for sourcing this function from the core snap.
     local cur prev words cword
     _init_completion -n : || return
@@ -62,4 +62,4 @@ _complete() {
     return 0
 }
 
-complete -F _complete snap
+complete -F _complete_snap snap

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -47,6 +47,7 @@ var (
 	SnapUdevRulesDir          string
 	SnapKModModulesDir        string
 	LocaleDir                 string
+	CompletersDir             string
 	SnapMetaDir               string
 	SnapdSocket               string
 	SnapSocket                string
@@ -181,6 +182,7 @@ func SetRootDir(rootdir string) {
 
 	LocaleDir = filepath.Join(rootdir, "/usr/share/locale")
 	ClassicDir = filepath.Join(rootdir, "/writable/classic")
+	CompletersDir = filepath.Join(rootdir, "/usr/share/bash-completion/completions/")
 
 	switch release.ReleaseInfo.ID {
 	case "fedora", "centos", "rhel":

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -47,7 +47,6 @@ var (
 	SnapUdevRulesDir          string
 	SnapKModModulesDir        string
 	LocaleDir                 string
-	CompletersDir             string
 	SnapMetaDir               string
 	SnapdSocket               string
 	SnapSocket                string
@@ -81,6 +80,8 @@ var (
 	XdgRuntimeDirGlob string
 
 	CompletionHelper string
+	CompletersDir    string
+	CompleteSh       string
 )
 
 const (
@@ -182,7 +183,6 @@ func SetRootDir(rootdir string) {
 
 	LocaleDir = filepath.Join(rootdir, "/usr/share/locale")
 	ClassicDir = filepath.Join(rootdir, "/writable/classic")
-	CompletersDir = filepath.Join(rootdir, "/usr/share/bash-completion/completions/")
 
 	switch release.ReleaseInfo.ID {
 	case "fedora", "centos", "rhel":
@@ -195,4 +195,6 @@ func SetRootDir(rootdir string) {
 	XdgRuntimeDirGlob = filepath.Join(rootdir, XdgRuntimeDirBase, "*/")
 
 	CompletionHelper = filepath.Join(CoreLibExecDir, "etelpmoc.sh")
+	CompletersDir = filepath.Join(rootdir, "/usr/share/bash-completion/completions/")
+	CompleteSh = filepath.Join(SnapMountDir, "core/current/usr/lib/snapd/complete.sh")
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -459,6 +459,18 @@ func (app *AppInfo) WrapperPath() string {
 	return filepath.Join(dirs.SnapBinariesDir, binName)
 }
 
+// CompleterPath returns the path to the completer snippet for the app binary.
+func (app *AppInfo) CompleterPath() string {
+	var binName string
+	if app.Name == app.Snap.Name() {
+		binName = filepath.Base(app.Name)
+	} else {
+		binName = fmt.Sprintf("%s.%s", app.Snap.Name(), filepath.Base(app.Name))
+	}
+
+	return filepath.Join(dirs.CompletersDir, binName)
+}
+
 func (app *AppInfo) launcherCommand(command string) string {
 	if command != "" {
 		command = " " + command

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -110,6 +110,18 @@ apps:
 	c.Check(info.Apps["foo"].WrapperPath(), Equals, filepath.Join(dirs.SnapBinariesDir, "foo"))
 }
 
+func (s *infoSuite) TestAppInfoCompleterPath(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`name: foo
+apps:
+   foo:
+   bar:
+`))
+	c.Assert(err, IsNil)
+
+	c.Check(info.Apps["bar"].CompleterPath(), Equals, filepath.Join(dirs.CompletersDir, "foo.bar"))
+	c.Check(info.Apps["foo"].CompleterPath(), Equals, filepath.Join(dirs.CompletersDir, "foo"))
+}
+
 func (s *infoSuite) TestAppInfoLauncherCommand(c *C) {
 	dirs.SetRootDir("")
 

--- a/tests/completion/snippets/task.exp
+++ b/tests/completion/snippets/task.exp
@@ -3,9 +3,7 @@ send "source $::env(SPREAD_PATH)/$::env(SPREAD_SUITE)/$::env(SPREAD_VARIANT).sh\
 next
 send "source /usr/share/bash-completion/bash_completion\n"
 next
-# because this sources complete.sh, it won't be using the snippets
-send "source $::env(SPREAD_PATH)/data/completion/complete.sh\n"
-next
+# compared to indirect/, this one does not source complete.sh
 chat "complexion \t\t" $::env(_OUT0)
 cancel
 # completion when the cursor is not at the end of the line:

--- a/tests/completion/snippets/task.yaml
+++ b/tests/completion/snippets/task.yaml
@@ -6,9 +6,6 @@ prepare: |
       snap try
       mv complexion.bash-completer complexion.bash-completer.orig
       cp "${SPREAD_PATH}/${SPREAD_SUITE}/${SPREAD_VARIANT}.complete" complexion.bash-completer
-      # current ordering should ensure this anyway, but just in case, make sure we're
-      # using complete.sh and not the generated snippet by removing the snippet
-      rm /usr/share/bash-completion/completions/complexion
   )
 
 restore: |

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -22,14 +22,11 @@ package wrappers
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
-
-var completeSh = filepath.Join(dirs.SnapMountDir, "core", "current", "usr", "lib", "snapd", "complete.sh")
 
 // AddSnapBinaries writes the wrapper binaries for the applications from the snap which aren't services.
 func AddSnapBinaries(s *snap.Info) (err error) {
@@ -47,7 +44,7 @@ func AddSnapBinaries(s *snap.Info) (err error) {
 		return err
 	}
 
-	noCompletion := !osutil.FileExists(dirs.CompletersDir) || !osutil.FileExists(completeSh)
+	noCompletion := !osutil.FileExists(dirs.CompletersDir) || !osutil.FileExists(dirs.CompleteSh)
 	for _, app := range s.Apps {
 		if app.IsService() {
 			continue
@@ -67,7 +64,7 @@ func AddSnapBinaries(s *snap.Info) (err error) {
 		}
 		// symlink the completion snippet
 		compPath := app.CompleterPath()
-		if err := os.Symlink(completeSh, compPath); err == nil {
+		if err := os.Symlink(dirs.CompleteSh, compPath); err == nil {
 			created = append(created, compPath)
 		} else if !os.IsExist(err) {
 			return err
@@ -79,14 +76,14 @@ func AddSnapBinaries(s *snap.Info) (err error) {
 
 // RemoveSnapBinaries removes the wrapper binaries for the applications from the snap which aren't services from.
 func RemoveSnapBinaries(s *snap.Info) error {
-	noCompletion := !osutil.FileExists(dirs.CompletersDir) || !osutil.FileExists(completeSh)
+	noCompletion := !osutil.FileExists(dirs.CompletersDir) || !osutil.FileExists(dirs.CompleteSh)
 	for _, app := range s.Apps {
 		os.Remove(app.WrapperPath())
 		if noCompletion || app.Completer == "" {
 			continue
 		}
 		compPath := app.CompleterPath()
-		if target, err := os.Readlink(compPath); err == nil && target == completeSh {
+		if target, err := os.Readlink(compPath); err == nil && target == dirs.CompleteSh {
 			os.Remove(compPath)
 		}
 	}

--- a/wrappers/binaries.go
+++ b/wrappers/binaries.go
@@ -76,10 +76,9 @@ func AddSnapBinaries(s *snap.Info) (err error) {
 
 // RemoveSnapBinaries removes the wrapper binaries for the applications from the snap which aren't services from.
 func RemoveSnapBinaries(s *snap.Info) error {
-	noCompletion := !osutil.FileExists(dirs.CompletersDir) || !osutil.FileExists(dirs.CompleteSh)
 	for _, app := range s.Apps {
 		os.Remove(app.WrapperPath())
-		if noCompletion || app.Completer == "" {
+		if app.Completer == "" {
 			continue
 		}
 		compPath := app.CompleterPath()

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -20,6 +20,7 @@
 package wrappers_test
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,6 +58,9 @@ description: Hello...
 apps:
  hello:
    command: bin/hello
+ world:
+   command: bin/world
+   completer: world-completer.sh
  svc1:
   command: bin/hello
   stop-command: bin/goodbye
@@ -66,20 +70,67 @@ apps:
 const contentsHello = "HELLO"
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
+	// no completers support -> no problem \o/
+	c.Assert(osutil.FileExists(dirs.CompletersDir), Equals, false)
+
+	s.testAddSnapBinariesAndRemove(c)
+}
+
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithCompleters(c *C) {
+	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
+	c.Assert(osutil.FileExists(wrappers.CompleteSh), Equals, true)
+	// full completers support -> we get completers \o/
+
+	s.testAddSnapBinariesAndRemove(c)
+}
+
+func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c *C) {
+	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
+	c.Assert(osutil.FileExists(wrappers.CompleteSh), Equals, true)
+	// existing completers -> they're left alone \o/
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.world"), nil, 0644), IsNil)
+
+	s.testAddSnapBinariesAndRemove(c)
+}
+
+func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C) {
 	info := snaptest.MockSnap(c, packageHello, contentsHello, &snap.SideInfo{Revision: snap.R(11)})
+	completer := filepath.Join(dirs.CompletersDir, "hello-snap.world")
+	completerExisted := osutil.FileExists(completer)
 
 	err := wrappers.AddSnapBinaries(info)
 	c.Assert(err, IsNil)
 
-	link := filepath.Join(dirs.SnapBinariesDir, "hello-snap.hello")
-	target, err := os.Readlink(link)
-	c.Assert(err, IsNil)
-	c.Check(target, Equals, "/usr/bin/snap")
+	bins := []string{"hello-snap.hello", "hello-snap.world"}
+
+	for _, bin := range bins {
+		link := filepath.Join(dirs.SnapBinariesDir, bin)
+		target, err := os.Readlink(link)
+		c.Assert(err, IsNil, Commentf(bin))
+		c.Check(target, Equals, "/usr/bin/snap", Commentf(bin))
+	}
+
+	if osutil.FileExists(dirs.CompletersDir) {
+		if completerExisted {
+			// there was a completer there before, so it should _not_ be a symlink to our complete.sh
+			c.Assert(osutil.IsSymlink(completer), Equals, false)
+		} else {
+			target, err := os.Readlink(completer)
+			c.Assert(err, IsNil)
+			c.Check(target, Equals, wrappers.CompleteSh)
+		}
+	}
 
 	err = wrappers.RemoveSnapBinaries(info)
 	c.Assert(err, IsNil)
 
-	c.Check(osutil.FileExists(link), Equals, false)
+	for _, bin := range bins {
+		link := filepath.Join(dirs.SnapBinariesDir, bin)
+		c.Check(osutil.FileExists(link), Equals, false, Commentf(bin))
+	}
+
+	// we left the existing completer alone, but removed it otherwise
+	c.Check(osutil.FileExists(completer), Equals, completerExisted)
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesCleansUpOnFailure(c *C) {

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -78,7 +78,8 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithCompleters(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
-	c.Assert(osutil.FileExists(wrappers.CompleteSh), Equals, true)
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteSh), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.CompleteSh, nil, 0644), IsNil)
 	// full completers support -> we get completers \o/
 
 	s.testAddSnapBinariesAndRemove(c)
@@ -86,7 +87,8 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithCompleters(c *C) {
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c *C) {
 	c.Assert(os.MkdirAll(dirs.CompletersDir, 0755), IsNil)
-	c.Assert(osutil.FileExists(wrappers.CompleteSh), Equals, true)
+	c.Assert(os.MkdirAll(filepath.Dir(dirs.CompleteSh), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(dirs.CompleteSh, nil, 0644), IsNil)
 	// existing completers -> they're left alone \o/
 	c.Assert(ioutil.WriteFile(filepath.Join(dirs.CompletersDir, "hello-snap.world"), nil, 0644), IsNil)
 
@@ -117,7 +119,7 @@ func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C) {
 		} else {
 			target, err := os.Readlink(completer)
 			c.Assert(err, IsNil)
-			c.Check(target, Equals, wrappers.CompleteSh)
+			c.Check(target, Equals, dirs.CompleteSh)
 		}
 	}
 

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -32,6 +32,9 @@ var (
 	SanitizeDesktopFile    = sanitizeDesktopFile
 	RewriteExecLine        = rewriteExecLine
 	IsValidDesktopFileLine = isValidDesktopFileLine
+
+	// completion
+	CompleteSh = completeSh
 )
 
 func MockKillWait(wait time.Duration) (restore func()) {

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -32,9 +32,6 @@ var (
 	SanitizeDesktopFile    = sanitizeDesktopFile
 	RewriteExecLine        = rewriteExecLine
 	IsValidDesktopFileLine = isValidDesktopFileLine
-
-	// completion
-	CompleteSh = completeSh
 )
 
 func MockKillWait(wait time.Duration) (restore func()) {


### PR DESCRIPTION
This also modifies complete.sh to support this, as well as some minor
changes to dirs and snap to accommodate.

Symlinking the snippets is itself simple enough that I didn't think it
was worth creating an ad-hoc helper, so it's just a few lines glommed
onto the end of the existing wrapper funcs (and tests).

> To be clear, I did write the helper, but between it being very few
> lines of code, it needing to return enough information to the
> caller to clean up behind it if something else went wrong, and
> especially as the other user of that helper would be the aliases
> and they don't have access to the AppInfo (which would be the
> obvious thing to pass to such helpers), I decided against it.

How aliases are going to play into completion is still an open
question on the implementation side, which I need to look into soon,
but this is not that work.