### PR TITLE
cmd/snap-seccomp,osutil: make user/group lookup functions public

### DIFF
--- a/cmd/snap-seccomp/export_test.go
+++ b/cmd/snap-seccomp/export_test.go
@@ -22,7 +22,6 @@ package main
 var (
 	Compile         = compile
 	SeccompResolver = seccompResolver
-	FindGid         = findGid
 )
 
 func MockArchUbuntuArchitecture(f func() string) (restore func()) {

--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -28,7 +28,6 @@ package main
 //#include <errno.h>
 //#include <linux/can.h>
 //#include <linux/netlink.h>
-//#include <grp.h>
 //#include <sched.h>
 //#include <search.h>
 //#include <stdbool.h>
@@ -136,11 +135,6 @@ package main
 //		return htobe64(val);
 //}
 //
-//static int mygetgrnam_r(const char *name, struct group *grp,char *buf,
-//			  size_t buflen, struct group **result) {
-//	return getgrnam_r(name, grp, buf, buflen, result);
-//}
-//
 import "C"
 
 import (
@@ -149,12 +143,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
-	"unsafe"
 
 	// FIXME: we want github.com/seccomp/libseccomp-golang but that
 	// will not work with trusty because libseccomp-golang checks
@@ -466,137 +457,6 @@ func readNumber(token string) (uint64, error) {
 	return strconv.ParseUint(token, 10, 64)
 }
 
-// Be very strict so usernames and groups specified in policy are widely
-// compatible. From NAME_REGEX in /etc/adduser.conf
-var userGroupNamePattern = regexp.MustCompile("^[a-z][-a-z0-9_]*$")
-
-func findUid(username string) (uint64, error) {
-	if !userGroupNamePattern.MatchString(username) {
-		return 0, fmt.Errorf("%q must be a valid username", username)
-	}
-	user, err := user.Lookup(username)
-	if err != nil {
-		return 0, err
-	}
-
-	return strconv.ParseUint(user.Uid, 10, 64)
-}
-
-// hrm, user.LookupGroup() doesn't exist yet:
-// https://github.com/golang/go/issues/2617
-//
-// Use implementation from upcoming releases:
-// https://golang.org/src/os/user/lookup_unix.go
-func lookupGroup(groupname string) (string, error) {
-	var grp C.struct_group
-	var result *C.struct_group
-
-	buf := alloc(groupBuffer)
-	defer buf.free()
-	cname := C.CString(groupname)
-	defer C.free(unsafe.Pointer(cname))
-
-	err := retryWithBuffer(buf, func() syscall.Errno {
-		return syscall.Errno(C.mygetgrnam_r(cname,
-			&grp,
-			(*C.char)(buf.ptr),
-			C.size_t(buf.size),
-			&result))
-	})
-	if err != nil {
-		return "", fmt.Errorf("group: lookup groupname %s: %v", groupname, err)
-	}
-	if result == nil {
-		return "", fmt.Errorf("group: unknown group %s", groupname)
-	}
-	return strconv.Itoa(int(grp.gr_gid)), nil
-}
-
-type bufferKind C.int
-
-const (
-	groupBuffer = bufferKind(C._SC_GETGR_R_SIZE_MAX)
-)
-
-func (k bufferKind) initialSize() C.size_t {
-	sz := C.sysconf(C.int(k))
-	if sz == -1 {
-		// DragonFly and FreeBSD do not have _SC_GETPW_R_SIZE_MAX.
-		// Additionally, not all Linux systems have it, either. For
-		// example, the musl libc returns -1.
-		return 1024
-	}
-	if !isSizeReasonable(int64(sz)) {
-		// Truncate.  If this truly isn't enough, retryWithBuffer will error on the first run.
-		return maxBufferSize
-	}
-	return C.size_t(sz)
-}
-
-type memBuffer struct {
-	ptr  unsafe.Pointer
-	size C.size_t
-}
-
-func alloc(kind bufferKind) *memBuffer {
-	sz := kind.initialSize()
-	return &memBuffer{
-		ptr:  C.malloc(sz),
-		size: sz,
-	}
-}
-
-func (mb *memBuffer) resize(newSize C.size_t) {
-	mb.ptr = C.realloc(mb.ptr, newSize)
-	mb.size = newSize
-}
-
-func (mb *memBuffer) free() {
-	C.free(mb.ptr)
-}
-
-// retryWithBuffer repeatedly calls f(), increasing the size of the
-// buffer each time, until f succeeds, fails with a non-ERANGE error,
-// or the buffer exceeds a reasonable limit.
-func retryWithBuffer(buf *memBuffer, f func() syscall.Errno) error {
-	for {
-		errno := f()
-		if errno == 0 {
-			return nil
-		} else if errno != syscall.ERANGE {
-			return errno
-		}
-		newSize := buf.size * 2
-		if !isSizeReasonable(int64(newSize)) {
-			return fmt.Errorf("internal buffer exceeds %d bytes", maxBufferSize)
-		}
-		buf.resize(newSize)
-	}
-}
-
-const maxBufferSize = 1 << 20
-
-func isSizeReasonable(sz int64) bool {
-	return sz > 0 && sz <= maxBufferSize
-}
-
-// end code from https://golang.org/src/os/user/lookup_unix.go
-
-func findGid(group string) (uint64, error) {
-	if !userGroupNamePattern.MatchString(group) {
-		return 0, fmt.Errorf("%q must be a valid group name", group)
-	}
-
-	//group, err := user.LookupGroup(group)
-	group, err := lookupGroup(group)
-	if err != nil {
-		return 0, err
-	}
-
-	//return strconv.ParseUint(group.Gid, 10, 64)
-	return strconv.ParseUint(group, 10, 64)
-}
-
 func parseLine(line string, secFilter *seccomp.ScmpFilter) error {
 	// ignore comments and empty lines
 	if strings.HasPrefix(line, "#") || line == "" {
@@ -649,13 +509,13 @@ func parseLine(line string, secFilter *seccomp.ScmpFilter) error {
 			value, err = readNumber(arg[1:])
 		} else if strings.HasPrefix(arg, "u:") {
 			cmpOp = seccomp.CompareEqual
-			value, err = findUid(arg[2:])
+			value, err = osutil.FindUid(arg[2:])
 			if err != nil {
 				return fmt.Errorf("cannot parse token %q (line %q): %v", arg, line, err)
 			}
 		} else if strings.HasPrefix(arg, "g:") {
 			cmpOp = seccomp.CompareEqual
-			value, err = findGid(arg[2:])
+			value, err = osutil.FindGid(arg[2:])
 			if err != nil {
 				return fmt.Errorf("cannot parse token %q (line %q): %v", arg, line, err)
 			}

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	main "github.com/snapcore/snapd/cmd/snap-seccomp"
+	"github.com/snapcore/snapd/osutil"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -341,7 +342,7 @@ restart_syscall
 //    {"read >=2", "read;native;0", main.SeccompRetKill},
 func (s *snapSeccompSuite) TestCompile(c *C) {
 	// The 'shadow' group is different in different distributions
-	shadowGid, err := main.FindGid("shadow")
+	shadowGid, err := osutil.FindGid("shadow")
 	c.Assert(err, IsNil)
 
 	for _, t := range []struct {

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -28,7 +28,6 @@ import "C"
 import (
 	"fmt"
 	"os/user"
-	"regexp"
 	"strconv"
 	"syscall"
 	"unsafe"
@@ -134,15 +133,8 @@ func isSizeReasonable(sz int64) bool {
 
 // end code from https://golang.org/src/os/user/lookup_unix.go
 
-// Be very strict so usernames and groups specified in policy are widely
-// compatible. From NAME_REGEX in /etc/adduser.conf
-var userGroupNamePattern = regexp.MustCompile("^[a-z][-a-z0-9_]*$")
-
 // FindUid returns the identifier of the given UNIX user name.
 func FindUid(username string) (uint64, error) {
-	if !userGroupNamePattern.MatchString(username) {
-		return 0, fmt.Errorf("%q must be a valid username", username)
-	}
 	user, err := user.Lookup(username)
 	if err != nil {
 		return 0, err
@@ -153,10 +145,6 @@ func FindUid(username string) (uint64, error) {
 
 // FindGid returns the identifier of the given UNIX group name.
 func FindGid(group string) (uint64, error) {
-	if !userGroupNamePattern.MatchString(group) {
-		return 0, fmt.Errorf("%q must be a valid group name", group)
-	}
-
 	// In golang 1.8 we can use the built-in function like this:
 	//group, err := user.LookupGroup(group)
 	group, err := lookupGroup(group)

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -1,0 +1,170 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+// #include <stdlib.h>
+// #include <sys/types.h>
+// #include <grp.h>
+// #include <unistd.h>
+import "C"
+
+import (
+	"fmt"
+	"os/user"
+	"regexp"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+// hrm, user.LookupGroup() doesn't exist yet:
+// https://github.com/golang/go/issues/2617
+//
+// Use implementation from upcoming releases:
+// https://golang.org/src/os/user/lookup_unix.go
+func lookupGroup(groupname string) (string, error) {
+	var grp C.struct_group
+	var result *C.struct_group
+
+	buf := alloc(groupBuffer)
+	defer buf.free()
+	cname := C.CString(groupname)
+	defer C.free(unsafe.Pointer(cname))
+
+	err := retryWithBuffer(buf, func() syscall.Errno {
+		return syscall.Errno(C.getgrnam_r(cname,
+			&grp,
+			(*C.char)(buf.ptr),
+			C.size_t(buf.size),
+			&result))
+	})
+	if err != nil {
+		return "", fmt.Errorf("group: lookup groupname %s: %v", groupname, err)
+	}
+	if result == nil {
+		return "", fmt.Errorf("group: unknown group %s", groupname)
+	}
+	return strconv.Itoa(int(grp.gr_gid)), nil
+}
+
+type bufferKind C.int
+
+const (
+	groupBuffer = bufferKind(C._SC_GETGR_R_SIZE_MAX)
+)
+
+func (k bufferKind) initialSize() C.size_t {
+	sz := C.sysconf(C.int(k))
+	if sz == -1 {
+		// DragonFly and FreeBSD do not have _SC_GETPW_R_SIZE_MAX.
+		// Additionally, not all Linux systems have it, either. For
+		// example, the musl libc returns -1.
+		return 1024
+	}
+	if !isSizeReasonable(int64(sz)) {
+		// Truncate.  If this truly isn't enough, retryWithBuffer will error on the first run.
+		return maxBufferSize
+	}
+	return C.size_t(sz)
+}
+
+type memBuffer struct {
+	ptr  unsafe.Pointer
+	size C.size_t
+}
+
+func alloc(kind bufferKind) *memBuffer {
+	sz := kind.initialSize()
+	return &memBuffer{
+		ptr:  C.malloc(sz),
+		size: sz,
+	}
+}
+
+func (mb *memBuffer) resize(newSize C.size_t) {
+	mb.ptr = C.realloc(mb.ptr, newSize)
+	mb.size = newSize
+}
+
+func (mb *memBuffer) free() {
+	C.free(mb.ptr)
+}
+
+// retryWithBuffer repeatedly calls f(), increasing the size of the
+// buffer each time, until f succeeds, fails with a non-ERANGE error,
+// or the buffer exceeds a reasonable limit.
+func retryWithBuffer(buf *memBuffer, f func() syscall.Errno) error {
+	for {
+		errno := f()
+		if errno == 0 {
+			return nil
+		} else if errno != syscall.ERANGE {
+			return errno
+		}
+		newSize := buf.size * 2
+		if !isSizeReasonable(int64(newSize)) {
+			return fmt.Errorf("internal buffer exceeds %d bytes", maxBufferSize)
+		}
+		buf.resize(newSize)
+	}
+}
+
+const maxBufferSize = 1 << 20
+
+func isSizeReasonable(sz int64) bool {
+	return sz > 0 && sz <= maxBufferSize
+}
+
+// end code from https://golang.org/src/os/user/lookup_unix.go
+
+// Be very strict so usernames and groups specified in policy are widely
+// compatible. From NAME_REGEX in /etc/adduser.conf
+var userGroupNamePattern = regexp.MustCompile("^[a-z][-a-z0-9_]*$")
+
+// FindUid returns the identifier of the given UNIX user name.
+func FindUid(username string) (uint64, error) {
+	if !userGroupNamePattern.MatchString(username) {
+		return 0, fmt.Errorf("%q must be a valid username", username)
+	}
+	user, err := user.Lookup(username)
+	if err != nil {
+		return 0, err
+	}
+
+	return strconv.ParseUint(user.Uid, 10, 64)
+}
+
+// FindGid returns the identifier of the given UNIX group name.
+func FindGid(group string) (uint64, error) {
+	if !userGroupNamePattern.MatchString(group) {
+		return 0, fmt.Errorf("%q must be a valid group name", group)
+	}
+
+	// In golang 1.8 we can use the built-in function like this:
+	//group, err := user.LookupGroup(group)
+	group, err := lookupGroup(group)
+	if err != nil {
+		return 0, err
+	}
+
+	// In golang 1.8 we can parse the group.Gid string instead.
+	//return strconv.ParseUint(group.Gid, 10, 64)
+	return strconv.ParseUint(group, 10, 64)
+}


### PR DESCRIPTION
This branch moves the `Find{Uid,Gid}` functions out of the cmd/snap-seccomp
program and into the osutil package where they can also be used by other parts
of snapd. Sadly golang 1.6 doesn't implement user.LookupGroup yet so we need
this kind of hackery.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>