### PR TITLE
packaging/arch: pre-create snapd directories when packaging

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -184,4 +184,15 @@ package_snapd-git() {
   # and make sure that target exists so that we don't have dangling symlinks
   # after installing the package
   install -d -m 755 "$pkgdir/var/lib/snapd/snap"
+
+  # pre-create directories
+  install -d -m 755 "$pkgdir/var/cache/snapd"
+  install -d -m 755 "$pkgdir/var/lib/snapd/assertions"
+  install -d -m 755 "$pkgdir/var/lib/snapd/desktop/applications"
+  install -d -m 755 "$pkgdir/var/lib/snapd/device"
+  install -d -m 755 "$pkgdir/var/lib/snapd/hostfs"
+  install -d -m 755 "$pkgdir/var/lib/snapd/mount"
+  install -d -m 755 "$pkgdir/var/lib/snapd/seccomp/bpf"
+  install -d -m 755 "$pkgdir/var/lib/snapd/snap/bin"
+  install -d -m 755 "$pkgdir/var/lib/snapd/snaps"
 }


### PR DESCRIPTION
Although snapd will create these directories at runtime it's more convenient to create them during packaging. Especially when some tests may assume that some of these already exist.

Also, it's now possible to do `pacman -Qo /var/cache/snapd` and get `snapd` in the output.
