### PR TITLE
many: add logger.MockLogger() and use it in the tests

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -38,6 +39,7 @@ func Test(t *testing.T) { TestingT(t) }
 
 type cmdSuite struct {
 	restoreExec   func()
+	restoreLogger func()
 	execCalled    int
 	lastExecArgv0 string
 	lastExecArgv  []string
@@ -51,6 +53,7 @@ var _ = Suite(&cmdSuite{})
 
 func (s *cmdSuite) SetUpTest(c *C) {
 	s.restoreExec = cmd.MockSyscallExec(s.syscallExec)
+	_, s.restoreLogger = logger.MockLogger()
 	s.execCalled = 0
 	s.lastExecArgv0 = ""
 	s.lastExecArgv = nil
@@ -64,6 +67,7 @@ func (s *cmdSuite) SetUpTest(c *C) {
 
 func (s *cmdSuite) TearDownTest(c *C) {
 	s.restoreExec()
+	s.restoreLogger()
 }
 
 func (s *cmdSuite) syscallExec(argv0 string, argv []string, envv []string) (err error) {

--- a/cmd/snap/cmd_userd_test.go
+++ b/cmd/snap/cmd_userd_test.go
@@ -27,15 +27,32 @@ import (
 	. "gopkg.in/check.v1"
 
 	snap "github.com/snapcore/snapd/cmd/snap"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/testutil"
 )
 
 type userdSuite struct {
 	BaseSnapSuite
 	testutil.DBusTest
+
+	restoreLogger func()
 }
 
 var _ = Suite(&userdSuite{})
+
+func (s *userdSuite) SetUpTest(c *C) {
+	s.BaseSnapSuite.SetUpTest(c)
+	s.DBusTest.SetUpTest(c)
+
+	_, s.restoreLogger = logger.MockLogger()
+}
+
+func (s *userdSuite) TearDownTest(c *C) {
+	s.BaseSnapSuite.TearDownTest(c)
+	s.DBusTest.TearDownTest(c)
+
+	s.restoreLogger()
+}
 
 func (s *userdSuite) TestUserdBadCommandline(c *C) {
 	_, err := snap.Parser().ParseArgs([]string{"userd", "extra-arg"})

--- a/httputil/logger_test.go
+++ b/httputil/logger_test.go
@@ -39,21 +39,21 @@ import (
 func TestHTTPUtil(t *testing.T) { check.TestingT(t) }
 
 type loggerSuite struct {
-	logbuf *bytes.Buffer
+	logbuf        *bytes.Buffer
+	restoreLogger func()
 }
 
 var _ = check.Suite(&loggerSuite{})
 
-func (loggerSuite) TearDownTest(c *check.C) {
+func (s *loggerSuite) TearDownTest(c *check.C) {
 	os.Unsetenv("SNAPD_DEBUG")
+	s.restoreLogger()
 }
 
 func (s *loggerSuite) SetUpTest(c *check.C) {
 	os.Setenv("SNAPD_DEBUG", "true")
 	s.logbuf = bytes.NewBuffer(nil)
-	l, err := logger.New(s.logbuf, logger.DefaultFlags)
-	c.Assert(err, check.IsNil)
-	logger.SetLogger(l)
+	s.logbuf, s.restoreLogger = logger.MockLogger()
 }
 
 func (loggerSuite) TestFlags(c *check.C) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -20,6 +20,7 @@
 package logger
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -84,6 +85,20 @@ func Debugf(format string, v ...interface{}) {
 	defer lock.Unlock()
 
 	logger.Debug(msg)
+}
+
+func MockLogger() (r io.Reader, restore func()) {
+	oldLogger := logger
+	buf := &bytes.Buffer{}
+	l, err := New(buf, DefaultFlags)
+	if err != nil {
+		panic(err)
+	}
+	SetLogger(l)
+	return buf, func() {
+		logger = oldLogger
+		SetLogger(oldLogger)
+	}
 }
 
 // SetLogger sets the global logger to the given one

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -87,9 +87,11 @@ func Debugf(format string, v ...interface{}) {
 	logger.Debug(msg)
 }
 
-func MockLogger() (r io.Reader, restore func()) {
+// MockLogger replaces the exiting logger with a buffer and returns
+// the log buffer and a restore function.
+func MockLogger() (buf *bytes.Buffer, restore func()) {
+	buf = bytes.NewBuffer(nil)
 	oldLogger := logger
-	buf := &bytes.Buffer{}
 	l, err := New(buf, DefaultFlags)
 	if err != nil {
 		panic(err)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -90,7 +90,7 @@ func Debugf(format string, v ...interface{}) {
 // MockLogger replaces the exiting logger with a buffer and returns
 // the log buffer and a restore function.
 func MockLogger() (buf *bytes.Buffer, restore func()) {
-	buf = bytes.NewBuffer(nil)
+	buf = &bytes.Buffer{}
 	oldLogger := logger
 	l, err := New(buf, DefaultFlags)
 	if err != nil {
@@ -98,7 +98,6 @@ func MockLogger() (buf *bytes.Buffer, restore func()) {
 	}
 	SetLogger(l)
 	return buf, func() {
-		logger = oldLogger
 		SetLogger(oldLogger)
 	}
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -36,16 +36,16 @@ func Test(t *testing.T) { TestingT(t) }
 var _ = Suite(&LogSuite{})
 
 type LogSuite struct {
-	oldLogger logger.Logger
+	logbuf        *bytes.Buffer
+	restoreLogger func()
 }
 
 func (s *LogSuite) SetUpTest(c *C) {
-	s.oldLogger = logger.GetLogger()
-	logger.SetLogger(logger.NullLogger)
+	s.logbuf, s.restoreLogger = logger.MockLogger()
 }
 
 func (s *LogSuite) TearDownTest(c *C) {
-	logger.SetLogger(s.oldLogger)
+	s.restoreLogger()
 }
 
 func (s *LogSuite) TestDefault(c *C) {
@@ -67,48 +67,24 @@ func (s *LogSuite) TestNew(c *C) {
 }
 
 func (s *LogSuite) TestDebugf(c *C) {
-	var logbuf bytes.Buffer
-	l, err := logger.New(&logbuf, logger.DefaultFlags)
-	c.Assert(err, IsNil)
-
-	logger.SetLogger(l)
-
 	logger.Debugf("xyzzy")
-	c.Check(logbuf.String(), Equals, "")
+	c.Check(s.logbuf.String(), Equals, "")
 }
 
 func (s *LogSuite) TestDebugfEnv(c *C) {
-	var logbuf bytes.Buffer
-	l, err := logger.New(&logbuf, logger.DefaultFlags)
-	c.Assert(err, IsNil)
-
-	logger.SetLogger(l)
-
 	os.Setenv("SNAPD_DEBUG", "1")
 	defer os.Unsetenv("SNAPD_DEBUG")
 
 	logger.Debugf("xyzzy")
-	c.Check(logbuf.String(), testutil.Contains, `DEBUG: xyzzy`)
+	c.Check(s.logbuf.String(), testutil.Contains, `DEBUG: xyzzy`)
 }
 
 func (s *LogSuite) TestNoticef(c *C) {
-	var logbuf bytes.Buffer
-	l, err := logger.New(&logbuf, logger.DefaultFlags)
-	c.Assert(err, IsNil)
-
-	logger.SetLogger(l)
-
 	logger.Noticef("xyzzy")
-	c.Check(logbuf.String(), Matches, `(?m).*logger_test\.go:\d+: xyzzy`)
+	c.Check(s.logbuf.String(), Matches, `(?m).*logger_test\.go:\d+: xyzzy`)
 }
 
 func (s *LogSuite) TestPanicf(c *C) {
-	var logbuf bytes.Buffer
-	l, err := logger.New(&logbuf, logger.DefaultFlags)
-	c.Assert(err, IsNil)
-
-	logger.SetLogger(l)
-
 	c.Check(func() { logger.Panicf("xyzzy") }, Panics, "xyzzy")
-	c.Check(logbuf.String(), Matches, `(?m).*logger_test\.go:\d+: PANIC xyzzy`)
+	c.Check(s.logbuf.String(), Matches, `(?m).*logger_test\.go:\d+: PANIC xyzzy`)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -20,7 +20,6 @@
 package snapstate_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -4699,11 +4698,8 @@ func (s *snapmgrTestSuite) TestEnsureRefreshRefusesWeekdaySchedules(c *C) {
 	defer s.state.Unlock()
 	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
 
-	logbuf := bytes.NewBuffer(nil)
-	l, err := logger.New(logbuf, logger.DefaultFlags)
-	c.Assert(err, IsNil)
-	logger.SetLogger(l)
-	defer logger.SetLogger(logger.NullLogger)
+	logbuf, restore := logger.MockLogger()
+	defer restore()
 
 	s.state.Set("last-refresh", time.Date(2009, 8, 13, 8, 0, 5, 0, time.UTC))
 	tr := config.NewTransaction(s.state)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -133,6 +133,8 @@ type remoteRepoTestSuite struct {
 
 	origDownloadFunc func(context.Context, string, string, string, *auth.UserState, *Store, io.ReadWriteSeeker, int64, progress.Meter) error
 	mockXDelta       *testutil.MockCmd
+
+	restoreLogger func()
 }
 
 var _ = Suite(&remoteRepoTestSuite{})
@@ -314,10 +316,7 @@ func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 	os.Setenv("SNAPD_DEBUG", "1")
 	t.AddCleanup(func() { os.Unsetenv("SNAPD_DEBUG") })
 
-	t.logbuf = bytes.NewBuffer(nil)
-	l, err := logger.New(t.logbuf, logger.DefaultFlags)
-	c.Assert(err, IsNil)
-	logger.SetLogger(l)
+	t.logbuf, t.restoreLogger = logger.MockLogger()
 
 	root, err := makeTestMacaroon()
 	c.Assert(err, IsNil)
@@ -344,10 +343,7 @@ func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 func (t *remoteRepoTestSuite) TearDownTest(c *C) {
 	download = t.origDownloadFunc
 	t.mockXDelta.Restore()
-}
-
-func (t *remoteRepoTestSuite) TearDownSuite(c *C) {
-	logger.SimpleSetup()
+	t.restoreLogger()
 }
 
 func (t *remoteRepoTestSuite) expectedAuthorization(c *C, user *auth.UserState) string {

--- a/testutil/dbustest.go
+++ b/testutil/dbustest.go
@@ -67,3 +67,6 @@ func (s *DBusTest) TearDownSuite(c *C) {
 	}
 
 }
+
+func (s *DBusTest) SetUpTest(c *C)    {}
+func (s *DBusTest) TearDownTest(c *C) {}


### PR DESCRIPTION
We have two noisy tests in the unittest runs right now. Messages
get logged to stdout which really should not be visible. With the use
of the new logger.MockLogger() those are now no longer visible.

I also tweaked the existing pattern of:
```
var logbuf bytes.Buffer
l, err := logger.New(&logbuf, logger.DefaultFlags)
c.Assert(err, IsNil)
logger.SetLogger(l)
```
to just use:
```
logbuf, restore := logger.MockLogger()
defer restore()
```

Please let me know what you think, if you think this simple setup should not have a MockLogger() helper I'm happy to adjust the PR to just switch to a different logger in the two noisy tests we currently have.
