### PR TITLE
overlord/snapstate: override Snapstate.UserID in refresh if the installing user is gone

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -606,8 +606,8 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if snapsup.Required { // set only on install and left alone on refresh
 		snapst.Required = true
 	}
-	// only set userID if unset in snapst and if we actually have
-	// an associated user
+	// only set userID if unset or logged out in snapst and if we
+	// actually have an associated user
 	if snapsup.UserID > 0 {
 		var user *auth.UserState
 		if snapst.UserID != 0 {
@@ -618,7 +618,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		}
 		if user == nil {
 			// if the original user installing the snap is
-			// no longer available transfer to to user who
+			// no longer available transfer to user who
 			// triggered this change
 			snapst.UserID = snapsup.UserID
 		}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -611,7 +611,10 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if snapsup.UserID > 0 {
 		var user *auth.UserState
 		if snapst.UserID != 0 {
-			user, _ = auth.User(st, snapst.UserID)
+			user, err = auth.User(st, snapst.UserID)
+			if err != nil && err != auth.ErrInvalidUser {
+				return err
+			}
 		}
 		if user == nil {
 			snapst.UserID = snapsup.UserID

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
@@ -607,8 +608,14 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 	// only set userID if unset in snapst and if we actually have
 	// an associated user
-	if snapst.UserID == 0 && snapsup.UserID > 0 {
-		snapst.UserID = snapsup.UserID
+	if snapsup.UserID > 0 {
+		var user *auth.UserState
+		if snapst.UserID != 0 {
+			user, _ = auth.User(st, snapst.UserID)
+		}
+		if user == nil {
+			snapst.UserID = snapsup.UserID
+		}
 	}
 
 	newInfo, err := readInfo(snapsup.Name(), cand)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -617,6 +617,9 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 			}
 		}
 		if user == nil {
+			// if the original user installing the snap is
+			// no longer available transfer to to user who
+			// triggered this change
 			snapst.UserID = snapsup.UserID
 		}
 	}


### PR DESCRIPTION
This lets override Snapstate.UserID by a refresh if the installing user has since logged out.

Do we want this behaviour? or only some explicit --reset-user option for switch and refresh? do we need a way to notify that a snap is in this state?
