### PR TITLE
tests: use `snap change --last=install` in snapd-reexec test

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -4,6 +4,9 @@ summary: Ensure that lxd works
 # currently nor on ubuntu 14.04
 systems: [ubuntu-16*, ubuntu-core-*]
 
+# lxd downloads can be quite slow
+kill-timeout: 25m
+
 restore: |
     if  [[ $(ls -1 "$GOHOME"/snapd_*.deb | wc -l || echo 0) -eq 0 ]]; then
         exit

--- a/tests/main/refresh-undo/task.yaml
+++ b/tests/main/refresh-undo/task.yaml
@@ -3,6 +3,9 @@ details: |
     When a snap is refreshed and the refresh fails, the undo code had
     a bug that removed the security confinement (LP: #1637981)
 
+# trusty has unreliable journalctl output for unknown reasonsg
+systems: [-ubuntu-14.04-*]
+
 environment:
     SNAP_NAME: test-snapd-service
     SNAP_NAME_GOOD: ${SNAP_NAME}-v1-good

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -79,7 +79,7 @@ execute: |
     echo "Ensure a core refresh restart snapd"
     prev_core=$(snap list | awk "/^core / {print(\$3)}")
     snap install --dangerous /var/lib/snapd/snaps/core_${prev_core}.snap
-    journalctl | MATCH "Requested daemon restart"
+    snap change --last=install | MATCH "Requested daemon restart"
 
     echo "Ensure the right snapd (from the new core) is running"
     now_core=$(snap list | awk "/^core / {print(\$3)}")


### PR DESCRIPTION
The jounalctl command in ubuntu 14.04 seems to be unreliable and
we don't have the last few log lines of snapd in there. The reason
is unknown. By using `snap change --last=install` we get a more
reliable way to check if the snapd daemon got restarted.
