### PR TITLE
tests: force delete when tests are restore to avoid suite failure

### DIFF
--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -46,7 +46,7 @@ restore: |
     systemctl stop snapd.service snapd.socket
     systemd_stop_and_destroy_unit fakedevicesvc
 
-    rm -r "$SEED_DIR"
+    rm -rf "$SEED_DIR"
     rm -f -- *.snap
     rm -f -- *.assert
     systemctl start snapd.socket snapd.service

--- a/tests/main/classic-firstboot/task.yaml
+++ b/tests/main/classic-firstboot/task.yaml
@@ -39,7 +39,7 @@ restore: |
         exit
     fi
 
-    rm -r "$SEED_DIR"
+    rm -rf "$SEED_DIR"
     rm -f -- *.snap
     rm -f -- *.assert
     systemctl start snapd.socket snapd.service

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -32,7 +32,7 @@ restore: |
     rm "$NAMES"
     [ -e "$NAMES.orig" ] && mv "$NAMES.orig" "$NAMES"
     systemctl start snapd.service
-    rm testdir/foo.snap bar.snap
+    rm -f testdir/foo.snap bar.snap
     rmdir testdir
 
 debug: |

--- a/tests/main/config-versions/task.yaml
+++ b/tests/main/config-versions/task.yaml
@@ -11,8 +11,8 @@ prepare: |
     snap pack $TESTSLIB/snaps/config-versions-v2
 
 restore: |
-    rm config-versions_1.0_all.snap
-    rm config-versions_2.0_all.snap
+    rm -f config-versions_1.0_all.snap
+    rm -f config-versions_2.0_all.snap
 
 execute: |
     verify_config_value() {

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -15,7 +15,7 @@ environment:
 restore: |
     for snap in basic test-snapd-tools basic-desktop
     do
-        rm ./${snap}_1.0_all.snap
+        rm -f ./${snap}_1.0_all.snap
     done
 
 execute: |

--- a/tests/main/install-socket-activation/task.yaml
+++ b/tests/main/install-socket-activation/task.yaml
@@ -8,7 +8,7 @@ prepare: |
     snap install --dangerous socket-activation_1.0_all.snap
 
 restore: |
-    rm socket-activation_1.0_all.snap
+    rm -f socket-activation_1.0_all.snap
     systemctl daemon-reload
 
 execute: |

--- a/tests/main/interfaces-hooks/task.yaml
+++ b/tests/main/interfaces-hooks/task.yaml
@@ -8,12 +8,8 @@ prepare: |
     snap install --dangerous basic-iface-hooks-producer_1.0_all.snap
 
 restore: |
-    rm basic-iface-hooks-consumer_1.0_all.snap
-    rm basic-iface-hooks-producer_1.0_all.snap
-
-restore: |
-    rm basic-iface-hooks-consumer_1.0_all.snap
-    rm basic-iface-hooks-producer_1.0_all.snap
+    rm -f basic-iface-hooks-consumer_1.0_all.snap
+    rm -f basic-iface-hooks-producer_1.0_all.snap
 
 execute: |
     echo "Test that snap connect with plug and slot hooks succeeds"

--- a/tests/main/interfaces-iio/task.yaml
+++ b/tests/main/interfaces-iio/task.yaml
@@ -33,7 +33,7 @@ restore: |
         echo "This test needs test keys to be trusted"
         exit
     fi
-    rm /dev/iio:device0
+    rm -f /dev/iio:device0
 
 execute: |
     . $TESTSLIB/dirs.sh

--- a/tests/main/revert-sideload/task.yaml
+++ b/tests/main/revert-sideload/task.yaml
@@ -4,7 +4,7 @@ prepare: |
     snap pack $TESTSLIB/snaps/basic
 
 restore: |
-    rm ./basic_1.0_all.snap
+    rm -f ./basic_1.0_all.snap
 
 execute: |
     echo Installing sideloaded snap

--- a/tests/main/security-profiles/task.yaml
+++ b/tests/main/security-profiles/task.yaml
@@ -3,7 +3,7 @@ summary: Check security profile generation for apps and hooks.
 prepare: |
     snap pack $TESTSLIB/snaps/basic-hooks
 restore: |
-    rm basic-hooks_1.0_all.snap
+    rm -f basic-hooks_1.0_all.snap
 
 execute: |
     if [ "$(snap debug confinement)" = partial ] ; then

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -9,7 +9,7 @@ prepare: |
     snap install --channel beta --devmode test-snapd-devmode
 
 restore: |
-    rm basic_1.0_all.snap
+    rm -f basic_1.0_all.snap
     . $TESTSLIB/pkgdb.sh
     distro_purge_package python3-yaml
     rm -f out

--- a/tests/main/snap-run-hook/task.yaml
+++ b/tests/main/snap-run-hook/task.yaml
@@ -13,7 +13,7 @@ prepare: |
     snap install --dangerous basic-hooks_1.0_all.snap
 
 restore: |
-    rm basic-hooks_1.0_all.snap
+    rm -f basic-hooks_1.0_all.snap
 
 execute: |
     # Note that `snap run` doesn't exit non-zero if the hook is missing, so we

--- a/tests/main/snap-set/task.yaml
+++ b/tests/main/snap-set/task.yaml
@@ -13,9 +13,9 @@ prepare: |
     snap install --dangerous snapctl-hooks_1.0_all.snap
 
 restore: |
-    rm basic_1.0_all.snap
-    rm failing-config-hooks_1.0_all.snap
-    rm snapctl-hooks_1.0_all.snap
+    rm -f basic_1.0_all.snap
+    rm -f failing-config-hooks_1.0_all.snap
+    rm -f snapctl-hooks_1.0_all.snap
 
 execute: |
     echo "Test that snap set fails without configure hook"

--- a/tests/main/snapctl-from-snap/task.yaml
+++ b/tests/main/snapctl-from-snap/task.yaml
@@ -6,7 +6,7 @@ prepare: |
     snap pack $TESTSLIB/snaps/snapctl-from-snap
   
 restore: |
-    rm snapctl-from-snap_1.0_all.snap
+    rm -f snapctl-from-snap_1.0_all.snap
 
 execute: |
     . $TESTSLIB/dirs.sh

--- a/tests/main/snapctl/task.yaml
+++ b/tests/main/snapctl/task.yaml
@@ -5,7 +5,7 @@ prepare: |
     snap install --dangerous snapctl-hooks_1.0_all.snap
 
 restore: |
-    rm snapctl-hooks_1.0_all.snap
+    rm -f snapctl-hooks_1.0_all.snap
 
 execute: |
     echo "Verify that snapctl -h runs without a context"

--- a/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
@@ -48,12 +48,12 @@ restore: |
        rm -f /var/lib/snapd/snaps/pc_x1.snap
        systemctl daemon-reload
     fi
-    rm /var/lib/snapd/seed/snaps/pc_x1.snap
+    rm -f /var/lib/snapd/seed/snaps/pc_x1.snap
     cp seed.yaml.bak /var/lib/snapd/seed/seed.yaml
-    rm /var/lib/snapd/seed/assertions/developer1.account
-    rm /var/lib/snapd/seed/assertions/developer1.account-key
-    rm /var/lib/snapd/seed/assertions/developer1-pc.model
-    rm /var/lib/snapd/seed/assertions/testrootorg-store.account-key
+    rm -f /var/lib/snapd/seed/assertions/developer1.account
+    rm -f /var/lib/snapd/seed/assertions/developer1.account-key
+    rm -f /var/lib/snapd/seed/assertions/developer1-pc.model
+    rm -f /var/lib/snapd/seed/assertions/testrootorg-store.account-key
     cp model.bak /var/lib/snapd/seed/assertions/model
     rm -f *.bak
     # kick first boot again

--- a/tests/main/ubuntu-core-custom-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg/task.yaml
@@ -47,12 +47,12 @@ restore: |
        rm -f /var/lib/snapd/snaps/pc_x1.snap
        systemctl daemon-reload
     fi
-    rm /var/lib/snapd/seed/snaps/pc_x1.snap
+    rm -f /var/lib/snapd/seed/snaps/pc_x1.snap
     cp seed.yaml.bak /var/lib/snapd/seed/seed.yaml
-    rm /var/lib/snapd/seed/assertions/developer1.account
-    rm /var/lib/snapd/seed/assertions/developer1.account-key
-    rm /var/lib/snapd/seed/assertions/developer1-pc.model
-    rm /var/lib/snapd/seed/assertions/testrootorg-store.account-key
+    rm -f /var/lib/snapd/seed/assertions/developer1.account
+    rm -f /var/lib/snapd/seed/assertions/developer1.account-key
+    rm -f /var/lib/snapd/seed/assertions/developer1-pc.model
+    rm -f /var/lib/snapd/seed/assertions/testrootorg-store.account-key
     cp model.bak /var/lib/snapd/seed/assertions/model
     rm -f *.bak
     # kick first boot again

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -73,11 +73,11 @@ restore: |
     rm /var/lib/snapd/seed/snaps/test-snapd-with-configure_*.snap
 
     cp seed.yaml.bak /var/lib/snapd/seed/seed.yaml
-    rm /var/lib/snapd/seed/assertions/developer1.account
-    rm /var/lib/snapd/seed/assertions/developer1.account-key
-    rm /var/lib/snapd/seed/assertions/developer1-pc-w-config.model
-    rm /var/lib/snapd/seed/assertions/testrootorg-store.account-key
-    rm /var/lib/snapd/seed/assertions/test-snapd-with-configure_*.assert
+    rm -f /var/lib/snapd/seed/assertions/developer1.account
+    rm -f /var/lib/snapd/seed/assertions/developer1.account-key
+    rm -f /var/lib/snapd/seed/assertions/developer1-pc-w-config.model
+    rm -f /var/lib/snapd/seed/assertions/testrootorg-store.account-key
+    rm -f /var/lib/snapd/seed/assertions/test-snapd-with-configure_*.assert
     cp model.bak /var/lib/snapd/seed/assertions/model
     rm -f *.bak
     # kick first boot again

--- a/tests/main/writable-areas/task.yaml
+++ b/tests/main/writable-areas/task.yaml
@@ -10,7 +10,7 @@ prepare: |
     snap pack $TESTSLIB/snaps/data-writer
 
 restore: |
-    rm data-writer_1.0_all.snap
+    rm -f data-writer_1.0_all.snap
 
 execute: |
     snap install --dangerous data-writer_1.0_all.snap


### PR DESCRIPTION
This change is to avoid this kind of errors on the restore to make sure
it does not fail even when the file to delete does not exist

2017-11-21 12:16:23 Error restoring external:ubuntu-
core-16-64:tests/main/snapctl-from-snap :
-----
+ rm snapctl-from-snap_1.0_all.snap
rm: cannot remove 'snapctl-from-snap_1.0_all.snap': No such file or
directory
-----
.
2017-11-21 12:16:23 Restoring external:ubuntu-core-16-64:tests/main/...
2017-11-21 12:16:26 Restoring project on external:ubuntu-core-16-64...
2017-11-21 12:16:33 Discarding external:ubuntu-core-16-64...
2017-11-21 12:16:33 Successful tasks: 140
2017-11-21 12:16:33 Aborted tasks: 19
2017-11-21 12:16:33 Failed task prepare: 1
    - external:ubuntu-core-16-64:tests/main/snapctl-from-snap
2017-11-21 12:16:33 Failed task restore: 1
    - external:ubuntu-core-16-64:tests/main/snapctl-from-snap
error: unsuccessful run

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
