### PR TITLE
tests/lib: handle distro specific grub-editenv naming

### DIFF
--- a/tests/lib/boot.sh
+++ b/tests/lib/boot.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
+GRUB_EDITENV=grub-editenv
+case "$SPREAD_SYSTEM" in
+    fedora-*|opensuse-*)
+        GRUB_EDITENV=grub2-editenv
+        ;;
+esac
+
 bootenv() {
     if [ $# -eq 0 ]; then
-        if command -v grub-editenv >/dev/null; then
-            grub-editenv list
+        if command -v "$GRUB_EDITENV" >/dev/null; then
+            "$GRUB_EDITENV" list
         else
             fw_printenv
         fi
     else
-        if command -v grub-editenv >/dev/null; then
-            grub-editenv list | grep "^$1"
+        if command -v "$GRUB_EDITENV" >/dev/null; then
+            "$GRUB_EDITENV" list | grep "^$1"
         else
             fw_printenv "$1"
         fi | sed "s/^${1}=//"
@@ -20,8 +27,8 @@ bootenv() {
 bootenv_unset() {
     local var="$1"
 
-    if command -v grub-editenv >/dev/null; then
-        grub-editenv /boot/grub/grubenv unset "$var"
+    if command -v "$GRUB_EDITENV" >/dev/null; then
+        "$GRUB_EDITENV" /boot/grub/grubenv unset "$var"
     else
         fw_setenv "$var"
     fi

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -207,10 +207,10 @@ EOF
             snap set core refresh.disabled=true
         fi
 
-        echo "Ensure that the grub-editenv list output does not contain any of the snap_* variables on classic"
+        echo "Ensure that the bootloader environment output does not contain any of the snap_* variables on classic"
         output="$(bootenv)"
         if echo "$output" | MATCH snap_ ; then
-            echo "Expected grub environment without snap_*, got:"
+            echo "Expected bootloader environment without snap_*, got:"
             echo "$output"
             exit 1
         fi

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -208,7 +208,8 @@ EOF
         fi
 
         echo "Ensure that the bootloader environment output does not contain any of the snap_* variables on classic"
-        output="$(bootenv)"
+        # shellcheck disable=SC2119
+        output=$(bootenv)
         if echo "$output" | MATCH snap_ ; then
             echo "Expected bootloader environment without snap_*, got:"
             echo "$output"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -8,6 +8,8 @@ set -eux
 . "$TESTSLIB/snaps.sh"
 # shellcheck source=tests/lib/pkgdb.sh
 . "$TESTSLIB/pkgdb.sh"
+# shellcheck source=tests/lib/boot.sh
+. "$TESTSLIB/boot.sh"
 
 disable_kernel_rate_limiting() {
     # kernel rate limiting hinders debugging security policy so turn it off
@@ -205,15 +207,8 @@ EOF
             snap set core refresh.disabled=true
         fi
 
-        GRUB_EDITENV=grub-editenv
-        case "$SPREAD_SYSTEM" in
-            fedora-*|opensuse-*)
-                GRUB_EDITENV=grub2-editenv
-                ;;
-        esac
-
         echo "Ensure that the grub-editenv list output does not contain any of the snap_* variables on classic"
-        output=$($GRUB_EDITENV list)
+        output="$(bootenv list)"
         if echo "$output" | MATCH snap_ ; then
             echo "Expected grub environment without snap_*, got:"
             echo "$output"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -208,7 +208,7 @@ EOF
         fi
 
         echo "Ensure that the grub-editenv list output does not contain any of the snap_* variables on classic"
-        output="$(bootenv list)"
+        output="$(bootenv)"
         if echo "$output" | MATCH snap_ ; then
             echo "Expected grub environment without snap_*, got:"
             echo "$output"


### PR DESCRIPTION
Fedora and OpenSUSE use `grub2-editenv` while Ubuntu and Debian seem to settle on `grub-editenv`. A workaround was already implemented in https://github.com/snapcore/snapd/commit/d0098bacda32bd5369829fe78d9c5d2ccba0a702 but the tests started failing on linode:fedora-25-64:project only now.
