### PR TITLE
asserts,overlord/devicestate: revert allowing 'generic'-signed serials

### DIFF
--- a/asserts/device_asserts.go
+++ b/asserts/device_asserts.go
@@ -276,13 +276,12 @@ func (ser *Serial) Timestamp() time.Time {
 // TODO: implement further consistency checks for Serial but first review approach
 
 func assembleSerial(assert assertionBase) (Assertion, error) {
-	authorityID := assert.AuthorityID()
-	brand := assert.HeaderString("brand-id")
-	if brand != authorityID && authorityID != "generic" {
-		return nil, fmt.Errorf(`serial assertions must be generic or signed by the brand (%q) instead of %q`, brand, authorityID)
+	err := checkAuthorityMatchesBrand(&assert)
+	if err != nil {
+		return nil, err
 	}
 
-	_, err := checkModel(assert.headers)
+	_, err = checkModel(assert.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/asserts/device_asserts_test.go
+++ b/asserts/device_asserts_test.go
@@ -348,7 +348,7 @@ func (ss *serialSuite) TestDecodeInvalid(c *C) {
 	invalidTests := []struct{ original, invalid, expectedErr string }{
 		{"brand-id: brand-id1\n", "", `"brand-id" header is mandatory`},
 		{"brand-id: brand-id1\n", "brand-id: \n", `"brand-id" header should not be empty`},
-		{"authority-id: brand-id1\n", "authority-id: random\n", `serial assertions must be generic or signed by the brand \("brand-id1"\) instead of "random"`},
+		{"authority-id: brand-id1\n", "authority-id: random\n", `authority-id and brand-id must match, serial assertions are expected to be signed by the brand: "random" != "brand-id1"`},
 		{"model: baz-3000\n", "", `"model" header is mandatory`},
 		{"model: baz-3000\n", "model: \n", `"model" header should not be empty`},
 		{"model: baz-3000\n", "model: _what\n", `"model" header contains invalid characters: "_what"`},
@@ -398,7 +398,6 @@ func (ss *serialSuite) TestSerialCheck(c *C) {
 		keyID   string
 	}{
 		{brandDB, brandDB.AuthorityID, "", brandDB.KeyID},
-		{storeDB, brandDB.AuthorityID, "generic", storeDB.GenericKey.PublicKeyID()},
 	}
 
 	for _, test := range tests {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -200,16 +200,8 @@ func (s *deviceMgrSuite) mockServer(c *C) *httptest.Server {
 			model := serialReq.Model()
 			authID := "canonical"
 			keyID := ""
-			switch model {
-			case "pc":
-				c.Check(brandID, Equals, "canonical")
-			case "my-model":
-				c.Check(brandID, Equals, "my-brand")
-				authID = "generic"
-				keyID = s.storeSigning.GenericKey.PublicKeyID()
-			default:
-				c.Fatal("unknown model")
-			}
+			c.Check(serialReq.BrandID(), Equals, "canonical")
+			c.Check(serialReq.Model(), Equals, "pc")
 			reqID := serialReq.RequestID()
 			if reqID == "REQID-BADREQ" {
 				w.Header().Set("Content-Type", "application/json")
@@ -351,6 +343,7 @@ version: gadget
 }
 
 func (s *deviceMgrSuite) TestFullDeviceRegistrationAltBrandHappy(c *C) {
+	c.Skip("not yet supported")
 	r1 := devicestate.MockKeyLength(testKeyLength)
 	defer r1()
 

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -54,9 +54,9 @@ func useStaging() bool {
 
 func deviceAPIBaseURL() string {
 	if useStaging() {
-		return "https://api.staging.snapcraft.io/api/v1/snaps/auth/"
+		return "https://myapps.developer.staging.ubuntu.com/identity/api/v1/"
 	}
-	return "https://api.snapcraft.io/api/v1/snaps/auth/"
+	return "https://myapps.developer.ubuntu.com/identity/api/v1/"
 }
 
 var (


### PR DESCRIPTION
This would revert allowing 'generic'-signed serials to permit further clarifications/discussions. 

This also stops for now using the new endpoints for registration in case we want to use them in lockstep with protocol adjustments.