### PR TITLE
cmd: "make hack" now also installs snap-update-ns

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -43,10 +43,15 @@ fmt: $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch]))
 # The hack target helps devlopers work on snap-confine on their live system by
 # installing a fresh copy of snap confine and the appropriate apparmor profile.
 .PHONY: hack
-hack: snap-confine/snap-confine snap-confine/snap-confine.apparmor
+hack: snap-confine/snap-confine snap-confine/snap-confine.apparmor snap-update-ns/snap-update-ns
 	sudo install -D -m 4755 snap-confine/snap-confine $(DESTDIR)$(libexecdir)/snap-confine
 	sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine
 	sudo apparmor_parser -r snap-confine/snap-confine.apparmor
+	sudo install -m 755 snap-update-ns/snap-update-ns $(DESTDIR)$(libexecdir)/snap-update-ns
+
+# for the hack target also:
+snap-update-ns/snap-update-ns: snap-update-ns/*.go snap-update-ns/*.[ch]
+	cd snap-update-ns && GOPATH=$(or $(GOPATH),$(realpath $(srcdir)/../../../../..)) go build -i -v
 
 ##
 ## libsnap-confine-private.a


### PR DESCRIPTION
`make hack` sets things up so the daredevil developer can dastardly and daringly ... do stuff. But as it wasn't building and copying `snap-update-ns` into place, often what said dastard would end up doing is having a chat with @zyga.

This fixes that.