### PR TITLE
packaging/arch: disable services when removing

### DIFF
--- a/packaging/arch/snapd.install
+++ b/packaging/arch/snapd.install
@@ -12,16 +12,25 @@ post_install() {
   echo 'For more informations, see https://wiki.archlinux.org/index.php/Snapd'
 }
 
-_stop_services() {
-  /usr/bin/systemctl stop \
+_systemctl_do_for_all() {
+  /usr/bin/systemctl "$@" \
                      snapd.service \
                      snapd.socket \
                      snapd.refresh.timer \
                      snapd.refresh.service > /dev/null 2>&1
 }
 
+_stop_services() {
+  _systemctl_do_for_all stop
+}
+
+_disable_services() {
+  _systemctl_do_for_all --no-reload disable
+}
+
 pre_remove() {
   _stop_services
+  _disable_services
 
   /usr/lib/snapd/snap-mgmt --purge || :
 }


### PR DESCRIPTION
Disable all snapd services when removing the package. This prevents the symlinks
to be left behind when the package is removed.

The problem was identified in #4285.
