### PR TITLE
tests: disable interfaces-network-control-tuntap

### DIFF
--- a/tests/main/interfaces-network-control-tuntap/task.yaml
+++ b/tests/main/interfaces-network-control-tuntap/task.yaml
@@ -9,6 +9,10 @@ details: |
 
     https://github.com/torvalds/linux/blob/master/Documentation/networking/tuntap.txt
 
+# This test is randomly failing when running with the full suite.
+# It may be a race or a sequence problem with an earlier test.
+manual: true
+
 environment:
     DEV/tun: tun255
     DEV/tap: tap255


### PR DESCRIPTION
The test is randomly failing on master. We've seen failures on Debian
and on Ubuntu 16.04. The reason is unclear. I'm disabling the test per
jdstrand's request to investigate.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>