### PR TITLE
packaging/arch: do not quote MAKEFLAGS

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -95,7 +95,7 @@ build() {
     --disable-apparmor \
     --enable-nvidia-biarch \
     --enable-merged-usr
-  make "$MAKEFLAGS"
+  make $MAKEFLAGS
 }
 
 check() {


### PR DESCRIPTION
Quoting MAKEFLAGS will lead to a nasty call `make ""` if those are unset in
/etc/makepkg.conf. In such case, make will try to build "" target, which will
fail.
