### PR TITLE
tests: fix revert test when a new core image is pushed

### DIFF
--- a/tests/main/revert/task.yaml
+++ b/tests/main/revert/task.yaml
@@ -86,8 +86,10 @@ execute: |
     fi
 
     echo "And a refresh doesn't update the snap"
-    snap refresh
-    snap list | MATCH "test-snapd-tools +[0-9]+\.[0-9]+ "
+    if snap refresh --list 2>&1 | MATCH "All snaps up to date"; then
+        snap refresh
+        snap list | MATCH "test-snapd-tools +[0-9]+\.[0-9]+ "
+    fi
 
     echo "Unless the snap is asked for explicitly"
     snap refresh --edge test-snapd-tools


### PR DESCRIPTION
This fix is to deal with the scenario when a new core is pushed during
the tests execution, and if "snap refresh" is executed, the new core is
installed and it reboots the machine making the whole suite fail.
This is reproduced when we run on edge channel with external backend.

ERROR:
https://travis-ci.org/snapcore/spread-cron/builds/281171181#L1495