### PR TITLE
cmd,dirs: treat "liri" the same way as "arch"

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -67,7 +67,7 @@ func distroSupportsReExec() bool {
 		return false
 	}
 	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch", "manjaro":
+	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch", "manjaro", "lirios":
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return false
 	}

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -166,7 +166,7 @@ func SetRootDir(rootdir string) {
 	GlobalRootDir = rootdir
 
 	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "arch", "manjaro":
+	case "fedora", "centos", "rhel", "arch", "manjaro", "lirios":
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	default:
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)


### PR DESCRIPTION
Liri is a derivative of Arch and should use the same support code.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>