### PR TITLE
Make snapd.autoimport configurable

### DIFF
--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -62,7 +62,7 @@ func switchDisableService(service, value string) error {
 }
 
 // services that can be disabled
-var services = []string{"ssh", "rsyslog"}
+var services = []string{"ssh", "rsyslog", "snapd.autoimport"}
 
 func handleServiceDisableConfiguration(tr Conf) error {
 	for _, service := range services {


### PR DESCRIPTION
Make disabling assertion auto-import possible via a core config option in line with: 
https://forum.snapcraft.io/t/disabling-the-assertion-auto-import-job-on-core-should-be-possible/2923
