### PR TITLE
corecfg: mock "systemctl" in all corecfg tests

### DIFF
--- a/corecfg/powerbtn_test.go
+++ b/corecfg/powerbtn_test.go
@@ -35,6 +35,8 @@ import (
 
 type powerbtnSuite struct {
 	mockPowerBtnCfg string
+
+	mockSystemctl *testutil.MockCmd
 }
 
 var _ = Suite(&powerbtnSuite{})
@@ -44,10 +46,13 @@ func (s *powerbtnSuite) SetUpTest(c *C) {
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc"), 0755), IsNil)
 
 	s.mockPowerBtnCfg = filepath.Join(dirs.GlobalRootDir, "/etc/systemd/logind.conf.d/00-snap-core.conf")
+
+	s.mockSystemctl = testutil.MockCommand(c, "systemctl", "")
 }
 
 func (s *powerbtnSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
+	s.mockSystemctl.Restore()
 }
 
 func (s *powerbtnSuite) TestConfigurePowerButtonInvalid(c *C) {

--- a/corecfg/proxy_test.go
+++ b/corecfg/proxy_test.go
@@ -35,6 +35,8 @@ import (
 
 type proxySuite struct {
 	mockEtcEnvironment string
+
+	mockSystemctl *testutil.MockCmd
 }
 
 var _ = Suite(&proxySuite{})
@@ -44,10 +46,13 @@ func (s *proxySuite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/"), 0755)
 	c.Assert(err, IsNil)
 	s.mockEtcEnvironment = filepath.Join(dirs.GlobalRootDir, "/etc/environment")
+
+	s.mockSystemctl = testutil.MockCommand(c, "systemctl", "")
 }
 
 func (s *proxySuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
+	s.mockSystemctl.Restore()
 }
 
 func (s *proxySuite) TestConfigureProxy(c *C) {

--- a/corecfg/services_test.go
+++ b/corecfg/services_test.go
@@ -35,6 +35,8 @@ import (
 
 type servicesSuite struct {
 	systemctlArgs [][]string
+
+	mockSystemctl *testutil.MockCmd
 }
 
 var _ = Suite(&servicesSuite{})
@@ -51,10 +53,13 @@ func (s *servicesSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc"), 0755), IsNil)
 	s.systemctlArgs = nil
+
+	s.mockSystemctl = testutil.MockCommand(c, "systemctl", "")
 }
 
 func (s *servicesSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
+	s.mockSystemctl.Restore()
 }
 
 func (s *servicesSuite) TestConfigureServiceInvalidValue(c *C) {


### PR DESCRIPTION
This is needed to ensure the tests can run on a system that does
not have systemctl (like ubuntu 14.04).
