### PR TITLE
interfaces/screen-inhibit-control: fix case in screen inhibit control

### DIFF
--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -56,9 +56,18 @@ dbus (send)
     peer=(label=unconfined),
 
 # freedesktop.org ScreenSaver
+# compatibility rule
 dbus (send)
     bus=session
     path=/Screensaver
+    interface=org.freedesktop.ScreenSaver
+    member=org.freedesktop.ScreenSaver.{Inhibit,UnInhibit,SimulateUserActivity}
+    peer=(label=unconfined),
+
+# API rule
+dbus (send)
+    bus=session
+    path=/{,org/freedesktop/,org.gnome/}ScreenSaver
     interface=org.freedesktop.ScreenSaver
     member=org.freedesktop.ScreenSaver.{Inhibit,UnInhibit,SimulateUserActivity}
     peer=(label=unconfined),

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -58,7 +58,7 @@ dbus (send)
 # freedesktop.org ScreenSaver
 dbus (send)
     bus=session
-    path=/{,org/freedesktop/,org.gnome/}Screensaver
+    path=/Screensaver
     interface=org.freedesktop.ScreenSaver
     member=org.freedesktop.ScreenSaver.{Inhibit,UnInhibit,SimulateUserActivity}
     peer=(label=unconfined),


### PR DESCRIPTION
d3af006501948662fc6dda9b0149e0695966740d attempted to address the reported denial in forum topic https://forum.snapcraft.io/t/possible-screen-inhibit-control-bug/876, but it did not which resulted in https://forum.snapcraft.io/t/possibly-erroneous-apparmor-denial/2879/2.

To fix this, revert the erroneous commit and add a new rule for the actual API. Leave the old pre-d3af006501948662fc6dda9b0149e0695966740d rule in place to preserve compatibility.