### PR TITLE
interfaces: do not match any file or directory in or under /sys/bus/pci/devices/

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -51,7 +51,7 @@ const openglConnectedPlugAppArmor = `
 
   # FIXME: this is an information leak and snapd should instead query udev for
   # the specific accesses associated with the above devices.
-  /sys/bus/pci/devices/** r,
+  /sys/bus/pci/devices/ r,
   /run/udev/data/+drm:card* r,
   /run/udev/data/+pci:[0-9]* r,
 


### PR DESCRIPTION
/sys/bus/pci/devices/ should be filled with symlinks, not actual files.
And we already have apparmor rule in place to resolves symlinks.
