### PR TITLE
interfaces/raw-usb: match on SUBSYSTEM, not SUBSYSTEMS

### DIFF
--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -45,7 +45,7 @@ const rawusbConnectedPlugAppArmor = `
 /run/udev/data/+usb:* r,
 `
 
-const rawusbConnectedPlugUDev = `SUBSYSTEMS=="usb", TAG+="###CONNECTED_SECURITY_TAGS###"`
+const rawusbConnectedPlugUDev = `SUBSYSTEM=="usb", TAG+="###CONNECTED_SECURITY_TAGS###"`
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -87,7 +87,7 @@ func (s *RawUsbInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
 	c.Assert(spec.Snippets(), HasLen, 1)
-	c.Assert(spec.Snippets()[0], testutil.Contains, `SUBSYSTEMS=="usb", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets()[0], testutil.Contains, `SUBSYSTEM=="usb", TAG+="snap_consumer_app"`)
 }
 
 func (s *RawUsbInterfaceSuite) TestStaticInfo(c *C) {


### PR DESCRIPTION
The raw-usb interface is intended to give access to all USB devices in
/dev/bus/usb. Part of that included udev tagging to add these devices to the
snap-specific device cgroup, and it did so using 'SUBSYSTEMS=="usb", ...'.
While this worked on newer systems, on at least Ubuntu Core 16 this caused a
udev_enumerate error. SUBSYSTEMS isn't correct anyway because it means to
include parent devices which in our case may or may not be USB and therefore
the security policy wouldn't allow those devices anyway. Update this to use
'SUBSYSTEM=="usb", ...' instead, which limits the tagging to just the USB
devices (not their parents) and works on Ubuntu Core 16.
