### PR TITLE
snap: support `command-not-found` symlink for `snap advise-command`

### DIFF
--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -87,7 +87,7 @@ func adviseCommand(cmd string, format string) error {
 	// find exact matches
 	matches, err := advisor.FindCommand(cmd)
 	if err != nil {
-		return err
+		return fmt.Errorf("advise-command error: %s", err)
 	}
 	if len(matches) > 0 {
 		switch format {
@@ -116,5 +116,5 @@ func adviseCommand(cmd string, format string) error {
 		}
 	}
 
-	return nil
+	return fmt.Errorf("%s command not found", cmd)
 }

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -1,8 +1,8 @@
 summary: Ensure that `snap advise-command` works
 
 # we need https://github.com/snapcore/core/pull/70 landed before
-# we can use this
-systems: [-ubuntu-core-*]
+# we can use this on ubuntu-core-*
+systems: [ubuntu-16-*, ubuntu-18-*]
 
 prepare: |
     mv /usr/lib/command-not-found /usr/lib/command-not-found.orig

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensure that `snap advise-command` works
 
+restore: |
+    rm -f /usr/lib/command-not-found
+
 execute: |
     echo "wait for snapd to pull in the commands data"
     echo "(it will do that on startup)"

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -1,7 +1,16 @@
 summary: Ensure that `snap advise-command` works
 
+# we need https://github.com/snapcore/core/pull/70 landed before
+# we can use this
+systems: [-ubuntu-core-*]
+
+prepare: |
+    mv /usr/lib/command-not-found /usr/lib/command-not-found.orig
+
 restore: |
-    rm -f /usr/lib/command-not-found
+    if [ -e /usr/lib/command-not-found.orig ]; then
+        mv /usr/lib/command-not-found.orig /usr/lib/command-not-found
+    fi
 
 execute: |
     echo "wait for snapd to pull in the commands data"
@@ -10,6 +19,7 @@ execute: |
        if stat /var/cache/snapd/commands.db; then
            break
        fi
+       sleep 1
     done
     stat /var/cache/snapd/commands.db
 

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -1,0 +1,27 @@
+summary: Ensure that `snap advise-command` works
+
+execute: |
+    echo "wait for snapd to pull in the commands data"
+    echo "(it will do that on startup)"
+    for i in $(seq 120); do
+       if stat /var/cache/snapd/commands.db; then
+           break
+       fi
+    done
+    stat /var/cache/snapd/commands.db
+
+    echo "Ensure `snap advise-command` lookup works"
+    snap advise-command test-snapd-tools.echo | MATCH test-snapd-tools
+
+    echo "Ensure `advise-command` works as command-not-found symlink"
+    ln -s /usr/bin/snap /usr/lib/command-not-found
+    /usr/lib/command-not-found test-snapd-tools.echo | MATCH test-snapd-tools
+
+    echo "Ensure short names are found too"
+    snap advise-command spotify | MATCH 'The program "spotify" can be found'
+
+    echo "Ensure advise-command without a match returns exit code 1"
+    if snap advise-command no-such-command-for-any-snap; then
+        echo "A not-found snap command should return an error"
+        exit 1
+    fi

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -31,7 +31,7 @@ execute: |
     /usr/lib/command-not-found test-snapd-tools.echo | MATCH test-snapd-tools
 
     echo "Ensure short names are found too"
-    snap advise-command spotify | MATCH 'The program "spotify" can be found'
+    snap advise-command test_snapd_wellknown1 | MATCH 'The program ".*" can be found'
 
     echo "Ensure advise-command without a match returns exit code 1"
     if snap advise-command no-such-command-for-any-snap; then


### PR DESCRIPTION
This adds support to have a symlink from /usr/lib/command-not-found
to /usr/bin/snap.

It also adds a spread test to ensure `snap advise-command` is
working as advised.

