### PR TITLE
snap: use stdout instead of stderr for "fetching" message

### DIFF
--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -114,7 +114,7 @@ func (x *cmdDownload) Execute(args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(Stderr, i18n.G("Fetching snap %q\n"), snapName)
+	fmt.Fprintf(Stdout, i18n.G("Fetching snap %q\n"), snapName)
 	dlOpts := image.DownloadOptions{
 		TargetDir: "", // cwd
 		Channel:   x.Channel,
@@ -124,7 +124,7 @@ func (x *cmdDownload) Execute(args []string) error {
 		return err
 	}
 
-	fmt.Fprintf(Stderr, i18n.G("Fetching assertions for %q\n"), snapName)
+	fmt.Fprintf(Stdout, i18n.G("Fetching assertions for %q\n"), snapName)
 	err = fetchSnapAssertions(tsto, snapPath, snapInfo)
 	if err != nil {
 		return err


### PR DESCRIPTION
We are currently printing "Fetching ..." to stderr in `snap download`. As this makes little sense here is a trivial PR to move this message to stdout.