### PR TITLE
many: sanitize NewStoreStack signature, have shared default store test private keys

### DIFF
--- a/asserts/assertstest/assertstest.go
+++ b/asserts/assertstest/assertstest.go
@@ -278,21 +278,33 @@ type StoreStack struct {
 	*SigningDB
 }
 
-// NewStoreStack creates a new store assertion stack. It panics on error.
-// optional privKeys can be in order: root, store, generic
-func NewStoreStack(authorityID string, privKeys ...asserts.PrivateKey) *StoreStack {
-	if len(privKeys) > 3 {
-		panic("too many private keys specified, expected at most: root, store, generic")
-	}
-	for len(privKeys) < 3 {
-		privKey, _ := GenerateKey(752)
-		privKeys = append(privKeys, privKey)
-	}
-	rootPrivKey := privKeys[0]
-	storePrivKey := privKeys[1]
-	genericPrivKey := privKeys[2]
+// StoreKeys holds a set of store private keys.
+type StoreKeys struct {
+	Root    asserts.PrivateKey
+	Store   asserts.PrivateKey
+	Generic asserts.PrivateKey
+}
 
-	rootSigning := NewSigningDB(authorityID, rootPrivKey)
+var (
+	rootPrivKey, _    = GenerateKey(1024)
+	storePrivKey, _   = GenerateKey(752)
+	genericPrivKey, _ = GenerateKey(752)
+
+	pregenKeys = StoreKeys{
+		Root:    rootPrivKey,
+		Store:   storePrivKey,
+		Generic: genericPrivKey,
+	}
+)
+
+// NewStoreStack creates a new store assertion stack. It panics on error.
+// Optional keys specify private keys to use for the various roles.
+func NewStoreStack(authorityID string, keys *StoreKeys) *StoreStack {
+	if keys == nil {
+		keys = &pregenKeys
+	}
+
+	rootSigning := NewSigningDB(authorityID, keys.Root)
 	ts := time.Now().Format(time.RFC3339)
 	trustedAcct := NewAccount(rootSigning, authorityID, map[string]interface{}{
 		"account-id": authorityID,
@@ -302,7 +314,7 @@ func NewStoreStack(authorityID string, privKeys ...asserts.PrivateKey) *StoreSta
 	trustedKey := NewAccountKey(rootSigning, trustedAcct, map[string]interface{}{
 		"name":  "root",
 		"since": ts,
-	}, rootPrivKey.PublicKey(), "")
+	}, keys.Root.PublicKey(), "")
 	trusted := []asserts.Assertion{trustedAcct, trustedKey}
 
 	genericAcct := NewAccount(rootSigning, "generic", map[string]interface{}{
@@ -320,26 +332,26 @@ func NewStoreStack(authorityID string, privKeys ...asserts.PrivateKey) *StoreSta
 	if err != nil {
 		panic(err)
 	}
-	err = db.ImportKey(storePrivKey)
+	err = db.ImportKey(keys.Store)
 	if err != nil {
 		panic(err)
 	}
 	storeKey := NewAccountKey(rootSigning, trustedAcct, map[string]interface{}{
 		"name": "store",
-	}, storePrivKey.PublicKey(), "")
+	}, keys.Store.PublicKey(), "")
 	err = db.Add(storeKey)
 	if err != nil {
 		panic(err)
 	}
 
-	err = db.ImportKey(genericPrivKey)
+	err = db.ImportKey(keys.Generic)
 	if err != nil {
 		panic(err)
 	}
 	genericKey := NewAccountKey(rootSigning, genericAcct, map[string]interface{}{
 		"name":  "serials",
 		"since": ts,
-	}, genericPrivKey.PublicKey(), "")
+	}, keys.Generic.PublicKey(), "")
 	err = db.Add(genericKey)
 	if err != nil {
 		panic(err)

--- a/asserts/assertstest/assertstest_test.go
+++ b/asserts/assertstest/assertstest_test.go
@@ -75,10 +75,7 @@ func (s *helperSuite) TestReadPrivKeyUnarmored(c *C) {
 }
 
 func (s *helperSuite) TestStoreStack(c *C) {
-	rootPrivKey, _ := assertstest.GenerateKey(1024)
-	storePrivKey, _ := assertstest.GenerateKey(752)
-
-	store := assertstest.NewStoreStack("super", rootPrivKey, storePrivKey)
+	store := assertstest.NewStoreStack("super", nil)
 
 	c.Check(store.TrustedAccount.AccountID(), Equals, "super")
 	c.Check(store.TrustedAccount.IsCertified(), Equals, true)

--- a/asserts/fetcher_test.go
+++ b/asserts/fetcher_test.go
@@ -39,9 +39,7 @@ type fetcherSuite struct {
 var _ = Suite(&fetcherSuite{})
 
 func (s *fetcherSuite) SetUpTest(c *C) {
-	rootPrivKey, _ := assertstest.GenerateKey(1024)
-	storePrivKey, _ := assertstest.GenerateKey(752)
-	s.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 }
 
 func fakeSnap(rev int) []byte {

--- a/asserts/gpgkeypairmgr_test.go
+++ b/asserts/gpgkeypairmgr_test.go
@@ -80,7 +80,7 @@ func (gkms *gpgKeypairMgrSuite) TestGetNotFound(c *C) {
 }
 
 func (gkms *gpgKeypairMgrSuite) TestUseInSigning(c *C) {
-	store := assertstest.NewStoreStack("trusted", testPrivKey0, testPrivKey1)
+	store := assertstest.NewStoreStack("trusted", nil)
 
 	devKey, err := gkms.keypairMgr.Get(assertstest.DevKeyID)
 	c.Assert(err, IsNil)

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -596,10 +596,7 @@ func (sbs *snapBuildSuite) TestDecodeInvalid(c *C) {
 }
 
 func makeStoreAndCheckDB(c *C) (store *assertstest.StoreStack, checkDB *asserts.Database) {
-	trustedPrivKey := testPrivKey0
-	storePrivKey := testPrivKey1
-
-	store = assertstest.NewStoreStack("canonical", trustedPrivKey, storePrivKey)
+	store = assertstest.NewStoreStack("canonical", nil)
 	cfg := &asserts.DatabaseConfig{
 		Backstore:       asserts.NewMemoryBackstore(),
 		Trusted:         store.Trusted,

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -49,9 +49,7 @@ type snapassertsSuite struct {
 var _ = Suite(&snapassertsSuite{})
 
 func (s *snapassertsSuite) SetUpTest(c *C) {
-	rootPrivKey, _ := assertstest.GenerateKey(1024)
-	storePrivKey, _ := assertstest.GenerateKey(752)
-	s.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 
 	s.dev1Acct = assertstest.NewAccount(s.storeSigning, "developer1", nil, "")
 

--- a/cmd/snap/cmd_export_key_test.go
+++ b/cmd/snap/cmd_export_key_test.go
@@ -58,9 +58,7 @@ func (s *SnapKeysSuite) TestExportKeyNonDefault(c *C) {
 }
 
 func (s *SnapKeysSuite) TestExportKeyAccount(c *C) {
-	rootPrivKey, _ := assertstest.GenerateKey(1024)
-	storePrivKey, _ := assertstest.GenerateKey(752)
-	storeSigning := assertstest.NewStoreStack("canonical", rootPrivKey, storePrivKey)
+	storeSigning := assertstest.NewStoreStack("canonical", nil)
 	manager := asserts.NewGPGKeypairManager()
 	assertstest.NewAccount(storeSigning, "developer1", nil, "")
 	rest, err := snap.Parser().ParseArgs([]string{"export-key", "another", "--account=developer1"})

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -201,11 +201,6 @@ func (s *apiBaseSuite) journalctl(svcs []string, n string, follow bool) (rc io.R
 	return rc, err
 }
 
-var (
-	rootPrivKey, _  = assertstest.GenerateKey(1024)
-	storePrivKey, _ = assertstest.GenerateKey(752)
-)
-
 func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	s.sysctlArgses = nil
 	s.sysctlBufs = nil
@@ -235,7 +230,7 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	s.buyOptions = nil
 	s.buyResult = nil
 
-	s.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	s.trustedRestorer = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
 	assertstateRefreshSnapDeclarations = nil

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -95,9 +95,7 @@ func (s *imageSuite) SetUpTest(c *C) {
 	s.storeSnapInfo = make(map[string]*snap.Info)
 	s.tsto = image.MockToolingStore(s)
 
-	rootPrivKey, _ := assertstest.GenerateKey(1024)
-	storePrivKey, _ := assertstest.GenerateKey(752)
-	s.storeSigning = assertstest.NewStoreStack("canonical", rootPrivKey, storePrivKey)
+	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
 
 	brandPrivKey, _ := assertstest.GenerateKey(752)
 	s.brandSigning = assertstest.NewSigningDB("my-brand", brandPrivKey)

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -87,9 +87,7 @@ func (sto *fakeStore) Assertion(assertType *asserts.AssertionType, key []string,
 func (s *assertMgrSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 
-	rootPrivKey, _ := assertstest.GenerateKey(1024)
-	storePrivKey, _ := assertstest.GenerateKey(752)
-	s.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	s.restore = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
 	dev1PrivKey, _ := assertstest.GenerateKey(752)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -105,9 +105,7 @@ func (s *deviceMgrSuite) SetUpTest(c *C) {
 
 	s.restoreOnClassic = release.MockOnClassic(false)
 
-	rootPrivKey, _ := assertstest.GenerateKey(testKeyLength)
-	storePrivKey, _ := assertstest.GenerateKey(752)
-	s.storeSigning = assertstest.NewStoreStack("canonical", rootPrivKey, storePrivKey)
+	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
 	s.state = state.New(nil)
 
 	brandPrivKey, _ := assertstest.GenerateKey(752)

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -97,9 +97,7 @@ func (s *FirstBootTestSuite) SetUpTest(c *C) {
 	err = ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), nil, 0644)
 	c.Assert(err, IsNil)
 
-	rootPrivKey, _ := assertstest.GenerateKey(1024)
-	storePrivKey, _ := assertstest.GenerateKey(752)
-	s.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	s.restore = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
 	s.brandPrivKey, _ = assertstest.GenerateKey(752)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -44,11 +44,6 @@ import (
 
 func TestInterfaceManager(t *testing.T) { TestingT(t) }
 
-var (
-	rootKey, _  = assertstest.GenerateKey(752)
-	storeKey, _ = assertstest.GenerateKey(752)
-)
-
 type interfaceManagerSuite struct {
 	state           *state.State
 	db              *asserts.Database
@@ -65,7 +60,7 @@ type interfaceManagerSuite struct {
 var _ = Suite(&interfaceManagerSuite{})
 
 func (s *interfaceManagerSuite) SetUpTest(c *C) {
-	s.storeSigning = assertstest.NewStoreStack("canonical", rootKey, storeKey)
+	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
 
 	s.mockSnapCmd = testutil.MockCommand(c, "snap", "")
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -92,9 +92,6 @@ var (
 )
 
 var (
-	rootPrivKey, _  = assertstest.GenerateKey(1024)
-	storePrivKey, _ = assertstest.GenerateKey(752)
-
 	brandPrivKey, _ = assertstest.GenerateKey(752)
 
 	develPrivKey, _ = assertstest.GenerateKey(752)
@@ -134,7 +131,7 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	ms.snapDiscardNs = testutil.MockCommand(c, "snap-discard-ns", "")
 	dirs.DistroLibExecDir = ms.snapDiscardNs.BinDir()
 
-	ms.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+	ms.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	ms.restoreTrusted = sysdb.InjectTrusted(ms.storeSigning.Trusted)
 
 	ms.devAcct = assertstest.NewAccount(ms.storeSigning, "devdevdev", map[string]interface{}{
@@ -1698,7 +1695,7 @@ func (s *authContextSetupSuite) SetUpTest(c *C) {
 	r := overlord.MockStoreNew(captureAuthContext)
 	defer r()
 
-	s.storeSigning = assertstest.NewStoreStack("can0nical", rootPrivKey, storePrivKey)
+	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)
 	s.restoreTrusted = sysdb.InjectTrusted(s.storeSigning.Trusted)
 
 	s.brandSigning = assertstest.NewSigningDB("my-brand", brandPrivKey)


### PR DESCRIPTION
This is a follow up to feedback on a previous PR  about varargs usage by NewStoreStack, this switches to an optional struct.