### PR TITLE
overlord/snapstate: no refresh just for hints if there was a recent regular full refresh

### DIFF
--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -39,20 +39,29 @@ func newRefreshHints(st *state.State) *refreshHints {
 	return &refreshHints{state: st}
 }
 
-func (r *refreshHints) lastRefresh() (time.Time, error) {
+func (r *refreshHints) lastRefresh(timestampKey string) (time.Time, error) {
 	var lastRefresh time.Time
-	if err := r.state.Get("last-refresh-hints", &lastRefresh); err != nil && err != state.ErrNoState {
+	if err := r.state.Get(timestampKey, &lastRefresh); err != nil && err != state.ErrNoState {
 		return time.Time{}, err
 	}
 	return lastRefresh, nil
 }
 
 func (r *refreshHints) needsUpdate() (bool, error) {
-	t, err := r.lastRefresh()
+	tFull, err := r.lastRefresh("last-refresh")
 	if err != nil {
 		return false, err
 	}
-	return t.Before(time.Now().Add(-refreshHintsDelay)), nil
+	tHints, err := r.lastRefresh("last-refresh-hints")
+	if err != nil {
+		return false, err
+	}
+
+	recentEnough := time.Now().Add(-refreshHintsDelay)
+	if tFull.After(recentEnough) || tFull.Equal(recentEnough) {
+		return false, nil
+	}
+	return tHints.Before(recentEnough), nil
 }
 
 func (r *refreshHints) refresh() error {

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -89,7 +89,22 @@ func (s *refreshHintsTestSuite) TestLastRefresh(c *C) {
 
 func (s *refreshHintsTestSuite) TestLastRefreshNoRefreshNeeded(c *C) {
 	s.state.Lock()
-	s.state.Set("last-refresh-hints", time.Now().Add(23*time.Hour))
+	s.state.Set("last-refresh-hints", time.Now().Add(-23*time.Hour))
+	s.state.Unlock()
+
+	rh := snapstate.NewRefreshHints(s.state)
+	err := rh.Ensure()
+	c.Check(err, IsNil)
+	c.Check(s.store.ops, HasLen, 0)
+}
+
+func (s *refreshHintsTestSuite) TestLastRefreshNoRefreshNeededBecauseOfFullAutoRefresh(c *C) {
+	s.state.Lock()
+	s.state.Set("last-refresh-hints", time.Now().Add(-48*time.Hour))
+	s.state.Unlock()
+
+	s.state.Lock()
+	s.state.Set("last-refresh", time.Now().Add(-23*time.Hour))
 	s.state.Unlock()
 
 	rh := snapstate.NewRefreshHints(s.state)

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -477,8 +477,10 @@ func (m *SnapManager) Ensure() error {
 		m.ensureAliasesV2(),
 		m.ensureForceDevmodeDropsDevmodeFromState(),
 		m.ensureUbuntuCoreTransition(),
-		m.refreshHints.Ensure(),
+		// we should check for full regular refreshes before
+		// considering issuing a hint only refresh request
 		m.autoRefresh.Ensure(),
+		m.refreshHints.Ensure(),
 		m.catalogRefresh.Ensure(),
 	}
 

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -80,6 +80,26 @@ execute: |
         exit 1
     fi
 
+    # make sure we trigger a refresh for hints at least once
+    systemctl stop snapd.socket snapd.service
+    jq ".data[\"last-refresh\"] = \"2007-08-22T09:30:44.449455783+01:00\"" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
+    systemctl start snapd.socket snapd.service
+
+    echo "Ensure that last-refresh-hit happens"
+    for i in $(seq 120); do
+        if cat /var/lib/snapd/state.json | jq '.data["last-refresh-hints"]' | grep $(date +%Y); then
+            break
+        fi
+        sleep 1
+    done
+    cat /var/lib/snapd/state.json | jq '.data["last-refresh-hints"]' | grep $(date +%Y)
+
+    # prevent refreshes again
+    systemctl stop snapd.socket snapd.service
+    jq ".data[\"last-refresh\"] = \"$(date +%Y-%m-%dT%H:%M:%S%:z)\"" /var/lib/snapd/state.json > /var/lib/snapd/state.json.new
+    mv /var/lib/snapd/state.json.new /var/lib/snapd/state.json
+    systemctl start snapd.socket snapd.service
 
     echo "When the snapd-control-with-manage plug is disconnected"
     snap disconnect test-snapd-control-consumer:snapd-control-with-manage
@@ -89,12 +109,3 @@ execute: |
        echo "refresh.schedule=managed was not rejected as it should be"
        exit 1
     fi
-
-    echo "Ensure that last-refresh-hit happens regardless of managed setting"
-    for i in $(seq 120); do
-        if cat /var/lib/snapd/state.json | jq '.data["last-refresh-hints"]' | grep $(date +%Y); then
-            break
-        fi
-        sleep 1
-    done
-    cat /var/lib/snapd/state.json | jq '.data["last-refresh-hints"]' | grep $(date +%Y)

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -11,7 +11,7 @@ prepare: |
 
     echo "Ensure jq is installed"
     if ! which jq; then
-        snap install jq
+        snap install --devmode jq
     fi
 
     snap debug can-manage-refreshes | MATCH false

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -88,12 +88,12 @@ execute: |
 
     echo "Ensure that last-refresh-hit happens"
     for i in $(seq 120); do
-        if cat /var/lib/snapd/state.json | jq '.data["last-refresh-hints"]' | grep $(date +%Y); then
+        if jq '.data["last-refresh-hints"]' /var/lib/snapd/state.json | grep $(date +%Y); then
             break
         fi
         sleep 1
     done
-    cat /var/lib/snapd/state.json | jq '.data["last-refresh-hints"]' | grep $(date +%Y)
+    jq '.data["last-refresh-hints"]' /var/lib/snapd/state.json | grep $(date +%Y)
 
     # prevent refreshes again
     systemctl stop snapd.socket snapd.service


### PR DESCRIPTION
Do not issue a refresh for hints  if there was a regular full refresh within the hints refresh interval (24h).