### PR TITLE
snap-update-ns: add missing unit test for desired/current profile handling

### DIFF
--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -42,6 +42,9 @@ var (
 	// utils
 	SecureMkdirAll   = secureMkdirAll
 	EnsureMountPoint = ensureMountPoint
+
+	// main
+	ComputeAndSaveChanges = computeAndSaveChanges
 )
 
 // fakeFileInfo implements os.FileInfo for one of the tests.
@@ -294,4 +297,12 @@ func MockFreezerCgroupDir(c *C) (restore func()) {
 
 func FreezerCgroupDir() string {
 	return freezerCgroupDir
+}
+
+func MockChangePerform(f func(chg *Change) ([]*Change, error)) func() {
+	origChangePerform := changePerform
+	changePerform = f
+	return func() {
+		changePerform = origChangePerform
+	}
 }

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -121,6 +121,14 @@ func run() error {
 		thawSnapProcesses(opts.Positionals.SnapName)
 	}()
 
+	return computeAndSaveChanges(snapName)
+}
+
+var changePerform = func(chg *Change) ([]*Change, error) {
+	return chg.Perform()
+}
+
+func computeAndSaveChanges(snapName string) error {
 	// Read the desired and current mount profiles. Note that missing files
 	// count as empty profiles so that we can gracefully handle a mount
 	// interface connection/disconnection.
@@ -147,7 +155,7 @@ func run() error {
 	var changesMade []*Change
 	for _, change := range changesNeeded {
 		logger.Debugf("\t * %s", change)
-		synthesised, err := change.Perform()
+		synthesised, err := changePerform(change)
 		// NOTE: we may have done something even if Perform itself has failed.
 		// We need to collect synthesized changes and store them.
 		changesMade = append(changesMade, synthesised...)

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -17,12 +17,19 @@
  *
  */
 
-package main
+package main_test
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "gopkg.in/check.v1"
+
+	update "github.com/snapcore/snapd/cmd/snap-update-ns"
+	"github.com/snapcore/snapd/dirs"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -30,3 +37,38 @@ func Test(t *testing.T) { TestingT(t) }
 type snapUpdateNsSuite struct{}
 
 var _ = Suite(&snapUpdateNsSuite{})
+
+func (s *snapUpdateNsSuite) TestComputeAndSaveChanges(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+
+	restore := update.MockChangePerform(func(chg *update.Change) ([]*update.Change, error) {
+		return nil, nil
+	})
+	defer restore()
+
+	snapName := "foo"
+	desiredProfileContent := `/var/lib/snapd/hostfs/usr/share/fonts /usr/share/fonts none bind,ro 0 0
+/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0`
+
+	desiredProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapMountPolicyDir, snapName)
+	err := os.MkdirAll(filepath.Dir(desiredProfilePath), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644)
+	c.Assert(err, IsNil)
+
+	currentProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapRunNsDir, snapName)
+	err = os.MkdirAll(filepath.Dir(currentProfilePath), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(currentProfilePath, nil, 0644)
+	c.Assert(err, IsNil)
+
+	err = update.ComputeAndSaveChanges("foo")
+	c.Assert(err, IsNil)
+
+	content, err := ioutil.ReadFile(currentProfilePath)
+	c.Assert(err, IsNil)
+	c.Check(string(content), Equals, `/var/lib/snapd/hostfs/usr/local/share/fonts /usr/local/share/fonts none bind,ro 0 0
+/var/lib/snapd/hostfs/usr/share/fonts /usr/share/fonts none bind,ro 0 0
+`)
+}


### PR DESCRIPTION
The cmd/snap-update-ns/main.go is a bit under-tested. This PR adds a direct unit test for the mount profile handling. It is a single test for now that tests the fix for https://github.com/snapcore/snapd/pull/4139, however it should be easy to expand to test more conditions.