### PR TITLE
disabling opensuse until timeout issue is fixed

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -73,6 +73,7 @@ backends:
                 workers: 3
             - opensuse-42.2-64:
                 workers: 2
+                manual: true
     qemu:
         systems:
             - ubuntu-14.04-32:


### PR DESCRIPTION
The prepare is getting stuck with this error. 

173 new packages to install.
Overall download size: 90.9 MiB. Already cached: 0 B. After the operation, additional 526.3 MiB will be used.
Continue? [y/n/? shows all options] (y): y

This is an example:
https://travis-ci.org/snapcore/snapd/builds/303450521?utm_source=github_status&utm_medium=notification