### PR TITLE
Adding fedora-26 image to snapd spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -71,6 +71,9 @@ backends:
                 workers: 4
             - fedora-25-64:
                 workers: 3
+            - fedora-26-64:
+                workers: 3
+                manual: true
             - opensuse-42.2-64:
                 workers: 3
                 manual: true
@@ -111,6 +114,9 @@ backends:
                 username: debian
                 password: debian
             - fedora-25-64:
+                username: fedora
+                password: fedora
+            - fedora-26-64:
                 username: fedora
                 password: fedora
     autopkgtest:

--- a/spread.yaml
+++ b/spread.yaml
@@ -71,9 +71,9 @@ backends:
                 workers: 4
             - fedora-25-64:
                 workers: 3
+                manual: true
             - fedora-26-64:
                 workers: 3
-                manual: true
             - opensuse-42.2-64:
                 workers: 3
                 manual: true


### PR DESCRIPTION
Here there is a log of the fedora 26 execution:
https://paste.ubuntu.com/26034866/