### PR TITLE
snap-confine: fix snap-confine under lxd

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -52,7 +52,7 @@ fmt: $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch]))
 # installing a fresh copy of snap confine and the appropriate apparmor profile.
 .PHONY: hack
 hack: snap-confine/snap-confine snap-confine/snap-confine.apparmor snap-update-ns/snap-update-ns snap-seccomp/snap-seccomp
-	sudo install -D -m 4755 snap-confine/snap-confine $(DESTDIR)$(libexecdir)/snap-confine
+	sudo install -D -m 6755 snap-confine/snap-confine $(DESTDIR)$(libexecdir)/snap-confine
 	sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)/etc/apparmor.d/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine.real
 	sudo install -d -m 755 $(DESTDIR)/var/lib/snapd/apparmor/snap-confine/
 	sudo apparmor_parser -r snap-confine/snap-confine.apparmor
@@ -321,8 +321,8 @@ if CAPS_OVER_SETUID
 # Ensure that snap-confine has CAP_SYS_ADMIN capability
 	setcap cap_sys_admin=pe $(DESTDIR)$(libexecdir)/snap-confine
 else
-# Ensure that snap-confine is +s (setuid)
-	chmod 4755 $(DESTDIR)$(libexecdir)/snap-confine
+# Ensure that snap-confine is u+s,g+s (setuid and setgid)
+	chmod 6755 $(DESTDIR)$(libexecdir)/snap-confine
 endif
 
 ##

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
 				}
 			}
 			sc_cgroup_freezer_join(snap_name, getpid());
-			if (geteuid() == 0) {
+			if (geteuid() == 0 && real_gid != 0) {
 				if (setegid(real_gid) != 0) {
 					die("cannot set effective group id to %d", real_gid);
 				}

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -131,29 +131,23 @@ int main(int argc, char **argv)
 	debug("base snap:    %s", base_snap_name);
 
 	// Who are we?
-	uid_t ruid, euid, suid;
-	gid_t rgid, egid, sgid;
-	getresuid(&ruid, &euid, &suid);
-	getresgid(&rgid, &egid, &sgid);
-	debug("ruid: %d, euid: %d, suid: %d", ruid, euid, suid);
-	debug("rgid: %d, egid: %d, sgid: %d", rgid, egid, sgid);
+	uid_t real_uid, effective_uid, saved_uid;
+	gid_t real_gid, effective_gid, saved_gid;
+	getresuid(&real_uid, &effective_uid, &saved_uid);
+	getresgid(&real_gid, &effective_gid, &saved_gid);
+	debug("ruid: %d, euid: %d, suid: %d",
+	      real_uid, effective_uid, saved_uid);
+	debug("rgid: %d, egid: %d, sgid: %d",
+	      real_gid, effective_gid, saved_gid);
 
-	// If we are running as group root but the real group id is not zero then
-	// the setgid root permission is in effect.  To limit the scope of the
-	// change this is causing for the code temporairly set the effective group
-	// id to the real group id. We will change that again below when we
-	// manipulate the freezer cgroup.
-	// Because LXD uses particular permissions for cgroups we need to be
-	// group-root for that operation to succeed.
-	if (euid == 0 && ruid != 0) {
-		if (setegid(ruid) != 0) {
-			die("cannot set effective group id to %d", ruid);
+	// snap-confine runs as both setuid root and setgid root.
+	// Temporarily drop group privileges here and reraise later
+	// as needed.
+	if (effective_gid == 0 && real_gid != 0) {
+		if (setegid(real_gid) != 0) {
+			die("cannot set effective group id to %d", real_gid);
 		}
 	}
-
-	uid_t real_uid = ruid;
-	gid_t real_gid = rgid;
-
 #ifndef CAPS_OVER_SETUID
 	// this code always needs to run as root for the cgroup/udev setup,
 	// however for the tests we allow it to run as non-root
@@ -246,14 +240,21 @@ int main(int argc, char **argv)
 			// control group. This simplifies testing if any processes
 			// belonging to a given snap are still alive.
 			// See the documentation of the function for details.
-			if (setegid(0) != 0) {
-				die("cannot set effective group id to root");
+
+			if (getegid() != 0 && saved_gid == 0) {
+				// Temporarily raise egid so we can chown the freezer cgroup
+				// under LXD.
+				if (setegid(0) != 0) {
+					die("cannot set effective group id to root");
+				}
 			}
 			sc_cgroup_freezer_join(snap_name, getpid());
-			if (setegid(rgid) != 0) {
-				die("cannot set effective group id to %d",
-				    rgid);
+			if (geteuid() == 0) {
+				if (setegid(real_gid) != 0) {
+					die("cannot set effective group id to %d", real_gid);
+				}
 			}
+
 			sc_unlock(snap_name, snap_lock_fd);
 
 			// Reset path as we cannot rely on the path from the host OS to

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -622,7 +622,7 @@ popd
 %dir %{_libexecdir}/snapd
 # For now, we can't use caps
 # FIXME: Switch to "%%attr(0755,root,root) %%caps(cap_sys_admin=pe)" asap!
-%attr(4755,root,root) %{_libexecdir}/snapd/snap-confine
+%attr(6755,root,root) %{_libexecdir}/snapd/snap-confine
 %{_libexecdir}/snapd/snap-discard-ns
 %{_libexecdir}/snapd/snap-seccomp
 %{_libexecdir}/snapd/snap-update-ns

--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -279,7 +279,7 @@ fi
 %dir /var/lib/snapd/seccomp/bpf
 %dir /var/lib/snapd/snaps
 %dir /var/cache/snapd
-%verify(not user group mode) %attr(04755,root,root) %{_libexecdir}/snapd/snap-confine
+%verify(not user group mode) %attr(06755,root,root) %{_libexecdir}/snapd/snap-confine
 %{_mandir}/man1/snap-confine.1.gz
 %{_mandir}/man5/snap-discard-ns.5.gz
 %{_udevrulesdir}/80-snappy-assign.rules

--- a/spread.yaml
+++ b/spread.yaml
@@ -73,6 +73,7 @@ backends:
                 workers: 3
             - opensuse-42.2-64:
                 workers: 2
+                manual: true
     qemu:
         systems:
             - ubuntu-14.04-32:

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -82,7 +82,10 @@ execute: |
 
     echo "Ensure we can use snapd inside lxd"
     lxd.lxc exec my-ubuntu snap install test-snapd-tools
-    lxd.lxc exec my-ubuntu test-snapd-tools.echo from-the-inside | MATCH from-the-inside
+    echo "And we can run snaps as regular users"
+    lxd.lxc exec my-ubuntu -- su -c "/snap/bin/test-snapd-tools.echo from-the-inside" ubuntu | MATCH from-the-inside
+    echo "And as root"
+    lxd.lxc exec my-ubuntu -- test-snapd-tools.echo from-the-inside | MATCH from-the-inside
 
     echo "Install lxd-demo server to exercise the lxd interface"
     snap install lxd-demo-server


### PR DESCRIPTION
This reproduces the error reported in https://forum.snapcraft.io/t/snapcraft-adt-failures-with-the-new-core-release/2850/12 and includes a fix for it.

This also includes #4244 to unblock this from landing.