### PR TITLE
tests: wait for service status change & file update in the test to avoid races

### DIFF
--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -8,39 +8,64 @@ restore: |
     rm -f $SERVICEOPTIONFILE
 
 execute: |
+
+    wait_for_service() {
+        retry=5
+        while ! snap services $1 | MATCH $2; do
+            retry=$(( retry - 1 ))
+            if [ $retry -le 0 ]; then
+                echo "Failed to match the status of service $1, expected: $2"
+                exit 1
+            fi
+            sleep 1
+        done
+    }
+
+    wait_for_file_change() {
+        retry=5
+        while ! cat $1 | MATCH $2; do
+            retry=$(( retry - 1 ))
+            if [ $retry -le 0 ]; then
+                echo "Failed to match the content of file $1, expected: $2"
+                exit 1
+            fi
+            sleep 1
+        done
+    }
+
     echo "When the service snap is installed"
     . $TESTSLIB/snaps.sh
     install_local test-snapd-service
 
     echo "We can see it running"
-    snap services test-snapd-service.test-snapd-service|MATCH " active"
+    wait_for_service "test-snapd-service.test-snapd-service" " active"
 
     echo "When we stop the service via configure hook"
     snap set test-snapd-service command=stop
 
     echo "It's stopped"
-    snap services test-snapd-service.test-snapd-service|MATCH " inactive"
+    wait_for_service "test-snapd-service.test-snapd-service" " inactive"
 
     echo "When we start the service via configure hook"
     snap set test-snapd-service command=start
 
     echo "It's running again"
-    snap services test-snapd-service.test-snapd-service|MATCH " active"
+    wait_for_service "test-snapd-service.test-snapd-service" " active"
 
     echo "When we stop it again"
     snap set test-snapd-service command=stop
 
     echo "It's stopped"
-    snap services test-snapd-service.test-snapd-service|MATCH " inactive"
+    wait_for_service "test-snapd-service.test-snapd-service" " inactive"
 
     echo "And then restart"
     snap set test-snapd-service service-option-source=foo command=restart
 
     echo "It's running"
-    snap services test-snapd-service.test-snapd-service|MATCH " active"
+    wait_for_service "test-snapd-service.test-snapd-service" " active"
 
     echo "And restart command was executed as part of configure hook change"
     snap tasks --last=configure|MATCH -z "restart of .test-snapd-service.test-snapd-service.+restart of .test-snapd-service.test-snapd-other-service"
 
     echo "And service could get the new service-option set from the hook"
-    cat $SERVICEOPTIONFILE | MATCH "^foo$"
+    wait_for_file_change $SERVICEOPTIONFILE "^foo$"


### PR DESCRIPTION
I haven't experienced the race locally, but it was failing on travis. Hopefully this fixes it.
