### PR TITLE
interfaces: mount host system fonts in desktop interface

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -242,6 +242,10 @@
     audit deny mount /** -> /snap/bin/**,
     # Allow the content interface to bind fonts from the host filesystem
     mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
+    # Allow the desktop interface to bind fonts from the host filesystem
+    mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts -> /usr/share/fonts,
+    mount options=(ro bind) /var/lib/snapd/hostfs/usr/local/share/fonts -> /usr/local/share/fonts,
+    mount options=(ro bind) /var/lib/snapd/hostfs/var/cache/fontconfig -> /var/cache/fontconfig,
 
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -87,6 +87,10 @@ var (
 	CompletionHelper string
 	CompletersDir    string
 	CompleteSh       string
+
+	SystemFontsDir           string
+	SystemLocalFontsDir      string
+	SystemFontconfigCacheDir string
 )
 
 const (
@@ -224,4 +228,8 @@ func SetRootDir(rootdir string) {
 	CompletionHelper = filepath.Join(CoreLibExecDir, "etelpmoc.sh")
 	CompletersDir = filepath.Join(rootdir, "/usr/share/bash-completion/completions/")
 	CompleteSh = filepath.Join(SnapMountDir, "core/current/usr/lib/snapd/complete.sh")
+
+	SystemFontsDir = filepath.Join(rootdir, "/usr/share/fonts")
+	SystemLocalFontsDir = filepath.Join(rootdir, "/usr/local/share/fonts")
+	SystemFontconfigCacheDir = filepath.Join(rootdir, "/var/cache/fontconfig")
 }

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -150,6 +150,7 @@ func (iface *desktopInterface) SanitizeSlot(slot *interfaces.Slot) error {
 }
 
 func (iface *desktopInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+	// allow what declarations allowed
 	return true
 }
 

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/mount"
@@ -125,12 +126,6 @@ dbus (send)
 deny /{dev,run,var/run}/shm/lttng-ust-* rw,
 `
 
-var desktopFontconfigDirs = []string{
-	"/usr/share/fonts",
-	"/usr/local/share/fonts",
-	"/var/cache/fontconfig",
-}
-
 type desktopInterface struct{}
 
 func (iface *desktopInterface) Name() string {
@@ -165,13 +160,19 @@ func (iface *desktopInterface) MountConnectedPlug(spec *mount.Specification, plu
 		return nil
 	}
 
-	for _, dir := range desktopFontconfigDirs {
+	fontconfigDirs := []string{
+		dirs.SystemFontsDir,
+		dirs.SystemLocalFontsDir,
+		dirs.SystemFontconfigCacheDir,
+	}
+
+	for _, dir := range fontconfigDirs {
 		if !osutil.IsDirectory(dir) {
 			continue
 		}
 		spec.AddMountEntry(mount.Entry{
 			Name:    "/var/lib/snapd/hostfs" + dir,
-			Dir:     dir,
+			Dir:     dirs.StripRootDir(dir),
 			Options: []string{"bind", "ro"},
 		})
 	}

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -127,15 +127,15 @@ func (s *DesktopInterfaceSuite) TestMountSpec(c *C) {
 	c.Assert(entries, HasLen, 3)
 
 	const hostfs = "/var/lib/snapd/hostfs"
-	c.Check(entries[0].Name, Equals, hostfs + dirs.SystemFontsDir)
+	c.Check(entries[0].Name, Equals, hostfs+dirs.SystemFontsDir)
 	c.Check(entries[0].Dir, Equals, "/usr/share/fonts")
 	c.Check(entries[0].Options, DeepEquals, []string{"bind", "ro"})
 
-	c.Check(entries[1].Name, Equals, hostfs + dirs.SystemLocalFontsDir)
+	c.Check(entries[1].Name, Equals, hostfs+dirs.SystemLocalFontsDir)
 	c.Check(entries[1].Dir, Equals, "/usr/local/share/fonts")
 	c.Check(entries[1].Options, DeepEquals, []string{"bind", "ro"})
 
-	c.Check(entries[2].Name, Equals, hostfs + dirs.SystemFontconfigCacheDir)
+	c.Check(entries[2].Name, Equals, hostfs+dirs.SystemFontconfigCacheDir)
 	c.Check(entries[2].Dir, Equals, "/var/cache/fontconfig")
 	c.Check(entries[2].Options, DeepEquals, []string{"bind", "ro"})
 }

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -105,7 +105,8 @@ func (s *DesktopInterfaceSuite) TestMountSpec(c *C) {
 
 	// On classic systems, a number of font related directories
 	// are bind mounted from the host system if they exist.
-	release.OnClassic = true
+	restore = release.MockOnClassic(true)
+	defer restore()
 	spec = &mount.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.coreSlot, nil), IsNil)
 	expectedMountPoints := []string{


### PR DESCRIPTION
On classic systems, bind mount the host system fonts and fontconfig cache into the sandbox for snaps using the `desktop` interface.  This is based on discussions on the forum here:

https://forum.snapcraft.io/t/desktop-allow-access-to-host-system-fonts/1796

The changes in this PR depend on certain directories existing in the core snap to be used as mount points.  At present this is only available in the edge channel, which can be installed with:

    snap refresh --channel=edge core

Here is a basic manual test plan:

1. Install [fontconfig_0.1_amd64.snap](http://people.canonical.com/~jamesh/fontconfig_0.1_amd64.snap) using vanilla snapd.  This snap contains the fontconfig command line utilities.

2. Run `fontconfig.fc-list` and note that no fonts are visible.

3. Switch to snapd from this PR.

4. Reconnect the `desktop` interface to make sure we've got the new rules:

        snap disconnect fontconfig:desktop
        snap connect fontconfig:desktop

5. Run `fontconfig.fc-list` and note that it lists all the host system fonts.

6. Run `snap run --shell fontconfig.fc-list` to open a shell within the sandbox to verify that fonts are visible under `/usr/share/fonts`.

7. Run

        rm -rf ~/snap/fontconfig/current/.cache/fontconfig
        fontconfig.fc-cache -s -v

    This checks the validity of the caches for all system font dirs, and updates any invalid ones.  You should see many "skipping, existing cache is valid" messages for the directories containing fonts.

8. Check that no new caches were written to the `~/snap/fontconfig/current/.cache/fontconfig` directory.