### PR TITLE
snapd.dirs: add var/lib/snapd/lib/gl32

### DIFF
--- a/packaging/ubuntu-16.04/snapd.dirs
+++ b/packaging/ubuntu-16.04/snapd.dirs
@@ -7,6 +7,7 @@ var/lib/snapd/desktop
 var/lib/snapd/environment
 var/lib/snapd/firstboot
 var/lib/snapd/lib/gl
+var/lib/snapd/lib/gl32
 var/lib/snapd/snaps/partial
 var/lib/snapd/void
 var/snap


### PR DESCRIPTION
If this dir is missing in the core snap then the bind mount of the
32 bit parts of libgl for nvidia will fail because the target dir
is not available.

This should fix the issue that Adam Collard reported.
