### PR TITLE
interfaces/mount,cmd/snap-update-ns: move change code

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -17,7 +17,7 @@
  *
  */
 
-package mount
+package main
 
 import (
 	"fmt"
@@ -25,6 +25,8 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+
+	"github.com/snapcore/snapd/interfaces/mount"
 )
 
 // Action represents a mount action (mount, remount, unmount, etc).
@@ -42,7 +44,7 @@ const (
 
 // Change describes a change to the mount table (action and the entry to act on).
 type Change struct {
-	Entry  Entry
+	Entry  mount.Entry
 	Action Action
 }
 
@@ -57,7 +59,7 @@ func (c Change) String() string {
 func (c *Change) Perform() error {
 	switch c.Action {
 	case Mount:
-		flags, err := OptsToFlags(c.Entry.Options)
+		flags, err := mount.OptsToFlags(c.Entry.Options)
 		if err != nil {
 			return err
 		}
@@ -75,11 +77,11 @@ func (c *Change) Perform() error {
 // lists are processed and a "diff" of mount changes is produced. The mount
 // changes, when applied in order, transform the current profile into the
 // desired profile.
-func NeededChanges(currentProfile, desiredProfile *Profile) []Change {
+func NeededChanges(currentProfile, desiredProfile *mount.Profile) []Change {
 	// Copy both profiles as we will want to mutate them.
-	current := make([]Entry, len(currentProfile.Entries))
+	current := make([]mount.Entry, len(currentProfile.Entries))
 	copy(current, currentProfile.Entries)
-	desired := make([]Entry, len(desiredProfile.Entries))
+	desired := make([]mount.Entry, len(desiredProfile.Entries))
 	copy(desired, desiredProfile.Entries)
 
 	// Clean the directory part of both profiles. This is done so that we can
@@ -97,7 +99,7 @@ func NeededChanges(currentProfile, desiredProfile *Profile) []Change {
 	sort.Sort(byMagicDir(desired))
 
 	// Construct a desired directory map.
-	desiredMap := make(map[string]*Entry)
+	desiredMap := make(map[string]*mount.Entry)
 	for i := range desired {
 		desiredMap[desired[i].Dir] = &desired[i]
 	}

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -118,10 +118,10 @@ func run() error {
 
 	// Compute the needed changes and perform each change if needed, collecting
 	// those that we managed to perform or that were performed already.
-	changesNeeded := mount.NeededChanges(currentBefore, desired)
-	var changesMade []mount.Change
+	changesNeeded := NeededChanges(currentBefore, desired)
+	var changesMade []Change
 	for _, change := range changesNeeded {
-		if change.Action == mount.Keep {
+		if change.Action == Keep {
 			changesMade = append(changesMade, change)
 			continue
 		}
@@ -136,7 +136,7 @@ func run() error {
 	// and save it back for next runs.
 	var currentAfter mount.Profile
 	for _, change := range changesMade {
-		if change.Action == mount.Mount || change.Action == mount.Keep {
+		if change.Action == Mount || change.Action == Keep {
 			currentAfter.Entries = append(currentAfter.Entries, change.Entry)
 		}
 	}

--- a/cmd/snap-update-ns/sorting.go
+++ b/cmd/snap-update-ns/sorting.go
@@ -17,32 +17,28 @@
  *
  */
 
-package mount
+package main
 
 import (
-	"sort"
+	"strings"
 
-	. "gopkg.in/check.v1"
+	"github.com/snapcore/snapd/interfaces/mount"
 )
 
-type sortSuite struct{}
+// byMagicDir allows sorting an array of entries that automagically assumes
+// each entry ends with a trailing slash.
+type byMagicDir []mount.Entry
 
-var _ = Suite(&sortSuite{})
-
-func (s *sortSuite) TestTrailingSlashesComparison(c *C) {
-	// Naively sorted entries.
-	entries := []Entry{
-		{Dir: "/a/b"},
-		{Dir: "/a/b-1"},
-		{Dir: "/a/b-1/3"},
-		{Dir: "/a/b/c"},
+func (c byMagicDir) Len() int      { return len(c) }
+func (c byMagicDir) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c byMagicDir) Less(i, j int) bool {
+	iDir := c[i].Dir
+	jDir := c[j].Dir
+	if !strings.HasSuffix(iDir, "/") {
+		iDir = iDir + "/"
 	}
-	sort.Sort(byMagicDir(entries))
-	// Entries sorted as if they had a trailing slash.
-	c.Assert(entries, DeepEquals, []Entry{
-		{Dir: "/a/b-1"},
-		{Dir: "/a/b-1/3"},
-		{Dir: "/a/b"},
-		{Dir: "/a/b/c"},
-	})
+	if !strings.HasSuffix(jDir, "/") {
+		jDir = jDir + "/"
+	}
+	return iDir < jDir
 }

--- a/cmd/snap-update-ns/sorting_test.go
+++ b/cmd/snap-update-ns/sorting_test.go
@@ -17,26 +17,34 @@
  *
  */
 
-package mount
+package main
 
 import (
-	"strings"
+	"sort"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/mount"
 )
 
-// byMagicDir allows sorting an array of entries that automagically assumes
-// each entry ends with a trailing slash.
-type byMagicDir []Entry
+type sortSuite struct{}
 
-func (c byMagicDir) Len() int      { return len(c) }
-func (c byMagicDir) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c byMagicDir) Less(i, j int) bool {
-	iDir := c[i].Dir
-	jDir := c[j].Dir
-	if !strings.HasSuffix(iDir, "/") {
-		iDir = iDir + "/"
+var _ = Suite(&sortSuite{})
+
+func (s *sortSuite) TestTrailingSlashesComparison(c *C) {
+	// Naively sorted entries.
+	entries := []mount.Entry{
+		{Dir: "/a/b"},
+		{Dir: "/a/b-1"},
+		{Dir: "/a/b-1/3"},
+		{Dir: "/a/b/c"},
 	}
-	if !strings.HasSuffix(jDir, "/") {
-		jDir = jDir + "/"
-	}
-	return iDir < jDir
+	sort.Sort(byMagicDir(entries))
+	// Entries sorted as if they had a trailing slash.
+	c.Assert(entries, DeepEquals, []mount.Entry{
+		{Dir: "/a/b-1"},
+		{Dir: "/a/b-1/3"},
+		{Dir: "/a/b"},
+		{Dir: "/a/b/c"},
+	})
 }


### PR DESCRIPTION
The mount.Change code is only used in snap-update-ns and will undergo
large growth and changes. Since snap-update-ns is now more security
sensitive due to being invoked invoked by snap-confine we'd like to keep
that code closer to where it is used and review it carefully there.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
