### PR TITLE
cmd: Correctly name the "Ubuntu" and "Arch" NVIDIA methods

### DIFF
--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -20,7 +20,7 @@ extra_opts=
 . /etc/os-release
 case "$ID" in
 	arch)
-		extra_opts="--libexecdir=/usr/lib/snapd --with-snap-mount-dir=/var/lib/snapd/snap --disable-apparmor --enable-nvidia-arch --enable-merged-usr"
+		extra_opts="--libexecdir=/usr/lib/snapd --with-snap-mount-dir=/var/lib/snapd/snap --disable-apparmor --enable-nvidia-biarch --enable-merged-usr"
 		;;
 	debian)
 		extra_opts="--libexecdir=/usr/lib/snapd"
@@ -28,10 +28,10 @@ case "$ID" in
 	ubuntu)
 		case "$VERSION_ID" in
 			16.04)
-				extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-ubuntu --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp"
+				extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp"
 				;;
 			*)
-				extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-ubuntu --enable-static-libcap"
+				extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap"
 				;;
 		esac
 		;;

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -114,32 +114,32 @@ PKG_CHECK_MODULES([UDEV], [udev])
 # PKG_CHECK_MODULES([LIBCAP], [libcap])
 
 # Enable special support for hosts with proprietary nvidia drivers on Ubuntu.
-AC_ARG_ENABLE([nvidia-ubuntu],
-    AS_HELP_STRING([--enable-nvidia-ubuntu], [Support for proprietary nvidia drivers (Ubuntu)]),
+AC_ARG_ENABLE([nvidia-multiarch],
+    AS_HELP_STRING([--enable-nvidia-multiarch], [Support for proprietary nvidia drivers (Ubuntu/Debian)]),
     [case "${enableval}" in
-        yes) enable_nvidia_ubuntu=yes ;;
-        no)  enable_nvidia_ubuntu=no ;;
-        *) AC_MSG_ERROR([bad value ${enableval} for --enable-nvidia-ubuntu])
-    esac], [enable_nvidia_ubuntu=no])
-AM_CONDITIONAL([NVIDIA_UBUNTU], [test "x$enable_nvidia_ubuntu" = "xyes"])
+        yes) enable_nvidia_multiarch=yes ;;
+        no)  enable_nvidia_multiarch=no ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-nvidia-multiarch])
+    esac], [enable_nvidia_multiarch=no])
+AM_CONDITIONAL([NVIDIA_MULTIARCH], [test "x$enable_nvidia_multiarch" = "xyes"])
 
-AS_IF([test "x$enable_nvidia_ubuntu" = "xyes"], [
-    AC_DEFINE([NVIDIA_UBUNTU], [1],
-        [Support for proprietary nvidia drivers (Ubuntu)])])
+AS_IF([test "x$enable_nvidia_multiarch" = "xyes"], [
+    AC_DEFINE([NVIDIA_MULTIARCH], [1],
+        [Support for proprietary nvidia drivers (Ubuntu/Debian)])])
 
 # Enable special support for hosts with proprietary nvidia drivers on Arch.
-AC_ARG_ENABLE([nvidia-arch],
-    AS_HELP_STRING([--enable-nvidia-arch], [Support for proprietary nvidia drivers (Arch)]),
+AC_ARG_ENABLE([nvidia-biarch],
+    AS_HELP_STRING([--enable-nvidia-biarch], [Support for proprietary nvidia drivers (bi-arch distributions)]),
     [case "${enableval}" in
-        yes) enable_nvidia_arch=yes ;;
-        no)  enable_nvidia_arch=no ;;
-        *) AC_MSG_ERROR([bad value ${enableval} for --enable-nvidia-arch])
-    esac], [enable_nvidia_arch=no])
-AM_CONDITIONAL([NVIDIA_ARCH], [test "x$enable_nvidia_arch" = "xyes"])
+        yes) enable_nvidia_biarch=yes ;;
+        no)  enable_nvidia_biarch=no ;;
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-nvidia-biarch])
+    esac], [enable_nvidia_biarch=no])
+AM_CONDITIONAL([NVIDIA_BIARCH], [test "x$enable_nvidia_biarch" = "xyes"])
 
-AS_IF([test "x$enable_nvidia_arch" = "xyes"], [
-    AC_DEFINE([NVIDIA_ARCH], [1],
-        [Support for proprietary nvidia drivers (Arch)])])
+AS_IF([test "x$enable_nvidia_biarch" = "xyes"], [
+    AC_DEFINE([NVIDIA_BIARCH], [1],
+        [Support for proprietary nvidia drivers (bi-arch distributions)])])
 
 AC_ARG_ENABLE([merged-usr],
     AS_HELP_STRING([--enable-merged-usr], [Enable support for merged /usr directory]),

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -33,7 +33,7 @@
 #include "../libsnap-confine-private/string-utils.h"
 #include "../libsnap-confine-private/utils.h"
 
-#ifdef NVIDIA_ARCH
+#ifdef NVIDIA_BIARCH
 
 // List of globs that describe nvidia userspace libraries.
 // This list was compiled from the following packages.
@@ -166,7 +166,7 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 	}
 }
 
-static void sc_mount_nvidia_driver_arch(const char *rootfs_dir)
+static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir)
 {
 	// Bind mount a tmpfs on $rootfs_dir/var/lib/snapd/lib/gl
 	char buf[512];
@@ -187,9 +187,9 @@ static void sc_mount_nvidia_driver_arch(const char *rootfs_dir)
 	}
 }
 
-#endif				// ifdef NVIDIA_ARCH
+#endif				// ifdef NVIDIA_BIARCH
 
-#ifdef NVIDIA_UBUNTU
+#ifdef NVIDIA_MULTIARCH
 
 struct sc_nvidia_driver {
 	int major_version;
@@ -224,7 +224,7 @@ static void sc_probe_nvidia_driver(struct sc_nvidia_driver *driver)
 	      driver->minor_version);
 }
 
-static void sc_mount_nvidia_driver_ubuntu(const char *rootfs_dir)
+static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir)
 {
 	struct sc_nvidia_driver driver;
 
@@ -256,14 +256,14 @@ static void sc_mount_nvidia_driver_ubuntu(const char *rootfs_dir)
 		die("cannot bind mount nvidia driver %s -> %s", src, dst);
 	}
 }
-#endif				// ifdef NVIDIA_UBUNTU
+#endif				// ifdef NVIDIA_MULTIARCH
 
 void sc_mount_nvidia_driver(const char *rootfs_dir)
 {
-#ifdef NVIDIA_UBUNTU
-	sc_mount_nvidia_driver_ubuntu(rootfs_dir);
-#endif				// ifdef NVIDIA_UBUNTU
-#ifdef NVIDIA_ARCH
-	sc_mount_nvidia_driver_arch(rootfs_dir);
-#endif				// ifdef NVIDIA_ARCH
+#ifdef NVIDIA_MULTIARCH
+	sc_mount_nvidia_driver_multiarch(rootfs_dir);
+#endif				// ifdef NVIDIA_MULTIARCH
+#ifdef NVIDIA_BIARCH
+	sc_mount_nvidia_driver_biarch(rootfs_dir);
+#endif				// ifdef NVIDIA_BIARCH
 }


### PR DESCRIPTION
Applying distribution names to widely used methods is a little disingenuous,
so let's say what they really arch. The "Ubuntu" method is in reality a
management method employed only on multiarch Linux distributions, used on
Ubuntu and portable to Debian.

The "Arch Linux" method is in fact just how classic "bi-arch" Linux
distributions work, i.e. multilib systems with lib32/lib64.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>