### PR TITLE
 snap: add new `snap advice-command` skeleton

### DIFF
--- a/advisor/cmdfinder.go
+++ b/advisor/cmdfinder.go
@@ -42,7 +42,7 @@ const (
 // based on CommandNotFound.py:similar_words.py
 func similarWords(word string) []string {
 	const alphabet = "abcdefghijklmnopqrstuvwxyz-_0123456789"
-	similar := map[string]bool{}
+	similar := make(map[string]bool, 2*len(word)+2*len(word)*len(alphabet))
 
 	// deletes
 	for i := range word {

--- a/advisor/cmdfinder.go
+++ b/advisor/cmdfinder.go
@@ -1,0 +1,44 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package advisor
+
+import (
+	"fmt"
+)
+
+type Finder interface {
+	Find(command string) (snaps []string, err error)
+}
+
+type boltFinder struct{}
+
+func (bf *boltFinder) Find(command string) ([]string, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+var Commands Finder = &boltFinder{}
+
+func ReplaceCommandsFinder(f Finder) (restore func()) {
+	old := Commands
+	Commands = f
+	return func() {
+		Commands = old
+	}
+}

--- a/advisor/cmdfinder_test.go
+++ b/advisor/cmdfinder_test.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package advisor_test
+
+import (
+	"sort"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/advisor"
+	"github.com/snapcore/snapd/testutil"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type cmdfinderSuite struct{}
+
+var _ = Suite(&cmdfinderSuite{})
+
+func (s *cmdfinderSuite) TestFindSimilarWordsCnf(c *C) {
+	words := advisor.SimilarWords("123")
+	sort.Strings(words)
+	c.Check(words, DeepEquals, []string{
+		// calculated using CommandNotFound.py:similar_words("123")
+		"-123", "-23", "0123", "023", "1-23", "1-3", "1023",
+		"103", "1123", "113", "12", "12-", "12-3", "120",
+		"1203", "121", "1213", "122", "1223", "123", "1233",
+		"124", "1243", "125", "1253", "126", "1263", "127",
+		"1273", "128", "1283", "129", "1293", "12_", "12_3",
+		"12a", "12a3", "12b", "12b3", "12c", "12c3", "12d",
+		"12d3", "12e", "12e3", "12f", "12f3", "12g", "12g3",
+		"12h", "12h3", "12i", "12i3", "12j", "12j3", "12k",
+		"12k3", "12l", "12l3", "12m", "12m3", "12n", "12n3",
+		"12o", "12o3", "12p", "12p3", "12q", "12q3", "12r",
+		"12r3", "12s", "12s3", "12t", "12t3", "12u", "12u3",
+		"12v", "12v3", "12w", "12w3", "12x", "12x3", "12y",
+		"12y3", "12z", "12z3", "13", "132", "1323", "133",
+		"1423", "143", "1523", "153", "1623", "163", "1723",
+		"173", "1823", "183", "1923", "193", "1_23", "1_3",
+		"1a23", "1a3", "1b23", "1b3", "1c23", "1c3", "1d23",
+		"1d3", "1e23", "1e3", "1f23", "1f3", "1g23", "1g3",
+		"1h23", "1h3", "1i23", "1i3", "1j23", "1j3", "1k23",
+		"1k3", "1l23", "1l3", "1m23", "1m3", "1n23", "1n3",
+		"1o23", "1o3", "1p23", "1p3", "1q23", "1q3", "1r23",
+		"1r3", "1s23", "1s3", "1t23", "1t3", "1u23", "1u3",
+		"1v23", "1v3", "1w23", "1w3", "1x23", "1x3", "1y23",
+		"1y3", "1z23", "1z3", "2123", "213", "223", "23",
+		"3123", "323", "4123", "423", "5123", "523", "6123",
+		"623", "7123", "723", "8123", "823", "9123", "923",
+		"_123", "_23", "a123", "a23", "b123", "b23", "c123",
+		"c23", "d123", "d23", "e123", "e23", "f123", "f23",
+		"g123", "g23", "h123", "h23", "i123", "i23", "j123",
+		"j23", "k123", "k23", "l123", "l23", "m123", "m23",
+		"n123", "n23", "o123", "o23", "p123", "p23", "q123",
+		"q23", "r123", "r23", "s123", "s23", "t123", "t23",
+		"u123", "u23", "v123", "v23", "w123", "w23", "x123",
+		"x23", "y123", "y23", "z123", "z23",
+	})
+}
+
+func (s *cmdfinderSuite) TestFindSimilarWordsTrivial(c *C) {
+	words := advisor.SimilarWords("hella")
+	c.Check(words, testutil.Contains, "hello")
+}

--- a/advisor/export_test.go
+++ b/advisor/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package advisor
+
+var SimilarWords = similarWords

--- a/cmd/snap/cmd_advice.go
+++ b/cmd/snap/cmd_advice.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/advisor"
+	"github.com/snapcore/snapd/i18n"
+)
+
+type cmdAdviceCommand struct {
+	Positionals struct {
+		Command string `required:"yes"`
+	} `positional-args:"true"`
+
+	Format string `long:"format"`
+}
+
+var shortAdviceCommandHelp = i18n.G("Advice on available snaps.")
+var longAdviceCommandHelp = i18n.G(`
+The advice-command command shows what snaps with the given command are 
+available.
+`)
+
+func init() {
+	cmd := addCommand("advice-command", shortAdviceCommandHelp, longAdviceCommandHelp, func() flags.Commander {
+		return &cmdAdviceCommand{}
+	}, nil, []argDesc{
+		{name: "<command>"},
+	})
+	cmd.hidden = true
+}
+
+func outputText(command string, snaps []string) error {
+	fmt.Fprintf(Stdout, i18n.G("The program %q can be found in the following snaps:\n"), command)
+	for _, snap := range snaps {
+		fmt.Fprintf(Stdout, " * %s\n", snap)
+	}
+	fmt.Fprintf(Stdout, i18n.G("Try: snap install <selected snap>\n"))
+	return nil
+}
+
+func outputJSON(command string, snaps []string) error {
+	enc := json.NewEncoder(Stdout)
+	enc.Encode(snaps)
+	return nil
+}
+
+func (x *cmdAdviceCommand) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	needle := x.Positionals.Command
+
+	snaps, err := advisor.Commands.Find(needle)
+	if err != nil {
+		return err
+	}
+	if len(snaps) == 0 {
+		return nil
+	}
+
+	switch x.Format {
+	case "json":
+		return outputJSON(needle, snaps)
+	case "text", "":
+		return outputText(needle, snaps)
+	default:
+		return fmt.Errorf("unsupported format %q", x.Format)
+	}
+
+	return nil
+}

--- a/cmd/snap/cmd_advice.go
+++ b/cmd/snap/cmd_advice.go
@@ -34,7 +34,7 @@ type cmdAdviceCommand struct {
 		Command string `required:"yes"`
 	} `positional-args:"true"`
 
-	Format string `long:"format"`
+	Format string `long:"format" default:"pretty"`
 }
 
 var shortAdviceCommandHelp = i18n.G("Advice on available snaps.")
@@ -93,7 +93,7 @@ func adviceCommand(cmd string, format string) error {
 		switch format {
 		case "json":
 			return outputJSON(cmd, matches)
-		case "text", "":
+		case "pretty":
 			return outputExactText(cmd, matches)
 		default:
 			return fmt.Errorf("unsupported format %q", format)
@@ -109,7 +109,7 @@ func adviceCommand(cmd string, format string) error {
 		switch format {
 		case "json":
 			return outputJSON(cmd, matches)
-		case "text", "":
+		case "pretty":
 			return outputMispellText(cmd, matches)
 		default:
 			return fmt.Errorf("unsupported format %q", format)

--- a/cmd/snap/cmd_advice.go
+++ b/cmd/snap/cmd_advice.go
@@ -52,7 +52,7 @@ func init() {
 	cmd.hidden = true
 }
 
-func outputExactText(command string, result []advisor.Command) error {
+func outputAdviceExactText(command string, result []advisor.Command) error {
 	fmt.Fprintf(Stdout, i18n.G("The program %q can be found in the following snaps:\n"), command)
 	for _, snap := range result {
 		fmt.Fprintf(Stdout, " * %s\n", snap.Snap)
@@ -61,7 +61,7 @@ func outputExactText(command string, result []advisor.Command) error {
 	return nil
 }
 
-func outputMispellText(command string, result []advisor.Command) error {
+func outputAdviceMispellText(command string, result []advisor.Command) error {
 	fmt.Fprintf(Stdout, i18n.G("No command %q found, did you mean:\n"), command)
 	for _, snap := range result {
 		fmt.Fprintf(Stdout, " Command %q from snap %q\n", snap.Command, snap.Snap)
@@ -69,7 +69,7 @@ func outputMispellText(command string, result []advisor.Command) error {
 	return nil
 }
 
-func outputJSON(command string, results []advisor.Command) error {
+func outputAdviceJSON(command string, results []advisor.Command) error {
 	enc := json.NewEncoder(Stdout)
 	enc.Encode(results)
 	return nil
@@ -92,9 +92,9 @@ func adviceCommand(cmd string, format string) error {
 	if len(matches) > 0 {
 		switch format {
 		case "json":
-			return outputJSON(cmd, matches)
+			return outputAdviceJSON(cmd, matches)
 		case "pretty":
-			return outputExactText(cmd, matches)
+			return outputAdviceExactText(cmd, matches)
 		default:
 			return fmt.Errorf("unsupported format %q", format)
 		}
@@ -108,9 +108,9 @@ func adviceCommand(cmd string, format string) error {
 	if len(matches) > 0 {
 		switch format {
 		case "json":
-			return outputJSON(cmd, matches)
+			return outputAdviceJSON(cmd, matches)
 		case "pretty":
-			return outputMispellText(cmd, matches)
+			return outputAdviceMispellText(cmd, matches)
 		default:
 			return fmt.Errorf("unsupported format %q", format)
 		}

--- a/cmd/snap/cmd_advice_test.go
+++ b/cmd/snap/cmd_advice_test.go
@@ -1,0 +1,68 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/advisor"
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+type sillyFinder struct{}
+
+func (sf *sillyFinder) Find(command string) ([]string, error) {
+	switch command {
+	case "hello":
+		return []string{"hello", "hello-wcm"}, nil
+	case "error-please":
+		return nil, fmt.Errorf("get failed")
+	default:
+		return nil, nil
+	}
+}
+
+func (s *SnapSuite) TestAdviceCommandHappyText(c *C) {
+	restore := advisor.ReplaceCommandsFinder(&sillyFinder{})
+	defer restore()
+
+	rest, err := snap.Parser().ParseArgs([]string{"advice-command", "hello"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	c.Assert(s.Stdout(), Equals, `The program "hello" can be found in the following snaps:
+ * hello
+ * hello-wcm
+Try: snap install <selected snap>
+`)
+	c.Assert(s.Stderr(), Equals, "")
+}
+
+func (s *SnapSuite) TestAdviceCommandHappyJSON(c *C) {
+	restore := advisor.ReplaceCommandsFinder(&sillyFinder{})
+	defer restore()
+
+	rest, err := snap.Parser().ParseArgs([]string{"advice-command", "--format=json", "hello"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, DeepEquals, []string{})
+	c.Assert(s.Stdout(), Equals, `["hello","hello-wcm"]`+"\n")
+	c.Assert(s.Stderr(), Equals, "")
+}

--- a/cmd/snap/cmd_advice_test.go
+++ b/cmd/snap/cmd_advice_test.go
@@ -70,17 +70,17 @@ func (s *SnapSuite) TestAdviceCommandHappyJSON(c *C) {
 	c.Assert(s.Stderr(), Equals, "")
 }
 
-func (s *SnapSuite) TestAdviceCommandMispellText(c *C) {
+func (s *SnapSuite) TestAdviceCommandMisspellText(c *C) {
 	restore := advisor.ReplaceCommandsFinder(&sillyFinder{})
 	defer restore()
 
-	for _, mispelling := range []string{"helo", "0hello", "hell0", "hello0"} {
-		err := snap.AdviceCommand(mispelling, "text")
+	for _, misspelling := range []string{"helo", "0hello", "hell0", "hello0"} {
+		err := snap.AdviceCommand(misspelling, "pretty")
 		c.Assert(err, IsNil)
 		c.Assert(s.Stdout(), Equals, fmt.Sprintf(`No command "%s" found, did you mean:
  Command "hello" from snap "hello"
  Command "hello" from snap "hello-wcm"
-`, mispelling))
+`, misspelling))
 		c.Assert(s.Stderr(), Equals, "")
 
 		s.stdout.Reset()

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -41,6 +41,7 @@ var (
 	MaybePrintServices = maybePrintServices
 	MaybePrintCommands = maybePrintCommands
 	SortByPath         = sortByPath
+	AdviceCommand      = adviceCommand
 )
 
 func MockPollTime(d time.Duration) (restore func()) {


### PR DESCRIPTION
This is the frontend work for `snap advice-command` that will be used as the command-not-found replacement on core devices. It will also be interfaced with the classic command-not-found implementation(s). 

It supports spelling corrections and will use the data from the catalog-refresh once that is available (@chipaca is working on that).