### PR TITLE
data/selinux: allow messages from policykit

### DIFF
--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -216,6 +216,7 @@ corenet_udp_sendrecv_dns_port(snappy_t)
 corenet_tcp_connect_dns_port(snappy_t)
 corenet_sendrecv_dns_client_packets(snappy_t)
 
-# allow polkit to reply to snapd
-gen_require(` type policykit_t; class dbus send_msg; ')
-allow policykit_t snappy_t:dbus send_msg;
+# allow communication with polkit over dbus
+optional_policy(`
+  policykit_dbus_chat(snappy_t)
+')

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-policy_module(snappy,0.0.12)
+policy_module(snappy,0.0.13)
 
 ########################################
 #

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -215,3 +215,7 @@ corenet_tcp_sendrecv_dns_port(snappy_t)
 corenet_udp_sendrecv_dns_port(snappy_t)
 corenet_tcp_connect_dns_port(snappy_t)
 corenet_sendrecv_dns_client_packets(snappy_t)
+
+# allow polkit to reply to snapd
+gen_require(` type policykit_t; class dbus send_msg; ')
+allow policykit_t snappy_t:dbus send_msg;


### PR DESCRIPTION
snapd talks to polkitd over DBus and calls
org.freedesktop.PolicyKit1.Authority.CheckAuthorization() method. The default
SELinux policy prevents polkitd from sending a reply back to snapd.

Resolves: https://forum.snapcraft.io/t/selinux-blocking-snapd-since-update-on-fedora-27/3002

Quoting dbus-daemon manual (SELinux section):

  > First, any time a message is routed from one connection to another connection,
  > the bus daemon will check permissions with the security context of the first
  > connection as source, security context of the second connection as target,
  > object class "dbus" and requested permission "send_msg".

The change adds adjusts the policy to allow DBus messages (dbus send_msg) to be
sent from processes with type polkit_t (polkitd) to processes with type
snappy_t (snapd).

@Conan-Kudo this affects the SELinux policy files.
