### PR TITLE
interfaces/mount: don't generate legacy per-hook/per-app mount profiles

### DIFF
--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -98,17 +98,8 @@ func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.
 	}
 	fstate := &osutil.FileState{Content: buffer.Bytes(), Mode: 0644}
 	content := make(map[string]*osutil.FileState)
-	// Add the new per-snap fstab file. This file will be read by snap-confine.
+	// Add the per-snap fstab file. This file is read by snap-update-ns.
 	content[fmt.Sprintf("snap.%s.fstab", snapInfo.Name())] = fstate
-	// Add legacy per-app/per-hook fstab files. Those are identical but
-	// snap-confine doesn't yet load it from a per-snap location. This can be
-	// safely removed once snap-confine is updated.
-	for _, appInfo := range snapInfo.Apps {
-		content[fmt.Sprintf("%s.fstab", appInfo.SecurityTag())] = fstate
-	}
-	for _, hookInfo := range snapInfo.Hooks {
-		content[fmt.Sprintf("%s.fstab", hookInfo.SecurityTag())] = fstate
-	}
 	return content
 }
 

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -150,15 +150,6 @@ func (s *backendSuite) TestSetupSetsupSimple(c *C) {
 	got := strings.Split(string(content), "\n")
 	sort.Strings(got)
 	c.Check(got, DeepEquals, expected)
-	// and that we have the legacy, per app/hook files as well.
-	for _, binary := range []string{"app1", "app2", "hook.configure"} {
-		fn := filepath.Join(dirs.SnapMountPolicyDir, fmt.Sprintf("snap.snap-name.%s.fstab", binary))
-		content, err := ioutil.ReadFile(fn)
-		c.Assert(err, IsNil, Commentf("Expected mount profile for %q", binary))
-		got := strings.Split(string(content), "\n")
-		sort.Strings(got)
-		c.Check(got, DeepEquals, expected)
-	}
 }
 
 func (s *backendSuite) TestSetupSetsupWithoutDir(c *C) {
@@ -169,9 +160,4 @@ func (s *backendSuite) TestSetupSetsupWithoutDir(c *C) {
 	// Ensure that backend.Setup() creates the required dir on demand
 	os.Remove(dirs.SnapMountPolicyDir)
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, mockSnapYaml, 0)
-
-	for _, binary := range []string{"app1", "app2", "hook.configure"} {
-		fn := filepath.Join(dirs.SnapMountPolicyDir, fmt.Sprintf("snap.snap-name.%s.fstab", binary))
-		c.Assert(osutil.FileExists(fn), Equals, true, Commentf("Expected mount file for %q", binary))
-	}
 }


### PR DESCRIPTION
Those are not used for a long time now and just clutter the directory
with mount profiles.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>