### PR TITLE
many: introduce asserts.NotFoundError replacing both ErrNotFound and store.AssertionNotFoundError

### DIFF
--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -102,7 +102,7 @@ func (ak *AccountKey) checkConsistency(db RODatabase, acck *AccountKey) error {
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": ak.AccountID(),
 	})
-	if err == ErrNotFound {
+	if IsNotFound(err) {
 		return fmt.Errorf("account-key assertion for %q does not have a matching account assertion", ak.AccountID())
 	}
 	if err != nil {
@@ -119,7 +119,7 @@ func (ak *AccountKey) checkConsistency(db RODatabase, acck *AccountKey) error {
 			"account-id": ak.AccountID(),
 			"name":       ak.Name(),
 		})
-		if err != nil && err != ErrNotFound {
+		if err != nil && !IsNotFound(err) {
 			return err
 		}
 		for _, assertion := range assertions {
@@ -227,7 +227,7 @@ func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) 
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": akr.AccountID(),
 	})
-	if err == ErrNotFound {
+	if IsNotFound(err) {
 		return fmt.Errorf("account-key-request assertion for %q does not have a matching account assertion", akr.AccountID())
 	}
 	if err != nil {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -153,7 +153,7 @@ func SuggestFormat(assertType *AssertionType, headers map[string]interface{}, bo
 	return formatnum, nil
 }
 
-// HeadersFromPrimaryKey construct a headers mapping from the
+// HeadersFromPrimaryKey constructs a headers mapping from the
 // primaryKey values and the assertion type, it errors if primaryKey
 // has the wrong length.
 func HeadersFromPrimaryKey(assertType *AssertionType, primaryKey []string) (headers map[string]string, err error) {

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -191,7 +191,9 @@ func (ref *Ref) Resolve(find func(assertType *AssertionType, headers map[string]
 	return find(ref.Type, headers)
 }
 
-// primaryKeyFromHeaders extracts the tuple of values from headers corresponding to the primary key, it errors if there are missing headers.
+// primaryKeyFromHeaders extracts the tuple of values from headers
+// corresponding to the primary key, it errors if there are missing
+// headers.
 func primaryKeyFromHeaders(assertType *AssertionType, headers map[string]string) (primaryKey []string, err error) {
 	primaryKey = make([]string, len(assertType.PrimaryKey))
 	for i, k := range assertType.PrimaryKey {
@@ -204,7 +206,9 @@ func primaryKeyFromHeaders(assertType *AssertionType, headers map[string]string)
 	return primaryKey, nil
 }
 
-// headersFromPrimaryKey construct an headers mapping from the primaryKey values for an assertion type, it errors if primaryKey has the wrong length.
+// headersFromPrimaryKey construct an headers mapping from the
+// primaryKey values for an assertion type, it errors if primaryKey
+// has the wrong length.
 func headersFromPrimaryKey(assertType *AssertionType, primaryKey []string) (headers map[string]string, err error) {
 	if len(primaryKey) != len(assertType.PrimaryKey) {
 		return nil, fmt.Errorf("primary key has wrong length for %q assertion", assertType.Name)

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -153,6 +153,35 @@ func SuggestFormat(assertType *AssertionType, headers map[string]interface{}, bo
 	return formatnum, nil
 }
 
+// HeadersFromPrimaryKey construct a headers mapping from the
+// primaryKey values and the assertion type, it errors if primaryKey
+// has the wrong length.
+func HeadersFromPrimaryKey(assertType *AssertionType, primaryKey []string) (headers map[string]string, err error) {
+	if len(primaryKey) != len(assertType.PrimaryKey) {
+		return nil, fmt.Errorf("primary key has wrong length for %q assertion", assertType.Name)
+	}
+	headers = make(map[string]string, len(assertType.PrimaryKey))
+	for i, name := range assertType.PrimaryKey {
+		headers[name] = primaryKey[i]
+	}
+	return headers, nil
+}
+
+// PrimaryKeyFromHeaders extracts the tuple of values from headers
+// corresponding to a primary key under the assertion type, it errors
+// if there are missing primary key headers.
+func PrimaryKeyFromHeaders(assertType *AssertionType, headers map[string]string) (primaryKey []string, err error) {
+	primaryKey = make([]string, len(assertType.PrimaryKey))
+	for i, k := range assertType.PrimaryKey {
+		keyVal := headers[k]
+		if keyVal == "" {
+			return nil, fmt.Errorf("must provide primary key: %v", k)
+		}
+		primaryKey[i] = keyVal
+	}
+	return primaryKey, nil
+}
+
 // Ref expresses a reference to an assertion.
 type Ref struct {
 	Type       *AssertionType
@@ -184,40 +213,11 @@ func (ref *Ref) Unique() string {
 
 // Resolve resolves the reference using the given find function.
 func (ref *Ref) Resolve(find func(assertType *AssertionType, headers map[string]string) (Assertion, error)) (Assertion, error) {
-	headers, err := headersFromPrimaryKey(ref.Type, ref.PrimaryKey)
+	headers, err := HeadersFromPrimaryKey(ref.Type, ref.PrimaryKey)
 	if err != nil {
 		return nil, fmt.Errorf("%q assertion reference primary key has the wrong length (expected %v): %v", ref.Type.Name, ref.Type.PrimaryKey, ref.PrimaryKey)
 	}
 	return find(ref.Type, headers)
-}
-
-// primaryKeyFromHeaders extracts the tuple of values from headers
-// corresponding to the primary key, it errors if there are missing
-// headers.
-func primaryKeyFromHeaders(assertType *AssertionType, headers map[string]string) (primaryKey []string, err error) {
-	primaryKey = make([]string, len(assertType.PrimaryKey))
-	for i, k := range assertType.PrimaryKey {
-		keyVal := headers[k]
-		if keyVal == "" {
-			return nil, fmt.Errorf("must provide primary key: %v", k)
-		}
-		primaryKey[i] = keyVal
-	}
-	return primaryKey, nil
-}
-
-// headersFromPrimaryKey construct an headers mapping from the
-// primaryKey values for an assertion type, it errors if primaryKey
-// has the wrong length.
-func headersFromPrimaryKey(assertType *AssertionType, primaryKey []string) (headers map[string]string, err error) {
-	if len(primaryKey) != len(assertType.PrimaryKey) {
-		return nil, fmt.Errorf("primary key has wrong length for %q assertion", assertType.Name)
-	}
-	headers = make(map[string]string, len(assertType.PrimaryKey))
-	for i, name := range assertType.PrimaryKey {
-		headers[name] = primaryKey[i]
-	}
-	return headers, nil
 }
 
 // Assertion represents an assertion through its general elements.

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -77,6 +77,37 @@ func (as *assertsSuite) TestSuggestFormat(c *C) {
 	c.Check(fmtnum, Equals, 0)
 }
 
+func (as *assertsSuite) TestPrimaryKeyHelpers(c *C) {
+	headers, err := asserts.HeadersFromPrimaryKey(asserts.TestOnlyType, []string{"one"})
+	c.Assert(err, IsNil)
+	c.Check(headers, DeepEquals, map[string]string{
+		"primary-key": "one",
+	})
+
+	headers, err = asserts.HeadersFromPrimaryKey(asserts.TestOnly2Type, []string{"bar", "baz"})
+	c.Assert(err, IsNil)
+	c.Check(headers, DeepEquals, map[string]string{
+		"pk1": "bar",
+		"pk2": "baz",
+	})
+
+	_, err = asserts.HeadersFromPrimaryKey(asserts.TestOnly2Type, []string{"bar"})
+	c.Check(err, ErrorMatches, `primary key has wrong length for "test-only-2" assertion`)
+
+	pk, err := asserts.PrimaryKeyFromHeaders(asserts.TestOnly2Type, headers)
+	c.Assert(err, IsNil)
+	c.Check(pk, DeepEquals, []string{"bar", "baz"})
+
+	headers["other"] = "foo"
+	pk1, err := asserts.PrimaryKeyFromHeaders(asserts.TestOnly2Type, headers)
+	c.Assert(err, IsNil)
+	c.Check(pk1, DeepEquals, pk)
+
+	delete(headers, "pk2")
+	_, err = asserts.PrimaryKeyFromHeaders(asserts.TestOnly2Type, headers)
+	c.Check(err, ErrorMatches, `must provide primary key: pk2`)
+}
+
 func (as *assertsSuite) TestRef(c *C) {
 	ref := &asserts.Ref{
 		Type:       asserts.TestOnly2Type,

--- a/asserts/assertstest/assertstest.go
+++ b/asserts/assertstest/assertstest.go
@@ -415,7 +415,7 @@ func (ss *StoreStack) StoreAccountKey(keyID string) *asserts.AccountKey {
 		"account-id":          ss.AuthorityID,
 		"public-key-sha3-384": keyID,
 	})
-	if err == asserts.ErrNotFound {
+	if asserts.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -46,7 +46,7 @@ func (e *NotFoundError) Error() string {
 	pk, err := primaryKeyFromHeaders(e.Type, e.Headers)
 	if err != nil || len(e.Headers) != len(pk) {
 		// TODO: worth conveying more information?
-		return fmt.Sprintf("%s(s) not found", e.Type.Name)
+		return fmt.Sprintf("%s assertion not found", e.Type.Name)
 	}
 
 	return fmt.Sprintf("%v not found", &Ref{Type: e.Type, PrimaryKey: pk})

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -22,11 +22,33 @@
 package asserts
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"time"
 )
+
+// NotFoundError is returned when an assertion can not be found.
+type NotFoundError struct {
+	Type       *AssertionType
+	PrimaryKey []string
+}
+
+func (e *NotFoundError) ref() *Ref {
+	return &Ref{Type: e.Type, PrimaryKey: e.PrimaryKey}
+}
+
+func (e *NotFoundError) Error() string {
+	if len(e.PrimaryKey) == 0 {
+		return fmt.Sprintf("%s(s) not found", e.Type.Name)
+	}
+	return fmt.Sprintf("%v not found", e.ref())
+}
+
+// IsNotFound returns whether err is an assertion not found error.
+func IsNotFound(err error) bool {
+	_, ok := err.(*NotFoundError)
+	return ok
+}
 
 // A Backstore stores assertions. It can store and retrieve assertions
 // by type under unique primary key headers (whose names are available
@@ -38,7 +60,7 @@ type Backstore interface {
 	// previously stored revision with the same primary key headers.
 	Put(assertType *AssertionType, assert Assertion) error
 	// Get returns the assertion with the given unique key for its primary key headers.
-	// If none is present it returns ErrNotFound.
+	// If none is present it returns a NotFoundError.
 	Get(assertType *AssertionType, key []string, maxFormat int) (Assertion, error)
 	// Search returns assertions matching the given headers.
 	// It invokes foundCb for each found assertion.
@@ -52,7 +74,7 @@ func (nbs nullBackstore) Put(t *AssertionType, a Assertion) error {
 }
 
 func (nbs nullBackstore) Get(t *AssertionType, k []string, maxFormat int) (Assertion, error) {
-	return nil, ErrNotFound
+	return nil, &NotFoundError{Type: t, PrimaryKey: k}
 }
 
 func (nbs nullBackstore) Search(t *AssertionType, h map[string]string, f func(Assertion), maxFormat int) error {
@@ -84,11 +106,6 @@ type DatabaseConfig struct {
 	// assertion checkers used by Database.Check, left unset DefaultCheckers will be used which is recommended
 	Checkers []Checker
 }
-
-// Well-known errors
-var (
-	ErrNotFound = errors.New("assertion not found")
-)
 
 // RevisionError indicates a revision improperly used for an operation.
 type RevisionError struct {
@@ -144,25 +161,25 @@ type RODatabase interface {
 	IsTrustedAccount(accountID string) bool
 	// Find an assertion based on arbitrary headers.
 	// Provided headers must contain the primary key for the assertion type.
-	// It returns ErrNotFound if the assertion cannot be found.
+	// It returns a NotFoundError if the assertion cannot be found.
 	Find(assertionType *AssertionType, headers map[string]string) (Assertion, error)
 	// FindPredefined finds an assertion in the predefined sets
 	// (trusted or not) based on arbitrary headers.  Provided
 	// headers must contain the primary key for the assertion
-	// type.  It returns ErrNotFound if the assertion cannot be
-	// found.
+	// type.  It returns a NotFoundError if the assertion cannot
+	// be found.
 	FindPredefined(assertionType *AssertionType, headers map[string]string) (Assertion, error)
 	// FindTrusted finds an assertion in the trusted set based on
 	// arbitrary headers.  Provided headers must contain the
-	// primary key for the assertion type.  It returns ErrNotFound
-	// if the assertion cannot be found.
+	// primary key for the assertion type.  It returns a
+	// NotFoundError if the assertion cannot be found.
 	FindTrusted(assertionType *AssertionType, headers map[string]string) (Assertion, error)
 	// FindMany finds assertions based on arbitrary headers.
-	// It returns ErrNotFound if no assertion can be found.
+	// It returns a NotFoundError if no assertion can be found.
 	FindMany(assertionType *AssertionType, headers map[string]string) ([]Assertion, error)
 	// FindManyPredefined finds assertions in the predefined sets
-	// (trusted or not) based on arbitrary headers.  It returns
-	// ErrNotFound if no assertion can be found.
+	// (trusted or not) based on arbitrary headers.  It returns a
+	// NotFoundError if no assertion can be found.
 	FindManyPredefined(assertionType *AssertionType, headers map[string]string) ([]Assertion, error)
 	// Check tests whether the assertion is properly signed and consistent with all the stored knowledge.
 	Check(assert Assertion) error
@@ -299,11 +316,11 @@ func (db *Database) findAccountKey(authorityID, keyID string) (*AccountKey, erro
 			}
 			return hit, nil
 		}
-		if err != ErrNotFound {
+		if !IsNotFound(err) {
 			return nil, err
 		}
 	}
-	return nil, ErrNotFound
+	return nil, &NotFoundError{Type: AccountKeyType, PrimaryKey: key}
 }
 
 // IsTrustedAccount returns whether the account is part of the trusted set.
@@ -329,7 +346,7 @@ func (db *Database) Check(assert Assertion) error {
 	if typ.flags&noAuthority == 0 {
 		// TODO: later may need to consider type of assert to find candidate keys
 		accKey, err = db.findAccountKey(assert.AuthorityID(), assert.SignKeyID())
-		if err == ErrNotFound {
+		if IsNotFound(err) {
 			return fmt.Errorf("no matching public key %q for signature by %q", assert.SignKeyID(), assert.AuthorityID())
 		}
 		if err != nil {
@@ -364,7 +381,7 @@ func (db *Database) Add(assert Assertion) error {
 	if err != nil {
 		if ufe, ok := err.(*UnsupportedFormatError); ok {
 			_, err := ref.Resolve(db.Find)
-			if err != nil && err != ErrNotFound {
+			if err != nil && !IsNotFound(err) {
 				return err
 			}
 			return &UnsupportedFormatError{Ref: ufe.Ref, Format: ufe.Format, Update: err == nil}
@@ -382,12 +399,12 @@ func (db *Database) Add(assert Assertion) error {
 	// through the os snap this seems the safest policy until we
 	// know more/better
 	_, err = db.trusted.Get(ref.Type, ref.PrimaryKey, ref.Type.MaxSupportedFormat())
-	if err != ErrNotFound {
+	if !IsNotFound(err) {
 		return fmt.Errorf("cannot add %q assertion with primary key clashing with a trusted assertion: %v", ref.Type.Name, ref.PrimaryKey)
 	}
 
 	_, err = db.predefined.Get(ref.Type, ref.PrimaryKey, ref.Type.MaxSupportedFormat())
-	if err != ErrNotFound {
+	if !IsNotFound(err) {
 		return fmt.Errorf("cannot add %q assertion with primary key clashing with a predefined assertion: %v", ref.Type.Name, ref.PrimaryKey)
 	}
 
@@ -433,13 +450,17 @@ func find(backstores []Backstore, assertionType *AssertionType, headers map[stri
 			assert = a
 			break
 		}
-		if err != ErrNotFound {
+		if !IsNotFound(err) {
 			return nil, err
 		}
 	}
 
 	if assert == nil || !searchMatch(assert, headers) {
-		return nil, ErrNotFound
+		notFound := &NotFoundError{Type: assertionType}
+		if len(headers) == len(assertionType.PrimaryKey) {
+			notFound.PrimaryKey = keyValues
+		}
+		return nil, notFound
 	}
 
 	return assert, nil
@@ -447,29 +468,29 @@ func find(backstores []Backstore, assertionType *AssertionType, headers map[stri
 
 // Find an assertion based on arbitrary headers.
 // Provided headers must contain the primary key for the assertion type.
-// It returns ErrNotFound if the assertion cannot be found.
+// It returns a NotFoundError if the assertion cannot be found.
 func (db *Database) Find(assertionType *AssertionType, headers map[string]string) (Assertion, error) {
 	return find(db.backstores, assertionType, headers, -1)
 }
 
 // FindMaxFormat finds an assertion like Find but such that its
 // format is <= maxFormat by passing maxFormat along to the backend.
-// It returns ErrNotFound if such an assertion cannot be found.
+// It returns a NotFoundError if such an assertion cannot be found.
 func (db *Database) FindMaxFormat(assertionType *AssertionType, headers map[string]string, maxFormat int) (Assertion, error) {
 	return find(db.backstores, assertionType, headers, maxFormat)
 }
 
 // FindPredefined finds an assertion in the predefined sets (trusted
 // or not) based on arbitrary headers.  Provided headers must contain
-// the primary key for the assertion type.  It returns ErrNotFound if
-// the assertion cannot be found.
+// the primary key for the assertion type.  It returns a NotFoundError
+// if the assertion cannot be found.
 func (db *Database) FindPredefined(assertionType *AssertionType, headers map[string]string) (Assertion, error) {
 	return find([]Backstore{db.trusted, db.predefined}, assertionType, headers, -1)
 }
 
 // FindTrusted finds an assertion in the trusted set based on arbitrary headers.
 // Provided headers must contain the primary key for the assertion type.
-// It returns ErrNotFound if the assertion cannot be found.
+// It returns a NotFoundError if the assertion cannot be found.
 func (db *Database) FindTrusted(assertionType *AssertionType, headers map[string]string) (Assertion, error) {
 	return find([]Backstore{db.trusted}, assertionType, headers, -1)
 }
@@ -495,20 +516,20 @@ func (db *Database) findMany(backstores []Backstore, assertionType *AssertionTyp
 	}
 
 	if len(res) == 0 {
-		return nil, ErrNotFound
+		return nil, &NotFoundError{Type: assertionType}
 	}
 	return res, nil
 }
 
 // FindMany finds assertions based on arbitrary headers.
-// It returns ErrNotFound if no assertion can be found.
+// It returns a NotFoundError if no assertion can be found.
 func (db *Database) FindMany(assertionType *AssertionType, headers map[string]string) ([]Assertion, error) {
 	return db.findMany(db.backstores, assertionType, headers)
 }
 
 // FindManyPrefined finds assertions in the predefined sets (trusted
-// or not) based on arbitrary headers.  It returns ErrNotFound if no
-// assertion can be found.
+// or not) based on arbitrary headers.  It returns a NotFoundError if
+// no assertion can be found.
 func (db *Database) FindManyPredefined(assertionType *AssertionType, headers map[string]string) ([]Assertion, error) {
 	return db.findMany([]Backstore{db.trusted, db.predefined}, assertionType, headers)
 }

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -651,7 +651,7 @@ func (safs *signAddFindSuite) TestNotFoundError(c *C) {
 		Type: asserts.SnapRevisionType,
 	}
 	c.Check(asserts.IsNotFound(err1), Equals, true)
-	c.Check(err2.Error(), Equals, "snap-revision(s) not found")
+	c.Check(err2.Error(), Equals, "snap-revision assertion not found")
 
 	err3 := asserts.NewNotFoundErrorPrimaryKey(asserts.SnapDeclarationType, []string{"16", "snap-id"})
 	c.Check(asserts.IsNotFound(err3), Equals, true)

--- a/asserts/database_test.go
+++ b/asserts/database_test.go
@@ -652,10 +652,6 @@ func (safs *signAddFindSuite) TestNotFoundError(c *C) {
 	}
 	c.Check(asserts.IsNotFound(err1), Equals, true)
 	c.Check(err2.Error(), Equals, "snap-revision assertion not found")
-
-	err3 := asserts.NewNotFoundErrorPrimaryKey(asserts.SnapDeclarationType, []string{"16", "snap-id"})
-	c.Check(asserts.IsNotFound(err3), Equals, true)
-	c.Check(err3.Error(), Equals, "snap-declaration (snap-id; series:16) not found")
 }
 
 func (safs *signAddFindSuite) TestFindNotFound(c *C) {

--- a/asserts/fetcher.go
+++ b/asserts/fetcher.go
@@ -66,7 +66,7 @@ func (f *fetcher) chase(ref *Ref, a Assertion) error {
 	if err == nil {
 		return nil
 	}
-	if err != ErrNotFound {
+	if !IsNotFound(err) {
 		return err
 	}
 	u := ref.Unique()

--- a/asserts/fsbackstore.go
+++ b/asserts/fsbackstore.go
@@ -174,7 +174,7 @@ func (fsbs *filesystemBackstore) Get(assertType *AssertionType, key []string, ma
 
 	a, err := fsbs.currentAssertion(assertType, key, maxFormat)
 	if err == errNotFound {
-		return nil, NewNotFoundErrorPrimaryKey(assertType, key)
+		return nil, &NotFoundError{Type: assertType}
 	}
 	return a, err
 }

--- a/asserts/fsbackstore.go
+++ b/asserts/fsbackstore.go
@@ -55,7 +55,7 @@ func OpenFSBackstore(path string) (Backstore, error) {
 func (fsbs *filesystemBackstore) readAssertion(assertType *AssertionType, diskPrimaryPath string) (Assertion, error) {
 	encoded, err := readEntry(fsbs.top, assertType.Name, diskPrimaryPath)
 	if os.IsNotExist(err) {
-		return nil, ErrNotFound
+		return nil, errNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("broken assertion storage, cannot read assertion: %v", err)
@@ -94,7 +94,7 @@ func (fsbs *filesystemBackstore) pickLatestAssertion(assertType *AssertionType, 
 		}
 	}
 	if a == nil {
-		return nil, ErrNotFound
+		return nil, errNotFound
 	}
 	return a, nil
 }
@@ -115,7 +115,7 @@ func (fsbs *filesystemBackstore) currentAssertion(assertType *AssertionType, pri
 	namesCb := func(relpaths []string) error {
 		var err error
 		a, err = fsbs.pickLatestAssertion(assertType, relpaths, maxFormat)
-		if err == ErrNotFound {
+		if err == errNotFound {
 			return nil
 		}
 		return err
@@ -129,7 +129,7 @@ func (fsbs *filesystemBackstore) currentAssertion(assertType *AssertionType, pri
 	}
 
 	if a == nil {
-		return nil, ErrNotFound
+		return nil, errNotFound
 	}
 
 	return a, nil
@@ -151,7 +151,7 @@ func (fsbs *filesystemBackstore) Put(assertType *AssertionType, assert Assertion
 		if curRev >= rev {
 			return &RevisionError{Current: curRev, Used: rev}
 		}
-	} else if err != ErrNotFound {
+	} else if err != errNotFound {
 		return err
 	}
 
@@ -172,14 +172,18 @@ func (fsbs *filesystemBackstore) Get(assertType *AssertionType, key []string, ma
 	fsbs.mu.RLock()
 	defer fsbs.mu.RUnlock()
 
-	return fsbs.currentAssertion(assertType, key, maxFormat)
+	a, err := fsbs.currentAssertion(assertType, key, maxFormat)
+	if err == errNotFound {
+		return nil, &NotFoundError{Type: assertType, PrimaryKey: key}
+	}
+	return a, err
 }
 
 func (fsbs *filesystemBackstore) search(assertType *AssertionType, diskPattern []string, foundCb func(Assertion), maxFormat int) error {
 	assertTypeTop := filepath.Join(fsbs.top, assertType.Name)
 	candCb := func(diskPrimaryPaths []string) error {
 		a, err := fsbs.pickLatestAssertion(assertType, diskPrimaryPaths, maxFormat)
-		if err == ErrNotFound {
+		if err == errNotFound {
 			return nil
 		}
 		if err != nil {

--- a/asserts/fsbackstore.go
+++ b/asserts/fsbackstore.go
@@ -139,10 +139,7 @@ func (fsbs *filesystemBackstore) Put(assertType *AssertionType, assert Assertion
 	fsbs.mu.Lock()
 	defer fsbs.mu.Unlock()
 
-	primaryPath := make([]string, len(assertType.PrimaryKey))
-	for i, k := range assertType.PrimaryKey {
-		primaryPath[i] = assert.HeaderString(k)
-	}
+	primaryPath := assert.Ref().PrimaryKey
 
 	curAssert, err := fsbs.currentAssertion(assertType, primaryPath, assertType.MaxSupportedFormat())
 	if err == nil {

--- a/asserts/fsbackstore.go
+++ b/asserts/fsbackstore.go
@@ -174,7 +174,7 @@ func (fsbs *filesystemBackstore) Get(assertType *AssertionType, key []string, ma
 
 	a, err := fsbs.currentAssertion(assertType, key, maxFormat)
 	if err == errNotFound {
-		return nil, &NotFoundError{Type: assertType, PrimaryKey: key}
+		return nil, NewNotFoundErrorPrimaryKey(assertType, key)
 	}
 	return a, err
 }

--- a/asserts/fsbackstore_test.go
+++ b/asserts/fsbackstore_test.go
@@ -150,13 +150,13 @@ func (fsbss *fsBackstoreSuite) TestGetFormat(c *C) {
 	c.Check(a.Revision(), Equals, 0)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 0)
-	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Assert(err, FitsTypeOf, &asserts.NotFoundError{})
 
 	err = bs.Put(asserts.TestOnlyType, af2)
 	c.Assert(err, IsNil)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 1)
-	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Assert(err, FitsTypeOf, &asserts.NotFoundError{})
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 2)
 	c.Assert(err, IsNil)

--- a/asserts/fsbackstore_test.go
+++ b/asserts/fsbackstore_test.go
@@ -151,8 +151,10 @@ func (fsbss *fsBackstoreSuite) TestGetFormat(c *C) {
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 0)
 	c.Assert(err, DeepEquals, &asserts.NotFoundError{
-		Type:       asserts.TestOnlyType,
-		PrimaryKey: []string{"zoo"},
+		Type: asserts.TestOnlyType,
+		Headers: map[string]string{
+			"primary-key": "zoo",
+		},
 	})
 	c.Check(a, IsNil)
 
@@ -161,8 +163,10 @@ func (fsbss *fsBackstoreSuite) TestGetFormat(c *C) {
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 1)
 	c.Assert(err, DeepEquals, &asserts.NotFoundError{
-		Type:       asserts.TestOnlyType,
-		PrimaryKey: []string{"zoo"},
+		Type: asserts.TestOnlyType,
+		Headers: map[string]string{
+			"primary-key": "zoo",
+		},
 	})
 	c.Check(a, IsNil)
 

--- a/asserts/fsbackstore_test.go
+++ b/asserts/fsbackstore_test.go
@@ -150,13 +150,21 @@ func (fsbss *fsBackstoreSuite) TestGetFormat(c *C) {
 	c.Check(a.Revision(), Equals, 0)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 0)
-	c.Assert(err, FitsTypeOf, &asserts.NotFoundError{})
+	c.Assert(err, DeepEquals, &asserts.NotFoundError{
+		Type:       asserts.TestOnlyType,
+		PrimaryKey: []string{"zoo"},
+	})
+	c.Check(a, IsNil)
 
 	err = bs.Put(asserts.TestOnlyType, af2)
 	c.Assert(err, IsNil)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 1)
-	c.Assert(err, FitsTypeOf, &asserts.NotFoundError{})
+	c.Assert(err, DeepEquals, &asserts.NotFoundError{
+		Type:       asserts.TestOnlyType,
+		PrimaryKey: []string{"zoo"},
+	})
+	c.Check(a, IsNil)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 2)
 	c.Assert(err, IsNil)

--- a/asserts/fsbackstore_test.go
+++ b/asserts/fsbackstore_test.go
@@ -152,9 +152,7 @@ func (fsbss *fsBackstoreSuite) TestGetFormat(c *C) {
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 0)
 	c.Assert(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlyType,
-		Headers: map[string]string{
-			"primary-key": "zoo",
-		},
+		// Headers can be omitted by Backstores
 	})
 	c.Check(a, IsNil)
 
@@ -164,9 +162,6 @@ func (fsbss *fsBackstoreSuite) TestGetFormat(c *C) {
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 1)
 	c.Assert(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlyType,
-		Headers: map[string]string{
-			"primary-key": "zoo",
-		},
 	})
 	c.Check(a, IsNil)
 

--- a/asserts/membackstore.go
+++ b/asserts/membackstore.go
@@ -167,7 +167,7 @@ func (mbs *memoryBackstore) Get(assertType *AssertionType, key []string, maxForm
 
 	a, err := mbs.top.get(internalKey, maxFormat)
 	if err == errNotFound {
-		return nil, NewNotFoundErrorPrimaryKey(assertType, key)
+		return nil, &NotFoundError{Type: assertType}
 	}
 	return a, err
 }

--- a/asserts/membackstore.go
+++ b/asserts/membackstore.go
@@ -20,6 +20,7 @@
 package asserts
 
 import (
+	"errors"
 	"sync"
 )
 
@@ -80,11 +81,13 @@ func (leaf memBSLeaf) put(assertType *AssertionType, key []string, assert Assert
 	return nil
 }
 
+var errNotFound = errors.New("assertion not found")
+
 func (br memBSBranch) get(key []string, maxFormat int) (Assertion, error) {
 	key0 := key[0]
 	down := br[key0]
 	if down == nil {
-		return nil, ErrNotFound
+		return nil, errNotFound
 	}
 	return down.get(key[1:], maxFormat)
 }
@@ -93,7 +96,7 @@ func (leaf memBSLeaf) get(key []string, maxFormat int) (Assertion, error) {
 	key0 := key[0]
 	cur := leaf.cur(key0, maxFormat)
 	if cur == nil {
-		return nil, ErrNotFound
+		return nil, errNotFound
 	}
 	return cur, nil
 }
@@ -160,7 +163,11 @@ func (mbs *memoryBackstore) Get(assertType *AssertionType, key []string, maxForm
 	internalKey[0] = assertType.Name
 	copy(internalKey[1:], key)
 
-	return mbs.top.get(internalKey, maxFormat)
+	a, err := mbs.top.get(internalKey, maxFormat)
+	if err == errNotFound {
+		return nil, &NotFoundError{Type: assertType, PrimaryKey: key}
+	}
+	return a, err
 }
 
 func (mbs *memoryBackstore) Search(assertType *AssertionType, headers map[string]string, foundCb func(Assertion), maxFormat int) error {

--- a/asserts/membackstore.go
+++ b/asserts/membackstore.go
@@ -147,11 +147,9 @@ func (mbs *memoryBackstore) Put(assertType *AssertionType, assert Assertion) err
 	mbs.mu.Lock()
 	defer mbs.mu.Unlock()
 
-	internalKey := make([]string, 1+len(assertType.PrimaryKey))
+	internalKey := make([]string, 1, 1+len(assertType.PrimaryKey))
 	internalKey[0] = assertType.Name
-	for i, name := range assertType.PrimaryKey {
-		internalKey[1+i] = assert.HeaderString(name)
-	}
+	internalKey = append(internalKey, assert.Ref().PrimaryKey...)
 
 	err := mbs.top.put(assertType, internalKey, assert)
 	return err

--- a/asserts/membackstore.go
+++ b/asserts/membackstore.go
@@ -81,6 +81,8 @@ func (leaf memBSLeaf) put(assertType *AssertionType, key []string, assert Assert
 	return nil
 }
 
+// errNotFound is used internally by backends, it is converted to the richer
+// NotFoundError only at their public interface boundary
 var errNotFound = errors.New("assertion not found")
 
 func (br memBSBranch) get(key []string, maxFormat int) (Assertion, error) {

--- a/asserts/membackstore.go
+++ b/asserts/membackstore.go
@@ -165,7 +165,7 @@ func (mbs *memoryBackstore) Get(assertType *AssertionType, key []string, maxForm
 
 	a, err := mbs.top.get(internalKey, maxFormat)
 	if err == errNotFound {
-		return nil, &NotFoundError{Type: assertType, PrimaryKey: key}
+		return nil, NewNotFoundErrorPrimaryKey(assertType, key)
 	}
 	return a, err
 }

--- a/asserts/membackstore_test.go
+++ b/asserts/membackstore_test.go
@@ -60,9 +60,7 @@ func (mbss *memBackstoreSuite) TestGetNotFound(c *C) {
 	a, err := mbss.bs.Get(asserts.TestOnlyType, []string{"foo"}, 0)
 	c.Assert(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlyType,
-		Headers: map[string]string{
-			"primary-key": "foo",
-		},
+		// Headers can be omitted by Backstores
 	})
 	c.Check(a, IsNil)
 
@@ -72,9 +70,6 @@ func (mbss *memBackstoreSuite) TestGetNotFound(c *C) {
 	a, err = mbss.bs.Get(asserts.TestOnlyType, []string{"bar"}, 0)
 	c.Assert(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.TestOnlyType,
-		Headers: map[string]string{
-			"primary-key": "bar",
-		},
 	})
 	c.Check(a, IsNil)
 }

--- a/asserts/membackstore_test.go
+++ b/asserts/membackstore_test.go
@@ -59,8 +59,10 @@ func (mbss *memBackstoreSuite) TestPutAndGet(c *C) {
 func (mbss *memBackstoreSuite) TestGetNotFound(c *C) {
 	a, err := mbss.bs.Get(asserts.TestOnlyType, []string{"foo"}, 0)
 	c.Assert(err, DeepEquals, &asserts.NotFoundError{
-		Type:       asserts.TestOnlyType,
-		PrimaryKey: []string{"foo"},
+		Type: asserts.TestOnlyType,
+		Headers: map[string]string{
+			"primary-key": "foo",
+		},
 	})
 	c.Check(a, IsNil)
 
@@ -69,8 +71,10 @@ func (mbss *memBackstoreSuite) TestGetNotFound(c *C) {
 
 	a, err = mbss.bs.Get(asserts.TestOnlyType, []string{"bar"}, 0)
 	c.Assert(err, DeepEquals, &asserts.NotFoundError{
-		Type:       asserts.TestOnlyType,
-		PrimaryKey: []string{"bar"},
+		Type: asserts.TestOnlyType,
+		Headers: map[string]string{
+			"primary-key": "bar",
+		},
 	})
 	c.Check(a, IsNil)
 }

--- a/asserts/membackstore_test.go
+++ b/asserts/membackstore_test.go
@@ -58,14 +58,20 @@ func (mbss *memBackstoreSuite) TestPutAndGet(c *C) {
 
 func (mbss *memBackstoreSuite) TestGetNotFound(c *C) {
 	a, err := mbss.bs.Get(asserts.TestOnlyType, []string{"foo"}, 0)
-	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Assert(err, DeepEquals, &asserts.NotFoundError{
+		Type:       asserts.TestOnlyType,
+		PrimaryKey: []string{"foo"},
+	})
 	c.Check(a, IsNil)
 
 	err = mbss.bs.Put(asserts.TestOnlyType, mbss.a)
 	c.Assert(err, IsNil)
 
 	a, err = mbss.bs.Get(asserts.TestOnlyType, []string{"bar"}, 0)
-	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Assert(err, DeepEquals, &asserts.NotFoundError{
+		Type:       asserts.TestOnlyType,
+		PrimaryKey: []string{"bar"},
+	})
 	c.Check(a, IsNil)
 }
 
@@ -247,13 +253,13 @@ func (mbss *memBackstoreSuite) TestGetFormat(c *C) {
 	c.Check(a.Revision(), Equals, 0)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 0)
-	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Assert(err, FitsTypeOf, &asserts.NotFoundError{})
 
 	err = bs.Put(asserts.TestOnlyType, af2)
 	c.Assert(err, IsNil)
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 1)
-	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Assert(err, FitsTypeOf, &asserts.NotFoundError{})
 
 	a, err = bs.Get(asserts.TestOnlyType, []string{"zoo"}, 2)
 	c.Assert(err, IsNil)

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -104,7 +104,7 @@ func (snapdcl *SnapDeclaration) checkConsistency(db RODatabase, acck *AccountKey
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": snapdcl.PublisherID(),
 	})
-	if err == ErrNotFound {
+	if IsNotFound(err) {
 		return fmt.Errorf("snap-declaration assertion for %q (id %q) does not have a matching account assertion for the publisher %q", snapdcl.SnapName(), snapdcl.SnapID(), snapdcl.PublisherID())
 	}
 	if err != nil {
@@ -436,7 +436,7 @@ func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) e
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": snaprev.DeveloperID(),
 	})
-	if err == ErrNotFound {
+	if IsNotFound(err) {
 		return fmt.Errorf("snap-revision assertion for snap id %q does not have a matching account assertion for the developer %q", snaprev.SnapID(), snaprev.DeveloperID())
 	}
 	if err != nil {
@@ -447,7 +447,7 @@ func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) e
 		"series":  release.Series,
 		"snap-id": snaprev.SnapID(),
 	})
-	if err == ErrNotFound {
+	if IsNotFound(err) {
 		return fmt.Errorf("snap-revision assertion for snap id %q does not have a matching snap-declaration assertion", snaprev.SnapID())
 	}
 	if err != nil {
@@ -557,7 +557,7 @@ func (validation *Validation) checkConsistency(db RODatabase, acck *AccountKey) 
 		"series":  validation.Series(),
 		"snap-id": validation.ApprovedSnapID(),
 	})
-	if err == ErrNotFound {
+	if IsNotFound(err) {
 		return fmt.Errorf("validation assertion by snap-id %q does not have a matching snap-declaration assertion for approved-snap-id %q", validation.SnapID(), validation.ApprovedSnapID())
 	}
 	if err != nil {
@@ -567,7 +567,7 @@ func (validation *Validation) checkConsistency(db RODatabase, acck *AccountKey) 
 		"series":  validation.Series(),
 		"snap-id": validation.SnapID(),
 	})
-	if err == ErrNotFound {
+	if IsNotFound(err) {
 		return fmt.Errorf("validation assertion by snap-id %q does not have a matching snap-declaration assertion", validation.SnapID())
 	}
 	if err != nil {
@@ -803,7 +803,7 @@ func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) 
 		"snap-id": snapdev.SnapID(),
 	})
 	if err != nil {
-		if err == ErrNotFound {
+		if IsNotFound(err) {
 			return fmt.Errorf("snap-developer assertion for snap id %q does not have a matching snap-declaration assertion", snapdev.SnapID())
 		}
 		return err
@@ -812,7 +812,7 @@ func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) 
 	// check there's an account for the publisher-id
 	_, err = db.Find(AccountType, map[string]string{"account-id": publisherID})
 	if err != nil {
-		if err == ErrNotFound {
+		if IsNotFound(err) {
 			return fmt.Errorf("snap-developer assertion for snap-id %q does not have a matching account assertion for the publisher %q", snapdev.SnapID(), publisherID)
 		}
 		return err
@@ -825,7 +825,7 @@ func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) 
 		}
 		_, err = db.Find(AccountType, map[string]string{"account-id": developerID})
 		if err != nil {
-			if err == ErrNotFound {
+			if IsNotFound(err) {
 				return fmt.Errorf("snap-developer assertion for snap-id %q does not have a matching account assertion for the developer %q", snapdev.SnapID(), developerID)
 			}
 			return err

--- a/asserts/snapasserts/snapasserts.go
+++ b/asserts/snapasserts/snapasserts.go
@@ -29,9 +29,10 @@ import (
 )
 
 type Finder interface {
-	// Find an assertion based on arbitrary headers.
-	// Provided headers must contain the primary key for the assertion type.
-	// It returns ErrNotFound if the assertion cannot be found.
+	// Find an assertion based on arbitrary headers.  Provided
+	// headers must contain the primary key for the assertion
+	// type.  It returns a asserts.NotFoundError if the assertion
+	// cannot be found.
 	Find(assertionType *asserts.AssertionType, headers map[string]string) (asserts.Assertion, error)
 }
 
@@ -85,7 +86,7 @@ func CrossCheck(name, snapSHA3_384 string, snapSize uint64, si *snap.SideInfo, d
 	return nil
 }
 
-// DeriveSideInfo tries to construct a SideInfo for the given snap using its digest to find the relevant snap assertions with the information in the given database. It will fail with asserts.ErrNotFound if it cannot find them.
+// DeriveSideInfo tries to construct a SideInfo for the given snap using its digest to find the relevant snap assertions with the information in the given database. It will fail with an asserts.NotFoundError if it cannot find them.
 func DeriveSideInfo(snapPath string, db Finder) (*snap.SideInfo, error) {
 	snapSHA3_384, snapSize, err := asserts.SnapFileSHA3_384(snapPath)
 	if err != nil {

--- a/asserts/snapasserts/snapasserts_test.go
+++ b/asserts/snapasserts/snapasserts_test.go
@@ -247,7 +247,7 @@ func (s *snapassertsSuite) TestDeriveSideInfoNoSignatures(c *C) {
 
 	_, err = snapasserts.DeriveSideInfo(snapPath, s.localDB)
 	// cannot find signatures with metadata for snap
-	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Assert(asserts.IsNotFound(err), Equals, true)
 }
 
 func (s *snapassertsSuite) TestDeriveSideInfoSizeMismatch(c *C) {

--- a/asserts/store_asserts.go
+++ b/asserts/store_asserts.go
@@ -41,7 +41,7 @@ func (store *Store) checkConsistency(db RODatabase, acck *AccountKey) error {
 
 	_, err := db.Find(AccountType, map[string]string{"account-id": store.OperatorID()})
 	if err != nil {
-		if err == ErrNotFound {
+		if IsNotFound(err) {
 			return fmt.Errorf(
 				"store assertion %q does not have a matching account assertion for the operator %q",
 				store.Store(), store.OperatorID())

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -550,10 +550,10 @@ func checkAuthorityID(a asserts.Assertion, trusted asserts.Backstore) error {
 	// a trusted authority
 	acctID := a.AuthorityID()
 	_, err := trusted.Get(asserts.AccountType, []string{acctID}, asserts.AccountType.MaxSupportedFormat())
-	if err != nil && err != asserts.ErrNotFound {
+	if err != nil && !asserts.IsNotFound(err) {
 		return err
 	}
-	if err == asserts.ErrNotFound {
+	if asserts.IsNotFound(err) {
 		return fmt.Errorf("%v not signed by trusted authority: %s", a.Ref(), acctID)
 	}
 	return nil
@@ -575,17 +575,17 @@ func verifySignatures(a asserts.Assertion, workBS asserts.Backstore, trusted ass
 		seen[u] = true
 		signKey := []string{a.SignKeyID()}
 		key, err := trusted.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
-		if err != nil && err != asserts.ErrNotFound {
+		if err != nil && !asserts.IsNotFound(err) {
 			return err
 		}
 		if err == nil {
 			bottom = true
 		} else {
 			key, err = workBS.Get(asserts.AccountKeyType, signKey, acctKeyMaxSuppFormat)
-			if err != nil && err != asserts.ErrNotFound {
+			if err != nil && !asserts.IsNotFound(err) {
 				return err
 			}
-			if err == asserts.ErrNotFound {
+			if asserts.IsNotFound(err) {
 				return fmt.Errorf("cannot find public key %q", signKey[0])
 			}
 			if err := checkAuthorityID(key, trusted); err != nil {

--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -76,13 +76,9 @@ func downloadAssertion(typeName string, headers map[string]string) ([]asserts.As
 	if at == nil {
 		return nil, fmt.Errorf("cannot find assertion type %q", typeName)
 	}
-	primaryKeys := make([]string, len(at.PrimaryKey))
-	for i, k := range at.PrimaryKey {
-		pk, ok := headers[k]
-		if !ok {
-			return nil, fmt.Errorf("missing primary header %q to query remote assertion", k)
-		}
-		primaryKeys[i] = pk
+	primaryKeys, err := asserts.PrimaryKeyFromHeaders(at, headers)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query remote assertion: %v", err)
 	}
 
 	sto := storeNew(nil, authContext)

--- a/cmd/snap/cmd_known_test.go
+++ b/cmd/snap/cmd_known_test.go
@@ -87,7 +87,7 @@ func (s *SnapSuite) TestKnownRemote(c *check.C) {
 
 func (s *SnapSuite) TestKnownRemoteMissingPrimaryKey(c *check.C) {
 	_, err := snap.Parser().ParseArgs([]string{"known", "--remote", "model", "series=16", "brand-id=canonical"})
-	c.Assert(err, check.ErrorMatches, `missing primary header "model" to query remote assertion`)
+	c.Assert(err, check.ErrorMatches, `cannot query remote assertion: must provide primary key: model`)
 }
 
 func (s *SnapSuite) TestAssertTypeNameCompletion(c *check.C) {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1405,11 +1405,11 @@ out:
 
 	if !dangerousOK {
 		si, err := snapasserts.DeriveSideInfo(tempPath, assertstate.DB(st))
-		switch err {
-		case nil:
+		switch {
+		case err == nil:
 			snapName = si.RealName
 			sideInfo = si
-		case asserts.ErrNotFound:
+		case asserts.IsNotFound(err):
 			// with devmode we try to find assertions but it's ok
 			// if they are not there (implies --dangerous)
 			if !isTrue(form, "devmode") {
@@ -1780,7 +1780,7 @@ func assertsFindMany(c *Command, r *http.Request, user *auth.UserState) Response
 	state.Unlock()
 
 	assertions, err := db.FindMany(assertType, headers)
-	if err == asserts.ErrNotFound {
+	if asserts.IsNotFound(err) {
 		return AssertResponse(nil, true)
 	} else if err != nil {
 		return InternalError("searching assertions failed: %v", err)
@@ -2018,7 +2018,7 @@ func createAllKnownSystemUsers(st *state.State, createData *postUserCreateData) 
 	st.Lock()
 	assertions, err := db.FindMany(asserts.SystemUserType, headers)
 	st.Unlock()
-	if err != nil && err != asserts.ErrNotFound {
+	if err != nil && !asserts.IsNotFound(err) {
 		return BadRequest("cannot find system-user assertion: %s", err)
 	}
 

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -202,17 +202,5 @@ func (tsto *ToolingStore) Find(at *asserts.AssertionType, headers map[string]str
 	for i, k := range at.PrimaryKey {
 		pk[i] = headers[k]
 	}
-	as, err := tsto.sto.Assertion(at, pk, tsto.user)
-	if err != nil {
-		// convert store error to something that the asserts would
-		// return
-		if _, ok := err.(*store.AssertionNotFoundError); ok {
-			return nil, &asserts.NotFoundError{
-				Type:       at,
-				PrimaryKey: pk,
-			}
-		}
-		return nil, err
-	}
-	return as, nil
+	return tsto.sto.Assertion(at, pk, tsto.user)
 }

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -198,9 +198,9 @@ func FetchAndCheckSnapAssertions(snapPath string, info *snap.Info, f asserts.Fet
 
 // Find provides the snapsserts.Finder interface for snapasserts.DerviceSideInfo
 func (tsto *ToolingStore) Find(at *asserts.AssertionType, headers map[string]string) (asserts.Assertion, error) {
-	pk := make([]string, len(at.PrimaryKey))
-	for i, k := range at.PrimaryKey {
-		pk[i] = headers[k]
+	pk, err := asserts.PrimaryKeyFromHeaders(at, headers)
+	if err != nil {
+		return nil, err
 	}
 	return tsto.sto.Assertion(at, pk, tsto.user)
 }

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -207,7 +207,10 @@ func (tsto *ToolingStore) Find(at *asserts.AssertionType, headers map[string]str
 		// convert store error to something that the asserts would
 		// return
 		if _, ok := err.(*store.AssertionNotFoundError); ok {
-			return nil, asserts.ErrNotFound
+			return nil, &asserts.NotFoundError{
+				Type:       at,
+				PrimaryKey: pk,
+			}
 		}
 		return nil, err
 	}

--- a/image/image.go
+++ b/image/image.go
@@ -105,7 +105,7 @@ func localSnaps(tsto *ToolingStore, opts *Options) (*localInfos, error) {
 			local[snapName] = info
 
 			si, err := snapasserts.DeriveSideInfo(snapName, tsto)
-			if err != nil && err != asserts.ErrNotFound {
+			if err != nil && !asserts.IsNotFound(err) {
 				return nil, err
 			}
 			if err == nil {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -58,7 +58,7 @@ func (s *emptyStore) Download(ctx context.Context, name, targetFn string, downlo
 }
 
 func (s *emptyStore) Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error) {
-	return nil, asserts.NewNotFoundErrorPrimaryKey(assertType, primaryKey)
+	return nil, &asserts.NotFoundError{Type: assertType}
 }
 
 func Test(t *testing.T) { TestingT(t) }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -58,7 +58,7 @@ func (s *emptyStore) Download(ctx context.Context, name, targetFn string, downlo
 }
 
 func (s *emptyStore) Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error) {
-	return nil, &asserts.NotFoundError{Type: assertType, PrimaryKey: primaryKey}
+	return nil, asserts.NewNotFoundErrorPrimaryKey(assertType, primaryKey)
 }
 
 func Test(t *testing.T) { TestingT(t) }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -58,7 +58,7 @@ func (s *emptyStore) Download(ctx context.Context, name, targetFn string, downlo
 }
 
 func (s *emptyStore) Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error) {
-	return nil, &store.AssertionNotFoundError{Ref: &asserts.Ref{Type: assertType, PrimaryKey: primaryKey}}
+	return nil, &asserts.NotFoundError{Type: assertType, PrimaryKey: primaryKey}
 }
 
 func Test(t *testing.T) { TestingT(t) }

--- a/overlord/assertstate/assertmgr.go
+++ b/overlord/assertstate/assertmgr.go
@@ -29,7 +29,6 @@ import (
 	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/store"
 )
 
 // AssertManager is responsible for the enforcement of assertions in
@@ -114,8 +113,8 @@ func doValidateSnap(t *state.Task, _ *tomb.Tomb) error {
 	err = doFetch(t.State(), snapsup.UserID, func(f asserts.Fetcher) error {
 		return snapasserts.FetchSnapAssertions(f, sha3_384)
 	})
-	if notFound, ok := err.(*store.AssertionNotFoundError); ok {
-		if notFound.Ref.Type == asserts.SnapRevisionType {
+	if notFound, ok := err.(*asserts.NotFoundError); ok {
+		if notFound.Type == asserts.SnapRevisionType {
 			return fmt.Errorf("cannot verify snap %q, no matching signatures found", snapsup.Name())
 		} else {
 			return fmt.Errorf("cannot find supported signatures to verify snap %q and its hash (%v)", snapsup.Name(), notFound)

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -105,12 +105,12 @@ func (b *Batch) Commit(st *state.State) error {
 	db := cachedDB(st)
 	retrieve := func(ref *asserts.Ref) (asserts.Assertion, error) {
 		a, err := b.bs.Get(ref.Type, ref.PrimaryKey, ref.Type.MaxSupportedFormat())
-		if err == asserts.ErrNotFound {
+		if asserts.IsNotFound(err) {
 			// fallback to pre-existing assertions
 			a, err = ref.Resolve(db.Find)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("cannot find %s: %s", ref, err)
+			return nil, findError("cannot find %s", ref, err)
 		}
 		return a, nil
 	}
@@ -127,6 +127,14 @@ func (b *Batch) Commit(st *state.State) error {
 	// (but try to save as much possible still),
 	// or err is a check error
 	return f.commit()
+}
+
+func findError(format string, ref *asserts.Ref, err error) error {
+	if asserts.IsNotFound(err) {
+		return fmt.Errorf(format, ref)
+	} else {
+		return fmt.Errorf(format+": %v", ref, err)
+	}
 }
 
 // RefreshSnapDeclarations refetches all the current snap declarations and their prerequisites.
@@ -194,7 +202,7 @@ func ValidateRefreshes(s *state.State, snapInfos []*snap.Info, userID int) (vali
 			"snap-id": gatingID,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("internal error: cannot find snap declaration for installed snap %q (id %q): err", snapName, gatingID)
+			return nil, fmt.Errorf("internal error: cannot find snap declaration for installed snap %q: %v", snapName, err)
 		}
 		decl := a.(*asserts.SnapDeclaration)
 		control := decl.RefreshControl()
@@ -245,7 +253,7 @@ func ValidateRefreshes(s *state.State, snapInfos []*snap.Info, userID int) (vali
 		for _, valref := range validationRefs {
 			a, err := valref.Resolve(db.Find)
 			if err != nil {
-				return nil, fmt.Errorf("internal error: cannot find just fetched %v: %v", valref, err)
+				return nil, findError("internal error: cannot find just fetched %v", valref, err)
 			}
 			if val := a.(*asserts.Validation); val.Revoked() {
 				revoked = val
@@ -273,7 +281,7 @@ func BaseDeclaration(s *state.State) (*asserts.BaseDeclaration, error) {
 	// via the store
 	baseDecl := asserts.BuiltinBaseDeclaration()
 	if baseDecl == nil {
-		return nil, asserts.ErrNotFound
+		return nil, &asserts.NotFoundError{Type: asserts.BaseDeclarationType}
 	}
 	return baseDecl, nil
 }

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -33,7 +33,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/store"
 )
 
 // Add the given assertion to the system assertion database.
@@ -233,7 +232,7 @@ func ValidateRefreshes(s *state.State, snapInfos []*snap.Info, userID int) (vali
 					PrimaryKey: []string{release.Series, gatingID, gatedID, candInfo.Revision.String()},
 				}
 				err := f.Fetch(valref)
-				if notFound, ok := err.(*store.AssertionNotFoundError); ok && notFound.Ref.Type == asserts.ValidationType {
+				if notFound, ok := err.(*asserts.NotFoundError); ok && notFound.Type == asserts.ValidationType {
 					return fmt.Errorf("no validation by %q", gatingNames[gatingID])
 				}
 				if err != nil {

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/snapcore/snapd/overlord/storestate"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/storetest"
 )
 
@@ -80,11 +79,7 @@ func (sto *fakeStore) pokeStateLock() {
 func (sto *fakeStore) Assertion(assertType *asserts.AssertionType, key []string, _ *auth.UserState) (asserts.Assertion, error) {
 	sto.pokeStateLock()
 	ref := &asserts.Ref{Type: assertType, PrimaryKey: key}
-	a, err := ref.Resolve(sto.db.Find)
-	if err != nil {
-		return nil, &store.AssertionNotFoundError{Ref: ref}
-	}
-	return a, nil
+	return ref.Resolve(sto.db.Find)
 }
 
 func (s *assertMgrSuite) SetUpTest(c *C) {

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -918,7 +918,7 @@ func (s *assertMgrSuite) TestBaseSnapDeclaration(c *C) {
 	defer r1()
 
 	baseDecl, err := assertstate.BaseDeclaration(s.state)
-	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Assert(asserts.IsNotFound(err), Equals, true)
 	c.Check(baseDecl, IsNil)
 
 	r2 := assertstest.MockBuiltinBaseDeclaration([]byte(`
@@ -950,7 +950,7 @@ func (s *assertMgrSuite) TestSnapDeclaration(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = assertstate.SnapDeclaration(s.state, "snap-id-other")
-	c.Check(err, Equals, asserts.ErrNotFound)
+	c.Check(asserts.IsNotFound(err), Equals, true)
 
 	snapDecl, err := assertstate.SnapDeclaration(s.state, "foo-id")
 	c.Assert(err, IsNil)
@@ -979,7 +979,7 @@ func (s *assertMgrSuite) TestAutoAliasesTemporaryFallback(c *C) {
 			SnapID:   "baz-id",
 		},
 	})
-	c.Check(err, ErrorMatches, `internal error: cannot find snap-declaration for installed snap "baz": assertion not found`)
+	c.Check(err, ErrorMatches, `internal error: cannot find snap-declaration for installed snap "baz": snap-declaration \(baz-id; series:16\) not found`)
 
 	info := snaptest.MockInfo(c, `
 name: foo
@@ -1039,7 +1039,7 @@ func (s *assertMgrSuite) TestAutoAliasesExplicit(c *C) {
 			SnapID:   "baz-id",
 		},
 	})
-	c.Check(err, ErrorMatches, `internal error: cannot find snap-declaration for installed snap "baz": assertion not found`)
+	c.Check(err, ErrorMatches, `internal error: cannot find snap-declaration for installed snap "baz": snap-declaration \(baz-id; series:16\) not found`)
 
 	// empty list
 	// have a declaration in the system db
@@ -1098,7 +1098,7 @@ func (s *assertMgrSuite) TestPublisher(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = assertstate.SnapDeclaration(s.state, "snap-id-other")
-	c.Check(err, Equals, asserts.ErrNotFound)
+	c.Check(asserts.IsNotFound(err), Equals, true)
 
 	acct, err := assertstate.Publisher(s.state, "foo-id")
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -51,7 +51,7 @@ func Model(st *state.State) (*asserts.Model, error) {
 		"brand-id": device.Brand,
 		"model":    device.Model,
 	})
-	if err == asserts.ErrNotFound {
+	if asserts.IsNotFound(err) {
 		return nil, state.ErrNoState
 	}
 	if err != nil {
@@ -77,7 +77,7 @@ func Serial(st *state.State) (*asserts.Serial, error) {
 		"model":    device.Model,
 		"serial":   device.Serial,
 	})
-	if err == asserts.ErrNotFound {
+	if asserts.IsNotFound(err) {
 		return nil, state.ErrNoState
 	}
 	if err != nil {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -55,7 +55,6 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
-	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/storetest"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -98,11 +97,7 @@ func (sto *fakeStore) pokeStateLock() {
 func (sto *fakeStore) Assertion(assertType *asserts.AssertionType, key []string, _ *auth.UserState) (asserts.Assertion, error) {
 	sto.pokeStateLock()
 	ref := &asserts.Ref{Type: assertType, PrimaryKey: key}
-	a, err := ref.Resolve(sto.db.Find)
-	if err != nil {
-		return nil, &store.AssertionNotFoundError{Ref: ref}
-	}
-	return a, nil
+	return ref.Resolve(sto.db.Find)
 }
 
 func (s *deviceMgrSuite) SetUpTest(c *C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -736,7 +736,7 @@ version: gadget
 		"model":    "pc",
 		"serial":   "9999",
 	})
-	c.Assert(err, Equals, asserts.ErrNotFound)
+	c.Assert(asserts.IsNotFound(err), Equals, true)
 
 	s.state.Unlock()
 	s.mgr.Ensure()

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -56,7 +56,7 @@ func installSeedSnap(st *state.State, sn *snap.SeedSnap, flags snapstate.Flags) 
 		sideInfo.RealName = sn.Name
 	} else {
 		si, err := snapasserts.DeriveSideInfo(path, assertstate.DB(st))
-		if err == asserts.ErrNotFound {
+		if asserts.IsNotFound(err) {
 			return nil, fmt.Errorf("cannot find signatures with metadata for snap %q (%q)", sn.Name, path)
 		}
 		if err != nil {

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -887,7 +887,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedMissingSig(c *C) {
 	// try import and verify that its rejects because other assertions are
 	// missing
 	_, err := devicestate.ImportAssertionsFromSeed(st)
-	c.Assert(err, ErrorMatches, "cannot find account-key .*: assertion not found")
+	c.Assert(err, ErrorMatches, "cannot find account-key .*")
 }
 
 func (s *FirstBootTestSuite) TestImportAssertionsFromSeedTwoModelAsserts(c *C) {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -430,7 +430,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 		"model":               device.Model,
 		"device-key-sha3-384": privKey.PublicKey().ID(),
 	})
-	if err != nil && err != asserts.ErrNotFound {
+	if err != nil && !asserts.IsNotFound(err) {
 		return err
 	}
 
@@ -500,7 +500,7 @@ func fetchKeys(st *state.State, keyID string) (errAcctKey error, err error) {
 		if err == nil {
 			return nil, nil
 		}
-		if err != asserts.ErrNotFound {
+		if !asserts.IsNotFound(err) {
 			return nil, err
 		}
 		st.Unlock()

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -564,7 +564,7 @@ func (s *interfaceManagerSuite) mockSnapDecl(c *C, name, publisher string, extra
 	_, err := s.db.Find(asserts.AccountType, map[string]string{
 		"account-id": publisher,
 	})
-	if err == asserts.ErrNotFound {
+	if asserts.IsNotFound(err) {
 		acct := assertstest.NewAccount(s.storeSigning, publisher, map[string]interface{}{
 			"account-id": publisher,
 		}, "")
@@ -604,7 +604,7 @@ func (s *interfaceManagerSuite) mockSnap(c *C, yamlText string) *snap.Info {
 		decl := a[0].(*asserts.SnapDeclaration)
 		snapInfo.SnapID = decl.SnapID()
 		sideInfo.SnapID = decl.SnapID()
-	} else if err == asserts.ErrNotFound {
+	} else if asserts.IsNotFound(err) {
 		err = nil
 	}
 	c.Assert(err, IsNil)

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -412,7 +412,7 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 				PrimaryKey: comps[3:],
 			}
 			a, err := ref.Resolve(ms.storeSigning.Find)
-			if err == asserts.ErrNotFound {
+			if asserts.IsNotFound(err) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(404)
 				w.Write([]byte(`{"status": 404}`))

--- a/store/errors.go
+++ b/store/errors.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-
-	"github.com/snapcore/snapd/asserts"
 )
 
 var (
@@ -109,13 +107,4 @@ func (e InvalidAuthDataError) Error() string {
 	//      full sentences (with periods and capitalization)
 	//      (empirically this checks out)
 	return strings.Join(es, "  ")
-}
-
-// AssertionNotFoundError is returned when an assertion can not be found
-type AssertionNotFoundError struct {
-	Ref *asserts.Ref
-}
-
-func (e *AssertionNotFoundError) Error() string {
-	return fmt.Sprintf("%v not found", e.Ref)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1676,7 +1676,7 @@ func (s *Store) Assertion(assertType *asserts.AssertionType, primaryKey []string
 					return fmt.Errorf("cannot decode assertion service error with HTTP status code %d: %v", resp.StatusCode, e)
 				}
 				if svcErr.Status == 404 {
-					return &asserts.NotFoundError{Type: assertType, PrimaryKey: primaryKey}
+					return asserts.NewNotFoundErrorPrimaryKey(assertType, primaryKey)
 				}
 				return fmt.Errorf("assertion service error: [%s] %q", svcErr.Title, svcErr.Detail)
 			}

--- a/store/store.go
+++ b/store/store.go
@@ -1676,7 +1676,12 @@ func (s *Store) Assertion(assertType *asserts.AssertionType, primaryKey []string
 					return fmt.Errorf("cannot decode assertion service error with HTTP status code %d: %v", resp.StatusCode, e)
 				}
 				if svcErr.Status == 404 {
-					return asserts.NewNotFoundErrorPrimaryKey(assertType, primaryKey)
+					// best-effort
+					headers, _ := asserts.HeadersFromPrimaryKey(assertType, primaryKey)
+					return &asserts.NotFoundError{
+						Type:    assertType,
+						Headers: headers,
+					}
 				}
 				return fmt.Errorf("assertion service error: [%s] %q", svcErr.Title, svcErr.Detail)
 			}

--- a/store/store.go
+++ b/store/store.go
@@ -1676,7 +1676,7 @@ func (s *Store) Assertion(assertType *asserts.AssertionType, primaryKey []string
 					return fmt.Errorf("cannot decode assertion service error with HTTP status code %d: %v", resp.StatusCode, e)
 				}
 				if svcErr.Status == 404 {
-					return &AssertionNotFoundError{&asserts.Ref{Type: assertType, PrimaryKey: primaryKey}}
+					return &asserts.NotFoundError{Type: assertType, PrimaryKey: primaryKey}
 				}
 				return fmt.Errorf("assertion service error: [%s] %q", svcErr.Title, svcErr.Detail)
 			}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3982,11 +3982,10 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionNotFound(c *C) {
 	repo := New(&cfg, nil)
 
 	_, err = repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
-	c.Check(err, DeepEquals, &AssertionNotFoundError{
-		Ref: &asserts.Ref{
-			Type:       asserts.SnapDeclarationType,
-			PrimaryKey: []string{"16", "snapidfoo"},
-		},
+	c.Check(asserts.IsNotFound(err), Equals, true)
+	c.Check(err, DeepEquals, &asserts.NotFoundError{
+		Type:       asserts.SnapDeclarationType,
+		PrimaryKey: []string{"16", "snapidfoo"},
 	})
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3984,8 +3984,11 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionNotFound(c *C) {
 	_, err = repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
 	c.Check(asserts.IsNotFound(err), Equals, true)
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
-		Type:       asserts.SnapDeclarationType,
-		PrimaryKey: []string{"16", "snapidfoo"},
+		Type: asserts.SnapDeclarationType,
+		Headers: map[string]string{
+			"series":  "16",
+			"snap-id": "snapidfoo",
+		},
 	})
 }
 

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -36,7 +36,6 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/store"
 )
 
 func MakeFakeRefreshForSnaps(snaps []string, blobDir string) error {
@@ -67,7 +66,7 @@ func MakeFakeRefreshForSnaps(snaps []string, blobDir string) error {
 		case 1:
 			return as[0], nil
 		case 0:
-			return nil, &store.AssertionNotFoundError{Ref: ref}
+			return nil, &asserts.NotFoundError{Type: ref.Type, PrimaryKey: ref.PrimaryKey}
 		default:
 			panic(fmt.Sprintf("multiple assertions when retrieving by primary key: %v", ref))
 		}

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -66,7 +66,7 @@ func MakeFakeRefreshForSnaps(snaps []string, blobDir string) error {
 		case 1:
 			return as[0], nil
 		case 0:
-			return nil, &asserts.NotFoundError{Type: ref.Type, PrimaryKey: ref.PrimaryKey}
+			return nil, &asserts.NotFoundError{Type: ref.Type, Headers: headers}
 		default:
 			panic(fmt.Sprintf("multiple assertions when retrieving by primary key: %v", ref))
 		}

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -193,7 +193,7 @@ func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Back
 	}
 
 	snapRev, devAcct, err := findSnapRevision(snapDigest, bs)
-	if err != nil && err != asserts.ErrNotFound {
+	if err != nil && !asserts.IsNotFound(err) {
 		http.Error(w, fmt.Sprintf("can get info for: %v: %v", fn, err), 400)
 		return nil, errInfo
 	}
@@ -477,7 +477,7 @@ func (s *Store) collectAssertions() (asserts.Backstore, error) {
 }
 
 func isAssertNotFound(err error) bool {
-	if err == asserts.ErrNotFound {
+	if asserts.IsNotFound(err) {
 		return true
 	}
 	if _, ok := err.(*store.AssertionNotFoundError); ok {
@@ -488,7 +488,7 @@ func isAssertNotFound(err error) bool {
 
 func (s *Store) retrieveAssertion(bs asserts.Backstore, assertType *asserts.AssertionType, primaryKey []string) (asserts.Assertion, error) {
 	a, err := bs.Get(assertType, primaryKey, assertType.MaxSupportedFormat())
-	if err == asserts.ErrNotFound && s.assertFallback {
+	if asserts.IsNotFound(err) && s.assertFallback {
 		return s.fallback.Assertion(assertType, primaryKey, nil)
 	}
 	return a, err

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -476,16 +476,6 @@ func (s *Store) collectAssertions() (asserts.Backstore, error) {
 	return bs, nil
 }
 
-func isAssertNotFound(err error) bool {
-	if asserts.IsNotFound(err) {
-		return true
-	}
-	if _, ok := err.(*store.AssertionNotFoundError); ok {
-		return true
-	}
-	return false
-}
-
 func (s *Store) retrieveAssertion(bs asserts.Backstore, assertType *asserts.AssertionType, primaryKey []string) (asserts.Assertion, error) {
 	a, err := bs.Get(assertType, primaryKey, assertType.MaxSupportedFormat())
 	if asserts.IsNotFound(err) && s.assertFallback {
@@ -523,7 +513,7 @@ func (s *Store) assertionsEndpoint(w http.ResponseWriter, req *http.Request) {
 	}
 
 	a, err := s.retrieveAssertion(bs, typ, comps[1:])
-	if isAssertNotFound(err) {
+	if asserts.IsNotFound(err) {
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(404)
 		w.Write([]byte(`{"status": 404}`))


### PR DESCRIPTION
This converts the singleton asserts.ErrNotFound to a richer asserts.NotFoundError struct carrying Type and optionally PrimaryKey, similar to store.AssertionNotFoundError which then gets folded with this.

This means code doesn't have to worry anymore which is which or to convert between the two. And when possible there is more information around.

A helper asserts.IsNotFound is also added to cover the simple  old ==/!= asserts.ErrNotFound needs.

This also fixes/adjust some error handling to usually not repeat the richer information twice.
