### PR TITLE
interfaces: don't crash if content slot has no attributes (2.27)

### DIFF
--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -74,6 +74,9 @@ func (iface *contentInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	}
 	content, ok := slot.Attrs["content"].(string)
 	if !ok || len(content) == 0 {
+		if slot.Attrs == nil {
+			slot.Attrs = make(map[string]interface{})
+		}
 		// content defaults to "slot" name if unspecified
 		slot.Attrs["content"] = slot.Name
 	}

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -198,6 +198,19 @@ apps:
 	c.Assert(err, ErrorMatches, "content plug must contain target path")
 }
 
+func (s *ContentSuite) TestSanitizeSlotNilAttrMap(c *C) {
+	const mockSnapYaml = `name: content-slot-snap
+version: 1.0
+apps:
+  foo:
+    command: foo
+    slots: [content]
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	slot := &interfaces.Slot{SlotInfo: info.Slots["content"]}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "read or write path must be set")
+}
+
 func (s *ContentSuite) TestResolveSpecialVariable(c *C) {
 	info := snaptest.MockInfo(c, "name: name", &snap.SideInfo{Revision: snap.R(42)})
 	c.Check(builtin.ResolveSpecialVariable("foo", info), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))


### PR DESCRIPTION
This mirros an earlier fix to the plug sanitize that was not mirrored to
the slot side. My bad :/

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>