### PR TITLE
timeutil: remove support to parse weekday schedules

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -5043,7 +5043,7 @@ func (s *snapmgrTestSuite) TestEnsureRefreshRefusesWeekdaySchedules(c *C) {
 	s.snapmgr.Ensure()
 	s.state.Lock()
 
-	c.Check(logbuf.String(), testutil.Contains, `cannot use refresh.schedule configuration: "mon@12:00-14:00" uses weekdays which is currently not supported`)
+	c.Check(logbuf.String(), testutil.Contains, `cannot use refresh.schedule configuration: cannot parse "mon@12:00-14:00": contains invalid @`)
 }
 
 func (s *snapmgrTestSuite) TestEnsureRefreshesNoUpdate(c *C) {

--- a/spread.yaml
+++ b/spread.yaml
@@ -379,7 +379,7 @@ restore: |
         # start and enable autorefresh
         if [ -e /snap/core/current/meta/hooks/configure ]; then
             systemctl enable --now snapd.refresh.timer
-            snap set core refresh.disabled=false
+            snap set core refresh.schedule=""
         fi
     fi
 

--- a/tests/main/auto-refresh/task.yaml
+++ b/tests/main/auto-refresh/task.yaml
@@ -5,10 +5,6 @@ prepare: |
 
 restore: |
     . "$TESTSLIB/dirs.sh"
-    if [ -e "$SNAP_MOUNT_DIR/core/current/meta/hooks/configure" ]; then
-        snap set core refresh.schedule="$(date +%a --date=2days)@12:00-14:00"
-        snap set core refresh.disabled=true
-    fi
 
 execute: |
     . "$TESTSLIB/dirs.sh"

--- a/timeutil/schedule.go
+++ b/timeutil/schedule.go
@@ -61,6 +61,8 @@ func ParseTime(s string) (t TimeOfDay, err error) {
 type Schedule struct {
 	Start TimeOfDay
 	End   TimeOfDay
+
+	Weekday string
 }
 
 func (sched *Schedule) String() string {
@@ -138,6 +140,16 @@ func Next(schedule []*Schedule, last time.Time) time.Duration {
 	when := a.Sub(now) + randDur(a, b)
 
 	return when
+}
+
+var weekdayMap = map[string]int{
+	"sun": 0,
+	"mon": 1,
+	"tue": 2,
+	"wed": 3,
+	"thu": 4,
+	"fri": 5,
+	"sat": 6,
 }
 
 // parseTimeInterval gets an input like "9:00-11:00"

--- a/timeutil/schedule.go
+++ b/timeutil/schedule.go
@@ -57,25 +57,18 @@ func ParseTime(s string) (t TimeOfDay, err error) {
 	return t, nil
 }
 
-// Schedule defines a start and end time and an optional weekday in which
-// events should run.
+// Schedule defines a start and end time in which events should run.
 type Schedule struct {
 	Start TimeOfDay
 	End   TimeOfDay
-
-	Weekday string
 }
 
 func (sched *Schedule) String() string {
-	if sched.Weekday == "" {
-		return fmt.Sprintf("%s-%s", sched.Start, sched.End)
-	}
-	return fmt.Sprintf("%s@%s-%s", sched.Weekday, sched.Start, sched.End)
+	return fmt.Sprintf("%s-%s", sched.Start, sched.End)
 }
 
 func (sched *Schedule) Next(last time.Time) (start, end time.Time) {
 	now := timeNow()
-	wd := time.Weekday(weekdayMap[sched.Weekday])
 
 	t := last
 	for {
@@ -86,10 +79,6 @@ func (sched *Schedule) Next(last time.Time) (start, end time.Time) {
 		// location is set
 		t = t.Add(24 * time.Hour)
 
-		// we have not hit the right day yet
-		if sched.Weekday != "" && a.Weekday() != wd {
-			continue
-		}
 		// same inteval as last update, move forward
 		if (last.Equal(a) || last.After(a)) && (last.Equal(b) || last.Before(b)) {
 			continue
@@ -151,36 +140,6 @@ func Next(schedule []*Schedule, last time.Time) time.Duration {
 	return when
 }
 
-var weekdayMap = map[string]int{
-	"sun": 0,
-	"mon": 1,
-	"tue": 2,
-	"wed": 3,
-	"thu": 4,
-	"fri": 5,
-	"sat": 6,
-}
-
-// parseWeekday gets an input like "mon@9:00-11:00" or "9:00-11:00"
-// and extracts the weekday of that schedule string (which can be
-// empty). It returns the remainder of the string, the weekday
-// and an error.
-func parseWeekday(s string) (weekday, rest string, err error) {
-	if !strings.Contains(s, "@") {
-		return "", s, nil
-	}
-	s = strings.ToLower(s)
-	l := strings.SplitN(s, "@", 2)
-	weekday = l[0]
-	_, ok := weekdayMap[weekday]
-	if !ok {
-		return "", "", fmt.Errorf(`cannot parse %q, want "mon", "tue", etc`, l[0])
-	}
-	rest = l[1]
-
-	return weekday, rest, nil
-}
-
 // parseTimeInterval gets an input like "9:00-11:00"
 // and extracts the start and end of that schedule string and
 // returns them and any errors.
@@ -211,19 +170,14 @@ func parseTimeInterval(s string) (start, end TimeOfDay, err error) {
 // parseSingleSchedule parses a schedule string like "mon@9:00-11:00" or
 // "9:00-11:00" and returns a Schedule struct and an error.
 func parseSingleSchedule(s string) (*Schedule, error) {
-	weekday, rest, err := parseWeekday(s)
-	if err != nil {
-		return nil, err
-	}
-	start, end, err := parseTimeInterval(rest)
+	start, end, err := parseTimeInterval(s)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Schedule{
-		Weekday: weekday,
-		Start:   start,
-		End:     end,
+		Start: start,
+		End:   end,
 	}, nil
 }
 


### PR DESCRIPTION
The current timeutil.ParseSchedule() code supports the notation of
running events at weekdays. However we are not supporting this in
snapstate at all and we are also reworking the schedule string to
follow a different (and incompatible) syntax. Therefor remove the
entire support.

The important part of this PR is that timeutil.ParseSchedule() and snapstate.checkRefreshSchedule() will give different results right now and that is confusing when corecfg is used to validate the schedule.