### PR TITLE
tests: check for invalid udev files during all tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -370,6 +370,12 @@ restore: |
     rm -f $SPREAD_PATH/snapd-state.tar.gz
     rm -rf ${GOPATH%%:*}/*
 
+restore-each: |
+    if grep "invalid .*snap.*.rules" /var/log/syslog; then
+        echo "Invalid udev file detected, test most likely broke it"
+        exit 1
+    fi
+
 suites:
     tests/main/:
         summary: Full-system tests for snapd


### PR DESCRIPTION
To prevent typos like
https://github.com/snapcore/snapd/pull/3617/files#diff-ec8cacef522dbb27eeb9ceed25f03b22R249
this PR adds a check that ensures we never create invalid udev
files during the tests.

Slightly heavy-handed to do it in restore, ideally we would have something like "test-each" or I can manually add it to each interface test, but I think it would be beneficial if it could be tests during each test.