### PR TITLE
snap-confine: increase sanity_timeout to 6s

### DIFF
--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -91,7 +91,7 @@ static void test_sc_enable_sanity_timeout()
 	if (g_test_subprocess()) {
 		sc_enable_sanity_timeout();
 		debug("waiting...");
-		usleep(4 * G_USEC_PER_SEC);
+		usleep(7 * G_USEC_PER_SEC);
 		debug("woke up");
 		sc_disable_sanity_timeout();
 		return;

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -60,7 +60,7 @@ void sc_enable_sanity_timeout()
 	if (sigaction(SIGALRM, &act, NULL) < 0) {
 		die("cannot install signal handler for SIGALRM");
 	}
-	alarm(3);
+	alarm(6);
 	debug("sanity timeout initialized and set for three seconds");
 }
 


### PR DESCRIPTION
We see failure on autopkgtest machines. These are likely because
the VMs are very slow and the existing timeout is not enough.

This PR doubles the timeout to deal with really slow environments.

If tests are green with that, this also needs to go to master.
