### PR TITLE
Do not emit cloud-init.disabled; cloud-init only runs if datasource is present

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -244,9 +244,6 @@ func installCloudConfig(gadgetDir string) error {
 	if osutil.FileExists(cloudConfig) {
 		dst := filepath.Join(cloudDir, "cloud.cfg")
 		err = osutil.CopyFile(cloudConfig, dst, osutil.CopyFlagOverwrite)
-	} else {
-		dst := filepath.Join(cloudDir, "cloud-init.disabled")
-		err = osutil.AtomicWriteFile(dst, nil, 0644, 0)
 	}
 	return err
 }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -564,9 +564,6 @@ func (s *imageSuite) TestBootstrapToRootDirLocalCoreBrandKernel(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(m["snap_core"], Equals, "core_x1.snap")
 
-	// check that cloud-init is setup correctly
-	c.Check(osutil.FileExists(filepath.Join(rootdir, "etc/cloud/cloud-init.disabled")), Equals, true)
-
 	c.Check(s.stderr.String(), Equals, "WARNING: \"core\", \"required-snap1\" were installed from local snaps disconnected from a store and cannot be refreshed subsequently!\n")
 }
 
@@ -675,7 +672,7 @@ func (s *imageSuite) TestInstallCloudConfigNoConfig(c *C) {
 	dirs.SetRootDir(targetDir)
 	err := image.InstallCloudConfig(emptyGadgetDir)
 	c.Assert(err, IsNil)
-	c.Check(osutil.FileExists(filepath.Join(targetDir, "etc/cloud/cloud-init.disabled")), Equals, true)
+	c.Check(osutil.FileExists(filepath.Join(targetDir, "etc/cloud")), Equals, true)
 }
 
 func (s *imageSuite) TestInstallCloudConfigWithCloudConfig(c *C) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -824,8 +824,5 @@ func (s *imageSuite) TestBootstrapToRootDirLocalSnapsWithStoreAsserts(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(m["snap_core"], Equals, "core_3.snap")
 
-	// check that cloud-init is setup correctly
-	c.Check(osutil.FileExists(filepath.Join(rootdir, "etc/cloud/cloud-init.disabled")), Equals, true)
-
 	c.Check(s.stderr.String(), Equals, "")
 }


### PR DESCRIPTION
The most recent cloud-init release in xenial-updates [1] and with
core-build configuration changes[2], snap prepare-image no longer
needs to disable cloud-init in the image as cloud-init itself will not
execute unless the image is booted on a cloud or provided cloud user-data.

1. 0.7.9-153-g16a7302f-0ubuntu1~16.04.2
2. https://github.com/snapcore/core-build/commit/1e60bf93d0f637e5ea338498ad8d1cf660ceaf0a