### PR TITLE
many: provide systemd.MockSystemctl() helper

### DIFF
--- a/corecfg/corecfg.go
+++ b/corecfg/corecfg.go
@@ -38,8 +38,7 @@ var (
 // ensureSupportInterface checks that the system has the core-support
 // interface. An error is returned if this is not the case
 func ensureSupportInterface() error {
-	_, err := systemd.SystemctlCmd("--version")
-	return err
+	return systemd.Available()
 }
 
 func snapctlGet(key string) (string, error) {

--- a/corecfg/services_test.go
+++ b/corecfg/services_test.go
@@ -36,13 +36,13 @@ import (
 type servicesSuite struct {
 	systemctlArgs [][]string
 
-	restorer func()
+	systemctlRestorer func()
 }
 
 var _ = Suite(&servicesSuite{})
 
 func (s *servicesSuite) SetUpSuite(c *C) {
-	s.restorer = systemd.MockSystemctl(func(args ...string) ([]byte, error) {
+	s.systemctlRestorer = systemd.MockSystemctl(func(args ...string) ([]byte, error) {
 		s.systemctlArgs = append(s.systemctlArgs, args[:])
 		output := []byte("ActiveState=inactive")
 		return output, nil
@@ -50,7 +50,7 @@ func (s *servicesSuite) SetUpSuite(c *C) {
 }
 
 func (s *servicesSuite) TearDownSuite(c *C) {
-	s.restorer()
+	s.systemctlRestorer()
 }
 
 func (s *servicesSuite) SetUpTest(c *C) {

--- a/corecfg/services_test.go
+++ b/corecfg/services_test.go
@@ -35,16 +35,22 @@ import (
 
 type servicesSuite struct {
 	systemctlArgs [][]string
+
+	restorer func()
 }
 
 var _ = Suite(&servicesSuite{})
 
 func (s *servicesSuite) SetUpSuite(c *C) {
-	systemd.SystemctlCmd = func(args ...string) ([]byte, error) {
+	s.restorer = systemd.MockSystemctl(func(args ...string) ([]byte, error) {
 		s.systemctlArgs = append(s.systemctlArgs, args[:])
 		output := []byte("ActiveState=inactive")
 		return output, nil
-	}
+	})
+}
+
+func (s *servicesSuite) TearDownSuite(c *C) {
+	s.restorer()
 }
 
 func (s *servicesSuite) SetUpTest(c *C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -87,12 +87,11 @@ type apiBaseSuite struct {
 	storeSigning      *assertstest.StoreStack
 	restoreRelease    func()
 	trustedRestorer   func()
-	systemctlRestorer func()
 
-	origSysctlCmd func(...string) ([]byte, error)
-	sysctlArgses  [][]string
-	sysctlBufs    [][]byte
-	sysctlErrs    []error
+	systemctlRestorer func()
+	sysctlArgses      [][]string
+	sysctlBufs        [][]byte
+	sysctlErrs        []error
 
 	origJctlCmd func([]string, string, bool) (io.ReadCloser, error)
 	jctlSvcses  [][]string

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -36,8 +36,8 @@ import (
 type backendSuite struct {
 	ifacetest.BackendSuite
 
-	systemctlArgs [][]string
-	restorer      func()
+	systemctlArgs     [][]string
+	systemctlRestorer func()
 }
 
 var _ = Suite(&backendSuite{})
@@ -53,14 +53,14 @@ func (s *backendSuite) SetUpTest(c *C) {
 	s.Backend = &systemd.Backend{}
 	s.BackendSuite.SetUpTest(c)
 	c.Assert(s.Repo.AddBackend(s.Backend), IsNil)
-	s.restorer = sysd.MockSystemctl(func(args ...string) ([]byte, error) {
+	s.systemctlRestorer = sysd.MockSystemctl(func(args ...string) ([]byte, error) {
 		s.systemctlArgs = append(s.systemctlArgs, append([]string{"systemctl"}, args...))
 		return []byte("ActiveState=inactive"), nil
 	})
 }
 
 func (s *backendSuite) TearDownTest(c *C) {
-	s.restorer()
+	s.systemctlRestorer()
 	s.BackendSuite.TearDownTest(c)
 }
 

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -29,14 +29,15 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/systemd"
-	"github.com/snapcore/snapd/testutil"
 
 	sysd "github.com/snapcore/snapd/systemd"
 )
 
 type backendSuite struct {
 	ifacetest.BackendSuite
-	systemctlCmd *testutil.MockCmd
+
+	systemctlArgs [][]string
+	restorer      func()
 }
 
 var _ = Suite(&backendSuite{})
@@ -52,11 +53,14 @@ func (s *backendSuite) SetUpTest(c *C) {
 	s.Backend = &systemd.Backend{}
 	s.BackendSuite.SetUpTest(c)
 	c.Assert(s.Repo.AddBackend(s.Backend), IsNil)
-	s.systemctlCmd = testutil.MockCommand(c, "systemctl", "echo ActiveState=inactive")
+	s.restorer = sysd.MockSystemctl(func(args ...string) ([]byte, error) {
+		s.systemctlArgs = append(s.systemctlArgs, append([]string{"systemctl"}, args...))
+		return []byte("ActiveState=inactive"), nil
+	})
 }
 
 func (s *backendSuite) TearDownTest(c *C) {
-	s.systemctlCmd.Restore()
+	s.restorer()
 	s.BackendSuite.TearDownTest(c)
 }
 
@@ -65,17 +69,17 @@ func (s *backendSuite) TestName(c *C) {
 }
 
 func (s *backendSuite) TestInstallingSnapWritesStartsServices(c *C) {
-	prevctlCmd := sysd.SystemctlCmd
-	defer func() { sysd.SystemctlCmd = prevctlCmd }()
-
 	var sysdLog [][]string
-	sysd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+
+	r := sysd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		sysdLog = append(sysdLog, cmd)
 		if cmd[0] == "show" {
 			return []byte("ActiveState=inactive\n"), nil
 		}
 		return []byte{}, nil
-	}
+	})
+	defer r()
+
 	s.Iface.SystemdPermanentSlotCallback = func(spec *systemd.Specification, slot *interfaces.Slot) error {
 		return spec.AddService("snap.samba.interface.foo.service", &systemd.Service{ExecStart: "/bin/true"})
 	}
@@ -100,14 +104,14 @@ func (s *backendSuite) TestRemovingSnapRemovesAndStopsServices(c *C) {
 	}
 	for _, opts := range testedConfinementOpts {
 		snapInfo := s.InstallSnap(c, opts, ifacetest.SambaYamlV1, 1)
-		s.systemctlCmd.ForgetCalls()
+		s.systemctlArgs = nil
 		s.RemoveSnap(c, snapInfo)
 		service := filepath.Join(dirs.SnapServicesDir, "snap.samba.interface.foo.service")
 		// the service file was removed
 		_, err := os.Stat(service)
 		c.Check(os.IsNotExist(err), Equals, true)
 		// the service was stopped
-		c.Check(s.systemctlCmd.Calls(), DeepEquals, [][]string{
+		c.Check(s.systemctlArgs, DeepEquals, [][]string{
 			{"systemctl", "--root", dirs.GlobalRootDir, "disable", "snap.samba.interface.foo.service"},
 			{"systemctl", "stop", "snap.samba.interface.foo.service"},
 			{"systemctl", "show", "--property=ActiveState", "snap.samba.interface.foo.service"},
@@ -125,7 +129,7 @@ func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 		return spec.AddService("snap.samba.interface.bar.service", &systemd.Service{ExecStart: "/bin/false"})
 	}
 	snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, ifacetest.SambaYamlV1, 1)
-	s.systemctlCmd.ForgetCalls()
+	s.systemctlArgs = nil
 	serviceFoo := filepath.Join(dirs.SnapServicesDir, "snap.samba.interface.foo.service")
 	serviceBar := filepath.Join(dirs.SnapServicesDir, "snap.samba.interface.bar.service")
 	// the services were created
@@ -141,7 +145,7 @@ func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 	// Update over to the same snap to regenerate security
 	s.UpdateSnap(c, snapInfo, interfaces.ConfinementOptions{}, ifacetest.SambaYamlV1, 0)
 	// The bar service should have been stopped
-	c.Check(s.systemctlCmd.Calls(), DeepEquals, [][]string{
+	c.Check(s.systemctlArgs, DeepEquals, [][]string{
 		{"systemctl", "--root", dirs.GlobalRootDir, "disable", "snap.samba.interface.bar.service"},
 		{"systemctl", "stop", "snap.samba.interface.bar.service"},
 		{"systemctl", "show", "--property=ActiveState", "snap.samba.interface.bar.service"},

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -69,9 +69,10 @@ type mgrsSuite struct {
 
 	prevctlCmd func(...string) ([]byte, error)
 
-	storeSigning   *assertstest.StoreStack
-	restoreTrusted func()
-	restore        func()
+	storeSigning     *assertstest.StoreStack
+	restoreTrusted   func()
+	restore          func()
+	restoreSystemctl func()
 
 	devAcct *asserts.Account
 
@@ -121,10 +122,10 @@ func (ms *mgrsSuite) SetUpTest(c *C) {
 	// create a fake systemd environment
 	os.MkdirAll(filepath.Join(dirs.SnapServicesDir, "multi-user.target.wants"), 0755)
 
-	ms.prevctlCmd = systemd.SystemctlCmd
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	ms.restoreSystemctl = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
-	}
+	})
+
 	ms.aa = testutil.MockCommand(c, "apparmor_parser", "")
 	ms.udev = testutil.MockCommand(c, "udevadm", "")
 	ms.umount = testutil.MockCommand(c, "umount", "")
@@ -169,8 +170,8 @@ func (ms *mgrsSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 	ms.restoreTrusted()
 	ms.restore()
+	ms.restoreSystemctl()
 	os.Unsetenv("SNAPPY_SQUASHFS_UNPACK_FOR_TESTS")
-	systemd.SystemctlCmd = ms.prevctlCmd
 	ms.udev.Restore()
 	ms.aa.Restore()
 	ms.umount.Restore()

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -67,8 +67,6 @@ type mgrsSuite struct {
 
 	snapDiscardNs *testutil.MockCmd
 
-	prevctlCmd func(...string) ([]byte, error)
-
 	storeSigning     *assertstest.StoreStack
 	restoreTrusted   func()
 	restore          func()

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -41,7 +41,7 @@ type linkSuite struct {
 	be           backend.Backend
 	nullProgress progress.NullProgress
 
-	restore func()
+	systemctlRestorer func()
 }
 
 var _ = Suite(&linkSuite{})
@@ -49,14 +49,14 @@ var _ = Suite(&linkSuite{})
 func (s *linkSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 
-	s.restore = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+	s.systemctlRestorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
 	})
 }
 
 func (s *linkSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-	s.restore()
+	s.systemctlRestorer()
 }
 
 func (s *linkSuite) TestLinkDoUndoGenerateWrappers(c *C) {

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -40,7 +40,8 @@ import (
 type linkSuite struct {
 	be           backend.Backend
 	nullProgress progress.NullProgress
-	prevctlCmd   func(...string) ([]byte, error)
+
+	restore func()
 }
 
 var _ = Suite(&linkSuite{})
@@ -48,15 +49,14 @@ var _ = Suite(&linkSuite{})
 func (s *linkSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 
-	s.prevctlCmd = systemd.SystemctlCmd
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	s.restore = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
-	}
+	})
 }
 
 func (s *linkSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-	systemd.SystemctlCmd = s.prevctlCmd
+	s.restore()
 }
 
 func (s *linkSuite) TestLinkDoUndoGenerateWrappers(c *C) {
@@ -257,9 +257,10 @@ Icon=${SNAP}/bin.png
 Exec=bin
 `), 0644), IsNil)
 
-	systemd.SystemctlCmd = func(...string) ([]byte, error) {
+	r := systemd.MockSystemctl(func(...string) ([]byte, error) {
 		return nil, nil
-	}
+	})
+	defer r()
 
 	// sanity checks
 	for _, d := range []string{dirs.SnapBinariesDir, dirs.SnapDesktopFilesDir, dirs.SnapServicesDir} {
@@ -300,9 +301,11 @@ func (s *linkCleanupSuite) TestLinkCleanupOnServicesFail(c *C) {
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnSystemctlFail(c *C) {
-	systemd.SystemctlCmd = func(...string) ([]byte, error) {
+	r := systemd.MockSystemctl(func(...string) ([]byte, error) {
 		return nil, errors.New("ouchie")
-	}
+	})
+	defer r()
+
 	err := s.be.LinkSnap(s.info)
 	c.Assert(err, ErrorMatches, "ouchie")
 

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -40,7 +40,7 @@ type mountunitSuite struct {
 	nullProgress progress.NullProgress
 	umount       *testutil.MockCmd
 
-	restore func()
+	systemctlRestorer func()
 }
 
 var _ = Suite(&mountunitSuite{})
@@ -51,7 +51,7 @@ func (s *mountunitSuite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc", "systemd", "system", "multi-user.target.wants"), 0755)
 	c.Assert(err, IsNil)
 
-	s.restore = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+	s.systemctlRestorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
 	})
 	s.umount = testutil.MockCommand(c, "umount", "")
@@ -59,8 +59,8 @@ func (s *mountunitSuite) SetUpTest(c *C) {
 
 func (s *mountunitSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-	s.umount.Restore()
-	s.restore()
+	s.umount.SystemctlRestorer()
+	s.systemctlRestorer()
 }
 
 func (s *mountunitSuite) TestAddMountUnit(c *C) {

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -59,7 +59,7 @@ func (s *mountunitSuite) SetUpTest(c *C) {
 
 func (s *mountunitSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-	s.umount.SystemctlRestorer()
+	s.umount.Restore()
 	s.systemctlRestorer()
 }
 

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -40,10 +40,10 @@ import (
 )
 
 type setupSuite struct {
-	be           backend.Backend
-	nullProgress progress.NullProgress
-	umount       *testutil.MockCmd
-	restore      func()
+	be                backend.Backend
+	nullProgress      progress.NullProgress
+	umount            *testutil.MockCmd
+	systemctlRestorer func()
 }
 
 var _ = Suite(&setupSuite{})
@@ -54,7 +54,7 @@ func (s *setupSuite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc", "systemd", "system", "multi-user.target.wants"), 0755)
 	c.Assert(err, IsNil)
 
-	s.restore = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+	s.systemctlRestorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
 	})
 
@@ -64,8 +64,8 @@ func (s *setupSuite) SetUpTest(c *C) {
 func (s *setupSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 	partition.ForceBootloader(nil)
-	s.umount.Restore()
-	s.restore()
+	s.umount.SystemctlRestorer()
+	s.systemctlRestorer()
 }
 
 func (s *setupSuite) TestSetupDoUndoSimple(c *C) {

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -42,8 +42,8 @@ import (
 type setupSuite struct {
 	be           backend.Backend
 	nullProgress progress.NullProgress
-	prevctlCmd   func(...string) ([]byte, error)
 	umount       *testutil.MockCmd
+	restore      func()
 }
 
 var _ = Suite(&setupSuite{})
@@ -54,18 +54,18 @@ func (s *setupSuite) SetUpTest(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc", "systemd", "system", "multi-user.target.wants"), 0755)
 	c.Assert(err, IsNil)
 
-	s.prevctlCmd = systemd.SystemctlCmd
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	s.restore = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
-	}
+	})
+
 	s.umount = testutil.MockCommand(c, "umount", "")
 }
 
 func (s *setupSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 	partition.ForceBootloader(nil)
-	systemd.SystemctlCmd = s.prevctlCmd
 	s.umount.Restore()
+	s.restore()
 }
 
 func (s *setupSuite) TestSetupDoUndoSimple(c *C) {

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -64,7 +64,7 @@ func (s *setupSuite) SetUpTest(c *C) {
 func (s *setupSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
 	partition.ForceBootloader(nil)
-	s.umount.SystemctlRestorer()
+	s.umount.Restore()
 	s.systemctlRestorer()
 }
 

--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 var (
-	SystemdRun = run // NOTE: plain Run clashes with check.v1
-	Jctl       = jctl
+	Jctl = jctl
 )
 
 func MockStopDelays(checkDelay, notifyDelay time.Duration) func() {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -45,8 +45,8 @@ var (
 	stopNotifyDelay = 20 * time.Second
 )
 
-// run calls systemctl with the given args, returning its standard output (and wrapped error)
-func run(args ...string) ([]byte, error) {
+// systemctlCmd calls systemctl with the given args, returning its standard output (and wrapped error)
+var systemctlCmd = func(args ...string) ([]byte, error) {
 	bs, err := exec.Command("systemctl", args...).CombinedOutput()
 	if err != nil {
 		exitCode, _ := osutil.ExitCode(err)
@@ -56,9 +56,20 @@ func run(args ...string) ([]byte, error) {
 	return bs, nil
 }
 
-// SystemctlCmd is called from the commands to actually call out to
+// MockSystemctl is called from the commands to actually call out to
 // systemctl. It's exported so it can be overridden by testing.
-var SystemctlCmd = run
+func MockSystemctl(f func(args ...string) ([]byte, error)) func() {
+	oldSystemctlCmd := systemctlCmd
+	systemctlCmd = f
+	return func() {
+		systemctlCmd = oldSystemctlCmd
+	}
+}
+
+func Available() error {
+	_, err := systemctlCmd("--version")
+	return err
+}
 
 var osutilStreamCommand = osutil.StreamCommand
 
@@ -126,25 +137,25 @@ type systemd struct {
 
 // DaemonReload reloads systemd's configuration.
 func (*systemd) DaemonReload() error {
-	_, err := SystemctlCmd("daemon-reload")
+	_, err := systemctlCmd("daemon-reload")
 	return err
 }
 
 // Enable the given service
 func (s *systemd) Enable(serviceName string) error {
-	_, err := SystemctlCmd("--root", s.rootDir, "enable", serviceName)
+	_, err := systemctlCmd("--root", s.rootDir, "enable", serviceName)
 	return err
 }
 
 // Disable the given service
 func (s *systemd) Disable(serviceName string) error {
-	_, err := SystemctlCmd("--root", s.rootDir, "disable", serviceName)
+	_, err := systemctlCmd("--root", s.rootDir, "disable", serviceName)
 	return err
 }
 
 // Start the given service
 func (*systemd) Start(serviceName string) error {
-	_, err := SystemctlCmd("start", serviceName)
+	_, err := systemctlCmd("start", serviceName)
 	return err
 }
 
@@ -168,7 +179,7 @@ func (s *systemd) Status(serviceNames ...string) ([]*ServiceStatus, error) {
 	cmd[0] = "show"
 	cmd[1] = "--property=" + strings.Join(expected, ",")
 	copy(cmd[2:], serviceNames)
-	bs, err := SystemctlCmd(cmd...)
+	bs, err := systemctlCmd(cmd...)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +253,7 @@ func (s *systemd) Status(serviceNames ...string) ([]*ServiceStatus, error) {
 
 // Stop the given service, and wait until it has stopped.
 func (s *systemd) Stop(serviceName string, timeout time.Duration) error {
-	if _, err := SystemctlCmd("stop", serviceName); err != nil {
+	if _, err := systemctlCmd("stop", serviceName); err != nil {
 		return err
 	}
 
@@ -260,7 +271,7 @@ loop:
 		case <-giveup.C:
 			break loop
 		case <-check.C:
-			bs, err := SystemctlCmd("show", "--property=ActiveState", serviceName)
+			bs, err := systemctlCmd("show", "--property=ActiveState", serviceName)
 			if err != nil {
 				return err
 			}
@@ -282,7 +293,7 @@ loop:
 
 // Kill all processes of the unit with the given signal
 func (s *systemd) Kill(serviceName, signal string) error {
-	_, err := SystemctlCmd("kill", serviceName, "-s", signal)
+	_, err := systemctlCmd("kill", serviceName, "-s", signal)
 	return err
 }
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -338,6 +338,12 @@ func (s *SystemdTestSuite) TestDisable(c *C) {
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "disable", "foo"}})
 }
 
+func (s *SystemdTestSuite) TestAvailable(c *C) {
+	err := Available()
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"--version"}})
+}
+
 func (s *SystemdTestSuite) TestEnable(c *C) {
 	err := New("xyzzy", s.rep).Enable("foo")
 	c.Assert(err, IsNil)

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -64,6 +64,8 @@ type SystemdTestSuite struct {
 	jfollows []bool
 
 	rep *testreporter
+
+	restore func()
 }
 
 var _ = Suite(&SystemdTestSuite{})
@@ -76,7 +78,7 @@ func (s *SystemdTestSuite) SetUpTest(c *C) {
 	// force UTC timezone, for reproducible timestamps
 	os.Setenv("TZ", "")
 
-	SystemctlCmd = s.myRun
+	s.restore = MockSystemctl(s.myRun)
 	s.i = 0
 	s.argses = nil
 	s.errors = nil
@@ -94,8 +96,8 @@ func (s *SystemdTestSuite) SetUpTest(c *C) {
 }
 
 func (s *SystemdTestSuite) TearDownTest(c *C) {
-	SystemctlCmd = SystemdRun
 	JournalctlCmd = Jctl
+	s.restore()
 }
 
 func (s *SystemdTestSuite) myRun(args ...string) (out []byte, err error) {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -38,8 +38,9 @@ import (
 )
 
 type servicesTestSuite struct {
-	tempdir    string
-	prevctlCmd func(...string) ([]byte, error)
+	tempdir string
+
+	restorer func()
 }
 
 var _ = Suite(&servicesTestSuite{})
@@ -48,23 +49,23 @@ func (s *servicesTestSuite) SetUpTest(c *C) {
 	s.tempdir = c.MkDir()
 	dirs.SetRootDir(s.tempdir)
 
-	s.prevctlCmd = systemd.SystemctlCmd
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	s.restorer = systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		return []byte("ActiveState=inactive\n"), nil
-	}
+	})
 }
 
 func (s *servicesTestSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("")
-	systemd.SystemctlCmd = s.prevctlCmd
+	s.restorer()
 }
 
 func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 	var sysdLog [][]string
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		sysdLog = append(sysdLog, cmd)
 		return []byte("ActiveState=inactive\n"), nil
-	}
+	})
+	defer r()
 
 	info := snaptest.MockSnap(c, packageHello, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
@@ -109,14 +110,15 @@ func (s *servicesTestSuite) TestRemoveSnapPackageFallbackToKill(c *C) {
 	defer restore()
 
 	var sysdLog [][]string
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		// filter out the "systemctl show" that
 		// StopServices generates
 		if cmd[0] != "show" {
 			sysdLog = append(sysdLog, cmd)
 		}
 		return []byte("ActiveState=active\n"), nil
-	}
+	})
+	defer r()
 
 	info := snaptest.MockSnap(c, `name: wat
 version: 42
@@ -147,10 +149,11 @@ apps:
 
 func (s *servicesTestSuite) TestStartServices(c *C) {
 	var sysdLog [][]string
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		sysdLog = append(sysdLog, cmd)
 		return []byte("ActiveState=inactive\n"), nil
-	}
+	})
+	defer r()
 
 	info := snaptest.MockSnap(c, packageHello, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
@@ -168,10 +171,11 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesFailCreateCleanup(c *C) {
 	svcFiles, _ := filepath.Glob(filepath.Join(dirs.SnapServicesDir, "snap.hello-snap.*.service"))
 	c.Check(svcFiles, HasLen, 0)
 
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		sysdLog = append(sysdLog, cmd)
 		return nil, nil
-	}
+	})
+	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
  svc2:
@@ -208,7 +212,7 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesFailEnableCleanup(c *C) {
 	svcFiles, _ := filepath.Glob(filepath.Join(dirs.SnapServicesDir, "snap.hello-snap.*.service"))
 	c.Check(svcFiles, HasLen, 0)
 
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		sysdLog = append(sysdLog, cmd)
 		sdcmd := cmd[0]
 		if len(cmd) >= 2 {
@@ -234,7 +238,8 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesFailEnableCleanup(c *C) {
 		default:
 			panic("unexpected systemctl command " + sdcmd)
 		}
-	}
+	})
+	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
  svc2:
@@ -267,7 +272,7 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesStartFailOnSystemdReloadClea
 	c.Check(svcFiles, HasLen, 0)
 
 	first := true
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		sysdLog = append(sysdLog, cmd)
 		if len(cmd) < 2 {
 			return nil, fmt.Errorf("failed")
@@ -281,7 +286,8 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesStartFailOnSystemdReloadClea
 		}
 		return nil, nil
 
-	}
+	})
+	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
  svc2:
@@ -311,7 +317,7 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
 	svc2Name := "snap.hello-snap.svc2.service"
 	numStarts := 0
 
-	systemd.SystemctlCmd = func(cmd ...string) ([]byte, error) {
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
 		sysdLog = append(sysdLog, cmd)
 		if len(cmd) >= 2 && cmd[len(cmd)-2] == "start" {
 			numStarts++
@@ -325,7 +331,8 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
 			}
 		}
 		return []byte("ActiveState=inactive\n"), nil
-	}
+	})
+	defer r()
 
 	info := snaptest.MockSnap(c, packageHello+`
  svc2:


### PR DESCRIPTION
This branch allows to MockSystemctl() in similar ways as we do for other snapd packages, i.e. to provide a restore helper.

A similar branch for systemd.JournalctlCmd() will follow if this one gets acceptance.