### PR TITLE
snap-confine: Ensure lib64 biarch directory is respected

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -396,14 +396,14 @@
     # from the distribution package. This is also the location used when using
     # the core/base snap on all-snap systems. The variants here represent
     # various locations of libexecdir across distributions.
-    /usr/lib{,exec}/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /usr/lib{,exec,64}/snapd/snap-update-ns Cxr -> snap_update_ns,
 
     # ...snap-confine is not, conceptually, re-executing and uses
     # snap-update-ns from the distribution package but we are already inside
     # the constructed mount namespace so we must traverse "hostfs". The
     # variants here represent various locations of libexecdir across
     # distributions.
-    /var/lib/snapd/hostfs/usr/lib{,exec}/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns Cxr -> snap_update_ns,
 
     # ..snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap. Note that the location of the core snap varies from


### PR DESCRIPTION
This fixes a 2.28+ regression whereby snap-update-ns no longer works
due to the strict apparmor rules.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>