### PR TITLE
cmd, errtracker: get rid of SNAP_DID_REEXEC environment

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -176,15 +176,6 @@ func ExecInCoreSnap() {
 
 	// Did we already re-exec?
 	if strings.HasPrefix(exe, dirs.SnapMountDir) {
-		// Older version of snapd (before 2.28) did use this env
-		// to check if they should re-exec or not. We still need
-		// to unset it because the host snap tool may be old and
-		// using this key. So if e.g. the host has snapd 2.27 and
-		// snapd re-execs to 2.29 then `snap run --shell classic-snap`
-		// will go into an environment where the snapd 2.27 sees
-		// this key and stops re-execing - which is not what we
-		// want. C.f. https://forum.snapcraft.io/t/seccomp-error-calling-snap-from-another-classic-snap-on-core-candidate/2736/7
-		mustUnsetenv("SNAP_DID_REEXEC")
 		return
 	}
 
@@ -210,7 +201,5 @@ func ExecInCoreSnap() {
 	}
 
 	logger.Debugf("restarting into %q", full)
-	// we keep this for e.g. the errtracker
-	env := append(os.Environ(), "SNAP_DID_REEXEC=1")
-	panic(syscallExec(full, os.Args, env))
+	panic(syscallExec(full, os.Args, os.Environ()))
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/release"
-	"github.com/snapcore/snapd/testutil"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -236,7 +235,6 @@ func (s *cmdSuite) TestExecInCoreSnap(c *C) {
 	c.Check(s.execCalled, Equals, 1)
 	c.Check(s.lastExecArgv0, Equals, filepath.Join(s.newCore, "/usr/lib/snapd/potato"))
 	c.Check(s.lastExecArgv, DeepEquals, os.Args)
-	c.Check(s.lastExecEnvv, testutil.Contains, "SNAP_DID_REEXEC=1")
 }
 
 func (s *cmdSuite) TestExecInOldCoreSnap(c *C) {
@@ -246,7 +244,6 @@ func (s *cmdSuite) TestExecInOldCoreSnap(c *C) {
 	c.Check(s.execCalled, Equals, 1)
 	c.Check(s.lastExecArgv0, Equals, filepath.Join(s.oldCore, "/usr/lib/snapd/potato"))
 	c.Check(s.lastExecArgv, DeepEquals, os.Args)
-	c.Check(s.lastExecEnvv, testutil.Contains, "SNAP_DID_REEXEC=1")
 }
 
 func (s *cmdSuite) TestExecInCoreSnapBailsNoCoreSupport(c *C) {
@@ -307,18 +304,4 @@ func (s *cmdSuite) TestExecInCoreSnapDisabled(c *C) {
 
 	cmd.ExecInCoreSnap()
 	c.Check(s.execCalled, Equals, 0)
-}
-
-func (s *cmdSuite) TestExecInCoreSnapUnsetsDidReexec(c *C) {
-	os.Setenv("SNAP_DID_REEXEC", "1")
-	defer os.Unsetenv("SNAP_DID_REEXEC")
-
-	selfExe := filepath.Join(s.fakeroot, "proc/self/exe")
-	err := os.Symlink(filepath.Join(s.fakeroot, "/snap/core/42/usr/lib/snapd"), selfExe)
-	c.Assert(err, IsNil)
-	cmd.MockSelfExe(selfExe)
-
-	cmd.ExecInCoreSnap()
-	c.Check(s.execCalled, Equals, 0)
-	c.Check(os.Getenv("SNAP_DID_REEXEC"), Equals, "")
 }

--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"gopkg.in/mgo.v2/bson"
@@ -91,8 +92,13 @@ func snapConfineProfileDigest(suffix string) string {
 	return fmt.Sprintf("%x", md5.Sum(profileText))
 }
 
-func didSnapdReExec() string {
-	if osutil.GetenvBool("SNAP_DID_REEXEC") {
+var didSnapdReExec = func() string {
+	// TODO: move this into osutil.Reexeced() ?
+	exe, err := os.Readlink("/proc/self/exe")
+	if err != nil {
+		return "unknown"
+	}
+	if strings.HasPrefix(exe, dirs.SnapMountDir) {
 		return "yes"
 	}
 	return "no"

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -73,7 +73,9 @@ func (s *ErrtrackerTestSuite) SetUpTest(c *C) {
 	s.AddCleanup(errtracker.MockMachineIDPaths([]string{p}))
 	s.AddCleanup(errtracker.MockHostSnapd(truePath))
 	s.AddCleanup(errtracker.MockCoreSnapd(falsePath))
-	s.AddCleanup(errtracker.MockReExec(true))
+	s.AddCleanup(errtracker.MockReExec(func() string {
+		return "yes"
+	}))
 
 	s.hostBuildID, err = osutil.ReadBuildID(truePath)
 	c.Assert(err, IsNil)

--- a/errtracker/export_test.go
+++ b/errtracker/export_test.go
@@ -20,10 +20,7 @@
 package errtracker
 
 import (
-	"os"
 	"time"
-
-	"github.com/snapcore/snapd/osutil"
 )
 
 func MockCrashDbURL(url string) (restorer func()) {
@@ -66,18 +63,10 @@ func MockTimeNow(f func() time.Time) (restorer func()) {
 	}
 }
 
-func MockReExec(didReExec bool) (restorer func()) {
-	old := osutil.GetenvBool("SNAP_DID_REEXEC")
-	if didReExec {
-		os.Setenv("SNAP_DID_REEXEC", "1")
-	} else {
-		os.Unsetenv("SNAP_DID_REEXEC")
-	}
+func MockReExec(f func() string) (restorer func()) {
+	oldDidSnapdReExec := didSnapdReExec
+	didSnapdReExec = f
 	return func() {
-		if old {
-			os.Setenv("SNAP_DID_REEXEC", "1")
-		} else {
-			os.Unsetenv("SNAP_DID_REEXEC")
-		}
+		didSnapdReExec = oldDidSnapdReExec
 	}
 }

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -9,7 +9,7 @@ debug: |
     cat *-vars.txt
 execute: |
     echo "Collect SNAP and XDG environment variables"
-    test-snapd-tools.env | egrep '^SNAP_' | egrep -v '^SNAP_DID_REEXEC'| sort > snap-vars.txt
+    test-snapd-tools.env | egrep '^SNAP_' | sort > snap-vars.txt
     test-snapd-tools.env | egrep '^XDG_' | sort > xdg-vars.txt
     test-snapd-tools.env | egrep '^EXTRA_' | sort > extra-vars.txt 
 

--- a/tests/regression/lp-1704860/task.yaml
+++ b/tests/regression/lp-1704860/task.yaml
@@ -20,6 +20,6 @@ execute: |
     install_local_classic test-snapd-classic-confinement
     # We don't want to see SNAP_DID_REEXEC being set.
     if snap run --shell test-snapd-classic-confinement ./snap-env-query.sh | grep 'SNAP_DID_REEXEC='; then
-        echo "SNAP_DID_REEXEC environment is not reset as it should be"
+        echo "SNAP_DID_REEXEC environment is set - it should *not* be set ever"
         exit 1
     fi


### PR DESCRIPTION
The SNAP_DID_REEXEC environment caused two bugs already, one with
classic confinement snapd and one in the error tracker. Instead
of relying on this we inspect the /proc/self/exe now to see if
snapd did reexec or not.
