### PR TITLE
cmd/snap-confine: update valid security tag regexp

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -54,7 +54,8 @@ static void test_verify_security_tag()
 	g_assert_false(verify_security_tag("snap.n@me.app", "n@me"));
 	g_assert_false(verify_security_tag("SNAP.name.app", "name"));
 	g_assert_false(verify_security_tag("snap.Name.app", "Name"));
-	g_assert_false(verify_security_tag("snap.0name.app", "0name"));
+	// This used to be false but it's now allowed.
+	g_assert_true(verify_security_tag("snap.0name.app", "0name"));
 	g_assert_false(verify_security_tag("snap.-name.app", "-name"));
 	g_assert_false(verify_security_tag("snap.name.@app", "name"));
 	g_assert_false(verify_security_tag(".name.app", "name"));
@@ -67,6 +68,13 @@ static void test_verify_security_tag()
 	g_assert_false(verify_security_tag("snap.foo.hook.bar", "fooo"));
 	g_assert_false(verify_security_tag("snap.foo.hook.bar", "snap"));
 	g_assert_false(verify_security_tag("snap.foo.hook.bar", "bar"));
+
+	// Regression test 12to8
+	g_assert_true(verify_security_tag("snap.12to8.128to8", "12to8"));
+	g_assert_true(verify_security_tag("snap.123test.123test", "123test"));
+	g_assert_true(verify_security_tag
+		      ("snap.123test.hook.configure", "123test"));
+
 }
 
 static void test_sc_snap_name_validate()
@@ -166,6 +174,12 @@ static void test_sc_snap_name_validate()
 			      (err, SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME));
 		sc_error_free(err);
 	}
+	// Regression test: 12to8 and 123test
+	sc_snap_name_validate("12to8", &err);
+	g_assert_null(err);
+	sc_snap_name_validate("123test", &err);
+	g_assert_null(err);
+
 }
 
 static void test_sc_snap_name_validate__respects_error_protocol()

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -30,7 +30,7 @@
 bool verify_security_tag(const char *security_tag, const char *snap_name)
 {
 	const char *whitelist_re =
-	    "^snap\\.([a-z](-?[a-z0-9])*)\\.([a-zA-Z0-9](-?[a-zA-Z0-9])*|hook\\.[a-z](-?[a-z])*)$";
+	    "^snap\\.([a-z0-9](-?[a-z0-9])*)\\.([a-zA-Z0-9](-?[a-zA-Z0-9])*|hook\\.[a-z](-?[a-z])*)$";
 	regex_t re;
 	if (regcomp(&re, whitelist_re, REG_EXTENDED) != 0)
 		die("can not compile regex %s", whitelist_re);


### PR DESCRIPTION
This was triggered by a bug where "12to8" snap with "12to8" app would
fail to validate as security tag.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>
