### PR TITLE
interfaces/many: misc policy updates for browser-support, cups-control and network-status

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -58,6 +58,12 @@ owner /var/tmp/etilqs_* rw,
 owner /{dev,run}/shm/{,.}org.chromium.* mrw,
 owner /{dev,run}/shm/{,.}com.google.Chrome.* mrw,
 
+# Chrome's Singleton API sometimes causes an ouid/fsuid mismatch denial, so
+# for now, allow non-owner read on the singleton socket (LP: #1731012). See
+# https://forum.snapcraft.io/t/electron-snap-killed-when-using-app-makesingleinstance-api/2667/20
+/run/user/[0-9]*/snap.@{SNAP_NAME}/{,.}org.chromium.*/SS r,
+/run/user/[0-9]*/snap.@{SNAP_NAME}/{,.}com.google.Chrome.*/SS r,
+
 # Allow reading platform files
 /run/udev/data/+platform:* r,
 

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -34,6 +34,7 @@ const cupsControlConnectedPlugAppArmor = `
 # privileged access to configure printing.
 
 #include <abstractions/cups-client>
+/run/cups/printcap r,
 `
 
 func init() {

--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -53,6 +53,13 @@ dbus (send)
 dbus (bind)
    bus=system
    name="com.ubuntu.connectivity1.NetworkingStatus",
+
+# allow queries from unconfined
+dbus (receive)
+    bus=system
+    path=/com/ubuntu/connectivity1/NetworkingStatus{,/**}
+    interface=org.freedesktop.DBus.*
+    peer=(label=unconfined),
 `
 
 const networkStatusConnectedSlotAppArmor = `


### PR DESCRIPTION
- interfaces/browser-support: allow non-owner read on chromium singleton socket

  Chrome's Singleton API sometimes causes an ouid/fsuid mismatch denial, so for
  now, allow non-owner read on the singleton socket. Because the socket is in
  XDG_RUNTIME_DIR and this directory is only readable by the user, this does
  expand permissions in practice.

  References:
  - https://launchpad.net/bugs/1731012
  - https://forum.snapcraft.io/t/electron-snap-killed-when-using-app-makesingleinstance-api/2667/20

- interfaces/cups-control: allow read on /run/cups/printcap
- interfaces/network-status: allow queries from unconfined