### PR TITLE
interfaces/udev: only 'trigger --action=change', not 'control --reload-rules'

### DIFF
--- a/cmd/snap-confine/spread-tests/main/cgroup-used/task.yaml
+++ b/cmd/snap-confine/spread-tests/main/cgroup-used/task.yaml
@@ -8,9 +8,7 @@ execute: |
     cd /
     echo "Clear udev tags and cgroups with non-test device and running snapd-hacker-toolbelt.busybox"
     echo 'KERNEL=="uinput", TAG+="snap_snapd-hacker-toolbelt_busybox"' > /etc/udev/rules.d/70-spread-test.rules
-    udevadm control --reload-rules
-    udevadm settle
-    udevadm trigger
+    udevadm trigger --action=change
     udevadm settle
     snapd-hacker-toolbelt.busybox echo "Hello World" | grep Hello
     echo "Verify no tags for snapd-hacker-toolbelt.busybox for kmsg"
@@ -18,9 +16,7 @@ execute: |
     echo "Manually add udev tags for snapd-hacker-toolbelt.busybox for kmsg"
     echo 'KERNEL=="kmsg", TAG+="snap_snapd-hacker-toolbelt_busybox"' > /etc/udev/rules.d/70-spread-test.rules
     echo "Simulate snapd udev triggers"
-    udevadm control --reload-rules
-    udevadm settle
-    udevadm trigger
+    udevadm trigger --action=change
     udevadm settle
     echo "Verify udev has tag for kmsg"
     if ! udevadm info /sys/devices/virtual/mem/kmsg | grep snap_snapd-hacker-toolbelt_busybox; then exit 1; fi
@@ -30,8 +26,6 @@ execute: |
 restore: |
     snap remove snapd-hacker-toolbelt
     rm -f /etc/udev/rules.d/70-spread-test.rules
-    udevadm control --reload-rules
-    udevadm settle
-    udevadm trigger
+    udevadm trigger --action=change
     udevadm settle
     # no way to clear cgroup for snapd-hacker-toolbelt atm

--- a/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
+++ b/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
@@ -37,9 +37,7 @@ execute: |
     cd /
     echo "Add a udev tag so affected code branch is exercised"
     echo 'KERNEL=="uinput", TAG+="snap_hello-world_env"' > /etc/udev/rules.d/70-spread-test.rules
-    udevadm control --reload-rules
-    udevadm settle
-    udevadm trigger
+    udevadm trigger --action=change
     udevadm settle
     PATH=/foo:$PATH TESTVAR=bar hello-world.env | grep PATH
     cat /run/udev/spread-test.out
@@ -62,8 +60,6 @@ restore: |
     rm -rf /squashfs-root
     rm -f /run/udev/spread-test.out
     rm -f /etc/udev/rules.d/70-spread-test.rules
-    udevadm control --reload-rules
-    udevadm settle
-    udevadm trigger
+    udevadm trigger --action=change
     udevadm settle
     systemctl start snapd.refresh.timer snapd.service snapd.socket

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -96,10 +96,9 @@ func (s *backendSuite) TestInstallingSnapWritesAndLoadsRules(c *C) {
 		// file called "70-snap.sambda.rules" was created
 		_, err := os.Stat(fname)
 		c.Check(err, IsNil)
-		// udevadm was used to reload rules and re-run triggers
+		// udevadm was used to re-run triggers
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
-			{"udevadm", "control", "--reload-rules"},
-			{"udevadm", "trigger"},
+			{"udevadm", "trigger", "--action=change"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -124,10 +123,9 @@ func (s *backendSuite) TestInstallingSnapWithHookWritesAndLoadsRules(c *C) {
 		_, err := os.Stat(fname)
 		c.Check(err, IsNil)
 
-		// Verify that udevadm was used to reload rules and re-run triggers.
+		// Verify that udevadm was used to re-run triggers.
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
-			{"udevadm", "control", "--reload-rules"},
-			{"udevadm", "trigger"},
+			{"udevadm", "trigger", "--action=change"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -164,10 +162,9 @@ func (s *backendSuite) TestRemovingSnapRemovesAndReloadsRules(c *C) {
 		// file called "70-snap.sambda.rules" was removed
 		_, err := os.Stat(fname)
 		c.Check(os.IsNotExist(err), Equals, true)
-		// udevadm was used to reload rules and re-run triggers
+		// udevadm was used to re-run triggers
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
-			{"udevadm", "control", "--reload-rules"},
-			{"udevadm", "trigger"},
+			{"udevadm", "trigger", "--action=change"},
 		})
 	}
 }
@@ -186,10 +183,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 		// file called "70-snap.sambda.rules" was created
 		_, err := os.Stat(fname)
 		c.Check(err, IsNil)
-		// udevadm was used to reload rules and re-run triggers
+		// udevadm was used to re-run triggers
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
-			{"udevadm", "control", "--reload-rules"},
-			{"udevadm", "trigger"},
+			{"udevadm", "trigger", "--action=change"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -215,10 +211,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreHooks(c *C) {
 		_, err := os.Stat(fname)
 		c.Check(err, IsNil)
 
-		// Verify that udevadm was used to reload rules and re-run triggers
+		// Verify that udevadm was used to re-run triggers
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
-			{"udevadm", "control", "--reload-rules"},
-			{"udevadm", "trigger"},
+			{"udevadm", "trigger", "--action=change"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -238,10 +233,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerApps(c *C) {
 		// file called "70-snap.sambda.rules" still exists
 		_, err := os.Stat(fname)
 		c.Check(err, IsNil)
-		// udevadm was used to reload rules and re-run triggers
+		// udevadm was used to re-run triggers
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
-			{"udevadm", "control", "--reload-rules"},
-			{"udevadm", "trigger"},
+			{"udevadm", "trigger", "--action=change"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -265,10 +259,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerHooks(c *C) {
 		// file called "70-snap.sambda.rules" still exists
 		_, err := os.Stat(fname)
 		c.Check(err, IsNil)
-		// Verify that udevadm was used to reload rules and re-run triggers
+		// Verify that udevadm was used to re-run triggers
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
-			{"udevadm", "control", "--reload-rules"},
-			{"udevadm", "trigger"},
+			{"udevadm", "trigger", "--action=change"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -356,10 +349,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithoutSlots(c *C) {
 		// file called "70-snap.sambda.rules" was removed
 		_, err := os.Stat(fname)
 		c.Check(os.IsNotExist(err), Equals, true)
-		// Verify that udevadm was used to reload rules and re-run triggers
+		// Verify that udevadm was used to re-run triggers
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
-			{"udevadm", "control", "--reload-rules"},
-			{"udevadm", "trigger"},
+			{"udevadm", "trigger", "--action=change"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -383,7 +375,7 @@ func (s *backendSuite) TestUpdatingSnapWithoutSlotsToOneWithoutSlots(c *C) {
 		// file called "70-snap.sambda.rules" still does not exist
 		_, err = os.Stat(fname)
 		c.Check(os.IsNotExist(err), Equals, true)
-		// Verify that udevadm was used to reload rules and re-run triggers
+		// Verify that udevadm was used to re-run triggers
 		c.Check(len(s.udevadmCmd.Calls()), Equals, 0)
 		s.RemoveSnap(c, snapInfo)
 	}

--- a/interfaces/udev/udev.go
+++ b/interfaces/udev/udev.go
@@ -26,14 +26,9 @@ import (
 
 // ReloadRules runs two commands that reload udev rule database.
 //
-// The commands are: udevadm control --reload-rules
-//                   udevadm trigger
+// The commands are: udevadm trigger --action=change
 func ReloadRules() error {
-	output, err := exec.Command("udevadm", "control", "--reload-rules").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("cannot reload udev rules: %s\nudev output:\n%s", err, string(output))
-	}
-	output, err = exec.Command("udevadm", "trigger").CombinedOutput()
+	output, err := exec.Command("udevadm", "trigger", "--action=change").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cannot run udev triggers: %s\nudev output:\n%s", err, string(output))
 	}

--- a/interfaces/udev/udev_test.go
+++ b/interfaces/udev/udev_test.go
@@ -44,26 +44,7 @@ func (s *uDevSuite) TestReloadUDevRulesRunsUDevAdm(c *C) {
 	err := udev.ReloadRules()
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"udevadm", "control", "--reload-rules"},
-		{"udevadm", "trigger"},
-	})
-}
-
-func (s *uDevSuite) TestReloadUDevRulesReportsErrorsFromReloadRules(c *C) {
-	cmd := testutil.MockCommand(c, "udevadm", `
-if [ "$1" = "control" ]; then
-	echo "failure 1"
-	exit 1
-fi
-	`)
-	defer cmd.Restore()
-	err := udev.ReloadRules()
-	c.Assert(err.Error(), Equals, ""+
-		"cannot reload udev rules: exit status 1\n"+
-		"udev output:\n"+
-		"failure 1\n")
-	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"udevadm", "control", "--reload-rules"},
+		{"udevadm", "trigger", "--action=change"},
 	})
 }
 
@@ -81,7 +62,6 @@ fi
 		"udev output:\n"+
 		"failure 2\n")
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
-		{"udevadm", "control", "--reload-rules"},
-		{"udevadm", "trigger"},
+		{"udevadm", "trigger", "--action=change"},
 	})
 }

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -26,8 +26,7 @@ prepare: |
 
 restore: |
     rm -f /etc/udev/rules.d/70-snap.test-snapd-tools.rules
-    udevadm control --reload-rules
-    udevadm trigger
+    udevadm trigger --action=change
 
 execute: |
     echo "Given a snap is installed"
@@ -48,9 +47,7 @@ execute: |
     echo "When a udev rule assigning the device to the snap is added"
     content="KERNEL==\"$DEVICE_NAME\", TAG+=\"snap_test-snapd-tools_env\""
     echo "$content" > /etc/udev/rules.d/70-snap.test-snapd-tools.rules
-    udevadm control --reload-rules
-    udevadm settle
-    udevadm trigger
+    udevadm trigger --action=change
     udevadm settle
 
     echo "Then the device is shown as assigned to the snap"


### PR DESCRIPTION
This simplifies updates to the udev database based on the discussion in https://forum.snapcraft.io/t/snap-remove-somesnap-triggers-keyboard-input-fallthrough-to-vt-ctrl-c-in-terminal-logs-out-of-current-gdm-session/2162/3