### PR TITLE
systemd: add support for the mask/unmask operations

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -110,6 +110,8 @@ type Systemd interface {
 	Status(services ...string) ([]*ServiceStatus, error)
 	LogReader(services []string, n string, follow bool) (io.ReadCloser, error)
 	WriteMountUnitFile(name, what, where, fstype string) (string, error)
+	Mask(service string) error
+	Unmask(service string) error
 }
 
 // A Log is a single entry in the systemd journal
@@ -152,9 +154,21 @@ func (s *systemd) Enable(serviceName string) error {
 	return err
 }
 
+// Unmask the given service
+func (s *systemd) Unmask(serviceName string) error {
+	_, err := systemctlCmd("--root", s.rootDir, "unmask", serviceName)
+	return err
+}
+
 // Disable the given service
 func (s *systemd) Disable(serviceName string) error {
 	_, err := systemctlCmd("--root", s.rootDir, "disable", serviceName)
+	return err
+}
+
+// Mask the given service
+func (s *systemd) Mask(serviceName string) error {
+	_, err := systemctlCmd("--root", s.rootDir, "mask", serviceName)
 	return err
 }
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -351,6 +351,18 @@ func (s *SystemdTestSuite) TestEnable(c *C) {
 	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "enable", "foo"}})
 }
 
+func (s *SystemdTestSuite) TestMask(c *C) {
+	err := New("xyzzy", s.rep).Mask("foo")
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "mask", "foo"}})
+}
+
+func (s *SystemdTestSuite) TestUnmask(c *C) {
+	err := New("xyzzy", s.rep).Unmask("foo")
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"--root", "xyzzy", "unmask", "foo"}})
+}
+
 func (s *SystemdTestSuite) TestRestart(c *C) {
 	restore := MockStopDelays(time.Millisecond, 25*time.Second)
 	defer restore()


### PR DESCRIPTION
We will need those for corecfg, i.e. to port the PR
https://github.com/snapcore/core/pull/61 to the new
internal corecfg code.

