### PR TITLE
cmd/snap-repair: skip disabled repairs

### DIFF
--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -720,6 +720,9 @@ func stringList(headers map[string]interface{}, name string) ([]string, error) {
 
 // Applicable returns whether a repair with the given headers is applicable to the device.
 func (run *Runner) Applicable(headers map[string]interface{}) bool {
+	if headers["disabled"] == "true" {
+		return false
+	}
 	series, err := stringList(headers, "series")
 	if err != nil {
 		return false

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -767,6 +767,8 @@ func (s *runnerSuite) TestApplicable(c *C) {
 		{map[string]interface{}{"models": []interface{}{"my-brand/xxx*"}}, false},
 		{map[string]interface{}{"models": []interface{}{"my-brand/my-mod*", "my-brand/xxx*"}}, true},
 		{map[string]interface{}{"models": []interface{}{"my*"}}, false},
+		{map[string]interface{}{"disabled": "true"}, false},
+		{map[string]interface{}{"disabled": "false"}, true},
 	}
 
 	for _, scen := range scenarios {
@@ -1140,7 +1142,8 @@ brand-id: canonical
 repair-id: 1
 summary: repair one rev1
 series:
-  - 33
+  - 16
+disabled: true
 timestamp: 2017-07-02T12:00:00Z
 body-length: 7
 sign-key-sha3-384: KPIl7M4vQ9d4AUjkoU41TGAwtOMLc_bWUCeW8AvdRWD4_xcP60Oo4ABsFNo6BtXj


### PR DESCRIPTION
This adds support for disabled in snap-repair, the flag means the repair must be skipped.
