### PR TITLE
tests/main/lxd: temporarily switch to manual

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -3,6 +3,7 @@ summary: Ensure that lxd works
 # only run this on ubuntu 16+, lxd will not work on !ubuntu systems
 # currently nor on ubuntu 14.04
 systems: [ubuntu-16*, ubuntu-core-*]
+manual: true
 
 # lxd downloads can be quite slow
 kill-timeout: 25m


### PR DESCRIPTION
`tests/main/lxd` was seen to take very long. Try disabling it and see if we can get green Travis jobs again.


