### PR TITLE
snapenv: add SNAP_ARCH_TRIPLET

### DIFF
--- a/arch/arch.go
+++ b/arch/arch.go
@@ -53,23 +53,52 @@ func UbuntuArchitecture() string {
 	return string(arch)
 }
 
+// UbuntuArchTriplet returns a normalized gnu triplet that is also
+// used by Ubuntu and Debian for its multi-arch locations.
+//
+// Taken from https://wiki.debian.org/Multiarch/Tuples
+func UbuntuArchTriplet() string {
+	switch arch {
+	case "arm64":
+		return "aarch64‑linux‑gnu"
+	case "armhf":
+		return "arm-linux-gnueabihf"
+	case "amd64":
+		return "x86_64-linux-gnu"
+	case "i386":
+		return "i386-linux-gnu"
+		// ppc64 available in debian and other distros
+	case "ppc64":
+		return "powerpc64-linux-gnu"
+	case "ppc64el":
+		return "powerpc64le-linux-gnu"
+	case "powerpc":
+		return "powerpc-linux-gnu"
+	case "s390x":
+		return "s390x-linux-gnu"
+	default:
+		return ""
+	}
+}
+
 // ubuntuArchFromGoArch maps a go architecture string to the coresponding
 // Ubuntu architecture string.
 //
 // E.g. the go "386" architecture string maps to the ubuntu "i386"
 // architecture.
 func ubuntuArchFromGoArch(goarch string) string {
+	// keep in sync with UbuntuArchTriplet
 	goArchMapping := map[string]string{
 		// go      ubuntu
-		"386":     "i386",
-		"amd64":   "amd64",
-		"arm":     "armhf",
-		"arm64":   "arm64",
+		"amd64": "amd64",
+		"arm":   "armhf",
+		"arm64": "arm64",
+		"386":   "i386",
+		// ppc64 available in debian and other distros
+		"ppc64":   "ppc64",
 		"ppc64le": "ppc64el",
-		"s390x":   "s390x",
 		"ppc":     "powerpc",
-		// available in debian and other distros
-		"ppc64": "ppc64",
+		"s390x":   "s390x",
 	}
 
 	// If we are running on an ARM platform we need to have a

--- a/arch/arch.go
+++ b/arch/arch.go
@@ -57,7 +57,7 @@ func UbuntuArchitecture() string {
 // used by Ubuntu and Debian for its multi-arch locations.
 //
 // Taken from https://wiki.debian.org/Multiarch/Tuples
-func UbuntuArchTriplet() string {
+func NormalizedGNUArchTriplet() string {
 	switch arch {
 	case "arm64":
 		return "aarch64‑linux‑gnu"

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -99,13 +99,14 @@ func basicEnv(info *snap.Info) map[string]string {
 		// shall *either* execute with the new mount namespace where snaps are
 		// always mounted on /snap OR it is a classically confined snap where
 		// /snap is a part of the distribution package.
-		"SNAP":          filepath.Join(dirs.CoreSnapMountDir, info.Name(), info.Revision.String()),
-		"SNAP_COMMON":   info.CommonDataDir(),
-		"SNAP_DATA":     info.DataDir(),
-		"SNAP_NAME":     info.Name(),
-		"SNAP_VERSION":  info.Version,
-		"SNAP_REVISION": info.Revision.String(),
-		"SNAP_ARCH":     arch.UbuntuArchitecture(),
+		"SNAP":              filepath.Join(dirs.CoreSnapMountDir, info.Name(), info.Revision.String()),
+		"SNAP_COMMON":       info.CommonDataDir(),
+		"SNAP_DATA":         info.DataDir(),
+		"SNAP_NAME":         info.Name(),
+		"SNAP_VERSION":      info.Version,
+		"SNAP_REVISION":     info.Revision.String(),
+		"SNAP_ARCH":         arch.UbuntuArchitecture(),
+		"SNAP_ARCH_TRIPLET": arch.UbuntuArchTriplet(),
 		// see https://github.com/snapcore/snapd/pull/2732#pullrequestreview-18827193
 		"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
 		"SNAP_REEXEC":       os.Getenv("SNAP_REEXEC"),

--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -106,7 +106,7 @@ func basicEnv(info *snap.Info) map[string]string {
 		"SNAP_VERSION":      info.Version,
 		"SNAP_REVISION":     info.Revision.String(),
 		"SNAP_ARCH":         arch.UbuntuArchitecture(),
-		"SNAP_ARCH_TRIPLET": arch.UbuntuArchTriplet(),
+		"SNAP_ARCH_TRIPLET": arch.NormalizedGNUArchTriplet(),
 		// see https://github.com/snapcore/snapd/pull/2732#pullrequestreview-18827193
 		"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
 		"SNAP_REEXEC":       os.Getenv("SNAP_REEXEC"),

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -74,7 +74,7 @@ func (ts *HTestSuite) TestBasic(c *C) {
 	c.Assert(env, DeepEquals, map[string]string{
 		"SNAP":              fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
 		"SNAP_ARCH":         arch.UbuntuArchitecture(),
-		"SNAP_ARCH_TRIPLET": arch.UbuntuArchTriplet(),
+		"SNAP_ARCH_TRIPLET": arch.NormalizedGNUArchTriplet(),
 		"SNAP_COMMON":       "/var/snap/foo/common",
 		"SNAP_DATA":         "/var/snap/foo/17",
 		"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
@@ -129,7 +129,7 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 			"HOME":              fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
 			"SNAP":              fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
 			"SNAP_ARCH":         arch.UbuntuArchitecture(),
-			"SNAP_ARCH_TRIPLET": arch.UbuntuArchTriplet(),
+			"SNAP_ARCH_TRIPLET": arch.NormalizedGNUArchTriplet(),
 			"SNAP_COMMON":       "/var/snap/snapname/common",
 			"SNAP_DATA":         "/var/snap/snapname/42",
 			"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -74,6 +74,7 @@ func (ts *HTestSuite) TestBasic(c *C) {
 	c.Assert(env, DeepEquals, map[string]string{
 		"SNAP":              fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
 		"SNAP_ARCH":         arch.UbuntuArchitecture(),
+		"SNAP_ARCH_TRIPLET": arch.UbuntuArchTriplet(),
 		"SNAP_COMMON":       "/var/snap/foo/common",
 		"SNAP_DATA":         "/var/snap/foo/17",
 		"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
@@ -128,6 +129,7 @@ func (s *HTestSuite) TestSnapRunSnapExecEnv(c *C) {
 			"HOME":              fmt.Sprintf("%s/snap/snapname/42", usr.HomeDir),
 			"SNAP":              fmt.Sprintf("%s/snapname/42", dirs.CoreSnapMountDir),
 			"SNAP_ARCH":         arch.UbuntuArchitecture(),
+			"SNAP_ARCH_TRIPLET": arch.UbuntuArchTriplet(),
 			"SNAP_COMMON":       "/var/snap/snapname/common",
 			"SNAP_DATA":         "/var/snap/snapname/42",
 			"SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -18,6 +18,7 @@ execute: |
 
     echo "Ensure that SNAP environment variables are what we expect"
     MATCH '^SNAP_ARCH=(amd64|i386|arm64|armhf|ppc64el)$'                  < snap-vars.txt
+    MATCH '^SNAP_ARCH_TRIPLET=(aarch64‑linux‑gnu|arm-linux-gnueabihf|x86_64-linux-gnu|i386-linux-gnu|powerpc64-linux-gnu|powerpc64le-linux-gnu|powerpc-linux-gnu|s390x-linux-gnu)$' < snap-vars.txt
     MATCH '^SNAP_COMMON=/var/snap/test-snapd-tools/common$'               < snap-vars.txt
     MATCH '^SNAP_DATA=/var/snap/test-snapd-tools/x1$'                     < snap-vars.txt
     MATCH '^SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void$' < snap-vars.txt
@@ -31,7 +32,7 @@ execute: |
     CTX=$(cat /var/lib/snapd/cookie/snap.test-snapd-tools)
     MATCH "^SNAP_COOKIE=$CTX"                                             < snap-vars.txt
     MATCH "^SNAP_CONTEXT=$CTX"                                            < snap-vars.txt
-    test $(wc -l < snap-vars.txt) -eq 12
+    test $(wc -l < snap-vars.txt) -eq 13
 
     echo "Enure that XDG environment variables are what we expect"
     MATCH '^XDG_RUNTIME_DIR=/run/user/0/snap.test-snapd-tools$'  < xdg-vars.txt


### PR DESCRIPTION
This adds a new environment variable for the snaps that identifies
the normalized GNU architecture triplet for the given architecutre.

This is useful for finding multi-arch paths inside snaps, e.g.
if there is a $SNAP/usr/lib/x86_64-linux-gnu/ then this can
now be written as "$SNAP/usr/lib/${SNAP_ARCH_TRIPLET}/.

There is a complication here - there might be subtle differences between distros. So we may need to make this base specific. For example on fedora the arm-32bit target uses "arm-linux-gnueabi" but on ubuntu we use "arm-linux-gnueabihf" which indicates that fedora is using soft-float here.

This addresses https://bugs.launchpad.net/snapd/+bug/1742565
