### PR TITLE
packaging/arch: add bash-completion as optional dependency

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -20,6 +20,7 @@ md5sums=('SKIP')
 
 pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd')
+optdepends=('bash-completion: bash completion support')
 provides=($pkgbase)
 # Community package is split into snapd and snap-confine, make sure we replace
 # both bits


### PR DESCRIPTION
Found when working on #4285 
