### PR TITLE
tests/set-proxy-store: exclude ubuntu-core-16 via systems: key

### DIFF
--- a/tests/main/set-proxy-store/task.yaml
+++ b/tests/main/set-proxy-store/task.yaml
@@ -4,10 +4,9 @@ environment:
     SNAP_VERSION_PATTERN: \d+\.\d+\+fake1
     BLOB_DIR: $(pwd)/fake-store-blobdir
 
+systems: [-ubuntu-core-16-*]
+
 prepare: |
-    if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
-        exit
-    fi
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit

--- a/tests/main/set-proxy-store/task.yaml
+++ b/tests/main/set-proxy-store/task.yaml
@@ -5,8 +5,6 @@ environment:
     SNAP_VERSION_PATTERN: \d+\.\d+\+fake1
     BLOB_DIR: $(pwd)/fake-store-blobdir
 
-systems: [-ubuntu-core-16-*]
-
 prepare: |
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"


### PR DESCRIPTION
Trivial followup for https://github.com/snapcore/snapd/pull/4179 (thanks to Sergio)