### PR TITLE
data/completion: small tweak to snap completion snippet

### DIFF
--- a/data/completion/snap
+++ b/data/completion/snap
@@ -19,24 +19,34 @@ _complete_snap() {
     local cur prev words cword
     _init_completion -n : || return
 
-    local command
-    if [[ ${#words[@]} -gt 2 ]]; then
-        if [[ ${words[1]} =~ ^-- ]]; then
-            # global options take no args
-            return 0
-        fi
-        if [[ ${words[-2]} = "--help" ]]; then
-            # help takes no args
-            return 0
-        fi
-
-        command=${words[-2]}
+    if [[ ${#words[@]} -le 2 ]]; then
+        # we're completing on the first word
+        COMPREPLY=($(GO_FLAGS_COMPLETION=1 "${words[@]}"))
+        return 0
     fi
+
+    local command
+    if [[ ${words[1]} =~ ^- ]]; then
+        # global options take no args
+        return 0
+    fi
+
+    for w in "${words[@]:1}"; do
+        if [[ "$w" == "-h" || "$w" == "--help" ]]; then
+            # completing on help gets confusing
+            return 0
+        fi
+    done
+
+    command=${words[1]}
 
     # Only split on newlines
     local IFS=$'\n'
 
-    COMPREPLY=($(GO_FLAGS_COMPLETION=1 "${words[@]}"))
+    # now we pass _just the bit that's being completed_ of the command
+    # to snap for it to figure it out. go-flags isn't smart enough to
+    # look at COMP_WORDS etc. itself.
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 snap "$command" "$cur"))
 
     case $command in
         install|info|sign-build)


### PR DESCRIPTION
previously, if you were completing from the middle of a command,
things might get weird. For example,

    $ snap install test- --devmode
                        ^ you are here

if you hit tab there, without this change, you get a very helpful
`--devmode` replacing `test-`.

This is because we were just passing all the command off to go flags
for it to figure out, and it doesn't work that way.

Anyway, this fixes that.
