### PR TITLE
interfaces/network-{control,observe}: allow receiving kobject_uevent() messages for 2.27

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -244,6 +244,9 @@ socket AF_NETLINK - NETLINK_DNRTMSG
 socket AF_NETLINK - NETLINK_ISCSI
 socket AF_NETLINK - NETLINK_RDMA
 socket AF_NETLINK - NETLINK_GENERIC
+
+# for receiving kobject_uevent() net messages from the kernel
+socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
 func init() {

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -117,6 +117,9 @@ network inet6 raw,
 
 # network devices
 /sys/devices/**/net/** r,
+
+# for receiving kobject_uevent() net messages from the kernel
+network netlink raw,
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/network-observe
@@ -139,6 +142,9 @@ socket AF_NETLINK - NETLINK_ROUTE
 
 # multicast statistics
 socket AF_NETLINK - NETLINK_GENERIC
+
+# for receiving kobject_uevent() net messages from the kernel
+socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
 func init() {


### PR DESCRIPTION
Pull back https://github.com/snapcore/snapd/pull/3867 for 2.27.