### PR TITLE
interfaces,tests: skip unknown plug/slot interfaces

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -822,6 +822,9 @@ func (r *Repository) AddSnap(snapInfo *snap.Info) error {
 	}
 
 	for plugName, plugInfo := range snapInfo.Plugs {
+		if _, ok := r.ifaces[plugInfo.Interface]; !ok {
+			continue
+		}
 		if r.plugs[snapName] == nil {
 			r.plugs[snapName] = make(map[string]*snap.PlugInfo)
 		}
@@ -829,6 +832,9 @@ func (r *Repository) AddSnap(snapInfo *snap.Info) error {
 	}
 
 	for slotName, slotInfo := range snapInfo.Slots {
+		if _, ok := r.ifaces[slotInfo.Interface]; !ok {
+			continue
+		}
 		if r.slots[snapName] == nil {
 			r.slots[snapName] = make(map[string]*snap.SlotInfo)
 		}

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1545,6 +1545,23 @@ func (s *AddRemoveSuite) TestAddSnapErrorsOnExistingSnapSlots(c *C) {
 	c.Assert(err, ErrorMatches, `cannot register interfaces for snap "producer" more than once`)
 }
 
+func (s *AddRemoveSuite) TestAddSnapSkipsUnknownInterfaces(c *C) {
+	info, err := s.addSnap(c, `
+name: bogus
+plugs:
+  bogus-plug:
+slots:
+  bogus-slot:
+`)
+	c.Assert(err, IsNil)
+	// the snap knowns about the bogus plug and slot
+	c.Assert(info.Plugs["bogus-plug"], NotNil)
+	c.Assert(info.Slots["bogus-slot"], NotNil)
+	// but the repository ignores them
+	c.Assert(s.repo.Plug("bogus", "bogus-plug"), IsNil)
+	c.Assert(s.repo.Slot("bogus", "bogus-slot"), IsNil)
+}
+
 func (s AddRemoveSuite) TestRemoveRemovesPlugs(c *C) {
 	_, err := s.addSnap(c, testConsumerYaml)
 	c.Assert(err, IsNil)

--- a/tests/lib/snaps/test-snapd-unknown-interfaces/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-unknown-interfaces/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: test-snapd-unknown-interfaces
+summary: A snap with unknown plus and slot interfaces.
+version: 1.0
+apps:
+    test-snapd-unknown-interfaces:
+        command: ../../../bin/sh
+plugs:
+    bogus-plug:
+slots:
+    bogus-slot:

--- a/tests/regression/lp-1732555/task.yaml
+++ b/tests/regression/lp-1732555/task.yaml
@@ -1,0 +1,15 @@
+summary: installing a snap with unknown plugs and slots is harmless
+details: >
+    Users have painfully found that a version of snapd crashed when a snap
+    contained unknown interfaces in either plugs or slots.
+prepare: |
+    . "$TESTSLIB/snaps.sh"
+    install_local_devmode test-snapd-unknown-interfaces
+execute: |
+    echo "Snapd did not die on us"
+    snap version
+    echo "The snap was installed and can be used"
+    test-snapd-unknown-interfaces -c true
+    echo "The bogus plugs and slots are not added"
+    snap interfaces | MATCH -v bogus-plug
+    snap interfaces | MATCH -v bogus-slot


### PR DESCRIPTION
This patch changes the Repository.AddSnap method to skip unknown
interfaces when adding constituent plugs and slots. This regression
happened because the repository no longer validates the snap, assuming
the loader did. The loader did notice but did not remove the offending
interfaces.

As it is unclear what should happen, this patch implements a minimal
solution to prevent snapd from crashing on nil interface.

Fixes: https://bugs.launchpad.net/snappy/+bug/1732555
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>