### PR TITLE
cmd/snap-confine: add detection of stale mount namespace

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/magic.h>
+#include <linux/kdev_t.h>
 #include <sched.h>
 #include <signal.h>
 #include <string.h>
@@ -241,13 +242,16 @@ void sc_close_ns_group(struct sc_ns_group *group)
 }
 
 void sc_create_or_join_ns_group(struct sc_ns_group *group,
-				struct sc_apparmor *apparmor)
+				struct sc_apparmor *apparmor,
+				const char *base_snap_name,
+				const char *snap_name)
 {
 	// Open the mount namespace file.
 	char mnt_fname[PATH_MAX];
 	sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s%s", group->name,
 			 SC_NS_MNT_FILE);
 	int mnt_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+
 	// NOTE: There is no O_EXCL here because the file can be around but
 	// doesn't have to be a mounted namespace.
 	//
@@ -255,33 +259,90 @@ void sc_create_or_join_ns_group(struct sc_ns_group *group,
 	// sc_discard_preserved_ns_group() it will revert to a regular file.  If
 	// snap-confine is killed for whatever reason after the file is created but
 	// before the file is bind-mounted it will also be a regular file.
-	mnt_fd =
-	    openat(group->dir_fd, mnt_fname,
-		   O_CREAT | O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0600);
+	mnt_fd = openat(group->dir_fd, mnt_fname,
+			O_CREAT | O_RDONLY | O_CLOEXEC | O_NOFOLLOW, 0600);
 	if (mnt_fd < 0) {
 		die("cannot open mount namespace file for namespace group %s",
 		    group->name);
 	}
-	// Check if we got an nsfs-based file or a regular file. This can be
-	// reliably tested because nsfs has an unique filesystem type NSFS_MAGIC.
-	// On older kernels that don't support nsfs yet we can look for
-	// PROC_SUPER_MAGIC instead.
+	// Check if we got an nsfs-based or procfs file or a regular file. This can
+	// be reliably tested because nsfs has an unique filesystem type
+	// NSFS_MAGIC.  On older kernels that don't support nsfs yet we can look
+	// for PROC_SUPER_MAGIC instead. 
 	// We can just ensure that this is the case thanks to fstatfs.
-	struct statfs buf;
-	if (fstatfs(mnt_fd, &buf) < 0) {
-		die("cannot perform fstatfs() on an mount namespace file descriptor");
+	struct statfs ns_statfs_buf;
+	if (fstatfs(mnt_fd, &ns_statfs_buf) < 0) {
+		die("cannot perform fstatfs() on the mount namespace file descriptor");
+	}
+	// Stat the mount namespace as well, this is later used to check if the
+	// namespace is used by other processes if we are considering discarding a
+	// stale namespace.
+	struct stat ns_stat_buf;
+	if (fstat(mnt_fd, &ns_stat_buf) < 0) {
+		die("cannot perform fstat() on the mount namespace file descriptor");
 	}
 #ifndef NSFS_MAGIC
 // Account for kernel headers old enough to not know about NSFS_MAGIC.
 #define NSFS_MAGIC 0x6e736673
 #endif
-	if (buf.f_type == NSFS_MAGIC || buf.f_type == PROC_SUPER_MAGIC) {
+	if (ns_statfs_buf.f_type == NSFS_MAGIC
+	    || ns_statfs_buf.f_type == PROC_SUPER_MAGIC) {
+		char fname[PATH_MAX];
+		char base_snap_rev[PATH_MAX];
+
+		// Read the revision of the base snap.
+		sc_must_snprintf(fname, sizeof fname, "%s/%s/current",
+				 SNAP_MOUNT_DIR, base_snap_name);
+		if (readlink(fname, base_snap_rev, sizeof base_snap_rev) < 0) {
+			die("cannot read symlink %s", fname);
+		}
+		// Find the backing device of the base snap.
+		// TODO: add support for "try mode" base snaps that also need
+		// consideration of the mie->root component.
+		dev_t base_snap_dev = 0;
+		{
+			char base_squashfs_path[PATH_MAX];
+			sc_must_snprintf(base_squashfs_path,
+					 sizeof base_squashfs_path, "%s/%s/%s",
+					 SNAP_MOUNT_DIR, base_snap_name,
+					 base_snap_rev);
+			struct sc_mountinfo *mi
+			    __attribute__ ((cleanup(sc_cleanup_mountinfo))) =
+			    NULL;
+			mi = sc_parse_mountinfo(NULL);
+			if (mi == NULL) {
+				die("cannot parse mountinfo of the current process");
+			}
+			bool found = false;
+			for (struct sc_mountinfo_entry * mie =
+			     sc_first_mountinfo_entry(mi); mie != NULL;
+			     mie = sc_next_mountinfo_entry(mie)) {
+				if (sc_streq
+				    (mie->mount_dir, base_squashfs_path)) {
+					base_snap_dev =
+					    MKDEV(mie->dev_major,
+						  mie->dev_minor);
+					debug
+					    ("found base snap filesystem device %d:%d",
+					     mie->dev_major, mie->dev_minor);
+					// Don't break when found, we are interested in the last
+					// entry as this is the "effective" one.
+					found = true;
+				}
+			}
+			if (!found) {
+				die("cannot find device backing the base snap %s", base_snap_name);
+			}
+		}
+
+		// Remember the vanilla working directory so that we may attempt to restore it later.
 		char *vanilla_cwd __attribute__ ((cleanup(sc_cleanup_string))) =
 		    NULL;
 		vanilla_cwd = get_current_dir_name();
 		if (vanilla_cwd == NULL) {
 			die("cannot get the current working directory");
 		}
+		// Move to the mount namespace of the snap we're trying to start.
 		debug
 		    ("attempting to re-associate the mount namespace with the namespace group %s",
 		     group->name);
@@ -291,6 +352,51 @@ void sc_create_or_join_ns_group(struct sc_ns_group *group,
 		debug
 		    ("successfully re-associated the mount namespace with the namespace group %s",
 		     group->name);
+
+		bool should_discard_ns;
+
+		// Inspect the namespace and check if we should discard it.
+		//
+		// The namespace may become "stale" when the rootfs is not the same
+		// device we found above. This will happen whenever the base snap is
+		// refreshed since the namespace was first created.
+		{
+			struct sc_mountinfo *mi
+			    __attribute__ ((cleanup(sc_cleanup_mountinfo))) =
+			    NULL;
+			mi = sc_parse_mountinfo(NULL);
+			if (mi == NULL) {
+				die("cannot parse mountinfo of the current process");
+			}
+			bool found = false;
+			// Assume we should not discard the namespace.
+			should_discard_ns = false;
+			for (struct sc_mountinfo_entry * mie =
+			     sc_first_mountinfo_entry(mi); mie != NULL;
+			     mie = sc_next_mountinfo_entry(mie)) {
+				if (sc_streq(mie->mount_dir, "/")) {
+					found = true;
+					should_discard_ns =
+					    base_snap_dev !=
+					    MKDEV(mie->dev_major,
+						  mie->dev_minor);
+					// NOTE: we want the initial rootfs just in case overmount
+					// was used to do something weird. The initial rootfs was
+					// set up by snap-confine and that is the one we want to
+					// measure.
+					debug
+					    ("found root filesystem inside the mount namespace %d:%d",
+					     mie->dev_major, mie->dev_minor);
+					break;
+				}
+			}
+			if (!found) {
+				die("cannot find mount entry of the root filesystem inside snap namespace");
+			}
+		}
+
+		debug("should the namespace be discarded: %s",
+		      should_discard_ns ? "yes" : "no");
 		// Try to re-locate back to vanilla working directory. This can fail
 		// because that directory is no longer present.
 		if (chdir(vanilla_cwd) != 0) {

--- a/cmd/snap-confine/ns-support.h
+++ b/cmd/snap-confine/ns-support.h
@@ -108,7 +108,9 @@ void sc_close_ns_group(struct sc_ns_group *group);
  * @returns true if the mount namespace needs to be populated
  **/
 void sc_create_or_join_ns_group(struct sc_ns_group *group,
-				struct sc_apparmor *apparmor);
+				struct sc_apparmor *apparmor,
+				const char *base_snap_name,
+				const char *snap_name);
 
 /**
  * Check if the namespace needs to be populated.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -179,7 +179,8 @@ int main(int argc, char **argv)
 			debug("initializing mount namespace: %s", snap_name);
 			struct sc_ns_group *group = NULL;
 			group = sc_open_ns_group(snap_name, 0);
-			sc_create_or_join_ns_group(group, &apparmor);
+			sc_create_or_join_ns_group(group, &apparmor,
+						   base_snap_name, snap_name);
 			if (sc_should_populate_ns_group(group)) {
 				sc_populate_mount_ns(base_snap_name, snap_name);
 				sc_preserve_populated_ns_group(group);


### PR DESCRIPTION
This patch adds *detection* of stale mount namespaces. This is 1/3 of
the required code, as we also need the code that checks if it is safe to
discard a stale namespace as well as code that actually performs the
discard (all somewhat tricky due to apparmor issues).

The detection logic is simple. We know which base snap we would like to
use and we measure it's major:minor device numbers. We then jump into an
existing namespace and measure the major:minor numbers of the device
backing the root filesystem. If they are different then the mount
namespace is stale.

The next branches will bring in detection of stale and *unused*
namespace, thanks to soon-landing freezer cgroup code.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
