### PR TITLE
tests: remove obsolete workaround

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -201,7 +201,7 @@ EOF
             done
             # Copy all of the snaps back to the spool directory. From there we
             # will reuse them during subsequent `snap install` operations.
-            cp --link *.snap /var/lib/snapd/snaps/
+            cp *.snap /var/lib/snapd/snaps/
             set +x
         )
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -199,9 +199,9 @@ EOF
             for snap_name in ${PRE_CACHE_SNAPS:-}; do
                 snap download "$snap_name"
             done
-            for snap_file in *.snap; do
-                cp --link "$snap_file" /var/lib/snapd/snaps/
-            done
+            # Copy all of the snaps back to the spool directory. From there we
+            # will reuse them during subsequent `snap install` operations.
+            cp --link *.snap /var/lib/snapd/snaps/
             set +x
         )
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -200,12 +200,7 @@ EOF
                 snap download "$snap_name"
             done
             for snap_file in *.snap; do
-                mv "$snap_file" "$snap_file.partial"
-                # There is a bug in snapd where partial file must be a proper
-                # prefix of the full file or we make a wrong request to the
-                # store.
-                truncate --size=-1 "$snap_file.partial"
-                mv "$snap_file.partial" /var/lib/snapd/snaps/
+                cp --link "$snap_file" /var/lib/snapd/snaps/
             done
             set +x
         )


### PR DESCRIPTION
Snapd used to have a bug where "snap install" would make wrong request
to the store if the locally available file was actually the full snap
already. This workaround is no longer necessary.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>