### PR TITLE
Fix econnreset test when the download needs a retry

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -10,7 +10,7 @@ execute: |
     su -c "/usr/bin/env SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &
 
     echo "Wait until the download started and downloaded more than 1 MB"
-    for i in $(seq 20); do
+    for i in $(seq 40); do
         if partial=$(ls test-snapd-huge_*.snap.partial | head -1); then
             if [ $(stat -c%s "$partial") -gt $(( 1024 * 1024 )) ]; then
                 break
@@ -21,6 +21,7 @@ execute: |
 
     if [ ! -f "$partial" ] || [ $(stat -c%s "$partial") -eq 0 ]; then
         echo "Partial file $partial did not start downloading, test broken"
+        kill -9 $(pidof snap)
         exit 1
     fi
 


### PR DESCRIPTION
In the tests for beta validation this test is often failing when the
retry is triggered. To deal with that, I am adding extra time to wait
until the partial file is created and the download is started.

Also, the snap process which is downloading the huge file is killed to
avoid the script fails with a timeout dalaying the whole suite
execution.

For an example see:
https://paste.ubuntu.com/25717714 line 1191
https://paste.ubuntu.com/25719948 line 388
