### PR TITLE
cmd/snap-mgmt: add more directories for cleanup and refactor purge() code

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -66,7 +66,9 @@ purge() {
             #  /var/lib/snapd/snap/core/3440  -> core/3440
             #  /snap/core/3440                -> core/3440
             #  /snap/core//3440               -> core/3440
-            snap_rev=$(systemctl show "$unit" -p Where --value | sed -e "s#$SNAP_MOUNT_DIR##" -e 's#^/*##')
+            # NOTE: we could have used `systemctl show $unit -p Where --value`
+            # but systemd 204 shipped with Ubuntu 14.04 does not support this
+            snap_rev=$(systemctl show "$unit" -p Where | sed -e 's#Where=##' -e "s#$SNAP_MOUNT_DIR##" -e 's#^/*##')
             snap=$(echo "$snap_rev" |cut -f1 -d/)
             rev=$(echo "$snap_rev" |cut -f2 -d/)
             if [ -n "$snap" ]; then

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -47,7 +47,7 @@ purge() {
         fi
     fi
 
-    units=$(systemctl list-unit-files --full | grep -vF snap.mount.service || true)
+    units=$(systemctl list-unit-files --no-legend --full | grep -vF snap.mount.service || true)
     mounts=$(echo "$units" | grep "^${SNAP_UNIT_PREFIX}[-.].*\.mount" | cut -f1 -d ' ')
     services=$(echo "$units" | grep "^${SNAP_UNIT_PREFIX}[-.].*\.service" | cut -f1 -d ' ')
     for unit in $services $mounts; do

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -60,34 +60,40 @@ purge() {
         echo "Stopping $unit"
         systemctl_stop "$unit"
 
-        # if it is a mount unit, we can find the snap name in the mount
-        # unit (we just ignore unit files)
-        snap=$(grep "Where=${SNAP_MOUNT_DIR}/" "/etc/systemd/system/$unit"|cut -f3 -d/)
-        rev=$(grep "Where=${SNAP_MOUNT_DIR}/" "/etc/systemd/system/$unit"|cut -f4 -d/)
-        if [ -n "$snap" ]; then
-            echo "Removing snap $snap"
-            # aliases
-            if [ -d "${SNAP_MOUNT_DIR}/bin" ]; then
-                find "${SNAP_MOUNT_DIR}/bin" -maxdepth 1 -lname "$snap" -delete
-                find "${SNAP_MOUNT_DIR}/bin" -maxdepth 1 -lname "$snap.*" -delete
-            fi
-            # generated binaries
-            rm -f "${SNAP_MOUNT_DIR}/bin/$snap"
-            rm -f "${SNAP_MOUNT_DIR}/bin/$snap".*
-            # snap mount dir
-            umount -l "${SNAP_MOUNT_DIR}/$snap/$rev" 2> /dev/null || true
-            rm -rf "${SNAP_MOUNT_DIR:?}/$snap/$rev"
-            rm -f "${SNAP_MOUNT_DIR}/$snap/current"
-            # snap data dir
-            rm -rf "/var/snap/$snap/$rev"
-            rm -rf "/var/snap/$snap/common"
-            rm -f "/var/snap/$snap/current"
-            # opportunistic remove (may fail if there are still revisions left)
-            for d in "${SNAP_MOUNT_DIR}/$snap" "/var/snap/$snap"; do
-                if [ -d "$d" ]; then
-                    rmdir --ignore-fail-on-non-empty "$d"
+        if echo "$unit" | grep -q ".*\.mount" ; then
+            # Transform ${SNAP_MOUNT_DIR}/core/3440 -> core/3440 removing any
+            # extra / preceding snap name, eg:
+            #  /var/lib/snapd/snap/core/3440  -> core/3440
+            #  /snap/core/3440                -> core/3440
+            #  /snap/core//3440               -> core/3440
+            snap_rev=$(systemctl show "$unit" -p Where --value | sed -e "s#$SNAP_MOUNT_DIR##" -e 's#^/*##')
+            snap=$(echo "$snap_rev" |cut -f1 -d/)
+            rev=$(echo "$snap_rev" |cut -f2 -d/)
+            if [ -n "$snap" ]; then
+                echo "Removing snap $snap"
+                # aliases
+                if [ -d "${SNAP_MOUNT_DIR}/bin" ]; then
+                    find "${SNAP_MOUNT_DIR}/bin" -maxdepth 1 -lname "$snap" -delete
+                    find "${SNAP_MOUNT_DIR}/bin" -maxdepth 1 -lname "$snap.*" -delete
                 fi
-            done
+                # generated binaries
+                rm -f "${SNAP_MOUNT_DIR}/bin/$snap"
+                rm -f "${SNAP_MOUNT_DIR}/bin/$snap".*
+                # snap mount dir
+                umount -l "${SNAP_MOUNT_DIR}/$snap/$rev" 2> /dev/null || true
+                rm -rf "${SNAP_MOUNT_DIR:?}/$snap/$rev"
+                rm -f "${SNAP_MOUNT_DIR}/$snap/current"
+                # snap data dir
+                rm -rf "/var/snap/$snap/$rev"
+                rm -rf "/var/snap/$snap/common"
+                rm -f "/var/snap/$snap/current"
+                # opportunistic remove (may fail if there are still revisions left)
+                for d in "${SNAP_MOUNT_DIR}/$snap" "/var/snap/$snap"; do
+                    if [ -d "$d" ]; then
+                        rmdir --ignore-fail-on-non-empty "$d"
+                    fi
+                done
+            fi
         fi
 
         echo "Removing $unit"

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -119,6 +119,9 @@ purge() {
     rm -rf /var/lib/snapd/seccomp/bpf/*
     rm -rf /var/lib/snapd/device/*
     rm -rf /var/lib/snapd/assertions/*
+    rm -rf /var/lib/snapd/cookie/*
+    rm -rf /var/lib/snapd/cache/*
+    rm -f /var/lib/snapd/state.json
 
     echo "Removing snapd catalog cache"
     rm -f /var/cache/snapd/*


### PR DESCRIPTION
A small series with little improvements to `snap-mgmt`.

I've added `/var/lib/snapd/cookie/*`, `/var/lib/snapd/cache/*`, `/var/lib/snapd/state.json` for removal. When the directories are not empty, the package manager may decide to not remove them. Then on reinstallation of snapd you'll likely get very awkward errors that look like this:
```
$ snap list
error: cannot list snaps: cannot list local snaps! cannot find publisher details: snap-declaration (99T7MUlRhtI3U0QFgl5mXXESAiSwt776; series:16) not found
```
The last piece of a small refactoring of mount units. Use `systemctl show .. -p ..` where possible and make sure that the mount path is transformed so that we can properly pick out the snap name and its revision.

@Conan-Kudo can you take a look as well?

