### PR TITLE
Disable reexec on debian

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -67,7 +67,7 @@ func distroSupportsReExec() bool {
 		return false
 	}
 	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch":
+	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch", "debian":
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return false
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -131,7 +131,7 @@ func (s *cmdSuite) TestDistroSupportsReExec(c *C) {
 	}
 
 	// While others do.
-	for _, id := range []string{"debian", "ubuntu"} {
+	for _, id := range []string{"ubuntu"} {
 		restore = release.MockReleaseInfo(&release.OS{ID: id})
 		defer restore()
 		c.Check(cmd.DistroSupportsReExec(), Equals, true, Commentf("ID: %q", id))


### PR DESCRIPTION
The core snap's snap-confine is built with apparmor support, which expects
snapd to have written a profile before invoking snap-confine. But because the
debian kernel does not support all apparmor features used by snapd yet, snapd
ill not have written that profile and snap-confine fails. snap-confine should
become more flexible about this but until this happens, disable re-exec-ing
into the core snap on Debian.