### PR TITLE
cmd/snap-update-ns: add new helpers for mount entries

### DIFF
--- a/cmd/snap-update-ns/entry.go
+++ b/cmd/snap-update-ns/entry.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"os"
 	"regexp"
-	"strings"
 
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/osutil"
@@ -38,19 +37,16 @@ var (
 // XSnapdMode returns the file mode associated with x-snapd.mode mount option.
 // If the mode is not specified explicitly then a default mode of 0755 is assumed.
 func XSnapdMode(e *mount.Entry) (os.FileMode, error) {
-	for _, opt := range e.Options {
-		if strings.HasPrefix(opt, "x-snapd.mode=") {
-			kv := strings.SplitN(opt, "=", 2)
-			if !validModeRe.MatchString(kv[1]) {
-				return 0, fmt.Errorf("cannot parse octal file mode from %q", kv[1])
-			}
-			var mode os.FileMode
-			n, err := fmt.Sscanf(kv[1], "%o", &mode)
-			if err != nil || n != 1 {
-				return 0, fmt.Errorf("cannot parse octal file mode from %q", kv[1])
-			}
-			return mode, nil
+	if opt, ok := e.OptStr("x-snapd.mode"); ok {
+		if !validModeRe.MatchString(opt) {
+			return 0, fmt.Errorf("cannot parse octal file mode from %q", opt)
 		}
+		var mode os.FileMode
+		n, err := fmt.Sscanf(opt, "%o", &mode)
+		if err != nil || n != 1 {
+			return 0, fmt.Errorf("cannot parse octal file mode from %q", opt)
+		}
+		return mode, nil
 	}
 	return 0755, nil
 }
@@ -59,23 +55,20 @@ func XSnapdMode(e *mount.Entry) (os.FileMode, error) {
 // the mode is not specified explicitly then a default "root" use is
 // returned.
 func XSnapdUid(e *mount.Entry) (uid uint64, err error) {
-	for _, opt := range e.Options {
-		if strings.HasPrefix(opt, "x-snapd.uid=") {
-			kv := strings.SplitN(opt, "=", 2)
-			if !validUserGroupRe.MatchString(kv[1]) {
-				return math.MaxUint64, fmt.Errorf("cannot parse user name %q", kv[1])
-			}
-			// Try to parse a numeric ID first.
-			if n, err := fmt.Sscanf(kv[1], "%d", &uid); n == 1 && err == nil {
-				return uid, nil
-			}
-			// Fall-back to system name lookup.
-			if uid, err = osutil.FindUid(kv[1]); err != nil {
-				// The error message from FindUid is not very useful so just skip it.
-				return math.MaxUint64, fmt.Errorf("cannot resolve user name %q", kv[1])
-			}
+	if opt, ok := e.OptStr("x-snapd.uid"); ok {
+		if !validUserGroupRe.MatchString(opt) {
+			return math.MaxUint64, fmt.Errorf("cannot parse user name %q", opt)
+		}
+		// Try to parse a numeric ID first.
+		if n, err := fmt.Sscanf(opt, "%d", &uid); n == 1 && err == nil {
 			return uid, nil
 		}
+		// Fall-back to system name lookup.
+		if uid, err = osutil.FindUid(opt); err != nil {
+			// The error message from FindUid is not very useful so just skip it.
+			return math.MaxUint64, fmt.Errorf("cannot resolve user name %q", opt)
+		}
+		return uid, nil
 	}
 	return 0, nil
 }
@@ -84,23 +77,20 @@ func XSnapdUid(e *mount.Entry) (uid uint64, err error) {
 // the mode is not specified explicitly then a default "root" use is
 // returned.
 func XSnapdGid(e *mount.Entry) (gid uint64, err error) {
-	for _, opt := range e.Options {
-		if strings.HasPrefix(opt, "x-snapd.gid=") {
-			kv := strings.SplitN(opt, "=", 2)
-			if !validUserGroupRe.MatchString(kv[1]) {
-				return math.MaxUint64, fmt.Errorf("cannot parse group name %q", kv[1])
-			}
-			// Try to parse a numeric ID first.
-			if n, err := fmt.Sscanf(kv[1], "%d", &gid); n == 1 && err == nil {
-				return gid, nil
-			}
-			// Fall-back to system name lookup.
-			if gid, err = osutil.FindGid(kv[1]); err != nil {
-				// The error message from FindGid is not very useful so just skip it.
-				return math.MaxUint64, fmt.Errorf("cannot resolve group name %q", kv[1])
-			}
+	if opt, ok := e.OptStr("x-snapd.gid"); ok {
+		if !validUserGroupRe.MatchString(opt) {
+			return math.MaxUint64, fmt.Errorf("cannot parse group name %q", opt)
+		}
+		// Try to parse a numeric ID first.
+		if n, err := fmt.Sscanf(opt, "%d", &gid); n == 1 && err == nil {
 			return gid, nil
 		}
+		// Fall-back to system name lookup.
+		if gid, err = osutil.FindGid(opt); err != nil {
+			// The error message from FindGid is not very useful so just skip it.
+			return math.MaxUint64, fmt.Errorf("cannot resolve group name %q", opt)
+		}
+		return gid, nil
 	}
 	return 0, nil
 }
@@ -111,13 +101,8 @@ func XSnapdGid(e *mount.Entry) (gid uint64, err error) {
 // that identifies a mount entry and is stable across invocations of snapd (it
 // is a hash of some sort).
 func XSnapdEntryID(e *mount.Entry) string {
-	for _, opt := range e.Options {
-		if strings.HasPrefix(opt, "x-snapd.id=") {
-			kv := strings.SplitN(opt, "=", 2)
-			return kv[1]
-		}
-	}
-	return ""
+	val, _ := e.OptStr("x-snapd.id")
+	return val
 }
 
 // XSnapdParentID returns the identifier of the parent mount entry.
@@ -126,13 +111,8 @@ func XSnapdEntryID(e *mount.Entry) string {
 // is a string that identifies a mount entry and is stable across invocations
 // of snapd (it is a hash of some sort).
 func XSnapdParentID(e *mount.Entry) string {
-	for _, opt := range e.Options {
-		if strings.HasPrefix(opt, "x-snapd.parent-id=") {
-			kv := strings.SplitN(opt, "=", 2)
-			return kv[1]
-		}
-	}
-	return ""
+	val, _ := e.OptStr("x-snapd.parent-id")
+	return val
 }
 
 // XSnapdSynthetic returns true of a given mount entry is synthetic.
@@ -142,10 +122,5 @@ func XSnapdParentID(e *mount.Entry) string {
 // possible.  They are identified by having the "x-snapd.synthetic" mount
 // option.
 func XSnapdSynthetic(e *mount.Entry) bool {
-	for _, opt := range e.Options {
-		if opt == "x-snapd.synthetic" {
-			return true
-		}
-	}
-	return false
+	return e.OptBool("x-snapd.synthetic")
 }

--- a/cmd/snap-update-ns/entry.go
+++ b/cmd/snap-update-ns/entry.go
@@ -134,3 +134,18 @@ func XSnapdParentID(e *mount.Entry) string {
 	}
 	return ""
 }
+
+// XSnapdSynthetic returns true of a given mount entry is synthetic.
+//
+// Synthetic mount entries are created by snap-update-ns itself, separately
+// from what snapd instructed. Such entries are needed to make other things
+// possible.  They are identified by having the "x-snapd.synthetic" mount
+// option.
+func XSnapdSynthetic(e *mount.Entry) bool {
+	for _, opt := range e.Options {
+		if opt == "x-snapd.synthetic" {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/snap-update-ns/entry.go
+++ b/cmd/snap-update-ns/entry.go
@@ -104,3 +104,18 @@ func XSnapdGid(e *mount.Entry) (gid uint64, err error) {
 	}
 	return 0, nil
 }
+
+// XSnapdEntryID returns the identifier of a given mount enrty.
+//
+// Identifiers are kept in the x-snapd.id mount option. The value is a string
+// that identifies a mount entry and is stable across invocations of snapd (it
+// is a hash of some sort).
+func XSnapdEntryID(e *mount.Entry) string {
+	for _, opt := range e.Options {
+		if strings.HasPrefix(opt, "x-snapd.id=") {
+			kv := strings.SplitN(opt, "=", 2)
+			return kv[1]
+		}
+	}
+	return ""
+}

--- a/cmd/snap-update-ns/entry.go
+++ b/cmd/snap-update-ns/entry.go
@@ -119,3 +119,18 @@ func XSnapdEntryID(e *mount.Entry) string {
 	}
 	return ""
 }
+
+// XSnapdParentID returns the identifier of the parent mount entry.
+//
+// Parent identifiers are kept in the x-snapd.parent-id mount option. The value
+// is a string that identifies a mount entry and is stable across invocations
+// of snapd (it is a hash of some sort).
+func XSnapdParentID(e *mount.Entry) string {
+	for _, opt := range e.Options {
+		if strings.HasPrefix(opt, "x-snapd.parent-id=") {
+			kv := strings.SplitN(opt, "=", 2)
+			return kv[1]
+		}
+	}
+	return ""
+}

--- a/cmd/snap-update-ns/entry_test.go
+++ b/cmd/snap-update-ns/entry_test.go
@@ -141,3 +141,13 @@ func (s *entrySuite) TestXSnapdEntryID(c *C) {
 	e = &mount.Entry{Options: []string{"x-snapd.id=foo"}}
 	c.Assert(update.XSnapdEntryID(e), Equals, "foo")
 }
+
+func (s *entrySuite) TestXSnapdParentID(c *C) {
+	// Parent entry ID is optional.
+	e := &mount.Entry{}
+	c.Assert(update.XSnapdParentID(e), Equals, "")
+
+	// Parent entry ID is parsed from the x-snapd.parent-id= option.
+	e = &mount.Entry{Options: []string{"x-snap.id=foo", "x-snapd.parent-id=bar"}}
+	c.Assert(update.XSnapdParentID(e), Equals, "bar")
+}

--- a/cmd/snap-update-ns/entry_test.go
+++ b/cmd/snap-update-ns/entry_test.go
@@ -151,3 +151,13 @@ func (s *entrySuite) TestXSnapdParentID(c *C) {
 	e = &mount.Entry{Options: []string{"x-snap.id=foo", "x-snapd.parent-id=bar"}}
 	c.Assert(update.XSnapdParentID(e), Equals, "bar")
 }
+
+func (s *entrySuite) TestXSnapdSynthetic(c *C) {
+	// Entries are not synthetic unless tagged as such.
+	e := &mount.Entry{}
+	c.Assert(update.XSnapdSynthetic(e), Equals, false)
+
+	// Tagging is done with x-snapd.synthetic option.
+	e = &mount.Entry{Options: []string{"x-snapd.synthetic"}}
+	c.Assert(update.XSnapdSynthetic(e), Equals, true)
+}

--- a/cmd/snap-update-ns/entry_test.go
+++ b/cmd/snap-update-ns/entry_test.go
@@ -131,3 +131,13 @@ func (s *entrySuite) TestXSnapdGid(c *C) {
 	c.Assert(err, ErrorMatches, `cannot parse group name "0bogus"`)
 	c.Assert(gid, Equals, uint64(math.MaxUint64))
 }
+
+func (s *entrySuite) TestXSnapdEntryID(c *C) {
+	// Entry ID is optional.
+	e := &mount.Entry{}
+	c.Assert(update.XSnapdEntryID(e), Equals, "")
+
+	// Entry ID is parsed from the x-snapd.id= option.
+	e = &mount.Entry{Options: []string{"x-snapd.id=foo"}}
+	c.Assert(update.XSnapdEntryID(e), Equals, "foo")
+}

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -216,3 +216,26 @@ func OptsToFlags(opts []string) (flags int, err error) {
 	}
 	return flags, nil
 }
+
+// OptStr returns the value part of a key=value mount option.
+// The name of the option must not contain the trailing "=" character.
+func (e *Entry) OptStr(name string) (string, bool) {
+	prefix := name + "="
+	for _, opt := range e.Options {
+		if strings.HasPrefix(opt, prefix) {
+			kv := strings.SplitN(opt, "=", 2)
+			return kv[1], true
+		}
+	}
+	return "", false
+}
+
+// OptBool returns true if a given mount option is present.
+func (e *Entry) OptBool(name string) bool {
+	for _, opt := range e.Options {
+		if opt == name {
+			return true
+		}
+	}
+	return false
+}

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -168,3 +168,23 @@ func (s *entrySuite) TestOptsToFlags(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(flags, Equals, 0)
 }
+
+func (s *entrySuite) TestOptStr(c *C) {
+	e := &mount.Entry{Options: []string{"key=value"}}
+	val, ok := e.OptStr("key")
+	c.Assert(ok, Equals, true)
+	c.Assert(val, Equals, "value")
+
+	val, ok = e.OptStr("missing")
+	c.Assert(ok, Equals, false)
+	c.Assert(val, Equals, "")
+}
+
+func (s *entrySuite) TestOptBool(c *C) {
+	e := &mount.Entry{Options: []string{"key"}}
+	val := e.OptBool("key")
+	c.Assert(val, Equals, true)
+
+	val = e.OptBool("missing")
+	c.Assert(val, Equals, false)
+}


### PR DESCRIPTION
This branch adds three small helper functions for looking up relationship of
mount entries and for checking if they are synthetic. See individual commit
messages for details.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>