### PR TITLE
tests/main/postrm-purge: stop snapd before purge and reinstall the package in restore

### DIFF
--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -11,6 +11,9 @@ execute: |
 
     . $TESTSLIB/dirs.sh
 
+    # purge is performed while/after removing the package
+    systemctl stop snapd.service snapd.socket
+
     # Ubuntu/Debian packaging has not been migrated to cross-distro snap-mgmt
     # tool
     if [[ "$SPREAD_SYSTEM" = ubuntu-* || "$SPREAD_SYSTEM" = debian-* ]]; then
@@ -31,3 +34,13 @@ execute: |
             exit 1
         fi
     done
+
+    . $TESTSLIB/pkgdb.sh
+
+    # remove the packaged
+    distro_purge_package snapd
+
+restore: |
+    . $TESTSLIB/pkgdb.sh
+    # reinstall the package for subsequent tests
+    distro_install_build_snapd


### PR DESCRIPTION
The 'purge' functionality is to be run when removing the package from the
system. Make sure that snapd services are stopped, like they would be when the
step was done through the package manager. Cleanup the remaining package files
before the test finishes.

Reinstall the package in restore to provide a consistent 'environment' for
subsequent tests.

