### PR TITLE
interfaces: Enhance full-confinement support for biarch distributions

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -35,6 +35,19 @@ const openglConnectedPlugAppArmor = `
   /var/lib/snapd/lib/gl/ r,
   /var/lib/snapd/lib/gl/** rm,
 
+  # Supports linux-driver-management from Solus (staged symlink trees into libdirs)
+  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}glx-provider/**.so{,.*}  rm,
+
+  # Bi-arch distribution nvidia support
+  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcuda*.so{,.*} rm,
+  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvidia*.so{,.*} rm,
+  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvcuvid.so{,.*} rm,
+  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}lib{GL,EGL}*nvidia.so{,.*} rm,
+  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libGLdispatch.so{,.*} rm,
+
+  # Main bi-arch GL libraries
+  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}lib{GL,EGL}.so{,.*} rm,
+
   /dev/dri/ r,
   /dev/dri/card0 rw,
   # nvidia


### PR DESCRIPTION
This change adds support for those using the "Arch Linux" (biarch) style
symlink farms for NVIDIA driver support when using full apparmor confinement.

Additionally this change adds support for the linux-driver-management method for
managing the host-side drivers, whereby the `glx-provider/*/` directories
are populated with the real library assets, with symlinks in the main
library directories being pointed to these locations.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>
