### PR TITLE
packaging: fix typo

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -699,7 +699,7 @@ fi
 * Fri Nov 17 2017 Michael Vogt <mvo@ubuntu.com>
 - New upstream release 2.29.4
  - snap-confine: fix snap-confine under lxd
- - tests: disable classic-ubuntu-core-transition on i386 temporarly
+ - tests: disable classic-ubuntu-core-transition on i386 temporarily
  - many: reject bad plugs/slots
  - interfaces,tests: skip unknown plug/slot interfaces
  - store: enable "base" field from the store

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -2,7 +2,7 @@ snapd (2.29.4~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #1726258
     - snap-confine: fix snap-confine under lxd
-    - tests: disable classic-ubuntu-core-transition on i386 temporarly
+    - tests: disable classic-ubuntu-core-transition on i386 temporarily
     - many: reject bad plugs/slots
     - interfaces,tests: skip unknown plug/slot interfaces
     - store: enable "base" field from the store

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -2,7 +2,7 @@ snapd (2.29.4) xenial; urgency=medium
 
   * New upstream release, LP: #1726258
     - snap-confine: fix snap-confine under lxd
-    - tests: disable classic-ubuntu-core-transition on i386 temporarly
+    - tests: disable classic-ubuntu-core-transition on i386 temporarily
     - many: reject bad plugs/slots
     - interfaces,tests: skip unknown plug/slot interfaces
     - store: enable "base" field from the store


### PR DESCRIPTION
Fix silly typo. This also stops "misspell" in the static tests from being unhappy.