### PR TITLE
tests: re-enable tun/tap test on Debian

### DIFF
--- a/tests/main/interfaces-network-control-tuntap/task.yaml
+++ b/tests/main/interfaces-network-control-tuntap/task.yaml
@@ -1,7 +1,5 @@
 summary: Ensure that the network-control interface works with TUN/TAP.
 
-systems: [-debian-unstable-64]
-
 details: |
     The network-control interface allows a snap to configure networking of
     TUN/TAP devices.


### PR DESCRIPTION
This test used to fail and was disabled to unblock master but upon
inspection it does not fail anymore. The reason of the earlier failure
remains unknown.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>