### PR TITLE
interfaces/mount,snap: early support for snap layouts

### DIFF
--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -61,9 +61,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, confinement interfaces.ConfinementO
 	if err != nil {
 		return fmt.Errorf("cannot obtain mount security snippets for snap %q: %s", snapName, err)
 	}
-	if err = spec.(*Specification).AddSnapLayout(snapInfo); err != nil {
-		return fmt.Errorf("cannot use layout of snap %q: %s", snapName, err)
-	}
+	spec.(*Specification).AddSnapLayout(snapInfo)
 	content := deriveContent(spec.(*Specification), snapInfo)
 	// synchronize the content with the filesystem
 	glob := fmt.Sprintf("snap.%s.*fstab", snapName)

--- a/interfaces/mount/entry.go
+++ b/interfaces/mount/entry.go
@@ -243,3 +243,33 @@ func (e *Entry) OptBool(name string) bool {
 	}
 	return false
 }
+
+// XSnapdKindSymlink returns the string "x-snapd.kind=symlink".
+func XSnapdKindSymlink() string {
+	return "x-snapd.kind=symlink"
+}
+
+// XSnapdKindFile returns the string "x-snapd.kind=file".
+func XSnapdKindFile() string {
+	return "x-snapd.kind=file"
+}
+
+// XSnapdUser returns the string "x-snapd.user=%d".
+func XSnapdUser(uid int) string {
+	return fmt.Sprintf("x-snapd.user=%d", uid)
+}
+
+// XSnapdGroup returns the string "x-snapd.group=%d".
+func XSnapdGroup(gid int) string {
+	return fmt.Sprintf("x-snapd.group=%d", gid)
+}
+
+// XSnapdMode returns the string "x-snapd.mode=%#o".
+func XSnapdMode(mode uint32) string {
+	return fmt.Sprintf("x-snapd.mode=%#o", mode)
+}
+
+// XSnapdSymlink returns the string "x-snapd.symlink=%s".
+func XSnapdSymlink(oldname string) string {
+	return fmt.Sprintf("x-snapd.symlink=%s", oldname)
+}

--- a/interfaces/mount/entry_test.go
+++ b/interfaces/mount/entry_test.go
@@ -208,3 +208,12 @@ func (s *entrySuite) TestOptBool(c *C) {
 	val = e.OptBool("missing")
 	c.Assert(val, Equals, false)
 }
+
+func (s *entrySuite) TestOptionHelpers(c *C) {
+	c.Assert(mount.XSnapdKindSymlink(), Equals, "x-snapd.kind=symlink")
+	c.Assert(mount.XSnapdKindFile(), Equals, "x-snapd.kind=file")
+	c.Assert(mount.XSnapdUser(1000), Equals, "x-snapd.user=1000")
+	c.Assert(mount.XSnapdGroup(1000), Equals, "x-snapd.group=1000")
+	c.Assert(mount.XSnapdMode(0755), Equals, "x-snapd.mode=0755")
+	c.Assert(mount.XSnapdSymlink("oldname"), Equals, "x-snapd.symlink=oldname")
+}

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -89,6 +89,7 @@ func mountEntryFromLayout(layout *snap.Layout) Entry {
 	}
 
 	var uid int
+	// Only root and nobody are allowed here. Root is default. This is validated in spec.go.
 	switch layout.User {
 	case "root", "":
 		uid = 0
@@ -102,6 +103,8 @@ func mountEntryFromLayout(layout *snap.Layout) Entry {
 	}
 
 	var gid int
+	// Only root and nobody (with an alias of nogroup) are allowed here. Root is default.
+	// This is validated in spec.go.
 	switch layout.Group {
 	case "root", "":
 		gid = 0

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -46,10 +46,7 @@ func (spec *Specification) AddMountEntry(e Entry) error {
 	return nil
 }
 
-// resolveSpecialVariable resolves one of the three $SNAP* variables at the
-// beginning of a given path.  The variables are $SNAP, $SNAP_DATA and
-// $SNAP_COMMON. If there are no variables then $SNAP is implicitly assumed
-// (this is the behavior that was used before the variables were supporter).
+// resolveSpecialVariable resolves $SNAP, $SNAP_DATA and $SNAP_COMMON.
 func resolveSpecialVariable(path string, snapInfo *snap.Info) string {
 	return os.Expand(path, func(v string) string {
 		switch v {

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -46,8 +46,8 @@ func (spec *Specification) AddMountEntry(e Entry) error {
 	return nil
 }
 
-// resolveSpecialVariable resolves $SNAP, $SNAP_DATA and $SNAP_COMMON.
-func resolveSpecialVariable(path string, snapInfo *snap.Info) string {
+// expandSnapVariables resolves $SNAP, $SNAP_DATA and $SNAP_COMMON.
+func expandSnapVariables(path string, snapInfo *snap.Info) string {
 	return os.Expand(path, func(v string) string {
 		switch v {
 		case "SNAP":
@@ -68,11 +68,11 @@ func resolveSpecialVariable(path string, snapInfo *snap.Info) string {
 func mountEntryFromLayout(layout *snap.Layout) Entry {
 	var entry Entry
 
-	mountPoint := resolveSpecialVariable(layout.Path, layout.Snap)
+	mountPoint := expandSnapVariables(layout.Path, layout.Snap)
 	entry.Dir = mountPoint
 
 	if layout.Bind != "" {
-		mountSource := resolveSpecialVariable(layout.Bind, layout.Snap)
+		mountSource := expandSnapVariables(layout.Bind, layout.Snap)
 		// XXX: what about ro mounts?
 		// XXX: what about file mounts, those need x-snapd.kind=file to create correctly?
 		entry.Options = []string{"bind", "rw"}
@@ -85,7 +85,7 @@ func mountEntryFromLayout(layout *snap.Layout) Entry {
 	}
 
 	if layout.Symlink != "" {
-		oldname := resolveSpecialVariable(layout.Symlink, layout.Snap)
+		oldname := expandSnapVariables(layout.Symlink, layout.Snap)
 		entry.Options = []string{"x-snapd.kind=symlink", fmt.Sprintf("x-snapd.symlink=%s", oldname)}
 	}
 

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -20,7 +20,6 @@
 package mount
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -86,7 +85,7 @@ func mountEntryFromLayout(layout *snap.Layout) Entry {
 
 	if layout.Symlink != "" {
 		oldname := expandSnapVariables(layout.Symlink, layout.Snap)
-		entry.Options = []string{"x-snapd.kind=symlink", fmt.Sprintf("x-snapd.symlink=%s", oldname)}
+		entry.Options = []string{XSnapdKindSymlink(), XSnapdSymlink(oldname)}
 	}
 
 	var uid int
@@ -99,7 +98,7 @@ func mountEntryFromLayout(layout *snap.Layout) Entry {
 		uid = 65534
 	}
 	if uid != 0 {
-		entry.Options = append(entry.Options, fmt.Sprintf("x-snapd.user=%d", uid))
+		entry.Options = append(entry.Options, XSnapdUser(uid))
 	}
 
 	var gid int
@@ -112,11 +111,11 @@ func mountEntryFromLayout(layout *snap.Layout) Entry {
 		gid = 65534
 	}
 	if gid != 0 {
-		entry.Options = append(entry.Options, fmt.Sprintf("x-snapd.group=%d", gid))
+		entry.Options = append(entry.Options, XSnapdGroup(gid))
 	}
 
 	if layout.Mode != 0755 {
-		entry.Options = append(entry.Options, fmt.Sprintf("x-snapd.mode=%#o", uint32(layout.Mode)))
+		entry.Options = append(entry.Options, XSnapdMode(uint32(layout.Mode)))
 	}
 	return entry
 }

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -68,10 +68,6 @@ func resolveSpecialVariable(path string, snapInfo *snap.Info) string {
 	})
 }
 
-func isAbsAndClean(path string) bool {
-	return filepath.IsAbs(path) && filepath.Clean(path) == path
-}
-
 func mountEntryFromLayout(layout *snap.Layout) Entry {
 	var entry Entry
 

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 type specSuite struct {
@@ -90,4 +91,28 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	c.Assert(s.spec.MountEntries(), DeepEquals, []mount.Entry{
 		{Name: "connected-plug"}, {Name: "connected-slot"},
 		{Name: "permanent-plug"}, {Name: "permanent-slot"}})
+}
+
+const snapWithLayout = `
+name: vanguard
+layout:
+  /usr:
+    bind: $SNAP/usr
+  /mytmp:
+    type: tmpfs
+    user: nobody
+    group: nogroup
+    mode: 1777
+  /mylink:
+    symlink: /link/target
+`
+
+func (s *specSuite) TestMountEntryFromLayout(c *C) {
+	snapInfo := snaptest.MockInfo(c, snapWithLayout, &snap.SideInfo{Revision: snap.R(42)})
+	c.Assert(s.spec.AddSnapLayout(snapInfo), IsNil)
+	c.Assert(s.spec.MountEntries(), DeepEquals, []mount.Entry{
+		{Dir: "/mylink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/link/target"}},
+		{Name: "tmpfs", Dir: "/mytmp", Type: "tmpfs", Options: []string{"x-snapd.user=65534", "x-snapd.group=65534", "x-snapd.mode=01777"}},
+		{Name: "/snap/vanguard/42/usr", Dir: "/usr", Options: []string{"bind", "rw"}},
+	})
 }

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -109,7 +109,7 @@ layout:
 
 func (s *specSuite) TestMountEntryFromLayout(c *C) {
 	snapInfo := snaptest.MockInfo(c, snapWithLayout, &snap.SideInfo{Revision: snap.R(42)})
-	c.Assert(s.spec.AddSnapLayout(snapInfo), IsNil)
+	s.spec.AddSnapLayout(snapInfo)
 	c.Assert(s.spec.MountEntries(), DeepEquals, []mount.Entry{
 		{Dir: "/mylink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/link/target"}},
 		{Name: "tmpfs", Dir: "/mytmp", Type: "tmpfs", Options: []string{"x-snapd.user=65534", "x-snapd.group=65534", "x-snapd.mode=01777"}},

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -471,7 +471,7 @@ func ValidateLayout(li *Layout) error {
 	if li.User != "" && li.User != "root" && li.User != "nobody" {
 		return fmt.Errorf("cannot accept user %q for %q", li.User, li.Path)
 	}
-	if li.Group != "" && li.Group != "root" && li.Group != "nobody" {
+	if li.Group != "" && li.Group != "root" && li.Group != "nogroup" {
 		return fmt.Errorf("cannot accept group %q for %q", li.Group, li.Path)
 	}
 	// "at most" 0777 permissions are allowed.

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -474,8 +474,8 @@ func ValidateLayout(li *Layout) error {
 	if li.Group != "" && li.Group != "root" && li.Group != "nogroup" {
 		return fmt.Errorf("cannot accept group %q for %q", li.Group, li.Path)
 	}
-	// "at most" 0777 permissions are allowed.
-	if li.Mode&^os.FileMode(0777) != 0 {
+	// "at most" 01777 permissions are allowed.
+	if li.Mode&^os.FileMode(01777) != 0 {
 		return fmt.Errorf("cannot accept mode %#0o for %q", li.Mode, li.Path)
 	}
 	return nil

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -494,6 +494,8 @@ func ValidateLayout(layout *Layout) error {
 		}
 	}
 
+	// When new users and groups are supported those must be added to interfaces/mount/spec.go as well.
+
 	switch layout.User {
 	case "root", "", "nobody":
 	// TODO: allow declared snap user and group names.

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -533,8 +533,8 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 		ErrorMatches, `cannot accept user "foo" for "/foo/bar"`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo/bar", Type: "tmpfs", Group: "foo"}),
 		ErrorMatches, `cannot accept group "foo" for "/foo/bar"`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Mode: 01755}),
-		ErrorMatches, `cannot accept mode 01755 for "/foo"`)
+	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Mode: 02755}),
+		ErrorMatches, `cannot accept mode 02755 for "/foo"`)
 	c.Check(ValidateLayout(&Layout{Path: "$FOO", Type: "tmpfs"}),
 		ErrorMatches, `cannot accept layout of "\$FOO": reference to unknown variable "\$FOO"`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "$BAR"}),
@@ -542,6 +542,7 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Symlink: "$BAR"}),
 		ErrorMatches, `cannot accept layout of "/foo": reference to unknown variable "\$BAR"`)
 	// Several valid layouts.
+	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Mode: 01755}), IsNil)
 	c.Check(ValidateLayout(&Layout{Path: "/tmp", Type: "tmpfs"}), IsNil)
 	c.Check(ValidateLayout(&Layout{Path: "/usr", Bind: "$SNAP/usr"}), IsNil)
 	c.Check(ValidateLayout(&Layout{Path: "/var", Bind: "$SNAP_DATA/var"}), IsNil)

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -518,29 +518,29 @@ func (s *ValidateSuite) TestValidateAlias(c *C) {
 func (s *ValidateSuite) TestValidateLayout(c *C) {
 	// Several invalid layouts.
 	c.Check(ValidateLayout(&Layout{}),
-		ErrorMatches, "cannot accept layout with empty path")
+		ErrorMatches, "layout cannot use an empty path")
 	c.Check(ValidateLayout(&Layout{Path: "/foo"}),
-		ErrorMatches, `cannot determine layout for "/foo"`)
+		ErrorMatches, `layout "/foo" must define a bind mount, a filesystem mount or a symlink`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "/bar", Type: "tmpfs"}),
-		ErrorMatches, `cannot accept conflicting layout for "/foo"`)
+		ErrorMatches, `layout "/foo" must define a bind mount, a filesystem mount or a symlink`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "/bar", Symlink: "/froz"}),
-		ErrorMatches, `cannot accept conflicting layout for "/foo"`)
+		ErrorMatches, `layout "/foo" must define a bind mount, a filesystem mount or a symlink`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Symlink: "/froz"}),
-		ErrorMatches, `cannot accept conflicting layout for "/foo"`)
+		ErrorMatches, `layout "/foo" must define a bind mount, a filesystem mount or a symlink`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "ext4"}),
-		ErrorMatches, `cannot accept filesystem "ext4" for "/foo"`)
+		ErrorMatches, `layout "/foo" uses invalid filesystem "ext4"`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo/bar", Type: "tmpfs", User: "foo"}),
-		ErrorMatches, `cannot accept user "foo" for "/foo/bar"`)
+		ErrorMatches, `layout "/foo/bar" uses invalid user "foo"`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo/bar", Type: "tmpfs", Group: "foo"}),
-		ErrorMatches, `cannot accept group "foo" for "/foo/bar"`)
+		ErrorMatches, `layout "/foo/bar" uses invalid group "foo"`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Mode: 02755}),
-		ErrorMatches, `cannot accept mode 02755 for "/foo"`)
+		ErrorMatches, `layout "/foo" uses invalid mode 02755`)
 	c.Check(ValidateLayout(&Layout{Path: "$FOO", Type: "tmpfs"}),
-		ErrorMatches, `cannot accept layout of "\$FOO": reference to unknown variable "\$FOO"`)
+		ErrorMatches, `layout "\$FOO" uses invalid mount point: reference to unknown variable "\$FOO"`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "$BAR"}),
-		ErrorMatches, `cannot accept layout of "/foo": reference to unknown variable "\$BAR"`)
+		ErrorMatches, `layout "/foo" uses invalid bind mount source "\$BAR": reference to unknown variable "\$BAR"`)
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Symlink: "$BAR"}),
-		ErrorMatches, `cannot accept layout of "/foo": reference to unknown variable "\$BAR"`)
+		ErrorMatches, `layout "/foo" uses invalid symlink old name "\$BAR": reference to unknown variable "\$BAR"`)
 	// Several valid layouts.
 	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Mode: 01755}), IsNil)
 	c.Check(ValidateLayout(&Layout{Path: "/tmp", Type: "tmpfs"}), IsNil)

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -549,7 +549,7 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 	c.Check(ValidateLayout(&Layout{Path: "/etc/foo.conf", Symlink: "$SNAP_DATA/etc/foo.conf"}), IsNil)
 	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", User: "nobody"}), IsNil)
 	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", User: "root"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", Group: "nobody"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", Group: "nogroup"}), IsNil)
 	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", Group: "root"}), IsNil)
 	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", Mode: 0655}), IsNil)
 	c.Check(ValidateLayout(&Layout{Path: "/usr", Symlink: "$SNAP/usr"}), IsNil)


### PR DESCRIPTION
This branch adds early support for snap layouts. The generated mount profile
for any snap will now contain mount entries from layouts, even though those won't work
in practice yet, pending on features from other PRs and from apparmor policy that needs
to be discussed.

I tweaked some of the layout validation code and used the example from the London spirnt
as a small unit test. This will certainly need to grow but I'm interested in early feedback.

Forum: https://forum.snapcraft.io/t/layouts-re-mapping-snap-directories/1471
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>