### PR TITLE
servicestate: use taskset

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2636,8 +2636,7 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 	st.Lock()
 	defer st.Unlock()
-	chg := st.NewChange("service-control", fmt.Sprintf("Running service command"))
-	chg.AddAll(ts)
+	chg := newChange(st, "service-control", fmt.Sprintf("Running service command"), []*state.TaskSet{ts}, inst.Names)
 	st.EnsureBefore(0)
 	return AsyncResponse(nil, &Meta{Change: chg.ID()})
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2627,13 +2627,17 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("no services found")
 	}
 
-	chg, err := servicestate.Change(st, appInfos, &inst)
+	ts, err := servicestate.Change(st, appInfos, &inst)
 	if err != nil {
 		if _, ok := err.(servicestate.ServiceActionConflictError); ok {
 			return Conflict(err.Error())
 		}
 		return BadRequest(err.Error())
 	}
+	st.Lock()
+	defer st.Unlock()
+	chg := st.NewChange("service-control", fmt.Sprintf("Running service command"))
+	chg.AddAll(ts)
 	st.EnsureBefore(0)
 	return AsyncResponse(nil, &Meta{Change: chg.ID()})
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2627,7 +2627,7 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("no services found")
 	}
 
-	ts, err := servicestate.Change(st, appInfos, &inst)
+	ts, err := servicestate.Control(st, appInfos, &inst)
 	if err != nil {
 		if _, ok := err.(servicestate.ServiceActionConflictError); ok {
 			return Conflict(err.Error())

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6144,8 +6144,11 @@ func (s *appSuite) TestPostAppsStartTwo(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a"}}
 	expected := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service"}
 	chg := s.testPostApps(c, inst, expected)
+	chg.State().Lock()
+	defer chg.State().Unlock()
 	// check the summary expands the snap into actual apps
-	c.Check(chg.Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2]")
+	c.Check(chg.Summary(), check.Equals, "Running service command")
+	c.Check(chg.Tasks()[0].Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2]")
 }
 
 func (s *appSuite) TestPostAppsStartThree(c *check.C) {
@@ -6153,7 +6156,10 @@ func (s *appSuite) TestPostAppsStartThree(c *check.C) {
 	expected := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service", "snap.snap-b.svc3.service"}
 	chg := s.testPostApps(c, inst, expected)
 	// check the summary expands the snap into actual apps
-	c.Check(chg.Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2 snap-b.svc3]")
+	c.Check(chg.Summary(), check.Equals, "Running service command")
+	chg.State().Lock()
+	defer chg.State().Unlock()
+	c.Check(chg.Tasks()[0].Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2 snap-b.svc3]")
 }
 
 func (s *appSuite) TestPosetAppsStop(c *check.C) {

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -29,7 +29,7 @@ import (
 var AttributesTask = attributesTask
 var CopyAttributes = copyAttributes
 
-func MockServiceChangeFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction) (*state.Change, error)) (restore func()) {
+func MockServiceChangeFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction) (*state.TaskSet, error)) (restore func()) {
 	old := servicechangeImpl
 	servicechangeImpl = f
 	return func() { servicechangeImpl = old }

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -29,10 +29,10 @@ import (
 var AttributesTask = attributesTask
 var CopyAttributes = copyAttributes
 
-func MockServiceChangeFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction) (*state.TaskSet, error)) (restore func()) {
-	old := servicechangeImpl
-	servicechangeImpl = f
-	return func() { servicechangeImpl = old }
+func MockServicestateControlFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction) (*state.TaskSet, error)) (restore func()) {
+	old := servicestateControl
+	servicestateControl = f
+	return func() { servicestateControl = old }
 }
 
 func AddMockCommand(name string) *MockCommand {

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -80,12 +80,13 @@ func runServiceCommand(context *hookstate.Context, inst *servicestate.Instructio
 		return err
 	}
 
-	chg, err := servicechangeImpl(st, appInfos, inst)
+	ts, err := servicechangeImpl(st, appInfos, inst)
 	if err != nil {
 		return err
 	}
-
 	st.Lock()
+	chg := st.NewChange("service-control", fmt.Sprintf("Running service command for snap %q", context.SnapName()))
+	chg.AddAll(ts)
 	st.EnsureBefore(0)
 	st.Unlock()
 

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -67,7 +67,7 @@ func getServiceInfos(st *state.State, snapName string, serviceNames []string) ([
 	return svcs, nil
 }
 
-var servicechangeImpl = servicestate.Change
+var servicestateControl = servicestate.Control
 
 func runServiceCommand(context *hookstate.Context, inst *servicestate.Instruction, serviceNames []string) error {
 	if context == nil {
@@ -80,7 +80,7 @@ func runServiceCommand(context *hookstate.Context, inst *servicestate.Instructio
 		return err
 	}
 
-	ts, err := servicechangeImpl(st, appInfos, inst)
+	ts, err := servicestateControl(st, appInfos, inst)
 	if err != nil {
 		return err
 	}

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -67,7 +67,7 @@ apps:
 `
 
 func mockServiceChangeFunc(testServiceControlInputs func(appInfos []*snap.AppInfo, inst *servicestate.Instruction)) func() {
-	return ctlcmd.MockServiceChangeFunc(func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction) (*state.TaskSet, error) {
+	return ctlcmd.MockServicestateControlFunc(func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction) (*state.TaskSet, error) {
 		testServiceControlInputs(appInfos, inst)
 		return nil, fmt.Errorf("forced error")
 	})

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -39,7 +39,7 @@ type Instruction struct {
 
 type ServiceActionConflictError struct{ error }
 
-func Change(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.TaskSet, error) {
+func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.TaskSet, error) {
 	// the argv to call systemctl will need at most one entry per appInfo,
 	// plus one for "systemctl", one for the action, and sometimes one for
 	// an option. That's a maximum of 3+len(appInfos).

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -39,7 +39,7 @@ type Instruction struct {
 
 type ServiceActionConflictError struct{ error }
 
-func Change(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.Change, error) {
+func Change(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.TaskSet, error) {
 	// the argv to call systemctl will need at most one entry per appInfo,
 	// plus one for "systemctl", one for the action, and sometimes one for
 	// an option. That's a maximum of 3+len(appInfos).
@@ -87,8 +87,5 @@ func Change(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*stat
 		return nil, &ServiceActionConflictError{err}
 	}
 
-	ts := cmdstate.Exec(st, desc, argv)
-	chg := st.NewChange("service-control", desc)
-	chg.AddAll(ts)
-	return chg, nil
+	return cmdstate.Exec(st, desc, argv), nil
 }


### PR DESCRIPTION
Use taskset for servicestate.Change(..). This was brought up during the initial review of servicestate, now I need to this for an upcoming enhancement to service commands.
