### PR TITLE
store: do not log the http body for catalog updates

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1210,6 +1210,7 @@ func (s *Store) WriteCatalogs(names io.Writer) error {
 	// do not log body for catalog updates (its huge)
 	client := httputil.NewHTTPClient(&httputil.ClientOpts{
 		MayLogBody: false,
+		Timeout:    10 * time.Second,
 	})
 	doRequest := func() (*http.Response, error) {
 		return s.doRequest(context.TODO(), client, reqOptions, nil)

--- a/store/store.go
+++ b/store/store.go
@@ -1207,8 +1207,12 @@ func (s *Store) WriteCatalogs(names io.Writer) error {
 		Accept: halJsonContentType,
 	}
 
+	// do not log body for catalog updates (its huge)
+	client := httputil.NewHTTPClient(&httputil.ClientOpts{
+		MayLogBody: false,
+	})
 	doRequest := func() (*http.Response, error) {
-		return s.doRequest(context.TODO(), s.client, reqOptions, nil)
+		return s.doRequest(context.TODO(), client, reqOptions, nil)
 	}
 	readResponse := func(resp *http.Response) error {
 		return decodeCatalog(resp, names)

--- a/tests/main/catalog-update/task.yaml
+++ b/tests/main/catalog-update/task.yaml
@@ -1,0 +1,16 @@
+summary: Ensure catalog update works
+
+execute: |
+    echo "Ensure that catalog refresh happens on startup"
+    for i in seq 60; do
+        if journalctl -u snapd | MATCH "Catalog refresh"; then
+            break
+        fi
+    done
+    journalctl -u snapd | MATCH "Catalog refresh"
+
+    echo "Ensure that we don't log all catalog body data"
+    if journalctl -u snapd | MATCH "Tools for testing the snapd application"; then
+        echo "Catalog update is doing verbose http logging (it should not)."
+        exit 1
+    fi


### PR DESCRIPTION
The catalog updates body contains a lot of data and is rarely useful
for debugging purposes. It also makes reading the spread error output
harder.
