### PR TITLE
interfaces: correctly backport the patch

### DIFF
--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -208,7 +208,8 @@ apps:
 `
 	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 	slot := &interfaces.Slot{SlotInfo: info.Slots["content"]}
-	c.Assert(slot.Sanitize(s.iface), ErrorMatches, "read or write path must be set")
+	err := s.iface.SanitizeSlot(slot)
+	c.Assert(err, ErrorMatches, "read or write path must be set")
 }
 
 func (s *ContentSuite) TestResolveSpecialVariable(c *C) {


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>