### PR TITLE
systemd: run all mount units before snapd.service to avoid race

### DIFF
--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -80,6 +80,7 @@ func (s *mountunitSuite) TestAddMountUnit(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(string(mount), Equals, fmt.Sprintf(`[Unit]
 Description=Mount unit for foo
+Before=snapd.service
 
 [Mount]
 What=/var/lib/snapd/snaps/foo_13.snap

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -428,6 +428,7 @@ func (s *systemd) WriteMountUnitFile(name, what, where, fstype string) (string, 
 
 	c := fmt.Sprintf(`[Unit]
 Description=Mount unit for %s
+Before=snapd.service
 
 [Mount]
 What=%s

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -453,6 +453,7 @@ func (s *SystemdTestSuite) TestWriteMountUnit(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(string(mount), Equals, fmt.Sprintf(`[Unit]
 Description=Mount unit for foo
+Before=snapd.service
 
 [Mount]
 What=%s
@@ -476,6 +477,7 @@ func (s *SystemdTestSuite) TestWriteMountUnitForDirs(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(string(mount), Equals, fmt.Sprintf(`[Unit]
 Description=Mount unit for foodir
+Before=snapd.service
 
 [Mount]
 What=%s
@@ -518,6 +520,7 @@ exit 0
 	c.Assert(err, IsNil)
 	c.Assert(string(mount), Equals, fmt.Sprintf(`[Unit]
 Description=Mount unit for foo
+Before=snapd.service
 
 [Mount]
 What=%s
@@ -556,6 +559,7 @@ exit 0
 	c.Assert(err, IsNil)
 	c.Assert(string(mount), Equals, fmt.Sprintf(`[Unit]
 Description=Mount unit for foo
+Before=snapd.service
 
 [Mount]
 What=%s


### PR DESCRIPTION
  There is a race on startup in Ubuntu 14.04. The mount units for
    the installed snaps and the systemd unit are started at similar
    times and sometimes the mount units are not ready when snapd
    starts. This results in confusing errors like snaps loose all
    their interfaces because the information about the interfaces
    is stored in the on-disk snap.yaml only (reported in
    LP: #1721518).
    
   This PR fixes this issue by adding a "Before=snapd.service"
    relation to all the snap mount units.

We will need to do a followup that rewrites the existing mount units.
