### PR TITLE
run-checks, tests/lib/snaps/: shellcheck fixes

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -104,9 +104,9 @@ missing_interface_spread_test() {
         esac
         if ! grep -q "$search" "$snap_yaml" ; then
             echo "Missing high-level test for interface '$iface'. Please add to:"
-            echo "- $snap_yaml"
-            echo "- $core_snap_yaml (if needed)"
-            echo "- $classic_snap_yaml (if needed)"
+            echo "* $snap_yaml"
+            echo "* $core_snap_yaml (if needed)"
+            echo "* $classic_snap_yaml (if needed)"
             exit 1
         fi
     done

--- a/run-checks
+++ b/run-checks
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$TRAVIS_BUILD_NUMBER" ]; then
     echo travis_fold:start:env

--- a/run-checks
+++ b/run-checks
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$TRAVIS_BUILD_NUMBER" ]; then
     echo travis_fold:start:env

--- a/run-checks
+++ b/run-checks
@@ -88,7 +88,7 @@ missing_interface_spread_test() {
     snap_yaml="tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml"
     core_snap_yaml="tests/lib/snaps/test-snapd-policy-app-provider-core/meta/snap.yaml"
     classic_snap_yaml="tests/lib/snaps/test-snapd-policy-app-provider-classic/meta/snap.yaml"
-    for iface in `go run ./tests/lib/list-interfaces.go` ; do
+    for iface in $(go run ./tests/lib/list-interfaces.go) ; do
         search="plugs: \[ $iface \]"
         case "$iface" in
             bool-file|gpio|hidraw|i2c|iio|serial-port|spi)

--- a/tests/lib/snaps/test-snapd-check-fs-access/bin/write-dir
+++ b/tests/lib/snaps/test-snapd-check-fs-access/bin/write-dir
@@ -12,7 +12,7 @@ if [ ! -d "$dir" ]; then
 fi
 
 filename=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '')
-file="$(echo $dir/$filename | sed 's/\/\//\//g')"
+file=$(echo "$dir/$filename" | sed 's/\/\//\//g')
 
 touch "$file" || exit 1
 

--- a/tests/lib/snaps/test-snapd-desktop/bin/check-dirs
+++ b/tests/lib/snaps/test-snapd-desktop/bin/check-dirs
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 for dir in "$@"; do
-    ls $dir
+    ls "$dir"
 done

--- a/tests/lib/snaps/test-snapd-desktop/bin/check-files
+++ b/tests/lib/snaps/test-snapd-desktop/bin/check-files
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 for file in "$@"; do
-    cat $file
+    cat "$file"
 done


### PR DESCRIPTION
Small series introducing fixes for warnings brought up by shellcheck 0.4.6.

