### PR TITLE
snap: refactor cmdGet.Execute()

### DIFF
--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -166,37 +166,7 @@ func (x *cmdGet) outputList(conf map[string]interface{}) error {
 	return nil
 }
 
-func (x *cmdGet) Execute(args []string) error {
-	if len(args) > 0 {
-		// TRANSLATORS: the %s is the list of extra arguments
-		return fmt.Errorf(i18n.G("too many arguments: %s"), strings.Join(args, " "))
-	}
-
-	if x.Document && x.Typed {
-		return fmt.Errorf("cannot use -d and -t together")
-	}
-
-	if x.Document && x.List {
-		return fmt.Errorf("cannot use -d and -l together")
-	}
-
-	snapName := string(x.Positional.Snap)
-	confKeys := x.Positional.Keys
-
-	cli := Client()
-	conf, err := cli.Conf(snapName, confKeys)
-	if err != nil {
-		return err
-	}
-
-	isTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
-	switch {
-	case x.Document:
-		return x.outputJson(conf)
-	case x.List || isTerminal:
-		return x.outputList(conf)
-	}
-
+func (x *cmdGet) outputDefault(conf map[string]interface{}, snapName string, confKeys []string) error {
 	rootRequested := len(confKeys) == 0
 	var confToPrint interface{} = conf
 
@@ -228,4 +198,39 @@ func (x *cmdGet) Execute(args []string) error {
 
 	fmt.Fprintln(Stdout, "")
 	return nil
+
+}
+
+func (x *cmdGet) Execute(args []string) error {
+	if len(args) > 0 {
+		// TRANSLATORS: the %s is the list of extra arguments
+		return fmt.Errorf(i18n.G("too many arguments: %s"), strings.Join(args, " "))
+	}
+
+	if x.Document && x.Typed {
+		return fmt.Errorf("cannot use -d and -t together")
+	}
+
+	if x.Document && x.List {
+		return fmt.Errorf("cannot use -d and -l together")
+	}
+
+	snapName := string(x.Positional.Snap)
+	confKeys := x.Positional.Keys
+
+	cli := Client()
+	conf, err := cli.Conf(snapName, confKeys)
+	if err != nil {
+		return err
+	}
+
+	isTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
+	switch {
+	case x.Document:
+		return x.outputJson(conf)
+	case x.List || isTerminal:
+		return x.outputList(conf)
+	default:
+		return x.outputDefault(conf, snapName, confKeys)
+	}
 }

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -139,7 +139,7 @@ func flattenConfig(cfg map[string]interface{}, root bool) (values []ConfigValue)
 	return values
 }
 
-func (c *cmdGet) outputJson(conf map[string]interface{}) error {
+func (c *cmdGet) outputJson(conf interface{}) error {
 	bytes, err := json.MarshalIndent(conf, "", "\t")
 	if err != nil {
 		return err
@@ -217,24 +217,15 @@ func (x *cmdGet) Execute(args []string) error {
 		fmt.Fprintf(Stderr, i18n.G(`WARNING: The output of "snap get" will become a list with columns - use -d or -l to force the output format.\n`))
 	}
 
-	if x.Typed && confToPrint == nil {
-		fmt.Fprintln(Stdout, "null")
-		return nil
-	}
-
 	if s, ok := confToPrint.(string); ok && !x.Typed {
 		fmt.Fprintln(Stdout, s)
 		return nil
 	}
 
-	var bytes []byte
-	if confToPrint != nil {
-		bytes, err = json.MarshalIndent(confToPrint, "", "\t")
-		if err != nil {
-			return err
-		}
+	if confToPrint != nil || x.Typed {
+		return x.outputJson(confToPrint)
 	}
 
-	fmt.Fprintln(Stdout, string(bytes))
+	fmt.Fprintln(Stdout, "")
 	return nil
 }

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -187,7 +187,6 @@ func (x *cmdGet) outputDefault(conf map[string]interface{}, snapName string, con
 	}
 
 	if cfg, ok := confToPrint.(map[string]interface{}); ok {
-		// FIXME: this needs a test
 		if isTerminal() {
 			return x.outputList(cfg)
 		} else {

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -69,6 +69,10 @@ var getTests = []getCmdArgs{{
 	stderr: `WARNING: The output of "snap get" will become a list with columns - use -d or -l to force the output format.\n`,
 	stdout: "{\n\t\"document\": {\n\t\t\"key1\": \"value1\",\n\t\t\"key2\": \"value2\"\n\t}\n}\n",
 }, {
+	isTerminal: true,
+	args:       "get snapname document",
+	stdout:     "Key            Value\ndocument.key1  value1\ndocument.key2  value2\n",
+}, {
 	args:   "get snapname -d test-key1 test-key2",
 	stdout: "{\n\t\"test-key1\": \"test-value1\",\n\t\"test-key2\": 2\n}\n",
 }, {

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -128,3 +128,11 @@ func AliasInfoLess(snapName1, alias1, cmd1, snapName2, alias2, cmd2 string) bool
 func AssertTypeNameCompletion(match string) []flags.Completion {
 	return assertTypeName("").Complete(match)
 }
+
+func MockIsTerminal(t bool) (restore func()) {
+	oldIsTerminal := isTerminal
+	isTerminal = func() bool { return t }
+	return func() {
+		isTerminal = oldIsTerminal
+	}
+}


### PR DESCRIPTION
Small tweak to make cmdGet.Execute() a little bit easier to follow. The (excellent) tests seem to agree with this refactor but I'm not super familiar with the details so feedback welcome.