### PR TITLE
progress: switch ansimeter's Spin() to use a spinner

### DIFF
--- a/progress/ansimeter.go
+++ b/progress/ansimeter.go
@@ -150,7 +150,7 @@ func (p *ANSIMeter) Set(current float64) {
 	fmt.Fprint(stdout, "\r", enterReverseMode, string(msg[:i]), exitAttributeMode, string(msg[i:]))
 }
 
-var spinner = []string{"⠋", "⠙", "⠸", "⠴", "⠦", "⠇"}
+var spinner = []string{".", "o", "O", "o"}
 
 func (p *ANSIMeter) Spin(msgstr string) {
 	msg := []rune(msgstr)

--- a/progress/ansimeter.go
+++ b/progress/ansimeter.go
@@ -150,24 +150,23 @@ func (p *ANSIMeter) Set(current float64) {
 	fmt.Fprint(stdout, "\r", enterReverseMode, string(msg[:i]), exitAttributeMode, string(msg[i:]))
 }
 
+var spinner = []string{"⠋", "⠙", "⠸", "⠴", "⠦", "⠇"}
+
 func (p *ANSIMeter) Spin(msgstr string) {
 	// spin moves a block a third of the screen's width right and
 	// left across the screen (each call to Spin bummps it left
 	// or right by 1%)
+	msg := []rune(msgstr)
 	col := termWidth()
-	msg := norm(col, []rune(msgstr))
-	p.spin++
-	if p.spin > 66 {
-		p.spin = -p.spin + 1
-
+	if col-2 >= len(msg) {
+		fmt.Fprint(stdout, "\r", spinner[p.spin], " ", string(norm(col-2, msg)))
+		p.spin++
+		if p.spin >= len(spinner) {
+			p.spin = 0
+		}
+	} else {
+		fmt.Fprint(stdout, "\r", string(norm(col, msg)))
 	}
-	spin := p.spin
-	if spin < 0 {
-		spin = -spin
-	}
-	i := spin * col / 100
-	j := 1 + (spin+33)*col/100
-	fmt.Fprint(stdout, "\r", string(msg[:i]), enterReverseMode, string(msg[i:j]), exitAttributeMode, string(msg[j:]))
 }
 
 func (*ANSIMeter) Finished() {

--- a/progress/ansimeter.go
+++ b/progress/ansimeter.go
@@ -153,13 +153,10 @@ func (p *ANSIMeter) Set(current float64) {
 var spinner = []string{"⠋", "⠙", "⠸", "⠴", "⠦", "⠇"}
 
 func (p *ANSIMeter) Spin(msgstr string) {
-	// spin moves a block a third of the screen's width right and
-	// left across the screen (each call to Spin bummps it left
-	// or right by 1%)
 	msg := []rune(msgstr)
 	col := termWidth()
 	if col-2 >= len(msg) {
-		fmt.Fprint(stdout, "\r", spinner[p.spin], " ", string(norm(col-2, msg)))
+		fmt.Fprint(stdout, "\r", string(norm(col-2, msg)), " ", spinner[p.spin])
 		p.spin++
 		if p.spin >= len(spinner) {
 			p.spin = 0

--- a/progress/ansimeter_test.go
+++ b/progress/ansimeter_test.go
@@ -185,7 +185,7 @@ func (ansiSuite) TestSpin(c *check.C) {
 	for i, s := range progress.Spinner {
 		buf.Reset()
 		p.Spin(msg)
-		expected := "\r" + s + " " + msg
+		expected := "\r" + msg + " " + s
 		c.Check(buf.String(), check.Equals, expected, check.Commentf("%d (%s)", i, s))
 	}
 }

--- a/progress/export_test.go
+++ b/progress/export_test.go
@@ -100,4 +100,7 @@ func MockStdout(w io.Writer) func() {
 	}
 }
 
-var Norm = norm
+var (
+	Norm    = norm
+	Spinner = spinner
+)


### PR DESCRIPTION
People objected to ansimeter's use of a background throbber, and asked
for a textual spinner instead. I succumb to their wishes.
