### PR TITLE
 interfaces/many: miscellaneous updates based on feedback from the field (2.29)

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -426,6 +426,14 @@ var defaultTemplate = `
   # interface is needed, we can rework this.
   deny /{dev,run,var/run}/shm/lttng-ust-* rw,
 
+  # Allow read-access on /home/ for navigating to other parts of the
+  # filesystem. While this allows enumerating users, this is already allowed
+  # via /etc/passwd and getent.
+  @{HOMEDIRS}/ r,
+
+  # Allow read-access to / for navigating to other parts of the filesystem.
+  / r,
+
 ###SNIPPETS###
 }
 `

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -91,10 +91,10 @@ const bluezPermanentSlotAppArmor = `
       bus=system
       name="org.bluez.obex",
 
-  # Allow traffic to/from our path and interface with any method for unconfined
-  # clients to talk to our bluez services. For the org.bluez interface we don't
-  # specify an Object Path since according to the bluez specification these can
-  # be anything (https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc).
+  # Allow traffic to/from our interface with any method for unconfined clients
+  # to talk to our bluez services. For the org.bluez interface we don't specify
+  # an Object Path since according to the bluez specification these can be
+  # anything (https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc).
   dbus (receive, send)
       bus=system
       interface=org.bluez.*

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -92,10 +92,11 @@ const bluezPermanentSlotAppArmor = `
       name="org.bluez.obex",
 
   # Allow traffic to/from our path and interface with any method for unconfined
-  # cliens to talk to our bluez services.
+  # clients to talk to our bluez services. For the org.bluez interface we don't
+  # specify an Object Path since according to the bluez specification these can
+  # be anything (https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc).
   dbus (receive, send)
       bus=system
-      path=/org/bluez{,/**}
       interface=org.bluez.*
       peer=(label=unconfined),
   dbus (receive, send)

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -66,6 +66,7 @@ owner /{dev,run}/shm/{,.}com.google.Chrome.* mrw,
 
 # Chromium content api in gnome-shell reads this
 /etc/opt/chrome/{,**} r,
+/etc/chromium/{,**} r,
 
 # Chrome/Chromium should be adjusted to not use gconf. It is only used with
 # legacy systems that don't have snapd

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -77,6 +77,12 @@ deny dbus (send)
 # webbrowser-app/webapp-container tries to read this file to determine if it is
 # confined or not, so explicitly deny to avoid noise in the logs.
 deny @{PROC}/@{pid}/attr/current r,
+
+# This is an information leak but disallowing it leads to developer confusion
+# when using the chromium content api file chooser due to a (harmless) glib
+# warning and the noisy AppArmor denial.
+owner @{PROC}/@{pid}/mounts r,
+owner @{PROC}/@{pid}/mountinfo r,
 `
 
 const browserSupportConnectedPlugAppArmorWithoutSandbox = `

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -127,6 +127,7 @@ owner @{PROC}/@{pid}/fd/[0-9]* w,
 /run/udev/data/c89:[0-9]* r,  # /dev/i2c-*
 /run/udev/data/c81:[0-9]* r,  # video4linux (/dev/video*, etc)
 /run/udev/data/c202:[0-9]* r, # /dev/cpu/*/msr
+/run/udev/data/c203:[0-9]* r, # /dev/cuse
 /run/udev/data/+acpi:* r,
 /run/udev/data/+hwmon:hwmon[0-9]* r,
 /run/udev/data/+i2c:* r,
@@ -149,6 +150,7 @@ deny /sys/devices/virtual/block/dm-[0-9]*/dm/name r,
 /run/udev/data/n[0-9]* r,
 /run/udev/data/+bluetooth:hci[0-9]* r,
 /run/udev/data/+rfkill:rfkill[0-9]* r,
+/run/udev/data/c241:[0-9]* r, # /dev/vhost-vsock
 
 # storage
 /run/udev/data/b1:[0-9]* r,   # /dev/ram*

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -71,7 +71,10 @@ owner @{HOME}/.config/gtk-3.0/bookmarks r,
 
 # subset of freedesktop.org
 owner @{HOME}/.local/share/mime/**   r,
-owner @{HOME}/.config/user-dirs.dirs r,
+owner @{HOME}/.config/user-dirs.* r,
+
+/etc/xdg/user-dirs.conf r,
+/etc/xdg/user-dirs.defaults r,
 
 # gmenu
 dbus (send)

--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -40,6 +40,7 @@ capability sys_rawio,
 # used by lspci
 capability sys_admin,
 /etc/modprobe.d/{,*} r,
+/lib/modprobe.d/{,*} r,
 
 # files in /sys pertaining to hardware (eg, 'lspci -A linux-sysfs')
 /sys/{block,bus,class,devices,firmware}/{,**} r,

--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -46,6 +46,7 @@ owner @{HOME}/[^s.]**             rwklix,
 owner @{HOME}/s[^n]**             rwklix,
 owner @{HOME}/sn[^a]**            rwklix,
 owner @{HOME}/sna[^p]**           rwklix,
+owner @{HOME}/snap[^/]**          rwklix,
 # Allow creating a few files not caught above
 owner @{HOME}/{s,sn,sna}{,/} rwklix,
 

--- a/interfaces/builtin/removable_media.go
+++ b/interfaces/builtin/removable_media.go
@@ -32,6 +32,13 @@ const removableMediaBaseDeclarationSlots = `
 const removableMediaConnectedPlugAppArmor = `
 # Description: Can access removable storage filesystems
 
+# Allow read-access to /run/ for navigating to removable media.
+/run/ r,
+
+# Allow read on /run/media/ for navigating to the mount points. While this
+# allows enumerating users, this is already allowed via /etc/passwd and getent.
+/{,run/}media/ r,
+
 # Mount points could be in /run/media/<user>/* or /media/<user>/*
 /{,run/}media/*/ r,
 /{,run/}media/*/** rw,

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -214,13 +214,17 @@ network netlink raw,
 # subset of freedesktop.org
 /usr/share/mime/**                   r,
 owner @{HOME}/.local/share/mime/**   r,
-owner @{HOME}/.config/user-dirs.dirs r,
+owner @{HOME}/.config/user-dirs.* r,
+
+/etc/xdg/user-dirs.conf r,
+/etc/xdg/user-dirs.defaults r,
 
 # gtk settings (subset of gnome abstraction)
 owner @{HOME}/.config/gtk-2.0/gtkfilechooser.ini r,
 owner @{HOME}/.config/gtk-3.0/settings.ini r,
 # Note: this leaks directory names that wouldn't otherwise be known to the snap
 owner @{HOME}/.config/gtk-3.0/bookmarks r,
+
 
 # accessibility
 #include <abstractions/dbus-accessibility-strict>

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -225,7 +225,6 @@ owner @{HOME}/.config/gtk-3.0/settings.ini r,
 # Note: this leaks directory names that wouldn't otherwise be known to the snap
 owner @{HOME}/.config/gtk-3.0/bookmarks r,
 
-
 # accessibility
 #include <abstractions/dbus-accessibility-strict>
 dbus (send)


### PR DESCRIPTION
This is a backport of https://github.com/snapcore/snapd/pull/4097 for 2.29:

    interfaces/desktop,unity7: allow read on system and session xdg user-dirs files
    interfaces/browser-support: allow /run/udev access for cuse and vhost-vsock
    interfaces: allow directory read on /home/ and / by default
    interfaces/removable-media: allowing read on /run/ and /run/media/
    interfaces/browser-support: also allowing reading /etc/chromium/{,**}
    interfaces/browser-support: allow /proc/pid/mount{s,info} to avoid confusion
    interfaces/home: allow reading files and dirs that start with 'snap[^/]'
    interfaces/bluez: don't mediate 'path' to/from unconfined
