### PR TITLE
snap: fix TestDirAndFileMethods() test to work with gccgo

### DIFF
--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -631,7 +631,8 @@ func (s *infoSuite) TestMinimalInfoDirAndFileMethods(c *C) {
 
 func (s *infoSuite) TestDirAndFileMethods(c *C) {
 	dirs.SetRootDir("")
-	info := &snap.Info{SuggestedName: "name", SideInfo: snap.SideInfo{Revision: snap.R(1)}}
+	info := &snap.Info{SuggestedName: "name"}
+	info.SideInfo = snap.SideInfo{Revision: snap.R(1)}
 	s.testDirAndFileMethods(c, info)
 }
 


### PR DESCRIPTION
The gccgo in Ubuntu 16.04 on powerpc fails to build and errors
with the following message:
```
src/github.com/snapcore/snapd/snap/info_test.go:634:44: error: use of undefined type ‘SideInfo’
  info := &snap.Info{SuggestedName: "name", SideInfo: snap.SideInfo{Revision: snap.R(1)}}
```
Rewriting the initialization slightly fixes the error.
