### PR TITLE
tests/main/postrm-purge: stop snapd before purge

### DIFF
--- a/tests/main/postrm-purge/task.yaml
+++ b/tests/main/postrm-purge/task.yaml
@@ -11,6 +11,9 @@ execute: |
 
     . $TESTSLIB/dirs.sh
 
+    # purge is performed while/after removing the package
+    systemctl stop snapd.service snapd.socket
+
     # Ubuntu/Debian packaging has not been migrated to cross-distro snap-mgmt
     # tool
     if [[ "$SPREAD_SYSTEM" = ubuntu-* || "$SPREAD_SYSTEM" = debian-* ]]; then


### PR DESCRIPTION
The 'purge' functionality is to be run when removing the package from the
system. Make sure that snapd services are stopped, like they would be when the
step was done through the package manager.
