### PR TITLE
tests/main: use rm -f in case file isn't there

### DIFF
--- a/tests/main/snap-get/task.yaml
+++ b/tests/main/snap-get/task.yaml
@@ -12,8 +12,8 @@ prepare: |
     snap install --dangerous snapctl-hooks_1.0_all.snap
 
 restore: |
-    rm basic_1.0_all.snap
-    rm snapctl-hooks_1.0_all.snap
+    rm -f basic_1.0_all.snap
+    rm -f snapctl-hooks_1.0_all.snap
 
 execute: |
     echo "Test that snap get fails on a snap without any hooks"


### PR DESCRIPTION
This fixes a test restore failure I saw on unrelated PR:

+ rm basic_1.0_all.snap
rm: cannot remove 'basic_1.0_all.snap': No such file or directory

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>