### PR TITLE
spread: Ubuntu 17.04 is EOL, remove it

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -112,9 +112,6 @@ backends:
             - ubuntu-16.10-64:
                 username: ubuntu
                 password: ubuntu
-            - ubuntu-17.04-64:
-                username: ubuntu
-                password: ubuntu
             - ubuntu-17.10-64:
                 username: ubuntu
                 password: ubuntu
@@ -191,22 +188,6 @@ backends:
             - ubuntu-16.10-s390x:
                 username: ubuntu
                 password: ubuntu
-            # Zesty
-            - ubuntu-17.04-amd64:
-                username: ubuntu
-                password: ubuntu
-            - ubuntu-17.04-i386:
-                username: ubuntu
-                password: ubuntu
-            - ubuntu-17.04-ppc64el:
-                username: ubuntu
-                password: ubuntu
-            - ubuntu-17.04-armhf:
-                username: ubuntu
-                password: ubuntu
-            - ubuntu-17.04-s390x:
-                username: ubuntu
-                password: ubuntu
             # Artful
             - ubuntu-17.10-amd64:
                 username: ubuntu
@@ -273,9 +254,6 @@ backends:
                 kernel: GRUB 2
                 workers: 2
             - ubuntu-16.10-64:
-                kernel: GRUB 2
-                workers: 2
-            - ubuntu-17.04-64:
                 kernel: GRUB 2
                 workers: 2
             - ubuntu-17.10-64:

--- a/spread.yaml
+++ b/spread.yaml
@@ -109,9 +109,6 @@ backends:
                 image: ubuntu-16.04-64
                 username: ubuntu
                 password: ubuntu
-            - ubuntu-16.10-64:
-                username: ubuntu
-                password: ubuntu
             - ubuntu-17.10-64:
                 username: ubuntu
                 password: ubuntu
@@ -170,22 +167,6 @@ backends:
                 username: ubuntu
                 password: ubuntu
             - ubuntu-16.04-s390x:
-                username: ubuntu
-                password: ubuntu
-            # Yakkety
-            - ubuntu-16.10-amd64:
-                username: ubuntu
-                password: ubuntu
-            - ubuntu-16.10-i386:
-                username: ubuntu
-                password: ubuntu
-            - ubuntu-16.10-ppc64el:
-                username: ubuntu
-                password: ubuntu
-            - ubuntu-16.10-armhf:
-                username: ubuntu
-                password: ubuntu
-            - ubuntu-16.10-s390x:
                 username: ubuntu
                 password: ubuntu
             # Artful
@@ -251,9 +232,6 @@ backends:
                 kernel: GRUB 2
                 workers: 2
             - ubuntu-16.04-64:
-                kernel: GRUB 2
-                workers: 2
-            - ubuntu-16.10-64:
                 kernel: GRUB 2
                 workers: 2
             - ubuntu-17.10-64:


### PR DESCRIPTION
Ubuntu Zesty has reached end-of-life now and doesn't need to be tested anymore.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
