### PR TITLE
snap: YAML and app validation parts of after/before app startup ordering

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -484,8 +484,8 @@ type AppInfo struct {
 
 	// list of other service names that this service will start after or
 	// before
-	StartAfter  []string
-	StartBefore []string
+	After  []string
+	Before []string
 }
 
 // ScreenshotInfo provides information about a screenshot.

--- a/snap/info.go
+++ b/snap/info.go
@@ -481,6 +481,11 @@ type AppInfo struct {
 	Sockets map[string]*SocketInfo
 
 	Environment strutil.OrderedMap
+
+	// list of other service names that this service will start after or
+	// before
+	StartAfter  []string
+	StartBefore []string
 }
 
 // ScreenshotInfo provides information about a screenshot.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -78,8 +78,8 @@ type appYaml struct {
 
 	Sockets map[string]socketsYaml `yaml:"sockets,omitempty"`
 
-	StartAfter  []string `yaml:"start-after,omitempty"`
-	StartBefore []string `yaml:"start-before,omitempty"`
+	After  []string `yaml:"after,omitempty"`
+	Before []string `yaml:"before,omitempty"`
 }
 
 type hookYaml struct {
@@ -292,8 +292,8 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			BusName:         yApp.BusName,
 			Environment:     yApp.Environment,
 			Completer:       yApp.Completer,
-			StartBefore:     yApp.StartBefore,
-			StartAfter:      yApp.StartAfter,
+			Before:          yApp.Before,
+			After:           yApp.After,
 		}
 		if len(y.Plugs) > 0 || len(yApp.PlugNames) > 0 {
 			app.Plugs = make(map[string]*PlugInfo)

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -77,6 +77,9 @@ type appYaml struct {
 	Environment strutil.OrderedMap `yaml:"environment,omitempty"`
 
 	Sockets map[string]socketsYaml `yaml:"sockets,omitempty"`
+
+	StartAfter  []string `yaml:"start-after,omitempty"`
+	StartBefore []string `yaml:"start-before,omitempty"`
 }
 
 type hookYaml struct {
@@ -289,6 +292,8 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			BusName:         yApp.BusName,
 			Environment:     yApp.Environment,
 			Completer:       yApp.Completer,
+			StartBefore:     yApp.StartBefore,
+			StartAfter:      yApp.StartAfter,
 		}
 		if len(y.Plugs) > 0 || len(yApp.PlugNames) > 0 {
 			app.Plugs = make(map[string]*PlugInfo)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1577,22 +1577,22 @@ apps:
 	c.Assert(err, IsNil)
 
 	c.Check(info.Apps, DeepEquals, map[string]*snap.AppInfo{
-		"foo": &snap.AppInfo{
+		"foo": {
 			Snap:       info,
 			Name:       "foo",
 			StartAfter: []string{"bar", "zed"},
 		},
-		"bar": &snap.AppInfo{
+		"bar": {
 			Snap:        info,
 			Name:        "bar",
 			StartBefore: []string{"foo"},
 		},
-		"baz": &snap.AppInfo{
+		"baz": {
 			Snap:       info,
 			Name:       "baz",
 			StartAfter: []string{"foo"},
 		},
-		"zed": &snap.AppInfo{
+		"zed": {
 			Snap: info,
 			Name: "zed",
 		},

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1565,11 +1565,11 @@ func (s *YamlSuite) TestSnapYamlAppStartOrder(c *C) {
 version: 42
 apps:
  foo:
-   start-after: [bar, zed]
+   after: [bar, zed]
  bar:
-   start-before: [foo]
+   before: [foo]
  baz:
-   start-after: [foo]
+   after: [foo]
  zed:
 
 `)
@@ -1578,19 +1578,19 @@ apps:
 
 	c.Check(info.Apps, DeepEquals, map[string]*snap.AppInfo{
 		"foo": {
-			Snap:       info,
-			Name:       "foo",
-			StartAfter: []string{"bar", "zed"},
+			Snap:  info,
+			Name:  "foo",
+			After: []string{"bar", "zed"},
 		},
 		"bar": {
-			Snap:        info,
-			Name:        "bar",
-			StartBefore: []string{"foo"},
+			Snap:   info,
+			Name:   "bar",
+			Before: []string{"foo"},
 		},
 		"baz": {
-			Snap:       info,
-			Name:       "baz",
-			StartAfter: []string{"foo"},
+			Snap:  info,
+			Name:  "baz",
+			After: []string{"foo"},
 		},
 		"zed": {
 			Snap: info,

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -319,20 +319,13 @@ func maybeOrderBeforeAfter(apps []*AppInfo) {
 				continue
 			}
 			var swap bool
-			if !swap && i < j && isAppOrdered(apps[i], orderAfter, apps[j]) {
-				// app i in lhs but ordered after j
+			if i < j &&
+				(isAppOrdered(apps[i], orderAfter, apps[j]) ||
+					isAppOrdered(apps[j], orderBefore, apps[i])) {
 				swap = true
-			}
-			if !swap && i > j && isAppOrdered(apps[i], orderBefore, apps[j]) {
-				// app i in rhs but ordered before j
-				swap = true
-			}
-			if !swap && j < i && isAppOrdered(apps[j], orderAfter, apps[i]) {
-				// app j in lhs but ordered after i
-				swap = true
-			}
-			if !swap && j > i && isAppOrdered(apps[j], orderBefore, apps[i]) {
-				// app j in rhs but ordered before i
+			} else if i > j &&
+				(isAppOrdered(apps[i], orderBefore, apps[j]) ||
+					isAppOrdered(apps[j], orderAfter, apps[i])) {
 				swap = true
 			}
 			if swap {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -273,10 +273,10 @@ const (
 
 func validateAppStartup(app *AppInfo, order appStartupOrder) error {
 	orderStr := "before"
-	deps := app.StartBefore
+	deps := app.Before
 	if order == orderAfter {
 		orderStr = "after"
-		deps = app.StartAfter
+		deps = app.After
 	}
 
 	for _, dep := range deps {
@@ -288,9 +288,9 @@ func validateAppStartup(app *AppInfo, order appStartupOrder) error {
 			// or it depends on us in the same order, eg. foo is
 			// started after bar, but bar is to be started after foo
 			// as well, validate only one dependency step
-			otherDeps := other.StartBefore
+			otherDeps := other.Before
 			if order == orderAfter {
-				otherDeps = other.StartAfter
+				otherDeps = other.After
 			}
 
 			if strutil.ListContains(otherDeps, app.Name) {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -669,6 +669,23 @@ apps:
    after: [bar]
    daemon: forking
 `)
+	// conflicting schedule for baz
+	badOrder3Cycle := []byte(`name: wat
+version: 42
+apps:
+ foo:
+   before: [bar]
+   after: [zed]
+   daemon: forking
+ bar:
+   before: [baz]
+   daemon: forking
+ baz:
+   before: [zed]
+   daemon: forking
+ zed:
+   daemon: forking
+`)
 	goodOrder1 := []byte(`name: wat
 version: 42
 apps:
@@ -729,6 +746,10 @@ apps:
 		desc: badOrder2,
 		err:  `cannot validate app "(bar|baz)" startup ordering: "(after|before)" dependencies cannot be satisfied`,
 	}, {
+		name: "bad order 3 - cycle",
+		desc: badOrder3Cycle,
+		err:  `cannot validate app "(foo|bar|baz)" startup ordering: "(after|before)" dependencies cannot be satisfied`,
+	}, {
 		name: "all good, 3 apps",
 		desc: goodOrder1,
 	}, {
@@ -746,9 +767,9 @@ apps:
 
 		err = Validate(info)
 		if tc.err != "" {
-			c.Check(err, ErrorMatches, tc.err)
+			c.Assert(err, ErrorMatches, tc.err)
 		} else {
-			c.Check(err, IsNil)
+			c.Assert(err, IsNil)
 		}
 	}
 }

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -740,15 +740,15 @@ apps:
 	}, {
 		name: "bad order 1",
 		desc: badOrder1,
-		err:  `cannot validate app "(foo|bar)" startup ordering: "after" dependencies cannot be satisfied`,
+		err:  `cannot validate app startup ordering: dependency cycle detected for apps "(foo, bar)|(bar, foo)"`,
 	}, {
 		name: "bad order 2",
 		desc: badOrder2,
-		err:  `cannot validate app "(bar|baz)" startup ordering: "(after|before)" dependencies cannot be satisfied`,
+		err:  `cannot validate app startup ordering: dependency cycle detected for apps "((foo|bar|baz)(, )?){3}"`,
 	}, {
 		name: "bad order 3 - cycle",
 		desc: badOrder3Cycle,
-		err:  `cannot validate app "(foo|bar|baz)" startup ordering: "(after|before)" dependencies cannot be satisfied`,
+		err:  `cannot validate app startup ordering: dependency cycle detected for apps "((foo|bar|baz|zed)(, )?){4}"`,
 	}, {
 		name: "all good, 3 apps",
 		desc: goodOrder1,
@@ -758,7 +758,7 @@ apps:
 	}, {
 		name: "self cycle",
 		desc: fooSelfCycle,
-		err:  `cannot validate app "foo" startup ordering: "after" dependencies cannot be satisfied`},
+		err:  `cannot validate app startup ordering: dependency cycle detected for apps "foo"`},
 	}
 	for _, tc := range tcs {
 		c.Logf("trying %q", tc.name)

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -602,7 +602,7 @@ name: foo
 version: 1.0
 apps:
   foo:
-    start-before: [baz]
+    before: [baz]
   bar:
 
 `)
@@ -619,7 +619,7 @@ name: foo
 version: 1.0
 apps:
   foo:
-    start-after: [baz]
+    after: [baz]
   bar:
 
 `)
@@ -635,9 +635,9 @@ func (s *YamlSuite) TestValidateAppStartSimpleDirectDependencyBad(c *C) {
 version: 42
 apps:
  foo:
-   start-after: [bar]
+   after: [bar]
  bar:
-   start-after: [foo]
+   after: [foo]
 
 `)
 	info, err := InfoFromSnapYaml(y)
@@ -654,11 +654,11 @@ func (s *YamlSuite) TestValidateAppStartOrderCorrect(c *C) {
 version: 42
 apps:
  foo:
-   start-after: [bar, zed]
+   after: [bar, zed]
  bar:
-   start-before: [foo]
+   before: [foo]
  baz:
-   start-after: [foo]
+   after: [foo]
  zed:
 
 `)

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -603,7 +603,6 @@ apps:
     daemon: simple
   bar:
     daemon: forking
-
 `)
 	fooBeforeBaz := []byte(`
 name: foo
@@ -614,7 +613,6 @@ apps:
     daemon: simple
   bar:
     daemon: forking
-
 `)
 
 	fooNotADaemon := []byte(`
@@ -625,7 +623,6 @@ apps:
     after: [bar]
   bar:
     daemon: forking
-
 `)
 
 	fooBarNotADaemon := []byte(`
@@ -636,7 +633,6 @@ apps:
     after: [bar]
     daemon: forking
   bar:
-
 `)
 	fooSelfCycle := []byte(`
 name: foo
@@ -646,7 +642,6 @@ apps:
     after: [foo]
     daemon: forking
   bar:
-
 `)
 	// cycle between foo and bar
 	badOrder1 := []byte(`name: wat
@@ -658,7 +653,6 @@ apps:
  bar:
    after: [foo]
    daemon: forking
-
 `)
 	// conflicting schedule for baz
 	badOrder2 := []byte(`name: wat
@@ -674,8 +668,6 @@ apps:
    before: [foo]
    after: [bar]
    daemon: forking
-
-
 `)
 	goodOrder1 := []byte(`name: wat
 version: 42
@@ -691,7 +683,6 @@ apps:
    daemon: forking
  zed:
    daemon: dbus
-
 `)
 	goodOrder2 := []byte(`name: wat
 version: 42
@@ -707,7 +698,6 @@ apps:
  zed:
    daemon: dbus
    after: [foo, bar, baz]
-
 `)
 
 	tcs := []struct {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -593,9 +593,6 @@ func (s *ValidateSuite) TestValidateSocketName(c *C) {
 	}
 }
 
-func (s *ValidateSuite) TestValidateStartupOrder(c *C) {
-
-}
 func (s *YamlSuite) TestValidateAppStartBeforeBad(c *C) {
 	y := []byte(`
 name: foo


### PR DESCRIPTION
This is the first part of app startup ordering support. This PR covers changes in YAML files and app validation. Related forum topic: https://forum.snapcraft.io/t/snap-app-startup-ordering/3009
