### PR TITLE
cmd/snap-confine: Make the vulkan ICD definition available

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -79,6 +79,7 @@ static const char *nvidia_globs[] = {
 	"/usr/lib/libnvidia-ml.so*",
 	"/usr/lib/libnvidia-ptxjitcompiler.so*",
 	"/usr/lib/libnvidia-tls.so*",
+	"/usr/share/vulkan/icd.d/10_nvidia*.json",
 };
 
 static const size_t nvidia_globs_len =


### PR DESCRIPTION
Under biarch link farms we'll also ensure that we expose the 10_nvidia*json
files under `/var/lib/snapd/lib/gl` so that they can be utilised alongside
the proprietary NVIDIA driver by interested parties.

To implement usage of them from within a snap, simply point the environmental
variable `VK_ICD_FILENAMES` at a glob of these files so that `libvulkan.so.1`
can load them.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>
