### PR TITLE
tests: make interfaces-snapd-control-with-manage more robust

### DIFF
--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -91,4 +91,10 @@ execute: |
     fi
 
     echo "Ensure that last-refresh-hit happens regardless of managed setting"
+    for i in $(seq 120); do
+        if cat /var/lib/snapd/state.json | jq '.data["last-refresh-hints"]' | grep $(date +%Y); then
+            break
+        fi
+        sleep 1
+    fi
     cat /var/lib/snapd/state.json | jq '.data["last-refresh-hints"]' | grep $(date +%Y)

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -96,5 +96,5 @@ execute: |
             break
         fi
         sleep 1
-    fi
+    done
     cat /var/lib/snapd/state.json | jq '.data["last-refresh-hints"]' | grep $(date +%Y)


### PR DESCRIPTION
The last-refresh-hints hit may take some time depending on how
fast the store is. Take that into account.
