### PR TITLE
cmd: downgrade log message in InternalToolPath to Debugf()

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -130,7 +130,7 @@ func InternalToolPath(tool string) string {
 	}
 
 	if !strings.HasPrefix(exe, dirs.SnapMountDir) {
-		logger.Noticef("exe doesn't have snap mount dir prefix: %q vs %q", exe, dirs.SnapMountDir)
+		logger.Debugf("exe doesn't have snap mount dir prefix: %q vs %q", exe, dirs.SnapMountDir)
 		return distroTool
 	}
 


### PR DESCRIPTION
Tiny tweak - I noticed we log that we are using the non-reexec tool on core a lot. There is really no need for this to be a noticef, a debugf is sufficient.