### PR TITLE
snapstate: add new refresh-hints helper and use it

### DIFF
--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -133,3 +133,8 @@ var (
 	WriteSnapReadme = writeSnapReadme
 	SnapReadme      = snapReadme
 )
+
+// refresh-hints
+var (
+	NewRefreshHints = newRefreshHints
+)

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -28,7 +28,7 @@ import (
 
 var refreshHintsDelay = time.Duration(24 * time.Hour)
 
-// refreshHints will ensure that we regular get data about refreshes
+// refreshHints will ensure that we get regular data about refreshes
 // so that we can potentially warn the user about important missing
 // refreshes.
 type refreshHints struct {
@@ -59,6 +59,8 @@ func (r *refreshHints) refresh() error {
 	refreshManaged := false
 
 	_, _, _, err := refreshCandidates(r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
+	// TODO: we currently set last-refresh-hints even when there was an
+	// error. In the future we may retry with a backoff.
 	r.state.Set("last-refresh-hints", time.Now())
 	return err
 }

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"time"
+
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/store"
+)
+
+var refreshHintsDelay = time.Duration(24 * time.Hour)
+
+// refreshHints will ensure that we regular get data about refreshes
+// so that we can potentially warn the user about importand missing
+// refreshes.
+type refreshHints struct {
+	state *state.State
+}
+
+func newRefreshHints(st *state.State) *refreshHints {
+	return &refreshHints{state: st}
+}
+
+func (r *refreshHints) lastRefresh() (time.Time, error) {
+	var lastRefresh time.Time
+	if err := r.state.Get("last-refresh-hints", &lastRefresh); err != nil && err != state.ErrNoState {
+		return time.Time{}, err
+	}
+	return lastRefresh, nil
+}
+
+func (r *refreshHints) needsUpdate() (bool, error) {
+	t, err := r.lastRefresh()
+	if err != nil {
+		return false, err
+	}
+	return t.Before(time.Now().Add(-refreshHintsDelay)), nil
+}
+
+func (r *refreshHints) refresh() error {
+	refreshManaged := false
+
+	_, _, _, err := refreshCandidates(r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
+	r.state.Set("last-refresh-hints", time.Now())
+	return err
+}
+
+// Ensure will ensure that refresh hints are available on a regular
+// interval.
+func (r *refreshHints) Ensure() error {
+	r.state.Lock()
+	defer r.state.Unlock()
+
+	// this is only false in tests
+	if CanAutoRefresh == nil {
+		return nil
+	}
+
+	needsUpdate, err := r.needsUpdate()
+	if err != nil {
+		return err
+	}
+	if !needsUpdate {
+		return nil
+	}
+	return r.refresh()
+}

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -29,7 +29,7 @@ import (
 var refreshHintsDelay = time.Duration(24 * time.Hour)
 
 // refreshHints will ensure that we regular get data about refreshes
-// so that we can potentially warn the user about importand missing
+// so that we can potentially warn the user about important missing
 // refreshes.
 type refreshHints struct {
 	state *state.State
@@ -69,9 +69,15 @@ func (r *refreshHints) Ensure() error {
 	r.state.Lock()
 	defer r.state.Unlock()
 
-	// this is only false in tests
+	// CanAutoRefresh is a hook that is set by the devicestate
+	// code to ensure that we only AutoRefersh if the device has
+	// bootstraped itself enough. This is only nil when snapstate
+	// is used in isolation (like in tests).
 	if CanAutoRefresh == nil {
 		return nil
+	}
+	if ok, err := CanAutoRefresh(r.state); err != nil || !ok {
+		return err
 	}
 
 	needsUpdate, err := r.needsUpdate()

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/store/storetest"
+)
+
+type recordingStore struct {
+	storetest.Store
+
+	ops []string
+}
+
+func (r *recordingStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+	r.ops = append(r.ops, "list-refresh")
+	return nil, nil
+}
+
+type refreshHintsTestSuite struct {
+	state *state.State
+
+	store *recordingStore
+}
+
+var _ = Suite(&refreshHintsTestSuite{})
+
+func (s *refreshHintsTestSuite) SetUpTest(c *C) {
+	s.state = state.New(nil)
+
+	s.store = &recordingStore{}
+	s.state.Lock()
+	snapstate.ReplaceStore(s.state, s.store)
+	s.state.Unlock()
+
+	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
+}
+
+func (s *refreshHintsTestSuite) TearDownTests(c *C) {
+	snapstate.CanAutoRefresh = nil
+}
+
+func (s *refreshHintsTestSuite) TestLastRefresh(c *C) {
+	rh := snapstate.NewRefreshHints(s.state)
+	err := rh.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
+}
+
+func (s *refreshHintsTestSuite) TestLastRefreshNoRefreshNeeded(c *C) {
+	s.state.Lock()
+	s.state.Set("last-refresh-hints", time.Now().Add(23*time.Hour))
+	s.state.Unlock()
+
+	rh := snapstate.NewRefreshHints(s.state)
+	err := rh.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, HasLen, 0)
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -79,6 +79,8 @@ type SnapManager struct {
 	nextRefresh            time.Time
 	lastRefreshAttempt     time.Time
 
+	refreshHints *refreshHints
+
 	nextCatalogRefresh time.Time
 
 	lastUbuntuCoreTransitionAttempt time.Time
@@ -300,9 +302,10 @@ func Manager(st *state.State) (*SnapManager, error) {
 	runner := state.NewTaskRunner(st)
 
 	m := &SnapManager{
-		state:   st,
-		backend: backend.Backend{},
-		runner:  runner,
+		state:        st,
+		backend:      backend.Backend{},
+		runner:       runner,
+		refreshHints: newRefreshHints(st),
 	}
 
 	if err := os.MkdirAll(dirs.SnapCookieDir, 0700); err != nil {
@@ -694,6 +697,7 @@ func (m *SnapManager) Ensure() error {
 		m.ensureAliasesV2(),
 		m.ensureForceDevmodeDropsDevmodeFromState(),
 		m.ensureUbuntuCoreTransition(),
+		m.refreshHints.Ensure(),
 		m.ensureRefreshes(),
 		m.ensureCatalogRefresh(),
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -545,11 +545,11 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 // RefreshCandidates gets a list of candidates for update
 // Note that the state must be locked by the caller.
 func RefreshCandidates(st *state.State, user *auth.UserState) ([]*snap.Info, error) {
-	updates, _, _, err := refreshCandidates(st, nil, user)
+	updates, _, _, err := refreshCandidates(st, nil, user, nil)
 	return updates, err
 }
 
-func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
+func refreshCandidates(st *state.State, names []string, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
 	snapStates, err := All(st)
 	if err != nil {
 		return nil, nil, nil, err
@@ -612,7 +612,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 	theStore := Store(st)
 
 	st.Unlock()
-	updates, err := theStore.ListRefresh(candidatesInfo, user, nil)
+	updates, err := theStore.ListRefresh(candidatesInfo, user, flags)
 	st.Lock()
 	if err != nil {
 		return nil, nil, nil, err
@@ -633,7 +633,7 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 		return nil, nil, err
 	}
 
-	updates, stateByID, ignoreValidation, err := refreshCandidates(st, names, user)
+	updates, stateByID, ignoreValidation, err := refreshCandidates(st, names, user, nil)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
The new refresh hints will be used to gather data about refreshes
without acting on them. Once we have the warnings system in place
we will use the data to warn the user about important refreshes.

My plan is to move more of the refresh code to this pattern, next will be the catalogRefresh.