### PR TITLE
osutil/sys: ppc has 32-bit getuid already

### DIFF
--- a/osutil/sys/sysnum_getpid_16.go
+++ b/osutil/sys/sysnum_getpid_16.go
@@ -1,5 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-// +build arm 386 ppc
+// +build arm 386
 
 /*
  * Copyright (C) 2017 Canonical Ltd
@@ -21,6 +21,9 @@
 package sys
 
 import "syscall"
+
+// these are the contsants for where getuid et al are 16-bit versions
+// (and so the 32 bit version is called getuid32 etc)
 
 const (
 	_SYS_GETUID  = syscall.SYS_GETUID32

--- a/osutil/sys/sysnum_getpid_16.go
+++ b/osutil/sys/sysnum_getpid_16.go
@@ -22,7 +22,7 @@ package sys
 
 import "syscall"
 
-// these are the contsants for where getuid et al are 16-bit versions
+// these are the constants for where getuid et al are 16-bit versions
 // (and so the 32 bit version is called getuid32 etc)
 
 const (

--- a/osutil/sys/sysnum_getpid_32.go
+++ b/osutil/sys/sysnum_getpid_32.go
@@ -22,7 +22,7 @@ package sys
 
 import "syscall"
 
-// these are the contsants for where getuid et al are already 32-bit
+// these are the constants for where getuid et al are already 32-bit
 
 const (
 	_SYS_GETUID  = syscall.SYS_GETUID

--- a/osutil/sys/sysnum_getpid_32.go
+++ b/osutil/sys/sysnum_getpid_32.go
@@ -1,5 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-// +build arm64 amd64 ppc64le s390x
+// +build arm64 amd64 ppc64le s390x ppc
 
 /*
  * Copyright (C) 2017 Canonical Ltd
@@ -21,6 +21,8 @@
 package sys
 
 import "syscall"
+
+// these are the contsants for where getuid et al are already 32-bit
 
 const (
 	_SYS_GETUID  = syscall.SYS_GETUID


### PR DESCRIPTION
Without this the powerpc build fails because it has no `getuid32`.

