### PR TITLE
arch: add "armv8l" to ubuntuArchFromKernelArch table

### DIFF
--- a/arch/arch.go
+++ b/arch/arch.go
@@ -125,6 +125,7 @@ func ubuntuArchFromKernelArch(utsMachine string) string {
 		"i686":    "i386",
 		"x86_64":  "amd64",
 		"armv7l":  "armhf",
+		"armv8l":  "arm64",
 		"aarch64": "arm64",
 		"ppc64le": "ppc64el",
 		"s390x":   "s390x",


### PR DESCRIPTION
We have a build failure currently in the armhf build. It is caused
by the unknown kernel utsname value "armv8l". By adding this to
the arch table things work again.
