### PR TITLE
cmd/snap,  tests/main/classic-confinement: fix snap-exec path when running under classic confinement

### DIFF
--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -158,9 +158,49 @@ func (s *SnapSuite) TestSnapRunClassicAppIntegration(c *check.C) {
 	c.Check(execArgs, check.DeepEquals, []string{
 		filepath.Join(dirs.DistroLibExecDir, "snap-confine"), "--classic",
 		"snap.snapname.app",
-		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
+		filepath.Join(dirs.DistroLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
+
+}
+
+func (s *SnapSuite) TestSnapRunClassicAppIntegrationReexeced(c *check.C) {
+	mountedCorePath := filepath.Join(dirs.SnapMountDir, "core/current")
+	mountedCoreLibExecPath := filepath.Join(mountedCorePath, dirs.CoreLibExecDir)
+
+	defer mockSnapConfine(mountedCoreLibExecPath)()
+
+	// mock installed snap
+	si := snaptest.MockSnap(c, string(mockYaml)+"confinement: classic\n", string(mockContents), &snap.SideInfo{
+		Revision: snap.R("x2"),
+	})
+	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
+	c.Assert(err, check.IsNil)
+
+	restore := snaprun.MockOsReadlink(func(name string) (string, error) {
+		// pretend 'snap' is reexeced from 'core'
+		return filepath.Join(mountedCorePath, "usr/bin/snap"), nil
+	})
+	defer restore()
+
+	execArg0 := ""
+	execArgs := []string{}
+	execEnv := []string{}
+	restorer := snaprun.MockSyscallExec(func(arg0 string, args []string, envv []string) error {
+		execArg0 = arg0
+		execArgs = args
+		execEnv = envv
+		return nil
+	})
+	defer restorer()
+	rest, err := snaprun.Parser().ParseArgs([]string{"run", "snapname.app", "--arg1", "arg2"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
+	c.Check(execArgs, check.DeepEquals, []string{
+		filepath.Join(mountedCoreLibExecPath, "snap-confine"), "--classic",
+		"snap.snapname.app",
+		filepath.Join(mountedCoreLibExecPath, "snap-exec"),
+		"snapname.app", "--arg1", "arg2"})
 }
 
 func (s *SnapSuite) TestSnapRunAppWithCommandIntegration(c *check.C) {

--- a/tests/main/classic-confinement/task.yaml
+++ b/tests/main/classic-confinement/task.yaml
@@ -4,11 +4,19 @@ environment:
     CLASSIC_SNAP: test-snapd-classic-confinement
 
 # Classic confinement isn't working yet on Fedora
-systems: [-ubuntu-core-*, -fedora-*]
+systems: [-ubuntu-core-*]
 
 prepare: |
     . $TESTSLIB/snaps.sh
+    . $TESTSLIB/dirs.sh
     snap pack "$TESTSLIB/snaps/$CLASSIC_SNAP/"
+
+    if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
+        # although classic snaps do not work out of the box on fedora,
+        # we still want to verify if the basics do work if the user
+        # symlinks /snap to $SNAP_MOUNT_DIR themselves
+        ln -sf $SNAP_MOUNT_DIR /snap
+    fi
 
 execute: |
     echo "Check that classic snaps work only with --classic"
@@ -40,3 +48,7 @@ execute: |
     snap info "$CLASSIC_SNAP"|MATCH "installed:.* 2.0 .*classic"
     "$CLASSIC_SNAP" | MATCH lala
 
+restore: |
+    if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
+        rm -f /snap
+    fi


### PR DESCRIPTION
Addresses this bug: https://bugs.launchpad.net/snapd/+bug/1736939

See https://github.com/snapcore/snapd/commit/563795fd8d628c64da4019aee3f5c6a845eb0fe7 commit message for details.