### PR TITLE
snap-confine: Only attempt to copy/mount NVIDIA libs when NVIDIA is used

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -33,6 +33,8 @@
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 
+#define SC_NVIDIA_DRIVER_VERSION_FILE "/sys/module/nvidia/version"
+
 #ifdef NVIDIA_ARCH
 
 // List of globs that describe nvidia userspace libraries.
@@ -196,7 +198,6 @@ struct sc_nvidia_driver {
 	int minor_version;
 };
 
-#define SC_NVIDIA_DRIVER_VERSION_FILE "/sys/module/nvidia/version"
 #define SC_LIBGL_DIR "/var/lib/snapd/lib/gl"
 
 static void sc_probe_nvidia_driver(struct sc_nvidia_driver *driver)
@@ -260,6 +261,10 @@ static void sc_mount_nvidia_driver_ubuntu(const char *rootfs_dir)
 
 void sc_mount_nvidia_driver(const char *rootfs_dir)
 {
+	/* If NVIDIA module isn't loaded, don't attempt to mount the drivers */
+	if (access(SC_NVIDIA_DRIVER_VERSION_FILE, F_OK) != 0) {
+		return;
+	}
 #ifdef NVIDIA_UBUNTU
 	sc_mount_nvidia_driver_ubuntu(rootfs_dir);
 #endif				// ifdef NVIDIA_UBUNTU


### PR DESCRIPTION
This hasn't _yet_ presented an issue in full confinement environments,
as the only fully confined environment available is Ubuntu, and the snaps
being tested are also built using the Ubuntu libraries.

This change will now only make the NVIDIA libraries available if the nvidia
kernel module is loaded and present, to ensure that confined snaps running
on open source drivers will not run into any linking issues by exposing the
host GL library into the runtime.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>