### PR TITLE
tests: don't chown the whole world to test.test

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -56,7 +56,8 @@ create_test_user(){
 
     echo 'test ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-    chown test.test -R ..
+    chown test.test -R "$SPREAD_PATH"
+    chown test.test "$SPREAD_PATH/../"
 }
 
 build_deb(){

--- a/tests/main/core-snap-not-test-test/task.yaml
+++ b/tests/main/core-snap-not-test-test/task.yaml
@@ -1,0 +1,5 @@
+summary: Files inside the core snap are not owned by test.test
+execute: |
+    [ $(find /snap/core/current/ -user test | wc -l) = 0 ]
+debug: |
+    find /snap/core/current/ -user test


### PR DESCRIPTION
Changing the owner of project files should suffice.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>