### PR TITLE
Set debian-sid-64 system as manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -69,6 +69,7 @@ backends:
             - debian-sid-64:
                 kernel: GRUB 2
                 workers: 4
+                manual: true
             - debian-9-64:
                 kernel: GRUB 2
                 workers: 4


### PR DESCRIPTION
This is because this system seems to be too much unstable and it is
making most of the branches/prs to fail.

This is an example of test log:
https://paste.ubuntu.com/26215170/
