### PR TITLE
tests: cache snaps to $TESTSLIB/cache

### DIFF
--- a/tests/lib/cache/README.txt
+++ b/tests/lib/cache/README.txt
@@ -1,0 +1,3 @@
+Any snap files present in this directory will be reused for tests and will save
+bandwidth. This is cost-effective when using qemu back-end as LAN bandwidth is
+faster and cheaper than internet traffic.

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -195,7 +195,9 @@ EOF
         # used for resuming downloads.
         (
             set -x
-            cd /tmp
+            cd $TESTSLIB/cache/
+            # Download each of the snaps we want to pre-cache. Note that `snap download`
+            # a quick no-op if the file is complete.
             for snap_name in ${PRE_CACHE_SNAPS:-}; do
                 snap download "$snap_name"
             done


### PR DESCRIPTION
The testbed prepare code downloads some snaps to /tmp and subsequently
copies them to /var/lib/snapd/snap where they can be reused by `snap
install` operations. This patch changes that to use $TESTLIB/cache which
may be present locally and may already have the required files, thus
cutting a significant chunk of network traffic.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>