### PR TITLE
interfaces/mount: test OptsToCommonFlags, filter out x-snapd. options

### DIFF
--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -150,6 +150,8 @@ func ParseEntry(s string) (Entry, error) {
 }
 
 // OptsToCommonFlags converts mount options strings to a mount flag, returning unparsed flags.
+// The unparsed flags will not contain any snapd-specific mount option, those
+// starting with the string "x-snapd."
 func OptsToCommonFlags(opts []string) (flags int, unparsed []string) {
 	for _, opt := range opts {
 		switch opt {
@@ -200,7 +202,9 @@ func OptsToCommonFlags(opts []string) (flags int, unparsed []string) {
 		case "strictatime":
 			flags |= syscall.MS_STRICTATIME
 		default:
-			unparsed = append(unparsed, opt)
+			if !strings.HasPrefix(opt, "x-snapd.") {
+				unparsed = append(unparsed, opt)
+			}
 		}
 	}
 	return flags, unparsed

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -169,6 +169,26 @@ func (s *entrySuite) TestOptsToFlags(c *C) {
 	c.Assert(flags, Equals, 0)
 }
 
+// Test (string) options -> (int, unparsed) flag conversion code.
+func (s *entrySuite) TestOptsToCommonFlags(c *C) {
+	flags, unparsed := mount.OptsToCommonFlags(nil)
+	c.Assert(flags, Equals, 0)
+	c.Assert(unparsed, HasLen, 0)
+	flags, unparsed = mount.OptsToCommonFlags([]string{"ro", "nodev", "nosuid"})
+	c.Assert(flags, Equals, syscall.MS_RDONLY|syscall.MS_NODEV|syscall.MS_NOSUID)
+	c.Assert(unparsed, HasLen, 0)
+	flags, unparsed = mount.OptsToCommonFlags([]string{"bogus"})
+	c.Assert(flags, Equals, 0)
+	c.Assert(unparsed, DeepEquals, []string{"bogus"})
+	// The x-snapd-prefix is reserved for non-kernel parameters that do not
+	// translate to kernel level mount flags. This is similar to systemd or
+	// udisks that use fstab options to convey additional data. Those are not
+	// returned as "unparsed" as we don't want to pass them to the kernel.
+	flags, unparsed = mount.OptsToCommonFlags([]string{"x-snapd.foo"})
+	c.Assert(flags, Equals, 0)
+	c.Assert(unparsed, HasLen, 0)
+}
+
 func (s *entrySuite) TestOptStr(c *C) {
 	e := &mount.Entry{Options: []string{"key=value"}}
 	val, ok := e.OptStr("key")


### PR DESCRIPTION
This patch adds a missing test for OptsToCommon flag and also makes it
filter out the snapd-specific mount options. The non-standard options
are passed to the kernel as a string but the snapd specific ones don't
make sense to pass (even if that is harmless) so filter them out.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
