### PR TITLE
cmd/snapctl: allow snapctl -h without a context (regression fix).

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2347,12 +2347,9 @@ func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("snapctl cannot run without args")
 	}
 
-	// Right now snapctl is only used for hooks. If at some point it grows
-	// beyond that, this probably shouldn't go straight to the HookManager.
-	context, err := c.d.overlord.HookManager().Context(snapctlOptions.ContextID)
-	if err != nil {
-		return BadRequest("error running snapctl: %s", err)
-	}
+	// Ignore missing context error to allow 'snapctl -h' without a context;
+	// Actual context is validated later by get/set.
+	context, _ := c.d.overlord.HookManager().Context(snapctlOptions.ContextID)
 	stdout, stderr, err := ctlcmd.Run(context, snapctlOptions.Args)
 	if err != nil {
 		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
@@ -2362,7 +2359,7 @@ func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 	}
 
-	if context.IsEphemeral() {
+	if context != nil && context.IsEphemeral() {
 		context.Lock()
 		defer context.Unlock()
 		if err := context.Done(); err != nil {

--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -11,6 +11,7 @@ execute: |
     echo "Verify that snapctl -h runs without a context"
     if ! snapctl -h; then
         echo "Expected snapctl -h to be successful"
+        exit 1
     fi
 
     echo "Verify that the snapd API is only available via the snapd socket"


### PR DESCRIPTION
Fix a subtle regression introduced with ephemeral contexts: snapctl -h wouldn't work anymore outside of hooks. Also fix the broken test that checks that.
