### PR TITLE
tests/main/kernel-snap-refresh-on-core: do not fail if edge and stable kernels are the same version

### DIFF
--- a/tests/main/kernel-snap-refresh-on-core/task.yaml
+++ b/tests/main/kernel-snap-refresh-on-core/task.yaml
@@ -55,7 +55,12 @@ execute: |
         snap list | awk "/^pc-kernel / {print(\$3)}" > nextBoot
 
         test "$(bootenv snap_kernel)" = "pc-kernel_$(cat prevBoot).snap"
-        test "$(bootenv snap_try_kernel)" = "pc-kernel_$(cat nextBoot).snap"
+
+        if [ "$(cat prevBoot)" = "$(cat nextBoot)" ]; then
+            echo "WARNING: kernel in edge / stable are the same"
+        else
+            test "$(bootenv snap_try_kernel)" = "pc-kernel_$(cat nextBoot).snap"
+        fi
 
         # test-snapd-tools works
         test-snapd-tools.echo hello | MATCH hello


### PR DESCRIPTION
Do not fail the test when stable and edge kernels are the same version. However,
after refreshing from stable, proceed with reboot just in case the refresh broke
something.

