### PR TITLE
snap-confine: init all arrays with `= {0,}`

### DIFF
--- a/cmd/decode-mount-opts/decode-mount-opts.c
+++ b/cmd/decode-mount-opts/decode-mount-opts.c
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "cannot parse given argument as a number\n");
 		return 1;
 	}
-	char buf[1000];
+	char buf[1000] = {0,};
 	printf("%#lx is %s\n", mountflags, sc_mount_opt2str(buf, sizeof buf, mountflags));
 	return 0;
 }

--- a/cmd/decode-mount-opts/decode-mount-opts.c
+++ b/cmd/decode-mount-opts/decode-mount-opts.c
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "cannot parse given argument as a number\n");
 		return 1;
 	}
-	char buf[1000] = {0,};
+	char buf[1000] = {0};
 	printf("%#lx is %s\n", mountflags, sc_mount_opt2str(buf, sizeof buf, mountflags));
 	return 0;
 }

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -20,7 +20,7 @@ static const char *freezer_cgroup_dir = "/sys/fs/cgroup/freezer";
 void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
 {
 	// Format the name of the cgroup hierarchy. 
-	char buf[PATH_MAX] = { 0, };
+	char buf[PATH_MAX] = { 0 };
 	sc_must_snprintf(buf, sizeof buf, "snap.%s", snap_name);
 
 	// Open the freezer cgroup directory.

--- a/cmd/libsnap-confine-private/cgroup-freezer-support.c
+++ b/cmd/libsnap-confine-private/cgroup-freezer-support.c
@@ -20,7 +20,7 @@ static const char *freezer_cgroup_dir = "/sys/fs/cgroup/freezer";
 void sc_cgroup_freezer_join(const char *snap_name, pid_t pid)
 {
 	// Format the name of the cgroup hierarchy. 
-	char buf[PATH_MAX];
+	char buf[PATH_MAX] = { 0, };
 	sc_must_snprintf(buf, sizeof buf, "snap.%s", snap_name);
 
 	// Open the freezer cgroup directory.

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -15,7 +15,7 @@ bool is_running_on_classic_distribution()
 		return true;
 	}
 
-	char buf[255];
+	char buf[255] = { 0, };
 	while (fgets(buf, sizeof buf, f) != NULL) {
 		if (strcmp(buf, "ID=ubuntu-core\n") == 0) {
 			return false;

--- a/cmd/libsnap-confine-private/classic.c
+++ b/cmd/libsnap-confine-private/classic.c
@@ -15,7 +15,7 @@ bool is_running_on_classic_distribution()
 		return true;
 	}
 
-	char buf[255] = { 0, };
+	char buf[255] = { 0 };
 	while (fgets(buf, sizeof buf, f) != NULL) {
 		if (strcmp(buf, "ID=ubuntu-core\n") == 0) {
 			return false;

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -99,7 +99,7 @@ int sc_lock(const char *scope)
 		die("cannot open lock directory");
 	}
 	// Construct the name of the lock file.
-	char lock_fname[PATH_MAX] = { 0, };
+	char lock_fname[PATH_MAX] = { 0 };
 	sc_must_snprintf(lock_fname, sizeof lock_fname, "%s/%s.lock",
 			 sc_lock_dir, scope ? : "");
 

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -99,7 +99,7 @@ int sc_lock(const char *scope)
 		die("cannot open lock directory");
 	}
 	// Construct the name of the lock file.
-	char lock_fname[PATH_MAX];
+	char lock_fname[PATH_MAX] = { 0, };
 	sc_must_snprintf(lock_fname, sizeof lock_fname, "%s/%s.lock",
 			 sc_lock_dir, scope ? : "");
 

--- a/cmd/libsnap-confine-private/mount-opt-test.c
+++ b/cmd/libsnap-confine-private/mount-opt-test.c
@@ -25,7 +25,7 @@
 
 static void test_sc_mount_opt2str()
 {
-	char buf[1000] = { 0, };
+	char buf[1000] = { 0 };
 	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, 0), ==, "");
 	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_RDONLY), ==, "ro");
 	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOSUID), ==,
@@ -93,7 +93,7 @@ static void test_sc_mount_opt2str()
 
 static void test_sc_mount_cmd()
 {
-	char cmd[10000] = { 0, };
+	char cmd[10000] = { 0 };
 
 	// Typical mount
 	sc_mount_cmd(cmd, sizeof cmd, "/dev/sda3", "/mnt", "ext4", MS_RDONLY,
@@ -146,8 +146,8 @@ static void test_sc_mount_cmd()
 	g_assert_cmpstr(cmd, ==, "mount --move /from /to");
 
 	// Monster (invalid but let's format it)
-	char from[PATH_MAX] = { 0, };
-	char to[PATH_MAX] = { 0, };
+	char from[PATH_MAX] = { 0 };
+	char to[PATH_MAX] = { 0 };
 	for (int i = 1; i < PATH_MAX - 1; ++i) {
 		from[i] = 'a';
 		to[i] = 'b';
@@ -176,7 +176,7 @@ static void test_sc_mount_cmd()
 
 static void test_sc_umount_cmd()
 {
-	char cmd[1000] = { 0, };
+	char cmd[1000] = { 0 };
 
 	// Typical umount
 	sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", 0);

--- a/cmd/libsnap-confine-private/mount-opt-test.c
+++ b/cmd/libsnap-confine-private/mount-opt-test.c
@@ -25,7 +25,7 @@
 
 static void test_sc_mount_opt2str()
 {
-	char buf[1000];
+	char buf[1000] = { 0, };
 	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, 0), ==, "");
 	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_RDONLY), ==, "ro");
 	g_assert_cmpstr(sc_mount_opt2str(buf, sizeof buf, MS_NOSUID), ==,
@@ -93,7 +93,7 @@ static void test_sc_mount_opt2str()
 
 static void test_sc_mount_cmd()
 {
-	char cmd[10000];
+	char cmd[10000] = { 0, };
 
 	// Typical mount
 	sc_mount_cmd(cmd, sizeof cmd, "/dev/sda3", "/mnt", "ext4", MS_RDONLY,
@@ -146,8 +146,8 @@ static void test_sc_mount_cmd()
 	g_assert_cmpstr(cmd, ==, "mount --move /from /to");
 
 	// Monster (invalid but let's format it)
-	char from[PATH_MAX];
-	char to[PATH_MAX];
+	char from[PATH_MAX] = { 0, };
+	char to[PATH_MAX] = { 0, };
 	for (int i = 1; i < PATH_MAX - 1; ++i) {
 		from[i] = 'a';
 		to[i] = 'b';
@@ -176,7 +176,7 @@ static void test_sc_mount_cmd()
 
 static void test_sc_umount_cmd()
 {
-	char cmd[1000];
+	char cmd[1000] = { 0, };
 
 	// Typical umount
 	sc_umount_cmd(cmd, sizeof cmd, "/mnt/foo", 0);

--- a/cmd/libsnap-confine-private/mount-opt.c
+++ b/cmd/libsnap-confine-private/mount-opt.c
@@ -109,7 +109,7 @@ const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags)
 #undef F
 	// Render any flags that are unaccounted for.
 	if (flags) {
-		char of[128];
+		char of[128] = { 0, };
 		sc_must_snprintf(of, sizeof of, "%#lx", flags);
 		sc_string_append(buf, buf_size, of);
 	}
@@ -197,7 +197,7 @@ const char *sc_mount_cmd(char *buf, size_t buf_size, const char *source, const c
 	}
 	// If regular option syntax exists then use it.
 	if (mountflags & ~used_special_flags) {
-		char opts_buf[1000];
+		char opts_buf[1000] = { 0, };
 		sc_mount_opt2str(opts_buf, sizeof opts_buf, mountflags &
 				 ~used_special_flags);
 		sc_string_append(buf, buf_size, " -o ");
@@ -249,7 +249,7 @@ void sc_do_mount(const char *source, const char *target,
 		 const char *fs_type, unsigned long mountflags,
 		 const void *data)
 {
-	char buf[10000];
+	char buf[10000] = { 0, };
 	const char *mount_cmd = NULL;
 
 	void ensure_mount_cmd() {
@@ -288,7 +288,7 @@ void sc_do_mount(const char *source, const char *target,
 
 void sc_do_umount(const char *target, int flags)
 {
-	char buf[10000];
+	char buf[10000] = { 0, };
 	const char *umount_cmd = NULL;
 
 	void ensure_umount_cmd() {

--- a/cmd/libsnap-confine-private/mount-opt.c
+++ b/cmd/libsnap-confine-private/mount-opt.c
@@ -109,7 +109,7 @@ const char *sc_mount_opt2str(char *buf, size_t buf_size, unsigned long flags)
 #undef F
 	// Render any flags that are unaccounted for.
 	if (flags) {
-		char of[128] = { 0, };
+		char of[128] = { 0 };
 		sc_must_snprintf(of, sizeof of, "%#lx", flags);
 		sc_string_append(buf, buf_size, of);
 	}
@@ -197,7 +197,7 @@ const char *sc_mount_cmd(char *buf, size_t buf_size, const char *source, const c
 	}
 	// If regular option syntax exists then use it.
 	if (mountflags & ~used_special_flags) {
-		char opts_buf[1000] = { 0, };
+		char opts_buf[1000] = { 0 };
 		sc_mount_opt2str(opts_buf, sizeof opts_buf, mountflags &
 				 ~used_special_flags);
 		sc_string_append(buf, buf_size, " -o ");
@@ -249,7 +249,7 @@ void sc_do_mount(const char *source, const char *target,
 		 const char *fs_type, unsigned long mountflags,
 		 const void *data)
 {
-	char buf[10000] = { 0, };
+	char buf[10000] = { 0 };
 	const char *mount_cmd = NULL;
 
 	void ensure_mount_cmd() {
@@ -288,7 +288,7 @@ void sc_do_mount(const char *source, const char *target,
 
 void sc_do_umount(const char *target, int flags)
 {
-	char buf[10000] = { 0, };
+	char buf[10000] = { 0 };
 	const char *umount_cmd = NULL;
 
 	void ensure_umount_cmd() {

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -55,7 +55,7 @@ static void test_sc_endswith()
 
 static void test_sc_must_snprintf()
 {
-	char buf[5];
+	char buf[5] = { 0, };
 	sc_must_snprintf(buf, sizeof buf, "1234");
 	g_assert_cmpstr(buf, ==, "1234");
 }

--- a/cmd/libsnap-confine-private/string-utils-test.c
+++ b/cmd/libsnap-confine-private/string-utils-test.c
@@ -55,7 +55,7 @@ static void test_sc_endswith()
 
 static void test_sc_must_snprintf()
 {
-	char buf[5] = { 0, };
+	char buf[5] = { 0 };
 	sc_must_snprintf(buf, sizeof buf, "1234");
 	g_assert_cmpstr(buf, ==, "1234");
 }
@@ -140,7 +140,7 @@ static void test_sc_string_append__empty_to_full()
 static void test_sc_string_append__overflow()
 {
 	if (g_test_subprocess()) {
-		char buf[4] = { 0, };
+		char buf[4] = { 0 };
 
 		// Try to append a string that's one character too long.
 		sc_string_append(buf, sizeof buf, "1234");

--- a/cmd/snap-confine/cookie-support-test.c
+++ b/cmd/snap-confine/cookie-support-test.c
@@ -47,7 +47,7 @@ static void set_fake_cookie_dir()
 static void create_dumy_cookie_file(const char *snap_name,
 				    const char *dummy_cookie)
 {
-	char path[PATH_MAX] = { 0, };
+	char path[PATH_MAX] = { 0 };
 	FILE *f;
 	int n;
 

--- a/cmd/snap-confine/cookie-support-test.c
+++ b/cmd/snap-confine/cookie-support-test.c
@@ -47,7 +47,7 @@ static void set_fake_cookie_dir()
 static void create_dumy_cookie_file(const char *snap_name,
 				    const char *dummy_cookie)
 {
-	char path[PATH_MAX];
+	char path[PATH_MAX] = { 0, };
 	FILE *f;
 	int n;
 

--- a/cmd/snap-confine/cookie-support.c
+++ b/cmd/snap-confine/cookie-support.c
@@ -39,7 +39,7 @@ static const char *sc_cookie_dir = SC_COOKIE_DIR;
 
 char *sc_cookie_get_from_snapd(const char *snap_name, struct sc_error **errorp)
 {
-	char context_path[PATH_MAX];
+	char context_path[PATH_MAX] = { 0, };
 	struct sc_error *err = NULL;
 	char *context = NULL;
 
@@ -55,7 +55,7 @@ char *sc_cookie_get_from_snapd(const char *snap_name, struct sc_error **errorp)
 		goto out;
 	}
 	// large enough buffer for opaque cookie string
-	char context_val[255];
+	char context_val[255] = { 0, };
 	ssize_t n = read(fd, context_val, sizeof(context_val) - 1);
 	if (n < 0) {
 		err =

--- a/cmd/snap-confine/cookie-support.c
+++ b/cmd/snap-confine/cookie-support.c
@@ -39,7 +39,7 @@ static const char *sc_cookie_dir = SC_COOKIE_DIR;
 
 char *sc_cookie_get_from_snapd(const char *snap_name, struct sc_error **errorp)
 {
-	char context_path[PATH_MAX] = { 0, };
+	char context_path[PATH_MAX] = { 0 };
 	struct sc_error *err = NULL;
 	char *context = NULL;
 
@@ -55,7 +55,7 @@ char *sc_cookie_get_from_snapd(const char *snap_name, struct sc_error **errorp)
 		goto out;
 	}
 	// large enough buffer for opaque cookie string
-	char context_val[255] = { 0, };
+	char context_val[255] = { 0 };
 	ssize_t n = read(fd, context_val, sizeof(context_val) - 1);
 	if (n < 0) {
 		err =

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -111,8 +111,8 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 	}
 	// Symlink each file found
 	for (size_t i = 0; i < glob_res.gl_pathc; ++i) {
-		char symlink_name[512] = { 0, };
-		char symlink_target[512] = { 0, };
+		char symlink_name[512] = { 0 };
+		char symlink_target[512] = { 0 };
 		const char *pathname = glob_res.gl_pathv[i];
 		char *pathname_copy
 		    SC_CLEANUP(sc_cleanup_string) = strdup(pathname);
@@ -170,7 +170,7 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir)
 {
 	// Bind mount a tmpfs on $rootfs_dir/var/lib/snapd/lib/gl
-	char buf[512] = { 0, };
+	char buf[512] = { 0 };
 	sc_must_snprintf(buf, sizeof(buf), "%s%s", rootfs_dir,
 			 "/var/lib/snapd/lib/gl");
 	const char *libgl_dir = buf;
@@ -237,8 +237,8 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir)
 	}
 	// Construct the paths for the driver userspace libraries
 	// and for the gl directory.
-	char src[PATH_MAX] = { 0, };
-	char dst[PATH_MAX] = { 0, };
+	char src[PATH_MAX] = { 0 };
+	char dst[PATH_MAX] = { 0 };
 	sc_must_snprintf(src, sizeof src, "/usr/lib/nvidia-%d",
 			 driver.major_version);
 	sc_must_snprintf(dst, sizeof dst, "%s%s", rootfs_dir, SC_LIBGL_DIR);

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -111,8 +111,8 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 	}
 	// Symlink each file found
 	for (size_t i = 0; i < glob_res.gl_pathc; ++i) {
-		char symlink_name[512];
-		char symlink_target[512];
+		char symlink_name[512] = { 0, };
+		char symlink_target[512] = { 0, };
 		const char *pathname = glob_res.gl_pathv[i];
 		char *pathname_copy
 		    SC_CLEANUP(sc_cleanup_string) = strdup(pathname);
@@ -170,7 +170,7 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir)
 {
 	// Bind mount a tmpfs on $rootfs_dir/var/lib/snapd/lib/gl
-	char buf[512];
+	char buf[512] = { 0, };
 	sc_must_snprintf(buf, sizeof(buf), "%s%s", rootfs_dir,
 			 "/var/lib/snapd/lib/gl");
 	const char *libgl_dir = buf;
@@ -237,7 +237,8 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir)
 	}
 	// Construct the paths for the driver userspace libraries
 	// and for the gl directory.
-	char src[PATH_MAX], dst[PATH_MAX];
+	char src[PATH_MAX] = { 0, };
+	char dst[PATH_MAX] = { 0, };
 	sc_must_snprintf(src, sizeof src, "/usr/lib/nvidia-%d",
 			 driver.major_version);
 	sc_must_snprintf(dst, sizeof dst, "%s%s", rootfs_dir, SC_LIBGL_DIR);

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -236,8 +236,8 @@ struct sc_mount_config {
 static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 {
 	char scratch_dir[] = "/tmp/snap.rootfs_XXXXXX";
-	char src[PATH_MAX] = { 0, };
-	char dst[PATH_MAX] = { 0, };
+	char src[PATH_MAX] = { 0 };
+	char dst[PATH_MAX] = { 0 };
 	if (mkdtemp(scratch_dir) == NULL) {
 		die("cannot create temporary directory for the root file system");
 	}
@@ -340,7 +340,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		// where $ROOT is either "/" or the "/snap/core/current"
 		// that we are re-execing from
 		char *src = NULL;
-		char self[PATH_MAX + 1] = { 0, };
+		char self[PATH_MAX + 1] = { 0 };
 		if (readlink("/proc/self/exe", self, sizeof(self) - 1) < 0) {
 			die("cannot read /proc/self/exe");
 		}
@@ -602,7 +602,7 @@ void sc_populate_mount_ns(const char *base_snap_name, const char *snap_name)
 			{"/run/netns", true},	// access to the 'ip netns' network namespaces
 			{},
 		};
-		char rootfs_dir[PATH_MAX] = { 0, };
+		char rootfs_dir[PATH_MAX] = { 0 };
 		sc_must_snprintf(rootfs_dir, sizeof rootfs_dir,
 				 "%s/%s/current/", SNAP_MOUNT_DIR,
 				 base_snap_name);

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -236,8 +236,8 @@ struct sc_mount_config {
 static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 {
 	char scratch_dir[] = "/tmp/snap.rootfs_XXXXXX";
-	char src[PATH_MAX];
-	char dst[PATH_MAX];
+	char src[PATH_MAX] = { 0, };
+	char dst[PATH_MAX] = { 0, };
 	if (mkdtemp(scratch_dir) == NULL) {
 		die("cannot create temporary directory for the root file system");
 	}
@@ -602,7 +602,7 @@ void sc_populate_mount_ns(const char *base_snap_name, const char *snap_name)
 			{"/run/netns", true},	// access to the 'ip netns' network namespaces
 			{},
 		};
-		char rootfs_dir[PATH_MAX];
+		char rootfs_dir[PATH_MAX] = { 0, };
 		sc_must_snprintf(rootfs_dir, sizeof rootfs_dir,
 				 "%s/%s/current/", SNAP_MOUNT_DIR,
 				 base_snap_name);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -116,8 +116,8 @@ void sc_reassociate_with_pid1_mount_ns()
 	if (self_mnt_fd < 0) {
 		die("cannot open mount namespace of the current process (O_PATH)");
 	}
-	char init_buf[128] = { 0, };
-	char self_buf[128] = { 0, };
+	char init_buf[128] = { 0 };
+	char self_buf[128] = { 0 };
 	memset(init_buf, 0, sizeof init_buf);
 	if (readlinkat(init_mnt_fd, "", init_buf, sizeof init_buf) < 0) {
 		if (errno == ENOENT) {
@@ -243,7 +243,7 @@ void sc_create_or_join_ns_group(struct sc_ns_group *group,
 				struct sc_apparmor *apparmor)
 {
 	// Open the mount namespace file.
-	char mnt_fname[PATH_MAX] = { 0, };
+	char mnt_fname[PATH_MAX] = { 0 };
 	sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s%s", group->name,
 			 SC_NS_MNT_FILE);
 	int mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
@@ -375,8 +375,8 @@ void sc_create_or_join_ns_group(struct sc_ns_group *group,
 		debug
 		    ("capturing mount namespace of process %d in namespace group %s",
 		     (int)parent, group->name);
-		char src[PATH_MAX] = { 0, };
-		char dst[PATH_MAX] = { 0, };
+		char src[PATH_MAX] = { 0 };
+		char dst[PATH_MAX] = { 0 };
 		sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt",
 				 (int)parent);
 		sc_must_snprintf(dst, sizeof dst, "%s%s", group->name,
@@ -446,7 +446,7 @@ void sc_discard_preserved_ns_group(struct sc_ns_group *group)
 		die("cannot move to namespace group directory");
 	}
 	// Unmount ${group_name}.mnt which holds the preserved namespace
-	char mnt_fname[PATH_MAX] = { 0, };
+	char mnt_fname[PATH_MAX] = { 0 };
 	sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s%s", group->name,
 			 SC_NS_MNT_FILE);
 	debug("unmounting preserved mount namespace file %s", mnt_fname);

--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -116,7 +116,8 @@ void sc_reassociate_with_pid1_mount_ns()
 	if (self_mnt_fd < 0) {
 		die("cannot open mount namespace of the current process (O_PATH)");
 	}
-	char init_buf[128], self_buf[128];
+	char init_buf[128] = { 0, };
+	char self_buf[128] = { 0, };
 	memset(init_buf, 0, sizeof init_buf);
 	if (readlinkat(init_mnt_fd, "", init_buf, sizeof init_buf) < 0) {
 		if (errno == ENOENT) {
@@ -242,7 +243,7 @@ void sc_create_or_join_ns_group(struct sc_ns_group *group,
 				struct sc_apparmor *apparmor)
 {
 	// Open the mount namespace file.
-	char mnt_fname[PATH_MAX];
+	char mnt_fname[PATH_MAX] = { 0, };
 	sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s%s", group->name,
 			 SC_NS_MNT_FILE);
 	int mnt_fd SC_CLEANUP(sc_cleanup_close) = -1;
@@ -374,8 +375,8 @@ void sc_create_or_join_ns_group(struct sc_ns_group *group,
 		debug
 		    ("capturing mount namespace of process %d in namespace group %s",
 		     (int)parent, group->name);
-		char src[PATH_MAX];
-		char dst[PATH_MAX];
+		char src[PATH_MAX] = { 0, };
+		char dst[PATH_MAX] = { 0, };
 		sc_must_snprintf(src, sizeof src, "/proc/%d/ns/mnt",
 				 (int)parent);
 		sc_must_snprintf(dst, sizeof dst, "%s%s", group->name,
@@ -445,7 +446,7 @@ void sc_discard_preserved_ns_group(struct sc_ns_group *group)
 		die("cannot move to namespace group directory");
 	}
 	// Unmount ${group_name}.mnt which holds the preserved namespace
-	char mnt_fname[PATH_MAX];
+	char mnt_fname[PATH_MAX] = { 0, };
 	sc_must_snprintf(mnt_fname, sizeof mnt_fname, "%s%s", group->name,
 			 SC_NS_MNT_FILE);
 	debug("unmounting preserved mount namespace file %s", mnt_fname);

--- a/cmd/snap-confine/quirks.c
+++ b/cmd/snap-confine/quirks.c
@@ -90,7 +90,7 @@ static void sc_quirk_mkdir_bind(const char *src_dir, const char *dest_dir,
 	if (sc_nonfatal_mkpath(dest_dir, 0755) < 0) {
 		die("cannot create empty directory at %s", dest_dir);
 	}
-	char buf[1000] = { 0, };
+	char buf[1000] = { 0 };
 	const char *flags_str = sc_mount_opt2str(buf, sizeof buf, flags);
 	debug("performing operation: mount %s %s -o %s", src_dir, dest_dir,
 	      flags_str);
@@ -137,8 +137,8 @@ static void sc_quirk_create_writable_mimic(const char *mimic_dir,
 	}
 	struct dirent *entryp = NULL;
 	do {
-		char src_name[PATH_MAX * 2] = { 0, };
-		char dest_name[PATH_MAX * 2] = { 0, };
+		char src_name[PATH_MAX * 2] = { 0 };
+		char dest_name[PATH_MAX * 2] = { 0 };
 		// Set errno to zero, if readdir fails it will not only return null but
 		// set errno to a non-zero value. This is how we can differentiate
 		// end-of-directory from an actual error.
@@ -203,7 +203,7 @@ void sc_setup_quirks()
 		    "/var/lib/snapd", snapd_tmp);
 	}
 	// now let's make /var/lib the vanilla /var/lib from the core snap
-	char buf[PATH_MAX] = { 0, };
+	char buf[PATH_MAX] = { 0 };
 	sc_must_snprintf(buf, sizeof buf, "%s/var/lib",
 			 sc_get_inner_core_mount_point());
 	sc_quirk_create_writable_mimic("/var/lib", buf,

--- a/cmd/snap-confine/quirks.c
+++ b/cmd/snap-confine/quirks.c
@@ -90,7 +90,7 @@ static void sc_quirk_mkdir_bind(const char *src_dir, const char *dest_dir,
 	if (sc_nonfatal_mkpath(dest_dir, 0755) < 0) {
 		die("cannot create empty directory at %s", dest_dir);
 	}
-	char buf[1000];
+	char buf[1000] = { 0, };
 	const char *flags_str = sc_mount_opt2str(buf, sizeof buf, flags);
 	debug("performing operation: mount %s %s -o %s", src_dir, dest_dir,
 	      flags_str);
@@ -137,8 +137,8 @@ static void sc_quirk_create_writable_mimic(const char *mimic_dir,
 	}
 	struct dirent *entryp = NULL;
 	do {
-		char src_name[PATH_MAX * 2];
-		char dest_name[PATH_MAX * 2];
+		char src_name[PATH_MAX * 2] = { 0, };
+		char dest_name[PATH_MAX * 2] = { 0, };
 		// Set errno to zero, if readdir fails it will not only return null but
 		// set errno to a non-zero value. This is how we can differentiate
 		// end-of-directory from an actual error.
@@ -203,7 +203,7 @@ void sc_setup_quirks()
 		    "/var/lib/snapd", snapd_tmp);
 	}
 	// now let's make /var/lib the vanilla /var/lib from the core snap
-	char buf[PATH_MAX];
+	char buf[PATH_MAX] = { 0, };
 	sc_must_snprintf(buf, sizeof buf, "%s/var/lib",
 			 sc_get_inner_core_mount_point());
 	sc_quirk_create_writable_mimic("/var/lib", buf,

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -116,7 +116,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 {
 	debug("loading bpf program for security tag %s", filter_profile);
 
-	char profile_path[PATH_MAX] = { 0, };
+	char profile_path[PATH_MAX] = { 0 };
 	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin",
 			 filter_profile_dir, filter_profile);
 
@@ -154,7 +154,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	validate_bpfpath_is_safe(profile_path);
 
 	// load bpf
-	unsigned char bpf[MAX_BPF_SIZE + 1] = { 0, };	// account for EOF
+	unsigned char bpf[MAX_BPF_SIZE + 1] = { 0 };	// account for EOF
 	FILE *fp = fopen(profile_path, "rb");
 	if (fp == NULL) {
 		die("cannot read %s", profile_path);

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -38,7 +38,7 @@
 static const char *filter_profile_dir = "/var/lib/snapd/seccomp/bpf/";
 
 // MAX_BPF_SIZE is an arbitrary limit.
-const int MAX_BPF_SIZE = 32 * 1024;
+#define MAX_BPF_SIZE (32 * 1024)
 
 typedef struct sock_filter bpf_instr;
 
@@ -116,7 +116,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 {
 	debug("loading bpf program for security tag %s", filter_profile);
 
-	char profile_path[PATH_MAX];
+	char profile_path[PATH_MAX] = { 0, };
 	sc_must_snprintf(profile_path, sizeof(profile_path), "%s/%s.bin",
 			 filter_profile_dir, filter_profile);
 
@@ -154,7 +154,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	validate_bpfpath_is_safe(profile_path);
 
 	// load bpf
-	unsigned char bpf[MAX_BPF_SIZE + 1];	// account for EOF
+	unsigned char bpf[MAX_BPF_SIZE + 1] = { 0, };	// account for EOF
 	FILE *fp = fopen(profile_path, "rb");
 	if (fp == NULL) {
 		die("cannot read %s", profile_path);

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -50,7 +50,7 @@ _run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
 		if (real_uid != 0 && effective_uid == 0)
 			if (setuid(0) != 0)
 				die("setuid failed");
-		char buf[64] = { 0, };
+		char buf[64] = { 0 };
 		// pass snappy-add-dev an empty environment so the
 		// user-controlled environment can't be used to subvert
 		// snappy-add-dev
@@ -177,7 +177,7 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 		die("snappy_udev->tagname has invalid length");
 
 	// create devices cgroup controller
-	char cgroup_dir[PATH_MAX] = { 0, };
+	char cgroup_dir[PATH_MAX] = { 0 };
 
 	sc_must_snprintf(cgroup_dir, sizeof(cgroup_dir),
 			 "/sys/fs/cgroup/devices/%s/", security_tag);
@@ -186,11 +186,11 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 		die("mkdir failed");
 
 	// move ourselves into it
-	char cgroup_file[PATH_MAX] = { 0, };
+	char cgroup_file[PATH_MAX] = { 0 };
 	sc_must_snprintf(cgroup_file, sizeof(cgroup_file), "%s%s", cgroup_dir,
 			 "tasks");
 
-	char buf[128] = { 0, };
+	char buf[128] = { 0 };
 	sc_must_snprintf(buf, sizeof(buf), "%i", getpid());
 	write_string_to_file(cgroup_file, buf);
 

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -50,7 +50,7 @@ _run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
 		if (real_uid != 0 && effective_uid == 0)
 			if (setuid(0) != 0)
 				die("setuid failed");
-		char buf[64];
+		char buf[64] = { 0, };
 		// pass snappy-add-dev an empty environment so the
 		// user-controlled environment can't be used to subvert
 		// snappy-add-dev
@@ -177,7 +177,7 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 		die("snappy_udev->tagname has invalid length");
 
 	// create devices cgroup controller
-	char cgroup_dir[PATH_MAX];
+	char cgroup_dir[PATH_MAX] = { 0, };
 
 	sc_must_snprintf(cgroup_dir, sizeof(cgroup_dir),
 			 "/sys/fs/cgroup/devices/%s/", security_tag);
@@ -186,11 +186,11 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 		die("mkdir failed");
 
 	// move ourselves into it
-	char cgroup_file[PATH_MAX];
+	char cgroup_file[PATH_MAX] = { 0, };
 	sc_must_snprintf(cgroup_file, sizeof(cgroup_file), "%s%s", cgroup_dir,
 			 "tasks");
 
-	char buf[128];
+	char buf[128] = { 0, };
 	sc_must_snprintf(buf, sizeof(buf), "%i", getpid());
 	write_string_to_file(cgroup_file, buf);
 

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 		sc_close_ns_group(group);
 	}
 	// Unlink the current mount profile, if any.
-	char profile_path[PATH_MAX];
+	char profile_path[PATH_MAX] = { 0, };
 	sc_must_snprintf(profile_path, sizeof(profile_path),
 			 "/run/snapd/ns/snap.%s.fstab", snap_name);
 	if (unlink(profile_path) < 0) {

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 		sc_close_ns_group(group);
 	}
 	// Unlink the current mount profile, if any.
-	char profile_path[PATH_MAX] = { 0, };
+	char profile_path[PATH_MAX] = { 0 };
 	sc_must_snprintf(profile_path, sizeof(profile_path),
 			 "/run/snapd/ns/snap.%s.fstab", snap_name);
 	if (unlink(profile_path) < 0) {


### PR DESCRIPTION
This branch ensures that all arrays we are used are properly
initialized. This adds one more layer of defense.
