### PR TITLE
corecfg: handle unknown keys that are explicitly set

### DIFF
--- a/corecfg/picfg_test.go
+++ b/corecfg/picfg_test.go
@@ -109,29 +109,25 @@ func (s *piCfgSuite) TestConfigurePiConfigAddNewOption(c *C) {
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigNoChangeUnset(c *C) {
-	st1, err := os.Stat(s.mockConfigPath)
+	// ensure we cannot write to the dir to test that we really
+	// do not update the file
+	err := os.Chmod(filepath.Dir(s.mockConfigPath), 0500)
 	c.Assert(err, IsNil)
+	defer os.Chmod(filepath.Dir(s.mockConfigPath), 0755)
 
 	err = corecfg.UpdatePiConfig(s.mockConfigPath, map[string]string{"hdmi_safe": ""})
 	c.Assert(err, IsNil)
-
-	st2, err := os.Stat(s.mockConfigPath)
-	c.Assert(err, IsNil)
-
-	c.Check(st1.ModTime(), DeepEquals, st2.ModTime())
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigNoChangeSet(c *C) {
-	st1, err := os.Stat(s.mockConfigPath)
+	// ensure we cannot write to the dir to test that we really
+	// do not update the file
+	err := os.Chmod(filepath.Dir(s.mockConfigPath), 0500)
 	c.Assert(err, IsNil)
+	defer os.Chmod(filepath.Dir(s.mockConfigPath), 0755)
 
 	err = corecfg.UpdatePiConfig(s.mockConfigPath, map[string]string{"unrelated_options": "are-kept"})
 	c.Assert(err, IsNil)
-
-	st2, err := os.Stat(s.mockConfigPath)
-	c.Assert(err, IsNil)
-
-	c.Check(st1.ModTime(), DeepEquals, st2.ModTime())
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {

--- a/corecfg/utils.go
+++ b/corecfg/utils.go
@@ -53,7 +53,13 @@ func updateKeyValueStream(r io.Reader, allConfig map[string]bool, newConfig map[
 	for scanner.Scan() {
 		line := scanner.Text()
 		matches := rx.FindStringSubmatch(line)
-		if len(matches) > 0 && allConfig[matches[2]] {
+		if len(matches) < 3 {
+			toWrite = append(toWrite, line)
+			continue
+		}
+		_, inNewConfig := newConfig[matches[2]]
+		inAllConfig := allConfig[matches[2]]
+		if inNewConfig || inAllConfig {
 			wasComment := (matches[1] == "#")
 			key := matches[2]
 			oldValue := matches[3]


### PR DESCRIPTION
When updateKeyValueStream is processing a stream with a key that is not
known but is explicitly listed in new configuration it would needlessly
indicate that the file needs writing.

The test that was checking this was flaky because the writes happened
so quickly we were never given a chance to observe the failure
(usually). Running the test repeatedly on my SSD makes it fail very
frequently tough.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>