### PR TITLE
debian: make "gnupg" a recommends

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -60,7 +60,6 @@ Architecture: any
 Depends: adduser,
          apparmor (>= 2.10.95-0ubuntu2.2),
          ca-certificates,
-         gnupg1 | gnupg,
          openssh-client,
          squashfs-tools,
          systemd,
@@ -69,6 +68,7 @@ Depends: adduser,
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
+Recommends: gnupg1 | gnupg
 Conflicts: snap (<< 2013-11-29-1ubuntu1)
 Built-Using: ${Built-Using} ${misc:Built-Using}
 Description: Daemon and tooling that enable snap packages


### PR DESCRIPTION
The gnupg binary is not needed for the core of snapd operations
so its fine to have it as a recommends and to not pull gpg into
the core snap.
