### PR TITLE
dirs: fix snap mount dir on Manjaro

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -168,7 +168,7 @@ func SetRootDir(rootdir string) {
 	}
 	GlobalRootDir = rootdir
 
-	if release.DistroLike("fedora", "arch") {
+	if release.DistroLike("fedora", "arch", "manjaro") {
 		SnapMountDir = filepath.Join(rootdir, "/var/lib/snapd/snap")
 	} else {
 		SnapMountDir = filepath.Join(rootdir, defaultSnapMountDir)


### PR DESCRIPTION
Manjaro doesn't define ID_LIKE so check for it explicitly.