### PR TITLE
cmd/snap-update-ns: initialize logger

### DIFF
--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -43,6 +43,7 @@ var opts struct {
 // snap-confine.
 
 func main() {
+	logger.SimpleSetup()
 	if err := run(); err != nil {
 		fmt.Printf("cannot update snap namespace: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This fixes logging (including logging of errors) from snap-update-ns.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>