### PR TITLE
interfaces/builtin: use snap.{Plug,Slot}Info over interfaces.{Plug,Slot}

### DIFF
--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -61,18 +61,18 @@ func MustInterface(name string) interfaces.Interface {
 	panic(fmt.Errorf("cannot find interface with name %q", name))
 }
 
-func MockPlug(c *C, yaml string, si *snap.SideInfo, plugName string) *interfaces.Plug {
+func MockPlug(c *C, yaml string, si *snap.SideInfo, plugName string) *snap.PlugInfo {
 	info := snaptest.MockInfo(c, yaml, si)
 	if plugInfo, ok := info.Plugs[plugName]; ok {
-		return &interfaces.Plug{PlugInfo: plugInfo}
+		return plugInfo
 	}
 	panic(fmt.Sprintf("cannot find plug %q in snap %q", plugName, info.Name()))
 }
 
-func MockSlot(c *C, yaml string, si *snap.SideInfo, slotName string) *interfaces.Slot {
+func MockSlot(c *C, yaml string, si *snap.SideInfo, slotName string) *snap.SlotInfo {
 	info := snaptest.MockInfo(c, yaml, si)
 	if slotInfo, ok := info.Slots[slotName]; ok {
-		return &interfaces.Slot{SlotInfo: slotInfo}
+		return slotInfo
 	}
 	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.Name()))
 }

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -66,11 +66,11 @@ func (s *utilsSuite) TestSanitizeSlotReservedForOSOrApp(c *C) {
 	c.Assert(builtin.SanitizeSlotReservedForOSOrApp(s.iface, s.slotGadget), ErrorMatches, errmsg)
 }
 
-func MockPlug(c *C, yaml string, si *snap.SideInfo, plugName string) *interfaces.Plug {
+func MockPlug(c *C, yaml string, si *snap.SideInfo, plugName string) *snap.PlugInfo {
 	return builtin.MockPlug(c, yaml, si, plugName)
 }
 
-func MockSlot(c *C, yaml string, si *snap.SideInfo, slotName string) *interfaces.Slot {
+func MockSlot(c *C, yaml string, si *snap.SideInfo, slotName string) *snap.SlotInfo {
 	return builtin.MockSlot(c, yaml, si, slotName)
 }
 


### PR DESCRIPTION
This patch tweaks test helpers to use the snap.{Plug,Slot}Info types
rather than the older ones from the interfaces package (which are on
they way out).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>