### PR TITLE
cmd/snap: return empty document if snap has no configuration

### DIFF
--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -29,9 +29,11 @@ import (
 	snapset "github.com/snapcore/snapd/cmd/snap"
 )
 
-var getTests = []struct {
+type getCmdArgs struct {
 	args, stdout, stderr, error string
-}{{
+}
+
+var getTests = []getCmdArgs{{
 	args:  "get snap-name --foo",
 	error: ".*unknown flag.*foo.*",
 }, {
@@ -81,10 +83,8 @@ var getTests = []struct {
 	stdout: "{\n\t\"bar\": 100,\n\t\"foo\": {\n\t\t\"key1\": \"value1\",\n\t\t\"key2\": \"value2\"\n\t}\n}\n",
 }}
 
-func (s *SnapSuite) TestSnapGetTests(c *C) {
-	s.mockGetConfigServer(c)
-
-	for _, test := range getTests {
+func (s *SnapSuite) runTests(cmds []getCmdArgs, c *C) {
+	for _, test := range cmds {
 		s.stdout.Truncate(0)
 		s.stderr.Truncate(0)
 
@@ -99,6 +99,27 @@ func (s *SnapSuite) TestSnapGetTests(c *C) {
 			c.Check(s.Stdout(), Equals, test.stdout)
 		}
 	}
+}
+
+func (s *SnapSuite) TestSnapGetTests(c *C) {
+	s.mockGetConfigServer(c)
+	s.runTests(getTests, c)
+}
+
+var getNoConfigTests = []getCmdArgs{{
+	args:  "get -l snapname",
+	error: `snap "snapname" has no configuration`,
+}, {
+	args:  "get snapname",
+	error: `snap "snapname" has no configuration`,
+}, {
+	args:   "get -d snapname",
+	stdout: "{}\n",
+}}
+
+func (s *SnapSuite) TestSnapGetNoConfiguration(c *C) {
+	s.mockGetEmptyConfigServer(c)
+	s.runTests(getNoConfigTests, c)
 }
 
 func (s *SnapSuite) TestSortByPath(c *C) {
@@ -166,5 +187,18 @@ func (s *SnapSuite) mockGetConfigServer(c *C) {
 		default:
 			c.Errorf("unexpected keys %q", query.Get("keys"))
 		}
+	})
+}
+
+func (s *SnapSuite) mockGetEmptyConfigServer(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/snaps/snapname/conf" {
+			c.Errorf("unexpected path %q", r.URL.Path)
+			return
+		}
+
+		c.Check(r.Method, Equals, "GET")
+
+		fmt.Fprintln(w, `{"type":"sync", "status-code": 200, "result": {}}`)
 	})
 }

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -64,6 +64,10 @@ var getTests = []getCmdArgs{{
 	args:   "get snapname -l test-key1 test-key2",
 	stdout: "Key        Value\ntest-key1  test-value1\ntest-key2  2\n",
 }, {
+	args:   "get snapname document",
+	stderr: `WARNING: The output of "snap get" will become a list with columns - use -d or -l to force the output format.\n`,
+	stdout: "{\n\t\"document\": {\n\t\t\"key1\": \"value1\",\n\t\t\"key2\": \"value2\"\n\t}\n}\n",
+}, {
 	args:   "get snapname -d test-key1 test-key2",
 	stdout: "{\n\t\"test-key1\": \"test-value1\",\n\t\"test-key2\": 2\n}\n",
 }, {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1526,6 +1526,11 @@ func getSnapConf(c *Command, r *http.Request, user *auth.UserState) Response {
 		var value interface{}
 		if err := tr.Get(snapName, key, &value); err != nil {
 			if config.IsNoOption(err) {
+				if key == "" {
+					// no configuration - return empty document
+					currentConfValues = make(map[string]interface{})
+					break
+				}
 				return BadRequest("%v", err)
 			} else {
 				return InternalError("%v", err)

--- a/overlord/configstate/config/transaction_test.go
+++ b/overlord/configstate/config/transaction_test.go
@@ -306,3 +306,15 @@ func (s *transactionSuite) TestGetUnmarshalError(c *C) {
 	err = tr.Get("test-snap", "foo", &broken)
 	c.Assert(err, ErrorMatches, ".*BAM!.*")
 }
+
+func (s *transactionSuite) TestNoConfiguration(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var res interface{}
+	tr := config.NewTransaction(s.state)
+	err := tr.Get("some-snap", "", &res)
+	c.Assert(err, NotNil)
+	c.Assert(config.IsNoOption(err), Equals, true)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has no configuration`)
+}

--- a/tests/main/snap-get/task.yaml
+++ b/tests/main/snap-get/task.yaml
@@ -22,7 +22,7 @@ execute: |
         exit 1
     fi
 
-    echo "Test that getting root document without any configuration produces an error"
+    echo "Test that getting root document without any configuration produces an error with list format"
     if output=$(snap get snapctl-hooks 2>&1); then
         echo "snap get didn't fail as expected"
         exit 1
@@ -32,6 +32,9 @@ execute: |
         echo "Expected '$expected' error, but it was '$output'"
         exit 1
     fi
+
+    echo "Test that getting root document without any configuration works for json output"
+    snap get snapctl-hooks -d | MATCH "^{}$"
 
     echo "Test that values set via snapctl can be obtained via snap get"
     if ! snap set snapctl-hooks command=test-snapctl-set-foo; then


### PR DESCRIPTION
If snap has no configuration then `snap get <snapname>`:
- returns empty json document if document (-d) was requested.
- otherwise returns 'snap ... has no configuration" error.
