### PR TITLE
tests: disable classic-ubuntu-core-transition on i386 temporarly

### DIFF
--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -4,7 +4,7 @@ summary: Ensure that the ubuntu-core -> core transition works
 # we disable on ppc64el because the downloads are very slow there
 # Both Fedora and openSUSE are disabled at the moment as there is something
 # fishy going on and the snapd service gets terminated during the process.
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -ubuntu-*-i386]
 
 warn-timeout: 1m
 kill-timeout: 5m


### PR DESCRIPTION
This test is failing in the autopkgtest environment of the distro.
However it is not failing in spread and it is not failing in qemu,
there is a strong indication that this is a testbed issue. Until
this is understood we should disable this test in 2.29 to ensure
that the -proposed -> -updates transition is not blocked on this.

