### PR TITLE
tests: fix race in snap userd test

### DIFF
--- a/tests/main/snap-userd/task.yaml
+++ b/tests/main/snap-userd/task.yaml
@@ -12,12 +12,6 @@ restore: |
     . "$TESTSLIB/dirs.sh"
     . "$TESTSLIB/pkgdb.sh"
     rm -f dbus.env
-    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
-        stop test-snap-userd || true
-        rm -f /etc/init/test-snap-userd.conf
-    else
-        systemctl stop --signal=KILL test-snap-userd.scope || true
-    fi
     umount -f /usr/bin/xdg-open || true
     umount -f $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-open || true
     distro_purge_package dbus-x11 xdg-utils
@@ -29,11 +23,11 @@ execute: |
     # Install necessary pacakges to get dbus-launch helper
     distro_install_package dbus-x11 xdg-utils
 
+    # launch dbus session bus
     dbus-launch > dbus.env
     export $(cat dbus.env | xargs)
 
-    # helper that returns true when io.snapcraft.Launcher.OpenURL
-    # responds
+    # wait for session to be ready
     ping_launcher() {
         dbus-send --session                                        \
             --dest=io.snapcraft.Launcher                           \
@@ -42,33 +36,9 @@ execute: |
             /                                                      \
             org.freedesktop.DBus.Peer.Ping
     }
-
-    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
-        cat << EOF > /etc/init/test-snap-userd.conf
-    env DISPLAY="$DISPLAY"
-    env DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"
-    env DBUS_SESSION_BUS_PID="$DBUS_SESSION_BUS_PID"
-    kill timeout 5
-    exec /usr/bin/snap userd
-    EOF
-        initctl reload-configuration
-        start test-snap-userd
-        while ! ping_launcher ; do
-            sleep .1
-        done
-    else
-        systemd-run \
-            --scope \
-            --unit=test-snap-userd \
-            --no-block \
-            --setenv=DISPLAY="$DISPLAY" \
-            --setenv=DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" \
-            --setenv=DBUS_SESSION_BUS_PID="$DBUS_SESSION_BUS_PID" \
-            /bin/sh -c '/usr/bin/snap userd &'
-        while ! ping_launcher ; do
-            sleep .1
-        done
-    fi
+    while ! ping_launcher ; do
+        sleep .5
+    done
 
     # Create a small helper which will tell us if snap passes
     # the URL correctly to the right handler
@@ -109,10 +79,3 @@ execute: |
     test ! -e /tmp/xdg-open-output
     ! $SNAP_MOUNT_DIR/core/current/usr/bin/xdg-open aabbcc
     test ! -e /tmp/xdg-open-output
-
-    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
-        stop test-snap-userd
-    else
-        systemctl list-units --type=scope  # debug
-        systemctl stop --signal=KILL test-snap-userd.scope || true
-    fi

--- a/userd/userd.go
+++ b/userd/userd.go
@@ -26,6 +26,8 @@ import (
 	"github.com/godbus/dbus"
 	"github.com/godbus/dbus/introspect"
 	"gopkg.in/tomb.v2"
+
+	"github.com/snapcore/snapd/logger"
 )
 
 const (
@@ -84,6 +86,8 @@ func (ud *Userd) Init() error {
 }
 
 func (ud *Userd) Start() {
+	logger.Noticef("Starting snap userd")
+
 	ud.tomb.Go(func() error {
 		// Listen to keep our thread up and running. All DBus bits
 		// are running in the background


### PR DESCRIPTION
Instead of starting a `snap userd` manually we can just let
the bus activation handle it for us. This removes the race
we used when we started it manually in the test and at the same
time the dbus activation may be triggered.
