### PR TITLE
spread: allow setting SPREAD_DEBUG_EACH=0 to disable debug-each section

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -18,6 +18,7 @@ environment:
     MODIFY_CORE_SNAP_FOR_REEXEC: "$(HOST: echo ${SPREAD_MODIFY_CORE_SNAP_FOR_REEXEC:-1})"
     SPREAD_STORE_USER: "$(HOST: echo $SPREAD_STORE_USER)"
     SPREAD_STORE_PASSWORD: "$(HOST: echo $SPREAD_STORE_PASSWORD)"
+    SPREAD_DEBUG_EACH: "$(HOST: echo ${SPREAD_DEBUG_EACH:-1})"
     LANG: "$(echo ${LANG:-C.UTF-8})"
     LANGUAGE: "$(echo ${LANGUAGE:-en})"
     # important to ensure adhoc and linode/qemu behave the same
@@ -258,14 +259,16 @@ prepare-each: |
     dmesg -c > /dev/null
 
 debug-each: |
-    echo '# journal messages for snapd'
-    journalctl -u snapd
-    echo '# apparmor denials '
-    dmesg --ctime | grep DENIED || true
-    echo '# seccomp denials (kills) '
-    dmesg --ctime | grep type=1326 || true
-    echo '# snap interfaces'
-    snap interfaces || true
+    if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
+        echo '# journal messages for snapd'
+        journalctl -u snapd
+        echo '# apparmor denials '
+        dmesg --ctime | grep DENIED || true
+        echo '# seccomp denials (kills) '
+        dmesg --ctime | grep type=1326 || true
+        echo '# snap interfaces'
+        snap interfaces || true
+    fi
 
 rename:
     # Move content into a directory, so that deltas computed by repack benefit


### PR DESCRIPTION
This aids in interactive debugging where we don't want to scroll through
mountains of unrelated syslog messages and we are running interactively
so we can inspect anything we want. The default stays the same as before
so spread runs on linode will show debug on failure.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>