### PR TITLE
tests/interfaces-network-control-tuntap: disable on debian-unstable for now

### DIFF
--- a/tests/main/interfaces-network-control-tuntap/task.yaml
+++ b/tests/main/interfaces-network-control-tuntap/task.yaml
@@ -1,5 +1,7 @@
 summary: Ensure that the network-control interface works with TUN/TAP.
 
+systems: [-debian-unstable-64]
+
 details: |
     The network-control interface allows a snap to configure networking of
     TUN/TAP devices.


### PR DESCRIPTION
We need to investigate the root cause but right now all PRs fail because of this.