### PR TITLE
snap: do not leak internal network errors to the user

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -374,6 +374,8 @@ const (
 	ErrorKindNoUpdateAvailable      = "snap-no-update-available"
 
 	ErrorKindNotSnap = "snap-not-a-snap"
+
+	ErrorKindNetworkTimeout = "network-timeout"
 )
 
 // IsTwoFactorError returns whether the given error is due to problems

--- a/client/packages.go
+++ b/client/packages.go
@@ -214,6 +214,9 @@ func (client *Client) FindOne(name string) (*Snap, *ResultInfo, error) {
 func (client *Client) snapsFromPath(path string, query url.Values) ([]*Snap, *ResultInfo, error) {
 	var snaps []*Snap
 	ri, err := client.doSync("GET", path, query, nil, nil, &snaps)
+	if e, ok := err.(*Error); ok {
+		return nil, nil, e
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot list snaps: %s", err)
 	}

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/logger"
 )
 
 var shortFindHelp = i18n.G("Finds packages to install")
@@ -132,6 +133,10 @@ func (x *cmdFind) Execute(args []string) error {
 func findSnaps(opts *client.FindOptions) error {
 	cli := Client()
 	snaps, resInfo, err := cli.Find(opts)
+	if e, ok := err.(*client.Error); ok && e.Kind == client.ErrorKindNetworkTimeout {
+		logger.Debugf("cannot list snaps: %v", e)
+		return fmt.Errorf("unable to contact snap store")
+	}
 	if err != nil {
 		return err
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"os"
 	"os/user"
@@ -609,6 +610,13 @@ func searchStore(c *Command, r *http.Request, user *auth.UserState) Response {
 		Private: private,
 		Prefix:  prefix,
 	}, user)
+	if e, ok := err.(net.Error); ok && e.Timeout() {
+		return SyncResponse(&resp{
+			Type:   ResponseTypeError,
+			Result: &errorResult{Message: err.Error(), Kind: errorKindNetworkTimeout},
+			Status: 400,
+		}, nil)
+	}
 	switch err {
 	case nil:
 		// pass

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -144,6 +144,8 @@ const (
 	errorKindSnapNeedsClassicSystem = errorKind("snap-needs-classic-system")
 
 	errorKindBadQuery = errorKind("bad-query")
+
+	errorKindNetworkTimeout = errorKind("network-timeout")
 )
 
 type errorValue interface{}


### PR DESCRIPTION
We currently present a rather ugly error message to the user when the snap store is not available. We will need to do something similar for "cmd_snap_op.go" (I will do a followup).

This addresses LP: 1688720.
