### PR TITLE
dbus: ensure io.snapcraft.Launcher.service is created on re-exec

### DIFF
--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -50,7 +50,7 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 }
 
 // setupDbusServiceForUserd will setup the service file for the new
-// `snap us erd` instance on re-exec
+// `snap userd` instance on re-exec
 func setupDbusServiceForUserd(snapInfo *snap.Info) error {
 	coreRoot := snapInfo.MountDir()
 	dst := "/usr/share/dbus-1/services/io.snapcraft.Launcher.service"
@@ -74,7 +74,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	// core on classic is special
 	if snapName == "core" && release.OnClassic && !release.ReleaseInfo.ForceDevMode() {
 		if err := setupDbusServiceForUserd(snapInfo); err != nil {
-			logger.Noticef("cannot create host snap-confine apparmor configuration: %s", err)
+			logger.Noticef("cannot create host `snap userd` dbus service file: %s", err)
 		}
 	}
 

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -31,10 +31,13 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -46,6 +49,17 @@ func (b *Backend) Name() interfaces.SecuritySystem {
 	return "dbus"
 }
 
+// setupDbusServiceForUserd will setup the service file for the new
+// `snap us erd` instance on re-exec
+func setupDbusServiceForUserd(snapInfo *snap.Info) error {
+	coreRoot := snapInfo.MountDir()
+	dst := "/usr/share/dbus-1/services/io.snapcraft.Launcher.service"
+	if osutil.FileExists(dst) {
+		return nil
+	}
+	return osutil.CopyFile(filepath.Join(coreRoot, dst), dst, osutil.CopyFlagPreserveAll)
+}
+
 // Setup creates dbus configuration files specific to a given snap.
 //
 // DBus has no concept of a complain mode so confinment type is ignored.
@@ -55,6 +69,13 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	spec, err := repo.SnapSpecification(b.Name(), snapName)
 	if err != nil {
 		return fmt.Errorf("cannot obtain dbus specification for snap %q: %s", snapName, err)
+	}
+
+	// core on classic is special
+	if snapName == "core" && release.OnClassic && !release.ReleaseInfo.ForceDevMode() {
+		if err := setupDbusServiceForUserd(snapInfo); err != nil {
+			logger.Noticef("cannot create host snap-confine apparmor configuration: %s", err)
+		}
 	}
 
 	// Get the files that this snap should have

--- a/tests/main/refresh-core/task.yaml
+++ b/tests/main/refresh-core/task.yaml
@@ -1,23 +1,16 @@
 summary: Check refresh will ensure dbus serivce file is there
 
-# FIXME: for now only
 systems: [-ubuntu-core-*]
-
-environment:
-    BROKEN_CORE_SNAP: core_broken.snap
-
-restore:
-    rm -rf squashfs-root
-    rm -f $BROKEN_CORE_SNAP
 
 execute: |
     snap list | awk "/^core / {print(\$3)}" > prevBoot
 
     echo "Ensure service file is created if missing (e.g. on re-exec)"
-    rm -f /usr/share/dbus-1/services/io.snapcraft.Launcher.service
+    mv /usr/share/dbus-1/services/io.snapcraft.Launcher.service /usr/share/dbus-1/services/io.snapcraft.Launcher.service.orig
 
     echo "Install new core"
     snap install --dangerous /var/lib/snapd/snaps/core_$(cat prevBoot).snap
 
     echo "Ensure the dbus service file got created"
     test -f /usr/share/dbus-1/services/io.snapcraft.Launcher.service
+    diff -u /usr/share/dbus-1/services/io.snapcraft.Launcher.service.orig /usr/share/dbus-1/services/io.snapcraft.Launcher.service

--- a/tests/main/refresh-core/task.yaml
+++ b/tests/main/refresh-core/task.yaml
@@ -1,0 +1,23 @@
+summary: Check refresh will ensure dbus serivce file is there
+
+# FIXME: for now only
+systems: [-ubuntu-core-*]
+
+environment:
+    BROKEN_CORE_SNAP: core_broken.snap
+
+restore:
+    rm -rf squashfs-root
+    rm -f $BROKEN_CORE_SNAP
+
+execute: |
+    snap list | awk "/^core / {print(\$3)}" > prevBoot
+
+    echo "Ensure service file is created if missing (e.g. on re-exec)"
+    rm -f /usr/share/dbus-1/services/io.snapcraft.Launcher.service
+
+    echo "Install new core"
+    snap install --dangerous /var/lib/snapd/snaps/core_$(cat prevBoot).snap
+
+    echo "Ensure the dbus service file got created"
+    test -f /usr/share/dbus-1/services/io.snapcraft.Launcher.service

--- a/tests/main/snap-userd-reexec/task.yaml
+++ b/tests/main/snap-userd-reexec/task.yaml
@@ -1,6 +1,7 @@
-summary: Check refresh will ensure dbus serivce file is there
+summary: Check that core refresh will create the userd dbus serivce file
 
-systems: [-ubuntu-core-*]
+# only run on systems that re-exec
+systems: [ubuntu-16*, ubuntu-17*]
 
 execute: |
     snap list | awk "/^core / {print(\$3)}" > prevBoot


### PR DESCRIPTION
For `snap userd` to work we need the file:
/usr/share/dbus-1/services/io.snapcraft.Launcher.service
    
It is part of the deb/rpm package. However if snapd is using
re-exec we need to ensure this file is created by the dbus
backend.

See https://forum.snapcraft.io/t/snapd-2-28-xdg-open-doesnt-work-for-electron-applications/2447/5