### PR TITLE
overlord/snapstate: record the 'kind' of conflicting change

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -6363,5 +6363,5 @@ func (s *appSuite) TestPostAppsConflict(c *check.C) {
 	rsp := postApps(appsCmd, req, nil).(*resp)
 	c.Check(rsp.Status, check.Equals, 400)
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
-	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `snap "snap-a" has changes in progress`)
+	c.Check(rsp.Result.(*errorResult).Message, check.Equals, `snap "snap-a" has "enable" change in progress`)
 }

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -284,7 +284,7 @@ func (s *servicectlSuite) TestConflictingChange(c *C) {
 
 	_, _, err := ctlcmd.Run(s.mockContext, []string{"start", "test-snap.test-service"})
 	c.Check(err, NotNil)
-	c.Check(err, ErrorMatches, `snap "test-snap" has changes in progress`)
+	c.Check(err, ErrorMatches, `snap "test-snap" has "conflicting change" change in progress`)
 }
 
 func (s *servicectlSuite) TestQueuedCommands(c *C) {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -237,7 +237,7 @@ func (s *interfaceManagerSuite) testConnectDisconnectConflicts(c *C, f func(*sta
 	chg.AddTask(t)
 
 	_, err := f(s.state, "consumer", "plug", "producer", "slot")
-	c.Assert(err, ErrorMatches, fmt.Sprintf(`snap "%s" has changes in progress`, snapName))
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`snap "%s" has "other-chg" change in progress`, snapName))
 }
 
 func (s *interfaceManagerSuite) TestConnectConflictsPugSnap(c *C) {
@@ -282,11 +282,11 @@ func (s *interfaceManagerSuite) TestConnectDoesntConflict(c *C) {
 
 	_, err = ifacestate.Connect(s.state, "consumer", "plug", "producer", "slot")
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, `snap "consumer" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "consumer" has "other-connect" change in progress`)
 
 	_, err = ifacestate.Disconnect(s.state, "consumer", "plug", "producer", "slot")
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, `snap "consumer" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "consumer" has "other-connect" change in progress`)
 }
 
 func (s *interfaceManagerSuite) TestEnsureProcessesConnectTask(c *C) {

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -712,7 +712,7 @@ func (s *snapmgrTestSuite) TestAliasUpdateChangeConflict(c *C) {
 	s.state.NewChange("alias", "...").AddAll(ts)
 
 	_, err = snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "alias" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestUpdateAliasChangeConflict(c *C) {
@@ -732,7 +732,7 @@ func (s *snapmgrTestSuite) TestUpdateAliasChangeConflict(c *C) {
 	s.state.NewChange("update", "...").AddAll(ts)
 
 	_, err = snapstate.Alias(s.state, "some-snap", "cmd1", "alias1")
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "update" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestAliasAliasConflict(c *C) {
@@ -1010,7 +1010,7 @@ func (s *snapmgrTestSuite) TestUpdateDisableAllAliasesChangeConflict(c *C) {
 	s.state.NewChange("update", "...").AddAll(ts)
 
 	_, err = snapstate.DisableAllAliases(s.state, "some-snap")
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "update" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestUpdateRemoveManualAliasChangeConflict(c *C) {
@@ -1033,7 +1033,7 @@ func (s *snapmgrTestSuite) TestUpdateRemoveManualAliasChangeConflict(c *C) {
 	s.state.NewChange("update", "...").AddAll(ts)
 
 	_, _, err = snapstate.RemoveManualAlias(s.state, "alias1")
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "update" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestDisableAllAliasesUpdateChangeConflict(c *C) {
@@ -1053,7 +1053,7 @@ func (s *snapmgrTestSuite) TestDisableAllAliasesUpdateChangeConflict(c *C) {
 	s.state.NewChange("alias", "...").AddAll(ts)
 
 	_, err = snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "alias" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestRemoveManualAliasUpdateChangeConflict(c *C) {
@@ -1076,7 +1076,7 @@ func (s *snapmgrTestSuite) TestRemoveManualAliasUpdateChangeConflict(c *C) {
 	s.state.NewChange("unalias", "...").AddAll(ts)
 
 	_, err = snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "unalias" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestPreferTasks(c *C) {
@@ -1174,7 +1174,7 @@ func (s *snapmgrTestSuite) TestUpdatePreferChangeConflict(c *C) {
 	s.state.NewChange("update", "...").AddAll(ts)
 
 	_, err = snapstate.Prefer(s.state, "some-snap")
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "update" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestPreferUpdateChangeConflict(c *C) {
@@ -1198,5 +1198,5 @@ func (s *snapmgrTestSuite) TestPreferUpdateChangeConflict(c *C) {
 	s.state.NewChange("prefer", "...").AddAll(ts)
 
 	_, err = snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "prefer" change in progress`)
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -338,10 +338,14 @@ func getPlugAndSlotRefs(task *state.Task) (*interfaces.PlugRef, *interfaces.Slot
 }
 
 type changeConflictError struct {
-	snapName string
+	snapName   string
+	changeKind string
 }
 
 func (e changeConflictError) Error() string {
+	if e.changeKind != "" {
+		return fmt.Sprintf("snap %q has %q change in progress", e.snapName, e.changeKind)
+	}
 	return fmt.Sprintf("snap %q has changes in progress", e.snapName)
 }
 
@@ -382,7 +386,7 @@ func CheckChangeConflictMany(st *state.State, snapNames []string, checkConflictP
 					} else {
 						snapName = slotRef.Snap
 					}
-					return changeConflictError{snapName}
+					return changeConflictError{snapName, chg.Kind()}
 				}
 			} else {
 				snapsup, err := TaskSnapSetup(task)
@@ -391,7 +395,7 @@ func CheckChangeConflictMany(st *state.State, snapNames []string, checkConflictP
 				}
 				snapName := snapsup.Name()
 				if (snapMap[snapName]) && (checkConflictPredicate == nil || checkConflictPredicate(task)) {
-					return changeConflictError{snapName}
+					return changeConflictError{snapName, chg.Kind()}
 				}
 			}
 		}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -968,7 +968,7 @@ func (s *snapmgrTestSuite) TestSwitchConflict(c *C) {
 	s.state.NewChange("switch-snap", "...").AddAll(ts)
 
 	_, err = snapstate.Switch(s.state, "some-snap", "other-channel")
-	c.Check(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Check(err, ErrorMatches, `snap "some-snap" has "switch-snap" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestSwitchUnhappy(c *C) {
@@ -1021,7 +1021,7 @@ func (s *snapmgrTestSuite) TestEnableConflict(c *C) {
 	s.state.NewChange("enable", "...").AddAll(ts)
 
 	_, err = snapstate.Enable(s.state, "some-snap")
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "enable" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestDisableConflict(c *C) {
@@ -1042,7 +1042,7 @@ func (s *snapmgrTestSuite) TestDisableConflict(c *C) {
 	s.state.NewChange("install", "...").AddAll(ts)
 
 	_, err = snapstate.Disable(s.state, "some-snap")
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "install" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestDoInstallChannelDefault(c *C) {
@@ -1083,7 +1083,7 @@ func (s *snapmgrTestSuite) TestInstallConflict(c *C) {
 	s.state.NewChange("install", "...").AddAll(ts)
 
 	_, err = snapstate.Install(s.state, "some-snap", "some-channel", snap.R(0), 0, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "install" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestInstallAliasConflict(c *C) {
@@ -1146,7 +1146,7 @@ func (s *snapmgrTestSuite) TestInstallPathConflict(c *C) {
 
 	mockSnap := makeTestSnap(c, "name: some-snap\nversion: 1.0")
 	_, err = snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "install" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestInstallPathMissingName(c *C) {
@@ -1447,7 +1447,7 @@ func (s *snapmgrTestSuite) TestUpdateConflict(c *C) {
 	s.state.NewChange("refresh", "...").AddAll(ts)
 
 	_, err = snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "refresh" change in progress`)
 }
 
 func (s *snapmgrTestSuite) testChangeConflict(c *C, kind string) {
@@ -1474,10 +1474,10 @@ func (s *snapmgrTestSuite) testChangeConflict(c *C, kind string) {
 	chg.AddTask(t)
 
 	_, err := snapstate.Update(s.state, "producer", "some-channel", snap.R(2), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "producer" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "producer" has "another change" change in progress`)
 
 	_, err = snapstate.Update(s.state, "consumer", "some-channel", snap.R(2), s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "consumer" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "consumer" has "another change" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestUpdateConflictWithConnect(c *C) {
@@ -1544,7 +1544,7 @@ func (s *snapmgrTestSuite) TestRemoveConflict(c *C) {
 	s.state.NewChange("remove", "...").AddAll(ts)
 
 	_, err = snapstate.Remove(s.state, "some-snap", snap.R(0))
-	c.Assert(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" has "remove" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
@@ -2536,7 +2536,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchesChannelConflict(c *C) {
 	s.state.NewChange("refresh", "refresh a snap").AddAll(ts)
 
 	_, err = snapstate.Update(s.state, "some-snap", "channel-for-7", snap.R(0), s.user.ID, snapstate.Flags{})
-	c.Check(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Check(err, ErrorMatches, `snap "some-snap" has "refresh" change in progress`)
 }
 
 func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
@@ -2663,7 +2663,7 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionToggleIgnoreValidationConflict(
 	s.state.NewChange("refresh", "refresh a snap").AddAll(ts)
 
 	_, err = snapstate.Update(s.state, "some-snap", "channel-for-7", snap.R(0), s.user.ID, snapstate.Flags{IgnoreValidation: true})
-	c.Check(err, ErrorMatches, `snap "some-snap" has changes in progress`)
+	c.Check(err, ErrorMatches, `snap "some-snap" has "refresh" change in progress`)
 
 }
 
@@ -3351,7 +3351,7 @@ func (s *snapmgrTestSuite) TestUpdateOneAutoAliasesScenarios(c *C) {
 		chg := s.state.NewChange("update", "...")
 		chg.AddAll(ts)
 		err = snapstate.CheckChangeConflict(s.state, scenario.names[0], nil, nil)
-		c.Check(err, ErrorMatches, `.* has changes in progress`)
+		c.Check(err, ErrorMatches, `.* has "update" change in progress`)
 		chg.SetStatus(state.DoneStatus)
 	}
 }
@@ -7842,7 +7842,7 @@ func (s *snapmgrTestSuite) TestConflictMany(c *C) {
 		{"a-snap", "c-snap"},
 		{"b-snap", "c-snap"},
 	} {
-		c.Check(snapstate.CheckChangeConflictMany(s.state, m, nil), ErrorMatches, `snap "[^"]*" has changes in progress`)
+		c.Check(snapstate.CheckChangeConflictMany(s.state, m, nil), ErrorMatches, `snap "[^"]*" has "enable" change in progress`)
 	}
 }
 


### PR DESCRIPTION
When checking for conflicts and finding one, record the 'kind' of conflicting change. This is somewhat related to [1] makes the returned error message slightly more user friendly. In case of `vlc` as mentioned in the bug report, the original error:

```
$ sudo snap refresh vlc
error: cannot refresh "vlc": snap "vlc" has changes in progress
```
becomes:
```
$ sudo snap refresh vlc
error: cannot refresh "vlc": snap "vlc" has "auto-refresh" change in progress
```

[1]. https://bugs.launchpad.net/snapd/+bug/1744433