### PR TITLE
vendor: update vendor.json after (presumed) manual edits

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -144,7 +144,7 @@
 			"revisionTime": "2017-06-28T23:42:41Z"
 		},
 		{
-			"checksumSHA1": "tyXdQ4OdVQelQdsil6fXUtKKIRw=",
+			"checksumSHA1": "K3C9lD5XgLfXd25MtZe3Uw5BRoA=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "35ef4487ce0a1ea5d4b616ffe71e34febe723695",
 			"revisionTime": "2017-07-27T13:28:57Z"


### PR DESCRIPTION
Running get-deps.sh on master results in a modified tree which suggests
that one of the earlier patches must have included had-made edits to
vendor.json, this should fix the problem.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>