### PR TITLE
tests: increase warn-timeout to 15m

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -302,6 +302,7 @@ repack: |
     fi
 
 kill-timeout: 20m
+warn-timeout: 15m
 
 prepare: |
     # NOTE: This part of the code needs to be in spread.yaml as it runs before


### PR DESCRIPTION
From looking at the logs where we spend time in our tests it
looks like preparing a machine takes in the order of 6m to 12m.

To make analysing the logs easier this PR increases the warn
timeout to 15m.
