### PR TITLE
interfaces: misc updates for default, browser-support, home and system-observe

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -292,6 +292,7 @@ var defaultTemplate = `
   @{PROC}/@{pid}/task/[0-9]*/status r,
   @{PROC}/sys/kernel/hostname r,
   @{PROC}/sys/kernel/osrelease r,
+  @{PROC}/sys/kernel/ostype r,
   @{PROC}/sys/kernel/yama/ptrace_scope r,
   @{PROC}/sys/kernel/shmmax r,
   @{PROC}/sys/fs/file-max r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -43,6 +43,9 @@ var defaultTemplate = `
   # for series 16 and cross-distro
   /etc/ld.so.preload r,
 
+  # The base abstraction doesn't yet have this
+  /usr/share/zoneinfo/** k,
+
   # for python apps/services
   #include <abstractions/python>
   /usr/bin/python{,2,2.[0-9]*,3,3.[0-9]*} ixr,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -226,7 +226,8 @@ var defaultTemplate = `
   /usr/share/distro-info/*.csv r,
 
   # Allow reading /etc/os-release. On Ubuntu 16.04+ it is a symlink to /usr/lib
-  # but on 14.04 it is an actual file so it doens't fall under other rules.
+  # which is allowed by the base abstraction, but on 14.04 it is an actual file
+  # so need to add it here.
   /etc/os-release r,
 
   # systemd native journal API (see sd_journal_print(4)). This should be in

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -44,6 +44,8 @@ var defaultTemplate = `
   /etc/ld.so.preload r,
 
   # The base abstraction doesn't yet have this
+  /lib/terminfo/** rk,
+  /usr/share/terminfo/** k,
   /usr/share/zoneinfo/** k,
   owner @{PROC}/@{pid}/maps k,
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -45,6 +45,7 @@ var defaultTemplate = `
 
   # The base abstraction doesn't yet have this
   /usr/share/zoneinfo/** k,
+  owner @{PROC}/@{pid}/maps k,
 
   # for python apps/services
   #include <abstractions/python>

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -231,8 +231,9 @@ var defaultTemplate = `
 
   # Allow reading /etc/os-release. On Ubuntu 16.04+ it is a symlink to /usr/lib
   # which is allowed by the base abstraction, but on 14.04 it is an actual file
-  # so need to add it here.
-  /etc/os-release r,
+  # so need to add it here. Also allow read locks on the file.
+  /etc/os-release rk,
+  /usr/lib/os-release k,
 
   # systemd native journal API (see sd_journal_print(4)). This should be in
   # AppArmor's base abstraction, but until it is, include here.

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -283,6 +283,7 @@ var defaultTemplate = `
   /etc/{,writable/}localtime r,
   /etc/{,writable/}mailname r,
   /etc/{,writable/}timezone r,
+  owner @{PROC}/@{pid}/cgroup r,
   @{PROC}/@{pid}/io r,
   owner @{PROC}/@{pid}/limits r,
   owner @{PROC}/@{pid}/loginuid r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -306,6 +306,8 @@ var defaultTemplate = `
   @{PROC}/sys/kernel/random/uuid r,
   @{PROC}/sys/kernel/random/boot_id r,
   /sys/devices/virtual/tty/{console,tty*}/active r,
+  /sys/fs/cgroup/memory/memory.limit_in_bytes r,
+  /sys/fs/cgroup/memory/snap.@{SNAP_NAME}{,.*}/memory.limit_in_bytes r,
   /{,usr/}lib/ r,
 
   # Reads of oom_adj and oom_score_adj are safe

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -55,7 +55,7 @@ owner /var/tmp/etilqs_* rw,
 
 # Chrome/Chromium should be modified to use snap.$SNAP_NAME.* or the snap
 # packaging adjusted to use LD_PRELOAD technique from LP: #1577514
-owner /{dev,run}/shm/{,.}org.chromium.Chromium.* mrw,
+owner /{dev,run}/shm/{,.}org.chromium.* mrw,
 owner /{dev,run}/shm/{,.}com.google.Chrome.* mrw,
 
 # Allow reading platform files

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -42,12 +42,12 @@ owner @{HOME}/ r,
 
 # Allow read/write access to all files in @{HOME}, except snap application
 # data in @{HOME}/snaps and toplevel hidden directories in @{HOME}.
-owner @{HOME}/[^s.]**             rwk,
-owner @{HOME}/s[^n]**             rwk,
-owner @{HOME}/sn[^a]**            rwk,
-owner @{HOME}/sna[^p]**           rwk,
+owner @{HOME}/[^s.]**             rwkix,
+owner @{HOME}/s[^n]**             rwkix,
+owner @{HOME}/sn[^a]**            rwkix,
+owner @{HOME}/sna[^p]**           rwkix,
 # Allow creating a few files not caught above
-owner @{HOME}/{s,sn,sna}{,/} rwk,
+owner @{HOME}/{s,sn,sna}{,/} rwkix,
 
 # Allow access to gvfs mounts for files owned by the user (including hidden
 # files; only allow writes to files, not the mount point).

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -42,12 +42,12 @@ owner @{HOME}/ r,
 
 # Allow read/write access to all files in @{HOME}, except snap application
 # data in @{HOME}/snaps and toplevel hidden directories in @{HOME}.
-owner @{HOME}/[^s.]**             rwkix,
-owner @{HOME}/s[^n]**             rwkix,
-owner @{HOME}/sn[^a]**            rwkix,
-owner @{HOME}/sna[^p]**           rwkix,
+owner @{HOME}/[^s.]**             rwklix,
+owner @{HOME}/s[^n]**             rwklix,
+owner @{HOME}/sn[^a]**            rwklix,
+owner @{HOME}/sna[^p]**           rwklix,
 # Allow creating a few files not caught above
-owner @{HOME}/{s,sn,sna}{,/} rwkix,
+owner @{HOME}/{s,sn,sna}{,/} rwklix,
 
 # Allow access to gvfs mounts for files owned by the user (including hidden
 # files; only allow writes to files, not the mount point).

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -66,6 +66,10 @@ deny ptrace (trace),
 @{PROC}/*/{,task/*/}statm r,
 @{PROC}/*/{,task/*/}status r,
 
+# Allow discovering the os-release of the host
+/var/lib/snapd/hostfs/etc/os-release r,
+/var/lib/snapd/hostfs/usr/lib/os-release r,
+
 #include <abstractions/dbus-strict>
 
 dbus (send)

--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -67,8 +67,8 @@ deny ptrace (trace),
 @{PROC}/*/{,task/*/}status r,
 
 # Allow discovering the os-release of the host
-/var/lib/snapd/hostfs/etc/os-release r,
-/var/lib/snapd/hostfs/usr/lib/os-release r,
+/var/lib/snapd/hostfs/etc/os-release rk,
+/var/lib/snapd/hostfs/usr/lib/os-release rk,
 
 #include <abstractions/dbus-strict>
 


### PR DESCRIPTION
In working with ISVs at the NYC rally, they reported a number of denials that were affecting them. This PR addresses them.