### PR TITLE
tests/main/manpages: set LC_ALL=C as man may complain if the locale is unset or unsupported

### DIFF
--- a/tests/main/manpages/task.yaml
+++ b/tests/main/manpages/task.yaml
@@ -9,7 +9,7 @@ restore: |
     distro_purge_package man
 execute: |
     for manpage in snap snap-confine snap-discard-ns; do
-        if ! man --what $manpage; then
+        if ! LC_ALL=C man --what $manpage; then
             echo "Expected to see manual page for $manpage"
             exit 1
         fi


### PR DESCRIPTION
We set `LANG=C.UTF-8` in the environment for the tests. This setting is not standard and fails on systems such as Arch.

This is change is already a part of #4285 