### PR TITLE
daemon: use client.Snap instead of map[string]interface{} for snaps.

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -506,21 +506,17 @@ func getSnapInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	return SyncResponse(result, nil)
 }
 
-func webify(result map[string]interface{}, resource string) map[string]interface{} {
-	result["resource"] = resource
-
-	icon, ok := result["icon"].(string)
-	if !ok || icon == "" || strings.HasPrefix(icon, "http") {
+func webify(result *client.Snap, resource string) *client.Snap {
+	if result.Icon == "" || strings.HasPrefix(result.Icon, "http") {
 		return result
 	}
-	result["icon"] = ""
+	result.Icon = ""
 
 	route := appIconCmd.d.router.Get(appIconCmd.Path)
 	if route != nil {
-		name, _ := result["name"].(string)
-		url, err := route.URL("name", name)
+		url, err := route.URL("name", result.Name)
 		if err == nil {
-			result["icon"] = url.String()
+			result.Icon = url.String()
 		}
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -539,41 +539,40 @@ UnitFileState=potatoes
 	c.Assert(ok, check.Equals, true)
 
 	c.Assert(rsp, check.NotNil)
-	c.Assert(rsp.Result, check.FitsTypeOf, map[string]interface{}{})
-	m := rsp.Result.(map[string]interface{})
+	c.Assert(rsp.Result, check.FitsTypeOf, &client.Snap{})
+	m := rsp.Result.(*client.Snap)
 
 	// installed-size depends on vagaries of the filesystem, just check type
-	c.Check(m["installed-size"], check.FitsTypeOf, int64(0))
-	delete(m, "installed-size")
+	c.Check(m.InstalledSize, check.FitsTypeOf, int64(0))
+	m.InstalledSize = 0
 	// ditto install-date
-	c.Check(m["install-date"], check.FitsTypeOf, time.Time{})
-	delete(m, "install-date")
+	c.Check(m.InstallDate, check.FitsTypeOf, time.Time{})
+	m.InstallDate = time.Time{}
 
 	meta := &Meta{}
 	expected := &resp{
 		Type:   ResponseTypeSync,
 		Status: 200,
-		Result: map[string]interface{}{
-			"id":               "foo-id",
-			"name":             "foo",
-			"revision":         snap.R(10),
-			"version":          "v1",
-			"channel":          "stable",
-			"tracking-channel": "beta",
-			"title":            "title",
-			"summary":          "summary",
-			"description":      "description",
-			"developer":        "bar",
-			"status":           "active",
-			"icon":             "/v2/icons/foo/icon",
-			"type":             string(snap.TypeApp),
-			"resource":         "/v2/snaps/foo",
-			"private":          false,
-			"devmode":          false,
-			"jailmode":         false,
-			"confinement":      snap.StrictConfinement,
-			"trymode":          false,
-			"apps": []*client.AppInfo{
+		Result: &client.Snap{
+			ID:              "foo-id",
+			Name:            "foo",
+			Revision:        snap.R(10),
+			Version:         "v1",
+			Channel:         "stable",
+			TrackingChannel: "beta",
+			Title:           "title",
+			Summary:         "summary",
+			Description:     "description",
+			Developer:       "bar",
+			Status:          "active",
+			Icon:            "/v2/icons/foo/icon",
+			Type:            string(snap.TypeApp),
+			Private:         false,
+			DevMode:         false,
+			JailMode:        false,
+			Confinement:     string(snap.StrictConfinement),
+			TryMode:         false,
+			Apps: []client.AppInfo{
 				{
 					Snap: "foo", Name: "cmd",
 					DesktopFile: df,
@@ -604,9 +603,9 @@ UnitFileState=potatoes
 					Active:  false,
 				},
 			},
-			"broken":  "",
-			"contact": "",
-			"license": "GPL-3.0",
+			Broken:  "",
+			Contact: "",
+			License: "GPL-3.0",
 		},
 		Meta: meta,
 	}
@@ -1404,7 +1403,7 @@ func (s *apiSuite) TestFind(c *check.C) {
 	c.Assert(snaps, check.HasLen, 1)
 	c.Assert(snaps[0]["name"], check.Equals, "store")
 	c.Check(snaps[0]["prices"], check.IsNil)
-	c.Check(snaps[0]["screenshots"], check.IsNil)
+	c.Check(snaps[0]["screenshots"], check.HasLen, 0)
 	c.Check(snaps[0]["channels"], check.IsNil)
 
 	c.Check(rsp.SuggestedCurrency, check.Equals, "EUR")
@@ -5755,13 +5754,13 @@ UnitFileState=enabled
 	rsp := getAppsInfo(appsCmd, req, nil).(*resp)
 	c.Assert(rsp.Status, check.Equals, 200)
 	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
-	c.Assert(rsp.Result, check.FitsTypeOf, []*client.AppInfo{})
-	apps := rsp.Result.([]*client.AppInfo)
+	c.Assert(rsp.Result, check.FitsTypeOf, []client.AppInfo{})
+	apps := rsp.Result.([]client.AppInfo)
 	c.Assert(apps, check.HasLen, 6)
 
 	for _, name := range svcNames {
 		snap, app := splitAppName(name)
-		c.Check(apps, testutil.DeepContains, &client.AppInfo{
+		c.Check(apps, testutil.DeepContains, client.AppInfo{
 			Snap:    snap,
 			Name:    app,
 			Daemon:  "simple",
@@ -5772,7 +5771,7 @@ UnitFileState=enabled
 
 	for _, name := range []string{"snap-b.cmd1", "snap-d.cmd2", "snap-d.cmd3"} {
 		snap, app := splitAppName(name)
-		c.Check(apps, testutil.DeepContains, &client.AppInfo{
+		c.Check(apps, testutil.DeepContains, client.AppInfo{
 			Snap: snap,
 			Name: app,
 		})
@@ -5793,13 +5792,13 @@ func (s *appSuite) TestGetAppsInfoNames(c *check.C) {
 	rsp := getAppsInfo(appsCmd, req, nil).(*resp)
 	c.Assert(rsp.Status, check.Equals, 200)
 	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
-	c.Assert(rsp.Result, check.FitsTypeOf, []*client.AppInfo{})
-	apps := rsp.Result.([]*client.AppInfo)
+	c.Assert(rsp.Result, check.FitsTypeOf, []client.AppInfo{})
+	apps := rsp.Result.([]client.AppInfo)
 	c.Assert(apps, check.HasLen, 2)
 
 	for _, name := range []string{"snap-d.cmd2", "snap-d.cmd3"} {
 		snap, app := splitAppName(name)
-		c.Check(apps, testutil.DeepContains, &client.AppInfo{
+		c.Check(apps, testutil.DeepContains, client.AppInfo{
 			Snap: snap,
 			Name: app,
 		})
@@ -5829,13 +5828,13 @@ UnitFileState=enabled
 	rsp := getAppsInfo(appsCmd, req, nil).(*resp)
 	c.Assert(rsp.Status, check.Equals, 200)
 	c.Assert(rsp.Type, check.Equals, ResponseTypeSync)
-	c.Assert(rsp.Result, check.FitsTypeOf, []*client.AppInfo{})
-	svcs := rsp.Result.([]*client.AppInfo)
+	c.Assert(rsp.Result, check.FitsTypeOf, []client.AppInfo{})
+	svcs := rsp.Result.([]client.AppInfo)
 	c.Assert(svcs, check.HasLen, 3)
 
 	for _, name := range svcNames {
 		snap, app := splitAppName(name)
-		c.Check(svcs, testutil.DeepContains, &client.AppInfo{
+		c.Check(svcs, testutil.DeepContains, client.AppInfo{
 			Snap:    snap,
 			Name:    app,
 			Daemon:  "simple",

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -163,13 +163,6 @@ func allLocalSnapInfos(st *state.State, all bool, wanted map[string]bool) ([]abo
 	return about, firstErr
 }
 
-// screenshotJSON contains the json for snap.ScreenshotInfo
-type screenshotJSON struct {
-	URL    string `json:"url"`
-	Width  int64  `json:"width,omitempty"`
-	Height int64  `json:"height,omitempty"`
-}
-
 type bySnapApp []*snap.AppInfo
 
 func (a bySnapApp) Len() int      { return len(a) }
@@ -282,14 +275,14 @@ func appInfosFor(st *state.State, names []string, opts appInfoOptions) ([]*snap.
 	return appInfos, nil
 }
 
-func clientAppInfosFromSnapAppInfos(apps []*snap.AppInfo) []*client.AppInfo {
+func clientAppInfosFromSnapAppInfos(apps []*snap.AppInfo) []client.AppInfo {
 	// TODO: pass in an actual notifier here instead of null
 	//       (Status doesn't _need_ it, but benefits from it)
 	sysd := systemd.New(dirs.GlobalRootDir, &progress.NullProgress{})
 
-	out := make([]*client.AppInfo, len(apps))
+	out := make([]client.AppInfo, len(apps))
 	for i, app := range apps {
-		out[i] = &client.AppInfo{
+		out[i] = client.AppInfo{
 			Snap: app.Snap.Name(),
 			Name: app.Name,
 		}
@@ -314,7 +307,7 @@ func clientAppInfosFromSnapAppInfos(apps []*snap.AppInfo) []*client.AppInfo {
 	return out
 }
 
-func mapLocal(about aboutSnap) map[string]interface{} {
+func mapLocal(about aboutSnap) *client.Snap {
 	localSnap, snapst := about.info, about.snapst
 	status := "installed"
 	if snapst.Active && localSnap.Revision == snapst.Current {
@@ -331,43 +324,37 @@ func mapLocal(about aboutSnap) map[string]interface{} {
 
 	// TODO: expose aliases information and state?
 
-	result := map[string]interface{}{
-		"description":      localSnap.Description(),
-		"developer":        about.publisher,
-		"icon":             snapIcon(localSnap),
-		"id":               localSnap.SnapID,
-		"install-date":     snapDate(localSnap),
-		"installed-size":   localSnap.Size,
-		"name":             localSnap.Name(),
-		"revision":         localSnap.Revision,
-		"status":           status,
-		"summary":          localSnap.Summary(),
-		"type":             string(localSnap.Type),
-		"version":          localSnap.Version,
-		"channel":          localSnap.Channel,
-		"tracking-channel": snapst.Channel,
-		"confinement":      localSnap.Confinement,
-		"devmode":          snapst.DevMode,
-		"trymode":          snapst.TryMode,
-		"jailmode":         snapst.JailMode,
-		"private":          localSnap.Private,
-		"apps":             apps,
-		"broken":           localSnap.Broken,
-		"contact":          localSnap.Contact,
-	}
-
-	if localSnap.Title() != "" {
-		result["title"] = localSnap.Title()
-	}
-
-	if localSnap.License != "" {
-		result["license"] = localSnap.License
+	result := &client.Snap{
+		Description:     localSnap.Description(),
+		Developer:       about.publisher,
+		Icon:            snapIcon(localSnap),
+		ID:              localSnap.SnapID,
+		InstallDate:     snapDate(localSnap),
+		InstalledSize:   localSnap.Size,
+		Name:            localSnap.Name(),
+		Revision:        localSnap.Revision,
+		Status:          status,
+		Summary:         localSnap.Summary(),
+		Type:            string(localSnap.Type),
+		Version:         localSnap.Version,
+		Channel:         localSnap.Channel,
+		TrackingChannel: snapst.Channel,
+		Confinement:     string(localSnap.Confinement),
+		DevMode:         snapst.DevMode,
+		TryMode:         snapst.TryMode,
+		JailMode:        snapst.JailMode,
+		Private:         localSnap.Private,
+		Apps:            apps,
+		Broken:          localSnap.Broken,
+		Contact:         localSnap.Contact,
+		Title:           localSnap.Title(),
+		License:         localSnap.License,
 	}
 
 	return result
 }
 
-func mapRemote(remoteSnap *snap.Info) map[string]interface{} {
+func mapRemote(remoteSnap *snap.Info) *client.Snap {
 	status := "available"
 	if remoteSnap.MustBuy {
 		status = "priced"
@@ -378,55 +365,37 @@ func mapRemote(remoteSnap *snap.Info) map[string]interface{} {
 		confinement = snap.StrictConfinement
 	}
 
-	screenshots := make([]screenshotJSON, len(remoteSnap.Screenshots))
+	screenshots := make([]client.Screenshot, len(remoteSnap.Screenshots))
 	for i, screenshot := range remoteSnap.Screenshots {
-		screenshots[i] = screenshotJSON{
+		screenshots[i] = client.Screenshot{
 			URL:    screenshot.URL,
 			Width:  screenshot.Width,
 			Height: screenshot.Height,
 		}
 	}
 
-	result := map[string]interface{}{
-		"description":   remoteSnap.Description(),
-		"developer":     remoteSnap.Publisher,
-		"download-size": remoteSnap.Size,
-		"icon":          snapIcon(remoteSnap),
-		"id":            remoteSnap.SnapID,
-		"name":          remoteSnap.Name(),
-		"revision":      remoteSnap.Revision,
-		"status":        status,
-		"summary":       remoteSnap.Summary(),
-		"type":          string(remoteSnap.Type),
-		"version":       remoteSnap.Version,
-		"channel":       remoteSnap.Channel,
-		"private":       remoteSnap.Private,
-		"confinement":   confinement,
-		"contact":       remoteSnap.Contact,
-	}
-
-	if remoteSnap.Title() != "" {
-		result["title"] = remoteSnap.Title()
-	}
-
-	if remoteSnap.License != "" {
-		result["license"] = remoteSnap.License
-	}
-
-	if len(screenshots) > 0 {
-		result["screenshots"] = screenshots
-	}
-
-	if len(remoteSnap.Prices) > 0 {
-		result["prices"] = remoteSnap.Prices
-	}
-
-	if len(remoteSnap.Channels) > 0 {
-		result["channels"] = remoteSnap.Channels
-	}
-
-	if len(remoteSnap.Tracks) > 0 {
-		result["tracks"] = remoteSnap.Tracks
+	result := &client.Snap{
+		Description:  remoteSnap.Description(),
+		Developer:    remoteSnap.Publisher,
+		DownloadSize: remoteSnap.Size,
+		Icon:         snapIcon(remoteSnap),
+		ID:           remoteSnap.SnapID,
+		Name:         remoteSnap.Name(),
+		Revision:     remoteSnap.Revision,
+		Status:       status,
+		Summary:      remoteSnap.Summary(),
+		Type:         string(remoteSnap.Type),
+		Version:      remoteSnap.Version,
+		Channel:      remoteSnap.Channel,
+		Private:      remoteSnap.Private,
+		Confinement:  string(confinement),
+		Contact:      remoteSnap.Contact,
+		Title:        remoteSnap.Title(),
+		License:      remoteSnap.License,
+		Screenshots:  screenshots,
+		Prices:       remoteSnap.Prices,
+		Channels:     remoteSnap.Channels,
+		Tracks:       remoteSnap.Tracks,
 	}
 
 	return result


### PR DESCRIPTION
A small refactoring branch that drops the hacky and error-prone
`map[string]interface{}` and switches to use client.Snap.

This should make asking for some fields easier, which is what I was looking at
when the need for this arose.
