### PR TITLE
tests: set test kernel-snap-refresh-on-core to manual

### DIFF
--- a/tests/main/kernel-snap-refresh-on-core/task.yaml
+++ b/tests/main/kernel-snap-refresh-on-core/task.yaml
@@ -7,7 +7,7 @@ details: |
     revision to a new one. It expects to find a new snap revision in the
     channel pointed by the NEW_CORE_CHANNEL env var.
 
-#manual: true
+manual: true
 
 environment:
     KERNEL_CHANNEL: stable


### PR DESCRIPTION
This test will run in the spread-cron nightly suite, adding @sergiocazzolato as reviewer to ensure he can add it :)