### PR TITLE
osutil: replace cgo bits with non-cgo, vendored os/user 

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -23,9 +23,10 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"os/user"
 	"syscall"
 	"time"
+
+	"github.com/snapcore/snapd/osutil/user"
 )
 
 func MockUserLookup(mock func(name string) (*user.User, error)) func() {

--- a/osutil/group.go
+++ b/osutil/group.go
@@ -19,119 +19,19 @@
 
 package osutil
 
-// #include <stdlib.h>
-// #include <sys/types.h>
-// #include <grp.h>
-// #include <unistd.h>
-import "C"
-
 import (
-	"fmt"
-	"os/user"
 	"strconv"
-	"syscall"
-	"unsafe"
+
+	"github.com/snapcore/snapd/osutil/user"
 )
 
-// hrm, user.LookupGroup() doesn't exist yet:
-// https://github.com/golang/go/issues/2617
+// Group represents a grouping of users.
 //
-// Use implementation from upcoming releases:
-// https://golang.org/src/os/user/lookup_unix.go
-func lookupGroup(groupname string) (string, error) {
-	var grp C.struct_group
-	var result *C.struct_group
-
-	buf := alloc(groupBuffer)
-	defer buf.free()
-	cname := C.CString(groupname)
-	defer C.free(unsafe.Pointer(cname))
-
-	err := retryWithBuffer(buf, func() syscall.Errno {
-		return syscall.Errno(C.getgrnam_r(cname,
-			&grp,
-			(*C.char)(buf.ptr),
-			C.size_t(buf.size),
-			&result))
-	})
-	if err != nil {
-		return "", fmt.Errorf("group: lookup groupname %s: %v", groupname, err)
-	}
-	if result == nil {
-		return "", fmt.Errorf("group: unknown group %s", groupname)
-	}
-	return strconv.Itoa(int(grp.gr_gid)), nil
+// On POSIX systems Gid contains a decimal number representing the group ID.
+type Group struct {
+	Gid  string // group ID
+	Name string // group name
 }
-
-type bufferKind C.int
-
-const (
-	groupBuffer = bufferKind(C._SC_GETGR_R_SIZE_MAX)
-)
-
-func (k bufferKind) initialSize() C.size_t {
-	sz := C.sysconf(C.int(k))
-	if sz == -1 {
-		// DragonFly and FreeBSD do not have _SC_GETPW_R_SIZE_MAX.
-		// Additionally, not all Linux systems have it, either. For
-		// example, the musl libc returns -1.
-		return 1024
-	}
-	if !isSizeReasonable(int64(sz)) {
-		// Truncate.  If this truly isn't enough, retryWithBuffer will error on the first run.
-		return maxBufferSize
-	}
-	return C.size_t(sz)
-}
-
-type memBuffer struct {
-	ptr  unsafe.Pointer
-	size C.size_t
-}
-
-func alloc(kind bufferKind) *memBuffer {
-	sz := kind.initialSize()
-	return &memBuffer{
-		ptr:  C.malloc(sz),
-		size: sz,
-	}
-}
-
-func (mb *memBuffer) resize(newSize C.size_t) {
-	mb.ptr = C.realloc(mb.ptr, newSize)
-	mb.size = newSize
-}
-
-func (mb *memBuffer) free() {
-	C.free(mb.ptr)
-}
-
-// retryWithBuffer repeatedly calls f(), increasing the size of the
-// buffer each time, until f succeeds, fails with a non-ERANGE error,
-// or the buffer exceeds a reasonable limit.
-func retryWithBuffer(buf *memBuffer, f func() syscall.Errno) error {
-	for {
-		errno := f()
-		if errno == 0 {
-			return nil
-		} else if errno != syscall.ERANGE {
-			return errno
-		}
-		newSize := buf.size * 2
-		if !isSizeReasonable(int64(newSize)) {
-			return fmt.Errorf("internal buffer exceeds %d bytes", maxBufferSize)
-		}
-		buf.resize(newSize)
-	}
-}
-
-const maxBufferSize = 1 << 20
-
-func isSizeReasonable(sz int64) bool {
-	return sz > 0 && sz <= maxBufferSize
-}
-
-// end code from https://golang.org/src/os/user/lookup_unix.go
 
 // FindUid returns the identifier of the given UNIX user name.
 func FindUid(username string) (uint64, error) {
@@ -144,15 +44,15 @@ func FindUid(username string) (uint64, error) {
 }
 
 // FindGid returns the identifier of the given UNIX group name.
-func FindGid(group string) (uint64, error) {
+func FindGid(groupName string) (uint64, error) {
 	// In golang 1.8 we can use the built-in function like this:
 	//group, err := user.LookupGroup(group)
-	group, err := lookupGroup(group)
+	group, err := user.LookupGroup(groupName)
 	if err != nil {
 		return 0, err
 	}
 
 	// In golang 1.8 we can parse the group.Gid string instead.
 	//return strconv.ParseUint(group.Gid, 10, 64)
-	return strconv.ParseUint(group, 10, 64)
+	return strconv.ParseUint(group.Gid, 10, 64)
 }

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -23,11 +23,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/snapcore/snapd/osutil/user"
 )
 
 var userLookup = user.Lookup

--- a/osutil/user/listgroups.go
+++ b/osutil/user/listgroups.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package user
+
+import (
+	"fmt"
+)
+
+func listGroups(u *User) ([]string, error) {
+	return nil, fmt.Errorf("user: list groups for %s: not implemented", u.Username)
+}

--- a/osutil/user/lookup.go
+++ b/osutil/user/lookup.go
@@ -1,0 +1,61 @@
+// Imported from https://golang.org/src/os/user/
+
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package user
+
+import "sync"
+
+// Current returns the current user.
+func Current() (*User, error) {
+	cache.Do(func() { cache.u, cache.err = current() })
+	if cache.err != nil {
+		return nil, cache.err
+	}
+	u := *cache.u // copy
+	return &u, nil
+}
+
+// cache of the current user
+var cache struct {
+	sync.Once
+	u   *User
+	err error
+}
+
+// Lookup looks up a user by username. If the user cannot be found, the
+// returned error is of type UnknownUserError.
+func Lookup(username string) (*User, error) {
+	if u, err := Current(); err == nil && u.Username == username {
+		return u, err
+	}
+	return lookupUser(username)
+}
+
+// LookupId looks up a user by userid. If the user cannot be found, the
+// returned error is of type UnknownUserIdError.
+func LookupId(uid string) (*User, error) {
+	if u, err := Current(); err == nil && u.Uid == uid {
+		return u, err
+	}
+	return lookupUserId(uid)
+}
+
+// LookupGroup looks up a group by name. If the group cannot be found, the
+// returned error is of type UnknownGroupError.
+func LookupGroup(name string) (*Group, error) {
+	return lookupGroup(name)
+}
+
+// LookupGroupId looks up a group by groupid. If the group cannot be found, the
+// returned error is of type UnknownGroupIdError.
+func LookupGroupId(gid string) (*Group, error) {
+	return lookupGroupId(gid)
+}
+
+// GroupIds returns the list of group IDs that the user is a member of.
+func (u *User) GroupIds() ([]string, error) {
+	return listGroups(u)
+}

--- a/osutil/user/lookup_unix.go
+++ b/osutil/user/lookup_unix.go
@@ -1,0 +1,196 @@
+// Imported from https://golang.org/src/os/user/
+
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package user
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const groupFile = "/etc/group"
+const userFile = "/etc/passwd"
+
+var colon = []byte{':'}
+
+func init() {
+	groupImplemented = false
+}
+
+// lineFunc returns a value, an error, or (nil, nil) to skip the row.
+type lineFunc func(line []byte) (v interface{}, err error)
+
+// readColonFile parses r as an /etc/group or /etc/passwd style file, running
+// fn for each row. readColonFile returns a value, an error, or (nil, nil) if
+// the end of the file is reached without a match.
+func readColonFile(r io.Reader, fn lineFunc) (v interface{}, err error) {
+	bs := bufio.NewScanner(r)
+	for bs.Scan() {
+		line := bs.Bytes()
+		// There's no spec for /etc/passwd or /etc/group, but we try to follow
+		// the same rules as the glibc parser, which allows comments and blank
+		// space at the beginning of a line.
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+		v, err = fn(line)
+		if v != nil || err != nil {
+			return
+		}
+	}
+	return nil, bs.Err()
+}
+
+func matchGroupIndexValue(value string, idx int) lineFunc {
+	var leadColon string
+	if idx > 0 {
+		leadColon = ":"
+	}
+	substr := []byte(leadColon + value + ":")
+	return func(line []byte) (v interface{}, err error) {
+		if !bytes.Contains(line, substr) || bytes.Count(line, colon) < 3 {
+			return
+		}
+		// wheel:*:0:root
+		parts := strings.SplitN(string(line), ":", 4)
+		if len(parts) < 4 || parts[0] == "" || parts[idx] != value ||
+			// If the file contains +foo and you search for "foo", glibc
+			// returns an "invalid argument" error. Similarly, if you search
+			// for a gid for a row where the group name starts with "+" or "-",
+			// glibc fails to find the record.
+			parts[0][0] == '+' || parts[0][0] == '-' {
+			return
+		}
+		if _, err := strconv.Atoi(parts[2]); err != nil {
+			return nil, nil
+		}
+		return &Group{Name: parts[0], Gid: parts[2]}, nil
+	}
+}
+
+func findGroupId(id string, r io.Reader) (*Group, error) {
+	if v, err := readColonFile(r, matchGroupIndexValue(id, 2)); err != nil {
+		return nil, err
+	} else if v != nil {
+		return v.(*Group), nil
+	}
+	return nil, UnknownGroupIdError(id)
+}
+
+func findGroupName(name string, r io.Reader) (*Group, error) {
+	if v, err := readColonFile(r, matchGroupIndexValue(name, 0)); err != nil {
+		return nil, err
+	} else if v != nil {
+		return v.(*Group), nil
+	}
+	return nil, UnknownGroupError(name)
+}
+
+// returns a *User for a row if that row's has the given value at the
+// given index.
+func matchUserIndexValue(value string, idx int) lineFunc {
+	var leadColon string
+	if idx > 0 {
+		leadColon = ":"
+	}
+	substr := []byte(leadColon + value + ":")
+	return func(line []byte) (v interface{}, err error) {
+		if !bytes.Contains(line, substr) || bytes.Count(line, colon) < 6 {
+			return
+		}
+		// kevin:x:1005:1006::/home/kevin:/usr/bin/zsh
+		parts := strings.SplitN(string(line), ":", 7)
+		if len(parts) < 6 || parts[idx] != value || parts[0] == "" ||
+			parts[0][0] == '+' || parts[0][0] == '-' {
+			return
+		}
+		if _, err := strconv.Atoi(parts[2]); err != nil {
+			return nil, nil
+		}
+		if _, err := strconv.Atoi(parts[3]); err != nil {
+			return nil, nil
+		}
+		u := &User{
+			Username: parts[0],
+			Uid:      parts[2],
+			Gid:      parts[3],
+			Name:     parts[4],
+			HomeDir:  parts[5],
+		}
+		// The pw_gecos field isn't quite standardized. Some docs
+		// say: "It is expected to be a comma separated list of
+		// personal data where the first item is the full name of the
+		// user."
+		if i := strings.Index(u.Name, ","); i >= 0 {
+			u.Name = u.Name[:i]
+		}
+		return u, nil
+	}
+}
+
+func findUserId(uid string, r io.Reader) (*User, error) {
+	i, e := strconv.Atoi(uid)
+	if e != nil {
+		return nil, errors.New("user: invalid userid " + uid)
+	}
+	if v, err := readColonFile(r, matchUserIndexValue(uid, 2)); err != nil {
+		return nil, err
+	} else if v != nil {
+		return v.(*User), nil
+	}
+	return nil, UnknownUserIdError(i)
+}
+
+func findUsername(name string, r io.Reader) (*User, error) {
+	if v, err := readColonFile(r, matchUserIndexValue(name, 0)); err != nil {
+		return nil, err
+	} else if v != nil {
+		return v.(*User), nil
+	}
+	return nil, UnknownUserError(name)
+}
+
+func lookupGroup(groupname string) (*Group, error) {
+	f, err := os.Open(groupFile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return findGroupName(groupname, f)
+}
+
+func lookupGroupId(id string) (*Group, error) {
+	f, err := os.Open(groupFile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return findGroupId(id, f)
+}
+
+func lookupUser(username string) (*User, error) {
+	f, err := os.Open(userFile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return findUsername(username, f)
+}
+
+func lookupUserId(uid string) (*User, error) {
+	f, err := os.Open(userFile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return findUserId(uid, f)
+}

--- a/osutil/user/lookup_unix_test.go
+++ b/osutil/user/lookup_unix_test.go
@@ -1,0 +1,278 @@
+// Imported from https://golang.org/src/os/user/
+
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd !android,linux nacl netbsd openbsd solaris
+// +build !cgo
+
+package user
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const testGroupFile = `# See the opendirectoryd(8) man page for additional 
+# information about Open Directory.
+##
+nobody:*:-2:
+nogroup:*:-1:
+wheel:*:0:root
+emptyid:*::root
+invalidgid:*:notanumber:root
++plussign:*:20:root
+-minussign:*:21:root
+      
+daemon:*:1:root
+    indented:*:7:
+# comment:*:4:found
+     # comment:*:4:found
+kmem:*:2:root
+`
+
+var groupTests = []struct {
+	in   string
+	name string
+	gid  string
+}{
+	{testGroupFile, "nobody", "-2"},
+	{testGroupFile, "kmem", "2"},
+	{testGroupFile, "notinthefile", ""},
+	{testGroupFile, "comment", ""},
+	{testGroupFile, "plussign", ""},
+	{testGroupFile, "+plussign", ""},
+	{testGroupFile, "-minussign", ""},
+	{testGroupFile, "minussign", ""},
+	{testGroupFile, "emptyid", ""},
+	{testGroupFile, "invalidgid", ""},
+	{testGroupFile, "indented", "7"},
+	{testGroupFile, "# comment", ""},
+	{"", "emptyfile", ""},
+}
+
+func TestFindGroupName(t *testing.T) {
+	for _, tt := range groupTests {
+		got, err := findGroupName(tt.name, strings.NewReader(tt.in))
+		if tt.gid == "" {
+			if err == nil {
+				t.Errorf("findGroupName(%s): got nil error, expected err", tt.name)
+				continue
+			}
+			switch terr := err.(type) {
+			case UnknownGroupError:
+				if terr.Error() != "group: unknown group "+tt.name {
+					t.Errorf("findGroupName(%s): got %v, want %v", tt.name, terr, tt.name)
+				}
+			default:
+				t.Errorf("findGroupName(%s): got unexpected error %v", tt.name, terr)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("findGroupName(%s): got unexpected error %v", tt.name, err)
+			}
+			if got.Gid != tt.gid {
+				t.Errorf("findGroupName(%s): got gid %v, want %s", tt.name, got.Gid, tt.gid)
+			}
+			if got.Name != tt.name {
+				t.Errorf("findGroupName(%s): got name %s, want %s", tt.name, got.Name, tt.name)
+			}
+		}
+	}
+}
+
+var groupIdTests = []struct {
+	in   string
+	gid  string
+	name string
+}{
+	{testGroupFile, "-2", "nobody"},
+	{testGroupFile, "2", "kmem"},
+	{testGroupFile, "notinthefile", ""},
+	{testGroupFile, "comment", ""},
+	{testGroupFile, "7", "indented"},
+	{testGroupFile, "4", ""},
+	{testGroupFile, "20", ""}, // row starts with a plus
+	{testGroupFile, "21", ""}, // row starts with a minus
+	{"", "emptyfile", ""},
+}
+
+func TestFindGroupId(t *testing.T) {
+	for _, tt := range groupIdTests {
+		got, err := findGroupId(tt.gid, strings.NewReader(tt.in))
+		if tt.name == "" {
+			if err == nil {
+				t.Errorf("findGroupId(%s): got nil error, expected err", tt.gid)
+				continue
+			}
+			switch terr := err.(type) {
+			case UnknownGroupIdError:
+				if terr.Error() != "group: unknown groupid "+tt.gid {
+					t.Errorf("findGroupId(%s): got %v, want %v", tt.name, terr, tt.name)
+				}
+			default:
+				t.Errorf("findGroupId(%s): got unexpected error %v", tt.name, terr)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("findGroupId(%s): got unexpected error %v", tt.name, err)
+			}
+			if got.Gid != tt.gid {
+				t.Errorf("findGroupId(%s): got gid %v, want %s", tt.name, got.Gid, tt.gid)
+			}
+			if got.Name != tt.name {
+				t.Errorf("findGroupId(%s): got name %s, want %s", tt.name, got.Name, tt.name)
+			}
+		}
+	}
+}
+
+const testUserFile = `   # Example user file
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:3:bin:/bin:/usr/sbin/nologin
+     indented:x:3:3:indented:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+negative:x:-5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+allfields:x:6:12:mansplit,man2,man3,man4:/home/allfields:/usr/sbin/nologin
++plussign:x:8:10:man:/var/cache/man:/usr/sbin/nologin
+-minussign:x:9:10:man:/var/cache/man:/usr/sbin/nologin
+
+malformed:x:27:12 # more:colons:after:comment
+
+struid:x:notanumber:12 # more:colons:after:comment
+
+# commented:x:28:12:commented:/var/cache/man:/usr/sbin/nologin
+      # commentindented:x:29:12:commentindented:/var/cache/man:/usr/sbin/nologin
+
+struid2:x:30:badgid:struid2name:/home/struid:/usr/sbin/nologin
+`
+
+var userIdTests = []struct {
+	in   string
+	uid  string
+	name string
+}{
+	{testUserFile, "-5", "negative"},
+	{testUserFile, "2", "bin"},
+	{testUserFile, "100", ""}, // not in the file
+	{testUserFile, "8", ""},   // plus sign, glibc doesn't find it
+	{testUserFile, "9", ""},   // minus sign, glibc doesn't find it
+	{testUserFile, "27", ""},  // malformed
+	{testUserFile, "28", ""},  // commented out
+	{testUserFile, "29", ""},  // commented out, indented
+	{testUserFile, "3", "indented"},
+	{testUserFile, "30", ""}, // the Gid is not valid, shouldn't match
+	{"", "1", ""},
+}
+
+func TestInvalidUserId(t *testing.T) {
+	_, err := findUserId("notanumber", strings.NewReader(""))
+	if err == nil {
+		t.Fatalf("findUserId('notanumber'): got nil error")
+	}
+	if want := "user: invalid userid notanumber"; err.Error() != want {
+		t.Errorf("findUserId('notanumber'): got %v, want %s", err, want)
+	}
+}
+
+func TestLookupUserId(t *testing.T) {
+	for _, tt := range userIdTests {
+		got, err := findUserId(tt.uid, strings.NewReader(tt.in))
+		if tt.name == "" {
+			if err == nil {
+				t.Errorf("findUserId(%s): got nil error, expected err", tt.uid)
+				continue
+			}
+			switch terr := err.(type) {
+			case UnknownUserIdError:
+				if want := "user: unknown userid " + tt.uid; terr.Error() != want {
+					t.Errorf("findUserId(%s): got %v, want %v", tt.name, terr, want)
+				}
+			default:
+				t.Errorf("findUserId(%s): got unexpected error %v", tt.name, terr)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("findUserId(%s): got unexpected error %v", tt.name, err)
+			}
+			if got.Uid != tt.uid {
+				t.Errorf("findUserId(%s): got uid %v, want %s", tt.name, got.Uid, tt.uid)
+			}
+			if got.Username != tt.name {
+				t.Errorf("findUserId(%s): got name %s, want %s", tt.name, got.Username, tt.name)
+			}
+		}
+	}
+}
+
+func TestLookupUserPopulatesAllFields(t *testing.T) {
+	u, err := findUsername("allfields", strings.NewReader(testUserFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &User{
+		Username: "allfields",
+		Uid:      "6",
+		Gid:      "12",
+		Name:     "mansplit",
+		HomeDir:  "/home/allfields",
+	}
+	if !reflect.DeepEqual(u, want) {
+		t.Errorf("findUsername: got %#v, want %#v", u, want)
+	}
+}
+
+var userTests = []struct {
+	in   string
+	name string
+	uid  string
+}{
+	{testUserFile, "negative", "-5"},
+	{testUserFile, "bin", "2"},
+	{testUserFile, "notinthefile", ""},
+	{testUserFile, "indented", "3"},
+	{testUserFile, "plussign", ""},
+	{testUserFile, "+plussign", ""},
+	{testUserFile, "minussign", ""},
+	{testUserFile, "-minussign", ""},
+	{testUserFile, "   indented", ""},
+	{testUserFile, "commented", ""},
+	{testUserFile, "commentindented", ""},
+	{testUserFile, "malformed", ""},
+	{testUserFile, "# commented", ""},
+	{"", "emptyfile", ""},
+}
+
+func TestLookupUser(t *testing.T) {
+	for _, tt := range userTests {
+		got, err := findUsername(tt.name, strings.NewReader(tt.in))
+		if tt.uid == "" {
+			if err == nil {
+				t.Errorf("lookupUser(%s): got nil error, expected err", tt.uid)
+				continue
+			}
+			switch terr := err.(type) {
+			case UnknownUserError:
+				if want := "user: unknown user " + tt.name; terr.Error() != want {
+					t.Errorf("lookupUser(%s): got %v, want %v", tt.name, terr, want)
+				}
+			default:
+				t.Errorf("lookupUser(%s): got unexpected error %v", tt.name, terr)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("lookupUser(%s): got unexpected error %v", tt.name, err)
+			}
+			if got.Uid != tt.uid {
+				t.Errorf("lookupUser(%s): got uid %v, want %s", tt.name, got.Uid, tt.uid)
+			}
+			if got.Username != tt.name {
+				t.Errorf("lookupUser(%s): got name %s, want %s", tt.name, got.Username, tt.name)
+			}
+		}
+	}
+}

--- a/osutil/user/user.go
+++ b/osutil/user/user.go
@@ -1,0 +1,81 @@
+// Imported from https://golang.org/src/os/user/
+
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package user allows user account lookups by name or id.
+package user
+
+import (
+	"strconv"
+)
+
+var (
+	userImplemented  = true // set to false by lookup_stubs.go's init
+	groupImplemented = true // set to false by lookup_stubs.go's init
+)
+
+// User represents a user account.
+type User struct {
+	// Uid is the user ID.
+	// On POSIX systems, this is a decimal number representing the uid.
+	// On Windows, this is a security identifier (SID) in a string format.
+	// On Plan 9, this is the contents of /dev/user.
+	Uid string
+	// Gid is the primary group ID.
+	// On POSIX systems, this is a decimal number representing the gid.
+	// On Windows, this is a SID in a string format.
+	// On Plan 9, this is the contents of /dev/user.
+	Gid string
+	// Username is the login name.
+	Username string
+	// Name is the user's real or display name.
+	// It might be blank.
+	// On POSIX systems, this is the first (or only) entry in the GECOS field
+	// list.
+	// On Windows, this is the user's display name.
+	// On Plan 9, this is the contents of /dev/user.
+	Name string
+	// HomeDir is the path to the user's home directory (if they have one).
+	HomeDir string
+}
+
+// Group represents a grouping of users.
+//
+// On POSIX systems Gid contains a decimal number representing the group ID.
+type Group struct {
+	Gid  string // group ID
+	Name string // group name
+}
+
+// UnknownUserIdError is returned by LookupId when a user cannot be found.
+type UnknownUserIdError int
+
+func (e UnknownUserIdError) Error() string {
+	return "user: unknown userid " + strconv.Itoa(int(e))
+}
+
+// UnknownUserError is returned by Lookup when
+// a user cannot be found.
+type UnknownUserError string
+
+func (e UnknownUserError) Error() string {
+	return "user: unknown user " + string(e)
+}
+
+// UnknownGroupIdError is returned by LookupGroupId when
+// a group cannot be found.
+type UnknownGroupIdError string
+
+func (e UnknownGroupIdError) Error() string {
+	return "group: unknown groupid " + string(e)
+}
+
+// UnknownGroupError is returned by LookupGroup when
+// a group cannot be found.
+type UnknownGroupError string
+
+func (e UnknownGroupError) Error() string {
+	return "group: unknown group " + string(e)
+}

--- a/osutil/user/user_current.go
+++ b/osutil/user/user_current.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package user
+
+import (
+	"strconv"
+	"syscall"
+)
+
+func current() (*User, error) {
+	return lookupUserId(strconv.Itoa(syscall.Getuid()))
+}

--- a/osutil/user/user_test.go
+++ b/osutil/user/user_test.go
@@ -1,0 +1,159 @@
+// Imported from https://golang.org/src/os/user/
+
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package user
+
+import (
+	"runtime"
+	"testing"
+)
+
+func checkUser(t *testing.T) {
+	if !userImplemented {
+		t.Skip("user: not implemented; skipping tests")
+	}
+}
+
+func TestCurrent(t *testing.T) {
+	u, err := Current()
+	if err != nil {
+		t.Fatalf("Current: %v (got %#v)", err, u)
+	}
+	if u.HomeDir == "" {
+		t.Errorf("didn't get a HomeDir")
+	}
+	if u.Username == "" {
+		t.Errorf("didn't get a username")
+	}
+}
+
+func BenchmarkCurrent(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Current()
+	}
+}
+
+func compare(t *testing.T, want, got *User) {
+	if want.Uid != got.Uid {
+		t.Errorf("got Uid=%q; want %q", got.Uid, want.Uid)
+	}
+	if want.Username != got.Username {
+		t.Errorf("got Username=%q; want %q", got.Username, want.Username)
+	}
+	if want.Name != got.Name {
+		t.Errorf("got Name=%q; want %q", got.Name, want.Name)
+	}
+	// TODO(brainman): fix it once we know how.
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping Gid and HomeDir comparisons")
+	}
+	if want.Gid != got.Gid {
+		t.Errorf("got Gid=%q; want %q", got.Gid, want.Gid)
+	}
+	if want.HomeDir != got.HomeDir {
+		t.Errorf("got HomeDir=%q; want %q", got.HomeDir, want.HomeDir)
+	}
+}
+
+func TestLookup(t *testing.T) {
+	checkUser(t)
+
+	if runtime.GOOS == "plan9" {
+		t.Skipf("Lookup not implemented on %q", runtime.GOOS)
+	}
+
+	want, err := Current()
+	if err != nil {
+		t.Fatalf("Current: %v", err)
+	}
+	// TODO: Lookup() has a fast path that calls Current() and returns if the
+	// usernames match, so this test does not exercise very much. It would be
+	// good to try and test finding a different user than the current user.
+	got, err := Lookup(want.Username)
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	compare(t, want, got)
+}
+
+func TestLookupId(t *testing.T) {
+	checkUser(t)
+
+	if runtime.GOOS == "plan9" {
+		t.Skipf("LookupId not implemented on %q", runtime.GOOS)
+	}
+
+	want, err := Current()
+	if err != nil {
+		t.Fatalf("Current: %v", err)
+	}
+	got, err := LookupId(want.Uid)
+	if err != nil {
+		t.Fatalf("LookupId: %v", err)
+	}
+	compare(t, want, got)
+}
+
+func checkGroup(t *testing.T) {
+	if !groupImplemented {
+		t.Skip("user: group not implemented; skipping test")
+	}
+}
+
+func TestLookupGroup(t *testing.T) {
+	checkGroup(t)
+	user, err := Current()
+	if err != nil {
+		t.Fatalf("Current(): %v", err)
+	}
+
+	g1, err := LookupGroupId(user.Gid)
+	if err != nil {
+		// NOTE(rsc): Maybe the group isn't defined. That's fine.
+		// On my OS X laptop, rsc logs in with group 5000 even
+		// though there's no name for group 5000. Such is Unix.
+		t.Logf("LookupGroupId(%q): %v", user.Gid, err)
+		return
+	}
+	if g1.Gid != user.Gid {
+		t.Errorf("LookupGroupId(%q).Gid = %s; want %s", user.Gid, g1.Gid, user.Gid)
+	}
+
+	g2, err := LookupGroup(g1.Name)
+	if err != nil {
+		t.Fatalf("LookupGroup(%q): %v", g1.Name, err)
+	}
+	if g1.Gid != g2.Gid || g1.Name != g2.Name {
+		t.Errorf("LookupGroup(%q) = %+v; want %+v", g1.Name, g2, g1)
+	}
+}
+
+func TestGroupIds(t *testing.T) {
+	checkGroup(t)
+	if runtime.GOOS == "solaris" {
+		t.Skip("skipping GroupIds, see golang.org/issue/14709")
+	}
+	user, err := Current()
+	if err != nil {
+		t.Fatalf("Current(): %v", err)
+	}
+	gids, err := user.GroupIds()
+	if err != nil {
+		t.Fatalf("%+v.GroupIds(): %v", user, err)
+	}
+	if !containsID(gids, user.Gid) {
+		t.Errorf("%+v.GroupIds() = %v; does not contain user GID %s", user, gids, user.Gid)
+	}
+}
+
+func containsID(ids []string, id string) bool {
+	for _, x := range ids {
+		if x == id {
+			return true
+		}
+	}
+	return false
+}

--- a/osutil/user_test.go
+++ b/osutil/user_test.go
@@ -22,13 +22,13 @@ package osutil_test
 import (
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strconv"
 
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/testutil"
 )
 


### PR DESCRIPTION
The aim of this series is to replace cgo dependent implementation of `osutil` APIs.

First, we import no-cgo bits of `os/user` from Go stdlib and provide our implementation of glue calls (namely `current()` and `listGroups()`). Imported files are exact copies of their upstream counterparts, plus a note at the top of the file that identifies where they came from.

Next drop cgo dependent bits in `osutil/group.go`, and replace all imports of `os/user` with our vendored one.

There's still a couple of `os/user` imports in snapd:
```
interfaces/apparmor/backend_test.go
26:     "os/user"

vendor/github.com/godbus/dbus/homedir_dynamic.go
6:      "os/user"

snap/snapenv/snapenv_test.go
25:     "os/user"

snap/snapenv/snapenv.go
25:     "os/user"

daemon/api_test.go
39:     "os/user"

daemon/api.go
32:     "os/user"

cmd/snap/error.go
28:     "os/user"

cmd/snap/cmd_run_test.go
25:     "os/user"

cmd/snap/export_test.go
23:     "os/user"

cmd/snap/cmd_run.go
26:     "os/user"
```

With this we could restore group files in #4185 and possibly some of the checks and fixes from #4135 

@niemeyer @mvo5 @zyga reviews? 