### PR TITLE
run-checks: use nakedret to check for naked returns on long functions

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -98,7 +98,7 @@ type InterfaceOptions struct {
 	Connected bool
 }
 
-func (client *Client) Interfaces(opts *InterfaceOptions) (interfaces []*Interface, err error) {
+func (client *Client) Interfaces(opts *InterfaceOptions) ([]*Interface, error) {
 	query := url.Values{}
 	if opts != nil && len(opts.Names) > 0 {
 		query.Set("names", strings.Join(opts.Names, ",")) // Return just those specific interfaces.
@@ -120,8 +120,10 @@ func (client *Client) Interfaces(opts *InterfaceOptions) (interfaces []*Interfac
 	} else {
 		query.Set("select", "all") // Return all interfaces.
 	}
-	_, err = client.doSync("GET", "/v2/interfaces", query, nil, nil, &interfaces)
-	return
+	var interfaces []*Interface
+	_, err := client.doSync("GET", "/v2/interfaces", query, nil, nil, &interfaces)
+
+	return interfaces, err
 }
 
 // performInterfaceAction performs a single action on the interface system.

--- a/cmd/snap-repair/runner.go
+++ b/cmd/snap-repair/runner.go
@@ -320,7 +320,7 @@ var (
 // auxiliary assertions. If revision>=0 the request will include an
 // If-None-Match header with an ETag for the revision, and
 // ErrRepairNotModified is returned if the revision is still current.
-func (run *Runner) Fetch(brandID string, repairID int, revision int) (repair *asserts.Repair, aux []asserts.Assertion, err error) {
+func (run *Runner) Fetch(brandID string, repairID int, revision int) (*asserts.Repair, []asserts.Assertion, error) {
 	u, err := run.BaseURL.Parse(fmt.Sprintf("repairs/%s/%d", brandID, repairID))
 	if err != nil {
 		return nil, nil, err
@@ -386,7 +386,7 @@ func (run *Runner) Fetch(brandID string, repairID int, revision int) (repair *as
 		return nil, nil, fmt.Errorf("cannot fetch repair, unexpected status %d", resp.StatusCode)
 	}
 
-	repair, aux, err = checkStream(brandID, repairID, r)
+	repair, aux, err := checkStream(brandID, repairID, r)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot fetch repair, %v", err)
 	}
@@ -398,7 +398,7 @@ func (run *Runner) Fetch(brandID string, repairID int, revision int) (repair *as
 		return nil, nil, ErrRepairNotModified
 	}
 
-	return
+	return repair, aux, err
 }
 
 func checkStream(brandID string, repairID int, r []asserts.Assertion) (repair *asserts.Repair, aux []asserts.Assertion, err error) {

--- a/cmd/snap-update-ns/bootstrap.go
+++ b/cmd/snap-update-ns/bootstrap.go
@@ -114,5 +114,6 @@ func processArguments(cmdline []byte) (snapName string, shouldSetNs bool) {
 		snapName = C.GoString(snapNameOut)
 	}
 	shouldSetNs = bool(shouldSetNsOut)
-	return
+
+	return snapName, shouldSetNs
 }

--- a/daemon/ucrednet.go
+++ b/daemon/ucrednet.go
@@ -57,7 +57,8 @@ func ucrednetGet(remoteAddr string) (pid uint32, uid uint32, err error) {
 	if pid == ucrednetNoProcess || uid == ucrednetNobody {
 		err = errNoID
 	}
-	return
+
+	return pid, uid, err
 }
 
 type ucrednetAddr struct {

--- a/osutil/cp_test.go
+++ b/osutil/cp_test.go
@@ -63,7 +63,7 @@ func (s *cpSuite) µ(msg string) (err error) {
 		}
 	}
 
-	return
+	return err
 }
 
 func (s *cpSuite) SetUpTest(c *C) {

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -192,7 +192,8 @@ func (s copydataSuite) populateHomeData(c *C, user string, revision snap.Revisio
 	c.Assert(err, IsNil)
 	err = ioutil.WriteFile(filepath.Join(homeData, "canary.home"), []byte(fmt.Sprintln(revision)), 0644)
 	c.Assert(err, IsNil)
-	return
+
+	return homedir
 }
 
 func (s *copydataSuite) TestCopyDataDoUndo(c *C) {

--- a/progress/ansimeter.go
+++ b/progress/ansimeter.go
@@ -201,7 +201,6 @@ func (*ANSIMeter) Notify(msgstr string) {
 
 func (p *ANSIMeter) Write(bs []byte) (n int, err error) {
 	n = len(bs)
-	// TODO: lock, n'eh
 	p.Set(p.written + float64(n))
 
 	return

--- a/run-checks
+++ b/run-checks
@@ -158,6 +158,16 @@ if [ "$STATIC" = 1 ]; then
     fi
     # ineffassign knows about ignoring vendor/ \o/
     ineffassign .
+
+    echo Checking for naked returns
+    if ! which nakedret >/dev/null; then
+        go get -u github.com/alexkohler/nakedret
+    fi
+    got=$(nakedret ./... 2>&1)
+    if [ -n "$got" ]; then
+        echo "$got"
+        exit 1
+    fi
 fi
 
 if [ "$UNIT" = 1 ]; then


### PR DESCRIPTION
[nakedret](https://github.com/alexkohler/nakedret/) is “a Go static analysis tool to find naked returns in functions greater than a specified function length” (5 by default). Because,
> Naked returns are okay if the function is a handful of lines. Once it's a medium sized function, be explicit with your return values. Corollary: it's not worth it to name result parameters just because it enables you to use naked returns. Clarity of docs is always more important than saving a line or two in your function.