### PR TITLE
errtracker: include detected virtualisation

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -127,6 +128,15 @@ func ReportRepair(repair, errMsg, dupSig string, extra map[string]string) (strin
 	return report(errMsg, dupSig, extra)
 }
 
+func detectVirt() string {
+	cmd := exec.Command("systemd-detect-virt")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
 func report(errMsg, dupSig string, extra map[string]string) (string, error) {
 	if CrashDbURLBase == "" {
 		return "", nil
@@ -160,6 +170,7 @@ func report(errMsg, dupSig string, extra map[string]string) (string, error) {
 	if coreBuildID == "" {
 		coreBuildID = "unknown"
 	}
+	detectedVirt := detectVirt()
 
 	report := map[string]string{
 		"Architecture":       arch.UbuntuArchitecture(),
@@ -180,6 +191,7 @@ func report(errMsg, dupSig string, extra map[string]string) (string, error) {
 			report[k] = v
 		}
 	}
+	report["DetectedVirt"] = detectedVirt
 
 	// include md5 hashes of the apparmor conffile for easier debbuging
 	// of not-updated snap-confine apparmor profiles

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -76,6 +76,8 @@ func (s *ErrtrackerTestSuite) SetUpTest(c *C) {
 	s.AddCleanup(errtracker.MockReExec(func() string {
 		return "yes"
 	}))
+	mockDetectVirt := testutil.MockCommand(c, "systemd-detect-virt", "echo none")
+	s.AddCleanup(mockDetectVirt.Restore)
 
 	s.hostBuildID, err = osutil.ReadBuildID(truePath)
 	c.Assert(err, IsNil)
@@ -133,9 +135,10 @@ func (s *ErrtrackerTestSuite) TestReport(c *C) {
 				"Architecture":       arch.UbuntuArchitecture(),
 				"DidSnapdReExec":     "yes",
 
-				"ProblemType": "Snap",
-				"Snap":        "some-snap",
-				"Channel":     "beta",
+				"ProblemType":  "Snap",
+				"Snap":         "some-snap",
+				"Channel":      "beta",
+				"DetectedVirt": "none",
 
 				"MD5SumSnapConfineAppArmorProfile":            "7a7aa5f21063170c1991b84eb8d86de1",
 				"MD5SumSnapConfineAppArmorProfileDpkgNew":     "93b885adfe0da089cdf634904fd59f71",
@@ -264,6 +267,7 @@ func (s *ErrtrackerTestSuite) TestReportRepair(c *C) {
 				"ErrorMessage":       "failure in script",
 				"DuplicateSignature": "[dupSig]",
 				"BrandID":            "canonical",
+				"DetectedVirt":       "none",
 			})
 			fmt.Fprintf(w, "c14388aa-f78d-11e6-8df0-fa163eaf9b83 OOPSID")
 		default:


### PR DESCRIPTION
This will help understand some errors (notably the `hook:core:configure:exit status 1\ncannot create lock directory /run/snapd/lock: Permission denied` better.