### PR TITLE
cmd/libsnap-confine-private, cmd/snap-confine: fix logging of failed [u]mount when run with SNAP_CONFINE_DEBUG=1

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -255,10 +255,10 @@ endif  # APPARMOR
 # an extra build that has additional debugging enabled at compile time
 
 noinst_PROGRAMS += snap-confine/snap-confine-debug
-snap_confine_snap_confine_debug_SOURCES = $(snap_confine_snap_confine_SOURCES) $(libsnap_confine_private_a_SOURCES)
-snap_confine_snap_confine_debug_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(libsnap_confine_private_a_CFLAGS)
+snap_confine_snap_confine_debug_SOURCES = $(snap_confine_snap_confine_SOURCES)
+snap_confine_snap_confine_debug_CFLAGS = $(snap_confine_snap_confine_CFLAGS)
 snap_confine_snap_confine_debug_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)
-snap_confine_snap_confine_debug_LDADD = $(filter-out libsnap-confine-private.d,$(snap_confine_snap_confine_LDADD))
+snap_confine_snap_confine_debug_LDADD = libsnap-confine-private-debug.a $(filter-out libsnap-confine-private.a,$(snap_confine_snap_confine_LDADD))
 snap_confine_snap_confine_debug_CFLAGS += -DSNAP_CONFINE_DEBUG_BUILD=1
 snap_confine_snap_confine_debug_STATIC = $(snap_confine_snap_confine_STATIC)
 

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -102,6 +102,10 @@ libsnap_confine_private_a_SOURCES = \
 	libsnap-confine-private/utils.h
 libsnap_confine_private_a_CFLAGS = $(CHECK_CFLAGS)
 
+noinst_LIBRARIES += libsnap-confine-private-debug.a
+libsnap_confine_private_debug_a_SOURCES = $(libsnap_confine_private_a_SOURCES)
+libsnap_confine_private_debug_a_CFLAGS = $(CHECK_CFLAGS) -DSNAP_CONFINE_DEBUG_BUILD=1
+
 if WITH_UNIT_TESTS
 noinst_PROGRAMS += libsnap-confine-private/unit-tests
 libsnap_confine_private_unit_tests_SOURCES = \

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -263,7 +263,11 @@ snap_confine_snap_confine_debug_CFLAGS += -DSNAP_CONFINE_DEBUG_BUILD=1
 snap_confine_snap_confine_debug_STATIC = $(snap_confine_snap_confine_STATIC)
 
 # Use a hacked rule if we're doing static build. This allows us to inject the LIBS += .. rule below.
-snap-confine/snap-confine-debug$(EXEEXT): $(snap_confine_snap_confine_debug_OBJECTS) $(snap_confine_snap_confine_debug_DEPENDENCIES) $(EXTRA_snap_confine_snap_confine_debug_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
+
+# NOTE: for some reason make/automake in Debian 9 mishandles the dependencies
+# and this particular snap-confine/snap-confine-debug ends up depending on
+# -ludev -lcap .. and so on, need to filter those out
+snap-confine/snap-confine-debug$(EXEEXT): $(snap_confine_snap_confine_debug_OBJECTS) $(filter-out -l%,$(snap_confine_snap_confine_debug_DEPENDENCIES)) $(EXTRA_snap_confine_snap_confine_debug_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
 	@rm -f snap-confine/snap-confine-debug$(EXEEXT)
 	$(AM_V_CCLD)$(snap_confine_snap_confine_debug_LINK) $(snap_confine_snap_confine_debug_OBJECTS) $(snap_confine_snap_confine_debug_LDADD) $(LIBS)
 

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -209,14 +209,19 @@ snap_confine_snap_confine_CFLAGS = $(CHECK_CFLAGS) $(AM_CFLAGS) -DLIBEXECDIR=\"$
 snap_confine_snap_confine_LDFLAGS = $(AM_LDFLAGS)
 snap_confine_snap_confine_LDADD = libsnap-confine-private.a
 snap_confine_snap_confine_CFLAGS += $(LIBUDEV_CFLAGS)
-snap_confine_snap_confine_LDADD += $(LIBUDEV_LIBS)
+snap_confine_snap_confine_LDADD += $(snap_confine_snap_confine_extra_libs)
 # _STATIC is where we collect statically linked in libraries
 snap_confine_snap_confine_STATIC =
+# use a separate variable instead of snap_confine_snap_confine_LDADD to collect
+# all external libraries, this way it can be reused in
+# snap_confine_snap_confine_debug_LDADD withouth applying any text
+# transformations
+snap_confine_snap_confine_extra_libs = $(LIBUDEV_LIBS)
 
 if STATIC_LIBCAP
 snap_confine_snap_confine_STATIC += -lcap
 else
-snap_confine_snap_confine_LDADD += -lcap
+snap_confine_snap_confine_extra_libs += -lcap
 endif  # STATIC_LIBCAP
 
 # Use a hacked rule if we're doing static build. This allows us to inject the LIBS += .. rule below.
@@ -239,7 +244,7 @@ snap_confine_snap_confine_CFLAGS += $(SECCOMP_CFLAGS)
 if STATIC_LIBSECCOMP
 snap_confine_snap_confine_STATIC += $(shell pkg-config --static --libs libseccomp)
 else
-snap_confine_snap_confine_LDADD += $(SECCOMP_LIBS)
+snap_confine_snap_confine_extra_libs += $(SECCOMP_LIBS)
 endif  # STATIC_LIBSECCOMP
 endif  # SECCOMP
 
@@ -248,7 +253,7 @@ snap_confine_snap_confine_CFLAGS += $(APPARMOR_CFLAGS)
 if STATIC_LIBAPPARMOR
 snap_confine_snap_confine_STATIC += $(shell pkg-config --static --libs libapparmor)
 else
-snap_confine_snap_confine_LDADD += $(APPARMOR_LIBS)
+snap_confine_snap_confine_extra_libs += $(APPARMOR_LIBS)
 endif  # STATIC_LIBAPPARMOR
 endif  # APPARMOR
 
@@ -258,16 +263,12 @@ noinst_PROGRAMS += snap-confine/snap-confine-debug
 snap_confine_snap_confine_debug_SOURCES = $(snap_confine_snap_confine_SOURCES)
 snap_confine_snap_confine_debug_CFLAGS = $(snap_confine_snap_confine_CFLAGS)
 snap_confine_snap_confine_debug_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)
-snap_confine_snap_confine_debug_LDADD = libsnap-confine-private-debug.a $(filter-out libsnap-confine-private.a,$(snap_confine_snap_confine_LDADD))
+snap_confine_snap_confine_debug_LDADD = libsnap-confine-private-debug.a $(snap_confine_snap_confine_extra_libs)
 snap_confine_snap_confine_debug_CFLAGS += -DSNAP_CONFINE_DEBUG_BUILD=1
 snap_confine_snap_confine_debug_STATIC = $(snap_confine_snap_confine_STATIC)
 
 # Use a hacked rule if we're doing static build. This allows us to inject the LIBS += .. rule below.
-
-# NOTE: for some reason make/automake in Debian 9 mishandles the dependencies
-# and this particular snap-confine/snap-confine-debug ends up depending on
-# -ludev -lcap .. and so on, need to filter those out
-snap-confine/snap-confine-debug$(EXEEXT): $(snap_confine_snap_confine_debug_OBJECTS) $(filter-out -l%,$(snap_confine_snap_confine_debug_DEPENDENCIES)) $(EXTRA_snap_confine_snap_confine_debug_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
+snap-confine/snap-confine-debug$(EXEEXT): $(snap_confine_snap_confine_debug_OBJECTS) $(snap_confine_snap_confine_debug_DEPENDENCIES) $(EXTRA_snap_confine_snap_confine_debug_DEPENDENCIES) libsnap-confine-private/$(am__dirstamp)
 	@rm -f snap-confine/snap-confine-debug$(EXEEXT)
 	$(AM_V_CCLD)$(snap_confine_snap_confine_debug_LINK) $(snap_confine_snap_confine_debug_OBJECTS) $(snap_confine_snap_confine_debug_LDADD) $(LIBS)
 

--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -251,10 +251,10 @@ endif  # APPARMOR
 # an extra build that has additional debugging enabled at compile time
 
 noinst_PROGRAMS += snap-confine/snap-confine-debug
-snap_confine_snap_confine_debug_SOURCES = $(snap_confine_snap_confine_SOURCES)
-snap_confine_snap_confine_debug_CFLAGS = $(snap_confine_snap_confine_CFLAGS)
+snap_confine_snap_confine_debug_SOURCES = $(snap_confine_snap_confine_SOURCES) $(libsnap_confine_private_a_SOURCES)
+snap_confine_snap_confine_debug_CFLAGS = $(snap_confine_snap_confine_CFLAGS) $(libsnap_confine_private_a_CFLAGS)
 snap_confine_snap_confine_debug_LDFLAGS = $(snap_confine_snap_confine_LDFLAGS)
-snap_confine_snap_confine_debug_LDADD = $(snap_confine_snap_confine_LDADD)
+snap_confine_snap_confine_debug_LDADD = $(filter-out libsnap-confine-private.d,$(snap_confine_snap_confine_LDADD))
 snap_confine_snap_confine_debug_CFLAGS += -DSNAP_CONFINE_DEBUG_BUILD=1
 snap_confine_snap_confine_debug_STATIC = $(snap_confine_snap_confine_STATIC)
 

--- a/cmd/libsnap-confine-private/mount-opt-test.c
+++ b/cmd/libsnap-confine-private/mount-opt-test.c
@@ -211,10 +211,13 @@ static bool broken_mount(struct sc_fault_state *state, void *ptr)
 	return true;
 }
 
-static void test_sc_do_mount(void)
+static void test_sc_do_mount(gconstpointer snap_debug)
 {
 	if (g_test_subprocess()) {
 		sc_break("mount", broken_mount);
+		if (GPOINTER_TO_INT(snap_debug) == 1) {
+			g_setenv("SNAP_CONFINE_DEBUG", "1", true);
+		}
 		sc_do_mount("/foo", "/bar", "ext4", MS_RDONLY, NULL);
 
 		g_test_message("expected sc_do_mount not to return");
@@ -224,8 +227,14 @@ static void test_sc_do_mount(void)
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
 	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
+	if (GPOINTER_TO_INT(snap_debug) == 0) {
+		g_test_trap_assert_stderr
+		    ("cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
+	} else {
+		g_test_trap_assert_stderr
+		    ("DEBUG: performing operation: (disabled) use debug build to see details\n"
+		     "cannot perform operation: mount -t ext4 -o ro /foo /bar: Permission denied\n");
+	}
 }
 
 static bool broken_umount(struct sc_fault_state *state, void *ptr)
@@ -234,10 +243,13 @@ static bool broken_umount(struct sc_fault_state *state, void *ptr)
 	return true;
 }
 
-static void test_sc_do_umount(void)
+static void test_sc_do_umount(gconstpointer snap_debug)
 {
 	if (g_test_subprocess()) {
 		sc_break("umount", broken_umount);
+		if (GPOINTER_TO_INT(snap_debug) == 1) {
+			g_setenv("SNAP_CONFINE_DEBUG", "1", true);
+		}
 		sc_do_umount("/foo", MNT_DETACH);
 
 		g_test_message("expected sc_do_umount not to return");
@@ -247,8 +259,14 @@ static void test_sc_do_umount(void)
 	}
 	g_test_trap_subprocess(NULL, 0, 0);
 	g_test_trap_assert_failed();
-	g_test_trap_assert_stderr
-	    ("cannot perform operation: umount --lazy /foo: Permission denied\n");
+	if (GPOINTER_TO_INT(snap_debug) == 0) {
+		g_test_trap_assert_stderr
+		    ("cannot perform operation: umount --lazy /foo: Permission denied\n");
+	} else {
+		g_test_trap_assert_stderr
+		    ("DEBUG: performing operation: (disabled) use debug build to see details\n"
+		     "cannot perform operation: umount --lazy /foo: Permission denied\n");
+	}
 }
 
 static void __attribute__ ((constructor)) init(void)
@@ -256,6 +274,12 @@ static void __attribute__ ((constructor)) init(void)
 	g_test_add_func("/mount/sc_mount_opt2str", test_sc_mount_opt2str);
 	g_test_add_func("/mount/sc_mount_cmd", test_sc_mount_cmd);
 	g_test_add_func("/mount/sc_umount_cmd", test_sc_umount_cmd);
-	g_test_add_func("/mount/sc_do_mount", test_sc_do_mount);
-	g_test_add_func("/mount/sc_do_umount", test_sc_do_umount);
+	g_test_add_data_func("/mount/sc_do_mount", GINT_TO_POINTER(0),
+			     test_sc_do_mount);
+	g_test_add_data_func("/mount/sc_do_umount", GINT_TO_POINTER(0),
+			     test_sc_do_umount);
+	g_test_add_data_func("/mount/sc_do_mount_with_debug",
+			     GINT_TO_POINTER(1), test_sc_do_mount);
+	g_test_add_data_func("/mount/sc_do_umount_with_debug",
+			     GINT_TO_POINTER(1), test_sc_do_umount);
 }

--- a/cmd/libsnap-confine-private/mount-opt.c
+++ b/cmd/libsnap-confine-private/mount-opt.c
@@ -251,6 +251,9 @@ const char *sc_umount_cmd(char *buf, size_t buf_size, const char *target,
 	return buf;
 }
 
+static const char use_debug_build[] =
+    "(disabled) use debug build to see details";
+
 void sc_do_mount(const char *source, const char *target,
 		 const char *fs_type, unsigned long mountflags,
 		 const void *data)
@@ -262,10 +265,9 @@ void sc_do_mount(const char *source, const char *target,
 #ifdef SNAP_CONFINE_DEBUG_BUILD
 		mount_cmd = sc_mount_cmd(buf, sizeof(buf), source,
 					 target, fs_type, mountflags, data);
-#else
-		mount_cmd = "(disabled) use debug build to see details";
 #endif
-		debug("performing operation: %s", mount_cmd);
+		debug("performing operation: %s",
+		      mount_cmd ? mount_cmd : use_debug_build);
 	}
 	if (sc_faulty("mount", NULL)
 	    || mount(source, target, fs_type, mountflags, data) < 0) {
@@ -296,10 +298,9 @@ void sc_do_umount(const char *target, int flags)
 	if (sc_is_debug_enabled()) {
 #ifdef SNAP_CONFINE_DEBUG_BUILD
 		umount_cmd = sc_umount_cmd(buf, sizeof(buf), target, flags);
-#else
-		umount_cmd = "(disabled) use debug build to see details";
 #endif
-		debug("performing operation: %s", umount_cmd);
+		debug("performing operation: %s",
+		      umount_cmd ? umount_cmd : use_debug_build);
 	}
 	if (sc_faulty("umount", NULL) || umount2(target, flags) < 0) {
 		// Save errno as ensure can clobber it.


### PR DESCRIPTION
The series fixes a failed [u]mount command not being logged when snap-confine is run with debug logging enabled.

The logic in `libsnap-confine-private.c:sc_do_[u]mount` would overwrite `[u]mount_cmd` with pointer to `(disabled) use debug build to see details` message, thus the later NULL check tests would fail. I've updated `sc_do_[u]mount` tests to cover this behavior.

Also, the `SNAP_CONFINE_DEBUG_BUILD` CFLAG does not propagate from `snap-confine-debug` to `libsnap-confine-private.a`. There are 2 options to fix this, one is to add a 'debug' variant of the library, or pull in the library source code directly into `snap-confine-debug`. I've opted for the second variant.