### PR TITLE
tests: add support on tests for cm3 gadget

### DIFF
--- a/tests/lib/names.sh
+++ b/tests/lib/names.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-gadget_name=$(snap list | sed -n 's/^\(pc\|pi[23]\|dragonboard\) .*/\1/p')
+gadget_name=$(snap list | sed -n 's/^\(pc\|pi[23]\|dragonboard\|cm3\) .*/\1/p')
 kernel_name=$gadget_name-kernel
 
-if [ "$kernel_name" = "pi3-kernel" ]; then
+if [ "$kernel_name" = "pi3-kernel" ] || [ "$kernel_name" = "cm3-kernel" ]; then
     kernel_name=pi2-kernel
 fi


### PR DESCRIPTION
This PR is to support a new device called cm3, which is similar to the pi3 and uses the pi2-kernel.
To test that use the following testflinger job: https://paste.ubuntu.com/26129607/
