### PR TITLE
Add documentation for supported Go versions

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -6,6 +6,10 @@ integration test framework for the integration/system level tests.
 
 ## Development
 
+### Supported Go versions
+
+snapd is supported on Go 1.6 onwards.
+
 ### Setting up a GOPATH
 
 When working with the source of Go programs, you should define a path within


### PR DESCRIPTION
Add simple prose to document the supported Go versions.

Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)? :white_check_mark: 
