### PR TITLE
store: add support for flags in ListRefresh()

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -129,7 +129,7 @@ func (s *apiBaseSuite) LookupRefresh(snap *store.RefreshCandidate, user *auth.Us
 	return s.rsnaps[0], s.err
 }
 
-func (s *apiBaseSuite) ListRefresh(snaps []*store.RefreshCandidate, user *auth.UserState) ([]*snap.Info, error) {
+func (s *apiBaseSuite) ListRefresh(snaps []*store.RefreshCandidate, user *auth.UserState, flags store.RefreshFlags) ([]*snap.Info, error) {
 	s.refreshCandidates = snaps
 	s.user = user
 

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -129,7 +129,7 @@ func (s *apiBaseSuite) LookupRefresh(snap *store.RefreshCandidate, user *auth.Us
 	return s.rsnaps[0], s.err
 }
 
-func (s *apiBaseSuite) ListRefresh(snaps []*store.RefreshCandidate, user *auth.UserState, flags store.RefreshFlags) ([]*snap.Info, error) {
+func (s *apiBaseSuite) ListRefresh(snaps []*store.RefreshCandidate, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
 	s.refreshCandidates = snaps
 	s.user = user
 

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -37,7 +37,7 @@ type StoreService interface {
 	SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
 	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 	LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info, error)
-	ListRefresh([]*store.RefreshCandidate, *auth.UserState, store.RefreshFlags) ([]*snap.Info, error)
+	ListRefresh([]*store.RefreshCandidate, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error)
 	Sections(user *auth.UserState) ([]string, error)
 	WriteCatalogs(names io.Writer) error
 	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -37,7 +37,7 @@ type StoreService interface {
 	SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
 	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 	LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info, error)
-	ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error)
+	ListRefresh([]*store.RefreshCandidate, *auth.UserState, store.RefreshFlags) ([]*snap.Info, error)
 	Sections(user *auth.UserState) ([]string, error)
 	WriteCatalogs(names io.Writer) error
 	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -227,7 +227,7 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 	return nil, store.ErrNoUpdateAvailable
 }
 
-func (f *fakeStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserState) ([]*snap.Info, error) {
+func (f *fakeStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserState, flags store.RefreshFlags) ([]*snap.Info, error) {
 	f.pokeStateLock()
 
 	if len(cands) == 0 {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -227,7 +227,7 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 	return nil, store.ErrNoUpdateAvailable
 }
 
-func (f *fakeStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserState, flags store.RefreshFlags) ([]*snap.Info, error) {
+func (f *fakeStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
 	f.pokeStateLock()
 
 	if len(cands) == 0 {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -612,7 +612,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 	theStore := Store(st)
 
 	st.Unlock()
-	updates, err := theStore.ListRefresh(candidatesInfo, user, 0)
+	updates, err := theStore.ListRefresh(candidatesInfo, user, nil)
 	st.Lock()
 	if err != nil {
 		return nil, nil, nil, err

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -612,7 +612,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 	theStore := Store(st)
 
 	st.Unlock()
-	updates, err := theStore.ListRefresh(candidatesInfo, user)
+	updates, err := theStore.ListRefresh(candidatesInfo, user, 0)
 	st.Lock()
 	if err != nil {
 		return nil, nil, nil, err

--- a/store/store.go
+++ b/store/store.go
@@ -69,6 +69,16 @@ const (
 	UbuntuCoreWireProtocol = "1"
 )
 
+type RefreshFlags int
+
+const (
+	_ = iota
+
+	// RefreshManaged indicates to the store that the refresh is
+	// managed via snapd-control.
+	RefreshManaged
+)
+
 // the LimitTime should be slightly more than 3 times of our http.Client
 // Timeout value
 var defaultRetryStrategy = retry.LimitCount(5, retry.LimitTime(33*time.Second,
@@ -688,6 +698,13 @@ type requestOptions struct {
 	Data         []byte
 }
 
+func (r *requestOptions) addHeader(k, v string) {
+	if r.ExtraHeaders == nil {
+		r.ExtraHeaders = make(map[string]string)
+	}
+	r.ExtraHeaders[k] = v
+}
+
 func cancelled(ctx context.Context) bool {
 	select {
 	case <-ctx.Done():
@@ -1270,7 +1287,7 @@ func currentSnap(cs *RefreshCandidate) *currentSnapJSON {
 }
 
 // query the store for the information about currently offered revisions of snaps
-func (s *Store) refreshForCandidates(currentSnaps []*currentSnapJSON, user *auth.UserState) ([]*snapDetails, error) {
+func (s *Store) refreshForCandidates(currentSnaps []*currentSnapJSON, user *auth.UserState, flags RefreshFlags) ([]*snapDetails, error) {
 	if len(currentSnaps) == 0 {
 		// nothing to do
 		return nil, nil
@@ -1295,9 +1312,10 @@ func (s *Store) refreshForCandidates(currentSnaps []*currentSnapJSON, user *auth
 
 	if useDeltas() {
 		logger.Debugf("Deltas enabled. Adding header X-Ubuntu-Delta-Formats: %v", s.deltaFormat)
-		reqOptions.ExtraHeaders = map[string]string{
-			"X-Ubuntu-Delta-Formats": s.deltaFormat,
-		}
+		reqOptions.addHeader("X-Ubuntu-Delta-Formats", s.deltaFormat)
+	}
+	if flags&RefreshManaged != 0 {
+		reqOptions.addHeader("X-Ubuntu-Refresh-Managed", "true")
 	}
 
 	var updateData searchResults
@@ -1324,7 +1342,7 @@ func (s *Store) LookupRefresh(installed *RefreshCandidate, user *auth.UserState)
 		return nil, ErrLocalSnap
 	}
 
-	latest, err := refreshForCandidates(s, []*currentSnapJSON{cur}, user)
+	latest, err := refreshForCandidates(s, []*currentSnapJSON{cur}, user, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -1343,8 +1361,7 @@ func (s *Store) LookupRefresh(installed *RefreshCandidate, user *auth.UserState)
 
 // ListRefresh returns the available updates for a list of refresh candidates.
 // NOTE ListRefresh can return nil, nil if e.g. all local snaps are passed in
-func (s *Store) ListRefresh(installed []*RefreshCandidate, user *auth.UserState) (snaps []*snap.Info, err error) {
-
+func (s *Store) ListRefresh(installed []*RefreshCandidate, user *auth.UserState, flags RefreshFlags) (snaps []*snap.Info, err error) {
 	candidateMap := map[string]*RefreshCandidate{}
 	currentSnaps := make([]*currentSnapJSON, 0, len(installed))
 	for _, cs := range installed {
@@ -1356,7 +1373,7 @@ func (s *Store) ListRefresh(installed []*RefreshCandidate, user *auth.UserState)
 		candidateMap[cs.SnapID] = cs
 	}
 
-	latest, err := s.refreshForCandidates(currentSnaps, user)
+	latest, err := s.refreshForCandidates(currentSnaps, user, flags)
 	if err != nil {
 		return nil, err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3121,7 +3121,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C
 			Channel:  "stable",
 			Revision: 1,
 		},
-	}, nil, 0)
+	}, nil, nil)
 
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
@@ -3169,14 +3169,14 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesRetri
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Name, Equals, "hello-world")
 }
 
-func mockRFC(newRFC func(*Store, []*currentSnapJSON, *auth.UserState, RefreshFlags) ([]*snapDetails, error)) func() {
+func mockRFC(newRFC func(*Store, []*currentSnapJSON, *auth.UserState, *RefreshOptions) ([]*snapDetails, error)) func() {
 	oldRFC := refreshForCandidates
 	refreshForCandidates = newRFC
 	return func() {
@@ -3185,7 +3185,7 @@ func mockRFC(newRFC func(*Store, []*currentSnapJSON, *auth.UserState, RefreshFla
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
-	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		c.Check(currentSnaps, DeepEquals, []*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
@@ -3220,7 +3220,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshIgnoreValidation(c *C) {
-	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		c.Check(currentSnaps, DeepEquals, []*currentSnapJSON{{
 			SnapID:           helloWorldSnapID,
 			Channel:          "stable",
@@ -3254,7 +3254,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshIgnoreValida
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c *C) {
-	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		panic("unexpected call to refreshForCandidates")
 	})()
 
@@ -3270,7 +3270,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c 
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *C) {
 	anError := errors.New("ouchie")
-	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		return nil, anError
 	})()
 
@@ -3286,7 +3286,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyResponse(c *C) {
-	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		return nil, nil
 	})()
 
@@ -3302,7 +3302,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyRespons
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshNoUpdate(c *C) {
-	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		return []*snapDetails{{
 			SnapID:   helloWorldDeveloperID,
 			Revision: 1,
@@ -3366,7 +3366,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 			Channel:  "stable",
 			Revision: snap.R(1),
 		},
-	}, nil, 0)
+	}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Name(), Equals, "hello-world")
@@ -3425,7 +3425,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshIgnoreValidati
 			Revision:         snap.R(1),
 			IgnoreValidation: true,
 		},
-	}, nil, 0)
+	}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Name(), Equals, "hello-world")
@@ -3478,7 +3478,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshDefaultChannel
 			SnapID:   helloWorldSnapID,
 			Revision: snap.R(1),
 		},
-	}, nil, 0)
+	}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Name(), Equals, "hello-world")
@@ -3525,7 +3525,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
 	c.Assert(results, HasLen, 1)
@@ -3567,7 +3567,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-		}}, nil, 0)
+		}}, nil, nil)
 		return err
 	}
 
@@ -3612,7 +3612,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `^Post http://127.0.0.1:.*?/metadata: EOF$`)
 	c.Assert(n, Equals, 5)
@@ -3644,7 +3644,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesUnaut
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(n, Equals, 1)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 401 via POST to "http://.*?/metadata"`)
 }
@@ -3663,7 +3663,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-	}}, nil, 0)
+	}}, nil, nil)
 	// the error differs depending on whether a proxy is in use (e.g. on travis), so don't inspect error message
 	c.Assert(err, NotNil)
 }
@@ -3690,7 +3690,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/metadata"`)
 	c.Assert(n, Equals, 5)
 }
@@ -3718,7 +3718,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/metadata"`)
 	c.Assert(n, Equals, 1)
 }
@@ -3775,7 +3775,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(26),
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 0)
 }
@@ -3820,7 +3820,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipBlocked(c 
 		Channel:  "stable",
 		Revision: snap.R(25),
 		Block:    []snap.Revision{snap.R(26)},
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 0)
 }
@@ -3910,7 +3910,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOn
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-		}}, nil, 0)
+		}}, nil, nil)
 	}
 }
 
@@ -3959,7 +3959,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Deltas, HasLen, 2)
@@ -4029,7 +4029,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Deltas, HasLen, 0)
@@ -4055,17 +4055,17 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(-2),
-	}}, nil, 0)
+	}}, nil, nil)
 	c.Assert(err, IsNil)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshFlags(c *C) {
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshOptions(c *C) {
 	for _, t := range []struct {
-		flag   RefreshFlags
+		flag   *RefreshOptions
 		header string
 	}{
-		{0, ""},
-		{RefreshManaged, "X-Ubuntu-Refresh-Managed"},
+		{nil, ""},
+		{&RefreshOptions{RefreshManaged: true}, "X-Ubuntu-Refresh-Managed"},
 	} {
 
 		mockServerHit := false

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3121,7 +3121,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C
 			Channel:  "stable",
 			Revision: 1,
 		},
-	}, nil)
+	}, nil, 0)
 
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
@@ -3169,14 +3169,14 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesRetri
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Name, Equals, "hello-world")
 }
 
-func mockRFC(newRFC func(*Store, []*currentSnapJSON, *auth.UserState) ([]*snapDetails, error)) func() {
+func mockRFC(newRFC func(*Store, []*currentSnapJSON, *auth.UserState, RefreshFlags) ([]*snapDetails, error)) func() {
 	oldRFC := refreshForCandidates
 	refreshForCandidates = newRFC
 	return func() {
@@ -3185,7 +3185,7 @@ func mockRFC(newRFC func(*Store, []*currentSnapJSON, *auth.UserState) ([]*snapDe
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
-	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
 		c.Check(currentSnaps, DeepEquals, []*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
@@ -3220,7 +3220,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshIgnoreValidation(c *C) {
-	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
 		c.Check(currentSnaps, DeepEquals, []*currentSnapJSON{{
 			SnapID:           helloWorldSnapID,
 			Channel:          "stable",
@@ -3254,7 +3254,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshIgnoreValida
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c *C) {
-	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
 		panic("unexpected call to refreshForCandidates")
 	})()
 
@@ -3270,7 +3270,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c 
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *C) {
 	anError := errors.New("ouchie")
-	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
 		return nil, anError
 	})()
 
@@ -3286,7 +3286,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyResponse(c *C) {
-	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
 		return nil, nil
 	})()
 
@@ -3302,7 +3302,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyRespons
 }
 
 func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshNoUpdate(c *C) {
-	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState) ([]*snapDetails, error) {
+	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ RefreshFlags) ([]*snapDetails, error) {
 		return []*snapDetails{{
 			SnapID:   helloWorldDeveloperID,
 			Revision: 1,
@@ -3366,7 +3366,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 			Channel:  "stable",
 			Revision: snap.R(1),
 		},
-	}, nil)
+	}, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Name(), Equals, "hello-world")
@@ -3425,7 +3425,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshIgnoreValidati
 			Revision:         snap.R(1),
 			IgnoreValidation: true,
 		},
-	}, nil)
+	}, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Name(), Equals, "hello-world")
@@ -3478,7 +3478,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshDefaultChannel
 			SnapID:   helloWorldSnapID,
 			Revision: snap.R(1),
 		},
-	}, nil)
+	}, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Name(), Equals, "hello-world")
@@ -3525,7 +3525,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
 	c.Assert(results, HasLen, 1)
@@ -3567,7 +3567,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-		}}, nil)
+		}}, nil, 0)
 		return err
 	}
 
@@ -3612,7 +3612,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `^Post http://127.0.0.1:.*?/metadata: EOF$`)
 	c.Assert(n, Equals, 5)
@@ -3644,7 +3644,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesUnaut
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(n, Equals, 1)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 401 via POST to "http://.*?/metadata"`)
 }
@@ -3663,7 +3663,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-	}}, nil)
+	}}, nil, 0)
 	// the error differs depending on whether a proxy is in use (e.g. on travis), so don't inspect error message
 	c.Assert(err, NotNil)
 }
@@ -3690,7 +3690,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500(c *C) {
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/metadata"`)
 	c.Assert(n, Equals, 5)
 }
@@ -3718,7 +3718,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 500 via POST to "http://.*?/metadata"`)
 	c.Assert(n, Equals, 1)
 }
@@ -3775,7 +3775,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(26),
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 0)
 }
@@ -3820,7 +3820,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipBlocked(c 
 		Channel:  "stable",
 		Revision: snap.R(25),
 		Block:    []snap.Revision{snap.R(26)},
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 0)
 }
@@ -3910,7 +3910,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOn
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
-		}}, nil)
+		}}, nil, 0)
 	}
 }
 
@@ -3959,7 +3959,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Deltas, HasLen, 2)
@@ -4029,7 +4029,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(results, HasLen, 1)
 	c.Assert(results[0].Deltas, HasLen, 0)
@@ -4055,8 +4055,47 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c 
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(-2),
-	}}, nil)
+	}}, nil, 0)
 	c.Assert(err, IsNil)
+}
+
+func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshFlags(c *C) {
+	for _, t := range []struct {
+		flag   RefreshFlags
+		header string
+	}{
+		{0, ""},
+		{RefreshManaged, "X-Ubuntu-Refresh-Managed"},
+	} {
+
+		mockServerHit := false
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertRequest(c, r, "POST", metadataPath)
+			if t.header != "" {
+				c.Check(r.Header.Get(t.header), Equals, "true")
+			}
+			mockServerHit = true
+			io.WriteString(w, `{}`)
+		}))
+
+		c.Assert(mockServer, NotNil)
+		defer mockServer.Close()
+
+		mockServerURL, _ := url.Parse(mockServer.URL)
+		cfg := Config{
+			StoreBaseURL: mockServerURL,
+		}
+		repo := New(&cfg, nil)
+		c.Assert(repo, NotNil)
+
+		_, err := repo.ListRefresh([]*RefreshCandidate{{
+			SnapID:   helloWorldSnapID,
+			Channel:  "stable",
+			Revision: snap.R(24),
+		}}, nil, t.flag)
+		c.Assert(err, IsNil)
+		c.Check(mockServerHit, Equals, true)
+	}
 }
 
 func (t *remoteRepoTestSuite) TestStructFieldsSurvivesNoTag(c *C) {

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -53,7 +53,7 @@ func (Store) LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info
 	panic("Store.LookupRefresh not expected")
 }
 
-func (Store) ListRefresh([]*store.RefreshCandidate, *auth.UserState) ([]*snap.Info, error) {
+func (Store) ListRefresh([]*store.RefreshCandidate, *auth.UserState, store.RefreshFlags) ([]*snap.Info, error) {
 	panic("Store.ListRefresh not expected")
 }
 

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -53,7 +53,7 @@ func (Store) LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info
 	panic("Store.LookupRefresh not expected")
 }
 
-func (Store) ListRefresh([]*store.RefreshCandidate, *auth.UserState, store.RefreshFlags) ([]*snap.Info, error) {
+func (Store) ListRefresh([]*store.RefreshCandidate, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error) {
 	panic("Store.ListRefresh not expected")
 }
 


### PR DESCRIPTION
For the upcoming snapd control managed code we will need a way
to tell the store that we want the refresh information but that
the actual refresh policy is managed. In preparation for this
add a new "RefreshFlags" to allow expressing this.TestUbuntuStoreRepositoryListRefreshFlags

Initially we support one flag:
- RefreshManaged which indicates that refreshes are managed by
  a snap via the snapd-control interface


Mostly mechanical, needed for PR 4161 (or a followup of that PR).