### PR TITLE
 tests: update auto-refresh-private to match messages from current master

### DIFF
--- a/tests/main/auto-refresh-private/task.yaml
+++ b/tests/main/auto-refresh-private/task.yaml
@@ -107,4 +107,4 @@ execute: |
     snap list|MATCH "test-snapd-private +1\.0.*private"
 
     # sanity check there is no access
-    snap find --private test-snapd-private 2>&1|MATCH "The search \"test-snapd-private\" returned 0 snaps"
+    snap find --private test-snapd-private 2>&1|MATCH 'No matching snaps for "test-snapd-private"'


### PR DESCRIPTION
This should make the travis test against master green again.

We only run the auto-refresh-private test against master because there are some secrets involved here.