### PR TITLE
store: move device auth endpoint uris to config

### DIFF
--- a/store/auth.go
+++ b/store/auth.go
@@ -237,7 +237,7 @@ func refreshDischargeMacaroon(discharge string) (string, error) {
 }
 
 // requestStoreDeviceNonce requests a nonce for device authentication against the store.
-func requestStoreDeviceNonce(deviceNonceAPI string) (string, error) {
+func requestStoreDeviceNonce(deviceNonceEndpoint string) (string, error) {
 	const errorPrefix = "cannot get nonce from store: "
 
 	var responseData struct {
@@ -248,7 +248,7 @@ func requestStoreDeviceNonce(deviceNonceAPI string) (string, error) {
 		"User-Agent": httputil.UserAgent(),
 		"Accept":     "application/json",
 	}
-	resp, err := retryPostRequestDecodeJSON(deviceNonceAPI, headers, nil, &responseData, nil)
+	resp, err := retryPostRequestDecodeJSON(deviceNonceEndpoint, headers, nil, &responseData, nil)
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
@@ -271,7 +271,7 @@ type deviceSessionRequestParamsEncoder interface {
 }
 
 // requestDeviceSession requests a device session macaroon from the store.
-func requestDeviceSession(deviceSessionAPI string, paramsEncoder deviceSessionRequestParamsEncoder, previousSession string) (string, error) {
+func requestDeviceSession(deviceSessionEndpoint string, paramsEncoder deviceSessionRequestParamsEncoder, previousSession string) (string, error) {
 	const errorPrefix = "cannot get device session from store: "
 
 	data := map[string]string{
@@ -298,7 +298,7 @@ func requestDeviceSession(deviceSessionAPI string, paramsEncoder deviceSessionRe
 		headers["X-Device-Authorization"] = fmt.Sprintf(`Macaroon root="%s"`, previousSession)
 	}
 
-	_, err = retryPostRequest(deviceSessionAPI, headers, deviceJSONData, func(resp *http.Response) error {
+	_, err = retryPostRequest(deviceSessionEndpoint, headers, deviceJSONData, func(resp *http.Response) error {
 		if resp.StatusCode == 200 || resp.StatusCode == 202 {
 			return json.NewDecoder(resp.Body).Decode(&responseData)
 		}

--- a/store/auth.go
+++ b/store/auth.go
@@ -33,12 +33,7 @@ import (
 )
 
 var (
-	baseAPIURL = apiURL()
-	// DeviceNonceAPI points to endpoint to get a nonce
-	DeviceNonceAPI = baseAPIURL.String() + "api/v1/snaps/auth/nonces"
-	// DeviceSessionAPI points to endpoint to get a device session
-	DeviceSessionAPI = baseAPIURL.String() + "api/v1/snaps/auth/sessions"
-	myappsAPIBase    = myappsURL()
+	myappsAPIBase = myappsURL()
 	// MyAppsMacaroonACLAPI points to MyApps endpoint to get a ACL macaroon
 	MyAppsMacaroonACLAPI = myappsAPIBase + "dev/api/acl/"
 	ubuntuoneAPIBase     = authURL()
@@ -242,7 +237,7 @@ func refreshDischargeMacaroon(discharge string) (string, error) {
 }
 
 // requestStoreDeviceNonce requests a nonce for device authentication against the store.
-func requestStoreDeviceNonce() (string, error) {
+func requestStoreDeviceNonce(deviceNonceAPI string) (string, error) {
 	const errorPrefix = "cannot get nonce from store: "
 
 	var responseData struct {
@@ -253,7 +248,7 @@ func requestStoreDeviceNonce() (string, error) {
 		"User-Agent": httputil.UserAgent(),
 		"Accept":     "application/json",
 	}
-	resp, err := retryPostRequestDecodeJSON(DeviceNonceAPI, headers, nil, &responseData, nil)
+	resp, err := retryPostRequestDecodeJSON(deviceNonceAPI, headers, nil, &responseData, nil)
 	if err != nil {
 		return "", fmt.Errorf(errorPrefix+"%v", err)
 	}
@@ -276,7 +271,7 @@ type deviceSessionRequestParamsEncoder interface {
 }
 
 // requestDeviceSession requests a device session macaroon from the store.
-func requestDeviceSession(paramsEncoder deviceSessionRequestParamsEncoder, previousSession string) (string, error) {
+func requestDeviceSession(deviceSessionAPI string, paramsEncoder deviceSessionRequestParamsEncoder, previousSession string) (string, error) {
 	const errorPrefix = "cannot get device session from store: "
 
 	data := map[string]string{
@@ -303,7 +298,7 @@ func requestDeviceSession(paramsEncoder deviceSessionRequestParamsEncoder, previ
 		headers["X-Device-Authorization"] = fmt.Sprintf(`Macaroon root="%s"`, previousSession)
 	}
 
-	_, err = retryPostRequest(DeviceSessionAPI, headers, deviceJSONData, func(resp *http.Response) error {
+	_, err = retryPostRequest(deviceSessionAPI, headers, deviceJSONData, func(resp *http.Response) error {
 		if resp.StatusCode == 200 || resp.StatusCode == 202 {
 			return json.NewDecoder(resp.Body).Decode(&responseData)
 		}

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -283,9 +283,9 @@ func (s *authTestSuite) TestRequestStoreDeviceNonce(c *C) {
 		io.WriteString(w, mockStoreReturnNonce)
 	}))
 	defer mockServer.Close()
-	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
-	nonce, err := requestStoreDeviceNonce()
+	deviceNonceAPI := mockServer.URL + "/api/v1/snaps/auth/nonces"
+	nonce, err := requestStoreDeviceNonce(deviceNonceAPI)
 	c.Assert(err, IsNil)
 	c.Assert(nonce, Equals, "the-nonce")
 }
@@ -301,9 +301,9 @@ func (s *authTestSuite) TestRequestStoreDeviceNonceRetry500(c *C) {
 		}
 	}))
 	defer mockServer.Close()
-	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
-	nonce, err := requestStoreDeviceNonce()
+	deviceNonceAPI := mockServer.URL + "/api/v1/snaps/auth/nonces"
+	nonce, err := requestStoreDeviceNonce(deviceNonceAPI)
 	c.Assert(err, IsNil)
 	c.Assert(nonce, Equals, "the-nonce")
 	c.Assert(n, Equals, 4)
@@ -316,17 +316,17 @@ func (s *authTestSuite) TestRequestStoreDeviceNonce500(c *C) {
 		w.WriteHeader(500)
 	}))
 	defer mockServer.Close()
-	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
-	_, err := requestStoreDeviceNonce()
+	deviceNonceAPI := mockServer.URL + "/api/v1/snaps/auth/nonces"
+	_, err := requestStoreDeviceNonce(deviceNonceAPI)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot get nonce from store: store server returned status 500`)
 	c.Assert(n, Equals, 5)
 }
 
 func (s *authTestSuite) TestRequestStoreDeviceNonceFailureOnDNS(c *C) {
-	DeviceNonceAPI = "http://nonexistingserver121321.com/api/v1/snaps/auth/nonces"
-	_, err := requestStoreDeviceNonce()
+	deviceNonceAPI := "http://nonexistingserver121321.com/api/v1/snaps/auth/nonces"
+	_, err := requestStoreDeviceNonce(deviceNonceAPI)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot get nonce from store.*`)
 }
@@ -336,9 +336,9 @@ func (s *authTestSuite) TestRequestStoreDeviceNonceEmptyResponse(c *C) {
 		io.WriteString(w, mockStoreReturnNoNonce)
 	}))
 	defer mockServer.Close()
-	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
-	nonce, err := requestStoreDeviceNonce()
+	deviceNonceAPI := mockServer.URL + "/api/v1/snaps/auth/nonces"
+	nonce, err := requestStoreDeviceNonce(deviceNonceAPI)
 	c.Assert(err, ErrorMatches, "cannot get nonce from store: empty nonce returned")
 	c.Assert(nonce, Equals, "")
 }
@@ -350,9 +350,9 @@ func (s *authTestSuite) TestRequestStoreDeviceNonceError(c *C) {
 		n++
 	}))
 	defer mockServer.Close()
-	DeviceNonceAPI = mockServer.URL + "/api/v1/snaps/auth/nonces"
 
-	nonce, err := requestStoreDeviceNonce()
+	deviceNonceAPI := mockServer.URL + "/api/v1/snaps/auth/nonces"
+	nonce, err := requestStoreDeviceNonce(deviceNonceAPI)
 	c.Assert(err, ErrorMatches, "cannot get nonce from store: store server returned status 500")
 	c.Assert(n, Equals, 5)
 	c.Assert(nonce, Equals, "")
@@ -382,9 +382,9 @@ func (s *authTestSuite) TestRequestDeviceSession(c *C) {
 		io.WriteString(w, mockStoreReturnMacaroon)
 	}))
 	defer mockServer.Close()
-	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
-	macaroon, err := requestDeviceSession(&testDeviceSessionRequestParamsEncoder{}, "")
+	deviceSessionAPI := mockServer.URL + "/api/v1/snaps/auth/sessions"
+	macaroon, err := requestDeviceSession(deviceSessionAPI, &testDeviceSessionRequestParamsEncoder{}, "")
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
@@ -399,9 +399,9 @@ func (s *authTestSuite) TestRequestDeviceSessionWithPreviousSession(c *C) {
 		io.WriteString(w, mockStoreReturnMacaroon)
 	}))
 	defer mockServer.Close()
-	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
-	macaroon, err := requestDeviceSession(&testDeviceSessionRequestParamsEncoder{}, "previous-session")
+	deviceSessionAPI := mockServer.URL + "/api/v1/snaps/auth/sessions"
+	macaroon, err := requestDeviceSession(deviceSessionAPI, &testDeviceSessionRequestParamsEncoder{}, "previous-session")
 	c.Assert(err, IsNil)
 	c.Assert(macaroon, Equals, "the-root-macaroon-serialized-data")
 }
@@ -411,9 +411,9 @@ func (s *authTestSuite) TestRequestDeviceSessionMissingData(c *C) {
 		io.WriteString(w, mockStoreReturnNoMacaroon)
 	}))
 	defer mockServer.Close()
-	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
-	macaroon, err := requestDeviceSession(&testDeviceSessionRequestParamsEncoder{}, "")
+	deviceSessionAPI := mockServer.URL + "/api/v1/snaps/auth/sessions"
+	macaroon, err := requestDeviceSession(deviceSessionAPI, &testDeviceSessionRequestParamsEncoder{}, "")
 	c.Assert(err, ErrorMatches, "cannot get device session from store: empty session returned")
 	c.Assert(macaroon, Equals, "")
 }
@@ -426,9 +426,9 @@ func (s *authTestSuite) TestRequestDeviceSessionError(c *C) {
 		n++
 	}))
 	defer mockServer.Close()
-	DeviceSessionAPI = mockServer.URL + "/api/v1/snaps/auth/sessions"
 
-	macaroon, err := requestDeviceSession(&testDeviceSessionRequestParamsEncoder{}, "")
+	deviceSessionAPI := mockServer.URL + "/api/v1/snaps/auth/sessions"
+	macaroon, err := requestDeviceSession(deviceSessionAPI, &testDeviceSessionRequestParamsEncoder{}, "")
 	c.Assert(err, ErrorMatches, `cannot get device session from store: store server returned status 500 and body "error body"`)
 	c.Assert(n, Equals, 5)
 	c.Assert(macaroon, Equals, "")


### PR DESCRIPTION
Move the device auth (nonce & session) URIs to Config so they're updated when changing the store API's base URL.