### PR TITLE
snap-confine: use #include in snap-confine.apparmor.in

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -8,7 +8,7 @@
     #
     # Those are discussed on https://forum.snapcraft.io/t/snapd-vs-upstream-kernel-vs-apparmor
     # and https://forum.snapcraft.io/t/snaps-and-nfs-home/
-    include "/var/lib/snapd/apparmor/snap-confine.d"
+    #include "/var/lib/snapd/apparmor/snap-confine.d"
 
     # We run privileged, so be fanatical about what we include and don't use
     # any abstractions


### PR DESCRIPTION
This unbreaks the python apparmor tools that do not support the
"include" keyword. Tools like aa-enforce currently fail on stable
because of our use of include. While this is arguable an apparmor
python tools bug we still need to help fix the situation by
changing our code to use "#include" which is supported.
