### PR TITLE
cmd/snap,client,daemon: support set/unset of store front

### DIFF
--- a/client/store.go
+++ b/client/store.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+type storeData struct {
+	Store string `json:"store"`
+}
+
+type setStoreResult struct {
+	URL string `json:"url"`
+}
+
+// SetStore configures the store according to an existing store assertion for
+// the given operator and store name.
+func (client *Client) SetStore(store string) (storeURL string, err error) {
+	body, err := json.Marshal(storeData{
+		Store: store,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var result setStoreResult
+	_, err = client.doSync("PUT", "/v2/store", nil, nil, bytes.NewReader(body), &result)
+	if err != nil {
+		return "", err
+	}
+	return result.URL, nil
+}
+
+// UnsetStore restores store configuration to system defaults.
+func (client *Client) UnsetStore() error {
+	_, err := client.doSync("DELETE", "/v2/store", nil, nil, nil, nil)
+	return err
+}

--- a/client/store_test.go
+++ b/client/store_test.go
@@ -1,0 +1,90 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"encoding/json"
+
+	"gopkg.in/check.v1"
+)
+
+func (cs *clientSuite) TestSetStore(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200,
+		"result": {
+			"url": "http://example.com/"
+		}
+	}`
+
+	storeURL, err := cs.cli.SetStore("store-1")
+	c.Assert(err, check.IsNil)
+
+	c.Check(storeURL, check.Equals, "http://example.com/")
+
+	c.Check(cs.req.Method, check.Equals, "PUT")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/store")
+	var body map[string]interface{}
+	decoder := json.NewDecoder(cs.req.Body)
+	err = decoder.Decode(&body)
+	c.Assert(err, check.IsNil)
+	c.Check(body, check.DeepEquals, map[string]interface{}{
+		"store": "store-1",
+	})
+}
+
+func (cs *clientSuite) TestSetStoreError(c *check.C) {
+	cs.rsp = `{
+		"type": "error",
+		"status-code": 400,
+		"result": {
+			"message": "a-message"
+		}
+	}`
+
+	_, err := cs.cli.SetStore("store-1")
+	c.Assert(err, check.NotNil)
+	c.Check(err, check.ErrorMatches, "a-message")
+}
+
+func (cs *clientSuite) TestUnsetStore(c *check.C) {
+	cs.rsp = `{
+		"type": "sync"
+	}`
+	err := cs.cli.UnsetStore()
+	c.Assert(err, check.IsNil)
+
+	c.Check(cs.req.Method, check.Equals, "DELETE")
+	c.Check(cs.req.URL.Path, check.Equals, "/v2/store")
+}
+
+func (cs *clientSuite) TestUnsetStoreError(c *check.C) {
+	cs.rsp = `{
+		"type": "error",
+		"status-code": 400,
+		"result": {
+			"message": "a-message"
+		}
+	}`
+
+	err := cs.cli.UnsetStore()
+	c.Assert(err, check.NotNil)
+	c.Check(err, check.ErrorMatches, "a-message")
+}

--- a/cmd/snap/cmd_store.go
+++ b/cmd/snap/cmd_store.go
@@ -1,0 +1,87 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/snapcore/snapd/i18n"
+)
+
+type cmdStore struct {
+	Revert bool `long:"revert"`
+
+	Positional struct {
+		Store string `positional-arg-name:"<store-id>"`
+	} `positional-args:"yes"`
+}
+
+var shortStoreHelp = i18n.G("Manages store configuration")
+var longStoreHelp = i18n.G(`
+The store command sets or reverts store configuration for the system.
+
+To configure the system to use an alternative store the command's arguments
+must identify a store assertion, by store ID, in the system's assertion
+database.
+
+Reverting store configuration updates the system to use the default store.
+`)
+
+func init() {
+	cmd := addCommand(
+		"store",
+		shortStoreHelp, longStoreHelp,
+		func() flags.Commander { return &cmdStore{} },
+		map[string]string{
+			"revert": i18n.G("Revert to system default store"),
+		}, []argDesc{{
+			name: i18n.G("<store id>"),
+			desc: i18n.G("ID of the store"),
+		}})
+	// XXX: hidden for now
+	cmd.hidden = true
+}
+
+func (cmd *cmdStore) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	if cmd.Revert {
+		if cmd.Positional.Store != "" {
+			return errors.New("store ID must not be provided when reverting")
+		}
+		return revert()
+	} else {
+		return setStore(cmd.Positional.Store)
+	}
+}
+
+func revert() error {
+	cli := Client()
+	return cli.UnsetStore()
+}
+
+func setStore(store string) error {
+	cli := Client()
+	_, err := cli.SetStore(store)
+	return err
+}

--- a/cmd/snap/cmd_store_test.go
+++ b/cmd/snap/cmd_store_test.go
@@ -1,0 +1,58 @@
+package main_test
+
+import (
+	"net/http"
+
+	"gopkg.in/check.v1"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+func assertRequest(c *check.C, r *http.Request, method, path string) {
+	c.Assert(r.Method, check.Equals, method)
+	c.Assert(r.URL.Path, check.Equals, path)
+}
+
+func (s *SnapSuite) TestStoreSet(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "PUT", "/v2/store")
+
+		w.Write([]byte(`{
+			"type": "sync",
+			"result": {
+				"url": "foo"
+			}
+		}`))
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"store", "foo"})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *SnapSuite) TestStoreRevert(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "DELETE", "/v2/store")
+
+		w.Write([]byte(`{
+			"type": "sync"
+		}`))
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"store", "--revert"})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *SnapSuite) TestStoreAPIError(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+			"type": "error",
+			"result": {
+				"message": "an error message",
+				"status": 400
+			}
+		}`))
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"store", "--revert"})
+	c.Check(err, check.ErrorMatches, "an error message")
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2735,8 +2735,8 @@ func putStore(c *Command, r *http.Request, user *auth.UserState) Response {
 		"store": storeData.Store,
 	})
 	if err != nil {
-		if err == asserts.ErrNotFound {
-			return BadRequest("cannot find store assertion with store %q: %s", storeData.Store, err)
+		if asserts.IsNotFound(err) {
+			return BadRequest("cannot find assertion: %s", err)
 		}
 		msg := "unexpected error finding store assertion"
 		logger.Noticef("%s: %s", msg, err)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6432,7 +6432,7 @@ func (s *storeSuite) TestPutAssertionNotFound(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Result.(*errorResult).Message, check.Matches,
-		`cannot find store assertion with store "store-1": assertion not found`)
+		`cannot find assertion: store \(store-1\) not found`)
 }
 
 func (s *storeSuite) TestPutAssertionNoURL(c *check.C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -714,7 +714,7 @@ func (s *apiSuite) TestListIncludesAll(c *check.C) {
 		"osutilAddUser",
 		"setupLocalUser",
 		"storeUserInfo",
-		"postCreateUserUcrednetGet",
+		"checkRootUserUcrednetGet",
 		"ensureStateSoon",
 	}
 	c.Check(found, check.Equals, len(api)+len(exceptions),
@@ -4635,7 +4635,7 @@ func (s *postCreateUserSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
 
 	s.daemon(c)
-	postCreateUserUcrednetGet = func(string) (uint32, uint32, error) {
+	checkRootUserUcrednetGet = func(string) (uint32, uint32, error) {
 		return 100, 0, nil
 	}
 	s.mockUserHome = c.MkDir()
@@ -4645,7 +4645,7 @@ func (s *postCreateUserSuite) SetUpTest(c *check.C) {
 func (s *postCreateUserSuite) TearDownTest(c *check.C) {
 	s.apiBaseSuite.TearDownTest(c)
 
-	postCreateUserUcrednetGet = ucrednetGet
+	checkRootUserUcrednetGet = ucrednetGet
 	userLookup = user.Lookup
 	osutilAddUser = osutil.AddUser
 	storeUserInfo = store.UserInfo
@@ -4996,11 +4996,11 @@ func (s *postCreateUserSuite) TestPostCreateUserFromAssertionAllKnownClassicErro
 
 	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
 
-	postCreateUserUcrednetGet = func(string) (uint32, uint32, error) {
+	checkRootUserUcrednetGet = func(string) (uint32, uint32, error) {
 		return 100, 0, nil
 	}
 	defer func() {
-		postCreateUserUcrednetGet = ucrednetGet
+		checkRootUserUcrednetGet = ucrednetGet
 	}()
 
 	// do it!


### PR DESCRIPTION
Simple CLI command to set or revert the current store API from an ack'd store assertion.