### PR TITLE
snap: use field names when initializing composite literals

### DIFF
--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -41,7 +41,7 @@ func createSampleApp() *AppInfo {
 		Snap: &Info{
 			SideInfo: SideInfo{
 				RealName: "mysnap",
-				Revision: Revision{20},
+				Revision: Revision{N: 20},
 			},
 		},
 		Name:  "foo",

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -41,7 +41,7 @@ func createSampleApp() *AppInfo {
 		Snap: &Info{
 			SideInfo: SideInfo{
 				RealName: "mysnap",
-				Revision: Revision{N: 20},
+				Revision: R(20),
 			},
 		},
 		Name:  "foo",


### PR DESCRIPTION
This makes go vet happy again.

