### PR TITLE
 snap-{confine,seccomp}: make @unrestricted fully unrestricted (2.29)

### DIFF
--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -170,6 +170,10 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	fclose(fp);
 	debug("read %zu bytes from %s", num_read, profile_path);
 
+	if (memcmp(bpf, "@unrestricted", strlen("@unrestricted")) == 0) {
+		return 0;
+	}
+
 	uid_t real_uid, effective_uid, saved_uid;
 	if (getresuid(&real_uid, &effective_uid, &saved_uid) < 0) {
 		die("cannot call getresuid");

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -154,7 +154,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	validate_bpfpath_is_safe(profile_path);
 
 	// load bpf
-	unsigned char bpf[MAX_BPF_SIZE + 1] = { 0 };	// account for EOF
+	char bpf[MAX_BPF_SIZE + 1] = { 0 };	// account for EOF
 	FILE *fp = fopen(profile_path, "rb");
 	if (fp == NULL) {
 		die("cannot read %s", profile_path);

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -170,7 +170,7 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 	fclose(fp);
 	debug("read %zu bytes from %s", num_read, profile_path);
 
-	if (memcmp(bpf, "@unrestricted", strlen("@unrestricted")) == 0) {
+	if (sc_streq(bpf, "@unrestricted\n")) {
 		return 0;
 	}
 

--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -619,13 +619,14 @@ func compile(content []byte, out string) error {
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 
-		// FIXME: right now complain mode is the equivalent to
-		// unrestricted.  We'll want to change this once we
-		// seccomp logging is in order.
-		//
-		// special case: unrestricted means we switch to an allow-all
-		//               filter and are done
-		if line == "@unrestricted" || line == "@complain" {
+		// special case: unrestricted means we stop early, we just
+		// write this special tag and evalulate in snap-confine
+		if line == "@unrestricted" {
+			return osutil.AtomicWrite(out, bytes.NewBufferString(line), 0644, 0)
+		}
+		// complain mode is a "allow-all" filter for now until
+		// we can land https://github.com/snapcore/snapd/pull/3998
+		if line == "@complain" {
 			secFilter, err = seccomp.NewFilter(seccomp.ActAllow)
 			if err != nil {
 				return fmt.Errorf("cannot create seccomp filter: %s", err)

--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -622,7 +622,7 @@ func compile(content []byte, out string) error {
 		// special case: unrestricted means we stop early, we just
 		// write this special tag and evalulate in snap-confine
 		if line == "@unrestricted" {
-			return osutil.AtomicWrite(out, bytes.NewBufferString(line), 0644, 0)
+			return osutil.AtomicWrite(out, bytes.NewBufferString(line+"\n"), 0644, 0)
 		}
 		// complain mode is a "allow-all" filter for now until
 		// we can land https://github.com/snapcore/snapd/pull/3998

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -324,7 +324,7 @@ restart_syscall
 }
 
 func (s *snapSeccompSuite) TestUnrestricted(c *C) {
-	inp := "@unrestricted"
+	inp := "@unrestricted\n"
 	outPath := filepath.Join(c.MkDir(), "bpf")
 	err := main.Compile([]byte(inp), outPath)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Cherry-pick of #4054 for the 2.29 branch.