### PR TITLE
cmd: clarify "This leaves %s tracking %s." message

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -379,7 +379,7 @@ func showDone(names []string, op string) error {
 		}
 		if snap.TrackingChannel != snap.Channel {
 			// TRANSLATORS: first %s is a snap name, following %s is a channel name
-			fmt.Fprintf(Stdout, i18n.G("This leaves %s tracking %s.\n"), snap.Name, snap.TrackingChannel)
+			fmt.Fprintf(Stdout, i18n.G("Snap %s is no longer tracking %s.\n"), snap.Name, snap.TrackingChannel)
 		}
 	}
 

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -439,7 +439,7 @@ func (s *SnapOpSuite) TestRevertRunthrough(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	// tracking channel is "" in the test server
 	c.Check(s.Stdout(), check.Equals, `foo reverted to 1.0
-This leaves foo tracking .
+Snap foo is no longer tracking .
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit


### PR DESCRIPTION
In https://bugs.launchpad.net/snapd/+bug/1739097 it is reported that the above message is not clear enough. If I understand the code correctly it means something like: `The 'atom' snap that used to track the 'edge' channel is no longer doing that`. I changed the message slightly, feedback/improvements welcome.