### PR TITLE
spdx: fix for WITH syntax, require a license name before the operator

### DIFF
--- a/spdx/parser.go
+++ b/spdx/parser.go
@@ -115,6 +115,9 @@ func (p *parser) validate(depth int) error {
 			if last == opAND || last == opOR {
 				return fmt.Errorf("expected license name, got %q", tok)
 			}
+			if tok == opWITH && last == "(" {
+				return fmt.Errorf("expected license name before %s", tok)
+			}
 			if last == opWITH {
 				return fmt.Errorf("expected exception name, got %q", tok)
 			}

--- a/spdx/parser_test.go
+++ b/spdx/parser_test.go
@@ -42,7 +42,7 @@ func (s *spdxSuite) TestParseHappy(c *C) {
 		"GPL-2.0 WITH GCC-exception-3.1",
 		"(GPL-2.0 AND BSD-2-Clause)",
 		"GPL-2.0 AND (BSD-2-Clause OR 0BSD)",
-		"GPL-2.0 AND (BSD-2-Clause OR 0BSD) WITH GCC-exception-3.1",
+		"(BSD-2-Clause OR 0BSD) AND GPL-2.0 WITH GCC-exception-3.1",
 		"((GPL-2.0 AND (BSD-2-Clause OR 0BSD)) OR GPL-3.0) ",
 	} {
 		err := spdx.ValidateLicense(t)
@@ -69,6 +69,7 @@ func (s *spdxSuite) TestParseError(c *C) {
 		{"GPL-2.0 OR", "missing license after OR"},
 		{"GPL-2.0 WITH BAR", "unknown license exception: BAR"},
 		{"GPL-2.0 WITH (foo)", `"\(" not allowed after WITH`},
+		{"(BSD-2-Clause OR 0BSD) WITH GCC-exception-3.1", `expected license name before WITH`},
 	} {
 		err := spdx.ValidateLicense(t.inp)
 		c.Check(err, ErrorMatches, t.errStr, Commentf("input: %q", t.inp))


### PR DESCRIPTION
According to SPDX spec[1], before WITH operator a simple license (ie. a license id) is required:
`simple-expression "WITH" license-exception-id`

So no compound-expression should be allowed on the left side of a WITH.

[1] https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60