### PR TITLE
test: ignore /snap/README

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -80,7 +80,7 @@ reset_all_snap() {
     for snap in "$SNAP_MOUNT_DIR"/*; do
         snap="${snap:6}"
         case "$snap" in
-            "bin" | "$gadget_name" | "$kernel_name" | core )
+            "bin" | "$gadget_name" | "$kernel_name" | core | README)
                 ;;
             *)
                 snap remove "$snap"


### PR DESCRIPTION
We recently added a /snap/README that explains what this directory
is about. We now need to adjust the tests to deal with it in
reset.sh.
