### PR TITLE
interfaces: add "refresh-schedule" attribute to snapd-control

### DIFF
--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -87,12 +87,6 @@ func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
-// SanitizePlug checks and possibly modifies a plug.
-//
-func (iface *commonInterface) SanitizePlug(plug *interfaces.Plug) error {
-	return nil
-}
-
 func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	if iface.connectedPlugAppArmor != "" {
 		spec.AddSnippet(iface.connectedPlugAppArmor)

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -87,6 +87,12 @@ func (iface *commonInterface) SanitizeSlot(slot *interfaces.Slot) error {
 	return nil
 }
 
+// SanitizePlug checks and possibly modifies a plug.
+//
+func (iface *commonInterface) SanitizePlug(plug *interfaces.Plug) error {
+	return nil
+}
+
 func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error {
 	if iface.connectedPlugAppArmor != "" {
 		spec.AddSnippet(iface.connectedPlugAppArmor)

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -63,16 +63,14 @@ func (iface *snapControlInterface) SanitizePlug(plug *interfaces.Plug) error {
 }
 
 func init() {
-	registerIface(&snapControlInterface{
-		commonInterface{
-			name:                  "snapd-control",
-			summary:               snapdControlSummary,
-			implicitOnCore:        true,
-			implicitOnClassic:     true,
-			baseDeclarationPlugs:  snapdControlBaseDeclarationPlugs,
-			baseDeclarationSlots:  snapdControlBaseDeclarationSlots,
-			connectedPlugAppArmor: snapdControlConnectedPlugAppArmor,
-			reservedForOS:         true,
-		},
-	})
+	registerIface(&snapControlInterface{commonInterface{
+		name:                  "snapd-control",
+		summary:               snapdControlSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationPlugs:  snapdControlBaseDeclarationPlugs,
+		baseDeclarationSlots:  snapdControlBaseDeclarationSlots,
+		connectedPlugAppArmor: snapdControlConnectedPlugAppArmor,
+		reservedForOS:         true,
+	}})
 }

--- a/interfaces/builtin/snapd_control.go
+++ b/interfaces/builtin/snapd_control.go
@@ -52,10 +52,6 @@ type snapControlInterface struct {
 }
 
 func (iface *snapControlInterface) SanitizePlug(plug *interfaces.Plug) error {
-	if err := iface.commonInterface.SanitizePlug(plug); err != nil {
-		return err
-	}
-
 	refreshSchedule, ok := plug.Attrs["refresh-schedule"].(string)
 	if ok {
 		if refreshSchedule != "" && refreshSchedule != "managed" {

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -77,6 +77,30 @@ func (s *SnapdControlInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(s.plug.Sanitize(s.iface), IsNil)
 }
 
+func (s *SnapdControlInterfaceSuite) TestSanitizePlugWithAttrHappy(c *C) {
+	const mockSnapYaml = `name: snapd-manager
+version: 1.0
+plugs:
+ snapd-control:
+  refresh-schedule: managed
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	plug := &interfaces.Plug{PlugInfo: info.Plugs["snapd-control"]}
+	c.Assert(plug.Sanitize(s.iface), IsNil)
+}
+
+func (s *SnapdControlInterfaceSuite) TestSanitizePlugWithAttrNotHappy(c *C) {
+	const mockSnapYaml = `name: snapd-manager
+version: 1.0
+plugs:
+ snapd-control:
+  refresh-schedule: unsupported-value
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	plug := &interfaces.Plug{PlugInfo: info.Plugs["snapd-control"]}
+	c.Assert(plug.Sanitize(s.iface), ErrorMatches, `unsupported refresh-schedule value: "unsupported-value"`)
+}
+
 func (s *SnapdControlInterfaceSuite) TestUsedSecuritySystems(c *C) {
 	// connected plugs have a non-nil security snippet for apparmor
 	apparmorSpec := &apparmor.Specification{}


### PR DESCRIPTION
Add a "refresh-schedule" attribute to the snapd-control interface
that can be set to "managed".

Part of #4161 but hopefully uncontroversial and should make the other review smaller and more targeted.