### PR TITLE
packaging: remove .mnt files on removal

### DIFF
--- a/packaging/fedora/snap-mgmt.sh
+++ b/packaging/fedora/snap-mgmt.sh
@@ -89,6 +89,7 @@ purge() {
     # opportunistic as those might not be actually mounted
     for mnt in /run/snapd/ns/*.mnt; do
         umount -l "$mnt" || true
+        rm -f "$mnt"
     done
     for fstab in /run/snapd/ns/*.fstab; do
         rm -f "$fstab"

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -80,6 +80,7 @@ if [ "$1" = "purge" ]; then
     # opportunistic as those might not be actually mounted
     for mnt in /run/snapd/ns/*.mnt; do
         umount -l "$mnt" || true
+        rm -f "$mnt"
     done
     for fstab in /run/snapd/ns/*.fstab; do
         rm -f "$fstab"

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -83,6 +83,7 @@ if [ "$1" = "purge" ]; then
     # opportunistic as those might not be actually mounted
     for mnt in /run/snapd/ns/*.mnt; do
         umount -l "$mnt" || true
+        rm -f "$mnt"
     done
     for fstab in /run/snapd/ns/*.fstab; do
         rm -f "$fstab"


### PR DESCRIPTION
The .mnt files are leftovers of preserved mount namespaces and they can
be safely removed. Cleaning this up also improves the readability of
system state in spread tests that rely on the same purge logic.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>