### PR TITLE
snapstate: move catalogRefresh into its own helper 

### DIFF
--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -1,0 +1,102 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+var catalogRefreshDelay = 24 * time.Hour
+
+type catalogRefresh struct {
+	state *state.State
+
+	nextCatalogRefresh time.Time
+}
+
+func newCatalogRefresh(st *state.State) *catalogRefresh {
+	return &catalogRefresh{state: st}
+}
+
+// Ensure will ensure that the catalog refresh happens
+func (r *catalogRefresh) Ensure() error {
+	r.state.Lock()
+	defer r.state.Unlock()
+
+	// sneakily don't do anything if in testing
+	if CanAutoRefresh == nil {
+		return nil
+	}
+
+	theStore := Store(r.state)
+	now := time.Now()
+	needsRefresh := r.nextCatalogRefresh.IsZero() || r.nextCatalogRefresh.Before(now)
+
+	if !needsRefresh {
+		return nil
+	}
+
+	next := now.Add(catalogRefreshDelay)
+	// catalog refresh does not carry on trying on error
+	r.nextCatalogRefresh = next
+
+	logger.Debugf("Catalog refresh starting now; next scheduled for %s.", next)
+
+	return refreshCatalogs(r.state, theStore)
+}
+
+func refreshCatalogs(st *state.State, theStore StoreService) error {
+	st.Unlock()
+	defer st.Lock()
+
+	if err := os.MkdirAll(dirs.SnapCacheDir, 0755); err != nil {
+		return fmt.Errorf("cannot create directory %q: %v", dirs.SnapCacheDir, err)
+	}
+
+	sections, err := theStore.Sections(nil)
+	if err != nil {
+		return err
+	}
+
+	sort.Strings(sections)
+	if err := osutil.AtomicWriteFile(dirs.SnapSectionsFile, []byte(strings.Join(sections, "\n")), 0644, 0); err != nil {
+		return err
+	}
+
+	namesFile, err := osutil.NewAtomicFile(dirs.SnapNamesFile, 0644, 0, -1, -1)
+	if err != nil {
+		return err
+	}
+	defer namesFile.Cancel()
+	if err := theStore.WriteCatalogs(namesFile); err != nil {
+		return err
+	}
+
+	return namesFile.Commit()
+}

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -1,0 +1,106 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"io"
+	"io/ioutil"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/store/storetest"
+)
+
+type catalogStore struct {
+	storetest.Store
+
+	ops []string
+}
+
+func (r *catalogStore) WriteCatalogs(w io.Writer) error {
+	r.ops = append(r.ops, "write-catalog")
+	w.Write([]byte("pkg1\npkg2"))
+	return nil
+}
+
+func (r *catalogStore) Sections(*auth.UserState) ([]string, error) {
+	r.ops = append(r.ops, "sections")
+	return []string{"section1", "section2"}, nil
+}
+
+type catalogRefreshTestSuite struct {
+	state *state.State
+
+	store  *catalogStore
+	tmpdir string
+}
+
+var _ = Suite(&catalogRefreshTestSuite{})
+
+func (s *catalogRefreshTestSuite) SetUpTest(c *C) {
+	s.tmpdir = c.MkDir()
+	dirs.SetRootDir(s.tmpdir)
+	s.state = state.New(nil)
+
+	s.store = &catalogStore{}
+	s.state.Lock()
+	snapstate.ReplaceStore(s.state, s.store)
+	s.state.Unlock()
+
+	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
+}
+
+func (s *catalogRefreshTestSuite) TearDownTest(c *C) {
+	snapstate.CanAutoRefresh = nil
+}
+
+func (s *catalogRefreshTestSuite) TestCatalogRefresh(c *C) {
+	cr7 := snapstate.NewCatalogRefresh(s.state)
+	err := cr7.Ensure()
+	c.Check(err, IsNil)
+
+	c.Check(s.store.ops, DeepEquals, []string{"sections", "write-catalog"})
+
+	c.Check(osutil.FileExists(dirs.SnapSectionsFile), Equals, true)
+	content, err := ioutil.ReadFile(dirs.SnapSectionsFile)
+	c.Assert(err, IsNil)
+	c.Check(string(content), Equals, "section1\nsection2")
+
+	c.Check(osutil.FileExists(dirs.SnapNamesFile), Equals, true)
+	content, err = ioutil.ReadFile(dirs.SnapNamesFile)
+	c.Assert(err, IsNil)
+	c.Check(string(content), Equals, "pkg1\npkg2")
+}
+
+func (s *catalogRefreshTestSuite) TestCatalogRefreshNotNeeded(c *C) {
+	cr7 := snapstate.NewCatalogRefresh(s.state)
+	snapstate.MockCatalogRefreshNextRefresh(cr7, time.Now().Add(1*time.Hour))
+	err := cr7.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, HasLen, 0)
+	c.Check(osutil.FileExists(dirs.SnapSectionsFile), Equals, false)
+	c.Check(osutil.FileExists(dirs.SnapNamesFile), Equals, false)
+}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -133,3 +133,8 @@ var (
 	WriteSnapReadme = writeSnapReadme
 	SnapReadme      = snapReadme
 )
+
+// refresh-hints
+var (
+	NewRefreshHints = newRefreshHints
+)

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -134,7 +134,12 @@ var (
 	SnapReadme      = snapReadme
 )
 
-// refresh-hints
+// refreshes
 var (
-	NewRefreshHints = newRefreshHints
+	NewRefreshHints   = newRefreshHints
+	NewCatalogRefresh = newCatalogRefresh
 )
+
+func MockCatalogRefreshNextRefresh(cr *catalogRefresh, when time.Time) {
+	cr.nextCatalogRefresh = when
+}

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"time"
+
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/store"
+)
+
+var refreshHintsDelay = time.Duration(24 * time.Hour)
+
+// refreshHints will ensure that we regular get data about refreshes
+// so that we can potentially warn the user about importand missing
+// refreshes.
+type refreshHints struct {
+	state *state.State
+}
+
+func newRefreshHints(st *state.State) *refreshHints {
+	return &refreshHints{state: st}
+}
+
+func (r *refreshHints) lastRefresh() (time.Time, error) {
+	var lastRefresh time.Time
+	if err := r.state.Get("last-refresh-hints", &lastRefresh); err != nil && err != state.ErrNoState {
+		return time.Time{}, err
+	}
+	return lastRefresh, nil
+}
+
+func (r *refreshHints) needsUpdate() (bool, error) {
+	t, err := r.lastRefresh()
+	if err != nil {
+		return false, err
+	}
+	return t.Before(time.Now().Add(-refreshHintsDelay)), nil
+}
+
+func (r *refreshHints) refresh() error {
+	refreshManaged := false
+
+	_, _, _, err := refreshCandidates(r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
+	r.state.Set("last-refresh-hints", time.Now())
+	return err
+}
+
+// Ensure will ensure that refresh hints are available on a regular
+// interval.
+func (r *refreshHints) Ensure() error {
+	r.state.Lock()
+	defer r.state.Unlock()
+
+	// this is only false in tests
+	if CanAutoRefresh == nil {
+		return nil
+	}
+
+	needsUpdate, err := r.needsUpdate()
+	if err != nil {
+		return err
+	}
+	if !needsUpdate {
+		return nil
+	}
+	return r.refresh()
+}

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -1,0 +1,85 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/store/storetest"
+)
+
+type recordingStore struct {
+	storetest.Store
+
+	ops []string
+}
+
+func (r *recordingStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+	r.ops = append(r.ops, "list-refresh")
+	return nil, nil
+}
+
+type refreshHintsTestSuite struct {
+	state *state.State
+
+	store *recordingStore
+}
+
+var _ = Suite(&refreshHintsTestSuite{})
+
+func (s *refreshHintsTestSuite) SetUpTest(c *C) {
+	s.state = state.New(nil)
+
+	s.store = &recordingStore{}
+	s.state.Lock()
+	snapstate.ReplaceStore(s.state, s.store)
+	s.state.Unlock()
+
+	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
+}
+
+func (s *refreshHintsTestSuite) TearDownTests(c *C) {
+	snapstate.CanAutoRefresh = nil
+}
+
+func (s *refreshHintsTestSuite) TestLastRefresh(c *C) {
+	rh := snapstate.NewRefreshHints(s.state)
+	err := rh.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
+}
+
+func (s *refreshHintsTestSuite) TestLastRefreshNoRefreshNeeded(c *C) {
+	s.state.Lock()
+	s.state.Set("last-refresh-hints", time.Now().Add(23*time.Hour))
+	s.state.Unlock()
+
+	rh := snapstate.NewRefreshHints(s.state)
+	err := rh.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, HasLen, 0)
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -79,6 +79,8 @@ type SnapManager struct {
 	nextRefresh            time.Time
 	lastRefreshAttempt     time.Time
 
+	refreshHints *refreshHints
+
 	nextCatalogRefresh time.Time
 
 	lastUbuntuCoreTransitionAttempt time.Time
@@ -300,9 +302,10 @@ func Manager(st *state.State) (*SnapManager, error) {
 	runner := state.NewTaskRunner(st)
 
 	m := &SnapManager{
-		state:   st,
-		backend: backend.Backend{},
-		runner:  runner,
+		state:        st,
+		backend:      backend.Backend{},
+		runner:       runner,
+		refreshHints: newRefreshHints(st),
 	}
 
 	if err := os.MkdirAll(dirs.SnapCookieDir, 0700); err != nil {
@@ -694,6 +697,7 @@ func (m *SnapManager) Ensure() error {
 		m.ensureAliasesV2(),
 		m.ensureForceDevmodeDropsDevmodeFromState(),
 		m.ensureUbuntuCoreTransition(),
+		m.refreshHints.Ensure(),
 		m.ensureRefreshes(),
 		m.ensureCatalogRefresh(),
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2017 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -545,11 +545,11 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 // RefreshCandidates gets a list of candidates for update
 // Note that the state must be locked by the caller.
 func RefreshCandidates(st *state.State, user *auth.UserState) ([]*snap.Info, error) {
-	updates, _, _, err := refreshCandidates(st, nil, user)
+	updates, _, _, err := refreshCandidates(st, nil, user, nil)
 	return updates, err
 }
 
-func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
+func refreshCandidates(st *state.State, names []string, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
 	snapStates, err := All(st)
 	if err != nil {
 		return nil, nil, nil, err
@@ -612,7 +612,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState) ([
 	theStore := Store(st)
 
 	st.Unlock()
-	updates, err := theStore.ListRefresh(candidatesInfo, user, nil)
+	updates, err := theStore.ListRefresh(candidatesInfo, user, flags)
 	st.Lock()
 	if err != nil {
 		return nil, nil, nil, err
@@ -633,7 +633,7 @@ func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state
 		return nil, nil, err
 	}
 
-	updates, stateByID, ignoreValidation, err := refreshCandidates(st, names, user)
+	updates, stateByID, ignoreValidation, err := refreshCandidates(st, names, user, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -23,17 +23,14 @@ package snapstate
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
@@ -1755,34 +1752,4 @@ func ConfigDefaults(st *state.State, snapName string) (map[string]interface{}, e
 	}
 
 	return defaults, nil
-}
-
-func refreshCatalogs(st *state.State, theStore StoreService) error {
-	st.Unlock()
-	defer st.Lock()
-
-	if err := os.MkdirAll(dirs.SnapCacheDir, 0755); err != nil {
-		return fmt.Errorf("cannot create directory %q: %v", dirs.SnapCacheDir, err)
-	}
-
-	sections, err := theStore.Sections(nil)
-	if err != nil {
-		return err
-	}
-
-	sort.Strings(sections)
-	if err := osutil.AtomicWriteFile(dirs.SnapSectionsFile, []byte(strings.Join(sections, "\n")), 0644, 0); err != nil {
-		return err
-	}
-
-	namesFile, err := osutil.NewAtomicFile(dirs.SnapNamesFile, 0644, 0, -1, -1)
-	if err != nil {
-		return err
-	}
-	defer namesFile.Cancel()
-	if err := theStore.WriteCatalogs(namesFile); err != nil {
-		return err
-	}
-
-	return namesFile.Commit()
 }


### PR DESCRIPTION
The catalogRefresh is now moved into its own helper to minimize
the impact in snapmgr.go. The catalog refresh also got some
basic tests now.

Based on #4266 