### PR TITLE
cmd: disable check-syntax-c

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -25,6 +25,7 @@ check: check-unit-tests
 .PHONY: check-syntax-c
 check-syntax-c:
 	echo "WARNING: check-syntax-c produces different results for different version of indent"
+	echo "Your version of indent: `indent --version`"
 	@d=`mktemp -d`; \
 	trap 'rm -rf $d' EXIT; \
 	for f in $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch])) ; do \

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -19,11 +19,12 @@ subdirs = snap-confine snap-discard-ns system-shutdown libsnap-confine-private
 
 # Run check-syntax when checking
 # TODO: conver those to autotools-style tests later
-check: check-syntax-c check-unit-tests
+check: check-unit-tests
 
 # Force particular coding style on all source and header files.
 .PHONY: check-syntax-c
 check-syntax-c:
+	echo "WARNING: check-syntax-c produces different results for different version of indent"
 	@d=`mktemp -d`; \
 	trap 'rm -rf $d' EXIT; \
 	for f in $(foreach dir,$(subdirs),$(wildcard $(srcdir)/$(dir)/*.[ch])) ; do \


### PR DESCRIPTION
The syntax checker is now an optional manual step. This is done because
it seems to produce different results across different versions of
indent despite the fact that we a use a fixed profile.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>