### PR TITLE
spread: opt into unsafe IO during spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -39,6 +39,8 @@ environment:
     NEW_CORE_CHANNEL: "$(HOST: echo $SPREAD_NEW_CORE_CHANNEL)"
     SRU_VALIDATION: "$(HOST: echo ${SPREAD_SRU_VALIDATION:-0})"
     PRE_CACHE_SNAPS: core ubuntu-core test-snapd-tools
+    # This skips various sync calls which can greatly speed up test execution.
+    SNAPD_UNSAFE_IO: 1
 
 backends:
     linode:


### PR DESCRIPTION
This patch enables a variable now honored by our atomic file write
helpers. As referenced earlier it offers massive improvements in time
needed to perform certain tests.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>