### PR TITLE
snap: add `snap run --strace` to be able to strace snap apps

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -471,6 +471,7 @@ func runCmdUnderStrace(origCmd, env []string) error {
 	// run with filter
 	gcmd := exec.Command(cmd[0], cmd[1:]...)
 	gcmd.Env = env
+	gcmd.Stdin = Stdin
 	gcmd.Stdout = Stdout
 	stderr, err := gcmd.StderrPipe()
 	if err != nil {
@@ -500,7 +501,7 @@ func runCmdUnderStrace(origCmd, env []string) error {
 				break
 			}
 		}
-		io.Copy(Stderr, stderr)
+		io.Copy(Stderr, r)
 		filterDone <- 1
 	}()
 	if err := gcmd.Start(); err != nil {

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2016 Canonical Ltd
+ * Copyright (C) 2014-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -500,11 +500,17 @@ func runCmdUnderStrace(origCmd, env []string) error {
 			fmt.Fprint(Stderr, s)
 		}
 
-		// the last thing that snap-exec does is to
+		// The last thing that snap-exec does is to
 		// execve() something inside the snap dir so
 		// we know that from that point on the output
-		// will be interessting to the user
-		needle := fmt.Sprintf(`execve("%s`, dirs.SnapMountDir)
+		// will be interessting to the user.
+		//
+		// We need check both /snap (which is where snaps
+		// are located inside the mount namespace) and the
+		// distro snap mount dir (which is different on e.g.
+		// fedora/arch) to fully work with classic snaps.
+		needle1 := fmt.Sprintf(`execve("%s`, dirs.SnapMountDir)
+		needle2 := `execve("/snap`
 		for {
 			s, err := r.ReadString('\n')
 			if err != nil {
@@ -516,7 +522,7 @@ func runCmdUnderStrace(origCmd, env []string) error {
 			// ensure we catch the execve but *not* the
 			// exec into
 			// /snap/core/current/usr/lib/snapd/snap-confine
-			if strings.Contains(s, needle) && !strings.Contains(s, "usr/lib/snapd/snap-confine") {
+			if (strings.Contains(s, needle1) || strings.Contains(s, needle2)) && !strings.Contains(s, "usr/lib/snapd/snap-confine") {
 				fmt.Fprint(Stderr, s)
 				break
 			}

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -666,6 +666,7 @@ func (s *SnapSuite) TestSnapRunAppWithStraceIntegration(c *check.C) {
 	// normally come from strace
 	sudoCmd := testutil.MockCommand(c, "sudo", fmt.Sprintf(`
 echo "stdout output 1"
+>&2 echo 'execve("/path/to/snap-confine")'
 >&2 echo "snap-confine/snap-exec strace stuff"
 >&2 echo "getuid() = 1000"
 >&2 echo 'execve("%s/snapName/x2/bin/foo")'

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -651,3 +651,54 @@ func (s *SnapSuite) TestAntialiasBailsIfUnhappy(c *check.C) {
 		c.Check(outArgs, check.DeepEquals, inArgs, check.Commentf(desc))
 	}
 }
+
+func (s *SnapSuite) TestSnapRunAppWithStraceIntegration(c *check.C) {
+	defer mockSnapConfine(dirs.DistroLibExecDir)()
+
+	// mock installed snap
+	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+		Revision: snap.R("x2"),
+	})
+	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
+	c.Assert(err, check.IsNil)
+
+	// pretend we have sudo and simulate some useful output that would
+	// normally come from strace
+	sudoCmd := testutil.MockCommand(c, "sudo", fmt.Sprintf(`
+echo "stdout output 1"
+>&2 echo "snap-confine/snap-exec strace stuff"
+>&2 echo "getuid() = 1000"
+>&2 echo 'execve("%s/snapName/x2/bin/foo")'
+>&2 echo "interessting strace output"
+>&2 echo "and more"
+echo "stdout output 2"
+`, dirs.SnapMountDir))
+	defer sudoCmd.Restore()
+
+	// pretend we have strace
+	straceCmd := testutil.MockCommand(c, "strace", "")
+	defer straceCmd.Restore()
+
+	user, err := user.Current()
+	c.Assert(err, check.IsNil)
+
+	// and run it under strace
+	rest, err := snaprun.Parser().ParseArgs([]string{"run", "--strace", "snapname.app", "--arg1", "arg2"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{"snapname.app", "--arg1", "arg2"})
+	c.Check(sudoCmd.Calls(), check.DeepEquals, [][]string{
+		{
+			"sudo", "-E",
+			filepath.Join(straceCmd.BinDir(), "strace"),
+			"-u", user.Username,
+			"-f",
+			"-e", "!select,pselect6,_newselect,clock_gettime",
+			filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
+			"snap.snapname.app",
+			filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
+			"snapname.app", "--arg1", "arg2",
+		},
+	})
+	c.Check(s.Stdout(), check.Equals, "stdout output 1\nstdout output 2\n")
+	c.Check(s.Stderr(), check.Equals, "interessting strace output\nand more\n")
+}

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -700,5 +700,5 @@ echo "stdout output 2"
 		},
 	})
 	c.Check(s.Stdout(), check.Equals, "stdout output 1\nstdout output 2\n")
-	c.Check(s.Stderr(), check.Equals, "interessting strace output\nand more\n")
+	c.Check(s.Stderr(), check.Equals, fmt.Sprintf("execve(%q)\ninteressting strace output\nand more\n", filepath.Join(dirs.SnapMountDir, "snapName/x2/bin/foo")))
 }

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -9,6 +9,15 @@ execute: |
     echo "Test that snap run use environments"
     basic-run.echo-data | MATCH ^/var/snap
 
+    # the strace on 14.04 is too old
+    if grep -q 'VERSION_ID="14.04"' /etc/os-release; then
+        snap install --edge strace-static
+    fi
+    # core has no strace
+    if grep -q 'ID=ubuntu-core' /etc/os-release; then
+        snap install --edge strace-static
+    fi
+
     echo "Test snap run --strace"
     snap run --strace test-snapd-tools.echo "hello-world" >stdout 2>stderr
     MATCH hello-world < stdout

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -3,7 +3,18 @@ summary: Check that `snap run` runs
 prepare: |
     . $TESTSLIB/snaps.sh
     install_local basic-run
+    install_local test-snapd-tools
 
 execute: |
     echo "Test that snap run use environments"
     basic-run.echo-data | MATCH ^/var/snap
+
+    echo "Test snap run --strace"
+    snap run --strace test-snapd-tools.echo "hello-world" >stdout 2>stderr
+    MATCH hello-world < stdout
+    MATCH 'write\(1, \"hello-world\\n\",' < stderr
+    if grep "snap-confine" stderr; then
+       echo "the snap-confine calls should be filtered out, something is wrong
+       cat stderr"
+       exit 1
+    fi

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -5,6 +5,9 @@ prepare: |
     install_local basic-run
     install_local test-snapd-tools
 
+debug:
+    cat stderr
+
 execute: |
     echo "Test that snap run use environments"
     basic-run.echo-data | MATCH ^/var/snap
@@ -17,7 +20,10 @@ execute: |
     if grep -q 'ID=ubuntu-core' /etc/os-release; then
         snap install --edge strace-static
     fi
-
+    # the strace on opensuse is too old
+    if grep -q 'ID=opensuse' /etc/os-release; then
+        snap install --edge strace-static
+    fi
     echo "Test snap run --strace"
     snap run --strace test-snapd-tools.echo "hello-world" >stdout 2>stderr
     MATCH hello-world < stdout

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -14,16 +14,17 @@ execute: |
 
     # the strace on 14.04 is too old
     if grep -q 'VERSION_ID="14.04"' /etc/os-release; then
-        snap install --edge strace-static
-    fi
-    # core has no strace
-    if grep -q 'ID=ubuntu-core' /etc/os-release; then
-        snap install --edge strace-static
+        snap install strace-static
     fi
     # the strace on opensuse is too old
     if grep -q 'ID=opensuse' /etc/os-release; then
-        snap install --edge strace-static
+        snap install strace-static
     fi
+    # install the snap if no system strace is found
+    if ! which strace; then
+        snap install strace-static
+    fi
+
     echo "Test snap run --strace"
     snap run --strace test-snapd-tools.echo "hello-world" >stdout 2>stderr
     MATCH hello-world < stdout


### PR DESCRIPTION
This is a first implementation to support
`snap run --strace`. It is based on the work by Jamie outlined
in https://forum.snapcraft.io/t/1433.

It will use the strace from outside to snap - either the system
strace or the new strace-static snap that is available in edge
in the store. It will then filter the output until it finds the snap
app getting executed and from that point on will show the
normal strace output.

No support for strace options yet, I will do a followup for this.

