### PR TITLE
snapstate: make no autorefresh message clearer

### DIFF
--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -204,7 +204,7 @@ func (m *autoRefresh) launchAutoRefresh() error {
 	var msg string
 	switch len(updated) {
 	case 0:
-		logger.Noticef(i18n.G("No snaps to auto-refresh found"))
+		logger.Noticef(i18n.G("auto-refresh: all snaps are up-to-date"))
 		return nil
 	case 1:
 		msg = fmt.Sprintf(i18n.G("Auto-refresh snap %q"), updated[0])


### PR DESCRIPTION
Our current log message when all snaps are up-to-date is confusing
to some people. This PR makes it clearer.

This fixes https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1677468
