### PR TITLE
cmd/snap-seccomp/main_test.go: add syscalls for armhf and arm64

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -305,6 +305,10 @@ sysinfo
 exit
 # i386
 set_thread_area
+# armhf
+set_tls
+# arm64
+readlinkat
 `
 	bpfPath := filepath.Join(c.MkDir(), "bpf")
 	err := main.Compile([]byte(common+seccompWhitelist), bpfPath)


### PR DESCRIPTION
This adds needed syscalls based on:
* https://launchpadlibrarian.net/335270158/buildlog_ubuntu-xenial-arm64.snapd_2.27.5+git354.834024b~ubuntu16.04.1_BUILDING.txt.gz
* https://launchpadlibrarian.net/335269966/buildlog_ubuntu-xenial-armhf.snapd_2.27.5+git354.834024b~ubuntu16.04.1_BUILDING.txt.gz

More may be needed...