### PR TITLE
many: configure store from state, reconfigure store at runtime

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -59,6 +59,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -524,12 +525,12 @@ func webify(result map[string]interface{}, resource string) map[string]interface
 	return result
 }
 
-func getStore(c *Command) snapstate.StoreService {
+func getStore(c *Command) storestate.StoreService {
 	st := c.d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
 
-	return snapstate.Store(st)
+	return storestate.Store(st)
 }
 
 func getSections(c *Command, r *http.Request, user *auth.UserState) Response {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -280,7 +281,7 @@ func (s *apiBaseSuite) daemon(c *check.C) *Daemon {
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	snapstate.ReplaceStore(st, s)
+	storestate.ReplaceStore(st, s)
 	// mark as already seeded
 	st.Set("seeded", true)
 	// registered

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/store"
@@ -108,7 +109,7 @@ func (s *assertMgrSuite) SetUpTest(c *C) {
 	s.mgr = mgr
 
 	s.state.Lock()
-	snapstate.ReplaceStore(s.state, &fakeStore{
+	storestate.ReplaceStore(s.state, &fakeStore{
 		state: s.state,
 		db:    s.storeSigning,
 	})

--- a/overlord/assertstate/helpers.go
+++ b/overlord/assertstate/helpers.go
@@ -26,8 +26,8 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 )
 
 // TODO: snapstate also has this, move to auth, or change a bit the approach now that we have AuthContext in the store?
@@ -104,7 +104,7 @@ func doFetch(s *state.State, userID int, fetching func(asserts.Fetcher) error) e
 		return err
 	}
 
-	sto := snapstate.Store(s)
+	sto := storestate.Store(s)
 
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		// TODO: ignore errors if already in db?

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/partition"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -140,7 +141,7 @@ func (s *deviceMgrSuite) SetUpTest(c *C) {
 	s.mgr = mgr
 
 	s.state.Lock()
-	snapstate.ReplaceStore(s.state, &fakeStore{
+	storestate.ReplaceStore(s.state, &fakeStore{
 		state: s.state,
 		db:    s.storeSigning,
 	})

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 )
 
 func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
@@ -490,7 +491,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 var repeatRequestSerial string // for tests
 
 func fetchKeys(st *state.State, keyID string) (errAcctKey error, err error) {
-	sto := snapstate.Store(st)
+	sto := storestate.Store(st)
 	db := assertstate.DB(st)
 	for {
 		_, err := db.FindPredefined(asserts.AccountKeyType, map[string]string{

--- a/overlord/export_test.go
+++ b/overlord/export_test.go
@@ -23,7 +23,8 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 )
 
 // MockEnsureInterval sets the overlord ensure interval for tests.
@@ -58,10 +59,10 @@ func (o *Overlord) Engine() *StateEngine {
 	return o.stateEng
 }
 
-// MockStoreNew mocks store.New as called by overlord.New.
-func MockStoreNew(new func(*store.Config, auth.AuthContext) *store.Store) (restore func()) {
-	storeNew = new
+// MockSetupStore mocks storestate.SetupStore as called by overlord.New.
+func MockSetupStore(new func(*state.State, auth.AuthContext) error) (restore func()) {
+	setupStore = new
 	return func() {
-		storeNew = store.New
+		setupStore = storestate.SetupStore
 	}
 }

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1696,11 +1696,11 @@ func (s *authContextSetupSuite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Dir(dirs.SnapStateFile), 0755)
 	c.Assert(err, IsNil)
 
-	captureAuthContext := func(_ *store.Config, ac auth.AuthContext) *store.Store {
+	captureAuthContext := func(_ *state.State, ac auth.AuthContext) error {
 		s.ac = ac
 		return nil
 	}
-	r := overlord.MockStoreNew(captureAuthContext)
+	r := overlord.MockSetupStore(captureAuthContext)
 	defer r()
 
 	s.storeSigning = assertstest.NewStoreStack("can0nical", nil)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/partition"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -460,7 +461,7 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 	mStore := store.New(&storeCfg, nil)
 	st := ms.o.State()
 	st.Lock()
-	snapstate.ReplaceStore(ms.o.State(), mStore)
+	storestate.ReplaceStore(ms.o.State(), mStore)
 	st.Unlock()
 
 	return mockServer

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -22,7 +22,6 @@ package overlord
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -45,7 +44,6 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storestate"
-	"github.com/snapcore/snapd/store"
 )
 
 var (
@@ -79,7 +77,7 @@ type Overlord struct {
 	cmdMgr    *cmdstate.CommandManager
 }
 
-var storeNew = store.New
+var setupStore = storestate.SetupStore
 
 // New creates a new Overlord with all its state managers.
 func New() (*Overlord, error) {
@@ -146,42 +144,18 @@ func New() (*Overlord, error) {
 	s.Lock()
 	defer s.Unlock()
 
-	// Setting up the store.
-	// The store's API address can be reconfigured at runtime but doing so
-	// requires an auth context. Unfortunately, an auth context is only
-	// available to the overlord (because of the device manager).
-	// For now, cache the auth context so it's possible for storestate to
-	// handle the store API change.
+	// setting up the store
 	authContext := auth.NewAuthContext(s, o.deviceMgr)
-	storestate.ReplaceAuthContext(s, authContext)
-	storeConfig, err := initialStoreConfig(s)
+	err = setupStore(s, authContext)
 	if err != nil {
 		return nil, err
 	}
-	sto := storeNew(storeConfig, authContext)
-	storestate.ReplaceStore(s, sto)
 
 	if err := o.snapMgr.GenerateCookies(s); err != nil {
 		return nil, fmt.Errorf("failed to generate cookies: %q", err)
 	}
 
 	return o, nil
-}
-
-func initialStoreConfig(s *state.State) (*store.Config, error) {
-	config := store.DefaultConfig()
-	apiState := storestate.API(s)
-	if apiState != "" {
-		api, err := url.Parse(apiState)
-		if err != nil {
-			return nil, fmt.Errorf("invalid store API URL: %s", err)
-		}
-		err = config.SetAPI(api)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return config, nil
 }
 
 func loadState(backend state.Backend) (*state.State, error) {

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -44,6 +44,7 @@ import (
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/store"
 )
 
@@ -160,11 +161,10 @@ func New() (*Overlord, error) {
 }
 
 func initialStoreConfig(s *state.State) (*store.Config, error) {
-	var storeState store.State
-	s.Get("store", &storeState)
 	config := store.DefaultConfig()
-	if storeState.API != "" {
-		api, err := url.Parse(storeState.API)
+	apiState := storestate.API(s)
+	if apiState != "" {
+		api, err := url.Parse(apiState)
 		if err != nil {
 			return nil, fmt.Errorf("invalid store API URL: %s", err)
 		}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -179,7 +179,7 @@ func initialStoreConfig(s *state.State) (*store.Config, error) {
 func replaceStore(o *Overlord, s *state.State, config *store.Config) {
 	authContext := auth.NewAuthContext(s, o.deviceMgr)
 	sto := storeNew(config, authContext)
-	snapstate.ReplaceStore(s, sto)
+	storestate.ReplaceStore(s, sto)
 }
 
 // ReplaceStore installs a new store.

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -83,9 +83,10 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	s.Get("patch-level", &patchLevel)
 	c.Check(patchLevel, Equals, 42)
 
-	// store is setup
+	// store is setup, including its auth context.
 	sto := storestate.Store(s)
 	c.Check(sto, FitsTypeOf, &store.Store{})
+	c.Check(storestate.AuthContext(s), NotNil)
 }
 
 func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
@@ -223,23 +224,6 @@ func (ovs *overlordSuite) TestNewStoreInvalidAPIFromState(c *C) {
 	_, err = overlord.New()
 	c.Assert(err, NotNil)
 	c.Check(err, ErrorMatches, "invalid store API URL: parse ://example.com/: missing protocol scheme")
-}
-
-func (ovs *overlordSuite) TestReplaceStore(c *C) {
-	var replacementStore store.Store
-	defer overlord.MockStoreNew(func(_ *store.Config, _ auth.AuthContext) *store.Store {
-		return &replacementStore
-	})()
-
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
-
-	s := o.State()
-	s.Lock()
-	defer s.Unlock()
-	o.ReplaceStore(s, store.DefaultConfig())
-
-	c.Check(storestate.Store(s), Equals, &replacementStore)
 }
 
 type witnessManager struct {

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -151,6 +151,96 @@ func (ovs *overlordSuite) TestNewWithPatches(c *C) {
 	c.Check(b, Equals, true)
 }
 
+func (ovs *overlordSuite) TestNewStoreDefaultAPI(c *C) {
+	var config *store.Config
+	defer overlord.MockStoreNew(func(c *store.Config, _ auth.AuthContext) *store.Store {
+		config = c
+		return nil
+	})()
+
+	o, err := overlord.New()
+	c.Assert(err, IsNil)
+
+	c.Check(o, NotNil)
+	c.Check(config.SearchURI.Host, Equals, "api.snapcraft.io")
+}
+
+func (ovs *overlordSuite) TestNewStoreAPIFromState(c *C) {
+	var config *store.Config
+	defer overlord.MockStoreNew(func(c *store.Config, _ auth.AuthContext) *store.Store {
+		config = c
+		return nil
+	})()
+
+	fakeState := []byte(`{"data":{"store":{"api": "http://example.com/"}}}`)
+	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	c.Assert(err, IsNil)
+
+	o, err := overlord.New()
+	c.Assert(err, IsNil)
+
+	c.Check(o, NotNil)
+	c.Check(config.SearchURI.Host, Equals, "example.com")
+}
+
+func (ovs *overlordSuite) TestNewBadEnvironURLOverride(c *C) {
+	// We need store api state to trigger this.
+	fakeState := []byte(`{"data":{"store":{"api": "http://example.com/"}}}`)
+	c.Assert(ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600), IsNil)
+
+	c.Assert(os.Setenv("SNAPPY_FORCE_API_URL", "://force-api.local/"), IsNil)
+	defer os.Setenv("SNAPPY_FORCE_API_URL", "")
+
+	_, err := overlord.New()
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_API_URL: parse ://force-api.local/: missing protocol scheme")
+}
+
+func (ovs *overlordSuite) TestNewStoreEmptyAPIFromState(c *C) {
+	var config *store.Config
+	defer overlord.MockStoreNew(func(c *store.Config, _ auth.AuthContext) *store.Store {
+		config = c
+		return nil
+	})()
+
+	fakeState := []byte(`{"data":{"store":{"api": ""}}}`)
+	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	c.Assert(err, IsNil)
+
+	o, err := overlord.New()
+	c.Assert(err, IsNil)
+
+	c.Check(o, NotNil)
+	c.Check(config.SearchURI.Host, Equals, "api.snapcraft.io")
+}
+
+func (ovs *overlordSuite) TestNewStoreInvalidAPIFromState(c *C) {
+	fakeState := []byte(`{"data":{"store":{"api": "://example.com/"}}}`)
+	err := ioutil.WriteFile(dirs.SnapStateFile, fakeState, 0600)
+	c.Assert(err, IsNil)
+
+	_, err = overlord.New()
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, "invalid store API URL: parse ://example.com/: missing protocol scheme")
+}
+
+func (ovs *overlordSuite) TestReplaceStore(c *C) {
+	var replacementStore store.Store
+	defer overlord.MockStoreNew(func(_ *store.Config, _ auth.AuthContext) *store.Store {
+		return &replacementStore
+	})()
+
+	o, err := overlord.New()
+	c.Assert(err, IsNil)
+
+	s := o.State()
+	s.Lock()
+	defer s.Unlock()
+	o.ReplaceStore(s, store.DefaultConfig())
+
+	c.Check(snapstate.Store(s), Equals, &replacementStore)
+}
+
 type witnessManager struct {
 	state          *state.State
 	expectedEnsure int

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -83,7 +84,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	c.Check(patchLevel, Equals, 42)
 
 	// store is setup
-	sto := snapstate.Store(s)
+	sto := storestate.Store(s)
 	c.Check(sto, FitsTypeOf, &store.Store{})
 }
 
@@ -238,7 +239,7 @@ func (ovs *overlordSuite) TestReplaceStore(c *C) {
 	defer s.Unlock()
 	o.ReplaceStore(s, store.DefaultConfig())
 
-	c.Check(snapstate.Store(s), Equals, &replacementStore)
+	c.Check(storestate.Store(s), Equals, &replacementStore)
 }
 
 type witnessManager struct {

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -20,31 +20,10 @@
 package snapstate
 
 import (
-	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/store"
-
-	"golang.org/x/net/context"
 )
-
-// A StoreService can find, list available updates and download snaps.
-type StoreService interface {
-	SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
-	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
-	LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info, error)
-	ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error)
-	Sections(user *auth.UserState) ([]string, error)
-	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error
-
-	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
-
-	SuggestedCurrency() string
-	Buy(options *store.BuyOptions, user *auth.UserState) (*store.BuyResult, error)
-	ReadyToBuy(*auth.UserState) error
-}
 
 type managerBackend interface {
 	// install releated

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -99,7 +99,6 @@ var (
 	CheckSnap              = checkSnap
 	CanRemove              = canRemove
 	CanDisable             = canDisable
-	CachedStore            = cachedStore
 	DefaultRefreshSchedule = defaultRefreshSchedule
 	NameAndRevnoFromSnap   = nameAndRevnoFromSnap
 )

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
@@ -223,7 +224,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	st.Lock()
-	theStore := Store(st)
+	theStore := storestate.Store(st)
 	user, err := userFromUserID(st, snapsup.UserID)
 	st.Unlock()
 	if err != nil {

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -49,7 +50,7 @@ func (s *downloadSnapSuite) SetUpTest(c *C) {
 		state:       s.state,
 		fakeBackend: s.fakeBackend,
 	}
-	snapstate.ReplaceStore(s.state, s.fakeStore)
+	storestate.ReplaceStore(s.state, s.fakeStore)
 
 	var err error
 	s.snapmgr, err = snapstate.Manager(s.state)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -37,7 +37,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timeutil"
 )
@@ -264,32 +263,6 @@ func revisionInSequence(snapst *SnapState, needle snap.Revision) bool {
 		}
 	}
 	return false
-}
-
-type cachedStoreKey struct{}
-
-// ReplaceStore replaces the store used by the manager.
-func ReplaceStore(state *state.State, store StoreService) {
-	state.Cache(cachedStoreKey{}, store)
-}
-
-func cachedStore(st *state.State) StoreService {
-	ubuntuStore := st.Cached(cachedStoreKey{})
-	if ubuntuStore == nil {
-		return nil
-	}
-	return ubuntuStore.(StoreService)
-}
-
-// the store implementation has the interface consumed here
-var _ StoreService = (*store.Store)(nil)
-
-// Store returns the store service used by the snapstate package.
-func Store(st *state.State) StoreService {
-	if cachedStore := cachedStore(st); cachedStore != nil {
-		return cachedStore
-	}
-	panic("internal error: needing the store before managers have initialized it")
 }
 
 // Manager returns a new snap manager.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
@@ -562,7 +563,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 		candidatesInfo = append(candidatesInfo, candidateInfo)
 	}
 
-	theStore := Store(st)
+	theStore := storestate.Store(st)
 
 	st.Unlock()
 	updates, err := theStore.ListRefresh(candidatesInfo, user)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -118,7 +119,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	}
 
 	s.state.Lock()
-	snapstate.ReplaceStore(s.state, s.fakeStore)
+	storestate.ReplaceStore(s.state, s.fakeStore)
 	s.user, err = auth.NewUser(s.state, "username", "email@test.com", "macaroon", []string{"discharge"})
 	c.Assert(err, IsNil)
 	s.state.Unlock()
@@ -133,20 +134,6 @@ func (s *snapmgrTestSuite) TearDownTest(c *C) {
 	snapstate.AutoAliases = nil
 	snapstate.CanAutoRefresh = nil
 	s.reset()
-}
-
-func (s *snapmgrTestSuite) TestStore(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	sto := &store.Store{}
-	snapstate.ReplaceStore(s.state, sto)
-	store1 := snapstate.Store(s.state)
-	c.Check(store1, Equals, sto)
-
-	// cached
-	store2 := snapstate.Store(s.state)
-	c.Check(store2, Equals, sto)
 }
 
 const (
@@ -965,7 +952,7 @@ func (s *snapmgrTestSuite) TestInstallStateConflict(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	snapstate.ReplaceStore(s.state, sneakyStore{fakeStore: s.fakeStore, state: s.state})
+	storestate.ReplaceStore(s.state, sneakyStore{fakeStore: s.fakeStore, state: s.state})
 
 	_, err := snapstate.Install(s.state, "some-snap", "some-channel", snap.R(0), 0, snapstate.Flags{})
 	c.Assert(err, ErrorMatches, `snap "some-snap" state changed during install preparations`)

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -22,6 +22,7 @@ package snapstate
 import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 )
@@ -55,7 +56,7 @@ func updateInfo(st *state.State, snapst *SnapState, channel string, userID int) 
 		Epoch:    curInfo.Epoch,
 	}
 
-	theStore := Store(st)
+	theStore := storestate.Store(st)
 	st.Unlock() // calls to the store should be done without holding the state lock
 	res, err := theStore.LookupRefresh(refreshCand, user)
 	st.Lock()
@@ -67,7 +68,7 @@ func snapInfo(st *state.State, name, channel string, revision snap.Revision, use
 	if err != nil {
 		return nil, err
 	}
-	theStore := Store(st)
+	theStore := storestate.Store(st)
 	st.Unlock() // calls to the store should be done without holding the state lock
 	spec := store.SnapSpec{
 		Name:     name,

--- a/overlord/storestate/export_test.go
+++ b/overlord/storestate/export_test.go
@@ -1,0 +1,35 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package storestate
+
+import (
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/store"
+)
+
+// MockStoreNew mocks store.New as called by storestate.SetupStore.
+func MockStoreNew(new func(*store.Config, auth.AuthContext) *store.Store) func() {
+	storeNew = new
+	return func() {
+		storeNew = store.New
+	}
+}
+
+var AuthContextTestsOnly = authContext

--- a/overlord/storestate/export_test.go
+++ b/overlord/storestate/export_test.go
@@ -32,4 +32,4 @@ func MockStoreNew(new func(*store.Config, auth.AuthContext) *store.Store) func()
 	}
 }
 
-var AuthContextTestsOnly = authContext
+var CachedAuthContext = cachedAuthContext

--- a/overlord/storestate/storestate.go
+++ b/overlord/storestate/storestate.go
@@ -37,12 +37,12 @@ var storeNew = store.New
 
 // StoreState holds the state for the store in the system.
 type StoreState struct {
-	// StoreLocation is the store API's base location.
-	StoreLocation string `json:"store-location"`
+	// BaseURL is the store API's base URL.
+	BaseURL string `json:"base-url"`
 }
 
-// StoreLocation returns the store API's explicit location.
-func StoreLocation(st *state.State) string {
+// BaseURL returns the store API's explicit base URL.
+func BaseURL(st *state.State) string {
 	var storeState StoreState
 
 	err := st.Get("store", &storeState)
@@ -50,14 +50,14 @@ func StoreLocation(st *state.State) string {
 		return ""
 	}
 
-	return storeState.StoreLocation
+	return storeState.BaseURL
 }
 
-// updateStoreLocation updates the store API's location in persistent state.
-func updateStoreLocation(st *state.State, location string) {
+// updateBaseURL updates the store API's base URL in persistent state.
+func updateBaseURL(st *state.State, baseURL string) {
 	var storeState StoreState
 	st.Get("store", &storeState)
-	storeState.StoreLocation = location
+	storeState.BaseURL = baseURL
 	st.Set("store", &storeState)
 }
 
@@ -89,13 +89,13 @@ func SetupStore(st *state.State, authContext auth.AuthContext) error {
 	return nil
 }
 
-// SetStoreLocation replaces the location of the store API used by the system.
+// SetBaseURL reconfigures the base URL of the store API used by the system.
 // If the URL is nil the store is reverted to the system's default.
-func SetStoreLocation(state *state.State, u *url.URL) error {
-	location := ""
+func SetBaseURL(state *state.State, u *url.URL) error {
+	baseURL := ""
 	config := store.DefaultConfig()
 	if u != nil {
-		location = u.String()
+		baseURL = u.String()
 		err := config.SetAPI(u)
 		if err != nil {
 			return err
@@ -103,16 +103,16 @@ func SetStoreLocation(state *state.State, u *url.URL) error {
 	}
 	store := store.New(config, cachedAuthContext(state))
 	ReplaceStore(state, store)
-	updateStoreLocation(state, location)
+	updateBaseURL(state, baseURL)
 	return nil
 }
 
 func initialStoreConfig(st *state.State) (*store.Config, error) {
 	config := store.DefaultConfig()
-	if location := StoreLocation(st); location != "" {
-		u, err := url.Parse(location)
+	if baseURL := BaseURL(st); baseURL != "" {
+		u, err := url.Parse(baseURL)
 		if err != nil {
-			return nil, fmt.Errorf("invalid store API location: %s", err)
+			return nil, fmt.Errorf("invalid store API base URL: %s", err)
 		}
 		err = config.SetAPI(u)
 		if err != nil {

--- a/overlord/storestate/storestate.go
+++ b/overlord/storestate/storestate.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package storestate
+
+import (
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// StoreState holds the state for the store in the system.
+type StoreState struct {
+	// API is the store's base API address.
+	API string `json:"api"`
+}
+
+// API returns the store's explicit address.
+func API(st *state.State) string {
+	var storeState StoreState
+
+	err := st.Get("store", &storeState)
+	if err != nil {
+		return ""
+	}
+
+	return storeState.API
+}
+
+// updateAPI writes the store's address to persistent state.
+func updateAPI(st *state.State, api string) {
+	var storeState StoreState
+	st.Get("store", &storeState)
+	storeState.API = api
+	st.Set("store", &storeState)
+}

--- a/overlord/storestate/storestate.go
+++ b/overlord/storestate/storestate.go
@@ -96,7 +96,7 @@ func SetBaseURL(state *state.State, u *url.URL) error {
 	config := store.DefaultConfig()
 	if u != nil {
 		baseURL = u.String()
-		err := config.SetAPI(u)
+		err := config.SetBaseURL(u)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func initialStoreConfig(st *state.State) (*store.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid store API base URL: %s", err)
 		}
-		err = config.SetAPI(u)
+		err = config.SetBaseURL(u)
 		if err != nil {
 			return nil, err
 		}

--- a/overlord/storestate/storestate.go
+++ b/overlord/storestate/storestate.go
@@ -20,7 +20,14 @@
 package storestate
 
 import (
+	"golang.org/x/net/context"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
 )
 
 // StoreState holds the state for the store in the system.
@@ -47,4 +54,46 @@ func updateAPI(st *state.State, api string) {
 	st.Get("store", &storeState)
 	storeState.API = api
 	st.Set("store", &storeState)
+}
+
+// A StoreService can find, list available updates and download snaps.
+type StoreService interface {
+	SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
+	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
+	LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info, error)
+	ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error)
+	Sections(user *auth.UserState) ([]string, error)
+	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error
+
+	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)
+
+	SuggestedCurrency() string
+	Buy(options *store.BuyOptions, user *auth.UserState) (*store.BuyResult, error)
+	ReadyToBuy(*auth.UserState) error
+}
+
+type cachedStoreKey struct{}
+
+// ReplaceStore replaces the store used by the system.
+func ReplaceStore(state *state.State, store StoreService) {
+	state.Cache(cachedStoreKey{}, store)
+}
+
+func cachedStore(st *state.State) StoreService {
+	ubuntuStore := st.Cached(cachedStoreKey{})
+	if ubuntuStore == nil {
+		return nil
+	}
+	return ubuntuStore.(StoreService)
+}
+
+// the store implementation has the interface consumed here
+var _ StoreService = (*store.Store)(nil)
+
+// Store returns the store service used by the system.
+func Store(st *state.State) StoreService {
+	if cachedStore := cachedStore(st); cachedStore != nil {
+		return cachedStore
+	}
+	panic("internal error: needing the store before managers have initialized it")
 }

--- a/overlord/storestate/storestate.go
+++ b/overlord/storestate/storestate.go
@@ -84,7 +84,7 @@ func SetupStore(st *state.State, authContext auth.AuthContext) error {
 		return err
 	}
 	sto := storeNew(storeConfig, authContext)
-	replaceAuthContext(st, authContext)
+	saveAuthContext(st, authContext)
 	ReplaceStore(st, sto)
 	return nil
 }
@@ -124,7 +124,7 @@ func initialStoreConfig(st *state.State) (*store.Config, error) {
 
 type cachedAuthContextKey struct{}
 
-func replaceAuthContext(state *state.State, authContext auth.AuthContext) {
+func saveAuthContext(state *state.State, authContext auth.AuthContext) {
 	state.Cache(cachedAuthContextKey{}, authContext)
 }
 

--- a/overlord/storestate/storestate_test.go
+++ b/overlord/storestate/storestate_test.go
@@ -20,8 +20,11 @@
 package storestate_test
 
 import (
+	"net/url"
+	"os"
 	"testing"
 
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/store"
@@ -30,6 +33,28 @@ import (
 )
 
 func Test(t *testing.T) { TestingT(t) }
+
+type fakeAuthContext struct{}
+
+func (*fakeAuthContext) Device() (*auth.DeviceState, error) {
+	panic("fakeAuthContext Device is not implemented")
+}
+
+func (*fakeAuthContext) UpdateDeviceAuth(*auth.DeviceState, string) (*auth.DeviceState, error) {
+	panic("fakeAuthContext UpdateDeviceAuth is not implemented")
+}
+
+func (*fakeAuthContext) UpdateUserAuth(*auth.UserState, []string) (*auth.UserState, error) {
+	panic("fakeAuthContext UpdateUserAuth is not implemented")
+}
+
+func (*fakeAuthContext) StoreID(string) (string, error) {
+	panic("fakeAuthContext StoreID is not implemented")
+}
+
+func (*fakeAuthContext) DeviceSessionRequestParams(nonce string) (*auth.DeviceSessionRequestParams, error) {
+	panic("fakeAuthContext DeviceSessionRequestParams is not implemented")
+}
 
 type storeStateSuite struct {
 	state *state.State
@@ -70,4 +95,62 @@ func (ss *storeStateSuite) TestStore(c *C) {
 	// cached
 	store2 := storestate.Store(ss.state)
 	c.Check(store2, Equals, sto)
+}
+
+func (ss *storeStateSuite) TestReplaceStoreAPI(c *C) {
+	ss.state.Lock()
+	defer ss.state.Unlock()
+
+	oldStore := &store.Store{}
+	storestate.ReplaceStore(ss.state, oldStore)
+	c.Assert(storestate.API(ss.state), Equals, "")
+
+	storestate.ReplaceAuthContext(ss.state, &fakeAuthContext{})
+
+	api, err := url.Parse("http://example.com/")
+	c.Assert(err, IsNil)
+	err = storestate.ReplaceStoreAPI(ss.state, api)
+	c.Assert(err, IsNil)
+
+	c.Check(storestate.Store(ss.state), Not(Equals), oldStore)
+	c.Check(storestate.API(ss.state), Equals, "http://example.com/")
+}
+
+func (ss *storeStateSuite) TestReplaceStoreAPIReset(c *C) {
+	ss.state.Lock()
+	defer ss.state.Unlock()
+
+	oldStore := &store.Store{}
+	storestate.ReplaceStore(ss.state, oldStore)
+	ss.state.Set("store", map[string]interface{}{
+		"api": "http://example.com/",
+	})
+	c.Assert(storestate.API(ss.state), Not(Equals), "")
+
+	storestate.ReplaceAuthContext(ss.state, &fakeAuthContext{})
+
+	err := storestate.ReplaceStoreAPI(ss.state, nil)
+	c.Assert(err, IsNil)
+
+	c.Check(storestate.Store(ss.state), Not(Equals), oldStore)
+	c.Check(storestate.API(ss.state), Equals, "")
+}
+
+func (ss *storeStateSuite) TestReplaceStoreAPIBadEnvironURLOverride(c *C) {
+	c.Assert(os.Setenv("SNAPPY_FORCE_API_URL", "://force-api.local/"), IsNil)
+	defer os.Setenv("SNAPPY_FORCE_API_URL", "")
+
+	api, _ := url.Parse("http://example.com/")
+	err := storestate.ReplaceStoreAPI(ss.state, api)
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_API_URL: parse ://force-api.local/: missing protocol scheme")
+}
+
+func (ss *storeStateSuite) TestAuthContext(c *C) {
+	ss.state.Lock()
+	defer ss.state.Unlock()
+
+	authContext := &fakeAuthContext{}
+	storestate.ReplaceAuthContext(ss.state, authContext)
+	c.Check(storestate.AuthContext(ss.state), Equals, authContext)
 }

--- a/overlord/storestate/storestate_test.go
+++ b/overlord/storestate/storestate_test.go
@@ -1,0 +1,58 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package storestate_test
+
+import (
+	"testing"
+
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/overlord/storestate"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type storeStateSuite struct {
+	state *state.State
+}
+
+var _ = Suite(&storeStateSuite{})
+
+func (ss *storeStateSuite) SetUpTest(c *C) {
+	ss.state = state.New(nil)
+}
+
+func (ss *storeStateSuite) TestDefaultAPI(c *C) {
+	ss.state.Lock()
+	api := storestate.API(ss.state)
+	ss.state.Unlock()
+	c.Check(api, Equals, "")
+}
+
+func (ss *storeStateSuite) TestExplicitAPI(c *C) {
+	ss.state.Lock()
+	defer ss.state.Unlock()
+
+	storeState := storestate.StoreState{API: "http://example.com/"}
+	ss.state.Set("store", &storeState)
+	api := storestate.API(ss.state)
+	c.Check(api, Equals, storeState.API)
+}

--- a/overlord/storestate/storestate_test.go
+++ b/overlord/storestate/storestate_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storestate"
+	"github.com/snapcore/snapd/store"
 
 	. "gopkg.in/check.v1"
 )
@@ -55,4 +56,18 @@ func (ss *storeStateSuite) TestExplicitAPI(c *C) {
 	ss.state.Set("store", &storeState)
 	api := storestate.API(ss.state)
 	c.Check(api, Equals, storeState.API)
+}
+
+func (ss *storeStateSuite) TestStore(c *C) {
+	ss.state.Lock()
+	defer ss.state.Unlock()
+
+	sto := &store.Store{}
+	storestate.ReplaceStore(ss.state, sto)
+	store1 := storestate.Store(ss.state)
+	c.Check(store1, Equals, sto)
+
+	// cached
+	store2 := storestate.Store(ss.state)
+	c.Check(store2, Equals, sto)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -190,9 +190,10 @@ type Config struct {
 	DeltaFormat  string
 }
 
-// SetAPI updates API URLs in the Config. Must not be used to change active config.
-func (cfg *Config) SetAPI(api *url.URL) error {
-	storeBaseURI, err := storeURL(api)
+// SetBaseURL updates the store API's base URL in the Config. Must not be used
+// to change active config.
+func (cfg *Config) SetBaseURL(u *url.URL) error {
+	storeBaseURI, err := storeURL(u)
 	if err != nil {
 		return err
 	}
@@ -400,7 +401,7 @@ func init() {
 	if storeBaseURI.RawQuery != "" {
 		panic("store API URL may not contain query string")
 	}
-	err = defaultConfig.SetAPI(storeBaseURI)
+	err = defaultConfig.SetBaseURL(storeBaseURI)
 	if err != nil {
 		panic(err)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -163,12 +163,6 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	return info
 }
 
-// State holds the state for the store in the system.
-type State struct {
-	// API is the store's base API address.
-	API string `json:"api"`
-}
-
 // Config represents the configuration to access the snap store
 type Config struct {
 	SearchURI      *url.URL

--- a/store/store.go
+++ b/store/store.go
@@ -163,6 +163,12 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	return info
 }
 
+// State holds the state for the store in the system.
+type State struct {
+	// API is the store's base API address.
+	API string `json:"api"`
+}
+
 // Config represents the configuration to access the snap store
 type Config struct {
 	SearchURI      *url.URL

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -61,16 +61,16 @@ type configTestSuite struct{}
 
 var _ = Suite(&configTestSuite{})
 
-func (suite *configTestSuite) TestSetAPI(c *C) {
+func (suite *configTestSuite) TestSetBaseURL(c *C) {
 	// Sanity check to prove at least one URI changes.
 	cfg := DefaultConfig()
 	c.Assert(cfg.SectionsURI.Scheme, Equals, "https")
 	c.Assert(cfg.SectionsURI.Host, Equals, "api.snapcraft.io")
 	c.Assert(cfg.SectionsURI.Path, Matches, "/api/v1/snaps/.*")
 
-	api, err := url.Parse("http://example.com/path/prefix/")
+	u, err := url.Parse("http://example.com/path/prefix/")
 	c.Assert(err, IsNil)
-	err = cfg.SetAPI(api)
+	err = cfg.SetBaseURL(u)
 	c.Assert(err, IsNil)
 
 	for _, uri := range cfg.apiURIs() {
@@ -79,47 +79,47 @@ func (suite *configTestSuite) TestSetAPI(c *C) {
 	}
 }
 
-func (suite *configTestSuite) TestSetAPIStoreOverrides(c *C) {
+func (suite *configTestSuite) TestSetBaseURLStoreOverrides(c *C) {
 	cfg := DefaultConfig()
-	c.Assert(cfg.SetAPI(apiURL()), IsNil)
+	c.Assert(cfg.SetBaseURL(apiURL()), IsNil)
 	c.Check(cfg.SearchURI, Matches, apiURL().String()+".*")
 
 	c.Assert(os.Setenv("SNAPPY_FORCE_API_URL", "https://force-api.local/"), IsNil)
 	defer os.Setenv("SNAPPY_FORCE_API_URL", "")
 	cfg = DefaultConfig()
-	c.Assert(cfg.SetAPI(apiURL()), IsNil)
+	c.Assert(cfg.SetBaseURL(apiURL()), IsNil)
 	for _, u := range cfg.apiURIs() {
 		c.Check(u.String(), Matches, "https://force-api.local/.*")
 	}
 }
 
-func (suite *configTestSuite) TestSetAPIStoreURLBadEnviron(c *C) {
+func (suite *configTestSuite) TestSetBaseURLStoreURLBadEnviron(c *C) {
 	c.Assert(os.Setenv("SNAPPY_FORCE_API_URL", "://example.com"), IsNil)
 	defer os.Setenv("SNAPPY_FORCE_API_URL", "")
 
 	cfg := DefaultConfig()
-	err := cfg.SetAPI(apiURL())
+	err := cfg.SetBaseURL(apiURL())
 	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_API_URL: parse ://example.com: missing protocol scheme")
 }
 
-func (suite *configTestSuite) TestSetAPIAssertsOverrides(c *C) {
+func (suite *configTestSuite) TestSetBaseURLAssertsOverrides(c *C) {
 	cfg := DefaultConfig()
-	c.Assert(cfg.SetAPI(apiURL()), IsNil)
+	c.Assert(cfg.SetBaseURL(apiURL()), IsNil)
 	c.Check(cfg.SearchURI, Matches, apiURL().String()+".*")
 
 	c.Assert(os.Setenv("SNAPPY_FORCE_SAS_URL", "https://force-sas.local/"), IsNil)
 	defer os.Setenv("SNAPPY_FORCE_SAS_URL", "")
 	cfg = DefaultConfig()
-	c.Assert(cfg.SetAPI(apiURL()), IsNil)
+	c.Assert(cfg.SetBaseURL(apiURL()), IsNil)
 	c.Check(cfg.AssertionsURI, Matches, "https://force-sas.local/.*")
 }
 
-func (suite *configTestSuite) TestSetAPIAssertsURLBadEnviron(c *C) {
+func (suite *configTestSuite) TestSetBaseURLAssertsURLBadEnviron(c *C) {
 	c.Assert(os.Setenv("SNAPPY_FORCE_SAS_URL", "://example.com"), IsNil)
 	defer os.Setenv("SNAPPY_FORCE_SAS_URL", "")
 
 	cfg := DefaultConfig()
-	err := cfg.SetAPI(apiURL())
+	err := cfg.SetBaseURL(apiURL())
 	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_SAS_URL: parse ://example.com: missing protocol scheme")
 }
 

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/auth"
-	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
@@ -37,7 +37,7 @@ import (
 type Store struct{}
 
 // ensure we conform
-var _ snapstate.StoreService = Store{}
+var _ storestate.StoreService = Store{}
 
 func (Store) SnapInfo(store.SnapSpec, *auth.UserState) (*snap.Info, error) {
 	panic("Store.SnapInfo not expected")


### PR DESCRIPTION
Configures the store's API from the state - recorded as a new `"store": {"api": "<url>"}` section in the state's data. Also adds a func to reconfigure the store to use a new base API URL at runtime.

The cached Store was previously managed by snapstate but that's moved to a new storestate package, alongside other store-related state helpers.

Note: caching the auth context in the state is a bit of a hack, but is the only sane way I could find (i.e. without affecting lots of code & tests) to make it available so the store's API can be changed by a call to a storestate func instead of going through the overlord.

Rebase of #3585.