### PR TITLE
tests/lib: fix shellcheck errors

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -195,7 +195,7 @@ EOF
         # used for resuming downloads.
         (
             set -x
-            cd $TESTSLIB/cache/
+            cd "$TESTSLIB/cache/"
             # Download each of the snaps we want to pre-cache. Note that `snap download`
             # a quick no-op if the file is complete.
             for snap_name in ${PRE_CACHE_SNAPS:-}; do

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -42,9 +42,9 @@ make_snap_installable(){
 
     cp -a "$snap_path" "$dir"
     p=$(fakestore new-snap-declaration --dir "$dir" "${snap_path}")
-    snap ack $p
+    snap ack "$p"
     p=$(fakestore new-snap-revision --dir "$dir" "${snap_path}")
-    snap ack $p
+    snap ack "$p"
 }
 
 setup_fake_store(){


### PR DESCRIPTION
Fix the following warnings:
```
In ./tests/lib/prepare.sh line 198:
            cd $TESTSLIB/cache/
               ^-- SC2086: Double quote to prevent globbing and word splitting.

In ./tests/lib/store.sh line 45:
    snap ack $p
             ^-- SC2086: Double quote to prevent globbing and word splitting.

In ./tests/lib/store.sh line 47:
    snap ack $p
             ^-- SC2086: Double quote to prevent globbing and word splitting.
```


