### PR TITLE
snap: tidy up top-level help output

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -46,7 +46,7 @@ type infoCmd struct {
 	} `positional-args:"yes" required:"yes"`
 }
 
-var shortInfoHelp = i18n.G("show detailed information about a snap")
+var shortInfoHelp = i18n.G("Show detailed information about a snap")
 var longInfoHelp = i18n.G(`
 The info command shows detailed information about a snap, be it by name or by path.`)
 

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -35,7 +35,7 @@ type packCmd struct {
 	} `positional-args:"yes"`
 }
 
-var shortPackHelp = i18n.G("pack the given target dir as a snap")
+var shortPackHelp = i18n.G("Pack the given target dir as a snap")
 var longPackHelp = i18n.G(`
 The pack command packs the given snap-dir as a snap.`)
 

--- a/cmd/snap/cmd_whoami.go
+++ b/cmd/snap/cmd_whoami.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-var shortWhoAmIHelp = i18n.G("Prints the email the user is logged in with.")
+var shortWhoAmIHelp = i18n.G("Prints the email the user is logged in with")
 var longWhoAmIHelp = i18n.G(`
 The whoami command prints the email the user is logged in with.
 `)


### PR DESCRIPTION
Nearly all the entries in the list of available commands have a short
description in sentence case and with no trailing full stop, but there
were a few exceptions.  Make them all consistent.