### PR TITLE
snap-confine: bind mount /usr/lib/snapd relative to snap-confine

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -362,20 +362,20 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		// bind mount the current $ROOT/usr/lib/snapd path,
 		// where $ROOT is either "/" or the "/snap/core/current"
 		// that we are re-execing from
-		char *src = LIBEXECDIR;
+		char *src = NULL;
 		char self[PATH_MAX] = { 0, };
-		if (readlink("/proc/self/exe", self, sizeof(self) - 1) > 0) {
-			// this cannot happen except when the kernel is buggy
-			if (strstr(self, "/snap-confine") == NULL) {
-				die("cannot use result from readlink: %s", src);
-			}
-			src = dirname(self);
-			// dirname(path) might return '.' depending on path. /proc/self/exe should always point
+		if (readlink("/proc/self/exe", self, sizeof(self) - 1) < 0) {
+			die("cannot read /proc/self/exe");
+		}
+		// this cannot happen except when the kernel is buggy
+		if (strstr(self, "/snap-confine") == NULL) {
+			die("cannot use result from readlink: %s", src);
+		}
+		src = dirname(self);
+		// dirname(path) might return '.' depending on path. /proc/self/exe should always point
 // to an absolute path, but let's guarantee that.
-			if (src[0] != '/') {
-				die("cannot use the result of dirname(): %s",
-				    src);
-			}
+		if (src[0] != '/') {
+			die("cannot use the result of dirname(): %s", src);
 		}
 
 		sc_do_mount(src, dst, NULL, MS_BIND, NULL);

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -379,7 +379,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			die("cannot use the result of dirname(): %s", src);
 		}
 
-		sc_do_mount(src, dst, NULL, MS_BIND, NULL);
+		sc_do_mount(src, dst, NULL, MS_BIND | MS_RDONLY, NULL);
 		sc_do_mount("none", dst, NULL, MS_SLAVE, NULL);
 
 		// FIXME: snapctl tool - our apparmor policy wants it in

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -363,7 +363,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		// where $ROOT is either "/" or the "/snap/core/current"
 		// that we are re-execing from
 		char *src = NULL;
-		char self[PATH_MAX] = { 0, };
+		char self[PATH_MAX + 1] = { 0, };
 		if (readlink("/proc/self/exe", self, sizeof(self) - 1) < 0) {
 			die("cannot read /proc/self/exe");
 		}
@@ -372,8 +372,9 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			die("cannot use result from readlink: %s", src);
 		}
 		src = dirname(self);
-		// dirname(path) might return '.' depending on path. /proc/self/exe should always point
-// to an absolute path, but let's guarantee that.
+		// dirname(path) might return '.' depending on path.
+		// /proc/self/exe should always point
+		// to an absolute path, but let's guarantee that.
 		if (src[0] != '/') {
 			die("cannot use the result of dirname(): %s", src);
 		}

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -362,13 +362,10 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		// bind mount the current $ROOT/usr/lib/snapd path,
 		// where $ROOT is either "/" or the "/snap/core/current"
 		// that we are re-execing from
-		char src[PATH_MAX + 1];
-		sc_must_snprintf(src, sizeof src, "%s", LIBEXECDIR);
-
+		char *src = LIBEXECDIR;
 		char self[PATH_MAX + 1] = { 0, };
 		if (readlink("/proc/self/exe", self, sizeof self) > 0) {
-			char *dir = dirname(self);
-			sc_must_snprintf(src, sizeof src, "%s", dir);
+			src = dirname(self);
 		}
 
 		sc_do_mount(src, dst, NULL, MS_BIND, NULL);

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -180,7 +180,7 @@
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
     # allow making re-execed host snap-exec available inside base snaps
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(ro bind) @SNAP_MOUNT_DIR@/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
     mount options=(rw bind) /usr/bin/snapctl -> /tmp/snap.rootfs_*/usr/bin/snapctl,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -179,6 +179,9 @@
     mount options=(rw bind) @LIBEXECDIR@/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
+    # allow making re-execed host snap-exec available inside base snaps
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/core/*/usr/lib/snapd -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+
     mount options=(rw bind) /usr/bin/snapctl -> /tmp/snap.rootfs_*/usr/bin/snapctl,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,
 

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -180,7 +180,7 @@
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
     # allow making re-execed host snap-exec available inside base snaps
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/core/*/usr/lib/snapd -> /tmp/snap.rootfs_*/usr/lib/snapd/,
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/core/*/usr/lib/snapd/ -> /tmp/snap.rootfs_*/usr/lib/snapd/,
 
     mount options=(rw bind) /usr/bin/snapctl -> /tmp/snap.rootfs_*/usr/bin/snapctl,
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,


### PR DESCRIPTION
Use the basedir of snap-confine to bind mount as /usr/lib/snapd
when using bases. This ensures we use the re-execed tools if we
are re-execing. This fixes the bug that busybox-static does not
work with the "bare" snap when using a snapd that re-execs from
e.g. beta.
