### PR TITLE
snapctl: added long help to stop/start/restart command

### DIFF
--- a/overlord/hookstate/ctlcmd/restart.go
+++ b/overlord/hookstate/ctlcmd/restart.go
@@ -28,7 +28,7 @@ import (
 var (
 	shortRestartHelp = i18n.G("Restart services")
 	longRestartHelp  = i18n.G(`
-The restart command restarts given services of the snap. If executed from the
+The restart command restarts the given services of the snap. If executed from the
 "configure" hook, the services will be restarted after the hook finishes.`)
 )
 

--- a/overlord/hookstate/ctlcmd/restart.go
+++ b/overlord/hookstate/ctlcmd/restart.go
@@ -41,7 +41,7 @@ type restartCommand struct {
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
-	Reload bool `long:"reload" description:"reload the given services if they support it (see man systemctl for details)"`
+	Reload bool `long:"reload" description:"Reload the given services if they support it (see man systemctl for details)"`
 }
 
 func (c *restartCommand) Execute(args []string) error {

--- a/overlord/hookstate/ctlcmd/restart.go
+++ b/overlord/hookstate/ctlcmd/restart.go
@@ -27,10 +27,13 @@ import (
 
 var (
 	shortRestartHelp = i18n.G("Restart services")
+	longRestartHelp  = i18n.G(`
+The restart command restarts given services of the snap. If executed from the
+"configure" hook, the services will be restarted after the hook finishes.`)
 )
 
 func init() {
-	addCommand("restart", shortRestartHelp, "", func() command { return &restartCommand{} })
+	addCommand("restart", shortRestartHelp, longRestartHelp, func() command { return &restartCommand{} })
 }
 
 type restartCommand struct {

--- a/overlord/hookstate/ctlcmd/restart.go
+++ b/overlord/hookstate/ctlcmd/restart.go
@@ -41,7 +41,7 @@ type restartCommand struct {
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
-	Reload bool `long:"reload"`
+	Reload bool `long:"reload" description:"reload the given services if they support it (see man systemctl for details)"`
 }
 
 func (c *restartCommand) Execute(args []string) error {

--- a/overlord/hookstate/ctlcmd/start.go
+++ b/overlord/hookstate/ctlcmd/start.go
@@ -41,7 +41,7 @@ type startCommand struct {
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
-	Enable bool `long:"enable" description:"enable the specified services (see man systemctl for details)"`
+	Enable bool `long:"enable" description:"Enable the specified services (see man systemctl for details)"`
 }
 
 func (c *startCommand) Execute(args []string) error {

--- a/overlord/hookstate/ctlcmd/start.go
+++ b/overlord/hookstate/ctlcmd/start.go
@@ -27,10 +27,13 @@ import (
 
 var (
 	shortStartHelp = i18n.G("Start services")
+	longStartHelp  = i18n.G(`
+The start command starts given services of the snap. If executed from the
+"configure" hook, the services will be started after the hook finishes.`)
 )
 
 func init() {
-	addCommand("start", shortStartHelp, "", func() command { return &startCommand{} })
+	addCommand("start", shortStartHelp, longStartHelp, func() command { return &startCommand{} })
 }
 
 type startCommand struct {

--- a/overlord/hookstate/ctlcmd/start.go
+++ b/overlord/hookstate/ctlcmd/start.go
@@ -28,7 +28,7 @@ import (
 var (
 	shortStartHelp = i18n.G("Start services")
 	longStartHelp  = i18n.G(`
-The start command starts given services of the snap. If executed from the
+The start command starts the given services of the snap. If executed from the
 "configure" hook, the services will be started after the hook finishes.`)
 )
 

--- a/overlord/hookstate/ctlcmd/start.go
+++ b/overlord/hookstate/ctlcmd/start.go
@@ -41,7 +41,7 @@ type startCommand struct {
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
-	Enable bool `long:"enable"`
+	Enable bool `long:"enable" description:"enable the specified services (see man systemctl for details)"`
 }
 
 func (c *startCommand) Execute(args []string) error {

--- a/overlord/hookstate/ctlcmd/stop.go
+++ b/overlord/hookstate/ctlcmd/stop.go
@@ -30,7 +30,7 @@ type stopCommand struct {
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
-	Disable bool `long:"disable" description:"disable the specified services (see man systemctl for details)"`
+	Disable bool `long:"disable" description:"Disable the specified services (see man systemctl for details)"`
 }
 
 var (

--- a/overlord/hookstate/ctlcmd/stop.go
+++ b/overlord/hookstate/ctlcmd/stop.go
@@ -30,7 +30,7 @@ type stopCommand struct {
 	Positional struct {
 		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
 	} `positional-args:"yes" required:"yes"`
-	Disable bool `long:"disable"`
+	Disable bool `long:"disable" description:"disable the specified services (see man systemctl for details)"`
 }
 
 var (

--- a/overlord/hookstate/ctlcmd/stop.go
+++ b/overlord/hookstate/ctlcmd/stop.go
@@ -36,7 +36,7 @@ type stopCommand struct {
 var (
 	shortStopHelp = i18n.G("Stop services")
 	longStopHelp  = i18n.G(`
-The stop command stops given services of the snap. If executed from the
+The stop command stops the given services of the snap. If executed from the
 "configure" hook, the services will be stopped after the hook finishes.`)
 )
 

--- a/overlord/hookstate/ctlcmd/stop.go
+++ b/overlord/hookstate/ctlcmd/stop.go
@@ -35,10 +35,13 @@ type stopCommand struct {
 
 var (
 	shortStopHelp = i18n.G("Stop services")
+	longStopHelp  = i18n.G(`
+The stop command stops given services of the snap. If executed from the
+"configure" hook, the services will be stopped after the hook finishes.`)
 )
 
 func init() {
-	addCommand("stop", shortStopHelp, "", func() command { return &stopCommand{} })
+	addCommand("stop", shortStopHelp, longStopHelp, func() command { return &stopCommand{} })
 }
 
 func (c *stopCommand) Execute(args []string) error {


### PR DESCRIPTION
Added long help to `snapctl stop/start/restart`; this is a followup to the implementation PR that just landed.
