### PR TITLE
daemon: allow Polkit authorization to cancel changes.

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -189,10 +189,11 @@ var (
 	}
 
 	stateChangeCmd = &Command{
-		Path:   "/v2/changes/{id}",
-		UserOK: true,
-		GET:    getChange,
-		POST:   abortChange,
+		Path:     "/v2/changes/{id}",
+		UserOK:   true,
+		PolkitOK: "io.snapcraft.snapd.manage",
+		GET:      getChange,
+		POST:     abortChange,
 	}
 
 	stateChangesCmd = &Command{


### PR DESCRIPTION
We allow Polkit to authorize clients to install/remove snaps.
If a user wants to cancel this transaction, this requires root/macaroon access.

This allows a Polkit user to cancel any transaction - if we make Polkit access
more fine grained in the future we may want to check what the transaction type
is before picking the Polkit action id to use.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
