### PR TITLE
tests: document and slightly refactor prepare/restore code

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -56,12 +56,10 @@ restore_project_each() {
 }
 
 restore_project() {
-    if [ "$SPREAD_BACKEND" = external ]; then
-        # start and enable autorefresh
-        if [ -e /snap/core/current/meta/hooks/configure ]; then
-            systemctl enable --now snapd.refresh.timer
-            snap set core refresh.schedule=""
-        fi
+    # XXX: Why are we enabling autorefresh for external targets?
+    if [ "$SPREAD_BACKEND" = external ] && [ -e /snap/core/current/meta/hooks/configure ]; then
+        systemctl enable --now snapd.refresh.timer
+        snap set core refresh.schedule=""
     fi
 
     rm -f "$SPREAD_PATH/snapd-state.tar.gz"

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -45,6 +45,10 @@ prepare_project_each() {
 }
 
 restore_project_each() {
+    # Udev rules are notoriously hard to write and seemingly correct but subtly
+    # wrong rules can pass review. Whenever that happens udev logs an error
+    # message. As a last resort from lack of a better mechanism we can try to
+    # pick up such errors.
     if grep "invalid .*snap.*.rules" /var/log/syslog; then
         echo "Invalid udev file detected, test most likely broke it"
         exit 1

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -62,7 +62,14 @@ restore_project() {
         snap set core refresh.schedule=""
     fi
 
+    # We use a trick to accelerate prepare/restore code in certain suites. That
+    # code uses a tarball to store the vanilla state. Here we just remove this
+    # tarball.
     rm -f "$SPREAD_PATH/snapd-state.tar.gz"
+
+    # Remove all of the code we pushed and any build results. This removes
+    # stale files and we cannot do incremental builds anyway so there's little
+    # point in keeping them.
     if [ -n "$GOPATH" ]; then
         rm -rf "${GOPATH%%:*}"
     fi


### PR DESCRIPTION
This branch contains assorted cleanups to the prepare/restore code. I'd suggest looking at each patch separately for details.