### PR TITLE
add spread test for allocating TUN/TAP devices with network-control

### DIFF
--- a/tests/lib/snaps/test-snapd-tuntap/bin/tuntap.py
+++ b/tests/lib/snaps/test-snapd-tuntap/bin/tuntap.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+
+import os
+import fcntl
+import re
+import struct
+import sys
+import time
+
+
+def if_open(dev):
+    TUNSETIFF = 0x400454ca
+    TUNSETOWNER = TUNSETIFF + 2
+    IFF_TUN = 0x0001
+    IFF_TAP = 0x0002
+    IFF_NO_PI = 0x1000
+
+    try:
+        fd = os.open("/dev/net/tun", os.O_RDWR)
+    except PermissionError as e:
+        print("%s" % e)
+        sys.exit(1)
+    except Exception:
+        raise
+
+    if_flags = None
+    if dev.startswith('tun'):
+        if_flags = IFF_TUN | IFF_NO_PI
+    elif dev.startswith('tap'):
+        if_flags = IFF_TAP | IFF_NO_PI
+
+    iface = fcntl.ioctl(fd, TUNSETIFF,
+                        struct.pack("16sH", str.encode(dev), if_flags))
+
+    # for setting to owner
+    # fcntl.ioctl(fd, TUNSETOWNER, 1000)
+
+    return fd
+
+
+def device_exists(dev):
+    return os.path.exists("/sys/devices/virtual/net/%s" % dev)
+
+
+def valid_device_name(dev):
+    if not re.search(r'^t(ap|un)[0-9]+$', dev):
+        raise Exception("device should be of form tun0-tun255 or tap0-tap255")
+
+    if_num = int(dev[3:])
+    if if_num > 255:
+        raise Exception("device should be of form tun0-tun255 or tap0-tap255")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("need to specify a tun/tap device (eg tun1 or tap2)")
+        sys.exit(1)
+
+    d = sys.argv[1]
+    valid_device_name(d)
+
+    if device_exists(d):
+        print("ERROR: device '%s' already exists" % d)
+        sys.exit(1)
+
+    fd = if_open(d)
+
+    found = False
+    if device_exists(d):
+        found = True
+        print("PASS")
+    else:
+        print("FAIL")
+
+    os.close(fd)
+
+    if not found:
+        sys.exit(1)

--- a/tests/lib/snaps/test-snapd-tuntap/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-tuntap/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: test-snapd-tuntap
+version: 1.0
+summary: Test policy app for allocating tun/tap devices
+description: Test policy app for allocating tun/tap devices
+confinement: strict
+
+apps:
+  tuntap:
+    command: bin/tuntap.py
+    plugs: [ network-control ]

--- a/tests/main/interfaces-network-control-tuntap/task.yaml
+++ b/tests/main/interfaces-network-control-tuntap/task.yaml
@@ -28,7 +28,7 @@ execute: |
 
     if [ "$(snap debug confinement)" = strict ] ; then
         echo "And cannot allocate the $DEV device"
-        test-snapd-tuntap.tuntap $DEV | MATCH "Permission denied"
+        test-snapd-tuntap.tuntap $DEV 2>&1 | MATCH "Permission denied"
     fi
 
     echo "When the plug is connected"

--- a/tests/main/interfaces-network-control-tuntap/task.yaml
+++ b/tests/main/interfaces-network-control-tuntap/task.yaml
@@ -1,0 +1,39 @@
+summary: Ensure that the network-control interface works with TUN/TAP.
+
+details: |
+    The network-control interface allows a snap to configure networking of
+    TUN/TAP devices.
+
+    A snap declaring a plug on this interface must be able to allocate TUN/TAP
+    virtual network devices.
+
+    https://github.com/torvalds/linux/blob/master/Documentation/networking/tuntap.txt
+
+environment:
+    DEV/tun: tun255
+    DEV/tap: tap255
+
+execute: |
+    echo "Given a snap declaring a plug on the network-control interface is installed"
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-tuntap
+
+    . "$TESTSLIB/network.sh"
+
+    CONNECTED_PATTERN=":network-control +test-snapd-tuntap"
+    DISCONNECTED_PATTERN="^- +test-snapd-tuntap:network-control$"
+
+    echo "Then the plug disconnected by default"
+    snap interfaces | MATCH "$DISCONNECTED_PATTERN"
+
+    if [ "$(snap debug confinement)" = strict ] ; then
+        echo "And cannot allocate the $DEV device"
+        test-snapd-tuntap.tuntap $DEV | MATCH "Permission denied"
+    fi
+
+    echo "When the plug is connected"
+    snap connect test-snapd-tuntap:network-control
+    snap interfaces | MATCH "$CONNECTED_PATTERN"
+
+    echo "Then the snap command can allocate the $DEV device"
+    test-snapd-tuntap.tuntap $DEV | MATCH "PASS"


### PR DESCRIPTION
Recently we fixed a udev_enumerate error when connecting the network-control interface. While that issue is fixed and we recently added new spread tests to catch the specific udev enumerate error, we didn't have a full test for allocating tun/tap devices. This PR addresses that.