### PR TITLE
snap-repair: make `repair` binary available for repair scripts

### DIFF
--- a/cmd/snap-repair/cmd_done_retry_skip.go
+++ b/cmd/snap-repair/cmd_done_retry_skip.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func init() {
+	cmd, err := parser.AddCommand("done", "Signal repair is done", "", &cmdDone{})
+	if err != nil {
+
+		panic(err)
+	}
+	cmd.Hidden = true
+
+	cmd, err = parser.AddCommand("skip", "Signal repair is done", "", &cmdSkip{})
+	if err != nil {
+		panic(err)
+	}
+	cmd.Hidden = true
+
+	cmd, err = parser.AddCommand("retry", "Signal repair is done", "", &cmdRetry{})
+	if err != nil {
+		panic(err)
+	}
+	cmd.Hidden = true
+}
+
+func writeToStatusFD(msg string) error {
+	statusFdStr := os.Getenv("SNAP_REPAIR_STATUS_FD")
+	if statusFdStr == "" {
+		return fmt.Errorf("cannot find SNAP_REPAIR_STATUS_FD environment")
+	}
+	fd, err := strconv.Atoi(statusFdStr)
+	if err != nil {
+		return fmt.Errorf("cannot parse SNAP_REPAIR_STATUS_FD environment: %s", err)
+	}
+	f := os.NewFile(uintptr(fd), "<snap-repair-status-fd>")
+	defer f.Close()
+	if _, err := f.Write([]byte(msg + "\n")); err != nil {
+		return err
+	}
+	return nil
+}
+
+type cmdDone struct{}
+
+func (c *cmdDone) Execute(args []string) error {
+	return writeToStatusFD("done")
+}
+
+type cmdSkip struct{}
+
+func (c *cmdSkip) Execute([]string) error {
+	return writeToStatusFD("skip")
+}
+
+type cmdRetry struct{}
+
+func (c *cmdRetry) Execute([]string) error {
+	return writeToStatusFD("retry")
+}

--- a/cmd/snap-repair/cmd_done_retry_skip.go
+++ b/cmd/snap-repair/cmd_done_retry_skip.go
@@ -33,13 +33,13 @@ func init() {
 	}
 	cmd.Hidden = true
 
-	cmd, err = parser.AddCommand("skip", "Signal repair is done", "", &cmdSkip{})
+	cmd, err = parser.AddCommand("skip", "Signal repair should be skipped", "", &cmdSkip{})
 	if err != nil {
 		panic(err)
 	}
 	cmd.Hidden = true
 
-	cmd, err = parser.AddCommand("retry", "Signal repair is done", "", &cmdRetry{})
+	cmd, err = parser.AddCommand("retry", "Signal repair must be retried next time", "", &cmdRetry{})
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/snap-repair/cmd_done_retry_skip_test.go
+++ b/cmd/snap-repair/cmd_done_retry_skip_test.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	. "gopkg.in/check.v1"
+
+	repair "github.com/snapcore/snapd/cmd/snap-repair"
+)
+
+func (r *repairSuite) TestStatusNoStatusFdEnv(c *C) {
+	for _, s := range []string{"done", "skip", "retry"} {
+		err := repair.ParseArgs([]string{s})
+		c.Check(err, ErrorMatches, "cannot find SNAP_REPAIR_STATUS_FD environment")
+	}
+}
+
+func (r *repairSuite) TestStatusBadStatusFD(c *C) {
+	for _, s := range []string{"done", "skip", "retry"} {
+		os.Setenv("SNAP_REPAIR_STATUS_FD", "123456789")
+		defer os.Unsetenv("SNAP_REPAIR_STATUS_FD")
+
+		err := repair.ParseArgs([]string{s})
+		c.Check(err, ErrorMatches, `write <snap-repair-status-fd>: bad file descriptor`)
+	}
+}
+
+func (r *repairSuite) TestStatusUnparsableStatusFD(c *C) {
+	for _, s := range []string{"done", "skip", "retry"} {
+		os.Setenv("SNAP_REPAIR_STATUS_FD", "xxx")
+		defer os.Unsetenv("SNAP_REPAIR_STATUS_FD")
+
+		err := repair.ParseArgs([]string{s})
+		c.Check(err, ErrorMatches, `cannot parse SNAP_REPAIR_STATUS_FD environment: strconv.ParseInt: parsing "xxx": invalid syntax`)
+	}
+}
+
+func (r *repairSuite) TestStatusHappy(c *C) {
+	for _, s := range []string{"done", "skip", "retry"} {
+		rp, wp, err := os.Pipe()
+		c.Assert(err, IsNil)
+		os.Setenv("SNAP_REPAIR_STATUS_FD", strconv.Itoa(int(wp.Fd())))
+		defer os.Unsetenv("SNAP_REPAIR_STATUS_FD")
+
+		err = repair.ParseArgs([]string{s})
+		c.Check(err, IsNil)
+
+		status, err := ioutil.ReadAll(rp)
+		c.Assert(err, IsNil)
+		c.Check(string(status), Equals, s+"\n")
+	}
+}

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -121,6 +121,14 @@ func (r *Repair) Run() error {
 	// except the ones in "cmd.ExtraFiles" we are safe to set "3"
 	env = append(env, "SNAP_REPAIR_STATUS_FD=3")
 	env = append(env, "SNAP_REPAIR_RUN_DIR="+rundir)
+	// inject /usr/lib/snapd/ into PATH so that the script can use
+	// `snap-repair done`
+	for i, envStr := range env {
+		if strings.HasPrefix(envStr, "PATH=") {
+			newEnv := fmt.Sprintf("%s:%s", strings.TrimSuffix(envStr, ":"), dirs.CoreLibExecDir)
+			env[i] = newEnv
+		}
+	}
 
 	workdir := filepath.Join(rundir, "work")
 	if err := os.MkdirAll(workdir, 0700); err != nil {

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -1674,3 +1674,29 @@ sleep 100
 "repair (1; brand-id:canonical)" failed: repair did not finish within 100ms`)
 	verifyRepairStatus(c, repair.RetryStatus)
 }
+
+func (s *runScriptSuite) TestRepairHasCorrectPath(c *C) {
+	r1 := sysdb.InjectTrusted(s.storeSigning.Trusted)
+	defer r1()
+	r2 := repair.MockTrustedRepairRootKeys([]*asserts.AccountKey{s.repairRootAcctKey})
+	defer r2()
+
+	restore := repair.MockDefaultRepairTimeout(100 * time.Millisecond)
+	defer restore()
+
+	script := `#!/bin/sh
+echo PATH=$PATH
+`
+	s.seqRepairs = []string{makeMockRepair(script)}
+	s.seqRepairs = s.signSeqRepairs(c, s.seqRepairs)
+
+	rpr, err := s.runner.Next("canonical")
+	c.Assert(err, IsNil)
+
+	err = rpr.Run()
+	c.Assert(err, IsNil)
+
+	output, err := ioutil.ReadFile(filepath.Join(s.runDir, "r0.retry"))
+	c.Assert(err, IsNil)
+	c.Check(string(output), Matches, fmt.Sprintf("(?ms)^PATH=.*:.*/usr/lib/snapd"))
+}

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -1686,6 +1686,7 @@ func (s *runScriptSuite) TestRepairHasCorrectPath(c *C) {
 
 	script := `#!/bin/sh
 echo PATH=$PATH
+ls -l ${PATH##*:}/repair
 `
 	s.seqRepairs = []string{makeMockRepair(script)}
 	s.seqRepairs = s.signSeqRepairs(c, s.seqRepairs)
@@ -1698,5 +1699,6 @@ echo PATH=$PATH
 
 	output, err := ioutil.ReadFile(filepath.Join(s.runDir, "r0.retry"))
 	c.Assert(err, IsNil)
-	c.Check(string(output), Matches, fmt.Sprintf("(?ms)^PATH=.*:.*/usr/lib/snapd"))
+	c.Check(string(output), Matches, fmt.Sprintf("(?ms)^PATH=.*:/tmp/repair-.*"))
+	c.Check(string(output), Matches, "(?ms).*/repair -> /usr/lib/snapd/snap-repair")
 }


### PR DESCRIPTION
via symlink in a tempdir to the real /usr/lib/snapd/snap-repair.

Based on https://github.com/snapcore/snapd/pull/3925