### PR TITLE
Mount with x-gdu.hide option

### DIFF
--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -86,7 +86,7 @@ Before=snapd.service
 What=/var/lib/snapd/snaps/foo_13.snap
 Where=%s/foo/13
 Type=squashfs
-Options=nodev,ro
+Options=nodev,ro,x-gdu.hide
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -416,7 +416,7 @@ func MountUnitPath(baseDir string) string {
 func (s *systemd) WriteMountUnitFile(name, what, where, fstype string) (string, error) {
 	options := []string{"nodev"}
 	if fstype == "squashfs" {
-		options = append(options, "ro")
+		options = append(options, "ro", "x-gdu.hide")
 	}
 	if osutil.IsDirectory(what) {
 		options = append(options, "bind")

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -459,7 +459,7 @@ Before=snapd.service
 What=%s
 Where=/apps/foo/1.0
 Type=squashfs
-Options=nodev,ro
+Options=nodev,ro,x-gdu.hide
 
 [Install]
 WantedBy=multi-user.target
@@ -483,7 +483,7 @@ Before=snapd.service
 What=%s
 Where=/apps/foo/1.0
 Type=none
-Options=nodev,ro,bind
+Options=nodev,ro,x-gdu.hide,bind
 
 [Install]
 WantedBy=multi-user.target
@@ -526,7 +526,7 @@ Before=snapd.service
 What=%s
 Where=/apps/foo/1.0
 Type=fuse.squashfuse
-Options=nodev,ro,allow_other
+Options=nodev,ro,x-gdu.hide,allow_other
 
 [Install]
 WantedBy=multi-user.target
@@ -565,7 +565,7 @@ Before=snapd.service
 What=%s
 Where=/apps/foo/1.0
 Type=squashfs
-Options=nodev,ro
+Options=nodev,ro,x-gdu.hide
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Once https://bugzilla.gnome.org/attachment.cgi?id=364324&action=diff and https://github.com/storaged-project/udisks/pull/460/ get merged this will allow to hide snapd squashfs from gnome-disk-utility.