### PR TITLE
tests: fix interfaces-cups-control test for cups-2.2.5

### DIFF
--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -61,7 +61,7 @@ execute: |
     echo "Then the snap command is able to print files"
     echo "Hello World" > $TEST_FILE
     test-snapd-cups-control-consumer.lpr $TEST_FILE
-    while ! test -e $HOME/PDF/test_file*.pdf; do sleep 1; done
+    while ! test -e $HOME/PDF/*.pdf; do sleep 1; done
 
     if [ "$(snap debug confinement)" = partial ] ; then
         exit 0


### PR DESCRIPTION
The test breaks with cups 2.2.5 becaue the output filename has
changed there. It used to be /root/PDF/test_file.pdf but now it
is /root/PDF/root_PDF.pdf. This PR makes the glob sufficiently
broad.

