### PR TITLE
tests/main: source mkpinentry.sh

### DIFF
--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -23,7 +23,7 @@ prepare: |
     touch bar.snap
     snap install core
     snap install test-snapd-tools
-    "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/mkpinentry.sh
     expect -d -f key.exp0
 
 restore: |

--- a/tests/main/create-key/task.yaml
+++ b/tests/main/create-key/task.yaml
@@ -3,7 +3,7 @@ summary: Checks for snap create-key
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
 prepare: |
-    "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/mkpinentry.sh
 
 debug: |
     sysctl kernel.random.entropy_avail || true

--- a/tests/main/snap-sign/task.yaml
+++ b/tests/main/snap-sign/task.yaml
@@ -4,7 +4,7 @@ summary: Run snap sign to sign a model assertion
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*]
 
 prepare: |
-    "$TESTSLIB"/mkpinentry.sh
+    . "$TESTSLIB"/mkpinentry.sh
 
 debug: |
     sysctl kernel.random.entropy_avail || true


### PR DESCRIPTION
mkpinentry.sh script is using MATCH, but this is not defined when running in a
subshell.
