### PR TITLE
release,cmd,dirs: Redo the distro checks to take into account distribution families

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,8 +66,7 @@ func distroSupportsReExec() bool {
 	if !release.OnClassic {
 		return false
 	}
-	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "opensuse", "suse", "poky", "arch", "manjaro", "lirios":
+	if !release.DistroLike("debian", "ubuntu") {
 		logger.Debugf("re-exec not supported on distro %q yet", release.ReleaseInfo.ID)
 		return false
 	}

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -156,10 +156,9 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel", "arch", "manjaro", "lirios":
+	if release.DistroLike("fedora", "arch") {
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
-	default:
+	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)
 	}
 

--- a/dirs/dirs_test.go
+++ b/dirs/dirs_test.go
@@ -78,20 +78,22 @@ func (s *DirsTestSuite) TestClassicConfinementSymlinkWorkaround(c *C) {
 }
 
 func (s *DirsTestSuite) TestClassicConfinementSupportOnSpecificDistributions(c *C) {
-	for _, current := range []struct {
-		Name     string
+	for _, t := range []struct {
+		ID       string
+		IDLike   []string
 		Expected bool
 	}{
-		{"fedora", false},
-		{"rhel", false},
-		{"centos", false},
-		{"ubuntu", true},
-		{"debian", true},
-		{"suse", true},
-		{"yocto", true}} {
-		reset := release.MockReleaseInfo(&release.OS{ID: current.Name})
+		{"fedora", nil, false},
+		{"rhel", []string{"fedora"}, false},
+		{"centos", []string{"fedora"}, false},
+		{"ubuntu", []string{"debian"}, true},
+		{"debian", nil, true},
+		{"suse", nil, true},
+		{"yocto", nil, true},
+	} {
+		reset := release.MockReleaseInfo(&release.OS{ID: t.ID, IDLike: t.IDLike})
 		defer reset()
 		dirs.SetRootDir("/")
-		c.Assert(dirs.SupportsClassicConfinement(), Equals, current.Expected)
+		c.Check(dirs.SupportsClassicConfinement(), Equals, t.Expected, Commentf("unexpected result for %v", t.ID))
 	}
 }

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -93,6 +93,35 @@ BUG_REPORT_URL="https://bugs.launchpad.net/elementary/+filebug"`
 	c.Check(os.VersionID, Equals, "0.4")
 }
 
+func (s *ReleaseTestSuite) TestFamilyOSRelease(c *C) {
+	mockOSRelease := filepath.Join(c.MkDir(), "mock-os-release")
+	dump := `NAME="CentOS Linux"
+VERSION="7 (Core)"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="7"
+PRETTY_NAME="CentOS Linux 7 (Core)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:7"
+HOME_URL="https://www.centos.org/"
+BUG_REPORT_URL="https://bugs.centos.org/"
+
+CENTOS_MANTISBT_PROJECT="CentOS-7"
+CENTOS_MANTISBT_PROJECT_VERSION="7"
+REDHAT_SUPPORT_PRODUCT="centos"
+REDHAT_SUPPORT_PRODUCT_VERSION="7"`
+	err := ioutil.WriteFile(mockOSRelease, []byte(dump), 0644)
+	c.Assert(err, IsNil)
+
+	reset := release.MockOSReleasePath(mockOSRelease)
+	defer reset()
+
+	os := release.ReadOSRelease()
+	c.Check(os.ID, Equals, "centos")
+	c.Check(os.VersionID, Equals, "7")
+	c.Check(os.IDLike, DeepEquals, []string{"rhel", "fedora"})
+}
+
 func (s *ReleaseTestSuite) TestReadOSReleaseNotFound(c *C) {
 	reset := release.MockOSReleasePath("not-there")
 	defer reset()


### PR DESCRIPTION
Cherry pick of https://github.com/snapcore/snapd/pull/3984 for 2.28 (in case we need to do another 2.28 release).