### PR TITLE
cmd/snap: warn when a snap is not from the tracking channel

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -367,10 +367,19 @@ func showDone(names []string, op string) error {
 			} else {
 				fmt.Fprintf(Stdout, i18n.G("%s%s %s refreshed\n"), snap.Name, channelStr, snap.Version)
 			}
+		case "revert":
+			// TRANSLATORS: first %s is a snap name, second %s is a revision
+			fmt.Fprintf(Stdout, i18n.G("%s reverted to %s\n"), snap.Name, snap.Version)
 		default:
 			fmt.Fprintf(Stdout, "internal error, unknown op %q", op)
 		}
+		if snap.TrackingChannel != snap.Channel {
+			fmt.Fprintf(Stdout, i18n.G("This leaves %s tracking %s, but the current revision is from %s.\n"),
+				snap.Name, snap.TrackingChannel, snap.Channel)
+			fmt.Fprintln(Stdout, "Use 'snap switch' to change the tracking channel.")
+		}
 	}
+
 	return nil
 }
 
@@ -934,18 +943,7 @@ func (x *cmdRevert) Execute(args []string) error {
 		return err
 	}
 
-	// show output as speced
-	snaps, err := cli.List([]string{name}, nil)
-	if err != nil {
-		return err
-	}
-	if len(snaps) != 1 {
-		// TRANSLATORS: %q gets the snap name, %v the list of things found when trying to list it
-		return fmt.Errorf(i18n.G("cannot get data for %q: %v"), name, snaps)
-	}
-	snap := snaps[0]
-	fmt.Fprintf(Stdout, i18n.G("%s reverted to %s\n"), name, snap.Version)
-	return nil
+	return showDone([]string{name}, "revert")
 }
 
 var shortSwitchHelp = i18n.G("Switches snap to a different channel")

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -378,10 +378,8 @@ func showDone(names []string, op string) error {
 			fmt.Fprintf(Stdout, "internal error, unknown op %q", op)
 		}
 		if snap.TrackingChannel != snap.Channel {
-			// TRANSLATORS: first %s is a snap name, following two %s are channel names
-			fmt.Fprintf(Stdout, i18n.G("This leaves %s tracking %s, but the current revision is from %s.\n"),
-				snap.Name, snap.TrackingChannel, snap.Channel)
-			fmt.Fprintln(Stdout, "Use 'snap switch' to change the tracking channel.")
+			// TRANSLATORS: first %s is a snap name, following %s is a channel name
+			fmt.Fprintf(Stdout, i18n.G("This leaves %s tracking %s.\n"), snap.Name, snap.TrackingChannel)
 		}
 	}
 

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -357,14 +357,18 @@ func showDone(names []string, op string) error {
 		switch op {
 		case "install":
 			if snap.Developer != "" {
+				// TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' installed")
 				fmt.Fprintf(Stdout, i18n.G("%s%s %s from '%s' installed\n"), snap.Name, channelStr, snap.Version, snap.Developer)
 			} else {
+				// TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 installed")
 				fmt.Fprintf(Stdout, i18n.G("%s%s %s installed\n"), snap.Name, channelStr, snap.Version)
 			}
 		case "refresh":
 			if snap.Developer != "" {
+				// TRANSLATORS: the args are a snap name optionally followed by a channel, then a version, then the developer name (e.g. "some-snap (beta) 1.3 from 'alice' refreshed")
 				fmt.Fprintf(Stdout, i18n.G("%s%s %s from '%s' refreshed\n"), snap.Name, channelStr, snap.Version, snap.Developer)
 			} else {
+				// TRANSLATORS: the args are a snap name optionally followed by a channel, then a version (e.g. "some-snap (beta) 1.3 refreshed")
 				fmt.Fprintf(Stdout, i18n.G("%s%s %s refreshed\n"), snap.Name, channelStr, snap.Version)
 			}
 		case "revert":
@@ -374,6 +378,7 @@ func showDone(names []string, op string) error {
 			fmt.Fprintf(Stdout, "internal error, unknown op %q", op)
 		}
 		if snap.TrackingChannel != snap.Channel {
+			// TRANSLATORS: first %s is a snap name, following two %s are channel names
 			fmt.Fprintf(Stdout, i18n.G("This leaves %s tracking %s, but the current revision is from %s.\n"),
 				snap.Name, snap.TrackingChannel, snap.Channel)
 			fmt.Fprintln(Stdout, "Use 'snap switch' to change the tracking channel.")

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -439,8 +439,7 @@ func (s *SnapOpSuite) TestRevertRunthrough(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	// tracking channel is "" in the test server
 	c.Check(s.Stdout(), check.Equals, `foo reverted to 1.0
-This leaves foo tracking , but the current revision is from potato.
-Use 'snap switch' to change the tracking channel.
+This leaves foo tracking .
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -423,6 +423,30 @@ func (s *SnapOpSuite) TestInstallPathDangerous(c *check.C) {
 	c.Check(s.srv.n, check.Equals, s.srv.total)
 }
 
+func (s *SnapOpSuite) TestRevertRunthrough(c *check.C) {
+	s.srv.total = 4
+	s.srv.channel = "potato"
+	s.srv.checker = func(r *http.Request) {
+		c.Check(r.URL.Path, check.Equals, "/v2/snaps/foo")
+		c.Check(DecodedRequestBody(c, r), check.DeepEquals, map[string]interface{}{
+			"action": "revert",
+		})
+	}
+
+	s.RedirectClientToTestServer(s.srv.handle)
+	rest, err := snap.Parser().ParseArgs([]string{"revert", "foo"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	// tracking channel is "" in the test server
+	c.Check(s.Stdout(), check.Equals, `foo reverted to 1.0
+This leaves foo tracking , but the current revision is from potato.
+Use 'snap switch' to change the tracking channel.
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+	// ensure that the fake server api was actually hit
+	c.Check(s.srv.n, check.Equals, s.srv.total)
+}
+
 func (s *SnapOpSuite) runRevertTest(c *check.C, opts *client.SnapOptions) {
 	modes := []struct {
 		enabled bool
@@ -976,8 +1000,8 @@ func (s *SnapOpSuite) TestNoWait(c *check.C) {
 		{"try", "--no-wait", "."},
 	}
 
+	s.RedirectClientToTestServer(s.srv.handle)
 	for _, cmd := range cmds {
-		s.RedirectClientToTestServer(s.srv.handle)
 		rest, err := snap.Parser().ParseArgs(cmd)
 		c.Assert(err, check.IsNil, check.Commentf("%v", cmd))
 		c.Assert(rest, check.DeepEquals, []string{})


### PR DESCRIPTION
`snap revert` and `snap refresh --revision` can leave a snap with its
current revision not coming from the channel the snap is tracking. As
this can be surprising to some users, print a little message abou tit.
