### PR TITLE
interfaces: added Ref() helpers, restored more detailed error message on spi iface

### DIFF
--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -57,10 +57,10 @@ func (iface *spiInterface) StaticInfo() interfaces.StaticInfo {
 
 var spiDevPattern = regexp.MustCompile("^/dev/spidev[0-9].[0-9]+$")
 
-func (iface *spiInterface) path(attrs map[string]interface{}) (string, error) {
+func (iface *spiInterface) path(slotRef *interfaces.SlotRef, attrs map[string]interface{}) (string, error) {
 	path, ok := attrs["path"].(string)
 	if !ok || path == "" {
-		return "", fmt.Errorf("spi slot must have a path attribute")
+		return "", fmt.Errorf("slot %q must have a path attribute", slotRef)
 	}
 	path = filepath.Clean(path)
 	if !spiDevPattern.MatchString(path) {
@@ -73,12 +73,12 @@ func (iface *spiInterface) SanitizeSlot(slot *snap.SlotInfo) error {
 	if err := sanitizeSlotReservedForOSOrGadget(iface, slot); err != nil {
 		return err
 	}
-	_, err := iface.path(slot.Attrs)
+	_, err := iface.path(&interfaces.SlotRef{Snap: slot.Snap.Name(), Name: slot.Name}, slot.Attrs)
 	return err
 }
 
 func (iface *spiInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	path, err := iface.path(slot.Attrs)
+	path, err := iface.path(slot.Ref(), slot.Attrs)
 	if err != nil {
 		return nil
 	}
@@ -88,7 +88,7 @@ func (iface *spiInterface) AppArmorConnectedPlug(spec *apparmor.Specification, p
 }
 
 func (iface *spiInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	path, err := iface.path(slot.Attrs)
+	path, err := iface.path(slot.Ref(), slot.Attrs)
 	if err != nil {
 		return nil
 	}

--- a/interfaces/builtin/spi_test.go
+++ b/interfaces/builtin/spi_test.go
@@ -169,7 +169,7 @@ func (s *spiInterfaceSuite) TestSanitizeSlot(c *C) {
 	err = interfaces.SanitizeSlot(s.iface, s.slotGadgetBad5Info)
 	c.Assert(err, ErrorMatches, `"/dev/spi-foo" is not a valid SPI device`)
 	err = interfaces.SanitizeSlot(s.iface, s.slotGadgetBad6Info)
-	c.Assert(err, ErrorMatches, `spi slot must have a path attribute`)
+	c.Assert(err, ErrorMatches, `slot "gadget:bad-spi-6" must have a path attribute`)
 	slot := &snap.SlotInfo{
 		Snap:      &snap.Info{SuggestedName: "some-snap"},
 		Name:      "spi",

--- a/interfaces/connection.go
+++ b/interfaces/connection.go
@@ -136,6 +136,11 @@ func (plug *ConnectedPlug) SetAttr(key string, value interface{}) error {
 	return nil
 }
 
+// Ref returns the PlugRef for this plug.
+func (plug *ConnectedPlug) Ref() *PlugRef {
+	return &PlugRef{Snap: plug.Snap().Name(), Name: plug.Name()}
+}
+
 // Interface returns the name of the interface for this slot.
 func (slot *ConnectedSlot) Interface() string {
 	return slot.slotInfo.Interface
@@ -201,6 +206,11 @@ func (slot *ConnectedSlot) SetAttr(key string, value interface{}) error {
 	}
 	slot.dynamicAttrs[key] = normalize(value)
 	return nil
+}
+
+// Ref returns the SlotRef for this slot.
+func (slot *ConnectedSlot) Ref() *SlotRef {
+	return &SlotRef{Snap: slot.Snap().Name(), Name: slot.Name()}
 }
 
 // Interface returns the name of the interface for this connection.

--- a/interfaces/connection_test.go
+++ b/interfaces/connection_test.go
@@ -71,6 +71,18 @@ func (s *connSuite) TestStaticSlotAttrs(c *C) {
 	})
 }
 
+func (s *connSuite) TestSlotRef(c *C) {
+	slot := NewConnectedSlot(s.slot, nil)
+	c.Assert(slot, NotNil)
+	c.Assert(*slot.Ref(), DeepEquals, SlotRef{Snap: "producer", Name: "slot"})
+}
+
+func (s *connSuite) TestPlugRef(c *C) {
+	plug := NewConnectedPlug(s.plug, nil)
+	c.Assert(plug, NotNil)
+	c.Assert(*plug.Ref(), DeepEquals, PlugRef{Snap: "consumer", Name: "plug"})
+}
+
 func (s *connSuite) TestStaticPlugAttrs(c *C) {
 	plug := NewConnectedPlug(s.plug, nil)
 	c.Assert(plug, NotNil)


### PR DESCRIPTION
This is followup to #4303 that restores the more detailed error message for spi interface slots. Added Ref() helpers to ConnectedPlug/Slot to make it clean.