### PR TITLE
 interfaces/kmod: simplify loadModules now that errors are ignored 

### DIFF
--- a/interfaces/kmod/backend.go
+++ b/interfaces/kmod/backend.go
@@ -88,7 +88,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementO
 	}
 
 	if len(changed) > 0 {
-		return loadModules(modules)
+		loadModules(modules)
 	}
 	return nil
 }

--- a/interfaces/kmod/kmod.go
+++ b/interfaces/kmod/kmod.go
@@ -20,28 +20,17 @@
 package kmod
 
 import (
-	"fmt"
 	"os/exec"
-
-	"github.com/snapcore/snapd/osutil"
 )
-
-func LoadModule(module string) error {
-	if output, err := exec.Command("modprobe", "--syslog", module).CombinedOutput(); err != nil {
-		return fmt.Errorf("cannot load module %s: %s", module, osutil.OutputErr(output, err))
-	}
-	return nil
-}
 
 // loadModules loads given list of modules via modprobe.
 // Since different kernels may not have the requested module, we treat any
 // error from modprobe as non-fatal and subsequent module loads are attempted
 // (otherwise failure to load a module means failure to connect the interface
 // and the other security backends)
-func loadModules(modules []string) error {
+func loadModules(modules []string) {
 	for _, mod := range modules {
-		LoadModule(mod) // ignore errors which are logged by
-		// LoadModule() via syslog
+		// ignore errors which are logged by loadModule() via syslog
+		_ = exec.Command("modprobe", "--syslog", mod).Run()
 	}
-	return nil
 }

--- a/interfaces/kmod/kmod_test.go
+++ b/interfaces/kmod/kmod_test.go
@@ -45,11 +45,10 @@ func (s *kmodSuite) TestModprobeCall(c *C) {
 	cmd := testutil.MockCommand(c, "modprobe", "")
 	defer cmd.Restore()
 
-	err := kmod.LoadModules([]string{
+	kmod.LoadModules([]string{
 		"module1",
 		"module2",
 	})
-	c.Assert(err, IsNil)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
 		{"modprobe", "--syslog", "module1"},
 		{"modprobe", "--syslog", "module2"},


### PR DESCRIPTION
Based on #4162 

In PR #4162  we removed failing in the kmod backend when modules cannot be loaded. 

I wanted to write a test for this and while doing so I realized that instead a bunch of code can be simplified/removed. Now there is no way for loadModules() to generate an error any more so we can remove the error return entirely.

Relevant commit is https://github.com/snapcore/snapd/commit/1dff2a9851d6a9e6082fd1d565f85e5c1f8e5560