### PR TITLE
snapd: fix handling of undo in the taskrunner

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -4960,7 +4960,7 @@ func (s *snapmgrTestSuite) TestRefreshFailureCausesErrorReport(c *C) {
 		"Revision":                  "11",
 	})
 	c.Check(errMsg, Matches, `(?sm)change "install": "install a snap"
-prerequisites: Done
+prerequisites: Undo
  snap-setup: "some-snap" \(11\) "some-channel"
 download-snap: Undoing
 validate-snap: Done
@@ -4975,7 +4975,7 @@ start-snap-services: Hold
 cleanup: Hold
 run-hook: Hold`)
 	c.Check(errSig, Matches, `(?sm)snap-install:
-prerequisites: Done
+prerequisites: Undo
  snap-setup: "some-snap"
 download-snap: Undoing
 validate-snap: Done

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -345,6 +345,7 @@ func (r *TaskRunner) Ensure() {
 		if status == UndoStatus && handlers.undo == nil {
 			// Although this has no dependencies itself, it must have waited
 			// above too since follow up tasks may have handlers again.
+			// Cannot undo. Revert to done status.
 			t.SetStatus(DoneStatus)
 			if len(t.WaitTasks()) > 0 {
 				r.state.EnsureBefore(0)

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -343,10 +343,9 @@ func (r *TaskRunner) Ensure() {
 		}
 
 		if status == UndoStatus && handlers.undo == nil {
-			// Cannot undo. Revert to done status.
+			// Although this has no dependencies itself, it must have waited
+			// above too since follow up tasks may have handlers again.
 			t.SetStatus(DoneStatus)
-			// We may have to wait for dependencies, as further
-			// tasks might have handlers again.
 			if len(t.WaitTasks()) > 0 {
 				r.state.EnsureBefore(0)
 			}

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -337,8 +337,6 @@ func (r *TaskRunner) Ensure() {
 			continue
 		}
 
-		// We may have to wait for dependencies, as further tasks might have handlers again.
-		// Cannot undo.
 		if mustWait(t) {
 			// Dependencies still unhandled.
 			continue
@@ -347,6 +345,8 @@ func (r *TaskRunner) Ensure() {
 		if status == UndoStatus && handlers.undo == nil {
 			// Cannot undo. Revert to done status.
 			t.SetStatus(DoneStatus)
+			// We may have to wait for dependencies, as further
+			// tasks might have handlers again.
 			if len(t.WaitTasks()) > 0 {
 				r.state.EnsureBefore(0)
 			}

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -336,17 +336,20 @@ func (r *TaskRunner) Ensure() {
 			}
 			continue
 		}
+
+		// Must have wait for dependencies, as further tasks may have handlers again.
+		// Cannot undo..
+		if mustWait(t) {
+			// Dependencies still unhandled.
+			continue
+		}
+
 		if status == UndoStatus && handlers.undo == nil {
 			// Cannot undo. Revert to done status.
 			t.SetStatus(DoneStatus)
 			if len(t.WaitTasks()) > 0 {
 				r.state.EnsureBefore(0)
 			}
-			continue
-		}
-
-		if mustWait(t) {
-			// Dependencies still unhandled.
 			continue
 		}
 

--- a/overlord/state/taskrunner.go
+++ b/overlord/state/taskrunner.go
@@ -337,8 +337,8 @@ func (r *TaskRunner) Ensure() {
 			continue
 		}
 
-		// Must have wait for dependencies, as further tasks may have handlers again.
-		// Cannot undo..
+		// We may have to wait for dependencies, as further tasks might have handlers again.
+		// Cannot undo.
 		if mustWait(t) {
 			// Dependencies still unhandled.
 			continue

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -697,6 +697,11 @@ func (ts *taskRunnerSuite) TestUndoSequence(c *C) {
 	chg := st.NewChange("install", "...")
 
 	var prev *state.Task
+
+	// create a sequence of tasks: 3 tasks with undo handlers, a task with
+	// no undo handler, 3 tasks with undo handler, a task with no undo
+	// handler, finally a task that errors out. Every task waits for previous
+	// taske.
 	for i := 0; i < 2; i++ {
 		for j := 0; j < 3; j++ {
 			t := st.NewTask("do-with-undo", "...")
@@ -716,6 +721,7 @@ func (ts *taskRunnerSuite) TestUndoSequence(c *C) {
 	terr := st.NewTask("error-trigger", "provoking undo")
 	terr.WaitFor(prev)
 	chg.AddTask(terr)
+
 	c.Check(chg.Tasks(), HasLen, 9) // sanity check
 
 	st.Unlock()

--- a/overlord/state/taskrunner_test.go
+++ b/overlord/state/taskrunner_test.go
@@ -93,24 +93,24 @@ func ensureChange(c *C, r *state.TaskRunner, sb *stateBackend, chg *state.Change
 //     <task>:...:1,2         - one of the above, and add task to lanes 1 and 2
 //     chg:abort              - call abort on the change
 //
-// Task wait order: ( t11 | t12 ) => ( t21 ) => ( t31 | t32 )
+// Task wait order: ( t11 | t12 ) => ( t21 ) => ( t22 ) => ( t31 | t32 ) => ( t23 )
 //
-// Task t12 has no undo.
+// Tasks t12, t22 and t23 have no undo.
 //
 // Final task statuses are tested based on the resulting events list.
 //
 var sequenceTests = []struct{ setup, result string }{{
 	setup:  "",
-	result: "t11:do t12:do t21:do t31:do t32:do",
+	result: "t11:do t12:do t21:do t22:do t31:do t32:do t23:do",
 }, {
 	setup:  "t11:was-done t12:was-doing",
-	result: "t12:do t21:do t31:do t32:do",
+	result: "t12:do t21:do t22:do t31:do t32:do t23:do",
 }, {
 	setup:  "t11:was-done t12:was-doing chg:abort",
 	result: "t11:undo",
 }, {
 	setup:  "t12:do-retry",
-	result: "t11:do t12:do t12:do-retry t12:do t21:do t31:do t32:do",
+	result: "t11:do t12:do t12:do-retry t12:do t21:do t22:do t31:do t32:do t23:do",
 }, {
 	setup:  "t11:do-block t12:do-error",
 	result: "t11:do t11:do-block t12:do t12:do-error t11:do-unblock t11:undo",
@@ -125,19 +125,22 @@ var sequenceTests = []struct{ setup, result string }{{
 	result: "t11:do t11:do-error t12:do t12:do-block t12:do-unblock t12:do-retry",
 }, {
 	setup:  "t31:do-error t21:undo-error",
-	result: "t11:do t12:do t21:do t31:do t31:do-error t32:do t32:undo t21:undo t21:undo-error t11:undo",
+	result: "t11:do t12:do t21:do t22:do t31:do t31:do-error t32:do t32:undo t21:undo t21:undo-error t11:undo",
 }, {
 	setup:  "t21:do-set-ready",
-	result: "t11:do t12:do t21:do t31:do t32:do",
+	result: "t11:do t12:do t21:do t22:do t31:do t32:do t23:do",
 }, {
 	setup:  "t31:do-error t21:undo-set-ready",
-	result: "t11:do t12:do t21:do t31:do t31:do-error t32:do t32:undo t21:undo t11:undo",
+	result: "t11:do t12:do t21:do t22:do t31:do t31:do-error t32:do t32:undo t21:undo t11:undo",
 }, {
-	setup:  "t11:was-done:1 t12:was-done:2 t21:was-done:1,2 t31:was-done:1 t32:do-error:2",
+	setup:  "t11:was-done:1 t12:was-done:2 t21:was-done:1,2 t22:was-done:1,2 t31:was-done:1 t32:do-error:2",
 	result: "t31:undo t32:do t32:do-error t21:undo t11:undo",
 }, {
-	setup:  "t11:was-done:1 t12:was-done:2 t21:was-done:2 t31:was-done:2 t32:do-error:2",
+	setup:  "t11:was-done:1 t12:was-done:2 t21:was-done:2 t22:was-done:2 t31:was-done:2 t32:do-error:2",
 	result: "t31:undo t32:do t32:do-error t21:undo",
+}, {
+	setup:  "t11:was-done t12:was-done t21:was-done t22:was-done t31:was-done t32:was-done t23:do-error",
+	result: "t23:do t23:do-error t31:undo t32:undo t21:undo t11:undo",
 }}
 
 func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
@@ -191,8 +194,8 @@ func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 
 		chg := st.NewChange("install", "...")
 		tasks := make(map[string]*state.Task)
-		for _, name := range strings.Fields("t11 t12 t21 t31 t32") {
-			if name == "t12" {
+		for _, name := range strings.Fields("t11 t12 t21 t22 t23 t31 t32") {
+			if name == "t12" || name == "t22" || name == "t23" {
 				tasks[name] = st.NewTask("do", name)
 			} else {
 				tasks[name] = st.NewTask("do-undo", name)
@@ -201,8 +204,11 @@ func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 		}
 		tasks["t21"].WaitFor(tasks["t11"])
 		tasks["t21"].WaitFor(tasks["t12"])
-		tasks["t31"].WaitFor(tasks["t21"])
-		tasks["t32"].WaitFor(tasks["t21"])
+		tasks["t22"].WaitFor(tasks["t21"])
+		tasks["t31"].WaitFor(tasks["t22"])
+		tasks["t32"].WaitFor(tasks["t22"])
+		tasks["t23"].WaitFor(tasks["t31"])
+		tasks["t23"].WaitFor(tasks["t32"])
 		st.Unlock()
 
 		c.Logf("-----")


### PR DESCRIPTION
On undo some tasks my be executed in wrong order if tasks they're don't have undo handler - in this case we prematurely transition such tasks from Undo -> Done without checking dependencies first. This "unblocks" a task that was waiting for the affected task, resulting in out-of-order undo tasks. This bug became apparent in another branch I'm working on, where I added one new hook to already existing hooks (run-hook tasks don't have undo handler) in snapstate.

There are two tests in snapstate_test that incorrectly depend on the wrong behavior, so they need to be fixed as well.
