### PR TITLE
packaging/arch: install missing directories, manpages and version info

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -96,6 +96,9 @@ build() {
     --enable-nvidia-biarch \
     --enable-merged-usr
   make $MAKEFLAGS
+
+  # generate man-pages for snap
+  $GOPATH/bin/snap help --man > "$srcdir/snap.1"
 }
 
 check() {
@@ -200,4 +203,9 @@ package_snapd-git() {
   install -d -m 000 "$pkgdir/var/lib/snapd/void"
   install -d -m 700 "$pkgdir/var/lib/snapd/cookie"
   install -d -m 700 "$pkgdir/var/lib/snapd/cache"
+
+  # Install snap(1) man page
+  install -m 644 -D "$srcdir/snap.1" \
+          "$pkgdir/usr/share/man/man1/snap.1"
+
 }

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -195,4 +195,9 @@ package_snapd-git() {
   install -d -m 755 "$pkgdir/var/lib/snapd/seccomp/bpf"
   install -d -m 755 "$pkgdir/var/lib/snapd/snap/bin"
   install -d -m 755 "$pkgdir/var/lib/snapd/snaps"
+  install -d -m 755 "$pkgdir/var/lib/snapd/lib/gl"
+  # these dirs have special permissions
+  install -d -m 000 "$pkgdir/var/lib/snapd/void"
+  install -d -m 700 "$pkgdir/var/lib/snapd/cookie"
+  install -d -m 700 "$pkgdir/var/lib/snapd/cache"
 }

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -208,4 +208,8 @@ package_snapd-git() {
   install -m 644 -D "$srcdir/snap.1" \
           "$pkgdir/usr/share/man/man1/snap.1"
 
+  # Install the "info" data file with snapd version
+  install -m 644 -D "$GOPATH/src/${_gourl}/data/info" \
+          "$pkgdir/usr/lib/snapd/info"
+
 }


### PR DESCRIPTION
A follow-up on #4296 
