### PR TITLE
interfaces: add udev netlink support to hardware-observe (2.27)

### DIFF
--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -56,6 +56,7 @@ capability sys_admin,
 
 # Needed for udevadm
 /run/udev/data/** r,
+network netlink raw,
 
 # util-linux
 /{,usr/}bin/lscpu ixr,
@@ -87,6 +88,10 @@ iopl
 
 # multicast statistics
 socket AF_NETLINK - NETLINK_GENERIC
+
+# kernel uevents
+socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
+bind
 `
 
 func init() {

--- a/interfaces/builtin/hardware_observe_test.go
+++ b/interfaces/builtin/hardware_observe_test.go
@@ -95,6 +95,7 @@ func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "capability sys_rawio,\n")
+	c.Assert(apparmorSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "network netlink raw,\n")
 
 	// connected plugs have a non-nil security snippet for seccomp
 	seccompSpec := &seccomp.Specification{}
@@ -102,6 +103,7 @@ func (s *HardwareObserveInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
 	c.Check(seccompSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "iopl\n")
+	c.Check(seccompSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "socket AF_NETLINK - NETLINK_KOBJECT_UEVENT\n")
 }
 
 func (s *HardwareObserveInterfaceSuite) TestInterfaces(c *C) {


### PR DESCRIPTION
With the addition of seccomp argument filtering the socket syscall
will not allow NETLINK_KOBJECT_UEVENT anymore. But this is crucial
for the hardware-observe interface to monitor udev. This patch
adds it back.
