### PR TITLE
tests: increase amount of workers for ubuntu-16.04-64 by one

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -58,7 +58,7 @@ backends:
                 workers: 4
             - ubuntu-16.04-64:
                 kernel: GRUB 2
-                workers: 4
+                workers: 5
             - ubuntu-16.04-32:
                 kernel: GRUB 2
                 workers: 4


### PR DESCRIPTION
The ubuntu-16.04-64 system runs more tests than the other systems:
canonical-livepatch, interfaces-libvirt, nfs-support, xdg-open-compat,
lp-1704860, gccgo. So we should allocate a machine more to bring
the runtime down.

Please do not merge just yet, lets see what the travis log shows first.