### PR TITLE
spread.yaml: increase workers for opensuse to 3

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -72,7 +72,7 @@ backends:
             - fedora-25-64:
                 workers: 3
             - opensuse-42.2-64:
-                workers: 2
+                workers: 3
     qemu:
         systems:
             - ubuntu-14.04-32:


### PR DESCRIPTION
We see issues with the timeout in travis again. Some seems to be slow on opensuse. Given that its the only system with just 2 workers this PR might help.