### PR TITLE
asserts,overlord/devicestate: accept generic serials only if the model has generic-serials: true

### DIFF
--- a/asserts/database.go
+++ b/asserts/database.go
@@ -247,6 +247,22 @@ func OpenDatabase(cfg *DatabaseConfig) (*Database, error) {
 	}, nil
 }
 
+// WithStackedBackstore returns new database that adds to backstore
+// and finds in backstore and then the base database backstore.
+func (db *Database) WithStackedBackstore(backstore Backstore) *Database {
+	backstores := []Backstore{db.trusted, db.predefined}
+	backstores = append(backstores, backstore)
+	backstores = append(backstores, db.backstores[2:]...)
+	return &Database{
+		bs:         backstore,
+		keypairMgr: db.keypairMgr,
+		trusted:    db.trusted,
+		predefined: db.predefined,
+		backstores: backstores,
+		checkers:   db.checkers,
+	}
+}
+
 // ImportKey stores the given private/public key pair.
 func (db *Database) ImportKey(privKey PrivateKey) error {
 	return db.keypairMgr.Put(privKey)


### PR DESCRIPTION
This make it so that generic serials (authority-id = 'generic' and brand-id != authority-id) are only accepted if the corresponding model assertion has generic-serials: true.

Note that registration does not send the model assertion along, so this can be enforced only later, OTOH this adds a test that shows that the situation is recoverable.

This also introduces asserts.Database.WithStackedBackstore to help setting up controlled cross-checks.