### PR TITLE
interfaces/builtin: allow introspecting UDisks2

### DIFF
--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -131,6 +131,14 @@ dbus (receive, send)
     path=/org/freedesktop/UDisks2/**
     interface=org.freedesktop.UDisks2.*
     peer=(label=###PLUG_SECURITY_TAGS###),
+
+# Allow clients to introspect the service
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/UDisks2
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=###PLUG_SECURITY_TAGS###),
 `
 
 const udisks2ConnectedPlugAppArmor = `
@@ -187,6 +195,10 @@ const udisks2PermanentSlotDBus = `
 <policy user="root">
     <allow own="org.freedesktop.UDisks2"/>
     <allow send_destination="org.freedesktop.UDisks2"/>
+</policy>
+
+<policy context="default">
+    <allow send_destination="org.freedesktop.UDisks2" send_interface="org.freedesktop.DBus.Introspectable" />
 </policy>
 `
 

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -163,6 +163,7 @@ func (s *UDisks2InterfaceSuite) TestDBusSpec(c *C) {
 	c.Assert(spec.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.producer.app"})
 	c.Assert(spec.SnippetForTag("snap.producer.app"), testutil.Contains, `<policy user="root">`)
+	c.Assert(spec.SnippetForTag("snap.producer.app"), testutil.Contains, `send_interface="org.freedesktop.DBus.Introspectable"`)
 }
 
 func (s *UDisks2InterfaceSuite) TestUDevSpec(c *C) {


### PR DESCRIPTION
Allow clients to introspect the service. This is required for some of the
clients that use introspection to build service proxy dynamically at runtime.

https://bugs.launchpad.net/snappy/+bug/1683368

