### PR TITLE
tests: more debug info for classic-ubuntu-core-transition

### DIFF
--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -13,6 +13,9 @@ restore: |
     rm -f state.json.new
 
 debug: |
+    snap list || true
+    snap info core || true
+    snap info ubuntu-core || true
     snap changes
     . "$TESTSLIB/changes.sh"
     snap change "$(change_id 'Transition ubuntu-core to core')" || true


### PR DESCRIPTION
This should help us track down why autopkgtest regresses on i386.

Please do not merge yet, the important part is the autopkgtest (xenial-i386) that I enabled just for that.