### PR TITLE
tests: try to fix staging tests

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -152,6 +152,10 @@ EOF
     if [ "$REMOTE_STORE" = staging ]; then
         # shellcheck source=tests/lib/store.sh
         . "$TESTSLIB/store.sh"
+        # reset seeding data that is likely tainted with production keys
+        systemctl stop snapd.service snapd.socket
+        rm -rf /var/lib/snapd/assertions/*
+        rm -f /var/lib/snapd/state.json
         setup_staging_store
     fi
 


### PR DESCRIPTION
Now after just starting snapd seeding data is likely immediately tainted with production keys.
Reset it before switching to use staging.
