### PR TITLE
many: add integrated snapfuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ cmd/snap-update-ns/unit-tests
 cmd/system-shutdown/system-shutdown
 cmd/system-shutdown/unit-tests
 
+# snapfuse
+cmd/swap.[ch].inc
+cmd/snapfuse/snapfuse
+
 # manual pages
 cmd/*/*.[1-9]
 

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -419,3 +419,52 @@ system_shutdown_unit_tests_LDADD = libsnap-confine-private.a
 system_shutdown_unit_tests_CFLAGS = $(GLIB_CFLAGS)
 system_shutdown_unit_tests_LDADD +=  $(GLIB_LIBS)
 endif
+
+bin_PROGRAMS = snapfuse/snapfuse
+snapfuse_snapfuse_CFLAGS = $(FUSE_CFLAGS) $(XZ_CFLAGS)
+snapfuse_snapfuse_LDADD = $(FUSE_LIBS) $(XZ_LIBS)
+snapfuse_snapfuse_SOURCES = \
+	snapfuse/cache.c \
+	snapfuse/cache.h \
+	snapfuse/common.h \
+	snapfuse/decompress.c \
+	snapfuse/decompress.h \
+	snapfuse/dir.c \
+	snapfuse/dir.h \
+	snapfuse/file.c \
+	snapfuse/file.h \
+	snapfuse/fs.c \
+	snapfuse/fs.h \
+	snapfuse/fuseprivate.c \
+	snapfuse/fuseprivate.h \
+	snapfuse/hash.c \
+	snapfuse/hash.h \
+	snapfuse/hl.c \
+	snapfuse/nonstd-enoattr.c \
+	snapfuse/nonstd-internal.h \
+	snapfuse/nonstd-makedev.c \
+	snapfuse/nonstd-pread.c \
+	snapfuse/nonstd-stat.c \
+	snapfuse/nonstd.h \
+	snapfuse/squashfs_fs.h \
+	snapfuse/squashfuse.h \
+	snapfuse/stack.c \
+	snapfuse/stack.h \
+	snapfuse/swap.c \
+	snapfuse/swap.h \
+	snapfuse/table.c \
+	snapfuse/table.h \
+	snapfuse/traverse.c \
+	snapfuse/traverse.h \
+	snapfuse/util.c \
+	snapfuse/util.h \
+	snapfuse/xattr.c \
+	snapfuse/xattr.h
+
+$(snapfuse_snapfuse_OBJECTS): swap.c.inc
+
+# Handle generation of swap include files
+CLEANFILES += swap.h.inc swap.c.inc
+EXTRA_DIST += swap.h.inc swap.c.inc
+swap.h.inc swap.c.inc: snapfuse/gen_swap.sh snapfuse/squashfs_fs.h
+	SED="sed" $(srcdir)/snapfuse/gen_swap.sh $(srcdir)/snapfuse/squashfs_fs.h

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -109,6 +109,9 @@ AS_IF([test "x$enable_apparmor" = "xyes"], [
 # Those are now used unconditionally even if apparmor is disabled.
 PKG_CHECK_MODULES([LIBUDEV], [libudev])
 PKG_CHECK_MODULES([UDEV], [udev])
+PKG_CHECK_MODULES([FUSE], [fuse])
+PKG_CHECK_MODULES([XZ], [liblzma])
+AC_DEFINE([HAVE_LZMA_H], [1], [Build with XZ support])
 
 # Check if libcap is available.
 # PKG_CHECK_MODULES([LIBCAP], [libcap])
@@ -208,6 +211,8 @@ AC_ARG_ENABLE([static-libseccomp],
         *) AC_MSG_ERROR([bad value ${enableval} for --enable-static-libseccomp])
     esac], [enable_static_libseccomp=no])
 AM_CONDITIONAL([STATIC_LIBSECCOMP], [test "x$enable_static_libseccomp" = "xyes"])
+
+AC_DEFINE([FUSE_USE_VERSION], [26], [Version of FUSE API to use])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/cmd/snapfuse/cache.c
+++ b/cmd/snapfuse/cache.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "cache.h"
+
+#include "fs.h"
+
+#include <stdlib.h>
+
+sqfs_err sqfs_cache_init(sqfs_cache *cache, size_t size, size_t count,
+		sqfs_cache_dispose dispose) {
+	cache->size = size;
+	cache->count = count;
+	cache->dispose = dispose;
+	cache->next = 0;
+	
+	cache->idxs = calloc(count, sizeof(sqfs_cache_idx));
+	cache->buf = calloc(count, size);
+	if (cache->idxs && cache->buf)
+		return SQFS_OK;
+	
+	sqfs_cache_destroy(cache);
+	return SQFS_ERR;
+}
+
+static void *sqfs_cache_entry(sqfs_cache *cache, size_t i) {
+	return cache->buf + i * cache->size;
+}
+
+void sqfs_cache_destroy(sqfs_cache *cache) {
+	if (cache->buf && cache->idxs) {
+		size_t i;
+		for (i = 0; i < cache->count; ++i) {
+			if (cache->idxs[i] != SQFS_CACHE_IDX_INVALID)
+				cache->dispose(sqfs_cache_entry(cache, i));
+		}
+	}
+	free(cache->buf);
+	free(cache->idxs);
+}
+
+void *sqfs_cache_get(sqfs_cache *cache, sqfs_cache_idx idx) {
+	size_t i;
+	for (i = 0; i < cache->count; ++i) {
+		if (cache->idxs[i] == idx)
+			return sqfs_cache_entry(cache, i);
+	}
+	return NULL;
+}
+
+void *sqfs_cache_add(sqfs_cache *cache, sqfs_cache_idx idx) {
+	size_t i = (cache->next++);
+	cache->next %= cache->count;
+	
+	if (cache->idxs[i] != SQFS_CACHE_IDX_INVALID)
+		cache->dispose(sqfs_cache_entry(cache, i));
+	
+	cache->idxs[i] = idx;
+	return sqfs_cache_entry(cache, i);
+}
+
+static void sqfs_block_cache_dispose(void *data) {
+	sqfs_block_cache_entry *entry = (sqfs_block_cache_entry*)data;
+	sqfs_block_dispose(entry->block);
+}
+
+sqfs_err sqfs_block_cache_init(sqfs_cache *cache, size_t count) {
+	return sqfs_cache_init(cache, sizeof(sqfs_block_cache_entry), count,
+		&sqfs_block_cache_dispose);
+}

--- a/cmd/snapfuse/cache.h
+++ b/cmd/snapfuse/cache.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_CACHE_H
+#define SQFS_CACHE_H
+
+#include "common.h"
+
+/* Really simplistic cache
+ *  - Linear search
+ *  - Linear eviction
+ *  - No thread safety
+ *  - Misses are caller's responsibility
+ */
+#define SQFS_CACHE_IDX_INVALID 0
+
+typedef uint64_t sqfs_cache_idx;
+typedef void (*sqfs_cache_dispose)(void* data);
+
+typedef struct {
+	sqfs_cache_idx *idxs;
+	uint8_t *buf;
+	
+	sqfs_cache_dispose dispose;
+	
+	size_t size, count;
+	size_t next; /* next block to evict */
+} sqfs_cache;
+
+sqfs_err sqfs_cache_init(sqfs_cache *cache, size_t size, size_t count,
+	sqfs_cache_dispose dispose);
+void sqfs_cache_destroy(sqfs_cache *cache);
+
+void *sqfs_cache_get(sqfs_cache *cache, sqfs_cache_idx idx);
+void *sqfs_cache_add(sqfs_cache *cache, sqfs_cache_idx idx);
+
+
+typedef struct {
+	sqfs_block *block;
+	size_t data_size;
+} sqfs_block_cache_entry;
+
+sqfs_err sqfs_block_cache_init(sqfs_cache *cache, size_t count);
+
+#endif

--- a/cmd/snapfuse/common.h
+++ b/cmd/snapfuse/common.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_COMMON_H
+#define SQFS_COMMON_H
+
+#include "config.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#ifdef _WIN32
+	#include <win32.h>
+#else
+	typedef mode_t sqfs_mode_t;
+	typedef uid_t sqfs_id_t;
+	typedef off_t sqfs_off_t;
+	typedef int sqfs_fd_t;
+#endif
+
+typedef enum {
+	SQFS_OK,
+	SQFS_ERR,
+	SQFS_BADFORMAT,		/* unsupported file format */
+	SQFS_BADVERSION,	/* unsupported squashfs version */
+	SQFS_BADCOMP,		/* unsupported compression method */
+	SQFS_UNSUP			/* unsupported feature */
+} sqfs_err;
+
+#define SQFS_INODE_ID_BYTES 6
+typedef uint64_t sqfs_inode_id;
+typedef uint32_t sqfs_inode_num;
+
+typedef struct sqfs sqfs;
+typedef struct sqfs_inode sqfs_inode;
+
+typedef struct {
+	size_t size;
+	void *data;
+} sqfs_block;
+
+typedef struct {
+	sqfs_off_t block;
+	size_t offset;
+} sqfs_md_cursor;
+
+#endif

--- a/cmd/snapfuse/decompress.c
+++ b/cmd/snapfuse/decompress.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "decompress.h"
+
+#include "squashfs_fs.h"
+
+#include <string.h>
+
+#if _WIN32
+	#include "win_decompress.c.inc"
+#endif
+
+
+#ifdef HAVE_ZLIB_H
+#include <zlib.h>
+
+static sqfs_err sqfs_decompressor_zlib(void *in, size_t insz,
+		void *out, size_t *outsz) {
+	uLongf zout = *outsz;
+	int zerr = uncompress((Bytef*)out, &zout, in, insz);
+	if (zerr != Z_OK)
+		return SQFS_ERR;
+	*outsz = zout;
+	return SQFS_OK;
+}
+#define CAN_DECOMPRESS_ZLIB 1
+#endif
+
+
+#ifdef HAVE_LZMA_H
+#include <lzma.h>
+
+static sqfs_err sqfs_decompressor_xz(void *in, size_t insz,
+		void *out, size_t *outsz) {
+	/* FIXME: Save stream state, to minimize setup time? */
+	uint64_t memlimit = UINT64_MAX;
+	size_t inpos = 0, outpos = 0;
+	lzma_ret err = lzma_stream_buffer_decode(&memlimit, 0, NULL, in, &inpos, insz,
+		out, &outpos, *outsz);
+	if (err != LZMA_OK)
+		return SQFS_ERR;
+	*outsz = outpos;
+	return SQFS_OK;
+}
+#define CAN_DECOMPRESS_XZ 1
+#endif
+
+
+#ifdef HAVE_LZO_LZO1X_H
+#include <lzo/lzo1x.h>
+
+static sqfs_err sqfs_decompressor_lzo(void *in, size_t insz,
+		void *out, size_t *outsz) {
+	lzo_uint lzout = *outsz;
+	int err = lzo1x_decompress_safe(in, insz, out, &lzout, NULL);
+	if (err != LZO_E_OK)
+		return SQFS_ERR;
+	*outsz = lzout;
+	return SQFS_OK;
+}
+#define CAN_DECOMPRESS_LZO 1
+#endif
+
+
+#ifdef HAVE_LZ4_H
+#include <lz4.h>
+static sqfs_err sqfs_decompressor_lz4(void *in, size_t insz,
+		void *out, size_t *outsz) {
+	int lz4out = LZ4_decompress_safe (in, out, insz, *outsz);
+	if (lz4out < 0)
+		return SQFS_ERR;
+	*outsz = lz4out;
+	return SQFS_OK;
+}
+#define CAN_DECOMPRESS_LZ4 1
+#endif
+
+
+#ifdef HAVE_ZSTD_H
+#include <zstd.h>
+static sqfs_err sqfs_decompressor_zstd(void *in, size_t insz,
+        void *out, size_t *outsz) {
+	const size_t zstdout = ZSTD_decompress(out, *outsz, in, insz);
+	if (ZSTD_isError(zstdout))
+		return SQFS_ERR;
+	*outsz = zstdout;
+	return SQFS_OK;
+}
+#define CAN_DECOMPRESS_ZSTD 1
+#endif
+
+sqfs_decompressor sqfs_decompressor_get(sqfs_compression_type type) {
+	switch (type) {
+#ifdef CAN_DECOMPRESS_ZLIB
+		case ZLIB_COMPRESSION: return &sqfs_decompressor_zlib;
+#endif
+#ifdef CAN_DECOMPRESS_XZ
+		case XZ_COMPRESSION: return &sqfs_decompressor_xz;
+#endif
+#ifdef CAN_DECOMPRESS_LZO
+		case LZO_COMPRESSION: return &sqfs_decompressor_lzo;
+#endif
+#ifdef CAN_DECOMPRESS_LZ4
+		case LZ4_COMPRESSION: return &sqfs_decompressor_lz4;
+#endif
+#ifdef CAN_DECOMPRESS_ZSTD
+		case ZSTD_COMPRESSION: return &sqfs_decompressor_zstd;
+#endif
+		default: return NULL;
+	}
+}
+
+static char *const sqfs_compression_names[SQFS_COMP_MAX] = {
+	NULL, "zlib", "lzma", "lzo", "xz", "lz4", "zstd",
+};
+
+char *sqfs_compression_name(sqfs_compression_type type) {
+	if (type < 0 || type >= SQFS_COMP_MAX)
+		return NULL;
+	return sqfs_compression_names[type];
+}
+
+void sqfs_compression_supported(sqfs_compression_type *types) {
+	size_t i = 0;
+	memset(types, SQFS_COMP_UNKNOWN, SQFS_COMP_MAX * sizeof(*types));
+#ifdef CAN_DECOMPRESS_LZO
+	types[i++] = LZO_COMPRESSION;
+#endif
+#ifdef CAN_DECOMPRESS_XZ
+	types[i++] = XZ_COMPRESSION;
+#endif
+#ifdef CAN_DECOMPRESS_ZLIB
+	types[i++] = ZLIB_COMPRESSION;
+#endif
+#ifdef CAN_DECOMPRESS_LZ4
+	types[i++] = LZ4_COMPRESSION;
+#endif
+#ifdef CAN_DECOMPRESS_ZSTD
+	types[i++] = ZSTD_COMPRESSION;
+#endif
+}

--- a/cmd/snapfuse/decompress.h
+++ b/cmd/snapfuse/decompress.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_DECOMPRESS_H
+#define SQFS_DECOMPRESS_H
+
+#include "common.h"
+
+#define SQFS_COMP_UNKNOWN	0
+#define SQFS_COMP_MAX		16
+
+typedef int sqfs_compression_type;
+
+char *sqfs_compression_name(sqfs_compression_type type);
+
+/* put supported compression types into an array */
+void sqfs_compression_supported(sqfs_compression_type *types);
+
+
+typedef sqfs_err (*sqfs_decompressor)(void *in, size_t insz,
+	void *out, size_t *outsz);
+
+sqfs_decompressor sqfs_decompressor_get(sqfs_compression_type type);
+
+#endif

--- a/cmd/snapfuse/dir.c
+++ b/cmd/snapfuse/dir.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "dir.h"
+
+#include "fs.h"
+#include "swap.h"
+
+#include <string.h>
+#include <sys/stat.h>
+
+/* Read some directory metadata, updating the dir structure as necessary */
+static sqfs_err sqfs_dir_md_read(sqfs *fs, sqfs_dir *dir, void *buf,
+		size_t size);
+
+/* Fast forwards to a directory header. */
+typedef sqfs_err sqfs_dir_header_f(sqfs *fs, sqfs_md_cursor *cur,
+	struct squashfs_dir_index *index, bool *stop, void *arg);
+static sqfs_err sqfs_dir_ff_header(sqfs *fs, sqfs_inode *inode, sqfs_dir *dir,
+	sqfs_dir_header_f func, void *arg);
+
+/* Fast forward a directory to the given offset. Return error if it doesn't
+	 exist. */
+static sqfs_err sqfs_dir_ff_offset(sqfs *fs, sqfs_inode *inode, sqfs_dir *dir,
+	sqfs_off_t offset);
+
+
+static sqfs_err sqfs_dir_md_read(sqfs *fs, sqfs_dir *dir, void *buf,
+		size_t size) {
+	dir->offset += size;
+	return sqfs_md_read(fs, &dir->cur, buf, size);
+}
+
+
+sqfs_err sqfs_dir_open(sqfs *fs, sqfs_inode *inode, sqfs_dir *dir,
+		off_t offset) {
+	if (!S_ISDIR(inode->base.mode))
+		return SQFS_ERR;
+
+	memset(dir, 0, sizeof(*dir));
+	dir->cur.block = inode->xtra.dir.start_block +
+		fs->sb.directory_table_start;
+	dir->cur.offset = inode->xtra.dir.offset;
+	dir->offset = 0;
+	dir->total = inode->xtra.dir.dir_size - 3;
+	
+	if (offset) {
+		/* Fast forward to the given offset */
+		sqfs_err err = sqfs_dir_ff_offset(fs, inode, dir, offset);
+		if (err)
+			return err;
+	}
+	
+	return SQFS_OK;
+}
+
+
+void sqfs_dentry_init(sqfs_dir_entry *entry, char *namebuf) {
+	entry->name = namebuf;
+}
+
+sqfs_off_t sqfs_dentry_offset(sqfs_dir_entry *entry) {
+	return entry->offset;
+}
+
+sqfs_off_t sqfs_dentry_next_offset(sqfs_dir_entry *entry) {
+	return entry->next_offset;
+}
+
+int sqfs_dentry_type(sqfs_dir_entry *entry) {
+	return entry->type;
+}
+sqfs_mode_t	sqfs_dentry_mode(sqfs_dir_entry *entry) {
+	return sqfs_mode(sqfs_dentry_type(entry));
+}
+
+sqfs_inode_id sqfs_dentry_inode(sqfs_dir_entry *entry) {
+	return entry->inode;
+}
+
+sqfs_inode_num sqfs_dentry_inode_num(sqfs_dir_entry *entry) {
+	return entry->inode_number;
+}
+
+size_t sqfs_dentry_name_size(sqfs_dir_entry *entry) {
+	return entry->name_size;
+}
+
+const char *sqfs_dentry_name(sqfs_dir_entry *entry) {
+	if (!entry->name)
+		return NULL;
+	
+	entry->name[sqfs_dentry_name_size(entry)] = '\0';
+	return entry->name;
+}
+
+bool sqfs_dentry_is_dir(sqfs_dir_entry *entry) {
+	return S_ISDIR(sqfs_dentry_mode(entry));
+}
+
+
+
+bool sqfs_dir_next(sqfs *fs, sqfs_dir *dir, sqfs_dir_entry *entry,
+		sqfs_err *err) {
+	struct squashfs_dir_entry e;
+	
+	*err = SQFS_OK;
+	entry->offset = dir->offset;
+	
+	while (dir->header.count == 0) {
+		if (dir->offset >= dir->total)
+			return false;
+		
+		if ((*err = sqfs_dir_md_read(fs, dir, &dir->header, sizeof(dir->header))))
+			return false;
+		sqfs_swapin_dir_header(&dir->header);
+		++(dir->header.count); /* biased by one */
+	}
+	
+	if ((*err = sqfs_dir_md_read(fs, dir, &e, sizeof(e))))
+		return false;
+	sqfs_swapin_dir_entry(&e);
+	--(dir->header.count);
+	
+	entry->type = e.type;
+	entry->name_size = e.size + 1;
+	entry->inode = ((uint64_t)dir->header.start_block << 16) + e.offset;
+	/* e.inode_number is signed */
+	entry->inode_number = dir->header.inode_number + (int16_t)e.inode_number;
+	
+	*err = sqfs_dir_md_read(fs, dir, entry->name, sqfs_dentry_name_size(entry));
+	if (*err)
+		return false;
+	
+	entry->next_offset = dir->offset;
+
+	return true;
+}
+
+
+static sqfs_err sqfs_dir_ff_header(sqfs *fs, sqfs_inode *inode,
+		sqfs_dir *dir, sqfs_dir_header_f func, void *arg) {
+	struct squashfs_dir_index idx;
+	sqfs_md_cursor cur = inode->next;
+	size_t count = inode->xtra.dir.idx_count;
+
+	if (count == 0)
+		return SQFS_OK;
+	
+	while (count--) {
+		sqfs_err err;
+		bool stop = 0;
+		
+		if ((err = sqfs_md_read(fs, &cur, &idx, sizeof(idx))))
+			return err;
+		sqfs_swapin_dir_index(&idx);
+		
+		if ((err = func(fs, &cur, &idx, &stop, arg)))
+			return err;
+		if (stop)
+			break;
+		
+		dir->cur.block = idx.start_block + fs->sb.directory_table_start;
+		dir->offset = idx.index;
+	}
+
+	dir->cur.offset = (dir->cur.offset + dir->offset) % SQUASHFS_METADATA_SIZE;
+	return SQFS_OK;
+}
+
+
+/* Helper for sqfs_dir_ff_offset */
+static sqfs_err sqfs_dir_ff_offset_f(sqfs *fs, sqfs_md_cursor *cur,
+		struct squashfs_dir_index *index, bool *stop, void *arg) {
+	sqfs_off_t offset = *(sqfs_off_t*)arg;
+	
+	if (index->index >= offset) {
+		*stop = true;
+		return SQFS_OK;
+	}
+	
+	return sqfs_md_read(fs, cur, NULL, index->size + 1); /* skip name */
+}
+
+static sqfs_err sqfs_dir_ff_offset(sqfs *fs, sqfs_inode *inode, sqfs_dir *dir,
+		sqfs_off_t offset) {
+	sqfs_err err;
+	sqfs_dir_entry entry;
+	
+	err = sqfs_dir_ff_header(fs, inode, dir, sqfs_dir_ff_offset_f, &offset);
+	if (err)
+		return err;
+	
+	sqfs_dentry_init(&entry, NULL);
+	while (dir->offset < offset && sqfs_dir_next(fs, dir, &entry, &err))
+		; /* pass */
+	
+	if (err)
+		return err;
+	return dir->offset == offset ? SQFS_OK : SQFS_ERR;
+}
+
+
+/* Helper for sqfs_dir_lookup */
+typedef struct {
+	const char *cmp;
+	size_t cmplen;
+	char *name;
+} sqfs_dir_ff_name_t;
+
+static sqfs_err sqfs_dir_ff_name_f(sqfs *fs, sqfs_md_cursor *cur,
+		struct squashfs_dir_index *index, bool *stop, void *arg) {
+	sqfs_err err;
+	sqfs_dir_ff_name_t *args = (sqfs_dir_ff_name_t*)arg;
+	size_t name_size = index->size + 1;
+	
+	if ((err = sqfs_md_read(fs, cur, args->name, name_size)))
+		return err;
+	args->name[name_size] = '\0';
+	
+	int order = strncmp(args->name, args->cmp, args->cmplen);
+	if (order > 0 || (order == 0 && name_size > args->cmplen))
+		*stop = true;
+	
+	return SQFS_OK;
+}
+
+sqfs_err sqfs_dir_lookup(sqfs *fs, sqfs_inode *inode,
+		const char *name, size_t namelen, sqfs_dir_entry *entry, bool *found) {
+	sqfs_err err;
+	sqfs_dir dir;
+	sqfs_dir_ff_name_t arg;
+	
+	*found = false;
+	
+	if ((err = sqfs_dir_open(fs, inode, &dir, 0)))
+		return err;
+	
+	/* Fast forward to header */
+	arg.cmp = name;
+	arg.cmplen = namelen;
+	arg.name = entry->name;
+	if ((err = sqfs_dir_ff_header(fs, inode, &dir, sqfs_dir_ff_name_f, &arg)))
+		return err;
+	
+	/* Iterate to find the right entry */
+	while (sqfs_dir_next(fs, &dir, entry, &err)) {
+		int order = strncmp(sqfs_dentry_name(entry), name, namelen);
+		if (order == 0 && sqfs_dentry_name_size(entry) == namelen)
+			*found = true;
+		if (order >= 0)
+			break;
+	}
+	
+	return err;
+}
+
+
+sqfs_err sqfs_lookup_path(sqfs *fs, sqfs_inode *inode, const char *path,
+		bool *found) {
+	sqfs_err err;
+	sqfs_name buf;
+	sqfs_dir_entry entry;
+	
+	*found = false;
+	sqfs_dentry_init(&entry, buf);
+	
+	while (*path) {
+		const char *name;
+		size_t size;
+		bool dfound;
+		
+		/* Find next path component */
+		while (*path == '/') /* skip leading slashes */
+			++path;
+		
+		name = path;
+		while (*path && *path != '/')
+			++path;
+		size = path - name;
+		if (size == 0) /* we're done */
+			break;
+		
+		if ((err = sqfs_dir_lookup(fs, inode, name, size, &entry, &dfound)))
+			return err;
+		if (!dfound)
+			return SQFS_OK; /* not found */
+		
+		if ((err = sqfs_inode_get(fs, inode, sqfs_dentry_inode(&entry))))
+			return err;
+	}
+	
+	*found = true;
+	return SQFS_OK;
+}

--- a/cmd/snapfuse/dir.h
+++ b/cmd/snapfuse/dir.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_DIR_H
+#define SQFS_DIR_H
+
+#include "common.h"
+
+#include "squashfs_fs.h"
+
+typedef struct {
+	sqfs_md_cursor cur;
+	sqfs_off_t offset, total;
+	struct squashfs_dir_header header;
+} sqfs_dir;
+
+typedef struct {
+	sqfs_inode_id inode;
+	sqfs_inode_num inode_number;
+	int type;
+	char *name;
+	size_t name_size;
+	sqfs_off_t offset, next_offset;
+} sqfs_dir_entry;
+
+typedef char sqfs_name[SQUASHFS_NAME_LEN + 1];
+
+/* Begin a directory traversal, initializing the dir structure.
+   If offset is non-zero, fast-forward to that offset in the directory. */
+sqfs_err 	sqfs_dir_open(sqfs *fs, sqfs_inode *inode, sqfs_dir *dir,
+	off_t offset);
+
+/* Initialize a dir_entry structure before use.
+	'namebuf' should be a character buffer of enough size to hold any name,
+	see sqfs_name. It may also be NULL, in which case no names will be placed
+	into this dir_entry. */
+void sqfs_dentry_init(sqfs_dir_entry *entry, char *namebuf);
+
+/* Get the next directory entry, filling in the dir_entry.
+	 Returns false when out of entries, or on error. */
+bool sqfs_dir_next(sqfs *fs, sqfs_dir *dir, sqfs_dir_entry *entry,
+	sqfs_err *err);
+
+/* Lookup an entry in a directory inode.
+	 The dir_entry must have been initialized with a buffer. */
+sqfs_err sqfs_dir_lookup(sqfs *fs, sqfs_inode *inode,
+	const char *name, size_t namelen, sqfs_dir_entry *entry, bool *found);
+
+/* Lookup a complete path, and replace *inode with the results.
+	 Uses / (slash) as the directory separator. */
+sqfs_err sqfs_lookup_path(sqfs *fs, sqfs_inode *inode, const char *path,
+	bool *found);
+
+
+/* Accessors on sqfs_dir_entry */
+sqfs_off_t			sqfs_dentry_offset			(sqfs_dir_entry *entry);
+sqfs_off_t			sqfs_dentry_next_offset	(sqfs_dir_entry *entry);
+int							sqfs_dentry_type				(sqfs_dir_entry *entry);
+sqfs_mode_t			sqfs_dentry_mode				(sqfs_dir_entry *entry);
+sqfs_inode_id		sqfs_dentry_inode				(sqfs_dir_entry *entry);
+sqfs_inode_num	sqfs_dentry_inode_num		(sqfs_dir_entry *entry);
+size_t					sqfs_dentry_name_size		(sqfs_dir_entry *entry);
+bool						sqfs_dentry_is_dir			(sqfs_dir_entry *entry);
+
+/* Yields the name of this directory entry, or NULL if the dir_entry structure
+   was initialized without a name buffer. Name will be nul-terminated. */
+const char *		sqfs_dentry_name				(sqfs_dir_entry *entry);
+
+#endif

--- a/cmd/snapfuse/extract.c
+++ b/cmd/snapfuse/extract.c
@@ -1,0 +1,180 @@
+#include "squashfuse.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include "squashfs_fs.h"
+#include "nonstd.h"
+
+
+#define PROGNAME "squashfuse_extract"
+
+#define ERR_MISC	(1)
+#define ERR_USAGE	(2)
+#define ERR_OPEN	(3)
+
+static void usage() {
+    fprintf(stderr, "Usage: %s ARCHIVE PATH_TO_EXTRACT\n", PROGNAME);
+    fprintf(stderr, "       %s ARCHIVE -a\n", PROGNAME);
+    exit(ERR_USAGE);
+}
+
+static void die(const char *msg) {
+    fprintf(stderr, "%s\n", msg);
+    exit(ERR_MISC);
+}
+
+bool startsWith(const char *pre, const char *str)
+{
+    size_t lenpre = strlen(pre),
+    lenstr = strlen(str);
+    return lenstr < lenpre ? false : strncmp(pre, str, lenpre) == 0;
+}
+
+/* Fill in a stat structure. Does not set st_ino */
+sqfs_err sqfs_stat(sqfs *fs, sqfs_inode *inode, struct stat *st) {
+	sqfs_err err = SQFS_OK;
+	uid_t id;
+	
+	memset(st, 0, sizeof(*st));
+	st->st_mode = inode->base.mode;
+	st->st_nlink = inode->nlink;
+	st->st_mtime = st->st_ctime = st->st_atime = inode->base.mtime;
+	
+	if (S_ISREG(st->st_mode)) {
+		/* FIXME: do symlinks, dirs, etc have a size? */
+		st->st_size = inode->xtra.reg.file_size;
+		st->st_blocks = st->st_size / 512;
+	} else if (S_ISBLK(st->st_mode) || S_ISCHR(st->st_mode)) {
+		st->st_rdev = sqfs_makedev(inode->xtra.dev.major,
+			inode->xtra.dev.minor);
+	} else if (S_ISLNK(st->st_mode)) {
+		st->st_size = inode->xtra.symlink_size;
+	}
+	
+	st->st_blksize = fs->sb.block_size; /* seriously? */
+	
+	err = sqfs_id_get(fs, inode->base.uid, &id);
+	if (err)
+		return err;
+	st->st_uid = id;
+	err = sqfs_id_get(fs, inode->base.guid, &id);
+	st->st_gid = id;
+	if (err)
+		return err;
+	
+	return SQFS_OK;
+}
+
+int main(int argc, char *argv[]) {
+    sqfs_err err = SQFS_OK;
+    sqfs_traverse trv;
+    sqfs fs;
+    char *image;
+    char *path_to_extract;
+    char *prefix;
+    char prefixed_path_to_extract[1024];
+    struct stat st;
+    
+    prefix = "squashfs-root/";
+    
+    if (access(prefix, F_OK ) == -1 ) {
+        if (mkdir(prefix, 0777) == -1) {
+            perror("mkdir error");
+            exit(EXIT_FAILURE);
+        }
+    }
+    
+    if (argc != 3)
+        usage();
+    image = argv[1];
+    path_to_extract = argv[2];
+    
+    if ((err = sqfs_open_image(&fs, image, 0)))
+        exit(ERR_OPEN);
+    
+    if ((err = sqfs_traverse_open(&trv, &fs, sqfs_inode_root(&fs))))
+        die("sqfs_traverse_open error");
+    while (sqfs_traverse_next(&trv, &err)) {
+        if (!trv.dir_end) {
+            if ((startsWith(path_to_extract, trv.path) != 0) || (strcmp("-a", path_to_extract) == 0)){
+                fprintf(stderr, "trv.path: %s\n", trv.path);
+                fprintf(stderr, "sqfs_inode_id: %lu\n", trv.entry.inode);
+                sqfs_inode inode;
+                if (sqfs_inode_get(&fs, &inode, trv.entry.inode))
+                    die("sqfs_inode_get error");
+                fprintf(stderr, "inode.base.inode_type: %i\n", inode.base.inode_type);
+                fprintf(stderr, "inode.xtra.reg.file_size: %lu\n", inode.xtra.reg.file_size);
+                strcpy(prefixed_path_to_extract, "");
+                strcat(strcat(prefixed_path_to_extract, prefix), trv.path);
+                if (inode.base.inode_type == SQUASHFS_DIR_TYPE){
+                    fprintf(stderr, "inode.xtra.dir.parent_inode: %ui\n", inode.xtra.dir.parent_inode);
+                    fprintf(stderr, "mkdir: %s/\n", prefixed_path_to_extract);
+                    if (access(prefixed_path_to_extract, F_OK ) == -1 ) {
+                        if (mkdir(prefixed_path_to_extract, 0777) == -1) {
+                            perror("mkdir error");
+                            exit(1);
+                        }
+                    }
+                } else if (inode.base.inode_type == SQUASHFS_REG_TYPE){
+                    fprintf(stderr, "Extract to: %s\n", prefixed_path_to_extract);
+                    if (sqfs_stat(&fs, &inode, &st) != 0)
+                        die("sqfs_stat error");
+                    printf("Permissions: ");
+                    printf( (S_ISDIR(st.st_mode)) ? "d" : "-");
+                    printf( (st.st_mode & S_IRUSR) ? "r" : "-");
+                    printf( (st.st_mode & S_IWUSR) ? "w" : "-");
+                    printf( (st.st_mode & S_IXUSR) ? "x" : "-");
+                    printf( (st.st_mode & S_IRGRP) ? "r" : "-");
+                    printf( (st.st_mode & S_IWGRP) ? "w" : "-");
+                    printf( (st.st_mode & S_IXGRP) ? "x" : "-");
+                    printf( (st.st_mode & S_IROTH) ? "r" : "-");
+                    printf( (st.st_mode & S_IWOTH) ? "w" : "-");
+                    printf( (st.st_mode & S_IXOTH) ? "x" : "-");
+                    printf("\n");
+        
+                    // Read the file in chunks
+                    off_t bytes_already_read = 0;
+                    sqfs_off_t bytes_at_a_time = 64*1024;
+                    FILE * f;
+                    f = fopen (prefixed_path_to_extract, "w+");
+                    if (f == NULL)
+                        die("fopen error");
+                    while (bytes_already_read < inode.xtra.reg.file_size)
+                    {
+                        char buf[bytes_at_a_time];
+                        if (sqfs_read_range(&fs, &inode, (sqfs_off_t) bytes_already_read, &bytes_at_a_time, buf))
+                            die("sqfs_read_range error");
+                        // fwrite(buf, 1, bytes_at_a_time, stdout);
+                        fwrite(buf, 1, bytes_at_a_time, f);                 
+                        bytes_already_read = bytes_already_read + bytes_at_a_time;
+                    }
+                    fclose(f);
+                    chmod (prefixed_path_to_extract, st.st_mode);
+                } else if (inode.base.inode_type == SQUASHFS_SYMLINK_TYPE){
+                    size_t size = strlen(trv.path)+1;
+                    char buf[size];
+                    int ret = sqfs_readlink(&fs, &inode, buf, &size);
+                    if (ret != 0)
+                        die("sqfs_readlink error");
+                    fprintf(stderr, "Symlink: %s to %s \n", prefixed_path_to_extract, buf);
+                    unlink(prefixed_path_to_extract);
+                    ret = symlink(buf, prefixed_path_to_extract);
+                    if (ret != 0)
+                        die("symlink error");
+                } else {
+                    fprintf(stderr, "TODO: Implement inode.base.inode_type %i\n", inode.base.inode_type);
+                }
+                fprintf(stderr, "\n");
+            }
+        }
+    }
+    if (err)
+        die("sqfs_traverse_next error");
+    sqfs_traverse_close(&trv);
+    sqfs_fd_close(fs.fd);
+    return 0;
+}

--- a/cmd/snapfuse/file.c
+++ b/cmd/snapfuse/file.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "file.h"
+
+#include "fs.h"
+#include "swap.h"
+#include "table.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+sqfs_err sqfs_frag_entry(sqfs *fs, struct squashfs_fragment_entry *frag,
+		uint32_t idx) {
+	sqfs_err err = SQFS_OK;
+	
+	if (idx == SQUASHFS_INVALID_FRAG)
+		return SQFS_ERR;
+	
+	err = sqfs_table_get(&fs->frag_table, fs, idx, frag);
+	sqfs_swapin_fragment_entry(frag);
+	return err;
+}
+
+sqfs_err sqfs_frag_block(sqfs *fs, sqfs_inode *inode,
+		size_t *offset, size_t *size, sqfs_block **block) {
+	struct squashfs_fragment_entry frag;
+	sqfs_err err = SQFS_OK;
+	
+	if (!S_ISREG(inode->base.mode))
+		return SQFS_ERR;
+	
+	err = sqfs_frag_entry(fs, &frag, inode->xtra.reg.frag_idx);
+	if (err)
+		return err;
+	
+	err = sqfs_data_cache(fs, &fs->frag_cache, frag.start_block,
+		frag.size, block);
+	if (err)
+		return SQFS_ERR;
+	
+	*offset = inode->xtra.reg.frag_off;
+	*size = inode->xtra.reg.file_size % fs->sb.block_size;
+	return SQFS_OK;
+}
+
+size_t sqfs_blocklist_count(sqfs *fs, sqfs_inode *inode) {
+	uint64_t size = inode->xtra.reg.file_size;
+	size_t block = fs->sb.block_size;
+	if (inode->xtra.reg.frag_idx == SQUASHFS_INVALID_FRAG) {
+		return sqfs_divceil(size, block);
+	} else {
+		return (size_t)(size / block);
+	}
+}
+
+void sqfs_blocklist_init(sqfs *fs, sqfs_inode *inode, sqfs_blocklist *bl) {
+	bl->fs = fs;
+	bl->remain = sqfs_blocklist_count(fs, inode);
+	bl->cur = inode->next;
+	bl->started = false;
+	bl->pos = 0;
+	bl->block = inode->xtra.reg.start_block;
+	bl->input_size = 0;
+}
+
+sqfs_err sqfs_blocklist_next(sqfs_blocklist *bl) {
+	sqfs_err err = SQFS_OK;
+	bool compressed;
+	
+	if (bl->remain == 0)
+		return SQFS_ERR;
+	--(bl->remain);
+	
+	err = sqfs_md_read(bl->fs, &bl->cur, &bl->header,
+		sizeof(bl->header));
+	if (err)
+		return err;
+	sqfs_swapin32(&bl->header);
+	
+	bl->block += bl->input_size;
+	sqfs_data_header(bl->header, &compressed, &bl->input_size);
+	
+	if (bl->started)
+		bl->pos += bl->fs->sb.block_size;
+	bl->started = true;
+	
+	return SQFS_OK;
+}
+
+sqfs_err sqfs_read_range(sqfs *fs, sqfs_inode *inode, sqfs_off_t start,
+		sqfs_off_t *size, void *buf) {
+	sqfs_err err = SQFS_OK;
+	
+	sqfs_off_t file_size;
+	size_t block_size;
+	sqfs_blocklist bl;
+	
+	size_t read_off;
+	char *buf_orig;
+	
+	if (!S_ISREG(inode->base.mode))
+		return SQFS_ERR;
+	
+	file_size = inode->xtra.reg.file_size;
+	block_size = fs->sb.block_size;
+	
+	if (*size < 0 || start > file_size)
+		return SQFS_ERR;
+	if (start == file_size) {
+		*size = 0;
+		return SQFS_OK;
+	}
+	
+	err = sqfs_blockidx_blocklist(fs, inode, &bl, start);
+	if (err)
+		return err;
+	
+	read_off = start % block_size;
+	buf_orig = buf;
+	while (*size > 0) {
+		sqfs_block *block = NULL;
+		size_t data_off, data_size;
+		size_t take;
+		
+		bool fragment = (bl.remain == 0);
+		if (fragment) { /* fragment */
+			if (inode->xtra.reg.frag_idx == SQUASHFS_INVALID_FRAG)
+				break;
+			err = sqfs_frag_block(fs, inode, &data_off, &data_size, &block);
+			if (err)
+				return err;
+		} else {			
+			if ((err = sqfs_blocklist_next(&bl)))
+				return err;
+			if (bl.pos + block_size <= start)
+				continue;
+			
+			data_off = 0;
+			if (bl.input_size == 0) { /* Hole! */
+				data_size = (size_t)(file_size - bl.pos);
+				if (data_size > block_size)
+					data_size = block_size;
+			} else {
+				err = sqfs_data_cache(fs, &fs->data_cache, bl.block,
+					bl.header, &block);
+				if (err)
+					return err;
+				data_size = block->size;
+			}
+		}
+		
+		take = data_size - read_off;
+		if (take > *size)
+			take = (size_t)(*size);
+		if (block) {
+			memcpy(buf, (char*)block->data + data_off + read_off, take);
+			/* BLOCK CACHED, DON'T DISPOSE */
+		} else {
+			memset(buf, 0, take);
+		}
+		read_off = 0;
+		*size -= take;
+		buf = (char*)buf + take;
+		
+		if (fragment)
+			break;
+	}
+	
+	*size = (char*)buf - buf_orig;
+	return *size ? SQFS_OK : SQFS_ERR;
+}
+
+
+/*
+To read block N of a M-block file, we have to read N blocksizes from the,
+metadata. This is a lot of work for large files! So for those files, we use
+an index to speed it up.
+
+The M blocksizes are split between M / SQUASHFS_METADATA_SIZE MD-blocks.
+For each of these blocks, we maintain in the index the location of the
+MD-block, and the location of the data block corresponding to the start
+of that MD-block.
+
+Then to read block N, we just calculate which metadata block index
+("metablock") we want, and get that block-index entry. Then we
+only need to read that one MD-block to seek within the file.
+*/
+
+/* Is a file worth indexing? */
+static bool sqfs_blockidx_indexable(sqfs *fs, sqfs_inode *inode) {
+	size_t blocks = sqfs_blocklist_count(fs, inode);
+	size_t md_size = blocks * sizeof(sqfs_blocklist_entry);
+	return md_size >= SQUASHFS_METADATA_SIZE;
+}
+
+static void sqfs_blockidx_dispose(void *data) {
+	free(*(sqfs_blockidx_entry**)data);
+}
+
+sqfs_err sqfs_blockidx_init(sqfs_cache *cache) {
+	return sqfs_cache_init(cache, sizeof(sqfs_blockidx_entry**),
+		SQUASHFS_META_SLOTS, &sqfs_blockidx_dispose);
+}
+
+sqfs_err sqfs_blockidx_add(sqfs *fs, sqfs_inode *inode,
+		sqfs_blockidx_entry **out) {
+	size_t blocks;	/* Number of blocks in the file */
+	size_t md_size; /* Amount of metadata necessary to hold the blocksizes */
+	size_t count; 	/* Number of block-index entries necessary */
+	
+	sqfs_blockidx_entry *blockidx;
+	sqfs_blocklist bl;
+	
+	/* For the cache */
+	sqfs_cache_idx idx;
+	sqfs_blockidx_entry **cachep;
+
+	size_t i = 0;
+	bool first = true;
+	
+	*out = NULL;
+	
+	blocks = sqfs_blocklist_count(fs, inode);
+	md_size = blocks * sizeof(sqfs_blocklist_entry);
+	count = (inode->next.offset + md_size - 1)
+		/ SQUASHFS_METADATA_SIZE;
+	blockidx = malloc(count * sizeof(sqfs_blockidx_entry));
+	if (!blockidx)
+		return SQFS_ERR;
+	
+	sqfs_blocklist_init(fs, inode, &bl);
+	while (bl.remain && i < count) {
+		sqfs_err err = SQFS_OK;
+		/* If the MD cursor offset is small, we found a new MD-block.
+		 * Skip the first MD-block, because we already know where it is:
+		 * inode->next.offset */
+		if (bl.cur.offset < sizeof(sqfs_blocklist_entry) && !first) {
+			blockidx[i].data_block = bl.block + bl.input_size;
+			blockidx[i++].md_block = (uint32_t)(bl.cur.block - fs->sb.inode_table_start);
+		}
+		first = false;
+		
+		err = sqfs_blocklist_next(&bl);
+		if (err) {
+			free(blockidx);
+			return SQFS_ERR;
+		}
+	}
+
+	idx = inode->base.inode_number + 1; /* zero means invalid */
+	cachep = sqfs_cache_add(&fs->blockidx, idx);
+	*out = *cachep = blockidx;
+	return SQFS_OK;
+}
+
+sqfs_err sqfs_blockidx_blocklist(sqfs *fs, sqfs_inode *inode,
+		sqfs_blocklist *bl, sqfs_off_t start) {
+	size_t block, metablock, skipped;
+	sqfs_blockidx_entry *blockidx, **bp;
+	sqfs_cache_idx idx;
+	
+	sqfs_blocklist_init(fs, inode, bl);
+	block = (size_t)(start / fs->sb.block_size);
+	if (block > bl->remain) { /* fragment */
+		bl->remain = 0;
+		return SQFS_OK;
+	}
+	
+	/* How many MD-blocks do we want to skip? */
+	metablock = (bl->cur.offset + block * sizeof(sqfs_blocklist_entry))
+		/ SQUASHFS_METADATA_SIZE;
+	if (metablock == 0)
+		return SQFS_OK; /* no skip needed, don't want an index */
+	if (!sqfs_blockidx_indexable(fs, inode))
+		return SQFS_OK; /* too small to index */
+	
+	/* Get the index, creating it if necessary */
+	idx = inode->base.inode_number + 1; /* zero means invalid index */
+	if ((bp = sqfs_cache_get(&fs->blockidx, idx))) {
+		blockidx = *bp;
+	} else {
+		sqfs_err err = sqfs_blockidx_add(fs, inode, &blockidx);
+		if (err)
+			return err;
+	}
+	
+	skipped = (metablock * SQUASHFS_METADATA_SIZE / sizeof(sqfs_blocklist_entry))
+		- (bl->cur.offset / sizeof(sqfs_blocklist_entry));
+	
+	blockidx += metablock - 1;
+	bl->cur.block = blockidx->md_block + fs->sb.inode_table_start;
+	bl->cur.offset %= sizeof(sqfs_blocklist_entry);
+	bl->remain -= skipped;
+	bl->pos = (uint64_t)skipped * fs->sb.block_size;
+	bl->block = blockidx->data_block;
+	return SQFS_OK;
+}
+

--- a/cmd/snapfuse/file.h
+++ b/cmd/snapfuse/file.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_FILE_H
+#define SQFS_FILE_H
+
+#include "common.h"
+
+#include "squashfs_fs.h"
+
+#include "cache.h"
+
+sqfs_err sqfs_frag_entry(sqfs *fs, struct squashfs_fragment_entry *frag,
+	uint32_t idx);
+
+sqfs_err sqfs_frag_block(sqfs *fs, sqfs_inode *inode,
+	size_t *offset, size_t *size, sqfs_block **block);
+
+typedef uint32_t sqfs_blocklist_entry;
+typedef struct {
+	sqfs *fs;
+	size_t remain;			/* How many blocks left in the file? */
+	sqfs_md_cursor cur;	/* Points to next blocksize in MD */
+	bool started;
+
+	uint64_t pos;
+	
+	uint64_t block;			/* Points to next data block location */
+	sqfs_blocklist_entry header; /* Packed blocksize data */
+	uint32_t input_size;				 /* Extracted size of this block */
+} sqfs_blocklist;
+
+size_t sqfs_blocklist_count(sqfs *fs, sqfs_inode *inode);
+
+void sqfs_blocklist_init(sqfs *fs, sqfs_inode *inode, sqfs_blocklist *bl);
+sqfs_err sqfs_blocklist_next(sqfs_blocklist *bl);
+
+
+sqfs_err sqfs_read_range(sqfs *fs, sqfs_inode *inode, sqfs_off_t start,
+	sqfs_off_t *size, void *buf);
+
+
+/*** Block index for skipping to the middle of large files ***/
+
+typedef struct {
+	uint64_t data_block;	/* A data block where the file continues */
+	uint32_t md_block;		/* A metadata block with blocksizes that continue from
+													 data_block */
+} sqfs_blockidx_entry;
+
+sqfs_err sqfs_blockidx_init(sqfs_cache *cache);
+
+/* Fill *out with all the block-index entries for this file */
+sqfs_err sqfs_blockidx_add(sqfs *fs, sqfs_inode *inode,
+	sqfs_blockidx_entry **out);
+
+/* Get a blocklist fast-forwarded to the correct location */
+sqfs_err sqfs_blockidx_blocklist(sqfs *fs, sqfs_inode *inode,
+	sqfs_blocklist *bl, sqfs_off_t start);
+
+#endif

--- a/cmd/snapfuse/fs.c
+++ b/cmd/snapfuse/fs.c
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "fs.h"
+
+#include "file.h"
+#include "nonstd.h"
+#include "swap.h"
+#include "xattr.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+
+#define DATA_CACHED_BLKS 1
+#define FRAG_CACHED_BLKS 3
+
+void sqfs_version_supported(int *min_major, int *min_minor, int *max_major,
+		int *max_minor) {
+	*min_major = *max_major = SQUASHFS_MAJOR;
+	*min_minor = 0;
+	*max_minor = SQUASHFS_MINOR;
+}
+
+void sqfs_version(sqfs *fs, int *major, int *minor) {
+	*major = fs->sb.s_major;
+	*minor = fs->sb.s_minor;
+}
+
+sqfs_compression_type sqfs_compression(sqfs *fs) {
+	return fs->sb.compression;
+}
+
+sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset) {
+	sqfs_err err = SQFS_OK;
+	memset(fs, 0, sizeof(*fs));
+	
+	fs->fd = fd;
+	fs->offset = offset;
+	if (sqfs_pread(fd, &fs->sb, sizeof(fs->sb), fs->offset) != sizeof(fs->sb))
+		return SQFS_BADFORMAT;
+	sqfs_swapin_super_block(&fs->sb);
+	
+	if (fs->sb.s_magic != SQUASHFS_MAGIC) {
+		if (fs->sb.s_magic != SQFS_MAGIC_SWAP)
+			return SQFS_BADFORMAT;
+		sqfs_swap16(&fs->sb.s_major);
+		sqfs_swap16(&fs->sb.s_minor);
+	}
+	if (fs->sb.s_major != SQUASHFS_MAJOR || fs->sb.s_minor > SQUASHFS_MINOR)
+		return SQFS_BADVERSION;
+	
+	if (!(fs->decompressor = sqfs_decompressor_get(fs->sb.compression)))
+		return SQFS_BADCOMP;
+	
+	err = sqfs_table_init(&fs->id_table, fd, fs->sb.id_table_start + fs->offset,
+		sizeof(uint32_t), fs->sb.no_ids);
+	err |= sqfs_table_init(&fs->frag_table, fd, fs->sb.fragment_table_start + fs->offset,
+		sizeof(struct squashfs_fragment_entry), fs->sb.fragments);
+	if (sqfs_export_ok(fs)) {
+		err |= sqfs_table_init(&fs->export_table, fd, fs->sb.lookup_table_start + fs->offset,
+			sizeof(uint64_t), fs->sb.inodes);
+	}
+	err |= sqfs_xattr_init(fs);
+	err |= sqfs_block_cache_init(&fs->md_cache, SQUASHFS_CACHED_BLKS);
+	err |= sqfs_block_cache_init(&fs->data_cache, DATA_CACHED_BLKS);
+	err |= sqfs_block_cache_init(&fs->frag_cache, FRAG_CACHED_BLKS);
+	err |= sqfs_blockidx_init(&fs->blockidx);
+	if (err) {
+		sqfs_destroy(fs);
+		return SQFS_ERR;
+	}
+	
+	return SQFS_OK;
+}
+
+void sqfs_destroy(sqfs *fs) {
+	sqfs_table_destroy(&fs->id_table);
+	sqfs_table_destroy(&fs->frag_table);
+	if (sqfs_export_ok(fs))
+		sqfs_table_destroy(&fs->export_table);
+	sqfs_cache_destroy(&fs->md_cache);
+	sqfs_cache_destroy(&fs->data_cache);
+	sqfs_cache_destroy(&fs->frag_cache);
+	sqfs_cache_destroy(&fs->blockidx);
+}
+
+void sqfs_md_header(uint16_t hdr, bool *compressed, uint16_t *size) {
+	*compressed = !(hdr & SQUASHFS_COMPRESSED_BIT);
+	*size = hdr & ~SQUASHFS_COMPRESSED_BIT;
+	if (!*size)
+		*size = SQUASHFS_COMPRESSED_BIT;
+}
+
+void sqfs_data_header(uint32_t hdr, bool *compressed, uint32_t *size) {
+	*compressed = !(hdr & SQUASHFS_COMPRESSED_BIT_BLOCK);
+	*size = hdr & ~SQUASHFS_COMPRESSED_BIT_BLOCK;
+}
+
+sqfs_err sqfs_block_read(sqfs *fs, sqfs_off_t pos, bool compressed,
+		uint32_t size, size_t outsize, sqfs_block **block) {
+	sqfs_err err = SQFS_ERR;
+	if (!(*block = malloc(sizeof(**block))))
+		return SQFS_ERR;
+	if (!((*block)->data = malloc(size)))
+		goto error;
+	
+	if (sqfs_pread(fs->fd, (*block)->data, size, pos + fs->offset) != size)
+		goto error;
+
+	if (compressed) {
+		char *decomp = malloc(outsize);
+		if (!decomp)
+			goto error;
+		
+		err = fs->decompressor((*block)->data, size, decomp, &outsize);
+		if (err) {
+			free(decomp);
+			goto error;
+		}
+		free((*block)->data);
+		(*block)->data = decomp;
+		(*block)->size = outsize;
+	} else {
+		(*block)->size = size;
+	}
+
+	return SQFS_OK;
+
+error:
+	sqfs_block_dispose(*block);
+	*block = NULL;
+	return err;
+}
+
+sqfs_err sqfs_md_block_read(sqfs *fs, sqfs_off_t pos, size_t *data_size,
+		sqfs_block **block) {
+	sqfs_err err = SQFS_OK;
+	uint16_t hdr;
+	bool compressed;
+	uint16_t size;
+	
+	*data_size = 0;
+	
+	if (sqfs_pread(fs->fd, &hdr, sizeof(hdr), pos + fs->offset) != sizeof(hdr))
+		return SQFS_ERR;
+	pos += sizeof(hdr);
+	*data_size += sizeof(hdr);
+	sqfs_swapin16(&hdr);
+	
+	sqfs_md_header(hdr, &compressed, &size);
+	
+	err = sqfs_block_read(fs, pos, compressed, size,
+		SQUASHFS_METADATA_SIZE, block);
+	*data_size += size;
+	return err;
+}
+
+sqfs_err sqfs_data_block_read(sqfs *fs, sqfs_off_t pos, uint32_t hdr,
+		sqfs_block **block) {
+	bool compressed;
+	uint32_t size;
+	sqfs_data_header(hdr, &compressed, &size);
+	return sqfs_block_read(fs, pos, compressed, size,
+		fs->sb.block_size, block);
+}
+
+sqfs_err sqfs_md_cache(sqfs *fs, sqfs_off_t *pos, sqfs_block **block) {
+	sqfs_block_cache_entry *entry = sqfs_cache_get(
+		&fs->md_cache, *pos);
+	if (!entry) {
+		sqfs_err err = SQFS_OK;
+		entry = sqfs_cache_add(&fs->md_cache, *pos);
+		/* fprintf(stderr, "MD BLOCK: %12llx\n", (long long)*pos); */
+		err = sqfs_md_block_read(fs, *pos,
+			&entry->data_size, &entry->block);
+		if (err)
+			return err;
+	}
+	*block = entry->block;
+	*pos += entry->data_size;
+	return SQFS_OK;
+}
+
+sqfs_err sqfs_data_cache(sqfs *fs, sqfs_cache *cache, sqfs_off_t pos,
+		uint32_t hdr, sqfs_block **block) {
+	sqfs_block_cache_entry *entry = sqfs_cache_get(cache, pos);
+	if (!entry) {
+		sqfs_err err = SQFS_OK;
+		entry = sqfs_cache_add(cache, pos);
+		err = sqfs_data_block_read(fs, pos, hdr,
+			&entry->block);
+		if (err)
+			return err;
+	}
+	*block = entry->block;
+	return SQFS_OK;
+}
+
+void sqfs_block_dispose(sqfs_block *block) {
+	free(block->data);
+	free(block);
+}
+
+void sqfs_md_cursor_inode(sqfs_md_cursor *cur, sqfs_inode_id id, sqfs_off_t base) {
+	cur->block = (id >> 16) + base;
+	cur->offset = id & 0xffff;
+}
+
+sqfs_err sqfs_md_read(sqfs *fs, sqfs_md_cursor *cur, void *buf, size_t size) {
+	sqfs_off_t pos = cur->block;
+	while (size > 0) {
+		sqfs_block *block;
+		size_t take;
+		sqfs_err err = sqfs_md_cache(fs, &pos, &block);
+		if (err)
+			return err;
+		
+		take = block->size - cur->offset;
+		if (take > size)
+			take = size;		
+		if (buf)
+			memcpy(buf, (char*)block->data + cur->offset, take);
+		/* BLOCK CACHED, DON'T DISPOSE */
+		
+		if (buf)
+			buf = (char*)buf + take;
+		size -= take;
+		cur->offset += take;
+		if (cur->offset == block->size) {
+			cur->block = pos;
+			cur->offset = 0;
+		}
+	}
+	return SQFS_OK;
+}
+
+size_t sqfs_divceil(uint64_t total, size_t group) {
+	size_t q = (size_t)(total / group);
+	if (total % group)
+		q += 1;
+	return q;
+}
+
+sqfs_err sqfs_id_get(sqfs *fs, uint16_t idx, sqfs_id_t *id) {
+	uint32_t rid;
+	sqfs_err err = sqfs_table_get(&fs->id_table, fs, idx, &rid);
+	if (err)
+		return err;
+	sqfs_swapin32(&rid);
+	*id = (sqfs_id_t)rid;
+	return SQFS_OK;
+}
+
+sqfs_err sqfs_readlink(sqfs *fs, sqfs_inode *inode, char *buf, size_t *size) {
+	size_t want;
+	sqfs_md_cursor cur;
+	sqfs_err err = SQFS_OK;
+	if (!S_ISLNK(inode->base.mode))
+		return SQFS_ERR;
+
+	want = inode->xtra.symlink_size;
+	if (!buf) {
+		*size = want + 1;
+		return SQFS_OK;
+	}
+
+	if (want > *size - 1)
+		want = *size - 1;
+	cur = inode->next;
+	err = sqfs_md_read(fs, &cur, buf, want);
+	buf[want] = '\0';
+	return err;
+}
+
+int sqfs_export_ok(sqfs *fs) {
+	return fs->sb.lookup_table_start != SQUASHFS_INVALID_BLK;
+}
+
+sqfs_err sqfs_export_inode(sqfs *fs, sqfs_inode_num n, sqfs_inode_id *i) {
+	uint64_t r;
+	sqfs_err err = SQFS_OK;
+	
+	if (!sqfs_export_ok(fs))
+		return SQFS_UNSUP;
+	
+	err = sqfs_table_get(&fs->export_table, fs, n - 1, &r);
+	if (err)
+		return err;
+	sqfs_swapin64(&r);
+	*i = r;
+	return SQFS_OK;
+}
+
+sqfs_inode_id sqfs_inode_root(sqfs *fs) {
+	return fs->sb.root_inode;
+}
+
+/* Turn the internal format of a device number to our system's dev_t
+ * It looks like rdev is just what the Linux kernel uses: 20 bit minor,
+ * split in two around a 12 bit major
+ */
+static void sqfs_decode_dev(sqfs_inode *i, uint32_t rdev) {
+	i->xtra.dev.major = (rdev >> 8) & 0xfff;
+	i->xtra.dev.minor = (rdev & 0xff) | ((rdev >> 12) & 0xfff00);
+}
+
+#define INODE_TYPE(_type) \
+	struct squashfs_##_type##_inode x; \
+	err = sqfs_md_read(fs, &inode->next, &x, sizeof(x)); \
+	if (err) return err; \
+	sqfs_swapin_##_type##_inode(&x)
+
+sqfs_err sqfs_inode_get(sqfs *fs, sqfs_inode *inode, sqfs_inode_id id) {
+	sqfs_md_cursor cur;
+	sqfs_err err = SQFS_OK;
+	
+	memset(inode, 0, sizeof(*inode));
+	inode->xattr = SQUASHFS_INVALID_XATTR;
+	
+	sqfs_md_cursor_inode(&cur, id, fs->sb.inode_table_start);
+	inode->next = cur;
+	
+	err = sqfs_md_read(fs, &cur, &inode->base, sizeof(inode->base));
+	if (err)
+		return err;
+	sqfs_swapin_base_inode(&inode->base);
+	
+	inode->base.mode |= sqfs_mode(inode->base.inode_type);
+	switch (inode->base.inode_type) {
+		case SQUASHFS_REG_TYPE: {
+			INODE_TYPE(reg);
+			inode->nlink = 1;
+			inode->xtra.reg.start_block = x.start_block;
+			inode->xtra.reg.file_size = x.file_size;
+			inode->xtra.reg.frag_idx = x.fragment;
+			inode->xtra.reg.frag_off = x.offset;
+			break;
+		}
+		case SQUASHFS_LREG_TYPE: {
+			INODE_TYPE(lreg);
+			inode->nlink = x.nlink;
+			inode->xtra.reg.start_block = x.start_block;
+			inode->xtra.reg.file_size = x.file_size;
+			inode->xtra.reg.frag_idx = x.fragment;
+			inode->xtra.reg.frag_off = x.offset;
+			inode->xattr = x.xattr;
+			break;
+		}
+		case SQUASHFS_DIR_TYPE: {
+			INODE_TYPE(dir);
+			inode->nlink = x.nlink;
+			inode->xtra.dir.start_block = x.start_block;
+			inode->xtra.dir.offset = x.offset;
+			inode->xtra.dir.dir_size = x.file_size;
+			inode->xtra.dir.idx_count = 0;
+			inode->xtra.dir.parent_inode = x.parent_inode;
+			break;
+		}
+		case SQUASHFS_LDIR_TYPE: {
+			INODE_TYPE(ldir);
+			inode->nlink = x.nlink;
+			inode->xtra.dir.start_block = x.start_block;
+			inode->xtra.dir.offset = x.offset;
+			inode->xtra.dir.dir_size = x.file_size;
+			inode->xtra.dir.idx_count = x.i_count;
+			inode->xtra.dir.parent_inode = x.parent_inode;
+			inode->xattr = x.xattr;
+			break;
+		}
+		case SQUASHFS_SYMLINK_TYPE:
+		case SQUASHFS_LSYMLINK_TYPE: {
+			INODE_TYPE(symlink);
+			inode->nlink = x.nlink;
+			inode->xtra.symlink_size = x.symlink_size;
+			
+			if (inode->base.inode_type == SQUASHFS_LSYMLINK_TYPE) {
+				/* skip symlink target */
+				cur = inode->next;
+				err = sqfs_md_read(fs, &cur, NULL, inode->xtra.symlink_size);
+				if (err)
+					return err;
+				err = sqfs_md_read(fs, &cur, &inode->xattr, sizeof(inode->xattr));
+				if (err)
+					return err;
+				sqfs_swapin32(&inode->xattr);
+			}
+			break;
+		}
+		case SQUASHFS_BLKDEV_TYPE:
+		case SQUASHFS_CHRDEV_TYPE: {
+			INODE_TYPE(dev);
+			inode->nlink = x.nlink;
+			sqfs_decode_dev(inode, x.rdev);
+			break;
+		}
+		case SQUASHFS_LBLKDEV_TYPE:
+		case SQUASHFS_LCHRDEV_TYPE: {
+			INODE_TYPE(ldev);
+			inode->nlink = x.nlink;
+			sqfs_decode_dev(inode, x.rdev);
+			inode->xattr = x.xattr;
+			break;
+		}
+		case SQUASHFS_SOCKET_TYPE:
+		case SQUASHFS_FIFO_TYPE: {
+			INODE_TYPE(ipc);
+			inode->nlink = x.nlink;
+			break;
+		}
+		case SQUASHFS_LSOCKET_TYPE:
+		case SQUASHFS_LFIFO_TYPE: {
+			INODE_TYPE(lipc);
+			inode->nlink = x.nlink;
+			inode->xattr = x.xattr;
+			break;
+		}
+		
+		default: return SQFS_ERR;
+	}
+	
+	return SQFS_OK;
+}
+#undef INODE_TYPE

--- a/cmd/snapfuse/fs.h
+++ b/cmd/snapfuse/fs.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_FS_H
+#define SQFS_FS_H
+
+#include "common.h"
+
+#include "squashfs_fs.h"
+
+#include "cache.h"
+#include "decompress.h"
+#include "table.h"
+
+struct sqfs {
+	sqfs_fd_t fd;
+	size_t offset;
+	struct squashfs_super_block sb;
+	sqfs_table id_table;
+	sqfs_table frag_table;
+	sqfs_table export_table;
+	sqfs_cache md_cache;
+	sqfs_cache data_cache;
+	sqfs_cache frag_cache;
+	sqfs_cache blockidx;
+	sqfs_decompressor decompressor;
+	
+	struct squashfs_xattr_id_table xattr_info;
+	sqfs_table xattr_table;
+};
+
+typedef uint32_t sqfs_xattr_idx;
+struct sqfs_inode {
+	struct squashfs_base_inode base;
+	int nlink;
+	sqfs_xattr_idx xattr;
+	
+	sqfs_md_cursor next;
+	
+	union {
+		struct {
+			int major, minor;
+		} dev;
+		size_t symlink_size;
+		struct {
+			uint64_t start_block;
+			uint64_t file_size;
+			uint32_t frag_idx;
+			uint32_t frag_off;
+		} reg;
+		struct {
+			uint32_t start_block;
+			uint16_t offset;
+			uint32_t dir_size;
+			uint16_t idx_count;
+			uint32_t parent_inode;
+		} dir;
+	} xtra;
+};
+
+void sqfs_version_supported(int *min_major, int *min_minor, int *max_major,
+	int *max_minor);
+
+/* Number of groups of size 'group' required to hold size 'total' */
+size_t sqfs_divceil(uint64_t total, size_t group);
+
+
+sqfs_err sqfs_init(sqfs *fs, sqfs_fd_t fd, size_t offset);
+void sqfs_destroy(sqfs *fs);
+
+/* Ok to call these even on incompletely constructed filesystems */
+void sqfs_version(sqfs *fs, int *major, int *minor);
+sqfs_compression_type sqfs_compression(sqfs *fs);
+
+
+void sqfs_md_header(uint16_t hdr, bool *compressed, uint16_t *size);
+void sqfs_data_header(uint32_t hdr, bool *compressed, uint32_t *size);
+
+sqfs_err sqfs_block_read(sqfs *fs, sqfs_off_t pos, bool compressed, uint32_t size,
+	size_t outsize, sqfs_block **block);
+void sqfs_block_dispose(sqfs_block *block);
+
+sqfs_err sqfs_md_block_read(sqfs *fs, sqfs_off_t pos, size_t *data_size,
+	sqfs_block **block);
+sqfs_err sqfs_data_block_read(sqfs *fs, sqfs_off_t pos, uint32_t hdr,
+	sqfs_block **block);
+
+/* Don't dispose after getting block, it's in the cache */
+sqfs_err sqfs_md_cache(sqfs *fs, sqfs_off_t *pos, sqfs_block **block);
+sqfs_err sqfs_data_cache(sqfs *fs, sqfs_cache *cache, sqfs_off_t pos,
+	uint32_t hdr, sqfs_block **block);
+
+void sqfs_md_cursor_inode(sqfs_md_cursor *cur, sqfs_inode_id id, sqfs_off_t base);
+
+sqfs_err sqfs_md_read(sqfs *fs, sqfs_md_cursor *cur, void *buf, size_t size);
+
+
+sqfs_err sqfs_inode_get(sqfs *fs, sqfs_inode *inode, sqfs_inode_id id);
+
+sqfs_mode_t sqfs_mode(int inode_type);
+sqfs_err sqfs_id_get(sqfs *fs, uint16_t idx, sqfs_id_t *id);
+
+/* Puts up to *size characters of the link name into buf. Always null-
+ * terminates the buffer. Pass null as buf to have the size returned. */
+sqfs_err sqfs_readlink(sqfs *fs, sqfs_inode *inode, char *buf, size_t *size);
+
+/* Find inode_id by inode_num */
+int sqfs_export_ok(sqfs *fs);
+sqfs_err sqfs_export_inode(sqfs *fs, sqfs_inode_num n, sqfs_inode_id *i);
+
+/* Find the root inode */
+sqfs_inode_id sqfs_inode_root(sqfs *fs);
+
+#endif

--- a/cmd/snapfuse/fuseprivate.c
+++ b/cmd/snapfuse/fuseprivate.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "fuseprivate.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nonstd.h"
+
+sqfs_err sqfs_stat(sqfs *fs, sqfs_inode *inode, struct stat *st) {
+	sqfs_err err = SQFS_OK;
+	uid_t id;
+	
+	memset(st, 0, sizeof(*st));
+	st->st_mode = inode->base.mode;
+	st->st_nlink = inode->nlink;
+	st->st_mtime = st->st_ctime = st->st_atime = inode->base.mtime;
+	
+	if (S_ISREG(st->st_mode)) {
+		/* FIXME: do symlinks, dirs, etc have a size? */
+		st->st_size = inode->xtra.reg.file_size;
+		st->st_blocks = st->st_size / 512;
+	} else if (S_ISBLK(st->st_mode) || S_ISCHR(st->st_mode)) {
+		st->st_rdev = sqfs_makedev(inode->xtra.dev.major,
+			inode->xtra.dev.minor);
+	} else if (S_ISLNK(st->st_mode)) {
+		st->st_size = inode->xtra.symlink_size;
+	}
+	
+	st->st_blksize = fs->sb.block_size; /* seriously? */
+	
+	err = sqfs_id_get(fs, inode->base.uid, &id);
+	if (err)
+		return err;
+	st->st_uid = id;
+	err = sqfs_id_get(fs, inode->base.guid, &id);
+	st->st_gid = id;
+	if (err)
+		return err;
+	
+	return SQFS_OK;
+}
+
+int sqfs_listxattr(sqfs *fs, sqfs_inode *inode, char *buf, size_t *size) {
+	sqfs_xattr x;
+	size_t count = 0;
+	
+	if (sqfs_xattr_open(fs, inode, &x))
+		return -EIO;
+	
+	while (x.remain) {
+		size_t n;
+		if (sqfs_xattr_read(&x))
+			 return EIO;
+		n = sqfs_xattr_name_size(&x);
+		count += n + 1;
+		
+		if (buf) {
+			if (count > *size)
+				return ERANGE;
+			if (sqfs_xattr_name(&x, buf, true))
+				return EIO;
+			buf += n;
+			*buf++ = '\0';
+		}
+	}
+	*size = count;
+	return 0;
+}
+
+void sqfs_usage(char *progname, bool fuse_usage) {
+	fprintf(stderr, "%s (c) 2012 Dave Vasilevsky\n\n", PACKAGE_STRING);
+	fprintf(stderr, "Usage: %s [options] ARCHIVE MOUNTPOINT\n",
+		progname ? progname : PACKAGE_NAME);
+	if (fuse_usage) {
+		struct fuse_args args = FUSE_ARGS_INIT(0, NULL);
+		fuse_opt_add_arg(&args, ""); /* progname */
+		fuse_opt_add_arg(&args, "-ho");
+		fprintf(stderr, "\n");
+		fuse_parse_cmdline(&args, NULL, NULL, NULL);
+	}
+	exit(-2);
+}
+
+int sqfs_opt_proc(void *data, const char *arg, int key,
+		struct fuse_args *outargs) {
+	sqfs_opts *opts = (sqfs_opts*)data;
+	if (key == FUSE_OPT_KEY_NONOPT) {
+		if (opts->mountpoint) {
+			return -1; /* Too many args */
+		} else if (opts->image) {
+			opts->mountpoint = 1;
+			return 1;
+		} else {
+			opts->image = arg;
+			return 0;
+		}
+	} else if (key == FUSE_OPT_KEY_OPT) {
+		if (strncmp(arg, "-h", 2) == 0 || strncmp(arg, "--h", 3) == 0)
+			sqfs_usage(opts->progname, true);
+	}
+	return 1; /* Keep */
+}

--- a/cmd/snapfuse/fuseprivate.h
+++ b/cmd/snapfuse/fuseprivate.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_FUSEPRIVATE_H
+#define SQFS_FUSEPRIVATE_H
+
+#include "squashfuse.h"
+
+#include <fuse.h>
+
+#include <sys/stat.h>
+
+/* Common functions for FUSE high- and low-level clients */
+
+/* Fill in a stat structure. Does not set st_ino */
+sqfs_err sqfs_stat(sqfs *fs, sqfs_inode *inode, struct stat *st);
+
+/* Populate an xattr list. Return an errno value. */
+int sqfs_listxattr(sqfs *fs, sqfs_inode *inode, char *buf, size_t *size);
+
+/* Print a usage string */
+void sqfs_usage(char *progname, bool fuse_usage);
+
+/* Parse command-line arguments */
+typedef struct {
+	char *progname;
+	const char *image;
+	int mountpoint;
+	size_t offset;
+} sqfs_opts;
+int sqfs_opt_proc(void *data, const char *arg, int key,
+	struct fuse_args *outargs);
+
+#endif

--- a/cmd/snapfuse/gen_swap.sh
+++ b/cmd/snapfuse/gen_swap.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+${SED:-sed} -n '
+/^struct squashfs_/,/^}/{
+	s/^struct \(squashfs_\([^[:space:]]*\)\).*/void sqfs_swapin_\2(struct \1 *s){/p;t decl
+	s/};/}/p;t
+	s/^[[:space:]]*__le\([[:digit:]]*\)[[:space:]]*\([a-z_]*\);$/sqfs_swapin\1_internal(\&s->\2);/p
+}
+d
+:decl
+s/{/;/
+w swap.h.inc
+' < "$1" > swap.c.inc

--- a/cmd/snapfuse/hash.c
+++ b/cmd/snapfuse/hash.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "hash.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static sqfs_err sqfs_hash_add_internal(sqfs_hash *h, int doubling,
+		sqfs_hash_key k, sqfs_hash_value v) {
+	size_t hash = (k & (h->capacity - 1));	
+	sqfs_hash_bucket *b = malloc(sizeof(sqfs_hash_bucket) + h->value_size);
+	if (!b)
+		return SQFS_ERR;
+	b->key = k;
+	memcpy(&b->value, v, h->value_size);
+	b->next = h->buckets[hash];
+	h->buckets[hash] = b;
+	++h->size;
+	
+	return SQFS_OK;
+}
+
+static sqfs_err sqfs_hash_double(sqfs_hash *h) {
+	sqfs_hash_bucket **ob = h->buckets;
+	size_t oc = h->capacity;
+	size_t i;
+	sqfs_err err;
+	
+	if ((err = sqfs_hash_init(h, h->value_size, oc * 2)))
+		return err;
+	
+	for (i = 0; i < oc; ++i) {
+		sqfs_hash_bucket *b = ob[i];
+		while (b) {
+			sqfs_hash_bucket *n;
+			if (!err)
+				err = sqfs_hash_add_internal(h, 1, b->key, &b->value);
+			n = b->next;
+			free(b);
+			b = n;
+		}
+	}
+	
+	free(ob);
+	return err;
+}
+
+sqfs_err sqfs_hash_init(sqfs_hash *h, size_t vsize, size_t initial) {
+	memset(h, 0, sizeof(*h));
+	if ((initial & (initial - 1))) /* not power of two? */
+		return SQFS_ERR;
+	
+	h->buckets = calloc(initial, sizeof(sqfs_hash_bucket*));
+	if (!h->buckets)
+		return SQFS_ERR;
+	h->capacity = initial;
+	h->size = 0;
+	h->value_size = vsize;
+	return SQFS_OK;
+}
+ 
+void sqfs_hash_destroy(sqfs_hash *h) {
+	size_t i;
+	for (i = 0; i < h->capacity; ++i) {
+		sqfs_hash_bucket *b = h->buckets[i];
+		while (b) {
+			sqfs_hash_bucket *n = b->next;
+			free(b);
+			b = n;
+		}
+	}
+	free(h->buckets);
+}
+
+sqfs_hash_value sqfs_hash_get(sqfs_hash *h, sqfs_hash_key k) {
+	size_t hash = (k & (h->capacity - 1));
+	sqfs_hash_bucket *b = h->buckets[hash];
+	while (b) {
+		if (b->key == k)
+			return &b->value;
+		b = b->next;
+	}
+	return NULL;
+}
+
+sqfs_err sqfs_hash_add(sqfs_hash *h, sqfs_hash_key k, sqfs_hash_value v) {
+	if (h->size >= h->capacity) {
+		sqfs_err err = sqfs_hash_double(h);
+		if (err)
+			return err;
+	}
+	return sqfs_hash_add_internal(h, 0, k, v);
+}
+
+sqfs_err sqfs_hash_remove(sqfs_hash *h, sqfs_hash_key k) {
+	size_t hash = (k & (h->capacity - 1));
+	sqfs_hash_bucket **bp = &h->buckets[hash];
+	while (*bp) {
+		if ((*bp)->key == k) {
+			sqfs_hash_bucket *b = *bp;
+			*bp = b->next;
+			free(b);
+			--h->size;
+			return SQFS_OK;
+		}
+		bp = &(*bp)->next;
+	}
+	return SQFS_OK;
+}

--- a/cmd/snapfuse/hash.h
+++ b/cmd/snapfuse/hash.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_HASH_H
+#define SQFS_HASH_H
+
+#include "common.h"
+
+/* Simple hashtable
+ *	- Keys are integers
+ *	- Values are opaque data
+ *
+ * Implementation
+ *	- Hash function is modulus
+ *	- Chaining for duplicates
+ *	- Sizes are powers of two
+ */
+typedef uint32_t sqfs_hash_key;
+typedef void *sqfs_hash_value;
+
+typedef struct sqfs_hash_bucket {
+	struct sqfs_hash_bucket *next;
+	sqfs_hash_key key;
+	char value[1]; /* extended to size */
+} sqfs_hash_bucket;
+
+typedef struct {
+	size_t value_size;
+	size_t capacity;
+	size_t size;
+	sqfs_hash_bucket **buckets;
+} sqfs_hash;
+
+sqfs_err sqfs_hash_init(sqfs_hash *h, size_t vsize, size_t initial);
+void sqfs_hash_destroy(sqfs_hash *h);
+
+sqfs_hash_value sqfs_hash_get(sqfs_hash *h, sqfs_hash_key k);
+
+sqfs_err sqfs_hash_add(sqfs_hash *h, sqfs_hash_key k, sqfs_hash_value v);
+sqfs_err sqfs_hash_remove(sqfs_hash *h, sqfs_hash_key k);
+
+#endif

--- a/cmd/snapfuse/hl.c
+++ b/cmd/snapfuse/hl.c
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "squashfuse.h"
+#include "fuseprivate.h"
+
+#include "nonstd.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+typedef struct sqfs_hl sqfs_hl;
+struct sqfs_hl {
+	sqfs fs;
+	sqfs_inode root;
+};
+
+static sqfs_err sqfs_hl_lookup(sqfs **fs, sqfs_inode *inode,
+		const char *path) {
+	bool found;
+	
+	sqfs_hl *hl = fuse_get_context()->private_data;
+	*fs = &hl->fs;
+	if (inode)
+		*inode = hl->root; /* copy */
+
+	if (path) {
+		sqfs_err err = sqfs_lookup_path(*fs, inode, path, &found);
+		if (err)
+			return err;
+		if (!found)
+			return SQFS_ERR;
+	}
+	return SQFS_OK;
+}
+
+
+static void sqfs_hl_op_destroy(void *user_data) {
+	sqfs_hl *hl = (sqfs_hl*)user_data;
+	sqfs_destroy(&hl->fs);
+	free(hl);
+}
+
+static void *sqfs_hl_op_init(struct fuse_conn_info *conn) {
+	return fuse_get_context()->private_data;
+}
+
+static int sqfs_hl_op_getattr(const char *path, struct stat *st) {
+	sqfs *fs;
+	sqfs_inode inode;
+	if (sqfs_hl_lookup(&fs, &inode, path))
+		return -ENOENT;
+	
+	if (sqfs_stat(fs, &inode, st))
+		return -ENOENT;
+	
+	return 0;
+}
+
+static int sqfs_hl_op_opendir(const char *path, struct fuse_file_info *fi) {
+	sqfs *fs;
+	sqfs_inode *inode;
+	
+	inode = malloc(sizeof(*inode));
+	if (!inode)
+		return -ENOMEM;
+	
+	if (sqfs_hl_lookup(&fs, inode, path)) {
+		free(inode);
+		return -ENOENT;
+	}
+		
+	if (!S_ISDIR(inode->base.mode)) {
+		free(inode);
+		return -ENOTDIR;
+	}
+	
+	fi->fh = (intptr_t)inode;
+	return 0;
+}
+
+static int sqfs_hl_op_releasedir(const char *path,
+		struct fuse_file_info *fi) {
+	free((sqfs_inode*)(intptr_t)fi->fh);
+	fi->fh = 0;
+	return 0;
+}
+
+static int sqfs_hl_op_readdir(const char *path, void *buf,
+		fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi) {
+	sqfs_err err;
+	sqfs *fs;
+	sqfs_inode *inode;
+	sqfs_dir dir;
+	sqfs_name namebuf;
+	sqfs_dir_entry entry;
+	struct stat st;
+	
+	sqfs_hl_lookup(&fs, NULL, NULL);
+	inode = (sqfs_inode*)(intptr_t)fi->fh;
+		
+	if (sqfs_dir_open(fs, inode, &dir, offset))
+		return -EINVAL;
+	
+	memset(&st, 0, sizeof(st));
+	sqfs_dentry_init(&entry, namebuf);
+	while (sqfs_dir_next(fs, &dir, &entry, &err)) {
+		sqfs_off_t doff = sqfs_dentry_next_offset(&entry);
+		st.st_mode = sqfs_dentry_mode(&entry);
+		if (filler(buf, sqfs_dentry_name(&entry), &st, doff))
+			return 0;
+	}
+	if (err)
+		return -EIO;
+	return 0;
+}
+
+static int sqfs_hl_op_open(const char *path, struct fuse_file_info *fi) {
+	sqfs *fs;
+	sqfs_inode *inode;
+	
+	if (fi->flags & (O_WRONLY | O_RDWR))
+		return -EROFS;
+	
+	inode = malloc(sizeof(*inode));
+	if (!inode)
+		return -ENOMEM;
+	
+	if (sqfs_hl_lookup(&fs, inode, path)) {
+		free(inode);
+		return -ENOENT;
+	}
+	
+	if (!S_ISREG(inode->base.mode)) {
+		free(inode);
+		return -EISDIR;
+	}
+	
+	fi->fh = (intptr_t)inode;
+	fi->keep_cache = 1;
+	return 0;
+}
+
+static int sqfs_hl_op_create(const char* unused_path, mode_t unused_mode,
+		struct fuse_file_info *unused_fi) {
+	return -EROFS;
+}
+static int sqfs_hl_op_release(const char *path, struct fuse_file_info *fi) {
+	free((sqfs_inode*)(intptr_t)fi->fh);
+	fi->fh = 0;
+	return 0;
+}
+
+static int sqfs_hl_op_read(const char *path, char *buf, size_t size,
+		off_t off, struct fuse_file_info *fi) {
+	sqfs *fs;
+	sqfs_hl_lookup(&fs, NULL, NULL);
+	sqfs_inode *inode = (sqfs_inode*)(intptr_t)fi->fh;
+
+	off_t osize = size;
+	if (sqfs_read_range(fs, inode, off, &osize, buf))
+		return -EIO;
+	return osize;
+}
+
+static int sqfs_hl_op_readlink(const char *path, char *buf, size_t size) {
+	sqfs *fs;
+	sqfs_inode inode;
+	if (sqfs_hl_lookup(&fs, &inode, path))
+		return -ENOENT;
+	
+	if (!S_ISLNK(inode.base.mode)) {
+		return -EINVAL;
+	} else if (sqfs_readlink(fs, &inode, buf, &size)) {
+		return -EIO;
+	}	
+	return 0;
+}
+
+static int sqfs_hl_op_listxattr(const char *path, char *buf, size_t size) {
+	sqfs *fs;
+	sqfs_inode inode;
+	int ferr;
+	
+	if (sqfs_hl_lookup(&fs, &inode, path))
+		return -ENOENT;
+
+	ferr = sqfs_listxattr(fs, &inode, buf, &size);
+	if (ferr)
+		return -ferr;
+	return size;
+}
+
+static int sqfs_hl_op_getxattr(const char *path, const char *name,
+		char *value, size_t size
+#ifdef FUSE_XATTR_POSITION
+		, uint32_t position
+#endif
+		) {
+	sqfs *fs;
+	sqfs_inode inode;
+	size_t real = size;
+
+#ifdef FUSE_XATTR_POSITION
+	if (position != 0) /* We don't support resource forks */
+		return -EINVAL;
+#endif
+
+	if (sqfs_hl_lookup(&fs, &inode, path))
+		return -ENOENT;
+	
+	if ((sqfs_xattr_lookup(fs, &inode, name, value, &real)))
+		return -EIO;
+	if (real == 0)
+		return -sqfs_enoattr();
+	if (size != 0 && size < real)
+		return -ERANGE;
+	return real;
+}
+
+static sqfs_hl *sqfs_hl_open(const char *path, size_t offset) {
+	sqfs_hl *hl;
+	
+	hl = malloc(sizeof(*hl));
+	if (!hl) {
+		perror("Can't allocate memory");
+	} else {
+		memset(hl, 0, sizeof(*hl));
+		if (sqfs_open_image(&hl->fs, path, offset) == SQFS_OK) {
+			if (sqfs_inode_get(&hl->fs, &hl->root, sqfs_inode_root(&hl->fs)))
+				fprintf(stderr, "Can't find the root of this filesystem!\n");
+			else
+				return hl;
+			sqfs_destroy(&hl->fs);
+		}
+		
+		free(hl);
+	}
+	return NULL;
+}
+
+int main(int argc, char *argv[]) {
+	struct fuse_args args;
+	sqfs_opts opts;
+	sqfs_hl *hl;
+	int ret;
+	
+	struct fuse_opt fuse_opts[] = {
+		{"offset=%u", offsetof(sqfs_opts, offset), 0},
+		FUSE_OPT_END
+	};
+
+	struct fuse_operations sqfs_hl_ops;
+	memset(&sqfs_hl_ops, 0, sizeof(sqfs_hl_ops));
+	sqfs_hl_ops.init			= sqfs_hl_op_init;
+	sqfs_hl_ops.destroy		= sqfs_hl_op_destroy;
+	sqfs_hl_ops.getattr		= sqfs_hl_op_getattr;
+	sqfs_hl_ops.opendir		= sqfs_hl_op_opendir;
+	sqfs_hl_ops.releasedir	= sqfs_hl_op_releasedir;
+	sqfs_hl_ops.readdir		= sqfs_hl_op_readdir;
+	sqfs_hl_ops.open		= sqfs_hl_op_open;
+	sqfs_hl_ops.create		= sqfs_hl_op_create;
+	sqfs_hl_ops.release		= sqfs_hl_op_release;
+	sqfs_hl_ops.read		= sqfs_hl_op_read;
+	sqfs_hl_ops.readlink	= sqfs_hl_op_readlink;
+	sqfs_hl_ops.listxattr	= sqfs_hl_op_listxattr;
+	sqfs_hl_ops.getxattr	= sqfs_hl_op_getxattr;
+  
+	args.argc = argc;
+	args.argv = argv;
+	args.allocated = 0;
+	
+	opts.progname = argv[0];
+	opts.image = NULL;
+	opts.mountpoint = 0;
+	opts.offset = 0;
+	if (fuse_opt_parse(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
+		sqfs_usage(argv[0], true);
+	if (!opts.image)
+		sqfs_usage(argv[0], true);
+	
+	hl = sqfs_hl_open(opts.image, opts.offset);
+	if (!hl)
+		return -1;
+	
+	fuse_opt_add_arg(&args, "-s"); /* single threaded */
+	ret = fuse_main(args.argc, args.argv, &sqfs_hl_ops, hl);
+	fuse_opt_free_args(&args);
+	return ret;
+}

--- a/cmd/snapfuse/ll.c
+++ b/cmd/snapfuse/ll.c
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "ll.h"
+#include "fuseprivate.h"
+
+#include "nonstd.h"
+
+#include <errno.h>
+#include <float.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const double SQFS_TIMEOUT = DBL_MAX;
+
+static void sqfs_ll_op_getattr(fuse_req_t req, fuse_ino_t ino,
+		struct fuse_file_info *fi) {
+	sqfs_ll_i lli;
+	struct stat st;
+	if (sqfs_ll_iget(req, &lli, ino))
+		return;
+	
+	if (sqfs_stat(&lli.ll->fs, &lli.inode, &st)) {
+		fuse_reply_err(req, ENOENT);
+	} else {
+		st.st_ino = ino;
+		fuse_reply_attr(req, &st, SQFS_TIMEOUT);
+	}
+}
+
+static void sqfs_ll_op_opendir(fuse_req_t req, fuse_ino_t ino,
+		struct fuse_file_info *fi) {
+	sqfs_ll_i *lli;
+	
+	fi->fh = (intptr_t)NULL;
+	
+	lli = malloc(sizeof(*lli));
+	if (!lli) {
+		fuse_reply_err(req, ENOMEM);
+		return;
+	}
+	
+	if (sqfs_ll_iget(req, lli, ino) == SQFS_OK) {
+		if (!S_ISDIR(lli->inode.base.mode)) {
+			fuse_reply_err(req, ENOTDIR);
+		} else {
+			fi->fh = (intptr_t)lli;
+			fuse_reply_open(req, fi);
+			return;
+		}
+	}
+	free(lli);
+}
+
+static void sqfs_ll_op_create(fuse_req_t req, fuse_ino_t parent, const char *name,
+			      mode_t mode, struct fuse_file_info *fi) {
+	fuse_reply_err(req, EROFS);
+}
+
+static void sqfs_ll_op_releasedir(fuse_req_t req, fuse_ino_t ino,
+		struct fuse_file_info *fi) {
+	free((sqfs_ll_i*)(intptr_t)fi->fh);
+	fuse_reply_err(req, 0); /* yes, this is necessary */
+}
+
+static size_t sqfs_ll_add_direntry(fuse_req_t req, char *buf, size_t bufsize,
+		const char *name, const struct stat *st, off_t off) {
+	#if HAVE_DECL_FUSE_ADD_DIRENTRY
+		return fuse_add_direntry(req, buf, bufsize, name, st, off);
+	#else
+		size_t esize = fuse_dirent_size(strlen(name));
+		if (bufsize >= esize)
+			fuse_add_dirent(buf, name, st, off);
+		return esize;
+	#endif
+}
+static void sqfs_ll_op_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
+		off_t off, struct fuse_file_info *fi) {
+	sqfs_err sqerr;
+	sqfs_dir dir;
+	sqfs_name namebuf;
+	sqfs_dir_entry entry;
+	size_t esize;
+	struct stat st;
+	
+	char *buf = NULL, *bufpos = NULL;
+	sqfs_ll_i *lli = (sqfs_ll_i*)(intptr_t)fi->fh;
+	int err = 0;
+	
+	if (sqfs_dir_open(&lli->ll->fs, &lli->inode, &dir, off))
+		err = EINVAL;
+	if (!err && !(bufpos = buf = malloc(size)))
+		err = ENOMEM;
+	
+	if (!err) {
+		memset(&st, 0, sizeof(st));
+		sqfs_dentry_init(&entry, namebuf);
+		while (sqfs_dir_next(&lli->ll->fs, &dir, &entry, &sqerr)) {
+			st.st_ino = lli->ll->ino_fuse_num(lli->ll, &entry);
+			st.st_mode = sqfs_dentry_mode(&entry);
+		
+			esize = sqfs_ll_add_direntry(req, bufpos, size, sqfs_dentry_name(&entry),
+				&st, sqfs_dentry_next_offset(&entry));
+			if (esize > size)
+				break;
+		
+			bufpos += esize;
+			size -= esize;
+		}
+		if (sqerr)
+			err = EIO;
+	}
+	
+	if (err)
+		fuse_reply_err(req, err);
+	else
+		fuse_reply_buf(req, buf, bufpos - buf);
+	free(buf);
+}
+
+static void sqfs_ll_op_lookup(fuse_req_t req, fuse_ino_t parent,
+		const char *name) {
+	sqfs_ll_i lli;
+	sqfs_err sqerr;
+	sqfs_name namebuf;
+	sqfs_dir_entry entry;
+	bool found;
+	sqfs_inode inode;
+	
+	if (sqfs_ll_iget(req, &lli, parent))
+		return;
+	
+	if (!S_ISDIR(lli.inode.base.mode)) {
+		fuse_reply_err(req, ENOTDIR);
+		return;
+	}
+	
+	sqfs_dentry_init(&entry, namebuf);
+	sqerr = sqfs_dir_lookup(&lli.ll->fs, &lli.inode, name, strlen(name), &entry,
+		&found);
+	if (sqerr) {
+		fuse_reply_err(req, EIO);
+		return;
+	}
+	if (!found) {
+		fuse_reply_err(req, ENOENT);
+		return;
+	}
+	
+	if (sqfs_inode_get(&lli.ll->fs, &inode, sqfs_dentry_inode(&entry))) {
+		fuse_reply_err(req, ENOENT);
+	} else {
+		struct fuse_entry_param fentry;
+		memset(&fentry, 0, sizeof(fentry));
+		if (sqfs_stat(&lli.ll->fs, &inode, &fentry.attr)) {
+			fuse_reply_err(req, EIO);
+		} else {
+			fentry.attr_timeout = fentry.entry_timeout = SQFS_TIMEOUT;
+			fentry.ino = lli.ll->ino_register(lli.ll, &entry);
+			fentry.attr.st_ino = fentry.ino;
+			fuse_reply_entry(req, &fentry);
+		}
+	}
+}
+
+static void sqfs_ll_op_open(fuse_req_t req, fuse_ino_t ino,
+		struct fuse_file_info *fi) {
+	sqfs_inode *inode;
+	sqfs_ll *ll;
+	
+	if (fi->flags & (O_WRONLY | O_RDWR)) {
+		fuse_reply_err(req, EROFS);
+		return;
+	}
+	
+	inode = malloc(sizeof(sqfs_inode));
+	if (!inode) {
+		fuse_reply_err(req, ENOMEM);
+		return;
+	}
+	
+	ll = fuse_req_userdata(req);
+	if (sqfs_ll_inode(ll, inode, ino)) {
+		fuse_reply_err(req, ENOENT);
+	} else if (!S_ISREG(inode->base.mode)) {
+		fuse_reply_err(req, EISDIR);
+	} else {
+		fi->fh = (intptr_t)inode;
+		fi->keep_cache = 1;
+		fuse_reply_open(req, fi);
+		return;
+	}
+	free(inode);
+}
+
+static void sqfs_ll_op_release(fuse_req_t req, fuse_ino_t ino,
+		struct fuse_file_info *fi) {
+	free((sqfs_inode*)(intptr_t)fi->fh);
+	fi->fh = 0;
+	fuse_reply_err(req, 0);
+}
+
+static void sqfs_ll_op_read(fuse_req_t req, fuse_ino_t ino,
+		size_t size, off_t off, struct fuse_file_info *fi) {
+	sqfs_ll *ll = fuse_req_userdata(req);
+	sqfs_inode *inode = (sqfs_inode*)(intptr_t)fi->fh;
+	sqfs_err err = SQFS_OK;
+	
+	off_t osize;
+	char *buf = malloc(size);
+	if (!buf) {
+		fuse_reply_err(req, ENOMEM);
+		return;
+	}
+	
+	osize = size;
+	err = sqfs_read_range(&ll->fs, inode, off, &osize, buf);
+	if (err) {
+		fuse_reply_err(req, EIO);
+	} else if (osize == 0) { /* EOF */
+		fuse_reply_buf(req, NULL, 0);
+	} else {
+		fuse_reply_buf(req, buf, osize);
+	}
+	free(buf);
+}
+
+static void sqfs_ll_op_readlink(fuse_req_t req, fuse_ino_t ino) {
+	char *dst;
+	size_t size;
+	sqfs_ll_i lli;
+	if (sqfs_ll_iget(req, &lli, ino))
+		return;
+	
+	if (!S_ISLNK(lli.inode.base.mode)) {
+		fuse_reply_err(req, EINVAL);
+	} else if (sqfs_readlink(&lli.ll->fs, &lli.inode, NULL, &size)) {
+		fuse_reply_err(req, EIO);
+	} else if (!(dst = malloc(size + 1))) {
+		fuse_reply_err(req, ENOMEM);
+	} else if (sqfs_readlink(&lli.ll->fs, &lli.inode, dst, &size)) {
+		fuse_reply_err(req, EIO);
+		free(dst);
+	} else {
+		fuse_reply_readlink(req, dst);
+		free(dst);
+	}
+}
+
+static void sqfs_ll_op_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
+	sqfs_ll_i lli;
+	char *buf;
+	int ferr;
+	
+	if (sqfs_ll_iget(req, &lli, ino))
+		return;
+
+	buf = NULL;
+	if (size && !(buf = malloc(size))) {
+		fuse_reply_err(req, ENOMEM);
+		return;
+	}
+	
+	ferr = sqfs_listxattr(&lli.ll->fs, &lli.inode, buf, &size);
+	if (ferr) {
+		fuse_reply_err(req, ferr);
+	} else if (buf) {
+		fuse_reply_buf(req, buf, size);
+	} else {
+		fuse_reply_xattr(req, size);
+	}
+	free(buf);
+}
+
+static void sqfs_ll_op_getxattr(fuse_req_t req, fuse_ino_t ino,
+		const char *name, size_t size
+#ifdef FUSE_XATTR_POSITION
+		, uint32_t position
+#endif
+		) {
+	sqfs_ll_i lli;
+	char *buf = NULL;
+	size_t real = size;
+
+#ifdef FUSE_XATTR_POSITION
+	if (position != 0) { /* We don't support resource forks */
+		fuse_reply_err(req, EINVAL);
+		return;
+	}
+#endif
+	
+	if (sqfs_ll_iget(req, &lli, ino))
+		return;
+	
+	if (!(buf = malloc(size)))
+		fuse_reply_err(req, ENOMEM);
+	else if (sqfs_xattr_lookup(&lli.ll->fs, &lli.inode, name, buf, &real))
+		fuse_reply_err(req, EIO);
+	else if (real == 0)
+		fuse_reply_err(req, sqfs_enoattr());
+	else if (size == 0)
+		fuse_reply_xattr(req, real);
+	else if (size < real)
+		fuse_reply_err(req, ERANGE);
+	else
+		fuse_reply_buf(req, buf, real);
+	free(buf);
+}
+
+static void sqfs_ll_op_forget(fuse_req_t req, fuse_ino_t ino,
+		unsigned long nlookup) {
+	sqfs_ll_i lli;
+	sqfs_ll_iget(req, &lli, SQFS_FUSE_INODE_NONE);
+	lli.ll->ino_forget(lli.ll, ino, nlookup);
+	fuse_reply_none(req);
+}
+
+
+/* Helpers to abstract out FUSE 2.5 vs 2.6+ differences */
+
+typedef struct {
+	int fd;
+	struct fuse_chan *ch;
+} sqfs_ll_chan;
+
+static sqfs_err sqfs_ll_mount(sqfs_ll_chan *ch, const char *mountpoint,
+		struct fuse_args *args) {
+	#ifdef HAVE_NEW_FUSE_UNMOUNT
+		ch->ch = fuse_mount(mountpoint, args);
+	#else
+		ch->fd = fuse_mount(mountpoint, args);
+		if (ch->fd == -1)
+			return SQFS_ERR;
+		ch->ch = fuse_kern_chan_new(ch->fd);
+	#endif
+	return ch->ch ? SQFS_OK : SQFS_ERR;
+}
+
+static void sqfs_ll_unmount(sqfs_ll_chan *ch, const char *mountpoint) {
+	#ifdef HAVE_NEW_FUSE_UNMOUNT
+		fuse_unmount(mountpoint, ch->ch);
+	#else
+		close(ch->fd);
+		fuse_unmount(mountpoint);
+	#endif
+}
+
+static sqfs_ll *sqfs_ll_open(const char *path, size_t offset) {
+	sqfs_ll *ll;
+	
+	ll = malloc(sizeof(*ll));
+	if (!ll) {
+		perror("Can't allocate memory");
+	} else {
+		memset(ll, 0, sizeof(*ll));
+		ll->fs.offset = offset;
+		if (sqfs_open_image(&ll->fs, path, offset) == SQFS_OK) {
+			if (sqfs_ll_init(ll))
+				fprintf(stderr, "Can't initialize this filesystem!\n");
+			else
+				return ll;
+			sqfs_destroy(&ll->fs);
+		}
+		
+		free(ll);
+	}
+	return NULL;
+}
+
+int main(int argc, char *argv[]) {
+	struct fuse_args args;
+	sqfs_opts opts;
+	
+	char *mountpoint = NULL;
+	int mt, fg;
+	
+	int err;
+	sqfs_ll *ll;
+	struct fuse_opt fuse_opts[] = {
+		{"offset=%u", offsetof(sqfs_opts, offset), 0},
+		FUSE_OPT_END
+	};
+	
+	struct fuse_lowlevel_ops sqfs_ll_ops;
+	memset(&sqfs_ll_ops, 0, sizeof(sqfs_ll_ops));
+	sqfs_ll_ops.getattr		= sqfs_ll_op_getattr;
+	sqfs_ll_ops.opendir		= sqfs_ll_op_opendir;
+	sqfs_ll_ops.releasedir	= sqfs_ll_op_releasedir;
+	sqfs_ll_ops.readdir		= sqfs_ll_op_readdir;
+	sqfs_ll_ops.lookup		= sqfs_ll_op_lookup;
+	sqfs_ll_ops.open		= sqfs_ll_op_open;
+	sqfs_ll_ops.create		= sqfs_ll_op_create;
+	sqfs_ll_ops.release		= sqfs_ll_op_release;
+	sqfs_ll_ops.read		= sqfs_ll_op_read;
+	sqfs_ll_ops.readlink	= sqfs_ll_op_readlink;
+	sqfs_ll_ops.listxattr	= sqfs_ll_op_listxattr;
+	sqfs_ll_ops.getxattr	= sqfs_ll_op_getxattr;
+	sqfs_ll_ops.forget		= sqfs_ll_op_forget;
+   
+	/* PARSE ARGS */
+	args.argc = argc;
+	args.argv = argv;
+	args.allocated = 0;
+	
+	opts.progname = argv[0];
+	opts.image = NULL;
+	opts.mountpoint = 0;
+	opts.offset = 0;
+	if (fuse_opt_parse(&args, &opts, fuse_opts, sqfs_opt_proc) == -1)
+		sqfs_usage(argv[0], true);
+
+	if (fuse_parse_cmdline(&args, &mountpoint, &mt, &fg) == -1)
+		sqfs_usage(argv[0], true);
+	if (mountpoint == NULL)
+		sqfs_usage(argv[0], true);
+	
+	/* OPEN FS */
+	err = !(ll = sqfs_ll_open(opts.image, opts.offset));
+	
+	/* STARTUP FUSE */
+	if (!err) {
+		sqfs_ll_chan ch;
+		err = -1;
+		if (sqfs_ll_mount(&ch, mountpoint, &args) == SQFS_OK) {
+			struct fuse_session *se = fuse_lowlevel_new(&args,
+				&sqfs_ll_ops, sizeof(sqfs_ll_ops), ll);	
+			if (se != NULL) {
+				if (sqfs_ll_daemonize(fg) != -1) {
+					if (fuse_set_signal_handlers(se) != -1) {
+						fuse_session_add_chan(se, ch.ch);
+						/* FIXME: multithreading */
+						err = fuse_session_loop(se);
+						fuse_remove_signal_handlers(se);
+						#if HAVE_DECL_FUSE_SESSION_REMOVE_CHAN
+							fuse_session_remove_chan(ch.ch);
+						#endif
+					}
+				}
+				fuse_session_destroy(se);
+			}
+			sqfs_ll_destroy(ll);
+			sqfs_ll_unmount(&ch, mountpoint);
+		}
+	}
+	fuse_opt_free_args(&args);
+	free(ll);
+	free(mountpoint);
+	
+	return -err;
+}

--- a/cmd/snapfuse/ll.h
+++ b/cmd/snapfuse/ll.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_LL_H
+#define SQFS_LL_H
+
+#include "squashfuse.h"
+
+#include <fuse_lowlevel.h>
+
+typedef struct sqfs_ll sqfs_ll;
+struct sqfs_ll {
+	sqfs fs;
+	
+	/* Converting inodes between squashfs and fuse */
+	fuse_ino_t (*ino_fuse)(sqfs_ll *ll, sqfs_inode_id i);
+	sqfs_inode_id (*ino_sqfs)(sqfs_ll *ll, fuse_ino_t i);
+	
+	/* Register a new inode, returning the fuse ID for it */
+	fuse_ino_t (*ino_register)(sqfs_ll *ll, sqfs_dir_entry *e);
+	void (*ino_forget)(sqfs_ll *ll, fuse_ino_t i, size_t refs);
+	
+	/* Like register, but don't actually remember it */
+	fuse_ino_t (*ino_fuse_num)(sqfs_ll *ll, sqfs_dir_entry *e);
+	
+	/* Private data, and how to destroy it */
+	void *ino_data;
+	void (*ino_destroy)(sqfs_ll *ll);	
+};
+
+sqfs_err sqfs_ll_init(sqfs_ll *ll);
+void sqfs_ll_destroy(sqfs_ll *ll);
+
+
+/* Get an inode from an sqfs_ll */
+sqfs_err sqfs_ll_inode(sqfs_ll *ll, sqfs_inode *inode, fuse_ino_t i);
+
+/* Convenience function: Get both ll and inode, and handle errors */
+#define SQFS_FUSE_INODE_NONE 0
+typedef struct {
+	sqfs_ll *ll;
+	sqfs_inode inode;
+} sqfs_ll_i;
+sqfs_err sqfs_ll_iget(fuse_req_t req, sqfs_ll_i *lli, fuse_ino_t i);
+
+
+int sqfs_ll_daemonize(int fg);
+
+#endif

--- a/cmd/snapfuse/ll_inode.c
+++ b/cmd/snapfuse/ll_inode.c
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "ll.h"
+
+#include "hash.h"
+#include "nonstd.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+
+We have three kinds of unique identifiers for inodes:
+
+1. sqfs_inode_id
+  - Points directly to the on-disk location of the inode data.
+  - A 48-bit integer (32-bit block id, and 16 bit offset within a block).
+  - Not assigned sequentially, two IDs will differ by at least 20.
+  - The root inode may have any value of sqfs_inode_id.
+  - You CAN easily get the inode data from an sqfs_inode_id.
+  - You CANNOT get the sqfs_inode_id from the inode data.
+
+2. sqfs_inode_number
+  - Arbitrary identifier for inodes, assigned by mksquashfs.
+  - A 32-bit integer.
+  - Assigned sequentially, starting at zero.
+  - The root inode generally has the value zero.
+  - You CANNOT find the inode data directly from an sqfs_inode_number.
+  - You CAN find the sqfs_inode_number from the inode data.
+  - You CAN lookup sqfs_inode_number -> sqfs_inode_id IFF the squashfs
+    archive has the optional export table enabled.
+
+3. fuse_ino_t
+  - Arbitrary identifier for inodes, assigned by the FUSE driver.
+  - Has the same width as 'long', either 32- or 64-bit.
+  - The value zero is reserved to indicate a non-existent entry.
+  - The value one is reserved to indicate the root inode.
+
+
+To implement a low-level filesystem, we must:
+  - Generate a fuse_ino_t when telling FUSE about a new inode.
+  - Find the inode data when FUSE asks us about a fuse_ino_t.
+
+So we need a bidirectional mapping between fuse_ino_t and sqfs_inode_id.
+We use several different strategies, depending on the bitness of the system,
+and whether or not the squashfs archive has an export table:
+
+1. On 64-bit systems: fuse_ino_t is big enough to hold the sqfs_inode_id.
+	 We can just make minor adjustments for the reserved values of fuse_ino_t.
+
+2. On 32-bit systems, with export table: fuse_ino_t can hold the
+	 sqfs_inode_number, with adjustments for reserved values. We can use the
+   export table to lookup the sqfs_inode_id from the sqfs_inode_number.
+
+3. On 32-bit systems, no export: fuse_ino_t again holds sqfs_inode_number.
+   But we have to maintain our own mapping of
+	 sqfs_inode_number -> sqfs_inode_id, which can use quite a lot of memory.
+
+*/
+
+
+/***** INODE CONVERSION FOR 64-BIT INODES ****
+ *
+ * sqfs(root) maps to FUSE_ROOT_ID == 1
+ * sqfs(0) maps to 2
+ *
+ * Both 1 and 2 are guaranteed not to be used by sqfs, due to inode size
+ */
+static fuse_ino_t sqfs_ll_ino64_fuse(sqfs_ll *ll, sqfs_inode_id i) {
+	if (i == sqfs_inode_root(&ll->fs)) {
+		return FUSE_ROOT_ID;
+	} else if (i == 0) {
+		return 2;
+	} else {
+		return i;
+	}
+}
+
+static sqfs_inode_id sqfs_ll_ino64_sqfs(sqfs_ll *ll, fuse_ino_t i) {
+	if (i == FUSE_ROOT_ID) {
+		return sqfs_inode_root(&ll->fs);
+	} else if (i == 2) {
+		return 0;
+	} else {
+		return i;
+	}
+}
+
+static fuse_ino_t sqfs_ll_ino64_fuse_num(sqfs_ll *ll, sqfs_dir_entry *e) {
+	return sqfs_ll_ino64_fuse(ll, sqfs_dentry_inode(e));
+}
+
+static sqfs_err sqfs_ll_ino64_init(sqfs_ll *ll) {
+	ll->ino_fuse = sqfs_ll_ino64_fuse;
+	ll->ino_sqfs = sqfs_ll_ino64_sqfs;
+	ll->ino_fuse_num = sqfs_ll_ino64_fuse_num;
+	return SQFS_OK;
+}
+
+
+
+/***** INODE CONVERSION FOR 32-BIT INODES ****
+ *
+ * We maintain a cache of sqfs_inode_num => sqfs_inode_id.
+ * We go the other direction by fetching inodes.
+ *
+ * Mapping: sqfs_inode_num <=> fuse_ino_t
+ *   Most num(N) maps to N + 1
+ *   num(root) maps to FUSE_ROOT_ID == 1
+ *   num(0) maps to num(root) + 1
+ *
+ * FIXME:
+ * - Theoretically this could overflow if a filesystem uses all 2 ** 32 inodes,
+ *   since fuse inode zero is unavailable.
+ */
+#define SQFS_ICACHE_INITIAL 32
+
+#define FUSE_INODE_NONE 0
+#define SQFS_INODE_NONE 1
+
+typedef struct {
+	sqfs_inode_num root;
+	sqfs_hash icache;
+} sqfs_ll_inode_map;
+
+/* Pack tightly to save memory */
+typedef struct {
+	uint32_t refcount;
+	uint32_t ino_hi;
+	uint16_t ino_lo;
+} sqfs_ll_inode_entry;
+
+#define IE_INODE(ie) (((uint64_t)(ie)->ino_hi << 16) | (ie)->ino_lo)
+#define INODE_HI(i) ((i) >> 16)
+#define INODE_LO(i) ((i) & 0xFFFF)
+
+static fuse_ino_t sqfs_ll_ino32_num2fuse(sqfs_ll *ll, sqfs_inode_num n) {
+	sqfs_ll_inode_map *map = ll->ino_data;
+	if (n == map->root) {
+		return FUSE_ROOT_ID;
+	} else if (n == 0) {
+		return map->root + 1;
+	} else {
+		return n + 1;
+	} 
+}
+
+static fuse_ino_t sqfs_ll_ino32_fuse2num(sqfs_ll *ll, fuse_ino_t i) {
+	sqfs_ll_inode_map *map = ll->ino_data;
+	if (i == FUSE_ROOT_ID) {
+		return map->root;
+	} else if (i == map->root + 1) {
+		return 0;
+	} else {
+		return i - 1;
+	}
+}
+
+static fuse_ino_t sqfs_ll_ino32_fuse(sqfs_ll *ll, sqfs_inode_id i) {
+	sqfs_inode inode;
+	if (sqfs_inode_get(&ll->fs, &inode, i))
+		return FUSE_INODE_NONE; /* We shouldn't get here! */
+	return sqfs_ll_ino32_num2fuse(ll, inode.base.inode_number);
+}
+
+static sqfs_inode_id sqfs_ll_ino32_sqfs(sqfs_ll *ll, fuse_ino_t i) {
+	sqfs_ll_inode_map *map;
+	sqfs_inode_num n;
+	sqfs_ll_inode_entry *ie;
+	
+	if (i == FUSE_ROOT_ID)
+		return sqfs_inode_root(&ll->fs);
+	
+	map = ll->ino_data;
+	n = sqfs_ll_ino32_fuse2num(ll, i);
+	
+	ie = sqfs_hash_get(&map->icache, n);
+	return ie ? IE_INODE(ie) : SQFS_INODE_NONE;
+}
+
+static fuse_ino_t sqfs_ll_ino32_fuse_num(sqfs_ll *ll, sqfs_dir_entry *e) {
+	return sqfs_ll_ino32_num2fuse(ll, sqfs_dentry_inode_num(e));
+}
+
+static fuse_ino_t sqfs_ll_ino32_register(sqfs_ll *ll, sqfs_dir_entry *e) {
+	sqfs_ll_inode_map *map = ll->ino_data;
+	
+	sqfs_ll_inode_entry *ie = sqfs_hash_get(&map->icache,
+		sqfs_dentry_inode_num(e));
+	if (ie) {
+		++ie->refcount;
+	} else {
+		sqfs_err err = SQFS_OK;
+		sqfs_inode_id i = sqfs_dentry_inode(e);
+		sqfs_ll_inode_entry nie;
+		nie.ino_hi = INODE_HI(i);
+		nie.ino_lo = INODE_LO(i);
+		nie.refcount = 1;
+		err = sqfs_hash_add(&map->icache, sqfs_dentry_inode_num(e), &nie);
+		if (err)
+			return FUSE_INODE_NONE;
+	}
+	
+	return sqfs_ll_ino32_fuse_num(ll, e);
+}
+
+static void sqfs_ll_ino32_forget(sqfs_ll *ll, fuse_ino_t i, size_t refs) {
+	sqfs_ll_inode_map *map = ll->ino_data;
+	sqfs_inode_num n = sqfs_ll_ino32_fuse2num(ll, i);
+	
+	sqfs_ll_inode_entry *ie = sqfs_hash_get(&map->icache, n);
+	if (!ie)
+		return;
+	
+	if (ie->refcount > refs) {
+		ie->refcount -= refs;
+	} else {
+		sqfs_hash_remove(&map->icache, n);
+	}
+}
+
+static void sqfs_ll_ino32_destroy(sqfs_ll *ll) {
+	sqfs_ll_inode_map *map = ll->ino_data;
+	sqfs_hash_destroy(&map->icache);
+	free(map);
+}
+
+static sqfs_err sqfs_ll_ino32_init(sqfs_ll *ll) {
+	sqfs_inode inode;
+	sqfs_ll_inode_map *map;
+	sqfs_err err = sqfs_inode_get(&ll->fs, &inode, sqfs_inode_root(&ll->fs));
+	if (err)
+		return err;
+		
+	map = malloc(sizeof(sqfs_ll_inode_map));
+	map->root = inode.base.inode_number;
+	sqfs_hash_init(&map->icache, sizeof(sqfs_ll_inode_entry),
+		SQFS_ICACHE_INITIAL);
+		
+	ll->ino_fuse = sqfs_ll_ino32_fuse;
+	ll->ino_sqfs = sqfs_ll_ino32_sqfs;
+	ll->ino_fuse_num = sqfs_ll_ino32_fuse_num;
+	ll->ino_register = sqfs_ll_ino32_register;
+	ll->ino_forget = sqfs_ll_ino32_forget;
+	ll->ino_destroy = sqfs_ll_ino32_destroy;
+	ll->ino_data = map;
+	
+	return err; 
+}
+
+
+
+/***** INODE CONVERSION FOR 32-BIT INODES, EXPORT TABLE AVAILABLE ****
+ *
+ * Same transformation as regular 32-bit, but no caching.
+ */
+static sqfs_inode_id sqfs_ll_ino32exp_sqfs(sqfs_ll *ll, fuse_ino_t i) {
+	sqfs_inode_num n;
+	sqfs_inode_id ret;
+	sqfs_err err = SQFS_OK;
+	
+	if (i == FUSE_ROOT_ID)
+		return sqfs_inode_root(&ll->fs);
+	
+	n = sqfs_ll_ino32_fuse2num(ll, i);
+	err = sqfs_export_inode(&ll->fs, n, &ret);
+	return err ? SQFS_INODE_NONE : ret;
+}
+
+static void sqfs_ll_ino32exp_destroy(sqfs_ll *ll) {
+	free(ll->ino_data);
+}
+
+static sqfs_err sqfs_ll_ino32exp_init(sqfs_ll *ll) {
+	sqfs_inode inode;
+	sqfs_ll_inode_map *map;
+	sqfs_err err = sqfs_inode_get(&ll->fs, &inode, sqfs_inode_root(&ll->fs));
+	if (err)
+		return err;
+		
+	map = malloc(sizeof(sqfs_ll_inode_map));
+	map->root = inode.base.inode_number;
+	
+	ll->ino_fuse = sqfs_ll_ino32_fuse;
+	ll->ino_sqfs = sqfs_ll_ino32exp_sqfs;
+	ll->ino_fuse_num = sqfs_ll_ino32_fuse_num;
+	ll->ino_destroy = sqfs_ll_ino32exp_destroy;
+	ll->ino_data = map;
+	
+	return err;
+}
+
+
+
+static void sqfs_ll_null_forget(sqfs_ll *ll, fuse_ino_t i, size_t refs) {
+	/* pass */
+}
+
+sqfs_err sqfs_ll_init(sqfs_ll *ll) {
+	sqfs_err err = SQFS_OK;	
+	if (sizeof(fuse_ino_t) >= SQFS_INODE_ID_BYTES) {
+		err = sqfs_ll_ino64_init(ll);
+	} else if (sqfs_export_ok(&ll->fs)) {
+		err = sqfs_ll_ino32exp_init(ll);
+	} else {
+		err = sqfs_ll_ino32_init(ll);
+	}
+	if (!ll->ino_register)
+		ll->ino_register = ll->ino_fuse_num;
+	if (!ll->ino_forget)
+		ll->ino_forget = sqfs_ll_null_forget;
+	
+	return err;
+}
+
+void sqfs_ll_destroy(sqfs_ll *ll) {
+	sqfs_destroy(&ll->fs);
+	if (ll->ino_destroy)
+		ll->ino_destroy(ll);
+}
+
+sqfs_err sqfs_ll_inode(sqfs_ll *ll, sqfs_inode *inode, fuse_ino_t i) {
+	return sqfs_inode_get(&ll->fs, inode, ll->ino_sqfs(ll, i));
+}
+
+
+sqfs_err sqfs_ll_iget(fuse_req_t req, sqfs_ll_i *lli, fuse_ino_t i) {
+	sqfs_err err = SQFS_OK;
+	lli->ll = fuse_req_userdata(req);
+	if (i != SQFS_FUSE_INODE_NONE) {
+		err = sqfs_ll_inode(lli->ll, &lli->inode, i);
+		if (err)
+			fuse_reply_err(req, ENOENT);
+	}
+	return err;
+}
+
+sqfs_err sqfs_ll_stat(sqfs_ll *ll, sqfs_inode *inode, struct stat *st) {
+	sqfs_err err = SQFS_OK;
+	uid_t id;
+	
+	memset(st, 0, sizeof(*st));
+	st->st_mode = inode->base.mode;
+	st->st_nlink = inode->nlink;
+	st->st_mtime = st->st_ctime = st->st_atime = inode->base.mtime;
+	
+	if (S_ISREG(st->st_mode)) {
+		/* FIXME: do symlinks, dirs, etc have a size? */
+		st->st_size = inode->xtra.reg.file_size;
+		st->st_blocks = st->st_size / 512;
+	} else if (S_ISBLK(st->st_mode) || S_ISCHR(st->st_mode)) {
+		st->st_rdev = sqfs_makedev(inode->xtra.dev.major,
+			inode->xtra.dev.minor);
+	}
+	
+	st->st_blksize = ll->fs.sb.block_size; /* seriously? */
+	
+	err = sqfs_id_get(&ll->fs, inode->base.uid, &id);
+	if (err)
+		return err;
+	st->st_uid = id;
+	err = sqfs_id_get(&ll->fs, inode->base.guid, &id);
+	st->st_gid = id;
+	if (err)
+		return err;
+	
+	return SQFS_OK;
+}

--- a/cmd/snapfuse/ls.c
+++ b/cmd/snapfuse/ls.c
@@ -1,0 +1,75 @@
+/*
+* Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+* THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "squashfuse.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#define PROGNAME "squashfuse_ls"
+
+#define ERR_MISC	(-1)
+#define ERR_USAGE	(-2)
+#define ERR_OPEN	(-3)
+
+static void usage() {
+	fprintf(stderr, "%s (c) 2013 Dave Vasilevsky\n\n", PROGNAME);
+	fprintf(stderr, "Usage: %s ARCHIVE\n", PROGNAME);
+	exit(ERR_USAGE);
+}
+
+static void die(const char *msg) {
+	fprintf(stderr, "%s\n", msg);
+	exit(ERR_MISC);
+}
+
+int main(int argc, char *argv[]) {
+	sqfs_err err = SQFS_OK;
+	sqfs_traverse trv;
+	sqfs fs;
+	char *image;
+
+	if (argc != 2)
+		usage();
+	image = argv[1];
+
+	if ((err = sqfs_open_image(&fs, image, 0)))
+		exit(ERR_OPEN);
+	
+	if ((err = sqfs_traverse_open(&trv, &fs, sqfs_inode_root(&fs))))
+		die("sqfs_traverse_open error");
+	while (sqfs_traverse_next(&trv, &err)) {
+		if (!trv.dir_end) {
+			printf("%s\n", trv.path);
+		}
+	}
+	if (err)
+		die("sqfs_traverse_next error");
+	sqfs_traverse_close(&trv);
+	
+	sqfs_fd_close(fs.fd);
+	return 0;
+}

--- a/cmd/snapfuse/nonstd-daemon.c
+++ b/cmd/snapfuse/nonstd-daemon.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+
+#define SQFEATURE NONSTD_DAEMON_DEF
+#include "nonstd-internal.h"
+
+#include <unistd.h>
+#include <fuse_lowlevel.h>
+
+int sqfs_ll_daemonize(int fg) {
+	#if HAVE_DECL_FUSE_DAEMONIZE
+		return fuse_daemonize(fg);
+	#else
+		return daemon(0,0);
+	#endif
+}
+

--- a/cmd/snapfuse/nonstd-enoattr.c
+++ b/cmd/snapfuse/nonstd-enoattr.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+
+#define SQFEATURE NONSTD_ENOATTR_DEF
+#include "nonstd-internal.h"
+
+#ifdef HAVE_ATTR_XATTR_H
+	#include <sys/types.h>
+	#include <attr/xattr.h>
+#endif
+#include <errno.h>
+
+#ifndef ENOATTR
+	 #define ENOATTR ENODATA
+#endif
+
+int sqfs_enoattr() {
+	return ENOATTR;
+}

--- a/cmd/snapfuse/nonstd-internal.h
+++ b/cmd/snapfuse/nonstd-internal.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#define CHANGE_XOPEN_SOURCE 1
+#define CHANGE_DARWIN_C_SOURCE 2
+#define CHANGE_BSD_SOURCE 3
+#define CHANGE_GNU_SOURCE 4
+#define CHANGE_POSIX_C_SOURCE 5
+#define CHANGE_NETBSD_SOURCE 6
+
+#if SQFEATURE == CHANGE_XOPEN_SOURCE
+	#define _XOPEN_SOURCE 500
+#elif SQFEATURE == CHANGE_NETBSD_SOURCE
+	#define _NETBSD_SOURCE
+#elif SQFEATURE == CHANGE_DARWIN_C_SOURCE
+	#define _DARWIN_C_SOURCE
+#elif SQFEATURE == CHANGE_BSD_SOURCE
+	#define _BSD_SOURCE
+#elif SQFEATURE == CHANGE_GNU_SOURCE
+	#define _GNU_SOURCE
+#elif SQFEATURE == CHANGE_POSIX_C_SOURCE
+	#undef _POSIX_C_SOURCE
+#endif

--- a/cmd/snapfuse/nonstd-makedev.c
+++ b/cmd/snapfuse/nonstd-makedev.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+
+#ifdef QNX_MAKEDEV
+	#include <sys/types.h>
+	#include <sys/sysmacros.h>
+	#include <sys/netmgr.h>
+	dev_t sqfs_makedev(int maj, int min) {
+		return makedev(ND_LOCAL_NODE, maj, min);
+	}
+#else
+	#define SQFEATURE NONSTD_MAKEDEV_DEF
+	#include "nonstd-internal.h"
+
+	#include <sys/types.h>
+	#ifdef HAVE_SYS_MKDEV_H
+		#include <sys/mkdev.h>
+	#endif
+	#ifdef HAVE_SYS_SYSMACROS_H
+		#include <sys/sysmacros.h>
+	#endif
+
+	dev_t sqfs_makedev(int maj, int min) {
+		return makedev(maj, min);
+	}
+#endif

--- a/cmd/snapfuse/nonstd-pread.c
+++ b/cmd/snapfuse/nonstd-pread.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+
+#ifdef _WIN32
+	#include "win32.h"
+
+	ssize_t sqfs_pread(HANDLE file, void *buf, size_t count, sqfs_off_t off) {
+		DWORD bread;
+		OVERLAPPED ov = { 0 };
+		ov.Offset = (DWORD)off;
+		ov.OffsetHigh = (DWORD)(off >> 32);
+
+		if (ReadFile(file, buf, count, &bread, &ov) == FALSE)
+			return -1;
+		return bread;
+	}
+#else
+	#define SQFEATURE NONSTD_PREAD_DEF
+	#include "nonstd-internal.h"
+
+	#include <unistd.h>
+
+	#include "common.h"
+
+	ssize_t sqfs_pread(sqfs_fd_t fd, void *buf, size_t count, sqfs_off_t off) {
+		return pread(fd, buf, count, off);
+	}
+#endif

--- a/cmd/snapfuse/nonstd-stat.c
+++ b/cmd/snapfuse/nonstd-stat.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+
+#define SQFEATURE NONSTD_S_IFSOCK_DEF
+#include "nonstd-internal.h"
+
+#include <sys/stat.h>
+
+#include "common.h"
+#include "squashfs_fs.h"
+
+/* S_IF* are not standard */
+sqfs_mode_t sqfs_mode(int inode_type) {
+	switch (inode_type) {
+		case SQUASHFS_DIR_TYPE:
+		case SQUASHFS_LDIR_TYPE:
+			return S_IFDIR;
+		case SQUASHFS_REG_TYPE:
+		case SQUASHFS_LREG_TYPE:
+			return S_IFREG;
+		case SQUASHFS_SYMLINK_TYPE:
+		case SQUASHFS_LSYMLINK_TYPE:
+			return S_IFLNK;
+		case SQUASHFS_BLKDEV_TYPE:
+		case SQUASHFS_LBLKDEV_TYPE:
+			return S_IFBLK;
+		case SQUASHFS_CHRDEV_TYPE:
+		case SQUASHFS_LCHRDEV_TYPE:
+			return S_IFCHR;
+		case SQUASHFS_FIFO_TYPE:
+		case SQUASHFS_LFIFO_TYPE:
+			return S_IFIFO;
+		case SQUASHFS_SOCKET_TYPE:
+		case SQUASHFS_LSOCKET_TYPE:
+			return S_IFSOCK;
+	}
+	return 0;
+}
+

--- a/cmd/snapfuse/nonstd.h
+++ b/cmd/snapfuse/nonstd.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_STD_H
+#define SQFS_STD_H
+
+#include "common.h"
+
+/* Non-standard functions that we need */
+
+dev_t sqfs_makedev(int maj, int min);
+
+ssize_t sqfs_pread(sqfs_fd_t fd, void *buf, size_t count, sqfs_off_t off);
+
+int sqfs_enoattr();
+
+#endif

--- a/cmd/snapfuse/squashfs_fs.h
+++ b/cmd/snapfuse/squashfs_fs.h
@@ -1,0 +1,322 @@
+/*
+ * squashfs_fs.h
+ *
+ * Copyright (c) 2012  Phillip Lougher <phillip@squashfs.org.uk>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQUASHFS_FS
+#define SQUASHFS_FS
+
+#ifdef HAVE_LINUX_TYPES_LE16
+	#include <linux/types.h>
+#else
+	#include <stdint.h>
+	typedef uint16_t __le16;
+	typedef uint32_t __le32;
+	typedef uint64_t __le64;
+#endif
+
+#define SQUASHFS_MAGIC 0x73717368
+
+
+#define SQUASHFS_CACHED_FRAGMENTS	CONFIG_SQUASHFS_FRAGMENT_CACHE_SIZE
+#define SQUASHFS_MAJOR			4
+#define SQUASHFS_MINOR			0
+#define SQUASHFS_START			0
+
+/* size of metadata (inode and directory) blocks */
+#define SQUASHFS_METADATA_SIZE		8192
+#define SQUASHFS_METADATA_LOG		13
+
+/* default size of data blocks */
+#define SQUASHFS_FILE_SIZE		131072
+#define SQUASHFS_FILE_LOG		17
+
+#define SQUASHFS_FILE_MAX_SIZE		1048576
+#define SQUASHFS_FILE_MAX_LOG		20
+
+/* Max number of uids and gids */
+#define SQUASHFS_IDS			65536
+
+/* Max length of filename (not 255) */
+#define SQUASHFS_NAME_LEN		256
+
+#define SQUASHFS_INVALID_FRAG		(0xffffffffU)
+#define SQUASHFS_INVALID_XATTR		(0xffffffffU)
+#define SQUASHFS_INVALID_BLK		((int64_t)-1)
+
+/* Filesystem flags */
+#define SQUASHFS_NOI			0
+#define SQUASHFS_NOD			1
+#define SQUASHFS_NOF			3
+#define SQUASHFS_NO_FRAG		4
+#define SQUASHFS_ALWAYS_FRAG		5
+#define SQUASHFS_DUPLICATE		6
+#define SQUASHFS_EXPORT			7
+#define SQUASHFS_COMP_OPT		10
+
+/* Max number of types and file types */
+#define SQUASHFS_DIR_TYPE		1
+#define SQUASHFS_REG_TYPE		2
+#define SQUASHFS_SYMLINK_TYPE		3
+#define SQUASHFS_BLKDEV_TYPE		4
+#define SQUASHFS_CHRDEV_TYPE		5
+#define SQUASHFS_FIFO_TYPE		6
+#define SQUASHFS_SOCKET_TYPE		7
+#define SQUASHFS_LDIR_TYPE		8
+#define SQUASHFS_LREG_TYPE		9
+#define SQUASHFS_LSYMLINK_TYPE		10
+#define SQUASHFS_LBLKDEV_TYPE		11
+#define SQUASHFS_LCHRDEV_TYPE		12
+#define SQUASHFS_LFIFO_TYPE		13
+#define SQUASHFS_LSOCKET_TYPE		14
+
+/* Xattr types */
+#define SQUASHFS_XATTR_USER             0
+#define SQUASHFS_XATTR_TRUSTED          1
+#define SQUASHFS_XATTR_SECURITY         2
+#define SQUASHFS_XATTR_VALUE_OOL        256
+#define SQUASHFS_XATTR_PREFIX_MASK      0xff
+
+#define SQUASHFS_COMPRESSED_BIT		(1 << 15)
+
+#define SQUASHFS_COMPRESSED_BIT_BLOCK	(1 << 24)
+
+
+/* cached data constants for filesystem */
+#define SQUASHFS_CACHED_BLKS		8
+
+#define SQUASHFS_MAX_FILE_SIZE_LOG	64
+
+#define SQUASHFS_MAX_FILE_SIZE		(1LL << \
+					(SQUASHFS_MAX_FILE_SIZE_LOG - 2))
+
+/* meta index cache */
+#define SQUASHFS_META_INDEXES	(SQUASHFS_METADATA_SIZE / sizeof(unsigned int))
+#define SQUASHFS_META_ENTRIES	127
+#define SQUASHFS_META_SLOTS	8
+
+
+/*
+ * definitions for structures on disk
+ */
+#define ZLIB_COMPRESSION	1
+#define LZMA_COMPRESSION	2
+#define LZO_COMPRESSION		3
+#define XZ_COMPRESSION		4
+#define LZ4_COMPRESSION		5
+#define ZSTD_COMPRESSION	6
+
+struct squashfs_super_block {
+	__le32			s_magic;
+	__le32			inodes;
+	__le32			mkfs_time;
+	__le32			block_size;
+	__le32			fragments;
+	__le16			compression;
+	__le16			block_log;
+	__le16			flags;
+	__le16			no_ids;
+	__le16			s_major;
+	__le16			s_minor;
+	__le64			root_inode;
+	__le64			bytes_used;
+	__le64			id_table_start;
+	__le64			xattr_id_table_start;
+	__le64			inode_table_start;
+	__le64			directory_table_start;
+	__le64			fragment_table_start;
+	__le64			lookup_table_start;
+};
+
+struct squashfs_dir_index {
+	__le32			index;
+	__le32			start_block;
+	__le32			size;
+};
+
+struct squashfs_base_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+};
+
+struct squashfs_ipc_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+	__le32			nlink;
+};
+
+struct squashfs_lipc_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+	__le32			nlink;
+	__le32			xattr;
+};
+
+struct squashfs_dev_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+	__le32			nlink;
+	__le32			rdev;
+};
+
+struct squashfs_ldev_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+	__le32			nlink;
+	__le32			rdev;
+	__le32			xattr;
+};
+
+struct squashfs_symlink_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+	__le32			nlink;
+	__le32			symlink_size;
+};
+
+struct squashfs_reg_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+	__le32			start_block;
+	__le32			fragment;
+	__le32			offset;
+	__le32			file_size;
+};
+
+struct squashfs_lreg_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+	__le64			start_block;
+	__le64			file_size;
+	__le64			sparse;
+	__le32			nlink;
+	__le32			fragment;
+	__le32			offset;
+	__le32			xattr;
+};
+
+struct squashfs_dir_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+	__le32			start_block;
+	__le32			nlink;
+	__le16			file_size;
+	__le16			offset;
+	__le32			parent_inode;
+};
+
+struct squashfs_ldir_inode {
+	__le16			inode_type;
+	__le16			mode;
+	__le16			uid;
+	__le16			guid;
+	__le32			mtime;
+	__le32			inode_number;
+	__le32			nlink;
+	__le32			file_size;
+	__le32			start_block;
+	__le32			parent_inode;
+	__le16			i_count;
+	__le16			offset;
+	__le32			xattr;
+};
+
+struct squashfs_dir_entry {
+	__le16			offset;
+	__le16			inode_number;
+	__le16			type;
+	__le16			size;
+};
+
+struct squashfs_dir_header {
+	__le32			count;
+	__le32			start_block;
+	__le32			inode_number;
+};
+
+struct squashfs_fragment_entry {
+	__le64			start_block;
+	__le32			size;
+	unsigned int		unused;
+};
+
+struct squashfs_xattr_entry {
+	__le16			type;
+	__le16			size;
+};
+
+struct squashfs_xattr_val {
+	__le32			vsize;
+};
+
+struct squashfs_xattr_id {
+	__le64			xattr;
+	__le32			count;
+	__le32			size;
+};
+
+struct squashfs_xattr_id_table {
+	__le64			xattr_table_start;
+	__le32			xattr_ids;
+	__le32			unused;
+};
+
+#endif

--- a/cmd/snapfuse/squashfuse.h
+++ b/cmd/snapfuse/squashfuse.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_SQUASHFUSE_H
+#define SQFS_SQUASHFUSE_H
+
+#include "dir.h"
+#include "file.h"
+#include "fs.h"
+#include "traverse.h"
+#include "util.h"
+#include "xattr.h"
+
+#endif

--- a/cmd/snapfuse/stack.c
+++ b/cmd/snapfuse/stack.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "stack.h"
+
+#include <stdlib.h>
+
+/* Ensure a capacity of cap */
+static sqfs_err sqfs_stack_capacity(sqfs_stack *s, size_t cap) {
+	char *items;
+	if (cap <= s->capacity)
+		return SQFS_OK;
+	
+	items = realloc(s->items, cap * s->value_size);
+	if (!items)
+		return SQFS_ERR;
+	
+	s->items = items;
+	s->capacity = cap;
+	return SQFS_OK;
+}
+
+/* Calculate the next capacity to use */
+#define CAPACITY_DEFAULT 8
+#define CAPACITY_RATIO 3 / 2
+static size_t sqfs_stack_next_capacity(size_t cap) {
+	size_t n;
+	
+	if (cap == 0)
+		return CAPACITY_DEFAULT;
+	
+	n = cap * CAPACITY_RATIO;
+	if (n <= cap)
+		return cap + 1;
+	return n;
+}
+
+/* Grow by one */
+static sqfs_err sqfs_stack_grow(sqfs_stack *s) {
+	if (s->size == s->capacity) {
+		sqfs_err err = sqfs_stack_capacity(s,
+			sqfs_stack_next_capacity(s->capacity));
+		if (err)
+			return err;
+	}
+	s->size++;
+	return SQFS_OK;
+}
+
+
+sqfs_err sqfs_stack_create(sqfs_stack *s, size_t vsize, size_t initial,
+		sqfs_stack_free_t freer) {
+	s->value_size = vsize;
+	s->freer = freer;
+	s->items = NULL;
+	s->capacity = s->size = 0;
+	return sqfs_stack_capacity(s, initial);
+}
+
+void sqfs_stack_init(sqfs_stack *s) {
+	s->items = NULL;
+	s->capacity = 0;
+}
+
+void sqfs_stack_destroy(sqfs_stack *s) {
+	while (sqfs_stack_pop(s))
+		; /* pass */
+	free(s->items);
+	sqfs_stack_init(s);
+}
+
+sqfs_err sqfs_stack_push(sqfs_stack *s, void *vout) {
+	sqfs_err err = sqfs_stack_grow(s);
+	if (err)
+		return err;
+	return sqfs_stack_top(s, vout);
+}
+
+bool sqfs_stack_pop(sqfs_stack *s) {
+	void *v;
+	
+	if (s->size == 0)
+		return false;
+	
+	sqfs_stack_top(s, &v);
+	if (s->freer)
+		s->freer(v);
+	s->size--;
+	return true;
+}
+
+size_t sqfs_stack_size(sqfs_stack *s) {
+	return s->size;
+}
+
+sqfs_err sqfs_stack_at(sqfs_stack *s, size_t i, void *vout) {
+	if (i >= s->size)
+		return SQFS_ERR;
+	
+	*(void**)vout = s->items + i * s->value_size;
+	return SQFS_OK;
+}
+
+sqfs_err sqfs_stack_top(sqfs_stack *s, void *vout) {
+	if (s->size == 0)
+		return SQFS_ERR;
+	
+	return sqfs_stack_at(s, s->size - 1, vout);
+}

--- a/cmd/snapfuse/stack.h
+++ b/cmd/snapfuse/stack.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_STACK_H
+#define SQFS_STACK_H
+
+#include "common.h"
+
+typedef void (*sqfs_stack_free_t)(void *v);
+
+typedef struct {
+	size_t value_size;
+	size_t size;
+	size_t capacity;
+	char *items;
+	sqfs_stack_free_t freer;
+} sqfs_stack;
+
+/* Ensures the struct is in a safe state */
+void sqfs_stack_init(sqfs_stack *s);
+
+sqfs_err sqfs_stack_create(sqfs_stack *s, size_t vsize, size_t initial,
+	sqfs_stack_free_t freer);
+void sqfs_stack_destroy(sqfs_stack *s);
+
+sqfs_err sqfs_stack_push(sqfs_stack *s, void *vout);
+bool sqfs_stack_pop(sqfs_stack *s);
+
+size_t sqfs_stack_size(sqfs_stack *s);
+sqfs_err sqfs_stack_at(sqfs_stack *s, size_t i, void *vout);
+sqfs_err sqfs_stack_top(sqfs_stack *s, void *vout);
+
+#endif

--- a/cmd/snapfuse/swap.c
+++ b/cmd/snapfuse/swap.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "swap.h"
+
+#define SWAP(BITS) \
+	void sqfs_swapin##BITS(uint##BITS##_t *v) { \
+		int i; \
+		uint8_t *c = (uint8_t*)v; \
+		uint##BITS##_t r = 0; \
+		for (i = sizeof(*v) - 1; i >= 0; --i) { \
+			r <<= 8; \
+			r += c[i]; \
+		} \
+		*v = r; \
+	}
+
+SWAP(16)
+SWAP(32)
+SWAP(64)
+#undef SWAP
+
+void sqfs_swapin16_internal(__le16 *v) { sqfs_swapin16((uint16_t*)v); }
+void sqfs_swapin32_internal(__le32 *v) { sqfs_swapin32((uint32_t*)v); }
+void sqfs_swapin64_internal(__le64 *v) { sqfs_swapin64((uint64_t*)v); }
+
+void sqfs_swap16(uint16_t *n) {
+	*n = (*n >> 8) + (*n << 8);
+}
+
+#include "squashfs_fs.h"
+#include "swap.c.inc"

--- a/cmd/snapfuse/swap.h
+++ b/cmd/snapfuse/swap.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_SWAP_H
+#define SQFS_SWAP_H
+
+#include "common.h"
+
+#define SQFS_MAGIC_SWAP 0x68737173
+
+void sqfs_swap16(uint16_t *n);
+
+void sqfs_swapin16(uint16_t *v);
+void sqfs_swapin32(uint32_t *v);
+void sqfs_swapin64(uint64_t *v);
+
+#include "squashfs_fs.h"
+#include "swap.h.inc"
+
+#endif

--- a/cmd/snapfuse/table.c
+++ b/cmd/snapfuse/table.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "table.h"
+
+#include "fs.h"
+#include "nonstd.h"
+#include "squashfs_fs.h"
+#include "swap.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+sqfs_err sqfs_table_init(sqfs_table *table, sqfs_fd_t fd, sqfs_off_t start, size_t each,
+		size_t count) {
+	size_t i;
+	size_t nblocks, bread;
+	
+	if (count == 0)
+		return SQFS_OK;
+	
+	nblocks = sqfs_divceil(each * count, SQUASHFS_METADATA_SIZE);
+	bread = nblocks * sizeof(uint64_t);
+	
+	table->each = each;
+	if (!(table->blocks = malloc(bread)))
+		goto err;
+	if (sqfs_pread(fd, table->blocks, bread, start) != bread)
+		goto err;
+	
+	for (i = 0; i < nblocks; ++i)
+		sqfs_swapin64(&table->blocks[i]);
+	
+	return SQFS_OK;
+	
+err:
+	free(table->blocks);
+	table->blocks = NULL;
+	return SQFS_ERR;
+}
+
+void sqfs_table_destroy(sqfs_table *table) {
+	free(table->blocks);
+	table->blocks = NULL;
+}
+
+sqfs_err sqfs_table_get(sqfs_table *table, sqfs *fs, size_t idx, void *buf) {
+	sqfs_block *block;
+	size_t pos = idx * table->each;
+	size_t bnum = pos / SQUASHFS_METADATA_SIZE,
+		off = pos % SQUASHFS_METADATA_SIZE;
+	
+	sqfs_off_t bpos = table->blocks[bnum];
+	if (sqfs_md_cache(fs, &bpos, &block))
+		return SQFS_ERR;
+	
+	memcpy(buf, (char*)(block->data) + off, table->each);
+	/* BLOCK CACHED, DON'T DISPOSE */
+	return SQFS_OK;
+}

--- a/cmd/snapfuse/table.h
+++ b/cmd/snapfuse/table.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_TABLE_H
+#define SQFS_TABLE_H
+
+#include "common.h"
+
+typedef struct {
+	size_t each;
+	uint64_t *blocks;
+} sqfs_table;
+
+sqfs_err sqfs_table_init(sqfs_table *table, sqfs_fd_t fd, sqfs_off_t start, size_t each,
+	size_t count);
+void sqfs_table_destroy(sqfs_table *table);
+
+sqfs_err sqfs_table_get(sqfs_table *table, sqfs *fs, size_t idx, void *buf);
+
+#endif

--- a/cmd/snapfuse/traverse.c
+++ b/cmd/snapfuse/traverse.c
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "traverse.h"
+
+#include "fs.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+
+#define TRAVERSE_PATH_SEPARATOR "/"
+
+/* Default initial capacity of trv.path */
+#define TRAVERSE_DEFAULT_PATH_CAP 32
+
+
+enum {
+	/* These states may be set on entry to sqfs_traverse_next(), with real
+	   work to do. */
+	TRAVERSE_DESCEND,		 	/* Descend into the current entry (a dir) */
+	TRAVERSE_NAME_REMOVE, /* Remove the name from the end of the stored path */
+	
+	/* End states */
+	TRAVERSE_ERROR,
+	TRAVERSE_FINISHED,
+	
+	/* Internal */
+	TRAVERSE_ASCEND,			/* Done with a directory, ascend a level */
+	TRAVERSE_NAME_ADD,		/* Add a name to the end of the stored path */
+	TRAVERSE_GET_ENTRY		/* Get the next entry at the same level */
+} sqfs_traverse_state;
+
+/* The struct stored in trv.stack */
+typedef struct {
+	sqfs_dir dir;
+	size_t name_size;
+} sqfs_traverse_level;
+
+
+/* Make our structure safe */
+static void sqfs_traverse_init(sqfs_traverse *trv);
+
+/* Path manipulation functions */
+static sqfs_err sqfs_traverse_path_init(sqfs_traverse *trv);
+static sqfs_err sqfs_traverse_path_add(sqfs_traverse *trv,
+	const char *str, size_t size);
+static sqfs_err sqfs_traverse_path_add_name(sqfs_traverse *trv);
+static sqfs_err sqfs_traverse_path_add_sep(sqfs_traverse *trv);
+static void sqfs_traverse_path_remove(sqfs_traverse *trv, size_t size);
+static void sqfs_traverse_path_remove_name(sqfs_traverse *trv);
+static void sqfs_traverse_path_remove_sep(sqfs_traverse *trv);
+/* Set the size of the last path component */
+static void sqfs_traverse_path_set_name_size(sqfs_traverse *trv, size_t size);
+/* Add nul-terminator */
+static void sqfs_traverse_path_terminate(sqfs_traverse *trv);
+
+/* Descend into new directories, and ascend back */
+static sqfs_err sqfs_traverse_descend_inode(sqfs_traverse *trv,
+	sqfs_inode *inode);
+static sqfs_err sqfs_traverse_descend(sqfs_traverse *trv, sqfs_inode_id iid);
+static sqfs_err sqfs_traverse_ascend(sqfs_traverse *trv);
+
+
+static void sqfs_traverse_init(sqfs_traverse *trv) {
+	sqfs_dentry_init(&trv->entry, trv->namebuf);
+	sqfs_stack_init(&trv->stack);
+	trv->state = TRAVERSE_ERROR;
+	trv->path = NULL;
+}
+
+sqfs_err sqfs_traverse_open_inode(sqfs_traverse *trv, sqfs *fs,
+		sqfs_inode *inode) {
+	sqfs_err err;
+	
+	sqfs_traverse_init(trv);	
+	if ((err = sqfs_traverse_path_init(trv)))
+		goto error;
+	err = sqfs_stack_create(&trv->stack, sizeof(sqfs_traverse_level), 0, NULL);
+	if (err)
+		goto error;
+	
+	trv->fs = fs;
+	if ((err = sqfs_traverse_descend_inode(trv, inode)))
+		goto error;
+	
+	sqfs_traverse_path_set_name_size(trv, 0); /* The root has no name */
+	trv->state = TRAVERSE_NAME_REMOVE;
+	return SQFS_OK;
+	
+error:
+	sqfs_traverse_close(trv);
+	return err;
+}
+
+sqfs_err sqfs_traverse_open(sqfs_traverse *trv, sqfs *fs, sqfs_inode_id iid) {
+	sqfs_err err;
+	sqfs_inode inode;
+	
+	if ((err = sqfs_inode_get(fs, &inode, iid)))
+		return err;
+	
+	return sqfs_traverse_open_inode(trv, fs, &inode);
+}
+
+void sqfs_traverse_close(sqfs_traverse *trv) {
+	sqfs_stack_destroy(&trv->stack);
+	free(trv->path);
+	sqfs_traverse_init(trv);
+}
+
+
+bool sqfs_traverse_next(sqfs_traverse *trv, sqfs_err *err) {
+	sqfs_traverse_level *level;
+	bool found;
+	
+	*err = SQFS_OK;
+	while (true) {
+		switch (trv->state) {
+			case TRAVERSE_GET_ENTRY:
+				if ((*err = sqfs_stack_top(&trv->stack, &level)))
+					goto error;
+				
+				found = sqfs_dir_next(trv->fs, &level->dir, &trv->entry, err);
+				if (*err)
+					goto error;
+				if (found)
+					trv->state = TRAVERSE_NAME_ADD;
+				else
+					trv->state = TRAVERSE_ASCEND;
+				break;
+			
+			case TRAVERSE_NAME_ADD:
+				if ((*err = sqfs_traverse_path_add_name(trv)))
+					goto error;
+				if (sqfs_dentry_is_dir(&trv->entry))
+					trv->state = TRAVERSE_DESCEND;
+				else
+					trv->state = TRAVERSE_NAME_REMOVE;
+				trv->dir_end = false;
+				return true;
+			
+			case TRAVERSE_NAME_REMOVE:
+				sqfs_traverse_path_remove_name(trv);
+				trv->state = TRAVERSE_GET_ENTRY;
+				break;
+			
+			case TRAVERSE_DESCEND:
+				*err = sqfs_traverse_descend(trv, sqfs_dentry_inode(&trv->entry));
+				if (*err)
+					goto error;
+				trv->state = TRAVERSE_GET_ENTRY;
+				break;
+			
+			case TRAVERSE_ASCEND:
+				if ((*err = sqfs_traverse_ascend(trv)))
+					goto error;
+				if (sqfs_stack_size(&trv->stack) > 0) {
+					trv->dir_end = true;
+					trv->state = TRAVERSE_NAME_REMOVE;
+					return true;
+				}
+				trv->state = TRAVERSE_FINISHED;
+				break;
+			
+			case TRAVERSE_FINISHED:
+				return false;
+			
+			case TRAVERSE_ERROR:
+				*err = SQFS_ERR;
+				goto error;
+		}
+	}
+	
+error:
+	trv->state = TRAVERSE_ERROR;
+	return false;
+}
+
+sqfs_err sqfs_traverse_prune(sqfs_traverse *trv) {
+	trv->state = TRAVERSE_NAME_REMOVE;
+	return SQFS_OK;
+}
+
+
+static sqfs_err sqfs_traverse_path_init(sqfs_traverse *trv) {
+	trv->path_cap = TRAVERSE_DEFAULT_PATH_CAP;
+	if (!(trv->path = malloc(trv->path_cap)))
+		return SQFS_ERR;
+	trv->path[0] = '\0';
+	trv->path_size = 1; /* includes nul-terminator */
+	return SQFS_OK;
+}
+
+static void sqfs_traverse_path_terminate(sqfs_traverse *trv) {
+	trv->path[trv->path_size - 1] = '\0';
+}
+
+static sqfs_err sqfs_traverse_path_add(sqfs_traverse *trv,
+		const char *str, size_t size) {
+	size_t need = trv->path_size + size;
+	if (need > trv->path_cap) {
+		char *next_path;
+		size_t next_cap = trv->path_cap;
+		while (need > next_cap)
+			next_cap *= 2;
+		
+		if (!(next_path = realloc(trv->path, next_cap)))
+			return SQFS_ERR;
+		
+		trv->path = next_path;
+		trv->path_cap = next_cap;
+	}
+	
+	memcpy(trv->path + trv->path_size - 1, str, size);
+	trv->path_size = need;
+	sqfs_traverse_path_terminate(trv);
+	return SQFS_OK;
+}
+
+static void sqfs_traverse_path_remove(sqfs_traverse *trv, size_t size) {
+	if (trv->path_size > size)
+		trv->path_size -= size;
+	else
+		trv->path_size = 1; /* only nul terminator left */
+	
+	sqfs_traverse_path_terminate(trv);
+}
+
+static sqfs_err sqfs_traverse_path_add_name(sqfs_traverse *trv) {
+	trv->path_last_size = sqfs_dentry_name_size(&trv->entry);
+	return sqfs_traverse_path_add(trv, sqfs_dentry_name(&trv->entry),
+		trv->path_last_size);
+}
+
+static sqfs_err sqfs_traverse_path_add_sep(sqfs_traverse *trv) {
+	return sqfs_traverse_path_add(trv, TRAVERSE_PATH_SEPARATOR,
+		strlen(TRAVERSE_PATH_SEPARATOR));
+}
+
+static void sqfs_traverse_path_remove_name(sqfs_traverse *trv) {
+	sqfs_traverse_path_remove(trv, trv->path_last_size);
+}
+
+static void sqfs_traverse_path_remove_sep(sqfs_traverse *trv) {
+	sqfs_traverse_path_remove(trv, strlen(TRAVERSE_PATH_SEPARATOR));
+}
+
+static void sqfs_traverse_path_set_name_size(sqfs_traverse *trv, size_t size) {
+	trv->path_last_size = size;
+}
+
+
+static sqfs_err sqfs_traverse_descend_inode(sqfs_traverse *trv,
+		sqfs_inode *inode) {
+	sqfs_err err;
+	sqfs_traverse_level *level;
+	bool initial;
+	
+	initial = (sqfs_stack_size(&trv->stack) == 0);
+	
+	if ((err = sqfs_stack_push(&trv->stack, &level)))
+		return err;	
+	if ((err = sqfs_dir_open(trv->fs, inode, &level->dir, 0)))
+		return err;
+	
+	if (initial) {
+		/* Don't add the separator or store the size for the root directory */
+		level->name_size = 0;
+	} else {
+		level->name_size = sqfs_dentry_name_size(&trv->entry);
+		if ((err = sqfs_traverse_path_add_sep(trv)))
+			return err;
+	}
+	
+	return err;
+}
+
+static sqfs_err sqfs_traverse_descend(sqfs_traverse *trv, sqfs_inode_id iid) {
+	sqfs_err err;
+	sqfs_inode inode;
+	
+	if ((err = sqfs_inode_get(trv->fs, &inode, iid)))
+		return err;
+	
+	return sqfs_traverse_descend_inode(trv, &inode);
+}
+
+static sqfs_err sqfs_traverse_ascend(sqfs_traverse *trv) {
+	sqfs_err err;
+	sqfs_traverse_level *level;
+	
+	if ((err = sqfs_stack_top(&trv->stack, &level)))
+		return err;
+	
+	sqfs_traverse_path_remove_sep(trv); /* safe even if initial */
+	sqfs_traverse_path_set_name_size(trv, level->name_size);
+	
+	sqfs_stack_pop(&trv->stack);
+	return SQFS_OK;
+}

--- a/cmd/snapfuse/traverse.h
+++ b/cmd/snapfuse/traverse.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_TRAVERSE_H
+#define SQFS_TRAVERSE_H
+
+#include "common.h"
+
+#include "dir.h"
+#include "stack.h"
+
+typedef struct {
+	bool dir_end;
+	sqfs_dir_entry entry;
+	char *path;
+	
+	
+	/* private */
+	int state;	
+	sqfs *fs;
+	sqfs_name namebuf;
+	sqfs_stack stack;
+	
+	size_t path_size, path_cap;
+	size_t path_last_size;
+} sqfs_traverse;
+
+/* Begin a recursive traversal of a filesystem tree.
+   Every sub-item of the given inode will be traversed in-order, but not
+   this inode itself. */
+sqfs_err sqfs_traverse_open(sqfs_traverse *trv, sqfs *fs, sqfs_inode_id iid);
+sqfs_err sqfs_traverse_open_inode(sqfs_traverse *trv, sqfs *fs,
+	sqfs_inode *inode);
+
+/* Clean up at any point during or after a traversal */
+void sqfs_traverse_close(sqfs_traverse *trv);
+
+/* Get the next item in the traversal. An item may be:
+   - A directory entry, in which case trv->entry will be filled
+	 - A marker that a directory is finished, in which case trv->dir_end will
+     be true.
+   Returns false if there are no more items. */
+bool sqfs_traverse_next(sqfs_traverse *trv, sqfs_err *err);
+
+/* Don't recurse into the directory just returned. */
+sqfs_err sqfs_traverse_prune(sqfs_traverse *trv);
+
+#endif

--- a/cmd/snapfuse/util.c
+++ b/cmd/snapfuse/util.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "util.h"
+
+#include "fs.h"
+
+#include <stdio.h>
+
+#ifdef _WIN32
+	#include <win32.h>
+	
+	sqfs_err sqfs_fd_open(const char *path, sqfs_fd_t *fd, bool print) {
+		*fd = CreateFileA(path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+		if (*fd != INVALID_HANDLE_VALUE)
+			return SQFS_OK;
+
+		// FIXME: Better error handling
+		if (print)
+			fprintf(stderr, "CreateFile error: %d\n", GetLastError());
+		return SQFS_ERR;
+	}
+
+	void sqfs_fd_close(sqfs_fd_t fd) {
+		CloseHandle(fd);
+	}
+#else
+	#include <fcntl.h>
+	#include <unistd.h>
+
+	sqfs_err sqfs_fd_open(const char *path, sqfs_fd_t *fd, bool print) {
+		*fd = open(path, O_RDONLY);
+		if (*fd != -1)
+			return SQFS_OK;
+
+		if (print)
+			perror("Can't open squashfs image");
+		return SQFS_ERR;
+	}
+
+	void sqfs_fd_close(sqfs_fd_t fd) {
+		close(fd);
+	}
+#endif
+
+
+/* TODO: WIN32 implementation of open/close */
+/* TODO: i18n of error messages */
+sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset) {
+	sqfs_err err;
+	sqfs_fd_t fd;
+
+	if ((err = sqfs_fd_open(image, &fd, stderr)))
+		return err;
+
+	err = sqfs_init(fs, fd, offset);
+	switch (err) {
+		case SQFS_OK:
+			break;
+		case SQFS_BADFORMAT:
+			fprintf(stderr, "This doesn't look like a squashfs image.\n");
+			break;
+		case SQFS_BADVERSION: {
+			int major, minor, mj1, mn1, mj2, mn2;
+			sqfs_version(fs, &major, &minor);
+			sqfs_version_supported(&mj1, &mn1, &mj2, &mn2);
+			fprintf(stderr, "Squashfs version %d.%d detected, only version",
+				major, minor);
+			if (mj1 == mj2 && mn1 == mn2)
+				fprintf(stderr, " %d.%d", mj1, mn1);
+			else
+				fprintf(stderr, "s %d.%d to %d.%d", mj1, mn1, mj2, mn2);
+			fprintf(stderr, " supported.\n");
+			break;
+		}
+		case SQFS_BADCOMP: {
+			bool first = true;
+			int i;
+			sqfs_compression_type sup[SQFS_COMP_MAX],
+				comp = sqfs_compression(fs);
+			sqfs_compression_supported(sup);
+			fprintf(stderr, "Squashfs image uses %s compression, this version "
+				"supports only ", sqfs_compression_name(comp));
+			for (i = 0; i < SQFS_COMP_MAX; ++i) {
+				if (sup[i] == SQFS_COMP_UNKNOWN)
+					continue;
+				if (!first)
+					fprintf(stderr, ", ");
+				fprintf(stderr, "%s", sqfs_compression_name(sup[i]));
+				first = false;
+			}
+			fprintf(stderr, ".\n");
+			break;
+		}
+		default:
+			fprintf(stderr, "Something went wrong trying to read the squashfs "
+				"image.\n");
+	}
+
+	if (err)
+		sqfs_fd_close(fd);
+	return err;
+}
+

--- a/cmd/snapfuse/util.h
+++ b/cmd/snapfuse/util.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_UTIL_H
+#define SQFS_UTIL_H
+
+#include "common.h"
+
+#include <stdio.h>
+
+/* Open a file, and optionally print a message on failure */
+sqfs_err sqfs_fd_open(const char *path, sqfs_fd_t *fd, bool print);
+
+/* Close a file */
+void sqfs_fd_close(sqfs_fd_t fd);
+
+/* Open a filesystem and print errors to stderr. */
+sqfs_err sqfs_open_image(sqfs *fs, const char *image, size_t offset);
+
+#endif

--- a/cmd/snapfuse/xattr.c
+++ b/cmd/snapfuse/xattr.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "xattr.h"
+
+#include "fs.h"
+#include "nonstd.h"
+#include "swap.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+
+#define SQFS_XATTR_PREFIX_MAX SQUASHFS_XATTR_SECURITY
+
+typedef struct {
+	const char *pref;
+	size_t len;
+} sqfs_prefix;
+ 
+sqfs_prefix sqfs_xattr_prefixes[] = {
+	{"user.", 5},
+	{"security.", 9},
+	{"trusted.", 8},
+};
+
+
+typedef enum {
+	CURS_VSIZE = 1,
+	CURS_VAL = 2,
+	CURS_NEXT = 4
+} sqfs_xattr_curs;
+
+sqfs_err sqfs_xattr_init(sqfs *fs) {
+	sqfs_off_t start = fs->sb.xattr_id_table_start;
+	size_t bread;
+	if (start == SQUASHFS_INVALID_BLK)
+		return SQFS_OK;
+	
+	bread = sqfs_pread(fs->fd, &fs->xattr_info, sizeof(fs->xattr_info),
+		start + fs->offset);
+	if (bread != sizeof(fs->xattr_info))
+		return SQFS_ERR;
+	sqfs_swapin_xattr_id_table(&fs->xattr_info);
+	
+	return sqfs_table_init(&fs->xattr_table, fs->fd,
+		start + sizeof(fs->xattr_info) + fs->offset, sizeof(struct squashfs_xattr_id),
+		fs->xattr_info.xattr_ids);
+}
+
+sqfs_err sqfs_xattr_open(sqfs *fs, sqfs_inode *inode, sqfs_xattr *x) {
+	sqfs_err err;
+	
+	x->remain = 0; /* assume none exist */
+	if (fs->xattr_info.xattr_ids == 0 || inode->xattr == SQUASHFS_INVALID_XATTR)
+		return SQFS_OK;
+	
+	err = sqfs_table_get(&fs->xattr_table, fs, inode->xattr,
+		&x->info);
+	if (err)
+		return SQFS_ERR;
+	sqfs_swapin_xattr_id(&x->info);
+	
+	sqfs_md_cursor_inode(&x->c_next, x->info.xattr,
+		fs->xattr_info.xattr_table_start);
+	
+	x->fs = fs;
+	x->remain = x->info.count;
+	x->cursors = CURS_NEXT;
+	return SQFS_OK;
+}
+
+sqfs_err sqfs_xattr_read(sqfs_xattr *x) {
+	sqfs_err err;
+	
+	if (x->remain == 0)
+		return SQFS_ERR;
+	
+	if (!(x->cursors & CURS_NEXT)) {
+		x->ool = false; /* force inline */
+		if ((err = sqfs_xattr_value(x, NULL)))
+			return err;
+	}
+	
+	x->c_name = x->c_next;
+	if ((err = sqfs_md_read(x->fs, &x->c_name, &x->entry, sizeof(x->entry))))
+		return err;
+	sqfs_swapin_xattr_entry(&x->entry);
+	
+	x->type = x->entry.type & SQUASHFS_XATTR_PREFIX_MASK;
+	x->ool = x->entry.type & SQUASHFS_XATTR_VALUE_OOL;
+	if (x->type > SQFS_XATTR_PREFIX_MAX)
+		return SQFS_ERR;
+	
+	--(x->remain);
+	x->cursors = 0;
+	return err;
+}
+
+size_t sqfs_xattr_name_size(sqfs_xattr *x) {
+	return x->entry.size + sqfs_xattr_prefixes[x->type].len;
+}
+
+sqfs_err sqfs_xattr_name(sqfs_xattr *x, char *name, bool prefix) {
+	sqfs_err err;
+	
+	if (name && prefix) {
+		sqfs_prefix *p = &sqfs_xattr_prefixes[x->type];
+		memcpy(name, p->pref, p->len);
+		name += p->len;
+	}
+	
+	x->c_vsize = x->c_name;
+	err = sqfs_md_read(x->fs, &x->c_vsize, name, x->entry.size);
+	if (err)
+		return err;
+	
+	x->cursors |= CURS_VSIZE;
+	return err;
+}
+
+sqfs_err sqfs_xattr_value_size(sqfs_xattr *x, size_t *size) {
+	sqfs_err err;
+	if (!(x->cursors & CURS_VSIZE))
+		if ((err = sqfs_xattr_name(x, NULL, false)))
+			return err;
+	
+	x->c_val = x->c_vsize;
+	if ((err = sqfs_md_read(x->fs, &x->c_val, &x->val, sizeof(x->val))))
+		return err;
+	sqfs_swapin_xattr_val(&x->val);
+	
+	if (x->ool) {
+		uint64_t pos;
+		x->c_next = x->c_val;
+		if ((err = sqfs_md_read(x->fs, &x->c_next, &pos, sizeof(pos))))
+			return err;
+		sqfs_swapin64(&pos);
+		x->cursors |= CURS_NEXT;
+		
+		sqfs_md_cursor_inode(&x->c_val, pos,
+			x->fs->xattr_info.xattr_table_start);
+		if ((err = sqfs_md_read(x->fs, &x->c_val, &x->val, sizeof(x->val))))
+			return err;
+		sqfs_swapin_xattr_val(&x->val);
+	}
+	
+	if (size)
+		*size = x->val.vsize;	
+	x->cursors |= CURS_VAL;
+	return err;
+}
+
+sqfs_err sqfs_xattr_value(sqfs_xattr *x, void *buf) {
+	sqfs_err err;
+	sqfs_md_cursor c;
+	
+	if (!(x->cursors & CURS_VAL))
+		if ((err = sqfs_xattr_value_size(x, NULL)))
+			return err;
+	
+	c = x->c_val;
+	if ((err = sqfs_md_read(x->fs, &c, buf, x->val.vsize)))
+		return err;
+	
+	if (!x->ool) {
+		x->c_next = c;
+		x->cursors |= CURS_NEXT;
+	}
+	return err;
+}
+
+static sqfs_err sqfs_xattr_find_prefix(const char *name, uint16_t *type) {
+	int i;
+	for (i = 0; i <= SQFS_XATTR_PREFIX_MAX; ++i) {
+		sqfs_prefix *p = &sqfs_xattr_prefixes[i];
+		if (strncmp(name, p->pref, p->len) == 0) {
+			*type = i;
+			return SQFS_OK;
+		}
+	}
+	return SQFS_ERR;
+}
+
+/* FIXME: Indicate EINVAL, ENOMEM? */
+sqfs_err sqfs_xattr_find(sqfs_xattr *x, const char *name, bool *found) {
+	sqfs_err err;
+	char *cmp = NULL;
+	uint16_t type;
+	size_t len;
+	
+	if ((err = sqfs_xattr_find_prefix(name, &type))) {
+		/* Consider an invalid prefix to just be not found, or OS X
+		 * Finder complains. */
+		*found = false;
+		return SQFS_OK;
+	}
+	
+	name += sqfs_xattr_prefixes[type].len;
+	len = strlen(name);
+	if (!(cmp = malloc(len)))
+		return SQFS_ERR;
+	
+	while (x->remain) {
+		if ((err = sqfs_xattr_read(x)))
+			goto done;
+		if (x->type != type && x->entry.size != len)
+			continue;
+		if ((err = sqfs_xattr_name(x, cmp, false)))
+			goto done;
+		if (strncmp(name, cmp, len) == 0) {
+			*found = true;
+			goto done;
+		}
+	}
+	
+	*found = false;
+	
+done:
+	free(cmp);
+	return err;
+}
+
+sqfs_err sqfs_xattr_lookup(sqfs *fs, sqfs_inode *inode, const char *name,
+		void *buf, size_t *size) {
+	sqfs_err err = SQFS_OK;
+	
+	sqfs_xattr xattr;
+	if ((err = sqfs_xattr_open(fs, inode, &xattr)))
+		return err;
+	
+	bool found = false;
+	if ((err = sqfs_xattr_find(&xattr, name, &found)))
+		return err;
+	if (!found) {
+		*size = 0;
+		return err;
+	}
+	
+	size_t real;
+	if ((err = sqfs_xattr_value_size(&xattr, &real)))
+		return err;
+	
+	if (buf && *size >= real) {
+		if ((err = sqfs_xattr_value(&xattr, buf)))
+			return err;
+	}
+	
+	*size = real;
+	return err;
+}
+

--- a/cmd/snapfuse/xattr.h
+++ b/cmd/snapfuse/xattr.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2012 Dave Vasilevsky <dave@vasilevsky.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SQFS_XATTR_H
+#define SQFS_XATTR_H
+
+#include "common.h"
+
+#include "squashfs_fs.h"
+
+
+/* Initialize xattr handling for this fs */
+sqfs_err sqfs_xattr_init(sqfs *fs);
+
+
+/* xattr iterator */
+typedef struct {
+	sqfs *fs;	
+	int cursors;
+	sqfs_md_cursor c_name, c_vsize, c_val, c_next;
+	
+	size_t remain;
+	struct squashfs_xattr_id info;
+	
+	uint16_t type;
+	bool ool;
+	struct squashfs_xattr_entry entry;
+	struct squashfs_xattr_val val;
+} sqfs_xattr;
+
+/* Get xattr iterator for this inode */
+sqfs_err sqfs_xattr_open(sqfs *fs, sqfs_inode *inode, sqfs_xattr *x);
+
+/* Get new xattr entry. Call while x->remain > 0 */
+sqfs_err sqfs_xattr_read(sqfs_xattr *x);
+
+/* Accessors on xattr entry. No null-termination! */
+size_t sqfs_xattr_name_size(sqfs_xattr *x);
+sqfs_err sqfs_xattr_name(sqfs_xattr *x, char *name, bool prefix);
+sqfs_err sqfs_xattr_value_size(sqfs_xattr *x, size_t *size);
+/* Yield first 'size' bytes */
+sqfs_err sqfs_xattr_value(sqfs_xattr *x, void *buf);
+
+/* Find an xattr entry */
+sqfs_err sqfs_xattr_find(sqfs_xattr *x, const char *name, bool *found);
+
+/* Helper to find an xattr value on an inode.
+   Returns in 'size' the size of the xattr, if found, or zero if not found.
+   Does not touch 'buf' if it's not big enough. */
+sqfs_err sqfs_xattr_lookup(sqfs *fs, sqfs_inode *inode, const char *name,
+	void *buf, size_t *size);
+
+#endif

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -122,8 +122,10 @@ BuildRequires:  gcc
 BuildRequires:  gettext
 BuildRequires:  gnupg
 BuildRequires:  indent
+BuildRequires:  pkgconfig(fuse)
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(libcap)
+BuildRequires:  pkgconfig(liblzma)
 BuildRequires:  pkgconfig(libseccomp)
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(systemd)
@@ -547,6 +549,7 @@ popd
 %doc README.md docs/*
 %{_bindir}/snap
 %{_bindir}/snapctl
+%{_bindir}/snapfuse
 %dir %{_libexecdir}/snapd
 %{_libexecdir}/snapd/snapd
 %{_libexecdir}/snapd/snap-exec

--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -51,6 +51,8 @@ BuildRequires:  gpg2
 BuildRequires:  indent
 BuildRequires:  libapparmor-devel
 BuildRequires:  libcap-devel
+BuildRequires:  libfuse-devel
+BuildRequires:  liblzma-devel
 BuildRequires:  libseccomp-devel
 BuildRequires:  libtool
 BuildRequires:  libudev-devel
@@ -289,6 +291,7 @@ fi
 %{_unitdir}/snapd.socket
 /usr/bin/snap
 /usr/bin/snapctl
+/usr/bin/snapfuse
 /usr/sbin/rcsnapd
 /usr/sbin/rcsnapd.refresh
 %{_libexecdir}/snapd/info

--- a/packaging/ubuntu-14.04/snapd.install
+++ b/packaging/ubuntu-14.04/snapd.install
@@ -29,3 +29,5 @@ usr/share/man/man5/snap-discard-ns.5
 # for compatibility with ancient snap installs that wrote the shell based
 # wrapper scripts instead of the modern symlinks
 usr/bin/ubuntu-core-launcher
+
+usr/bin/snapfuse

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -20,9 +20,13 @@ Build-Depends: autoconf,
                golang-any (>=2:1.6) | golang-1.6,
                indent,
                init-system-helpers,
-               libcap-dev,
                libapparmor-dev,
+               libcap-dev,
+               libfuse-dev,
                libglib2.0-dev,
+               liblz4-dev,
+               liblzma-dev,
+               liblzo2-dev,
                libseccomp-dev,
                libudev-dev,
                openssh-client,
@@ -32,7 +36,8 @@ Build-Depends: autoconf,
                python3-markdown,
                squashfs-tools,
                udev,
-               xfslibs-dev
+               xfslibs-dev,
+               zlib1g-dev
 Standards-Version: 3.9.7
 Homepage: https://github.com/snapcore/snapd
 Vcs-Browser: https://github.com/snapcore/snapd

--- a/packaging/ubuntu-16.04/snapd.install
+++ b/packaging/ubuntu-16.04/snapd.install
@@ -29,3 +29,5 @@ usr/share/man/man5/snap-discard-ns.5
 # for compatibility with ancient snap installs that wrote the shell based
 # wrapper scripts instead of the modern symlinks
 usr/bin/ubuntu-core-launcher
+
+usr/bin/snapfuse

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -389,8 +389,7 @@ func useFuse() bool {
 		return false
 	}
 
-	_, err := exec.LookPath("squashfuse")
-	if err != nil {
+	if !osutil.ExecutableExists("squashfuse") && !osutil.ExecutableExists("snapfuse") {
 		return false
 	}
 
@@ -423,7 +422,14 @@ func (s *systemd) WriteMountUnitFile(name, what, where, fstype string) (string, 
 		fstype = "none"
 	} else if fstype == "squashfs" && useFuse() {
 		options = append(options, "allow_other")
-		fstype = "fuse.squashfuse"
+		switch {
+		case osutil.ExecutableExists("squashfuse"):
+			fstype = "fuse.squashfuse"
+		case osutil.ExecutableExists("snapfuse"):
+			fstype = "fuse.snapfuse"
+		default:
+			panic("cannot happen because useFuse() ensures on of the two executables is there")
+		}
 	}
 
 	c := fmt.Sprintf(`[Unit]

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -70,10 +70,6 @@ execute: |
     lxd.lxc exec my-ubuntu -- systemctl restart snapd.service
     lxd.lxc exec my-ubuntu -- cat /etc/environment
 
-    # FIXME: workaround for missing squashfuse
-    lxd.lxc exec my-ubuntu apt update
-    lxd.lxc exec my-ubuntu -- apt install -y squashfuse
-
     # FIXME: ensure that the kernel running is recent enough, this
     #        will only work with an up-to-date xenial kernel (4.4.0-78+)
 


### PR DESCRIPTION
This branch adds an integrated copy of squashfuse as the snapfuse executable.
This allows us to not depend on additional executables and thus introduce new
functionality without new (debian) dependencies which are breaking some
invocations of apt update logic.
