### PR TITLE
snap-confine: add new SC_CLEANUP and use it

### DIFF
--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -24,7 +24,7 @@ void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
 	sc_must_snprintf(buf, sizeof buf, "snap.%s", snap_name);
 
 	// Open the freezer cgroup directory.
-	int cgroup_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int cgroup_fd SC_CLEANUP(sc_cleanup_close) = -1;
 	cgroup_fd = open(freezer_cgroup_dir,
 			 O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
 	if (cgroup_fd < 0) {
@@ -36,7 +36,7 @@ void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
 		    snap_name);
 	}
 	// Open the hierarchy directory for the given snap.
-	int hierarchy_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int hierarchy_fd SC_CLEANUP(sc_cleanup_close) = -1;
 	hierarchy_fd = openat(cgroup_fd, buf,
 			      O_PATH | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
 	if (hierarchy_fd < 0) {
@@ -49,7 +49,7 @@ void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
 		die("cannot change owner of freezer cgroup hierarchy for snap %s to root.root", snap_name);
 	}
 	// Open the tasks file.
-	int tasks_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int tasks_fd SC_CLEANUP(sc_cleanup_close) = -1;
 	tasks_fd = openat(hierarchy_fd, "tasks",
 			  O_WRONLY | O_NOFOLLOW | O_CLOEXEC);
 	if (tasks_fd < 0) {

--- a/cmd/libsnap-confine-private/cleanup-funcs-test.c
+++ b/cmd/libsnap-confine-private/cleanup-funcs-test.c
@@ -28,7 +28,7 @@ static void test_cleanup_sanity()
 		called = 1;
 	}
 	{
-		int test __attribute__ ((cleanup(fn)));
+		int test SC_CLEANUP(fn);
 		test = 0;
 		test++;
 	}

--- a/cmd/libsnap-confine-private/cleanup-funcs.h
+++ b/cmd/libsnap-confine-private/cleanup-funcs.h
@@ -27,6 +27,10 @@
 #include <sys/types.h>
 #include <dirent.h>
 
+// SC_CLEANUP will run the given cleanup function when the variable next
+// to it goes out of scope.
+#define SC_CLEANUP(n) __attribute__((cleanup(n)))
+
 /**
  * Free a dynamically allocated string.
  *

--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -65,12 +65,12 @@ static void test_sc_lock_unlock()
 	const char *lock_dir = sc_test_use_fake_lock_dir();
 	int fd = sc_lock("foo");
 	// Construct the name of the lock file
-	char *lock_file __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *lock_file SC_CLEANUP(sc_cleanup_string) = NULL;
 	lock_file = g_strdup_printf("%s/foo.lock", lock_dir);
 	// Open the lock file again to obtain a separate file descriptor.
 	// According to flock(2) locks are associated with an open file table entry
 	// so this descriptor will be separate and can compete for the same lock.
-	int lock_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int lock_fd SC_CLEANUP(sc_cleanup_close) = -1;
 	lock_fd = open(lock_file, O_RDWR | O_CLOEXEC | O_NOFOLLOW);
 	g_assert_cmpint(lock_fd, !=, -1);
 	// The non-blocking lock operation should fail with EWOULDBLOCK as the lock

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -92,7 +92,7 @@ int sc_lock(const char *scope)
 		die("cannot create lock directory %s", sc_lock_dir);
 	}
 	debug("opening lock directory %s", sc_lock_dir);
-	int dir_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
 	dir_fd =
 	    open(sc_lock_dir, O_DIRECTORY | O_PATH | O_CLOEXEC | O_NOFOLLOW);
 	if (dir_fd < 0) {

--- a/cmd/libsnap-confine-private/mountinfo.c
+++ b/cmd/libsnap-confine-private/mountinfo.c
@@ -78,13 +78,13 @@ struct sc_mountinfo *sc_parse_mountinfo(const char *fname)
 	if (fname == NULL) {
 		fname = "/proc/self/mountinfo";
 	}
-	FILE *f __attribute__ ((cleanup(sc_cleanup_file))) = NULL;
+	FILE *f SC_CLEANUP(sc_cleanup_file) = NULL;
 	f = fopen(fname, "rt");
 	if (f == NULL) {
 		free(info);
 		return NULL;
 	}
-	char *line __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *line SC_CLEANUP(sc_cleanup_string) = NULL;
 	size_t line_size = 0;
 	struct sc_mountinfo_entry *entry, *last = NULL;
 	for (;;) {

--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -163,7 +163,7 @@ int sc_nonfatal_mkpath(const char *const path, mode_t mode)
 	}
 	// We're going to use strtok_r, which needs to modify the path, so we'll
 	// make a copy of it.
-	char *path_copy __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *path_copy SC_CLEANUP(sc_cleanup_string) = NULL;
 	path_copy = strdup(path);
 	if (path_copy == NULL) {
 		return -1;
@@ -178,7 +178,7 @@ int sc_nonfatal_mkpath(const char *const path, mode_t mode)
 	// of mkdir calls, to avoid following symlinks and placing the user data
 	// directory somewhere we never intended for it to go. The first step is to
 	// get an initial file descriptor.
-	int fd __attribute__ ((cleanup(sc_cleanup_close))) = AT_FDCWD;
+	int fd SC_CLEANUP(sc_cleanup_close) = AT_FDCWD;
 	if (path_copy[0] == '/') {
 		fd = open("/", open_flags);
 		if (fd < 0) {

--- a/cmd/snap-confine/apparmor-support.c
+++ b/cmd/snap-confine/apparmor-support.c
@@ -73,7 +73,7 @@ void sc_init_apparmor_support(struct sc_apparmor *apparmor)
 	// Use aa_getcon() to check the label of the current process and
 	// confinement type. Note that the returned label must be released with
 	// free() but the mode is a constant string that must not be freed.
-	char *label __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *label SC_CLEANUP(sc_cleanup_string) = NULL;
 	char *mode = NULL;
 	if (aa_getcon(&label, &mode) < 0) {
 		die("cannot query current apparmor profile");

--- a/cmd/snap-confine/cookie-support.c
+++ b/cmd/snap-confine/cookie-support.c
@@ -45,7 +45,7 @@ char *sc_cookie_get_from_snapd(const char *snap_name, struct sc_error **errorp)
 
 	sc_must_snprintf(context_path, sizeof(context_path), "%s/snap.%s",
 			 sc_cookie_dir, snap_name);
-	int fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int fd SC_CLEANUP(sc_cleanup_close) = -1;
 	fd = open(context_path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
 	if (fd < 0) {
 		err =

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -95,7 +95,7 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 						   const char *glob_list[],
 						   size_t glob_list_len)
 {
-	glob_t glob_res __attribute__ ((__cleanup__(globfree))) = {
+	glob_t glob_res SC_CLEANUP(globfree) = {
 	.gl_pathv = NULL};
 	// Find all the entries matching the list of globs
 	for (size_t i = 0; i < glob_list_len; ++i) {
@@ -115,8 +115,7 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 		char symlink_target[512];
 		const char *pathname = glob_res.gl_pathv[i];
 		char *pathname_copy
-		    __attribute__ ((cleanup(sc_cleanup_string))) =
-		    strdup(pathname);
+		    SC_CLEANUP(sc_cleanup_string) = strdup(pathname);
 		char *filename = basename(pathname_copy);
 		struct stat stat_buf;
 		int err = lstat(pathname, &stat_buf);
@@ -202,7 +201,7 @@ struct sc_nvidia_driver {
 
 static void sc_probe_nvidia_driver(struct sc_nvidia_driver *driver)
 {
-	FILE *file __attribute__ ((cleanup(sc_cleanup_file))) = NULL;
+	FILE *file SC_CLEANUP(sc_cleanup_file) = NULL;
 	debug("opening file describing nvidia driver version");
 	file = fopen(SC_NVIDIA_DRIVER_VERSION_FILE, "rt");
 	if (file == NULL) {

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -156,8 +156,7 @@ static void sc_setup_mount_profiles(int snap_update_ns_fd,
 	}
 	if (child == 0) {
 		// We are the child, execute snap-update-ns
-		char *snap_name_copy
-		    __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+		char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
 		snap_name_copy = strdup(snap_name);
 		if (snap_name_copy == NULL) {
 			die("cannot copy snap name");
@@ -545,7 +544,7 @@ static int sc_open_snap_update_ns()
 	if (buf[0] != '/') {	// this shouldn't happen, but make sure have absolute path
 		die("readlink /proc/self/exe returned relative path");
 	}
-	char *bufcopy __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *bufcopy SC_CLEANUP(sc_cleanup_string) = NULL;
 	bufcopy = strdup(buf);
 	if (bufcopy == NULL) {
 		die("cannot copy buffer");
@@ -566,14 +565,14 @@ void sc_populate_mount_ns(const char *base_snap_name, const char *snap_name)
 	// Get the current working directory before we start fiddling with
 	// mounts and possibly pivot_root.  At the end of the whole process, we
 	// will try to re-locate to the same directory (if possible).
-	char *vanilla_cwd __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *vanilla_cwd SC_CLEANUP(sc_cleanup_string) = NULL;
 	vanilla_cwd = get_current_dir_name();
 	if (vanilla_cwd == NULL) {
 		die("cannot get the current working directory");
 	}
 	// Find and open snap-update-ns from the same path as where we
 	// (snap-confine) were called.
-	int snap_update_ns_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int snap_update_ns_fd SC_CLEANUP(sc_cleanup_close) = -1;
 	snap_update_ns_fd = sc_open_snap_update_ns();
 
 	bool on_classic_distro = is_running_on_classic_distribution();
@@ -682,8 +681,7 @@ static bool is_mounted_with_shared_option(const char *dir)
 
 static bool is_mounted_with_shared_option(const char *dir)
 {
-	struct sc_mountinfo *sm
-	    __attribute__ ((cleanup(sc_cleanup_mountinfo))) = NULL;
+	struct sc_mountinfo *sm SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 	sm = sc_parse_mountinfo(NULL);
 	if (sm == NULL) {
 		die("cannot parse /proc/self/mountinfo");

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -78,8 +78,7 @@ static const char *sc_ns_dir = SC_NS_DIR;
  **/
 static bool sc_is_ns_group_dir_private()
 {
-	struct sc_mountinfo *info
-	    __attribute__ ((cleanup(sc_cleanup_mountinfo))) = NULL;
+	struct sc_mountinfo *info SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
 	info = sc_parse_mountinfo(NULL);
 	if (info == NULL) {
 		die("cannot parse /proc/self/mountinfo");
@@ -101,8 +100,8 @@ static bool sc_is_ns_group_dir_private()
 
 void sc_reassociate_with_pid1_mount_ns()
 {
-	int init_mnt_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
-	int self_mnt_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int init_mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
+	int self_mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
 
 	debug("checking if the current process shares mount namespace"
 	      " with the init process");
@@ -141,8 +140,7 @@ void sc_reassociate_with_pid1_mount_ns()
 		      "the init process, re-association required");
 		// NOTE: we cannot use O_NOFOLLOW here because that file will always be a
 		// symbolic link. We actually want to open it this way.
-		int init_mnt_fd_real
-		    __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+		int init_mnt_fd_real SC_CLEANUP(sc_cleanup_close) = -1;
 		init_mnt_fd_real = open("/proc/1/ns/mnt", O_RDONLY | O_CLOEXEC);
 		if (init_mnt_fd_real < 0) {
 			die("cannot open mount namespace of the init process");
@@ -247,7 +245,7 @@ void sc_create_or_join_ns_group(struct sc_ns_group *group,
 	char mnt_fname[PATH_MAX];
 	sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s%s", group->name,
 			 SC_NS_MNT_FILE);
-	int mnt_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
 	// NOTE: There is no O_EXCL here because the file can be around but
 	// doesn't have to be a mounted namespace.
 	//
@@ -276,8 +274,7 @@ void sc_create_or_join_ns_group(struct sc_ns_group *group,
 #define NSFS_MAGIC 0x6e736673
 #endif
 	if (buf.f_type == NSFS_MAGIC || buf.f_type == PROC_SUPER_MAGIC) {
-		char *vanilla_cwd __attribute__ ((cleanup(sc_cleanup_string))) =
-		    NULL;
+		char *vanilla_cwd SC_CLEANUP(sc_cleanup_string) = NULL;
 		vanilla_cwd = get_current_dir_name();
 		if (vanilla_cwd == NULL) {
 			die("cannot get the current working directory");
@@ -438,7 +435,7 @@ void sc_preserve_populated_ns_group(struct sc_ns_group *group)
 void sc_discard_preserved_ns_group(struct sc_ns_group *group)
 {
 	// Remember the current working directory
-	int old_dir_fd __attribute__ ((cleanup(sc_cleanup_close))) = -1;
+	int old_dir_fd SC_CLEANUP(sc_cleanup_close) = -1;
 	old_dir_fd = open(".", O_PATH | O_DIRECTORY | O_CLOEXEC);
 	if (old_dir_fd < 0) {
 		die("cannot open current directory");

--- a/cmd/snap-confine/quirks.c
+++ b/cmd/snap-confine/quirks.c
@@ -130,7 +130,7 @@ static void sc_quirk_create_writable_mimic(const char *mimic_dir,
 	}
 
 	debug("bind-mounting all the files from the reference directory");
-	DIR *dirp __attribute__ ((cleanup(sc_cleanup_closedir))) = NULL;
+	DIR *dirp SC_CLEANUP(sc_cleanup_closedir) = NULL;
 	dirp = opendir(ref_dir);
 	if (dirp == NULL) {
 		die("cannot open reference directory %s", ref_dir);

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -66,7 +66,7 @@ static void validate_bpfpath_is_safe(const char *path)
 		die("valid_bpfpath_is_safe needs an absolute path as input");
 	}
 	// strtok_r() modifies its first argument, so work on a copy
-	char *tokenized __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *tokenized SC_CLEANUP(sc_cleanup_string) = NULL;
 	tokenized = strdup(path);
 	if (tokenized == NULL) {
 		die("cannot allocate memory for copy of path");
@@ -74,7 +74,7 @@ static void validate_bpfpath_is_safe(const char *path)
 	// allocate a string large enough to hold path, and initialize it to
 	// '/'
 	size_t checked_path_size = strlen(path) + 1;
-	char *checked_path __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *checked_path SC_CLEANUP(sc_cleanup_string) = NULL;
 	checked_path = calloc(checked_path_size, 1);
 	if (checked_path == NULL) {
 		die("cannot allocate memory for checked_path");
@@ -93,7 +93,7 @@ static void validate_bpfpath_is_safe(const char *path)
 	// reconstruct the path from '/' down to profile_name
 	char *buf_token = strtok_r(tokenized, "/", &buf_saveptr);
 	while (buf_token != NULL) {
-		char *prev __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+		char *prev SC_CLEANUP(sc_cleanup_string) = NULL;
 		prev = strdup(checked_path);	// needed by vsnprintf in sc_must_snprintf
 		if (prev == NULL) {
 			die("cannot allocate memory for copy of checked_path");

--- a/cmd/snap-confine/snap-confine-args-test.c
+++ b/cmd/snap-confine/snap-confine-args-test.c
@@ -17,6 +17,7 @@
 
 #include "snap-confine-args.h"
 #include "snap-confine-args.c"
+#include "../libsnap-confine-private/cleanup-funcs.h"
 
 #include <stdarg.h>
 
@@ -76,8 +77,8 @@ static void test_test_argc_argv()
 static void test_sc_nonfatal_parse_args__typical()
 {
 	// Test that typical invocation of snap-confine is parsed correctly.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -109,7 +110,7 @@ static void test_sc_nonfatal_parse_args__typical()
 static void test_sc_cleanup_args()
 {
 	// Check that NULL argument parser can be cleaned up
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 	struct sc_args *args = NULL;
 	sc_cleanup_args(&args);
 
@@ -130,8 +131,8 @@ static void test_sc_cleanup_args()
 static void test_sc_nonfatal_parse_args__typical_classic()
 {
 	// Test that typical invocation of snap-confine is parsed correctly.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -165,8 +166,8 @@ static void test_sc_nonfatal_parse_args__ubuntu_core_launcher()
 	// Test that typical legacy invocation of snap-confine via the
 	// ubuntu-core-launcher symlink, with duplicated security tag, is parsed
 	// correctly.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -198,8 +199,8 @@ static void test_sc_nonfatal_parse_args__ubuntu_core_launcher()
 static void test_sc_nonfatal_parse_args__version()
 {
 	// Test that snap-confine --version is detected.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -228,8 +229,8 @@ static void test_sc_nonfatal_parse_args__version()
 static void test_sc_nonfatal_parse_args__evil_input()
 {
 	// Check that calling without any arguments is reported as error.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	// NULL argcp/argvp attack
 	args = sc_nonfatal_parse_args(NULL, NULL, &err);
@@ -268,8 +269,8 @@ static void test_sc_nonfatal_parse_args__evil_input()
 static void test_sc_nonfatal_parse_args__nothing_to_parse()
 {
 	// Check that calling without any arguments is reported as error.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -287,8 +288,8 @@ static void test_sc_nonfatal_parse_args__nothing_to_parse()
 static void test_sc_nonfatal_parse_args__no_security_tag()
 {
 	// Check that lack of security tag is reported as error.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -309,8 +310,8 @@ static void test_sc_nonfatal_parse_args__no_security_tag()
 static void test_sc_nonfatal_parse_args__no_executable()
 {
 	// Check that lack of security tag is reported as error.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -331,8 +332,8 @@ static void test_sc_nonfatal_parse_args__no_executable()
 static void test_sc_nonfatal_parse_args__unknown_option()
 {
 	// Check that unrecognized option switch is reported as error.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -360,8 +361,7 @@ static void test_sc_nonfatal_parse_args__forwards_error()
 			       "--frozbonicator", NULL);
 
 		// Call sc_nonfatal_parse_args() without an error handle
-		struct sc_args *args
-		    __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+		struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 		args = sc_nonfatal_parse_args(&argc, &argv, NULL);
 		(void)args;
 
@@ -379,8 +379,8 @@ static void test_sc_nonfatal_parse_args__forwards_error()
 static void test_sc_nonfatal_parse_args__base_snap()
 {
 	// Check that --base specifies the name of the base snap.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -407,8 +407,8 @@ static void test_sc_nonfatal_parse_args__base_snap()
 static void test_sc_nonfatal_parse_args__base_snap__missing_arg()
 {
 	// Check that --base specifies the name of the base snap.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;
@@ -429,8 +429,8 @@ static void test_sc_nonfatal_parse_args__base_snap__missing_arg()
 static void test_sc_nonfatal_parse_args__base_snap__twice()
 {
 	// Check that --base specifies the name of the base snap.
-	struct sc_error *err __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 
 	int argc;
 	char **argv;

--- a/cmd/snap-confine/snap-confine-args.h
+++ b/cmd/snap-confine/snap-confine-args.h
@@ -77,7 +77,7 @@ void sc_args_free(struct sc_args *args);
  * Cleanup an error with sc_args_free()
  *
  * This function is designed to be used with
- * __attribute__((cleanup(sc_cleanup_args))).
+ * SC_CLEANUP(sc_cleanup_args).
  **/
 void sc_cleanup_args(struct sc_args **ptr);
 

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
 {
 	// Use our super-defensive parser to figure out what we've been asked to do.
 	struct sc_error *err = NULL;
-	struct sc_args *args __attribute__ ((cleanup(sc_cleanup_args))) = NULL;
+	struct sc_args *args SC_CLEANUP(sc_cleanup_args) = NULL;
 	args = sc_nonfatal_parse_args(&argc, &argv, &err);
 	sc_die_on_error(err);
 
@@ -113,11 +113,10 @@ int main(int argc, char **argv)
 	}
 #endif
 
-	char *snap_context __attribute__ ((cleanup(sc_cleanup_string))) = NULL;
+	char *snap_context SC_CLEANUP(sc_cleanup_string) = NULL;
 	// Do no get snap context value if running a hook (we don't want to overwrite hook's SNAP_COOKIE)
 	if (!sc_is_hook_security_tag(security_tag)) {
-		struct sc_error *err
-		    __attribute__ ((cleanup(sc_cleanup_error))) = NULL;
+		struct sc_error *err SC_CLEANUP(sc_cleanup_error) = NULL;
 		snap_context = sc_cookie_get_from_snapd(snap_name, &err);
 		if (err != NULL) {
 			error("%s\n", sc_error_msg(err));


### PR DESCRIPTION
This makes reading the code (hopefully) slightly easier as it
shortens the __attribute__((cleanup(n))) use.

