### PR TITLE
cmd/snap-update-ns: fix collection of changes made

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -83,7 +83,7 @@ func (c *Change) Perform() error {
 // lists are processed and a "diff" of mount changes is produced. The mount
 // changes, when applied in order, transform the current profile into the
 // desired profile.
-func NeededChanges(currentProfile, desiredProfile *mount.Profile) []Change {
+func NeededChanges(currentProfile, desiredProfile *mount.Profile) []*Change {
 	// Copy both profiles as we will want to mutate them.
 	current := make([]mount.Entry, len(currentProfile.Entries))
 	copy(current, currentProfile.Entries)
@@ -131,21 +131,21 @@ func NeededChanges(currentProfile, desiredProfile *mount.Profile) []Change {
 	}
 
 	// We are now ready to compute the necessary mount changes.
-	var changes []Change
+	var changes []*Change
 
 	// Unmount entries not reused in reverse to handle children before their parent.
 	for i := len(current) - 1; i >= 0; i-- {
 		if reuse[current[i].Dir] {
-			changes = append(changes, Change{Action: Keep, Entry: current[i]})
+			changes = append(changes, &Change{Action: Keep, Entry: current[i]})
 		} else {
-			changes = append(changes, Change{Action: Unmount, Entry: current[i]})
+			changes = append(changes, &Change{Action: Unmount, Entry: current[i]})
 		}
 	}
 
 	// Mount desired entries not reused.
 	for i := range desired {
 		if !reuse[desired[i].Dir] {
-			changes = append(changes, Change{Action: Mount, Entry: desired[i]})
+			changes = append(changes, &Change{Action: Mount, Entry: desired[i]})
 		}
 	}
 

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -68,7 +68,7 @@ func (s *changeSuite) TestNeededChangesNoChange(c *C) {
 	current := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
 	desired := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
 	changes := update.NeededChanges(current, desired)
-	c.Assert(changes, DeepEquals, []update.Change{
+	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: mount.Entry{Dir: "/common/stuf"}, Action: update.Keep},
 	})
 }
@@ -78,7 +78,7 @@ func (s *changeSuite) TestNeededChangesTrivialMount(c *C) {
 	current := &mount.Profile{}
 	desired := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
 	changes := update.NeededChanges(current, desired)
-	c.Assert(changes, DeepEquals, []update.Change{
+	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: desired.Entries[0], Action: update.Mount},
 	})
 }
@@ -88,7 +88,7 @@ func (s *changeSuite) TestNeededChangesTrivialUnmount(c *C) {
 	current := &mount.Profile{Entries: []mount.Entry{{Dir: "/common/stuf"}}}
 	desired := &mount.Profile{}
 	changes := update.NeededChanges(current, desired)
-	c.Assert(changes, DeepEquals, []update.Change{
+	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: current.Entries[0], Action: update.Unmount},
 	})
 }
@@ -101,7 +101,7 @@ func (s *changeSuite) TestNeededChangesUnmountOrder(c *C) {
 	}}
 	desired := &mount.Profile{}
 	changes := update.NeededChanges(current, desired)
-	c.Assert(changes, DeepEquals, []update.Change{
+	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: update.Unmount},
 		{Entry: mount.Entry{Dir: "/common/stuf"}, Action: update.Unmount},
 	})
@@ -115,7 +115,7 @@ func (s *changeSuite) TestNeededChangesMountOrder(c *C) {
 		{Dir: "/common/stuf"},
 	}}
 	changes := update.NeededChanges(current, desired)
-	c.Assert(changes, DeepEquals, []update.Change{
+	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: mount.Entry{Dir: "/common/stuf"}, Action: update.Mount},
 		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: update.Mount},
 	})
@@ -134,7 +134,7 @@ func (s *changeSuite) TestNeededChangesChangedParentSameChild(c *C) {
 		{Dir: "/common/unrelated"},
 	}}
 	changes := update.NeededChanges(current, desired)
-	c.Assert(changes, DeepEquals, []update.Change{
+	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: mount.Entry{Dir: "/common/unrelated"}, Action: update.Keep},
 		{Entry: mount.Entry{Dir: "/common/stuf/extra"}, Action: update.Unmount},
 		{Entry: mount.Entry{Dir: "/common/stuf", Name: "/dev/sda1"}, Action: update.Unmount},
@@ -156,7 +156,7 @@ func (s *changeSuite) TestNeededChangesSameParentChangedChild(c *C) {
 		{Dir: "/common/unrelated"},
 	}}
 	changes := update.NeededChanges(current, desired)
-	c.Assert(changes, DeepEquals, []update.Change{
+	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: mount.Entry{Dir: "/common/unrelated"}, Action: update.Keep},
 		{Entry: mount.Entry{Dir: "/common/stuf/extra", Name: "/dev/sda1"}, Action: update.Unmount},
 		{Entry: mount.Entry{Dir: "/common/stuf"}, Action: update.Keep},
@@ -182,7 +182,7 @@ func (s *changeSuite) TestNeededChangesSmartEntryComparison(c *C) {
 		{Dir: "/a/b/c"},
 	}}
 	changes := update.NeededChanges(current, desired)
-	c.Assert(changes, DeepEquals, []update.Change{
+	c.Assert(changes, DeepEquals, []*update.Change{
 		{Entry: mount.Entry{Dir: "/a/b/c"}, Action: update.Unmount},
 		{Entry: mount.Entry{Dir: "/a/b", Name: "/dev/sda1"}, Action: update.Unmount},
 		{Entry: mount.Entry{Dir: "/a/b-1/3"}, Action: update.Unmount},

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -120,7 +120,7 @@ func run() error {
 	// Compute the needed changes and perform each change if needed, collecting
 	// those that we managed to perform or that were performed already.
 	changesNeeded := NeededChanges(currentBefore, desired)
-	var changesMade []Change
+	var changesMade []*Change
 	for _, change := range changesNeeded {
 		if change.Action == Keep {
 			changesMade = append(changesMade, change)


### PR DESCRIPTION
This patch fixes a nasty bug that results in wrong list of made changes.
This is caused by how the for / range syntax operates in golang.

Before this patch the list of changes made contains N copies of the
first change. This seems to be caused by golang using a hidden temporary
variable that gets overwritten but has the same address. We add the
address of that variable to the list of changes.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>