### PR TITLE
progress: be more flexible in testing ansimeter

### DIFF
--- a/progress/ansimeter_test.go
+++ b/progress/ansimeter_test.go
@@ -106,7 +106,7 @@ func (ansiSuite) TestSetLayout(c *check.C) {
 
 	p := &progress.ANSIMeter{}
 	msg := "0123456789"
-	ticker := time.NewTicker(time.Second / 100)
+	ticker := time.NewTicker(time.Millisecond)
 	defer ticker.Stop()
 	p.Start(msg, 1E300)
 	for i := 1; i <= 80; i++ {
@@ -127,7 +127,7 @@ func (ansiSuite) TestSetLayout(c *check.C) {
 		case i <= 29:
 			c.Check(out, check.Equals, fmt.Sprintf("\r%*s   0%% ages!", -(i-11), msg), desc)
 		default:
-			c.Check(out, check.Equals, fmt.Sprintf("\r%*s   0%%    99B/s ages!", -(i-20), msg), desc)
+			c.Check(out, check.Matches, fmt.Sprintf("\r%*s   0%%  [ 0-9]{4}B/s ages!", -(i-20), msg), desc)
 		}
 	}
 }


### PR DESCRIPTION
ansimeter's unit tests only passed if the device under test was able to reliably build a progress bar in under 10ms. Some environments in which we run the tests cannot do this (they come close!). This change makes the test a lot more lenient, replacing an exact string match for a regexp, and should work well everywhere.