### PR TITLE
userd: generalize dbusInterface

### DIFF
--- a/userd/launcher.go
+++ b/userd/launcher.go
@@ -54,6 +54,11 @@ func (s *Launcher) Name() string {
 	return "io.snapcraft.Launcher"
 }
 
+// BasePath returns the base path of the object
+func (s *Launcher) BasePath() dbus.ObjectPath {
+	return "/io/snapcraft/Launcher"
+}
+
 // IntrospectionData gives the XML formatted introspection description
 // of the DBus service.
 func (s *Launcher) IntrospectionData() string {

--- a/userd/launcher_test.go
+++ b/userd/launcher_test.go
@@ -20,6 +20,8 @@
 package userd_test
 
 import (
+	"testing"
+
 	"github.com/godbus/dbus"
 
 	. "gopkg.in/check.v1"
@@ -27,6 +29,8 @@ import (
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/userd"
 )
+
+func Test(t *testing.T) { TestingT(t) }
 
 type launcherSuite struct {
 	launcher *userd.Launcher

--- a/userd/userd.go
+++ b/userd/userd.go
@@ -20,7 +20,6 @@
 package userd
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/godbus/dbus"
@@ -60,18 +59,12 @@ func (ud *Userd) Init() error {
 		}
 
 		if reply != dbus.RequestNameReplyPrimaryOwner {
-			err = fmt.Errorf("cannot obtain bus name '%s'", iface.Name())
-			return err
+			return fmt.Errorf("cannot obtain bus name '%s'", iface.Name())
 		}
 
-		var buffer bytes.Buffer
-		buffer.WriteString("<node>")
-		buffer.WriteString(iface.IntrospectionData())
-		buffer.WriteString(introspect.IntrospectDataString)
-		buffer.WriteString("</node>")
-
+		xml := "<node>" + iface.IntrospectionData() + introspect.IntrospectDataString + "</node>"
 		ud.conn.Export(iface, iface.BasePath(), iface.Name())
-		ud.conn.Export(introspect.Introspectable(buffer.String()), iface.BasePath(), "org.freedesktop.DBus.Introspectable")
+		ud.conn.Export(introspect.Introspectable(xml), iface.BasePath(), "org.freedesktop.DBus.Introspectable")
 	}
 	return nil
 }


### PR DESCRIPTION
This prepares for having multiple dbus interfaces provided by
snap userd.

Part of the (much) large #4073 but should be trivial and will make the other PR smaller and easier to check.
