### PR TITLE
daemon: add new polkit action to manage interfaces

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -167,10 +167,11 @@ var (
 	}
 
 	interfacesCmd = &Command{
-		Path:   "/v2/interfaces",
-		UserOK: true,
-		GET:    interfacesConnectionsMultiplexer,
-		POST:   changeInterfaces,
+		Path:     "/v2/interfaces",
+		UserOK:   true,
+		PolkitOK: "io.snapcraft.snapd.manage-interfaces",
+		GET:      interfacesConnectionsMultiplexer,
+		POST:     changeInterfaces,
 	}
 
 	// TODO: allow to post assertions for UserOK? they are verified anyway

--- a/data/polkit/io.snapcraft.snapd.policy
+++ b/data/polkit/io.snapcraft.snapd.policy
@@ -28,7 +28,7 @@
   </action>
 
   <action id="io.snapcraft.snapd.manage-interfaces">
-    <description>Connect, disconnect interfaces </description>
+    <description>Connect, disconnect interfaces</description>
     <message>Authentication is required to connect or disconnect interfaces</message>
     <defaults>
       <allow_any>auth_admin</allow_any>

--- a/data/polkit/io.snapcraft.snapd.policy
+++ b/data/polkit/io.snapcraft.snapd.policy
@@ -26,4 +26,15 @@
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
+
+  <action id="io.snapcraft.snapd.manage-interfaces">
+    <description>Connect, disconnect interfaces </description>
+    <message>Authentication is required to connect or disconnect interfaces</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
 </policyconfig>


### PR DESCRIPTION
There was a bugreport about that we use polkit a bit inconsistently.
Common operations like install/remove/refresh are covered but
interfaces connections/disconnections are not. This PR adds a new
polkit action for managing interfaces.

Reported in https://bugs.launchpad.net/snapd/+bug/1738985
