### PR TITLE
cmd/snap-confine: allow reading /proc/filesystems

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -57,6 +57,8 @@
     @{PROC}/[0-9]*/attr/exec w,
     # Reading current profile
     @{PROC}/[0-9]*/attr/current r,
+    # Reading available filesystems
+    @{PROC}/filesystems r,
 
     # To find where apparmor is mounted
     @{PROC}/[0-9]*/mounts r,


### PR DESCRIPTION
This rule is required to make snap-confine work on openSUSE tumbleweed.
The rule is presumably required by selinux as seen in the following
strace fragment:

23075 statfs("/sys/fs/selinux", 0x7ffdaa3ad9b0) = -1 ENOENT (No such file or directory)
23075 statfs("/selinux", {f_type=BTRFS_SUPER_MAGIC, f_bsize=4096, f_blocks=10486528, f_bfree=6317286, f_bavail=5992378, f_files=0, f_ffree=0, f_fsid={val=[2999193500, 2112688126]}, f_namelen=255, f_frsize=4096, f_flags=ST_VALID|ST_RELATIME}) = 0
23075 brk(NULL)                         = 0x20b4000
23075 brk(0x20d5000)                    = 0x20d5000
23075 open("/proc/filesystems", O_RDONLY) = 3

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>