### PR TITLE
git: make the .gitingore file a bit more targeted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,17 +51,17 @@ snap-confine-*.tar.gz
 .deps
 
 # Autoconf
-aclocal.m4
-autom4te.cache
-compile
-config.guess
-config.h
-config.h.in
-config.status
-config.sub
-configure
-depcomp
-install-sh
-missing
-stamp-h1
-test-driver
+cmd/aclocal.m4
+cmd/autom4te.cache
+cmd/compile
+cmd/config.guess
+cmd/config.h
+cmd/config.h.in
+cmd/config.status
+cmd/config.sub
+cmd/configure
+cmd/depcomp
+cmd/install-sh
+cmd/missing
+cmd/stamp-h1
+cmd/test-driver


### PR DESCRIPTION
Right now our snapd-vendor branch is missing "meta/hooks/configure" because our .gitignore is a bit too broad.