### PR TITLE
snap: fix missing error check when multiple snaps are refreshed

### DIFF
--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -162,6 +162,13 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState, fl
 		return nil, nil, nil, err
 	}
 
+	// check if we have this name at all
+	for _, name := range names {
+		if _, ok := snapStates[name]; !ok {
+			return nil, nil, nil, snap.NotInstalledError{Snap: name}
+		}
+	}
+
 	sort.Strings(names)
 
 	stateByID := make(map[string]*SnapState, len(snapStates))

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -113,3 +113,10 @@ execute: |
 
     snap refresh --candidate $SNAP_NAME 2>&1 | MATCH "$SNAP_NAME \(candidate\).*"
     snap info $SNAP_NAME | MATCH "tracking: +candidate"
+
+    echo "When multiple snaps are refreshed we error if we have unknown names"
+    if snap refresh core invälid-snap-name 2> out.err; then
+        echo "snap refresh invalid-snap-name should fail but it did not?"
+        exit 1
+    fi
+    cat out.err | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot refresh .* is not installed'


### PR DESCRIPTION
This fixes the bug that depending on the ordering of the commandline
the command `snap refresh core fdhjaslfdjsal` will work (but should
show an error that the "fdhjaslfdjsal" is not installed).

See https://bugs.launchpad.net/snapd/+bug/1741294
