### PR TITLE
cmd/snap-update-ns: untangle upcoming cyclic initialization

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -55,15 +55,10 @@ func (c Change) String() string {
 }
 
 // changePerform is Change.Perform that can be mocked for testing.
-var changePerform = (*Change).Perform
+var changePerform func(*Change) ([]*Change, error)
 
-// Perform executes the desired mount or unmount change using system calls.
-// Filesystems that depend on helper programs or multiple independent calls to
-// the kernel (--make-shared, for example) are unsupported.
-//
-// Perform may synthesize *additional* changes that were necessary to perform
-// this change (such as mounted tmpfs or overlayfs).
-func (c *Change) Perform() ([]*Change, error) {
+// changePerformImpl is the real implementation of Change.Perform
+func changePerformImpl(c *Change) ([]*Change, error) {
 	if c.Action == Mount {
 		const (
 			mode = 0755
@@ -84,6 +79,20 @@ func (c *Change) Perform() ([]*Change, error) {
 		}
 	}
 	return nil, c.lowLevelPerform()
+}
+
+func init() {
+	changePerform = changePerformImpl
+}
+
+// Perform executes the desired mount or unmount change using system calls.
+// Filesystems that depend on helper programs or multiple independent calls to
+// the kernel (--make-shared, for example) are unsupported.
+//
+// Perform may synthesize *additional* changes that were necessary to perform
+// this change (such as mounted tmpfs or overlayfs).
+func (c *Change) Perform() ([]*Change, error) {
+	return changePerform(c)
 }
 
 // lowLevelPerform is simple bridge from Change to mount / unmount syscall.


### PR DESCRIPTION
This patch uses init() to untangle a problem where Change.Perform
needs to call itself recursively but is also a mockable function for
testing.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>