### PR TITLE
snap-repair: update snap-repair/runner_test.go for API change in makeMockServer

### DIFF
--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -867,7 +867,7 @@ scriptB
 
 AXNpZw==`}
 
-	mockServer := makeMockServer(c, &seqRepairs)
+	mockServer := makeMockServer(c, &seqRepairs, false)
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()
@@ -903,7 +903,7 @@ exit 0
 
 AXNpZw==`}
 
-	mockServer := makeMockServer(c, &seqRepairs)
+	mockServer := makeMockServer(c, &seqRepairs, false)
 	defer mockServer.Close()
 
 	runner := repair.NewRunner()


### PR DESCRIPTION
This fixes master which is currently broken.