### PR TITLE
interfaces/mount: exspose mount.{Escape,Unescape}

### DIFF
--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -83,6 +83,14 @@ var unescape = strings.NewReplacer(
 	`\134`, "\\",
 ).Replace
 
+func Escape(path string) string {
+	return escape(path)
+}
+
+func Unescape(path string) string {
+	return unescape(path)
+}
+
 func (e Entry) String() string {
 	// Name represents name of the device in a mount entry.
 	name := "none"


### PR DESCRIPTION
The mount system uses a special escape function to convert certain
characters, such as spaces, into a format that is passed between
userspace and kernel space.

This patch exposes those functions for public use.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>