### PR TITLE
overlord/ifacestate: refresh udev backend on startup

### DIFF
--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -141,7 +141,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 			// The issue this is attempting to fix is only
 			// affecting seccomp/apparmor so limit the work just to
 			// this backend.
-			shouldRefresh := (backend.Name() == interfaces.SecuritySecComp || backend.Name() == interfaces.SecurityAppArmor)
+			shouldRefresh := (backend.Name() == interfaces.SecuritySecComp || backend.Name() == interfaces.SecurityAppArmor || backend.Name() == interfaces.SecurityUDev)
 			if !shouldRefresh {
 				continue
 			}


### PR DESCRIPTION
With the recent fixes to the udev snippets of various interfaces we need
to refresh udev profiles on startup. Note that like all profiles, those
are only refreshed if they differ from the values we intend have.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>