### PR TITLE
corecfg: mock "systemctl" in all corecfg tests

### DIFF
--- a/corecfg/corecfg_test.go
+++ b/corecfg/corecfg_test.go
@@ -31,11 +31,29 @@ import (
 
 func Test(t *testing.T) { TestingT(t) }
 
-type coreCfgSuite struct{}
+// coreCfgSuite is the base for all the corecfg tests
+type coreCfgSuite struct {
+	mockSystemctl *testutil.MockCmd
+}
 
 var _ = Suite(&coreCfgSuite{})
 
-func (s *coreCfgSuite) TestConfigureErrorsOnClassic(c *C) {
+func (s *coreCfgSuite) SetUpSuite(c *C) {
+	s.mockSystemctl = testutil.MockCommand(c, "systemctl", "")
+}
+
+func (s *coreCfgSuite) TearDownSuite(c *C) {
+	s.mockSystemctl.Restore()
+}
+
+// runCfgSuite tests corecfg.Run()
+type runCfgSuite struct {
+	coreCfgSuite
+}
+
+var _ = Suite(&runCfgSuite{})
+
+func (s *runCfgSuite) TestConfigureErrorsOnClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
@@ -43,7 +61,7 @@ func (s *coreCfgSuite) TestConfigureErrorsOnClassic(c *C) {
 	c.Check(err, ErrorMatches, "cannot run core-configure on classic distribution")
 }
 
-func (s *coreCfgSuite) TestConfigureErrorOnMissingCoreSupport(c *C) {
+func (s *runCfgSuite) TestConfigureErrorOnMissingCoreSupport(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 

--- a/corecfg/picfg_test.go
+++ b/corecfg/picfg_test.go
@@ -35,9 +35,9 @@ import (
 )
 
 type piCfgSuite struct {
-	mockConfigPath string
+	coreCfgSuite
 
-	mockSystemctl *testutil.MockCmd
+	mockConfigPath string
 }
 
 var _ = Suite(&piCfgSuite{})
@@ -60,12 +60,10 @@ func (s *piCfgSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.mockConfig(c, mockConfigTxt)
 
-	s.mockSystemctl = testutil.MockCommand(c, "systemctl", "")
 }
 
 func (s *piCfgSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
-	s.mockSystemctl.Restore()
 }
 
 func (s *piCfgSuite) mockConfig(c *C, txt string) {

--- a/corecfg/powerbtn_test.go
+++ b/corecfg/powerbtn_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 type powerbtnSuite struct {
+	coreCfgSuite
+
 	mockPowerBtnCfg string
 }
 

--- a/corecfg/proxy_test.go
+++ b/corecfg/proxy_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 type proxySuite struct {
+	coreCfgSuite
+
 	mockEtcEnvironment string
 }
 

--- a/corecfg/services_test.go
+++ b/corecfg/services_test.go
@@ -29,27 +29,14 @@ import (
 	"github.com/snapcore/snapd/corecfg"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type servicesSuite struct {
 	coreCfgSuite
-
-	systemctlArgs [][]string
 }
 
 var _ = Suite(&servicesSuite{})
-
-func (s *servicesSuite) SetUpSuite(c *C) {
-	s.coreCfgSuite.SetUpSuite(c)
-
-	systemd.SystemctlCmd = func(args ...string) ([]byte, error) {
-		s.systemctlArgs = append(s.systemctlArgs, args[:])
-		output := []byte("ActiveState=inactive")
-		return output, nil
-	}
-}
 
 func (s *servicesSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())

--- a/corecfg/services_test.go
+++ b/corecfg/services_test.go
@@ -34,12 +34,16 @@ import (
 )
 
 type servicesSuite struct {
+	coreCfgSuite
+
 	systemctlArgs [][]string
 }
 
 var _ = Suite(&servicesSuite{})
 
 func (s *servicesSuite) SetUpSuite(c *C) {
+	s.coreCfgSuite.SetUpSuite(c)
+
 	systemd.SystemctlCmd = func(args ...string) ([]byte, error) {
 		s.systemctlArgs = append(s.systemctlArgs, args[:])
 		output := []byte("ActiveState=inactive")


### PR DESCRIPTION
This is needed to ensure the tests can run on a system that does
not have systemctl (like ubuntu 14.04).
