### PR TITLE
cmd/snap-seccomp/main_test.go: add one more syscall for arm64

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -309,6 +309,7 @@ set_thread_area
 set_tls
 # arm64
 readlinkat
+faccessat
 `
 	bpfPath := filepath.Join(c.MkDir(), "bpf")
 	err := main.Compile([]byte(common+seccompWhitelist), bpfPath)


### PR DESCRIPTION
I tested this locally on dragonboard in classic by running:
```
$ go build -v github.com/snapcore/snapd/... && go test -v github.com/snapcore/snapd/cmd/snap-seccomp
...
=== RUN   Test
OK: 11 passed
--- PASS: Test (355.58s)
PASS
ok  	github.com/snapcore/snapd/cmd/snap-seccomp	355.600s
```