### PR TITLE
switch to canonical path for gopkg.in/cheggaaa/pb.v1

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -25,8 +25,8 @@ import (
 	"os"
 	"unicode"
 
-	"github.com/cheggaaa/pb"
 	"golang.org/x/crypto/ssh/terminal"
+	"gopkg.in/cheggaaa/pb.v1"
 )
 
 // Meter is an interface to show progress to the user

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -8,7 +8,7 @@
 		},
 		{
 			"checksumSHA1": "f4UJKXymPS31lDRMfsmPA4PvwVw=",
-			"path": "github.com/cheggaaa/pb",
+			"path": "gopkg.in/cheggaaa/pb.v1",
 			"revision": "6e9d17711bb763b26b68b3931d47f24c1323abab",
 			"revisionTime": "2016-08-12T10:57:48Z"
 		},


### PR DESCRIPTION
this will let me remove a particularly silly bit of the debian delta.