### PR TITLE
interfaces/uhid: unconditionally add existing uhid device to the device cgroup

### DIFF
--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -256,6 +256,13 @@ void setup_devices_cgroup(const char *security_tag, struct snappy_udev *udev_s)
 					       MAJOR(sbuf.st_rdev),
 					       MINOR(sbuf.st_rdev));
 	}
+	// /dev/uhid isn't represented in sysfs, so add it to the device cgroup
+	// if it exists and let AppArmor handle the mediation
+	if (stat("/dev/uhid", &sbuf) == 0) {
+		_run_snappy_app_dev_add_majmin(udev_s, "/dev/uhid",
+					       MAJOR(sbuf.st_rdev),
+					       MINOR(sbuf.st_rdev));
+	}
 	// add the assigned devices
 	while (udev_s->assigned != NULL) {
 		const char *path = udev_list_entry_get_name(udev_s->assigned);

--- a/interfaces/builtin/uhid.go
+++ b/interfaces/builtin/uhid.go
@@ -37,7 +37,7 @@ const uhidConnectedPlugAppArmor = `
   /dev/uhid rw,
 `
 
-const uhidConnectedPlugUDev = `KERNEL=="uhid", TAG+="###CONNECTED_SECURITY_TAGS###"`
+// Note: uhid is not represented in sysfs so it cannot be udev tagged
 
 func init() {
 	registerIface(&commonInterface{
@@ -47,7 +47,6 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  uhidBaseDeclarationSlots,
 		connectedPlugAppArmor: uhidConnectedPlugAppArmor,
-		connectedPlugUDev:     uhidConnectedPlugUDev,
 		reservedForOS:         true,
 	})
 }

--- a/interfaces/builtin/uhid_test.go
+++ b/interfaces/builtin/uhid_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
-	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -82,13 +81,6 @@ func (s *UhidInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/uhid rw,\n")
-}
-
-func (s *UhidInterfaceSuite) TestUDevSpec(c *C) {
-	spec := &udev.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], Equals, `KERNEL=="uhid", TAG+="snap_consumer_app"`)
 }
 
 func (s *UhidInterfaceSuite) TestStaticInfo(c *C) {

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -40,6 +40,11 @@ prepare: |
     if [ -e /dev/nvidia254 ]; then
         mv /dev/nvidia254 /dev/nvidia254.spread
     fi
+    # create uhid device if it doesn't exist
+    if [ ! -e /dev/uhid ]; then
+        mknod /dev/uhid c 10 239
+        touch /dev/uhid.spread
+    fi
 
 restore: |
     if [ -e /dev/nvidia0.spread ]; then
@@ -53,6 +58,9 @@ restore: |
     fi
     if [ -e /dev/nvidia254.spread ]; then
         mv /dev/nvidia254.spread /dev/nvidia254
+    fi
+    if [ -e /dev/uhid.spread ]; then
+        rm -f /dev/uhid /dev/uhid.spread
     fi
     rm -f /etc/udev/rules.d/70-snap.test-snapd-tools.rules
     udevadm control --reload-rules
@@ -106,5 +114,8 @@ execute: |
 
     echo "But nonexisting nvidia devices are not"
     MATCH -v "c 195:254 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
+
+    echo "But the existing uhid device is in the snap's device cgroup"
+    MATCH "c 10:239 rwm" < /sys/fs/cgroup/devices/snap.test-snapd-tools.env/devices.list
 
     # TODO: check device unassociated after removing the udev file and rebooting


### PR DESCRIPTION
uhid isn't represented in sysfs so it cannot be tagged. Add /dev/uhid to the
device cgroup if it exists, and let AppArmor handle the mediation.

This issue was not reported from the field but like with the other PRs I've recently submitted I think it is 2.29 worthy since the widespread use of udev tagging in 2.28 means that this interface will be broken if combined with an interface that uses udev tagging. I have not milestoned it for 2.29 and leave that for your consideration.