### PR TITLE
vendor: use old golang.org/x/crypto/ssh/terminal to build on powerpc again

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -132,10 +132,11 @@
 			"revisionTime": "2017-06-29T04:06:47Z"
 		},
 		{
-			"checksumSHA1": "ZaU56svwLgiJD0y8JOB3+/mpYBA=",
+			"checksumSHA1": "9C4Av3ypK5pi173F76ogJT/d8x4=",
 			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "5ef0053f77724838734b6945dd364d3847e5de1d",
-			"revisionTime": "2017-06-29T04:06:47Z"
+			"revision": "a19fa444682e099bed1a53260e1d755754cd098a",
+		        "revisionTime": "2015-11-02T21:41:26Z",
+                        "comment": "using revision before x/sys/unix/ was added to allow building on powerpc"
 		},
 		{
 			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
@@ -148,12 +149,6 @@
 			"path": "golang.org/x/net/context/ctxhttp",
 			"revision": "c81e7f25cb61200d8bf0ae971a0bac8cb638d5bc",
 			"revisionTime": "2017-06-28T23:42:41Z"
-		},
-		{
-			"checksumSHA1": "K3C9lD5XgLfXd25MtZe3Uw5BRoA=",
-			"path": "golang.org/x/sys/unix",
-			"revision": "35ef4487ce0a1ea5d4b616ffe71e34febe723695",
-			"revisionTime": "2017-07-27T13:28:57Z"
 		},
 		{
 			"checksumSHA1": "CEFTYXtWmgSh+3Ik1NmDaJcz4E0=",


### PR DESCRIPTION
The recent update of golang.org/x/crypto/ssh/terminal to the latest
revision broke the builds of snapd on powerpc. The reason for this
is that new golang.org/x/crypto/ssh/terminal pulls in x/sys/unix
which does not build on the powerpc platform. But x/sys/unix is
only needed for solaris support of x/crypto/ssh/terminal so we
can ignore that.

This is the easiest way to get working builds on powerpc back.
We could also fork x/crypto/terminal and remove the solaris
support or we could work on adding powerpc support with gccgo
to x/sys/unix (given that powerpc is no longer a supported
platform in ubuntu 17.04+ this is probably not a good investment).