### PR TITLE
tests: add new `fakestore new-snap-{declaration,revision}` helpers

### DIFF
--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_decl.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_decl.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/snapcore/snapd/tests/lib/fakestore/refresh"
+)
+
+type cmdNewSnapDeclaration struct {
+	Positional struct {
+		Snap string
+	} `positional-args:"yes"`
+
+	TopDir           string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
+	SnapDeclJsonPath string `long:"snap-decl-json" description:"Path to a json encoded snap declaration"`
+}
+
+func (x *cmdNewSnapDeclaration) Execute(args []string) error {
+	headers := map[string]interface{}{}
+	if x.SnapDeclJsonPath != "" {
+		content, err := ioutil.ReadFile(x.SnapDeclJsonPath)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(content, &headers); err != nil {
+			return err
+		}
+	}
+
+	return refresh.NewSnapDeclaration(x.TopDir, x.Positional.Snap, headers)
+}
+
+var shortNewSnapDeclarationHelp = "make new snap declaration"
+
+func init() {
+	parser.AddCommand("new-snap-declaration", shortNewSnapDeclarationHelp, "", &cmdNewSnapDeclaration{})
+}

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_decl.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_decl.go
@@ -50,7 +50,7 @@ func (x *cmdNewSnapDeclaration) Execute(args []string) error {
 	return refresh.NewSnapDeclaration(x.TopDir, x.Positional.Snap, headers)
 }
 
-var shortNewSnapDeclarationHelp = "make new snap declaration"
+var shortNewSnapDeclarationHelp = "Make new snap declaration"
 
 func init() {
 	parser.AddCommand("new-snap-declaration", shortNewSnapDeclarationHelp, "", &cmdNewSnapDeclaration{})

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_decl.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_decl.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/snapcore/snapd/tests/lib/fakestore/refresh"
@@ -47,7 +48,12 @@ func (x *cmdNewSnapDeclaration) Execute(args []string) error {
 		}
 	}
 
-	return refresh.NewSnapDeclaration(x.TopDir, x.Positional.Snap, headers)
+	p, err := refresh.NewSnapDeclaration(x.TopDir, x.Positional.Snap, headers)
+	if err != nil {
+		return err
+	}
+	fmt.Println(p)
+	return nil
 }
 
 var shortNewSnapDeclarationHelp = "Make new snap declaration"

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_rev.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_rev.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/snapcore/snapd/tests/lib/fakestore/refresh"
@@ -47,7 +48,12 @@ func (x *cmdNewSnapRevision) Execute(args []string) error {
 		}
 	}
 
-	return refresh.NewSnapRevision(x.TopDir, x.Positional.Snap, headers)
+	p, err := refresh.NewSnapRevision(x.TopDir, x.Positional.Snap, headers)
+	if err != nil {
+		return err
+	}
+	fmt.Println(p)
+	return nil
 }
 
 var shortNewSnapRevisionHelp = "Make new snap revision"

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_rev.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_rev.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/snapcore/snapd/tests/lib/fakestore/refresh"
+)
+
+type cmdNewSnapRevision struct {
+	Positional struct {
+		Snap string
+	} `positional-args:"yes"`
+
+	TopDir          string `long:"dir" description:"Directory to be used by the store to keep and serve snaps, <dir>/asserts is used for assertions"`
+	SnapRevJsonPath string `long:"snap-rev-json" description:"Path to a json encoded snap revision"`
+}
+
+func (x *cmdNewSnapRevision) Execute(args []string) error {
+	headers := map[string]interface{}{}
+	if x.SnapRevJsonPath != "" {
+		content, err := ioutil.ReadFile(x.SnapRevJsonPath)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(content, &headers); err != nil {
+			return err
+		}
+	}
+
+	return refresh.NewSnapRevision(x.TopDir, x.Positional.Snap, headers)
+}
+
+var shortNewSnapRevisionHelp = "make new snap revision"
+
+func init() {
+	parser.AddCommand("new-snap-revision", shortNewSnapRevisionHelp, "", &cmdNewSnapRevision{})
+}

--- a/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_rev.go
+++ b/tests/lib/fakestore/cmd/fakestore/cmd_new_snap_rev.go
@@ -50,7 +50,7 @@ func (x *cmdNewSnapRevision) Execute(args []string) error {
 	return refresh.NewSnapRevision(x.TopDir, x.Positional.Snap, headers)
 }
 
-var shortNewSnapRevisionHelp = "make new snap revision"
+var shortNewSnapRevisionHelp = "Make new snap revision"
 
 func init() {
 	parser.AddCommand("new-snap-revision", shortNewSnapRevisionHelp, "", &cmdNewSnapRevision{})

--- a/tests/lib/fakestore/refresh/refresh.go
+++ b/tests/lib/fakestore/refresh/refresh.go
@@ -152,7 +152,7 @@ func makeFakeRefreshForSnap(snap, targetDir string, db *asserts.Database, f asse
 	}
 
 	// new test-signed snap-revision
-	_, err = makeNewSnapRevision(origInfo, newInfo, targetDir, db)
+	err = makeNewSnapRevision(origInfo, newInfo, targetDir, db)
 	if err != nil {
 		return fmt.Errorf("cannot make new snap-revision: %v", err)
 	}
@@ -230,12 +230,12 @@ func copySnapAsserts(info *info, f asserts.Fetcher) error {
 	return snapasserts.FetchSnapAssertions(f, info.digest)
 }
 
-func makeNewSnapRevision(orig, new *info, targetDir string, db *asserts.Database) (string, error) {
+func makeNewSnapRevision(orig, new *info, targetDir string, db *asserts.Database) error {
 	a, err := db.Find(asserts.SnapRevisionType, map[string]string{
 		"snap-sha3-384": orig.digest,
 	})
 	if err != nil {
-		return "", err
+		return err
 	}
 	origSnapRev := a.(*asserts.SnapRevision)
 
@@ -250,8 +250,9 @@ func makeNewSnapRevision(orig, new *info, targetDir string, db *asserts.Database
 	}
 	a, err = db.Sign(asserts.SnapRevisionType, headers, nil, systestkeys.TestStoreKeyID)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	return writeAssert(a, targetDir)
+	_, err = writeAssert(a, targetDir)
+	return err
 }

--- a/tests/lib/fakestore/refresh/snapAsserts.go
+++ b/tests/lib/fakestore/refresh/snapAsserts.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package refresh
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/systestkeys"
+)
+
+func snapNameFromPath(snapPath string) string {
+	return strings.Split(filepath.Base(snapPath), "_")[0]
+}
+
+// TODO: also support reading/copying form a store snap
+
+func NewSnapRevision(targetDir string, snap string, headers map[string]interface{}) error {
+	db, err := newAssertsDB()
+	if err != nil {
+		return err
+	}
+	digest, size, err := asserts.SnapFileSHA3_384(snap)
+	if err != nil {
+		return err
+	}
+
+	headers["authority-id"] = "testrootorg"
+	headers["snap-sha3-384"] = digest
+	if _, ok := headers["developer-id"]; !ok {
+		headers["developer-id"] = "testrootorg"
+	}
+	if _, ok := headers["snap-id"]; !ok {
+		headers["snap-id"] = snapNameFromPath(snap) + "-id"
+	}
+	if _, ok := headers["snap-revision"]; !ok {
+		headers["snap-revision"] = "42"
+	}
+	headers["snap-size"] = fmt.Sprintf("%d", size)
+	headers["timestamp"] = time.Now().Format(time.RFC3339)
+
+	a, err := db.Sign(asserts.SnapRevisionType, headers, nil, systestkeys.TestStoreKeyID)
+	if err != nil {
+		return err
+	}
+	return writeAssert(a, targetDir)
+}
+
+func NewSnapDeclaration(targetDir string, snap string, headers map[string]interface{}) error {
+	db, err := newAssertsDB()
+	if err != nil {
+		return err
+	}
+
+	if _, ok := headers["snap-name"]; !ok {
+		headers["snap-name"] = snapNameFromPath(snap)
+	}
+
+	headers["authority-id"] = "testrootorg"
+	headers["series"] = "16"
+	if _, ok := headers["snap-id"]; !ok {
+		headers["snap-id"] = snapNameFromPath(snap) + "-id"
+	}
+	if _, ok := headers["publisher-id"]; !ok {
+		headers["publisher-id"] = "testrootorg"
+	}
+	if _, ok := headers["snap-name"]; !ok {
+		headers["snap-name"] = snapNameFromPath(snap)
+	}
+	headers["timestamp"] = time.Now().Format(time.RFC3339)
+
+	a, err := db.Sign(asserts.SnapDeclarationType, headers, nil, systestkeys.TestStoreKeyID)
+	if err != nil {
+		return err
+	}
+	return writeAssert(a, targetDir)
+}

--- a/tests/lib/fakestore/refresh/snap_asserts.go
+++ b/tests/lib/fakestore/refresh/snap_asserts.go
@@ -35,14 +35,14 @@ func snapNameFromPath(snapPath string) string {
 
 // TODO: also support reading/copying form a store snap
 
-func NewSnapRevision(targetDir string, snap string, headers map[string]interface{}) error {
+func NewSnapRevision(targetDir string, snap string, headers map[string]interface{}) (string, error) {
 	db, err := newAssertsDB()
 	if err != nil {
-		return err
+		return "", err
 	}
 	digest, size, err := asserts.SnapFileSHA3_384(snap)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	fallbacks := map[string]interface{}{
@@ -62,15 +62,15 @@ func NewSnapRevision(targetDir string, snap string, headers map[string]interface
 
 	a, err := db.Sign(asserts.SnapRevisionType, headers, nil, systestkeys.TestStoreKeyID)
 	if err != nil {
-		return err
+		return "", err
 	}
 	return writeAssert(a, targetDir)
 }
 
-func NewSnapDeclaration(targetDir string, snap string, headers map[string]interface{}) error {
+func NewSnapDeclaration(targetDir string, snap string, headers map[string]interface{}) (string, error) {
 	db, err := newAssertsDB()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	fallbacks := map[string]interface{}{
@@ -89,7 +89,7 @@ func NewSnapDeclaration(targetDir string, snap string, headers map[string]interf
 
 	a, err := db.Sign(asserts.SnapDeclarationType, headers, nil, systestkeys.TestStoreKeyID)
 	if err != nil {
-		return err
+		return "", err
 	}
 	return writeAssert(a, targetDir)
 }

--- a/tests/lib/fakestore/refresh/snap_asserts.go
+++ b/tests/lib/fakestore/refresh/snap_asserts.go
@@ -45,17 +45,18 @@ func NewSnapRevision(targetDir string, snap string, headers map[string]interface
 		return err
 	}
 
+	fallbacks := map[string]interface{}{
+		"developer-id":  "testrootorg",
+		"snap-id":       snapNameFromPath(snap) + "-id",
+		"snap-revision": "1",
+	}
+	for k, v := range fallbacks {
+		if _, ok := headers[k]; !ok {
+			headers[k] = v
+		}
+	}
 	headers["authority-id"] = "testrootorg"
 	headers["snap-sha3-384"] = digest
-	if _, ok := headers["developer-id"]; !ok {
-		headers["developer-id"] = "testrootorg"
-	}
-	if _, ok := headers["snap-id"]; !ok {
-		headers["snap-id"] = snapNameFromPath(snap) + "-id"
-	}
-	if _, ok := headers["snap-revision"]; !ok {
-		headers["snap-revision"] = "42"
-	}
 	headers["snap-size"] = fmt.Sprintf("%d", size)
 	headers["timestamp"] = time.Now().Format(time.RFC3339)
 
@@ -72,21 +73,18 @@ func NewSnapDeclaration(targetDir string, snap string, headers map[string]interf
 		return err
 	}
 
-	if _, ok := headers["snap-name"]; !ok {
-		headers["snap-name"] = snapNameFromPath(snap)
+	fallbacks := map[string]interface{}{
+		"snap-id":      snapNameFromPath(snap) + "-id",
+		"snap-name":    snapNameFromPath(snap),
+		"publisher-id": "testrootorg",
 	}
-
+	for k, v := range fallbacks {
+		if _, ok := headers[k]; !ok {
+			headers[k] = v
+		}
+	}
 	headers["authority-id"] = "testrootorg"
 	headers["series"] = "16"
-	if _, ok := headers["snap-id"]; !ok {
-		headers["snap-id"] = snapNameFromPath(snap) + "-id"
-	}
-	if _, ok := headers["publisher-id"]; !ok {
-		headers["publisher-id"] = "testrootorg"
-	}
-	if _, ok := headers["snap-name"]; !ok {
-		headers["snap-name"] = snapNameFromPath(snap)
-	}
 	headers["timestamp"] = time.Now().Format(time.RFC3339)
 
 	a, err := db.Sign(asserts.SnapDeclarationType, headers, nil, systestkeys.TestStoreKeyID)

--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-install_local() {
+make_snap() {
     local SNAP_NAME="$1"
     shift;
     local SNAP_FILE="$TESTSLIB/snaps/${SNAP_NAME}/${SNAP_NAME}_1.0_all.snap"
@@ -8,8 +8,16 @@ install_local() {
     # assigned in a separate step to avoid hiding a failure
     SNAP_DIR="$(dirname "$SNAP_FILE")"
     if [ ! -f "$SNAP_FILE" ]; then
-        snap pack "$SNAP_DIR" "$SNAP_DIR"
+        snap pack "$SNAP_DIR" "$SNAP_DIR" >/dev/null
     fi
+    echo "$SNAP_FILE"
+}
+
+install_local() {
+    local SNAP_NAME="$1"
+    shift
+    SNAP_FILE=$(make_snap "$SNAP_NAME")
+
     snap install --dangerous "$@" "$SNAP_FILE"
 }
 

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -30,10 +30,21 @@ teardown_staging_store(){
 }
 
 init_fake_refreshes(){
-    local dir=$1
+    local dir="$1"
     shift
 
     fakestore make-refreshable --dir "$dir" "$@" 
+}
+
+make_snap_installable(){
+    local dir="$1"
+    local snap_path="$2"
+
+    cp -a "$snap_path" "$dir"
+    fakestore new-snap-declaration --dir "$dir" "${snap_path}"
+    snap ack $dir/asserts/*.snap-declaration
+    fakestore new-snap-revision --dir "$dir" "${snap_path}"
+    snap ack $dir/asserts/*.snap-revision
 }
 
 setup_fake_store(){

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -41,10 +41,10 @@ make_snap_installable(){
     local snap_path="$2"
 
     cp -a "$snap_path" "$dir"
-    fakestore new-snap-declaration --dir "$dir" "${snap_path}"
-    snap ack $dir/asserts/*.snap-declaration
-    fakestore new-snap-revision --dir "$dir" "${snap_path}"
-    snap ack $dir/asserts/*.snap-revision
+    p=$(fakestore new-snap-declaration --dir "$dir" "${snap_path}")
+    snap ack $p
+    p=$(fakestore new-snap-revision --dir "$dir" "${snap_path}")
+    snap ack $p
 }
 
 setup_fake_store(){

--- a/tests/main/fakestore-install/task.yaml
+++ b/tests/main/fakestore-install/task.yaml
@@ -1,0 +1,30 @@
+summary: Ensure that the fakestore works
+
+environment:
+  BLOB_DIR: $(pwd)/fake-store-blobdir
+
+restore: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+    . $TESTSLIB/store.sh
+    teardown_fake_store $BLOB_DIR
+  
+execute: |
+    if [ "$TRUST_TEST_KEYS" = "false" ]; then
+        echo "This test needs test keys to be trusted"
+        exit
+    fi
+
+    snap ack "$TESTSLIB/assertions/testrootorg-store.account-key"
+
+    . $TESTSLIB/store.sh
+    setup_fake_store $BLOB_DIR
+
+    . $TESTSLIB/snaps.sh
+    snap_path=$(make_snap basic)
+    make_snap_installable $BLOB_DIR ${snap_path}
+
+    snap install basic
+    snap info basic | MATCH "snap-id:[ ]+basic-id"


### PR DESCRIPTION
This allows to create snap-{declaration,revision} assertions signed
with the TestStore keys. This allows us to put arbitrary snaps
into the fakestore for testing.

This will be used in #4161 