### PR TITLE
tests: add test for frame buffer interface

### DIFF
--- a/tests/lib/snaps/test-snapd-framebuffer/bin/read
+++ b/tests/lib/snaps/test-snapd-framebuffer/bin/read
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-head -c 10 /dev/fb0
+dd if=/dev/fb0 of=/dev/null count=10

--- a/tests/lib/snaps/test-snapd-framebuffer/bin/read
+++ b/tests/lib/snaps/test-snapd-framebuffer/bin/read
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+head -c 10 /dev/fb0

--- a/tests/lib/snaps/test-snapd-framebuffer/bin/write
+++ b/tests/lib/snaps/test-snapd-framebuffer/bin/write
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo "$1" | dd bs=4 seek=$((100 * 1024 + 200)) >/dev/fb0
+echo "$1" | dd bs=4 seek=$((100 * 1024 + 200)) of=/dev/fb0

--- a/tests/lib/snaps/test-snapd-framebuffer/bin/write
+++ b/tests/lib/snaps/test-snapd-framebuffer/bin/write
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$1" | dd bs=4 seek=$((100 * 1024 + 200)) >/dev/fb0

--- a/tests/lib/snaps/test-snapd-framebuffer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-framebuffer/meta/snap.yaml
@@ -1,7 +1,7 @@
 name: test-snapd-framebuffer
 version: 1.0
-summary: Basic snap to check access to file system
-description: A basic snap to check access to file system
+summary: Basic snap to check r/w access to the linux framebuffer
+description: A basic snap to check r/w access to the linux framebuffer
 
 apps:
     read:

--- a/tests/lib/snaps/test-snapd-framebuffer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-framebuffer/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: test-snapd-framebuffer
+version: 1.0
+summary: Basic snap to check access to file system
+description: A basic snap to check access to file system
+
+apps:
+    read:
+        command: bin/read
+        plugs: [framebuffer]
+    write:
+        command: bin/write
+        plugs: [framebuffer]

--- a/tests/main/interfaces-framebuffer/task.yaml
+++ b/tests/main/interfaces-framebuffer/task.yaml
@@ -1,0 +1,48 @@
+summary: Ensure that the framebuffer interface works.
+
+details: |
+    The framebuffer interface allows to access the /dev/fb* buffer files.
+
+    The test uses the test-snapd-framebuffer snap to write/read from /dev/fb0.
+
+    The test also checks the interface connection and disconnection works properly.
+
+prepare: |
+    snap try $TESTSLIB/snaps/test-snapd-framebuffer
+
+execute: |
+    CONNECTED_PATTERN=":framebuffer +test-snapd-framebuffer"
+    DISCONNECTED_PATTERN="\- +test-snapd-framebuffer:framebuffer"
+
+    if [ ! -e /dev/fb0 ]; then
+        echo "Framebuffer not available on /dev/fb0"
+        exit 0
+    fi
+
+    echo "The plug is not connected by default"
+    snap interfaces | MATCH "$DISCONNECTED_PATTERN"
+
+    echo "When the interface is connected"
+    snap connect test-snapd-framebuffer:framebuffer
+    snap interfaces | MATCH "$CONNECTED_PATTERN"
+
+    echo "Then the snap is able to write in the framebuffer
+    test-snapd-framebuffer.write "123"
+    MATCH "123" < /dev/fb0
+
+    echo "Then the snap is able to read from the framebuffer
+    test-snapd-framebuffer.read
+
+    if [ "$(snap debug confinement)" = partial ] ; then
+        exit 0
+    fi
+
+    echo "When the plug is disconnected"
+    snap disconnect test-snapd-framebuffer:framebuffer
+
+    echo "Then the snap is not able to access the framebuffer"
+    if test-snapd-framebuffer.write "123" 2>${PWD}/call.error; then
+        echo "Expected permission error trying to write the framebuffer"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error


### PR DESCRIPTION
To test this use a device which has the file /dev/fb0, most of the cloud images don't have it. 