### PR TITLE
interfaces: clean system apparmor cache on core device (2.29)

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -152,6 +152,19 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 			logger.Noticef("cannot create host snap-confine apparmor configuration: %s", err)
 		}
 	}
+	// core on core devices is also special, the apparmor cache gets
+	// confused too easy, especially at rollbacks, so we delete the cache.
+	// See LP:#1460152 and
+	// https://forum.snapcraft.io/t/core-snap-revert-issues-on-core-devices/
+	if snapName == "core" && !release.OnClassic {
+		if l, err := filepath.Glob(dirs.SystemApparmorCacheDir + "/*"); err == nil {
+			for _, p := range l {
+				if err := os.Remove(p); err != nil {
+					logger.Noticef("cannot remove %q: %s", p, err)
+				}
+			}
+		}
+	}
 
 	// Get the files that this snap should have
 	content, err := b.deriveContent(spec.(*Specification), snapInfo, opts)

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -157,10 +157,12 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	// See LP:#1460152 and
 	// https://forum.snapcraft.io/t/core-snap-revert-issues-on-core-devices/
 	if snapName == "core" && !release.OnClassic {
-		if l, err := filepath.Glob(filepath.Join(dirs.SystemApparmorCacheDir, "*")); err == nil {
-			for _, p := range l {
-				if err := os.Remove(p); err != nil {
-					logger.Noticef("cannot remove %q: %s", p, err)
+		if li, err := filepath.Glob(filepath.Join(dirs.SystemApparmorCacheDir, "*")); err == nil {
+			for _, p := range li {
+				if st, err := os.Stat(p); err == nil && st.Mode().IsRegular() {
+					if err := os.Remove(p); err != nil {
+						logger.Noticef("cannot remove %q: %s", p, err)
+					}
 				}
 			}
 		}

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -157,7 +157,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	// See LP:#1460152 and
 	// https://forum.snapcraft.io/t/core-snap-revert-issues-on-core-devices/
 	if snapName == "core" && !release.OnClassic {
-		if l, err := filepath.Glob(dirs.SystemApparmorCacheDir + "/*"); err == nil {
+		if l, err := filepath.Glob(filepath.Join(dirs.SystemApparmorCacheDir, "*")); err == nil {
 			for _, p := range l {
 				if err := os.Remove(p); err != nil {
 					logger.Noticef("cannot remove %q: %s", p, err)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -503,9 +503,16 @@ func (s *backendSuite) TestCoreOnCoreCleansApparmorCache(c *C) {
 
 	err := os.MkdirAll(dirs.SystemApparmorCacheDir, 0755)
 	c.Assert(err, IsNil)
+	// the canary file in the cache will be removed
 	canaryPath := filepath.Join(dirs.SystemApparmorCacheDir, "meep")
 	err = ioutil.WriteFile(canaryPath, nil, 0644)
 	c.Assert(err, IsNil)
+	// but non-regular entries in the cache dir are kept
+	dirsAreKept := filepath.Join(dirs.SystemApparmorCacheDir, "dir")
+	err = os.MkdirAll(dirsAreKept, 0755)
+	c.Assert(err, IsNil)
+	symlinksAreKept := filepath.Join(dirs.SystemApparmorCacheDir, "symlink")
+	err = os.Symlink("some-sylink-target", symlinksAreKept)
 
 	// install the new core snap on classic triggers a new snap-confine
 	// for this snap-confine on core
@@ -513,5 +520,6 @@ func (s *backendSuite) TestCoreOnCoreCleansApparmorCache(c *C) {
 
 	l, err := filepath.Glob(filepath.Join(dirs.SystemApparmorCacheDir, "*"))
 	c.Assert(err, IsNil)
-	c.Check(l, HasLen, 0)
+	// canary is gone, extra stuff is kept
+	c.Check(l, DeepEquals, []string{dirsAreKept, symlinksAreKept})
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -513,6 +513,7 @@ func (s *backendSuite) TestCoreOnCoreCleansApparmorCache(c *C) {
 	c.Assert(err, IsNil)
 	symlinksAreKept := filepath.Join(dirs.SystemApparmorCacheDir, "symlink")
 	err = os.Symlink("some-sylink-target", symlinksAreKept)
+	c.Assert(err, IsNil)
 
 	// install the new core snap on classic triggers a new snap-confine
 	// for this snap-confine on core


### PR DESCRIPTION
Cherry-pick of https://github.com/snapcore/snapd/pull/4060 to 2.29.