### PR TITLE
daemon: avoid panic'ing building an error response w/no snaps given

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1133,7 +1133,12 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 
 	switch err {
 	case store.ErrSnapNotFound:
-		return SnapNotFound(inst.Snaps[0], err)
+		if len(inst.Snaps) > 0 {
+			return SnapNotFound(inst.Snaps[0], err)
+		}
+		// store.ErrSnapNotFound should only be returned for
+		// individual snap queries; something's wrong
+		return InternalError("store.SnapNotFound with no snap given")
 	case store.ErrNoUpdateAvailable:
 		kind = errorKindSnapNoUpdateAvailable
 	case store.ErrLocalSnap:
@@ -1159,10 +1164,10 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 			if err.Timeout() {
 				kind = errorKindNetworkTimeout
 			} else {
-				return BadRequest("cannot %s %q: %v", inst.Action, inst.Snaps[0], err)
+				return BadRequest("cannot %s %q: %v", inst.Action, inst.Snaps, err)
 			}
 		default:
-			return BadRequest("cannot %s %q: %v", inst.Action, inst.Snaps[0], err)
+			return BadRequest("cannot %s %q: %v", inst.Action, inst.Snaps, err)
 		}
 	}
 


### PR DESCRIPTION
the (snapInstruction).errToResponse code in daemon/api.go assumed that
some of the errors were only possible when the instruction would have
at least one snap, and used that as part of the response message.

As the code has grown, with no checks for this assumption, it no
longer holds; we're seeing panics due to this.

This fixes that.
