### PR TITLE
snap-repair: fix missing Close() in TestStatusHappy

### DIFF
--- a/cmd/snap-repair/cmd_done_retry_skip_test.go
+++ b/cmd/snap-repair/cmd_done_retry_skip_test.go
@@ -60,6 +60,9 @@ func (r *repairSuite) TestStatusHappy(c *C) {
 	for _, s := range []string{"done", "skip", "retry"} {
 		rp, wp, err := os.Pipe()
 		c.Assert(err, IsNil)
+		defer rp.Close()
+		defer wp.Close()
+
 		os.Setenv("SNAP_REPAIR_STATUS_FD", strconv.Itoa(int(wp.Fd())))
 		defer os.Unsetenv("SNAP_REPAIR_STATUS_FD")
 


### PR DESCRIPTION
This issue has caused unrelated test failures in the TestFetch500
and similar tests.

In more detail, the issue here is that the OS fd underlying wp is closed through the NewFile/defer Close ops done by the code under test (in writeToStatusFD), but the state tracked in wp itself doesn't know anything about this though, so the closing of wp done by its finalizer (given we didn't close it explicitly) at a later point would end up either failing silently with EBADF or worse closing a different file/socket that was in between associated with the since free-to-use OS fd.

Together with https://github.com/snapcore/snapd/pull/3947 tests should be happy again.
