### PR TITLE
tests: adding more debug information for the interfaces-cups-control …

### DIFF
--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -43,6 +43,7 @@ restore: |
 
 debug: |
     systemctl status cups || true
+    journalctl -u cpus || true
 
 execute: |
     CONNECTED_PATTERN=":cups-control +test-snapd-cups-control-consumer"


### PR DESCRIPTION
…test

The interfaces-cups-control test is still failing sporadically, the test
is failing because the service is inactive when the snap tries to print.
The idea of this change is to get more information about the cups
service status.

Error:
https://travis-ci.org/snapcore/snapd/builds/264333791