### PR TITLE
tests: adding more debug information for the interfaces-cups-control test

### DIFF
--- a/tests/main/install-snaps/task.yaml
+++ b/tests/main/install-snaps/task.yaml
@@ -4,62 +4,79 @@ manual: true
 
 environment:
     # High Profile
-    INSTALL/azurecli: azure-cli --classic
-    INSTALL/awscli: aws-cli --classic
-    INSTALL/heroku: heroku --classic
-    INSTALL/hiri: hiri  
-    INSTALL/kubectl: kubectl --classic
-    INSTALL/rocketchatserver: rocketchat-server
+    SNAP/azurecli: azure-cli
+    SNAP/awscli: aws-cli
+    SNAP/heroku: heroku
+    SNAP/hiri: hiri
+    SNAP/kubectl: kubectl
+    SNAP/rocketchatserver: rocketchat-server
     # Selected from recent insights posts
-    INSTALL/corebird: corebird
-    INSTALL/gitterdesktop: gitter-desktop
-    INSTALL/helm: helm
-    INSTALL/mattermostdesktop: mattermost-desktop
-    INSTALL/mentaplexmediaserver: menta-plexmediaserver
-    INSTALL/openspades: openspades
-    INSTALL/pintown: pin-town
-    INSTALL/postgresql10: postgresql10
-    INSTALL/storjshare: storjshare
-    INSTALL/slackterm: slack-term
-    INSTALL/vectr: vectr
-    INSTALL/wekan: wekan
-    INSTALL/wormhole: wormhole
+    SNAP/corebird: corebird
+    SNAP/gitterdesktop: gitter-desktop
+    SNAP/helm: helm
+    SNAP/mattermostdesktop: mattermost-desktop
+    SNAP/mentaplexmediaserver: menta-plexmediaserver
+    SNAP/openspades: openspades
+    SNAP/pintown: pin-town
+    SNAP/postgresql10: postgresql10
+    SNAP/storjshare: storjshare
+    SNAP/slackterm: slack-term
+    SNAP/vectr: vectr
+    SNAP/wekan: wekan
+    SNAP/wormhole: wormhole
     # Featured snaps in Ubuntu Software
-    INSTALL/anboxinstaller: anbox-installer --classic
-    INSTALL/lxd: lxd    
+    SNAP/anboxinstaller: anbox-installer
+    SNAP/lxd: lxd
     # Top non canonical snaps
-    INSTALL/atom: atom --classic
-    INSTALL/conjureup: conjure-up --classic
-    INSTALL/discord: discord
-    INSTALL/docker: docker
-    INSTALL/etcd: etcd
-    INSTALL/geocoder: geocoder --edge
-    INSTALL/gimp: gimp --beta    
-    INSTALL/huggle: huggle
-    INSTALL/hugo: hugo
-    INSTALL/ia: ia --edge
-    INSTALL/kurly: kurly
-    INSTALL/micro: micro --beta
-    INSTALL/nikola: nikola
-    INSTALL/parity: parity --edge
-    INSTALL/paritybitcoin: parity-bitcoin --edge
-    INSTALL/remmina: remmina
-    INSTALL/telegramsergiusens: telegram-sergiusens
-    INSTALL/zeronet: zeronet
-    INSTALL/zeronetjs: zeronet-js --beta    
+    SNAP/atom: atom
+    SNAP/discord: discord
+    SNAP/docker: docker
+    SNAP/etcd: etcd
+    SNAP/geocoder: geocoder
+    SNAP/gimp: gimp
+    SNAP/huggle: huggle
+    SNAP/hugo: hugo
+    SNAP/ia: ia
+    SNAP/kurly: kurly
+    SNAP/micro: micro
+    SNAP/nikola: nikola
+    SNAP/parity: parity
+    SNAP/paritybitcoin: parity-bitcoin
+    SNAP/remmina: remmina
+    SNAP/telegramsergiusens: telegram-sergiusens
+    SNAP/zeronet: zeronet
+    SNAP/zeronetjs: zeronet-js
     # Top canonical snaps
-    INSTALL/bare: bare --edge
-    INSTALL/bluez: bluez
-    INSTALL/gedit: gedit
-    INSTALL/go: go --classic
-    INSTALL/juju: juju --classic
-    INSTALL/neutron: neutron --edge
-    INSTALL/nova: nova --edge
-    INSTALL/snapcraft: snapcraft --beta --classic
-    INSTALL/solc: solc
-    INSTALL/vault: vault
+    SNAP/bare: bare
+    SNAP/bluez: bluez
+    SNAP/conjureup: conjure-up
+    SNAP/gedit: gedit
+    SNAP/go: go
+    SNAP/juju: juju
+    SNAP/neutron: neutron
+    SNAP/nova: nova
+    SNAP/snapcraft: snapcraft
+    SNAP/solc: solc
+    SNAP/vault: vault
 
 execute: |
-    SNAPNAME="$(echo $INSTALL | sed 's/ .*//')"
-    snap install $INSTALL
-    snap list | MATCH $SNAPNAME
+    CHANNELS=(stable candidate beta edge)
+    for CHANNEL in "${CHANNELS[@]}"; do
+        CHANNEL_INFO="$(snap info $SNAP | grep " $CHANNEL: ")" || exit
+        if echo $CHANNEL_INFO | grep -q -E "$CHANNEL:.*–"; then
+            continue
+        fi
+
+        if echo $CHANNEL_INFO | MATCH "$CHANNEL:.*classic"; then
+            snap install $SNAP --$CHANNEL --classic
+        elif echo $CHANNEL_INFO | MATCH"$CHANNEL:.*jailmode"; then
+            snap install $SNAP --$CHANNEL --jailmode
+        elif echo $CHANNEL_INFO | MATCH "$CHANNEL:.*devmode"; then
+            snap install $SNAP --$CHANNEL --devmode
+        else
+            snap install $SNAP --$CHANNEL
+        fi
+        break
+    done
+
+    snap list | grep -q -E $SNAP

--- a/tests/main/install-snaps/task.yaml
+++ b/tests/main/install-snaps/task.yaml
@@ -1,57 +1,65 @@
-summary: Check install snaps
+summary: Check install popular snaps
+
+manual: true
 
 environment:
-    # Non Canonical snaps
-    SNAP/atomify: atomify
-    FLAGS/atomify:
-    SNAP/geocoder: geocoder
-    FLAGS/geocoder: --edge
-    SNAP/gimp: gimp
-    FLAGS/gimp: --beta
-    SNAP/heroku: heroku
-    FLAGS/heroku: --classic
-    SNAP/huggle: huggle
-    FLAGS/huggle:
-    SNAP/hugo: hugo
-    FLAGS/hugo:
-    SNAP/ia: ia
-    FLAGS/ia: --edge
-    SNAP/kurly: kurly
-    FLAGS/kurly:
-    SNAP/micro: micro
-    FLAGS/micro: --beta
-    SNAP/nikola: nikola
-    FLAGS/nikola:
-    SNAP/parity: parity
-    FLAGS/parity: --edge
-    SNAP/paritybitcoin: parity-bitcoin
-    FLAGS/paritybitcoin: --edge
-    SNAP/zeronetjs: zeronet-js
-    FLAGS/zeronetjs: --beta
-    # Canonical snaps
-    SNAP/bare: bare
-    FLAGS/bare: --edge
-    SNAP/bluez: bluez
-    FLAGS/bluez:
-    SNAP/gedit: gedit
-    FLAGS/gedit:
-    SNAP/go: go
-    FLAGS/go: --classic
-    SNAP/juju: juju
-    FLAGS/juju: --classic
-    SNAP/lxd: lxd
-    FLAGS/lxd:
-    SNAP/neutron: neutron
-    FLAGS/neutron: --edge
-    SNAP/nova: nova
-    FLAGS/nova: --edge
-    SNAP/snapcraft: snapcraft
-    FLAGS/snapcraft: --beta --classic
-    SNAP/solc: solc
-    FLAGS/solc:
-    SNAP/vault: vault
-    FLAGS/vault:
+    # High Profile
+    INSTALL/azurecli: azure-cli --classic
+    INSTALL/awscli: aws-cli --classic
+    INSTALL/heroku: heroku --classic
+    INSTALL/hiri: hiri  
+    INSTALL/kubectl: kubectl --classic
+    INSTALL/rocketchatserver: rocketchat-server
+    # Selected from recent insights posts
+    INSTALL/corebird: corebird
+    INSTALL/gitterdesktop: gitter-desktop
+    INSTALL/helm: helm
+    INSTALL/mattermostdesktop: mattermost-desktop
+    INSTALL/mentaplexmediaserver: menta-plexmediaserver
+    INSTALL/openspades: openspades
+    INSTALL/pintown: pin-town
+    INSTALL/postgresql10: postgresql10
+    INSTALL/storjshare: storjshare
+    INSTALL/slackterm: slack-term
+    INSTALL/vectr: vectr
+    INSTALL/wekan: wekan
+    INSTALL/wormhole: wormhole
+    # Featured snaps in Ubuntu Software
+    INSTALL/anboxinstaller: anbox-installer --classic
+    INSTALL/lxd: lxd    
+    # Top non canonical snaps
+    INSTALL/atom: atom --classic
+    INSTALL/conjureup: conjure-up --classic
+    INSTALL/discord: discord
+    INSTALL/docker: docker
+    INSTALL/etcd: etcd
+    INSTALL/geocoder: geocoder --edge
+    INSTALL/gimp: gimp --beta    
+    INSTALL/huggle: huggle
+    INSTALL/hugo: hugo
+    INSTALL/ia: ia --edge
+    INSTALL/kurly: kurly
+    INSTALL/micro: micro --beta
+    INSTALL/nikola: nikola
+    INSTALL/parity: parity --edge
+    INSTALL/paritybitcoin: parity-bitcoin --edge
+    INSTALL/remmina: remmina
+    INSTALL/telegramsergiusens: telegram-sergiusens
+    INSTALL/zeronet: zeronet
+    INSTALL/zeronetjs: zeronet-js --beta    
+    # Top canonical snaps
+    INSTALL/bare: bare --edge
+    INSTALL/bluez: bluez
+    INSTALL/gedit: gedit
+    INSTALL/go: go --classic
+    INSTALL/juju: juju --classic
+    INSTALL/neutron: neutron --edge
+    INSTALL/nova: nova --edge
+    INSTALL/snapcraft: snapcraft --beta --classic
+    INSTALL/solc: solc
+    INSTALL/vault: vault
 
 execute: |
-    snap install $FLAGS $SNAP
-    snap list | MATCH $SNAP
+    SNAPNAME="$(echo $INSTALL | sed 's/ .*//')"
+    snap install $INSTALL
+    snap list | MATCH $SNAPNAME

--- a/tests/main/install-snaps/task.yaml
+++ b/tests/main/install-snaps/task.yaml
@@ -1,0 +1,57 @@
+summary: Check install snaps
+
+environment:
+    # Non Canonical snaps
+    SNAP/atomify: atomify
+    FLAGS/atomify:
+    SNAP/geocoder: geocoder
+    FLAGS/geocoder: --edge
+    SNAP/gimp: gimp
+    FLAGS/gimp: --beta
+    SNAP/heroku: heroku
+    FLAGS/heroku: --classic
+    SNAP/huggle: huggle
+    FLAGS/huggle:
+    SNAP/hugo: hugo
+    FLAGS/hugo:
+    SNAP/ia: ia
+    FLAGS/ia: --edge
+    SNAP/kurly: kurly
+    FLAGS/kurly:
+    SNAP/micro: micro
+    FLAGS/micro: --beta
+    SNAP/nikola: nikola
+    FLAGS/nikola:
+    SNAP/parity: parity
+    FLAGS/parity: --edge
+    SNAP/paritybitcoin: parity-bitcoin
+    FLAGS/paritybitcoin: --edge
+    SNAP/zeronetjs: zeronet-js
+    FLAGS/zeronetjs: --beta
+    # Canonical snaps
+    SNAP/bare: bare
+    FLAGS/bare: --edge
+    SNAP/bluez: bluez
+    FLAGS/bluez:
+    SNAP/gedit: gedit
+    FLAGS/gedit:
+    SNAP/go: go
+    FLAGS/go: --classic
+    SNAP/juju: juju
+    FLAGS/juju: --classic
+    SNAP/lxd: lxd
+    FLAGS/lxd:
+    SNAP/neutron: neutron
+    FLAGS/neutron: --edge
+    SNAP/nova: nova
+    FLAGS/nova: --edge
+    SNAP/snapcraft: snapcraft
+    FLAGS/snapcraft: --beta --classic
+    SNAP/solc: solc
+    FLAGS/solc:
+    SNAP/vault: vault
+    FLAGS/vault:
+
+execute: |
+    snap install $FLAGS $SNAP
+    snap list | MATCH $SNAP

--- a/tests/main/install-snaps/task.yaml
+++ b/tests/main/install-snaps/task.yaml
@@ -69,7 +69,7 @@ execute: |
 
         if echo $CHANNEL_INFO | MATCH "$CHANNEL:.*classic"; then
             snap install $SNAP --$CHANNEL --classic
-        elif echo $CHANNEL_INFO | MATCH"$CHANNEL:.*jailmode"; then
+        elif echo $CHANNEL_INFO | MATCH "$CHANNEL:.*jailmode"; then
             snap install $SNAP --$CHANNEL --jailmode
         elif echo $CHANNEL_INFO | MATCH "$CHANNEL:.*devmode"; then
             snap install $SNAP --$CHANNEL --devmode

--- a/tests/main/install-snaps/task.yaml
+++ b/tests/main/install-snaps/task.yaml
@@ -1,5 +1,12 @@
 summary: Check install popular snaps
 
+details: |
+    This test is intended to install some popular snaps from
+    different channels. The idea is to detect any problem
+    installing that are currently published and some of them
+    with many revisions.
+    The execution of this test is made on the nightly build.
+
 manual: true
 
 environment:
@@ -60,15 +67,25 @@ environment:
     SNAP/vault: vault
 
 execute: |
-    CHANNELS=(stable candidate beta edge)
-    for CHANNEL in "${CHANNELS[@]}"; do
-        CHANNEL_INFO="$(snap info $SNAP | grep " $CHANNEL: ")" || exit
-        if echo $CHANNEL_INFO | grep -q -E "$CHANNEL:.*–"; then
+    . "$TESTSLIB/snaps.sh"
+
+    CHANNELS="stable candidate beta edge"
+    for CHANNEL in $CHANNELS; do
+        if ! CHANNEL_INFO="$(snap info $SNAP | grep " $CHANNEL: ")"; then
+            echo "Snap $SNAP not found"
+            exit
+        fi
+        if echo $CHANNEL_INFO | MATCH "$CHANNEL:.*–"; then
             continue
         fi
 
         if echo $CHANNEL_INFO | MATCH "$CHANNEL:.*classic"; then
-            snap install $SNAP --$CHANNEL --classic
+            if is_classic_confinement_supported; then
+                snap install $SNAP --$CHANNEL --classic
+            else
+                echo "The snap $SNAP requires classic confinement which is not supported yet"
+                exit
+            fi
         elif echo $CHANNEL_INFO | MATCH "$CHANNEL:.*jailmode"; then
             snap install $SNAP --$CHANNEL --jailmode
         elif echo $CHANNEL_INFO | MATCH "$CHANNEL:.*devmode"; then
@@ -79,4 +96,4 @@ execute: |
         break
     done
 
-    snap list | grep -q -E $SNAP
+    snap list | MATCH $SNAP

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -43,6 +43,7 @@ restore: |
 
 debug: |
     systemctl status cups || true
+    journalctl -u cups || true
 
 execute: |
     CONNECTED_PATTERN=":cups-control +test-snapd-cups-control-consumer"


### PR DESCRIPTION
The interfaces-cups-control test is still failing sporadically, the test is failing because the service is inactive when the snap tries to print. The idea of this change is to get more information about the cups service status. 