### PR TITLE
interfaces/desktop,unity7: allow status/activate/lock of screensavers

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -133,6 +133,22 @@ dbus (send)
     interface=io.snapcraft.Launcher
     member=OpenURL
     peer=(label=unconfined),
+
+# Allow checking status, activating and locking the screensaver
+# gnome/kde/freedesktop.org
+dbus (send)
+    bus=session
+    path="/{,org/freedesktop/,org/gnome/}ScreenSaver"
+    interface="org.{freedesktop,gnome}.ScreenSaver"
+    member="{GetActive,GetActiveTime,Lock,SetActive}"
+    peer=(label=unconfined),
+
+dbus (receive)
+    bus=session
+    path="/{,org/freedesktop/,org/gnome/}ScreenSaver"
+    interface="org.{freedesktop,gnome}.ScreenSaver"
+    member=ActiveChanged
+    peer=(label=unconfined),
 `
 
 type desktopInterface struct{}

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -548,6 +548,30 @@ dbus (send)
   path=/org/gnome/SettingsDaemon/MediaKeys
   member="Get{,All}"
   peer=(label=unconfined),
+
+# Allow checking status, activating and locking the screensaver
+# mate
+dbus (send)
+    bus=session
+    path="/{,org/mate/}ScreenSaver"
+    interface=org.mate.ScreenSaver
+    member="{GetActive,GetActiveTime,Lock,SetActive}"
+    peer=(label=unconfined),
+
+dbus (receive)
+    bus=session
+    path="/{,org/mate/}ScreenSaver"
+    interface=org.mate.ScreenSaver
+    member=ActiveChanged
+    peer=(label=unconfined),
+
+# Unity
+dbus (send)
+  bus=session
+  interface=com.canonical.Unity.Session
+  path=/com/canonical/Unity/Session
+  member="{ActivateScreenSaver,IsLocked,Lock}"
+  peer=(label=unconfined),
 `
 
 const unity7ConnectedPlugSeccomp = `


### PR DESCRIPTION
Allow Unity and MATE screensaver in the legacy unity7 interface and allow
freedesktop.org (KDE) and GNOME screensavers in desktop interface.

Reference:
https://forum.snapcraft.io/t/need-an-interface-to-lock-the-screen/1972