### PR TITLE
tests: increase workers for ubuntu-{14,16}.04-64 by one

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -55,10 +55,10 @@ backends:
         systems:
             - ubuntu-14.04-64:
                 kernel: GRUB 2
-                workers: 4
+                workers: 5
             - ubuntu-16.04-64:
                 kernel: GRUB 2
-                workers: 4
+                workers: 5
             - ubuntu-16.04-32:
                 kernel: GRUB 2
                 workers: 4

--- a/spread.yaml
+++ b/spread.yaml
@@ -302,6 +302,7 @@ repack: |
     fi
 
 kill-timeout: 20m
+warn-timeout: 15m
 
 prepare: |
     # NOTE: This part of the code needs to be in spread.yaml as it runs before


### PR DESCRIPTION
Looking at the times we spend executing the travis tests by machine
it appears that we spend quite a bit more time in these two setups
than in the others. Increase workers here.

This also includes https://github.com/snapcore/snapd/pull/4347 to
get a more useful log. 

Please do not merge just yet, I would like to analyse the resulting
log first. 