### PR TITLE
interfaces: fix udev rules for tun

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -253,7 +253,7 @@ socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 const networkControlConnectedPlugUDev = `
 KERNEL=="rfkill",    TAG+="###CONNECTED_SECURITY_TAGS###"
 KERNEL=="tap[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="tun",       TAG+="###CONNECTED_SECURITY_TAGS###",
+KERNEL=="tun",       TAG+="###CONNECTED_SECURITY_TAGS###"
 KERNEL=="tun[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
 `
 


### PR DESCRIPTION
This commit fixes a typo in udev rules that caused following
error/warning message:

invalid key/value pair in file /etc/udev/rules.d/70-snap.bluez.rules on
line 5, starting at character 46 (',')

