### PR TITLE
interfaces/lxd: lxd slot implementation can also be an app snap

### DIFF
--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -50,6 +50,5 @@ func init() {
 		baseDeclarationSlots:  lxdBaseDeclarationSlots,
 		connectedPlugAppArmor: lxdConnectedPlugAppArmor,
 		connectedPlugSecComp:  lxdConnectedPlugSecComp,
-		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/lxd_test.go
+++ b/interfaces/builtin/lxd_test.go
@@ -69,8 +69,7 @@ func (s *LxdInterfaceSuite) TestSanitizeSlot(c *C) {
 		Interface: "lxd",
 	}}
 
-	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
-		"lxd slots are reserved for the core snap")
+	c.Assert(slot.Sanitize(s.iface), IsNil)
 }
 
 func (s *LxdInterfaceSuite) TestSanitizePlug(c *C) {


### PR DESCRIPTION
The lxd snap has existed for a while, but the interface mistakenly used 'reservedForOS: true'.