### PR TITLE
tests: refactor and expand content interface test

### DIFF
--- a/tests/lib/snaps/test-snapd-content-advanced-plug/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-advanced-plug/meta/snap.yaml
@@ -5,9 +5,18 @@ apps:
     sh:
         command: ../../../bin/sh
 plugs:
+    # NOTE: The following content interface relies on the fact that when
+    # content interface attribute "content" is not provided it defaults to the
+    # plug or slot name. In effect the "data" plug has the "content" attribute
+    # set to "data" and this matches the slot definitions in
+    # test-snapd-content-advanced-slot. The same is true for "common" and
+    # "snap".
     data:
         interface: content
         target: $SNAP_DATA/target
     common:
         interface: content
         target: $SNAP_COMMON/target
+    snap:
+        interface: content
+        target: $SNAP/target

--- a/tests/lib/snaps/test-snapd-content-advanced-slot/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-content-advanced-slot/meta/snap.yaml
@@ -11,3 +11,6 @@ slots:
     common:
         interface: content
         write: [$SNAP_COMMON/source]
+    snap:
+        interface: content
+        write: [$SNAP/source]

--- a/tests/lib/snaps/test-snapd-content-advanced-slot/source/canary
+++ b/tests/lib/snaps/test-snapd-content-advanced-slot/source/canary
@@ -1,0 +1,1 @@
+just some data

--- a/tests/main/interfaces-content-mkdir-writable/task.yaml
+++ b/tests/main/interfaces-content-mkdir-writable/task.yaml
@@ -3,7 +3,20 @@ details: |
     When snap-update-ns is invoked by snap-confine to construct a mount
     namespace it will create missing directories for the mount target.
     This will succeed in specific writable locations, such as $SNAP_DATA and
-    $SNAP_COMMON.
+    $SNAP_COMMON. The $SNAP location is read only but thanks to overalyfs it
+    too can be modified for the calling snap. The test is divided into variants
+    for one of each $SNAP, $SNAP_DATA and $SNAP_COMMON. There's a slight
+    variation for the $SNAP variable, see below for details.
+environment:
+    PLUG/data: test-snapd-content-advanced-plug:data
+    PLUG/common: test-snapd-content-advanced-plug:common
+    PLUG/snap: test-snapd-content-advanced-plug:snap
+    SLOT/data: test-snapd-content-advanced-slot:data
+    SLOT/common: test-snapd-content-advanced-slot:common
+    SLOT/snap: test-snapd-content-advanced-slot:snap
+    VAR/data: SNAP_DATA
+    VAR/common: SNAP_COMMON
+    VAR/snap: SNAP
 prepare: |
     # Install a pair of snaps that both have two content interfaces as
     # sub-directories of $SNAP_DATA and $SNAP_COMMON.
@@ -11,53 +24,82 @@ prepare: |
     install_local test-snapd-content-advanced-plug
     install_local test-snapd-content-advanced-slot
 execute: |
-    # Test that initially there are no mount points because nothing is connected.
-    test-snapd-content-advanced-plug.sh -c 'test ! -e $SNAP_DATA/target'
-    test-snapd-content-advanced-plug.sh -c 'test ! -e $SNAP_COMMON/target'
-    test-snapd-content-advanced-slot.sh -c 'test ! -e $SNAP_DATA/source'
-    test-snapd-content-advanced-slot.sh -c 'test ! -e $SNAP_COMMON/source'
+    # Put our internal tools on PATH so that we can call snap-discard-ns easily.
+    case $SPREAD_SYSTEM in
+        fedora-*) export PATH=/usr/libexec/snapd/:$PATH ;;
+        *) export PATH=/usr/lib/snapd/:$PATH ;;
+    esac
+
+    # Skip the SNAP variant until the related branch is merged.
+    if [ "$VAR" = "SNAP" ]; then
+        echo "Poking holes in read-only space is not yet supported."
+        exit 0
+    fi
+
+    # Test that initially there are no mount points on the plug side (because
+    # nothing is connected). All of the plug side target directories are
+    # created dynamically when the corresponding content interface connects.
+    test-snapd-content-advanced-plug.sh -c "$(printf 'test ! -e $%s/target' "$VAR")"
+
+    # Test that initially there are almost no mount sources on the slot side
+    # (again because nothing is connected yet). All of the slot side source
+    # directories are created upon connection. The only exception is the
+    # $SNAP/source directory that must be present at all times.
+    if [ "$VAR" != "SNAP" ]; then
+        test-snapd-content-advanced-slot.sh -c "$(printf 'test ! -e $%s/source' "$VAR")"
+    else
+        # The reason why this directory exists in $SNAP/source is that the snap
+        # simply always has it. The snap with the content plug cannot poke a
+        # hole that would be visible to the snap that holds the slot because
+        # both snaps see separate mount namespaces and the changes that they
+        # make in their own mount namespace are not propagated to each other.
+        #
+        # In result, the source of a content share, if placed in $SNAP
+        # somewhere, must exist in the snap and cannot be created dynamically. 
+        test-snapd-content-advanced-slot.sh -c "$(printf 'test -d $%s/source' "$VAR")"
+    fi
+
     # Discard the namespaces, we want to do this because the code path when
     # snap-update-ns is invoked from snapd is easier than the one when
     # snap-confine invokes it to do the initial setup. We are testing the
     # initial setup here.
-    case $SPREAD_SYSTEM in
-        fedora-*)
-        /usr/libexec/snapd/snap-discard-ns test-snapd-content-advanced-plug
-        /usr/libexec/snapd/snap-discard-ns test-snapd-content-advanced-slot
-        ;;
-        *)
-        /usr/lib/snapd/snap-discard-ns test-snapd-content-advanced-plug
-        /usr/lib/snapd/snap-discard-ns test-snapd-content-advanced-slot
-        ;;
-    esac
-    # Connect the pair of plugs to the pair of slots.
-    # This should just write the mount profiles to disk.
-    snap connect test-snapd-content-advanced-plug:data test-snapd-content-advanced-slot:data
-    snap connect test-snapd-content-advanced-plug:common test-snapd-content-advanced-slot:common
-    # Test that mount points were created automatically.
-    # This also tests apparmor confinement for snap-update-ns
-    test-snapd-content-advanced-plug.sh -c 'test -d $SNAP_DATA/target'
-    test-snapd-content-advanced-plug.sh -c 'test -d $SNAP_DATA/target'
-    test-snapd-content-advanced-slot.sh -c 'test -d $SNAP_COMMON/source'
-    test-snapd-content-advanced-slot.sh -c 'test -d $SNAP_COMMON/source'
-    # Write some data into from the slot side.
-    test-snapd-content-advanced-slot.sh -c 'touch $SNAP_DATA/source/canary'
-    test-snapd-content-advanced-slot.sh -c 'touch $SNAP_COMMON/source/canary'
+    snap-discard-ns test-snapd-content-advanced-plug
+    snap-discard-ns test-snapd-content-advanced-slot
+
+    # Connect the plug to the slot. This should just write the mount profiles
+    # to disk as we just have discarded the namespaces so there is nothing to
+    # modify.
+    snap connect "$PLUG" "$SLOT"
+
+    # Test that mount points are created automatically upon initialization of
+    # the namespace.  This also tests apparmor confinement for snap-update-ns
+    test-snapd-content-advanced-plug.sh -c "$(printf 'test -d $%s/target' "$VAR")"
+    test-snapd-content-advanced-slot.sh -c "$(printf 'test -d $%s/source' "$VAR")"
+
+    # Write some data into from the slot side. The $SNAP/source/canary file is
+    # always present and we cannot write to it anyway.
+    if [ "$VAR" != "SNAP" ]; then
+        test-snapd-content-advanced-slot.sh -c "$(printf 'touch $%s/source/canary' "$VAR")"
+    fi
+
     # Ensure that the bind mounts worked correctly by observing the data from plug side.
-    test-snapd-content-advanced-plug.sh -c 'test -f $SNAP_DATA/target/canary'
-    test-snapd-content-advanced-plug.sh -c 'test -f $SNAP_COMMON/target/canary'
-    # Without discarding the namespace disconnect both plugs and slots. This
-    # should undo the bind mounts but keep the directories around.
-    snap disconnect test-snapd-content-advanced-plug:data test-snapd-content-advanced-slot:data
-    snap disconnect test-snapd-content-advanced-plug:common test-snapd-content-advanced-slot:common
-    test-snapd-content-advanced-plug.sh -c 'test -d $SNAP_DATA/target'
-    test-snapd-content-advanced-plug.sh -c 'test ! -e $SNAP_DATA/target/canary'
-    test-snapd-content-advanced-plug.sh -c 'test -d $SNAP_DATA/target'
-    test-snapd-content-advanced-plug.sh -c 'test ! -e $SNAP_COMMON/target/canary'
-    test-snapd-content-advanced-slot.sh -c 'test -d $SNAP_COMMON/source'
-    test-snapd-content-advanced-slot.sh -c 'test -d $SNAP_COMMON/source'
-    # Re-connect plugs and slots. We should now see the data again.
-    snap connect test-snapd-content-advanced-plug:data test-snapd-content-advanced-slot:data
-    snap connect test-snapd-content-advanced-plug:common test-snapd-content-advanced-slot:common
-    test-snapd-content-advanced-plug.sh -c 'test -f $SNAP_DATA/target/canary'
-    test-snapd-content-advanced-plug.sh -c 'test -f $SNAP_COMMON/target/canary'
+    test-snapd-content-advanced-plug.sh -c "$(printf 'test -f $%s/target/canary' "$VAR")"
+
+    # Without discarding the namespace disconnect the content interface. This
+    # should undo the bind mounts but keep the directories around. The canary
+    # file is thus no longer accessible but all the directories are in place
+    # because we never remove them explicitly.
+    snap disconnect "$PLUG" "$SLOT"
+
+    if [ "$VAR" != "SNAP" ]; then
+        test-snapd-content-advanced-plug.sh -c "$(printf 'test -d $%s/target' "$VAR")"
+    else
+        test-snapd-content-advanced-plug.sh -c "$(printf 'test ! -d $%s/target' "$VAR")"
+    fi
+    test-snapd-content-advanced-plug.sh -c "$(printf 'test ! -e $%s/target/canary' "$VAR")"
+    test-snapd-content-advanced-slot.sh -c "$(printf 'test -d $%s/source' "$VAR")"
+    test-snapd-content-advanced-slot.sh -c "$(printf 'test -e $%s/source/canary' "$VAR")"
+
+    # Re-connect the content interface. We should now see the data again.
+    snap connect "$PLUG" "$SLOT"
+    test-snapd-content-advanced-plug.sh -c "$(printf 'test -e $%s/target/canary' "$VAR")"

--- a/tests/main/interfaces-content-mkdir-writable/task.yaml
+++ b/tests/main/interfaces-content-mkdir-writable/task.yaml
@@ -25,10 +25,8 @@ prepare: |
     install_local test-snapd-content-advanced-slot
 execute: |
     # Put our internal tools on PATH so that we can call snap-discard-ns easily.
-    case $SPREAD_SYSTEM in
-        fedora-*) export PATH=/usr/libexec/snapd/:$PATH ;;
-        *) export PATH=/usr/lib/snapd/:$PATH ;;
-    esac
+    . $TESTSLIB/dirs.sh
+    PATH=$LIBEXECDIR/snapd:$PATH
 
     # Skip the SNAP variant until the related branch is merged.
     if [ "$VAR" = "SNAP" ]; then


### PR DESCRIPTION
This patch simplifies and explains the content interface test to
separate handling of $SNAP, $SNAP_DATA and $SNAP_COMMON directories.

The $SNAP variant is disabled for now since the corresponding feature is
not merged yet. The rest should just pass.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>