### PR TITLE
cmd/snap-confine: Respect biarch nature of libdirs

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -440,8 +440,8 @@
     profile snap_update_ns (attach_disconnected) {
         # The next four rules mirror those above. We want to be able to read
         # and map snap-update-ns into memory but it may come from a variety of places.
-        /usr/lib{,exec}/snapd/snap-update-ns mr,
-        /var/lib/snapd/hostfs/usr/lib{,exec}/snapd/snap-update-ns mr,
+        /usr/lib{,exec,64}/snapd/snap-update-ns mr,
+        /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns mr,
         /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
         /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
 

--- a/tests/main/xdg-open-compat/task.yaml
+++ b/tests/main/xdg-open-compat/task.yaml
@@ -11,6 +11,10 @@ description: |
 # we must have snapd-xdg-open available
 systems: [ubuntu-16.04-*]
 
+# disabled because the "old" snapd-xdg-open is no longer available in the
+# archive
+manual: true
+
 environment:
     DISPLAY: :0
     XDG_OPEN_OUTPUT: /tmp/xdg-open-output


### PR DESCRIPTION
This follows the same bi-arching seen in other parts of the policy and
ensures snap-update-ns rules are actually matched on biarch distributions
employing a lib64 tree.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>