### PR TITLE
snap: introduce structured epochs.

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -333,6 +333,7 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 		SideInfo:      *si,
 		Architectures: []string{"all"},
 		Type:          snap.TypeApp,
+		Epoch:         snap.EpochZero(),
 	}
 	if strings.Contains(name, "alias-snap") {
 		name = "alias-snap"

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -333,7 +333,6 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 		SideInfo:      *si,
 		Architectures: []string{"all"},
 		Type:          snap.TypeApp,
-		Epoch:         snap.EpochZero(),
 	}
 	if strings.Contains(name, "alias-snap") {
 		name = "alias-snap"

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1581,7 +1581,6 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 				Channel:  "some-channel",
 				SnapID:   "services-snap-id",
 				Revision: snap.R(7),
-				Epoch:    snap.EpochZero(),
 			},
 			revno: snap.R(11),
 		},
@@ -1760,7 +1759,6 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 				Channel:  "some-channel",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(7),
-				Epoch:    snap.EpochZero(),
 			},
 			revno: snap.R(11),
 		},
@@ -1920,7 +1918,6 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 				Channel:  "some-channel",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(7),
-				Epoch:    snap.EpochZero(),
 			},
 			revno: snap.R(11),
 		},
@@ -2126,7 +2123,6 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 				Channel:  "channel-for-7",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(7),
-				Epoch:    snap.EpochZero(),
 			},
 		},
 	}
@@ -2263,7 +2259,6 @@ func (s *snapmgrTestSuite) TestSingleUpdateBlockedRevision(c *C) {
 		cand: store.RefreshCandidate{
 			SnapID:   "some-snap-id",
 			Revision: snap.R(7),
-			Epoch:    snap.EpochZero(),
 			Channel:  "some-channel",
 		},
 	})
@@ -2304,7 +2299,6 @@ func (s *snapmgrTestSuite) TestMultiUpdateBlockedRevision(c *C) {
 		cand: store.RefreshCandidate{
 			SnapID:   "some-snap-id",
 			Revision: snap.R(7),
-			Epoch:    snap.EpochZero(),
 		},
 	})
 
@@ -2343,7 +2337,6 @@ func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
 			SnapID:   "some-snap-id",
 			Revision: snap.R(7),
 			Block:    []snap.Revision{snap.R(11)},
-			Epoch:    snap.EpochZero(),
 		},
 	})
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1581,7 +1581,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 				Channel:  "some-channel",
 				SnapID:   "services-snap-id",
 				Revision: snap.R(7),
-				Epoch:    "0",
+				Epoch:    snap.EpochZero(),
 			},
 			revno: snap.R(11),
 		},
@@ -1760,7 +1760,7 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 				Channel:  "some-channel",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(7),
-				Epoch:    "",
+				Epoch:    snap.EpochZero(),
 			},
 			revno: snap.R(11),
 		},
@@ -1920,7 +1920,7 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 				Channel:  "some-channel",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(7),
-				Epoch:    "",
+				Epoch:    snap.EpochZero(),
 			},
 			revno: snap.R(11),
 		},
@@ -2126,7 +2126,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 				Channel:  "channel-for-7",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(7),
-				Epoch:    "",
+				Epoch:    snap.EpochZero(),
 			},
 		},
 	}
@@ -2263,7 +2263,7 @@ func (s *snapmgrTestSuite) TestSingleUpdateBlockedRevision(c *C) {
 		cand: store.RefreshCandidate{
 			SnapID:   "some-snap-id",
 			Revision: snap.R(7),
-			Epoch:    "",
+			Epoch:    snap.EpochZero(),
 			Channel:  "some-channel",
 		},
 	})
@@ -2304,6 +2304,7 @@ func (s *snapmgrTestSuite) TestMultiUpdateBlockedRevision(c *C) {
 		cand: store.RefreshCandidate{
 			SnapID:   "some-snap-id",
 			Revision: snap.R(7),
+			Epoch:    snap.EpochZero(),
 		},
 	})
 
@@ -2342,6 +2343,7 @@ func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
 			SnapID:   "some-snap-id",
 			Revision: snap.R(7),
 			Block:    []snap.Revision{snap.R(11)},
+			Epoch:    snap.EpochZero(),
 		},
 	})
 

--- a/snap/epoch.go
+++ b/snap/epoch.go
@@ -65,12 +65,12 @@ type Epoch struct {
 
 // E returns the epoch represented by the expression s. It's meant for use in
 // testing, as it panics at the first sign of trouble.
-func E(s string) Epoch {
+func E(s string) *Epoch {
 	var e Epoch
 	if err := e.fromString(s); err != nil {
 		panic(fmt.Errorf("%q: %v", s, err))
 	}
-	return e
+	return &e
 }
 
 func (e *Epoch) fromString(s string) error {

--- a/snap/epoch.go
+++ b/snap/epoch.go
@@ -1,0 +1,288 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+var (
+	ErrBadEpochExpression  = errors.New("invalid epoch expression")
+	ErrEpochOhSplat        = errors.New("0* is an invalid epoch")
+	ErrBadEpochNumber      = errors.New("epoch numbers must match [1-9][0-9]*")
+	ErrHugeEpochNumber     = errors.New("epoch numbers must be less than 2³²")
+	ErrBadEpochList        = errors.New("epoch read/write attributes must be lists of epoch numbers")
+	ErrEmptyEpochList      = errors.New("epoch list cannot be explicitly empty")
+	ErrEpochListNotSorted  = errors.New("epoch list must be in ascending order")
+	ErrNoEpochIntersection = errors.New("epoch read and write lists must have a non-empty intersection")
+)
+
+// An Epoch represents the ability of the snap to read and write its data. Most
+// developers need not worry about it, and snaps default to the 0th epoch, and
+// users are only offered refreshes to epoch 0 snaps. Once an epoch bump is in
+// order, there's a simplified expression they can use which should cover the
+// majority of the cases:
+//
+//   epoch: N
+//
+// means a snap can read/write exactly the Nth epoch's data, and
+//
+//   epoch: N*
+//
+// means a snap can additionally read (N-1)th epoch's data, which means it's a
+// snap that can migrate epochs (so a user on epoch 0 can get offered a refresh
+// to a snap on epoch 1*).
+//
+// If the above is not enough, a developer can explicitly describe what epochs a
+// snap can read and write:
+//
+//   epoch:
+//     read: [1, 2, 3]
+//     write: [1, 3]
+//
+// the read attribute defaults to the value of the write attribute, and the
+// write attribute defaults to the last item in the read attribute. If both are
+// unset, it's the same as not specifying an epoch at all (i.e. epoch: 0). The
+// lists must be in ascending order, and there must be a non-empty intersection
+// between them.
+//
+// Epoch numbers must be written as base 10 numbers, with no zero padding.
+type Epoch struct {
+	Read  []uint32 `yaml:"read"`
+	Write []uint32 `yaml:"write"`
+}
+
+// E returns the epoch represented by the expression s. It's meant for use in
+// testing, as it panics at the first sign of trouble.
+func E(s string) Epoch {
+	var e Epoch
+	if err := e.fromEpochString(s); err != nil {
+		panic(fmt.Errorf("%q: %v", s, err))
+	}
+	return e
+}
+
+// EpochZero returns the epoch represented by the expression "0".
+func EpochZero() Epoch {
+	return Epoch{Read: []uint32{0}, Write: []uint32{0}}
+}
+
+// IsNull checks whether this epoch looks like it's not been initialized.
+func (e Epoch) IsNull() bool {
+	return len(e.Read) == 0 && len(e.Write) == 0
+}
+
+func (e *Epoch) fromEpochString(s string) error {
+	if len(s) == 0 {
+		e.Read = []uint32{0}
+		e.Write = []uint32{0}
+		return nil
+	}
+	splat := false
+	if s[len(s)-1] == '*' {
+		splat = true
+		s = s[:len(s)-1]
+	}
+	n, err := parseInt(s)
+	if err != nil {
+		return err
+	}
+	if splat {
+		if n == 0 {
+			return ErrEpochOhSplat
+		}
+		e.Read = []uint32{n - 1, n}
+	} else {
+		e.Read = []uint32{n}
+	}
+	e.Write = []uint32{n}
+
+	return nil
+}
+
+func (e *Epoch) fromStructured(newEpoch structuredEpoch) error {
+	if newEpoch.Read == nil {
+		if newEpoch.Write == nil {
+			newEpoch.Write = []uint32{0}
+		}
+		newEpoch.Read = newEpoch.Write
+	} else if len(newEpoch.Read) == 0 {
+		// this means they explicitly set it to []. Bad they!
+		return ErrEmptyEpochList
+	}
+	if newEpoch.Write == nil {
+		newEpoch.Write = newEpoch.Read[len(newEpoch.Read)-1:]
+	} else if len(newEpoch.Write) == 0 {
+		return ErrEmptyEpochList
+	}
+	e.Read = newEpoch.Read
+	e.Write = newEpoch.Write
+
+	if err := e.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *Epoch) UnmarshalJSON(bs []byte) error {
+	return e.UnmarshalYAML(func(v interface{}) error {
+		return json.Unmarshal(bs, &v)
+	})
+}
+
+func (e *Epoch) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var oldEpoch string
+	if err := unmarshal(&oldEpoch); err == nil {
+		return e.fromEpochString(oldEpoch)
+	}
+	var newEpoch structuredEpoch
+	if err := unmarshal(&newEpoch); err != nil {
+		return err
+	}
+
+	return e.fromStructured(newEpoch)
+}
+
+// Validate checks that the epoch makes sense.
+func (e *Epoch) Validate() error {
+	if e == nil || len(e.Read) == 0 || len(e.Write) == 0 {
+		return ErrEmptyEpochList
+	}
+	if !(sort.IsSorted(uint32Slice(e.Read)) && sort.IsSorted(uint32Slice(e.Write))) {
+		return ErrEpochListNotSorted
+	}
+	foundOne := false
+	for i := range e.Read {
+		idx := sort.Search(len(e.Write), func(j int) bool { return e.Write[j] >= e.Read[i] })
+		if idx < len(e.Write) && e.Write[idx] == e.Read[i] {
+			foundOne = true
+			break
+		}
+	}
+	if !foundOne {
+		return ErrNoEpochIntersection
+	}
+
+	return nil
+}
+
+func (e *Epoch) simplify() interface{} {
+	if len(e.Write) == 1 && len(e.Read) == 1 && e.Read[0] == e.Write[0] {
+		return strconv.FormatUint(uint64(e.Read[0]), 10)
+	}
+	if len(e.Write) == 1 && len(e.Read) == 2 && e.Read[0]+1 == e.Read[1] && e.Read[1] == e.Write[0] {
+		return strconv.FormatUint(uint64(e.Read[1]), 10) + "*"
+	}
+	return &structuredEpoch{Read: e.Read, Write: e.Write}
+}
+
+func (e Epoch) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.simplify())
+}
+
+func (e Epoch) String() string {
+	i := e.simplify()
+	if s, ok := i.(string); ok {
+		return s
+	}
+
+	buf, err := json.Marshal(i)
+	if err != nil {
+		// can this happen?
+		return fmt.Sprintf("%#v", e)
+	}
+	return string(buf)
+}
+
+type uint32Slice []uint32
+
+func (ns uint32Slice) Len() int           { return len(ns) }
+func (ns uint32Slice) Less(i, j int) bool { return ns[i] < ns[j] }
+func (ns uint32Slice) Swap(i, j int)      { panic("no reordering") }
+
+func parseInt(s string) (uint32, error) {
+	if len(s) > 1 && s[0] == '0' {
+		return 0, ErrBadEpochNumber
+	}
+	u, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		e, ok := err.(*strconv.NumError)
+		if !ok {
+			// strconv docs say this can't happen
+			return 0, err
+		}
+		switch e.Err {
+		case strconv.ErrSyntax:
+			err = ErrBadEpochNumber
+		case strconv.ErrRange:
+			err = ErrHugeEpochNumber
+		default:
+			// strconv docs say this can't happen either
+			err = e.Err
+		}
+	}
+	return uint32(u), err
+}
+
+type zeroniner []uint32
+
+func (z *zeroniner) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var ss []string
+	if err := unmarshal(&ss); err != nil {
+		return ErrBadEpochList
+	}
+	x := make([]uint32, len(ss))
+	for i, s := range ss {
+		n, err := parseInt(s)
+		if err != nil {
+			return err
+		}
+		x[i] = n
+	}
+	*z = x
+	return nil
+}
+
+func (z *zeroniner) UnmarshalJSON(bs []byte) error {
+	var ss []json.RawMessage
+	if err := json.Unmarshal(bs, &ss); err != nil {
+		return ErrBadEpochList
+	}
+	x := make([]uint32, len(ss))
+	for i, s := range ss {
+		n, err := parseInt(string(s))
+		if err != nil {
+			return err
+		}
+		x[i] = n
+	}
+	*z = x
+	return nil
+}
+
+type structuredEpoch struct {
+	Read  zeroniner `json:"read"`
+	Write zeroniner `json:"write"`
+}

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -216,13 +216,13 @@ func (s *epochSuite) TestEpochMarshal(c *check.C) {
 
 func (s *epochSuite) TestE(c *check.C) {
 	tests := []struct {
-		e snap.Epoch
+		e *snap.Epoch
 		s string
 	}{
-		{s: "0", e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
-		{s: "1", e: snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}},
-		{s: "1*", e: snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}},
-		{s: "400*", e: snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}},
+		{s: "0", e: &snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: "1", e: &snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}},
+		{s: "1*", e: &snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}},
+		{s: "400*", e: &snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}},
 	}
 	for _, test := range tests {
 		c.Check(snap.E(test.s), check.DeepEquals, test.e, check.Commentf(test.s))

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -1,0 +1,211 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snap_test
+
+import (
+	"encoding/json"
+	"github.com/snapcore/snapd/snap"
+
+	"gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
+)
+
+type epochSuite struct{}
+
+var _ = check.Suite(&epochSuite{})
+
+func (s epochSuite) TestBadEpochs(c *check.C) {
+	type Tt struct {
+		s string
+		e error
+		y int
+	}
+
+	tests := []Tt{
+		{s: `"rubbish"`, e: snap.ErrBadEpochNumber},                        // SISO
+		{s: `0xA`, e: snap.ErrBadEpochNumber, y: 1},                        // no hex
+		{s: `"0xA"`, e: snap.ErrBadEpochNumber},                            //
+		{s: `001`, e: snap.ErrBadEpochNumber, y: 1},                        // no octal, in fact no zero prefixes at all
+		{s: `"001"`, e: snap.ErrBadEpochNumber},                            //
+		{s: `{"read": 5}`, e: snap.ErrBadEpochList},                        // when split, must be list
+		{s: `{"write": 5}`, e: snap.ErrBadEpochList},                       //
+		{s: `{"read": "5"}`, e: snap.ErrBadEpochList},                      //
+		{s: `{"write": "5"}`, e: snap.ErrBadEpochList},                     //
+		{s: `{"read": "1*"}`, e: snap.ErrBadEpochList},                     // what
+		{s: `{"read": [-1]}`, e: snap.ErrBadEpochNumber},                   // negative not allowed
+		{s: `{"write": [-1]}`, e: snap.ErrBadEpochNumber},                  //
+		{s: `{"read": ["-1"]}`, e: snap.ErrBadEpochNumber},                 //
+		{s: `{"write": ["-1"]}`, e: snap.ErrBadEpochNumber},                //
+		{s: `{"read": ["yes"]}`, e: snap.ErrBadEpochNumber},                // must be numbers
+		{s: `{"write": ["yes"]}`, e: snap.ErrBadEpochNumber},               //
+		{s: `{"read": ["Ⅰ","Ⅱ"]}`, e: snap.ErrBadEpochNumber},              // not roman numerals you idiot
+		{s: `{"read": [0xA]}`, e: snap.ErrBadEpochNumber, y: 1},            //
+		{s: `{"read": [010]}`, e: snap.ErrBadEpochNumber, y: 1},            //
+		{s: `{"read": [9999999999]}`, e: snap.ErrHugeEpochNumber},          // you done yet?
+		{s: `"0*"`, e: snap.ErrEpochOhSplat},                               // 0* means nothing
+		{s: `"42**"`, e: snap.ErrBadEpochNumber},                           // N** is dead
+		{s: `{"read": []}`, e: snap.ErrEmptyEpochList},                     // explicitly empty is bad
+		{s: `{"write": []}`, e: snap.ErrEmptyEpochList},                    //
+		{s: `{"read": [1,2,4,3]}`, e: snap.ErrEpochListNotSorted},          // must be ordered
+		{s: `{"write": [4,3,2,1]}`, e: snap.ErrEpochListNotSorted},         // ...in ascending order
+		{s: `{"read": [0], "write": [1]}`, e: snap.ErrNoEpochIntersection}, // must have at least one in common
+	}
+
+	for _, test := range tests {
+		var v snap.Epoch
+		err := yaml.Unmarshal([]byte(test.s), &v)
+		c.Check(err, check.Equals, test.e, check.Commentf("YAML: %#q", test.s))
+
+		if test.y == 1 {
+			continue
+		}
+		err = json.Unmarshal([]byte(test.s), &v)
+		c.Check(err, check.Equals, test.e, check.Commentf("JSON: %#q", test.s))
+	}
+}
+
+func (s epochSuite) TestGoodEpochs(c *check.C) {
+	type Tt struct {
+		s string
+		e snap.Epoch
+		y int
+	}
+
+	tests := []Tt{
+		{s: `0`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, y: 1},
+		{s: `""`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `"0"`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `{}`, e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}},
+		{s: `"2*"`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{2}}},
+		{s: `{"read": [2]}`, e: snap.Epoch{Read: []uint32{2}, Write: []uint32{2}}},
+		{s: `{"read": [1, 2]}`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{2}}},
+		{s: `{"write": [2]}`, e: snap.Epoch{Read: []uint32{2}, Write: []uint32{2}}},
+		{s: `{"write": [1, 2]}`, e: snap.Epoch{Read: []uint32{1, 2}, Write: []uint32{1, 2}}},
+		{s: `{"read": [2,4,8], "write": [2,3,5]}`, e: snap.Epoch{Read: []uint32{2, 4, 8}, Write: []uint32{2, 3, 5}}},
+	}
+
+	for _, test := range tests {
+		var v snap.Epoch
+		err := yaml.Unmarshal([]byte(test.s), &v)
+		c.Check(err, check.IsNil, check.Commentf("YAML: %s", test.s))
+		c.Check(v, check.DeepEquals, test.e)
+
+		if test.y > 0 {
+			continue
+		}
+
+		err = json.Unmarshal([]byte(test.s), &v)
+		c.Check(err, check.IsNil, check.Commentf("JSON: %s", test.s))
+		c.Check(v, check.DeepEquals, test.e)
+	}
+}
+
+func (s *epochSuite) TestEpochZero(c *check.C) {
+	z := snap.EpochZero()
+	c.Check(z.String(), check.Equals, "0")
+	c.Check(z, check.DeepEquals, snap.Epoch{
+		Read:  []uint32{0},
+		Write: []uint32{0},
+	})
+}
+
+func (s *epochSuite) TestEpochValidate(c *check.C) {
+	validEpochs := []snap.Epoch{
+		snap.EpochZero(),
+		{Read: []uint32{0}, Write: []uint32{0}}, // same as EpochZero()
+		{Read: []uint32{0, 1}, Write: []uint32{1}},
+		{Read: []uint32{1}, Write: []uint32{1}},
+		{Read: []uint32{399, 400}, Write: []uint32{400}},
+		{Read: []uint32{1, 2, 3}, Write: []uint32{1, 2, 3}},
+	}
+	for _, epoch := range validEpochs {
+		err := epoch.Validate()
+		c.Check(err, check.IsNil, check.Commentf("%s", epoch))
+	}
+	invalidEpochs := []struct {
+		epoch *snap.Epoch
+		err   error
+	}{
+		{epoch: nil, err: snap.ErrEmptyEpochList},
+		{epoch: &snap.Epoch{}, err: snap.ErrEmptyEpochList},
+		{epoch: &snap.Epoch{Read: []uint32{1}, Write: []uint32{2}}, err: snap.ErrNoEpochIntersection},
+		{epoch: &snap.Epoch{Read: []uint32{1, 3, 5}, Write: []uint32{2, 4, 6}}, err: snap.ErrNoEpochIntersection},
+		{epoch: &snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{3, 2, 1}}, err: snap.ErrEpochListNotSorted},
+		{epoch: &snap.Epoch{Read: []uint32{3, 2, 1}, Write: []uint32{1, 2, 3}}, err: snap.ErrEpochListNotSorted},
+		{epoch: &snap.Epoch{Read: []uint32{3, 2, 1}, Write: []uint32{3, 2, 1}}, err: snap.ErrEpochListNotSorted},
+	}
+	for _, test := range invalidEpochs {
+		err := test.epoch.Validate()
+		c.Check(err, check.Equals, test.err, check.Commentf("%s", test.epoch))
+	}
+}
+
+func (s *epochSuite) TestEpochString(c *check.C) {
+	tests := []struct {
+		e snap.Epoch
+		s string
+	}{
+		{e: snap.EpochZero(), s: "0"},
+		{e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: "0"},
+		{e: snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: "1*"},
+		{e: snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: "1"},
+		{e: snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}, s: "400*"},
+		{e: snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{1, 2, 3}}, s: `{"read":[1,2,3],"write":[1,2,3]}`},
+	}
+	for _, test := range tests {
+		c.Check(test.e.String(), check.Equals, test.s, check.Commentf(test.s))
+	}
+}
+
+func (s *epochSuite) TestEpochMarshal(c *check.C) {
+	tests := []struct {
+		e snap.Epoch
+		s string
+	}{
+		{e: snap.EpochZero(), s: `"0"`},
+		{e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: `"0"`},
+		{e: snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: `"1*"`},
+		{e: snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: `"1"`},
+		{e: snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}, s: `"400*"`},
+		{e: snap.Epoch{Read: []uint32{1, 2, 3}, Write: []uint32{1, 2, 3}}, s: `{"read":[1,2,3],"write":[1,2,3]}`},
+	}
+	for _, test := range tests {
+		bs, err := json.Marshal(test.e)
+		c.Assert(err, check.IsNil)
+		c.Check(string(bs), check.Equals, test.s, check.Commentf(test.s))
+	}
+}
+
+func (s *epochSuite) TestE(c *check.C) {
+	tests := []struct {
+		e snap.Epoch
+		s string
+	}{
+		{e: snap.EpochZero(), s: "0"},
+		{e: snap.Epoch{Read: []uint32{0}, Write: []uint32{0}}, s: "0"},
+		{e: snap.Epoch{Read: []uint32{0, 1}, Write: []uint32{1}}, s: "1*"},
+		{e: snap.Epoch{Read: []uint32{1}, Write: []uint32{1}}, s: "1"},
+		{e: snap.Epoch{Read: []uint32{399, 400}, Write: []uint32{400}}, s: "400*"},
+	}
+	for _, test := range tests {
+		c.Check(snap.E(test.s), check.DeepEquals, test.e, check.Commentf(test.s))
+		c.Check(test.e.String(), check.Equals, test.s, check.Commentf(test.s))
+	}
+}

--- a/snap/epoch_test.go
+++ b/snap/epoch_test.go
@@ -134,7 +134,7 @@ func (s epochSuite) TestGoodEpochs(c *check.C) {
 func (s *epochSuite) TestEpochValidate(c *check.C) {
 	validEpochs := []*snap.Epoch{
 		nil,
-		&snap.Epoch{},
+		{},
 		{Read: []uint32{0}, Write: []uint32{0}},
 		{Read: []uint32{0, 1}, Write: []uint32{1}},
 		{Read: []uint32{1}, Write: []uint32{1}},

--- a/snap/info.go
+++ b/snap/info.go
@@ -156,7 +156,7 @@ type Info struct {
 	LicenseAgreement string
 	LicenseVersion   string
 	License          string
-	Epoch            string
+	Epoch            Epoch
 	Base             string
 	Confinement      ConfinementType
 	Apps             map[string]*AppInfo
@@ -212,7 +212,7 @@ type ChannelSnapInfo struct {
 	Confinement ConfinementType `json:"confinement"`
 	Version     string          `json:"version"`
 	Channel     string          `json:"channel"`
-	Epoch       string          `json:"epoch"`
+	Epoch       Epoch           `json:"epoch"`
 	Size        int64           `json:"size"`
 }
 

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -180,10 +180,6 @@ func infoSkeletonFromSnapYaml(y snapYaml) *Info {
 	if y.Type != "" {
 		typ = y.Type
 	}
-	epoch := y.Epoch
-	if epoch.IsNull() {
-		epoch = EpochZero()
-	}
 	confinement := StrictConfinement
 	if y.Confinement != "" {
 		confinement = y.Confinement
@@ -202,7 +198,7 @@ func infoSkeletonFromSnapYaml(y snapYaml) *Info {
 		License:             y.License,
 		LicenseAgreement:    y.LicenseAgreement,
 		LicenseVersion:      y.LicenseVersion,
-		Epoch:               epoch,
+		Epoch:               y.Epoch,
 		Confinement:         confinement,
 		Base:                y.Base,
 		Apps:                make(map[string]*AppInfo),

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -44,7 +44,7 @@ type snapYaml struct {
 	License          string                 `yaml:"license,omitempty"`
 	LicenseAgreement string                 `yaml:"license-agreement,omitempty"`
 	LicenseVersion   string                 `yaml:"license-version,omitempty"`
-	Epoch            string                 `yaml:"epoch,omitempty"`
+	Epoch            Epoch                  `yaml:"epoch,omitempty"`
 	Base             string                 `yaml:"base,omitempty"`
 	Confinement      ConfinementType        `yaml:"confinement,omitempty"`
 	Environment      strutil.OrderedMap     `yaml:"environment,omitempty"`
@@ -180,9 +180,9 @@ func infoSkeletonFromSnapYaml(y snapYaml) *Info {
 	if y.Type != "" {
 		typ = y.Type
 	}
-	epoch := "0"
-	if y.Epoch != "" {
-		epoch = y.Epoch
+	epoch := y.Epoch
+	if epoch.IsNull() {
+		epoch = EpochZero()
 	}
 	confinement := StrictConfinement
 	if y.Confinement != "" {

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1089,7 +1089,7 @@ slots:
 	c.Check(info.Name(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Type, Equals, snap.TypeApp)
-	c.Check(info.Epoch.String(), DeepEquals, "1*")
+	c.Check(info.Epoch.String(), Equals, "1*")
 	c.Check(info.Confinement, Equals, snap.DevModeConfinement)
 	c.Check(info.Title(), Equals, "Foo")
 	c.Check(info.Summary(), Equals, "foo app")

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1089,7 +1089,7 @@ slots:
 	c.Check(info.Name(), Equals, "foo")
 	c.Check(info.Version, Equals, "1.2")
 	c.Check(info.Type, Equals, snap.TypeApp)
-	c.Check(info.Epoch, Equals, "1*")
+	c.Check(info.Epoch.String(), DeepEquals, "1*")
 	c.Check(info.Confinement, Equals, snap.DevModeConfinement)
 	c.Check(info.Title(), Equals, "Foo")
 	c.Check(info.Summary(), Equals, "foo app")
@@ -1229,7 +1229,7 @@ version: 1.0
 `)
 	info, err := snap.InfoFromSnapYaml(y)
 	c.Assert(err, IsNil)
-	c.Assert(info.Epoch, Equals, "0")
+	c.Assert(info.Epoch.String(), Equals, "0")
 }
 
 func (s *YamlSuite) TestSnapYamlConfinementDefault(c *C) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -258,7 +258,7 @@ confinement: devmode`
 	c.Check(info.Version, Equals, "1.0")
 	c.Check(info.Type, Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(0))
-	c.Check(info.Epoch, Equals, "1*")
+	c.Check(info.Epoch.String(), Equals, "1*")
 	c.Check(info.Confinement, Equals, snap.DevModeConfinement)
 	c.Check(info.NeedsDevMode(), Equals, true)
 	c.Check(info.NeedsClassic(), Equals, false)
@@ -300,7 +300,7 @@ type: app`
 	c.Check(info.Version, Equals, "1.0")
 	c.Check(info.Type, Equals, snap.TypeApp)
 	c.Check(info.Revision, Equals, snap.R(0))
-	c.Check(info.Epoch, Equals, "0") // Defaults to 0
+	c.Check(info.Epoch.String(), Equals, "0") // Defaults to 0
 	c.Check(info.Confinement, Equals, snap.StrictConfinement)
 	c.Check(info.NeedsDevMode(), Equals, false)
 }

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -30,7 +30,6 @@ import (
 
 // Regular expression describing correct identifiers.
 var validSnapName = regexp.MustCompile("^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$")
-var validEpoch = regexp.MustCompile("^(?:0|[1-9][0-9]*[*]?)$")
 var validHookName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
 
 // ValidateName checks if a string can be used as a snap name.
@@ -38,15 +37,6 @@ func ValidateName(name string) error {
 	valid := validSnapName.MatchString(name)
 	if !valid {
 		return fmt.Errorf("invalid snap name: %q", name)
-	}
-	return nil
-}
-
-// ValidateEpoch checks if a string can be used as a snap epoch.
-func ValidateEpoch(epoch string) error {
-	valid := validEpoch.MatchString(epoch)
-	if !valid {
-		return fmt.Errorf("invalid snap epoch: %q", epoch)
 	}
 	return nil
 }
@@ -90,11 +80,7 @@ func Validate(info *Info) error {
 		return err
 	}
 
-	epoch := info.Epoch
-	if epoch == "" {
-		return fmt.Errorf("snap epoch cannot be empty")
-	}
-	err = ValidateEpoch(epoch)
+	err = info.Epoch.Validate()
 	if err != nil {
 		return err
 	}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -65,23 +65,6 @@ func (s *ValidateSuite) TestValidateName(c *C) {
 	}
 }
 
-func (s *ValidateSuite) TestValidateEpoch(c *C) {
-	validEpochs := []string{
-		"0", "1*", "1", "400*", "1234",
-	}
-	for _, epoch := range validEpochs {
-		err := ValidateEpoch(epoch)
-		c.Assert(err, IsNil)
-	}
-	invalidEpochs := []string{
-		"0*", "_", "1-", "1+", "-1", "+1", "-1*", "a", "1a", "1**",
-	}
-	for _, epoch := range invalidEpochs {
-		err := ValidateEpoch(epoch)
-		c.Assert(err, ErrorMatches, `invalid snap epoch: ".*"`)
-	}
-}
-
 func (s *ValidateSuite) TestValidateLicense(c *C) {
 	validLicenses := []string{
 		"GPL-3.0", "(GPL-3.0)", "GPL-3.0+", "GPL-3.0 AND GPL-2.0", "GPL-3.0 OR GPL-2.0", "MIT OR (GPL-3.0 AND GPL-2.0)", "MIT OR(GPL-3.0 AND GPL-2.0)",
@@ -243,14 +226,11 @@ version: 1.0
 }
 
 func (s *ValidateSuite) TestIllegalSnapEpoch(c *C) {
-	info, err := InfoFromSnapYaml([]byte(`name: foo
+	_, err := InfoFromSnapYaml([]byte(`name: foo
 version: 1.0
 epoch: 0*
 `))
-	c.Assert(err, IsNil)
-
-	err = Validate(info)
-	c.Check(err, ErrorMatches, `invalid snap epoch: "0\*"`)
+	c.Assert(err, ErrorMatches, `.*invalid epoch.*`)
 }
 
 func (s *ValidateSuite) TestMissingSnapEpochIsOkay(c *C) {

--- a/store/details.go
+++ b/store/details.go
@@ -34,7 +34,7 @@ type snapDetails struct {
 	Deltas           []snapDeltaDetail  `json:"deltas,omitempty"`
 	DownloadSize     int64              `json:"binary_filesize,omitempty"`
 	DownloadURL      string             `json:"download_url,omitempty"`
-	Epoch            string             `json:"epoch"`
+	Epoch            snap.Epoch         `json:"epoch"`
 	IconURL          string             `json:"icon_url"`
 	LastUpdated      string             `json:"last_updated,omitempty"`
 	Name             string             `json:"package_name"`
@@ -84,11 +84,11 @@ type snapDeltaDetail struct {
 // channelSnapInfoDetails is the subset of snapDetails we need to get
 // information about the snaps in the various channels
 type channelSnapInfoDetails struct {
-	Revision     int    `json:"revision"` // store revisions are ints starting at 1
-	Confinement  string `json:"confinement"`
-	Version      string `json:"version"`
-	Channel      string `json:"channel"`
-	Epoch        string `json:"epoch"`
-	DownloadSize int64  `json:"binary_filesize"`
-	Info         string `json:"info"`
+	Revision     int        `json:"revision"` // store revisions are ints starting at 1
+	Confinement  string     `json:"confinement"`
+	Version      string     `json:"version"`
+	Channel      string     `json:"channel"`
+	Epoch        snap.Epoch `json:"epoch"`
+	DownloadSize int64      `json:"binary_filesize"`
+	Info         string     `json:"info"`
 }

--- a/store/store.go
+++ b/store/store.go
@@ -83,7 +83,11 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.Architectures = d.Architectures
 	info.Type = d.Type
 	info.Version = d.Version
-	info.Epoch = "0"
+	if d.Epoch.IsNull() {
+		info.Epoch = snap.EpochZero()
+	} else {
+		info.Epoch = d.Epoch
+	}
 	info.RealName = d.Name
 	info.SnapID = d.SnapID
 	info.Revision = snap.R(d.Revision)
@@ -1189,7 +1193,7 @@ func (s *Store) WriteCatalogs(names io.Writer) error {
 type RefreshCandidate struct {
 	SnapID   string
 	Revision snap.Revision
-	Epoch    string
+	Epoch    snap.Epoch
 	Block    []snap.Revision
 
 	// the desired channel
@@ -1198,11 +1202,11 @@ type RefreshCandidate struct {
 
 // the exact bits that we need to send to the store
 type currentSnapJSON struct {
-	SnapID      string `json:"snap_id"`
-	Channel     string `json:"channel"`
-	Revision    int    `json:"revision,omitempty"`
-	Epoch       string `json:"epoch"`
-	Confinement string `json:"confinement"`
+	SnapID      string     `json:"snap_id"`
+	Channel     string     `json:"channel"`
+	Revision    int        `json:"revision,omitempty"`
+	Epoch       snap.Epoch `json:"epoch"`
+	Confinement string     `json:"confinement"`
 }
 
 type metadataWrapper struct {

--- a/store/store.go
+++ b/store/store.go
@@ -83,11 +83,7 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.Architectures = d.Architectures
 	info.Type = d.Type
 	info.Version = d.Version
-	if d.Epoch.IsNull() {
-		info.Epoch = snap.EpochZero()
-	} else {
-		info.Epoch = d.Epoch
-	}
+	info.Epoch = d.Epoch
 	info.RealName = d.Name
 	info.SnapID = d.SnapID
 	info.Revision = snap.R(d.Revision)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2137,7 +2137,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 			Confinement: snap.StrictConfinement,
 			Channel:     "stable",
 			Size:        12345,
-			Epoch:       snap.E("0"),
+			Epoch:       *snap.E("0"),
 		},
 		"latest/candidate": {
 			Revision:    snap.R(2),
@@ -2145,7 +2145,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 			Confinement: snap.StrictConfinement,
 			Channel:     "candidate",
 			Size:        12345,
-			Epoch:       snap.E("0"),
+			Epoch:       *snap.E("0"),
 		},
 		"latest/beta": {
 			Revision:    snap.R(8),
@@ -2153,7 +2153,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 			Confinement: snap.DevModeConfinement,
 			Channel:     "beta",
 			Size:        12345,
-			Epoch:       snap.E("0"),
+			Epoch:       *snap.E("0"),
 		},
 		"latest/edge": {
 			Revision:    snap.R(9),
@@ -2161,7 +2161,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 			Confinement: snap.DevModeConfinement,
 			Channel:     "edge",
 			Size:        12345,
-			Epoch:       snap.E("0"),
+			Epoch:       *snap.E("0"),
 		},
 	})
 
@@ -2844,7 +2844,7 @@ func (t *remoteRepoTestSuite) TestCurrentSnap(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
-		Epoch:    snap.E("1"),
+		Epoch:    *snap.E("1"),
 	}
 	cs := currentSnap(cand)
 	c.Assert(cs, NotNil)
@@ -2859,7 +2859,7 @@ func (t *remoteRepoTestSuite) TestCurrentSnapNoChannel(c *C) {
 	cand := &RefreshCandidate{
 		SnapID:   helloWorldSnapID,
 		Revision: snap.R(1),
-		Epoch:    snap.E("1"),
+		Epoch:    *snap.E("1"),
 	}
 	cs := currentSnap(cand)
 	c.Assert(cs, NotNil)
@@ -3056,7 +3056,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-			Epoch:    snap.E("0"),
+			Epoch:    *snap.E("0"),
 		}})
 		return []*snapDetails{{
 			Name:        "hello-world",
@@ -3074,7 +3074,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
-		Epoch:    snap.E("0"),
+		Epoch:    *snap.E("0"),
 	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(result.Name(), Equals, "hello-world")

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1974,7 +1974,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(result.Contact, Equals, "mailto:snappy-devel@lists.ubuntu.com")
 
 	// Make sure the epoch (currently not sent by the store) defaults to "0"
-	c.Check(result.Epoch, Equals, "0")
+	c.Check(result.Epoch.String(), Equals, "0")
 
 	c.Check(repo.SuggestedCurrency(), Equals, "GBP")
 
@@ -2137,7 +2137,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 			Confinement: snap.StrictConfinement,
 			Channel:     "stable",
 			Size:        12345,
-			Epoch:       "0",
+			Epoch:       snap.E("0"),
 		},
 		"latest/candidate": {
 			Revision:    snap.R(2),
@@ -2145,7 +2145,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 			Confinement: snap.StrictConfinement,
 			Channel:     "candidate",
 			Size:        12345,
-			Epoch:       "0",
+			Epoch:       snap.E("0"),
 		},
 		"latest/beta": {
 			Revision:    snap.R(8),
@@ -2153,7 +2153,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 			Confinement: snap.DevModeConfinement,
 			Channel:     "beta",
 			Size:        12345,
-			Epoch:       "0",
+			Epoch:       snap.E("0"),
 		},
 		"latest/edge": {
 			Revision:    snap.R(9),
@@ -2161,7 +2161,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 			Confinement: snap.DevModeConfinement,
 			Channel:     "edge",
 			Size:        12345,
-			Epoch:       "0",
+			Epoch:       snap.E("0"),
 		},
 	})
 
@@ -2844,13 +2844,13 @@ func (t *remoteRepoTestSuite) TestCurrentSnap(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
-		Epoch:    "1",
+		Epoch:    snap.E("1"),
 	}
 	cs := currentSnap(cand)
 	c.Assert(cs, NotNil)
 	c.Check(cs.SnapID, Equals, cand.SnapID)
 	c.Check(cs.Channel, Equals, cand.Channel)
-	c.Check(cs.Epoch, Equals, cand.Epoch)
+	c.Check(cs.Epoch, DeepEquals, cand.Epoch)
 	c.Check(cs.Revision, Equals, cand.Revision.N)
 	c.Check(t.logbuf.String(), Equals, "")
 }
@@ -2859,13 +2859,13 @@ func (t *remoteRepoTestSuite) TestCurrentSnapNoChannel(c *C) {
 	cand := &RefreshCandidate{
 		SnapID:   helloWorldSnapID,
 		Revision: snap.R(1),
-		Epoch:    "1",
+		Epoch:    snap.E("1"),
 	}
 	cs := currentSnap(cand)
 	c.Assert(cs, NotNil)
 	c.Check(cs.SnapID, Equals, cand.SnapID)
 	c.Check(cs.Channel, Equals, "stable")
-	c.Check(cs.Epoch, Equals, cand.Epoch)
+	c.Check(cs.Epoch, DeepEquals, cand.Epoch)
 	c.Check(cs.Revision, Equals, cand.Revision.N)
 	c.Check(t.logbuf.String(), Equals, "")
 }
@@ -2986,7 +2986,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-			Epoch:    "0",
+			Epoch:    snap.E("0"),
 		},
 	}, nil)
 
@@ -3036,7 +3036,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesRetri
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
@@ -3058,7 +3058,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-			Epoch:    "0",
+			Epoch:    snap.E("0"),
 		}})
 		return []*snapDetails{{
 			Name:        "hello-world",
@@ -3076,7 +3076,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(result.Name(), Equals, "hello-world")
@@ -3199,7 +3199,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: snap.R(1),
-			Epoch:    "0",
+			Epoch:    snap.E("0"),
 		},
 	}, nil)
 	c.Assert(err, IsNil)
@@ -3256,7 +3256,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshDefaultChannel
 		{
 			SnapID:   helloWorldSnapID,
 			Revision: snap.R(1),
-			Epoch:    "0",
+			Epoch:    snap.E("0"),
 		},
 	}, nil)
 	c.Assert(err, IsNil)
@@ -3305,7 +3305,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
@@ -3348,7 +3348,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-			Epoch:    "0",
+			Epoch:    snap.E("0"),
 		}}, nil)
 		return err
 	}
@@ -3394,7 +3394,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `^Post http://127.0.0.1:.*?/metadata: EOF$`)
@@ -3427,7 +3427,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesUnaut
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(n, Equals, 1)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 401 via POST to "http://.*?/metadata"`)
@@ -3447,7 +3447,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	// the error differs depending on whether a proxy is in use (e.g. on travis), so don't inspect error message
 	c.Assert(err, NotNil)
@@ -3475,7 +3475,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/metadata"`)
 	c.Assert(n, Equals, 5)
@@ -3504,7 +3504,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/metadata"`)
 	c.Assert(n, Equals, 1)
@@ -3562,7 +3562,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(26),
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 0)
@@ -3607,7 +3607,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipBlocked(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(25),
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 		Block:    []snap.Revision{snap.R(26)},
 	}}, nil)
 	c.Assert(err, IsNil)
@@ -3699,7 +3699,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOn
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-			Epoch:    "0",
+			Epoch:    snap.E("0"),
 		}}, nil)
 	}
 }
@@ -3749,7 +3749,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
@@ -3820,7 +3820,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
@@ -3847,7 +3847,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(-2),
-		Epoch:    "0",
+		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2986,7 +2986,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-			Epoch:    snap.E("0"),
 		},
 	}, nil)
 
@@ -3036,7 +3035,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesRetri
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
@@ -3199,7 +3197,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: snap.R(1),
-			Epoch:    snap.E("0"),
 		},
 	}, nil)
 	c.Assert(err, IsNil)
@@ -3256,7 +3253,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshDefaultChannel
 		{
 			SnapID:   helloWorldSnapID,
 			Revision: snap.R(1),
-			Epoch:    snap.E("0"),
 		},
 	}, nil)
 	c.Assert(err, IsNil)
@@ -3305,7 +3301,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
@@ -3348,7 +3343,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-			Epoch:    snap.E("0"),
 		}}, nil)
 		return err
 	}
@@ -3394,7 +3388,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `^Post http://127.0.0.1:.*?/metadata: EOF$`)
@@ -3427,7 +3420,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesUnaut
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(n, Equals, 1)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 401 via POST to "http://.*?/metadata"`)
@@ -3447,7 +3439,6 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-		Epoch:    snap.E("0"),
 	}}, nil)
 	// the error differs depending on whether a proxy is in use (e.g. on travis), so don't inspect error message
 	c.Assert(err, NotNil)
@@ -3475,7 +3466,6 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/metadata"`)
 	c.Assert(n, Equals, 5)
@@ -3504,7 +3494,6 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/metadata"`)
 	c.Assert(n, Equals, 1)
@@ -3562,7 +3551,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(26),
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 0)
@@ -3607,7 +3595,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipBlocked(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(25),
-		Epoch:    snap.E("0"),
 		Block:    []snap.Revision{snap.R(26)},
 	}}, nil)
 	c.Assert(err, IsNil)
@@ -3699,7 +3686,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOn
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-			Epoch:    snap.E("0"),
 		}}, nil)
 	}
 }
@@ -3749,7 +3735,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
@@ -3820,7 +3805,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
@@ -3847,7 +3831,6 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(-2),
-		Epoch:    snap.E("0"),
 	}}, nil)
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Structured epochs are backwards-compatible with the epochs we had, but
allow to express scenarios that the old ones did not.

From the comment on the Epoch type,

>     epoch: N
>
> means a snap can read/write exactly the Nth epoch's data, and
>
>     epoch: N*
>
> means a snap can additionally read (N-1)th epoch's data, which means it's a
> snap that can migrate epochs (so a user on epoch 0 can get offered a refresh
> to a snap on epoch 1*).

this is as things were. And now,

> If the above is not enough, a developer can explicitly describe what epochs a
> snap can read and write:
>
>   epoch:
>     read: [1, 2, 3]
>     write: [1, 3]
>
> the read attribute defaults to the value of the write attribute, and the
> write attribute defaults to the last item in the read attribute. If both are
> unset, it's the same as not specifying an epoch at all (i.e. epoch: 0). The
> lists must not have more than 10 elements, they must be in ascending order,
> and there must be a non-empty intersection between them.

The current commit tries to serialise epochs in the older format
first, and only uses the new format if it can't be done. This keeps
things nice and simple for the common case, and has the additional
benefit of keeping the store happy until things are implemented there.
