### PR TITLE
cmd/snap-confine: allow running snap-exec without confinement

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -87,6 +87,12 @@
     # deny change_profile unsafe /** -> {unconfined,/**},
     # change_profile unsafe /** -> **,
 
+    # Allow executing snap-exec without confinement.
+    # The rule is spelled twice because snap-exec is typically called after
+    # pivot_root when the desired base snap is the root filesystem but may not
+    # be the case if classic confinement is used.
+    /{@LIBEXECDIR@/,usr/lib/snapd/}snap-exec rux,
+
     # reading seccomp filters
     /{tmp/snap.rootfs_*/,}var/lib/snapd/seccomp/bpf/*.bin r,
 


### PR DESCRIPTION
This is a openSUSE specific patch that I think only makes sense in the
case when snap-confine is confined but snap applications are not.
Proposed to gather feedback.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>