### PR TITLE
tests: adding extra info for fakestore when fails to start

### DIFF
--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -61,6 +61,8 @@ setup_fake_store(){
     done
 
     echo "fakestore service not started properly"
+    netstat -ntlp | grep "127.0.0.1:11028" || true
+    journalctl -u fakestore || true
     exit 1
 }
 


### PR DESCRIPTION
This is to understand the cause of this error:

https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac
/autopkgtest-xenial-snappy-dev-
image/xenial/amd64/s/snapd/20170824_094354_789aa@/log.gz