### PR TITLE
interfaces: miscellaneous policy updates

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -308,6 +308,7 @@ var defaultTemplate = `
   @{PROC}/sys/kernel/yama/ptrace_scope r,
   @{PROC}/sys/kernel/shmmax r,
   @{PROC}/sys/fs/file-max r,
+  @{PROC}/sys/fs/inotify/max_* r,
   @{PROC}/sys/kernel/pid_max r,
   @{PROC}/sys/kernel/random/uuid r,
   @{PROC}/sys/kernel/random/boot_id r,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -125,6 +125,7 @@ var defaultTemplate = `
   /{,usr/}bin/diff{,3} ixr,
   /{,usr/}bin/dir ixr,
   /{,usr/}bin/dirname ixr,
+  /{,usr/}bin/du ixr,
   /{,usr/}bin/echo ixr,
   /{,usr/}bin/{,e,f,r}grep ixr,
   /{,usr/}bin/env ixr,

--- a/interfaces/builtin/bluetooth_control.go
+++ b/interfaces/builtin/bluetooth_control.go
@@ -42,6 +42,8 @@ const bluetoothControlConnectedPlugAppArmor = `
   # File accesses
   /sys/bus/usb/drivers/btusb/     r,
   /sys/bus/usb/drivers/btusb/**   r,
+  /sys/module/btusb/              r,
+  /sys/module/btusb/**            r,
   /sys/class/bluetooth/           r,
   /sys/devices/**/bluetooth/      rw,
   /sys/devices/**/bluetooth/**    rw,

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -157,6 +157,13 @@ dbus (receive)
     interface="org.{freedesktop,gnome}.ScreenSaver"
     member=ActiveChanged
     peer=(label=unconfined),
+
+# Allow unconfined to introspect us
+dbus (receive)
+    bus=session
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
 `
 
 type desktopInterface struct{}

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -98,7 +98,7 @@ dbus (send)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
-    member="{GetCapabilities,GetServerInformation,Notify}"
+    member="{GetCapabilities,GetServerInformation,Notify,CloseNotification}"
     peer=(label=unconfined),
 
 dbus (receive)

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -45,6 +45,14 @@ const desktopConnectedPlugAppArmor = `
 #include <abstractions/dbus-strict>
 #include <abstractions/dbus-session-strict>
 
+# Allow finding the DBus session bus id (eg, via dbus_bus_get_id())
+dbus (send)
+     bus=session
+     path=/org/freedesktop/DBus
+     interface=org.freedesktop.DBus
+     member=GetId
+     peer=(name=org.freedesktop.DBus, label=unconfined),
+
 #include <abstractions/fonts>
 owner @{HOME}/.local/share/fonts/{,**} r,
 /var/cache/fontconfig/   r,

--- a/interfaces/builtin/network_observe.go
+++ b/interfaces/builtin/network_observe.go
@@ -35,9 +35,9 @@ const networkObserveConnectedPlugAppArmor = `
 # it gives privileged read-only access to networking information and should
 # only be used with trusted apps.
 
-# network-monitor can't allow this otherwise we are basically
-# network-management, but don't explicitly deny since someone might try to use
-# network-management with network-monitor and that shouldn't fail weirdly
+# network-observe can't allow this otherwise we are basically network-control,
+# but don't explicitly deny since someone might try to use network-control with
+# network-observe and that shouldn't fail weirdly
 #capability net_admin,
 
 #include <abstractions/nameservice>

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -61,7 +61,7 @@ dbus (send)
     bus=session
     path=/Screensaver
     interface=org.freedesktop.ScreenSaver
-    member=org.freedesktop.ScreenSaver.{Inhibit,UnInhibit,SimulateUserActivity}
+    member={Inhibit,UnInhibit,SimulateUserActivity}
     peer=(label=unconfined),
 
 # API rule
@@ -69,7 +69,7 @@ dbus (send)
     bus=session
     path=/{,org/freedesktop/,org.gnome/}ScreenSaver
     interface=org.freedesktop.ScreenSaver
-    member=org.freedesktop.ScreenSaver.{Inhibit,UnInhibit,SimulateUserActivity}
+    member={Inhibit,UnInhibit,SimulateUserActivity}
     peer=(label=unconfined),
 
 # gnome, kde and cinnamon screensaver

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -429,7 +429,7 @@ dbus (send)
     bus=session
     path=/org/freedesktop/Notifications
     interface=org.freedesktop.Notifications
-    member="{GetCapabilities,GetServerInformation,Notify}"
+    member="{GetCapabilities,GetServerInformation,Notify,CloseNotification}"
     peer=(label=unconfined),
 
 dbus (receive)

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -44,6 +44,15 @@ const unity7ConnectedPlugAppArmor = `
 
 #include <abstractions/dbus-strict>
 #include <abstractions/dbus-session-strict>
+
+# Allow finding the DBus session bus id (eg, via dbus_bus_get_id())
+dbus (send)
+     bus=session
+     path=/org/freedesktop/DBus
+     interface=org.freedesktop.DBus
+     member=GetId
+     peer=(name=org.freedesktop.DBus, label=unconfined),
+
 #include <abstractions/X>
 
 #include <abstractions/fonts>

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -581,6 +581,13 @@ dbus (send)
   path=/com/canonical/Unity/Session
   member="{ActivateScreenSaver,IsLocked,Lock}"
   peer=(label=unconfined),
+
+# Allow unconfined to introspect us
+dbus (receive)
+    bus=session
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
 `
 
 const unity7ConnectedPlugSeccomp = `


### PR DESCRIPTION
- interfaces/screen-inhibit-control: use the correct member name with AppArmor
- interfaces/bluetooth-control: allow read on /sys/module/btusb/** (LP: #1698412)
- interfaces/default: allow read of inotify max values
  Normal ACLs (DAC, MAC) control what a snap can use inotify on so no special
  permissions are needed beyond AppArmor policy. Some applications want to know
  the limits set by the kernel. Allow these by default.
- interfaces/network-observe: update comment for modern interface names
- interfaces/desktop,unity7: Allow finding the DBus session bus id
- interfaces/desktop,unity7: allow unconfined to introspect us
- interfaces/desktop,unity7: allow org.freedesktop.Notifications.CloseNotification
