### PR TITLE
snapd: allow hooks to have slots

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -420,7 +420,9 @@ func (slot *SlotInfo) SecurityTags() []string {
 	for _, app := range slot.Apps {
 		tags = append(tags, app.SecurityTag())
 	}
-	// NOTE: hooks cannot have slots
+	for _, hook := range slot.Hooks {
+		tags = append(tags, hook.SecurityTag())
+	}
 	sort.Strings(tags)
 	return tags
 }
@@ -439,6 +441,7 @@ type SlotInfo struct {
 	Attrs     map[string]interface{}
 	Label     string
 	Apps      map[string]*AppInfo
+	Hooks     map[string]*HookInfo
 }
 
 // AppInfo provides information about a app.
@@ -481,6 +484,7 @@ type HookInfo struct {
 
 	Name  string
 	Plugs map[string]*PlugInfo
+	Slots map[string]*SlotInfo
 }
 
 // SecurityTag returns application-specific security tag.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -79,6 +79,7 @@ type appYaml struct {
 
 type hookYaml struct {
 	PlugNames []string `yaml:"plugs,omitempty"`
+	SlotNames []string `yaml:"slots,omitempty"`
 }
 
 type layoutYaml struct {
@@ -130,7 +131,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 	// Bind unbound plugs to all apps and hooks
 	bindUnboundPlugs(globalPlugNames, snap)
 
-	// Bind unbound slots to all apps
+	// Bind unbound slots to all apps and hooks
 	bindUnboundSlots(globalSlotNames, snap)
 
 	// Collect layout elements.
@@ -256,6 +257,9 @@ func setSlotsFromSnapYaml(y snapYaml, snap *Info) error {
 		if len(y.Apps) > 0 {
 			snap.Slots[name].Apps = make(map[string]*AppInfo)
 		}
+		if len(y.Hooks) > 0 {
+			snap.Slots[name].Hooks = make(map[string]*HookInfo)
+		}
 	}
 
 	return nil
@@ -340,6 +344,10 @@ func setHooksFromSnapYaml(y snapYaml, snap *Info) {
 		if len(y.Plugs) > 0 || len(yHook.PlugNames) > 0 {
 			hook.Plugs = make(map[string]*PlugInfo)
 		}
+		if len(y.Slots) > 0 || len(yHook.SlotNames) > 0 {
+			hook.Slots = make(map[string]*SlotInfo)
+		}
+
 		snap.Hooks[hookName] = hook
 		// Bind all plugs/slots listed in this hook
 		for _, plugName := range yHook.PlugNames {
@@ -358,6 +366,23 @@ func setHooksFromSnapYaml(y snapYaml, snap *Info) {
 			}
 			hook.Plugs[plugName] = plug
 			plug.Hooks[hookName] = hook
+		}
+		for _, slotName := range yHook.SlotNames {
+			slot, ok := snap.Slots[slotName]
+			if !ok {
+				// Create implicit slot definitions if required
+				slot = &SlotInfo{
+					Snap:      snap,
+					Name:      slotName,
+					Interface: slotName,
+					Hooks:     make(map[string]*HookInfo),
+				}
+				snap.Slots[slotName] = slot
+			} else if slot.Hooks == nil {
+				slot.Hooks = make(map[string]*HookInfo)
+			}
+			hook.Slots[slotName] = slot
+			slot.Hooks[hookName] = hook
 		}
 	}
 }
@@ -394,10 +419,16 @@ func bindUnboundSlots(slotNames []string, snap *Info) error {
 			return fmt.Errorf("no slot named %q", slotName)
 		}
 
-		if len(slot.Apps) == 0 {
+		// A slot is considered unbound if it isn't being used by any apps
+		// or hooks. In which case we bind them to all apps and hooks.
+		if len(slot.Apps) == 0 && len(slot.Hooks) == 0 {
 			for appName, app := range snap.Apps {
 				app.Slots[slotName] = slot
 				slot.Apps[appName] = app
+			}
+			for hookName, hook := range snap.Hooks {
+				hook.Slots[slotName] = slot
+				slot.Hooks[hookName] = hook
 			}
 		}
 	}

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -725,6 +725,73 @@ slots:
 	})
 }
 
+func (s *YamlSuite) TestUnmarshalGlobalSlotsBindToHooks(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+slots:
+    test-slot:
+hooks:
+    test-hook:
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name(), Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	c.Check(info.Apps, HasLen, 0)
+	c.Check(info.Hooks, HasLen, 1)
+
+	slot, ok := info.Slots["test-slot"]
+	c.Assert(ok, Equals, true, Commentf("Expected slots to include 'test-slot'"))
+	hook, ok := info.Hooks["test-hook"]
+	c.Assert(ok, Equals, true, Commentf("Expected hooks to include 'test-hook'"))
+
+	c.Check(slot, DeepEquals, &snap.SlotInfo{
+		Snap:      info,
+		Name:      "test-slot",
+		Interface: "test-slot",
+		Hooks:     map[string]*snap.HookInfo{hook.Name: hook},
+	})
+	c.Check(hook, DeepEquals, &snap.HookInfo{
+		Snap:  info,
+		Name:  "test-hook",
+		Slots: map[string]*snap.SlotInfo{slot.Name: slot},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalHookWithSlot(c *C) {
+	// NOTE: yaml content cannot use tabs, indent the section with spaces.
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+hooks:
+    test-hook:
+        slots: [test-slot]
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Name(), Equals, "snap")
+	c.Check(info.Plugs, HasLen, 0)
+	c.Check(info.Slots, HasLen, 1)
+	c.Check(info.Apps, HasLen, 0)
+	c.Check(info.Hooks, HasLen, 1)
+
+	slot, ok := info.Slots["test-slot"]
+	c.Assert(ok, Equals, true, Commentf("Expected slots to include 'test-slot'"))
+	hook, ok := info.Hooks["test-hook"]
+	c.Assert(ok, Equals, true, Commentf("Expected hooks to include 'test-hook'"))
+
+	c.Check(slot, DeepEquals, &snap.SlotInfo{
+		Snap:      info,
+		Name:      "test-slot",
+		Interface: "test-slot",
+		Hooks:     map[string]*snap.HookInfo{hook.Name: hook},
+	})
+	c.Check(hook, DeepEquals, &snap.HookInfo{
+		Snap:  info,
+		Name:  "test-hook",
+		Slots: map[string]*snap.SlotInfo{slot.Name: slot},
+	})
+}
+
 func (s *YamlSuite) TestUnmarshalCorruptedSlotWithNonStringInterfaceName(c *C) {
 	// NOTE: yaml content cannot use tabs, indent the section with spaces.
 	_, err := snap.InfoFromSnapYaml([]byte(`
@@ -1071,6 +1138,7 @@ apps:
 hooks:
     test-hook:
        plugs: [foo-socket-plug]
+       slots: [foo-socket-slot]
 plugs:
     foo-socket-plug:
         interface: socket
@@ -1139,14 +1207,16 @@ slots:
 	c.Check(app2.Slots, DeepEquals, map[string]*snap.SlotInfo{
 		slot2.Name: slot2})
 
-	// hook1 has two plugs ("foo-socket", "logging"). The plug "logging" is
-	// global while "foo-socket" is hook-bound.
+	// hook1 has two plugs ("foo-socket", "logging") and two slots ("foo-socket", "tracing").
+	// The plug "logging" and slot "tracing" are global while "foo-socket" is hook-bound.
 
 	c.Assert(hook, NotNil)
 	c.Check(hook.Snap, Equals, info)
 	c.Check(hook.Name, Equals, "test-hook")
 	c.Check(hook.Plugs, DeepEquals, map[string]*snap.PlugInfo{
 		plug3.Name: plug3, plug4.Name: plug4})
+	c.Check(hook.Slots, DeepEquals, map[string]*snap.SlotInfo{
+		slot1.Name: slot1, slot2.Name: slot2})
 
 	// plug1 ("network") is implicitly defined and app-bound to "daemon"
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -115,7 +115,7 @@ slots:
 	c.Assert(info.Plugs["plug"].SecurityTags(), DeepEquals, []string{
 		"snap.name.app1", "snap.name.app2", "snap.name.hook.hook1"})
 	c.Assert(info.Slots["slot"].SecurityTags(), DeepEquals, []string{
-		"snap.name.app1", "snap.name.app2"})
+		"snap.name.app1", "snap.name.app2", "snap.name.hook.hook1"})
 }
 
 func (s *infoSuite) TestAppInfoWrapperPath(c *C) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -567,14 +567,15 @@ func (s *infoSuite) TestReadInfoImplicitAndExplicitHooks(c *C) {
 version: 1.0
 hooks:
   explicit:
-    plugs: [test-plug]`
+    plugs: [test-plug]
+    slots: [test-slot]`
 	s.checkInstalledSnapAndSnapFile(c, yaml, "SNAP", []string{"explicit", "implicit"}, func(c *C, info *snap.Info) {
 		// Verify that the `implicit` hook has now been loaded, and that it has
 		// no associated plugs. Also verify that the `explicit` hook is still
 		// valid.
 		c.Check(info.Hooks, HasLen, 2)
 		verifyImplicitHook(c, info, "implicit")
-		verifyExplicitHook(c, info, "explicit", []string{"test-plug"})
+		verifyExplicitHook(c, info, "explicit", []string{"test-plug"}, []string{"test-slot"})
 	})
 }
 
@@ -585,11 +586,12 @@ func verifyImplicitHook(c *C, info *snap.Info, hookName string) {
 	c.Check(hook.Plugs, IsNil)
 }
 
-func verifyExplicitHook(c *C, info *snap.Info, hookName string, plugNames []string) {
+func verifyExplicitHook(c *C, info *snap.Info, hookName string, plugNames []string, slotNames []string) {
 	hook := info.Hooks[hookName]
 	c.Assert(hook, NotNil, Commentf("Expected hooks to contain %q", hookName))
 	c.Check(hook.Name, Equals, hookName)
 	c.Check(hook.Plugs, HasLen, len(plugNames))
+	c.Check(hook.Slots, HasLen, len(slotNames))
 
 	for _, plugName := range plugNames {
 		// Verify that the HookInfo and PlugInfo point to each other
@@ -604,6 +606,21 @@ func verifyExplicitHook(c *C, info *snap.Info, hookName string, plugNames []stri
 		// Verify also that the hook plug made it into info.Plugs
 		c.Check(info.Plugs[plugName], DeepEquals, plug)
 	}
+
+	for _, slotName := range slotNames {
+		// Verify that the HookInfo and SlotInfo point to each other
+		slot := hook.Slots[slotName]
+		c.Assert(slot, NotNil, Commentf("Expected hook slots to contain %q", slotName))
+		c.Check(slot.Name, Equals, slotName)
+		c.Check(slot.Hooks, HasLen, 1)
+		hook = slot.Hooks[hookName]
+		c.Assert(hook, NotNil, Commentf("Expected slot to be associated with hook %q", hookName))
+		c.Check(hook.Name, Equals, hookName)
+
+		// Verify also that the hook plug made it into info.Slots
+		c.Check(info.Slots[slotName], DeepEquals, slot)
+	}
+
 }
 
 func (s *infoSuite) TestMinimalInfoDirAndFileMethods(c *C) {


### PR DESCRIPTION
Allow hooks to have slots to have fully symmetric API for plugs and slots.
