### PR TITLE
spread.yaml: update delta ref to 2.27

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -30,7 +30,7 @@ environment:
     GADGET_CHANNEL: "$(HOST: echo ${SPREAD_GADGET_CHANNEL:-edge})"
     REMOTE_STORE: "$(HOST: echo ${SPREAD_REMOTE_STORE:-production})"
     SNAPPY_USE_STAGING_STORE: "$(HOST: if [ $SPREAD_REMOTE_STORE = staging ]; then echo 1; else echo 0; fi)"
-    DELTA_REF: 2.17
+    DELTA_REF: 2.27
     DELTA_PREFIX: snapd-$DELTA_REF/
     SNAPD_PUBLISHED_VERSION: "$(HOST: echo $SPREAD_SNAPD_PUBLISHED_VERSION)"
     HTTP_PROXY: "$(HOST: echo $SPREAD_HTTP_PROXY)"


### PR DESCRIPTION
This will speed up local spread testing by reusing delta from a more
recent release than before.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>