### PR TITLE
cmd/snap: display snap license information

### DIFF
--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -226,7 +226,8 @@ const findPricedJSON = `
       "status": "priced",
       "summary": "GNU Hello, the \"hello world\" snap",
       "type": "app",
-      "version": "2.10"
+      "version": "2.10",
+      "license": "Proprietary"
     }
   ],
   "sources": [

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -317,9 +317,11 @@ func (x *infoCmd) Execute([]string) error {
 		if both.Contact != "" {
 			fmt.Fprintf(w, "contact:\t%s\n", strings.TrimPrefix(both.Contact, "mailto:"))
 		}
-		if both.License != "" {
-			fmt.Fprintf(w, "license:\t%s\n", both.License)
+		license := both.License
+		if license == "" {
+			license = "unknown"
 		}
+		fmt.Fprintf(w, "license:\t%s\n", license)
 		maybePrintPrice(w, remote, resInfo)
 		// FIXME: find out for real
 		termWidth := 77

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -317,11 +317,9 @@ func (x *infoCmd) Execute([]string) error {
 		if both.Contact != "" {
 			fmt.Fprintf(w, "contact:\t%s\n", strings.TrimPrefix(both.Contact, "mailto:"))
 		}
-		license := both.License
-		if license == "" {
-			license = "(undefined)"
+		if both.License != "" {
+			fmt.Fprintf(w, "license:\t%s\n", both.License)
 		}
-		fmt.Fprintf(w, "license:\t%s\n", license)
 		maybePrintPrice(w, remote, resInfo)
 		// FIXME: find out for real
 		termWidth := 77

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -319,7 +319,7 @@ func (x *infoCmd) Execute([]string) error {
 		}
 		license := both.License
 		if license == "" {
-			license = "- (undefined)"
+			license = "(undefined)"
 		}
 		fmt.Fprintf(w, "license:\t%s\n", license)
 		maybePrintPrice(w, remote, resInfo)

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -317,6 +317,11 @@ func (x *infoCmd) Execute([]string) error {
 		if both.Contact != "" {
 			fmt.Fprintf(w, "contact:\t%s\n", strings.TrimPrefix(both.Contact, "mailto:"))
 		}
+		license := both.License
+		if license == "" {
+			license = "- (undefined)"
+		}
+		fmt.Fprintf(w, "license:\t%s\n", license)
 		maybePrintPrice(w, remote, resInfo)
 		// FIXME: find out for real
 		termWidth := 77

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -188,3 +188,126 @@ snap-id: mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
+
+const mockInfoJSONOtherLicense = `
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+      "channel": "stable",
+      "confinement": "strict",
+      "description": "GNU hello prints a friendly greeting. This is part of the snapcraft tour at https://snapcraft.io/",
+      "developer": "canonical",
+      "id": "mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6",
+      "name": "hello",
+      "private": false,
+      "resource": "/v2/snaps/hello",
+      "revision": "1",
+      "status": "available",
+      "summary": "The GNU Hello snap",
+      "type": "app",
+      "version": "2.10",
+      "license": "BSD-3",
+      "tracking-channel": "beta",
+      "installed-size": 1024
+    }
+}
+`
+const mockInfoJSONNoLicense = `
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": {
+      "channel": "stable",
+      "confinement": "strict",
+      "description": "GNU hello prints a friendly greeting. This is part of the snapcraft tour at https://snapcraft.io/",
+      "developer": "canonical",
+      "id": "mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6",
+      "name": "hello",
+      "private": false,
+      "resource": "/v2/snaps/hello",
+      "revision": "1",
+      "status": "available",
+      "summary": "The GNU Hello snap",
+      "type": "app",
+      "version": "2.10",
+      "license": "",
+      "tracking-channel": "beta",
+      "installed-size": 1024
+    }
+}
+`
+
+func (s *SnapSuite) TestInfoWithLocalDifferentLicense(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/find")
+			fmt.Fprintln(w, mockInfoJSON)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
+			fmt.Fprintln(w, mockInfoJSONOtherLicense)
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d (%v)", n+1, r)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser().ParseArgs([]string{"info", "hello"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, `name:      hello
+summary:   The GNU Hello snap
+publisher: canonical
+license:   BSD-3
+description: |
+  GNU hello prints a friendly greeting. This is part of the snapcraft tour at
+  https://snapcraft.io/
+snap-id:   mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
+tracking:  beta
+installed: 2.10 (1) 1kB disabled
+refreshed: 0001-01-01 00:00:00 +0000 UTC
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestInfoWithLocalNoLicense(c *check.C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch n {
+		case 0:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/find")
+			fmt.Fprintln(w, mockInfoJSON)
+		case 1:
+			c.Check(r.Method, check.Equals, "GET")
+			c.Check(r.URL.Path, check.Equals, "/v2/snaps/hello")
+			fmt.Fprintln(w, mockInfoJSONNoLicense)
+		default:
+			c.Fatalf("expected to get 1 requests, now on %d (%v)", n+1, r)
+		}
+
+		n++
+	})
+	rest, err := snap.Parser().ParseArgs([]string{"info", "hello"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.DeepEquals, []string{})
+	c.Check(s.Stdout(), check.Equals, `name:      hello
+summary:   The GNU Hello snap
+publisher: canonical
+license:   unknown
+description: |
+  GNU hello prints a friendly greeting. This is part of the snapcraft tour at
+  https://snapcraft.io/
+snap-id:   mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
+tracking:  beta
+installed: 2.10 (1) 1kB disabled
+refreshed: 0001-01-01 00:00:00 +0000 UTC
+`)
+	c.Check(s.Stderr(), check.Equals, "")
+}

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -114,6 +114,7 @@ func (s *SnapSuite) TestInfoPriced(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   GNU Hello, the "hello world" snap
 publisher: canonical
+license:   Proprietary
 price:     1.99GBP
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
@@ -144,7 +145,8 @@ const mockInfoJSON = `
       "status": "available",
       "summary": "The GNU Hello snap",
       "type": "app",
-      "version": "2.10"
+      "version": "2.10",
+      "license": "MIT"
     }
   ],
   "sources": [
@@ -178,6 +180,7 @@ func (s *SnapSuite) TestInfoUnquoted(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `name:      hello
 summary:   The GNU Hello snap
 publisher: canonical
+license:   MIT
 description: |
   GNU hello prints a friendly greeting. This is part of the snapcraft tour at
   https://snapcraft.io/

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -87,6 +87,7 @@ check("test-snapd-tools", res[2],
     ("edge", matches, verRevNotesRx("-")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-tools"]),
+   ("license", equals, "unknown"), # TODO: update once snap.yaml contains the right license
 )
 
 check("test-snapd-devmode", res[3],
@@ -105,6 +106,7 @@ check("test-snapd-devmode", res[3],
     ("edge", matches, verRevNotesRx("devmode")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-devmode"]),
+   ("license", equals, "unknown"), # TODO: update once snap.yaml contains the right license
 )
 
 check("core", res[4],
@@ -121,6 +123,7 @@ check("core", res[4],
       # sideload "core"
       ("contact", maybe),
       ("snap-id", maybe),
+      ("license", equals, "unknown"), # TODO: update once snap.yaml contains the right license
 )
 
 check("error", res[5],

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -87,7 +87,6 @@ check("test-snapd-tools", res[2],
     ("edge", matches, verRevNotesRx("-")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-tools"]),
-   ("license", equals, "(undefined)"), # TODO: update once snap licenses are stored locall
 )
 
 check("test-snapd-devmode", res[3],
@@ -106,7 +105,6 @@ check("test-snapd-devmode", res[3],
     ("edge", matches, verRevNotesRx("devmode")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-devmode"]),
-   ("license", equals, "(undefined)"), # TODO: update once snap licenses are stored locall
 )
 
 check("core", res[4],
@@ -123,7 +121,6 @@ check("core", res[4],
       # sideload "core"
       ("contact", maybe),
       ("snap-id", maybe),
-      ("license", equals, "(undefined)"), # TODO: update once snap licenses are stored locall
 )
 
 check("error", res[5],

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -87,6 +87,7 @@ check("test-snapd-tools", res[2],
     ("edge", matches, verRevNotesRx("-")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-tools"]),
+   ("license", equals, "(undefined)"), # TODO: update once snap licenses are stored locall
 )
 
 check("test-snapd-devmode", res[3],
@@ -105,6 +106,7 @@ check("test-snapd-devmode", res[3],
     ("edge", matches, verRevNotesRx("devmode")),
    ),
    ("snap-id", equals, snap_ids["test-snapd-devmode"]),
+   ("license", equals, "(undefined)"), # TODO: update once snap licenses are stored locall
 )
 
 check("core", res[4],
@@ -121,6 +123,7 @@ check("core", res[4],
       # sideload "core"
       ("contact", maybe),
       ("snap-id", maybe),
+      ("license", equals, "(undefined)"), # TODO: update once snap licenses are stored locall
 )
 
 check("error", res[5],
@@ -136,5 +139,5 @@ check("test-snapd-python-webserver", res[6],
    ("description", exists),
    ("channels", exists),
    ("snap-id", equals, snap_ids["test-snapd-python-webserver"]),
-
+   ("license", equals, "Other Open Source"),
 )


### PR DESCRIPTION
I'd appreciate comments on what to display when license information is unavailable.
