### PR TITLE
cmd/snap-seccomp: support parsing 'u:' and 'g:' for username and groups

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -580,6 +580,7 @@ const maxBufferSize = 1 << 20
 func isSizeReasonable(sz int64) bool {
 	return sz > 0 && sz <= maxBufferSize
 }
+
 // end code from https://golang.org/src/os/user/lookup_unix.go
 
 func findGid(group string) (uint64, error) {

--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -28,6 +28,7 @@ package main
 //#include <errno.h>
 //#include <linux/can.h>
 //#include <linux/netlink.h>
+//#include <grp.h>
 //#include <sched.h>
 //#include <search.h>
 //#include <stdbool.h>
@@ -135,6 +136,11 @@ package main
 //		return htobe64(val);
 //}
 //
+//static int mygetgrnam_r(const char *name, struct group *grp,char *buf,
+//			  size_t buflen, struct group **result) {
+//	return getgrnam_r(name, grp, buf, buflen, result);
+//}
+//
 import "C"
 
 import (
@@ -143,10 +149,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
+	"unsafe"
 
 	// FIXME: we want github.com/seccomp/libseccomp-golang but that
 	// will not work with trusty because libseccomp-golang checks
@@ -458,6 +467,136 @@ func readNumber(token string) (uint64, error) {
 	return strconv.ParseUint(token, 10, 64)
 }
 
+// Be very strict so usernames and groups specified in policy are widely
+// compatible. From NAME_REGEX in /etc/adduser.conf
+var userGroupNamePattern = regexp.MustCompile("^[a-z][-a-z0-9_]*$")
+
+func findUid(username string) (uint64, error) {
+	if !userGroupNamePattern.MatchString(username) {
+		return 0, fmt.Errorf("\"%s\" must be a valid username", username)
+	}
+	user, err := user.Lookup(username)
+	if err != nil {
+		return 0, err
+	}
+
+	return strconv.ParseUint(user.Uid, 10, 64)
+}
+
+// hrm, user.LookupGroup() doesn't exist yet:
+// https://github.com/golang/go/issues/2617
+//
+// Use implementation from upcoming releases:
+// https://golang.org/src/os/user/lookup_unix.go
+func lookupGroup(groupname string) (string, error) {
+	var grp C.struct_group
+	var result *C.struct_group
+
+	buf := alloc(groupBuffer)
+	defer buf.free()
+	cname := C.CString(groupname)
+	defer C.free(unsafe.Pointer(cname))
+
+	err := retryWithBuffer(buf, func() syscall.Errno {
+		return syscall.Errno(C.mygetgrnam_r(cname,
+			&grp,
+			(*C.char)(buf.ptr),
+			C.size_t(buf.size),
+			&result))
+	})
+	if err != nil {
+		return "", fmt.Errorf("group: lookup groupname %s: %v", groupname, err)
+	}
+	if result == nil {
+		return "", fmt.Errorf("group: unknown group %s", groupname)
+	}
+	return strconv.Itoa(int(grp.gr_gid)), nil
+}
+
+type bufferKind C.int
+
+const (
+	groupBuffer = bufferKind(C._SC_GETGR_R_SIZE_MAX)
+)
+
+func (k bufferKind) initialSize() C.size_t {
+	sz := C.sysconf(C.int(k))
+	if sz == -1 {
+		// DragonFly and FreeBSD do not have _SC_GETPW_R_SIZE_MAX.
+		// Additionally, not all Linux systems have it, either. For
+		// example, the musl libc returns -1.
+		return 1024
+	}
+	if !isSizeReasonable(int64(sz)) {
+		// Truncate.  If this truly isn't enough, retryWithBuffer will error on the first run.
+		return maxBufferSize
+	}
+	return C.size_t(sz)
+}
+
+type memBuffer struct {
+	ptr  unsafe.Pointer
+	size C.size_t
+}
+
+func alloc(kind bufferKind) *memBuffer {
+	sz := kind.initialSize()
+	return &memBuffer{
+		ptr:  C.malloc(sz),
+		size: sz,
+	}
+}
+
+func (mb *memBuffer) resize(newSize C.size_t) {
+	mb.ptr = C.realloc(mb.ptr, newSize)
+	mb.size = newSize
+}
+
+func (mb *memBuffer) free() {
+	C.free(mb.ptr)
+}
+
+// retryWithBuffer repeatedly calls f(), increasing the size of the
+// buffer each time, until f succeeds, fails with a non-ERANGE error,
+// or the buffer exceeds a reasonable limit.
+func retryWithBuffer(buf *memBuffer, f func() syscall.Errno) error {
+	for {
+		errno := f()
+		if errno == 0 {
+			return nil
+		} else if errno != syscall.ERANGE {
+			return errno
+		}
+		newSize := buf.size * 2
+		if !isSizeReasonable(int64(newSize)) {
+			return fmt.Errorf("internal buffer exceeds %d bytes", maxBufferSize)
+		}
+		buf.resize(newSize)
+	}
+}
+
+const maxBufferSize = 1 << 20
+
+func isSizeReasonable(sz int64) bool {
+	return sz > 0 && sz <= maxBufferSize
+}
+// end code from https://golang.org/src/os/user/lookup_unix.go
+
+func findGid(group string) (uint64, error) {
+	if !userGroupNamePattern.MatchString(group) {
+		return 0, fmt.Errorf("\"%s\" must be a valid group name", group)
+	}
+
+	//group, err := user.LookupGroup(group)
+	group, err := lookupGroup(group)
+	if err != nil {
+		return 0, err
+	}
+
+	//return strconv.ParseUint(group.Gid, 10, 64)
+	return strconv.ParseUint(group, 10, 64)
+}
+
 func parseLine(line string, secFilter *seccomp.ScmpFilter) error {
 	// ignore comments and empty lines
 	if strings.HasPrefix(line, "#") || line == "" {
@@ -508,6 +647,18 @@ func parseLine(line string, secFilter *seccomp.ScmpFilter) error {
 		} else if strings.HasPrefix(arg, "|") {
 			cmpOp = seccomp.CompareMaskedEqual
 			value, err = readNumber(arg[1:])
+		} else if strings.HasPrefix(arg, "u:") {
+			cmpOp = seccomp.CompareEqual
+			value, err = findUid(arg[2:])
+			if err != nil {
+				return fmt.Errorf("cannot parse token %q (line %q): %v", arg, line, err)
+			}
+		} else if strings.HasPrefix(arg, "g:") {
+			cmpOp = seccomp.CompareEqual
+			value, err = findGid(arg[2:])
+			if err != nil {
+				return fmt.Errorf("cannot parse token %q (line %q): %v", arg, line, err)
+			}
 		} else {
 			cmpOp = seccomp.CompareEqual
 			value, err = readNumber(arg)

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -398,6 +398,22 @@ func (s *snapSeccompSuite) TestCompileBadInput(c *C) {
 		{"setpriority <=", `cannot parse line: cannot parse token "<=" .*`},
 		{"setpriority |", `cannot parse line: cannot parse token "|" .*`},
 		{"setpriority !", `cannot parse line: cannot parse token "!" .*`},
+
+		// u:<username>
+		{"setuid :root", `cannot parse line: cannot parse token ":root" .*`},
+		{"setuid u:", `cannot parse line: cannot parse token "u:" \(line "setuid u:"\): "" must be a valid username`},
+		{"setuid u:0", `cannot parse line: cannot parse token "u:0" \(line "setuid u:0"\): "0" must be a valid username`},
+		{"setuid u:b@d|npu+", `cannot parse line: cannot parse token "u:b@d|npu+" \(line "setuid u:b@d|npu+"\): "b@d|npu+" must be a valid username`},
+		{"setuid u:snap.bad", `cannot parse line: cannot parse token "u:snap.bad" \(line "setuid u:snap.bad"\): "snap.bad" must be a valid username`},
+		{"setuid U:root", `cannot parse line: cannot parse token "U:root" .*`},
+		{"setuid u:nonexistent", `cannot parse line: cannot parse token "u:nonexistent" \(line "setuid u:nonexistent"\): user: unknown user nonexistent`},
+		// g:<groupname>
+		{"setgid g:", `cannot parse line: cannot parse token "g:" \(line "setgid g:"\): "" must be a valid group name`},
+		{"setgid g:0", `cannot parse line: cannot parse token "g:0" \(line "setgid g:0"\): "0" must be a valid group name`},
+		{"setgid g:b@d|npu+", `cannot parse line: cannot parse token "g:b@d|npu+" \(line "setgid g:b@d|npu+"\): "b@d|npu+" must be a valid group name`},
+		{"setgid g:snap.bad", `cannot parse line: cannot parse token "g:snap.bad" \(line "setgid g:snap.bad"\): "snap.bad" must be a valid group name`},
+		{"setgid G:root", `cannot parse line: cannot parse token "G:root" .*`},
+		{"setgid g:nonexistent", `cannot parse line: cannot parse token "g:nonexistent" \(line "setgid g:nonexistent"\): group: unknown group nonexistent`},
 	} {
 		outPath := filepath.Join(c.MkDir(), "bpf")
 		err := main.Compile([]byte(t.inp), outPath)
@@ -568,6 +584,28 @@ func (s *snapSeccompSuite) TestRestrictionsWorkingArgsTermios(c *C) {
 		{"ioctl - TIOCSTI", "ioctl;native;-,TIOCSTI", main.SeccompRetAllow},
 		// bad input
 		{"ioctl - TIOCSTI", "quotactl;native;-,99", main.SeccompRetKill},
+	} {
+		simulateBpf(c, t.seccompWhitelist, t.bpfInput, t.expected)
+	}
+}
+
+func (s *snapSeccompSuite) TestRestrictionsWorkingArgsUidGid(c *C) {
+	for _, t := range []struct {
+		seccompWhitelist string
+		bpfInput         string
+		expected         int
+	}{
+		// good input. 'root' and 'daemon' are guaranteed to be '0' and
+		// '1' respectively
+		{"setuid u:root", "setuid;native;0", main.SeccompRetAllow},
+		{"setuid u:daemon", "setuid;native;1", main.SeccompRetAllow},
+		{"setgid g:root", "setgid;native;0", main.SeccompRetAllow},
+		{"setgid g:daemon", "setgid;native;1", main.SeccompRetAllow},
+		// bad input
+		{"setuid u:root", "setuid;native;99", main.SeccompRetKill},
+		{"setuid u:daemon", "setuid;native;99", main.SeccompRetKill},
+		{"setgid g:root", "setgid;native;99", main.SeccompRetKill},
+		{"setgid g:daemon", "setgid;native;99", main.SeccompRetKill},
 	} {
 		simulateBpf(c, t.seccompWhitelist, t.bpfInput, t.expected)
 	}


### PR DESCRIPTION
This adds support in snap-seccomp to parse 'u:<username>' and 'g:<groupname>' in the policy so we can do things like:
```
setuid u:daemon
fchown - u:root g:shadow
```

This is a required building block for security policy support for https://forum.snapcraft.io/t/multiple-users-and-groups-in-snaps/1461. It will also be the basis for allowing use of the 'daemon' user and group by default (see https://bugs.launchpad.net/snappy/+bug/1619888/comments/6) for privilege dropping, etc.