### PR TITLE
systemd: do not run auto-import and repair services on classic

### DIFF
--- a/data/systemd/snapd.autoimport.service.in
+++ b/data/systemd/snapd.autoimport.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=Auto import assertions from block devices
 After=snapd.service snapd.socket
+# don't run on classic
+ConditionKernelCommandLine=snap_core
 
 [Service]
 Type=oneshot

--- a/data/systemd/snapd.core-fixup.service.in
+++ b/data/systemd/snapd.core-fixup.service.in
@@ -1,7 +1,8 @@
 [Unit]
 Description=Automatically repair incorrect owner/permissions on core devices
 Before=snapd.service
-ConditionPathExists=/writable/system-data
+# don't run on classic
+ConditionKernelCommandLine=snap_core
 ConditionPathExists=!/var/lib/snapd/device/ownership-change.after
 Documentation=man:snap(1)
 

--- a/data/systemd/snapd.snap-repair.service.in
+++ b/data/systemd/snapd.snap-repair.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=Automatically fetch and run repair assertions
 Documentation=man:snap(1)
+# don't run on classic
+ConditionKernelCommandLine=snap_core
 
 [Service]
 Type=oneshot

--- a/data/systemd/snapd.snap-repair.timer
+++ b/data/systemd/snapd.snap-repair.timer
@@ -1,5 +1,7 @@
 [Unit]
 Description=Timer to automatically fetch and run repair assertions
+# don't run on classic
+ConditionKernelCommandLine=snap_core
 
 [Timer]
 OnCalendar=*-*-* 5,11,17,23:00


### PR DESCRIPTION
Change the systemd units to conditionally start on "snap_core="
in the kernel commandline. Also update core-fixup to follow
the same pattern.

See https://forum.snapcraft.io/t/ubuntu-snapd-with-no-snaps-installed-firing-recurring-hids-alerts