### PR TITLE
store: have an ad-hoc method on cfg to get its list of uris for tests.

### DIFF
--- a/store/export_test.go
+++ b/store/export_test.go
@@ -20,6 +20,8 @@
 package store
 
 import (
+	"net/url"
+
 	"github.com/snapcore/snapd/testutil"
 
 	"gopkg.in/retry.v1"
@@ -32,4 +34,17 @@ func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
 	t.AddCleanup(func() {
 		defaultRetryStrategy = originalDefaultRetryStrategy
 	})
+}
+
+func (cfg *Config) apiURIs() []*url.URL {
+	return []*url.URL{
+		cfg.SearchURI,
+		cfg.DetailsURI,
+		cfg.BulkURI,
+		cfg.SectionsURI,
+		cfg.OrdersURI,
+		cfg.BuyURI,
+		cfg.CustomersMeURI,
+		cfg.AssertionsURI,
+	}
 }

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -21,6 +21,7 @@ package store
 
 import (
 	"net/url"
+	"reflect"
 
 	"github.com/snapcore/snapd/testutil"
 
@@ -36,15 +37,18 @@ func MockDefaultRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
 	})
 }
 
-func (cfg *Config) apiURIs() []*url.URL {
-	return []*url.URL{
-		cfg.SearchURI,
-		cfg.DetailsURI,
-		cfg.BulkURI,
-		cfg.SectionsURI,
-		cfg.OrdersURI,
-		cfg.BuyURI,
-		cfg.CustomersMeURI,
-		cfg.AssertionsURI,
+func (cfg *Config) apiURIs() map[string]*url.URL {
+	urls := map[string]*url.URL{}
+
+	v := reflect.ValueOf(*cfg)
+	t := reflect.TypeOf(*cfg)
+	n := v.NumField()
+	for i := 0; i < n; i++ {
+		vf := v.Field(i)
+		if u, ok := vf.Interface().(*url.URL); ok {
+			urls[t.Field(i).Name] = u
+		}
 	}
+
+	return urls
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -73,17 +73,7 @@ func (suite *configTestSuite) TestSetAPI(c *C) {
 	err = cfg.SetAPI(api)
 	c.Assert(err, IsNil)
 
-	uris := []*url.URL{
-		cfg.SearchURI,
-		cfg.DetailsURI,
-		cfg.BulkURI,
-		cfg.SectionsURI,
-		cfg.OrdersURI,
-		cfg.BuyURI,
-		cfg.CustomersMeURI,
-		cfg.AssertionsURI,
-	}
-	for _, uri := range uris {
+	for _, uri := range cfg.apiURIs() {
 		c.Assert(uri, NotNil)
 		c.Check(uri.String(), Matches, "http://example.com/path/prefix/api/v1/snaps/.*")
 	}
@@ -98,7 +88,7 @@ func (suite *configTestSuite) TestSetAPIStoreOverrides(c *C) {
 	defer os.Setenv("SNAPPY_FORCE_API_URL", "")
 	cfg = DefaultConfig()
 	c.Assert(cfg.SetAPI(apiURL()), IsNil)
-	for _, u := range []*url.URL{cfg.SearchURI, cfg.DetailsURI, cfg.BulkURI, cfg.SectionsURI, cfg.AssertionsURI} {
+	for _, u := range cfg.apiURIs() {
 		c.Check(u.String(), Matches, "https://force-api.local/.*")
 	}
 }


### PR DESCRIPTION
This makes tests that want to check all the uris in cfg easier to keep
up to date as the cfg object evolves; we had two such tests, already
out of sync.
