### PR TITLE
devicestate: fix unkeyed fields error

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2106,8 +2106,8 @@ func makeMockRepoWithConnectedSnaps(c *C, st *state.State, info11, core11 *snap.
 	err = repo.AddSnap(core11)
 	c.Assert(err, IsNil)
 	err = repo.Connect(interfaces.ConnRef{
-		interfaces.PlugRef{Snap: info11.Name(), Name: ifname},
-		interfaces.SlotRef{Snap: core11.Name(), Name: ifname},
+		PlugRef: interfaces.PlugRef{Snap: info11.Name(), Name: ifname},
+		SlotRef: interfaces.SlotRef{Snap: core11.Name(), Name: ifname},
 	})
 	c.Assert(err, IsNil)
 	conns, err := repo.Connected("snap-with-snapd-control", "snapd-control")


### PR DESCRIPTION
Getting the error now after recent changes in master.
