### PR TITLE
Recognise Solus as a classic Linux distribution

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -67,7 +67,7 @@ func distroSupportsReExec() bool {
 		return false
 	}
 	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch", "manjaro", "lirios":
+	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch", "manjaro", "lirios", "solus":
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return false
 	}

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -11,5 +11,6 @@ bool is_running_on_classic_distribution()
 	    || access("/var/lib/pacman", F_OK) == 0
 	    || access("/var/lib/portage", F_OK) == 0
 	    || access("/var/lib/rpm", F_OK) == 0
+	    || access("/var/lib/eopkg", F_OK) == 0
 	    || access("/sbin/procd", F_OK) == 0;
 }


### PR DESCRIPTION
This allows snapd to recognise Solus as a classic Linux distribution so
that confinement operates correctly, and ensures it behaves correctly;
in as much as rexecution for snapd will not be supported on Solus.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>