### PR TITLE
snap: use existing files in `snap download` if digest/size matches

### DIFF
--- a/tests/main/snap-download/task.yaml
+++ b/tests/main/snap-download/task.yaml
@@ -11,6 +11,9 @@ execute: |
     ls test-snapd-control-consumer_*.snap
     verify_asserts test-snapd-control-consumer_*.assert
 
+    echo "Snap will use existing files"
+    SNAPD_DEBUG=1 snap download test-snapd-control-consumer 2>&1 | MATCH "not downloading, using existing file"
+
     echo "Snap download understand --edge"
     snap download --edge test-snapd-tools
     ls test-snapd-tools_*.snap


### PR DESCRIPTION
When `snap download` sees an existing file it will only re-download
if the digest/size does not match. Otherwise the local file is
used and not downloaded from the store.
