### PR TITLE
interfaces/many: misc updates for default, browser-support, opengl, desktop, unity7, x11

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -96,6 +96,7 @@ var defaultTemplate = `
   /bin/dash ixr,
   /etc/bash.bashrc r,
   /etc/{passwd,group,nsswitch.conf} r,  # very common
+  /etc/default/nss r,
   /etc/libnl-3/{classid,pktloc} r,      # apps that use libnl
   /var/lib/extrausers/{passwd,group} r,
   /etc/profile r,

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -94,6 +94,15 @@ deny @{PROC}/@{pid}/attr/current r,
 # warning and the noisy AppArmor denial.
 owner @{PROC}/@{pid}/mounts r,
 owner @{PROC}/@{pid}/mountinfo r,
+
+# Since snapd still uses SECCOMP_RET_KILL, we have added a workaround rule to
+# allow mknod on character devices since chromium unconditionally performs
+# a mknod() to create the /dev/nvidiactl device, regardless of if it exists or
+# not or if the process has CAP_MKNOD or not. Since we don't want to actually
+# grant the ability to create character devices, explicitly deny the
+# capability. When snapd uses SECCOMP_RET_ERRNO, we can remove this rule.
+# https://forum.snapcraft.io/t/call-for-testing-chromium-62-0-3202-62/2569/46
+deny capability mknod,
 `
 
 const browserSupportConnectedPlugAppArmorWithoutSandbox = `
@@ -248,6 +257,17 @@ accept4
 # TODO: fine-tune when seccomp arg filtering available in stable distro
 # releases
 setpriority
+
+# Since snapd still uses SECCOMP_RET_KILL, add a workaround rule to allow mknod
+# on character devices since chromium unconditionally performs a mknod() to
+# create the /dev/nvidiactl device, regardless of if it exists or not or if the
+# process has CAP_MKNOD or not. Since we don't want to actually grant the
+# ability to create character devices, we added an explicit deny AppArmor rule
+# for this capability. When snapd uses SECCOMP_RET_ERRNO, we can remove this
+# rule.
+# https://forum.snapcraft.io/t/call-for-testing-chromium-62-0-3202-62/2569/46
+mknod - |S_IFCHR -
+mknodat - - |S_IFCHR -
 `
 
 const browserSupportConnectedPlugSecCompWithSandbox = `

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -46,6 +46,7 @@ const desktopConnectedPlugAppArmor = `
 #include <abstractions/dbus-session-strict>
 
 #include <abstractions/fonts>
+owner @{HOME}/.local/share/fonts/{,**} r,
 /var/cache/fontconfig/   r,
 /var/cache/fontconfig/** mr,
 

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -97,7 +97,7 @@ dbus (receive)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
-    member=NotificationClosed
+    member={ActionInvoked,NotificationClosed}
     peer=(label=unconfined),
 
 # Allow requesting interest in receiving media key events. This tells Gnome

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -36,6 +36,12 @@ const joystickConnectedPlugAppArmor = `
 # only js0-js31 is valid so limit the /dev and udev entries to those devices.
 /dev/input/js{[0-9],[12][0-9],3[01]} rw,
 /run/udev/data/c13:{[0-9],[12][0-9],3[01]} r,
+
+# Allow reading for supported event reports for all input devices. See
+# https://www.kernel.org/doc/Documentation/input/event-codes.txt
+# FIXME: this is a very minor information leak and snapd should instead query
+# udev for the specific accesses associated with the above devices.
+/sys/devices/**/input[0-9]*/capabilities/* r,
 `
 
 var joystickConnectedPlugUDev = []string{`KERNEL=="js[0-9]*"`}

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -31,60 +31,60 @@ const openglBaseDeclarationSlots = `
 const openglConnectedPlugAppArmor = `
 # Description: Can access opengl.
 
-  # specific gl libs
-  /var/lib/snapd/lib/gl{,32}/ r,
-  /var/lib/snapd/lib/gl{,32}/** rm,
+# specific gl libs
+/var/lib/snapd/lib/gl{,32}/ r,
+/var/lib/snapd/lib/gl{,32}/** rm,
 
-  # Supports linux-driver-management from Solus (staged symlink trees into libdirs)
-  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}glx-provider/**.so{,.*}  rm,
+# Supports linux-driver-management from Solus (staged symlink trees into libdirs)
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}glx-provider/**.so{,.*}  rm,
 
-  # Bi-arch distribution nvidia support
-  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcuda*.so{,.*} rm,
-  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvidia*.so{,.*} rm,
-  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvcuvid.so{,.*} rm,
-  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}lib{GL,EGL}*nvidia.so{,.*} rm,
-  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libGLdispatch.so{,.*} rm,
+# Bi-arch distribution nvidia support
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcuda*.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvidia*.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvcuvid.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}lib{GL,EGL}*nvidia.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libGLdispatch.so{,.*} rm,
 
-  # Support reading the Vulkan ICD files
-  /var/lib/snapd/lib/vulkan/ r,
-  /var/lib/snapd/lib/vulkan/** r,
-  /var/lib/snapd/hostfs/usr/share/vulkan/icd.d/*nvidia*.json r,
+# Support reading the Vulkan ICD files
+/var/lib/snapd/lib/vulkan/ r,
+/var/lib/snapd/lib/vulkan/** r,
+/var/lib/snapd/hostfs/usr/share/vulkan/icd.d/*nvidia*.json r,
 
-  # Main bi-arch GL libraries
-  /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}lib{GL,EGL}.so{,.*} rm,
+# Main bi-arch GL libraries
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}lib{GL,EGL}.so{,.*} rm,
 
-  /dev/dri/ r,
-  /dev/dri/card0 rw,
-  # nvidia
-  @{PROC}/driver/nvidia/params r,
-  @{PROC}/modules r,
-  /dev/nvidia* rw,
-  unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),
+/dev/dri/ r,
+/dev/dri/card0 rw,
+# nvidia
+@{PROC}/driver/nvidia/params r,
+@{PROC}/modules r,
+/dev/nvidia* rw,
+unix (send, receive) type=dgram peer=(addr="@nvidia[0-9a-f]*"),
 
-  # eglfs
-  /dev/vchiq rw,
+# eglfs
+/dev/vchiq rw,
 
-  # /sys/devices
-  /sys/devices/pci[0-9]*/**/config r,
-  /sys/devices/pci[0-9]*/**/revision r,
-  /sys/devices/pci[0-9]*/**/{,subsystem_}device r,
-  /sys/devices/pci[0-9]*/**/{,subsystem_}vendor r,
-  /sys/devices/**/drm{,_dp_aux_dev}/** r,
+# /sys/devices
+/sys/devices/pci[0-9]*/**/config r,
+/sys/devices/pci[0-9]*/**/revision r,
+/sys/devices/pci[0-9]*/**/{,subsystem_}device r,
+/sys/devices/pci[0-9]*/**/{,subsystem_}vendor r,
+/sys/devices/**/drm{,_dp_aux_dev}/** r,
 
-  # FIXME: this is an information leak and snapd should instead query udev for
-  # the specific accesses associated with the above devices.
-  /sys/bus/pci/devices/ r,
-  /sys/bus/platform/devices/soc:gpu/ r,
-  /run/udev/data/+drm:card* r,
-  /run/udev/data/+pci:[0-9]* r,
-  /run/udev/data/+platform:soc:gpu* r,
+# FIXME: this is an information leak and snapd should instead query udev for
+# the specific accesses associated with the above devices.
+/sys/bus/pci/devices/ r,
+/sys/bus/platform/devices/soc:gpu/ r,
+/run/udev/data/+drm:card* r,
+/run/udev/data/+pci:[0-9]* r,
+/run/udev/data/+platform:soc:gpu* r,
 
-  # FIXME: for each device in /dev that this policy references, lookup the
-  # device type, major and minor and create rules of this form:
-  # /run/udev/data/<type><major>:<minor> r,
-  # For now, allow 'c'haracter devices and 'b'lock devices based on
-  # https://www.kernel.org/doc/Documentation/devices.txt
-  /run/udev/data/c226:[0-9]* r,  # 226 drm
+# FIXME: for each device in /dev that this policy references, lookup the
+# device type, major and minor and create rules of this form:
+# /run/udev/data/<type><major>:<minor> r,
+# For now, allow 'c'haracter devices and 'b'lock devices based on
+# https://www.kernel.org/doc/Documentation/devices.txt
+/run/udev/data/c226:[0-9]* r,  # 226 drm
 `
 
 // The nvidia modules don't use sysfs (therefore they can't be udev tagged) and

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -56,6 +56,7 @@ const openglConnectedPlugAppArmor = `
 /dev/dri/ r,
 /dev/dri/card0 rw,
 # nvidia
+/etc/vdpau_wrapper.cfg r,
 @{PROC}/driver/nvidia/params r,
 @{PROC}/modules r,
 /dev/nvidia* rw,

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -47,6 +47,7 @@ const unity7ConnectedPlugAppArmor = `
 #include <abstractions/X>
 
 #include <abstractions/fonts>
+owner @{HOME}/.local/share/fonts/{,**} r,
 /var/cache/fontconfig/   r,
 /var/cache/fontconfig/** mr,
 

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -427,7 +427,7 @@ dbus (receive)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
-    member=NotificationClosed
+    member={ActionInvoked,NotificationClosed}
     peer=(label=unconfined),
 
 dbus (send)

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -34,7 +34,7 @@ const x11ConnectedPlugAppArmor = `
 
 #include <abstractions/X>
 #include <abstractions/fonts>
-
+owner @{HOME}/.local/share/fonts/{,**} r,
 /var/cache/fontconfig/   r,
 /var/cache/fontconfig/** mr,
 


### PR DESCRIPTION
- interfaces/{desktop,unity7}: allow receiving ActionInvoked notification signal
- interfaces/{desktop,unity7,x11}: allow reading fonts in ~/.local/share/fonts
- interfaces: allow reads on /etc/default/nss (NSS configuration) by default
- interfaces/opengl: allow read on /etc/vdpau_wrapper.cfg
- remove leading whitespace in apparmor policy in opengl interface
- interfaces/browser-support: allow mknod() syscall for chromium nividiactl

Note the opengl changes look larger than they are: the first commit just removes leading whitespace and was confirmed to do nothing else with `git diff -w`. The individual commit at https://github.com/snapcore/snapd/commit/6b8f3ee6204e87b0259e29062720084da0712eb5 shows that better, with https://github.com/snapcore/snapd/commit/4b996f40245798a0d5feaa6ee0daaa6219fb83da showing the real change.