### PR TITLE
tests: add test to ensure amd64 can run i386 syscall binaries

### DIFF
--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -125,3 +125,14 @@ execute: |
     ( (sleep 3; $SNAP_SECCOMP compile ${PROFILE}.src ${PROFILE}.bin) &)
     echo "Ensure the code still runs"
     test-snapd-tools.echo hello | MATCH hello
+
+    if [ "$(uname -p)" = "x86_64" ]; then
+        echo "Ensure secondary arch works for amd64 with i386 binaries"
+        snap install --edge test-snapd-hello-multi-arch
+        test-snapd-hello-multi-arch.hello-i386
+
+        echo "Ensure secondary arch works in @complain mode too"
+        snap remove test-snapd-hello-multi-arch
+        snap install --devmode --edge test-snapd-hello-multi-arch
+        test-snapd-hello-multi-arch.hello-i386
+    fi


### PR DESCRIPTION
This adds a missing integration test for the secondary architecture handling in snap-seccomp. It tests both the confined and unconfined case. This test catches the bug that @morphis found last night.