### PR TITLE
Make snapd.autoimport configurable

### DIFF
--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -69,7 +69,7 @@ func (iface *serialPortInterface) String() string {
 //  - ttyXRUSBx  (Exar Corp. USB UART devices)
 //  - ttySX (UART serial ports)
 //  - ttyOX (UART serial ports on ARM)
-var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(USB|ACM|AMA|XRUSB|S|O|mxc)[0-9]+$")
+var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(USB|ACM|AMA|XRUSB|S|O)[0-9]+$")
 
 // Pattern that is considered valid for the udev symlink to the serial device,
 // path attributes will be compared to this for validity when usb vid and pid

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -69,7 +69,7 @@ func (iface *serialPortInterface) String() string {
 //  - ttyXRUSBx  (Exar Corp. USB UART devices)
 //  - ttySX (UART serial ports)
 //  - ttyOX (UART serial ports on ARM)
-var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(USB|ACM|AMA|XRUSB|S|O)[0-9]+$")
+var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(USB|ACM|AMA|XRUSB|S|O|mxc)[0-9]+$")
 
 // Pattern that is considered valid for the udev symlink to the serial device,
 // path attributes will be compared to this for validity when usb vid and pid

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -62,7 +62,7 @@ func switchDisableService(service, value string) error {
 }
 
 // services that can be disabled
-var services = []string{"ssh", "rsyslog"}
+var services = []string{"ssh", "rsyslog", "snapd.autoimport"}
 
 func handleServiceDisableConfiguration(tr Conf) error {
 	for _, service := range services {

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -83,7 +83,7 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	for _, srvName := range []string{"ssh", "rsyslog"} {
+	for _, srvName := range []string{"ssh", "rsyslog", "snapd.autoimport"} {
 		s.systemctlArgs = nil
 
 		err := configcore.Run(&mockConf{
@@ -106,7 +106,7 @@ func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	for _, srvName := range []string{"ssh", "rsyslog"} {
+	for _, srvName := range []string{"ssh", "rsyslog", "snapd.autoimport"} {
 		s.systemctlArgs = nil
 		err := configcore.Run(&mockConf{
 			conf: map[string]interface{}{


### PR DESCRIPTION
Make disabling assertion auto-import possible via a core config option in line with:
https://forum.snapcraft.io/t/disabling-the-assertion-auto-import-job-on-core-should-be-possible/2923