### PR TITLE
cmd: pretend we're running on Ubuntu in TestExecInCoreSnapUnsetsDidRe…

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -314,7 +314,7 @@ func (s *cmdSuite) TestExecInCoreSnapUnsetsDidReexec(c *C) {
 	defer os.Unsetenv("SNAP_DID_REEXEC")
 
 	selfExe := filepath.Join(s.fakeroot, "proc/self/exe")
-	err := os.Symlink(filepath.Join(s.fakeroot, "/snap/core/42/usr/lib/snapd"), selfExe)
+	err := os.Symlink(filepath.Join(dirs.SnapMountDir, "/snap/core/42/usr/lib/snapd"), selfExe)
 	c.Assert(err, IsNil)
 	cmd.MockSelfExe(selfExe)
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -313,13 +313,6 @@ func (s *cmdSuite) TestExecInCoreSnapUnsetsDidReexec(c *C) {
 	os.Setenv("SNAP_DID_REEXEC", "1")
 	defer os.Unsetenv("SNAP_DID_REEXEC")
 
-	restore := release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
-	defer func() {
-		restore()
-		dirs.SetRootDir(s.fakeroot)
-	}()
-	dirs.SetRootDir(s.fakeroot)
-
 	selfExe := filepath.Join(s.fakeroot, "proc/self/exe")
 	err := os.Symlink(filepath.Join(s.fakeroot, "/snap/core/42/usr/lib/snapd"), selfExe)
 	c.Assert(err, IsNil)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -313,6 +313,13 @@ func (s *cmdSuite) TestExecInCoreSnapUnsetsDidReexec(c *C) {
 	os.Setenv("SNAP_DID_REEXEC", "1")
 	defer os.Unsetenv("SNAP_DID_REEXEC")
 
+	restore := release.MockReleaseInfo(&release.OS{ID: "ubuntu"})
+	defer func() {
+		restore()
+		dirs.SetRootDir(s.fakeroot)
+	}()
+	dirs.SetRootDir(s.fakeroot)
+
 	selfExe := filepath.Join(s.fakeroot, "proc/self/exe")
 	err := os.Symlink(filepath.Join(s.fakeroot, "/snap/core/42/usr/lib/snapd"), selfExe)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
…exec()

Mock distribution os-release so that the test runs in a fixed environment.
