### PR TITLE
cmd/snap-confine: Ensure snap-confine is allowed to access os-release

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -213,6 +213,9 @@
     umount /var/lib/snapd/hostfs/proc/,
     mount options=(rw rslave) -> /var/lib/snapd/hostfs/,
 
+    # Allow reading the os-release file (possibly a symlink to /usr/lib).
+    /{etc/,usr/lib/}os-release r,
+
     # set up snap-specific private /tmp dir
     capability chown,
     /tmp/ w,

--- a/tests/main/xdg-open-compat/task.yaml
+++ b/tests/main/xdg-open-compat/task.yaml
@@ -11,6 +11,10 @@ description: |
 # we must have snapd-xdg-open available
 systems: [ubuntu-16.04-*]
 
+# disabled because the "old" snapd-xdg-open is no longer available in the
+# archive
+manual: true
+
 environment:
     DISPLAY: :0
     XDG_OPEN_OUTPUT: /tmp/xdg-open-output


### PR DESCRIPTION
This dupes the existing rule and fixes a regression on Solus where we
see a denial for the os-release file.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>
