### PR TITLE
daemon,overlord/snapstate: return snap-not-installed error in more cases.

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -5197,7 +5197,7 @@ func (s *apiSuite) TestAliasErrors(c *check.C) {
 	}{
 		{func(a *aliasAction) { a.Action = "" }, `unsupported alias action: ""`},
 		{func(a *aliasAction) { a.Action = "what" }, `unsupported alias action: "what"`},
-		{func(a *aliasAction) { a.Snap = "lalala" }, `cannot find snap "lalala"`},
+		{func(a *aliasAction) { a.Snap = "lalala" }, `snap "lalala" is not installed`},
 		{func(a *aliasAction) { a.Alias = ".foo" }, `invalid alias name: ".foo"`},
 		{func(a *aliasAction) { a.Aliases = []string{"baz"} }, `cannot interpret request, snaps can no longer be expected to declare their aliases`},
 	}

--- a/overlord/snapstate/aliasesv2.go
+++ b/overlord/snapstate/aliasesv2.go
@@ -537,7 +537,7 @@ func Alias(st *state.State, snapName, app, alias string) (*state.TaskSet, error)
 	var snapst SnapState
 	err := Get(st, snapName, &snapst)
 	if err == state.ErrNoState {
-		return nil, fmt.Errorf("cannot find snap %q", snapName)
+		return nil, &snap.NotInstalledError{Snap: snapName}
 	}
 	if err != nil {
 		return nil, err
@@ -592,7 +592,7 @@ func DisableAllAliases(st *state.State, snapName string) (*state.TaskSet, error)
 	var snapst SnapState
 	err := Get(st, snapName, &snapst)
 	if err == state.ErrNoState {
-		return nil, fmt.Errorf("cannot find snap %q", snapName)
+		return nil, &snap.NotInstalledError{Snap: snapName}
 	}
 	if err != nil {
 		return nil, err
@@ -675,7 +675,7 @@ func Prefer(st *state.State, name string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
 	if err == state.ErrNoState {
-		return nil, fmt.Errorf("cannot find snap %q", name)
+		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -874,7 +874,7 @@ func Switch(st *state.State, name, channel string) (*state.TaskSet, error) {
 		return nil, err
 	}
 	if !snapst.IsInstalled() {
-		return nil, fmt.Errorf("cannot find snap %q", name)
+		return nil, &snap.NotInstalledError{Snap: name}
 	}
 
 	if err := CheckChangeConflict(st, name, nil, nil); err != nil {
@@ -901,7 +901,7 @@ func Update(st *state.State, name, channel string, revision snap.Revision, userI
 		return nil, err
 	}
 	if !snapst.IsInstalled() {
-		return nil, fmt.Errorf("cannot find snap %q", name)
+		return nil, &snap.NotInstalledError{Snap: name}
 	}
 
 	// FIXME: snaps that are not active are skipped for now
@@ -1051,7 +1051,7 @@ func Enable(st *state.State, name string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
 	if err == state.ErrNoState {
-		return nil, fmt.Errorf("cannot find snap %q", name)
+		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {
 		return nil, err
@@ -1098,7 +1098,7 @@ func Disable(st *state.State, name string) (*state.TaskSet, error) {
 	var snapst SnapState
 	err := Get(st, name, &snapst)
 	if err == state.ErrNoState {
-		return nil, fmt.Errorf("cannot find snap %q", name)
+		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {
 		return nil, err
@@ -1528,7 +1528,7 @@ func Info(st *state.State, name string, revision snap.Revision) (*snap.Info, err
 	var snapst SnapState
 	err := Get(st, name, &snapst)
 	if err == state.ErrNoState {
-		return nil, fmt.Errorf("cannot find snap %q", name)
+		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	if err != nil {
 		return nil, err
@@ -1552,7 +1552,7 @@ func CurrentInfo(st *state.State, name string) (*snap.Info, error) {
 	}
 	info, err := snapst.CurrentInfo()
 	if err == ErrNoCurrent {
-		return nil, fmt.Errorf("cannot find snap %q", name)
+		return nil, &snap.NotInstalledError{Snap: name}
 	}
 	return info, err
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -908,7 +908,7 @@ func (s *snapmgrTestSuite) TestSwitchUnhappy(c *C) {
 	defer s.state.Unlock()
 
 	_, err := snapstate.Switch(s.state, "non-existing-snap", "some-channel")
-	c.Assert(err, ErrorMatches, `cannot find snap "non-existing-snap"`)
+	c.Assert(err, ErrorMatches, `snap "non-existing-snap" is not installed`)
 }
 
 func (s *snapmgrTestSuite) TestDisableTasks(c *C) {
@@ -5416,7 +5416,7 @@ func (s *snapmgrQuerySuite) TestCurrentInfoAbsent(c *C) {
 	defer st.Unlock()
 
 	_, err := snapstate.CurrentInfo(st, "absent")
-	c.Assert(err, ErrorMatches, `cannot find snap "absent"`)
+	c.Assert(err, ErrorMatches, `snap "absent" is not installed`)
 }
 
 func (s *snapmgrQuerySuite) TestActiveInfos(c *C) {


### PR DESCRIPTION
This fixes snap enable/disable etc from returning a generic error when a snap is
not installed.
