### PR TITLE
configcore: ensure config.txt has a final newline

### DIFF
--- a/overlord/configstate/configcore/picfg.go
+++ b/overlord/configstate/configcore/picfg.go
@@ -68,6 +68,8 @@ func updatePiConfig(path string, config map[string]string) error {
 
 	if toWrite != nil {
 		s := strings.Join(toWrite, "\n")
+		// ensure we have a final newline in the file
+		s += "\n"
 		return osutil.AtomicWriteFile(path, []byte(s), 0644, 0)
 	}
 

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -47,7 +47,8 @@ var mockConfigTxt = `
 # uncomment this if your display has a black border of unused pixels visible
 # and your display can output without overscan
 #disable_overscan=1
-unrelated_options=are-kept`
+unrelated_options=are-kept
+`
 
 func (s *piCfgSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
@@ -83,12 +84,12 @@ func (s *piCfgSuite) TestConfigurePiConfigUncommentExisting(c *C) {
 }
 
 func (s *piCfgSuite) TestConfigurePiConfigCommentExisting(c *C) {
-	s.mockConfig(c, mockConfigTxt+"\navoid_warnings=1\n")
+	s.mockConfig(c, mockConfigTxt+"avoid_warnings=1\n")
 
 	err := configcore.UpdatePiConfig(s.mockConfigPath, map[string]string{"avoid_warnings": ""})
 	c.Assert(err, IsNil)
 
-	expected := mockConfigTxt + "\n" + "#avoid_warnings=1"
+	expected := mockConfigTxt + "#avoid_warnings=1\n"
 	s.checkMockConfig(c, expected)
 }
 
@@ -96,13 +97,13 @@ func (s *piCfgSuite) TestConfigurePiConfigAddNewOption(c *C) {
 	err := configcore.UpdatePiConfig(s.mockConfigPath, map[string]string{"framebuffer_depth": "16"})
 	c.Assert(err, IsNil)
 
-	expected := mockConfigTxt + "\n" + "framebuffer_depth=16"
+	expected := mockConfigTxt + "framebuffer_depth=16\n"
 	s.checkMockConfig(c, expected)
 
 	// add again, verify its not added twice but updated
 	err = configcore.UpdatePiConfig(s.mockConfigPath, map[string]string{"framebuffer_depth": "32"})
 	c.Assert(err, IsNil)
-	expected = mockConfigTxt + "\n" + "framebuffer_depth=32"
+	expected = mockConfigTxt + "framebuffer_depth=32\n"
 	s.checkMockConfig(c, expected)
 }
 


### PR DESCRIPTION
This is another take on fixing the config.txt test failure on pi2/pi3 (there is another one in #4419). I think we should add the final newline in our corecfg code instead of doing it just in the test. The reason is that the upstream pi2 config.txt file also has a final newline so the file we write should do the same.