### PR TITLE
spread: switch fedora 26 to manual again

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -80,6 +80,7 @@ backends:
                 manual: true
             - fedora-26-64:
                 workers: 3
+                manual: true
             - opensuse-42.2-64:
                 workers: 3
                 manual: true


### PR DESCRIPTION
We're seeing more issues, even after switching to the main fedora
archive. The set of test machines is spread around two data centres so
it's possible that one of them is being affected by network packet
corruption somewhere. At all times failures were not about 404s from the
server but about hash mismatches.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>