### PR TITLE
snap-confine: add workaround for snap-confine on 4.13/upstream

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -350,6 +350,10 @@
     signal (send, receive) set=(alrm, exists) peer=@LIBEXECDIR@/snap-confine,
     signal (receive) set=(exists) peer=@LIBEXECDIR@/snap-confine//mount-namespace-capture-helper,
 
+    # workaround for linux 4.13/upstream, see
+    # https://forum.snapcraft.io/t/snapd-2-27-6-2-in-debian-sid-blocked-on-apparmor-in-kernel-4-13-0-1/2813/3
+    ptrace (trace, tracedby) peer=@LIBEXECDIR@/snapd/snap-confine,
+
     # For aa_change_hat() to go into ^mount-namespace-capture-helper
     @{PROC}/[0-9]*/attr/current w,
 

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -74,7 +74,6 @@ ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
     BUILT_USING_PACKAGES=libcap-dev libapparmor-dev libseccomp-dev
 else
 ifeq ($(shell dpkg-vendor --query Vendor),Debian)
-    VENDOR_ARGS=--disable-apparmor --disable-seccomp
     BUILT_USING_PACKAGES=libcap-dev
 else
     VENDOR_ARGS=--disable-apparmor
@@ -192,15 +191,7 @@ override_dh_install:
 	$(MAKE) -C cmd install DESTDIR=$(CURDIR)/debian/tmp
 
 	# Rename the apparmor profile, see dh_apparmor call above for an explanation.
-ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
 	mv $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine.real
-else
-	# HACK: As we want to share the packaging bits between Debian and Ubuntu
-	# we have to get an empty file in place which satisfies the item in
-	# the snapd.install file.
-	install -d $(CURDIR)/debian/tmp/etc/apparmor.d
-	touch $(CURDIR)/debian/tmp/etc/apparmor.d/usr.lib.snapd.snap-confine.real
-endif
 
 	dh_install
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -107,6 +107,9 @@ backends:
             - debian-9-64:
                 username: debian
                 password: debian
+            - debian-sid-64:
+                username: debian
+                password: debian
             - fedora-25-64:
                 username: fedora
                 password: fedora

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -406,6 +406,9 @@ pkg_dependencies_ubuntu_classic(){
                 "
             ;;
         debian-*)
+            echo "
+                net-tools
+                "
             ;;
     esac
 }


### PR DESCRIPTION
There is a apparmor failure on linux 4.13/upstream that is showing
in Debian. Adding a apparmor rule as a workaround to unblock the
this.

See also https://forum.snapcraft.io/t/2813
