### PR TITLE
store: do not resume a download when we already have the whole thing  (2.27)

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1325,7 +1325,22 @@ func (s *Store) Download(ctx context.Context, name string, targetPath string, do
 		url = downloadInfo.DownloadURL
 	}
 
-	err = download(ctx, name, downloadInfo.Sha3_384, url, user, s, w, resume, pbar)
+	if downloadInfo.Size == 0 || resume < downloadInfo.Size {
+		err = download(ctx, name, downloadInfo.Sha3_384, url, user, s, w, resume, pbar)
+	} else {
+		// we're done! check the hash though
+		h := crypto.SHA3_384.New()
+		if _, err := w.Seek(0, os.SEEK_SET); err != nil {
+			return err
+		}
+		if _, err := io.Copy(h, w); err != nil {
+			return err
+		}
+		actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
+		if downloadInfo.Sha3_384 != actualSha3 {
+			err = HashError{name, actualSha3, downloadInfo.Sha3_384}
+		}
+	}
 	// If hashsum is incorrect retry once
 	if _, ok := err.(HashError); ok {
 		logger.Debugf("Hashsum error on download: %v", err.Error())


### PR DESCRIPTION
* store: do not resume a download when we already have the whole thing

Without this a .partial file that has been completely downloaded still
triggers a request to the server (which will then come back with a
416).

This lets you drop a .snap in /var/lib/snapd/snaps as a .partial,
which could be used to speed up tests. It'll still be checksummed
(twice), but it won't hit the network for the download unless the
store says it's got a delta.

Doing the same thing for delta downloads is left as an exercise to the
reader.

* store: address review feedback (thanks pedronis)