### PR TITLE
[RFC] snap: improve error for snaps not available in the given context

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -364,14 +364,15 @@ const (
 	ErrorKindPaymentDeclined   = "payment-declined"
 	ErrorKindPasswordPolicy    = "password-policy"
 
-	ErrorKindSnapAlreadyInstalled   = "snap-already-installed"
-	ErrorKindSnapNotInstalled       = "snap-not-installed"
-	ErrorKindSnapNotFound           = "snap-not-found"
-	ErrorKindSnapLocal              = "snap-local"
-	ErrorKindSnapNeedsDevMode       = "snap-needs-devmode"
-	ErrorKindSnapNeedsClassic       = "snap-needs-classic"
-	ErrorKindSnapNeedsClassicSystem = "snap-needs-classic-system"
-	ErrorKindNoUpdateAvailable      = "snap-no-update-available"
+	ErrorKindSnapAlreadyInstalled       = "snap-already-installed"
+	ErrorKindSnapNotInstalled           = "snap-not-installed"
+	ErrorKindSnapNotFound               = "snap-not-found"
+	ErrorKindSnapNotFoundInGivenContext = "snap-not-found-in-given-context"
+	ErrorKindSnapLocal                  = "snap-local"
+	ErrorKindSnapNeedsDevMode           = "snap-needs-devmode"
+	ErrorKindSnapNeedsClassic           = "snap-needs-classic"
+	ErrorKindSnapNeedsClassicSystem     = "snap-needs-classic-system"
+	ErrorKindNoUpdateAvailable          = "snap-no-update-available"
 
 	ErrorKindNotSnap = "snap-not-a-snap"
 )

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -117,6 +117,12 @@ func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (stri
 				msg = fmt.Sprintf(i18n.G("snap %%q not found (at least in channel %q)"), opts.Channel)
 			}
 		}
+	case client.ErrorKindSnapNotFoundInGivenContext:
+		// TRANSLATORS: %%q will become a %q for the snap name
+		msg = i18n.G(`
+snap not found in the given context. Please use "snap info %s" to list available releases.
+`)
+
 	case client.ErrorKindSnapAlreadyInstalled:
 		isError = false
 		msg = i18n.G(`snap %q is already installed, see "snap refresh --help"`)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1122,6 +1122,8 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 	switch err {
 	case store.ErrSnapNotFound:
 		return SnapNotFound(inst.Snaps[0], err)
+	case store.ErrSnapNotFoundInGivenContext:
+		return SnapNotFoundInGivenContext(inst.Snaps[0], err)
 	case store.ErrNoUpdateAvailable:
 		kind = errorKindSnapNoUpdateAvailable
 	case store.ErrLocalSnap:

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -130,12 +130,13 @@ const (
 	errorKindPaymentDeclined   = errorKind("payment-declined")
 	errorKindPasswordPolicy    = errorKind("password-policy")
 
-	errorKindSnapAlreadyInstalled  = errorKind("snap-already-installed")
-	errorKindSnapNotInstalled      = errorKind("snap-not-installed")
-	errorKindSnapNotFound          = errorKind("snap-not-found")
-	errorKindAppNotFound           = errorKind("app-not-found")
-	errorKindSnapLocal             = errorKind("snap-local")
-	errorKindSnapNoUpdateAvailable = errorKind("snap-no-update-available")
+	errorKindSnapAlreadyInstalled       = errorKind("snap-already-installed")
+	errorKindSnapNotInstalled           = errorKind("snap-not-installed")
+	errorKindSnapNotFound               = errorKind("snap-not-found")
+	errorKindSnapNotFoundInGivenContext = errorKind("snap-not-found-in-given-context")
+	errorKindAppNotFound                = errorKind("app-not-found")
+	errorKindSnapLocal                  = errorKind("snap-local")
+	errorKindSnapNoUpdateAvailable      = errorKind("snap-no-update-available")
 
 	errorKindNotSnap = errorKind("snap-not-a-snap")
 
@@ -327,6 +328,20 @@ func SnapNotFound(snapName string, err error) Response {
 		Result: &errorResult{
 			Message: err.Error(),
 			Kind:    errorKindSnapNotFound,
+			Value:   snapName,
+		},
+		Status: 404,
+	}
+}
+
+// SnapNotFoundInGivenContext is an error responder used when an operation is
+// requested on a snap that doesn't exist in the given context.
+func SnapNotFoundInGivenContext(snapName string, err error) Response {
+	return &resp{
+		Type: ResponseTypeError,
+		Result: &errorResult{
+			Message: err.Error(),
+			Kind:    errorKindSnapNotFoundInGivenContext,
 			Value:   snapName,
 		},
 		Status: 404,

--- a/store/errors.go
+++ b/store/errors.go
@@ -33,6 +33,10 @@ var (
 	// ErrSnapNotFound is returned when a snap can not be found
 	ErrSnapNotFound = errors.New("snap not found")
 
+	// ErrSnapNotFoundInGivenContext is returned when the snap exists
+	// but not in the given context (e.g. in a different channel/track)
+	ErrSnapNotFoundInGivenContext = errors.New("snap not found in given context")
+
 	// ErrUnauthenticated is returned when authentication is needed to complete the query
 	ErrUnauthenticated = errors.New("you need to log in first")
 

--- a/store/store.go
+++ b/store/store.go
@@ -1003,6 +1003,36 @@ type SnapSpec struct {
 	Revision snap.Revision
 }
 
+func (s *Store) whyNotFound(snapSpec SnapSpec, user *auth.UserState) error {
+	query := s.defaultSnapQuery()
+	query.Set("channel", "") // AnyChannel
+
+	// FIXME: also add support to query without architecture to given
+	//        meaningful error about this too
+
+	u := s.endpointURL(path.Join(detailsEndpPath, snapSpec.Name), query)
+	reqOptions := &requestOptions{
+		Method: "GET",
+		URL:    u,
+		Accept: halJsonContentType,
+	}
+
+	var remote *snapDetails
+	resp, err := s.retryRequestDecodeJSON(context.TODO(), reqOptions, user, &remote, nil)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		return ErrSnapNotFoundInGivenContext
+	case 404:
+		return ErrSnapNotFound
+	}
+	msg := fmt.Sprintf("get details for snap %q", snapSpec.Name)
+	return respToError(resp, msg)
+}
+
 // SnapInfo returns the snap.Info for the store-hosted snap matching the given spec, or an error.
 func (s *Store) SnapInfo(snapSpec SnapSpec, user *auth.UserState) (*snap.Info, error) {
 	query := s.defaultSnapQuery()
@@ -1043,7 +1073,7 @@ func (s *Store) SnapInfo(snapSpec SnapSpec, user *auth.UserState) (*snap.Info, e
 	case 200:
 		// OK
 	case 404:
-		return nil, ErrSnapNotFound
+		return nil, s.whyNotFound(snapSpec, user)
 	default:
 		msg := fmt.Sprintf("get details for snap %q%s", snapSpec.Name, sel)
 		return nil, respToError(resp, msg)


### PR DESCRIPTION
When we have a snap in the store that is not available in the
channel that the user requested we currently show a "not-found"
error. But it is better to display more meaningful information.

This is a RFC PR that adds this but has the cost of one extra
round-trip to the store.

Fixes https://bugs.launchpad.net/snapstore/+bug/1665787
