### PR TITLE
spread: add mtr logs to diagnose linode issues

### DIFF
--- a/tests/lib/prepare-project.sh
+++ b/tests/lib/prepare-project.sh
@@ -229,6 +229,14 @@ case "$SPREAD_SYSTEM" in
         ;;
 esac
 
+case "$SPREAD_SYSTEM" in
+    debian-*|ubuntu-*)
+        apt-get install mtr-tiny
+        mtr -rw github.com
+    ;;
+esac
+
+
 # update vendoring
 if [ -z "$(which govendor)" ]; then
     rm -rf "$GOPATH/src/github.com/kardianos/govendor"


### PR DESCRIPTION
Tiny branch to get mtr data for linode to get to the bottom of the github network issues.