### PR TITLE
interfaces: remove invalid plugs/slots from SnapInfo on sanitization.

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
@@ -3333,9 +3334,9 @@ func snapList(rawSnaps interface{}) []map[string]interface{} {
 // Tests for GET /v2/interfaces
 
 func (s *apiSuite) TestInterfaces(c *check.C) {
+	builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	d := s.daemon(c)
 
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -3511,9 +3512,9 @@ func (s *apiSuite) TestInterfaceDetail404(c *check.C) {
 // Test for POST /v2/interfaces
 
 func (s *apiSuite) TestConnectPlugSuccess(c *check.C) {
+	builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	d := s.daemon(c)
 
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -3673,9 +3674,9 @@ func (s *apiSuite) TestConnectPlugFailureNoSuchSlot(c *check.C) {
 }
 
 func (s *apiSuite) testDisconnect(c *check.C, plugSnap, plugName, slotSnap, slotName string) {
+	builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	d := s.daemon(c)
 
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 
@@ -3737,9 +3738,9 @@ func (s *apiSuite) TestDisconnectPlugSuccessWithEmptySlot(c *check.C) {
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
+	builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.daemon(c)
 
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
 	// there is no consumer, no plug defined
 	s.mockSnap(c, producerYaml)
 
@@ -3770,9 +3771,9 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchPlug(c *check.C) {
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
+	builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.daemon(c)
 
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	// there is no producer, no slot defined
 
@@ -3804,9 +3805,9 @@ func (s *apiSuite) TestDisconnectPlugFailureNoSuchSlot(c *check.C) {
 }
 
 func (s *apiSuite) TestDisconnectPlugFailureNotConnected(c *check.C) {
+	builtin.MockInterface(&ifacetest.TestInterface{InterfaceName: "test"})
 	s.daemon(c)
 
-	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
 	s.mockSnap(c, consumerYaml)
 	s.mockSnap(c, producerYaml)
 

--- a/interfaces/builtin/all.go
+++ b/interfaces/builtin/all.go
@@ -61,16 +61,19 @@ func SanitizePlugsSlots(snapInfo *snap.Info) {
 		iface, ok := allInterfaces[plugInfo.Interface]
 		if !ok {
 			snapInfo.BadInterfaces[plugName] = fmt.Sprintf("unknown interface %q", plugInfo.Interface)
+			delete(snapInfo.Plugs, plugName)
 			continue
 		}
 		// Reject plug with invalid name
 		if err := interfaces.ValidateName(plugName); err != nil {
 			snapInfo.BadInterfaces[plugName] = err.Error()
+			delete(snapInfo.Plugs, plugName)
 			continue
 		}
 		plug := &interfaces.Plug{PlugInfo: plugInfo}
 		if err := plug.Sanitize(iface); err != nil {
 			snapInfo.BadInterfaces[plugName] = err.Error()
+			delete(snapInfo.Plugs, plugName)
 			continue
 		}
 	}
@@ -79,19 +82,26 @@ func SanitizePlugsSlots(snapInfo *snap.Info) {
 		iface, ok := allInterfaces[slotInfo.Interface]
 		if !ok {
 			snapInfo.BadInterfaces[slotName] = fmt.Sprintf("unknown interface %q", slotInfo.Interface)
+			delete(snapInfo.Slots, slotName)
 			continue
 		}
 		// Reject slot with invalid name
 		if err := interfaces.ValidateName(slotName); err != nil {
 			snapInfo.BadInterfaces[slotName] = err.Error()
+			delete(snapInfo.Slots, slotName)
 			continue
 		}
 		slot := &interfaces.Slot{SlotInfo: slotInfo}
 		if err := slot.Sanitize(iface); err != nil {
 			snapInfo.BadInterfaces[slotName] = err.Error()
+			delete(snapInfo.Slots, slotName)
 			continue
 		}
 	}
+}
+
+func MockInterface(iface interfaces.Interface) {
+	allInterfaces[iface.Name()] = iface
 }
 
 type byIfaceName []interfaces.Interface

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -332,6 +332,20 @@ apps:
         plugs: [iface]
 `
 
+const testInvalidSlotInterfaceYaml = `
+name: testsnap
+slots:
+ foo:
+  interface: iface
+`
+
+const testInvalidPlugInterfaceYaml = `
+name: testsnap
+plugs:
+ bar:
+  interface: iface
+`
+
 func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotNames(c *C) {
 	restore := builtin.MockInterfaces(map[string]interfaces.Interface{
 		"iface": &ifacetest.TestInterface{InterfaceName: "iface"},
@@ -354,6 +368,20 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
 	snap.SanitizePlugsSlots(snapInfo)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
 	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "consumer" has bad plugs or slots: ttyS3 \(invalid interface name: "ttyS3"\)`)
+}
+
+func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotInterface(c *C) {
+	snapInfo := snaptest.MockInfo(c, testInvalidSlotInterfaceYaml, nil)
+	snap.SanitizePlugsSlots(snapInfo)
+	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
+	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "testsnap" has bad plugs or slots: foo \(unknown interface "iface"\)`)
+}
+
+func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugInterface(c *C) {
+	snapInfo := snaptest.MockInfo(c, testInvalidPlugInterfaceYaml, nil)
+	snap.SanitizePlugsSlots(snapInfo)
+	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
+	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "testsnap" has bad plugs or slots: bar \(unknown interface "iface"\)`)
 }
 
 func (s *AllSuite) TestUnexpectedSpecSignatures(c *C) {

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -335,15 +335,27 @@ apps:
 const testInvalidSlotInterfaceYaml = `
 name: testsnap
 slots:
- foo:
+ iface:
   interface: iface
+apps:
+    app:
+        slots: [iface]
+hooks:
+    install:
+        slots: [iface]
 `
 
 const testInvalidPlugInterfaceYaml = `
 name: testsnap
 plugs:
- bar:
+ iface:
   interface: iface
+apps:
+    app:
+        plugs: [iface]
+hooks:
+    install:
+        plugs: [iface]
 `
 
 func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotNames(c *C) {
@@ -372,16 +384,30 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
 
 func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotInterface(c *C) {
 	snapInfo := snaptest.MockInfo(c, testInvalidSlotInterfaceYaml, nil)
+	c.Check(snapInfo.Apps["app"].Slots, HasLen, 1)
+	c.Check(snapInfo.Hooks["install"].Slots, HasLen, 1)
+	c.Check(snapInfo.Slots, HasLen, 1)
 	snap.SanitizePlugsSlots(snapInfo)
+	c.Check(snapInfo.Apps["app"].Slots, HasLen, 0)
+	c.Check(snapInfo.Hooks["install"].Slots, HasLen, 0)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
-	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "testsnap" has bad plugs or slots: foo \(unknown interface "iface"\)`)
+	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "testsnap" has bad plugs or slots: iface \(unknown interface "iface"\)`)
+	c.Assert(snapInfo.Plugs, HasLen, 0)
+	c.Assert(snapInfo.Slots, HasLen, 0)
 }
 
 func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugInterface(c *C) {
 	snapInfo := snaptest.MockInfo(c, testInvalidPlugInterfaceYaml, nil)
+	c.Check(snapInfo.Apps["app"].Plugs, HasLen, 1)
+	c.Check(snapInfo.Hooks["install"].Plugs, HasLen, 1)
+	c.Assert(snapInfo.Plugs, HasLen, 1)
 	snap.SanitizePlugsSlots(snapInfo)
+	c.Assert(snapInfo.Apps["app"].Plugs, HasLen, 0)
+	c.Check(snapInfo.Hooks["install"].Plugs, HasLen, 0)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)
-	c.Check(snap.BadInterfacesSummary(snapInfo), Matches, `snap "testsnap" has bad plugs or slots: bar \(unknown interface "iface"\)`)
+	c.Assert(snap.BadInterfacesSummary(snapInfo), Matches, `snap "testsnap" has bad plugs or slots: iface \(unknown interface "iface"\)`)
+	c.Assert(snapInfo.Plugs, HasLen, 0)
+	c.Assert(snapInfo.Slots, HasLen, 0)
 }
 
 func (s *AllSuite) TestUnexpectedSpecSignatures(c *C) {


### PR DESCRIPTION
This is a followup for the quickfix @zyga made at the repository level for https://bugs.launchpad.net/snappy/+bug/1732555

With this branch invalid plugsinfo/slotinfo gets removed from SnapInfo as it should.