### PR TITLE
osutil/user: replace our uses of os/user and filepath.Glob("/home/*")

### DIFF
--- a/asserts/gpgkeypairmgr.go
+++ b/asserts/gpgkeypairmgr.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/snapcore/snapd/osutil"
@@ -38,19 +37,11 @@ func ensureGPGHomeDirectory() (string, error) {
 		return "", err
 	}
 
-	uid, err := strconv.Atoi(real.Uid)
-	if err != nil {
-		return "", err
-	}
-
-	gid, err := strconv.Atoi(real.Gid)
-	if err != nil {
-		return "", err
-	}
+	uid, gid := real.UID(), real.GID()
 
 	homedir := os.Getenv("SNAP_GNUPG_HOME")
 	if homedir == "" {
-		homedir = filepath.Join(real.HomeDir, ".snap", "gnupg")
+		homedir = filepath.Join(real.Home(), ".snap", "gnupg")
 	}
 
 	if err := osutil.MkdirAllChown(homedir, 0700, uid, gid); err != nil {

--- a/client/login.go
+++ b/client/login.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/snapcore/snapd/osutil"
 )
@@ -99,7 +98,8 @@ func storeAuthDataFilename(homeDir string) string {
 		if err != nil {
 			panic(err)
 		}
-		homeDir = real.HomeDir
+
+		homeDir = real.Home()
 	}
 
 	return filepath.Join(homeDir, ".snap", "auth.json")
@@ -112,17 +112,8 @@ func writeAuthData(user User) error {
 		return err
 	}
 
-	uid, err := strconv.Atoi(real.Uid)
-	if err != nil {
-		return err
-	}
-
-	gid, err := strconv.Atoi(real.Gid)
-	if err != nil {
-		return err
-	}
-
-	targetFile := storeAuthDataFilename(real.HomeDir)
+	uid, gid := real.UID(), real.GID()
+	targetFile := storeAuthDataFilename(real.Home())
 
 	if err := osutil.MkdirAllChown(filepath.Dir(targetFile), 0700, uid, gid); err != nil {
 		return err

--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -142,6 +142,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"regexp"
 	"strconv"
@@ -651,7 +652,7 @@ func compile(content []byte, out string) error {
 	}
 
 	// write atomically
-	fout, err := osutil.NewAtomicFile(out, 0644, 0, -1, -1)
+	fout, err := osutil.NewAtomicFile(out, 0644, 0, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return err
 	}
@@ -672,7 +673,11 @@ func findUid(username string) (uint64, error) {
 	if !userGroupNamePattern.MatchString(username) {
 		return 0, fmt.Errorf("%q must be a valid username", username)
 	}
-	return osutil.FindUid(username)
+	uid, err := osutil.FindUid(username)
+	if err != nil {
+		return math.MaxUint64, err
+	}
+	return uint64(uid), nil
 }
 
 // findGid returns the identifier of the given UNIX group name.
@@ -680,7 +685,11 @@ func findGid(group string) (uint64, error) {
 	if !userGroupNamePattern.MatchString(group) {
 		return 0, fmt.Errorf("%q must be a valid group name", group)
 	}
-	return osutil.FindGid(group)
+	gid, err := osutil.FindGid(group)
+	if err != nil {
+		return math.MaxUint64, err
+	}
+	return uint64(gid), nil
 }
 
 func showSeccompLibraryVersion() error {

--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -559,7 +559,7 @@ func (s *snapSeccompSuite) TestCompileBadInput(c *C) {
 		{"setuid u:b@d|npu+", `cannot parse line: cannot parse token "u:b@d|npu+" \(line "setuid u:b@d|npu+"\): "b@d|npu+" must be a valid username`},
 		{"setuid u:snap.bad", `cannot parse line: cannot parse token "u:snap.bad" \(line "setuid u:snap.bad"\): "snap.bad" must be a valid username`},
 		{"setuid U:root", `cannot parse line: cannot parse token "U:root" .*`},
-		{"setuid u:nonexistent", `cannot parse line: cannot parse token "u:nonexistent" \(line "setuid u:nonexistent"\): user: unknown user nonexistent`},
+		{"setuid u:nonexistent", `cannot parse line: cannot parse token "u:nonexistent" \(line "setuid u:nonexistent"\): user not found`},
 		// g:<groupname>
 		{"setgid g:", `cannot parse line: cannot parse token "g:" \(line "setgid g:"\): "" must be a valid group name`},
 		{"setgid g:0", `cannot parse line: cannot parse token "g:0" \(line "setgid g:0"\): "0" must be a valid group name`},

--- a/cmd/snap-update-ns/entry.go
+++ b/cmd/snap-update-ns/entry.go
@@ -54,10 +54,11 @@ func XSnapdMode(e *mount.Entry) (os.FileMode, error) {
 // XSnapdUID returns the user associated with x-snapd-user mount option.  If
 // the mode is not specified explicitly then a default "root" use is
 // returned.
-func XSnapdUID(e *mount.Entry) (uid uint64, err error) {
+func XSnapdUID(e *mount.Entry) (uid uint32, err error) {
 	if opt, ok := e.OptStr("x-snapd.uid"); ok {
 		if !validUserGroupRe.MatchString(opt) {
-			return math.MaxUint64, fmt.Errorf("cannot parse user name %q", opt)
+			// math.MaxUint32 is user.FlagID
+			return math.MaxUint32, fmt.Errorf("cannot parse user name %q", opt)
 		}
 		// Try to parse a numeric ID first.
 		if n, err := fmt.Sscanf(opt, "%d", &uid); n == 1 && err == nil {
@@ -66,7 +67,7 @@ func XSnapdUID(e *mount.Entry) (uid uint64, err error) {
 		// Fall-back to system name lookup.
 		if uid, err = osutil.FindUid(opt); err != nil {
 			// The error message from FindUid is not very useful so just skip it.
-			return math.MaxUint64, fmt.Errorf("cannot resolve user name %q", opt)
+			return math.MaxUint32, fmt.Errorf("cannot resolve user name %q", opt)
 		}
 		return uid, nil
 	}
@@ -76,10 +77,10 @@ func XSnapdUID(e *mount.Entry) (uid uint64, err error) {
 // XSnapdGID returns the user associated with x-snapd-user mount option.  If
 // the mode is not specified explicitly then a default "root" use is
 // returned.
-func XSnapdGID(e *mount.Entry) (gid uint64, err error) {
+func XSnapdGID(e *mount.Entry) (gid uint32, err error) {
 	if opt, ok := e.OptStr("x-snapd.gid"); ok {
 		if !validUserGroupRe.MatchString(opt) {
-			return math.MaxUint64, fmt.Errorf("cannot parse group name %q", opt)
+			return math.MaxUint32, fmt.Errorf("cannot parse group name %q", opt)
 		}
 		// Try to parse a numeric ID first.
 		if n, err := fmt.Sscanf(opt, "%d", &gid); n == 1 && err == nil {
@@ -88,7 +89,7 @@ func XSnapdGID(e *mount.Entry) (gid uint64, err error) {
 		// Fall-back to system name lookup.
 		if gid, err = osutil.FindGid(opt); err != nil {
 			// The error message from FindGid is not very useful so just skip it.
-			return math.MaxUint64, fmt.Errorf("cannot resolve group name %q", opt)
+			return math.MaxUint32, fmt.Errorf("cannot resolve group name %q", opt)
 		}
 		return gid, nil
 	}

--- a/cmd/snap-update-ns/entry_test.go
+++ b/cmd/snap-update-ns/entry_test.go
@@ -71,7 +71,7 @@ func (s *entrySuite) TestXSnapdUID(c *C) {
 	e := &mount.Entry{}
 	uid, err := update.XSnapdUID(e)
 	c.Assert(err, IsNil)
-	c.Assert(uid, Equals, uint64(0))
+	c.Assert(uid, Equals, uint32(0))
 
 	// User is parsed from the x-snapd.uid= option.
 	nobodyUID, err := osutil.FindUid("nobody")
@@ -85,19 +85,19 @@ func (s *entrySuite) TestXSnapdUID(c *C) {
 	e = &mount.Entry{Options: []string{"x-snapd.uid=123"}}
 	uid, err = update.XSnapdUID(e)
 	c.Assert(err, IsNil)
-	c.Assert(uid, Equals, uint64(123))
+	c.Assert(uid, Equals, uint32(123))
 
 	// Unknown user names are invalid.
 	e = &mount.Entry{Options: []string{"x-snapd.uid=bogus"}}
 	uid, err = update.XSnapdUID(e)
 	c.Assert(err, ErrorMatches, `cannot resolve user name "bogus"`)
-	c.Assert(uid, Equals, uint64(math.MaxUint64))
+	c.Assert(uid, Equals, uint32(math.MaxUint32))
 
 	// And even valid values with trailing garbage.
 	e = &mount.Entry{Options: []string{"x-snapd.uid=0bogus"}}
 	uid, err = update.XSnapdUID(e)
 	c.Assert(err, ErrorMatches, `cannot parse user name "0bogus"`)
-	c.Assert(uid, Equals, uint64(math.MaxUint64))
+	c.Assert(uid, Equals, uint32(math.MaxUint32))
 }
 
 func (s *entrySuite) TestXSnapdGID(c *C) {
@@ -105,11 +105,11 @@ func (s *entrySuite) TestXSnapdGID(c *C) {
 	e := &mount.Entry{}
 	gid, err := update.XSnapdGID(e)
 	c.Assert(err, IsNil)
-	c.Assert(gid, Equals, uint64(0))
+	c.Assert(gid, Equals, uint32(0))
 
 	// Group is parsed from the x-snapd-group= option.
 	var nogroup string
-	var nogroupGID uint64
+	var nogroupGID uint32
 	// try to cover differences between distributions and find a suitable
 	// 'nogroup' like group, eg. Ubuntu uses 'nogroup' while Arch uses
 	// 'nobody'
@@ -134,19 +134,19 @@ func (s *entrySuite) TestXSnapdGID(c *C) {
 	e = &mount.Entry{Options: []string{"x-snapd.gid=456"}}
 	gid, err = update.XSnapdGID(e)
 	c.Assert(err, IsNil)
-	c.Assert(gid, Equals, uint64(456))
+	c.Assert(gid, Equals, uint32(456))
 
 	// Unknown group names are invalid.
 	e = &mount.Entry{Options: []string{"x-snapd.gid=bogus"}}
 	gid, err = update.XSnapdGID(e)
 	c.Assert(err, ErrorMatches, `cannot resolve group name "bogus"`)
-	c.Assert(gid, Equals, uint64(math.MaxUint64))
+	c.Assert(gid, Equals, uint32(math.MaxUint32))
 
 	// And even valid values with trailing garbage.
 	e = &mount.Entry{Options: []string{"x-snapd.gid=0bogus"}}
 	gid, err = update.XSnapdGID(e)
 	c.Assert(err, ErrorMatches, `cannot parse group name "0bogus"`)
-	c.Assert(gid, Equals, uint64(math.MaxUint64))
+	c.Assert(gid, Equals, uint32(math.MaxUint32))
 }
 
 func (s *entrySuite) TestXSnapdEntryID(c *C) {

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -36,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapenv"
 	"github.com/snapcore/snapd/x11"
@@ -184,7 +184,7 @@ func getSnapInfo(snapName string, revision snap.Revision) (*snap.Info, error) {
 
 func createOrUpdateUserDataSymlink(info *snap.Info, usr *user.User) error {
 	// 'current' symlink for user data (SNAP_USER_DATA)
-	userData := info.UserDataDir(usr.HomeDir)
+	userData := info.UserDataDir(usr.Home())
 	wantedSymlinkValue := filepath.Base(userData)
 	currentActiveSymlink := filepath.Join(userData, "..", "current")
 
@@ -233,8 +233,8 @@ func createUserDataDirs(info *snap.Info) error {
 	}
 
 	// see snapenv.User
-	userData := info.UserDataDir(usr.HomeDir)
-	commonUserData := info.UserCommonDataDir(usr.HomeDir)
+	userData := info.UserDataDir(usr.Home())
+	commonUserData := info.UserCommonDataDir(usr.Home())
 	for _, d := range []string{userData, commonUserData} {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			// TRANSLATORS: %q is the directory whose creation failed, %v the error message
@@ -298,7 +298,7 @@ func migrateXauthority(info *snap.Info) (string, error) {
 
 	// If our target directory (XDG_RUNTIME_DIR) doesn't exist we
 	// don't attempt to create it.
-	baseTargetDir := filepath.Join(dirs.XdgRuntimeDirBase, u.Uid)
+	baseTargetDir := filepath.Join(dirs.XdgRuntimeDirBase, strconv.FormatUint(uint64(u.UID()), 10))
 	if !osutil.FileExists(baseTargetDir) {
 		return "", nil
 	}
@@ -359,11 +359,8 @@ func migrateXauthority(info *snap.Info) (string, error) {
 	if sys == nil {
 		return "", fmt.Errorf(i18n.G("cannot validate owner of file %s"), fin.Name())
 	}
-	// cheap comparison as the current uid is only available as a string
-	// but it is better to convert the uid from the stat result to a
-	// string than a string into a number.
-	if fmt.Sprintf("%d", sys.(*syscall.Stat_t).Uid) != u.Uid {
-		return "", fmt.Errorf(i18n.G("Xauthority file isn't owned by the current user %s"), u.Uid)
+	if sys.(*syscall.Stat_t).Uid != u.UID() {
+		return "", fmt.Errorf(i18n.G("Xauthority file isn't owned by the current user %d"), u.UID())
 	}
 
 	targetPath := filepath.Join(baseTargetDir, ".Xauthority")

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"go/doc"
 	"os"
-	"os/user"
 	"strings"
 
 	"golang.org/x/crypto/ssh/terminal"
@@ -33,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/user"
 )
 
 var errorPrefix = i18n.G("error: %v\n")
@@ -141,8 +141,7 @@ If you understand and want to proceed repeat the command including --classic.
 `)
 	case client.ErrorKindLoginRequired:
 		usesSnapName = false
-		u, _ := user.Current()
-		if u != nil && u.Username == "root" {
+		if user.Geteuid() == 0 {
 			// TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 			msg = fmt.Sprintf(i18n.G(`%s (see "snap login --help")`), err.Message)
 		} else {

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -20,11 +20,11 @@
 package main
 
 import (
-	"os/user"
 	"time"
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/store"
 )

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -36,7 +36,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"os/user"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -57,6 +56,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -4655,7 +4655,7 @@ func (s *postCreateUserSuite) TearDownTest(c *check.C) {
 	s.apiBaseSuite.TearDownTest(c)
 
 	postCreateUserUcrednetGet = ucrednetGet
-	userLookup = user.Lookup
+	userLookup = user.FromName
 	osutilAddUser = osutil.AddUser
 	storeUserInfo = store.UserInfo
 }
@@ -4663,9 +4663,7 @@ func (s *postCreateUserSuite) TearDownTest(c *check.C) {
 func mkUserLookup(userHomeDir string) func(string) (*user.User, error) {
 	return func(username string) (*user.User, error) {
 		cur, err := user.Current()
-		cur.Username = username
-		cur.HomeDir = userHomeDir
-		return cur, err
+		return user.Fake(username, userHomeDir, cur.UID(), cur.GID()), err
 	}
 }
 

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -38,7 +38,6 @@ var (
 
 	SnapBlobDir               string
 	SnapDataDir               string
-	SnapDataHomeGlob          string
 	SnapDownloadCacheDir      string
 	SnapAppArmorDir           string
 	AppArmorCacheDir          string
@@ -108,6 +107,8 @@ const (
 	// are in the snap confinement environment.
 	CoreLibExecDir   = "/usr/lib/snapd"
 	CoreSnapMountDir = "/snap"
+
+	SnapDataHome = "snap"
 )
 
 var (
@@ -174,7 +175,6 @@ func SetRootDir(rootdir string) {
 	}
 
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
-	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/snap/")
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	SnapConfineAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "snap-confine")
 	AppArmorCacheDir = filepath.Join(rootdir, "/var/cache/apparmor")
@@ -236,7 +236,6 @@ func SetRootDir(rootdir string) {
 	}
 
 	XdgRuntimeDirBase = filepath.Join(rootdir, "/run/user")
-	XdgRuntimeDirGlob = filepath.Join(rootdir, XdgRuntimeDirBase, "*/")
 
 	CompletionHelper = filepath.Join(CoreLibExecDir, "etelpmoc.sh")
 	CompletersDir = filepath.Join(rootdir, "/usr/share/bash-completion/completions/")

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -34,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -869,7 +869,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyError5(c *C) {
 	// This test cannot run as root as root bypassed DAC checks.
 	u, err := user.Current()
 	c.Assert(err, IsNil)
-	if u.Uid == "0" {
+	if u.UID() == 0 {
 		c.Skip("this test cannot run as root")
 	}
 

--- a/interfaces/builtin/account_control.go
+++ b/interfaces/builtin/account_control.go
@@ -89,7 +89,7 @@ func makeAccountControlSecCompSnippet() (string, error) {
 	}
 
 	snippet := strings.Replace(accountControlConnectedPlugSecCompTemplate,
-		"{{group}}", strconv.FormatUint(gid, 10), -1)
+		"{{group}}", strconv.FormatUint(uint64(gid), 10), -1)
 
 	return snippet, nil
 }

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -23,9 +23,10 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"os/user"
 	"syscall"
 	"time"
+
+	"github.com/snapcore/snapd/osutil/user"
 )
 
 func MockUserLookup(mock func(name string) (*user.User, error)) func() {
@@ -85,7 +86,7 @@ func WaitingReaderGuts(r io.Reader) (io.Reader, *exec.Cmd) {
 	return wr.reader, wr.cmd
 }
 
-func MockChown(f func(*os.File, int, int) error) func() {
+func MockChown(f func(*os.File, uint32, uint32) error) func() {
 	oldChown := chown
 	chown = f
 	return func() {

--- a/osutil/fshelpers.go
+++ b/osutil/fshelpers.go
@@ -24,7 +24,7 @@ import (
 )
 
 // FindGidOwning obtains UNIX group ID and name owning file `path`.
-func FindGidOwning(path string) (uint64, error) {
+func FindGidOwning(path string) (uint32, error) {
 	var stat syscall.Stat_t
 	if err := syscall.Stat(path, &stat); err != nil {
 		if err == syscall.ENOENT {
@@ -33,6 +33,5 @@ func FindGidOwning(path string) (uint64, error) {
 		return 0, err
 	}
 
-	gid := uint64(stat.Gid)
-	return gid, nil
+	return stat.Gid, nil
 }

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -177,19 +177,11 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) 
 	c.Assert(err, ErrorMatches, "open .*: file exists")
 }
 
-func (ts *AtomicWriteTestSuite) TestAtomicFileUidGidError(c *C) {
-	d := c.MkDir()
-	p := filepath.Join(d, "foo")
-
-	_, err := osutil.NewAtomicFile(p, 0644, 0, -1, 1)
-	c.Check(err, ErrorMatches, ".*needs none or both of uid and gid set")
-}
-
 func (ts *AtomicWriteTestSuite) TestAtomicFileChownError(c *C) {
-	eUid := 42
-	eGid := 74
+	eUid := uint32(42)
+	eGid := uint32(74)
 	eErr := errors.New("this didn't work")
-	defer osutil.MockChown(func(fd *os.File, uid int, gid int) error {
+	defer osutil.MockChown(func(fd *os.File, uid uint32, gid uint32) error {
 		c.Check(uid, Equals, eUid)
 		c.Check(gid, Equals, eGid)
 		return eErr
@@ -211,7 +203,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileChownError(c *C) {
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancelError(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, -1, -1)
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 
 	c.Assert(aw.File.Close(), IsNil)
@@ -222,7 +214,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancelError(c *C) {
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancelBadError(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, -1, -1)
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	defer aw.Close()
 
@@ -234,7 +226,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancelBadError(c *C) {
 func (ts *AtomicWriteTestSuite) TestAtomicFileCancelNoClose(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, -1, -1)
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	c.Assert(aw.Close(), IsNil)
 
@@ -245,7 +237,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancel(c *C) {
 	d := c.MkDir()
 	p := filepath.Join(d, "foo")
 
-	aw, err := osutil.NewAtomicFile(p, 0644, 0, -1, -1)
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	fn := aw.File.Name()
 	c.Check(osutil.FileExists(fn), Equals, true)

--- a/osutil/mkdirallchown.go
+++ b/osutil/mkdirallchown.go
@@ -23,11 +23,13 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/snapcore/snapd/osutil/user"
 )
 
 // MkdirAllChown is like os.MkdirAll but it calls os.Chown on any
 // directories it creates.
-func MkdirAllChown(path string, perm os.FileMode, uid, gid int) error {
+func MkdirAllChown(path string, perm os.FileMode, uid, gid uint32) error {
 	if s, err := os.Stat(path); err == nil {
 		if s.IsDir() {
 			return nil
@@ -54,7 +56,7 @@ func MkdirAllChown(path string, perm os.FileMode, uid, gid int) error {
 		return err
 	}
 
-	if err := os.Chown(cand, uid, gid); err != nil {
+	if err := user.ChownPath(cand, uid, gid); err != nil {
 		return err
 	}
 

--- a/osutil/user/export_test.go
+++ b/osutil/user/export_test.go
@@ -17,34 +17,12 @@
  *
  */
 
-package osutil
+package user
 
-import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
-	. "gopkg.in/check.v1"
-)
-
-type groupFindGidOwningSuite struct{}
-
-var _ = Suite(&groupFindGidOwningSuite{})
-
-func (s *groupFindGidOwningSuite) TestSelfOwnedFile(c *C) {
-	name := filepath.Join(c.MkDir(), "testownedfile")
-	err := ioutil.WriteFile(name, nil, 0644)
-	c.Assert(err, IsNil)
-
-	gid, err := FindGidOwning(name)
-	c.Check(err, IsNil)
-
-	self, err := RealUser()
-	c.Assert(err, IsNil)
-	c.Check(gid, Equals, self.GID())
+func Shells() []string {
+	return shells
 }
 
-func (s *groupFindGidOwningSuite) TestNoOwnedFile(c *C) {
-	_, err := FindGidOwning("/tmp/filedoesnotexistbutwhy")
-	c.Assert(err, DeepEquals, os.ErrNotExist)
+func Passwds() []string {
+	return passwds
 }

--- a/osutil/user/syscall.go
+++ b/osutil/user/syscall.go
@@ -1,0 +1,84 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package user
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// uid_t is an unsigned 32-bit integer in linux right now.
+// so syscall.Gete?[ug]id are wrong, and break in 32 bits
+// (see https://github.com/golang/go/issues/22739)
+func Getuid() uint32 {
+	return getid(syscall.SYS_GETUID)
+}
+
+func Geteuid() uint32 {
+	return getid(syscall.SYS_GETEUID)
+}
+
+func Getgid() uint32 {
+	return getid(syscall.SYS_GETGID)
+}
+
+// FlagID can be passed to chown-ish functions to mean "no change",
+// and can be returned from getuid-ish functions to mean "not found".
+const FlagID = uint32(0xffffffff)
+
+func getid(id uintptr) uint32 {
+	r0, _, errno := syscall.RawSyscall(id, 0, 0, 0)
+	if errno != 0 {
+		// -1 is used as a flag to mean 'no change' to chown(2), so it's safe
+		// to use as a flag for ourselves as well.
+		return FlagID
+	}
+	return uint32(r0)
+}
+
+func Chown(f *os.File, uid, gid uint32) error {
+	return Fchown(f.Fd(), uid, gid)
+}
+
+func Fchown(fd uintptr, uid, gid uint32) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_FCHOWN, fd, uintptr(uid), uintptr(gid))
+	if errno == 0 {
+		return nil
+	}
+	return errno
+}
+
+func ChownPath(path string, uid, gid uint32) error {
+	AT_FDCWD := -0x64
+	return FchownAt(uintptr(AT_FDCWD), path, uid, gid, 0)
+}
+
+func FchownAt(dirfd uintptr, path string, uid uint32, gid uint32, flags int) error {
+	p0, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	_, _, errno := syscall.Syscall6(syscall.SYS_FCHOWNAT, dirfd, uintptr(unsafe.Pointer(p0)), uintptr(uid), uintptr(gid), uintptr(flags), 0)
+	if errno == 0 {
+		return nil
+	}
+	return errno
+}

--- a/osutil/user/user.go
+++ b/osutil/user/user.go
@@ -1,0 +1,280 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// osutil.user implements a local user lookup and iteration module.
+//
+// Right now it's very dumb, and will not be happy on systems with a
+// lot of users. These things will get fixed, but the API this exposes
+// should survive that fix.
+package user
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/strutil"
+)
+
+var minUserUID uint32
+var shells = []string{"/bin/sh"}
+
+func init() {
+	Init()
+}
+
+func Init() {
+	// any others?
+	if release.DistroLike("fedora") {
+		minUserUID = 500
+	} else {
+		minUserUID = 1000
+	}
+
+	if f, err := os.Open(filepath.Join(dirs.GlobalRootDir, "/etc/shells")); err == nil {
+		defer f.Close()
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := bytes.TrimSpace(scanner.Bytes())
+			if len(line) == 0 || line[0] == '#' {
+				continue
+			}
+			shells = append(shells, string(line))
+		}
+	}
+
+	me, meErr = FromUID(Getuid())
+}
+
+// IsNonSystem is a filter that will return true only if the given
+// user is not a "system" user. The exact meaning of this is
+// backend-dependent, but in general system users aren't 'people'.
+func IsNonSystem(u *User) bool {
+	return !u.isSystemUser()
+}
+
+type User struct {
+	name  string
+	home  string
+	shell string
+	uid   uint32
+	gid   uint32
+}
+
+func (u *User) Name() string {
+	return u.name
+}
+
+func (u *User) Home() string {
+	return u.home
+}
+
+func (u *User) UID() uint32 {
+	return u.uid
+}
+
+func (u *User) GID() uint32 {
+	return u.gid
+}
+
+func (u *User) isSystemUser() bool {
+	if u.uid > 0 && u.uid < minUserUID {
+		return true
+	}
+
+	if u.name == "nobody" {
+		return true
+	}
+
+	return !strutil.ListContains(shells, u.shell)
+}
+
+var me *User
+var meErr error
+
+func Current() (*User, error) {
+	return me, meErr
+}
+
+// NotFound is returned by First when no users are found that match the given filter.
+var NotFound = errors.New("user not found")
+
+// First tries to return a user that matches the given filter.
+func First(filter func(*User) bool) (*User, error) {
+	var it Iter
+	defer it.Finish()
+	for it.Scan(filter) {
+		return it.User(), nil
+	}
+
+	err := NotFound
+	if it.err != nil {
+		err = it.err
+	}
+
+	return nil, err
+}
+
+// FromUID tries to find a user with the given UID.
+func FromUID(uid uint32) (*User, error) {
+	return First(func(u *User) bool {
+		return u.uid == uid
+	})
+}
+
+// FromName tries to find a user with the given name.
+func FromName(name string) (*User, error) {
+	return First(func(u *User) bool {
+		return u.name == name
+	})
+}
+
+var passwds = []string{
+	// order could be important
+	"/var/lib/extrausers/passwd",
+	"/etc/passwd",
+}
+
+// an Iter will iterate over the user database.
+type Iter struct {
+	pwi     int
+	pwf     *os.File
+	scanner *bufio.Scanner
+	cur     *User
+	err     error
+}
+
+// User returns the user found by Scan.
+func (it *Iter) User() *User {
+	return it.cur
+}
+
+// Scan advances the iterator until it finds a user that matches all
+// the given conditions.
+func (it *Iter) Scan(conds ...func(*User) bool) bool {
+	if it.err != nil {
+		return false
+	}
+
+	for it.scanner == nil {
+		if it.pwi >= len(passwds) {
+			// no more files to scan
+			return false
+		}
+		if it.pwf != nil {
+			it.err = it.pwf.Close()
+		}
+		if it.err != nil {
+			return false
+		}
+		it.pwf, it.err = os.Open(filepath.Join(dirs.GlobalRootDir, passwds[it.pwi]))
+		it.pwi++
+		if it.err != nil {
+			// ignore missing files
+			if !os.IsNotExist(it.err) {
+				return false
+			}
+			it.err = nil
+			// try next file
+			continue
+		}
+		it.scanner = bufio.NewScanner(it.pwf)
+	}
+
+outer:
+	for it.scanner.Scan() {
+		it.cur = nil
+		line := bytes.TrimSpace(it.scanner.Bytes())
+		if len(line) == 0 || line[0] == '#' {
+			// blank or comment; ignore
+			continue
+		}
+		fields := bytes.SplitN(line, []byte{':'}, 8)
+		if len(fields) != 7 {
+			// bogus line; ignore
+			continue
+		}
+		// root:x:0:0:root:/root:/bin/bash
+		uid, err := strconv.ParseUint(string(fields[2]), 10, 32)
+		if err != nil {
+			continue
+		}
+		gid, err := strconv.ParseUint(string(fields[3]), 10, 32)
+		if err != nil {
+			continue
+		}
+		u := &User{
+			name:  string(fields[0]),
+			home:  string(fields[5]),
+			shell: string(fields[6]),
+			uid:   uint32(uid),
+			gid:   uint32(gid),
+		}
+		for _, cond := range conds {
+			if !cond(u) {
+				continue outer
+			}
+		}
+
+		it.cur = u
+		return true
+	}
+	it.err = it.scanner.Err()
+	it.scanner = nil
+
+	return it.Scan(conds...)
+}
+
+// Finish closes down any connections the iterator might have to
+// whatever backend(s) it's inspecting. The error is returned for
+// convenience, but can also be obtained from Err().
+func (it *Iter) Finish() error {
+	if it == nil {
+		return nil
+	}
+	if it.pwf != nil {
+		e := it.pwf.Close()
+		if it.err == nil && e != nil {
+			it.err = e
+		}
+		it.pwf = nil
+	}
+	return it.err
+}
+
+// Err returns the Iter's error.
+func (it *Iter) Err() error {
+	return it.err
+}
+
+// Fake returns a fake user for use in testing.
+func Fake(name, home string, uid, gid uint32) *User {
+	return &User{
+		name:  name,
+		home:  home,
+		shell: "/bin/sh",
+		uid:   uid,
+		gid:   gid,
+	}
+}

--- a/osutil/user/user_test.go
+++ b/osutil/user/user_test.go
@@ -1,0 +1,130 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package user_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil/user"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { check.TestingT(t) }
+
+type suite struct{}
+
+var _ = check.Suite(suite{})
+
+func (suite) SetUpTest(c *check.C) {
+	rootDir := c.MkDir()
+	dirs.SetRootDir(rootDir)
+	// create some users
+	passdata := fmt.Sprintf(`
+user1::%d:%d::/home/user1:/bin/sh
+user2::4294967294:4294967294::/home/user2:/bin/sh
+`[1:], user.Getuid(), user.Getgid())
+
+	for _, dir := range user.Passwds() {
+		c.Assert(os.MkdirAll(filepath.Dir(filepath.Join(rootDir, dir)), 0755), check.IsNil)
+	}
+	c.Assert(ioutil.WriteFile(filepath.Join(rootDir, "/var/lib/extrausers/passwd"), []byte(passdata), 0644), check.IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(rootDir, "etc/passwd"), []byte("sshd:x:124:65534::/var/run/sshd:/usr/sbin/nologin\n"), 0644), check.IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(rootDir, "etc", "shells"), []byte("/bin/sh\n"), 0644), check.IsNil)
+	user.Init()
+}
+
+func (suite) TestCurrent(c *check.C) {
+	me, err := user.Current()
+	c.Assert(err, check.IsNil)
+	c.Check(me.Name(), check.DeepEquals, "user1")
+}
+
+func (suite) TestFromUID(c *check.C) {
+	u1, err := user.FromUID(0xfffffffe)
+	c.Assert(err, check.IsNil)
+	c.Check(u1.UID(), check.Equals, uint32(0xfffffffe))
+	c.Check(u1.Name(), check.Equals, "user2")
+	c.Check(u1.Home(), check.Equals, "/home/user2")
+}
+
+func (suite) TestFromName(c *check.C) {
+	u1, err := user.FromName("user2")
+	c.Assert(err, check.IsNil)
+	c.Check(u1.UID(), check.Equals, uint32(0xfffffffe))
+	c.Check(u1.Name(), check.Equals, "user2")
+	c.Check(u1.Home(), check.Equals, "/home/user2")
+}
+
+func (suite) TestFromNameOtherSource(c *check.C) {
+	u1, err := user.FromName("sshd")
+	c.Assert(err, check.IsNil)
+	c.Check(u1.UID(), check.Equals, uint32(124))
+	c.Check(u1.Name(), check.Equals, "sshd")
+	c.Check(u1.Home(), check.Equals, "/var/run/sshd")
+}
+
+func (suite) TestIterFull(c *check.C) {
+	var us []string
+	var it user.Iter
+	defer it.Finish()
+	for it.Scan() {
+		us = append(us, it.User().Name())
+	}
+	// XXX this assumes an order, which isn't necessarily true for arbitrary backends
+	c.Check(us, check.DeepEquals, []string{"user1", "user2", "sshd"})
+}
+
+func (suite) TestIterNoSystem(c *check.C) {
+	var us []string
+	var it user.Iter
+	defer it.Finish()
+	for it.Scan(user.IsNonSystem) {
+		us = append(us, it.User().Name())
+	}
+	// XXX this assumes an order, which isn't necessarily true for arbitrary backends
+	c.Check(us, check.DeepEquals, []string{"user1", "user2"})
+}
+
+func (suite) TestIterArbitrary(c *check.C) {
+	var us []string
+	var it user.Iter
+	defer it.Finish()
+	for it.Scan(func(u *user.User) bool {
+		return !strings.HasSuffix(u.Name(), "2")
+	}) {
+		us = append(us, it.User().Name())
+	}
+	// XXX this assumes an order, which isn't necessarily true for arbitrary backends
+	c.Check(us, check.DeepEquals, []string{"user1", "sshd"})
+}
+
+func (suite) TestFirst(c *check.C) {
+	u, err := user.First(func(*user.User) bool { return false })
+	c.Assert(u, check.IsNil)
+	c.Check(err, check.Equals, user.NotFound)
+}

--- a/overlord/snapstate/backend/copydata.go
+++ b/overlord/snapstate/backend/copydata.go
@@ -78,15 +78,7 @@ func (b Backend) UndoCopySnapData(newInfo *snap.Info, oldInfo *snap.Info, meter 
 
 // ClearTrashedData removes the trash. It returns no errors on the assumption that it is called very late in the game.
 func (b Backend) ClearTrashedData(oldSnap *snap.Info) {
-	dirs, err := snapDataDirs(oldSnap)
-	if err != nil {
+	if err := snapDataDirsDo(oldSnap, clearTrash); err != nil {
 		logger.Noticef("Cannot remove previous data for %q: %v", oldSnap.Name(), err)
-		return
-	}
-
-	for _, d := range dirs {
-		if err := clearTrash(d); err != nil {
-			logger.Noticef("Cannot remove %s: %v", d, err)
-		}
 	}
 }

--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -89,7 +89,7 @@ func refreshCatalogs(st *state.State, theStore StoreService) error {
 		return err
 	}
 
-	namesFile, err := osutil.NewAtomicFile(dirs.SnapNamesFile, 0644, 0, -1, -1)
+	namesFile, err := osutil.NewAtomicFile(dirs.SnapNamesFile, 0644, 0, osutil.NoChown, osutil.NoChown)
 	if err != nil {
 		return err
 	}

--- a/snap/info.go
+++ b/snap/info.go
@@ -60,16 +60,7 @@ type PlaceInfo interface {
 	UserCommonDataDir(home string) string
 
 	// UserXdgRuntimeDir returns the per user XDG_RUNTIME_DIR directory
-	UserXdgRuntimeDir(userID int) string
-
-	// DataHomeDir returns the a glob that matches all per user data directories of a snap.
-	DataHomeDir() string
-
-	// CommonDataHomeDir returns a glob that matches all per user data directories common across revisions of the snap.
-	CommonDataHomeDir() string
-
-	// XdgRuntimeDirs returns a glob that matches all XDG_RUNTIME_DIR directories for all users of the snap.
-	XdgRuntimeDirs() string
+	UserXdgRuntimeDir(userID uint32) string
 }
 
 // MinimalPlaceInfo returns a PlaceInfo with just the location information for a snap of the given name and revision.
@@ -271,12 +262,12 @@ func (s *Info) DataDir() string {
 
 // UserDataDir returns the user-specific data directory of the snap.
 func (s *Info) UserDataDir(home string) string {
-	return filepath.Join(home, "snap", s.Name(), s.Revision.String())
+	return filepath.Join(dirs.GlobalRootDir, home, "snap", s.Name(), s.Revision.String())
 }
 
 // UserCommonDataDir returns the user-specific data directory common across revision of the snap.
 func (s *Info) UserCommonDataDir(home string) string {
-	return filepath.Join(home, "snap", s.Name(), "common")
+	return filepath.Join(dirs.GlobalRootDir, home, "snap", s.Name(), "common")
 }
 
 // CommonDataDir returns the data directory common across revisions of the snap.
@@ -284,24 +275,9 @@ func (s *Info) CommonDataDir() string {
 	return filepath.Join(dirs.SnapDataDir, s.Name(), "common")
 }
 
-// DataHomeDir returns the per user data directory of the snap.
-func (s *Info) DataHomeDir() string {
-	return filepath.Join(dirs.SnapDataHomeGlob, s.Name(), s.Revision.String())
-}
-
-// CommonDataHomeDir returns the per user data directory common across revisions of the snap.
-func (s *Info) CommonDataHomeDir() string {
-	return filepath.Join(dirs.SnapDataHomeGlob, s.Name(), "common")
-}
-
 // UserXdgRuntimeDir returns the XDG_RUNTIME_DIR directory of the snap for a particular user.
-func (s *Info) UserXdgRuntimeDir(euid int) string {
-	return filepath.Join("/run/user", fmt.Sprintf("%d/snap.%s", euid, s.Name()))
-}
-
-// XdgRuntimeDirs returns the XDG_RUNTIME_DIR directories for all users of the snap.
-func (s *Info) XdgRuntimeDirs() string {
-	return filepath.Join(dirs.XdgRuntimeDirGlob, fmt.Sprintf("snap.%s", s.Name()))
+func (s *Info) UserXdgRuntimeDir(euid uint32) string {
+	return filepath.Join(dirs.GlobalRootDir, "/run/user", fmt.Sprintf("%d/snap.%s", euid, s.Name()))
 }
 
 // NeedsDevMode returns whether the snap needs devmode.

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -644,10 +644,6 @@ func (s *infoSuite) testDirAndFileMethods(c *C, info snap.PlaceInfo) {
 	c.Check(info.UserCommonDataDir("/home/bob"), Equals, "/home/bob/snap/name/common")
 	c.Check(info.CommonDataDir(), Equals, "/var/snap/name/common")
 	c.Check(info.UserXdgRuntimeDir(12345), Equals, "/run/user/12345/snap.name")
-	// XXX: Those are actually a globs, not directories
-	c.Check(info.DataHomeDir(), Equals, "/home/*/snap/name/1")
-	c.Check(info.CommonDataHomeDir(), Equals, "/home/*/snap/name/common")
-	c.Check(info.XdgRuntimeDirs(), Equals, "/run/user/*/snap.name")
 }
 
 func makeFakeDesktopFile(c *C, name, content string) string {

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -22,12 +22,12 @@ package snapenv
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -75,7 +75,7 @@ func snapEnv(info *snap.Info) map[string]string {
 
 	usr, err := user.Current()
 	if err == nil {
-		home = usr.HomeDir
+		home = usr.Home()
 	}
 
 	env := basicEnv(info)
@@ -119,7 +119,7 @@ func userEnv(info *snap.Info, home string) map[string]string {
 	result := map[string]string{
 		"SNAP_USER_COMMON": info.UserCommonDataDir(home),
 		"SNAP_USER_DATA":   info.UserDataDir(home),
-		"XDG_RUNTIME_DIR":  info.UserXdgRuntimeDir(os.Geteuid()),
+		"XDG_RUNTIME_DIR":  info.UserXdgRuntimeDir(user.Geteuid()),
 	}
 	// For non-classic snaps, we set HOME but on classic allow snaps to see real HOME
 	if !info.NeedsClassic() {

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -22,7 +22,6 @@ package snapenv
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"strings"
 	"testing"
 
@@ -30,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -91,7 +91,7 @@ func (ts *HTestSuite) TestUser(c *C) {
 		"HOME":             "/root/snap/foo/17",
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
-		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", os.Geteuid()),
+		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", user.Geteuid()),
 	})
 }
 
@@ -102,7 +102,7 @@ func (ts *HTestSuite) TestUserForClassicConfinement(c *C) {
 		// NOTE HOME Is absent! we no longer override it
 		"SNAP_USER_COMMON": "/root/snap/foo/common",
 		"SNAP_USER_DATA":   "/root/snap/foo/17",
-		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", os.Geteuid()),
+		"XDG_RUNTIME_DIR":  fmt.Sprintf("/run/user/%d/snap.foo", user.Geteuid()),
 	})
 }
 
@@ -124,7 +124,7 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 
 		env := snapEnv(info)
 		c.Check(env, DeepEquals, map[string]string{
-			"HOME":              fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"HOME":              fmt.Sprintf("%s/snap/snapname/42", usr.Home()),
 			"SNAP":              fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
 			"SNAP_ARCH":         arch.UbuntuArchitecture(),
 			"SNAP_COMMON":       "/var/snap/snapname/common",
@@ -133,10 +133,10 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 			"SNAP_NAME":         "snapname",
 			"SNAP_REEXEC":       "",
 			"SNAP_REVISION":     "42",
-			"SNAP_USER_COMMON":  fmt.Sprintf("%s/snap/snapname/common", usr.HomeDir),
-			"SNAP_USER_DATA":    fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
+			"SNAP_USER_COMMON":  fmt.Sprintf("%s/snap/snapname/common", usr.Home()),
+			"SNAP_USER_DATA":    fmt.Sprintf("%s/snap/snapname/42", usr.Home()),
 			"SNAP_VERSION":      "1.0",
-			"XDG_RUNTIME_DIR":   fmt.Sprintf("/run/user/%d/snap.snapname", os.Geteuid()),
+			"XDG_RUNTIME_DIR":   fmt.Sprintf("/run/user/%d/snap.snapname", user.Geteuid()),
 		})
 	}
 }

--- a/tests/main/user-data-handling/task.yaml
+++ b/tests/main/user-data-handling/task.yaml
@@ -6,8 +6,8 @@ execute: |
     rev=$(snap list|grep test-snapd-tools|tr -s ' '|cut -f3 -d' ')
 
     echo "That has some user data"
-    mkdir -p /home/*/snap/test-snapd-tools/$rev/
-    touch /home/*/snap/test-snapd-tools/$rev/mock-data
+    mkdir -p /home/test/snap/test-snapd-tools/$rev/
+    touch /home/test/snap/test-snapd-tools/$rev/mock-data
     mkdir -p /root/snap/test-snapd-tools/$rev/
     touch /root/snap/test-snapd-tools/$rev/mock-data
 
@@ -16,12 +16,12 @@ execute: |
     new_rev=$(snap list|grep test-snapd-tools|tr -s ' '|cut -f3 -d' ')
 
     echo "Then the user data gets copied"
-    test -e /home/*/snap/test-snapd-tools/$new_rev/mock-data
+    test -e /home/test/snap/test-snapd-tools/$new_rev/mock-data
     test -e /root/snap/test-snapd-tools/$new_rev/mock-data
 
     echo "When the snap is removed"
     snap remove test-snapd-tools
 
     echo "Then all user data and root data is gone"
-    ! test -e /home/*/snap/test-snapd-tools/$new_rev/mock-data
+    ! test -e /home/test/snap/test-snapd-tools/$new_rev/mock-data
     ! test -e /root/snap/test-snapd-tools/$new_rev/mock-data


### PR DESCRIPTION
Previously we were using a mixture of os/user and filepath globs to
get at users in the system. This replaces those uses with an ad-hoc
package, which is initially a very minimal backend that just knows
about files, but is careful to have an interface that should make
replacing it with a bigger, or more modular backend possible down the
road with no impact on the rest of the codebase.

Tangentially to this but also impacting it is [golang#22739](https://github.com/golang/go/issues/22739) which means
os.Getuid() and co use the wrong integer type and are thus wrong for
high ids (especially noticeable on 32-bit arches). This change also
addresses this (the only remaining uses are for comparing with 0,
which is OK), but it still impacts godbus in our dependencies --
anything that uses godbus on a system with high uids is broken today.

There is still some room for things to break: osutil still includes a
cgo-based implementation of group lookup, which should probably be
replaced by something analogous to the current user. AppArmor doesn't
afaik really know about user homes outside of /home/ (except /root?),
and this code will produce such users (this was broken before, in the
opposite direction: users with homes outside of /home/ were partially
invisible; in both cases snapd is unusabe without tweaks to the local
system's rules).
