### PR TITLE
devicestate: fix misbehaving test when using systemd-resolved

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -766,7 +766,7 @@ version: gadget
 func (s *deviceMgrSuite) TestDoRequestSerialErrorsOnNoHost(c *C) {
 	privKey, _ := assertstest.GenerateKey(testKeyLength)
 
-	nowhere := "http://so-very-invälid.com"
+	nowhere := "http://nowhere.nowhere.test"
 
 	mockRequestIDURL := nowhere + requestIDURLPath
 	restore := devicestate.MockRequestIDURL(mockRequestIDURL)

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -766,7 +766,7 @@ version: gadget
 func (s *deviceMgrSuite) TestDoRequestSerialErrorsOnNoHost(c *C) {
 	privKey, _ := assertstest.GenerateKey(testKeyLength)
 
-	nowhere := "http://nowhere.invalid"
+	nowhere := "http://so-very-invälid.com"
 
 	mockRequestIDURL := nowhere + requestIDURLPath
 	restore := devicestate.MockRequestIDURL(mockRequestIDURL)


### PR DESCRIPTION
When using systemd-resolved it handles `.invalid` TLDs special
and returns SERVFAIL instead of NXDOMAIN. This means that our
go code considers this a temporary error and will retry instead
of failing. Workaround this by simply using a truely invalid
domain name.

See also https://forum.snapcraft.io/t/run-checks-failure-in-lxd-container-new-in-2-30/3057