### PR TITLE
snap: print friendly message if `snap keys` is empty

### DIFF
--- a/cmd/snap/cmd_keys.go
+++ b/cmd/snap/cmd_keys.go
@@ -49,42 +49,54 @@ type Key struct {
 	Sha3_384 string `json:"sha3-384"`
 }
 
+func outputJSON(keys []Key) error {
+	obj, err := json.Marshal(keys)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(Stdout, "%s\n", obj)
+	return nil
+}
+
+func outputText(keys []Key) error {
+	if len(keys) == 0 {
+		fmt.Fprintf(Stdout, "No keys registered, see `snapcraft create-key`")
+		return nil
+	}
+
+	w := tabWriter()
+	defer w.Flush()
+
+	fmt.Fprintln(w, i18n.G("Name\tSHA3-384"))
+	for _, key := range keys {
+		fmt.Fprintf(w, "%s\t%s\n", key.Name, key.Sha3_384)
+	}
+	return nil
+}
+
 func (x *cmdKeys) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
 
-	w := tabWriter()
-	if !x.JSON {
-		fmt.Fprintln(w, i18n.G("Name\tSHA3-384"))
-		defer w.Flush()
-	}
 	keys := []Key{}
 
 	manager := asserts.NewGPGKeypairManager()
-	display := func(privk asserts.PrivateKey, fpr string, uid string) error {
+	collect := func(privk asserts.PrivateKey, fpr string, uid string) error {
 		key := Key{
 			Name:     uid,
 			Sha3_384: privk.PublicKey().ID(),
 		}
-		if x.JSON {
-			keys = append(keys, key)
-		} else {
-			fmt.Fprintf(w, "%s\t%s\n", key.Name, key.Sha3_384)
-		}
+		keys = append(keys, key)
 		return nil
 	}
-	err := manager.Walk(display)
+	err := manager.Walk(collect)
 	if err != nil {
 		return err
 	}
 	if x.JSON {
-		obj, err := json.Marshal(keys)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(Stdout, "%s\n", obj)
+		return outputJSON(keys)
 	}
 
-	return nil
+	return outputText(keys)
 }


### PR DESCRIPTION
This addresses bug https://bugs.launchpad.net/snapd/+bug/1720211