### PR TITLE
interfaces/many: updates based on chromium and mrrescue denials

### DIFF
--- a/interfaces/builtin/alsa.go
+++ b/interfaces/builtin/alsa.go
@@ -36,6 +36,7 @@ const alsaConnectedPlugAppArmor = `
 /dev/snd/* rw,
 
 /run/udev/data/c116:[0-9]* r, # alsa
+/run/udev/data/+sound:card[0-9]* r,
 
 # Allow access to the alsa state dir
 /var/lib/alsa/{,*}         r,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -61,6 +61,9 @@ owner /{dev,run}/shm/{,.}com.google.Chrome.* mrw,
 # Allow reading platform files
 /run/udev/data/+platform:* r,
 
+# miscellaneous accesses
+@{PROC}/vmstat r,
+
 # Chromium content api in gnome-shell reads this
 /etc/opt/chrome/{,**} r,
 
@@ -126,7 +129,8 @@ owner @{PROC}/@{pid}/fd/[0-9]* w,
 /run/udev/data/c108:[0-9]* r, # /dev/ppp
 /run/udev/data/c189:[0-9]* r, # USB serial converters
 /run/udev/data/c89:[0-9]* r,  # /dev/i2c-*
-/run/udev/data/c81:[0-9]* r, # video4linux (/dev/video*, etc)
+/run/udev/data/c81:[0-9]* r,  # video4linux (/dev/video*, etc)
+/run/udev/data/c202:[0-9]* r, # /dev/cpu/*/msr
 /run/udev/data/+acpi:* r,
 /run/udev/data/+hwmon:hwmon[0-9]* r,
 /run/udev/data/+i2c:* r,
@@ -153,10 +157,12 @@ deny /sys/devices/virtual/block/dm-[0-9]*/dm/name r,
 /run/udev/data/b1:[0-9]* r,   # /dev/ram*
 /run/udev/data/b7:[0-9]* r,   # /dev/loop*
 /run/udev/data/b8:[0-9]* r,   # /dev/sd*
+/run/udev/data/b11:[0-9]* r,  # /dev/scd* and sr*
 /run/udev/data/c21:[0-9]* r,  # /dev/sg*
 /run/udev/data/+usb:[0-9]* r,
 
 # experimental
+/run/udev/data/b252:[0-9]* r,
 /run/udev/data/b253:[0-9]* r,
 /run/udev/data/b259:[0-9]* r,
 /run/udev/data/c242:[0-9]* r,

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -33,6 +33,7 @@ const opticalDriveConnectedPlugAppArmor = `
 /dev/sr[0-9]* r,
 /dev/scd[0-9]* r,
 @{PROC}/sys/dev/cdrom/info r,
+/run/udev/data/b11:[0-9]* r,
 `
 
 func init() {

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -45,6 +45,9 @@ owner /{,var/}run/pulse/ r,
 owner /{,var/}run/pulse/native rwk,
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pulse/ rw,
+
+/run/udev/data/c116:[0-9]* r,
+/run/udev/data/+sound:card[0-9]* r,
 `
 
 const pulseaudioConnectedPlugAppArmorDesktop = `


### PR DESCRIPTION
- interfaces/alsa,pulseaudio: allow read on udev data for sound
- interfaces/optical-drive: read access to udev data for /dev/scd*
- interfaces/browser-support: read on /proc/vmstat and misc udev data