### PR TITLE
interfaces/network-control: remove incorrect rules for tun

### DIFF
--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -165,11 +165,11 @@ capability setuid,
 
 /etc/rpc r,
 
-# TUN/TAP
+# TUN/TAP - https://www.kernel.org/doc/Documentation/networking/tuntap.txt
+#
+# We only need to tag /dev/net/tun since the tap[0-9]* and tun[0-9]* devices
+# are virtual and don't show up in /dev
 /dev/net/tun rw,
-# These are dynamically created via ioctl() on /dev/net/tun
-/dev/tun[0-9]{,[0-9]*} rw,
-/dev/tap[0-9]{,[0-9]*} rw,
 
 # access to bridge sysfs interfaces for bridge settings
 /sys/devices/virtual/net/*/bridge/* rw,
@@ -250,9 +250,13 @@ socket AF_NETLINK - NETLINK_GENERIC
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
+/* https://www.kernel.org/doc/Documentation/networking/tuntap.txt
+ *
+ * We only need to tag /dev/net/tun since the tap[0-9]* and tun[0-9]* devices
+ * are virtual and don't show up in /dev
+ */
 const networkControlConnectedPlugUDev = `
 KERNEL=="rfkill",    TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="tap[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
 KERNEL=="tun",       TAG+="###CONNECTED_SECURITY_TAGS###"
 `
 

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -254,7 +254,6 @@ const networkControlConnectedPlugUDev = `
 KERNEL=="rfkill",    TAG+="###CONNECTED_SECURITY_TAGS###"
 KERNEL=="tap[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
 KERNEL=="tun",       TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="tun[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
 `
 
 func init() {

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -256,8 +256,8 @@ socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
  * are virtual and don't show up in /dev
  */
 const networkControlConnectedPlugUDev = `
-KERNEL=="rfkill",    TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="tun",       TAG+="###CONNECTED_SECURITY_TAGS###"
+KERNEL=="rfkill", TAG+="###CONNECTED_SECURITY_TAGS###"
+KERNEL=="tun",    TAG+="###CONNECTED_SECURITY_TAGS###"
 `
 
 func init() {

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -95,7 +95,7 @@ func (s *NetworkControlInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `KERNEL=="tun[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets()[0], testutil.Contains, `KERNEL=="tun",    TAG+="snap_consumer_app"`)
 }
 
 func (s *NetworkControlInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
We had two udev rules to tag tun: `tun` and `tun[0-9]*`. This results in
'udev_enumerate_scan failed' errors. This is because udev ships this rule

`KERNEL=="tun", MODE="0666", OPTIONS+="static_node=net/tun"`

so we don't need the `tun[0-9]*` or `tap[0-9]*` rules. Removing it resolves the issue. This PR is safe because `tun[0-9]*`  and `tap[0-9]*` are virtual devices (like other network devices) and aren't represented in /dev, and therefore don't need to be added to the device cgroup and therefore don't need to be udev tagged.

This PR also revert 65b7ef7f076c899312327fbacaac775623745eb9 to remove the unneeded apparmor rules (the devices don't show up in /dev-- these rules weren't ever needed and mistakenly added proactively).