### PR TITLE
 interfaces/opengl: don't udev tag nvidia devices and use snap-confine instead (2.28)

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -250,10 +250,8 @@
     # able to bind mount the nvidia dir
     /sys/module/nvidia/version r,
     /sys/bus/pci/drivers/nvidia/uevent r,
-    /sys/module/nvidia_uvm/uevent r,
-    /sys/module/nvidia_modeset/uevent r,
-    /sys/module/nvidia_drm/uevent r,
-    /sys/module/nvidia/uevent r,
+    /sys/**/nvidia*/uevent r,
+    /sys/module/nvidia/* r,
     /dev/nvidia[0-9]* r,
     /dev/nvidiactl r,
     /dev/nvidia-uvm r,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -250,6 +250,10 @@
     # able to bind mount the nvidia dir
     /sys/module/nvidia/version r,
     /sys/bus/pci/drivers/nvidia/uevent r,
+    /sys/module/nvidia_uvm/uevent r,
+    /sys/module/nvidia_modeset/uevent r,
+    /sys/module/nvidia_drm/uevent r,
+    /sys/module/nvidia/uevent r,
     /dev/nvidia[0-9]* r,
     /dev/nvidiactl r,
     /dev/nvidia-uvm r,

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -249,6 +249,10 @@
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir
     /sys/module/nvidia/version r,
+    /sys/bus/pci/drivers/nvidia/uevent r,
+    /dev/nvidia[0-9]* r,
+    /dev/nvidiactl r,
+    /dev/nvidia-uvm r,
     /usr/** r,
     mount options=(rw bind) /usr/lib/nvidia-*/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/gl/,
 

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -249,9 +249,9 @@
     # nvidia handling, glob needs /usr/** and the launcher must be
     # able to bind mount the nvidia dir
     /sys/module/nvidia/version r,
-    /sys/bus/pci/drivers/nvidia/uevent r,
+    /sys/**/drivers/nvidia{,_*}/* r,
     /sys/**/nvidia*/uevent r,
-    /sys/module/nvidia/* r,
+    /sys/module/nvidia{,_*}/* r,
     /dev/nvidia[0-9]* r,
     /dev/nvidiactl r,
     /dev/nvidia-uvm r,

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -238,12 +238,10 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 
 	// add the assigned devices
 	while (udev_s->assigned != NULL) {
-		const char *path =
-		    udev_list_entry_get_name(udev_s->assigned);
+		const char *path = udev_list_entry_get_name(udev_s->assigned);
 		if (path == NULL)
 			die("udev_list_entry_get_name failed");
 		run_snappy_app_dev_add(udev_s, path);
-		udev_s->assigned =
-		    udev_list_entry_get_next(udev_s->assigned);
+		udev_s->assigned = udev_list_entry_get_next(udev_s->assigned);
 	}
 }

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -210,30 +210,37 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 	// We'll want to rethink this if snapd needs to mediate access to other
 	// proprietary devices.
 	struct stat sbuf;
-	char nvpath[16] = { 0 };	// /dev/nvidiaXXX, ctl and -uvm
-	for (unsigned minor = 0; minor < 255; minor++) {
+	char nv_path[15] = { 0 };	// /dev/nvidiaXXX
+	const unsigned nv_major = 195;
+	for (unsigned nv_minor = 0; nv_minor < 255; nv_minor++) {
 		// https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt
 		// /dev/nvidia0 through /dev/nvidia254
-		sc_must_snprintf(nvpath, sizeof(nvpath), "/dev/nvidia%u",
-				 minor);
+		sc_must_snprintf(nv_path, sizeof(nv_path), "/dev/nvidia%u",
+				 nv_minor);
 
 		// Stop trying to find devices after one is not found. In this
 		// manner, we'll add /dev/nvidia0 and /dev/nvidia1 but stop
 		// trying to find nvidia3 - nvidia254 if nvidia2 is not found.
-		if (stat(nvpath, &sbuf) != 0) {
+		if (stat(nv_path, &sbuf) != 0) {
 			break;
 		}
-		_run_snappy_app_dev_add_majmin(udev_s, nvpath, 195, minor);
+		_run_snappy_app_dev_add_majmin(udev_s, nv_path, nv_major,
+					       nv_minor);
 	}
 
-	sc_must_snprintf(nvpath, sizeof(nvpath), "/dev/nvidia%s", "ctl");
-	if (stat(nvpath, &sbuf) == 0) {
-		_run_snappy_app_dev_add_majmin(udev_s, nvpath, 195, 255);
+	const char *nvctl_path = "/dev/nvidiactl";
+	const unsigned nvctl_minor = 255;
+	if (stat(nvctl_path, &sbuf) == 0) {
+		_run_snappy_app_dev_add_majmin(udev_s, nvctl_path,
+					       nv_major, nvctl_minor);
 	}
 
-	sc_must_snprintf(nvpath, sizeof(nvpath), "/dev/nvidia%s", "-uvm");
-	if (stat(nvpath, &sbuf) == 0) {
-		_run_snappy_app_dev_add_majmin(udev_s, nvpath, 247, 0);
+	const char *nvuvm_path = "/dev/nvidia-uvm";
+	const unsigned nvuvm_major = 247;
+	const unsigned nvuvm_minor = 0;
+	if (stat(nvuvm_path, &sbuf) == 0) {
+		_run_snappy_app_dev_add_majmin(udev_s, nvuvm_path,
+					       nvuvm_major, nvuvm_minor);
 	}
 	// add the assigned devices
 	while (udev_s->assigned != NULL) {

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -235,7 +235,6 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 	if (stat(nvpath, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvpath, 247, 0);
 	}
-
 	// add the assigned devices
 	while (udev_s->assigned != NULL) {
 		const char *path = udev_list_entry_get_name(udev_s->assigned);

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -242,7 +242,6 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 		_run_snappy_app_dev_add_majmin(udev_s, nvctl_path,
 					       nv_major, nvctl_minor);
 	}
-
 	// /dev/nvidia-uvm
 	if (stat(nvuvm_path, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvuvm_path,

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -56,6 +56,8 @@ _run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
 		// snappy-add-dev
 		char *env[] = { NULL };
 		sc_must_snprintf(buf, sizeof(buf), "%u:%u", major, minor);
+		debug("running snappy-app-dev add %s %s %s", udev_s->tagname,
+		      path, buf);
 		execle("/lib/udev/snappy-app-dev", "/lib/udev/snappy-app-dev",
 		       "add", udev_s->tagname, path, buf, NULL, env);
 		die("execl failed");

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -231,12 +231,15 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 	if (stat(nvpath, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvpath, 247, 0);
 
-	// add the assigned devices
-	while (udev_s->assigned != NULL) {
-		const char *path = udev_list_entry_get_name(udev_s->assigned);
-		if (path == NULL)
-			die("udev_list_entry_get_name failed");
-		run_snappy_app_dev_add(udev_s, path);
-		udev_s->assigned = udev_list_entry_get_next(udev_s->assigned);
+		// add the assigned devices
+		while (udev_s->assigned != NULL) {
+			const char *path =
+			    udev_list_entry_get_name(udev_s->assigned);
+			if (path == NULL)
+				die("udev_list_entry_get_name failed");
+			run_snappy_app_dev_add(udev_s, path);
+			udev_s->assigned =
+			    udev_list_entry_get_next(udev_s->assigned);
+		}
 	}
 }

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -229,20 +229,21 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 	sc_must_snprintf(nvpath, sizeof(nvpath), "/dev/nvidia%s", "ctl");
 	if (stat(nvpath, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvpath, 195, 255);
+	}
 
 	sc_must_snprintf(nvpath, sizeof(nvpath), "/dev/nvidia%s", "-uvm");
 	if (stat(nvpath, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvpath, 247, 0);
+	}
 
-		// add the assigned devices
-		while (udev_s->assigned != NULL) {
-			const char *path =
-			    udev_list_entry_get_name(udev_s->assigned);
-			if (path == NULL)
-				die("udev_list_entry_get_name failed");
-			run_snappy_app_dev_add(udev_s, path);
-			udev_s->assigned =
-			    udev_list_entry_get_next(udev_s->assigned);
-		}
+	// add the assigned devices
+	while (udev_s->assigned != NULL) {
+		const char *path =
+		    udev_list_entry_get_name(udev_s->assigned);
+		if (path == NULL)
+			die("udev_list_entry_get_name failed");
+		run_snappy_app_dev_add(udev_s, path);
+		udev_s->assigned =
+		    udev_list_entry_get_next(udev_s->assigned);
 	}
 }

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -32,9 +32,9 @@
 #include "../libsnap-confine-private/utils.h"
 #include "udev-support.h"
 
-void _run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
-				    const char *path, unsigned major,
-				    unsigned minor)
+void
+_run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
+			       const char *path, unsigned major, unsigned minor)
 {
 	int status = 0;
 	pid_t pid = fork();

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -68,9 +68,10 @@ const openglConnectedPlugAppArmor = `
   /run/udev/data/c226:[0-9]* r,  # 226 drm
 `
 
+// The nvidia modules don't use sysfs (therefore they can't be udev tagged) and
+// will be added by snap-confine.
 const openglConnectedPlugUDev = `
 SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="nvidia*", TAG+="###CONNECTED_SECURITY_TAGS###"
 KERNEL=="vchiq",   TAG+="###CONNECTED_SECURITY_TAGS###"
 `
 

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -28,6 +28,10 @@ prepare: |
         mknod /dev/nvidia0 c 195 0
         touch /dev/nvidia0.spread
     fi
+    if [ ! -e /dev/nvidiactl ]; then
+        mknod /dev/nvidiactl c 195 255
+        touch /dev/nvidiactl.spread
+    fi
     if [ ! -e /dev/nvidia-uvm ]; then
         mknod /dev/nvidia-uvm c 247 0
         touch /dev/nvidia-uvm.spread
@@ -40,6 +44,9 @@ prepare: |
 restore: |
     if [ -e /dev/nvidia0.spread ]; then
         rm -f /dev/nvidia0 /dev/nvidia0.spread
+    fi
+    if [ -e /dev/nvidiactl.spread ]; then
+        rm -f /dev/nvidiactl /dev/nvidiactl.spread
     fi
     if [ -e /dev/nvidia-uvm.spread ]; then
         rm -f /dev/nvidia-uvm /dev/nvidia-uvm.spread

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -101,6 +101,7 @@ execute: |
 
     echo "But existing nvidia devices are in the snap's device cgroup"
     MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    MATCH "c 195:255 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
     MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
 
     echo "But nonexisting nvidia devices are not"

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -23,8 +23,15 @@ prepare: |
     if [ ! -e /sys/devices/virtual/misc/uinput ]; then
         modprobe uinput
     fi
+    if [ ! -e /dev/nvidia0 ]; then
+        mknod /dev/nvidia0 c 195 0
+        touch /dev/nvidia0.spread
+    fi
 
 restore: |
+    if [ -e /dev/nvidia0.spread ]; then
+        rm -f /dev/nvidia0 /dev/nvidia0.spread
+    fi
     rm -f /etc/udev/rules.d/70-snap.test-snapd-tools.rules
     udevadm control --reload-rules
     udevadm trigger
@@ -69,5 +76,11 @@ execute: |
 
     echo "And other devices are not shown in the snap device list"
     MATCH -v "$OTHER_DEVICE_ID" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+
+    echo "But existing nvidia devices are in the snap's device cgroup"
+    MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+
+    echo "But nonexisting nvidia devices are not"
+    MATCH -v "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
 
     # TODO: check device unassociated after removing the udev file and rebooting

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -23,14 +23,29 @@ prepare: |
     if [ ! -e /sys/devices/virtual/misc/uinput ]; then
         modprobe uinput
     fi
+    # create nvidia devices if they don't exist
     if [ ! -e /dev/nvidia0 ]; then
         mknod /dev/nvidia0 c 195 0
         touch /dev/nvidia0.spread
+    fi
+    if [ ! -e /dev/nvidia-uvm ]; then
+        mknod /dev/nvidia-uvm c 247 0
+        touch /dev/nvidia-uvm.spread
+    fi
+    # move aside an existing nvidia device
+    if [ -e /dev/nvidia254 ]; then
+        mv /dev/nvidia254 /dev/nvidia254.spread
     fi
 
 restore: |
     if [ -e /dev/nvidia0.spread ]; then
         rm -f /dev/nvidia0 /dev/nvidia0.spread
+    fi
+    if [ -e /dev/nvidia-uvm.spread ]; then
+        rm -f /dev/nvidia-uvm /dev/nvidia-uvm.spread
+    fi
+    if [ -e /dev/nvidia254.spread ]; then
+        mv /dev/nvidia254.spread /dev/nvidia254
     fi
     rm -f /etc/udev/rules.d/70-snap.test-snapd-tools.rules
     udevadm control --reload-rules
@@ -79,6 +94,7 @@ execute: |
 
     echo "But existing nvidia devices are in the snap's device cgroup"
     MATCH "c 195:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+    MATCH "c 247:0 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
 
     echo "But nonexisting nvidia devices are not"
     MATCH -v "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list


### PR DESCRIPTION
This should fix the regression in the opengl interface with the nvidia driver.

This is the 2.28 version of https://github.com/snapcore/snapd/pull/3938