### PR TITLE
tests: save the snapd-state without compression

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -243,7 +243,7 @@ prepare_classic() {
         done
         snapd_env="/etc/environment /etc/systemd/system/snapd.service.d /etc/systemd/system/snapd.socket.d"
         # shellcheck disable=SC2086
-        tar czf "$SPREAD_PATH"/snapd-state.tar.gz /var/lib/snapd "$SNAP_MOUNT_DIR" /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount /etc/systemd/system/multi-user.target.wants/"$escaped_snap_mount_dir"-*core*.mount $snapd_env
+        tar cf "$SPREAD_PATH"/snapd-state.tar.gz /var/lib/snapd "$SNAP_MOUNT_DIR" /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount /etc/systemd/system/multi-user.target.wants/"$escaped_snap_mount_dir"-*core*.mount $snapd_env
         systemctl daemon-reload # Workaround for http://paste.ubuntu.com/17735820/
         core="$(readlink -f "$SNAP_MOUNT_DIR/core/current")"
         # on 14.04 it is possible that the core snap is still mounted at this point, unmount
@@ -502,7 +502,7 @@ prepare_all_snap() {
         fi
 
         systemctl stop snapd.service snapd.socket
-        tar czf "$SPREAD_PATH/snapd-state.tar.gz" /var/lib/snapd $BOOT /etc/systemd/system/snap-*core*.mount
+        tar cf "$SPREAD_PATH/snapd-state.tar.gz" /var/lib/snapd $BOOT /etc/systemd/system/snap-*core*.mount
         systemctl start snapd.socket
     fi
 

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -52,7 +52,7 @@ reset_classic() {
         rm -rf /etc/systemd/system/snapd.socket.d
 
         # Restore snapd state and start systemd service units
-        tar -C/ -xzf "$SPREAD_PATH/snapd-state.tar.gz"
+        tar -C/ -xf "$SPREAD_PATH/snapd-state.tar.gz"
         escaped_snap_mount_dir="$(systemd-escape --path "$SNAP_MOUNT_DIR")"
         mounts="$(systemctl list-unit-files --full | grep "^$escaped_snap_mount_dir[-.].*\.mount" | cut -f1 -d ' ')"
         services="$(systemctl list-unit-files --full | grep "^$escaped_snap_mount_dir[-.].*\.service" | cut -f1 -d ' ')"
@@ -93,7 +93,7 @@ reset_all_snap() {
     # ensure we have the same state as initially
     systemctl stop snapd.service snapd.socket
     rm -rf /var/lib/snapd/*
-    tar -C/ -xzf "$SPREAD_PATH/snapd-state.tar.gz"
+    tar -C/ -xf "$SPREAD_PATH/snapd-state.tar.gz"
     rm -rf /root/.snap
     if [ "$1" != "--keep-stopped" ]; then
         systemctl start snapd.service snapd.socket


### PR DESCRIPTION
Removing the compression option to save execution time.

For the rpi3 the time to save the state with compression is about 141
seconds, and without compression is about 11 seconds. To apply the state
in the reset.sh it is taking about 20 seconds when the state is
compressed and about 10 seconds when it is uncompressed (this operation
is repeated for all the tests).

For a linode machine there is also a big difference. All the numbers are
stored in the following links.

With this change, if we execute all the tests in a single linode server,
the time saves should be about 7 minutes (2.5 seconds aprox by test
executed).

Pi3:
with compression: https://paste.ubuntu.com/26185300/
without compression: https://paste.ubuntu.com/26185446/

Linode ubuntu-16.04-64:
with compression: https://paste.ubuntu.com/26186380/
without compression: https://paste.ubuntu.com/26186378/
