### PR TITLE
interfaces: allow /usr/bin/xdg-open in unity7 (2.27)

### DIFF
--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -85,8 +85,8 @@ const unity7ConnectedPlugAppArmor = `
 # only in environments supporting dbus-send (eg, X11). In the future once
 # snappy's xdg-open supports all snaps images, this access may move to another
 # interface.
-/usr/local/bin/xdg-open ixr,
-/usr/local/share/applications/{,*} r,
+/usr/bin/xdg-open ixr,
+/usr/share/applications/{,*} r,
 /usr/bin/dbus-send ixr,
 dbus (send)
     bus=session


### PR DESCRIPTION
This fixes an apparmor denial. The xdg-open binary moved from /usr/local/bin/xdg-open to /usr/bin/xdg-open in the core snap but the interfaces did not get updated.

Backport for 2.27.