### PR TITLE
tests: add test that ensures we never parse versions as numbers

### DIFF
--- a/tests/lib/snaps/test-snapd-number-version/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-number-version/meta/snap.yaml
@@ -1,0 +1,3 @@
+name: test-snapd-number-version
+version: "2.10"
+architectures: ["all"]

--- a/tests/lib/snaps/test-snapd-tools/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-tools/meta/snap.yaml
@@ -1,5 +1,5 @@
 name: test-snapd-tools
-version: "2.10"
+version: 1.0
 architectures: ["all"]
 environment:
   EXTRA_GLOBAL: extra-global

--- a/tests/lib/snaps/test-snapd-tools/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-tools/meta/snap.yaml
@@ -1,5 +1,6 @@
 name: test-snapd-tools
-version: 1.0
+version: "2.10"
+architectures: ["all"]
 environment:
   EXTRA_GLOBAL: extra-global
   EXTRA_CACHE_DIR: $SNAP_USER_DATA/.cache

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -41,3 +41,6 @@ execute: |
     MATCH 'warning: no snap found for "no-such-snap"' < out.stdout
     # no error output generated
     ! test -s out.stderr
+
+    echo "Ensure we show versions as strings (LP: 1669291)
+    snap info test-snapd-tools | MATCH "beta:[ ]+2.10"

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -42,5 +42,5 @@ execute: |
     # no error output generated
     ! test -s out.stderr
 
-    echo "Ensure we show versions as strings (LP: 1669291)
-    snap info test-snapd-tools | MATCH "beta:[ ]+2.10"
+    echo "Ensure we show versions as strings (LP: 1669291)"
+    snap info test-snapd-number-version | MATCH "edge:[ ]+2.10"


### PR DESCRIPTION
This is a regression test for LP: 1669291

The bugreport is about `snap info lxd` showing version 2.10 as 2.1 indicating that something was parsing the version as a number instead of a string.  I cannot reproduce this with snapd and suspect it is a snapcraft bug. However the test is cheap (and already written when I tried to reproduce it) so we might as well include it.