### PR TITLE
cmd/snap: show header/footer when `snap find` is used without arguments

### DIFF
--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -113,15 +113,24 @@ func (x *cmdFind) Execute(args []string) error {
 	}
 
 	// magic! `snap find` returns the featured snaps
-	if x.Positional.Query == "" && x.Section == "" {
+	showFeatured := (x.Positional.Query == "" && x.Section == "")
+	if showFeatured {
 		x.Section = "featured"
+		fmt.Fprintf(Stdout, i18n.G("No search term specified, showing the featured snaps:\n\n"))
 	}
 
-	return findSnaps(&client.FindOptions{
+	if err := findSnaps(&client.FindOptions{
 		Private: x.Private,
 		Section: string(x.Section),
 		Query:   x.Positional.Query,
-	})
+	}); err != nil {
+		return err
+	}
+
+	if showFeatured {
+		fmt.Fprintf(Stdout, i18n.G("\nSee `snap find --help` for more granular searches.\n"))
+	}
+	return nil
 }
 
 func findSnaps(opts *client.FindOptions) error {

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -130,13 +130,13 @@ func (x *cmdFind) Execute(args []string) error {
 	}
 	if len(snaps) == 0 {
 		// TRANSLATORS: the %q is the (quoted) query the user entered
-		fmt.Fprintf(Stderr, i18n.G("The search %q returned 0 snaps\n"), opts.Query)
+		fmt.Fprintf(Stderr, i18n.G("No matching snaps for %q\n"), opts.Query)
 		return nil
 	}
 
 	// show featured header *after* we checked for errors from the find
 	if showFeatured {
-		fmt.Fprintf(Stdout, i18n.G("No search term specified. Here are some interessting snaps:\n\n"))
+		fmt.Fprintf(Stdout, i18n.G("No search term specified. Here are some interesting snaps:\n\n"))
 	}
 
 	w := tabWriter()
@@ -148,7 +148,7 @@ func (x *cmdFind) Execute(args []string) error {
 	w.Flush()
 
 	if showFeatured {
-		fmt.Fprintf(Stdout, i18n.G("\nSee `snap find --help` for more granular searches.\n"))
+		fmt.Fprintf(Stdout, i18n.G("\nProvide a search term for more specific results.\n"))
 	}
 	return nil
 }

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -116,45 +116,39 @@ func (x *cmdFind) Execute(args []string) error {
 	showFeatured := (x.Positional.Query == "" && x.Section == "")
 	if showFeatured {
 		x.Section = "featured"
-		fmt.Fprintf(Stdout, i18n.G("No search term specified, showing the featured snaps:\n\n"))
 	}
 
-	if err := findSnaps(&client.FindOptions{
+	cli := Client()
+	opts := &client.FindOptions{
 		Private: x.Private,
 		Section: string(x.Section),
 		Query:   x.Positional.Query,
-	}); err != nil {
-		return err
 	}
-
-	if showFeatured {
-		fmt.Fprintf(Stdout, i18n.G("\nSee `snap find --help` for more granular searches.\n"))
-	}
-	return nil
-}
-
-func findSnaps(opts *client.FindOptions) error {
-	cli := Client()
 	snaps, resInfo, err := cli.Find(opts)
 	if err != nil {
 		return err
 	}
-
 	if len(snaps) == 0 {
 		// TRANSLATORS: the %q is the (quoted) query the user entered
 		fmt.Fprintf(Stderr, i18n.G("The search %q returned 0 snaps\n"), opts.Query)
 		return nil
 	}
 
+	// show featured header *after* we checked for errors from the find
+	if showFeatured {
+		fmt.Fprintf(Stdout, i18n.G("No search term specified. Here are some interessting snaps:\n\n"))
+	}
+
 	w := tabWriter()
-	defer w.Flush()
-
 	fmt.Fprintln(w, i18n.G("Name\tVersion\tDeveloper\tNotes\tSummary"))
-
 	for _, snap := range snaps {
 		// TODO: get snap.Publisher, so we can only show snap.Developer if it's different
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", snap.Name, snap.Version, snap.Developer, NotesFromRemote(snap, resInfo), snap.Summary)
 	}
+	w.Flush()
 
+	if showFeatured {
+		fmt.Fprintf(Stdout, i18n.G("\nSee `snap find --help` for more granular searches.\n"))
+	}
 	return nil
 }

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -2,7 +2,7 @@ summary: Check snap search
 
 execute: |
     echo "List all featured snaps"
-    expected="(?s)Name +Version +Developer +Notes +Summary *\n\
+    expected="(?s).*Name +Version +Developer +Notes +Summary *\n\
     (.*?\n)?\
     .*"
     snap find | grep -Pzq "$expected"

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -1,11 +1,22 @@
 summary: Check snap search
 
+restore: |
+    rm -f featured.txt
+
 execute: |
     echo "List all featured snaps"
     expected="(?s).*Name +Version +Developer +Notes +Summary *\n\
     (.*?\n)?\
     .*"
-    snap find | grep -Pzq "$expected"
+    snap find > featured.txt
+    if ! grep -Pzq "$expected" < featured.txt; then
+        echo "expected out put $expected not found in:"
+        cat featured.txt
+        exit 1
+    fi
+    MATCH "No search term specified. Here are some interesting snaps" < featured.txt
+    MATCH "Provide a search term for more specific results." < featured.txt
+
     if [ $(snap find | wc -l) -gt 50 ]; then
         echo "Found more than 50 featured apps, this seems bogus:"
         snap find
@@ -44,5 +55,5 @@ execute: |
     if [ $(uname -m) = "x86_64" ]; then
         snap find --section=database cassandra | MATCH cassandra
     else
-        snap find --section=database cassandra 2>&1 | MATCH '0 snaps'
+        snap find --section=database cassandra 2>&1 | MATCH 'No matching snaps'
     fi


### PR DESCRIPTION
As discussed in LP#1700560 just showing the list of featured snaps
from `snap list` is not intuitive enough. This PR adds a header
and footer as suggested in the bug.

