### PR TITLE
snap: fix race in `snap run --strace`

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -461,7 +461,7 @@ func straceCmd() ([]string, error) {
 		stracePath,
 		"-u", current.Username,
 		"-f",
-		"-e", "!select,pselect6,_newselect,clock_gettime",
+		"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid",
 	}, nil
 }
 
@@ -533,8 +533,8 @@ func runCmdUnderStrace(origCmd, env []string) error {
 	if err := gcmd.Start(); err != nil {
 		return err
 	}
-	err = gcmd.Wait()
 	<-filterDone
+	err = gcmd.Wait()
 	return err
 }
 

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -482,8 +482,10 @@ func runCmdUnderStrace(origCmd, env []string) error {
 	if err != nil {
 		return err
 	}
-	filterDone := make(chan int)
+	filterDone := make(chan bool, 1)
 	go func() {
+		defer func() { filterDone <- true }()
+
 		r := bufio.NewReader(stderr)
 
 		// the first thing from strace if things work is
@@ -528,7 +530,6 @@ func runCmdUnderStrace(origCmd, env []string) error {
 			}
 		}
 		io.Copy(Stderr, r)
-		filterDone <- 1
 	}()
 	if err := gcmd.Start(); err != nil {
 		return err

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -689,7 +689,7 @@ echo "stdout output 2"
 			filepath.Join(straceCmd.BinDir(), "strace"),
 			"-u", user.Username,
 			"-f",
-			"-e", "!select,pselect6,_newselect,clock_gettime",
+			"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid",
 			filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 			"snap.snapname.app",
 			filepath.Join(dirs.CoreLibExecDir, "snap-exec"),


### PR DESCRIPTION
This fixes a race when gcmd.Wait() cleans the process up before
the filter go routine finished reading the output of gcmd.

While testing I blacklisted two more syscalls that seem to have
caused my strace to hang sometimes.
