### PR TITLE
snapctl: cherry pick service commands changes

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2632,7 +2632,7 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("no services found")
 	}
 
-	ts, err := servicestate.Change(st, appInfos, &inst)
+	ts, err := servicestate.Control(st, appInfos, &inst)
 	if err != nil {
 		if _, ok := err.(servicestate.ServiceActionConflictError); ok {
 			return Conflict(err.Error())

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2632,13 +2632,17 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 		return InternalError("no services found")
 	}
 
-	chg, err := servicestate.Change(st, appInfos, &inst)
+	ts, err := servicestate.Change(st, appInfos, &inst)
 	if err != nil {
 		if _, ok := err.(servicestate.ServiceActionConflictError); ok {
 			return Conflict(err.Error())
 		}
 		return BadRequest(err.Error())
 	}
+	st.Lock()
+	defer st.Unlock()
+	chg := st.NewChange("service-control", fmt.Sprintf("Running service command"))
+	chg.AddAll(ts)
 	st.EnsureBefore(0)
 	return AsyncResponse(nil, &Meta{Change: chg.ID()})
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2641,8 +2641,7 @@ func postApps(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 	st.Lock()
 	defer st.Unlock()
-	chg := st.NewChange("service-control", fmt.Sprintf("Running service command"))
-	chg.AddAll(ts)
+	chg := newChange(st, "service-control", fmt.Sprintf("Running service command"), []*state.TaskSet{ts}, inst.Names)
 	st.EnsureBefore(0)
 	return AsyncResponse(nil, &Meta{Change: chg.ID()})
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6144,8 +6144,11 @@ func (s *appSuite) TestPostAppsStartTwo(c *check.C) {
 	inst := servicestate.Instruction{Action: "start", Names: []string{"snap-a"}}
 	expected := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service"}
 	chg := s.testPostApps(c, inst, expected)
+	chg.State().Lock()
+	defer chg.State().Unlock()
 	// check the summary expands the snap into actual apps
-	c.Check(chg.Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2]")
+	c.Check(chg.Summary(), check.Equals, "Running service command")
+	c.Check(chg.Tasks()[0].Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2]")
 }
 
 func (s *appSuite) TestPostAppsStartThree(c *check.C) {
@@ -6153,7 +6156,10 @@ func (s *appSuite) TestPostAppsStartThree(c *check.C) {
 	expected := []string{"systemctl", "start", "snap.snap-a.svc1.service", "snap.snap-a.svc2.service", "snap.snap-b.svc3.service"}
 	chg := s.testPostApps(c, inst, expected)
 	// check the summary expands the snap into actual apps
-	c.Check(chg.Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2 snap-b.svc3]")
+	c.Check(chg.Summary(), check.Equals, "Running service command")
+	chg.State().Lock()
+	defer chg.State().Unlock()
+	c.Check(chg.Tasks()[0].Summary(), check.Equals, "start of [snap-a.svc1 snap-a.svc2 snap-b.svc3]")
 }
 
 func (s *appSuite) TestPosetAppsStop(c *check.C) {

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -80,6 +80,11 @@ func (c *Context) SnapRevision() snap.Revision {
 	return c.setup.Revision
 }
 
+// Task returns the task associated with the hook or nil if the context is ephemeral
+func (c *Context) Task() *state.Task {
+	return c.task
+}
+
 // HookName returns the name of the hook in this context.
 func (c *Context) HookName() string {
 	return c.setup.Hook

--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -80,9 +80,10 @@ func (c *Context) SnapRevision() snap.Revision {
 	return c.setup.Revision
 }
 
-// Task returns the task associated with the hook or nil if the context is ephemeral
-func (c *Context) Task() *state.Task {
-	return c.task
+// Task returns the task associated with the hook or (nil, false) if the context is ephemeral
+// and task is not available.
+func (c *Context) Task() (*state.Task, bool) {
+	return c.task, c.task != nil
 }
 
 // HookName returns the name of the hook in this context.

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -29,7 +29,7 @@ import (
 var AttributesTask = attributesTask
 var CopyAttributes = copyAttributes
 
-func MockServiceChangeFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction) (*state.Change, error)) (restore func()) {
+func MockServiceChangeFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction) (*state.TaskSet, error)) (restore func()) {
 	old := servicechangeImpl
 	servicechangeImpl = f
 	return func() { servicechangeImpl = old }

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -29,10 +29,10 @@ import (
 var AttributesTask = attributesTask
 var CopyAttributes = copyAttributes
 
-func MockServiceChangeFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction) (*state.TaskSet, error)) (restore func()) {
-	old := servicechangeImpl
-	servicechangeImpl = f
-	return func() { servicechangeImpl = old }
+func MockServicestateControlFunc(f func(*state.State, []*snap.AppInfo, *servicestate.Instruction) (*state.TaskSet, error)) (restore func()) {
+	old := servicestateControl
+	servicestateControl = f
+	return func() { servicestateControl = old }
 }
 
 func AddMockCommand(name string) *MockCommand {

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -80,12 +80,13 @@ func runServiceCommand(context *hookstate.Context, inst *servicestate.Instructio
 		return err
 	}
 
-	chg, err := servicechangeImpl(st, appInfos, inst)
+	ts, err := servicechangeImpl(st, appInfos, inst)
 	if err != nil {
 		return err
 	}
-
 	st.Lock()
+	chg := st.NewChange("service-control", fmt.Sprintf("Running service command for snap %q", context.SnapName()))
+	chg.AddAll(ts)
 	st.EnsureBefore(0)
 	st.Unlock()
 

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -67,7 +67,7 @@ func getServiceInfos(st *state.State, snapName string, serviceNames []string) ([
 	return svcs, nil
 }
 
-var servicechangeImpl = servicestate.Change
+var servicestateControl = servicestate.Control
 
 func runServiceCommand(context *hookstate.Context, inst *servicestate.Instruction, serviceNames []string) error {
 	if context == nil {
@@ -80,7 +80,7 @@ func runServiceCommand(context *hookstate.Context, inst *servicestate.Instructio
 		return err
 	}
 
-	ts, err := servicechangeImpl(st, appInfos, inst)
+	ts, err := servicestateControl(st, appInfos, inst)
 	if err != nil {
 		return err
 	}

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -75,7 +75,11 @@ func queueCommand(context *hookstate.Context, ts *state.TaskSet) {
 	st.Lock()
 	defer st.Unlock()
 
-	change := context.Task().Change()
+	task, ok := context.Task()
+	if !ok {
+		panic("attempted to queue command with ephemeral context")
+	}
+	change := task.Change()
 	tasks := change.Tasks()
 	ts.WaitAll(state.NewTaskSet(tasks...))
 	change.AddAll(ts)
@@ -97,7 +101,7 @@ func runServiceCommand(context *hookstate.Context, inst *servicestate.Instructio
 		return err
 	}
 
-	if !context.IsEphemeral() && context.HookName() == "configure" && (inst.Action == "restart" || inst.Action == "start") {
+	if !context.IsEphemeral() && context.HookName() == "configure" {
 		queueCommand(context, ts)
 		return nil
 	}

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -69,6 +69,18 @@ func getServiceInfos(st *state.State, snapName string, serviceNames []string) ([
 
 var servicestateControl = servicestate.Control
 
+func queueCommand(context *hookstate.Context, ts *state.TaskSet) {
+	// queue command task after all existing tasks of the hook's change
+	st := context.State()
+	st.Lock()
+	defer st.Unlock()
+
+	change := context.Task().Change()
+	tasks := change.Tasks()
+	ts.WaitAll(state.NewTaskSet(tasks...))
+	change.AddAll(ts)
+}
+
 func runServiceCommand(context *hookstate.Context, inst *servicestate.Instruction, serviceNames []string) error {
 	if context == nil {
 		return fmt.Errorf(i18n.G("cannot %s without a context"), inst.Action)
@@ -84,6 +96,12 @@ func runServiceCommand(context *hookstate.Context, inst *servicestate.Instructio
 	if err != nil {
 		return err
 	}
+
+	if !context.IsEphemeral() && context.HookName() == "configure" && (inst.Action == "restart" || inst.Action == "start") {
+		queueCommand(context, ts)
+		return nil
+	}
+
 	st.Lock()
 	chg := st.NewChange("service-control", fmt.Sprintf("Running service command for snap %q", context.SnapName()))
 	chg.AddAll(ts)

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -67,7 +67,7 @@ apps:
 `
 
 func mockServiceChangeFunc(testServiceControlInputs func(appInfos []*snap.AppInfo, inst *servicestate.Instruction)) func() {
-	return ctlcmd.MockServiceChangeFunc(func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction) (*state.TaskSet, error) {
+	return ctlcmd.MockServicestateControlFunc(func(st *state.State, appInfos []*snap.AppInfo, inst *servicestate.Instruction) (*state.TaskSet, error) {
 		testServiceControlInputs(appInfos, inst)
 		return nil, fmt.Errorf("forced error")
 	})

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -39,7 +39,7 @@ type Instruction struct {
 
 type ServiceActionConflictError struct{ error }
 
-func Change(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.TaskSet, error) {
+func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.TaskSet, error) {
 	// the argv to call systemctl will need at most one entry per appInfo,
 	// plus one for "systemctl", one for the action, and sometimes one for
 	// an option. That's a maximum of 3+len(appInfos).

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -39,7 +39,7 @@ type Instruction struct {
 
 type ServiceActionConflictError struct{ error }
 
-func Change(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.Change, error) {
+func Change(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*state.TaskSet, error) {
 	// the argv to call systemctl will need at most one entry per appInfo,
 	// plus one for "systemctl", one for the action, and sometimes one for
 	// an option. That's a maximum of 3+len(appInfos).
@@ -87,8 +87,5 @@ func Change(st *state.State, appInfos []*snap.AppInfo, inst *Instruction) (*stat
 		return nil, &ServiceActionConflictError{err}
 	}
 
-	ts := cmdstate.Exec(st, desc, argv)
-	chg := st.NewChange("service-control", desc)
-	chg.AddAll(ts)
-	return chg, nil
+	return cmdstate.Exec(st, desc, argv), nil
 }

--- a/tests/lib/snaps/test-snapd-service/bin/start
+++ b/tests/lib/snaps/test-snapd-service/bin/start
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+echo $(snapctl get configvalue) > $SNAP_DATA/configvalue
 while true; do
     echo "running"
     sleep 10

--- a/tests/lib/snaps/test-snapd-service/bin/start
+++ b/tests/lib/snaps/test-snapd-service/bin/start
@@ -1,5 +1,5 @@
 #!/bin/sh
-echo $(snapctl get configvalue) > $SNAP_DATA/configvalue
+snapctl get service-option > $SNAP_DATA/service-option
 while true; do
     echo "running"
     sleep 10

--- a/tests/lib/snaps/test-snapd-service/bin/start-other
+++ b/tests/lib/snaps/test-snapd-service/bin/start-other
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo $(snapctl get configvalue) > $SNAP_DATA/configvalue
+while true; do
+    echo "running"
+    sleep 10
+done

--- a/tests/lib/snaps/test-snapd-service/bin/start-other
+++ b/tests/lib/snaps/test-snapd-service/bin/start-other
@@ -1,5 +1,5 @@
 #!/bin/sh
-echo $(snapctl get configvalue) > $SNAP_DATA/configvalue
+snapctl get service-option > $SNAP_DATA/service-option
 while true; do
     echo "running"
     sleep 10

--- a/tests/lib/snaps/test-snapd-service/meta/hooks/configure
+++ b/tests/lib/snaps/test-snapd-service/meta/hooks/configure
@@ -4,6 +4,11 @@ snapctl set configvalue=$(snapctl get sourcevalue)
 
 COMMAND=$(snapctl get command)
 if [ "$COMMAND" != "" ]; then
-    snapctl "$COMMAND" test-snapd-service.test-snapd-service
+    if [ "$COMMAND" = "restart" ]; then
+        snapctl restart test-snapd-service.test-snapd-service
+        snapctl restart test-snapd-service.test-snapd-other-service
+    else
+        snapctl "$COMMAND" test-snapd-service.test-snapd-service
+    fi
 fi
 sleep 3

--- a/tests/lib/snaps/test-snapd-service/meta/hooks/configure
+++ b/tests/lib/snaps/test-snapd-service/meta/hooks/configure
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-snapctl set configvalue=$(snapctl get sourcevalue)
+snapctl set service-option=$(snapctl get service-option-source)
 
 COMMAND=$(snapctl get command)
 if [ "$COMMAND" != "" ]; then

--- a/tests/lib/snaps/test-snapd-service/meta/hooks/configure
+++ b/tests/lib/snaps/test-snapd-service/meta/hooks/configure
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+snapctl set configvalue=$(snapctl get sourcevalue)
+
 COMMAND=$(snapctl get command)
 if [ "$COMMAND" != "" ]; then
     snapctl "$COMMAND" test-snapd-service.test-snapd-service

--- a/tests/lib/snaps/test-snapd-service/meta/hooks/configure
+++ b/tests/lib/snaps/test-snapd-service/meta/hooks/configure
@@ -6,3 +6,4 @@ COMMAND=$(snapctl get command)
 if [ "$COMMAND" != "" ]; then
     snapctl "$COMMAND" test-snapd-service.test-snapd-service
 fi
+sleep 3

--- a/tests/lib/snaps/test-snapd-service/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service/meta/snap.yaml
@@ -5,4 +5,7 @@ apps:
   command: bin/start
   daemon: simple
   reload-command: bin/reload
+ test-snapd-other-service:
+  command: bin/start-other
+  daemon: simple
 

--- a/tests/lib/snaps/test-snapd-service/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service/meta/snap.yaml
@@ -1,11 +1,10 @@
 name: test-snapd-service
 version: 1.0
 apps:
- test-snapd-service:
-  command: bin/start
-  daemon: simple
-  reload-command: bin/reload
- test-snapd-other-service:
-  command: bin/start-other
-  daemon: simple
-
+    test-snapd-service:
+        command: bin/start
+        daemon: simple
+        reload-command: bin/reload
+    test-snapd-other-service:
+        command: bin/start-other
+        daemon: simple

--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -1,6 +1,12 @@
 summary: Check that own services can be controlled by snapctl
 
 kill-timeout: 3m
+environment:
+    CONFIGVALUEFILE: /var/snap/test-snapd-service/current/configvalue
+
+restore: |
+    rm -f $CONFIGVALUEFILE
+
 execute: |
     echo "When the service snap is installed"
     . $TESTSLIB/snaps.sh
@@ -28,7 +34,10 @@ execute: |
     snap services test-snapd-service.test-snapd-service|MATCH " inactive"
 
     echo "And then restart"
-    snap set test-snapd-service command=restart
+    snap set test-snapd-service sourcevalue=foo command=restart
 
     echo "It's running"
     snap services test-snapd-service.test-snapd-service|MATCH " active"
+
+    echo "And service could get the new configvalue set from the hook"
+    cat $CONFIGVALUEFILE | MATCH "^foo$"

--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -40,7 +40,7 @@ execute: |
     snap services test-snapd-service.test-snapd-service|MATCH " active"
 
     echo "And restart command was executed as part of configure hook change"
-    snap tasks --last=configure | MATCH "restart of .test-snapd-service.test-snapd-service"
+    snap tasks --last=configure|MATCH -z "restart of .test-snapd-service.test-snapd-service.+restart of .test-snapd-service.test-snapd-other-service"
 
     echo "And service could get the new configvalue set from the hook"
     cat $CONFIGVALUEFILE | MATCH "^foo$"

--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -2,10 +2,10 @@ summary: Check that own services can be controlled by snapctl
 
 kill-timeout: 3m
 environment:
-    CONFIGVALUEFILE: /var/snap/test-snapd-service/current/configvalue
+    SERVICEOPTIONFILE: /var/snap/test-snapd-service/current/service-option
 
 restore: |
-    rm -f $CONFIGVALUEFILE
+    rm -f $SERVICEOPTIONFILE
 
 execute: |
     echo "When the service snap is installed"
@@ -34,7 +34,7 @@ execute: |
     snap services test-snapd-service.test-snapd-service|MATCH " inactive"
 
     echo "And then restart"
-    snap set test-snapd-service sourcevalue=foo command=restart
+    snap set test-snapd-service service-option-source=foo command=restart
 
     echo "It's running"
     snap services test-snapd-service.test-snapd-service|MATCH " active"
@@ -42,5 +42,5 @@ execute: |
     echo "And restart command was executed as part of configure hook change"
     snap tasks --last=configure|MATCH -z "restart of .test-snapd-service.test-snapd-service.+restart of .test-snapd-service.test-snapd-other-service"
 
-    echo "And service could get the new configvalue set from the hook"
-    cat $CONFIGVALUEFILE | MATCH "^foo$"
+    echo "And service could get the new service-option set from the hook"
+    cat $SERVICEOPTIONFILE | MATCH "^foo$"

--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -39,5 +39,8 @@ execute: |
     echo "It's running"
     snap services test-snapd-service.test-snapd-service|MATCH " active"
 
+    echo "And restart command was executed as part of configure hook change"
+    snap tasks --last=configure | MATCH "restart of .test-snapd-service.test-snapd-service"
+
     echo "And service could get the new configvalue set from the hook"
     cat $CONFIGVALUEFILE | MATCH "^foo$"


### PR DESCRIPTION
Cherry pick changes from master, for release 2.29. Doesn't include help changes that have not landed yet.

This covers #4065 and #4070