### PR TITLE
snap: make `snap info invalid-snap` output more user friendly

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -301,10 +301,10 @@ func (x *infoCmd) Execute([]string) error {
 
 		if both == nil {
 			if len(x.Positional.Snaps) == 1 {
-				return fmt.Errorf("no snap named %q found", snapName)
+				return fmt.Errorf("no snap found for %q", snapName)
 			}
 
-			fmt.Fprintf(w, fmt.Sprintf(i18n.G("warning:\tno snap named %q found\n"), snapName))
+			fmt.Fprintf(w, fmt.Sprintf(i18n.G("warning:\tno snap found for %q\n"), snapName))
 			continue
 		}
 		noneOK = false

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -300,7 +300,11 @@ func (x *infoCmd) Execute([]string) error {
 		both := coalesce(local, remote)
 
 		if both == nil {
-			fmt.Fprintf(w, "argument:\t%q\nwarning:\t%s\n", snapName, i18n.G("not a valid snap"))
+			if len(x.Positional.Snaps) == 1 {
+				return fmt.Errorf("no snap named %q found", snapName)
+			}
+
+			fmt.Fprintf(w, fmt.Sprintf(i18n.G("warning:\tno snap named %q found\n"), snapName))
 			continue
 		}
 		noneOK = false

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -124,7 +124,7 @@ check("core", res[4],
 )
 
 check("error", res[5],
-   ("warning", equals, 'no snap named "/etc/passwd" found'),
+   ("warning", equals, 'no snap found for "/etc/passwd"'),
 )
 
 # not installed snaps have "contact" information

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -124,8 +124,7 @@ check("core", res[4],
 )
 
 check("error", res[5],
-   ("argument", equals, "/etc/passwd"),
-   ("warning", equals, "not a valid snap"),
+   ("warning", equals, 'no snap named "/etc/passwd" found'),
 )
 
 # not installed snaps have "contact" information

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -27,3 +27,17 @@ execute: |
     snap info --verbose $TESTSLIB/snaps/basic-desktop
     snap info --verbose basic_1.0_all.snap|MATCH "sha3-384:"
     snap info --verbose test-snapd-tools|MATCH "  ignore-validation:"
+
+    echo "Ensure we show friendly error messages"
+    snap info no-such-snap > out.stdout 2> out.stderr
+    MATCH 'no snap named "no-such-snap" found' < out.stderr
+
+    snap info no-such-snap no-such-other-snap > out.stdout 2> out.stderr
+    MATCH 'warning: no snap named "no-such-snap" found' < out.stdout
+    MATCH 'warning: no snap named "no-such-other-snap" found' < out.stdout
+    MATCH 'error: no valid snaps given' < out.stderr
+
+    snap info no-such-snap test-snapd-tools > out.stdout 2> out.stderr
+    MATCH 'warning: no snap named "no-such-snap" found' < out.stdout
+    # no error output generated
+    ! test -s out.stderr

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -29,15 +29,15 @@ execute: |
     snap info --verbose test-snapd-tools|MATCH "  ignore-validation:"
 
     echo "Ensure we show friendly error messages"
-    snap info no-such-snap > out.stdout 2> out.stderr
-    MATCH 'no snap named "no-such-snap" found' < out.stderr
+    snap info no-such-snap > out.stdout 2> out.stderr || true
+    MATCH 'no snap found for "no-such-snap"' < out.stderr
 
-    snap info no-such-snap no-such-other-snap > out.stdout 2> out.stderr
-    MATCH 'warning: no snap named "no-such-snap" found' < out.stdout
-    MATCH 'warning: no snap named "no-such-other-snap" found' < out.stdout
+    snap info no-such-snap no-such-other-snap > out.stdout 2> out.stderr || true
+    MATCH 'warning: no snap found for "no-such-snap"' < out.stdout 
+    MATCH 'warning: no snap found for "no-such-other-snap"' < out.stdout
     MATCH 'error: no valid snaps given' < out.stderr
 
     snap info no-such-snap test-snapd-tools > out.stdout 2> out.stderr
-    MATCH 'warning: no snap named "no-such-snap" found' < out.stdout
+    MATCH 'warning: no snap found for "no-such-snap"' < out.stdout
     # no error output generated
     ! test -s out.stderr


### PR DESCRIPTION
We are currently a bit verbose when `snap info invalid-snap` does not find anything:
```
$ snap info covfefe
argument: "covfefe"
warning: not a valid snap
error: no valid snaps given
```

This was reported in https://bugs.launchpad.net/snapd/+bug/1705489.

This PR implements a fix by not-warning when there is only a single snap argument.

As a drive-by it changes the "warning" if a snap is not found/valid from two lines into a single line. The exact wording is up for discussion, I picked: `"warning:\tno snap named %q found\n"), snapName)` however we could also use `no valid snap  %q found` for similar to make it clear that its not only about snap names but also about snap files. 