### PR TITLE
Add read access to virtual disk hard drives in udisk2 interface.

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -102,6 +102,8 @@ umount /{,run/}media/**,
 # give raw read access to the system disks and therefore the entire system.
 /dev/sd* r,
 /dev/mmcblk* r,
+/dev/vd* r,
+
 
 # Needed for probing raw devices
 capability sys_rawio,


### PR DESCRIPTION
Add /dev/vd* in apparmor rule in udisk2 interface to support virtual disk hard drives.