### PR TITLE
interfaces: convert uhid to common interface and test cases improvement for time_control and opengl

### DIFF
--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -79,40 +79,7 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), Equals, `
-# Description: Can access opengl.
-
-  # specific gl libs
-  /var/lib/snapd/lib/gl/ r,
-  /var/lib/snapd/lib/gl/** rm,
-
-  /dev/dri/ r,
-  /dev/dri/card0 rw,
-  # nvidia
-  @{PROC}/driver/nvidia/params r,
-  @{PROC}/modules r,
-  /dev/nvidia* rw,
-  unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),
-
-  # eglfs
-  /dev/vchiq rw,
-  /sys/devices/pci[0-9]*/**/config r,
-  /sys/devices/pci[0-9]*/**/{,subsystem_}device r,
-  /sys/devices/pci[0-9]*/**/{,subsystem_}vendor r,
-
-  # FIXME: this is an information leak and snapd should instead query udev for
-  # the specific accesses associated with the above devices.
-  /sys/bus/pci/devices/** r,
-  /run/udev/data/+drm:card* r,
-  /run/udev/data/+pci:[0-9]* r,
-
-  # FIXME: for each device in /dev that this policy references, lookup the
-  # device type, major and minor and create rules of this form:
-  # /run/udev/data/<type><major>:<minor> r,
-  # For now, allow 'c'haracter devices and 'b'lock devices based on
-  # https://www.kernel.org/doc/Documentation/devices.txt
-  /run/udev/data/c226:[0-9]* r,  # 226 drm
-`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/nvidia* rw,`)
 }
 
 func (s *OpenglInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/uhid_test.go
+++ b/interfaces/builtin/uhid_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -26,7 +26,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/udev"
-	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -40,27 +40,21 @@ var _ = Suite(&UhidInterfaceSuite{
 	iface: builtin.MustInterface("uhid"),
 })
 
-func (s *UhidInterfaceSuite) SetUpTest(c *C) {
-	// Mocking
-	osSnapInfo := snaptest.MockInfo(c, `
-name: ubuntu-core
+const uhidConsumerYaml = `name: consumer
+apps:
+ app:
+  plugs: [uhid]
+`
+
+const uhidCoreYaml = `name: core
 type: os
 slots:
-  test-slot-1:
-    interface: uhid
-    path: /dev/uhid
-`, nil)
-	s.slot = &interfaces.Slot{SlotInfo: osSnapInfo.Slots["test-slot-1"]}
+  uhid:
+`
 
-	// Snap Consumers
-	consumingSnapInfo := snaptest.MockInfo(c, `
-name: client-snap
-apps:
-  app-accessing-slot-1:
-    command: foo
-    plugs: [uhid]
-`, nil)
-	s.plug = &interfaces.Plug{PlugInfo: consumingSnapInfo.Plugs["uhid"]}
+func (s *UhidInterfaceSuite) SetUpTest(c *C) {
+	s.plug = MockPlug(c, uhidConsumerYaml, nil, "uhid")
+	s.slot = MockSlot(c, uhidCoreYaml, nil, "uhid")
 }
 
 func (s *UhidInterfaceSuite) TestName(c *C) {
@@ -69,29 +63,40 @@ func (s *UhidInterfaceSuite) TestName(c *C) {
 
 func (s *UhidInterfaceSuite) TestSanitizeSlot(c *C) {
 	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "uhid",
+		Interface: "uhid",
+	}}
+
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"uhid slots are reserved for the core snap")
 }
 
 func (s *UhidInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
-func (s *UhidInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
-	// connected plugs have a non-nil security snippet for apparmor
-	apparmorSpec := &apparmor.Specification{}
-	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)
-	c.Assert(err, IsNil)
-	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.client-snap.app-accessing-slot-1"})
-	c.Assert(apparmorSpec.SnippetForTag("snap.client-snap.app-accessing-slot-1"), testutil.Contains, "/dev/uhid rw,\n")
+func (s *UhidInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/uhid rw,\n")
 }
 
-func (s *UhidInterfaceSuite) TestConnectedPlugUDevSnippets(c *C) {
-	expectedSnippet1 := `KERNEL=="uhid", TAG+="snap_client-snap_app-accessing-slot-1"`
+func (s *UhidInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
-	err := spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil)
-	c.Assert(err, IsNil)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 1)
-	snippet := spec.Snippets()[0]
-	c.Assert(snippet, Equals, expectedSnippet1)
+	c.Assert(spec.Snippets()[0], Equals, `KERNEL=="uhid", TAG+="snap_consumer_app"`)
+}
+
+func (s *UhidInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows control over UHID devices`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "uhid")
 }
 
 func (s *UhidInterfaceSuite) TestAutoConnect(c *C) {


### PR DESCRIPTION
* Simplify uhid interface and improve test case. 
* Improve test case for time control interface.
* Keep code clean for apparmor rules checking in opengl interface.

Note: we have udev rule tagged for time control since earlier version of snapd and try to fine-tune the rules in a separated PR(#3617). We just improve the test case in this PR. Similar case for uhid interface.



