### PR TITLE
cmd/snap: improve `snap aliases` output when no aliases are defined

### DIFF
--- a/cmd/snap/cmd_aliases.go
+++ b/cmd/snap/cmd_aliases.go
@@ -90,28 +90,34 @@ func (x *cmdAliases) Execute(args []string) error {
 	}
 
 	allStatuses, err := Client().Aliases()
-	if err == nil {
+	if err != nil {
+		return err
+	}
+
+	var infos aliasInfos
+	filterSnap := string(x.Positionals.Snap)
+	if filterSnap != "" {
+		allStatuses = map[string]map[string]client.AliasStatus{
+			filterSnap: allStatuses[filterSnap],
+		}
+	}
+	for snapName, aliasStatuses := range allStatuses {
+		for alias, aliasStatus := range aliasStatuses {
+			infos = append(infos, &aliasInfo{
+				Snap:    snapName,
+				Command: aliasStatus.Command,
+				Alias:   alias,
+				Status:  aliasStatus.Status,
+				Auto:    aliasStatus.Auto,
+			})
+		}
+	}
+
+	if len(infos) > 0 {
 		w := tabWriter()
 		fmt.Fprintln(w, i18n.G("Command\tAlias\tNotes"))
 		defer w.Flush()
-		var infos aliasInfos
-		filterSnap := string(x.Positionals.Snap)
-		if filterSnap != "" {
-			allStatuses = map[string]map[string]client.AliasStatus{
-				filterSnap: allStatuses[filterSnap],
-			}
-		}
-		for snapName, aliasStatuses := range allStatuses {
-			for alias, aliasStatus := range aliasStatuses {
-				infos = append(infos, &aliasInfo{
-					Snap:    snapName,
-					Command: aliasStatus.Command,
-					Alias:   alias,
-					Status:  aliasStatus.Status,
-					Auto:    aliasStatus.Auto,
-				})
-			}
-		}
+
 		sort.Sort(infos)
 
 		for _, info := range infos {
@@ -128,6 +134,13 @@ func (x *cmdAliases) Execute(args []string) error {
 			}
 			fmt.Fprintf(w, "%s\t%s\t%s\n", info.Command, info.Alias, notesStr)
 		}
+	} else {
+		if filterSnap != "" {
+			fmt.Fprintf(Stderr, i18n.G("No aliases are currently defined for snap %q.\n"), filterSnap)
+		} else {
+			fmt.Fprintln(Stderr, i18n.G("No aliases are currently defined."))
+		}
+		fmt.Fprintln(Stderr, i18n.G("\nUse snap alias --help to learn how to create aliases manually."))
 	}
-	return err
+	return nil
 }


### PR DESCRIPTION
Improve the output of `snap aliases` command when there are no aliases at all,
or no aliases for given snap.

https://bugs.launchpad.net/snappy/+bug/1673757

Output when there are no aliases:
```

$ snap aliases                                     
No aliases are currently defined.

Use snap alias --help to learn how to create aliases manually.
```
Output when there are no aliases for snap `foo`:
```
$ snap aliases foo
No aliases are currently defined for snap "foo".

Use snap alias --help to learn how to create aliases manually.
```