### PR TITLE
snap: use the -no-fragments mksquashfs option

### DIFF
--- a/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
+++ b/cmd/snap-confine/spread-tests/regression/lp-1599608/task.yaml
@@ -27,7 +27,7 @@ prepare: |
     unsquashfs $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1)
     echo 'echo PATH=$PATH > /run/udev/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
     echo 'echo TESTVAR=$TESTVAR >> /run/udev/spread-test.out' >> ./squashfs-root/lib/udev/snappy-app-dev
-    mksquashfs ./squashfs-root $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1 | sed 's/.orig//') -comp xz
+    mksquashfs ./squashfs-root $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap.orig | tail -1 | sed 's/.orig//') -comp xz -no-fragments
     if [ ! -e $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) ]; then exit 1; fi
     echo "Mount modified core snap"
     mount $(ls -1 /var/lib/snapd/snaps/ubuntu-core_*.snap | tail -1) $(ls -1d /snap/ubuntu-core/* | grep -v current | tail -1)

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -155,6 +155,7 @@ func (s *Snap) Build(buildDir string) error {
 			"-noappend",
 			"-comp", "xz",
 			"-no-xattrs",
+			"-no-fragments",
 		).Run()
 	})
 }

--- a/tests/lib/snaps.sh
+++ b/tests/lib/snaps.sh
@@ -41,9 +41,9 @@ mksnap_fast() {
 
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         # trusty does not support  -Xcompression-level 1
-        mksquashfs "$dir" "$snap" -comp gzip
+        mksquashfs "$dir" "$snap" -comp gzip -no-fragments
     else
-        mksquashfs "$dir" "$snap" -comp gzip -Xcompression-level 1
+        mksquashfs "$dir" "$snap" -comp gzip -Xcompression-level 1 -no-fragments
     fi
 }
 

--- a/tests/main/confinement-classic/test-snapd-hello-classic/Makefile
+++ b/tests/main/confinement-classic/test-snapd-hello-classic/Makefile
@@ -63,7 +63,7 @@ test-snapd-hello-classic.$(snap_arch).bin: test-snapd-hello-classic.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
 
 $(snap_file): test-snapd-hello-classic.$(snap_arch).bin meta/snap.yaml
-	mksquashfs . $@ -e $@ -noappend -no-xattrs -comp xz
+	mksquashfs . $@ -e $@ -noappend -no-xattrs -comp xz -no-fragments
 
 meta: Makefile
 	mkdir -p $@

--- a/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg-extras/task.yaml
@@ -16,7 +16,7 @@ prepare: |
     unsquashfs /var/lib/snapd/snaps/pc_*.snap
     mkdir -p squashfs-root/meta/hooks
     cp prepare-device squashfs-root/meta/hooks
-    mksquashfs squashfs-root pc_x1.snap -comp xz
+    mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments
     rm -rf squashfs-root
     cp pc_x1.snap /var/lib/snapd/seed/snaps/
     mv /var/lib/snapd/seed/assertions/model model.bak

--- a/tests/main/ubuntu-core-custom-device-reg/task.yaml
+++ b/tests/main/ubuntu-core-custom-device-reg/task.yaml
@@ -15,7 +15,7 @@ prepare: |
     unsquashfs /var/lib/snapd/snaps/pc_*.snap
     mkdir -p squashfs-root/meta/hooks
     cp prepare-device squashfs-root/meta/hooks
-    mksquashfs squashfs-root pc_x1.snap -comp xz
+    mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments
     rm -rf squashfs-root
     cp pc_x1.snap /var/lib/snapd/seed/snaps/
     mv /var/lib/snapd/seed/assertions/model model.bak

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -28,7 +28,7 @@ prepare: |
          a: A
          b: B
     EOF
-    mksquashfs squashfs-root pc_x1.snap -comp xz
+    mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments
     rm -rf squashfs-root
     cp pc_x1.snap /var/lib/snapd/seed/snaps/
     cp test-snapd-with-configure_*.snap /var/lib/snapd/seed/snaps/


### PR DESCRIPTION
Use of the Squashfs fragments feature results in unpredictable snap
composition due to how fragments are gathered and compressed using a
separate thread in mksquashfs. Disable fragments entirely in `snap pack`
and tests that call mksquashfs directly so that the review tools can
perform validation of snaps and to be consistent with what snapcraft is
doing.

Fixes: https://launchpad.net/bugs/1576763
Signed-off-by: Tyler Hicks <tyhicks@canonical.com>

This PR corresponds to the following:

https://github.com/snapcore/snapcraft/pull/1805
https://forum.snapcraft.io/t/proposal-to-disable-squashfs-fragments-in-snaps/3103
