### PR TITLE
Revert " wrappers: fail install if exec-line cannot be re-written 

### DIFF
--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -100,10 +100,6 @@ apps:
 func (s *linkSuite) TestLinkDoUndoCurrentSymlink(c *C) {
 	const yaml = `name: hello
 version: 1.0
-
-apps:
- bin:
-  command: hello.bin
 `
 	const contents = ""
 
@@ -241,8 +237,6 @@ environment:
  KEY: value
 
 apps:
- bin:
-   command: bin
  foo:
    command: foo
  bar:
@@ -259,7 +253,7 @@ apps:
 [Desktop Entry]
 Name=bin
 Icon=${SNAP}/bin.png
-Exec=hello.bin
+Exec=bin
 `), 0644), IsNil)
 
 	r := systemd.MockSystemctl(func(...string) ([]byte, error) {

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -147,8 +147,7 @@ Icon=${SNAP}/meep
 
 # the empty line above is fine`)
 
-	e, err := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(err, IsNil)
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 Name=foo
 Icon=%s/foo/12/meep
@@ -171,8 +170,10 @@ Name=foo
 Exec=baz
 `)
 
-	_, err = wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(err, ErrorMatches, `invalid exec command: "baz"`)
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
+	c.Assert(string(e), Equals, `[Desktop Entry]
+Name=foo
+`)
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExecPrefix(c *C) {
@@ -189,8 +190,10 @@ Name=foo
 Exec=snap.app.evil.evil
 `)
 
-	_, err = wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(err, ErrorMatches, `invalid exec command: "snap.app.evil.evil"`)
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
+	c.Assert(string(e), Equals, `[Desktop Entry]
+Name=foo
+`)
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExecOk(c *C) {
@@ -207,8 +210,7 @@ Name=foo
 Exec=snap.app %U
 `)
 
-	e, err := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(err, IsNil)
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 Name=foo
 Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app %%U
@@ -231,8 +233,7 @@ Name=foo
 TryExec=snap.app %U
 `)
 
-	e, err := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(err, IsNil)
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
 Name=foo
 `)
@@ -250,8 +251,7 @@ Invalid=key
 Invalid[i18n]=key
 `)
 
-	e, err := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(err, IsNil)
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, `[Desktop Entry]
 Name=foo
 GenericName=bar
@@ -265,8 +265,7 @@ func (s *sanitizeDesktopFileSuite) TestSanitizeDesktopActionsOk(c *C) {
 	snap := &snap.Info{}
 	desktopContent := []byte("[Desktop Action is-ok]\n")
 
-	e, err := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(err, IsNil)
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, string(desktopContent))
 }
 
@@ -287,8 +286,7 @@ Name=Private Mode
 TargetEnvironment=Unity
 `)
 
-	e, err := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
-	c.Assert(err, IsNil)
+	e := wrappers.SanitizeDesktopFile(snap, "foo.desktop", desktopContent)
 	c.Assert(string(e), Equals, string(desktopContent))
 }
 


### PR DESCRIPTION
This reverts commit 8b87ee531027e402a8147ddd0588b165f0633919.

We got reports from various people that for some important snaps like libreoffice, chromium this error is triggered. So we cannot fail if the exec line cannot be re-written - at least not for 2.29.