### PR TITLE
interfaces/builtin/lxd_support: allow discovering of host's os-release

### DIFF
--- a/interfaces/builtin/lxd_support.go
+++ b/interfaces/builtin/lxd_support.go
@@ -41,6 +41,9 @@ const lxdSupportConnectedPlugAppArmor = `
 # to its containers. This gives device ownership to connected snaps.
 @{PROC}/**/attr/current r,
 /usr/sbin/aa-exec ux,
+
+# Allow discovering the os-release of the host
+/var/lib/snapd/hostfs/{etc,usr/lib}/os-release r,
 `
 
 const lxdSupportConnectedPlugSecComp = `


### PR DESCRIPTION
Fix the following denial:

audit: type=1400 audit(1510219691.912:133): apparmor="DENIED" operation="open"
       profile="snap.lxd.lxc" name="/var/lib/snapd/hostfs/usr/lib/os-release" pid=29008
       comm="snap-exec" requested_mask="r" denied_mask="r" fsuid=0 ouid=0

@zyga might be of interest to you