### PR TITLE
spread.yaml: bump delta ref to 2.29

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -31,7 +31,7 @@ environment:
     GADGET_CHANNEL: "$(HOST: echo ${SPREAD_GADGET_CHANNEL:-edge})"
     REMOTE_STORE: "$(HOST: echo ${SPREAD_REMOTE_STORE:-production})"
     SNAPPY_USE_STAGING_STORE: "$(HOST: if [ $SPREAD_REMOTE_STORE = staging ]; then echo 1; else echo 0; fi)"
-    DELTA_REF: 2.27
+    DELTA_REF: 2.29
     DELTA_PREFIX: snapd-$DELTA_REF/
     SNAPD_PUBLISHED_VERSION: "$(HOST: echo $SPREAD_SNAPD_PUBLISHED_VERSION)"
     HTTP_PROXY: "$(HOST: echo $SPREAD_HTTP_PROXY)"


### PR DESCRIPTION
Just a tiny bump to get smaller deltas when testing on Linode.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>