### PR TITLE
interfaces/screen-inhibit-control: handle ScreenSaver/Screensaver in DBus API

### DIFF
--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -58,16 +58,16 @@ dbus (send)
 # freedesktop.org ScreenSaver
 dbus (send)
     bus=session
-    path=/{,org/freedesktop/,org.gnome/}Screensaver
-    interface=org.freedesktop.ScreenSaver
-    member=org.freedesktop.ScreenSaver.{Inhibit,UnInhibit,SimulateUserActivity}
+    path=/{,org/freedesktop/,org.gnome/}Screen{s,S}aver
+    interface=org.freedesktop.Screen{s,S}aver
+    member=org.freedesktop.Screen{s,S}aver.{Inhibit,UnInhibit,SimulateUserActivity}
     peer=(label=unconfined),
 
 # gnome, kde and cinnamon screensaver
 dbus (send)
     bus=session
-    path=/{,ScreenSaver}
-    interface=org.{gnome.ScreenSaver,kde.screensaver,cinnamon.ScreenSaver}
+    path=/{,Screensaver,ScreenSaver}
+    interface=org.{gnome.Screensaver,gnome.ScreenSaver,kde.screensaver,cinnamon.ScreenSaver}
     member=SimulateUserActivity
     peer=(label=unconfined),
 `


### PR DESCRIPTION
Something is different in one of the gtk screensaver libraries since some use Screensaver and other ScreenSaver. Adjust for that.

Reference:
https://forum.snapcraft.io/t/possibly-erroneous-apparmor-denial/2879/2