### PR TITLE
release: merge 2.30~rc1 back into master

### DIFF
--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,225 @@
+snapd (2.30~14.04~rc1) trusty; urgency=medium
+
+  * New upstream release, LP: #1735344
+    - tests: add support for autopkgtests on s390x
+    - snapstate: support for pre-refresh hook
+    - many: allow to configure core before it is installed
+    - devicestate: fix unkeyed fields error
+    - snap-confine: create mount target for lib32,vulkan on demand
+    - snapstate: add support for refresh.schedule=managed
+    - cmd/snap-update-ns: teach update logic to handle synthetic changes
+    - many: remove configure-snapd task again and handle internally
+    - snap: fix TestDirAndFileMethods() test to work with gccgo
+    - debian: ensure /var/lib/snapd/lib/vulkan is available
+    - cmd/snap-confine: use #include instead of bare include
+    - snapstate: store userID in snapstate
+    - snapd.dirs: add var/lib/snapd/lib/gl32
+    - timeutil, overlod/snapstate: cleanup remaining pieces of timeutil
+      weekday support
+    - packaging/arch: install missing directories, manpages and version
+      info
+    - snapstate,store: store if a snap is a paid snap in the sideinfo
+    - packaging/arch: pre-create snapd directories when packaging
+    - tests/main/manpages: set LC_ALL=C as man may complain if the
+      locale is unset or unsupported
+    - repo: ConnectedPlug and ConnectedSlot types
+    - snapd: fix handling of undo in the taskrunner
+    - store: fix download caching and add integration test
+    - snapstate: move autorefresh code into autoRefresh helper
+    - snapctl: don't error out on start/stop/restart from configure hook
+      during install or refresh
+    - cmd/snap-update-ns: add planWritableMimic
+    - deamon: don't omit responses, even if null
+    - tests: add test for frame buffer interface
+    - tests/lib: fix shellcheck errors
+    - apparmor: generate the snap-confine re-exec profile for
+      AppArmor{Partial,Full}
+    - tests: remove obsolete workaround
+    - snap: use existing files in `snap download` if digest/size matches
+    - tests: merge pepare-project.sh into prepare-restore.sh
+    - tests: cache snaps to $TESTSLIB/cache
+    - tests: set -e, -o pipefail in prepare-restore.sh
+    - apparmor: generate the snap-confine re-exec profile for
+      AppArmor{Partial,Full}
+    - cmd/snap-seccomp: fix uid/gid restrictions tests on Arch
+    - tests: document and slightly refactor prepare/restore code
+    - snapstate: ensure RefreshSchedule() gives accurate results
+    - snapstate: add new refresh-hints helper and use it
+    - spread.yaml,tests: move most of project-wide prepare/restore to
+      separate file
+    - timeutil: introduce helpers for weekdays and TimeOfDay
+    - tests: adding new test for uhid interface
+    - cmd/libsnap: fix parsing of empty mountinfo fields
+    - overlord/devicestate:  best effort to go to early full retries for
+      registration on the like of DNS no host
+    - spread.yaml: bump delta ref to 2.29
+    - tests: adding test to test physical memory observe interface
+    - cmd, errtracker: get rid of SNAP_DID_REEXEC environment
+    - timeutil: remove support to parse weekday schedules
+    - snap-confine: add workaround for snap-confine on 4.13/upstream
+    - store: do not log the http body for catalog updates
+    - snapstate: move catalogRefresh into its own helper
+    - spread.yaml: fix shellcheck issues and trivial refactor
+    - spread.yaml: move prepare-each closer to restore-each
+    - spread.yaml: increase workers for opensuse to 3
+    - tests: force delete when tests are restore to avoid suite failure
+    - test: ignore /snap/README
+    - interfaces/opengl: also allow read on 'revision' in
+      /sys/devices/pci...
+    - interfaces/screen-inhibit-control: fix case in screen inhibit
+      control
+    - asserts/sysdb: panic early if pointed to staging but staging keys
+      are not compiled-in
+    - interfaces: allow /bin/chown and fchownat to root:root
+    - timeutil: include test input in error message in
+      TestParseSchedule()
+    - interfaces/browser-support: adjust base declaration for auto-
+      connection
+    - snap-confine: fix snap-confine under lxd
+    - store: bit less aggressive retry strategy
+    - tests: add new `fakestore new-snap-{declaration,revision}` helpers
+    - cmd/snap-update-ns: add secureMkfileAll
+    - snap: use field names when initializing composite literals
+    - HACKING: fix path in snap install
+    - store: add support for flags in ListRefresh()
+    - interfaces: remove invalid plugs/slots from SnapInfo on
+      sanitization.
+    - debian: add missing udev dependency
+    - snap/validate: extend socket validation tests
+    - interfaces: add "refresh-schedule" attribute to snapd-control
+    - interfaces/builtin/account_control: use gid owning /etc/shadow to
+      setup seccomp rules
+    - cmd/snap-update-ns: tweak changePerform
+    - interfaces,tests: skip unknown plug/slot interfaces
+    - tests: disable interfaces-network-control-tuntap
+    - cmd: use a preinit_array function rather than parsing
+      /proc/self/cmdline
+    - interfaces/time*_control: explicitly deny noisy read on
+      /proc/1/environ
+    - cmd/snap-update-ns: misc cleanups
+    - snapd: allow hooks to have slots
+    - fakestore: add go-flags to prepare for `new-snap-declaration` cmd
+    - interfaces/browser-support: add shm path for nwjs
+    - many: add magic /snap/README file
+    - overlord/snapstate: support completion for command aliases
+    - tests: re-enable tun/tap test on Debian
+    - snap,wrappers: add support for socket activation
+    - repo: use PlugInfo and SlotInfo for permanent plugs/slots
+    - tests/interfaces-network-control-tuntap: disable on debian-
+      unstable for now
+    - cmd/snap-confine: Loosen the NVIDIA Vulkan ICD glob
+    - cmd/snap-update-ns: detect and report read-only filesystems
+    - cmd/snap-update-ns: re-factor secureMkdirAll into
+      secureMk{Prefix,Dir}
+    - run-checks, tests/lib/snaps/: shellcheck fixes
+    - corecfg: validate refresh.schedule when it is applied
+    - tests: adjust test to match stderr
+    - snapd: fix snap cookie bugs
+    - packaging/arch: do not quote MAKEFLAGS
+    - state: add change.LaneTasks helper
+    - cmd/snap-update-ns: do not assume 'nogroup' exists
+    - tests/lib: handle distro specific grub-editenv naming
+    - cmd/snap-confine: Add missing bi-arch NVIDIA filesthe
+      `/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl/vdpau` paths within
+    - cmd: Support exposing NVIDIA Vulkan ICD files to the snaps
+    - cmd/snap-confine: Implement full 32-bit NVIDIA driver support
+    - packaging/arch: packaging update
+    - cmd/snap-confine: Support bash as base runtime entry
+    - wrappers: do not error on incorrect Exec= lines
+    - interfaces: fix udev tagging for hooks
+    - tests/set-proxy-store: exclude ubuntu-core-16 via systems: key
+    - tests: new tests for network setup control and observe interfaces
+    - osutil: add helper for obtaining group ID of given file path
+    - daemon,overlord/snapstate: return snap-not-installed error in more
+      cases
+    - interfaces/builtin/lxd_support: allow discovering of host's os-
+      release
+    - configstate: add support for configure-snapd for
+      snapstate.IgnoreHookError
+    - tests:  add a spread test for proxy.store setting together with
+      store assertion
+    - cmd/snap-seccomp: do not use group 'shadow' in tests
+    - asserts/assertstest:  fix use of hardcoded value when the passed
+      or default keys should be used
+    - interfaces/many: misc policy updates for browser-support, cups-
+      control and network-status
+    - tests: fix xdg-open-compat
+    - daemon: for /v2/logs, 404 when no services are found
+    - packaging/fedora: Merge changes from Fedora Dist-Git
+    - cmd/snap-update-ns: add new helpers for mount entries
+    - cmd/snap-confine: Respect biarch nature of libdirs
+    - cmd/snap-confine: Ensure snap-confine is allowed to access os-
+      release
+    - cmd: fix re-exec bug with classic confinement for host snapd <
+      2.28
+    - interfaces/kmod: simplify loadModules now that errors are ignored
+    - tests: disable xdg-open-compat test
+    - tests: add test that checks core reverts on core devices
+    - dirs: use alt root when checking classic confinement support
+      without …
+    - interfaces/kmod: treat failure to load module as non-fatal
+    - cmd/snap-update-ns: fix golint and some stale comments
+    - corecfg:  support setting proxy.store if there's a matching store
+      assertion
+    - overlord/snapstate: toggle ignore-validation as needed as we do
+      for channel
+    - tests: fix security-device-cgroup* tests on devices with
+      framebuffer
+    - interfaces/raw-usb: match on SUBSYSTEM, not SUBSYSTEMS
+    - interfaces: add USB interface number attribute in udev rule for
+      serial-port interface
+    - overlord/devicestate: switch to the new endpoints for registration
+    - snap-update-ns: add missing unit test for desired/current profile
+      handling
+    - cmd/{snap-confine,libsnap-confine-private,snap-shutdown}: cleanup
+      low-level C bits
+    - ifacestate: make interfaces.Repository available via state cache
+    - overlord/snapstate: cleanups around switch-snap*
+    - cmd/snapd,client,daemon: display ignore-validation flag through
+      the notes mechanism
+    - cmd/snap-update-ns: add logging to snap-update-ns
+    - many: have a timestamp on store assertions
+    - many: lookup and use the URL from a store assertion if one is set
+      for use
+    - tests/test-snapd-service: fix shellcheck issues
+    - tests: new test for hardware-random-control interface
+    - tests: use `snap change --last=install` in snapd-reexec test
+    - repo, daemon: use PlugInfo, SlotInfo
+    - many: handle core configuration internally instead of using the
+      core configure hook
+    - tests: refactor and expand content interface test
+    - snap-seccomp: skip in-kernel bpf tests for socket() in trusty/i386
+    - cmd/snap-update-ns: allow Change.Perform to return changes
+    - snap-confine: Support biarch Linux distribution confinement
+    - partition/ubootenv: don't panic when uboot.env is missing the eof
+      marker
+    - cmd/snap-update-ns: allow fault injection to provide dynamic
+      result
+    - interfaces/mount: exspose mount.{Escape,Unescape}
+    - snapctl: added long help to stop/start/restart command
+    - cmd/snap-update-ns: create missing mount points automatically.
+    - cmd: downgrade log message in InternalToolPath to Debugf()
+    - tests: wait for service status change & file update in the test to
+      avoid races
+    - daemon, store: forward SSO invalid credentials errors as 401
+      Unauthorized responses
+    - spdx: fix for WITH syntax, require a license name before the
+      operator
+    - many: reorg things in preparation to make handling of the base url
+      in store dynamic
+    - hooks/configure: queue service restarts
+    - cmd/snap: warn when a snap is not from the tracking channel
+    - interfaces/mount: add support for parsing x-snapd.{mode,uid,gid}=
+    - cmd/snap-confine: add detection of stale mount namespace
+    - interfaces: add plugRef/slotRef helpers for PlugInfo/SlotInfo
+    - tests: check for invalid udev files during all tests
+    - daemon: use newChange() in changeAliases for consistency
+    - servicestate: use taskset
+    - many: add support for /home on NFS
+    - packaging,spread: fix and re-enable opensuse builds
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Thu, 30 Nov 2017 08:59:12 +0100
+
 snapd (2.29.4~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #1726258

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,11 @@
+snapd (2.29.4.1) xenial; urgency=medium
+
+  * New upstream release, LP: #1726258
+    - tests: more debug info for classic-ubuntu-core-transition
+    - packaging: fix typo that causes error in the misspell test
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Tue, 28 Nov 2017 07:45:23 +0100
+
 snapd (2.29.4) xenial; urgency=medium
 
   * New upstream release, LP: #1726258

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,225 @@
+snapd (2.30~rc1) xenial; urgency=medium
+
+  * New upstream release, LP: #1735344
+    - tests: add support for autopkgtests on s390x
+    - snapstate: support for pre-refresh hook
+    - many: allow to configure core before it is installed
+    - devicestate: fix unkeyed fields error
+    - snap-confine: create mount target for lib32,vulkan on demand
+    - snapstate: add support for refresh.schedule=managed
+    - cmd/snap-update-ns: teach update logic to handle synthetic changes
+    - many: remove configure-snapd task again and handle internally
+    - snap: fix TestDirAndFileMethods() test to work with gccgo
+    - debian: ensure /var/lib/snapd/lib/vulkan is available
+    - cmd/snap-confine: use #include instead of bare include
+    - snapstate: store userID in snapstate
+    - snapd.dirs: add var/lib/snapd/lib/gl32
+    - timeutil, overlod/snapstate: cleanup remaining pieces of timeutil
+      weekday support
+    - packaging/arch: install missing directories, manpages and version
+      info
+    - snapstate,store: store if a snap is a paid snap in the sideinfo
+    - packaging/arch: pre-create snapd directories when packaging
+    - tests/main/manpages: set LC_ALL=C as man may complain if the
+      locale is unset or unsupported
+    - repo: ConnectedPlug and ConnectedSlot types
+    - snapd: fix handling of undo in the taskrunner
+    - store: fix download caching and add integration test
+    - snapstate: move autorefresh code into autoRefresh helper
+    - snapctl: don't error out on start/stop/restart from configure hook
+      during install or refresh
+    - cmd/snap-update-ns: add planWritableMimic
+    - deamon: don't omit responses, even if null
+    - tests: add test for frame buffer interface
+    - tests/lib: fix shellcheck errors
+    - apparmor: generate the snap-confine re-exec profile for
+      AppArmor{Partial,Full}
+    - tests: remove obsolete workaround
+    - snap: use existing files in `snap download` if digest/size matches
+    - tests: merge pepare-project.sh into prepare-restore.sh
+    - tests: cache snaps to $TESTSLIB/cache
+    - tests: set -e, -o pipefail in prepare-restore.sh
+    - apparmor: generate the snap-confine re-exec profile for
+      AppArmor{Partial,Full}
+    - cmd/snap-seccomp: fix uid/gid restrictions tests on Arch
+    - tests: document and slightly refactor prepare/restore code
+    - snapstate: ensure RefreshSchedule() gives accurate results
+    - snapstate: add new refresh-hints helper and use it
+    - spread.yaml,tests: move most of project-wide prepare/restore to
+      separate file
+    - timeutil: introduce helpers for weekdays and TimeOfDay
+    - tests: adding new test for uhid interface
+    - cmd/libsnap: fix parsing of empty mountinfo fields
+    - overlord/devicestate:  best effort to go to early full retries for
+      registration on the like of DNS no host
+    - spread.yaml: bump delta ref to 2.29
+    - tests: adding test to test physical memory observe interface
+    - cmd, errtracker: get rid of SNAP_DID_REEXEC environment
+    - timeutil: remove support to parse weekday schedules
+    - snap-confine: add workaround for snap-confine on 4.13/upstream
+    - store: do not log the http body for catalog updates
+    - snapstate: move catalogRefresh into its own helper
+    - spread.yaml: fix shellcheck issues and trivial refactor
+    - spread.yaml: move prepare-each closer to restore-each
+    - spread.yaml: increase workers for opensuse to 3
+    - tests: force delete when tests are restore to avoid suite failure
+    - test: ignore /snap/README
+    - interfaces/opengl: also allow read on 'revision' in
+      /sys/devices/pci...
+    - interfaces/screen-inhibit-control: fix case in screen inhibit
+      control
+    - asserts/sysdb: panic early if pointed to staging but staging keys
+      are not compiled-in
+    - interfaces: allow /bin/chown and fchownat to root:root
+    - timeutil: include test input in error message in
+      TestParseSchedule()
+    - interfaces/browser-support: adjust base declaration for auto-
+      connection
+    - snap-confine: fix snap-confine under lxd
+    - store: bit less aggressive retry strategy
+    - tests: add new `fakestore new-snap-{declaration,revision}` helpers
+    - cmd/snap-update-ns: add secureMkfileAll
+    - snap: use field names when initializing composite literals
+    - HACKING: fix path in snap install
+    - store: add support for flags in ListRefresh()
+    - interfaces: remove invalid plugs/slots from SnapInfo on
+      sanitization.
+    - debian: add missing udev dependency
+    - snap/validate: extend socket validation tests
+    - interfaces: add "refresh-schedule" attribute to snapd-control
+    - interfaces/builtin/account_control: use gid owning /etc/shadow to
+      setup seccomp rules
+    - cmd/snap-update-ns: tweak changePerform
+    - interfaces,tests: skip unknown plug/slot interfaces
+    - tests: disable interfaces-network-control-tuntap
+    - cmd: use a preinit_array function rather than parsing
+      /proc/self/cmdline
+    - interfaces/time*_control: explicitly deny noisy read on
+      /proc/1/environ
+    - cmd/snap-update-ns: misc cleanups
+    - snapd: allow hooks to have slots
+    - fakestore: add go-flags to prepare for `new-snap-declaration` cmd
+    - interfaces/browser-support: add shm path for nwjs
+    - many: add magic /snap/README file
+    - overlord/snapstate: support completion for command aliases
+    - tests: re-enable tun/tap test on Debian
+    - snap,wrappers: add support for socket activation
+    - repo: use PlugInfo and SlotInfo for permanent plugs/slots
+    - tests/interfaces-network-control-tuntap: disable on debian-
+      unstable for now
+    - cmd/snap-confine: Loosen the NVIDIA Vulkan ICD glob
+    - cmd/snap-update-ns: detect and report read-only filesystems
+    - cmd/snap-update-ns: re-factor secureMkdirAll into
+      secureMk{Prefix,Dir}
+    - run-checks, tests/lib/snaps/: shellcheck fixes
+    - corecfg: validate refresh.schedule when it is applied
+    - tests: adjust test to match stderr
+    - snapd: fix snap cookie bugs
+    - packaging/arch: do not quote MAKEFLAGS
+    - state: add change.LaneTasks helper
+    - cmd/snap-update-ns: do not assume 'nogroup' exists
+    - tests/lib: handle distro specific grub-editenv naming
+    - cmd/snap-confine: Add missing bi-arch NVIDIA filesthe
+      `/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl/vdpau` paths within
+    - cmd: Support exposing NVIDIA Vulkan ICD files to the snaps
+    - cmd/snap-confine: Implement full 32-bit NVIDIA driver support
+    - packaging/arch: packaging update
+    - cmd/snap-confine: Support bash as base runtime entry
+    - wrappers: do not error on incorrect Exec= lines
+    - interfaces: fix udev tagging for hooks
+    - tests/set-proxy-store: exclude ubuntu-core-16 via systems: key
+    - tests: new tests for network setup control and observe interfaces
+    - osutil: add helper for obtaining group ID of given file path
+    - daemon,overlord/snapstate: return snap-not-installed error in more
+      cases
+    - interfaces/builtin/lxd_support: allow discovering of host's os-
+      release
+    - configstate: add support for configure-snapd for
+      snapstate.IgnoreHookError
+    - tests:  add a spread test for proxy.store setting together with
+      store assertion
+    - cmd/snap-seccomp: do not use group 'shadow' in tests
+    - asserts/assertstest:  fix use of hardcoded value when the passed
+      or default keys should be used
+    - interfaces/many: misc policy updates for browser-support, cups-
+      control and network-status
+    - tests: fix xdg-open-compat
+    - daemon: for /v2/logs, 404 when no services are found
+    - packaging/fedora: Merge changes from Fedora Dist-Git
+    - cmd/snap-update-ns: add new helpers for mount entries
+    - cmd/snap-confine: Respect biarch nature of libdirs
+    - cmd/snap-confine: Ensure snap-confine is allowed to access os-
+      release
+    - cmd: fix re-exec bug with classic confinement for host snapd <
+      2.28
+    - interfaces/kmod: simplify loadModules now that errors are ignored
+    - tests: disable xdg-open-compat test
+    - tests: add test that checks core reverts on core devices
+    - dirs: use alt root when checking classic confinement support
+      without …
+    - interfaces/kmod: treat failure to load module as non-fatal
+    - cmd/snap-update-ns: fix golint and some stale comments
+    - corecfg:  support setting proxy.store if there's a matching store
+      assertion
+    - overlord/snapstate: toggle ignore-validation as needed as we do
+      for channel
+    - tests: fix security-device-cgroup* tests on devices with
+      framebuffer
+    - interfaces/raw-usb: match on SUBSYSTEM, not SUBSYSTEMS
+    - interfaces: add USB interface number attribute in udev rule for
+      serial-port interface
+    - overlord/devicestate: switch to the new endpoints for registration
+    - snap-update-ns: add missing unit test for desired/current profile
+      handling
+    - cmd/{snap-confine,libsnap-confine-private,snap-shutdown}: cleanup
+      low-level C bits
+    - ifacestate: make interfaces.Repository available via state cache
+    - overlord/snapstate: cleanups around switch-snap*
+    - cmd/snapd,client,daemon: display ignore-validation flag through
+      the notes mechanism
+    - cmd/snap-update-ns: add logging to snap-update-ns
+    - many: have a timestamp on store assertions
+    - many: lookup and use the URL from a store assertion if one is set
+      for use
+    - tests/test-snapd-service: fix shellcheck issues
+    - tests: new test for hardware-random-control interface
+    - tests: use `snap change --last=install` in snapd-reexec test
+    - repo, daemon: use PlugInfo, SlotInfo
+    - many: handle core configuration internally instead of using the
+      core configure hook
+    - tests: refactor and expand content interface test
+    - snap-seccomp: skip in-kernel bpf tests for socket() in trusty/i386
+    - cmd/snap-update-ns: allow Change.Perform to return changes
+    - snap-confine: Support biarch Linux distribution confinement
+    - partition/ubootenv: don't panic when uboot.env is missing the eof
+      marker
+    - cmd/snap-update-ns: allow fault injection to provide dynamic
+      result
+    - interfaces/mount: exspose mount.{Escape,Unescape}
+    - snapctl: added long help to stop/start/restart command
+    - cmd/snap-update-ns: create missing mount points automatically.
+    - cmd: downgrade log message in InternalToolPath to Debugf()
+    - tests: wait for service status change & file update in the test to
+      avoid races
+    - daemon, store: forward SSO invalid credentials errors as 401
+      Unauthorized responses
+    - spdx: fix for WITH syntax, require a license name before the
+      operator
+    - many: reorg things in preparation to make handling of the base url
+      in store dynamic
+    - hooks/configure: queue service restarts
+    - cmd/snap: warn when a snap is not from the tracking channel
+    - interfaces/mount: add support for parsing x-snapd.{mode,uid,gid}=
+    - cmd/snap-confine: add detection of stale mount namespace
+    - interfaces: add plugRef/slotRef helpers for PlugInfo/SlotInfo
+    - tests: check for invalid udev files during all tests
+    - daemon: use newChange() in changeAliases for consistency
+    - servicestate: use taskset
+    - many: add support for /home on NFS
+    - packaging,spread: fix and re-enable opensuse builds
+
+ -- Michael Vogt <michael.vogt@ubuntu.com>  Thu, 30 Nov 2017 08:59:12 +0100
+
 snapd (2.29.4.1) xenial; urgency=medium
 
   * New upstream release, LP: #1726258

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -13,6 +13,9 @@ restore: |
     rm -f state.json.new
 
 debug: |
+    snap list || true
+    snap info core || true
+    snap info ubuntu-core || true
     snap changes
     . "$TESTSLIB/changes.sh"
     snap change "$(change_id 'Transition ubuntu-core to core')" || true


### PR DESCRIPTION
This also contains a trivial unmerged debug change from 2.29.4.1 that was added to track down an autopkgtest failure in the ubuntu CI system.