### PR TITLE
interfaces: fix network-manager plug

### DIFF
--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -464,7 +464,7 @@ func (iface *networkManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifi
 	return nil
 }
 
-func (iface *networkManagerInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug) error {
+func (iface *networkManagerInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	spec.AddSnippet(networkManagerConnectedPlugSecComp)
 	return nil
 }

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -252,7 +252,7 @@ dbus (receive, send)
 
 const networkManagerConnectedPlugSecComp = `
 # Description: This is needed to talk to the network-manager service
-socket AF_NETLINK - KOBJECT_UEVENT
+socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
 const networkManagerPermanentSlotSecComp = `

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -263,6 +263,11 @@ shutdown
 socket AF_NETLINK - -
 `
 
+const networkManagerPermanentPlugSecComp = `
+# Description: This is needed to talk to the network-manager service
+socket AF_NETLINK - KOBJECT_UEVENT
+`
+
 const networkManagerPermanentSlotDBus = `
 <!-- DBus policy for NetworkManager (upstream version 1.2.2) -->
 <policy user="root">
@@ -456,6 +461,11 @@ func (iface *networkManagerInterface) DBusPermanentSlot(spec *dbus.Specification
 
 func (iface *networkManagerInterface) SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error {
 	spec.AddSnippet(networkManagerPermanentSlotSecComp)
+	return nil
+}
+
+func (iface *networkManagerInterface) SecCompPermanentPlug(spec *seccomp.Specification, plug *interfaces.Plug) error {
+	spec.AddSnippet(networkManagerPermanentPlugSecComp)
 	return nil
 }
 

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -250,6 +250,11 @@ dbus (receive, send)
     peer=(label=###SLOT_SECURITY_TAGS###),
 `
 
+const networkManagerConnectedPlugSecComp = `
+# Description: This is needed to talk to the network-manager service
+socket AF_NETLINK - KOBJECT_UEVENT
+`
+
 const networkManagerPermanentSlotSecComp = `
 # Description: Allow operating as the NetworkManager service. This gives
 # privileged access to the system.
@@ -261,11 +266,6 @@ sethostname
 shutdown
 # netlink
 socket AF_NETLINK - -
-`
-
-const networkManagerPermanentPlugSecComp = `
-# Description: This is needed to talk to the network-manager service
-socket AF_NETLINK - KOBJECT_UEVENT
 `
 
 const networkManagerPermanentSlotDBus = `
@@ -464,8 +464,8 @@ func (iface *networkManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifi
 	return nil
 }
 
-func (iface *networkManagerInterface) SecCompPermanentPlug(spec *seccomp.Specification, plug *interfaces.Plug) error {
-	spec.AddSnippet(networkManagerPermanentPlugSecComp)
+func (iface *networkManagerInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug) error {
+	spec.AddSnippet(networkManagerConnectedPlugSecComp)
 	return nil
 }
 

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -36,3 +36,7 @@ execute: |
     expected="(?s)$DEVMODE_SNAP .*"
     actual=$(snap install --channel beta --devmode $DEVMODE_SNAP)
     echo "$actual" | grep -Pzq "$expected"
+
+    echo "Install network-manager and do basic smoke test"
+    snap install network-manager
+    network-manager.nmcli d show


### PR DESCRIPTION
Add networkManagerPermanentPlugSecComp that adds socket AF_NETLINK - KOBJECT_UEVENT to unbreak nmcli.

We should squash-merge this and then cherry-pick it for 2.27.