### PR TITLE
snap-seccomp: manually resolve socket() call in tests

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -232,8 +232,14 @@ faccessat
 	var syscallRunnerArgs [7]string
 	syscallNr, err := seccomp.GetSyscallFromName(l[0])
 	c.Assert(err, IsNil)
-	if syscallNr < 0 {
-		c.Skip(fmt.Sprintf("skipping %v because it resolves to negative %v", l[0], syscallNr))
+	switch {
+	case syscallNr == -101:
+		// "socket"
+		// see libseccomp: _s390x_sock_demux(), _x86_sock_demux()
+		// the -101 is translated to 359 (socket)
+		syscallNr = 359
+	case syscallNr < 0:
+		c.Errorf("failed to resolve %v: %v", l[0], syscallNr)
 		return
 	}
 


### PR DESCRIPTION
In libseccomp 2.3.x the "socket" call on i386/s390x returns a
negative syscall number. This breaks our in-kernel tests. This
patch fixes this by manually resolving the syscall to the real
socket syscall (359).

It also errors now when negative syscalls are found, this should
ensure that we always test all our syscalls.

See also https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1576066/comments/12
