### PR TITLE
cmd,packaging: enable apparmor on openSUSE

### DIFF
--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -39,11 +39,7 @@ case "$ID" in
 		extra_opts="--libexecdir=/usr/libexec/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-merged-usr --disable-apparmor"
 		;;
 	opensuse)
-		# NOTE: we need to disable apparmor as the version on OpenSUSE
-		# is too old to confine snap-confine and installed snaps
-		# themselves. This should be changed once all the kernel
-		# patches find their way into the distribution.
-		extra_opts="--libexecdir=/usr/lib/snapd --disable-apparmor"
+		extra_opts="--libexecdir=/usr/lib/snapd"
 		;;
 	solus)
 		extra_opts="--enable-nvidia-biarch"

--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -49,17 +49,18 @@ BuildRequires:  glibc-devel-static
 BuildRequires:  golang-packaging
 BuildRequires:  gpg2
 BuildRequires:  indent
+BuildRequires:  libapparmor-devel
 BuildRequires:  libcap-devel
 BuildRequires:  libseccomp-devel
 BuildRequires:  libtool
 BuildRequires:  libudev-devel
 BuildRequires:  libuuid-devel
 BuildRequires:  make
+BuildRequires:  openssh
 BuildRequires:  pkg-config
 BuildRequires:  python-docutils
 BuildRequires:  python3-docutils
 BuildRequires:  squashfs
-BuildRequires:  openssh
 BuildRequires:  timezone
 BuildRequires:  udev
 BuildRequires:  xfsprogs-devel
@@ -73,6 +74,7 @@ BuildRequires: systemd-rpm-macros
 PreReq:         permissions
 
 Requires(post): permissions
+Requires:       apparmor
 Requires:       gpg2
 Requires:       openssh
 Requires:       squashfs


### PR DESCRIPTION
With the changes made earlier, apparmor can now be used in "partial" mode where
certain features are not enabled but this does not preclude the system from
enabling the backend. This allows us to use apparmor on openSUSE.
