### PR TITLE
interfaces/gpg-keys: force use of '--no-random-seed-file' via explicit deny

### DIFF
--- a/interfaces/builtin/gpg_keys.go
+++ b/interfaces/builtin/gpg_keys.go
@@ -42,8 +42,10 @@ owner @{HOME}/.gnupg/{,**} r,
 # trustdb. For now, silence the denial since no other policy references this
 deny @{HOME}/.gnupg/trustdb.gpg w,
 
-# 'wk' is required for gpg encrypt and sign
-owner @{HOME}/.gnupg/random_seed wk,
+# gpg stores its internal random pool in @{HOME}/.gnupg/random_seed to make
+# random number generation faster. 'gpg --no-random-seed-file' disables this
+# optimization. Force consumers of this interface to use --no-random-seed-file.
+audit deny @{HOME}/.gnupg/random_seed wk,
 `
 
 func init() {


### PR DESCRIPTION
gpg stores its internal random pool in ~/.gnupg/random_seed to make random number generation faster and gpg will update this file with sign and encrypt operations. 'gpg --no-random-seed-file' disables this optimization. Force consumers of this interface to use --no-random-seed-file.

'--no-random-seed-file' was tested to work with both gpg1 and gpg2. Allowing write access to the random_seed file is a bit unexpected from the read-only nature of this interface and allows tampering with the file.

Note that disallowing 'wk' of this file means that when not specifying --no-random-seed-file gpg will hang forever with no meaningful feedback during encrypt and sign operations. We can mitigate this developer obstacle through documentation (ie, mention the encrypt/sign requires use of --no-random-seed-file) and by updating snappy-debug to suggest --no-random-seed-file when accessing this file.