### PR TITLE
interfaces/time*_control: explicitly deny noisy read on /proc/1/environ

### DIFF
--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -74,6 +74,13 @@ dbus (receive)
 # set-local-rtc commands.
 /usr/bin/timedatectl{,.real} ixr,
 
+# Silence this noisy denial. systemd utilities look at /proc/1/environ to see
+# if running in a container, but they will fallback gracefully. No other
+# interfaces allow this denial, so no problems with silencing it for now. Note
+# that allowing this triggers a 'ptrace trace peer=unconfined' denial, which we
+# want to avoid.
+deny @{PROC}/1/environ r,
+
 # Allow write access to system real-time clock
 # See 'man 4 rtc' for details.
 

--- a/interfaces/builtin/timeserver_control.go
+++ b/interfaces/builtin/timeserver_control.go
@@ -78,6 +78,13 @@ dbus (receive)
 # D-Bus method for controlling network time synchronization via
 # timedatectl's set-ntp command.
 /usr/bin/timedatectl{,.real} ixr,
+
+# Silence this noisy denial. systemd utilities look at /proc/1/environ to see
+# if running in a container, but they will fallback gracefully. No other
+# interfaces allow this denial, so no problems with silencing it for now. Note
+# that allowing this triggers a 'ptrace trace peer=unconfined' denial, which we
+# want to avoid.
+deny @{PROC}/1/environ r,
 `
 
 func init() {

--- a/interfaces/builtin/timezone_control.go
+++ b/interfaces/builtin/timezone_control.go
@@ -80,6 +80,13 @@ dbus (receive)
 # D-Bus method for setting the timezone via timedatectl's set-timezone
 # command.
 /usr/bin/timedatectl{,.real} ixr,
+
+# Silence this noisy denial. systemd utilities look at /proc/1/environ to see
+# if running in a container, but they will fallback gracefully. No other
+# interfaces allow this denial, so no problems with silencing it for now. Note
+# that allowing this triggers a 'ptrace trace peer=unconfined' denial, which we
+# want to avoid.
+deny @{PROC}/1/environ r,
 `
 
 func init() {


### PR DESCRIPTION
systemd utilities look at /proc/1/environ to see if running in a container, but
they will fallback gracefully. No other interfaces allow this denial, so no
problems with silencing it for now. Note that allowing this triggers a 'ptrace
trace peer=unconfined' denial, which we want to avoid.

Reference:
https://forum.snapcraft.io/t/managing-time-date-and-timezone-in-ubuntu-core/408/44
