### PR TITLE
corecfg: pam_env can only handle 1024 byte

### DIFF
--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -53,6 +53,9 @@ func Run(tr Conf) error {
 	if err := validateProxyStore(tr); err != nil {
 		return err
 	}
+	if err := validateProxyLimits(tr); err != nil {
+		return err
+	}
 	if err := validateRefreshSchedule(tr); err != nil {
 		return err
 	}

--- a/overlord/configstate/configcore/proxy.go
+++ b/overlord/configstate/configcore/proxy.go
@@ -94,3 +94,19 @@ func validateProxyStore(tr Conf) error {
 	}
 	return err
 }
+
+func validateProxyLimits(tr Conf) error {
+	// pam_env (that reads /etc/environment) has a size limit for
+	// the environment vars of 1024 byte. We need to honor this.
+	for _, key := range []string{"http", "https", "ftp"} {
+		s, err := coreCfg(tr, "proxy."+key)
+		if err != nil {
+			return err
+		}
+		if len(s) > 1024 {
+			return fmt.Errorf("cannot apply proxy setting %q: longer than 1024 byte", key)
+		}
+	}
+
+	return nil
+}

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -98,6 +99,21 @@ PATH="/usr/bin"
 		c.Check(string(content), Equals, fmt.Sprintf(`
 PATH="/usr/bin"
 %[1]s_proxy=%[1]s://example.com`, proto))
+	}
+}
+
+func (s *proxySuite) TestConfigureProxyTooLong(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	tooLong := strings.Repeat("x", 1025)
+	for _, proto := range []string{"http", "https", "ftp"} {
+		err := configcore.Run(&mockConf{
+			conf: map[string]interface{}{
+				fmt.Sprintf("proxy.%s", proto): tooLong,
+			},
+		})
+		c.Check(err, ErrorMatches, fmt.Sprintf(`cannot apply proxy setting %q: longer than 1024 byte`, proto))
 	}
 }
 


### PR DESCRIPTION
In bug https://bugs.launchpad.net/snapd/+bug/1737332 it is pointed out that pam_env has a limit of 1024 bytes for the env vars. From our `snap set core proxy.{http,https,ftp}` we write /etc/environment. So we need to honor that limit. Or we go a different route and do not write /etc/environment and only use `core.proxy.{http,https,ftp}` for snapd itself. But that feels slightly odd and is also a change from the existing behaviour. 