### PR TITLE
interfaces/builtin: allow receiving dbus messages

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -112,7 +112,7 @@ const udisks2ConnectedSlotAppArmor = `
 # Allow connected clients to interact with the service. This gives privileged
 # access to the system.
 
-dbus (send)
+dbus (receive, send)
     bus=system
     path=/org/freedesktop/UDisks2/**
     interface=org.freedesktop.DBus.Properties


### PR DESCRIPTION
The AppArmor rules for udisks2 connected slot don't allow receiving
messages from the connected clients, just sending them. This breaks the
interface.

Fixes: https://bugs.launchpad.net/snappy/+bug/1717857
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
