### PR TITLE
 interfaces: fix udev tagging for hooks (2.29)

### DIFF
--- a/interfaces/builtin/alsa.go
+++ b/interfaces/builtin/alsa.go
@@ -46,15 +46,15 @@ const alsaConnectedPlugAppArmor = `
 @{PROC}/asound/** rw,
 `
 
-const alsaConnectedPlugUDev = `
-KERNEL=="controlC[0-9]*",        TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="hwC[0-9]*D[0-9]*",      TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="midiC[0-9]*D[0-9]*",    TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="timer",                 TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="seq",                   TAG+="###CONNECTED_SECURITY_TAGS###"
-SUBSYSTEM=="sound", KERNEL=="card[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
-`
+var alsaConnectedPlugUDev = []string{
+	`KERNEL=="controlC[0-9]*"`,
+	`KERNEL=="hwC[0-9]*D[0-9]*"`,
+	`KERNEL=="pcmC[0-9]*D[0-9]*[cp]"`,
+	`KERNEL=="midiC[0-9]*D[0-9]*"`,
+	`KERNEL=="timer"`,
+	`KERNEL=="seq"`,
+	`SUBSYSTEM=="sound", KERNEL=="card[0-9]*"`,
+}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -86,8 +86,8 @@ func (s *AlsaInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *AlsaInterfaceSuite) TestUDevpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), HasLen, 7)
+	c.Assert(spec.Snippets(), testutil.Contains, `KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="snap_consumer_app"`)
 }
 
 func (s *AlsaInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -56,7 +56,7 @@ const bluetoothControlConnectedPlugSecComp = `
 bind
 `
 
-const bluetoothControlConnectedPlugUDev = `SUBSYSTEM=="bluetooth", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var bluetoothControlConnectedPlugUDev = []string{`SUBSYSTEM=="bluetooth"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -197,8 +197,6 @@ const bluezPermanentSlotDBus = `
 </policy>
 `
 
-const bluezConnectedPlugUDev = `KERNEL=="rfkill", TAG+="###CONNECTED_SECURITY_TAGS###"`
-
 type bluezInterface struct{}
 
 func (iface *bluezInterface) Name() string {
@@ -244,12 +242,7 @@ func (iface *bluezInterface) AppArmorConnectedSlot(spec *apparmor.Specification,
 }
 
 func (iface *bluezInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
-	old := "###CONNECTED_SECURITY_TAGS###"
-	for appName := range plug.Apps {
-		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
-		snippet := strings.Replace(bluezConnectedPlugUDev, old, tag, -1)
-		spec.AddSnippet(snippet)
-	}
+	spec.TagDevice(`KERNEL=="rfkill"`)
 	return nil
 }
 

--- a/interfaces/builtin/broadcom_asic_control.go
+++ b/interfaces/builtin/broadcom_asic_control.go
@@ -49,10 +49,10 @@ const broadcomAsicControlConnectedPlugAppArmor = `
 /run/udev/data/+pci:[0-9]* r,
 `
 
-const broadcomAsicControlConnectedPlugUDev = `
-SUBSYSTEM=="pci", DRIVER=="linux-kernel-bde", TAG+="###CONNECTED_SECURITY_TAGS###"
-SUBSYSTEM=="net", KERNEL=="bcm[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
-`
+var broadcomAsicControlConnectedPlugUDev = []string{
+	`SUBSYSTEM=="pci", DRIVER=="linux-kernel-bde"`,
+	`SUBSYSTEM=="net", KERNEL=="bcm[0-9]*"`,
+}
 
 // The upstream linux kernel doesn't come with support for the
 // necessary kernel modules we need to drive a Broadcom ASIC.

--- a/interfaces/builtin/broadcom_asic_control_test.go
+++ b/interfaces/builtin/broadcom_asic_control_test.go
@@ -89,8 +89,8 @@ func (s *BroadcomAsicControlSuite) TestAppArmorSpec(c *C) {
 func (s *BroadcomAsicControlSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `SUBSYSTEM=="net", KERNEL=="bcm[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `SUBSYSTEM=="net", KERNEL=="bcm[0-9]*", TAG+="snap_consumer_app"`)
 }
 
 func (s *BroadcomAsicControlSuite) TestKModSpec(c *C) {

--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -42,7 +42,7 @@ const cameraConnectedPlugAppArmor = `
 /sys/devices/pci**/usb*/**/video4linux/** r,
 `
 
-const cameraConnectedPlugUDev = `KERNEL=="video[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var cameraConnectedPlugUDev = []string{`KERNEL=="video[0-9]*"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -21,7 +21,6 @@ package builtin
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
@@ -49,7 +48,7 @@ type commonInterface struct {
 
 	connectedPlugAppArmor  string
 	connectedPlugSecComp   string
-	connectedPlugUDev      string
+	connectedPlugUDev      []string
 	reservedForOS          bool
 	rejectAutoConnectPairs bool
 
@@ -147,13 +146,8 @@ func (iface *commonInterface) SecCompConnectedPlug(spec *seccomp.Specification, 
 }
 
 func (iface *commonInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
-	old := "###CONNECTED_SECURITY_TAGS###"
-	if iface.connectedPlugUDev != "" {
-		for appName := range plug.Apps {
-			tag := udevSnapSecurityName(plug.Snap.Name(), appName)
-			snippet := strings.Replace(iface.connectedPlugUDev, old, tag, -1)
-			spec.AddSnippet(snippet)
-		}
+	for _, rule := range iface.connectedPlugUDev {
+		spec.TagDevice(rule)
 	}
 	return nil
 }

--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -49,7 +49,7 @@ slots:
 	// common interface can define connected plug udev rules
 	iface := &commonInterface{
 		name:              "common",
-		connectedPlugUDev: `KERNEL=="foo", TAG+="###CONNECTED_SECURITY_TAGS###"`,
+		connectedPlugUDev: []string{`KERNEL=="foo"`},
 	}
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(iface, plug, nil, slot, nil), IsNil)

--- a/interfaces/builtin/framebuffer.go
+++ b/interfaces/builtin/framebuffer.go
@@ -37,7 +37,7 @@ const framebufferConnectedPlugAppArmor = `
 /run/udev/data/c29:[0-9]* r,
 `
 
-const framebufferConnectedPlugUDev = `KERNEL=="fb[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var framebufferConnectedPlugUDev = []string{`KERNEL=="fb[0-9]*"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/fuse_support.go
+++ b/interfaces/builtin/fuse_support.go
@@ -83,7 +83,7 @@ deny /etc/fuse.conf r,
 #/{,usr/}bin/fusermount ixr,
 `
 
-const fuseSupportConnectedPlugUDev = `KERNEL=="fuse", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var fuseSupportConnectedPlugUDev = []string{`KERNEL=="fuse"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/hardware_random_control.go
+++ b/interfaces/builtin/hardware_random_control.go
@@ -45,7 +45,7 @@ const hardwareRandomControlConnectedPlugAppArmor = `
 /sys/devices/virtual/misc/hw_random/rng_current w,
 `
 
-const hardwareRandomControlConnectedPlugUDev = `KERNEL=="hwrng", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var hardwareRandomControlConnectedPlugUDev = []string{`KERNEL=="hwrng"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/hardware_random_observe.go
+++ b/interfaces/builtin/hardware_random_observe.go
@@ -40,7 +40,7 @@ const hardwareRandomObserveConnectedPlugAppArmor = `
 /sys/devices/virtual/misc/hw_random/rng_{available,current} r,
 `
 
-const hardwareRandomObserveConnectedPlugUDev = `KERNEL=="hwrng", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var hardwareRandomObserveConnectedPlugUDev = []string{`KERNEL=="hwrng"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -172,14 +172,11 @@ func (iface *hidrawInterface) UDevConnectedPlug(spec *udev.Specification, plug *
 		return nil
 	}
 
-	for appName := range plug.Apps {
-		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
-		if hasOnlyPath {
-			spec.AddSnippet(fmt.Sprintf("SUBSYSTEM==\"hidraw\", KERNEL==\"%s\", TAG+=\"%s\"", strings.TrimPrefix(path, "/dev/"), tag))
-
-		} else {
-			spec.AddSnippet(udevUsbDeviceSnippet("hidraw", usbVendor, usbProduct, "TAG", tag))
-		}
+	if hasOnlyPath {
+		spec.TagDevice(fmt.Sprintf(`SUBSYSTEM=="hidraw", KERNEL=="%s"`, strings.TrimPrefix(path, "/dev/")))
+	} else {
+		spec.TagDevice(fmt.Sprintf(`IMPORT{builtin}="usb_id"
+SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%04x", ATTRS{idProduct}=="%04x"`, usbVendor, usbProduct))
 	}
 	return nil
 }

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -48,8 +48,6 @@ const i2cConnectedPlugAppArmor = `
 /sys/devices/platform/{*,**.i2c}/%s/** rw,
 `
 
-const i2cConnectedPlugUDev = `KERNEL=="%s", TAG+="%s"`
-
 // The type for i2c interface
 type i2cInterface struct{}
 
@@ -111,11 +109,7 @@ func (iface *i2cInterface) UDevConnectedPlug(spec *udev.Specification, plug *int
 	if !pathOk {
 		return nil
 	}
-	const pathPrefix = "/dev/"
-	for appName := range plug.Apps {
-		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
-		spec.AddSnippet(fmt.Sprintf(i2cConnectedPlugUDev, strings.TrimPrefix(path, pathPrefix), tag))
-	}
+	spec.TagDevice(fmt.Sprintf(`KERNEL=="%s"`, strings.TrimPrefix(path, "/dev/")))
 	return nil
 }
 

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -51,8 +51,6 @@ const iioConnectedPlugAppArmor = `
 /sys/devices/**/###IIO_DEVICE_NAME###/** rwk,
 `
 
-const iioConnectedPlugUDev = `KERNEL=="%s", TAG+="%s"`
-
 // The type for iio interface
 type iioInterface struct{}
 
@@ -123,11 +121,7 @@ func (iface *iioInterface) UDevConnectedPlug(spec *udev.Specification, plug *int
 	if !pathOk {
 		return nil
 	}
-	const pathPrefix = "/dev/"
-	for appName := range plug.Apps {
-		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
-		spec.AddSnippet(fmt.Sprintf(iioConnectedPlugUDev, strings.TrimPrefix(path, pathPrefix), tag))
-	}
+	spec.TagDevice(fmt.Sprintf(`KERNEL=="%s"`, strings.TrimPrefix(path, "/dev/")))
 	return nil
 }
 

--- a/interfaces/builtin/io_ports_control.go
+++ b/interfaces/builtin/io_ports_control.go
@@ -47,7 +47,8 @@ const ioPortsControlConnectedPlugSecComp = `
 ioperm
 iopl
 `
-const ioPortsControlConnectedPlugUDev = `KERNEL=="port", TAG+="###CONNECTED_SECURITY_TAGS###"`
+
+var ioPortsControlConnectedPlugUDev = []string{`KERNEL=="port"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -38,7 +38,7 @@ const joystickConnectedPlugAppArmor = `
 /run/udev/data/c13:{[0-9],[12][0-9],3[01]} r,
 `
 
-const joystickConnectedPlugUDev = `KERNEL=="js[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var joystickConnectedPlugUDev = []string{`KERNEL=="js[0-9]*"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/kernel_module_control.go
+++ b/interfaces/builtin/kernel_module_control.go
@@ -60,7 +60,8 @@ init_module
 finit_module
 delete_module
 `
-const kernelModuleControlConnectedPlugUDev = `KERNEL=="mem", TAG+="###CONNECTED_SECURITY_TAGS###"`
+
+var kernelModuleControlConnectedPlugUDev = []string{`KERNEL=="mem"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/kvm.go
+++ b/interfaces/builtin/kvm.go
@@ -36,7 +36,7 @@ const kvmConnectedPlugAppArmor = `
 /dev/kvm rw,
 `
 
-const kvmConnectedPlugUDev = `KERNEL=="kvm", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var kvmConnectedPlugUDev = []string{`KERNEL=="kvm"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -20,7 +20,6 @@
 package builtin
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -89,16 +88,6 @@ unix (receive, send) type=seqpacket addr=none peer=(label=###SLOT_SECURITY_TAGS#
 /run/user/[0-9]*/mir_socket rw,
 `
 
-const mirPermanentSlotUdev = `
-KERNEL=="tty[0-9]*", TAG+="%[1]s"
-
-# input devices
-KERNEL=="mice",   TAG+="%[1]s"
-KERNEL=="mouse[0-9]*", TAG+="%[1]s"
-KERNEL=="event[0-9]*", TAG+="%[1]s"
-KERNEL=="ts[0-9]*",    TAG+="%[1]s"
-`
-
 type mirInterface struct{}
 
 func (iface *mirInterface) Name() string {
@@ -139,10 +128,11 @@ func (iface *mirInterface) SecCompPermanentSlot(spec *seccomp.Specification, slo
 }
 
 func (iface *mirInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
-	for appName := range slot.Apps {
-		tag := udevSnapSecurityName(slot.Snap.Name(), appName)
-		spec.AddSnippet(fmt.Sprintf(mirPermanentSlotUdev, tag))
-	}
+	spec.TagDevice(`KERNEL=="tty[0-9]*"`)
+	spec.TagDevice(`KERNEL=="mice"`)
+	spec.TagDevice(`KERNEL=="mouse[0-9]*"`)
+	spec.TagDevice(`KERNEL=="event[0-9]*"`)
+	spec.TagDevice(`KERNEL=="ts[0-9]*"`)
 	return nil
 }
 

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -139,8 +139,8 @@ func (s *MirInterfaceSuite) TestSecCompOnClassic(c *C) {
 func (s *MirInterfaceSuite) TestUDevSpec(c *C) {
 	udevSpec := &udev.Specification{}
 	c.Assert(udevSpec.AddPermanentSlot(s.iface, s.coreSlot), IsNil)
-	c.Assert(udevSpec.Snippets(), HasLen, 1)
-	c.Assert(udevSpec.Snippets()[0], testutil.Contains, `KERNEL=="event[0-9]*", TAG+="snap_mir-server_mir"`)
+	c.Assert(udevSpec.Snippets(), HasLen, 5)
+	c.Assert(udevSpec.Snippets(), testutil.Contains, `KERNEL=="event[0-9]*", TAG+="snap_mir-server_mir"`)
 }
 
 func (s *MirInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1188,10 +1188,6 @@ KERNEL=="cdc-wdm*", SUBSYSTEM=="usbmisc", ENV{ID_MM_CANDIDATE}="1"
 LABEL="mm_candidate_end"
 `
 
-const modemManagerPermanentSlotUDevTag = `
-KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
-`
-
 type modemManagerInterface struct{}
 
 func (iface *modemManagerInterface) Name() string {
@@ -1233,13 +1229,8 @@ func (iface *modemManagerInterface) DBusPermanentSlot(spec *dbus.Specification, 
 }
 
 func (iface *modemManagerInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
-	old := "###CONNECTED_SECURITY_TAGS###"
-	udevRule := modemManagerPermanentSlotUDev
-	for appName := range slot.Apps {
-		tag := udevSnapSecurityName(slot.Snap.Name(), appName)
-		udevRule += strings.Replace(modemManagerPermanentSlotUDevTag, old, tag, -1)
-	}
-	spec.AddSnippet(udevRule)
+	spec.AddSnippet(modemManagerPermanentSlotUDev)
+	spec.TagDevice(`KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*"`)
 	return nil
 }
 

--- a/interfaces/builtin/modem_manager_test.go
+++ b/interfaces/builtin/modem_manager_test.go
@@ -207,9 +207,9 @@ func (s *ModemManagerInterfaceSuite) TestUsedSecuritySystems(c *C) {
 
 	udevSpec := &udev.Specification{}
 	c.Assert(udevSpec.AddPermanentSlot(s.iface, s.slot), IsNil)
-	c.Assert(udevSpec.Snippets(), HasLen, 1)
+	c.Assert(udevSpec.Snippets(), HasLen, 2)
 	c.Assert(udevSpec.Snippets()[0], testutil.Contains, `SUBSYSTEMS=="usb"`)
-	c.Assert(udevSpec.Snippets()[0], testutil.Contains, `KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="snap_modem-manager_mm"`)
+	c.Assert(udevSpec.Snippets(), testutil.Contains, `KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="snap_modem-manager_mm"`)
 }
 
 func (s *ModemManagerInterfaceSuite) TestPermanentSlotDBus(c *C) {

--- a/interfaces/builtin/network_control.go
+++ b/interfaces/builtin/network_control.go
@@ -255,10 +255,10 @@ socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
  * We only need to tag /dev/net/tun since the tap[0-9]* and tun[0-9]* devices
  * are virtual and don't show up in /dev
  */
-const networkControlConnectedPlugUDev = `
-KERNEL=="rfkill", TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="tun",    TAG+="###CONNECTED_SECURITY_TAGS###"
-`
+var networkControlConnectedPlugUDev = []string{
+	`KERNEL=="rfkill"`,
+	`KERNEL=="tun"`,
+}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -94,8 +94,8 @@ func (s *NetworkControlInterfaceSuite) TestSecCompSpec(c *C) {
 func (s *NetworkControlInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `KERNEL=="tun",    TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `KERNEL=="tun", TAG+="snap_consumer_app"`)
 }
 
 func (s *NetworkControlInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -414,8 +414,6 @@ const networkManagerPermanentSlotDBus = `
 <limit name="max_match_rules_per_connection">2048</limit>
 `
 
-const networkManagerPermanentSlotUdev = `KERNEL=="rfkill", TAG+="###CONNECTED_SECURITY_TAGS###"`
-
 type networkManagerInterface struct{}
 
 func (iface *networkManagerInterface) Name() string {
@@ -469,12 +467,7 @@ func (iface *networkManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifi
 }
 
 func (iface *networkManagerInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
-	old := "###CONNECTED_SECURITY_TAGS###"
-	for appName := range slot.Apps {
-		tag := udevSnapSecurityName(slot.Snap.Name(), appName)
-		udevRule := strings.Replace(networkManagerPermanentSlotUdev, old, tag, -1)
-		spec.AddSnippet(udevRule)
-	}
+	spec.TagDevice(`KERNEL=="rfkill"`)
 	return nil
 }
 

--- a/interfaces/builtin/ofono_test.go
+++ b/interfaces/builtin/ofono_test.go
@@ -200,9 +200,9 @@ func (s *OfonoInterfaceSuite) TestPermanentSlotSnippetSecComp(c *C) {
 func (s *OfonoInterfaceSuite) TestPermanentSlotSnippetUDev(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
+	c.Assert(spec.Snippets(), HasLen, 5)
 	c.Assert(spec.Snippets()[0], testutil.Contains, `LABEL="ofono_isi_end"`)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="snap_ofono_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `KERNEL=="tty[A-Z]*[0-9]*|cdc-wdm[0-9]*", TAG+="snap_ofono_app"`)
 }
 
 func (s *OfonoInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -83,10 +83,10 @@ const openglConnectedPlugAppArmor = `
 
 // The nvidia modules don't use sysfs (therefore they can't be udev tagged) and
 // will be added by snap-confine.
-const openglConnectedPlugUDev = `
-SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="vchiq",   TAG+="###CONNECTED_SECURITY_TAGS###"
-`
+var openglConnectedPlugUDev = []string{
+	`SUBSYSTEM=="drm", KERNEL=="card[0-9]*"`,
+	`KERNEL=="vchiq"`,
+}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -86,8 +86,8 @@ func (s *OpenglInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *OpenglInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `SUBSYSTEM=="drm", KERNEL=="card[0-9]*", TAG+="snap_consumer_app"`)
 }
 
 func (s *OpenglInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/optical_drive.go
+++ b/interfaces/builtin/optical_drive.go
@@ -36,10 +36,10 @@ const opticalDriveConnectedPlugAppArmor = `
 /run/udev/data/b11:[0-9]* r,
 `
 
-const opticalDriveConnectedPlugUDev = `
-KERNEL=="sr[0-9]*",  TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="scd[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
-`
+var opticalDriveConnectedPlugUDev = []string{
+	`KERNEL=="sr[0-9]*"`,
+	`KERNEL=="scd[0-9]*"`,
+}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/optical_drive_test.go
+++ b/interfaces/builtin/optical_drive_test.go
@@ -86,8 +86,8 @@ func (s *OpticalDriveInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *OpticalDriveInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `KERNEL=="sr[0-9]*",  TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `KERNEL=="sr[0-9]*", TAG+="snap_consumer_app"`)
 }
 
 func (s *OpticalDriveInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/physical_memory_control.go
+++ b/interfaces/builtin/physical_memory_control.go
@@ -41,7 +41,7 @@ capability sys_rawio,
 /dev/mem rw,
 `
 
-const physicalMemoryControlConnectedPlugUDev = `KERNEL=="mem", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var physicalMemoryControlConnectedPlugUDev = []string{`KERNEL=="mem"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/physical_memory_observe.go
+++ b/interfaces/builtin/physical_memory_observe.go
@@ -37,7 +37,7 @@ const physicalMemoryObserveConnectedPlugAppArmor = `
 /dev/mem r,
 `
 
-const physicalMemoryObserveConnectedPlugUDev = `KERNEL=="mem", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var physicalMemoryObserveConnectedPlugUDev = []string{`KERNEL=="mem"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/ppp.go
+++ b/interfaces/builtin/ppp.go
@@ -55,10 +55,10 @@ var pppConnectedPlugKmod = []string{
 	"ppp_generic",
 }
 
-const pppConnectedPlugUDev = `
-KERNEL=="ppp", TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="tty[A-Z]*[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"
-`
+var pppConnectedPlugUDev = []string{
+	`KERNEL=="ppp"`,
+	`KERNEL=="tty[A-Z]*[0-9]*"`,
+}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/ppp_test.go
+++ b/interfaces/builtin/ppp_test.go
@@ -96,8 +96,8 @@ func (s *PppInterfaceSuite) TestKModSpec(c *C) {
 func (s *PppInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `KERNEL=="ppp", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `KERNEL=="ppp", TAG+="snap_consumer_app"`)
 }
 
 func (s *PppInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -20,8 +20,6 @@
 package builtin
 
 import (
-	"strings"
-
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
@@ -129,12 +127,6 @@ setgroups32
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `
 
-const pulseaudioPermanentSlotUdev = `
-KERNEL=="controlC[0-9]*",        TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="###CONNECTED_SECURITY_TAGS###"
-KERNEL=="timer",                 TAG+="###CONNECTED_SECURITY_TAGS###"
-`
-
 type pulseAudioInterface struct{}
 
 func (iface *pulseAudioInterface) Name() string {
@@ -158,12 +150,9 @@ func (iface *pulseAudioInterface) AppArmorConnectedPlug(spec *apparmor.Specifica
 }
 
 func (iface *pulseAudioInterface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
-	old := "###CONNECTED_SECURITY_TAGS###"
-	for appName := range slot.Apps {
-		tag := udevSnapSecurityName(slot.Snap.Name(), appName)
-		udevRule := strings.Replace(pulseaudioPermanentSlotUdev, old, tag, -1)
-		spec.AddSnippet(udevRule)
-	}
+	spec.TagDevice(`KERNEL=="controlC[0-9]*"`)
+	spec.TagDevice(`KERNEL=="pcmC[0-9]*D[0-9]*[cp]"`)
+	spec.TagDevice(`KERNEL=="timer"`)
 	return nil
 }
 

--- a/interfaces/builtin/pulseaudio_test.go
+++ b/interfaces/builtin/pulseaudio_test.go
@@ -115,8 +115,8 @@ func (s *PulseAudioInterfaceSuite) TestSecCompOnAllSnaps(c *C) {
 func (s *PulseAudioInterfaceSuite) TestUDev(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.coreSlot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="snap_pulseaudio_app1"`)
+	c.Assert(spec.Snippets(), HasLen, 3)
+	c.Assert(spec.Snippets(), testutil.Contains, `KERNEL=="pcmC[0-9]*D[0-9]*[cp]", TAG+="snap_pulseaudio_app1"`)
 }
 
 func (s *PulseAudioInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -45,7 +45,7 @@ const rawusbConnectedPlugAppArmor = `
 /run/udev/data/+usb:* r,
 `
 
-const rawusbConnectedPlugUDev = `SUBSYSTEMS=="usb", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var rawusbConnectedPlugUDev = []string{`SUBSYSTEMS=="usb"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -180,13 +180,11 @@ func (iface *serialPortInterface) UDevConnectedPlug(spec *udev.Specification, pl
 		return nil
 	}
 
-	for appName := range plug.Apps {
-		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
-		if hasOnlyPath {
-			spec.AddSnippet(fmt.Sprintf("SUBSYSTEM==\"tty\", KERNEL==\"%s\", TAG+=\"%s\"", strings.TrimPrefix(path, "/dev/"), tag))
-		} else {
-			spec.AddSnippet(udevUsbDeviceSnippet("tty", usbVendor, usbProduct, "TAG", tag))
-		}
+	if hasOnlyPath {
+		spec.TagDevice(fmt.Sprintf(`SUBSYSTEM=="tty", KERNEL=="%s"`, strings.TrimPrefix(path, "/dev/")))
+	} else {
+		spec.TagDevice(fmt.Sprintf(`IMPORT{builtin}="usb_id"
+SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%04x", ATTRS{idProduct}=="%04x"`, usbVendor, usbProduct))
 	}
 	return nil
 }

--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -91,10 +91,7 @@ func (iface *spiInterface) UDevConnectedPlug(spec *udev.Specification, plug *int
 	if err != nil {
 		return nil
 	}
-	for appName := range plug.Apps {
-		tag := udevSnapSecurityName(plug.Snap.Name(), appName)
-		spec.AddSnippet(fmt.Sprintf(`KERNEL=="%s", TAG+="%s"`, strings.TrimPrefix(path, "/dev/"), tag))
-	}
+	spec.TagDevice(fmt.Sprintf(`KERNEL=="%s"`, strings.TrimPrefix(path, "/dev/")))
 	return nil
 }
 

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -92,7 +92,7 @@ capability sys_time,
 /sbin/hwclock ixr,
 `
 
-const timeControlConnectedPlugUDev = `SUBSYSTEM=="rtc", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var timeControlConnectedPlugUDev = []string{`SUBSYSTEM=="rtc"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/tpm.go
+++ b/interfaces/builtin/tpm.go
@@ -35,7 +35,7 @@ const tpmConnectedPlugAppArmor = `
 /dev/tpm0 rw,
 `
 
-const tpmConnectedPlugUDev = `KERNEL=="tpm[0-9]*", TAG+="###CONNECTED_SECURITY_TAGS###"`
+var tpmConnectedPlugUDev = []string{`KERNEL=="tpm[0-9]*"`}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -353,12 +353,6 @@ KERNEL=="sr*", ENV{ID_VENDOR}=="SanDisk", ENV{ID_MODEL}=="Cruzer", ENV{ID_FS_LAB
 ENV{ID_PART_TABLE_TYPE}=="dos", ENV{ID_PART_ENTRY_TYPE}=="0x0", ENV{ID_PART_ENTRY_NUMBER}=="1", ENV{ID_FS_TYPE}=="iso9660|udf", ENV{UDISKS_IGNORE}="0"
 `
 
-const udisks2PermanentSlotUDevTag = `
-SUBSYSTEM=="block", TAG+="###CONNECTED_SECURITY_TAGS###"
-# This tags all USB devices, so we'll use AppArmor to mediate specific access (eg, /dev/sd* and /dev/mmcblk*)
-SUBSYSTEM=="usb", TAG+="###CONNECTED_SECURITY_TAGS###"
-`
-
 type udisks2Interface struct{}
 
 func (iface *udisks2Interface) Name() string {
@@ -396,13 +390,10 @@ func (iface *udisks2Interface) AppArmorPermanentSlot(spec *apparmor.Specificatio
 }
 
 func (iface *udisks2Interface) UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error {
-	old := "###CONNECTED_SECURITY_TAGS###"
-	udevRule := udisks2PermanentSlotUDev
-	for appName := range slot.Apps {
-		tag := udevSnapSecurityName(slot.Snap.Name(), appName)
-		udevRule += strings.Replace(udisks2PermanentSlotUDevTag, old, tag, -1)
-	}
-	spec.AddSnippet(udevRule)
+	spec.AddSnippet(udisks2PermanentSlotUDev)
+	spec.TagDevice(`SUBSYSTEM=="block"`)
+	// # This tags all USB devices, so we'll use AppArmor to mediate specific access (eg, /dev/sd* and /dev/mmcblk*)
+	spec.TagDevice(`SUBSYSTEM=="usb"`)
 	return nil
 }
 

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -165,9 +165,9 @@ func (s *UDisks2InterfaceSuite) TestDBusSpec(c *C) {
 func (s *UDisks2InterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddPermanentSlot(s.iface, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 1)
+	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets()[0], testutil.Contains, `LABEL="udisks_probe_end"`)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `SUBSYSTEM=="usb", TAG+="snap_producer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `SUBSYSTEM=="usb", TAG+="snap_producer_app"`)
 }
 
 func (s *UDisks2InterfaceSuite) TestSecCompSpec(c *C) {

--- a/interfaces/udev/spec_test.go
+++ b/interfaces/udev/spec_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/udev"
-	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 type specSuite struct {
@@ -55,21 +55,22 @@ var _ = Suite(&specSuite{
 			return nil
 		},
 	},
-	plug: &interfaces.Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "snap1"},
-			Name:      "name",
-			Interface: "test",
-		},
-	},
-	slot: &interfaces.Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "snap2"},
-			Name:      "name",
-			Interface: "test",
-		},
-	},
 })
+
+func (s *specSuite) SetUpSuite(c *C) {
+	info1 := snaptest.MockInfo(c, `name: snap1
+plugs:
+    name:
+        interface: test
+`, nil)
+	info2 := snaptest.MockInfo(c, `name: snap2
+slots:
+    name:
+        interface: test
+`, nil)
+	s.plug = &interfaces.Plug{PlugInfo: info1.Plugs["name"]}
+	s.slot = &interfaces.Slot{SlotInfo: info2.Slots["name"]}
+}
 
 func (s *specSuite) SetUpTest(c *C) {
 	s.spec = &udev.Specification{}


### PR DESCRIPTION
This is a backport of https://github.com/snapcore/snapd/pull/4144 for 2.29; Original description follows.

This branch aims to fix udev tagging to support hooks in addition to apps that were added earlier.

There are three main patches here:
 - add spec.TagDevice method to udev.Specification, this automatically tags both apps and hooks
 - switch non-common interfaces to TagDevice, with exception of some special uses of AddSnippet
 - switch common interfaces to TagDevice, with some trivial changes to how that is defined.

The only remaining uses of spec.AddSnippet are special-cases that add large chunk of arbitrary
udev code that is not specifically aiming to tag a device.

This passes local unit testing, no testing was done on any hardware.
Signed-off-by: Zygmunt Krynicki zygmunt.krynicki@canonical.com