### PR TITLE
daemon: remove unused installSnap var

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2246,12 +2246,10 @@ func (s *apiSuite) TestTrySnap(c *check.C) {
 			return state.NewTaskSet(t), nil
 		}
 
-		installSnap := ""
 		snapstateInstall = func(s *state.State, name, channel string, revision snap.Revision, userID int, flags snapstate.Flags) (*state.TaskSet, error) {
 			if name != "core" {
 				c.Check(flags, check.DeepEquals, t.flags, check.Commentf(t.desc))
 			}
-			installSnap = name
 			t := s.NewTask("fake-install-snap", "Doing a fake install")
 			return state.NewTaskSet(t), nil
 		}


### PR DESCRIPTION
gccgo complained about this in https://launchpadlibrarian.net/336782642/buildlog_ubuntu-xenial-powerpc.snapd_2.27.6+git368.fcf271c~ubuntu16.04.1_BUILDING.txt.gz and we are indeed not using it in the test.