### PR TITLE
tests: add test that ensures that all core services are working

### DIFF
--- a/tests/main/ubuntu-core-services/task.yaml
+++ b/tests/main/ubuntu-core-services/task.yaml
@@ -1,0 +1,17 @@
+summary: Ensure all services on Core are active
+
+systems: [ubuntu-core-*]
+
+execute: |
+    echo "Ensure one-shot services are working"
+    for oneshot in snapd.autoimport.service snapd.sshd-keygen.service; do
+        systemctl status $oneshot|MATCH SUCCESS
+    done
+
+    echo "Ensure services are working"
+    systemctl status snapd.service |MATCH active
+    
+    echo "Ensure timers are working"
+    for timer in snapd.snapd.refresh.timer snapd.snap-repair.timer; do
+        systemctl status $timer |MATCH active
+    done


### PR DESCRIPTION
On my pi2 the `snapd.snap-repair.timer` is not active, I'm digging into the root cause and while doing this wrote this test to ensure we always that the core services are still there.