### PR TITLE
snap-repair: fix test failure in TestRepairHitsTimeout

### DIFF
--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -1648,7 +1648,7 @@ func (s *runScriptSuite) TestRepairHitsTimeout(c *C) {
 	r2 := repair.MockTrustedRepairRootKeys([]*asserts.AccountKey{s.repairRootAcctKey})
 	defer r2()
 
-	restore := repair.MockDefaultRepairTimeout(10 * time.Millisecond)
+	restore := repair.MockDefaultRepairTimeout(100 * time.Millisecond)
 	defer restore()
 
 	script := `#!/bin/sh
@@ -1671,6 +1671,6 @@ sleep 100
 	})
 	s.verifyOutput(c, "r0.retry", `output before timeout
 
-"repair (1; brand-id:canonical)" failed: repair did not finish within 10ms`)
+"repair (1; brand-id:canonical)" failed: repair did not finish within 100ms`)
 	verifyRepairStatus(c, repair.RetryStatus)
 }


### PR DESCRIPTION
The TestRepairHitsTimeout waits for 10ms before stopping the
process. On a busy machine this may not be enough to start the
repair script and produce output. So instead increase the timeout
to 100ms.

This should fix https://launchpadlibrarian.net/336782799/buildlog_ubuntu-xenial-i386.snapd_2.27.6+git368.fcf271c~ubuntu16.04.1_BUILDING.txt.gz

