### PR TITLE
spread: disable openSUSE on linode backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -72,8 +72,9 @@ backends:
                 workers: 4
             - fedora-25-64:
                 workers: 3
-            - opensuse-42.2-64:
-                workers: 2
+            # Disabled on 2017-09-06 13:26 CET due to SUSE infrastructure failure.
+            #- opensuse-42.2-64:
+            #    workers: 2
     qemu:
         systems:
             - ubuntu-14.04-32:


### PR DESCRIPTION
The openSUSE infrastructure has suffered a major outage and in effect
all package servers are offline. To allow development those are now
temporarily disabled.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>