### PR TITLE
snapstate: move autorefresh code into autoRefresh helper

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -795,7 +795,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 			"snap-bin-dir":   dirs.SnapBinariesDir,
 		},
 		"refresh": map[string]interface{}{
-			"schedule": "00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59",
+			"schedule": "00:00-05:59/6:00-11:59/12:00-17:59/18:00-23:59",
 		},
 		"confinement": "partial",
 	}

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -1,0 +1,236 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/timeutil"
+)
+
+// the default refresh pattern
+const defaultRefreshSchedule = "00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59"
+
+// hooks setup by devicestate
+var (
+	CanAutoRefresh func(st *state.State) (bool, error)
+)
+
+// refreshRetryDelay specified the minimum time to retry failed refreshes
+var refreshRetryDelay = 10 * time.Minute
+
+func resetRefreshScheduleToDefault(st *state.State) (ts []*timeutil.Schedule, scheduleStr string) {
+	refreshSchedule, err := timeutil.ParseSchedule(defaultRefreshSchedule)
+	if err != nil {
+		panic(fmt.Sprintf("defaultRefreshSchedule cannot be parsed: %s", err))
+	}
+	tr := config.NewTransaction(st)
+	tr.Set("core", "refresh.schedule", defaultRefreshSchedule)
+	tr.Commit()
+
+	return refreshSchedule, defaultRefreshSchedule
+}
+
+func autoRefreshInFlight(st *state.State) bool {
+	for _, chg := range st.Changes() {
+		if chg.Kind() == "auto-refresh" && !chg.Status().Ready() {
+			return true
+		}
+	}
+	return false
+}
+
+// autoRefresh will ensure that snaps are refreshed automatically
+// according to the refresh schedule.
+type autoRefresh struct {
+	state *state.State
+
+	lastRefreshSchedule string
+	nextRefresh         time.Time
+	lastRefreshAttempt  time.Time
+}
+
+func newAutoRefresh(st *state.State) *autoRefresh {
+	return &autoRefresh{
+		state: st,
+	}
+}
+
+// RefreshSchedule will return a user visible string with the current
+// schedule for the automatic refreshes.
+func (m *autoRefresh) RefreshSchedule() (string, error) {
+	_, scheduleStr, err := m.refreshScheduleWithDefaultsFallback()
+	return scheduleStr, err
+}
+
+// NextRefresh returns when the next automatic refresh will happen.
+func (m *autoRefresh) NextRefresh() time.Time {
+	return m.nextRefresh
+}
+
+// LastRefresh returns when the last refresh happened.
+func (m *autoRefresh) LastRefresh() (time.Time, error) {
+	var lastRefresh time.Time
+	err := m.state.Get("last-refresh", &lastRefresh)
+	if err != nil && err != state.ErrNoState {
+		return time.Time{}, err
+	}
+	return lastRefresh, nil
+}
+
+// Ensure ensures that we refresh all installed snaps periodically
+func (m *autoRefresh) Ensure() error {
+	m.state.Lock()
+	defer m.state.Unlock()
+
+	// see if it even makes sense to try to refresh
+	if CanAutoRefresh == nil {
+		return nil
+	}
+	if ok, err := CanAutoRefresh(m.state); err != nil || !ok {
+		return err
+	}
+
+	// Check that we have reasonable delays between attempts.
+	// If the store is under stress we need to make sure we do not
+	// hammer it too often
+	if !m.lastRefreshAttempt.IsZero() && m.lastRefreshAttempt.Add(refreshRetryDelay).After(time.Now()) {
+		return nil
+	}
+
+	// get lastRefresh and schedule
+	lastRefresh, err := m.LastRefresh()
+	if err != nil {
+		return err
+	}
+
+	refreshSchedule, refreshScheduleStr, err := m.refreshScheduleWithDefaultsFallback()
+	if err != nil {
+		return err
+	}
+	// we already have a refresh time, check if we got a new config
+	if !m.nextRefresh.IsZero() {
+		if m.lastRefreshSchedule != refreshScheduleStr {
+			// the refresh schedule has changed
+			logger.Debugf("Option refresh.schedule changed.")
+			m.nextRefresh = time.Time{}
+		}
+	}
+	m.lastRefreshSchedule = refreshScheduleStr
+
+	// ensure nothing is in flight already
+	if autoRefreshInFlight(m.state) {
+		return nil
+	}
+
+	// compute next refresh attempt time (if needed)
+	if m.nextRefresh.IsZero() {
+		// store attempts in memory so that we can backoff
+		if !lastRefresh.IsZero() {
+			delta := timeutil.Next(refreshSchedule, lastRefresh)
+			m.nextRefresh = time.Now().Add(delta)
+		} else {
+			// immediate
+			m.nextRefresh = time.Now()
+		}
+		logger.Debugf("Next refresh scheduled for %s.", m.nextRefresh)
+	}
+
+	// do refresh attempt (if needed)
+	if !m.nextRefresh.After(time.Now()) {
+		err = m.launchAutoRefresh()
+		// clear nextRefresh only if the refresh worked. There is
+		// still the lastRefreshAttempt rate limit so things will
+		// not go into a busy store loop
+		if err == nil {
+			m.nextRefresh = time.Time{}
+		}
+	}
+
+	return err
+}
+
+// refreshScheduleWithDefaultsFallback returns the current refresh schedule
+// and refresh string. When an invalid refresh schedule is set by the user
+// the refresh schedule is automatically reset to the default.
+//
+// TODO: we can remove the refreshSchedule reset because we have validation
+//       of the schedule now.
+func (m *autoRefresh) refreshScheduleWithDefaultsFallback() (ts []*timeutil.Schedule, scheduleAsStr string, err error) {
+	refreshScheduleStr := defaultRefreshSchedule
+	tr := config.NewTransaction(m.state)
+	err = tr.Get("core", "refresh.schedule", &refreshScheduleStr)
+	if err != nil && !config.IsNoOption(err) {
+		return nil, "", err
+	}
+
+	refreshSchedule, err := timeutil.ParseSchedule(refreshScheduleStr)
+	if err != nil {
+		logger.Noticef("cannot use refresh.schedule configuration: %s", err)
+		refreshSchedule, refreshScheduleStr = resetRefreshScheduleToDefault(m.state)
+	}
+
+	return refreshSchedule, refreshScheduleStr, nil
+}
+
+// launchAutoRefresh creates the auto-refresh taskset and a change for it.
+func (m *autoRefresh) launchAutoRefresh() error {
+	m.lastRefreshAttempt = time.Now()
+	updated, tasksets, err := AutoRefresh(m.state)
+	if err != nil {
+		logger.Noticef("Cannot prepare auto-refresh change: %s", err)
+		return err
+	}
+
+	// Set last refresh time only if the store (in AutoRefresh) gave
+	// us no error.
+	m.state.Set("last-refresh", time.Now())
+
+	var msg string
+	switch len(updated) {
+	case 0:
+		logger.Noticef(i18n.G("No snaps to auto-refresh found"))
+		return nil
+	case 1:
+		msg = fmt.Sprintf(i18n.G("Auto-refresh snap %q"), updated[0])
+	case 2:
+	case 3:
+		quoted := strutil.Quoted(updated)
+		// TRANSLATORS: the %s is a comma-separated list of quoted snap names
+		msg = fmt.Sprintf(i18n.G("Auto-refresh snaps %s"), quoted)
+	default:
+		msg = fmt.Sprintf(i18n.G("Auto-refresh %d snaps"), len(updated))
+	}
+
+	chg := m.state.NewChange("auto-refresh", msg)
+	for _, ts := range tasksets {
+		chg.AddAll(ts)
+	}
+	chg.Set("snap-names", updated)
+	chg.Set("api-data", map[string]interface{}{"snap-names": updated})
+
+	return nil
+}

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1,0 +1,118 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"fmt"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/store/storetest"
+)
+
+type autoRefreshStore struct {
+	storetest.Store
+
+	ops []string
+
+	listRefreshErr error
+}
+
+func (r *autoRefreshStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+	r.ops = append(r.ops, "list-refresh")
+	return nil, r.listRefreshErr
+}
+
+type autoRefreshTestSuite struct {
+	state *state.State
+
+	store *autoRefreshStore
+}
+
+var _ = Suite(&autoRefreshTestSuite{})
+
+func (s *autoRefreshTestSuite) SetUpTest(c *C) {
+	s.state = state.New(nil)
+
+	s.store = &autoRefreshStore{}
+	s.state.Lock()
+	snapstate.ReplaceStore(s.state, s.store)
+	s.state.Unlock()
+
+	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
+}
+
+func (s *autoRefreshTestSuite) TearDownTest(c *C) {
+	snapstate.CanAutoRefresh = nil
+}
+
+func (s *autoRefreshTestSuite) TestLastRefresh(c *C) {
+	af := snapstate.NewAutoRefresh(s.state)
+	err := af.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
+
+	var lastRefresh time.Time
+	s.state.Lock()
+	s.state.Get("last-refresh", &lastRefresh)
+	s.state.Unlock()
+	c.Check(lastRefresh.Year(), Equals, time.Now().Year())
+}
+
+func (s *autoRefreshTestSuite) TestLastRefreshNoRefreshNeeded(c *C) {
+	s.state.Lock()
+	s.state.Set("last-refresh", time.Now())
+	s.state.Unlock()
+
+	af := snapstate.NewAutoRefresh(s.state)
+	err := af.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, HasLen, 0)
+}
+
+func (s *autoRefreshTestSuite) TestRefreshBackoff(c *C) {
+	s.store.listRefreshErr = fmt.Errorf("random store error")
+	af := snapstate.NewAutoRefresh(s.state)
+	err := af.Ensure()
+	c.Check(err, ErrorMatches, "random store error")
+	c.Check(s.store.ops, HasLen, 1)
+	c.Check(s.store.ops, DeepEquals, []string{"list-refresh"})
+
+	// call ensure again, our back-off will prevent the store from
+	// being hit again
+	err = af.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, HasLen, 1)
+
+	// fake that the retryRefreshDelay is over
+	restore := snapstate.MockRefreshRetryDelay(1 * time.Millisecond)
+	defer restore()
+	time.Sleep(10 * time.Millisecond)
+
+	err = af.Ensure()
+	c.Check(err, ErrorMatches, "random store error")
+	c.Check(s.store.ops, HasLen, 2)
+}

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -136,10 +136,19 @@ var (
 
 // refreshes
 var (
+	NewAutoRefresh    = newAutoRefresh
 	NewRefreshHints   = newRefreshHints
 	NewCatalogRefresh = newCatalogRefresh
 )
 
 func MockCatalogRefreshNextRefresh(cr *catalogRefresh, when time.Time) {
 	cr.nextCatalogRefresh = when
+}
+
+func MockRefreshRetryDelay(d time.Duration) func() {
+	origRefreshRetryDelay := refreshRetryDelay
+	refreshRetryDelay = d
+	return func() {
+		refreshRetryDelay = origRefreshRetryDelay
+	}
 }

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -62,7 +62,7 @@ func (s *refreshHintsTestSuite) SetUpTest(c *C) {
 	snapstate.CanAutoRefresh = func(*state.State) (bool, error) { return true, nil }
 }
 
-func (s *refreshHintsTestSuite) TearDownTests(c *C) {
+func (s *refreshHintsTestSuite) TearDownTest(c *C) {
 	snapstate.CanAutoRefresh = nil
 }
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -30,19 +30,12 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/errtracker"
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
-	"github.com/snapcore/snapd/strutil"
-	"github.com/snapcore/snapd/timeutil"
 )
-
-// the default refresh pattern
-const defaultRefreshSchedule = "00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59"
 
 // overridden in the tests
 var errtrackerReport = errtracker.Report
@@ -52,10 +45,7 @@ type SnapManager struct {
 	state   *state.State
 	backend managerBackend
 
-	lastRefreshSchedule string
-	nextRefresh         time.Time
-	lastRefreshAttempt  time.Time
-
+	autoRefresh    *autoRefresh
 	refreshHints   *refreshHints
 	catalogRefresh *catalogRefresh
 
@@ -281,6 +271,7 @@ func Manager(st *state.State) (*SnapManager, error) {
 		state:          st,
 		backend:        backend.Backend{},
 		runner:         runner,
+		autoRefresh:    newAutoRefresh(st),
 		refreshHints:   newRefreshHints(st),
 		catalogRefresh: newCatalogRefresh(st),
 	}
@@ -359,178 +350,24 @@ func (m *SnapManager) blockedTask(cand *state.Task, running []*state.Task) bool 
 	return false
 }
 
-var CanAutoRefresh func(st *state.State) (bool, error)
-
-func resetRefreshScheduleToDefault(st *state.State) (ts []*timeutil.Schedule, scheduleStr string) {
-	refreshSchedule, err := timeutil.ParseSchedule(defaultRefreshSchedule)
-	if err != nil {
-		panic(fmt.Sprintf("defaultRefreshSchedule cannot be parsed: %s", err))
-	}
-	tr := config.NewTransaction(st)
-	tr.Set("core", "refresh.schedule", defaultRefreshSchedule)
-	tr.Commit()
-
-	return refreshSchedule, defaultRefreshSchedule
-}
-
-func (m *SnapManager) refreshScheduleWithDefaultsFallback() (ts []*timeutil.Schedule, scheduleAsStr string, err error) {
-	refreshScheduleStr := defaultRefreshSchedule
-
-	tr := config.NewTransaction(m.state)
-	err = tr.Get("core", "refresh.schedule", &refreshScheduleStr)
-	if err != nil && !config.IsNoOption(err) {
-		return nil, "", err
-	}
-
-	refreshSchedule, err := timeutil.ParseSchedule(refreshScheduleStr)
-	if err != nil {
-		logger.Noticef("cannot use refresh.schedule configuration: %s", err)
-		refreshSchedule, refreshScheduleStr = resetRefreshScheduleToDefault(m.state)
-	}
-
-	return refreshSchedule, refreshScheduleStr, nil
-}
-
-func (m *SnapManager) launchAutoRefresh() error {
-	m.lastRefreshAttempt = time.Now()
-	updated, tasksets, err := AutoRefresh(m.state)
-	if err != nil {
-		logger.Noticef("Cannot prepare auto-refresh change: %s", err)
-		return err
-	}
-
-	// Set last refresh time only if the store (in AutoRefresh) gave
-	// us no error.
-	m.state.Set("last-refresh", time.Now())
-
-	var msg string
-	switch len(updated) {
-	case 0:
-		logger.Noticef(i18n.G("No snaps to auto-refresh found"))
-		return nil
-	case 1:
-		msg = fmt.Sprintf(i18n.G("Auto-refresh snap %q"), updated[0])
-	case 2:
-	case 3:
-		quoted := strutil.Quoted(updated)
-		// TRANSLATORS: the %s is a comma-separated list of quoted snap names
-		msg = fmt.Sprintf(i18n.G("Auto-refresh snaps %s"), quoted)
-	default:
-		msg = fmt.Sprintf(i18n.G("Auto-refresh %d snaps"), len(updated))
-	}
-
-	chg := m.state.NewChange("auto-refresh", msg)
-	for _, ts := range tasksets {
-		chg.AddAll(ts)
-	}
-	chg.Set("snap-names", updated)
-	chg.Set("api-data", map[string]interface{}{"snap-names": updated})
-
-	return nil
-}
-
-func autoRefreshInFlight(st *state.State) bool {
-	for _, chg := range st.Changes() {
-		if chg.Kind() == "auto-refresh" && !chg.Status().Ready() {
-			return true
-		}
-	}
-	return false
-}
-
-func (m *SnapManager) LastRefresh() (time.Time, error) {
-	var lastRefresh time.Time
-	err := m.state.Get("last-refresh", &lastRefresh)
-	if err != nil && err != state.ErrNoState {
-		return time.Time{}, err
-	}
-	return lastRefresh, nil
-}
-
 // NextRefresh returns the time the next update of the system's snaps
 // will be attempted.
 // The caller should be holding the state lock.
 func (m *SnapManager) NextRefresh() time.Time {
-	return m.nextRefresh
+	return m.autoRefresh.NextRefresh()
+}
+
+// LastRefresh returns the time the last snap update.
+// The caller should be holding the state lock.
+func (m *SnapManager) LastRefresh() (time.Time, error) {
+	return m.autoRefresh.LastRefresh()
 }
 
 // RefreshSchedule returns the current refresh schedule as a string
 // suitable to display to a user.
 // The caller should be holding the state lock.
 func (m *SnapManager) RefreshSchedule() (string, error) {
-	_, scheduleStr, err := m.refreshScheduleWithDefaultsFallback()
-	return scheduleStr, err
-}
-
-// ensureRefreshes ensures that we refresh all installed snaps periodically
-func (m *SnapManager) ensureRefreshes() error {
-	m.state.Lock()
-	defer m.state.Unlock()
-
-	// see if it even makes sense to try to refresh
-	if CanAutoRefresh == nil {
-		return nil
-	}
-	if ok, err := CanAutoRefresh(m.state); err != nil || !ok {
-		return err
-	}
-
-	// get lastRefresh and schedule
-	lastRefresh, err := m.LastRefresh()
-	if err != nil {
-		return err
-	}
-	refreshSchedule, refreshScheduleStr, err := m.refreshScheduleWithDefaultsFallback()
-	if err != nil {
-		return err
-	}
-	// we already have a refresh time, check if we got a new config
-	if !m.nextRefresh.IsZero() {
-		if m.lastRefreshSchedule != refreshScheduleStr {
-			// the refresh schedule has changed
-			logger.Debugf("Option refresh.schedule changed.")
-			m.nextRefresh = time.Time{}
-		}
-	}
-	m.lastRefreshSchedule = refreshScheduleStr
-
-	// ensure nothing is in flight already
-	if autoRefreshInFlight(m.state) {
-		return nil
-	}
-
-	// compute next refresh attempt time (if needed)
-	if m.nextRefresh.IsZero() {
-		// store attempts in memory so that we can backoff
-		if !lastRefresh.IsZero() {
-			delta := timeutil.Next(refreshSchedule, lastRefresh)
-			m.nextRefresh = time.Now().Add(delta)
-		} else {
-			// immediate
-			m.nextRefresh = time.Now()
-		}
-		logger.Debugf("Next refresh scheduled for %s.", m.nextRefresh)
-	}
-
-	// Check that we have reasonable delays between unsuccessful attempts.
-	// If the store is under stress we need to make sure we do not
-	// hammer it too often
-	if !m.lastRefreshAttempt.IsZero() && m.lastRefreshAttempt.Add(10*time.Minute).After(time.Now()) {
-		return nil
-	}
-
-	// do refresh attempt (if needed)
-	if !m.nextRefresh.After(time.Now()) {
-		err = m.launchAutoRefresh()
-		// clear nextRefresh only if the refresh worked. There is
-		// still the lastRefreshAttempt rate limit so things will
-		// not go into a busy store loop
-		if err == nil {
-			m.nextRefresh = time.Time{}
-		}
-	}
-
-	return err
+	return m.autoRefresh.RefreshSchedule()
 }
 
 // ensureForceDevmodeDropsDevmodeFromState undoes the froced devmode
@@ -638,7 +475,7 @@ func (m *SnapManager) Ensure() error {
 		m.ensureForceDevmodeDropsDevmodeFromState(),
 		m.ensureUbuntuCoreTransition(),
 		m.refreshHints.Ensure(),
-		m.ensureRefreshes(),
+		m.autoRefresh.Ensure(),
 		m.catalogRefresh.Ensure(),
 	}
 


### PR DESCRIPTION
This cleans up the snapmgr.go file a bit and moves the
autorefresh logic into a single place/structure which
makes tests easier. Also adds some more tests around autoRefresh.

The first commit just moves things around and adds some tests,
the second commit adds using a new "RefreshScheduleManaged" helper.

Happy to split into two PRs if desired.
