### PR TITLE
debian/tests: add missing autopkgtest test dependencies for debian

### DIFF
--- a/packaging/ubuntu-16.04/tests/control
+++ b/packaging/ubuntu-16.04/tests/control
@@ -5,5 +5,8 @@ Depends: @builddeps@,
          ca-certificates,
          git,
          golang-golang-x-net-dev,
+         locales,
          openssh-server,
+         netcat-openbsd,
+         net-tools,
          snapd


### PR DESCRIPTION
Trivial PR to fix https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1659868