### PR TITLE
cmd/snap-confine: put processes into freezer hierarchy

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -64,6 +64,8 @@ snap-seccomp/snap-seccomp: snap-seccomp/*.go
 noinst_LIBRARIES += libsnap-confine-private.a
 
 libsnap_confine_private_a_SOURCES = \
+	libsnap-confine-private/cgroup-freezer-support.c \
+	libsnap-confine-private/cgroup-freezer-support.h \
 	libsnap-confine-private/classic.c \
 	libsnap-confine-private/classic.h \
 	libsnap-confine-private/cleanup-funcs.c \

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -55,7 +55,9 @@ void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
 	if (tasks_fd < 0) {
 		die("cannot open tasks file for freezer cgroup hierarchy for snap %s", snap_name);
 	}
-	// Write the process (task) number to the tasks file.
+	// Write the process (task) number to the tasks file. Linux task IDs are
+	// limited to 2^29 so a long int is enough to represent it.
+	// See include/linux/threads.h in the kernel source tree for details.
 	int n = sc_must_snprintf(buf, sizeof buf, "%ld", (long)pid);
 	if (write(tasks_fd, buf, n) < 0) {
 		die("cannot move process %ld to freezer cgroup hierarchy for snap %s", (long)pid, snap_name);

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -11,9 +11,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "../libsnap-confine-private/cleanup-funcs.h"
-#include "../libsnap-confine-private/string-utils.h"
-#include "../libsnap-confine-private/utils.h"
+#include "cleanup-funcs.h"
+#include "string-utils.h"
+#include "utils.h"
 
 static const char *freezer_cgroup_dir = "/sys/fs/cgroup/freezer";
 

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -1,0 +1,65 @@
+// For AT_EMPTY_PATH and O_PATH
+#define _GNU_SOURCE
+
+#include "cgroup-freezer-support.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "../libsnap-confine-private/cleanup-funcs.h"
+#include "../libsnap-confine-private/string-utils.h"
+#include "../libsnap-confine-private/utils.h"
+
+static const char *freezer_cgroup_dir = "/sys/fs/cgroup/freezer";
+
+void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
+{
+	// Format the name of the cgroup hierarchy. 
+	char buf[PATH_MAX];
+	sc_must_snprintf(buf, sizeof buf, "snap.%s", snap_name);
+
+	// Open the freezer cgroup directory.
+	int cgroup_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	cgroup_fd = open(freezer_cgroup_dir,
+			 O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+	if (cgroup_fd < 0) {
+		die("cannot open freezer cgroup (%s)", freezer_cgroup_dir);
+	}
+	// Create the freezer hierarchy for the given snap.
+	if (mkdirat(cgroup_fd, buf, 0755) < 0 && errno != EEXIST) {
+		die("cannot create freezer cgroup hierarchy for snap %s",
+		    snap_name);
+	}
+	// Open the hierarchy directory for the given snap.
+	int hierarchy_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	hierarchy_fd = openat(cgroup_fd, buf,
+			      O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+	if (hierarchy_fd < 0) {
+		die("cannot open freezer cgroup hierarchy for snap %s",
+		    snap_name);
+	}
+	// Since we may be running from a setuid but not setgid executable, ensure
+	// that the group and owner of the hierarchy directory is root.root. 
+	if (fchownat(hierarchy_fd, "", 0, 0, AT_EMPTY_PATH) < 0) {
+		die("cannot change owner of freezer cgroup hierarchy for snap %s to root.root", snap_name);
+	}
+	// Open the tasks file.
+	int tasks_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	tasks_fd = openat(hierarchy_fd, "tasks",
+			  O_WRONLY | O_NOFOLLOW | O_CLOEXEC);
+	if (tasks_fd < 0) {
+		die("cannot open tasks file for freezer cgroup hierarchy for snap %s", snap_name);
+	}
+	// Write the process (task) number to the tasks file.
+	int n = sc_must_snprintf(buf, sizeof buf, "%ld", (long)pid);
+	if (write(tasks_fd, buf, n) < 0) {
+		die("cannot move process %ld to freezer cgroup hierarchy for snap %s", (long)pid, snap_name);
+	}
+	debug("moved process %ld to freezer cgroup hierarchy for snap %s",
+	      (long)pid, snap_name);
+}

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -59,7 +59,7 @@ void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
 	// limited to 2^29 so a long int is enough to represent it.
 	// See include/linux/threads.h in the kernel source tree for details.
 	int n = sc_must_snprintf(buf, sizeof buf, "%ld", (long)pid);
-	if (write(tasks_fd, buf, n) < 0) {
+	if (write(tasks_fd, buf, n) < n) {
 		die("cannot move process %ld to freezer cgroup hierarchy for snap %s", (long)pid, snap_name);
 	}
 	debug("moved process %ld to freezer cgroup hierarchy for snap %s",

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.h
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.h
@@ -17,6 +17,9 @@
  * The "tasks" file belonging to the cgroup contains the set of all the
  * processes that originate from the given snap. Examining that file one can
  * reliably determine if the set is empty or not.
+ *
+ * For more details please review:
+ * https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt
 **/
 void sc_cgroup_freezer_join(const char *snap_name, pid_t pid);
 

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.h
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.h
@@ -1,0 +1,15 @@
+#ifndef SC_CGROUP_FREEZER_SUPPORT_H
+#define SC_CGROUP_FREEZER_SUPPORT_H
+
+#include <sys/types.h>
+#include "error.h"
+
+/**
+ * Join the freezer cgroup of the given snap.
+ *
+ * This function adds the specified task to the freezer cgroup specific to the
+ * given snap. The name of the cgroup is "snap.$snap_name".
+**/
+void sc_cgroup_freezer_join(const char *snap_name, pid_t pid);
+
+#endif

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.h
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.h
@@ -5,10 +5,18 @@
 #include "error.h"
 
 /**
- * Join the freezer cgroup of the given snap.
+ * Join the freezer cgroup for the given snap.
  *
  * This function adds the specified task to the freezer cgroup specific to the
  * given snap. The name of the cgroup is "snap.$snap_name".
+ *
+ * Interestingly we don't need to actually freeze the processes. The group
+ * allows us to track processes belonging to a given snap. This makes the
+ * measurement "are any processes of this snap still alive" very simple.
+ *
+ * The "tasks" file belonging to the cgroup contains the set of all the
+ * processes that originate from the given snap. Examining that file one can
+ * reliably determine if the set is empty or not.
 **/
 void sc_cgroup_freezer_join(const char *snap_name, pid_t pid);
 

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -43,12 +43,17 @@
     /dev/pts/[0-9]* rw,
     /dev/tty rw,
 
-    # cgroups
+    # cgroup: devices
     capability sys_admin,
     capability dac_override,
     /sys/fs/cgroup/devices/snap{,py}.*/ w,
     /sys/fs/cgroup/devices/snap{,py}.*/tasks w,
     /sys/fs/cgroup/devices/snap{,py}.*/devices.{allow,deny} w,
+
+    # cgroup: freezer
+    /sys/fs/cgroup/freezer/ r,
+    /sys/fs/cgroup/freezer/snap.*/ w,
+    /sys/fs/cgroup/freezer/snap.*/tasks w,
 
     # querying udev
     /etc/udev/udev.conf r,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -51,6 +51,9 @@
     /sys/fs/cgroup/devices/snap{,py}.*/devices.{allow,deny} w,
 
     # cgroup: freezer
+    # Allow creating per-snap cgroup freezers and adding snap command (task)
+    # invocations to the freezer. This allows for reliably enumerating all
+    # running tasks for the snap.
     /sys/fs/cgroup/freezer/ r,
     /sys/fs/cgroup/freezer/snap.*/ w,
     /sys/fs/cgroup/freezer/snap.*/tasks w,

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "../libsnap-confine-private/cgroup-freezer-support.h"
 #include "../libsnap-confine-private/classic.h"
 #include "../libsnap-confine-private/cleanup-funcs.h"
 #include "../libsnap-confine-private/locking.h"
@@ -190,6 +191,7 @@ int main(int argc, char **argv)
 			// for systems that had their NS created with an
 			// old version
 			sc_maybe_fixup_permissions();
+			sc_cgroup_freezer_join(snap_name, getpid());
 			sc_unlock(snap_name, snap_lock_fd);
 
 			// Reset path as we cannot rely on the path from the host OS to

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -191,6 +191,10 @@ int main(int argc, char **argv)
 			// for systems that had their NS created with an
 			// old version
 			sc_maybe_fixup_permissions();
+			// Associate each snap process with a dedicated snap freezer
+			// control group. This simplifies testing if any processes
+			// belonging to a given snap are still alive.
+			// See the documentation of the function for details.
 			sc_cgroup_freezer_join(snap_name, getpid());
 			sc_unlock(snap_name, snap_lock_fd);
 

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -6,19 +6,30 @@ prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-sh
 execute: |
-    test-snapd-sh -c 'sleep 30' &
-    pid=$!
-
+    # Start a "sleep" process in the background
+    test-snapd-sh -c 'exec sleep 1h' &
+    pid1=$!
     # Give snap-confine a moment to start and perform its task.
     sleep 3
-
     # While the process is alive its PID can be seen in the tasks file of the
     # control group.
-    cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH "$pid"
+    cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH "$pid1"
 
-    # When the process is gone the control group is updated and the task no
+    # Start a second process so that we can check adding tasks to an existing
+    # control group.
+    test-snapd-sh -c 'exec sleep 1h' &
+    pid2=$!
+    sleep 3
+    cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH "$pid2"
+
+    # When the process terminates the control group is updated and the task no
     # longer registers there.
-    kill "$pid"
-    cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH -v "$pid"
+    kill "$pid1"
+    wait -n || true  # wait returns the exit code and we kill the process
+    cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH -v "$pid1"
+
+    kill "$pid2"
+    wait -n || true  # same as above
+    cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH -v "$pid2"
 restore: |
     rmdir /sys/fs/cgroup/freezer/snap.test-snapd-sh || true

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -7,19 +7,26 @@ prepare: |
     install_local test-snapd-sh
 execute: |
     # Start a "sleep" process in the background
-    test-snapd-sh -c 'exec sleep 1h' &
+    test-snapd-sh -c 'touch $SNAP_DATA/1.stamp && exec sleep 1h' &
     pid1=$!
-    # Give snap-confine a moment to start and perform its task.
-    sleep 3
+    # Ensure that snap-confine has finished its task and that the snap process
+    # is active. Note that we don't want to wait forever either.
+    for i in $(seq 30); do
+        test -e /var/snap/test-snapd-sh/current/1.stamp && break
+        sleep 0.1
+    done
     # While the process is alive its PID can be seen in the tasks file of the
     # control group.
     cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH "$pid1"
 
     # Start a second process so that we can check adding tasks to an existing
     # control group.
-    test-snapd-sh -c 'exec sleep 1h' &
+    test-snapd-sh -c 'touch $SNAP_DATA/2.stamp && exec sleep 1h' &
     pid2=$!
-    sleep 3
+    for i in $(seq 30); do
+        test -e /var/snap/test-snapd-sh/current/2.stamp && break
+        sleep 0.1
+    done
     cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH "$pid2"
 
     # When the process terminates the control group is updated and the task no

--- a/tests/main/cgroup-freezer/task.yaml
+++ b/tests/main/cgroup-freezer/task.yaml
@@ -1,0 +1,24 @@
+summary: Each snap process is moved to appropriate freezer cgroup
+details: |
+    This test creates a snap process that suspends itself and ensures that it
+    placed into the appropriate hierarchy under the freezer cgroup.
+prepare: |
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-sh
+execute: |
+    test-snapd-sh -c 'sleep 30' &
+    pid=$!
+
+    # Give snap-confine a moment to start and perform its task.
+    sleep 3
+
+    # While the process is alive its PID can be seen in the tasks file of the
+    # control group.
+    cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH "$pid"
+
+    # When the process is gone the control group is updated and the task no
+    # longer registers there.
+    kill "$pid"
+    cat /sys/fs/cgroup/freezer/snap.test-snapd-sh/tasks | MATCH -v "$pid"
+restore: |
+    rmdir /sys/fs/cgroup/freezer/snap.test-snapd-sh || true


### PR DESCRIPTION
This patch makes snap-confine move each started snap process into a
freezer cgroup hierarchy called "snap.$SNAP_NAME". This allows for
reliable enumeration of all processes belonging to a given snap.

Reliable enumeration will be required by the upcoming base snap
invalidation feature, where preserved mount namespaces that are not
using the current revision of the base snap *and* have no processes, can
be and are discarded.

We cannot rely on the per-snap flock(2)-lock file since existing
processes do not need to acquire that lock to fork. While a simple
flock-based approach can reliably block new apps/hook processes from
starting it cannot stop processes from freely forking or exiting without
a race condition. A malicious (or just unlucky) process could repeatedly
fork and exit and could isolate itself from changes to the snap mount
namespace.

Subsequent patches will build upon this feature to detect when a mount
namespace is stale and vacant and can be discarded and re-built.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>