### PR TITLE
tests: add test for lxd interface

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -80,3 +80,7 @@ execute: |
     echo "Ensure we can use snapd inside lxd"
     lxd.lxc exec my-ubuntu snap install test-snapd-tools
     lxd.lxc exec my-ubuntu test-snapd-tools.echo from-the-inside | MATCH from-the-inside
+
+    echo "Install lxd-demo server to exercise the lxd interface"
+    snap install lxd-demo-server
+    snap connect lxd-demo-server:lxd lxd:lxd


### PR DESCRIPTION
The 2.28 release broke the lxd interface. This is fixed already but
we do not have a regression test. For more details about the bug:
https://forum.snapcraft.io/t/snapd-2-28-breaks-the-lxc-interface
