### PR TITLE
tests/main/searching: handle changes in featured snaps list

### DIFF
--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -34,8 +34,15 @@ execute: |
     .*"
     snap find test-snapd- | grep -Pzq "$expected"
 
+    echo "List of snaps in a section works"
+    # NOTE: this probably shows featured snaps, do not
+    # make any assumptions about the contents
+    test $(snap find --section=database | wc -l) -gt 1
+
     # cassandra only available for amd64
+    echo "List of snaps in a section includes architecture"
     if [ $(uname -m) = "x86_64" ]; then
-        echo "List of snaps in a section works"
-        snap find --section=database | MATCH cassandra
+        snap find --section=database cassandra | MATCH cassandra
+    else
+        snap find --section=database cassandra | MATCH '0 snaps'
     fi

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -44,5 +44,5 @@ execute: |
     if [ $(uname -m) = "x86_64" ]; then
         snap find --section=database cassandra | MATCH cassandra
     else
-        snap find --section=database cassandra | MATCH '0 snaps'
+        snap find --section=database cassandra 2>&1 | MATCH '0 snaps'
     fi


### PR DESCRIPTION
When doing `snap find --section=..` do not make any assumptions about the list
of returned snaps. Use specific snap when checking if section list uses host's
architecture.
