### PR TITLE
wrappers: fix unit tests to use dirs.SnapMountDir

### DIFF
--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -211,10 +211,10 @@ Exec=snap.app.evil.evil
 `)
 
 	e := wrappers.SanitizeDesktopFile(snap, "app.desktop", desktopContent)
-	c.Assert(string(e), Equals, `[Desktop Entry]
+	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
 Name=foo
-Exec=env BAMF_DESKTOP_FILE_HINT=app.desktop /snap/bin/snap.app
-`)
+Exec=env BAMF_DESKTOP_FILE_HINT=app.desktop %s/bin/snap.app
+`, dirs.SnapMountDir))
 }
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExecOk(c *C) {


### PR DESCRIPTION
Use dirs.SnapMountDir instead of hardcoding the path. This allows the tests to
pass on systems not using /snap.
