### PR TITLE
interfaces/apparmor: add missing call to dirs.SetRootDir

### DIFF
--- a/interfaces/apparmor/apparmor_test.go
+++ b/interfaces/apparmor/apparmor_test.go
@@ -90,6 +90,8 @@ func (s *appArmorSuite) TestLoadProfileRunsAppArmorParserReplaceWithSnapdDebug(c
 // Tests for Profile.Unload()
 
 func (s *appArmorSuite) TestUnloadProfileRunsAppArmorParserRemove(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("")
 	cmd := testutil.MockCommand(c, "apparmor_parser", "")
 	defer cmd.Restore()
 	err := apparmor.UnloadProfile("snap.samba.smbd")


### PR DESCRIPTION
This patch corrects a test that was failing on openSUSE. On Ubuntu it
was passing by accident because /var/cache/apparmor/$something did not
exist (the code treats file-not-found as an OK condition). On openSUSE
the permissions prevent non-root users from traversing
/var/cache/apparmor so the test failed with permission error.

In both cases what was missing was a call to dirs.SetRootDir(), to
isolate the test from the real system.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>