### PR TITLE
interfaces: allow /bin/chown and fchownat to root:root

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -113,6 +113,7 @@ var defaultTemplate = `
   /{,usr/}bin/bzip2 ixr,
   /{,usr/}bin/cat ixr,
   /{,usr/}bin/chmod ixr,
+  /{,usr/}bin/chown ixr,
   /{,usr/}bin/clear ixr,
   /{,usr/}bin/cmp ixr,
   /{,usr/}bin/cp ixr,

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -73,6 +73,7 @@ chown - u:root g:root
 chown32 - u:root g:root
 fchown - u:root g:root
 fchown32 - u:root g:root
+fchownat - - u:root g:root
 lchown - u:root g:root
 lchown32 - u:root g:root
 


### PR DESCRIPTION
For sometime we've allowed the syscalls for chown'ing to root:root. We
mistakenly left out the fchownat syscall and use of the /bin/chown binary.
