### PR TITLE
snap-confine: add support for handling /dev/nvidia-modeset

### DIFF
--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -214,12 +214,10 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 	// currently isn't listed):
 	// https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt
 	char nv_path[15] = { 0 };	// /dev/nvidiaXXX
-	const unsigned nv_major = 195;
 	const char *nvctl_path = "/dev/nvidiactl";
-	const unsigned nvctl_minor = 255;
 	const char *nvuvm_path = "/dev/nvidia-uvm";
-	const unsigned nvuvm_major = 247;
-	const unsigned nvuvm_minor = 0;
+	const char *nvidia_modeset_path = "/dev/nvidia-modeset";
+
 	struct stat sbuf;
 
 	// /dev/nvidia0 through /dev/nvidia254
@@ -233,19 +231,28 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 		if (stat(nv_path, &sbuf) != 0) {
 			break;
 		}
-		_run_snappy_app_dev_add_majmin(udev_s, nv_path, nv_major,
-					       nv_minor);
+		_run_snappy_app_dev_add_majmin(udev_s, nv_path,
+					       MAJOR(sbuf.st_rdev),
+					       MINOR(sbuf.st_rdev));
 	}
 
 	// /dev/nvidiactl
 	if (stat(nvctl_path, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvctl_path,
-					       nv_major, nvctl_minor);
+					       MAJOR(sbuf.st_rdev),
+					       MINOR(sbuf.st_rdev));
 	}
 	// /dev/nvidia-uvm
 	if (stat(nvuvm_path, &sbuf) == 0) {
 		_run_snappy_app_dev_add_majmin(udev_s, nvuvm_path,
-					       nvuvm_major, nvuvm_minor);
+					       MAJOR(sbuf.st_rdev),
+					       MINOR(sbuf.st_rdev));
+	}
+	// /dev/nvidia-modeset
+	if (stat(nvidia_modeset_path, &sbuf) == 0) {
+		_run_snappy_app_dev_add_majmin(udev_s, nvidia_modeset_path,
+					       MAJOR(sbuf.st_rdev),
+					       MINOR(sbuf.st_rdev));
 	}
 	// add the assigned devices
 	while (udev_s->assigned != NULL) {


### PR DESCRIPTION
Our compatiblity handling for the nvidia modules was not handling
the new /dev/nvidia-modeset. This caused crashes with nvidia driver
version 375+. This PR fixes the issue.
