### PR TITLE
daemon, store: forward SSO invalid credentials errors as 401 Unauthorized responses

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -545,7 +545,7 @@ func getSections(c *Command, r *http.Request, user *auth.UserState) Response {
 		// pass
 	case store.ErrEmptyQuery, store.ErrBadQuery:
 		return BadRequest("%v", err)
-	case store.ErrUnauthenticated:
+	case store.ErrUnauthenticated, store.ErrInvalidCredentials:
 		return Unauthorized("%v", err)
 	default:
 		return InternalError("%v", err)
@@ -606,7 +606,7 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 		// pass
 	case store.ErrEmptyQuery, store.ErrBadQuery:
 		return BadRequest("%v", err)
-	case store.ErrUnauthenticated:
+	case store.ErrUnauthenticated, store.ErrInvalidCredentials:
 		return Unauthorized(err.Error())
 	default:
 		return InternalError("%v", err)
@@ -631,10 +631,14 @@ func findOne(c *Command, r *http.Request, user *auth.UserState, name string) Res
 		AnyChannel: true,
 	}
 	snapInfo, err := theStore.SnapInfo(spec, user)
-	if err != nil {
-		if err == store.ErrSnapNotFound {
-			return SnapNotFound(name, err)
-		}
+	switch err {
+	case nil:
+		// pass
+	case store.ErrInvalidCredentials:
+		return Unauthorized("%v", err)
+	case store.ErrSnapNotFound:
+		return SnapNotFound(name, err)
+	default:
 		return InternalError("%v", err)
 	}
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1166,7 +1166,7 @@ func (s *apiSuite) TestLoginUserInvalidCredentialsError(c *check.C) {
 
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Status, check.Equals, 401)
-	c.Check(rsp.Result.(*errorResult).Message, testutil.Contains, "cannot authenticate to snap store")
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, "invalid credentials")
 }
 
 func (s *apiSuite) TestUserFromRequestNoHeader(c *check.C) {

--- a/store/auth.go
+++ b/store/auth.go
@@ -192,6 +192,8 @@ func requestDischargeMacaroon(endpoint string, data map[string]string) (string, 
 			return "", ErrAuthenticationNeeds2fa
 		case "TWOFACTOR_FAILURE":
 			return "", Err2faFailed
+		case "INVALID_CREDENTIALS":
+			return "", ErrInvalidCredentials
 		case "INVALID_DATA":
 			return "", InvalidAuthDataError(msg.Extra)
 		case "PASSWORD_POLICY_ERROR":

--- a/store/auth_test.go
+++ b/store/auth_test.go
@@ -172,7 +172,7 @@ func (s *authTestSuite) TestDischargeAuthCaveatInvalidLogin(c *C) {
 	UbuntuoneDischargeAPI = mockServer.URL + "/tokens/discharge"
 
 	discharge, err := dischargeAuthCaveat("third-party-caveat", "foo@example.com", "passwd", "")
-	c.Assert(err, ErrorMatches, "cannot authenticate to snap store: Provided email/password is not correct.")
+	c.Assert(err, Equals, ErrInvalidCredentials)
 	c.Assert(discharge, Equals, "")
 }
 
@@ -221,7 +221,7 @@ func (s *authTestSuite) TestRefreshDischargeMacaroonInvalidLogin(c *C) {
 	UbuntuoneRefreshDischargeAPI = mockServer.URL + "/tokens/refresh"
 
 	discharge, err := refreshDischargeMacaroon("soft-expired-serialized-discharge-macaroon")
-	c.Assert(err, ErrorMatches, "cannot authenticate to snap store: Provided email/password is not correct.")
+	c.Assert(err, Equals, ErrInvalidCredentials)
 	c.Assert(discharge, Equals, "")
 }
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -46,6 +46,8 @@ var (
 	Err2faFailed = errors.New("two factor authentication failed")
 
 	// ErrInvalidCredentials is returned on login error
+	// It can also be returned when refreshing the discharge
+	// macaroon if the user has changed their password.
 	ErrInvalidCredentials = errors.New("invalid credentials")
 
 	// ErrTOSNotAccepted is returned when the user has not accepted the store's terms of service.

--- a/tests/main/login/unsuccessful_login.exp
+++ b/tests/main/login/unsuccessful_login.exp
@@ -6,7 +6,7 @@ expect "Password of "
 send "wrong-password\n"
 
 expect {
-    -re "not\[ \n\r\]*correct" {
+    -re "invalid\[ \n\r\]*credentials" {
         exit 0
     } default {
         exit 1


### PR DESCRIPTION
When refreshing the store macaroon discharge, the SSO server will return an INVALID_CREDENTIALS error if the user has changed their password since the original macaroon was created.

At the moment, this filters out through the snapd API as a generic `500 Internal Server Error` response.  This is not particularly helpful for clients that would want to do more than just display the error to the user (e.g. get them to provide the new password).

This branch forwards the error on as a 401 Unauthorized error, so the client knows it needs to log in again.