### PR TITLE
interfaces/i2c: adjust sysfs rule for alternate paths

### DIFF
--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -94,7 +94,7 @@ func (iface *i2cInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 
 	cleanedPath := filepath.Clean(path)
 	spec.AddSnippet(fmt.Sprintf("%s rw,", cleanedPath))
-	spec.AddSnippet(fmt.Sprintf("/sys/devices/platform/**.i2c/%s/** rw,", strings.TrimPrefix(path, "/dev/")))
+	spec.AddSnippet(fmt.Sprintf("/sys/devices/platform/{*,**.i2c}/%s/** rw,", strings.TrimPrefix(path, "/dev/")))
 	return nil
 }
 

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -169,7 +169,7 @@ func (s *I2cInterfaceSuite) TestConnectedPlugUDevSnippets(c *C) {
 
 func (s *I2cInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 	expectedSnippet1 := `/dev/i2c-1 rw,
-/sys/devices/platform/**.i2c/i2c-1/** rw,`
+/sys/devices/platform/{*,**.i2c}/i2c-1/** rw,`
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, nil, s.testUDev1, nil)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Addresses issue reported in https://forum.snapcraft.io/t/permission-denied-using-sysfs-from-i2c-plug/364