### PR TITLE
hookstate: add compat "configure-snapd" task.

### DIFF
--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -120,6 +120,12 @@ func Manager(s *state.State) (*HookManager, error) {
 	}
 
 	runner.AddHandler("run-hook", manager.doRunHook, nil)
+	// Compatibility with snapd between 2.29 and 2.30 in edge only.
+	// We generated a configure-snapd task on core refreshes and
+	// for compatibility we need to handle those.
+	runner.AddHandler("configure-snapd", func(*state.Task, *tomb.Tomb) error {
+		return nil
+	}, nil)
 
 	setupHooks(manager)
 

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -928,3 +928,22 @@ func (s *hookManagerSuite) TestHookTasksForDifferentSnapsRunConcurrently(c *C) {
 	c.Assert(testSnap1HookCalls, Equals, 1)
 	c.Assert(testSnap2HookCalls, Equals, 1)
 }
+
+func (s *hookManagerSuite) TestCompatForConfigureSnapd(c *C) {
+	st := s.state
+
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("configure-snapd", "Snapd between 2.29 and 2.30 in edge insertd those tasks")
+	chg := st.NewChange("configure", "configure snapd")
+	chg.AddTask(task)
+
+	st.Unlock()
+	s.manager.Ensure()
+	s.manager.Wait()
+	st.Lock()
+
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	c.Check(task.Status(), Equals, state.DoneStatus)
+}


### PR DESCRIPTION
We created a `configure-snapd` task for some versions of snapd
between 2.29 and 2.30. We do not use this task anymore but systems
that generated it will not refresh properly because the task is
unknown in the latest snapd. Add a compatibility wrapper for this
task. 

We can remove that at some point in the future.
