### PR TITLE
cmd/snap-mgmt: fix out of source tree build

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -342,7 +342,7 @@ endif
 
 libexec_PROGRAMS += snap-mgmt/snap-mgmt
 
-snap-mgmt/snap-mgmt: snap-mgmt/snap-mgmt.sh.in Makefile
+snap-mgmt/snap-mgmt: snap-mgmt/snap-mgmt.sh.in Makefile snap-mgmt/$(am__dirstamp)
 	sed -e 's,[@]SNAP_MOUNT_DIR[@],$(SNAP_MOUNT_DIR),' <$< >$@
 
 


### PR DESCRIPTION
Add explicit dependency on `snap-mgmt/$(am__dirstamp)`. This ensures that snap-mgmt
directory is present before the rule generated the script file.
