### PR TITLE
testutil: do not use echo for printing potentially conflicting arguments

### DIFF
--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -40,7 +40,7 @@ type MockCmd struct {
 var scriptTpl = `#!/bin/sh
 echo "$(basename "$0")" >> %[1]q
 for arg in "$@"; do
-    echo "$arg" >> %[1]q
+    printf "%%s\n" "$arg" >> %[1]q
 done
 echo >> %[1]q
 %s

--- a/testutil/exec_test.go
+++ b/testutil/exec_test.go
@@ -52,3 +52,13 @@ func (s *mockCommandSuite) TestMockCommandAlso(c *C) {
 	c.Check(mock.Calls(), DeepEquals, [][]string{{"fst"}, {"snd"}})
 	c.Check(mock.Calls(), DeepEquals, also.Calls())
 }
+
+func (s *mockCommandSuite) TestMockCommandConflictEcho(c *C) {
+	mock := MockCommand(c, "do-not-swallow-echo-args", "")
+	defer mock.Restore()
+
+	c.Assert(exec.Command("do-not-swallow-echo-args", "-E", "-n", "-e").Run(), IsNil)
+	c.Assert(mock.Calls(), DeepEquals, [][]string{
+		{"do-not-swallow-echo-args", "-E", "-n", "-e"},
+	})
+}


### PR DESCRIPTION
This comes as a result of investigating a failure of
SnapSuite.TestSnapRunAppWithStraceIntegration on Arch [1]. In this particular case,
/bin/sh is symlinked to bash, thus `echo` is actually a [/usr]/bin/echo coming
from coreutils.

strace command in the test is called like this (sans the newlines and \):
  sudo -E <strace-path> -u maciek -f \
       -e !select,pselect6,_newselect,clock_gettime \
       <snap-confine-path> \
       snap.snapname.app \
       /usr/lib/snapd/snap-exec \
       snapname.app --arg1 arg2

Then the piece of shell script is expected to save each argument in a separate
line, with the script:

 for arg in "$@"; do
    echo "$arg" >> %[1]q
 done

the arguments -E and -e will be called like this:

  echo "-E"  <-- actually /usr/bin/echo "-E"
  echo "-e"

According to echo(1) both -e and -E are valid arguments and will be 'swallowed'
by the command, thus never appearing in the output.

Fix this by using a printf which does not have this problem.

[1]. https://paste.ubuntu.com/26463740/