### PR TITLE
packaging/fedora: Ensure vendor/ is empty for builds and fix spec to build current master

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -86,6 +86,8 @@ Requires:       %{name}-selinux = %{version}-%{release}
 %if ! 0%{?with_bundled}
 BuildRequires: golang(github.com/cheggaaa/pb)
 BuildRequires: golang(github.com/coreos/go-systemd/activation)
+BuildRequires: golang(github.com/godbus/dbus)
+BuildRequires: golang(github.com/godbus/dbus/introspect)
 BuildRequires: golang(github.com/gorilla/mux)
 BuildRequires: golang(github.com/jessevdk/go-flags)
 BuildRequires: golang(github.com/mvo5/uboot-go/uenv)
@@ -171,6 +173,8 @@ BuildArch:     noarch
 %if ! 0%{?with_bundled}
 Requires:      golang(github.com/cheggaaa/pb)
 Requires:      golang(github.com/coreos/go-systemd/activation)
+Requires:      golang(github.com/godbus/dbus)
+Requires:      golang(github.com/godbus/dbus/introspect)
 Requires:      golang(github.com/gorilla/mux)
 Requires:      golang(github.com/jessevdk/go-flags)
 Requires:      golang(github.com/mvo5/uboot-go/uenv)
@@ -194,6 +198,8 @@ Requires:      golang(gopkg.in/yaml.v2)
 # *sigh*... I hate golang...
 Provides:      bundled(golang(github.com/cheggaaa/pb))
 Provides:      bundled(golang(github.com/coreos/go-systemd/activation))
+Provides:      bundled(golang(github.com/godbus/dbus))
+Provides:      bundled(golang(github.com/godbus/dbus/introspect))
 Provides:      bundled(golang(github.com/gorilla/mux))
 Provides:      bundled(golang(github.com/jessevdk/go-flags))
 Provides:      bundled(golang(github.com/mvo5/uboot-go/uenv))

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -324,6 +324,10 @@ providing packages with %{import_path} prefix.
 %prep
 %setup -q
 
+%if ! 0%{?with_bundled}
+# Ensure there's no bundled stuff accidentally leaking in...
+rm -rf vendor/*
+%endif
 
 %build
 # Generate version files

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -84,7 +84,6 @@ Requires:       bash-completion
 Requires:       %{name}-selinux = %{version}-%{release}
 
 %if ! 0%{?with_bundled}
-BuildRequires: golang(github.com/cheggaaa/pb)
 BuildRequires: golang(github.com/coreos/go-systemd/activation)
 BuildRequires: golang(github.com/godbus/dbus)
 BuildRequires: golang(github.com/godbus/dbus/introspect)
@@ -100,6 +99,7 @@ BuildRequires: golang(golang.org/x/crypto/ssh/terminal)
 BuildRequires: golang(golang.org/x/net/context)
 BuildRequires: golang(golang.org/x/net/context/ctxhttp)
 BuildRequires: golang(gopkg.in/check.v1)
+BuildRequires: golang(gopkg.in/cheggaaa/pb.v1)
 BuildRequires: golang(gopkg.in/macaroon.v1)
 BuildRequires: golang(gopkg.in/mgo.v2/bson)
 BuildRequires: golang(gopkg.in/retry.v1)
@@ -171,7 +171,6 @@ BuildArch:     noarch
 %endif
 
 %if ! 0%{?with_bundled}
-Requires:      golang(github.com/cheggaaa/pb)
 Requires:      golang(github.com/coreos/go-systemd/activation)
 Requires:      golang(github.com/godbus/dbus)
 Requires:      golang(github.com/godbus/dbus/introspect)
@@ -187,6 +186,7 @@ Requires:      golang(golang.org/x/crypto/ssh/terminal)
 Requires:      golang(golang.org/x/net/context)
 Requires:      golang(golang.org/x/net/context/ctxhttp)
 Requires:      golang(gopkg.in/check.v1)
+Requires:      golang(gopkg.in/cheggaaa/pb.v1)
 Requires:      golang(gopkg.in/macaroon.v1)
 Requires:      golang(gopkg.in/mgo.v2/bson)
 Requires:      golang(gopkg.in/retry.v1)
@@ -196,7 +196,6 @@ Requires:      golang(gopkg.in/yaml.v2)
 # These Provides are unversioned because the sources in
 # the bundled tarball are unversioned (they go by git commit)
 # *sigh*... I hate golang...
-Provides:      bundled(golang(github.com/cheggaaa/pb))
 Provides:      bundled(golang(github.com/coreos/go-systemd/activation))
 Provides:      bundled(golang(github.com/godbus/dbus))
 Provides:      bundled(golang(github.com/godbus/dbus/introspect))
@@ -212,6 +211,7 @@ Provides:      bundled(golang(golang.org/x/crypto/ssh/terminal))
 Provides:      bundled(golang(golang.org/x/net/context))
 Provides:      bundled(golang(golang.org/x/net/context/ctxhttp))
 Provides:      bundled(golang(gopkg.in/check.v1))
+Provides:      bundled(golang(gopkg.in/cheggaaa/pb.v1))
 Provides:      bundled(golang(gopkg.in/macaroon.v1))
 Provides:      bundled(golang(gopkg.in/mgo.v2/bson))
 Provides:      bundled(golang(gopkg.in/retry.v1))

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -84,6 +84,7 @@ Requires:       bash-completion
 Requires:       %{name}-selinux = %{version}-%{release}
 
 %if ! 0%{?with_bundled}
+BuildRequires: golang(github.com/cheggaaa/pb)
 BuildRequires: golang(github.com/coreos/go-systemd/activation)
 BuildRequires: golang(github.com/godbus/dbus)
 BuildRequires: golang(github.com/godbus/dbus/introspect)
@@ -99,7 +100,6 @@ BuildRequires: golang(golang.org/x/crypto/ssh/terminal)
 BuildRequires: golang(golang.org/x/net/context)
 BuildRequires: golang(golang.org/x/net/context/ctxhttp)
 BuildRequires: golang(gopkg.in/check.v1)
-BuildRequires: golang(gopkg.in/cheggaaa/pb.v1)
 BuildRequires: golang(gopkg.in/macaroon.v1)
 BuildRequires: golang(gopkg.in/mgo.v2/bson)
 BuildRequires: golang(gopkg.in/retry.v1)
@@ -171,6 +171,7 @@ BuildArch:     noarch
 %endif
 
 %if ! 0%{?with_bundled}
+Requires:      golang(github.com/cheggaaa/pb)
 Requires:      golang(github.com/coreos/go-systemd/activation)
 Requires:      golang(github.com/godbus/dbus)
 Requires:      golang(github.com/godbus/dbus/introspect)
@@ -186,7 +187,6 @@ Requires:      golang(golang.org/x/crypto/ssh/terminal)
 Requires:      golang(golang.org/x/net/context)
 Requires:      golang(golang.org/x/net/context/ctxhttp)
 Requires:      golang(gopkg.in/check.v1)
-Requires:      golang(gopkg.in/cheggaaa/pb.v1)
 Requires:      golang(gopkg.in/macaroon.v1)
 Requires:      golang(gopkg.in/mgo.v2/bson)
 Requires:      golang(gopkg.in/retry.v1)
@@ -196,6 +196,7 @@ Requires:      golang(gopkg.in/yaml.v2)
 # These Provides are unversioned because the sources in
 # the bundled tarball are unversioned (they go by git commit)
 # *sigh*... I hate golang...
+Provides:      bundled(golang(github.com/cheggaaa/pb))
 Provides:      bundled(golang(github.com/coreos/go-systemd/activation))
 Provides:      bundled(golang(github.com/godbus/dbus))
 Provides:      bundled(golang(github.com/godbus/dbus/introspect))
@@ -211,7 +212,6 @@ Provides:      bundled(golang(golang.org/x/crypto/ssh/terminal))
 Provides:      bundled(golang(golang.org/x/net/context))
 Provides:      bundled(golang(golang.org/x/net/context/ctxhttp))
 Provides:      bundled(golang(gopkg.in/check.v1))
-Provides:      bundled(golang(gopkg.in/cheggaaa/pb.v1))
 Provides:      bundled(golang(gopkg.in/macaroon.v1))
 Provides:      bundled(golang(gopkg.in/mgo.v2/bson))
 Provides:      bundled(golang(gopkg.in/retry.v1))
@@ -333,6 +333,12 @@ providing packages with %{import_path} prefix.
 %if ! 0%{?with_bundled}
 # Ensure there's no bundled stuff accidentally leaking in...
 rm -rf vendor/*
+
+# XXX: HACK: Fake that we have the right import path because bad testing
+# did not verify that this path was actually valid on all supported systems.
+mkdir -p vendor/gopkg.in/cheggaaa
+ln -s %{gopath}/src/github.com/cheggaaa/pb vendor/gopkg.in/cheggaaa/pb.v1
+
 %endif
 
 %build


### PR DESCRIPTION
### DO NOT SQUASH MERGE THIS ###

For Fedora, we're building with unbundled components, but it seems that vendored stuff is leaking into spread tests and other things.

So let's just enforce that we build the right way so that we don't get misled by spread tests.

In addition, some basic fixes to the spec file so that it matches reality have been done, too.

Unfortunately, because CI checkmarks rule over everything and this *needs* to be in 2.28 (because the build is broken), a temporary hack has been pushed to fix the build too.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>