### PR TITLE
tests/lib: introduce helpers for setting up /dev/random using /dev/urandom in project prepare

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -22,6 +22,9 @@ set -o pipefail
 # shellcheck source=tests/lib/pkgdb.sh
 . "$TESTSLIB/pkgdb.sh"
 
+# shellcheck source=tests/lib/random.sh
+. "$TESTSLIB/random.sh"
+
 ###
 ### Utility functions reused below.
 ###
@@ -181,6 +184,8 @@ prepare_project() {
         echo "Ongoing reboot upgrade process, please try again when finished"
         exit 1
     fi
+
+    fixup_dev_random
 
     # declare the "quiet" wrapper
 
@@ -350,6 +355,8 @@ restore_project() {
     if [ -n "$GOPATH" ]; then
         rm -rf "${GOPATH%%:*}"
     fi
+
+    restore_dev_random
 }
 
 case "$1" in

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -185,8 +185,6 @@ prepare_project() {
         exit 1
     fi
 
-    fixup_dev_random
-
     # declare the "quiet" wrapper
 
     if [ "$SPREAD_BACKEND" = external ]; then
@@ -320,9 +318,13 @@ prepare_project_each() {
 
     # Clear the kernel ring buffer.
     dmesg -c > /dev/null
+
+    fixup_dev_random
 }
 
 restore_project_each() {
+    restore_dev_random
+
     # Udev rules are notoriously hard to write and seemingly correct but subtly
     # wrong rules can pass review. Whenever that happens udev logs an error
     # message. As a last resort from lack of a better mechanism we can try to
@@ -345,8 +347,6 @@ restore_project() {
     if [ -n "$GOPATH" ]; then
         rm -rf "${GOPATH%%:*}"
     fi
-
-    restore_dev_random
 }
 
 case "$1" in

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -252,30 +252,6 @@ EOF
         systemctl start snapd.socket
     fi
 
-    if [[ "$SPREAD_SYSTEM" == debian-* || "$SPREAD_SYSTEM" == ubuntu-* ]]; then
-        if [[ "$SPREAD_SYSTEM" == ubuntu-* ]]; then
-            pollinate
-        fi
-
-        # Improve entropy for the whole system quite a lot to get fast
-        # key generation during our test cycles
-        echo "HRNGDEVICE=/dev/urandom" > /etc/default/rng-tools
-        /etc/init.d/rng-tools restart
-
-        if systemctl list-units | MATCH "rng-tools.service"; then
-            mkdir -p /etc/systemd/system/rng-tools.service.d/
-            cat <<EOF > /etc/systemd/system/rng-tools.service.d/local.conf
-[Service]
-Restart=always
-RestartSec=2
-RemainAfterExit=no
-PIDFile=/var/run/rngd.pid
-EOF
-        systemctl daemon-reload
-        systemctl restart rng-tools.service
-        fi
-    fi
-
     disable_kernel_rate_limiting
 }
 

--- a/tests/lib/random.sh
+++ b/tests/lib/random.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Helpers for replacing the proper random number generator with faster, but less
+# secure one and restoring it back. See
+# http://elixir.free-electrons.com/linux/latest/source/Documentation/admin-guide/devices.txt
+# for major:minor assignments.
+
+fixup_dev_random() {
+    rm -f /dev/random /dev/real_random
+    # same as /dev/random
+    mknod /dev/real_random c 1 8
+    # same as /dev/urandom
+    mknod /dev/random c 1 9
+}
+
+restore_dev_random() {
+    rm -f /dev/random /dev/real_random
+    # restore proper /dev/random
+    mknod /dev/random c 1 8
+}

--- a/tests/lib/random.sh
+++ b/tests/lib/random.sh
@@ -6,15 +6,14 @@
 # for major:minor assignments.
 
 fixup_dev_random() {
-    rm -f /dev/random /dev/real_random
-    # same as /dev/random
-    mknod /dev/real_random c 1 8
+    # keep  the original /dev/random around
+    mv /dev/random /dev/random.orig
     # same as /dev/urandom
     mknod /dev/random c 1 9
 }
 
 restore_dev_random() {
-    rm -f /dev/random /dev/real_random
-    # restore proper /dev/random
-    mknod /dev/random c 1 8
+    if test -c /dev/random.orig ; then
+        mv /dev/random.orig /dev/random
+    fi
 }

--- a/tests/lib/random.sh
+++ b/tests/lib/random.sh
@@ -27,3 +27,13 @@ restore_dev_random() {
         mv /dev/random.orig /dev/random
     fi
 }
+
+debug_random() {
+    sysctl kernel.random.entropy_avail || true
+    ls -l /dev/*random*
+    pids=$(pidof gpg-agent)
+    for p in $pids; do
+        ps -q "$p"
+        ls -l "/proc/$p/fd"
+    done
+}

--- a/tests/lib/random.sh
+++ b/tests/lib/random.sh
@@ -5,15 +5,21 @@
 # http://elixir.free-electrons.com/linux/latest/source/Documentation/admin-guide/devices.txt
 # for major:minor assignments.
 
+kill_gpg_agent() {
+    # gpg-agent might have started before, need to kill it, normally we would
+    # call gpgconf --kill gpg-agent but this does not seem 100% reliable, try
+    # more direct approach; if gpg-agent gets blocked reading from /dev/random
+    # it will not react to SIGTERM, use SIGKILL instead
+    pkill -9 -e gpg-agent || true
+}
+
 fixup_dev_random() {
     # keep  the original /dev/random around
     mv /dev/random /dev/random.orig
     # same as /dev/urandom
     mknod /dev/random c 1 9
-    # gpg-agent might have started before, need to kill it, normally we would
-    # call gpgconf --kill gpg-agent but this does not seem 100% reliable, try
-    # more direct approach
-    pkill -e gpg-agent || true
+    # make sure that gpg-agent picks up the new device
+    kill_gpg_agent
 }
 
 restore_dev_random() {

--- a/tests/lib/random.sh
+++ b/tests/lib/random.sh
@@ -10,6 +10,10 @@ fixup_dev_random() {
     mv /dev/random /dev/random.orig
     # same as /dev/urandom
     mknod /dev/random c 1 9
+    # gpg-agent might have started before, need to kill it, normally we would
+    # call gpgconf --kill gpg-agent but this does not seem 100% reliable, try
+    # more direct approach
+    pkill -e gpg-agent || true
 }
 
 restore_dev_random() {

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -24,6 +24,8 @@ prepare: |
     snap install core
     snap install test-snapd-tools
     . "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/random.sh
+    kill_gpg_agent
     expect -d -f key.exp0
 
 restore: |

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -23,7 +23,7 @@ prepare: |
     touch bar.snap
     snap install core
     snap install test-snapd-tools
-    "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/mkpinentry.sh
     expect -d -f key.exp0
 
 restore: |

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -36,7 +36,8 @@ restore: |
     rmdir testdir
 
 debug: |
-    sysctl kernel.random.entropy_avail || true
+    . "$TESTSLIB"/random.sh
+    debug_random
 
 execute: |
     for i in *.exp; do

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -6,7 +6,8 @@ prepare: |
     . "$TESTSLIB"/mkpinentry.sh
 
 debug: |
-    sysctl kernel.random.entropy_avail || true
+    . "$TESTSLIB"/random.sh
+    debug_random
 
 execute: |
     echo "Checking passphrase mismatch error"

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -3,7 +3,7 @@ summary: Checks for snap create-key
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
-    "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/mkpinentry.sh
 
 debug: |
     sysctl kernel.random.entropy_avail || true

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -4,6 +4,8 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
     . "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/random.sh
+    kill_gpg_agent
 
 debug: |
     . "$TESTSLIB"/random.sh

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -7,7 +7,8 @@ prepare: |
     . "$TESTSLIB"/mkpinentry.sh
 
 debug: |
-    sysctl kernel.random.entropy_avail || true
+    . "$TESTSLIB"/random.sh
+    debug_random
 
 execute: |
     echo "Creating a new key without a password"

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -5,6 +5,8 @@ systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*]
 
 prepare: |
     . "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/random.sh
+    kill_gpg_agent
 
 debug: |
     . "$TESTSLIB"/random.sh

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -4,7 +4,7 @@ summary: Run snap sign to sign a model assertion
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*]
 
 prepare: |
-    "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/mkpinentry.sh
 
 debug: |
     sysctl kernel.random.entropy_avail || true


### PR DESCRIPTION
The hosts used for testing may run out of entropy in /dev/random, thus causing
any crypto operations to potentially block. Since we do not need a high quality
RNG source for the tests, set up /dev/random to be the same as /dev/urandom in
project prepare and restore it back to the proper state in project restore
phase.