### PR TITLE
tests: disable xdg-open-compat test

### DIFF
--- a/tests/main/xdg-open-compat/task.yaml
+++ b/tests/main/xdg-open-compat/task.yaml
@@ -11,6 +11,10 @@ description: |
 # we must have snapd-xdg-open available
 systems: [ubuntu-16.04-*]
 
+# disabled because the "old" snapd-xdg-open is no longer available in the
+# archive
+manual: true
+
 environment:
     DISPLAY: :0
     XDG_OPEN_OUTPUT: /tmp/xdg-open-output


### PR DESCRIPTION
The test relies on the "old" snapd-xdg-open deb package. However
with the promotion of snapd 2.28.5 into xenial-updates the pervious
snapd-xdg-open version 0.0.0~16.04 is no longer available to
download. This means we can not run the test. Disable for now
until we find a way to fix it.

