### PR TITLE
cmd/snap-update-ns: add logging to snap-update-ns

### DIFF
--- a/cmd/libsnap-confine-private/utils.c
+++ b/cmd/libsnap-confine-private/utils.c
@@ -121,7 +121,8 @@ static bool getenv_bool(const char *name, bool default_value)
 
 bool sc_is_debug_enabled()
 {
-	return getenv_bool("SNAP_CONFINE_DEBUG", false);
+	return getenv_bool("SNAP_CONFINE_DEBUG", false)
+	    || getenv_bool("SNAPD_DEBUG", false);
 }
 
 bool sc_is_reexec_enabled()

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -165,7 +165,10 @@ static void sc_setup_mount_profiles(int snap_update_ns_fd,
 			"snap-update-ns", "--from-snap-confine", snap_name_copy,
 			NULL
 		};
-		char *envp[] = { NULL };
+		char *envp[3] = { NULL };
+		if (sc_is_debug_enabled()) {
+			envp[0] = "SNAPD_DEBUG=1";
+		}
 		debug("fexecv(%d (snap-update-ns), %s %s %s,)",
 		      snap_update_ns_fd, argv[0], argv[1], argv[2]);
 		fexecve(snap_update_ns_fd, argv, envp);

--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -298,10 +298,14 @@ void bootstrap(void)
     // We may have been started via a setuid-root snap-confine. In order to
     // prevent environment-based attacks we start by erasing all environment
     // variables.
+    char *snapd_debug = getenv("SNAPD_DEBUG");
     if (clearenv() != 0) {
         bootstrap_errno = 0;
         bootstrap_msg = "bootstrap could not clear the environment";
         return;
+    }
+    if (snapd_debug != NULL) {
+        setenv("SNAPD_DEBUG", snapd_debug, 0);
     }
     // We don't have argc/argv so let's imitate that by reading cmdline
     // NOTE: use explicit initialization to avoid optimizing-out memset.

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 
 	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/logger"
 )
 
 // Action represents a mount action (mount, remount, unmount, etc).
@@ -86,9 +87,13 @@ func (c *Change) lowLevelPerform() error {
 	switch c.Action {
 	case Mount:
 		flags, unparsed := mount.OptsToCommonFlags(c.Entry.Options)
-		return sysMount(c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flags), strings.Join(unparsed, ","))
+		err := sysMount(c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flags), strings.Join(unparsed, ","))
+		logger.Debugf("mount %q %q %q %d %q -> %s", c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flags), strings.Join(unparsed, ","), err)
+		return err
 	case Unmount:
-		return sysUnmount(c.Entry.Dir, UMOUNT_NOFOLLOW)
+		err := sysUnmount(c.Entry.Dir, UMOUNT_NOFOLLOW)
+		logger.Debugf("umount %q -> %v", c.Entry.Dir, err)
+		return err
 	case Keep:
 		return nil
 	}

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -69,6 +69,7 @@ func run() error {
 		// If there is no mount namespace to transition to let's just quit
 		// instantly without any errors as there is nothing to do anymore.
 		if err == ErrNoNamespace {
+			logger.Debugf("no preserved mount namespace, nothing to update")
 			return nil
 		}
 		return err
@@ -87,8 +88,12 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("cannot open lock file for mount namespace of snap %q: %s", snapName, err)
 	}
-	defer lock.Close()
+	defer func() {
+		logger.Debugf("unlocking mount namespace of snap %q", snapName)
+		lock.Close()
+	}()
 
+	logger.Debugf("locking mount namespace of snap %q", snapName)
 	if opts.FromSnapConfine {
 		// When --from-snap-confine is passed then we just ensure that the
 		// namespace is locked. This is used by snap-confine to use
@@ -107,10 +112,14 @@ func run() error {
 	// symlinks or perform other malicious activity (such as attempting to
 	// introduce a symlink that would cause us to mount something other
 	// than what we expected).
+	logger.Debugf("freezing processes of snap %q", snapName)
 	if err := freezeSnapProcesses(opts.Positionals.SnapName); err != nil {
 		return err
 	}
-	defer thawSnapProcesses(opts.Positionals.SnapName)
+	defer func() {
+		logger.Debugf("thawing processes of snap %q", snapName)
+		thawSnapProcesses(opts.Positionals.SnapName)
+	}()
 
 	// Read the desired and current mount profiles. Note that missing files
 	// count as empty profiles so that we can gracefully handle a mount
@@ -120,22 +129,34 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("cannot load desired mount profile of snap %q: %s", snapName, err)
 	}
+	debugShowProfile(desired, "desired mount profile")
 
 	currentProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapRunNsDir, snapName)
 	currentBefore, err := mount.LoadProfile(currentProfilePath)
 	if err != nil {
 		return fmt.Errorf("cannot load current mount profile of snap %q: %s", snapName, err)
 	}
+	debugShowProfile(currentBefore, "current mount profile (before applying changes)")
 
 	// Compute the needed changes and perform each change if needed, collecting
 	// those that we managed to perform or that were performed already.
 	changesNeeded := NeededChanges(currentBefore, desired)
+	debugShowChanges(changesNeeded, "mount changes needed")
+
+	logger.Debugf("performing mount changes:")
 	var changesMade []*Change
 	for _, change := range changesNeeded {
+		logger.Debugf("\t * %s", change)
 		synthesised, err := change.Perform()
 		// NOTE: we may have done something even if Perform itself has failed.
 		// We need to collect synthesized changes and store them.
 		changesMade = append(changesMade, synthesised...)
+		if len(synthesised) > 0 {
+			logger.Debugf("\tsynthesised additional mount changes:")
+			for _, synth := range synthesised {
+				logger.Debugf(" * \t\t%s", synth)
+			}
+		}
 		if err != nil {
 			logger.Noticef("cannot change mount namespace of snap %q according to change %s: %s", snapName, change, err)
 			continue
@@ -151,8 +172,33 @@ func run() error {
 			currentAfter.Entries = append(currentAfter.Entries, change.Entry)
 		}
 	}
+	debugShowProfile(&currentAfter, "current mount profile (after applying changes)")
+
+	logger.Debugf("saving current mount profile of snap %q", snapName)
 	if err := currentAfter.Save(currentProfilePath); err != nil {
 		return fmt.Errorf("cannot save current mount profile of snap %q: %s", snapName, err)
 	}
 	return nil
+}
+
+func debugShowProfile(profile *mount.Profile, header string) {
+	if len(profile.Entries) > 0 {
+		logger.Debugf("%s:", header)
+		for _, entry := range profile.Entries {
+			logger.Debugf("\t%s", entry)
+		}
+	} else {
+		logger.Debugf("%s: (none)", header)
+	}
+}
+
+func debugShowChanges(changes []*Change, header string) {
+	if len(changes) > 0 {
+		logger.Debugf("%s:", header)
+		for _, change := range changes {
+			logger.Debugf("\t%s", change)
+		}
+	} else {
+		logger.Debugf("%s: (none)", header)
+	}
 }


### PR DESCRIPTION
This branch adds a number of useful debug messages to snap-update-ns.
They can now be enabled by running with SNAPD_DEBUG=1 set.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>