### PR TITLE
spread: work around temporary packaging issue in debian sid

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -297,6 +297,12 @@ prepare: |
         echo "Tests cannot run inside a container"
         exit 1
     fi
+    if [[ "$SPREAD_SYSTEM" == debian-unstable-* ]]; then
+        # There's a packaging bug in Debian sid lately where some packages
+        # conflict on manual page file. To work around it simply remove the
+        # manpages package.
+        apt-get remove --purge -y manpages
+    fi
 
     # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
     cat <<EOF > gai.conf

--- a/spread.yaml
+++ b/spread.yaml
@@ -297,6 +297,9 @@ prepare: |
         echo "Tests cannot run inside a container"
         exit 1
     fi
+
+    # FIXME: remove once the following bug is fixed:
+    #   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=876128
     if [[ "$SPREAD_SYSTEM" == debian-unstable-* ]]; then
         # There's a packaging bug in Debian sid lately where some packages
         # conflict on manual page file. To work around it simply remove the


### PR DESCRIPTION
Due to apparent packaging bug in Debian the manpages-dev package clashes
with the manpages package. This patch makes us remove manpages in
attempt to work around the problem.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>