### PR TITLE
dirs: check if distro 'is like' fedora when picking path to libexecdir

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -230,10 +230,11 @@ func SetRootDir(rootdir string) {
 	LocaleDir = filepath.Join(rootdir, "/usr/share/locale")
 	ClassicDir = filepath.Join(rootdir, "/writable/classic")
 
-	switch release.ReleaseInfo.ID {
-	case "fedora", "centos", "rhel":
+	if release.DistroLike("fedora") {
+		// rhel, centos, fedora and derivatives
+		// both rhel and centos list "fedora" in ID_LIKE
 		DistroLibExecDir = filepath.Join(rootdir, "/usr/libexec/snapd")
-	default:
+	} else {
 		DistroLibExecDir = filepath.Join(rootdir, "/usr/lib/snapd")
 	}
 


### PR DESCRIPTION
The original bug report [1] comes from Korora, a Fedora derivative. Address it
by checking if distro 'is like' fedora rather than using a hardcoded list of
options. Both RHEL and CentOS list ID_LIKE="..fedora.." in their /etc/os-release
files. Korora, being a derivative also has ID_LIKE="fedora".

[1]. https://bugs.launchpad.net/snappy/+bug/1743301


