### PR TITLE
osutil: adjust StreamCommand tests for golang 1.9

### DIFF
--- a/osutil/exec_test.go
+++ b/osutil/exec_test.go
@@ -207,8 +207,9 @@ func (s *execSuite) TestStreamCommandHappy(c *C) {
 
 	wrf, wrc := osutil.WaitingReaderGuts(stdout)
 	c.Assert(wrf, FitsTypeOf, &os.File{})
-	c.Check(wrf.(*os.File).Close(), Equals, syscall.EINVAL) // i.e. already closed
-	c.Check(wrc.ProcessState, NotNil)                       // i.e. already waited for
+	// Depending on golang version the error is one of the two.
+	c.Check(wrf.(*os.File).Close(), ErrorMatches, "invalid argument|file already closed")
+	c.Check(wrc.ProcessState, NotNil) // i.e. already waited for
 }
 
 func (s *execSuite) TestStreamCommandSad(c *C) {
@@ -221,6 +222,7 @@ func (s *execSuite) TestStreamCommandSad(c *C) {
 
 	wrf, wrc := osutil.WaitingReaderGuts(stdout)
 	c.Assert(wrf, FitsTypeOf, &os.File{})
-	c.Check(wrf.(*os.File).Close(), Equals, syscall.EINVAL) // i.e. already closed
-	c.Check(wrc.ProcessState, NotNil)                       // i.e. already waited for
+	// Depending on golang version the error is one of the two.
+	c.Check(wrf.(*os.File).Close(), ErrorMatches, "invalid argument|file already closed")
+	c.Check(wrc.ProcessState, NotNil) // i.e. already waited for
 }

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -214,7 +214,8 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancelError(c *C) {
 	aw, err := osutil.NewAtomicFile(p, 0644, 0, -1, -1)
 	c.Assert(err, IsNil)
 	c.Assert(osutil.GetAtomicFile(aw).Close(), IsNil)
-	c.Check(aw.Cancel(), ErrorMatches, "invalid argument")
+	// Depending on golang version the error is one of the two.
+	c.Check(aw.Cancel(), ErrorMatches, "invalid argument|file already closed")
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancelBadError(c *C) {


### PR DESCRIPTION
In golang 1.9 there are richer error constructs returned from certain
operations and tests were very precisely monitoring the result. This
patch adjust tests to work on both golang 1.9 and earlier.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
