### PR TITLE
cmd/snap-update-ns: allow Change.Perform to return changes

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -59,7 +59,7 @@ func (c Change) String() string {
 // the kernel (--make-shared, for example) are unsupported.
 //
 // Perform may synthesize *additional* changes that were necessary to perform
-// the this change (such as mounted tmpfs or overlayfs).
+// this change (such as mounted tmpfs or overlayfs).
 func (c *Change) Perform() ([]*Change, error) {
 	if c.Action == Mount {
 		mode := os.FileMode(0755)

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -129,17 +129,17 @@ func run() error {
 	// Compute the needed changes and perform each change if needed, collecting
 	// those that we managed to perform or that were performed already.
 	changesNeeded := NeededChanges(currentBefore, desired)
-	var changesMade []Change
+	var changesMade []*Change
 	for _, change := range changesNeeded {
-		if change.Action == Keep {
-			changesMade = append(changesMade, change)
-			continue
-		}
-		if err := change.Perform(); err != nil {
+		synthesised, err := change.Perform()
+		// NOTE: we may have done something even if Perform itself has failed.
+		// We need to collect synthesized changes and store them.
+		changesMade = append(changesMade, synthesised...)
+		if err != nil {
 			logger.Noticef("cannot change mount namespace of snap %q according to change %s: %s", snapName, change, err)
 			continue
 		}
-		changesMade = append(changesMade, change)
+		changesMade = append(changesMade, &change)
 	}
 
 	// Compute the new current profile so that it contains only changes that were made


### PR DESCRIPTION
To perform some changes the Perform function may need to create
(synthesise) additional changes. This modification also simplifies
accounting to be generic in all cases.

In the future the synthesized changes will represent additional steps
that were necessary to poke a writable hole in a read-only filesystem.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>