### PR TITLE
ifacestate: make interfaces.Repository available via state cache

### DIFF
--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -23,6 +23,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -55,6 +56,10 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, extraInterfaces
 	if err := m.initialize(extraInterfaces, extraBackends); err != nil {
 		return nil, err
 	}
+
+	s.Lock()
+	ifacerepo.Replace(s, m.repo)
+	s.Unlock()
 
 	// interface tasks might touch more than the immediate task target snap, serialize them
 	runner.SetBlocked(func(_ *state.Task, running []*state.Task) bool {

--- a/overlord/ifacestate/ifacerepo/repo.go
+++ b/overlord/ifacestate/ifacerepo/repo.go
@@ -1,0 +1,41 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacerepo
+
+import (
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type interfacesRepoKey struct{}
+
+// Replace replaces the interface repository used by the managers.
+func Replace(st *state.State, repo *interfaces.Repository) {
+	st.Cache(interfacesRepoKey{}, repo)
+}
+
+// Get returns the interface repository used by the managers.
+func Get(st *state.State) *interfaces.Repository {
+	repo := st.Cached(interfacesRepoKey{})
+	if repo == nil {
+		panic("internal error: cannot find cached interfaces repository, interface manager not initialized?")
+	}
+	return repo.(*interfaces.Repository)
+}

--- a/overlord/ifacestate/ifacerepo/repo_test.go
+++ b/overlord/ifacestate/ifacerepo/repo_test.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacerepo_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type ifaceRepoSuite struct {
+	o    *overlord.Overlord
+	repo *interfaces.Repository
+}
+
+var _ = Suite(&ifaceRepoSuite{})
+
+func (s *ifaceRepoSuite) SetUpTest(c *C) {
+	s.o = overlord.Mock()
+	s.repo = &interfaces.Repository{}
+}
+
+func (s *ifaceRepoSuite) TestHappy(c *C) {
+	st := s.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	ifacerepo.Replace(st, s.repo)
+
+	repo := ifacerepo.Get(st)
+	c.Check(s.repo, DeepEquals, repo)
+}
+
+func (s *ifaceRepoSuite) TestGetPanics(c *C) {
+	st := s.o.State()
+	st.Lock()
+	defer st.Unlock()
+
+	c.Check(func() { ifacerepo.Get(st) }, PanicMatches, `internal error: cannot find cached interfaces repository, interface manager not initialized\?`)
+}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -137,6 +138,14 @@ func (s *interfaceManagerSuite) TestSmoke(c *C) {
 	mgr := s.manager(c)
 	mgr.Ensure()
 	mgr.Wait()
+}
+
+func (s *interfaceManagerSuite) TestRepoAvailable(c *C) {
+	_ = s.manager(c)
+	s.state.Lock()
+	defer s.state.Unlock()
+	repo := ifacerepo.Get(s.state)
+	c.Check(repo, FitsTypeOf, &interfaces.Repository{})
 }
 
 func (s *interfaceManagerSuite) TestConnectTask(c *C) {

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -105,25 +105,23 @@ func New() (*Overlord, error) {
 	}
 	o.addManager(hookMgr)
 
+	snapMgr, err := snapstate.Manager(s)
+	if err != nil {
+		return nil, err
+	}
+	o.addManager(snapMgr)
+
 	assertMgr, err := assertstate.Manager(s)
 	if err != nil {
 		return nil, err
 	}
 	o.addManager(assertMgr)
 
-	// init ifaceMgr before snapMgr as the later uses the
-	// repository database via the state cache
 	ifaceMgr, err := ifacestate.Manager(s, hookMgr, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 	o.addManager(ifaceMgr)
-
-	snapMgr, err := snapstate.Manager(s)
-	if err != nil {
-		return nil, err
-	}
-	o.addManager(snapMgr)
 
 	configMgr, err := configstate.Manager(s, hookMgr)
 	if err != nil {

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -105,25 +105,26 @@ func New() (*Overlord, error) {
 	}
 	o.addManager(hookMgr)
 
-	snapMgr, err := snapstate.Manager(s)
-	if err != nil {
-		return nil, err
-	}
-	o.addManager(snapMgr)
-
 	assertMgr, err := assertstate.Manager(s)
 	if err != nil {
 		return nil, err
 	}
 	o.addManager(assertMgr)
 
+	// init ifaceMgr before snapMgr as the later uses the
+	// repository database via the state cache
 	ifaceMgr, err := ifacestate.Manager(s, hookMgr, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 	o.addManager(ifaceMgr)
 
-	// TODO: this is a bit weird, not actually a StateManager
+	snapMgr, err := snapstate.Manager(s)
+	if err != nil {
+		return nil, err
+	}
+	o.addManager(snapMgr)
+
 	configMgr, err := configstate.Manager(s, hookMgr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR makes the interfaces.Repository available for other managers
via the state cache. This is similar to how the assertdb is made
available. This allows e.g. snapstate to get the interfaces
repository and answer questions like "is this plug connected".

The code to get/set the cached repository is in it's own sub-package
to avoid circular imports between snapstate and ifacestate.
