### PR TITLE
interfaces: allow socket "shutdown" syscall in default profile

### DIFF
--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -171,7 +171,6 @@ accept
 accept4
 bind
 listen
-shutdown
 # libudev
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `

--- a/interfaces/builtin/lxd.go
+++ b/interfaces/builtin/lxd.go
@@ -39,7 +39,6 @@ const lxdConnectedPlugSecComp = `
 # Description: allow access to the LXD daemon socket. This gives privileged
 # access to the system via LXD's socket API.
 
-shutdown
 socket AF_NETLINK - NETLINK_GENERIC
 `
 

--- a/interfaces/builtin/lxd_test.go
+++ b/interfaces/builtin/lxd_test.go
@@ -89,7 +89,7 @@ func (s *LxdInterfaceSuite) TestSecCompSpec(c *C) {
 	spec := &seccomp.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "shutdown\n")
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "socket AF_NETLINK - NETLINK_GENERIC\n")
 }
 
 func (s *LxdInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -179,7 +179,6 @@ accept
 accept4
 bind
 listen
-shutdown
 # libgudev
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 `

--- a/interfaces/builtin/network.go
+++ b/interfaces/builtin/network.go
@@ -66,7 +66,6 @@ dbus send
 const networkConnectedPlugSecComp = `
 # Description: Can access the network as a client.
 bind
-shutdown
 
 # FIXME: some kernels require this with common functions in go's 'net' library.
 # While this should remain in network-bind, network-control and

--- a/interfaces/builtin/network_bind.go
+++ b/interfaces/builtin/network_bind.go
@@ -85,7 +85,6 @@ accept
 accept4
 bind
 listen
-shutdown
 # TODO: remove this rule once seccomp errno with logging is implemented.
 # java apps attempt this, presumably to handle interface changes, but a
 # corresponding AppArmor rule is required (eg, network netlink dgram) to use

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -266,7 +266,6 @@ accept4
 bind
 listen
 sethostname
-shutdown
 # netlink
 socket AF_NETLINK - -
 `

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -195,7 +195,6 @@ accept
 accept4
 bind
 listen
-shutdown
 socket AF_NETLINK - NETLINK_ROUTE
 # libudev
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT

--- a/interfaces/builtin/online_accounts_service.go
+++ b/interfaces/builtin/online_accounts_service.go
@@ -95,7 +95,6 @@ accept
 accept4
 bind
 listen
-shutdown
 `
 
 type onlineAccountsServiceInterface struct{}

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -579,9 +579,6 @@ const unity7ConnectedPlugSeccomp = `
 # to various DBus services and this environment does not prevent eavesdropping
 # or apps interfering with one another.
 
-# X
-shutdown
-
 # Needed by QtSystems on X to detect mouse and keyboard
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 bind

--- a/interfaces/builtin/unity7_test.go
+++ b/interfaces/builtin/unity7_test.go
@@ -96,7 +96,7 @@ func (s *Unity7InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.other-snap.app2"})
-	c.Check(seccompSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, "shutdown\n")
+	c.Check(seccompSpec.SnippetForTag("snap.other-snap.app2"), testutil.Contains, "bind\n")
 }
 
 func (s *Unity7InterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
-	"github.com/snapcore/snapd/interfaces/seccomp"
 )
 
 const unity8Summary = `allows operating as or interacting with Unity 8`
@@ -88,10 +87,6 @@ dbus (receive)
      peer=(name=com.ubuntu.content.dbus.Service,label=###SLOT_SECURITY_TAGS###),
 `
 
-const unity8ConnectedPlugSecComp = `
-shutdown
-`
-
 type unity8Interface struct{}
 
 func (iface *unity8Interface) Name() string {
@@ -115,11 +110,6 @@ func (iface *unity8Interface) AppArmorConnectedPlug(spec *apparmor.Specification
 	newTags := slotAppLabelExpr(slot)
 	snippet := strings.Replace(unity8ConnectedPlugAppArmor, oldTags, newTags, -1)
 	spec.AddSnippet(snippet)
-	return nil
-}
-
-func (iface *unity8Interface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	spec.AddSnippet(unity8ConnectedPlugSecComp)
 	return nil
 }
 

--- a/interfaces/builtin/unity8_test.go
+++ b/interfaces/builtin/unity8_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
-	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -80,13 +79,6 @@ func (s *unity8InterfaceSuite) TestUsedSecuritySystems(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.unity8-app"})
 	c.Check(apparmorSpec.SnippetForTag("snap.other.unity8-app"), testutil.Contains, "name=com.canonical.URLDispatcher")
-
-	// connected plugs have a non-nil security snippet for seccomp
-	seccompSpec := &seccomp.Specification{}
-	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
-	c.Assert(err, IsNil)
-	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.other.unity8-app"})
-	c.Check(seccompSpec.SnippetForTag("snap.other.unity8-app"), testutil.Contains, "shutdown\n")
 }
 
 func (s *unity8InterfaceSuite) TestSecurityTags(c *C) {

--- a/interfaces/builtin/x11.go
+++ b/interfaces/builtin/x11.go
@@ -55,8 +55,6 @@ const x11ConnectedPlugSecComp = `
 # Description: Can access the X server. Restricted because X does not prevent
 # eavesdropping or apps interfering with one another.
 
-shutdown
-
 # Needed by QtSystems on X to detect mouse and keyboard
 socket AF_NETLINK - NETLINK_KOBJECT_UEVENT
 bind

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -97,7 +97,7 @@ func (s *X11InterfaceSuite) TestLP1574526(c *C) {
 	err := seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
-	c.Check(seccompSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "shutdown\n")
+	c.Check(seccompSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "bind\n")
 }
 
 func (s *X11InterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/seccomp/template.go
+++ b/interfaces/seccomp/template.go
@@ -396,6 +396,7 @@ shmat
 shmctl
 shmdt
 shmget
+shutdown
 signal
 sigaction
 signalfd


### PR DESCRIPTION
A bit of an RFC branch to deal with https://bugs.launchpad.net/snapd/+bug/1689577:

We allow the "connect" syscall in the default seccomp profile but we do not allow
the socket "shutdown". We do allow systemd-cat in the default apparmor tools
but systemd-cat will not work because it uses connect("/run/systemd/jounral/stdout") and shutdown().
Allowing "shutdown" will make systemd-cat work and in general it seems like if we allow "connect()" by default we should also allow "shutdown()" as well.

Feedback welcome, especially from @jdstrand 
