### PR TITLE
spread: don't set HTTPS?_PROXY for linode

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -47,6 +47,10 @@ backends:
         key: "$(HOST: echo $SPREAD_LINODE_KEY)"
         halt-timeout: 2h
         environment:
+            # Using proxy can help to accelerate testing in local conditions
+            # but it is unlikely anyone has a proxy that is addressable from
+            # Linode network. As such, don't honor host's SPREAD_HTTP_PROXY
+            # that was set globally above.
             HTTP_PROXY: null
             HTTPS_PROXY: null
         systems:

--- a/spread.yaml
+++ b/spread.yaml
@@ -46,6 +46,9 @@ backends:
     linode:
         key: "$(HOST: echo $SPREAD_LINODE_KEY)"
         halt-timeout: 2h
+        environment:
+            HTTP_PROXY: null
+            HTTPS_PROXY: null
         systems:
             - ubuntu-14.04-64:
                 kernel: GRUB 2


### PR DESCRIPTION
I'm using a proxy at home, this includes me having SPREAD_HTTPS?_PROXY
environment variables set. This works perfectly for qemu or other local
targets but fails miserably for linode. Since using a proxy in linode is
unlikely to be useful this patch disables those two variables for that
backend.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>