### PR TITLE
tests: Increase SNAPD_CONFIGURE_HOOK_TIMEOUT to 3 minutes to install real snaps

### DIFF
--- a/tests/main/install-snaps/task.yaml
+++ b/tests/main/install-snaps/task.yaml
@@ -66,6 +66,17 @@ environment:
     SNAP/solc: solc
     SNAP/vault: vault
 
+prepare: |
+    cp /etc/systemd/system/snapd.service.d/local.conf /etc/systemd/system/snapd.service.d/local.conf.bak
+    sed 's/SNAPD_CONFIGURE_HOOK_TIMEOUT=.*s/SNAPD_CONFIGURE_HOOK_TIMEOUT=180s/g' -i /etc/systemd/system/snapd.service.d/local.conf
+    systemctl daemon-reload
+    systemctl restart snapd.socket
+
+restore: |
+    mv /etc/systemd/system/snapd.service.d/local.conf.bak /etc/systemd/system/snapd.service.d/local.conf
+    systemctl daemon-reload
+    systemctl restart snapd.socket
+
 execute: |
     . "$TESTSLIB/snaps.sh"
 


### PR DESCRIPTION
This is to give more time to real snaps to run the configure hook. For
example currently the juju snap is installing lxd as part of the
configure hooks and the current 30 seconds that we use for testing is
not enough.
This is used on a test which is set as manual and executed in a nightly
execution.