### PR TITLE
snap-confine: fix base snaps on core

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -547,9 +547,10 @@ void sc_populate_mount_ns(const char *base_snap_name, const char *snap_name)
 	if (vanilla_cwd == NULL) {
 		die("cannot get the current working directory");
 	}
-	// Remember if we are on classic, some things behave differently there.
 	bool on_classic_distro = is_running_on_classic_distribution();
-	if (on_classic_distro) {
+	// on classic or with alternative base snaps we need to setup
+	// a different confinement
+	if (on_classic_distro || !sc_streq(base_snap_name, "core")) {
 		const struct sc_mount mounts[] = {
 			{"/dev"},	// because it contains devices on host OS
 			{"/etc"},	// because that's where /etc/resolv.conf lives, perhaps a bad idea

--- a/tests/main/base-snaps/task.yaml
+++ b/tests/main/base-snaps/task.yaml
@@ -36,6 +36,12 @@ execute: |
     #  https://bugs.launchpad.net/snapstore/+bug/1715824
     #
     snap install --edge test-snapd-base-bare
-    snap install --edge test-snapd-busybox-static
+    snap install --edge --devmode test-snapd-busybox-static
     echo "Ensure we can run a statically linked binary from an empty base"
     test-snapd-busybox-static.busybox-static echo hello | MATCH hello
+
+    if test-snapd-busybox-static.busybox-static ls /bin/dd; then
+        echo "bare should be empty but it is not:"
+        test-snapd-busybox-static.busybox-static ls /bin
+        exit 1
+    fi


### PR DESCRIPTION
On core devices we don't setup the same confinement as we do with
classic. However when we use base snaps we need to setup the
confinement in a similar way as on classic. Update the code to
do this.
