### PR TITLE
tests: improve revert related testing

### DIFF
--- a/tests/main/revert/task.yaml
+++ b/tests/main/revert/task.yaml
@@ -66,6 +66,9 @@ execute: |
     echo "Then the new version is installed"
     snap list | MATCH "test-snapd-tools +[0-9]+\.[0-9]+\+fake1"
 
+    echo "And the snap runs"
+    test-snapd-tools.echo hello|MATCH hello
+
     echo "When a revert is made"
     snap revert test-snapd-tools
 
@@ -78,6 +81,9 @@ execute: |
 
     echo "And the snap runs confined"
     snap list|MATCH 'test-snapd-tools.* -$'
+
+    echo "And the still snap runs"
+    test-snapd-tools.echo hello|MATCH hello
 
     echo "And a new revert fails"
     if snap revert test-snapd-tools; then

--- a/tests/main/ubuntu-core-upgrade/task.yaml
+++ b/tests/main/ubuntu-core-upgrade/task.yaml
@@ -16,6 +16,7 @@ restore: |
 
 prepare: |
     snap list | awk "/^core / {print(\$3)}" > nextBoot
+    snap install test-snapd-tools
 
 execute: |
     . $TESTSLIB/boot.sh
@@ -61,6 +62,9 @@ execute: |
 
     # wait for the link task to be done
     while ! snap change ${chg_id}|grep -q "^Done.*Make snap.*available to the system" ; do sleep 1 ; done
+
+    echo "Ensure the test snap still runs"
+    test-snapd-tools.echo hello | MATCH hello
 
     echo "Ensure the bootloader is correct before reboot"
     snap list | awk "/^core / {print(\$3)}" > nextBoot


### PR DESCRIPTION
We got reports that under some circumstances after a core revert
snaps did not work correctly. Add tests so that we excercise snaps
in the revert tests.
