### PR TITLE
interfaces/many: misc policy updates for browser-support, cups-control and network-status (2.29)

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -58,6 +58,12 @@ owner /var/tmp/etilqs_* rw,
 owner /{dev,run}/shm/{,.}org.chromium.* mrw,
 owner /{dev,run}/shm/{,.}com.google.Chrome.* mrw,
 
+# Chrome's Singleton API sometimes causes an ouid/fsuid mismatch denial, so
+# for now, allow non-owner read on the singleton socket (LP: #1731012). See
+# https://forum.snapcraft.io/t/electron-snap-killed-when-using-app-makesingleinstance-api/2667/20
+/run/user/[0-9]*/snap.@{SNAP_NAME}/{,.}org.chromium.*/SS r,
+/run/user/[0-9]*/snap.@{SNAP_NAME}/{,.}com.google.Chrome.*/SS r,
+
 # Allow reading platform files
 /run/udev/data/+platform:* r,
 

--- a/interfaces/builtin/cups_control.go
+++ b/interfaces/builtin/cups_control.go
@@ -34,6 +34,7 @@ const cupsControlConnectedPlugAppArmor = `
 # privileged access to configure printing.
 
 #include <abstractions/cups-client>
+/run/cups/printcap r,
 `
 
 func init() {

--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -53,6 +53,13 @@ dbus (send)
 dbus (bind)
    bus=system
    name="com.ubuntu.connectivity1.NetworkingStatus",
+
+# allow queries from unconfined
+dbus (receive)
+    bus=system
+    path=/com/ubuntu/connectivity1/NetworkingStatus{,/**}
+    interface=org.freedesktop.DBus.*
+    peer=(label=unconfined),
 `
 
 const networkStatusConnectedSlotAppArmor = `


### PR DESCRIPTION
https://github.com/snapcore/snapd/pull/4180 for 2.29.