### PR TITLE
client, daemon: update user's email when logging in with new account

### DIFF
--- a/client/login_test.go
+++ b/client/login_test.go
@@ -58,6 +58,42 @@ func (cs *clientSuite) TestClientLogin(c *check.C) {
 	c.Check(string(content), check.Equals, `{"username":"the-user-name","macaroon":"the-root-macaroon","discharges":["discharge-macaroon"]}`)
 }
 
+func (cs *clientSuite) TestClientLoginWhenLoggedIn(c *check.C) {
+	cs.rsp = `{"type": "sync", "result":
+                     {"username": "the-user-name",
+                      "email": "zed@bar.com",
+                      "macaroon": "the-root-macaroon",
+                      "discharges": ["discharge-macaroon"]}}`
+
+	outfile := filepath.Join(c.MkDir(), "json")
+	os.Setenv(client.TestAuthFileEnvKey, outfile)
+	defer os.Unsetenv(client.TestAuthFileEnvKey)
+
+	err := ioutil.WriteFile(outfile, []byte(`{"email":"foo@bar.com","macaroon":"macaroon"}`), 0600)
+	c.Assert(cs.cli.LoggedInUser(), check.DeepEquals, &client.User{
+		Email:    "foo@bar.com",
+		Macaroon: "macaroon",
+	})
+
+	user, err := cs.cli.Login("username", "pass", "")
+	expected := &client.User{
+		Email:      "zed@bar.com",
+		Username:   "the-user-name",
+		Macaroon:   "the-root-macaroon",
+		Discharges: []string{"discharge-macaroon"},
+	}
+	c.Check(err, check.IsNil)
+	c.Check(user, check.DeepEquals, expected)
+	c.Check(cs.req.Header.Get("Authorization"), check.Matches, `Macaroon root="macaroon"`)
+
+	c.Assert(cs.cli.LoggedInUser(), check.DeepEquals, expected)
+
+	c.Check(osutil.FileExists(outfile), check.Equals, true)
+	content, err := ioutil.ReadFile(outfile)
+	c.Check(err, check.IsNil)
+	c.Check(string(content), check.Equals, `{"username":"the-user-name","email":"zed@bar.com","macaroon":"the-root-macaroon","discharges":["discharge-macaroon"]}`)
+}
+
 func (cs *clientSuite) TestClientLoginError(c *check.C) {
 	cs.rsp = `{
 		"result": {},

--- a/client/login_test.go
+++ b/client/login_test.go
@@ -70,6 +70,7 @@ func (cs *clientSuite) TestClientLoginWhenLoggedIn(c *check.C) {
 	defer os.Unsetenv(client.TestAuthFileEnvKey)
 
 	err := ioutil.WriteFile(outfile, []byte(`{"email":"foo@bar.com","macaroon":"macaroon"}`), 0600)
+	c.Assert(err, check.IsNil)
 	c.Assert(cs.cli.LoggedInUser(), check.DeepEquals, &client.User{
 		Email:    "foo@bar.com",
 		Macaroon: "macaroon",

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -413,6 +413,8 @@ func loginUser(c *Command, r *http.Request, user *auth.UserState) Response {
 		// local user logged-in, set its store macaroons
 		user.StoreMacaroon = macaroon
 		user.StoreDischarges = []string{discharge}
+		// user's email address authenticated by the store
+		user.Email = loginData.Email
 		err = auth.UpdateUser(state, user)
 	} else {
 		user, err = auth.NewUser(state, loginData.Username, loginData.Email, macaroon, []string{discharge})


### PR DESCRIPTION
Small series with fixes for https://bugs.launchpad.net/snapd/+bug/1709807

The first patch extends tests of `client.Login()` to double check that we're using user's auth data if they are already logged in.

The second patch is a fix for the actual LP bug. When a local user is already logged in and attempts to log in with a new SSO account, we update the store macaroon but the users email address is left
unchanged. The patch addresses this by updating the user's state data email to one used for logging in.

