### PR TITLE
osutil: AtomicWriter (an io.Writer), and io.Reader versions of AtomicWrite*

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -21,6 +21,7 @@ package osutil
 
 import (
 	"io"
+	"os"
 	"os/exec"
 	"os/user"
 	"syscall"
@@ -84,4 +85,21 @@ var KillProcessGroup = killProcessGroup
 func WaitingReaderGuts(r io.Reader) (io.Reader, *exec.Cmd) {
 	wr := r.(*waitingReader)
 	return wr.reader, wr.cmd
+}
+
+func MockChown(f func(*os.File, int, int) error) func() {
+	oldChown := chown
+	chown = f
+	return func() {
+		chown = oldChown
+	}
+}
+
+func SetAtomicFileRenamed(aw AtomicWriter, renamed bool) {
+	aw.(*atomicFile).renamed = renamed
+}
+
+func GetAtomicFileName(aw AtomicWriter) string {
+	return aw.(*atomicFile).Name()
+
 }

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -96,10 +96,11 @@ func MockChown(f func(*os.File, int, int) error) func() {
 }
 
 func SetAtomicFileRenamed(aw AtomicWriter, renamed bool) {
+	println("renamed", renamed)
 	aw.(*atomicFile).renamed = renamed
 }
 
-func GetAtomicFileName(aw AtomicWriter) string {
-	return aw.(*atomicFile).Name()
+func GetAtomicFile(aw AtomicWriter) *os.File {
+	return aw.(*atomicFile).File
 
 }

--- a/osutil/io.go
+++ b/osutil/io.go
@@ -130,9 +130,11 @@ func (aw *atomicFile) Cancel() error {
 	return nil
 }
 
+var chown = (*os.File).Chown
+
 func (aw *atomicFile) Finalize() error {
 	if aw.uid > -1 && aw.gid > -1 {
-		if err := aw.Chown(aw.uid, aw.gid); err != nil {
+		if err := chown(aw.File, aw.uid, aw.gid); err != nil {
 			return err
 		}
 	}

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -17,14 +17,16 @@
  *
  */
 
-package osutil
+package osutil_test
 
 import (
+	"errors"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
 
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
 
 	. "gopkg.in/check.v1"
@@ -38,7 +40,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFile(c *C) {
 	tmpdir := c.MkDir()
 
 	p := filepath.Join(tmpdir, "foo")
-	err := AtomicWriteFile(p, []byte("canary"), 0644, 0)
+	err := osutil.AtomicWriteFile(p, []byte("canary"), 0644, 0)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(p)
@@ -55,7 +57,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFilePermissions(c *C) {
 	tmpdir := c.MkDir()
 
 	p := filepath.Join(tmpdir, "foo")
-	err := AtomicWriteFile(p, []byte(""), 0600, 0)
+	err := osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
 	c.Assert(err, IsNil)
 
 	st, err := os.Stat(p)
@@ -67,7 +69,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwrite(c *C) {
 	tmpdir := c.MkDir()
 	p := filepath.Join(tmpdir, "foo")
 	c.Assert(ioutil.WriteFile(p, []byte("hello"), 0644), IsNil)
-	c.Assert(AtomicWriteFile(p, []byte("hi"), 0600, 0), IsNil)
+	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0), IsNil)
 
 	content, err := ioutil.ReadFile(p)
 	c.Assert(err, IsNil)
@@ -84,7 +86,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	err := AtomicWriteFile(p, []byte("hi"), 0600, 0)
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0)
 	c.Assert(err, NotNil)
 }
 
@@ -98,7 +100,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAbsoluteSymlinks(c *C) {
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	err := AtomicWriteFile(p, []byte("hi"), 0600, AtomicWriteFollow)
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(p)
@@ -117,7 +119,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteAbsoluteSymlink(c *C
 	defer os.Chmod(rodir, 0700)
 
 	c.Assert(ioutil.WriteFile(s, []byte("hello"), 0644), IsNil)
-	c.Assert(AtomicWriteFile(p, []byte("hi"), 0600, AtomicWriteFollow), IsNil)
+	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow), IsNil)
 
 	content, err := ioutil.ReadFile(p)
 	c.Assert(err, IsNil)
@@ -133,7 +135,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileRelativeSymlinks(c *C) {
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	err := AtomicWriteFile(p, []byte("hi"), 0600, AtomicWriteFollow)
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow)
 	c.Assert(err, IsNil)
 
 	content, err := ioutil.ReadFile(p)
@@ -152,7 +154,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteRelativeSymlink(c *C
 	defer os.Chmod(rodir, 0700)
 
 	c.Assert(ioutil.WriteFile(s, []byte("hello"), 0644), IsNil)
-	c.Assert(AtomicWriteFile(p, []byte("hi"), 0600, AtomicWriteFollow), IsNil)
+	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow), IsNil)
 
 	content, err := ioutil.ReadFile(p)
 	c.Assert(err, IsNil)
@@ -171,7 +173,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) 
 	err := ioutil.WriteFile(p+"."+expectedRandomness, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
-	err = AtomicWriteFile(p, []byte(""), 0600, 0)
+	err = osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
 	c.Assert(err, ErrorMatches, "open .*: file exists")
 }
 
@@ -179,31 +181,37 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileUidGidError(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
 
-	_, err := NewAtomicFile(p, 0644, 0, -1, 1)
+	_, err := osutil.NewAtomicFile(p, 0644, 0, -1, 1)
 	c.Check(err, ErrorMatches, ".*needs none or both of uid and gid set")
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicFileChownError(c *C) {
-	if os.Getuid() == 0 {
-		c.Skip("this will fail if run as root")
-	}
+	eUid := 42
+	eGid := 74
+	eErr := errors.New("this didn't work")
+	defer osutil.MockChown(func(fd *os.File, uid int, gid int) error {
+		c.Check(uid, Equals, eUid)
+		c.Check(gid, Equals, eGid)
+		return eErr
+	})()
+
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
 
-	aw, err := NewAtomicFile(p, 0644, 0, 0, 0)
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, eUid, eGid)
 	c.Assert(err, IsNil)
 	defer aw.Cancel()
 
 	_, err = aw.Write([]byte("hello"))
 	c.Assert(err, IsNil)
 
-	c.Check(aw.Finalize(), ErrorMatches, ".* operation not permitted")
+	c.Check(aw.Finalize(), Equals, eErr)
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancelError(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	aw, err := NewAtomicFile(p, 0644, 0, -1, -1)
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, -1, -1)
 	c.Assert(err, IsNil)
 	c.Assert(aw.Close(), IsNil)
 	c.Check(aw.Cancel(), ErrorMatches, "invalid argument")
@@ -212,23 +220,23 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancelError(c *C) {
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancelBadError(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	aw, err := NewAtomicFile(p, 0644, 0, -1, -1)
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, -1, -1)
 	c.Assert(err, IsNil)
 	defer aw.Close()
 
-	aw.(*atomicFile).renamed = true
+	osutil.SetAtomicFileRenamed(aw, true)
 
-	c.Check(aw.Cancel(), Equals, ErrCannotCancel)
+	c.Check(aw.Cancel(), Equals, osutil.ErrCannotCancel)
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancel(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
 
-	aw, err := NewAtomicFile(p, 0644, 0, -1, -1)
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, -1, -1)
 	c.Assert(err, IsNil)
-	fn := aw.(*atomicFile).Name()
-	c.Check(FileExists(fn), Equals, true)
+	fn := osutil.GetAtomicFileName(aw)
+	c.Check(osutil.FileExists(fn), Equals, true)
 	c.Check(aw.Cancel(), IsNil)
-	c.Check(FileExists(fn), Equals, false)
+	c.Check(osutil.FileExists(fn), Equals, false)
 }


### PR DESCRIPTION
(instead of taking a []byte, that is).

Wait, you wanted specialised tests for this? psh. Look at it. It's got
enough coverage already :-D