### PR TITLE
spread: switch fedora-26-64 back to manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -80,6 +80,7 @@ backends:
                 manual: true
             - fedora-26-64:
                 workers: 3
+                manual: true
             - opensuse-42.2-64:
                 workers: 3
                 manual: true


### PR DESCRIPTION
We're seeing consistent failures when installing/updating packages:

```
  quiet: dnf -y --refresh install curl dbus-x11 expect git golang jq mock redhat-lsb-core rpm-build xdg-user-dirs
  quiet: exit status 1. Output follows:
  Failed to set locale, defaulting to C
  Error: Failed to synchronize cache for repo 'updates'
  quiet: end of output.
```
