### PR TITLE
cmd,dirs: treat manjaro the same as arch linux

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -67,7 +67,7 @@ func distroSupportsReExec() bool {
 		return false
 	}
 	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch":
+	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch", "manjaro":
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return false
 	}

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -157,7 +157,7 @@ func SetRootDir(rootdir string) {
 	GlobalRootDir = rootdir
 
 	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "arch":
+	case "fedora", "centos", "rhel", "arch", "manjaro":
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	default:
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)


### PR DESCRIPTION
Manjaro is a derivative of Arch and needs to be treated as such.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>