### PR TITLE
cmd/snap-confine: use #include instead of bare include

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -8,7 +8,7 @@
     #
     # Those are discussed on https://forum.snapcraft.io/t/snapd-vs-upstream-kernel-vs-apparmor
     # and https://forum.snapcraft.io/t/snaps-and-nfs-home/
-    include "/var/lib/snapd/apparmor/snap-confine"
+    #include "/var/lib/snapd/apparmor/snap-confine"
 
     # We run privileged, so be fanatical about what we include and don't use
     # any abstractions


### PR DESCRIPTION
While the bare include option is still documented on the apparmor wiki
http://wiki.apparmor.net/index.php/QuickProfileLanguage#Include_Rules
using the language "The # is optional and shouldn't be used in newer
profiles" it seems that recent upstream broke this support in the
parser.

While upstream sorts this out, let's adapt.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
