### PR TITLE
tests: fix security-device-cgroup* tests on devices with framebuffer

### DIFF
--- a/tests/lib/snaps/test-classic-cgroup/bin/read-fb
+++ b/tests/lib/snaps/test-classic-cgroup/bin/read-fb
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-cat /dev/fb255
+cat /dev/fb0

--- a/tests/lib/snaps/test-devmode-cgroup/bin/read-fb
+++ b/tests/lib/snaps/test-devmode-cgroup/bin/read-fb
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-cat /dev/fb255
+cat /dev/fb0

--- a/tests/lib/snaps/test-strict-cgroup/bin/read-fb
+++ b/tests/lib/snaps/test-strict-cgroup/bin/read-fb
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-cat /dev/fb255
+cat /dev/fb0

--- a/tests/main/security-device-cgroups-classic/task.yaml
+++ b/tests/main/security-device-cgroups-classic/task.yaml
@@ -12,9 +12,9 @@ systems: [-fedora-*, -ubuntu-core-*]
 prepare: |
     # Create framebuffer device node and give it some content we can verify
     # the test snap can read.
-    if [ ! -e /dev/fb255 ]; then
-        mknod /dev/fb255 c 29 255
-        touch /dev/fb255.spread
+    if [ ! -e /dev/fb0 ]; then
+        mknod /dev/fb0 c 29 0
+        touch /dev/fb0.spread
     fi
 
     echo "Given a snap declaring a plug on framebuffer is installed in classic"
@@ -22,8 +22,8 @@ prepare: |
     install_local_classic test-classic-cgroup
 
 restore: |
-    if [ -e /dev/fb255.spread ]; then
-        rm -f /dev/fb255 /dev/fb255.spread
+    if [ -e /dev/fb0.spread ]; then
+        rm -f /dev/fb0 /dev/fb0.spread
     fi
 
 execute: |
@@ -31,7 +31,7 @@ execute: |
 
     # classic snaps don't use 'plugs', so just test the accesses after install
     echo "the classic snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-classic-cgroup.read-fb 2>&1 | MATCH -v 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-classic-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the classic snap can access other devices"
     test "`$SNAP_MOUNT_DIR/bin/test-classic-cgroup.read-kmsg`"

--- a/tests/main/security-device-cgroups-devmode/task.yaml
+++ b/tests/main/security-device-cgroups-devmode/task.yaml
@@ -8,9 +8,9 @@ details: |
 prepare: |
     # Create framebuffer device node and give it some content we can verify
     # the test snap can read.
-    if [ ! -e /dev/fb255 ]; then
-        mknod /dev/fb255 c 29 255
-        touch /dev/fb255.spread
+    if [ ! -e /dev/fb0 ]; then
+        mknod /dev/fb0 c 29 0
+        touch /dev/fb0.spread
     fi
 
     echo "Given a snap declaring a plug on framebuffer is installed in devmode"
@@ -18,8 +18,8 @@ prepare: |
     install_local_devmode test-devmode-cgroup
 
 restore: |
-    if [ -e /dev/fb255.spread ]; then
-        rm -f /dev/fb255 /dev/fb255.spread
+    if [ -e /dev/fb0.spread ]; then
+        rm -f /dev/fb0 /dev/fb0.spread
     fi
 
 execute: |
@@ -28,7 +28,7 @@ execute: |
     echo "And the framebuffer plug is connected"
     snap connect test-devmode-cgroup:framebuffer
     echo "the devmode snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH -v 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
     test "`$SNAP_MOUNT_DIR/bin/test-devmode-cgroup.read-kmsg`"
@@ -36,7 +36,7 @@ execute: |
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-devmode-cgroup:framebuffer
     echo "the devmode snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH -v 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the devmode snap can access other devices"
     test "`$SNAP_MOUNT_DIR/bin/test-devmode-cgroup.read-kmsg`"

--- a/tests/main/security-device-cgroups-jailmode/task.yaml
+++ b/tests/main/security-device-cgroups-jailmode/task.yaml
@@ -11,9 +11,9 @@ systems: [-fedora-*, -opensuse-*, -debian-unstable-*]
 prepare: |
     # Create framebuffer device node and give it some content we can verify
     # the test snap can read.
-    if [ ! -e /dev/fb255 ]; then
-        mknod /dev/fb255 c 29 255
-        touch /dev/fb255.spread
+    if [ ! -e /dev/fb0 ]; then
+        mknod /dev/fb0 c 29 0
+        touch /dev/fb0.spread
     fi
 
     echo "Given a snap declaring a plug on framebuffer is installed in jailmode"
@@ -21,8 +21,8 @@ prepare: |
     install_local_jailmode test-devmode-cgroup
 
 restore: |
-    if [ -e /dev/fb255.spread ]; then
-        rm -f /dev/fb255 /dev/fb255.spread
+    if [ -e /dev/fb0.spread ]; then
+        rm -f /dev/fb0 /dev/fb0.spread
     fi
 
 execute: |
@@ -31,15 +31,15 @@ execute: |
     echo "And the framebuffer plug is connected"
     snap connect test-devmode-cgroup:framebuffer
     echo "the jailmode snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH -v 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the jailmode snap cannot access other devices"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-kmsg 2>&1 | MATCH 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-kmsg 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-devmode-cgroup:framebuffer
     echo "the jailmode snap cannot access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-fb 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "the jailmode snap cannot access other devices"
-    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-kmsg 2>&1 | MATCH 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-devmode-cgroup.read-kmsg 2>&1 | MATCH '(Permission denied|Operation not permitted)'

--- a/tests/main/security-device-cgroups-strict/task.yaml
+++ b/tests/main/security-device-cgroups-strict/task.yaml
@@ -10,9 +10,9 @@ systems: [-fedora-*, -opensuse-*,-debian-unstable-*]
 prepare: |
     # Create framebuffer device node and give it some content we can verify
     # the test snap can read.
-    if [ ! -e /dev/fb255 ]; then
-        mknod /dev/fb255 c 29 255
-        touch /dev/fb255.spread
+    if [ ! -e /dev/fb0 ]; then
+        mknod /dev/fb0 c 29 0
+        touch /dev/fb0.spread
     fi
 
     echo "Given a snap declaring a plug on framebuffer is installed in strict"
@@ -20,8 +20,8 @@ prepare: |
     install_local test-strict-cgroup
 
 restore: |
-    if [ -e /dev/fb255.spread ]; then
-        rm -f /dev/fb255 /dev/fb255.spread
+    if [ -e /dev/fb0.spread ]; then
+        rm -f /dev/fb0 /dev/fb0.spread
     fi
 
 execute: |
@@ -30,15 +30,15 @@ execute: |
     echo "And the framebuffer plug is connected"
     snap connect test-strict-cgroup:framebuffer
     echo "the strict snap can access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-fb 2>&1 | MATCH -v 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-fb 2>&1 | MATCH -v '(Permission denied|Operation not permitted)'
 
     echo "the strict snap cannot access other devices"
-    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-kmsg 2>&1 | MATCH 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-kmsg 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "And the framebuffer plug is disconnected"
     snap disconnect test-strict-cgroup:framebuffer
     echo "the strict snap cannot access the framebuffer"
-    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-fb 2>&1 | MATCH 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-fb 2>&1 | MATCH '(Permission denied|Operation not permitted)'
 
     echo "the strict snap cannot access other devices"
-    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-kmsg 2>&1 | MATCH 'Permission denied'
+    "$SNAP_MOUNT_DIR"/bin/test-strict-cgroup.read-kmsg 2>&1 | MATCH '(Permission denied|Operation not permitted)'


### PR DESCRIPTION
The tests that check if the device cgroup works for framebuffer
devices is broken currently on devices that have an active
framebuffer. We did not notice so far because all virtual machines
we use to test do not have a framebuffer device.

However devices like the pi2/pi3 have framebuffers. There it is
not enough to create /dev/fb255 because the cgroup for framebuffer
device is active (it contains fb0). On machines that do not have
any framebuffer device the device cgroup is not active and we only
test that the apparmor based access is working.

The fix is to always use "fb0" in the tests and only create it
if it is missing. On systems were it is missing we tests the
apparmor based permissions as before. But on systems with a
framebuffer we now test also the right device in the cgroup
so that the test can actually work, i.e. snap-confine will
add the right (fb0) udev device to the devices cgroup. The
artificially created fb255 that was used before was not known
to udev and therefore not added by snap-confine to the devices
cgroup.

Fwiw, I ran this on my pi3 and it works there. Once this lands in stable
we need to cherry pick it to the release/2.29 branch.