### PR TITLE
debian: add missing udev dependency

### DIFF
--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -68,6 +68,7 @@ Depends: adduser,
 # only needed on trusty to pull in the right version.
          sudo (>= 1.8.9p5-1ubuntu1.3),
          systemd (>= 204-5ubuntu20.20),
+         udev,
 # only needed on trusty to pull in the right version.
          util-linux (>=2.20.1-5.1ubuntu20.9),
          ${misc:Depends},

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -64,6 +64,7 @@ Depends: adduser,
          openssh-client,
          squashfs-tools,
          systemd,
+         udev,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)


### PR DESCRIPTION
We run udevadm in our udev backend. So we need to ensure we have
a dependency on this binary via the "udev" package.

C.f. https://bugs.launchpad.net/snapd/+bug/1731519
