### PR TITLE
overlord/devicestate: switch to the new endpoints for registration

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -175,10 +175,8 @@ func (s *deviceMgrSuite) settle(c *C) {
 }
 
 const (
-	// will become "/api/v1/snaps/auth/request-id"
-	requestIDURLPath = "/identity/api/v1/request-id"
-	// will become "/api/v1/snaps/auth/serial"
-	serialURLPath = "/identity/api/v1/devices"
+	requestIDURLPath = "/api/v1/snaps/auth/request-id"
+	serialURLPath    = "/api/v1/snaps/auth/devices"
 )
 
 // seeding avoids triggering a real full seeding, it simulates having it in process instead

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -54,9 +54,9 @@ func useStaging() bool {
 
 func deviceAPIBaseURL() string {
 	if useStaging() {
-		return "https://myapps.developer.staging.ubuntu.com/identity/api/v1/"
+		return "https://api.staging.snapcraft.io/api/v1/snaps/auth/"
 	}
-	return "https://myapps.developer.ubuntu.com/identity/api/v1/"
+	return "https://api.snapcraft.io/api/v1/snaps/auth/"
 }
 
 var (


### PR DESCRIPTION
There is no need to wait further at this point, API evolution will be based on request content.

Redoes part of what was reverted in 90f5dc6