### PR TITLE
overlord/snapstate: for Enable's tasks refer to the first task with snap-setup, do not duplicate

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1018,20 +1018,20 @@ func Enable(st *state.State, name string) (*state.TaskSet, error) {
 	prepareSnap.Set("snap-setup", &snapsup)
 
 	setupProfiles := st.NewTask("setup-profiles", fmt.Sprintf(i18n.G("Setup snap %q (%s) security profiles"), snapsup.Name(), snapst.Current))
-	setupProfiles.Set("snap-setup", &snapsup)
+	setupProfiles.Set("snap-setup-task", prepareSnap.ID())
 	setupProfiles.WaitFor(prepareSnap)
 
 	linkSnap := st.NewTask("link-snap", fmt.Sprintf(i18n.G("Make snap %q (%s) available to the system"), snapsup.Name(), snapst.Current))
-	linkSnap.Set("snap-setup", &snapsup)
+	linkSnap.Set("snap-setup-task", prepareSnap.ID())
 	linkSnap.WaitFor(setupProfiles)
 
 	// setup aliases
 	setupAliases := st.NewTask("setup-aliases", fmt.Sprintf(i18n.G("Setup snap %q aliases"), snapsup.Name()))
-	setupAliases.Set("snap-setup", &snapsup)
+	setupAliases.Set("snap-setup-task", prepareSnap.ID())
 	setupAliases.WaitFor(linkSnap)
 
 	startSnapServices := st.NewTask("start-snap-services", fmt.Sprintf(i18n.G("Start snap %q (%s) services"), snapsup.Name(), snapst.Current))
-	startSnapServices.Set("snap-setup", &snapsup)
+	startSnapServices.Set("snap-setup-task", prepareSnap.ID())
 	startSnapServices.WaitFor(setupAliases)
 
 	return state.NewTaskSet(prepareSnap, setupProfiles, linkSnap, setupAliases, startSnapServices), nil


### PR DESCRIPTION
In passing I noticed that Enable for some reason wasn't following the usual pattern of having a first task with snap-setup and the other chaining/referring to it using snap-setup-task set to the first task ID. This fixes that.

