### PR TITLE
snapctl: disable stop/start/restart (2.29)

### DIFF
--- a/overlord/hookstate/ctlcmd/restart.go
+++ b/overlord/hookstate/ctlcmd/restart.go
@@ -33,7 +33,8 @@ The restart command restarts the given services of the snap. If executed from th
 )
 
 func init() {
-	addCommand("restart", shortRestartHelp, longRestartHelp, func() command { return &restartCommand{} })
+	// FIXME: uncomment once the feature is fixed to work on install/refresh
+	// addCommand("restart", shortRestartHelp, longRestartHelp, func() command { return &restartCommand{} })
 }
 
 type restartCommand struct {

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	. "gopkg.in/check.v1"
 
-	//"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
-	//"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
@@ -76,6 +76,8 @@ func mockServiceChangeFunc(testServiceControlInputs func(appInfos []*snap.AppInf
 }
 
 func (s *servicectlSuite) SetUpTest(c *C) {
+	c.Skip("disabled until snapctl start/stop/restart commands are restored")
+
 	s.BaseTest.SetUpTest(c)
 	oldRoot := dirs.GlobalRootDir
 	dirs.SetRootDir(c.MkDir())
@@ -135,8 +137,6 @@ func (s *servicectlSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 }
 
-// FIXME: uncomment once the feature is fixed to work on install/refresh
-/*
 func (s *servicectlSuite) TestStopCommand(c *C) {
 	var serviceChangeFuncCalled bool
 	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
@@ -256,4 +256,4 @@ func (s *servicectlSuite) TestQueuedCommands(c *C) {
 	c.Check(allTasks[1].Summary(), Equals, "stop of [test-snap.test-service]")
 	c.Check(allTasks[2].Summary(), Equals, "start of [test-snap.test-service]")
 	c.Check(allTasks[3].Summary(), Equals, "restart of [test-snap.test-service]")
-}*/
+}

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/client"
+	//"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
-	"github.com/snapcore/snapd/overlord/configstate"
+	//"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
@@ -135,6 +135,8 @@ func (s *servicectlSuite) TearDownTest(c *C) {
 	s.BaseTest.TearDownTest(c)
 }
 
+// FIXME: uncomment once the feature is fixed to work on install/refresh
+/*
 func (s *servicectlSuite) TestStopCommand(c *C) {
 	var serviceChangeFuncCalled bool
 	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
@@ -254,4 +256,4 @@ func (s *servicectlSuite) TestQueuedCommands(c *C) {
 	c.Check(allTasks[1].Summary(), Equals, "stop of [test-snap.test-service]")
 	c.Check(allTasks[2].Summary(), Equals, "start of [test-snap.test-service]")
 	c.Check(allTasks[3].Summary(), Equals, "restart of [test-snap.test-service]")
-}
+}*/

--- a/overlord/hookstate/ctlcmd/start.go
+++ b/overlord/hookstate/ctlcmd/start.go
@@ -33,7 +33,8 @@ The start command starts the given services of the snap. If executed from the
 )
 
 func init() {
-	addCommand("start", shortStartHelp, longStartHelp, func() command { return &startCommand{} })
+	// FIXME: uncomment once the feature is fixed to work on install/refresh
+	// addCommand("start", shortStartHelp, longStartHelp, func() command { return &startCommand{} })
 }
 
 type startCommand struct {

--- a/overlord/hookstate/ctlcmd/stop.go
+++ b/overlord/hookstate/ctlcmd/stop.go
@@ -41,7 +41,8 @@ The stop command stops the given services of the snap. If executed from the
 )
 
 func init() {
-	addCommand("stop", shortStopHelp, longStopHelp, func() command { return &stopCommand{} })
+	// FIXME: uncomment once the feature is fixed to work on install/refresh
+	// addCommand("stop", shortStopHelp, longStopHelp, func() command { return &stopCommand{} })
 }
 
 func (c *stopCommand) Execute(args []string) error {

--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -8,6 +8,8 @@ restore: |
     rm -f $SERVICEOPTIONFILE
 
 execute: |
+    echo "The test is disabled for now until the functionality is restored"
+    exit 0
 
     wait_for_service() {
         retry=5


### PR DESCRIPTION
Disable snapctl start/stop/restart in 2.29 until they are fixed to work from install/refresh hooks.
