### PR TITLE
many: lookup and use the URL from a store assertion if one is set for use

### DIFF
--- a/cmd/snap/cmd_known_test.go
+++ b/cmd/snap/cmd_known_test.go
@@ -69,7 +69,7 @@ func (s *SnapSuite) TestKnownRemote(c *check.C) {
 		switch n {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
-			c.Check(r.URL.Path, check.Equals, "/assertions/model/16/canonical/pi99")
+			c.Check(r.URL.Path, check.Equals, "/api/v1/snaps/assertions/model/16/canonical/pi99")
 			fmt.Fprintln(w, mockModelAssertion)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -318,6 +318,19 @@ func Publisher(s *state.State, snapID string) (*asserts.Account, error) {
 	return a.(*asserts.Account), nil
 }
 
+// Store returns the store assertion with the given name/id if it is
+// present in the system assertion database.
+func Store(s *state.State, store string) (*asserts.Store, error) {
+	db := DB(s)
+	a, err := db.Find(asserts.StoreType, map[string]string{
+		"store": store,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return a.(*asserts.Store), nil
+}
+
 // AutoAliases returns the explicit automatic aliases alias=>app mapping for the given installed snap.
 func AutoAliases(s *state.State, info *snap.Info) (map[string]string, error) {
 	if info.SnapID == "" {

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -1101,3 +1101,28 @@ func (s *assertMgrSuite) TestPublisher(c *C) {
 	c.Check(acct.AccountID(), Equals, s.dev1Acct.AccountID())
 	c.Check(acct.Username(), Equals, "developer1")
 }
+
+func (s *assertMgrSuite) TestStore(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	err := assertstate.Add(s.state, s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, s.dev1Acct)
+	c.Assert(err, IsNil)
+	storeHeaders := map[string]interface{}{
+		"store":       "foo",
+		"operator-id": s.dev1Acct.AccountID(),
+	}
+	fooStore, err := s.storeSigning.Sign(asserts.StoreType, storeHeaders, nil, "")
+	c.Assert(err, IsNil)
+	err = assertstate.Add(s.state, fooStore)
+	c.Assert(err, IsNil)
+
+	_, err = assertstate.Store(s.state, "bar")
+	c.Check(asserts.IsNotFound(err), Equals, true)
+
+	store, err := assertstate.Store(s.state, "foo")
+	c.Assert(err, IsNil)
+	c.Check(store.Store(), Equals, "foo")
+}

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -20,6 +20,7 @@
 package auth_test
 
 import (
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -39,9 +40,17 @@ func Test(t *testing.T) { TestingT(t) }
 
 type authSuite struct {
 	state *state.State
+
+	defURL *url.URL
 }
 
 var _ = Suite(&authSuite{})
+
+func (as *authSuite) SetupSuite(c *C) {
+	var err error
+	as.defURL, err = url.Parse("http://store")
+	c.Assert(err, IsNil)
+}
 
 func (as *authSuite) SetUpTest(c *C) {
 	as.state = state.New(nil)
@@ -509,12 +518,17 @@ func (as *authSuite) TestAuthContextUpdateDeviceAuthOtherUpdate(c *C) {
 	})
 }
 
-func (as *authSuite) TestAuthContextStoreIDFallback(c *C) {
+func (as *authSuite) TestAuthContextStoreParamsFallback(c *C) {
 	authContext := auth.NewAuthContext(as.state, nil)
 
 	storeID, err := authContext.StoreID("store-id")
 	c.Assert(err, IsNil)
 	c.Check(storeID, Equals, "store-id")
+
+	proxyStoreID, proxyStoreURL, err := authContext.ProxyStoreParams(as.defURL)
+	c.Assert(err, IsNil)
+	c.Check(proxyStoreID, Equals, "")
+	c.Check(proxyStoreURL, Equals, as.defURL)
 }
 
 func (as *authSuite) TestAuthContextStoreIDFromEnv(c *C) {
@@ -580,6 +594,15 @@ timestamp: @TS@
 sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
 
 AXNpZw=`
+
+	exStore = `type: store
+authority-id: canonical
+store: foo
+operator-id: foo-operator
+url: http://foo.internal
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw=`
 )
 
 type testDeviceAssertions struct {
@@ -636,6 +659,17 @@ func (da *testDeviceAssertions) DeviceSessionRequestParams(nonce string) (*auth.
 	}, nil
 }
 
+func (da *testDeviceAssertions) ProxyStore() (*asserts.Store, error) {
+	if da.nothing {
+		return nil, state.ErrNoState
+	}
+	a, err := asserts.Decode([]byte(exStore))
+	if err != nil {
+		return nil, err
+	}
+	return a.(*asserts.Store), nil
+}
+
 func (as *authSuite) TestAuthContextMissingDeviceAssertions(c *C) {
 	// no assertions in state
 	authContext := auth.NewAuthContext(as.state, &testDeviceAssertions{nothing: true})
@@ -646,6 +680,11 @@ func (as *authSuite) TestAuthContextMissingDeviceAssertions(c *C) {
 	storeID, err := authContext.StoreID("fallback")
 	c.Assert(err, IsNil)
 	c.Check(storeID, Equals, "fallback")
+
+	proxyStoreID, proxyStoreURL, err := authContext.ProxyStoreParams(as.defURL)
+	c.Assert(err, IsNil)
+	c.Check(proxyStoreID, Equals, "")
+	c.Check(proxyStoreURL, Equals, as.defURL)
 }
 
 func (as *authSuite) TestAuthContextWithDeviceAssertions(c *C) {
@@ -673,6 +712,15 @@ func (as *authSuite) TestAuthContextWithDeviceAssertions(c *C) {
 	storeID, err := authContext.StoreID("store-id")
 	c.Assert(err, IsNil)
 	c.Check(storeID, Equals, "my-brand-store-id")
+
+	// proxy store
+	fooURL, err := url.Parse("http://foo.internal")
+	c.Assert(err, IsNil)
+
+	proxyStoreID, proxyStoreURL, err := authContext.ProxyStoreParams(as.defURL)
+	c.Assert(err, IsNil)
+	c.Check(proxyStoreID, Equals, "foo")
+	c.Check(proxyStoreURL, DeepEquals, fooURL)
 }
 
 func (as *authSuite) TestAuthContextWithDeviceAssertionsGenericClassicModel(c *C) {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -466,3 +466,11 @@ func (m *DeviceManager) DeviceSessionRequestParams(nonce string) (*auth.DeviceSe
 	}, err
 
 }
+
+// ProxyStore returns the store assertion for the proxy store if one is set.
+func (m *DeviceManager) ProxyStore() (*asserts.Store, error) {
+	m.state.Lock()
+	defer m.state.Unlock()
+
+	return ProxyStore(m.state)
+}

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -478,10 +479,8 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 	c.Assert(mockServer, NotNil)
 
 	baseURL, _ = url.Parse(mockServer.URL)
-	assertionsBaseURL, _ := baseURL.Parse("api/v1/snaps")
 	storeCfg := store.Config{
-		StoreBaseURL:      baseURL,
-		AssertionsBaseURL: assertionsBaseURL,
+		StoreBaseURL: baseURL,
 	}
 
 	mStore := store.New(&storeCfg, nil)
@@ -1796,7 +1795,7 @@ func (s *authContextSetupSuite) TestStoreID(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(storeID, Equals, "fallback")
 
-	// setup model in system state
+	// setup model in system statey
 	auth.SetDevice(st, &auth.DeviceState{
 		Brand:  s.serial.BrandID(),
 		Model:  s.serial.Model(),
@@ -1846,4 +1845,47 @@ func (s *authContextSetupSuite) TestDeviceSessionRequestParams(c *C) {
 	c.Check(params.EncodedSerial(), DeepEquals, string(asserts.Encode(s.serial)))
 	c.Check(params.EncodedModel(), DeepEquals, string(asserts.Encode(s.model)))
 
+}
+
+func (s *authContextSetupSuite) TestProxyStoreParams(c *C) {
+	st := s.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	defURL, err := url.Parse("http://store")
+	c.Assert(err, IsNil)
+
+	st.Unlock()
+	proxyStoreID, proxyStoreURL, err := s.ac.ProxyStoreParams(defURL)
+	st.Lock()
+	c.Assert(err, IsNil)
+	c.Check(proxyStoreID, Equals, "")
+	c.Check(proxyStoreURL, Equals, defURL)
+
+	// setup proxy store reference and assertion
+	operatorAcct := assertstest.NewAccount(s.storeSigning, "foo-operator", nil, "")
+	err = assertstate.Add(st, operatorAcct)
+	c.Assert(err, IsNil)
+	stoAs, err := s.storeSigning.Sign(asserts.StoreType, map[string]interface{}{
+		"store":       "foo",
+		"operator-id": operatorAcct.AccountID(),
+		"url":         "http://foo.internal",
+	}, nil, "")
+	c.Assert(err, IsNil)
+	err = assertstate.Add(st, stoAs)
+	c.Assert(err, IsNil)
+	tr := config.NewTransaction(st)
+	err = tr.Set("core", "proxy.store", "foo")
+	c.Assert(err, IsNil)
+	tr.Commit()
+
+	fooURL, err := url.Parse("http://foo.internal")
+	c.Assert(err, IsNil)
+
+	st.Unlock()
+	proxyStoreID, proxyStoreURL, err = s.ac.ProxyStoreParams(defURL)
+	st.Lock()
+	c.Assert(err, IsNil)
+	c.Check(proxyStoreID, Equals, "foo")
+	c.Check(proxyStoreURL, DeepEquals, fooURL)
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -73,7 +73,7 @@ func (suite *configTestSuite) TestSetBaseURL(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(cfg.StoreBaseURL.String(), Equals, "http://example.com/path/prefix/")
-	c.Check(cfg.AssertionsBaseURL.String(), Equals, "http://example.com/path/prefix/api/v1/snaps")
+	c.Check(cfg.AssertionsBaseURL, IsNil)
 }
 
 func (suite *configTestSuite) TestSetBaseURLStoreOverrides(c *C) {
@@ -86,7 +86,7 @@ func (suite *configTestSuite) TestSetBaseURLStoreOverrides(c *C) {
 	cfg = DefaultConfig()
 	c.Assert(cfg.setBaseURL(apiURL()), IsNil)
 	c.Check(cfg.StoreBaseURL.String(), Equals, "https://force-api.local/")
-	c.Check(cfg.AssertionsBaseURL.String(), Equals, "https://force-api.local/api/v1/snaps")
+	c.Check(cfg.AssertionsBaseURL, IsNil)
 }
 
 func (suite *configTestSuite) TestSetBaseURLStoreURLBadEnviron(c *C) {
@@ -101,7 +101,7 @@ func (suite *configTestSuite) TestSetBaseURLStoreURLBadEnviron(c *C) {
 func (suite *configTestSuite) TestSetBaseURLAssertsOverrides(c *C) {
 	cfg := DefaultConfig()
 	c.Assert(cfg.setBaseURL(apiURL()), IsNil)
-	c.Check(cfg.AssertionsBaseURL, Matches, apiURL().String()+".*")
+	c.Check(cfg.AssertionsBaseURL, IsNil)
 
 	c.Assert(os.Setenv("SNAPPY_FORCE_SAS_URL", "https://force-sas.local/"), IsNil)
 	defer os.Setenv("SNAPPY_FORCE_SAS_URL", "")
@@ -142,7 +142,7 @@ func detailsPath(snapName string) string {
 func assertRequest(c *C, r *http.Request, method, pathPattern string) {
 	pathMatch, err := regexp.MatchString("^"+pathPattern+"$", r.URL.Path)
 	c.Assert(err, IsNil)
-	if r.Method != method && pathMatch {
+	if r.Method != method || !pathMatch {
 		c.Fatalf("request didn't match (expected %s %s, got %s %s)", method, pathPattern, r.Method, r.URL.Path)
 	}
 }
@@ -216,6 +216,9 @@ type testAuthContext struct {
 	device *auth.DeviceState
 	user   *auth.UserState
 
+	proxyStoreID  string
+	proxyStoreURL *url.URL
+
 	storeID string
 }
 
@@ -270,6 +273,13 @@ func (ac *testAuthContext) DeviceSessionRequestParams(nonce string) (*auth.Devic
 		Serial:  serial.(*asserts.Serial),
 		Model:   model.(*asserts.Model),
 	}, nil
+}
+
+func (ac *testAuthContext) ProxyStoreParams(defaultURL *url.URL) (string, *url.URL, error) {
+	if ac.proxyStoreID != "" {
+		return ac.proxyStoreID, ac.proxyStoreURL, nil
+	}
+	return "", defaultURL, nil
 }
 
 func makeTestMacaroon() (*macaroon.Macaroon, error) {
@@ -2284,6 +2294,75 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryStoreIDFromAuthContext(c 
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContext(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "GET", detailsPathPattern)
+
+		w.WriteHeader(200)
+		io.WriteString(w, MockDetailsJSON)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	nowhereURL, err := url.Parse("http://nowhere.nowhere")
+	c.Assert(err, IsNil)
+	cfg := DefaultConfig()
+	cfg.StoreBaseURL = nowhereURL
+	repo := New(cfg, &testAuthContext{
+		c:             c,
+		device:        t.device,
+		proxyStoreID:  "foo",
+		proxyStoreURL: mockServerURL,
+	})
+	c.Assert(repo, NotNil)
+
+	// the actual test
+	spec := SnapSpec{
+		Name:     "hello-world",
+		Channel:  "edge",
+		Revision: snap.R(0),
+	}
+	result, err := repo.SnapInfo(spec, nil)
+	c.Assert(err, IsNil)
+	c.Check(result.Name(), Equals, "hello-world")
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContextURLFallback(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "GET", detailsPathPattern)
+
+		w.WriteHeader(200)
+		io.WriteString(w, MockDetailsJSON)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := DefaultConfig()
+	cfg.StoreBaseURL = mockServerURL
+	repo := New(cfg, &testAuthContext{
+		c:      c,
+		device: t.device,
+		// mock an assertion that has id but no url
+		proxyStoreID:  "foo",
+		proxyStoreURL: nil,
+	})
+	c.Assert(repo, NotNil)
+
+	// the actual test
+	spec := SnapSpec{
+		Name:     "hello-world",
+		Channel:  "edge",
+		Revision: snap.R(0),
+	}
+	result, err := repo.SnapInfo(spec, nil)
+	c.Assert(err, IsNil)
+	c.Check(result.Name(), Equals, "hello-world")
+}
+
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRevision(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -3953,32 +4032,6 @@ func (t *remoteRepoTestSuite) TestStoreURLBadEnvironCPI(c *C) {
 	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_CPI_URL: parse ://force-cpi.local/: missing protocol scheme")
 }
 
-func (t *remoteRepoTestSuite) TestAssertsURLDependsOnEnviron(c *C) {
-	// This also depends on the store API, but that's tested separately (see
-	// TestStoreURLDependsOnEnviron).
-	apiBaseURI := apiURL()
-
-	c.Assert(os.Setenv("SNAPPY_FORCE_SAS_URL", ""), IsNil)
-	before, err := assertsURL(apiBaseURI)
-	c.Assert(err, IsNil)
-
-	c.Assert(os.Setenv("SNAPPY_FORCE_SAS_URL", "https://assertions.example.org/v1/"), IsNil)
-	defer os.Setenv("SNAPPY_FORCE_SAS_URL", "")
-	after, err := assertsURL(apiBaseURI)
-	c.Assert(err, IsNil)
-
-	c.Check(before.String(), Not(Equals), after.String())
-	c.Check(after.String(), Equals, "https://assertions.example.org/v1/")
-}
-
-func (t *remoteRepoTestSuite) TestAssertsURLBadEnviron(c *C) {
-	c.Assert(os.Setenv("SNAPPY_FORCE_SAS_URL", "://example.com"), IsNil)
-	defer os.Setenv("SNAPPY_FORCE_SAS_URL", "")
-
-	_, err := assertsURL(apiURL())
-	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_SAS_URL: parse ://example.com: missing protocol scheme")
-}
-
 func (t *remoteRepoTestSuite) TestMyAppsURLDependsOnEnviron(c *C) {
 	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
 	before := myappsURL()
@@ -3992,7 +4045,7 @@ func (t *remoteRepoTestSuite) TestMyAppsURLDependsOnEnviron(c *C) {
 
 func (t *remoteRepoTestSuite) TestDefaultConfig(c *C) {
 	c.Check(defaultConfig.StoreBaseURL.String(), Equals, "https://api.snapcraft.io/")
-	c.Check(defaultConfig.AssertionsBaseURL.String(), Equals, "https://api.snapcraft.io/api/v1/snaps")
+	c.Check(defaultConfig.AssertionsBaseURL, IsNil)
 }
 
 func (t *remoteRepoTestSuite) TestNew(c *C) {
@@ -4021,7 +4074,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertion(c *C) {
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 88)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", "/assertions/.*")
+		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
 		// check device authorization is set, implicitly checking doRequest was used
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
 
@@ -4036,7 +4089,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertion(c *C) {
 
 	mockServerURL, _ := url.Parse(mockServer.URL)
 	cfg := Config{
-		AssertionsBaseURL: mockServerURL,
+		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: t.device}
 	repo := New(&cfg, authContext)
@@ -4047,9 +4100,46 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertion(c *C) {
 	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
 }
 
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionProxyStoreFromAuthContext(c *C) {
+	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 88)
+	defer restore()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
+		c.Check(r.URL.Path, Matches, ".*/snap-declaration/16/snapidfoo")
+		c.Check(r.URL.Query().Get("max-format"), Equals, "88")
+		io.WriteString(w, testAssertion)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	nowhereURL, err := url.Parse("http://nowhere.nowhere")
+	c.Assert(err, IsNil)
+	cfg := Config{
+		AssertionsBaseURL: nowhereURL,
+	}
+	authContext := &testAuthContext{
+		c:             c,
+		device:        t.device,
+		proxyStoreID:  "foo",
+		proxyStoreURL: mockServerURL,
+	}
+	repo := New(&cfg, authContext)
+
+	a, err := repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
+	c.Assert(err, IsNil)
+	c.Check(a, NotNil)
+	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
+}
+
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionNotFound(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", "/assertions/.*")
+		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
 		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
 		c.Check(r.URL.Path, Matches, ".*/snap-declaration/16/snapidfoo")
 		w.Header().Set("Content-Type", "application/problem+json")
@@ -4080,7 +4170,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionNotFound(c *C) {
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertion500(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", "/assertions/.*")
+		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
 		n++
 		w.WriteHeader(500)
 	}))

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -42,7 +42,7 @@ execute: |
     cp $TESTSLIB/assertions/developer1.account $STORE_DIR/asserts
     cp $TESTSLIB/assertions/developer1.account-key $STORE_DIR/asserts
     # have snap use the fakestore for assertions (but nothing else)
-    export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR/api/v1/snaps/
+    export SNAPPY_FORCE_SAS_URL=http://$STORE_ADDR
 
     echo Running prepare-image
     su -c "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE snap prepare-image --channel edge --extra-snaps snapweb $TESTSLIB/assertions/developer1-pc.model $ROOT" test


### PR DESCRIPTION
Use the store URL from a store assertion enabled by the proxy.store config.

The full feature will need to enable setting proxy.store on top of work in #4076 