### PR TITLE
fakestore: add go-flags to prepare for `new-snap-declaration` cmd

### DIFF
--- a/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
@@ -28,16 +28,12 @@ type cmdMakeRefreshable struct {
 }
 
 func (x *cmdMakeRefreshable) Execute(args []string) error {
-	return runManage(x.TopDir, args)
+	// setup fake new revisions of snaps for refresh
+	return refresh.MakeFakeRefreshForSnaps(args, x.TopDir)
 }
 
 var shortMakeRefreshableHelp = "List of snaps with new versions"
 
 func init() {
 	parser.AddCommand("make-refreshable", shortMakeRefreshableHelp, "", &cmdMakeRefreshable{})
-}
-
-func runManage(topDir string, snaps []string) error {
-	// setup fake new revisions of snaps for refresh
-	return refresh.MakeFakeRefreshForSnaps(snaps, topDir)
 }

--- a/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
@@ -1,0 +1,43 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/tests/lib/fakestore/refresh"
+)
+
+type cmdMakeRefreshable struct {
+	TopDir string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
+}
+
+func (x *cmdMakeRefreshable) Execute(args []string) error {
+	return runManage(x.TopDir, args)
+}
+
+var shortMakeRefreshableHelp = "List of snaps with new versions"
+
+func init() {
+	parser.AddCommand("make-refreshable", shortMakeRefreshableHelp, "", &cmdMakeRefreshable{})
+}
+
+func runManage(topDir string, snaps []string) error {
+	// setup fake new revisions of snaps for refresh
+	return refresh.MakeFakeRefreshForSnaps(snaps, topDir)
+}

--- a/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_make_refreshable.go
@@ -32,7 +32,7 @@ func (x *cmdMakeRefreshable) Execute(args []string) error {
 	return refresh.MakeFakeRefreshForSnaps(args, x.TopDir)
 }
 
-var shortMakeRefreshableHelp = "List of snaps with new versions"
+var shortMakeRefreshableHelp = "Makes new versions of the given snaps"
 
 func init() {
 	parser.AddCommand("make-refreshable", shortMakeRefreshableHelp, "", &cmdMakeRefreshable{})

--- a/tests/lib/fakestore/cmd/fakestore/cmd_run.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_run.go
@@ -27,7 +27,7 @@ import (
 	"github.com/snapcore/snapd/tests/lib/fakestore/store"
 )
 
-type cmdStart struct {
+type cmdRun struct {
 	TopDir         string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
 	Addr           string `long:"addr" default:"localhost:11028" description:"Store address"`
 	AssertFallback bool   `long:"assert-fallback" description:"Fallback to the main online store for missing assertions"`
@@ -36,9 +36,9 @@ type cmdStart struct {
 	HttpsProxy string `long:"https-proxy" description:"HTTPS proxy address"`
 }
 
-var shortStartHelp = "Start the store service"
+var shortRunHelp = "Run the store service"
 
-func (x *cmdStart) Execute(args []string) error {
+func (x *cmdRun) Execute(args []string) error {
 	if x.HttpsProxy != "" {
 		os.Setenv("https_proxy", x.HttpsProxy)
 	}
@@ -50,7 +50,7 @@ func (x *cmdStart) Execute(args []string) error {
 }
 
 func init() {
-	if _, err := parser.AddCommand("start", shortStartHelp, "", &cmdStart{}); err != nil {
+	if _, err := parser.AddCommand("run", shortRunHelp, "", &cmdRun{}); err != nil {
 		panic(err)
 	}
 }

--- a/tests/lib/fakestore/cmd/fakestore/cmd_start.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_start.go
@@ -1,0 +1,70 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/snapcore/snapd/tests/lib/fakestore/store"
+)
+
+type cmdStart struct {
+	TopDir         string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
+	Addr           string `long:"addr" default:"localhost:11028" description:"Store address"`
+	AssertFallback bool   `long:"assert-fallback" description:"Fallback to the main online store for missing assertions"`
+
+	HttpProxy  string `long:"http-proxy" description:"HTTP proxy address"`
+	HttpsProxy string `long:"https-proxy" description:"HTTPS proxy address"`
+}
+
+var shortStartHelp = "Start the store service"
+
+func (x *cmdStart) Execute(args []string) error {
+	if x.HttpsProxy != "" {
+		os.Setenv("https_proxy", x.HttpsProxy)
+	}
+	if x.HttpProxy != "" {
+		os.Setenv("http_proxy", x.HttpProxy)
+	}
+
+	return runServer(x.TopDir, x.Addr, x.AssertFallback)
+}
+
+func init() {
+	if _, err := parser.AddCommand("start", shortStartHelp, "", &cmdStart{}); err != nil {
+		panic(err)
+	}
+}
+
+func runServer(topDir, addr string, assertFallback bool) error {
+	st := store.NewStore(topDir, addr, assertFallback)
+
+	if err := st.Start(); err != nil {
+		return err
+	}
+
+	ch := make(chan os.Signal)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	<-ch
+
+	return st.Stop()
+}

--- a/tests/lib/fakestore/cmd/fakestore/main.go
+++ b/tests/lib/fakestore/cmd/fakestore/main.go
@@ -20,27 +20,17 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
-	"os/signal"
-	"strings"
-	"syscall"
+
+	"github.com/jessevdk/go-flags"
 
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/tests/lib/fakestore/refresh"
-	"github.com/snapcore/snapd/tests/lib/fakestore/store"
 )
 
-var (
-	start           = flag.Bool("start", false, "Start the store service")
-	assertFallback  = flag.Bool("assert-fallback", false, "Fallback to the main online store for missing assertions")
-	topDir          = flag.String("dir", "", "Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions")
-	makeRefreshable = flag.String("make-refreshable", "", "List of snaps with new versions separated by commas")
-	addr            = flag.String("addr", "localhost:11028", "Store address")
-	https_proxy     = flag.String("https-proxy", "", "HTTPS proxy address")
-	http_proxy      = flag.String("http-proxy", "", "HTTP proxy address")
-)
+type Options struct{}
+
+var parser = flags.NewParser(&Options{}, flags.Default)
 
 func main() {
 	if err := logger.SimpleSetup(); err != nil {
@@ -56,43 +46,6 @@ func main() {
 }
 
 func run() error {
-	flag.Parse()
-
-	if len(*https_proxy) > 0 {
-		os.Setenv("https_proxy", *https_proxy)
-	}
-
-	if len(*http_proxy) > 0 {
-		os.Setenv("http_proxy", *http_proxy)
-	}
-
-	if *start {
-		return runServer(*topDir, *addr, *assertFallback)
-	}
-
-	if *makeRefreshable != "" {
-		return runManage(*topDir, *makeRefreshable)
-	}
-
-	return fmt.Errorf("please specify either start or make-refreshable")
-}
-
-func runServer(topDir, addr string, assertFallback bool) error {
-	st := store.NewStore(topDir, addr, assertFallback)
-
-	if err := st.Start(); err != nil {
-		return err
-	}
-
-	ch := make(chan os.Signal)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	<-ch
-
-	return st.Stop()
-}
-
-func runManage(topDir, snaps string) error {
-	// setup fake new revisions of snaps for refresh
-	snapList := strings.Split(snaps, ",")
-	return refresh.MakeFakeRefreshForSnaps(snapList, topDir)
+	_, err := parser.Parse()
+	return err
 }

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -30,10 +30,10 @@ teardown_staging_store(){
 }
 
 init_fake_refreshes(){
-    local refreshable_snaps=$1
-    local dir=$2
+    local dir=$1
+    shift
 
-    fakestore make-refreshable "$refreshable_snaps" --dir "$dir"
+    fakestore make-refreshable --dir "$dir" "$@" 
 }
 
 setup_fake_store(){
@@ -47,7 +47,7 @@ setup_fake_store(){
     https_proxy=${https_proxy:-}
     http_proxy=${http_proxy:-}
 
-    systemd_create_and_start_unit fakestore "$(which fakestore) start --dir $top_dir --addr localhost:11028 --https-proxy=${https_proxy} --http-proxy=${http_proxy} --assert-fallback" "SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
+    systemd_create_and_start_unit fakestore "$(which fakestore) run --dir $top_dir --addr localhost:11028 --https-proxy=${https_proxy} --http-proxy=${http_proxy} --assert-fallback" "SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
 
     echo "And snapd is configured to use the controlled store"
     _configure_store_backends "SNAPPY_FORCE_API_URL=http://localhost:11028" "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -33,7 +33,7 @@ init_fake_refreshes(){
     local refreshable_snaps=$1
     local dir=$2
 
-    fakestore -make-refreshable "$refreshable_snaps" -dir "$dir"
+    fakestore make-refreshable "$refreshable_snaps" --dir "$dir"
 }
 
 setup_fake_store(){
@@ -47,7 +47,7 @@ setup_fake_store(){
     https_proxy=${https_proxy:-}
     http_proxy=${http_proxy:-}
 
-    systemd_create_and_start_unit fakestore "$(which fakestore) -start -dir $top_dir -addr localhost:11028 -https-proxy=${https_proxy} -http-proxy=${http_proxy} -assert-fallback" "SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
+    systemd_create_and_start_unit fakestore "$(which fakestore) start --dir $top_dir --addr localhost:11028 --https-proxy=${https_proxy} --http-proxy=${http_proxy} --assert-fallback" "SNAPD_DEBUG=1 SNAPD_DEBUG_HTTP=7 SNAPPY_TESTING=1 SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"
 
     echo "And snapd is configured to use the controlled store"
     _configure_store_backends "SNAPPY_FORCE_API_URL=http://localhost:11028" "SNAPPY_USE_STAGING_STORE=$SNAPPY_USE_STAGING_STORE"

--- a/tests/main/refresh-all-undo/task.yaml
+++ b/tests/main/refresh-all-undo/task.yaml
@@ -45,9 +45,9 @@ execute: |
     echo "When the store is configured to make them refreshable"
     . $TESTSLIB/files.sh
     . $TESTSLIB/store.sh
-    init_fake_refreshes "$GOOD_SNAP" "$BLOB_DIR"
+    init_fake_refreshes "$BLOB_DIR" "$GOOD_SNAP"
     wait_for_file "$BLOB_DIR"/"${GOOD_SNAP}"*fake1*.snap 4 .5
-    init_fake_refreshes "$BAD_SNAP" "$BLOB_DIR"
+    init_fake_refreshes "$BLOB_DIR" "$BAD_SNAP"
     wait_for_file "$BLOB_DIR"/"${BAD_SNAP}"*fake1*.snap 4 .5
 
     echo "When a snap is broken"

--- a/tests/main/refresh-all/task.yaml
+++ b/tests/main/refresh-all/task.yaml
@@ -48,9 +48,9 @@ execute: |
     echo "When the store is configured to make them refreshable"
     . $TESTSLIB/files.sh
     . $TESTSLIB/store.sh
-    init_fake_refreshes test-snapd-tools $BLOB_DIR
+    init_fake_refreshes $BLOB_DIR test-snapd-tools 
     wait_for_file $BLOB_DIR/test-snapd-tools*fake1*.snap 4 .5
-    init_fake_refreshes test-snapd-python-webserver $BLOB_DIR
+    init_fake_refreshes  $BLOB_DIR test-snapd-python-webserver
     wait_for_file $BLOB_DIR/test-snapd-python-webserver*fake1*.snap 4 .5
 
     echo "And a refresh is performed"

--- a/tests/main/refresh-devmode/task.yaml
+++ b/tests/main/refresh-devmode/task.yaml
@@ -35,7 +35,7 @@ prepare: |
 
         echo "And a new version of that snap put in the controlled store"
         . $TESTSLIB/store.sh
-        init_fake_refreshes test-snapd-tools $BLOB_DIR
+        init_fake_refreshes $BLOB_DIR test-snapd-tools
     fi
 
 restore: |

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -46,7 +46,7 @@ prepare: |
 
         echo "And a new version of that snap put in the controlled store"
         . $TESTSLIB/store.sh
-        init_fake_refreshes $SNAP_NAME $BLOB_DIR
+        init_fake_refreshes $BLOB_DIR $SNAP_NAME
     fi
 
 restore: |

--- a/tests/main/revert-devmode/task.yaml
+++ b/tests/main/revert-devmode/task.yaml
@@ -25,7 +25,7 @@ prepare: |
 
         echo "And a new version of that snap put in the controlled store"
         . $TESTSLIB/store.sh
-        init_fake_refreshes test-snapd-tools $BLOB_DIR
+        init_fake_refreshes $BLOB_DIR test-snapd-tools
     fi
 
 restore: |

--- a/tests/main/revert/task.yaml
+++ b/tests/main/revert/task.yaml
@@ -25,7 +25,7 @@ prepare: |
 
         echo "And a new version of that snap put in the controlled store"
         . $TESTSLIB/store.sh
-        init_fake_refreshes test-snapd-tools $BLOB_DIR
+        init_fake_refreshes $BLOB_DIR test-snapd-tools
     fi
 
 restore: |

--- a/tests/main/set-proxy-store/task.yaml
+++ b/tests/main/set-proxy-store/task.yaml
@@ -32,7 +32,7 @@ prepare: |
     snap ack fake.store
 
     echo "And a new version of that snap put in the controlled store"
-    init_fake_refreshes $SNAP_NAME $BLOB_DIR
+    init_fake_refreshes $BLOB_DIR $SNAP_NAME
 
 restore: |
     rm -f fake.store


### PR DESCRIPTION
The fakestore will need to grow one more command (new-snap-declaration)
soon to make testing easier. To prepare for this this PR moves
the fakestore to use go-flags.
