### PR TITLE
 snap: rename `snap advise-command` to `snap advise-snap --command` 

### DIFF
--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -29,25 +29,29 @@ import (
 	"github.com/snapcore/snapd/i18n"
 )
 
-type cmdAdviseCommand struct {
+type cmdAdviseSnap struct {
 	Positionals struct {
-		Command string `required:"yes"`
+		CommandOrPkg string `required:"yes"`
 	} `positional-args:"true"`
 
-	Format string `long:"format" default:"pretty"`
+	Format  string `long:"format" default:"pretty"`
+	Command bool   `long:"command"`
 }
 
-var shortAdviseCommandHelp = i18n.G("Advise on available snaps.")
-var longAdviseCommandHelp = i18n.G(`
+var shortAdviseSnapHelp = i18n.G("Advise on available snaps.")
+var longAdviseSnapHelp = i18n.G(`
 The advise-command command shows what snaps with the given command are 
 available.
 `)
 
 func init() {
-	cmd := addCommand("advise-command", shortAdviseCommandHelp, longAdviseCommandHelp, func() flags.Commander {
-		return &cmdAdviseCommand{}
-	}, nil, []argDesc{
-		{name: "<command>"},
+	cmd := addCommand("advise-snap", shortAdviseSnapHelp, longAdviseSnapHelp, func() flags.Commander {
+		return &cmdAdviseSnap{}
+	}, map[string]string{
+		"command": i18n.G("Advise on snaps that provide the given command"),
+		"format":  i18n.G("Use the given output format (pretty or json)"),
+	}, []argDesc{
+		{name: "<command or pkg>"},
 	})
 	cmd.hidden = true
 }
@@ -75,12 +79,16 @@ func outputAdviseJSON(command string, results []advisor.Command) error {
 	return nil
 }
 
-func (x *cmdAdviseCommand) Execute(args []string) error {
+func (x *cmdAdviseSnap) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
 
-	return adviseCommand(x.Positionals.Command, x.Format)
+	if x.Command {
+		return adviseCommand(x.Positionals.CommandOrPkg, x.Format)
+	}
+
+	return fmt.Errorf("snap advise-snap is only implemented with --command")
 }
 
 func adviseCommand(cmd string, format string) error {

--- a/cmd/snap/cmd_advise_test.go
+++ b/cmd/snap/cmd_advise_test.go
@@ -54,7 +54,7 @@ func (s *SnapSuite) TestAdviseCommandHappyText(c *C) {
 	restore := advisor.ReplaceCommandsFinder(mkSillyFinder)
 	defer restore()
 
-	rest, err := snap.Parser().ParseArgs([]string{"advise-command", "hello"})
+	rest, err := snap.Parser().ParseArgs([]string{"advise-snap", "--command", "hello"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, `The program "hello" can be found in the following snaps:
@@ -69,7 +69,7 @@ func (s *SnapSuite) TestAdviseCommandHappyJSON(c *C) {
 	restore := advisor.ReplaceCommandsFinder(mkSillyFinder)
 	defer restore()
 
-	rest, err := snap.Parser().ParseArgs([]string{"advise-command", "--format=json", "hello"})
+	rest, err := snap.Parser().ParseArgs([]string{"advise-snap", "--command", "--format=json", "hello"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
 	c.Assert(s.Stdout(), Equals, `[{"Snap":"hello","Command":"hello"},{"Snap":"hello-wcm","Command":"hello"}]`+"\n")

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -282,8 +282,11 @@ func main() {
 	// check for magic symlink to /usr/bin/snap:
 	// 1. symlink from command-not-found to /usr/bin/snap: run c-n-f
 	if os.Args[0] == filepath.Join(dirs.GlobalRootDir, "/usr/lib/command-not-found") {
-		cmd := &cmdAdviseCommand{Format: "pretty"}
-		cmd.Positionals.Command = os.Args[1]
+		cmd := &cmdAdviseSnap{
+			Command: true,
+			Format:  "pretty",
+		}
+		cmd.Positionals.CommandOrPkg = os.Args[1]
 		if err := cmd.Execute(nil); err != nil {
 			fmt.Fprintf(Stderr, "%s\n", err)
 		}

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -1,4 +1,4 @@
-summary: Ensure that `snap advise-command` works
+summary: Ensure that `snap advise-snap` works
 
 restore: |
     rm -f /usr/lib/command-not-found
@@ -13,18 +13,18 @@ execute: |
     done
     stat /var/cache/snapd/commands.db
 
-    echo "Ensure `snap advise-command` lookup works"
-    snap advise-command test-snapd-tools.echo | MATCH test-snapd-tools
+    echo "Ensure `snap advise-snap --command` lookup works"
+    snap advise-snap --command test-snapd-tools.echo | MATCH test-snapd-tools
 
-    echo "Ensure `advise-command` works as command-not-found symlink"
+    echo "Ensure `advise-snap --command` works as command-not-found symlink"
     ln -s /usr/bin/snap /usr/lib/command-not-found
     /usr/lib/command-not-found test-snapd-tools.echo | MATCH test-snapd-tools
 
     echo "Ensure short names are found too"
-    snap advise-command spotify | MATCH 'The program "spotify" can be found'
+    snap advise-snap --command spotify | MATCH 'The program "spotify" can be found'
 
-    echo "Ensure advise-command without a match returns exit code 1"
-    if snap advise-command no-such-command-for-any-snap; then
+    echo "Ensure advise-snap without a match returns exit code 1"
+    if snap advise-snap --command no-such-command-for-any-snap; then
         echo "A not-found snap command should return an error"
         exit 1
     fi


### PR DESCRIPTION
As discussed recently the name `snap advise-snap --command` is a better fit for the functionality.

Based on https://github.com/snapcore/snapd/pull/4450