### PR TITLE
dirs: fix classic support detection

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -132,14 +132,14 @@ func StripRootDir(dir string) string {
 
 // SupportsClassicConfinement returns true if the current directory layout supports classic confinement.
 func SupportsClassicConfinement() bool {
-	if SnapMountDir == defaultSnapMountDir {
+	smd := filepath.Join(GlobalRootDir, defaultSnapMountDir)
+	if SnapMountDir == smd {
 		return true
 	}
 
 	// distros with a non-default /snap location may still be good
 	// if there is a symlink in place that links from the
 	// defaultSnapMountDir (/snap) to the distro specific mount dir
-	smd := filepath.Join(GlobalRootDir, defaultSnapMountDir)
 	fi, err := os.Lstat(smd)
 	if err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		if target, err := filepath.EvalSymlinks(smd); err == nil {

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -58,7 +58,7 @@ func (s *DirsTestSuite) TestClassicConfinementSupport(c *C) {
 	dirs.SetRootDir("/")
 	c.Check(dirs.SupportsClassicConfinement(), Equals, true)
 
-	dirs.SetRootDir("/alt")
+	dirs.SnapMountDir = "/alt"
 	defer dirs.SetRootDir("/")
 	c.Check(dirs.SupportsClassicConfinement(), Equals, false)
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -361,6 +361,9 @@ func (s *snapmgrTestSuite) TestInstallFailsWhenClassicSnapsAreNotSupported(c *C)
 	})
 	defer reset()
 
+	// this needs doing because dirs depends on the release info
+	dirs.SetRootDir(dirs.GlobalRootDir)
+
 	_, err := snapstate.Install(s.state, "some-snap", "channel-for-classic", snap.R(0), s.user.ID, snapstate.Flags{Classic: true})
 	c.Assert(err, ErrorMatches, "classic confinement requires snaps under /snap or symlink from /snap to "+dirs.SnapMountDir)
 }
@@ -483,7 +486,7 @@ func (s *snapmgrTestSuite) TestRevertTasksJailMode(c *C) {
 
 func (s *snapmgrTestSuite) TestRevertTasksClassic(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 	s.testRevertTasks(snapstate.Flags{Classic: true}, c)
 }
@@ -580,7 +583,7 @@ func (s *snapmgrTestSuite) TestUpdateManyDevModeConfinementFiltering(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateManyClassicConfinementFiltering(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 
 	s.state.Lock()
@@ -602,7 +605,7 @@ func (s *snapmgrTestSuite) TestUpdateManyClassicConfinementFiltering(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateManyClassic(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 
 	s.state.Lock()
@@ -1085,7 +1088,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksCoreSetsIgnoreOnConfigure(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateDevModeConfinementFiltering(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 
 	s.state.Lock()
@@ -1111,7 +1114,7 @@ func (s *snapmgrTestSuite) TestUpdateDevModeConfinementFiltering(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateClassicConfinementFiltering(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 
 	s.state.Lock()
@@ -1151,7 +1154,7 @@ func (s *snapmgrTestSuite) TestUpdateClassicConfinementFiltering(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateClassicFromClassic(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 
 	s.state.Lock()
@@ -1223,7 +1226,7 @@ func (s *snapmgrTestSuite) TestUpdateClassicFromClassic(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateStrictFromClassic(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 
 	s.state.Lock()
@@ -5282,7 +5285,7 @@ func (s *snapmgrTestSuite) TestTrySetsTryModeJailMode(c *C) {
 }
 func (s *snapmgrTestSuite) TestTrySetsTryModeClassic(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 	s.testTrySetsTryMode(snapstate.Flags{Classic: true}, c)
 }
@@ -5336,7 +5339,7 @@ func (s *snapmgrTestSuite) testTrySetsTryMode(flags snapstate.Flags, c *C) {
 
 func (s *snapmgrTestSuite) TestTryUndoRemovesTryFlag(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 	s.testTrySetsTryMode(snapstate.Flags{}, c)
 }
@@ -5349,7 +5352,7 @@ func (s *snapmgrTestSuite) TestTryUndoRemovesTryFlagLeavesJailMode(c *C) {
 }
 func (s *snapmgrTestSuite) TestTryUndoRemovesTryFlagLeavesClassic(c *C) {
 	if !dirs.SupportsClassicConfinement() {
-		return
+		c.Skip("no support for classic")
 	}
 	s.testTrySetsTryMode(snapstate.Flags{Classic: true}, c)
 }


### PR DESCRIPTION
`dirs.SupportsClassicConfinement()` was (mostly) just checking

    dirs.SnapMountDir == "/snap"

without looking at `dirs.GlobalRootDir`, meaning that any and all
tests that (properly) called `dirs.SetRootDir(c.MkDir())`,
`dirs.SupportsClassicConfinement()` was returning `false`.

This was hidden by the fact that most tests that cared would simply
return on getting `false`, instead of skipping, so they quietly passed
without testing anything.

This PR addresses both of these issues.