### PR TITLE
overlord/snapstate: rename HasCurrent to IsInstalled, remove superfluous/misleading check from All

### DIFF
--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -152,8 +152,8 @@ func (snapst *SnapState) SetType(typ snap.Type) {
 	snapst.SnapType = string(typ)
 }
 
-// HasCurrent returns whether snapst.Current is set.
-func (snapst *SnapState) HasCurrent() bool {
+// IsInstalled returns whether the snap is installed, i.e. snapst represents an installed snap with Current revision set.
+func (snapst *SnapState) IsInstalled() bool {
 	if snapst.Current.Unset() {
 		if len(snapst.Sequence) > 0 {
 			panic(fmt.Sprintf("snapst.Current and snapst.Sequence out of sync: %#v %#v", snapst.Current, snapst.Sequence))
@@ -176,11 +176,9 @@ func (snapst *SnapState) LocalRevision() snap.Revision {
 	return local
 }
 
-// TODO: unexport CurrentSideInfo and HasCurrent?
-
 // CurrentSideInfo returns the side info for the revision indicated by snapst.Current in the snap revision sequence if there is one.
 func (snapst *SnapState) CurrentSideInfo() *snap.SideInfo {
-	if !snapst.HasCurrent() {
+	if !snapst.IsInstalled() {
 		return nil
 	}
 	if idx := snapst.LastIndex(snapst.Current); idx >= 0 {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1498,9 +1498,7 @@ func All(st *state.State) (map[string]*SnapState, error) {
 	}
 	curStates := make(map[string]*SnapState, len(stateMap))
 	for snapName, snapst := range stateMap {
-		if snapst.HasCurrent() {
-			curStates[snapName] = snapst
-		}
+		curStates[snapName] = snapst
 	}
 	return curStates, nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -67,7 +67,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 			return nil, fmt.Errorf(i18n.G("classic confinement requires snaps under /snap or symlink from /snap to %s"), dirs.SnapMountDir)
 		}
 	}
-	if !snapst.HasCurrent() { // install?
+	if !snapst.IsInstalled() { // install?
 		// check that the snap command namespace doesn't conflict with an enabled alias
 		if err := checkSnapAliasConflict(st, snapsup.Name()); err != nil {
 			return nil, err
@@ -170,14 +170,14 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	prev = setupAliases
 
 	// run refresh hook when updating existing snap, otherwise run install hook
-	if snapst.HasCurrent() && !snapsup.Flags.Revert {
+	if snapst.IsInstalled() && !snapsup.Flags.Revert {
 		refreshHook := SetupRefreshHook(st, snapsup.Name())
 		addTask(refreshHook)
 		prev = refreshHook
 	}
 
 	// only run install hook if installing the snap for the first time
-	if !snapst.HasCurrent() {
+	if !snapst.IsInstalled() {
 		installHook := SetupInstallHook(st, snapsup.Name())
 		addTask(installHook)
 		prev = installHook
@@ -189,7 +189,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	prev = startSnapServices
 
 	// Do not do that if we are reverting to a local revision
-	if snapst.HasCurrent() && !snapsup.Flags.Revert {
+	if snapst.IsInstalled() && !snapsup.Flags.Revert {
 		seq := snapst.Sequence
 		currentIndex := snapst.LastIndex(snapst.Current)
 
@@ -242,7 +242,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	}
 
 	var confFlags int
-	if !snapst.HasCurrent() && snapsup.SideInfo != nil && snapsup.SideInfo.SnapID != "" {
+	if !snapst.IsInstalled() && snapsup.SideInfo != nil && snapsup.SideInfo.SnapID != "" {
 		// installation, run configure using the gadget defaults
 		// if available
 		confFlags |= UseConfigDefaults
@@ -455,7 +455,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
-	if snapst.HasCurrent() {
+	if snapst.IsInstalled() {
 		return nil, &snap.AlreadyInstalledError{Snap: name}
 	}
 
@@ -826,7 +826,7 @@ func Switch(st *state.State, name, channel string) (*state.TaskSet, error) {
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
-	if !snapst.HasCurrent() {
+	if !snapst.IsInstalled() {
 		return nil, fmt.Errorf("cannot find snap %q", name)
 	}
 
@@ -849,7 +849,7 @@ func Update(st *state.State, name, channel string, revision snap.Revision, userI
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
-	if !snapst.HasCurrent() {
+	if !snapst.IsInstalled() {
 		return nil, fmt.Errorf("cannot find snap %q", name)
 	}
 
@@ -1141,7 +1141,7 @@ func Remove(st *state.State, name string, revision snap.Revision) (*state.TaskSe
 		return nil, err
 	}
 
-	if !snapst.HasCurrent() {
+	if !snapst.IsInstalled() {
 		return nil, &snap.NotInstalledError{Snap: name, Rev: snap.R(0)}
 	}
 
@@ -1364,7 +1364,7 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
-	if !oldSnapst.HasCurrent() {
+	if !oldSnapst.IsInstalled() {
 		return nil, fmt.Errorf("cannot transition snap %q: not installed", oldName)
 	}
 
@@ -1380,7 +1380,7 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 	if err != nil && err != state.ErrNoState {
 		return nil, err
 	}
-	if !newSnapst.HasCurrent() {
+	if !newSnapst.IsInstalled() {
 		// start by instaling the new snap
 		tsInst, err := doInstall(st, &newSnapst, &SnapSetup{
 			Channel:      oldSnapst.Channel,
@@ -1564,7 +1564,7 @@ func infosForTypes(st *state.State, snapType snap.Type) ([]*snap.Info, error) {
 
 	var res []*snap.Info
 	for _, snapst := range stateMap {
-		if !snapst.HasCurrent() {
+		if !snapst.IsInstalled() {
 			continue
 		}
 		typ, err := snapst.Type()


### PR DESCRIPTION
Having SnapState.Current unset and .Sequence set is illegal (see panic in HasCurrent), and snapstate.Set never puts in "snaps" a SnapState with len(.Sequence) == 0 so this check is superfluous.