### PR TITLE
strutil/quantity: new package that exports formatFoo (from progress)

### DIFF
--- a/progress/ansimeter.go
+++ b/progress/ansimeter.go
@@ -27,6 +27,8 @@ import (
 	"unicode"
 
 	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/snapcore/snapd/strutil/quantity"
 )
 
 var stdout io.Writer = os.Stdout
@@ -132,11 +134,11 @@ func (p *ANSIMeter) Set(current float64) {
 		since := time.Now().UTC().Sub(p.t0).Seconds()
 		per := since / p.written
 		left := (p.total - p.written) * per
-		timeleft = " " + formatDuration(left)
+		timeleft = " " + quantity.FormatDuration(left)
 		if col > 20 {
 			percent = " " + p.percent()
 			if col > 29 {
-				speed = " " + formatBPS(p.written, since, -1)
+				speed = " " + quantity.FormatBPS(p.written, since, -1)
 			}
 		}
 	}

--- a/progress/export_test.go
+++ b/progress/export_test.go
@@ -23,10 +23,6 @@ import (
 	"io"
 )
 
-var FormatAmount = formatAmount
-var FormatBPS = formatBPS
-var FormatDuration = formatDuration
-
 var (
 	ClrEOL            = clrEOL
 	CursorInvisible   = cursorInvisible

--- a/strutil/quantity/example_test.go
+++ b/strutil/quantity/example_test.go
@@ -17,18 +17,18 @@
  *
  */
 
-package progress_test
+package quantity_test
 
 import (
 	"fmt"
 	"math"
 	"time"
 
-	"github.com/snapcore/snapd/progress"
+	"github.com/snapcore/snapd/strutil/quantity"
 )
 
 func ExampleFormatAmount_short() {
-	fmt.Printf("%q\n", progress.FormatAmount(12345, -1))
+	fmt.Printf("%q\n", quantity.FormatAmount(12345, -1))
 	// Output: "12.3k"
 }
 
@@ -42,9 +42,9 @@ func ExampleFormatAmount_long() {
 	} {
 		fmt.Printf("- %5d: 3: %q  5: %q  7: %q\n",
 			amount,
-			progress.FormatAmount(amount, 3),
-			progress.FormatAmount(amount, -1),
-			progress.FormatAmount(amount, 7),
+			quantity.FormatAmount(amount, 3),
+			quantity.FormatAmount(amount, -1),
+			quantity.FormatAmount(amount, 7),
 		)
 	}
 	// Output:
@@ -60,7 +60,7 @@ func ExampleFormatAmount_long() {
 }
 
 func ExampleFormatBPS() {
-	fmt.Printf("%q\n", progress.FormatBPS(12345, (10*time.Millisecond).Seconds(), -1))
+	fmt.Printf("%q\n", quantity.FormatBPS(12345, (10*time.Millisecond).Seconds(), -1))
 	// Output: "1.23MB/s"
 }
 
@@ -84,10 +84,10 @@ func ExampleFormatDuration() {
 		math.MaxInt64 / 10,
 		math.MaxInt64,
 	} {
-		fmt.Printf("%q\n", progress.FormatDuration(dt.Seconds()))
+		fmt.Printf("%q\n", quantity.FormatDuration(dt.Seconds()))
 	}
-	fmt.Printf("%q\n", progress.FormatDuration(float64(math.MaxUint64)*365*24*60*60))
-	fmt.Printf("%q\n", progress.FormatDuration(math.MaxFloat64))
+	fmt.Printf("%q\n", quantity.FormatDuration(float64(math.MaxUint64)*365*24*60*60))
+	fmt.Printf("%q\n", quantity.FormatDuration(math.MaxFloat64))
 
 	// Output:
 	// "3.0ns"

--- a/strutil/quantity/quantity.go
+++ b/strutil/quantity/quantity.go
@@ -17,7 +17,7 @@
  *
  */
 
-package progress
+package quantity
 
 import (
 	"fmt"
@@ -28,7 +28,7 @@ import (
 
 // these are taken from github.com/chipaca/quantity with permission :-)
 
-func formatAmount(amount uint64, width int) string {
+func FormatAmount(amount uint64, width int) string {
 	if width < 0 {
 		width = 5
 	}
@@ -81,11 +81,11 @@ func formatAmount(amount uint64, width int) string {
 	return s
 }
 
-func formatBPS(n, sec float64, width int) string {
+func FormatBPS(n, sec float64, width int) string {
 	if sec < 0 {
 		sec = -sec
 	}
-	return formatAmount(uint64(n/sec), width-2) + "B/s"
+	return FormatAmount(uint64(n/sec), width-2) + "B/s"
 }
 
 const (
@@ -112,7 +112,7 @@ var (
 )
 
 // dt is seconds (as in the output of time.Now().Seconds())
-func formatDuration(dt float64) string {
+func FormatDuration(dt float64) string {
 	if dt < 60 {
 		if dt >= 9.995 {
 			return fmt.Sprintf("%.1f%s", dt, secs)
@@ -198,5 +198,5 @@ func formatDuration(dt float64) string {
 		return "ages!"
 	}
 
-	return formatAmount(uint64(dt), 4) + years
+	return FormatAmount(uint64(dt), 4) + years
 }


### PR DESCRIPTION
Package progress had some useful formatting functions (originally
taken from github.com/chipaca/quantity), that are more generally
useful. Circular imports mean they can't be in strutil directly
(quantity uses i18n which uses strutil), but strutil/quantity seems
fine to me.
