### PR TITLE
tests: fix regex to check core version on snap list

### DIFF
--- a/tests/nested/extra-snaps-assertions/task.yaml
+++ b/tests/nested/extra-snaps-assertions/task.yaml
@@ -64,4 +64,4 @@ execute: |
     execute_remote "snap known model" | MATCH "series: 16"
 
     echo "Make sure core has an actual revision"
-    execute_remote "snap list" | MATCH "^core +[0-9]+\-[0-9.]+ +[0-9]+ +canonical +\-"
+    execute_remote "snap list" | MATCH "^core +[0-9]+\-[0-9.]+ +[0-9]+ +canonical +"


### PR DESCRIPTION
This is to fix the nested manual test which is failing because the core
has a note and it is expecting a -.
