### PR TITLE
hooks: do not error out when hook is optional and no hook handler is registered

### DIFF
--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -227,6 +227,9 @@ func (m *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	handlers := m.repository.generateHandlers(context)
 	handlersCount := len(handlers)
 	if handlersCount == 0 {
+		if hooksup.Optional && !hookExists {
+			return nil
+		}
 		return fmt.Errorf("internal error: no registered handlers for hook %q", hooksup.Hook)
 	}
 	if handlersCount > 1 {

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -227,6 +227,9 @@ func (m *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	handlers := m.repository.generateHandlers(context)
 	handlersCount := len(handlers)
 	if handlersCount == 0 {
+		// Do not report error if hook handler doesn't exist as long as the hook is optional.
+		// This is to avoid issues when downgrading to an old core snap that doesn't know about
+		// particular hook type and a task for it exists (e.g. "refresh" hook).
 		if hooksup.Optional {
 			return nil
 		}

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -227,7 +227,7 @@ func (m *HookManager) doRunHook(task *state.Task, tomb *tomb.Tomb) error {
 	handlers := m.repository.generateHandlers(context)
 	handlersCount := len(handlers)
 	if handlersCount == 0 {
-		if hooksup.Optional && !hookExists {
+		if hooksup.Optional {
 			return nil
 		}
 		return fmt.Errorf("internal error: no registered handlers for hook %q", hooksup.Hook)

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -594,6 +594,31 @@ func (s *hookManagerSuite) TestHookWithoutHookOptional(c *C) {
 	c.Logf("Task log:\n%s\n", s.task.Log())
 }
 
+func (s *hookManagerSuite) TestOptionalHookWithMissingHandler(c *C) {
+	hooksup := &hookstate.HookSetup{
+		Snap:     "test-snap",
+		Hook:     "missing-hook-and-no-handler",
+		Optional: true,
+	}
+	s.state.Lock()
+	s.task.Set("hook-setup", hooksup)
+	s.state.Unlock()
+
+	s.manager.Ensure()
+	s.manager.Wait()
+
+	c.Check(s.command.Calls(), IsNil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(s.task.Kind(), Equals, "run-hook")
+	c.Check(s.task.Status(), Equals, state.DoneStatus)
+	c.Check(s.change.Status(), Equals, state.DoneStatus)
+
+	c.Logf("Task log:\n%s\n", s.task.Log())
+}
+
 func checkTaskLogContains(c *C, task *state.Task, pattern string) {
 	exp := regexp.MustCompile(pattern)
 	found := false


### PR DESCRIPTION
Don't report error if there is no hook handler registered for given hook as long as hook is optional. This happens with:
$ sudo snap refresh --edge core
$ sudo snap refresh --stable core    
error: cannot perform the following tasks:
- Run refresh hook of "core" snap if present (internal error: no registered handlers for hook "refresh")
