### PR TITLE
tests/test-snapd-service: fix shellcheck issues

### DIFF
--- a/tests/lib/snaps/test-snapd-service/bin/start
+++ b/tests/lib/snaps/test-snapd-service/bin/start
@@ -1,5 +1,5 @@
 #!/bin/sh
-snapctl get service-option > $SNAP_DATA/service-option
+snapctl get service-option > "$SNAP_DATA/service-option"
 while true; do
     echo "running"
     sleep 10

--- a/tests/lib/snaps/test-snapd-service/bin/start-other
+++ b/tests/lib/snaps/test-snapd-service/bin/start-other
@@ -1,5 +1,5 @@
 #!/bin/sh
-snapctl get service-option > $SNAP_DATA/service-option
+snapctl get service-option > "$SNAP_DATA/service-option"
 while true; do
     echo "running"
     sleep 10

--- a/tests/lib/snaps/test-snapd-service/meta/hooks/configure
+++ b/tests/lib/snaps/test-snapd-service/meta/hooks/configure
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-snapctl set service-option=$(snapctl get service-option-source)
+snapctl set service-option="$(snapctl get service-option-source)"
 
 COMMAND=$(snapctl get command)
 if [ "$COMMAND" != "" ]; then


### PR DESCRIPTION
Fix issues raised by shellcheck 0.4.6:

  In tests/lib/snaps/test-snapd-service/bin/start line 2:
  snapctl get service-option > $SNAP_DATA/service-option
                               ^-- SC2086: Double quote to prevent globbing and word splitting.

  In tests/lib/snaps/test-snapd-service/bin/start-other line 2:
  snapctl get service-option > $SNAP_DATA/service-option
                               ^-- SC2086: Double quote to prevent globbing and word splitting.

  In tests/lib/snaps/test-snapd-service/meta/hooks/configure line 3:
  snapctl set service-option=$(snapctl get service-option-source)
                             ^-- SC2046: Quote this to prevent word splitting.

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

