### PR TITLE
tests/lib/snaps/test-snapd-service: refactor service reload

### DIFF
--- a/tests/lib/snaps/test-snapd-service/bin/reload
+++ b/tests/lib/snaps/test-snapd-service/bin/reload
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-echo "reloading reloading reloading"
+if [ -z "$MAINPID" ]; then
+    echo "error: MAINPID is not set"
+    exit 1
+fi
+echo "reloading main PID: $MAINPID"
+kill -HUP $MAINPID

--- a/tests/lib/snaps/test-snapd-service/bin/start
+++ b/tests/lib/snaps/test-snapd-service/bin/start
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+trap "echo reloading reloading reloading" HUP
+
 snapctl get service-option > "$SNAP_DATA/service-option"
 while true; do
     echo "running"


### PR DESCRIPTION
linode:ubuntu-14.04-64:tests/main/snap-service is mysteriously failing. Upon
further investigation, the journal did not contain any logs from the reload
command, however the status command did show that reload was executed
successfuly.

Since the tests/main/snap-service relies on observing 'reloading reloading
reloading' message in the logs, move the logging into the main service.
