### PR TITLE
interfaces: remove duplicated MockPlug/MockSlot helpers from interface tests

### DIFF
--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *AlsaInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, alsaConsumerYaml, nil, "alsa")
-	s.slot = MockSlot(c, alsaCoreYaml, nil, "alsa")
+	s.plug = builtin.MockPlug(c, alsaConsumerYaml, nil, "alsa")
+	s.slot = builtin.MockSlot(c, alsaCoreYaml, nil, "alsa")
 }
 
 func (s *AlsaInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/avahi_control_test.go
+++ b/interfaces/builtin/avahi_control_test.go
@@ -60,9 +60,9 @@ slots:
 `
 
 func (s *AvahiControlInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, avahiControlConsumerYaml, nil, "avahi-control")
-	s.appSlot = MockSlot(c, avahiControlProducerYaml, nil, "avahi-control")
-	s.coreSlot = MockSlot(c, avahiControlCoreYaml, nil, "avahi-control")
+	s.plug = builtin.MockPlug(c, avahiControlConsumerYaml, nil, "avahi-control")
+	s.appSlot = builtin.MockSlot(c, avahiControlProducerYaml, nil, "avahi-control")
+	s.coreSlot = builtin.MockSlot(c, avahiControlCoreYaml, nil, "avahi-control")
 }
 
 func (s *AvahiControlInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -60,9 +60,9 @@ slots:
 `
 
 func (s *AvahiObserveInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, avahiObserveConsumerYaml, nil, "avahi-observe")
-	s.appSlot = MockSlot(c, avahiObserveProducerYaml, nil, "avahi-observe")
-	s.coreSlot = MockSlot(c, avahiObserveCoreYaml, nil, "avahi-observe")
+	s.plug = builtin.MockPlug(c, avahiObserveConsumerYaml, nil, "avahi-observe")
+	s.appSlot = builtin.MockSlot(c, avahiObserveProducerYaml, nil, "avahi-observe")
+	s.coreSlot = builtin.MockSlot(c, avahiObserveCoreYaml, nil, "avahi-observe")
 }
 
 func (s *AvahiObserveInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -95,9 +95,9 @@ slots:
 `
 
 func (s *BluezInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, bluezConsumerYaml, nil, "bluez")
-	s.appSlot = MockSlot(c, bluezProducerYaml, nil, "bluez")
-	s.coreSlot = MockSlot(c, bluezCoreYaml, nil, "bluez")
+	s.plug = builtin.MockPlug(c, bluezConsumerYaml, nil, "bluez")
+	s.appSlot = builtin.MockSlot(c, bluezProducerYaml, nil, "bluez")
+	s.coreSlot = builtin.MockSlot(c, bluezCoreYaml, nil, "bluez")
 }
 
 func (s *BluezInterfaceSuite) TestName(c *C) {
@@ -116,14 +116,14 @@ func (s *BluezInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `peer=(label="snap.producer.app"),`)
 
 	// The label glob when all apps are bound to the bluez slot
-	slot := MockSlot(c, bluezProducerTwoAppsYaml, nil, "bluez")
+	slot := builtin.MockSlot(c, bluezProducerTwoAppsYaml, nil, "bluez")
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `peer=(label="snap.producer.*"),`)
 
 	// The label uses alternation when some, but not all, apps is bound to the bluez slot
-	slot = MockSlot(c, bluezProducerThreeAppsYaml, nil, "bluez")
+	slot = builtin.MockSlot(c, bluezProducerThreeAppsYaml, nil, "bluez")
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
@@ -136,14 +136,14 @@ func (s *BluezInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.producer.app"), testutil.Contains, `peer=(label="snap.consumer.app"),`)
 
 	// The label glob when all apps are bound to the bluez plug
-	plug := MockPlug(c, bluezConsumerTwoAppsYaml, nil, "bluez")
+	plug := builtin.MockPlug(c, bluezConsumerTwoAppsYaml, nil, "bluez")
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, plug, nil, s.appSlot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 	c.Assert(spec.SnippetForTag("snap.producer.app"), testutil.Contains, `peer=(label="snap.consumer.*"),`)
 
 	// The label uses alternation when some, but not all, apps is bound to the bluez plug
-	plug = MockPlug(c, bluezConsumerThreeAppsYaml, nil, "bluez")
+	plug = builtin.MockPlug(c, bluezConsumerThreeAppsYaml, nil, "bluez")
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, plug, nil, s.appSlot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})

--- a/interfaces/builtin/camera_test.go
+++ b/interfaces/builtin/camera_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *CameraInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, cameraConsumerYaml, nil, "camera")
-	s.slot = MockSlot(c, cameraCoreYaml, nil, "camera")
+	s.plug = builtin.MockPlug(c, cameraConsumerYaml, nil, "camera")
+	s.slot = builtin.MockSlot(c, cameraCoreYaml, nil, "camera")
 }
 
 func (s *CameraInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/desktop_legacy_test.go
+++ b/interfaces/builtin/desktop_legacy_test.go
@@ -52,8 +52,8 @@ slots:
 `
 
 func (s *DesktopLegacyInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, desktopLegacyConsumerYaml, nil, "desktop-legacy")
-	s.coreSlot = MockSlot(c, desktopLegacyCoreYaml, nil, "desktop-legacy")
+	s.plug = builtin.MockPlug(c, desktopLegacyConsumerYaml, nil, "desktop-legacy")
+	s.coreSlot = builtin.MockSlot(c, desktopLegacyCoreYaml, nil, "desktop-legacy")
 }
 
 func (s *DesktopLegacyInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -58,8 +58,8 @@ slots:
 `
 
 func (s *DesktopInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, desktopConsumerYaml, nil, "desktop")
-	s.coreSlot = MockSlot(c, desktopCoreYaml, nil, "desktop")
+	s.plug = builtin.MockPlug(c, desktopConsumerYaml, nil, "desktop")
+	s.coreSlot = builtin.MockSlot(c, desktopCoreYaml, nil, "desktop")
 }
 
 func (s *DesktopInterfaceSuite) TearDownTest(c *C) {

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -54,8 +54,8 @@ var _ = Suite(&FirewallControlInterfaceSuite{
 })
 
 func (s *FirewallControlInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, firewallControlConsumerYaml, nil, "firewall-control")
-	s.slot = MockSlot(c, firewallControlCoreYaml, nil, "firewall-control")
+	s.plug = builtin.MockPlug(c, firewallControlConsumerYaml, nil, "firewall-control")
+	s.slot = builtin.MockSlot(c, firewallControlCoreYaml, nil, "firewall-control")
 }
 
 func (s *FirewallControlInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -55,8 +55,8 @@ var _ = Suite(&FramebufferInterfaceSuite{
 })
 
 func (s *FramebufferInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, framebufferConsumerYaml, nil, "framebuffer")
-	s.slot = MockSlot(c, framebufferOsYaml, nil, "framebuffer")
+	s.plug = builtin.MockPlug(c, framebufferConsumerYaml, nil, "framebuffer")
+	s.slot = builtin.MockSlot(c, framebufferOsYaml, nil, "framebuffer")
 }
 
 func (s *FramebufferInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -55,8 +55,8 @@ var _ = Suite(&FuseSupportInterfaceSuite{
 })
 
 func (s *FuseSupportInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, fuseSupportConsumerYaml, nil, "fuse-support")
-	s.slot = MockSlot(c, fuseSupportCoreYaml, nil, "fuse-support")
+	s.plug = builtin.MockPlug(c, fuseSupportConsumerYaml, nil, "fuse-support")
+	s.slot = builtin.MockSlot(c, fuseSupportCoreYaml, nil, "fuse-support")
 }
 
 func (s *FuseSupportInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/hardware_random_control_test.go
+++ b/interfaces/builtin/hardware_random_control_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *HardwareRandomControlInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, hardwareRandomControlConsumerYaml, nil, "hardware-random-control")
-	s.slot = MockSlot(c, hardwareRandomControlCoreYaml, nil, "hardware-random-control")
+	s.plug = builtin.MockPlug(c, hardwareRandomControlConsumerYaml, nil, "hardware-random-control")
+	s.slot = builtin.MockSlot(c, hardwareRandomControlCoreYaml, nil, "hardware-random-control")
 }
 
 func (s *HardwareRandomControlInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/hardware_random_observe_test.go
+++ b/interfaces/builtin/hardware_random_observe_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *HardwareRandomObserveInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, hardwareRandomObserveConsumerYaml, nil, "hardware-random-observe")
-	s.slot = MockSlot(c, hardwareRandomObserveCoreYaml, nil, "hardware-random-observe")
+	s.plug = builtin.MockPlug(c, hardwareRandomObserveConsumerYaml, nil, "hardware-random-observe")
+	s.slot = builtin.MockSlot(c, hardwareRandomObserveCoreYaml, nil, "hardware-random-observe")
 }
 
 func (s *HardwareRandomObserveInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -54,8 +54,8 @@ slots:
 `
 
 func (s *ioPortsControlInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, ioPortsControlConsumerYaml, nil, "io-ports-control")
-	s.slot = MockSlot(c, ioPortsControlCoreYaml, nil, "io-ports-control")
+	s.plug = builtin.MockPlug(c, ioPortsControlConsumerYaml, nil, "io-ports-control")
+	s.slot = builtin.MockSlot(c, ioPortsControlCoreYaml, nil, "io-ports-control")
 }
 
 func (s *ioPortsControlInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *JoystickInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, joystickConsumerYaml, nil, "joystick")
-	s.slot = MockSlot(c, joystickCoreYaml, nil, "joystick")
+	s.plug = builtin.MockPlug(c, joystickConsumerYaml, nil, "joystick")
+	s.slot = builtin.MockSlot(c, joystickCoreYaml, nil, "joystick")
 }
 
 func (s *JoystickInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -54,8 +54,8 @@ slots:
 `
 
 func (s *KernelModuleControlInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, kernelmodctlConsumerYaml, nil, "kernel-module-control")
-	s.slot = MockSlot(c, kernelmodctlCoreYaml, nil, "kernel-module-control")
+	s.plug = builtin.MockPlug(c, kernelmodctlConsumerYaml, nil, "kernel-module-control")
+	s.slot = builtin.MockSlot(c, kernelmodctlCoreYaml, nil, "kernel-module-control")
 }
 
 func (s *KernelModuleControlInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/kvm_test.go
+++ b/interfaces/builtin/kvm_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *kvmInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, kvmConsumerYaml, nil, "kvm")
-	s.slot = MockSlot(c, kvmCoreYaml, nil, "kvm")
+	s.plug = builtin.MockPlug(c, kvmConsumerYaml, nil, "kvm")
+	s.slot = builtin.MockSlot(c, kvmCoreYaml, nil, "kvm")
 }
 
 func (s *kvmInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *LxdSupportInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, lxdSupportConsumerYaml, nil, "lxd-support")
-	s.slot = MockSlot(c, lxdSupportCoreYaml, nil, "lxd-support")
+	s.plug = builtin.MockPlug(c, lxdSupportConsumerYaml, nil, "lxd-support")
+	s.slot = builtin.MockSlot(c, lxdSupportCoreYaml, nil, "lxd-support")
 }
 
 func (s *LxdSupportInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/lxd_test.go
+++ b/interfaces/builtin/lxd_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *LxdInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, lxdConsumerYaml, nil, "lxd")
-	s.slot = MockSlot(c, lxdCoreYaml, nil, "lxd")
+	s.plug = builtin.MockPlug(c, lxdConsumerYaml, nil, "lxd")
+	s.slot = builtin.MockSlot(c, lxdCoreYaml, nil, "lxd")
 }
 
 func (s *LxdInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -54,8 +54,8 @@ slots:
 `
 
 func (s *NetworkControlInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, networkControlConsumerYaml, nil, "network-control")
-	s.slot = MockSlot(c, networkControlCoreYaml, nil, "network-control")
+	s.plug = builtin.MockPlug(c, networkControlConsumerYaml, nil, "network-control")
+	s.slot = builtin.MockSlot(c, networkControlCoreYaml, nil, "network-control")
 }
 
 func (s *NetworkControlInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *OpenglInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, openglConsumerYaml, nil, "opengl")
-	s.slot = MockSlot(c, openglCoreYaml, nil, "opengl")
+	s.plug = builtin.MockPlug(c, openglConsumerYaml, nil, "opengl")
+	s.slot = builtin.MockSlot(c, openglCoreYaml, nil, "opengl")
 }
 
 func (s *OpenglInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/optical_drive_test.go
+++ b/interfaces/builtin/optical_drive_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *OpticalDriveInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, opticalDriveConsumerYaml, nil, "optical-drive")
-	s.slot = MockSlot(c, opticalDriveCoreYaml, nil, "optical-drive")
+	s.plug = builtin.MockPlug(c, opticalDriveConsumerYaml, nil, "optical-drive")
+	s.slot = builtin.MockSlot(c, opticalDriveCoreYaml, nil, "optical-drive")
 }
 
 func (s *OpticalDriveInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *PhysicalMemoryControlInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, physicalMemoryControlConsumerYaml, nil, "physical-memory-control")
-	s.slot = MockSlot(c, physicalMemoryControlCoreYaml, nil, "physical-memory-control")
+	s.plug = builtin.MockPlug(c, physicalMemoryControlConsumerYaml, nil, "physical-memory-control")
+	s.slot = builtin.MockSlot(c, physicalMemoryControlCoreYaml, nil, "physical-memory-control")
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -54,8 +54,8 @@ slots:
 `
 
 func (s *PhysicalMemoryObserveInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, physicalMemoryObserveConsumerYaml, nil, "physical-memory-observe")
-	s.slot = MockSlot(c, physicalMemoryObserveCoreYaml, nil, "physical-memory-observe")
+	s.plug = builtin.MockPlug(c, physicalMemoryObserveConsumerYaml, nil, "physical-memory-observe")
+	s.slot = builtin.MockSlot(c, physicalMemoryObserveCoreYaml, nil, "physical-memory-observe")
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/ppp_test.go
+++ b/interfaces/builtin/ppp_test.go
@@ -54,8 +54,8 @@ slots:
 `
 
 func (s *PppInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, pppConsumerYaml, nil, "ppp")
-	s.slot = MockSlot(c, pppCoreYaml, nil, "ppp")
+	s.plug = builtin.MockPlug(c, pppConsumerYaml, nil, "ppp")
+	s.slot = builtin.MockSlot(c, pppCoreYaml, nil, "ppp")
 }
 
 func (s *PppInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *RawUsbInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, rawusbConsumerYaml, nil, "raw-usb")
-	s.slot = MockSlot(c, rawusbCoreYaml, nil, "raw-usb")
+	s.plug = builtin.MockPlug(c, rawusbConsumerYaml, nil, "raw-usb")
+	s.slot = builtin.MockSlot(c, rawusbCoreYaml, nil, "raw-usb")
 }
 
 func (s *RawUsbInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -61,8 +61,8 @@ slots:
 `
 
 func (s *TimeControlInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, timectlConsumerYaml, nil, "time-control")
-	s.slot = MockSlot(c, timectlCoreYaml, nil, "time-control")
+	s.plug = builtin.MockPlug(c, timectlConsumerYaml, nil, "time-control")
+	s.slot = builtin.MockSlot(c, timectlCoreYaml, nil, "time-control")
 }
 
 func (s *TimeControlInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *TpmInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, tpmConsumerYaml, nil, "tpm")
-	s.slot = MockSlot(c, tpmCoreYaml, nil, "tpm")
+	s.plug = builtin.MockPlug(c, tpmConsumerYaml, nil, "tpm")
+	s.slot = builtin.MockSlot(c, tpmCoreYaml, nil, "tpm")
 }
 
 func (s *TpmInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -88,8 +88,8 @@ apps:
 `
 
 func (s *UDisks2InterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, udisks2ConsumerYaml, nil, "udisks2")
-	s.slot = MockSlot(c, udisks2ProducerYaml, nil, "udisks2")
+	s.plug = builtin.MockPlug(c, udisks2ConsumerYaml, nil, "udisks2")
+	s.slot = builtin.MockSlot(c, udisks2ProducerYaml, nil, "udisks2")
 }
 
 func (s *UDisks2InterfaceSuite) TestName(c *C) {
@@ -108,14 +108,14 @@ func (s *UDisks2InterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `peer=(label="snap.producer.app"),`)
 
 	// The label glob when all apps are bound to the udisks2 slot
-	slot := MockSlot(c, udisks2ProducerTwoAppsYaml, nil, "udisks2")
+	slot := builtin.MockSlot(c, udisks2ProducerTwoAppsYaml, nil, "udisks2")
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `peer=(label="snap.producer.*"),`)
 
 	// The label uses alternation when some, but not all, apps is bound to the udisks2 slot
-	slot = MockSlot(c, udisks2ProducerThreeAppsYaml, nil, "udisks2")
+	slot = builtin.MockSlot(c, udisks2ProducerThreeAppsYaml, nil, "udisks2")
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
@@ -128,14 +128,14 @@ func (s *UDisks2InterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.producer.app"), testutil.Contains, `peer=(label="snap.consumer.app"),`)
 
 	// The label glob when all apps are bound to the udisks2 plug
-	plug := MockPlug(c, udisks2ConsumerTwoAppsYaml, nil, "udisks2")
+	plug := builtin.MockPlug(c, udisks2ConsumerTwoAppsYaml, nil, "udisks2")
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 	c.Assert(spec.SnippetForTag("snap.producer.app"), testutil.Contains, `peer=(label="snap.consumer.*"),`)
 
 	// The label uses alternation when some, but not all, apps is bound to the udisks2 plug
-	plug = MockPlug(c, udisks2ConsumerThreeAppsYaml, nil, "udisks2")
+	plug = builtin.MockPlug(c, udisks2ConsumerThreeAppsYaml, nil, "udisks2")
 	spec = &apparmor.Specification{}
 	c.Assert(spec.AddConnectedSlot(s.iface, plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})

--- a/interfaces/builtin/uhid_test.go
+++ b/interfaces/builtin/uhid_test.go
@@ -53,8 +53,8 @@ slots:
 `
 
 func (s *UhidInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, uhidConsumerYaml, nil, "uhid")
-	s.slot = MockSlot(c, uhidCoreYaml, nil, "uhid")
+	s.plug = builtin.MockPlug(c, uhidConsumerYaml, nil, "uhid")
+	s.slot = builtin.MockSlot(c, uhidCoreYaml, nil, "uhid")
 }
 
 func (s *UhidInterfaceSuite) TestName(c *C) {

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -20,15 +20,12 @@
 package builtin_test
 
 import (
-	"fmt"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 type utilsSuite struct {
@@ -64,20 +61,4 @@ func (s *utilsSuite) TestSanitizeSlotReservedForOSOrApp(c *C) {
 	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotOS), IsNil)
 	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotApp), IsNil)
 	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotGadget), ErrorMatches, errmsg)
-}
-
-func MockPlug(c *C, yaml string, si *snap.SideInfo, plugName string) *interfaces.Plug {
-	info := snaptest.MockInfo(c, yaml, si)
-	if plugInfo, ok := info.Plugs[plugName]; ok {
-		return &interfaces.Plug{PlugInfo: plugInfo}
-	}
-	panic(fmt.Sprintf("cannot find plug %q in snap %q", plugName, info.Name()))
-}
-
-func MockSlot(c *C, yaml string, si *snap.SideInfo, slotName string) *interfaces.Slot {
-	info := snaptest.MockInfo(c, yaml, si)
-	if slotInfo, ok := info.Slots[slotName]; ok {
-		return &interfaces.Slot{SlotInfo: slotInfo}
-	}
-	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.Name()))
 }

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -52,8 +52,8 @@ slots:
 `
 
 func (s *WaylandInterfaceSuite) SetUpTest(c *C) {
-	s.plug = MockPlug(c, waylandConsumerYaml, nil, "wayland")
-	s.coreSlot = MockSlot(c, waylandCoreYaml, nil, "wayland")
+	s.plug = builtin.MockPlug(c, waylandConsumerYaml, nil, "wayland")
+	s.coreSlot = builtin.MockSlot(c, waylandCoreYaml, nil, "wayland")
 }
 
 func (s *WaylandInterfaceSuite) TestName(c *C) {


### PR DESCRIPTION
Use MockPlug/MockSlot helpers from builtin (defined in export_test.go instead).
