### PR TITLE
spread.yaml,tests: move most of project-wide prepare/restore to separate file

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -289,109 +289,13 @@ repack: |
 kill-timeout: 20m
 
 prepare: |
-    # check if running inside a container, the testsuite will not
-    # work in such an environment
-    if systemd-detect-virt -c; then
-        echo "Tests cannot run inside a container"
-        exit 1
-    fi
-    if [[ "$SPREAD_SYSTEM" == debian-unstable-* ]]; then
-        # There's a packaging bug in Debian sid lately where some packages
-        # conflict on manual page file. To work around it simply remove the
-        # manpages package.
-        apt-get remove --purge -y manpages
-    fi
-
-    # FIXME: remove once the following bug is fixed:
-    #   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=876128
-    if [[ "$SPREAD_SYSTEM" == debian-unstable-* ]]; then
-        # There's a packaging bug in Debian sid lately where some packages
-        # conflict on manual page file. To work around it simply remove the
-        # manpages package.
-        apt-get remove --purge -y manpages
-    fi
-
-    # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
-    cat <<EOF > gai.conf
-    precedence  ::1/128       50
-    precedence  ::/0          40
-    precedence  2002::/16     30
-    precedence ::/96          20
-    precedence ::ffff:0:0/96 100
-    EOF
-    if ! mv gai.conf /etc/gai.conf; then
-        echo "/etc/gai.conf is not writable, ubuntu-core system? apt update won't be affected in that case"
-        rm -f gai.conf
-    fi
-
-    # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
-    # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)
-    if [ -f current.delta ]; then
-        tf=$(mktemp)
-        # NOTE: We can't use tests/lib/pkgdb.sh here as it doesn't exist at
-        # this time when none of the test files is yet in place.
-        case "$SPREAD_SYSTEM" in
-            ubuntu-*|debian-*)
-                apt-get update >& "$tf" || ( cat "$tf"; exit 1 )
-                apt-get install -y xdelta3 curl >& "$tf" || ( cat "$tf"; exit 1 )
-                ;;
-            fedora-*)
-                dnf install --refresh -y xdelta curl &> "$tf" || (cat "$tf"; exit 1)
-                ;;
-            opensuse-*)
-                zypper -q install -y xdelta3 curl &> "$tf" || (cat "$tf"; exit 1)
-                ;;
-        esac
-        rm -f "$tf"
-        curl -sS -o - "https://codeload.github.com/snapcore/snapd/tar.gz/$DELTA_REF" | gunzip > delta-ref.tar
-        xdelta3 -q -d -s delta-ref.tar current.delta | tar x --strip-components=1
-        rm -f delta-ref.tar current.delta
-    elif [ -d "$DELTA_PREFIX" ]; then
-        find "$DELTA_PREFIX" -mindepth 1 -maxdepth 1 -exec mv {} . \;
-        rmdir "$DELTA_PREFIX"
-    fi
-
-    "$TESTSLIB"/prepare-project.sh
-
+    "$TESTSLIB"/prepare-restore.sh --prepare-project
 prepare-each: |
-    # systemd on 14.04 does not know about --rotate or --vacuum-time.
-    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
-        journalctl --rotate
-        sleep .1
-        journalctl --vacuum-time=1ms
-    else
-        # Force a log rotation with small size
-        sed -i.bak s/#SystemMaxUse=/SystemMaxUse=1K/g /etc/systemd/journald.conf
-        systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
-
-        # Restore the initial configuration and rotate logs
-        mv /etc/systemd/journald.conf.bak /etc/systemd/journald.conf
-        systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
-
-        # Remove rotated journal logs
-        systemctl stop systemd-journald.service
-        find /run/log/journal/ -name "*@*.journal" -delete
-        systemctl start systemd-journald.service
-    fi
-    dmesg -c > /dev/null
-
+    "$TESTSLIB"/prepare-restore.sh --prepare-project-each
 restore: |
-    if [ "$SPREAD_BACKEND" = external ]; then
-        # start and enable autorefresh
-        if [ -e /snap/core/current/meta/hooks/configure ]; then
-            systemctl enable --now snapd.refresh.timer
-            snap set core refresh.disabled=false
-        fi
-    fi
-
-    rm -f $SPREAD_PATH/snapd-state.tar.gz
-    rm -rf ${GOPATH%%:*}/*
-
+    "$TESTSLIB"/prepare-restore.sh --restore-project
 restore-each: |
-    if grep "invalid .*snap.*.rules" /var/log/syslog; then
-        echo "Invalid udev file detected, test most likely broke it"
-        exit 1
-    fi
+    "$TESTSLIB"/prepare-restore.sh --restore-project-each
 
 suites:
     tests/main/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -289,6 +289,53 @@ repack: |
 kill-timeout: 20m
 
 prepare: |
+    # NOTE: This part of the code needs to be in spread.yaml as it runs before
+    # the rest of the source code (including the tests/lib directory) is
+    # around. The purpose of this code is to fix some connectivity issues and
+    # then apply the delta of the git repository.
+
+    # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
+    cat <<EOF > gai.conf
+    precedence  ::1/128       50
+    precedence  ::/0          40
+    precedence  2002::/16     30
+    precedence ::/96          20
+    precedence ::ffff:0:0/96 100
+    EOF
+    if ! mv gai.conf /etc/gai.conf; then
+        echo "/etc/gai.conf is not writable, ubuntu-core system? apt update won't be affected in that case"
+        rm -f gai.conf
+    fi
+
+    # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
+    # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)
+    if [ -f current.delta ]; then
+        tf=$(mktemp)
+        # NOTE: We can't use tests/lib/pkgdb.sh here as it doesn't exist at
+        # this time when none of the test files is yet in place.
+        case "$SPREAD_SYSTEM" in
+            ubuntu-*|debian-*)
+                apt-get update >& "$tf" || ( cat "$tf"; exit 1 )
+                apt-get install -y xdelta3 curl >& "$tf" || ( cat "$tf"; exit 1 )
+                ;;
+            fedora-*)
+                dnf install --refresh -y xdelta curl &> "$tf" || (cat "$tf"; exit 1)
+                ;;
+            opensuse-*)
+                zypper -q install -y xdelta3 curl &> "$tf" || (cat "$tf"; exit 1)
+                ;;
+        esac
+        rm -f "$tf"
+        curl -sS -o - "https://codeload.github.com/snapcore/snapd/tar.gz/$DELTA_REF" | gunzip > delta-ref.tar
+        xdelta3 -q -d -s delta-ref.tar current.delta | tar x --strip-components=1
+        rm -f delta-ref.tar current.delta
+    elif [ -d "$DELTA_PREFIX" ]; then
+        find "$DELTA_PREFIX" -mindepth 1 -maxdepth 1 -exec mv {} . \;
+        rmdir "$DELTA_PREFIX"
+    fi
+
+    # NOTE: At this stage the source tree is available and no more special
+    # considerations apply.
     "$TESTSLIB"/prepare-restore.sh --prepare-project
 prepare-each: |
     "$TESTSLIB"/prepare-restore.sh --prepare-project-each

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -106,7 +106,9 @@ restore_project() {
     fi
 
     rm -f "$SPREAD_PATH/snapd-state.tar.gz"
-    rm -rf ${GOPATH%%:*}/*
+    if [ -n "$GOPATH" ]; then
+        rm -rf "${GOPATH%%:*}"
+    fi
 }
 
 case "$1" in

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+prepare_project() {
+    true
+}
+
+prepare_project_each() {
+    true
+}
+
+restore_project_each() {
+    true
+}
+
+restore_project() {
+    true
+}
+
+case "$1" in
+    --prepare-project)
+        prepare_project
+        ;;
+    --prepare-project-each)
+        prepare_project_each
+        ;;
+    --restore-project-each)
+        restore_project_each
+        ;;
+    --restore-project)
+        restore_project
+        ;;
+    *)
+        echo "unsupported argument: $1"
+        echo "try one of --{prepare,restore}-project{,-each}"
+        exit 1
+        ;;
+esac

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -105,7 +105,7 @@ restore_project() {
         fi
     fi
 
-    rm -f $SPREAD_PATH/snapd-state.tar.gz
+    rm -f "$SPREAD_PATH/snapd-state.tar.gz"
     rm -rf ${GOPATH%%:*}/*
 }
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -8,15 +8,6 @@ prepare_project() {
         exit 1
     fi
 
-    # FIXME: remove once the following bug is fixed:
-    #   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=876128
-    if [[ "$SPREAD_SYSTEM" == debian-unstable-* ]]; then
-        # There's a packaging bug in Debian sid lately where some packages
-        # conflict on manual page file. To work around it simply remove the
-        # manpages package.
-        apt-get remove --purge -y manpages
-    fi
-
     # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
     cat <<EOF > gai.conf
 precedence  ::1/128       50

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -1,19 +1,112 @@
 #!/bin/bash
 
 prepare_project() {
-    true
+    # check if running inside a container, the testsuite will not
+    # work in such an environment
+    if systemd-detect-virt -c; then
+        echo "Tests cannot run inside a container"
+        exit 1
+    fi
+    if [[ "$SPREAD_SYSTEM" == debian-unstable-* ]]; then
+        # There's a packaging bug in Debian sid lately where some packages
+        # conflict on manual page file. To work around it simply remove the
+        # manpages package.
+        apt-get remove --purge -y manpages
+    fi
+
+    # FIXME: remove once the following bug is fixed:
+    #   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=876128
+    if [[ "$SPREAD_SYSTEM" == debian-unstable-* ]]; then
+        # There's a packaging bug in Debian sid lately where some packages
+        # conflict on manual page file. To work around it simply remove the
+        # manpages package.
+        apt-get remove --purge -y manpages
+    fi
+
+    # apt update is hanging on security.ubuntu.com with IPv6, prefer IPv4 over IPv6
+    cat <<EOF > gai.conf
+precedence  ::1/128       50
+precedence  ::/0          40
+precedence  2002::/16     30
+precedence ::/96          20
+precedence ::ffff:0:0/96 100
+EOF
+    if ! mv gai.conf /etc/gai.conf; then
+        echo "/etc/gai.conf is not writable, ubuntu-core system? apt update won't be affected in that case"
+        rm -f gai.conf
+    fi
+
+    # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
+    # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)
+    if [ -f current.delta ]; then
+        tf=$(mktemp)
+        # NOTE: We can't use tests/lib/pkgdb.sh here as it doesn't exist at
+        # this time when none of the test files is yet in place.
+        case "$SPREAD_SYSTEM" in
+            ubuntu-*|debian-*)
+                apt-get update >& "$tf" || ( cat "$tf"; exit 1 )
+                apt-get install -y xdelta3 curl >& "$tf" || ( cat "$tf"; exit 1 )
+                ;;
+            fedora-*)
+                dnf install --refresh -y xdelta curl &> "$tf" || (cat "$tf"; exit 1)
+                ;;
+            opensuse-*)
+                zypper -q install -y xdelta3 curl &> "$tf" || (cat "$tf"; exit 1)
+                ;;
+        esac
+        rm -f "$tf"
+        curl -sS -o - "https://codeload.github.com/snapcore/snapd/tar.gz/$DELTA_REF" | gunzip > delta-ref.tar
+        xdelta3 -q -d -s delta-ref.tar current.delta | tar x --strip-components=1
+        rm -f delta-ref.tar current.delta
+    elif [ -d "$DELTA_PREFIX" ]; then
+        find "$DELTA_PREFIX" -mindepth 1 -maxdepth 1 -exec mv {} . \;
+        rmdir "$DELTA_PREFIX"
+    fi
+
+    "$TESTSLIB"/prepare-project.sh
 }
 
 prepare_project_each() {
-    true
+    # systemd on 14.04 does not know about --rotate or --vacuum-time.
+    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
+        journalctl --rotate
+        sleep .1
+        journalctl --vacuum-time=1ms
+    else
+        # Force a log rotation with small size
+        sed -i.bak s/#SystemMaxUse=/SystemMaxUse=1K/g /etc/systemd/journald.conf
+        systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
+
+        # Restore the initial configuration and rotate logs
+        mv /etc/systemd/journald.conf.bak /etc/systemd/journald.conf
+        systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
+
+        # Remove rotated journal logs
+        systemctl stop systemd-journald.service
+        find /run/log/journal/ -name "*@*.journal" -delete
+        systemctl start systemd-journald.service
+    fi
+    dmesg -c > /dev/null
 }
 
 restore_project_each() {
-    true
+    if grep "invalid .*snap.*.rules" /var/log/syslog; then
+        echo "Invalid udev file detected, test most likely broke it"
+        exit 1
+    fi
 }
 
 restore_project() {
-    true
+    if [ "$SPREAD_BACKEND" = external ]; then
+        # start and enable autorefresh
+        if [ -e /snap/core/current/meta/hooks/configure ]; then
+            systemctl enable --now snapd.refresh.timer
+            snap set core refresh.disabled=false
+        fi
+    fi
+
+    rm -f $SPREAD_PATH/snapd-state.tar.gz
+    rm -rf ${GOPATH%%:*}/*
 }
 
 case "$1" in

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 prepare_project() {
-    # check if running inside a container, the testsuite will not
-    # work in such an environment
+    # Check if running inside a container.
+    # The testsuite will not work in such an environment
     if systemd-detect-virt -c; then
         echo "Tests cannot run inside a container"
         exit 1

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -7,12 +7,6 @@ prepare_project() {
         echo "Tests cannot run inside a container"
         exit 1
     fi
-    if [[ "$SPREAD_SYSTEM" == debian-unstable-* ]]; then
-        # There's a packaging bug in Debian sid lately where some packages
-        # conflict on manual page file. To work around it simply remove the
-        # manpages package.
-        apt-get remove --purge -y manpages
-    fi
 
     # FIXME: remove once the following bug is fixed:
     #   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=876128


### PR DESCRIPTION
This branch contains a small refactor of the project-wide prepare/restore code.
Apart from moving most of the code to a dedicated, shellchecked file there
are some trivial cleanups (e.g. one for Debian that is no longer needed) and fixes.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>