### PR TITLE
tests: make journalctl check wait a bit for output

### DIFF
--- a/tests/main/catalog-update/task.yaml
+++ b/tests/main/catalog-update/task.yaml
@@ -2,10 +2,11 @@ summary: Ensure catalog update works
 
 execute: |
     echo "Ensure that catalog refresh happens on startup"
-    for i in seq 60; do
+    for i in $(seq 60); do
         if journalctl -u snapd | MATCH "Catalog refresh"; then
             break
         fi
+        sleep 1
     done
     journalctl -u snapd | MATCH "Catalog refresh"
 

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -38,6 +38,12 @@ execute: |
     mount --bind /tmp/old-info $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/info
     systemctl start snapd.service snapd.socket
     snap list
+    for i in $(seq 60); do
+        if journalctl | MATCH "core snap \(at .*\) is older \(.*\) than distribution package"; then
+            break
+        fi
+        sleep 1
+    done
     journalctl | MATCH "core snap \(at .*\) is older \(.*\) than distribution package"
 
     echo "Revert back to normal"

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -38,6 +38,8 @@ execute: |
     mount --bind /tmp/old-info $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/info
     systemctl start snapd.service snapd.socket
     snap list
+    # sometimes there is a delay between data written to the journal and it
+    # appearing via journalctl - so wait a little bit.
     for i in $(seq 60); do
         if journalctl | MATCH "core snap \(at .*\) is older \(.*\) than distribution package"; then
             break


### PR DESCRIPTION
The snapd-reexec and catalog-update tests are checking for
journalctl output. However it appears that on some systems like
debian-sid there is a small delay before the output is available.
Give journalctl a bit of extra time in these tests.
