### PR TITLE
tests: set TRUST_TEST_KEYS=false for all the external backends

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -230,17 +230,14 @@ backends:
         environment:
             SPREAD_EXTERNAL_ADDRESS: "$(HOST: echo ${SPREAD_EXTERNAL_ADDRESS:-localhost:8022})"
             MANAGED_DEVICE: "true"
+            TRUST_TEST_KEYS: "false"
         allocate: |
             ADDRESS $SPREAD_EXTERNAL_ADDRESS
         systems:
             - ubuntu-core-16-64:
-                environment:
-                    TRUST_TEST_KEYS: "false"
                 username: test
                 password: ubuntu
             - ubuntu-core-16-32:
-                environment:
-                    TRUST_TEST_KEYS: "false"
                 username: test
                 password: ubuntu
             - ubuntu-core-16-arm-64:


### PR DESCRIPTION
All the external backends are not building the core snap, so they don't
have the test keys. This change is setting the same config for all the
external backend.
