### PR TITLE
release,cmd,dirs: Redo the distro checks to take into account distribution families

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,8 +66,8 @@ func distroSupportsReExec() bool {
 	if !release.OnClassic {
 		return false
 	}
-	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch", "manjaro", "lirios", "solus":
+	if release.ReleaseInfo.ID != "debian" || !strutil.ListContains(release.ReleaseInfo.IDLike, "debian") ||
+		release.ReleaseInfo.ID != "ubuntu" || !strutil.ListContains(release.ReleaseInfo.IDLike, "ubuntu") {
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return false
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,8 +66,7 @@ func distroSupportsReExec() bool {
 	if !release.OnClassic {
 		return false
 	}
-	if release.ReleaseInfo.ID != "debian" || !strutil.ListContains(release.ReleaseInfo.IDLike, "debian") ||
-		release.ReleaseInfo.ID != "ubuntu" || !strutil.ListContains(release.ReleaseInfo.IDLike, "ubuntu") {
+	if !release.DistroLike("debian", "ubuntu") {
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return false
 	}

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/strutil"
 )
 
 // the various file paths
@@ -166,8 +167,8 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "arch", "manjaro", "lirios":
+	switch {
+	case release.ReleaseInfo.ID == "fedora", strutil.ListContains(release.ReleaseInfo.IDLike, "fedora"), release.ReleaseInfo.ID == "arch", strutil.ListContains(release.ReleaseInfo.IDLike, "arch"):
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	default:
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/strutil"
 )
 
 // the various file paths
@@ -167,10 +166,9 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	switch {
-	case release.ReleaseInfo.ID == "fedora", strutil.ListContains(release.ReleaseInfo.IDLike, "fedora"), release.ReleaseInfo.ID == "arch", strutil.ListContains(release.ReleaseInfo.IDLike, "arch"):
+	if release.DistroLike("fedora", "arch") {
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
-	default:
+	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)
 	}
 

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -78,20 +78,22 @@ func (s *DirsTestSuite) TestClassicConfinementSymlinkWorkaround(c *C) {
 }
 
 func (s *DirsTestSuite) TestClassicConfinementSupportOnSpecificDistributions(c *C) {
-	for _, current := range []struct {
-		Name     string
+	for _, t := range []struct {
+		ID       string
+		IDLike   []string
 		Expected bool
 	}{
-		{"fedora", false},
-		{"rhel", false},
-		{"centos", false},
-		{"ubuntu", true},
-		{"debian", true},
-		{"suse", true},
-		{"yocto", true}} {
-		reset := release.MockReleaseInfo(&release.OS{ID: current.Name})
+		{"fedora", nil, false},
+		{"rhel", []string{"fedora"}, false},
+		{"centos", []string{"fedora"}, false},
+		{"ubuntu", []string{"debian"}, true},
+		{"debian", nil, true},
+		{"suse", nil, true},
+		{"yocto", nil, true},
+	} {
+		reset := release.MockReleaseInfo(&release.OS{ID: t.ID, IDLike: t.IDLike})
 		defer reset()
 		dirs.SetRootDir("/")
-		c.Assert(dirs.SupportsClassicConfinement(), Equals, current.Expected)
+		c.Check(dirs.SupportsClassicConfinement(), Equals, t.Expected, Commentf("unexpected result for %v", t.ID))
 	}
 }

--- a/release/release.go
+++ b/release/release.go
@@ -31,8 +31,9 @@ var Series = "16"
 
 // OS contains information about the system extracted from /etc/os-release.
 type OS struct {
-	ID        string `json:"id"`
-	VersionID string `json:"version-id,omitempty"`
+	ID        string   `json:"id"`
+	IDLike    []string `json:"-"`
+	VersionID string   `json:"version-id,omitempty"`
 }
 
 // ForceDevMode returns true if the distribution doesn't implement required
@@ -85,6 +86,9 @@ func readOSRelease() OS {
 			// not being too good at reading comprehension.
 			// Works around e.g. lp:1602317
 			osRelease.ID = strings.Fields(strings.ToLower(v))[0]
+		case "ID_LIKE":
+			// This is like ID, except it's a space separated list... hooray?
+			osRelease.IDLike = strings.Fields(strings.ToLower(v))
 		case "VERSION_ID":
 			osRelease.VersionID = v
 		}

--- a/release/release.go
+++ b/release/release.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"strings"
 	"unicode"
+
+	"github.com/snapcore/snapd/strutil"
 )
 
 // Series holds the Ubuntu Core series for snapd to use.
@@ -40,6 +42,15 @@ type OS struct {
 // security features for confinement and devmode is forced.
 func (o *OS) ForceDevMode() bool {
 	return AppArmorLevel() != FullAppArmor
+}
+
+func DistroLike(distros ...string) bool {
+	for _, distro := range distros {
+		if ReleaseInfo.ID == distro || strutil.ListContains(ReleaseInfo.IDLike, distro) {
+			return true
+		}
+	}
+	return false
 }
 
 var (

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -93,6 +93,35 @@ BUG_REPORT_URL="https://bugs.launchpad.net/elementary/+filebug"`
 	c.Check(os.VersionID, Equals, "0.4")
 }
 
+func (s *ReleaseTestSuite) TestFamilyOSRelease(c *C) {
+	mockOSRelease := filepath.Join(c.MkDir(), "mock-os-release")
+	dump := `NAME="CentOS Linux"
+VERSION="7 (Core)"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="7"
+PRETTY_NAME="CentOS Linux 7 (Core)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:7"
+HOME_URL="https://www.centos.org/"
+BUG_REPORT_URL="https://bugs.centos.org/"
+
+CENTOS_MANTISBT_PROJECT="CentOS-7"
+CENTOS_MANTISBT_PROJECT_VERSION="7"
+REDHAT_SUPPORT_PRODUCT="centos"
+REDHAT_SUPPORT_PRODUCT_VERSION="7"`
+	err := ioutil.WriteFile(mockOSRelease, []byte(dump), 0644)
+	c.Assert(err, IsNil)
+
+	reset := release.MockOSReleasePath(mockOSRelease)
+	defer reset()
+
+	os := release.ReadOSRelease()
+	c.Check(os.ID, Equals, "centos")
+	c.Check(os.VersionID, Equals, "7")
+	c.Check(os.IDLike, DeepEquals, []string{"rhel", "fedora"})
+}
+
 func (s *ReleaseTestSuite) TestReadOSReleaseNotFound(c *C) {
 	reset := release.MockOSReleasePath("not-there")
 	defer reset()


### PR DESCRIPTION
This PR changes the distribution checks in snapd to account for distribution families, so that snapd behaves as expected across not only the main distributions we support, but their derivatives, too.