### PR TITLE
debian: do not build with -buildmode=pie on i386

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -25,7 +25,7 @@ GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 # ways (LP: #1711052).
 # See also https://forum.snapcraft.io/t/artful-i386-panics/
 BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
-ifneq ($(shell dpkg --print-architecture),i386)
+ifneq ($(shell dpkg-architecture -qDEB_TARGET_ARCH),i386)
 BUILDFLAGS+= -buildmode=pie
 endif
 

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -21,7 +21,14 @@ SYSTEMD_UNITS_DESTDIR="lib/systemd/system/"
 # work around that by constructing the appropriate -I flag by hand.
 GCCGO := $(shell go tool dist env > /dev/null 2>&1 && echo no || echo yes)
 
-BUILDFLAGS:=-buildmode=pie -pkgdir=$(CURDIR)/_build/std
+# Disable -buildmode=pie mode on i386 as can panics in spectacular
+# ways (LP: #1711052).
+# See also https://forum.snapcraft.io/t/artful-i386-panics/
+BUILDFLAGS:=-pkgdir=$(CURDIR)/_build/std
+ifneq ($(shell dpkg --print-architecture),i386)
+BUILDFLAGS+= -buildmode=pie
+endif
+
 GCCGOFLAGS=
 ifeq ($(GCCGO),yes)
 GOARCH := $(shell go env GOARCH)


### PR DESCRIPTION
With -buildmode=pie mode on i386 snapd panics in spectacular
ways (LP: #1711052) so we need to disable it for the time
being.

See also https://forum.snapcraft.io/t/artful-i386-panics/