### PR TITLE
systemd: disable `Nice=-5` to fix error when running inside lxd

### DIFF
--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -3,7 +3,9 @@ Description=Snappy daemon
 Requires=snapd.socket
 
 [Service]
-Nice=-5
+# Disabled because it breaks lxd
+# (https://bugs.launchpad.net/snapd/+bug/1709536)
+#Nice=-5
 OOMScoreAdjust=-900
 ExecStart=@libexecdir@/snapd/snapd
 EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@


### PR DESCRIPTION
See https://bugs.launchpad.net/snapd/+bug/1709536