### PR TITLE
tests: change regex used to validate installed ubuntu core snap

### DIFF
--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -13,6 +13,9 @@ execute: |
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the ubuntu-core snap is sideloaded"
         expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +core *$'
+    elif [ "$SRU_VALIDATION" = "1" ]; then
+        echo "When sru validation is the ubuntu-core snap is installed from the store"
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +core *$'
     else
         expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +core *$'
     fi

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -11,10 +11,10 @@ execute: |
     # but edge will have a timestamp in there, "16.2+201701010932", so add an optional \+[0-9]+ to the end
     # *current* edge also has .git. and a hash snippet, so add an optional .git.[0-9a-f]+ to the already optional timestamp
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
-        echo "With customized images the ubuntu-core snap is sideloaded"
+        echo "With customized images the core snap is sideloaded"
         expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +core *$'
     elif [ "$SRU_VALIDATION" = "1" ]; then
-        echo "When sru validation is the ubuntu-core snap is installed from the store"
+        echo "When sru validation is done the core snap is installed from the store"
         expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +core *$'
     else
         expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +core *$'


### PR DESCRIPTION
This change is used to when the ubuntu core is installed from the store such as when sru validation is done.
