### PR TITLE
debian: ensure /var/lib/snapd/lib/vulkan is available

### DIFF
--- a/packaging/ubuntu-16.04/snapd.dirs
+++ b/packaging/ubuntu-16.04/snapd.dirs
@@ -8,6 +8,7 @@ var/lib/snapd/environment
 var/lib/snapd/firstboot
 var/lib/snapd/lib/gl
 var/lib/snapd/lib/gl32
+var/lib/snapd/lib/vulkan
 var/lib/snapd/snaps/partial
 var/lib/snapd/void
 var/snap


### PR DESCRIPTION
The nvidia support will also try to bind mount the vulkan directory
from the nvidia driver. This directory is needed to support that.
