### PR TITLE
cmd/snap: SetRootDir from SetUpTest, not in just some individual tests.

### DIFF
--- a/cmd/snap/cmd_auto_import_test.go
+++ b/cmd/snap/cmd_auto_import_test.go
@@ -187,9 +187,6 @@ func (s *SnapSuite) TestAutoImportIntoSpool(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	dirs.SetRootDir(c.MkDir())
-	defer dirs.SetRootDir("")
-
 	l, err := logger.New(s.stderr, 0)
 	c.Assert(err, IsNil)
 	logger.SetLogger(l)
@@ -257,9 +254,6 @@ func (s *SnapSuite) TestAutoImportFromSpoolHappy(c *C) {
 
 	})
 
-	dirs.SetRootDir(c.MkDir())
-	defer dirs.SetRootDir("")
-
 	fakeAssertsFn := filepath.Join(dirs.SnapAssertsSpoolDir, "1234343")
 	err := os.MkdirAll(filepath.Dir(fakeAssertsFn), 0755)
 	c.Assert(err, IsNil)
@@ -286,9 +280,6 @@ func (s *SnapSuite) TestAutoImportFromSpoolHappy(c *C) {
 func (s *SnapSuite) TestAutoImportIntoSpoolUnhappyTooBig(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
-
-	dirs.SetRootDir(c.MkDir())
-	defer dirs.SetRootDir("")
 
 	l, err := logger.New(s.stderr, 0)
 	c.Assert(err, IsNil)

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -65,8 +65,6 @@ func (s *SnapSuite) TestInvalidParameters(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunWhenMissingConfine(c *check.C) {
-	dirs.SetRootDir(c.MkDir())
-
 	// mock installed snap
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R("x2"),
@@ -95,11 +93,9 @@ func (s *SnapSuite) TestSnapRunWhenMissingConfine(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
+	// mock installed snap
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
@@ -132,11 +128,9 @@ func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunClassicAppIntegration(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
+	// mock installed snap
 	si := snaptest.MockSnap(c, string(mockYaml)+"confinement: classic\n", string(mockContents), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
@@ -169,11 +163,9 @@ func (s *SnapSuite) TestSnapRunClassicAppIntegration(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunAppWithCommandIntegration(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
+	// mock installed snap
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
@@ -222,11 +214,9 @@ func (s *SnapSuite) TestSnapRunCreateDataDirs(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
+	// mock installed snap
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
@@ -258,11 +248,9 @@ func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunHookUnsetRevisionIntegration(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
+	// mock installed snap
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
@@ -294,11 +282,9 @@ func (s *SnapSuite) TestSnapRunHookUnsetRevisionIntegration(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunHookSpecificRevisionIntegration(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
+	// mock installed snap
 	// Create both revisions 41 and 42
 	snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R(41),
@@ -332,10 +318,6 @@ func (s *SnapSuite) TestSnapRunHookSpecificRevisionIntegration(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunHookMissingRevisionIntegration(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
-
 	// Only create revision 42
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R(42),
@@ -362,10 +344,6 @@ func (s *SnapSuite) TestSnapRunHookInvalidRevisionIntegration(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunHookMissingHookIntegration(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
-
 	// Only create revision 42
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R(42),
@@ -402,11 +380,9 @@ func (s *SnapSuite) TestSnapRunErorrForUnavailableApp(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunSaneEnvironmentHandling(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
+	// mock installed snap
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
@@ -460,11 +436,9 @@ func (s *SnapSuite) TestSnapRunIsReexeced(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine(filepath.Join(dirs.SnapMountDir, "core", "current", dirs.CoreLibExecDir))()
 
+	// mock installed snap
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
@@ -503,10 +477,6 @@ func (s *SnapSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
-	// mock installed snap; happily this also gives us a directory
-	// below /tmp which the Xauthority migration expects.
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
 	u, err := user.Current()
@@ -516,6 +486,8 @@ func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
 	err = os.MkdirAll(filepath.Join(dirs.XdgRuntimeDirBase, u.Uid), 0700)
 	c.Assert(err, check.IsNil)
 
+	// mock installed snap; happily this also gives us a directory
+	// below /tmp which the Xauthority migration expects.
 	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -27,7 +27,6 @@ import (
 	"gopkg.in/check.v1"
 
 	snapset "github.com/snapcore/snapd/cmd/snap"
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 )
@@ -47,9 +46,6 @@ func (s *SnapSuite) TestInvalidSetParameters(c *check.C) {
 
 func (s *SnapSuite) TestSnapSetIntegrationString(c *check.C) {
 	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
-
 	snaptest.MockSnap(c, string(validApplyYaml), string(validApplyContents), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
@@ -64,9 +60,6 @@ func (s *SnapSuite) TestSnapSetIntegrationString(c *check.C) {
 
 func (s *SnapSuite) TestSnapSetIntegrationNumber(c *check.C) {
 	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
-
 	snaptest.MockSnap(c, string(validApplyYaml), string(validApplyContents), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
@@ -80,10 +73,6 @@ func (s *SnapSuite) TestSnapSetIntegrationNumber(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapSetIntegrationBigInt(c *check.C) {
-	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
-
 	snaptest.MockSnap(c, string(validApplyYaml), string(validApplyContents), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
@@ -98,9 +87,6 @@ func (s *SnapSuite) TestSnapSetIntegrationBigInt(c *check.C) {
 
 func (s *SnapSuite) TestSnapSetIntegrationJson(c *check.C) {
 	// mock installed snap
-	dirs.SetRootDir(c.MkDir())
-	defer func() { dirs.SetRootDir("/") }()
-
 	snaptest.MockSnap(c, string(validApplyYaml), string(validApplyContents), &snap.SideInfo{
 		Revision: snap.R(42),
 	})

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -61,6 +61,8 @@ func (s *BaseSnapSuite) readPassword(fd int) ([]byte, error) {
 
 func (s *BaseSnapSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+
 	s.stdin = bytes.NewBuffer(nil)
 	s.stdout = bytes.NewBuffer(nil)
 	s.stderr = bytes.NewBuffer(nil)
@@ -83,6 +85,7 @@ func (s *BaseSnapSuite) TearDownTest(c *C) {
 	c.Assert(s.AuthFile == "", Equals, false)
 	err := os.Unsetenv(TestAuthFileEnvKey)
 	c.Assert(err, IsNil)
+	dirs.SetRootDir("/")
 	s.BaseTest.TearDownTest(c)
 }
 
@@ -241,9 +244,6 @@ func (s *SnapSuite) TestUnknownCommand(c *C) {
 }
 
 func (s *SnapSuite) TestResolveApp(c *C) {
-	dirs.SetRootDir(c.MkDir())
-	defer dirs.SetRootDir("/")
-
 	err := os.MkdirAll(dirs.SnapBinariesDir, 0755)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
This stops accidentally writing on the developer's system.
