### PR TITLE
Make updateKeyValueStream reject unsupported options

### DIFF
--- a/corecfg/picfg_test.go
+++ b/corecfg/picfg_test.go
@@ -43,9 +43,7 @@ var _ = Suite(&piCfgSuite{})
 var mockConfigTxt = `
 # For more options and information see
 # http://www.raspberrypi.org/documentation/configuration/config-txt.md
-# Some settings may impact device functionality. See link above for details
-# uncomment if you get no picture on HDMI for a default "safe" mode
-#hdmi_safe=1
+#hdmi_group=1
 # uncomment this if your display has a black border of unused pixels visible
 # and your display can output without overscan
 #disable_overscan=1
@@ -115,7 +113,7 @@ func (s *piCfgSuite) TestConfigurePiConfigNoChangeUnset(c *C) {
 	c.Assert(err, IsNil)
 	defer os.Chmod(filepath.Dir(s.mockConfigPath), 0755)
 
-	err = corecfg.UpdatePiConfig(s.mockConfigPath, map[string]string{"hdmi_safe": ""})
+	err = corecfg.UpdatePiConfig(s.mockConfigPath, map[string]string{"hdmi_group": ""})
 	c.Assert(err, IsNil)
 }
 
@@ -126,8 +124,8 @@ func (s *piCfgSuite) TestConfigurePiConfigNoChangeSet(c *C) {
 	c.Assert(err, IsNil)
 	defer os.Chmod(filepath.Dir(s.mockConfigPath), 0755)
 
-	err = corecfg.UpdatePiConfig(s.mockConfigPath, map[string]string{"unrelated_options": "are-kept"})
-	c.Assert(err, IsNil)
+	err = corecfg.UpdatePiConfig(s.mockConfigPath, map[string]string{"unrelated_options": "cannot-be-set"})
+	c.Assert(err, ErrorMatches, `cannot set unsupported configuration value "unrelated_options"`)
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {

--- a/corecfg/picfg_test.go
+++ b/corecfg/picfg_test.go
@@ -109,29 +109,25 @@ func (s *piCfgSuite) TestConfigurePiConfigAddNewOption(c *C) {
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigNoChangeUnset(c *C) {
-	st1, err := os.Stat(s.mockConfigPath)
+	// ensure we cannot write to the dir to test that we really
+	// do not update the file
+	err := os.Chmod(filepath.Dir(s.mockConfigPath), 0500)
 	c.Assert(err, IsNil)
+	defer os.Chmod(filepath.Dir(s.mockConfigPath), 0755)
 
 	err = corecfg.UpdatePiConfig(s.mockConfigPath, map[string]string{"hdmi_safe": ""})
 	c.Assert(err, IsNil)
-
-	st2, err := os.Stat(s.mockConfigPath)
-	c.Assert(err, IsNil)
-
-	c.Check(st1.ModTime(), DeepEquals, st2.ModTime())
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigNoChangeSet(c *C) {
-	st1, err := os.Stat(s.mockConfigPath)
+	// ensure we cannot write to the dir to test that we really
+	// do not update the file
+	err := os.Chmod(filepath.Dir(s.mockConfigPath), 0500)
 	c.Assert(err, IsNil)
+	defer os.Chmod(filepath.Dir(s.mockConfigPath), 0755)
 
 	err = corecfg.UpdatePiConfig(s.mockConfigPath, map[string]string{"unrelated_options": "are-kept"})
 	c.Assert(err, IsNil)
-
-	st2, err := os.Stat(s.mockConfigPath)
-	c.Assert(err, IsNil)
-
-	c.Check(st1.ModTime(), DeepEquals, st2.ModTime())
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {

--- a/corecfg/proxy.go
+++ b/corecfg/proxy.go
@@ -29,9 +29,9 @@ import (
 )
 
 var proxyConfigKeys = map[string]bool{
-	"http":  true,
-	"https": true,
-	"ftp":   true,
+	"http_proxy":  true,
+	"https_proxy": true,
+	"ftp_proxy":   true,
 }
 
 func etcEnvironment() string {

--- a/corecfg/utils.go
+++ b/corecfg/utils.go
@@ -37,10 +37,12 @@ var rx = regexp.MustCompile(`^[ \t]*(#?)[ \t#]*([a-z_]+)=(.*)$`)
 // the "config" input is applied. If changes need to be written a []string
 // that contains the full file is returned. On error an error is returned.
 func updateKeyValueStream(r io.Reader, allConfig map[string]bool, newConfig map[string]string) (toWrite []string, err error) {
-	// build regexp
 	cfgKeys := make([]string, len(newConfig))
 	i := 0
 	for k := range newConfig {
+		if !allConfig[k] {
+			return nil, fmt.Errorf("cannot set unsupported configuration value %q", k)
+		}
 		cfgKeys[i] = k
 		i++
 	}

--- a/corecfg/utils_test.go
+++ b/corecfg/utils_test.go
@@ -31,7 +31,7 @@ type utilsSuite struct{}
 
 var _ = Suite(&utilsSuite{})
 
-func (s *utilsSuite) TestUpdateKeyValueStreamNoChanges(c *C) {
+func (s *utilsSuite) TestUpdateKeyValueStreamNoNewConfig(c *C) {
 	in := bytes.NewBufferString("foo=bar")
 	newConfig := map[string]string{}
 	allConfig := map[string]bool{}
@@ -39,6 +39,17 @@ func (s *utilsSuite) TestUpdateKeyValueStreamNoChanges(c *C) {
 	toWrite, err := corecfg.UpdateKeyValueStream(in, allConfig, newConfig)
 	c.Check(err, IsNil)
 	c.Check(toWrite, IsNil)
+}
+
+func (s *utilsSuite) TestUpdateKeyValueStreamConfigNotInAllConfig(c *C) {
+	in := bytes.NewBufferString("")
+	newConfig := map[string]string{"unsupported-options": "cannot be set"}
+	allConfig := map[string]bool{
+		"foo": true,
+	}
+
+	_, err := corecfg.UpdateKeyValueStream(in, allConfig, newConfig)
+	c.Check(err, ErrorMatches, `cannot set unsupported configuration value \"unsupported-options"`)
 }
 
 func (s *utilsSuite) TestUpdateKeyValueStreamOneChange(c *C) {

--- a/corecfg/utils_test.go
+++ b/corecfg/utils_test.go
@@ -49,7 +49,7 @@ func (s *utilsSuite) TestUpdateKeyValueStreamConfigNotInAllConfig(c *C) {
 	}
 
 	_, err := corecfg.UpdateKeyValueStream(in, supportedConfigKeys, newConfig)
-	c.Check(err, ErrorMatches, `cannot set unsupported configuration value \"unsupported-options"`)
+	c.Check(err, ErrorMatches, `cannot set unsupported configuration value "unsupported-options"`)
 }
 
 func (s *utilsSuite) TestUpdateKeyValueStreamOneChange(c *C) {

--- a/corecfg/utils_test.go
+++ b/corecfg/utils_test.go
@@ -34,9 +34,9 @@ var _ = Suite(&utilsSuite{})
 func (s *utilsSuite) TestUpdateKeyValueStreamNoNewConfig(c *C) {
 	in := bytes.NewBufferString("foo=bar")
 	newConfig := map[string]string{}
-	allConfig := map[string]bool{}
+	supportedConfigKeys := map[string]bool{}
 
-	toWrite, err := corecfg.UpdateKeyValueStream(in, allConfig, newConfig)
+	toWrite, err := corecfg.UpdateKeyValueStream(in, supportedConfigKeys, newConfig)
 	c.Check(err, IsNil)
 	c.Check(toWrite, IsNil)
 }
@@ -44,22 +44,22 @@ func (s *utilsSuite) TestUpdateKeyValueStreamNoNewConfig(c *C) {
 func (s *utilsSuite) TestUpdateKeyValueStreamConfigNotInAllConfig(c *C) {
 	in := bytes.NewBufferString("")
 	newConfig := map[string]string{"unsupported-options": "cannot be set"}
-	allConfig := map[string]bool{
+	supportedConfigKeys := map[string]bool{
 		"foo": true,
 	}
 
-	_, err := corecfg.UpdateKeyValueStream(in, allConfig, newConfig)
+	_, err := corecfg.UpdateKeyValueStream(in, supportedConfigKeys, newConfig)
 	c.Check(err, ErrorMatches, `cannot set unsupported configuration value \"unsupported-options"`)
 }
 
 func (s *utilsSuite) TestUpdateKeyValueStreamOneChange(c *C) {
 	in := bytes.NewBufferString("foo=bar")
 	newConfig := map[string]string{"foo": "baz"}
-	allConfig := map[string]bool{
+	supportedConfigKeys := map[string]bool{
 		"foo": true,
 	}
 
-	toWrite, err := corecfg.UpdateKeyValueStream(in, allConfig, newConfig)
+	toWrite, err := corecfg.UpdateKeyValueStream(in, supportedConfigKeys, newConfig)
 	c.Check(err, IsNil)
 	c.Check(toWrite, DeepEquals, []string{"foo=baz"})
 }


### PR DESCRIPTION
This also improves the tests and superseeds https://github.com/snapcore/snapd/pull/3746