### PR TITLE
overlord: introduce Mock which enables to use Overlord.Settle for settle in many more places

### DIFF
--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -42,7 +42,7 @@ type AssertManager struct {
 
 // Manager returns a new assertion manager.
 func Manager(s *state.State) (*AssertManager, error) {
-	crossInit()
+	delayedCrossMgrInit()
 
 	runner := state.NewTaskRunner(s)
 

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -42,6 +42,8 @@ type AssertManager struct {
 
 // Manager returns a new assertion manager.
 func Manager(s *state.State) (*AssertManager, error) {
+	crossInit()
+
 	runner := state.NewTaskRunner(s)
 
 	runner.AddHandler("validate-snap", doValidateSnap, nil)

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -344,7 +344,7 @@ func AutoAliases(s *state.State, info *snap.Info) (map[string]string, error) {
 	return res, nil
 }
 
-func crossInit() {
+func delayedCrossMgrInit() {
 	// hook validation of refreshes into snapstate logic
 	snapstate.ValidateRefreshes = ValidateRefreshes
 	// hook auto refresh of assertions into snapstate

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -267,13 +267,6 @@ func ValidateRefreshes(s *state.State, snapInfos []*snap.Info, userID int) (vali
 	return validated, nil
 }
 
-func init() {
-	// hook validation of refreshes into snapstate logic
-	snapstate.ValidateRefreshes = ValidateRefreshes
-	// hook auto refresh of assertions into snapstate
-	snapstate.AutoRefreshAssertions = AutoRefreshAssertions
-}
-
 // BaseDeclaration returns the base-declaration assertion with policies governing all snaps.
 func BaseDeclaration(s *state.State) (*asserts.BaseDeclaration, error) {
 	// TODO: switch keeping this in the DB and have it revisioned/updated
@@ -351,7 +344,11 @@ func AutoAliases(s *state.State, info *snap.Info) (map[string]string, error) {
 	return res, nil
 }
 
-func init() {
+func crossInit() {
+	// hook validation of refreshes into snapstate logic
+	snapstate.ValidateRefreshes = ValidateRefreshes
+	// hook auto refresh of assertions into snapstate
+	snapstate.AutoRefreshAssertions = AutoRefreshAssertions
 	// hook retrieving auto-aliases into snapstate logic
 	snapstate.AutoAliases = AutoAliases
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -55,7 +55,7 @@ type DeviceManager struct {
 
 // Manager returns a new device manager.
 func Manager(s *state.State, hookManager *hookstate.HookManager) (*DeviceManager, error) {
-	crossInit()
+	delayedCrossMgrInit()
 
 	runner := state.NewTaskRunner(s)
 

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -55,6 +55,8 @@ type DeviceManager struct {
 
 // Manager returns a new device manager.
 func Manager(s *state.State, hookManager *hookstate.HookManager) (*DeviceManager, error) {
+	crossInit()
+
 	runner := state.NewTaskRunner(s)
 
 	keypairMgr, err := asserts.OpenFSKeypairManager(dirs.SnapDeviceDir)
@@ -252,6 +254,9 @@ func (m *DeviceManager) ensureOperational() error {
 		}
 		prepareDevice = hookstate.HookTask(m.state, summary, hooksup, nil)
 		tasks = append(tasks, prepareDevice)
+		// hooks are under a different manager, make sure we consider
+		// it immediately
+		m.state.EnsureBefore(0)
 	}
 
 	genKey := m.state.NewTask("generate-device-key", i18n.G("Generate device key"))

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -188,7 +188,7 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags sn
 	return nil
 }
 
-func init() {
+func crossInit() {
 	snapstate.AddCheckSnapCallback(checkGadgetOrKernel)
 	snapstate.CanAutoRefresh = canAutoRefresh
 }

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -23,6 +23,7 @@ package devicestate
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/logger"
@@ -188,7 +189,11 @@ func checkGadgetOrKernel(st *state.State, snapInfo, curInfo *snap.Info, flags sn
 	return nil
 }
 
-func crossInit() {
-	snapstate.AddCheckSnapCallback(checkGadgetOrKernel)
+var once sync.Once
+
+func delayedCrossMgrInit() {
+	once.Do(func() {
+		snapstate.AddCheckSnapCallback(checkGadgetOrKernel)
+	})
 	snapstate.CanAutoRefresh = canAutoRefresh
 }

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -362,7 +362,7 @@ snaps:
 	chg1.SetStatus(state.DoingStatus)
 
 	st.Unlock()
-	s.overlord.Settle()
+	s.overlord.Settle(5 * time.Second)
 	st.Lock()
 	// unlocked by defer
 
@@ -534,7 +534,7 @@ snaps:
 	chg1.SetStatus(state.DoingStatus)
 
 	st.Unlock()
-	s.overlord.Settle()
+	s.overlord.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(chg.Err(), IsNil)
 
@@ -717,7 +717,7 @@ snaps:
 	chg1.SetStatus(state.DoingStatus)
 
 	st.Unlock()
-	s.overlord.Settle()
+	s.overlord.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(chg.Err(), IsNil)
 

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -32,6 +32,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -46,6 +47,7 @@ func TestHookManager(t *testing.T) { TestingT(t) }
 type hookManagerSuite struct {
 	testutil.BaseTest
 
+	o           *overlord.Overlord
 	state       *state.State
 	manager     *hookstate.HookManager
 	context     *hookstate.Context
@@ -85,10 +87,12 @@ func (s *hookManagerSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
 	dirs.SetRootDir(c.MkDir())
-	s.state = state.New(nil)
+	s.o = overlord.Mock()
+	s.state = s.o.State()
 	manager, err := hookstate.Manager(s.state)
 	c.Assert(err, IsNil)
 	s.manager = manager
+	s.o.AddManager(s.manager)
 
 	hooksup := &hookstate.HookSetup{
 		Snap:     "test-snap",
@@ -138,10 +142,7 @@ func (s *hookManagerSuite) TearDownTest(c *C) {
 }
 
 func (s *hookManagerSuite) settle() {
-	for i := 0; i < 50; i++ {
-		s.manager.Ensure()
-		s.manager.Wait()
-	}
+	s.o.Settle(5 * time.Second)
 }
 
 func (s *hookManagerSuite) TestSmoke(c *C) {

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -38,7 +38,7 @@ type InterfaceManager struct {
 // Manager returns a new InterfaceManager.
 // Extra interfaces can be provided for testing.
 func Manager(s *state.State, hookManager *hookstate.HookManager, extraInterfaces []interfaces.Interface, extraBackends []interfaces.SecurityBackend) (*InterfaceManager, error) {
-	crossInit()
+	delayedCrossMgrInit()
 
 	// NOTE: hookManager is nil only when testing.
 	if hookManager != nil {

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -38,6 +38,8 @@ type InterfaceManager struct {
 // Manager returns a new InterfaceManager.
 // Extra interfaces can be provided for testing.
 func Manager(s *state.State, hookManager *hookstate.HookManager, extraInterfaces []interfaces.Interface, extraBackends []interfaces.SecurityBackend) (*InterfaceManager, error) {
+	crossInit()
+
 	// NOTE: hookManager is nil only when testing.
 	if hookManager != nil {
 		setupHooks(hookManager)

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -23,6 +23,7 @@ package ifacestate
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/snapcore/snapd/i18n/dumb"
 	"github.com/snapcore/snapd/interfaces"
@@ -201,9 +202,13 @@ func CheckInterfaces(st *state.State, snapInfo *snap.Info) error {
 	return ic.Check()
 }
 
-func crossInit() {
+var once sync.Once
+
+func delayedCrossMgrInit() {
 	// hook interface checks into snapstate installation logic
-	snapstate.AddCheckSnapCallback(func(st *state.State, snapInfo, _ *snap.Info, _ snapstate.Flags) error {
-		return CheckInterfaces(st, snapInfo)
+	once.Do(func() {
+		snapstate.AddCheckSnapCallback(func(st *state.State, snapInfo, _ *snap.Info, _ snapstate.Flags) error {
+			return CheckInterfaces(st, snapInfo)
+		})
 	})
 }

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -201,7 +201,7 @@ func CheckInterfaces(st *state.State, snapInfo *snap.Info) error {
 	return ic.Check()
 }
 
-func init() {
+func crossInit() {
 	// hook interface checks into snapstate installation logic
 	snapstate.AddCheckSnapCallback(func(st *state.State, snapInfo, _ *snap.Info, _ snapstate.Flags) error {
 		return CheckInterfaces(st, snapInfo)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -207,6 +207,8 @@ func (ms *mgrsSuite) TearDownTest(c *C) {
 	ms.snapSeccomp.Restore()
 }
 
+var settleTimeout = 10 * time.Second
+
 func makeTestSnap(c *C, snapYamlContent string) string {
 	return snaptest.MakeTestSnapWithFiles(c, snapYamlContent, nil)
 }
@@ -229,7 +231,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -279,7 +281,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -545,7 +547,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -594,7 +596,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -658,7 +660,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -726,7 +728,7 @@ slots:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -763,7 +765,7 @@ version: @VERSION@
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -841,7 +843,7 @@ version: @VERSION@
 	chg.AddAll(tss[0])
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -881,7 +883,7 @@ type: os
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -901,7 +903,7 @@ type: os
 	bootloader.BootVars["snap_core"] = "core_x1.snap"
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -971,7 +973,7 @@ type: kernel`
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1003,7 +1005,7 @@ func (ms *mgrsSuite) installLocalTestSnap(c *C, snapYamlContent string) *snap.In
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1022,7 +1024,7 @@ func (ms *mgrsSuite) removeSnap(c *C, name string) {
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1067,7 +1069,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1106,7 +1108,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1152,7 +1154,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1172,7 +1174,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1225,7 +1227,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1285,7 +1287,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1330,7 +1332,7 @@ apps:
 	chg.AddAll(tss[0])
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1390,7 +1392,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1431,7 +1433,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1503,7 +1505,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1517,7 +1519,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1579,7 +1581,7 @@ apps:
 	chg.AddAll(tss[2])
 
 	st.Unlock()
-	err = ms.o.Settle(5 * time.Second)
+	err = ms.o.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -201,7 +201,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -251,7 +251,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -517,7 +517,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -566,7 +566,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -632,7 +632,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -702,7 +702,7 @@ slots:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -739,7 +739,7 @@ version: @VERSION@
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -817,7 +817,7 @@ version: @VERSION@
 	chg.AddAll(tss[0])
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -857,7 +857,7 @@ type: os
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -877,7 +877,7 @@ type: os
 	bootloader.BootVars["snap_core"] = "core_x1.snap"
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -949,7 +949,7 @@ type: kernel`
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -981,7 +981,7 @@ func (ms *mgrsSuite) installLocalTestSnap(c *C, snapYamlContent string) *snap.In
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1000,7 +1000,7 @@ func (ms *mgrsSuite) removeSnap(c *C, name string) {
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1045,7 +1045,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1084,7 +1084,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1130,7 +1130,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1150,7 +1150,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1203,7 +1203,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1263,7 +1263,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1308,7 +1308,7 @@ apps:
 	chg.AddAll(tss[0])
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1368,7 +1368,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1409,7 +1409,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1481,7 +1481,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1495,7 +1495,7 @@ apps:
 	chg.AddAll(ts)
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 
@@ -1557,7 +1557,7 @@ apps:
 	chg.AddAll(tss[2])
 
 	st.Unlock()
-	err = ms.o.Settle()
+	err = ms.o.Settle(5 * time.Second)
 	st.Lock()
 	c.Assert(err, IsNil)
 

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -68,6 +68,7 @@ type Overlord struct {
 	// restarts
 	restartHandler func(t state.RestartType)
 	// managers
+	inited    bool
 	snapMgr   *snapstate.SnapManager
 	assertMgr *assertstate.AssertManager
 	ifaceMgr  *ifacestate.InterfaceManager
@@ -83,6 +84,7 @@ var setupStore = storestate.SetupStore
 func New() (*Overlord, error) {
 	o := &Overlord{
 		loopTomb: new(tomb.Tomb),
+		inited:   true,
 	}
 
 	backend := &overlordStateBackend{
@@ -101,30 +103,27 @@ func New() (*Overlord, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.hookMgr = hookMgr
-	o.stateEng.AddManager(o.hookMgr)
+	o.addManager(hookMgr)
 
 	snapMgr, err := snapstate.Manager(s)
 	if err != nil {
 		return nil, err
 	}
-	o.snapMgr = snapMgr
-	o.stateEng.AddManager(o.snapMgr)
+	o.addManager(snapMgr)
 
 	assertMgr, err := assertstate.Manager(s)
 	if err != nil {
 		return nil, err
 	}
-	o.assertMgr = assertMgr
-	o.stateEng.AddManager(o.assertMgr)
+	o.addManager(assertMgr)
 
 	ifaceMgr, err := ifacestate.Manager(s, hookMgr, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	o.ifaceMgr = ifaceMgr
-	o.stateEng.AddManager(o.ifaceMgr)
+	o.addManager(ifaceMgr)
 
+	// TODO: this is a bit weird, not actually a StateManager
 	configMgr, err := configstate.Manager(s, hookMgr)
 	if err != nil {
 		return nil, err
@@ -135,11 +134,9 @@ func New() (*Overlord, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.deviceMgr = deviceMgr
-	o.stateEng.AddManager(o.deviceMgr)
+	o.addManager(deviceMgr)
 
-	o.cmdMgr = cmdstate.Manager(s)
-	o.stateEng.AddManager(o.cmdMgr)
+	o.addManager(cmdstate.Manager(s))
 
 	s.Lock()
 	defer s.Unlock()
@@ -156,6 +153,24 @@ func New() (*Overlord, error) {
 	}
 
 	return o, nil
+}
+
+func (o *Overlord) addManager(mgr StateManager) {
+	switch x := mgr.(type) {
+	case *hookstate.HookManager:
+		o.hookMgr = x
+	case *snapstate.SnapManager:
+		o.snapMgr = x
+	case *assertstate.AssertManager:
+		o.assertMgr = x
+	case *ifacestate.InterfaceManager:
+		o.ifaceMgr = x
+	case *devicestate.DeviceManager:
+		o.deviceMgr = x
+	case *cmdstate.CommandManager:
+		o.cmdMgr = x
+	}
+	o.stateEng.AddManager(mgr)
 }
 
 func loadState(backend state.Backend) (*state.State, error) {
@@ -268,8 +283,8 @@ func (o *Overlord) Stop() error {
 // Settle runs first a state engine Ensure and then wait for activities to settle.
 // That's done by waiting for all managers activities to settle while
 // making sure no immediate further Ensure is scheduled. Chiefly for tests.
-// Cannot be used in conjunction with Loop.
-func (o *Overlord) Settle() error {
+// Cannot be used in conjunction with Loop. Errors if settlings takes long than timeout if timeout is not zero.
+func (o *Overlord) Settle(timeout time.Duration) error {
 	func() {
 		o.ensureLock.Lock()
 		defer o.ensureLock.Unlock()
@@ -286,9 +301,17 @@ func (o *Overlord) Settle() error {
 		o.ensureTimer = nil
 	}()
 
+	t0 := time.Now()
 	done := false
 	var errs []error
 	for !done {
+		if timeout > 0 && time.Since(t0) > timeout {
+			err := fmt.Errorf("Settle is not converging")
+			if len(errs) != 0 {
+				return &ensureError{append(errs, err)}
+			}
+			return err
+		}
 		next := o.ensureTimerReset()
 		err := o.stateEng.Ensure()
 		switch ee := err.(type) {
@@ -302,6 +325,18 @@ func (o *Overlord) Settle() error {
 		o.ensureLock.Lock()
 		done = o.ensureNext.Equal(next)
 		o.ensureLock.Unlock()
+		if done {
+			// we should wait also for cleanup handlers
+			st := o.State()
+			st.Lock()
+			for _, chg := range st.Changes() {
+				if chg.IsReady() && !chg.IsClean() {
+					done = false
+					break
+				}
+			}
+			st.Unlock()
+		}
 	}
 	if len(errs) != 0 {
 		return &ensureError{errs}
@@ -346,4 +381,47 @@ func (o *Overlord) DeviceManager() *devicestate.DeviceManager {
 // CommandManager returns the manager responsible for running odd jobs
 func (o *Overlord) CommandManager() *cmdstate.CommandManager {
 	return o.cmdMgr
+}
+
+// Mock creates an Overlord without any managers and with a backend
+// not using disk. Managers can be added with AddManager. For testing.
+func Mock() *Overlord {
+	o := &Overlord{
+		loopTomb: new(tomb.Tomb),
+		inited:   false,
+	}
+	o.stateEng = NewStateEngine(state.New(mockBackend{o: o}))
+	return o
+}
+
+// AddManager adds a manager to the overlord created with Mock. For
+// testing.
+func (o *Overlord) AddManager(mgr StateManager) {
+	if o.inited {
+		panic("internal error: cannot add managers to a fully initialized Overlord")
+	}
+	o.addManager(mgr)
+}
+
+type mockBackend struct {
+	o *Overlord
+}
+
+func (mb mockBackend) Checkpoint(data []byte) error {
+	return nil
+}
+
+func (mb mockBackend) EnsureBefore(d time.Duration) {
+	mb.o.ensureLock.Lock()
+	timer := mb.o.ensureTimer
+	mb.o.ensureLock.Unlock()
+	if timer == nil {
+		return
+	}
+
+	mb.o.ensureBefore(d)
+}
+
+func (mb mockBackend) RequestRestart(t state.RestartType) {
+	mb.o.requestRestart(t)
 }

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -282,8 +282,9 @@ func (o *Overlord) Stop() error {
 
 // Settle runs first a state engine Ensure and then wait for activities to settle.
 // That's done by waiting for all managers activities to settle while
-// making sure no immediate further Ensure is scheduled. Chiefly for tests.
-// Cannot be used in conjunction with Loop. Errors if settlings takes long than timeout if timeout is not zero.
+// making sure no immediate further Ensure is scheduled. Chiefly for
+// tests.  Cannot be used in conjunction with Loop. If timeout is
+// non-zero and settling takes longer than timeout, returns an error.
 func (o *Overlord) Settle(timeout time.Duration) error {
 	func() {
 		o.ensureLock.Lock()

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -76,7 +76,9 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	c.Check(o.SnapManager(), NotNil)
 	c.Check(o.AssertManager(), NotNil)
 	c.Check(o.InterfaceManager(), NotNil)
+	c.Check(o.HookManager(), NotNil)
 	c.Check(o.DeviceManager(), NotNil)
+	c.Check(o.CommandManager(), NotNil)
 
 	s := o.State()
 	c.Check(s, NotNil)
@@ -216,17 +218,15 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 func (ovs *overlordSuite) TestEnsureLoopRunAndStop(c *C) {
 	restoreIntv := overlord.MockEnsureInterval(10 * time.Millisecond)
 	defer restoreIntv()
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
 	witness := &witnessManager{
 		state:          o.State(),
 		expectedEnsure: 3,
 		ensureCalled:   make(chan struct{}),
 	}
-	o.Engine().AddManager(witness)
+	o.AddManager(witness)
 
-	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -238,15 +238,14 @@ func (ovs *overlordSuite) TestEnsureLoopRunAndStop(c *C) {
 	}
 	c.Check(time.Since(t0) >= 10*time.Millisecond, Equals, true)
 
-	err = o.Stop()
+	err := o.Stop()
 	c.Assert(err, IsNil)
 }
 
 func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeImmediate(c *C) {
 	restoreIntv := overlord.MockEnsureInterval(10 * time.Minute)
 	defer restoreIntv()
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
 	ensure := func(s *state.State) error {
 		s.EnsureBefore(0)
@@ -259,10 +258,8 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeImmediate(c *C) {
 		ensureCalled:   make(chan struct{}),
 		ensureCallback: ensure,
 	}
-	se := o.Engine()
-	se.AddManager(witness)
+	o.AddManager(witness)
 
-	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -276,8 +273,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeImmediate(c *C) {
 func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBefore(c *C) {
 	restoreIntv := overlord.MockEnsureInterval(10 * time.Minute)
 	defer restoreIntv()
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
 	ensure := func(s *state.State) error {
 		s.EnsureBefore(10 * time.Millisecond)
@@ -290,10 +286,8 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBefore(c *C) {
 		ensureCalled:   make(chan struct{}),
 		ensureCallback: ensure,
 	}
-	se := o.Engine()
-	se.AddManager(witness)
+	o.AddManager(witness)
 
-	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -307,9 +301,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBefore(c *C) {
 func (ovs *overlordSuite) TestEnsureBeforeSleepy(c *C) {
 	restoreIntv := overlord.MockEnsureInterval(10 * time.Minute)
 	defer restoreIntv()
-
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
 	ensure := func(s *state.State) error {
 		overlord.MockEnsureNext(o, time.Now().Add(-10*time.Hour))
@@ -323,10 +315,8 @@ func (ovs *overlordSuite) TestEnsureBeforeSleepy(c *C) {
 		ensureCalled:   make(chan struct{}),
 		ensureCallback: ensure,
 	}
-	se := o.Engine()
-	se.AddManager(witness)
+	o.AddManager(witness)
 
-	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -340,8 +330,7 @@ func (ovs *overlordSuite) TestEnsureBeforeSleepy(c *C) {
 func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeOutsideEnsure(c *C) {
 	restoreIntv := overlord.MockEnsureInterval(10 * time.Minute)
 	defer restoreIntv()
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
 	ch := make(chan struct{})
 	ensure := func(s *state.State) error {
@@ -355,10 +344,8 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeOutsideEnsure(c *C) 
 		ensureCalled:   make(chan struct{}),
 		ensureCallback: ensure,
 	}
-	se := o.Engine()
-	se.AddManager(witness)
+	o.AddManager(witness)
 
-	markSeeded(o)
 	o.Loop()
 	defer o.Stop()
 
@@ -368,7 +355,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeOutsideEnsure(c *C) 
 		c.Fatal("Ensure calls not happening")
 	}
 
-	se.State().EnsureBefore(0)
+	o.State().EnsureBefore(0)
 
 	select {
 	case <-witness.ensureCalled:
@@ -380,8 +367,7 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeOutsideEnsure(c *C) 
 func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 	restoreIntv := overlord.MockPruneInterval(200*time.Millisecond, 1000*time.Millisecond, 1000*time.Millisecond)
 	defer restoreIntv()
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
 	st := o.State()
 	st.Lock()
@@ -414,10 +400,8 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 	witness := &witnessManager{
 		ensureCallback: waitForPrune,
 	}
-	se := o.Engine()
-	se.AddManager(witness)
+	o.AddManager(witness)
 
-	markSeeded(o)
 	o.Loop()
 
 	select {
@@ -426,7 +410,7 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 		c.Fatal("Pruning should have happened by now")
 	}
 
-	err = o.Stop()
+	err := o.Stop()
 	c.Assert(err, IsNil)
 
 	st.Lock()
@@ -441,8 +425,7 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	restoreIntv := overlord.MockPruneInterval(100*time.Millisecond, 1000*time.Millisecond, 1*time.Hour)
 	defer restoreIntv()
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
 	// create two changes, one that can be pruned now, one in progress
 	st := o.State()
@@ -458,7 +441,6 @@ func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	c.Check(st.Changes(), HasLen, 2)
 	st.Unlock()
 
-	markSeeded(o)
 	// start the loop that runs the prune ticker
 	o.Loop()
 
@@ -478,7 +460,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneRunsMultipleTimes(c *C) {
 	st.Unlock()
 
 	// cleanup loop ticker
-	err = o.Stop()
+	err := o.Stop()
 	c.Assert(err, IsNil)
 }
 
@@ -534,6 +516,27 @@ func newRunnerManager(s *state.State) *runnerManager {
 		s.EnsureBefore(20 * time.Millisecond)
 		return nil
 	}, nil)
+	rm.runner.AddHandler("runMgrForever", func(t *state.Task, _ *tomb.Tomb) error {
+		s := t.State()
+		s.Lock()
+		defer s.Unlock()
+		s.EnsureBefore(20 * time.Millisecond)
+		return &state.Retry{}
+	}, nil)
+	rm.runner.AddHandler("runMgrWCleanup", func(t *state.Task, _ *tomb.Tomb) error {
+		s := t.State()
+		s.Lock()
+		defer s.Unlock()
+		s.Set("runMgrWCleanupMark", 1)
+		return nil
+	}, nil)
+	rm.runner.AddCleanup("runMgrWCleanup", func(t *state.Task, _ *tomb.Tomb) error {
+		s := t.State()
+		s.Lock()
+		defer s.Unlock()
+		s.Set("runMgrWCleanupCleanedUp", 1)
+		return nil
+	})
 
 	return rm
 }
@@ -557,13 +560,11 @@ func (rm *runnerManager) Wait() {
 func (ovs *overlordSuite) TestTrivialSettle(c *C) {
 	restoreIntv := overlord.MockEnsureInterval(1 * time.Minute)
 	defer restoreIntv()
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
-	se := o.Engine()
-	s := se.State()
+	s := o.State()
 	rm1 := newRunnerManager(s)
-	se.AddManager(rm1)
+	o.AddManager(rm1)
 
 	defer o.Engine().Stop()
 
@@ -575,28 +576,49 @@ func (ovs *overlordSuite) TestTrivialSettle(c *C) {
 	chg.AddTask(t1)
 
 	s.Unlock()
-
-	markSeeded(o)
-	o.Settle()
-
+	o.Settle(5 * time.Second)
 	s.Lock()
 	c.Check(t1.Status(), Equals, state.DoneStatus)
 
 	var v int
-	err = s.Get("runMgr1Mark", &v)
+	err := s.Get("runMgr1Mark", &v)
 	c.Check(err, IsNil)
+}
+
+func (ovs *overlordSuite) TestSettleNotConverging(c *C) {
+	restoreIntv := overlord.MockEnsureInterval(1 * time.Minute)
+	defer restoreIntv()
+	o := overlord.Mock()
+
+	s := o.State()
+	rm1 := newRunnerManager(s)
+	o.AddManager(rm1)
+
+	defer o.Engine().Stop()
+
+	s.Lock()
+	defer s.Unlock()
+
+	chg := s.NewChange("chg", "...")
+	t1 := s.NewTask("runMgrForever", "1...")
+	chg.AddTask(t1)
+
+	s.Unlock()
+	err := o.Settle(250 * time.Millisecond)
+	s.Lock()
+
+	c.Check(err, ErrorMatches, `Settle is not converging`)
+
 }
 
 func (ovs *overlordSuite) TestSettleChain(c *C) {
 	restoreIntv := overlord.MockEnsureInterval(1 * time.Minute)
 	defer restoreIntv()
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
-	se := o.Engine()
-	s := se.State()
+	s := o.State()
 	rm1 := newRunnerManager(s)
-	se.AddManager(rm1)
+	o.AddManager(rm1)
 
 	defer o.Engine().Stop()
 
@@ -610,29 +632,60 @@ func (ovs *overlordSuite) TestSettleChain(c *C) {
 	chg.AddAll(state.NewTaskSet(t1, t2))
 
 	s.Unlock()
-
-	markSeeded(o)
-	o.Settle()
-
+	o.Settle(5 * time.Second)
 	s.Lock()
 	c.Check(t1.Status(), Equals, state.DoneStatus)
 	c.Check(t2.Status(), Equals, state.DoneStatus)
 
 	var v int
-	err = s.Get("runMgr1Mark", &v)
+	err := s.Get("runMgr1Mark", &v)
 	c.Check(err, IsNil)
 	err = s.Get("runMgr2Mark", &v)
+	c.Check(err, IsNil)
+}
+
+func (ovs *overlordSuite) TestSettleChainWCleanup(c *C) {
+	restoreIntv := overlord.MockEnsureInterval(1 * time.Minute)
+	defer restoreIntv()
+	o := overlord.Mock()
+
+	s := o.State()
+	rm1 := newRunnerManager(s)
+	o.AddManager(rm1)
+
+	defer o.Engine().Stop()
+
+	s.Lock()
+	defer s.Unlock()
+
+	chg := s.NewChange("chg", "...")
+	t1 := s.NewTask("runMgrWCleanup", "1...")
+	t2 := s.NewTask("runMgr2", "2...")
+	t2.WaitFor(t1)
+	chg.AddAll(state.NewTaskSet(t1, t2))
+
+	s.Unlock()
+	o.Settle(5 * time.Second)
+	s.Lock()
+	c.Check(t1.Status(), Equals, state.DoneStatus)
+	c.Check(t2.Status(), Equals, state.DoneStatus)
+
+	var v int
+	err := s.Get("runMgrWCleanupMark", &v)
+	c.Check(err, IsNil)
+	err = s.Get("runMgr2Mark", &v)
+	c.Check(err, IsNil)
+
+	err = s.Get("runMgrWCleanupCleanedUp", &v)
 	c.Check(err, IsNil)
 }
 
 func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 	restoreIntv := overlord.MockEnsureInterval(1 * time.Minute)
 	defer restoreIntv()
-	o, err := overlord.New()
-	c.Assert(err, IsNil)
+	o := overlord.Mock()
 
-	se := o.Engine()
-	s := se.State()
+	s := o.State()
 	rm1 := newRunnerManager(s)
 	rm1.ensureCallback = func() {
 		s.Lock()
@@ -642,7 +695,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 		s.Set("ensureCount", v+1)
 	}
 
-	se.AddManager(rm1)
+	o.AddManager(rm1)
 
 	defer o.Engine().Stop()
 
@@ -652,16 +705,14 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 	chg := s.NewChange("chg", "...")
 	t := s.NewTask("runMgrEnsureBefore", "...")
 	chg.AddTask(t)
+
 	s.Unlock()
-
-	markSeeded(o)
-	o.Settle()
-
+	o.Settle(5 * time.Second)
 	s.Lock()
 	c.Check(t.Status(), Equals, state.DoneStatus)
 
 	var v int
-	err = s.Get("ensureCount", &v)
+	err := s.Get("ensureCount", &v)
 	c.Check(err, IsNil)
 	c.Check(v, Equals, 2)
 }


### PR DESCRIPTION
overlord.Mock creates a no-manager Overlord supporting AddManager to add a subset of managers, mainly for letting tests use Overlord.Settle even with just 1 or few managers.

Moved calling some global init code into Manager creation functions to avoid unexpected confusing side-effects on tests once they all start to import overlord which imports all managers.

TODO for a follow up:
* similar changes in ifacestate
* see if some uses of Overlord.Loop in daemon/api_test.go can be avoided using Mock


