### PR TITLE
osutil: adjust StreamCommand tests for golang 1.9 (2.28)

### DIFF
--- a/osutil/exec_test.go
+++ b/osutil/exec_test.go
@@ -207,8 +207,9 @@ func (s *execSuite) TestStreamCommandHappy(c *C) {
 
 	wrf, wrc := osutil.WaitingReaderGuts(stdout)
 	c.Assert(wrf, FitsTypeOf, &os.File{})
-	c.Check(wrf.(*os.File).Close(), Equals, syscall.EINVAL) // i.e. already closed
-	c.Check(wrc.ProcessState, NotNil)                       // i.e. already waited for
+	// Depending on golang version the error is one of the two.
+	c.Check(wrf.(*os.File).Close(), ErrorMatches, "invalid argument|file already closed")
+	c.Check(wrc.ProcessState, NotNil) // i.e. already waited for
 }
 
 func (s *execSuite) TestStreamCommandSad(c *C) {
@@ -221,6 +222,7 @@ func (s *execSuite) TestStreamCommandSad(c *C) {
 
 	wrf, wrc := osutil.WaitingReaderGuts(stdout)
 	c.Assert(wrf, FitsTypeOf, &os.File{})
-	c.Check(wrf.(*os.File).Close(), Equals, syscall.EINVAL) // i.e. already closed
-	c.Check(wrc.ProcessState, NotNil)                       // i.e. already waited for
+	// Depending on golang version the error is one of the two.
+	c.Check(wrf.(*os.File).Close(), ErrorMatches, "invalid argument|file already closed")
+	c.Check(wrc.ProcessState, NotNil) // i.e. already waited for
 }


### PR DESCRIPTION
In golang 1.9 there are richer error constructs returned from certain
operations and tests were very precisely monitoring the result. This
patch adjust tests to work on both golang 1.9 and earlier.
