### PR TITLE
tests: adding debug information for refresh-all tests

### DIFF
--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -38,7 +38,6 @@ prepare: |
     tail -n200 /var/log/syslog || true
     systemctl status fakestore || true
     journalctl -u fakestore || true
-    snap changes
     exit 1
 
 restore: |

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -59,6 +59,9 @@ execute: |
         exit
     fi
 
+    echo "Sanity check for the fake store"
+    snap refresh 2>&1 | MATCH "All snaps up to date."
+
     echo "When the store is configured to make them refreshable"
     . $TESTSLIB/files.sh
     . $TESTSLIB/store.sh

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -35,9 +35,9 @@ restore: |
 
 debug: |
     systemctl status fakestore || true
-    netstat -ntlp | grep LISTEN
     journalctl -u fakestore
     snap changes || true
+    netstat -ntlp | grep LISTEN
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -44,15 +44,6 @@ restore: |
     teardown_fake_store $BLOB_DIR
     rm -rf $BLOB_DIR
 
-debug: |
-    netstat -ntlp | grep LISTEN || true
-    netstat -ntlp | grep 11028 || true
-    dmesg || true
-    tail -n200 /var/log/syslog || true
-    systemctl status fakestore || true
-    journalctl -u fakestore || true
-    snap changes || true
-
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -23,6 +23,17 @@ prepare: |
     echo "And the daemon is configured to point to the fake store"
     setup_fake_store $BLOB_DIR
 
+    echo "Wait until fake store is ready"
+    for i in $(seq 5); do
+        if snap refresh 2>&1 | MATCH "All snaps up to date"; then
+            exit
+        fi
+        sleep 1
+    done
+
+    echo "Snap refresh against the fakestore not working properly"
+    exit 1
+
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
@@ -44,9 +55,6 @@ execute: |
         echo "This test needs test keys to be trusted"
         exit
     fi
-
-    echo "Sanity check for the fake store"
-    snap refresh 2>&1 | MATCH "All snaps up to date"
 
     echo "When the store is configured to make them refreshable"
     . $TESTSLIB/files.sh

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -48,7 +48,6 @@ debug: |
     systemctl status fakestore || true
     journalctl -u fakestore
     snap changes || true
-    netstat -ntlp | grep LISTEN
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -38,7 +38,7 @@ prepare: |
     tail -n200 /var/log/syslog || true
     systemctl status fakestore || true
     journalctl -u fakestore || true
-    snap changes || true
+    snap changes
     exit 1
 
 restore: |

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -24,20 +24,14 @@ prepare: |
     setup_fake_store $BLOB_DIR
 
     echo "Wait until fake store is ready"
-    for i in $(seq 2); do
+    for i in $(seq 10); do
         if snap refresh 2>&1 | MATCH "All snaps up to date"; then
             exit
         fi
         sleep 1
     done
 
-    echo "Snap refresh against the fakestore not working properly"
-    netstat -ntlp | grep LISTEN
-    netstat -ntlp | grep 11028
-    dmesg || true
-    tail -n200 /var/log/syslog || true
-    systemctl status fakestore || true
-    journalctl -u fakestore || true
+    echo "fakestore not working properly"
     exit 1
 
 restore: |
@@ -51,8 +45,8 @@ restore: |
     rm -rf $BLOB_DIR
 
 debug: |
-    netstat -ntlp | grep LISTEN
-    netstat -ntlp | grep 11028
+    netstat -ntlp | grep LISTEN || true
+    netstat -ntlp | grep 11028 || true
     dmesg || true
     tail -n200 /var/log/syslog || true
     systemctl status fakestore || true

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -33,6 +33,10 @@ restore: |
     teardown_fake_store $BLOB_DIR
     rm -rf $BLOB_DIR
 
+debug: |
+    systemctl status fakestore || true
+    netstat -ntlp | grep LISTEN
+
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -25,7 +25,7 @@ prepare: |
 
     echo "Wait until fake store is ready"
     for i in $(seq 10); do
-        if snap refresh 2>&1 | MATCH "All snaps up to date"; then
+        if netstat -ntlp | MATCH "127.0.0.1:11028*.*LISTEN"; then
             exit
         fi
         sleep 1

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -32,6 +32,13 @@ prepare: |
     done
 
     echo "Snap refresh against the fakestore not working properly"
+    netstat -ntlp | grep LISTEN
+    netstat -ntlp | grep 11028
+    dmesg || true
+    tail -n200 /var/log/syslog || true
+    systemctl status fakestore || true
+    journalctl -u fakestore || true
+    snap changes || true
     exit 1
 
 restore: |
@@ -45,8 +52,12 @@ restore: |
     rm -rf $BLOB_DIR
 
 debug: |
+    netstat -ntlp | grep LISTEN
+    netstat -ntlp | grep 11028
+    dmesg || true
+    tail -n200 /var/log/syslog || true
     systemctl status fakestore || true
-    journalctl -u fakestore
+    journalctl -u fakestore || true
     snap changes || true
 
 execute: |

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -24,7 +24,7 @@ prepare: |
     setup_fake_store $BLOB_DIR
 
     echo "Wait until fake store is ready"
-    for i in $(seq 5); do
+    for i in $(seq 3); do
         if snap refresh 2>&1 | MATCH "All snaps up to date"; then
             exit
         fi

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -24,7 +24,7 @@ prepare: |
     setup_fake_store $BLOB_DIR
 
     echo "Wait until fake store is ready"
-    for i in $(seq 3); do
+    for i in $(seq 2); do
         if snap refresh 2>&1 | MATCH "All snaps up to date"; then
             exit
         fi

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -36,6 +36,8 @@ restore: |
 debug: |
     systemctl status fakestore || true
     netstat -ntlp | grep LISTEN
+    journalctl -u fakestore
+    snap changes || true
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -26,6 +26,17 @@ prepare: |
     echo "And the daemon is configured to point to the fake store"
     setup_fake_store $BLOB_DIR
 
+    echo "Wait until fake store is ready"
+    for i in $(seq 5); do
+        if snap refresh 2>&1 | MATCH "All snaps up to date"; then
+            exit
+        fi
+        sleep 1
+    done
+
+    echo "Snap refresh against the fakestore not working properly"
+    exit 1
+
 restore: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
@@ -47,9 +58,6 @@ execute: |
         echo "This test needs test keys to be trusted"
         exit
     fi
-
-    echo "Sanity check for the fake store"
-    snap refresh 2>&1 | MATCH "All snaps up to date."
 
     echo "When the store is configured to make them refreshable"
     . $TESTSLIB/files.sh

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -47,15 +47,6 @@ restore: |
     teardown_fake_store $BLOB_DIR
     rm -rf $BLOB_DIR
 
-debug: |
-    netstat -ntlp | grep LISTEN || true
-    netstat -ntlp | grep 11028 || true
-    dmesg || true
-    tail -n200 /var/log/syslog || true
-    systemctl status fakestore || true
-    journalctl -u fakestore || true
-    snap changes || true
-
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -35,6 +35,13 @@ prepare: |
     done
 
     echo "Snap refresh against the fakestore not working properly"
+    netstat -ntlp | grep LISTEN
+    netstat -ntlp | grep 11028
+    dmesg || true
+    tail -n200 /var/log/syslog || true
+    systemctl status fakestore || true
+    journalctl -u fakestore || true
+    snap changes || true
     exit 1
 
 restore: |
@@ -48,8 +55,12 @@ restore: |
     rm -rf $BLOB_DIR
 
 debug: |
+    netstat -ntlp | grep LISTEN
+    netstat -ntlp | grep 11028
+    dmesg || true
+    tail -n200 /var/log/syslog || true
     systemctl status fakestore || true
-    journalctl -u fakestore
+    journalctl -u fakestore || true
     snap changes || true
 
 execute: |

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -27,20 +27,14 @@ prepare: |
     setup_fake_store $BLOB_DIR
 
     echo "Wait until fake store is ready"
-    for i in $(seq 2); do
-        if snap refresh 2>&1 | MATCH "All snaps up to date"; then
+    for i in $(seq 10); do
+        if netstat -ntlp | MATCH "127.0.0.1:11028*.*LISTEN"; then
             exit
         fi
         sleep 1
     done
 
-    echo "Snap refresh against the fakestore not working properly"
-    netstat -ntlp | grep LISTEN
-    netstat -ntlp | grep 11028
-    dmesg || true
-    tail -n200 /var/log/syslog || true
-    systemctl status fakestore || true
-    journalctl -u fakestore || true
+    echo "fakestore not working properly"
     exit 1
 
 restore: |
@@ -54,8 +48,8 @@ restore: |
     rm -rf $BLOB_DIR
 
 debug: |
-    netstat -ntlp | grep LISTEN
-    netstat -ntlp | grep 11028
+    netstat -ntlp | grep LISTEN || true
+    netstat -ntlp | grep 11028 || true
     dmesg || true
     tail -n200 /var/log/syslog || true
     systemctl status fakestore || true

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -38,9 +38,9 @@ restore: |
 
 debug: |
     systemctl status fakestore || true
-    netstat -ntlp | grep LISTEN
     journalctl -u fakestore
     snap changes || true
+    netstat -ntlp | grep LISTEN
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -27,7 +27,7 @@ prepare: |
     setup_fake_store $BLOB_DIR
 
     echo "Wait until fake store is ready"
-    for i in $(seq 3); do
+    for i in $(seq 2); do
         if snap refresh 2>&1 | MATCH "All snaps up to date"; then
             exit
         fi

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -41,7 +41,6 @@ prepare: |
     tail -n200 /var/log/syslog || true
     systemctl status fakestore || true
     journalctl -u fakestore || true
-    snap changes
     exit 1
 
 restore: |

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -27,7 +27,7 @@ prepare: |
     setup_fake_store $BLOB_DIR
 
     echo "Wait until fake store is ready"
-    for i in $(seq 5); do
+    for i in $(seq 3); do
         if snap refresh 2>&1 | MATCH "All snaps up to date"; then
             exit
         fi

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -62,6 +62,9 @@ execute: |
         exit
     fi
 
+    echo "Sanity check for the fake store"
+    snap refresh 2>&1 | MATCH "All snaps up to date."
+
     echo "When the store is configured to make them refreshable"
     . $TESTSLIB/files.sh
     . $TESTSLIB/store.sh

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -36,6 +36,10 @@ restore: |
     teardown_fake_store $BLOB_DIR
     rm -rf $BLOB_DIR
 
+debug: |
+    systemctl status fakestore || true
+    netstat -ntlp | grep LISTEN
+
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -39,6 +39,8 @@ restore: |
 debug: |
     systemctl status fakestore || true
     netstat -ntlp | grep LISTEN
+    journalctl -u fakestore
+    snap changes || true
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -41,7 +41,7 @@ prepare: |
     tail -n200 /var/log/syslog || true
     systemctl status fakestore || true
     journalctl -u fakestore || true
-    snap changes || true
+    snap changes
     exit 1
 
 restore: |

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -51,7 +51,6 @@ debug: |
     systemctl status fakestore || true
     journalctl -u fakestore
     snap changes || true
-    netstat -ntlp | grep LISTEN
 
 execute: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then


### PR DESCRIPTION
This debug information is what we need to understand why those tests are
failing on autopkgtests execution on each PR