### PR TITLE
interfaces/iio: add read/write for missing sysfs entries

### DIFF
--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -47,6 +47,8 @@ const iioConnectedPlugAppArmor = `
 ###IIO_DEVICE_PATH### rw,
 /sys/bus/iio/devices/###IIO_DEVICE_NAME###/ r,
 /sys/bus/iio/devices/###IIO_DEVICE_NAME###/** rwk,
+/sys/devices/**/###IIO_DEVICE_NAME###/ r,
+/sys/devices/**/###IIO_DEVICE_NAME###/** rwk,
 `
 
 // The type for iio interface

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -170,6 +170,8 @@ func (s *IioInterfaceSuite) TestConnectedPlugAppArmorSnippets(c *C) {
 /dev/iio:device1 rw,
 /sys/bus/iio/devices/iio:device1/ r,
 /sys/bus/iio/devices/iio:device1/** rwk,
+/sys/devices/**/iio:device1/ r,
+/sys/devices/**/iio:device1/** rwk,
 `
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.testPlugPort1, nil, s.testUDev1, nil)


### PR DESCRIPTION
Reference: https://forum.snapcraft.io/t/permission-denied-using-sysfs-from-i2c-plug/364/17 for denials listed in in https://forum.snapcraft.io/t/permission-denied-using-sysfs-from-i2c-plug/364/9.

Note, there were recently changes for the i2c interface that were similar, but correct for i2c. This is for iio.