### PR TITLE
client, daemon: rest api to configure store api

### DIFF
--- a/client/store.go
+++ b/client/store.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+type storeData struct {
+	Store string `json:"store"`
+}
+
+type setStoreResult struct {
+	URL string `json:"url"`
+}
+
+// SetStore configures the store according to an existing store assertion for
+// the given operator and store name.
+func (client *Client) SetStore(store string) (storeURL string, err error) {
+	body, err := json.Marshal(storeData{
+		Store: store,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var result setStoreResult
+	_, err = client.doSync("PUT", "/v2/store", nil, nil, bytes.NewReader(body), &result)
+	if err != nil {
+		return "", err
+	}
+	return result.URL, nil
+}
+
+// UnsetStore restores store configuration to system defaults.
+func (client *Client) UnsetStore() error {
+	_, err := client.doSync("DELETE", "/v2/store", nil, nil, nil, nil)
+	return err
+}

--- a/client/store_test.go
+++ b/client/store_test.go
@@ -1,0 +1,90 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"encoding/json"
+
+	"gopkg.in/check.v1"
+)
+
+func (cs *clientSuite) TestSetStore(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200,
+		"result": {
+			"url": "http://example.com/"
+		}
+	}`
+
+	storeURL, err := cs.cli.SetStore("store-1")
+	c.Assert(err, check.IsNil)
+
+	c.Check(storeURL, check.Equals, "http://example.com/")
+
+	c.Check(cs.req.Method, check.Equals, "PUT")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/store")
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Assert(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"store": "store-1",
+	})
+}
+
+func (cs *clientSuite) TestSetStoreError(c *check.C) {
+	cs.rsp = `{
+		"type": "error",
+		"status-code": 400,
+		"result": {
+			"message": "a-message"
+		}
+	}`
+
+	_, err := cs.cli.SetStore("store-1")
+	c.Assert(err, check.NotNil)
+	c.Check(err, check.ErrorMatches, "a-message")
+}
+
+func (cs *clientSuite) TestUnsetStore(c *check.C) {
+	cs.rsp = `{
+		"type": "sync"
+	}`
+	err := cs.cli.UnsetStore()
+	c.Assert(err, check.IsNil)
+
+	c.Check(cs.req.Method, check.Equals, "DELETE")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/store")
+}
+
+func (cs *clientSuite) TestUnsetStoreError(c *check.C) {
+	cs.rsp = `{
+		"type": "error",
+		"status-code": 400,
+		"result": {
+			"message": "a-message"
+		}
+	}`
+
+	err := cs.cli.UnsetStore()
+	c.Assert(err, check.NotNil)
+	c.Check(err, check.ErrorMatches, "a-message")
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2735,8 +2735,8 @@ func putStore(c *Command, r *http.Request, user *auth.UserState) Response {
 		"store": storeData.Store,
 	})
 	if err != nil {
-		if err == asserts.ErrNotFound {
-			return BadRequest("cannot find store assertion with store %q: %s", storeData.Store, err)
+		if asserts.IsNotFound(err) {
+			return BadRequest("cannot find assertion: %s", err)
 		}
 		msg := "unexpected error finding store assertion"
 		logger.Noticef("%s: %s", msg, err)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6432,7 +6432,7 @@ func (s *storeSuite) TestPutAssertionNotFound(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result.(*errorResult).Message, check.Matches,
-		`cannot find store assertion with store "store-1": assertion not found`)
+		`cannot find assertion: store \(store-1\) not found`)
 }
 
 func (s *storeSuite) TestPutAssertionNoURL(c *check.C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -714,7 +714,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"osutilAddUser",
 		"setupLocalUser",
 		"storeUserInfo",
-		"postCreateUserUcrednetGet",
+		"checkRootUserUcrednetGet",
 		"ensureStateSoon",
 	}
 	c.Check(found, check.Equals, len(api)+len(exceptions),
@@ -4635,7 +4635,7 @@ func (s *postCreateUserSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
 
 	s.daemon(c)
-	postCreateUserUcrednetGet = func(string) (uint32, uint32, error) {
+	checkRootUserUcrednetGet = func(string) (uint32, uint32, error) {
 		return 100, 0, nil
 	}
 	s.mockUserHome = c.MkDir()
@@ -4645,7 +4645,7 @@ func (s *postCreateUserSuite) SetUpTest(c *check.C) {
 func (s *postCreateUserSuite) TearDownTest(c *check.C) {
 	s.apiBaseSuite.TearDownTest(c)
 
-	postCreateUserUcrednetGet = ucrednetGet
+	checkRootUserUcrednetGet = ucrednetGet
 	userLookup = user.Lookup
 	osutilAddUser = osutil.AddUser
 	storeUserInfo = store.UserInfo
@@ -4996,11 +4996,11 @@ func (s *postCreateUserSuite) TestPostCreateUserFromAssertionAllKnownClassicErro
 
 	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
 
-	postCreateUserUcrednetGet = func(string) (uint32, uint32, error) {
+	checkRootUserUcrednetGet = func(string) (uint32, uint32, error) {
 		return 100, 0, nil
 	}
 	defer func() {
-		postCreateUserUcrednetGet = ucrednetGet
+		checkRootUserUcrednetGet = ucrednetGet
 	}()
 
 	// do it!


### PR DESCRIPTION
Daemon HTTP API and corresponding Go client changes to configure the store API from an already ack'd `store` assertion.