### PR TITLE
tests: change interfaces-fuse_support to be debug friendly

### DIFF
--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -57,5 +57,5 @@ execute: |
     test-snapd-fuse-consumer.create $MOUNT_POINT
     # use "[f]oo" to search for "foo" in ps output without having to filter yourself out
     PID=$(ps aux | awk '/[t]est-snapd.*create/{print $2}')
-    MATCH "Hello World!" < /proc/${PID}/root/$MOUNT_POINT/hello
+    cat /proc/${PID}/root/$MOUNT_POINT/hello | MATCH "Hello World!"
     kill -9 ${PID}


### PR DESCRIPTION
The interfaces-fuse_support test sometimes fails in spread with
an "ambiguous redirect" error. To get to the bottom of this
we need to see what the glob is expanded to. This PR uses
`cat .. | MATCH` instead of `MATCH ... < ` to archive that.
