### PR TITLE
snap-confine: allow reading uevents from any where in /sys

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -60,7 +60,7 @@
 
     # querying udev
     /etc/udev/udev.conf r,
-    /sys/devices/**/uevent r,
+    /sys/**/uevent r,
     /lib/udev/snappy-app-dev ixr, # drop
     /run/udev/** rw,
     /{,usr/}bin/tr ixr,


### PR DESCRIPTION
uvent files are in more places than just /sys/devices (for example,
/sys/module/rfkill/uevent), so allow reading them from anywhre in /sys.
