### PR TITLE
interfaces: deny lttng by default

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -409,6 +409,11 @@ var defaultTemplate = `
   capability sys_chroot,
   /{,usr/}sbin/chroot ixr,
 
+  # Lttng tracing is very noisy and should not be allowed by confined apps. Can
+  # safely deny for the normal case (LP: #1260491). If/when an lttng-trace
+  # interface is needed, we can rework this.
+  deny /{dev,run,var/run}/shm/lttng-ust-* rw,
+
 ###SNIPPETS###
 }
 `

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -73,10 +73,6 @@ deny dbus (send)
     bus=session
     interface="org.gnome.GConf.Server",
 
-# Lttng tracing is very noisy and should not be allowed by confined apps. Can
-# safely deny. LP: #1260491
-deny /{dev,run,var/run}/shm/lttng-ust-* rw,
-
 # webbrowser-app/webapp-container tries to read this file to determine if it is
 # confined or not, so explicitly deny to avoid noise in the logs.
 deny @{PROC}/@{pid}/attr/current r,

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -128,10 +128,6 @@ dbus (send)
     interface=io.snapcraft.Launcher
     member=OpenURL
     peer=(label=unconfined),
-
-# Lttng tracing is very noisy and should not be allowed by confined apps. Can
-# safely deny. LP: #1260491
-deny /{dev,run,var/run}/shm/lttng-ust-* rw,
 `
 
 type desktopInterface struct{}

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -87,10 +87,6 @@ const mirConnectedPlugAppArmor = `
 unix (receive, send) type=seqpacket addr=none peer=(label=###SLOT_SECURITY_TAGS###),
 /run/mir_socket rw,
 /run/user/[0-9]*/mir_socket rw,
-
-# Lttng tracing is very noisy and should not be allowed by confined apps. Can
-# safely deny. LP: #1260491
-deny /{dev,run,var/run}/shm/lttng-ust-* rw,
 `
 
 const mirPermanentSlotUdev = `

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -543,10 +543,6 @@ dbus (send)
   path=/org/gnome/SettingsDaemon/MediaKeys
   member="Get{,All}"
   peer=(label=unconfined),
-
-# Lttng tracing is very noisy and should not be allowed by confined apps. Can
-# safely deny. LP: #1260491
-deny /{dev,run,var/run}/shm/lttng-ust-* rw,
 `
 
 const unity7ConnectedPlugSeccomp = `

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -86,10 +86,6 @@ dbus (receive)
      path=/
      member={PasteboardChanged,PasteFormatsChanged,PasteSelected,PasteSelectionCancelled}
      peer=(name=com.ubuntu.content.dbus.Service,label=###SLOT_SECURITY_TAGS###),
-
-# Lttng tracing is very noisy and should not be allowed by confined apps.
-# Can safely deny. LP: #1260491
-deny /{dev,run,var/run}/shm/lttng-ust-* rw,
 `
 
 const unity8ConnectedPlugSecComp = `


### PR DESCRIPTION
Move the lttng deny rules out from the individual interfaces to the default template. If/when an lttng-trace interface is needed, we can rework this.

This came up with an ISV at the NYC rally where a cli application was seeing these denials. The ISV agreed that an explicit denial is fine to reduce confusion.