### PR TITLE
cmd/snap-confine,tests: fix unmounting on systems without rshared /

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -120,6 +120,8 @@
     # LP: #1668659
     mount options=(rw rbind) /snap/ -> /snap/,
     mount options=(rw rshared) -> /snap/,
+    /etc/systemd/system/ r,
+    /bin/systemctl Ux,
 
     # boostrapping the mount namespace
     mount options=(rw rshared) -> /,

--- a/tests/main/lxd-refresh-cycle/task.yaml
+++ b/tests/main/lxd-refresh-cycle/task.yaml
@@ -1,0 +1,64 @@
+summary: Ensure that we can refresh/remove snaps in LXD
+details: >
+    There is a bug affecting snapd in environments when the root filesystem is
+    not initially "rshared" (in the sense of mount --make-rshared). This test
+    reproduces the issue inside LXD (the issue also affects Ubuntu 14.04
+    without systemd running as init). The issue only happens after we invoke
+    snap-confine at least once, otherwise it is hidden.
+systems: [ubuntu-16*, ubuntu-core-*]
+kill-timeout: 25m # lxd downloads can be quite slow
+restore: |
+    if  [ $(ls -1 "$GOHOME"/snapd_*.deb | wc -l || echo 0) -eq 0 ]; then
+        exit
+    fi
+    lxd.lxc stop my-ubuntu
+    lxd.lxc delete my-ubuntu
+    rm -f mountinfo.*
+debug: |
+    journalctl -u snap.lxd.daemon.service # debug output from lxd
+execute: |
+    if  [[ $(ls -1 "$GOHOME"/snapd_*.deb | wc -l || echo 0) -eq 0 ]]; then
+        echo "No run lxd test when there are not .deb files built"
+        exit
+    fi
+    wait_for_lxd(){
+        while ! printf "GET / HTTP/1.0\n\n" | nc -U /var/snap/lxd/common/lxd/unix.socket | MATCH "200 OK"; do sleep 1; done
+    }
+    echo "Install lxd"
+    snap install lxd
+    echo "Create a trivial container using the lxd snap"
+    wait_for_lxd
+    lxd init --auto
+    lxd.lxc launch ubuntu:16.04 my-ubuntu
+    echo "Ensure we can run things inside"
+    lxd.lxc exec my-ubuntu echo hello | MATCH hello
+    echo "Ensure we can get network"
+    lxd.lxc network create testbr0
+    lxd.lxc network attach testbr0 my-ubuntu eth0
+    lxd.lxc exec my-ubuntu dhclient eth0
+    echo "Install locally built snapd inside the container"
+    lxd.lxc exec my-ubuntu -- apt autoremove --purge -y snapd ubuntu-core-launcher
+    lxd.lxc exec my-ubuntu -- cat /proc/self/mountinfo > mountinfo.after-purge
+    lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"
+    lxd.lxc file push "$GOHOME"/snapd_*.deb my-ubuntu/$GOPATH/
+    lxd.lxc exec my-ubuntu -- dpkg -i "$GOHOME"/snapd_*.deb
+    lxd.lxc exec my-ubuntu -- cat /proc/self/mountinfo > mountinfo.after-install
+    # FIXME: workaround for missing squashfuse
+    lxd.lxc exec my-ubuntu -- apt update
+    lxd.lxc exec my-ubuntu -- apt install -y squashfuse
+    echo "Download and side-load a test snap three times"
+    # Revision cannot be globbed remotely so download and glob here.
+    snap download test-snapd-tools
+    lxd.lxc exec my-ubuntu -- snap download test-snapd-tools
+    snap_file=$(ls test-snapd-tools_*.snap)
+    echo "We can refresh the snap as many times for now..."
+    for i in $(seq 5); do
+        lxd.lxc exec my-ubuntu -- snap install --dangerous "$snap_file"
+    done
+    echo "We can also remove it successfully"
+    lxd.lxc exec my-ubuntu -- snap remove test-snapd-tools
+    echo "Running an installed snap will fix the sharing of the mount point"
+    lxd.lxc exec my-ubuntu -- snap install --dangerous "$snap_file"
+    lxd.lxc exec my-ubuntu -- snap run test-snapd-tools.success
+    echo "But not in a way that breaks removal"
+    lxd.lxc exec my-ubuntu -- snap remove test-snapd-tools


### PR DESCRIPTION
This patch adds a test that reproduces a bug in snap-confine/snapd that
affects Ubuntu 16.04 running an LXD container with snapd. Inside such
container the root directory is not implicitly rshared by systemd and
after running any snap command snaps cannot be removed/unmounted
correctly.

The error is addressed by a little trick in snap-confine. All the snap
bind mounts are stopped. The /snap directory is bind-mounted over
itself, rshare is applied and then all the snap mount units are started
again. We must rely on this trick as there is insufficient information
in the mount table for to correctly stop and then restart fuse
(squashfuse) mounts.

With-Kind-Regards-To: Kyle Fazzari
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

