### PR TITLE
daemon: for /v2/logs, 404 when no services are found

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -155,9 +155,9 @@ var (
 	}
 
 	logsCmd = &Command{
-		Path:   "/v2/logs",
-		UserOK: true,
-		GET:    getLogs,
+		Path:     "/v2/logs",
+		PolkitOK: "io.snapcraft.snapd.manage",
+		GET:      getLogs,
 	}
 
 	snapConfCmd = &Command{

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2642,6 +2642,9 @@ func getLogs(c *Command, r *http.Request, user *auth.UserState) Response {
 	if rsp != nil {
 		return rsp
 	}
+	if len(appInfos) == 0 {
+		return AppNotFound("no matching services")
+	}
 
 	serviceNames := make([]string, len(appInfos))
 	for i, appInfo := range appInfos {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -5998,6 +5998,24 @@ func (s *appSuite) TestAppInfosForMissingSnap(c *check.C) {
 	c.Assert(appInfos, check.IsNil)
 }
 
+func (s *apiSuite) TestLogsNoServices(c *check.C) {
+	// NOTE this is *apiSuite, not *appSuite, so there are no
+	// installed snaps with services
+
+	cmd := testutil.MockCommand(c, "systemctl", "").Also("journalctl", "")
+	defer cmd.Restore()
+	s.daemon(c)
+	s.d.overlord.Loop()
+	defer s.d.overlord.Stop()
+
+	req, err := http.NewRequest("GET", "/v2/logs", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := getLogs(logsCmd, req, nil).(*resp)
+	c.Assert(rsp.Status, check.Equals, 404)
+	c.Assert(rsp.Type, check.Equals, ResponseTypeError)
+}
+
 func (s *appSuite) TestLogs(c *check.C) {
 	s.jctlRCs = []io.ReadCloser{ioutil.NopCloser(strings.NewReader(`
 {"MESSAGE": "hello1", "SYSLOG_IDENTIFIER": "xyzzy", "_PID": "42", "__REALTIME_TIMESTAMP": "42"}


### PR DESCRIPTION
When getting service logs, if a snap name is given but it has no
services, a 404 is returned. However if no names were given we would
call journalctl with no match arguments (because ∀ is true on the
empty set), meaning we'd ship all the logs out. This fixes that.
