### PR TITLE
daemon: store email, ID and macaroon when creating a new user

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2212,10 +2212,17 @@ func setupLocalUser(st *state.State, username, email string) error {
 	if err != nil {
 		return fmt.Errorf("cannot persist authentication details: %v", err)
 	}
-	// store macaroon auth in auth.json in the new users home dir
+	// store macaroon auth, user's ID, email and username in auth.json in
+	// the new users home dir
 	outStr, err := json.Marshal(struct {
+		ID       int    `json:"id"`
+		Username string `json:"username"`
+		Email    string `json:"email"`
 		Macaroon string `json:"macaroon"`
 	}{
+		ID:       authUser.ID,
+		Username: authUser.Username,
+		Email:    authUser.Email,
 		Macaroon: authUser.Macaroon,
 	})
 	if err != nil {

--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -30,3 +30,12 @@ execute: |
 
     echo "ensure proper sudoers.d file"
     MATCH "$USER_NAME ALL=\(ALL\) NOPASSWD:ALL" < /etc/sudoers.d/create-user-$USER_NAME
+
+    echo "ensure the user's home directory exists"
+    test -d /home/$USER_NAME
+
+    echo "ensure ~/.snap/auth.json was created"
+    test -f /home/$USER_NAME/.snap/auth.json
+
+    echo "ensure user's email was stored in ~/.snap/auth.json"
+    MATCH "\"email\":\"$USER_EMAIL\"" < /home/$USER_NAME/.snap/auth.json

--- a/tests/main/ubuntu-core-create-user/task.yaml
+++ b/tests/main/ubuntu-core-create-user/task.yaml
@@ -36,3 +36,12 @@ execute: |
 
     echo "Ensure the user is a sudo user"
     sudo -u mvo sudo true
+
+    echo "ensure the user's home directory exists"
+    test -d /home/mvo
+
+    echo "ensure ~/.snap/auth.json was created"
+    test -f /home/mvo/.snap/auth.json
+
+    echo "ensure user's email was stored in ~/.snap/auth.json"
+    MATCH '"email":"mvo@ubuntu.com"' < /home/mvo/.snap/auth.json


### PR DESCRIPTION
Address empty email when creating a user through console-conf as described in
LP#1709807.

[1]. https://bugs.launchpad.net/snapd/+bug/1709807
