### PR TITLE
snap-confine: is_running_on_classic_distribution() looks into os-release

### DIFF
--- a/cmd/libsnap-confine-private/classic-test.c
+++ b/cmd/libsnap-confine-private/classic-test.c
@@ -20,4 +20,33 @@
 
 #include <glib.h>
 
-// TODO: write some tests
+const char *os_release_classic = ""
+    "NAME=\"Ubuntu\"\n"
+    "VERSION=\"17.04 (Zesty Zapus)\"\n" "ID=ubuntu\n" "ID_LIKE=debian\n";
+
+static void test_is_on_classic()
+{
+	g_file_set_contents("os-release.classic", os_release_classic,
+			    strlen(os_release_classic), NULL);
+	os_release = "os-release.classic";
+	g_assert_true(is_running_on_classic_distribution());
+	unlink("os-release.classic");
+}
+
+const char *os_release_core = ""
+    "NAME=\"Ubuntu Core\"\n" "VERSION=\"16\"\n" "ID=ubuntu-core\n";
+
+static void test_is_on_core()
+{
+	g_file_set_contents("os-release.core", os_release_core,
+			    strlen(os_release_core), NULL);
+	os_release = "os-release.core";
+	g_assert_false(is_running_on_classic_distribution());
+	unlink("os-release.core");
+}
+
+static void __attribute__ ((constructor)) init()
+{
+	g_test_add_func("/classic/on-classic", test_is_on_classic);
+	g_test_add_func("/classic/on-core", test_is_on_core);
+}

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -10,18 +10,16 @@ char *os_release = "/etc/os-release";
 
 bool is_running_on_classic_distribution()
 {
-	char buf[255];
-	int is_core = false;
-
 	FILE *f SC_CLEANUP(sc_cleanup_file) = fopen(os_release, "r");
 	if (f == NULL) {
-		return !is_core;
+		return true;
 	}
+
+	char buf[255];
 	while (fgets(buf, sizeof buf, f) != NULL) {
 		if (strcmp(buf, "ID=ubuntu-core\n") == 0) {
-			is_core = true;
-			break;
+			return false;
 		}
 	}
-	return !is_core;
+	return true;
 }

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "classic.h"
+#include "../libsnap-confine-private/cleanup-funcs.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -12,7 +13,7 @@ bool is_running_on_classic_distribution()
 	char buf[255];
 	int is_core = false;
 
-	FILE *f = fopen(os_release, "r");
+	FILE *f SC_CLEANUP(sc_cleanup_file) = fopen(os_release, "r");
 	if (f == NULL) {
 		return !is_core;
 	}
@@ -22,6 +23,5 @@ bool is_running_on_classic_distribution()
 			break;
 		}
 	}
-	fclose(f);
 	return !is_core;
 }

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -1,15 +1,27 @@
 #include "config.h"
 #include "classic.h"
 
+#include <string.h>
+#include <stdio.h>
 #include <unistd.h>
+
+char *os_release = "/etc/os-release";
 
 bool is_running_on_classic_distribution()
 {
-	// NOTE: keep this list sorted please
-	return false
-	    || access("/var/lib/dpkg/status", F_OK) == 0
-	    || access("/var/lib/pacman", F_OK) == 0
-	    || access("/var/lib/portage", F_OK) == 0
-	    || access("/var/lib/rpm", F_OK) == 0
-	    || access("/sbin/procd", F_OK) == 0;
+	char buf[255];
+	int is_core = false;
+
+	FILE *f = fopen(os_release, "r");
+	if (f == NULL) {
+		return !is_core;
+	}
+	while (fgets(buf, sizeof buf, f) != NULL) {
+		if (strcmp(buf, "ID=ubuntu-core\n") == 0) {
+			is_core = true;
+			break;
+		}
+	}
+	fclose(f);
+	return !is_core;
 }

--- a/cmd/libsnap-confine-private/cleanup-funcs.h
+++ b/cmd/libsnap-confine-private/cleanup-funcs.h
@@ -27,6 +27,10 @@
 #include <sys/types.h>
 #include <dirent.h>
 
+// SC_CLEANUP will run the given cleanup function when the variable next
+// to it goes out of scope.
+#define SC_CLEANUP(n) __attribute__((cleanup(n)))
+
 /**
  * Free a dynamically allocated string.
  *


### PR DESCRIPTION
The is_running_on_classic_distribution() is now looking at
/etc/os-release to figure out if it is running on classic or not.
