### PR TITLE
tests: fix econnreset scenario when the iptables rule was not created

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that ECONNRESET is handled
 restore: |
     echo "Remove the firewall rule again"
-    iptables -D OUTPUT -m owner --uid-owner $(id -u test) -j REJECT  -p tcp --reject-with tcp-reset
+    iptables -D OUTPUT -m owner --uid-owner $(id -u test) -j REJECT -p tcp --reject-with tcp-reset || true
 
     rm -f test-snapd-huge_*
 


### PR DESCRIPTION
Sometimes the partial file is not created because of an internet issue,
then the iptables rule is not created as part of the test and when it is
deleted as part of the restore, it fails making the whole suite fail.

Errors:
https://paste.ubuntu.com/25717714/ on dragonboard 
https://paste.ubuntu.com/25719948/ on core i386