### PR TITLE
daemon: return "bad-query" error kind for store.ErrBadQuery

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -546,8 +546,12 @@ func getSections(c *Command, r *http.Request, user *auth.UserState) Response {
 	switch err {
 	case nil:
 		// pass
-	case store.ErrEmptyQuery, store.ErrBadQuery:
-		return BadRequest("%v", err)
+	case store.ErrBadQuery:
+		return SyncResponse(&resp{
+			Type:   ResponseTypeError,
+			Result: &errorResult{Message: err.Error(), Kind: errorKindBadQuery},
+			Status: 400,
+		}, nil)
 	case store.ErrUnauthenticated, store.ErrInvalidCredentials:
 		return Unauthorized("%v", err)
 	default:
@@ -607,8 +611,12 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 	switch err {
 	case nil:
 		// pass
-	case store.ErrEmptyQuery, store.ErrBadQuery:
-		return BadRequest("%v", err)
+	case store.ErrBadQuery:
+		return SyncResponse(&resp{
+			Type:   ResponseTypeError,
+			Result: &errorResult{Message: err.Error(), Kind: errorKindBadQuery},
+			Status: 400,
+		}, nil)
 	case store.ErrUnauthenticated, store.ErrInvalidCredentials:
 		return Unauthorized(err.Error())
 	default:

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -1590,6 +1590,18 @@ func (s *apiSuite) TestFindRefreshNotQ(c *check.C) {
 	c.Check(rsp.Result.(*errorResult).Message, check.Matches, "cannot use 'q' with 'select=refresh'")
 }
 
+func (s *apiSuite) TestFindBadQueryReturnsCorrectErrorKind(c *check.C) {
+	s.err = store.ErrBadQuery
+	req, err := http.NewRequest("GET", "/v2/find?q=return-bad-query-please", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := searchStore(findCmd, req, nil).(*resp)
+	c.Check(rsp.Type, check.Equals, ResponseTypeError)
+	c.Check(rsp.Status, check.Equals, 400)
+	c.Check(rsp.Result.(*errorResult).Message, check.Matches, "bad query")
+	c.Check(rsp.Result.(*errorResult).Kind, check.Equals, errorKindBadQuery)
+}
+
 func (s *apiSuite) TestFindPriced(c *check.C) {
 	s.suggestedCurrency = "GBP"
 

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -142,6 +142,8 @@ const (
 	errorKindSnapNeedsDevMode       = errorKind("snap-needs-devmode")
 	errorKindSnapNeedsClassic       = errorKind("snap-needs-classic")
 	errorKindSnapNeedsClassicSystem = errorKind("snap-needs-classic-system")
+
+	errorKindBadQuery = errorKind("bad-query")
 )
 
 type errorValue interface{}

--- a/store/errors.go
+++ b/store/errors.go
@@ -27,9 +27,6 @@ import (
 )
 
 var (
-	// ErrEmptyQuery is returned from Find when the query, stripped of any prefixes, is empty.
-	ErrEmptyQuery = errors.New("empty query")
-
 	// ErrBadQuery is returned from Find when the query has special characters in strange places.
 	ErrBadQuery = errors.New("bad query")
 


### PR DESCRIPTION
This allows clients to distinguish bad queries and to do something
useful in their UI. This was requested in bug:
https://bugs.launchpad.net/snapd/+bug/1717573

This also removes the store.ErrEmptyQuery which is never created
in the current code.
