### PR TITLE
tests: fix unit tests on Ubuntu 14.04

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -137,6 +137,7 @@ int main(int argc, char** argv)
     // for details.
     syscall(l[0], l[1], l[2], l[3], l[4], l[5], l[6]);
     syscall(SYS_exit, 0, 0, 0, 0, 0, 0);
+    return 0;
 }
 `)
 
@@ -164,7 +165,7 @@ func (s *snapSeccompSuite) SetUpSuite(c *C) {
 	s.seccompSyscallRunner = filepath.Join(c.MkDir(), "seccomp_syscall_runner")
 	err = ioutil.WriteFile(s.seccompSyscallRunner+".c", seccompSyscallRunnerContent, 0644)
 	c.Assert(err, IsNil)
-	cmd = exec.Command("gcc", "-Werror", "-Wall", "-static", s.seccompSyscallRunner+".c", "-o", s.seccompSyscallRunner, "-Wl,-static", "-static-libgcc")
+	cmd = exec.Command("gcc", "-std=c99", "-Werror", "-Wall", "-static", s.seccompSyscallRunner+".c", "-o", s.seccompSyscallRunner, "-Wl,-static", "-static-libgcc")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()

--- a/corecfg/picfg_test.go
+++ b/corecfg/picfg_test.go
@@ -36,6 +36,8 @@ import (
 
 type piCfgSuite struct {
 	mockConfigPath string
+
+	mockSystemctl *testutil.MockCmd
 }
 
 var _ = Suite(&piCfgSuite{})
@@ -57,10 +59,13 @@ func (s *piCfgSuite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Dir(s.mockConfigPath), 0755)
 	c.Assert(err, IsNil)
 	s.mockConfig(c, mockConfigTxt)
+
+	s.mockSystemctl = testutil.MockCommand(c, "systemctl", "")
 }
 
 func (s *piCfgSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
+	s.mockSystemctl.Restore()
 }
 
 func (s *piCfgSuite) mockConfig(c *C, txt string) {

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -101,7 +102,7 @@ func (s *FuseSupportInterfaceSuite) TestUDevSpec(c *C) {
 func (s *FuseSupportInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, true)
-	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, !(release.ReleaseInfo.ID == "ubuntu" && release.ReleaseInfo.VersionID == "14.04"))
 	c.Assert(si.Summary, Equals, `allows access to the FUSE file system`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "fuse-support")
 }


### PR DESCRIPTION
Some fixes to make the unittests run on 14.04:
- gcc behaves slightly different and needs more options
- no systemctl on trusty we need to mock it
- fuse-support is not available on 14.04
