### PR TITLE
tests: new regex used to validate the core version on extra snaps ass...

### DIFF
--- a/tests/nested/extra-snaps-assertions/task.yaml
+++ b/tests/nested/extra-snaps-assertions/task.yaml
@@ -64,4 +64,4 @@ execute: |
     execute_remote "snap known model" | MATCH "series: 16"
 
     echo "Make sure core has an actual revision"
-    execute_remote "snap list" | MATCH "^core +[0-9]+\-[0-9]+ +[0-9]+ +canonical +\-"
+    execute_remote "snap list" | MATCH "^core +[0-9]+\-[0-9.]+ +[0-9]+ +canonical +\-"


### PR DESCRIPTION
This minor change fixes the test tests/nested/extra-snaps-assertions which is failing on the nightly test suite. 
Error:
https://travis-ci.org/snapcore/spread-cron/builds/269040061