### PR TITLE
interfaces/browser-support: adjust base declaration for auto-connection

### DIFF
--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -37,6 +37,9 @@ const browserSupportBaseDeclarationSlots = `
     deny-connection:
       plug-attributes:
         allow-sandbox: true
+    deny-auto-connection:
+      plug-attributes:
+        allow-sandbox: true
 `
 
 const browserSupportConnectedPlugAppArmor = `

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -791,3 +791,17 @@ series: 16
 revision: 0
 `)
 }
+
+func (s *baseDeclSuite) TestBrowserSupportAllowSandbox(c *C) {
+	const plugYaml = `name: plug-snap
+plugs:
+  browser-support:
+   allow-sandbox: true
+`
+	cand := s.connectCand(c, "browser-support", "", plugYaml)
+	err := cand.Check()
+	c.Check(err, NotNil)
+
+	err = cand.CheckAutoConnect()
+	c.Check(err, NotNil)
+}

--- a/tests/main/interfaces-browser-support/task.yaml
+++ b/tests/main/interfaces-browser-support/task.yaml
@@ -55,8 +55,15 @@ execute: |
     CONNECTED_PATTERN=":browser-support +browser-support-consumer"
     DISCONNECTED_PATTERN="^\- +browser-support-consumer:browser-support"
 
-    echo "Then the plug is connected by default"
-    snap interfaces | MATCH "$CONNECTED_PATTERN"
+    if [ "$ALLOW_SANDBOX" = "false" ]; then
+       echo "If allow-sandbox is false then the plug is connected by default"
+       snap interfaces | MATCH "$CONNECTED_PATTERN"
+    else
+       echo "If allow-sandbox is true then the plug is not connected by default"
+       ! snap interfaces | MATCH "$CONNECTED_PATTERN"
+       echo "Do connect it manually"
+       snap connect browser-support-consumer:browser-support
+    fi
 
     echo "And the snap is able to access tmp"
     echo "test" > /var/tmp/test


### PR DESCRIPTION
During a review, pedronis discovered that the browser-support interface only
had a deny-connection constraint without a corresponding deny-auto-connection
constraint. Since constraints are evaluated independently of each other, this
meant that if a snap that used 'allow-sandbox: true' was manually approved in
the store without a snap declaration, then the interface would be
auto-connected. In practice, there were no snaps that were in the is state.
Existing snap declarations in the store for this interface have already been
adjusted to use 'allow-auto-connection: true' in addition to
'allow-connection: true'.