### PR TITLE
interfaces: add gpio-memory-control interface

### DIFF
--- a/interfaces/builtin/gpio_memory_control.go
+++ b/interfaces/builtin/gpio_memory_control.go
@@ -1,0 +1,51 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const gpioMemoryControlSummary = `allows write access to all gpio memory`
+
+const gpioMemoryControlBaseDeclarationSlots = `
+  gpio-memory-control:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const gpioMemoryControlConnectedPlugAppArmor = `
+# Description: Allow writing to /dev/gpiomem on kernels that provide it.
+#
+/dev/gpiomem rw,
+`
+
+var gpioMemoryControlConnectedPlugUDev = []string{`KERNEL=="gpiomem"`}
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "gpio-memory-control",
+		summary:               gpioMemoryControlSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  gpioMemoryControlBaseDeclarationSlots,
+		connectedPlugAppArmor: gpioMemoryControlConnectedPlugAppArmor,
+		connectedPlugUDev:     gpioMemoryControlConnectedPlugUDev,
+		reservedForOS:         true,
+	})
+}

--- a/interfaces/builtin/gpio_memory_control.go
+++ b/interfaces/builtin/gpio_memory_control.go
@@ -19,6 +19,7 @@
 
 package builtin
 
+// https://github.com/raspberrypi/linux/blob/rpi-4.4.y/drivers/char/broadcom/bcm2835-gpiomem.c
 const gpioMemoryControlSummary = `allows write access to all gpio memory`
 
 const gpioMemoryControlBaseDeclarationSlots = `
@@ -30,8 +31,10 @@ const gpioMemoryControlBaseDeclarationSlots = `
 `
 
 const gpioMemoryControlConnectedPlugAppArmor = `
-# Description: Allow writing to /dev/gpiomem on kernels that provide it.
-#
+# Description: Allow writing to /dev/gpiomem on kernels that provide it (eg,
+# via the bcm2835-gpiomem kernel module). This allows direct access to the
+# physical memory for GPIO devices (i.e. a subset of /dev/mem) and therefore
+# grants access to all GPIO devices on the system.
 /dev/gpiomem rw,
 `
 

--- a/interfaces/builtin/gpio_memory_control_test.go
+++ b/interfaces/builtin/gpio_memory_control_test.go
@@ -1,0 +1,108 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type GpioMemoryControlInterfaceSuite struct {
+	iface interfaces.Interface
+	slot  *interfaces.Slot
+	plug  *interfaces.Plug
+}
+
+var _ = Suite(&GpioMemoryControlInterfaceSuite{
+	iface: builtin.MustInterface("gpio-memory-control"),
+})
+
+const gpioMemoryControlConsumerYaml = `name: consumer
+apps:
+ app:
+  plugs: [gpio-memory-control]
+`
+
+const gpioMemoryControlCoreYaml = `name: core
+type: os
+slots:
+  gpio-memory-control:
+`
+
+func (s *GpioMemoryControlInterfaceSuite) SetUpTest(c *C) {
+	s.plug = MockPlug(c, gpioMemoryControlConsumerYaml, nil, "gpio-memory-control")
+	s.slot = MockSlot(c, gpioMemoryControlCoreYaml, nil, "gpio-memory-control")
+}
+
+func (s *GpioMemoryControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "gpio-memory-control")
+}
+
+func (s *GpioMemoryControlInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(s.slot.Sanitize(s.iface), IsNil)
+	slot := &interfaces.Slot{SlotInfo: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "gpio-memory-control",
+		Interface: "gpio-memory-control",
+	}}
+	c.Assert(slot.Sanitize(s.iface), ErrorMatches,
+		"gpio-memory-control slots are reserved for the core snap")
+}
+
+func (s *GpioMemoryControlInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(s.plug.Sanitize(s.iface), IsNil)
+}
+
+func (s *GpioMemoryControlInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/gpiomem rw,`)
+}
+
+func (s *GpioMemoryControlInterfaceSuite) TestUDevSpec(c *C) {
+	spec := &udev.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, nil, s.slot, nil), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 1)
+	c.Assert(spec.Snippets(), testutil.Contains, `# gpio-memory-control
+KERNEL=="gpiomem", TAG+="snap_consumer_app"`)
+}
+
+func (s *GpioMemoryControlInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows write access to all gpio memory`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "gpio-memory-control")
+}
+
+func (s *GpioMemoryControlInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plug, s.slot), Equals, true)
+}
+
+func (s *GpioMemoryControlInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -83,6 +83,9 @@ apps:
   fwupd:
     command: bin/run
     plugs: [ fwupd ]
+  gpio-memory-control:
+    command: bin/run
+    plugs: [ gpio-memory-control ]
   greengrass-support:
     command: bin/run
     plugs: [ greengrass-support ]


### PR DESCRIPTION
Raspberry Pi systems expose GPIO-only memory at /dev/gpiomem, which provides much faster memory-mapped access than sysfs while being more constrained than /dev/mem.

Support write-access to /dev/gpiomem with a new interface named gpio-memory-control.