### PR TITLE
interfaces/kmod: treat failure to load module as non-fatal

### DIFF
--- a/interfaces/kmod/kmod.go
+++ b/interfaces/kmod/kmod.go
@@ -34,11 +34,16 @@ func LoadModule(module string) error {
 }
 
 // loadModules loads given list of modules via modprobe.
-// Any error from modprobe interrupts loading of subsequent modules and returns the error.
+// Since different kernels may not have the requested module, we treat any
+// error from modprobe as non-fatal and subsequent module loads are attempted
+// (otherwise failure to load a module means failure to connect the interface
+// and the other security backends)
 func loadModules(modules []string) error {
 	for _, mod := range modules {
 		if err := LoadModule(mod); err != nil {
-			return err
+			// LoadModule() already logs via syslog, so just
+			// continue
+			continue
 		}
 	}
 	return nil

--- a/interfaces/kmod/kmod.go
+++ b/interfaces/kmod/kmod.go
@@ -40,11 +40,8 @@ func LoadModule(module string) error {
 // and the other security backends)
 func loadModules(modules []string) error {
 	for _, mod := range modules {
-		if err := LoadModule(mod); err != nil {
-			// LoadModule() already logs via syslog, so just
-			// continue
-			continue
-		}
+		LoadModule(mod) // ignore errors which are logged by
+				// LoadModule() via syslog
 	}
 	return nil
 }

--- a/interfaces/kmod/kmod.go
+++ b/interfaces/kmod/kmod.go
@@ -41,7 +41,7 @@ func LoadModule(module string) error {
 func loadModules(modules []string) error {
 	for _, mod := range modules {
 		LoadModule(mod) // ignore errors which are logged by
-				// LoadModule() via syslog
+		// LoadModule() via syslog
 	}
 	return nil
 }


### PR DESCRIPTION
Since different kernels may not have the requested module, treat any error from
modprobe as non-fatal and attempt any subsequent module loads. Without this,
failure to load a module means failure to connect the interface and the other
security backends.

This issue was found as part of https://github.com/snapcore/snapd/pull/4157
where the broadcom-asic-control and firewall-control interfaces could not be
connected because some of the modules were not available in the test
environments. Importantly, this change is not just for the test environment;
different kernels will have different kernel configs and we need to make sure
that the interface is connectable for the other backends.
