### PR TITLE
config, overlord/snapstate, timeutil: rename ParseSchedule to ParseLegacySchedule

### DIFF
--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -46,6 +46,6 @@ func validateRefreshSchedule(tr Conf) error {
 		return nil
 	}
 
-	_, err = timeutil.ParseSchedule(refreshScheduleStr)
+	_, err = timeutil.ParseLegacySchedule(refreshScheduleStr)
 	return err
 }

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -179,7 +179,7 @@ func (m *autoRefresh) refreshScheduleWithDefaultsFallback() (ts []*timeutil.Sche
 		return nil, "", err
 	}
 
-	refreshSchedule, err := timeutil.ParseSchedule(refreshScheduleStr)
+	refreshSchedule, err := timeutil.ParseLegacySchedule(refreshScheduleStr)
 	if err != nil {
 		logger.Noticef("cannot use refresh.schedule configuration: %s", err)
 		refreshSchedule, refreshScheduleStr = resetRefreshScheduleToDefault(m.state)
@@ -228,7 +228,7 @@ func (m *autoRefresh) launchAutoRefresh() error {
 }
 
 func resetRefreshScheduleToDefault(st *state.State) (ts []*timeutil.Schedule, scheduleStr string) {
-	refreshSchedule, err := timeutil.ParseSchedule(defaultRefreshSchedule)
+	refreshSchedule, err := timeutil.ParseLegacySchedule(defaultRefreshSchedule)
 	if err != nil {
 		panic(fmt.Sprintf("defaultRefreshSchedule cannot be parsed: %s", err))
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -5352,7 +5352,7 @@ func (s *snapmgrTestSuite) TestEnsureRefreshesDisabledViaSnapdControl(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestDefaultRefreshScheduleParsing(c *C) {
-	l, err := timeutil.ParseSchedule(snapstate.DefaultRefreshSchedule)
+	l, err := timeutil.ParseLegacySchedule(snapstate.DefaultRefreshSchedule)
 	c.Assert(err, IsNil)
 	c.Assert(l, HasLen, 4)
 }

--- a/timeutil/schedule.go
+++ b/timeutil/schedule.go
@@ -214,13 +214,13 @@ func parseSingleSchedule(s string) (*Schedule, error) {
 	}, nil
 }
 
-// ParseSchedule takes a schedule string in the form of:
+// ParseLegacySchedule takes a schedule string in the form of:
 //
 // 9:00-15:00 (every day between 9am and 3pm)
 // 9:00-15:00/21:00-22:00 (every day between 9am,5pm and 9pm,10pm)
 //
 // and returns a list of Schedule types or an error
-func ParseSchedule(scheduleSpec string) ([]*Schedule, error) {
+func ParseLegacySchedule(scheduleSpec string) ([]*Schedule, error) {
 	var schedule []*Schedule
 
 	for _, s := range strings.Split(scheduleSpec, "/") {

--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -100,7 +100,7 @@ func (ts *timeutilSuite) TestParseSchedule(c *C) {
 		{"9:00-11:00", []*timeutil.Schedule{{Start: timeutil.TimeOfDay{Hour: 9}, End: timeutil.TimeOfDay{Hour: 11}}}, ""},
 		{"9:00-11:00/20:00-22:00", []*timeutil.Schedule{{Start: timeutil.TimeOfDay{Hour: 9}, End: timeutil.TimeOfDay{Hour: 11}}, {Start: timeutil.TimeOfDay{Hour: 20}, End: timeutil.TimeOfDay{Hour: 22}}}, ""},
 	} {
-		schedule, err := timeutil.ParseSchedule(t.in)
+		schedule, err := timeutil.ParseLegacySchedule(t.in)
 		if t.errStr != "" {
 			c.Check(err, ErrorMatches, t.errStr, Commentf("%q returned unexpected error: %s", t.in, err))
 		} else {
@@ -231,7 +231,7 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 		})
 		defer restorer()
 
-		sched, err := timeutil.ParseSchedule(t.schedule)
+		sched, err := timeutil.ParseLegacySchedule(t.schedule)
 		c.Assert(err, IsNil)
 		minDist, maxDist := parse(c, t.next)
 

--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -81,7 +81,7 @@ func (ts *timeutilSuite) TestScheduleString(c *C) {
 	}
 }
 
-func (ts *timeutilSuite) TestParseSchedule(c *C) {
+func (ts *timeutilSuite) TestParseLegacySchedule(c *C) {
 	for _, t := range []struct {
 		in       string
 		expected []*timeutil.Schedule
@@ -142,7 +142,7 @@ func parse(c *C, s string) (time.Duration, time.Duration) {
 	return a, b
 }
 
-func (ts *timeutilSuite) TestScheduleNext(c *C) {
+func (ts *timeutilSuite) TestLegacyScheduleNext(c *C) {
 	const shortForm = "2006-01-02 15:04"
 
 	for _, t := range []struct {


### PR DESCRIPTION
Making room for new schedule parser.

Related to #4313 