### PR TITLE
many: switch to use the new osutil.AtomicWriter where reasonable.

### DIFF
--- a/client/login.go
+++ b/client/login.go
@@ -128,12 +128,17 @@ func writeAuthData(user User) error {
 		return err
 	}
 
-	outStr, err := json.Marshal(user)
+	fd, err := osutil.NewAtomicFile(targetFile, 0600, 0, uid, gid)
 	if err != nil {
+		return err
+	}
+	defer fd.Cancel()
+
+	if err := json.NewEncoder(fd).Encode(user); err != nil {
 		return nil
 	}
 
-	return osutil.AtomicWriteFileChown(targetFile, []byte(outStr), 0600, 0, uid, gid)
+	return fd.Commit()
 }
 
 // readAuthData reads previously written authentication details

--- a/client/login_test.go
+++ b/client/login_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/check.v1"
 
@@ -55,7 +56,7 @@ func (cs *clientSuite) TestClientLogin(c *check.C) {
 	c.Check(osutil.FileExists(outfile), check.Equals, true)
 	content, err := ioutil.ReadFile(outfile)
 	c.Check(err, check.IsNil)
-	c.Check(string(content), check.Equals, `{"username":"the-user-name","macaroon":"the-root-macaroon","discharges":["discharge-macaroon"]}`)
+	c.Check(strings.TrimSpace(string(content)), check.Equals, `{"username":"the-user-name","macaroon":"the-root-macaroon","discharges":["discharge-macaroon"]}`)
 }
 
 func (cs *clientSuite) TestClientLoginError(c *check.C) {
@@ -111,7 +112,7 @@ func (cs *clientSuite) TestWriteAuthData(c *check.C) {
 	c.Check(osutil.FileExists(outfile), check.Equals, true)
 	content, err := ioutil.ReadFile(outfile)
 	c.Check(err, check.IsNil)
-	c.Check(string(content), check.Equals, `{"macaroon":"macaroon","discharges":["discharge"]}`)
+	c.Check(strings.TrimSpace(string(content)), check.Equals, `{"macaroon":"macaroon","discharges":["discharge"]}`)
 }
 
 func (cs *clientSuite) TestReadAuthData(c *check.C) {

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -710,7 +710,7 @@ func (s *runnerSuite) TestSaveState(c *C) {
 
 	data, err := ioutil.ReadFile(dirs.SnapRepairStateFile)
 	c.Assert(err, IsNil)
-	c.Check(string(data), Equals, `{"device":{"brand":"my-brand","model":"my-model"},"sequences":{"canonical":[{"sequence":1,"revision":3,"status":0}]},"time-lower-bound":"2017-08-11T15:49:49Z"}`)
+	c.Check(strings.TrimSpace(string(data)), Equals, `{"device":{"brand":"my-brand","model":"my-model"},"sequences":{"canonical":[{"sequence":1,"revision":3,"status":0}]},"time-lower-bound":"2017-08-11T15:49:49Z"}`)
 }
 
 func (s *runnerSuite) TestApplicable(c *C) {
@@ -1176,7 +1176,7 @@ func (s *runnerSuite) TestNextNotFound(c *C) {
 	c.Check(expected, Not(Equals), freshStateJSON)
 	data, err = ioutil.ReadFile(dirs.SnapRepairStateFile)
 	c.Assert(err, IsNil)
-	c.Check(string(data), Equals, expected)
+	c.Check(strings.TrimSpace(string(data)), Equals, expected)
 }
 
 func (s *runnerSuite) TestNextSaveStateError(c *C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4849,7 +4849,7 @@ func (s *postCreateUserSuite) TestPostCreateUser(c *check.C) {
 	c.Check(osutil.FileExists(outfile), check.Equals, true)
 	content, err := ioutil.ReadFile(outfile)
 	c.Check(err, check.IsNil)
-	c.Check(string(content), check.Equals, fmt.Sprintf(`{"macaroon":"%s"}`, user.Macaroon))
+	c.Check(strings.TrimSpace(string(content)), check.Equals, fmt.Sprintf(`{"macaroon":"%s"}`, user.Macaroon))
 }
 
 func (s *postCreateUserSuite) TestGetUserDetailsFromAssertionModelNotFound(c *check.C) {

--- a/partition/androidbootenv/androidbootenv.go
+++ b/partition/androidbootenv/androidbootenv.go
@@ -21,7 +21,6 @@ package androidbootenv
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -78,13 +77,17 @@ func (a *Env) Load() error {
 }
 
 func (a *Env) Save() error {
-	var w bytes.Buffer
+	fd, err := osutil.NewAtomicFile(a.path, 0644, 0, -1, -1)
+	if err != nil {
+		return err
+	}
+	defer fd.Cancel()
 
 	for k, v := range a.env {
-		if _, err := fmt.Fprintf(&w, "%s=%s\n", k, v); err != nil {
+		if _, err := fmt.Fprintf(fd, "%s=%s\n", k, v); err != nil {
 			return err
 		}
 	}
 
-	return osutil.AtomicWriteFile(a.path, w.Bytes(), 0644, 0)
+	return fd.Commit()
 }

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -20,11 +20,11 @@
 package wrappers_test
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 
 	. "gopkg.in/check.v1"
-
-	"strings"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
@@ -112,9 +112,10 @@ apps:
 	info.Revision = snap.R(44)
 	app := info.Apps["app"]
 
-	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
+	var buf bytes.Buffer
+	err = wrappers.GenerateSnapServiceFile(&buf, app)
 	c.Assert(err, IsNil)
-	c.Check(string(generatedWrapper), Equals, expectedAppService)
+	c.Check(buf.String(), Equals, expectedAppService)
 }
 
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileRestart(c *C) {
@@ -132,9 +133,10 @@ apps:
 		info.Revision = snap.R(44)
 		app := info.Apps["app"]
 
-		generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
+		var buf bytes.Buffer
+		err = wrappers.GenerateSnapServiceFile(&buf, app)
 		c.Assert(err, IsNil)
-		wrapperText := string(generatedWrapper)
+		wrapperText := buf.String()
 		if cond == snap.RestartNever {
 			c.Check(wrapperText, Matches,
 				`(?ms).*^Restart=no$.*`, Commentf(name))
@@ -161,9 +163,10 @@ func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileTypeForking(c *C) {
 		Daemon:          "forking",
 	}
 
-	generatedWrapper, err := wrappers.GenerateSnapServiceFile(service)
+	var buf bytes.Buffer
+	err := wrappers.GenerateSnapServiceFile(&buf, service)
 	c.Assert(err, IsNil)
-	c.Assert(string(generatedWrapper), Equals, expectedTypeForkingWrapper)
+	c.Assert(buf.String(), Equals, expectedTypeForkingWrapper)
 }
 
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileIllegalChars(c *C) {
@@ -182,7 +185,8 @@ func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFileIllegalChars(c *C) 
 		Daemon:          "simple",
 	}
 
-	_, err := wrappers.GenerateSnapServiceFile(service)
+	var buf bytes.Buffer
+	err := wrappers.GenerateSnapServiceFile(&buf, service)
 	c.Assert(err, NotNil)
 }
 
@@ -207,10 +211,11 @@ apps:
 	info.Revision = snap.R(44)
 	app := info.Apps["app"]
 
-	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
+	var buf bytes.Buffer
+	err = wrappers.GenerateSnapServiceFile(&buf, app)
 	c.Assert(err, IsNil)
 
-	c.Assert(string(generatedWrapper), Equals, expectedDbusService)
+	c.Assert(buf.String(), Equals, expectedDbusService)
 }
 
 func (s *servicesWrapperGenSuite) TestGenOneshotServiceFile(c *C) {
@@ -230,8 +235,9 @@ apps:
 
 	app := info.Apps["app"]
 
-	generatedWrapper, err := wrappers.GenerateSnapServiceFile(app)
+	var buf bytes.Buffer
+	err := wrappers.GenerateSnapServiceFile(&buf, app)
 	c.Assert(err, IsNil)
 
-	c.Assert(string(generatedWrapper), Equals, expectedOneshotService)
+	c.Assert(buf.String(), Equals, expectedOneshotService)
 }


### PR DESCRIPTION
With the introduction of `osutil.AtomicWriter` it's no longer necessary to build the contents of a file in memory when you need to write it out "atomically". This branch does the switch, wherever it was reasonable straightforward to do (in most case a simple code reorg; in a couple of cases a refactor to receiving an `io.Writer` instead of returning a `[]byte`).

Also snuck into this PR is a change to wrappers/service that moves the template construction out of the function body. A silly change, reminiscent of when we moved regexp construction out of function bodies way back when, and for the same reasons. Hopefully not too distracting; if it is, I can back it out and submit it separately.