### PR TITLE
tests/main/interfaces-fuse_support: fix confinement, allow unmount, fix spread tests

### DIFF
--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -40,11 +40,11 @@ execute: |
 
     if [ "$(snap debug confinement)" = strict ] ; then
         echo "Then the snap is not able to create a fuse file system"
-        if test-snapd-fuse-consumer.create $MOUNT_POINT 2>${PWD}/fuse.error; then
+        if test-snapd-fuse-consumer.create -f $MOUNT_POINT 2>${PWD}/fuse.error; then
             echo "Expected permission error creating fuse filesystem with disconnected plug"
             exit 1
         fi
-        MATCH "Permission denied" fuse.error
+        MATCH "Permission denied" < fuse.error
 
         echo "==================================="
     fi
@@ -54,11 +54,31 @@ execute: |
     snap interfaces | grep -Pzq "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to create a fuse filesystem"
-    test-snapd-fuse-consumer.create $MOUNT_POINT
-    # use "[f]oo" to search for "foo" in ps output without having to filter yourself out
-    PID=$(ps aux | awk '/[t]est-snapd.*create/{print $2}')
-    for p in $PID; do
-        echo "$p command: $(cat /proc/${p}/cmdline | tr '\0' ' ')"
+    # start fuse consumer in foreground and make it a background job
+    test-snapd-fuse-consumer.create -f $MOUNT_POINT &
+    createpid=$!
+    # cleanup the background job on exit
+    trap 'kill $createpid; wait $createpid' EXIT
+
+    # it may take a while for hello file to appear
+    for i in $(seq 100); do
+        if test -r /proc/${createpid}/root/${MOUNT_POINT}/hello; then
+            break
+        fi
+        sleep .1
     done
-    cat /proc/${PID}/root/$MOUNT_POINT/hello | MATCH "Hello World!"
-    kill -9 ${PID}
+    test -r /proc/${createpid}/root/${MOUNT_POINT}/hello
+    # prefer cat ... | MATCH so that we can see which PID is used
+    cat /proc/${createpid}/root/${MOUNT_POINT}/hello | MATCH "Hello World!"
+
+    # SIGTERM triggers a clean exit
+    kill $createpid
+    trap - EXIT
+
+    # the create app will try to unmount the fuse filesystem while exiting,
+    # if it fails due to apparmor or seccomp rules we'll not by its exit status
+    echo "The snap exited cleanly"
+    wait $createpid
+
+    # verify that the mount_point was removed from mount namespace of the snap
+    ! (nsenter --mount=/run/snapd/ns/test-snapd-fuse-consumer.mnt mount) | MATCH $(basename $MOUNT_POINT)

--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -28,7 +28,12 @@ prepare: |
     mkdir -p $MOUNT_POINT
 
 restore: |
-    umount $MOUNT_POINT || true
+    # remove the mount point
+    mounts=$(nsenter --mount=/run/snapd/ns/test-snapd-fuse-consumer.mnt cat /proc/mounts | \
+             grep "$(basename $MOUNT_POINT) fuse" | cut -f2 -d' ')
+    for m in $mounts; do
+        nsenter --mount=/run/snapd/ns/test-snapd-fuse-consumer.mnt umount "$m"
+    done
     rm -rf $MOUNT_POINT fuse.error
 
 execute: |
@@ -76,9 +81,13 @@ execute: |
     trap - EXIT
 
     # the create app will try to unmount the fuse filesystem while exiting,
-    # if it fails due to apparmor or seccomp rules we'll not by its exit status
-    echo "The snap exited cleanly"
-    wait $createpid
+    # it will fail, as seccomp rules are blocking umount2
+    echo "The snap exited with an error"
+    # SIGSYS - 31 on x86, wait exit status if killed by signal = 128 + <signal-number>
+    wait $createpid || test "$?" = "159"
 
-    # verify that the mount_point was removed from mount namespace of the snap
-    ! (nsenter --mount=/run/snapd/ns/test-snapd-fuse-consumer.mnt mount) | MATCH $(basename $MOUNT_POINT)
+    # verify that the mount_point was not removed from mount namespace of the snap
+    mountpath=$(nsenter --mount=/run/snapd/ns/test-snapd-fuse-consumer.mnt cat /proc/mounts | \
+                grep "$(basename $MOUNT_POINT) fuse" | cut -f2 -d' ')
+    test -n "$mountpath"
+


### PR DESCRIPTION
Multiple processes may match the `ps | awk` combo. We should be able to find the
needle for at least one of those.
