### PR TITLE
tests: make TestCmdWatch more robust

### DIFF
--- a/cmd/snap/cmd_watch_test.go
+++ b/cmd/snap/cmd_watch_test.go
@@ -81,5 +81,5 @@ func (s *SnapSuite) TestCmdWatch(c *C) {
 
 	buf, err := ioutil.ReadFile(stdout.Name())
 	c.Assert(err, IsNil)
-	c.Check(string(buf), testutil.Contains, "\rmy-snap 50.00 KB / 100.00 KB")
+	c.Check(string(buf), testutil.Contains, "\rmy-snap 0 B / 100.00 KB")
 }


### PR DESCRIPTION
The test checks for progress data. However the progress data update
is timer dependent so the test is always racy. Instead of checking
if we see updated progress just check that the progress display
started.

This fixes the: 
```
FAIL: cmd_watch_test.go:44: SnapSuite.TestCmdWatch

cmd_watch_test.go:84:
    c.Check(string(buf), testutil.Contains, "\rmy-snap 50.00 KB / 100.00 KB")
... container string = "\rmy-snap 0 B / 100.00 KB    0.00%\r\x1b[K"
... elem string = "\rmy-snap 50.00 KB / 100.00 KB"
```
that we see frequently in unit tests.