### PR TITLE
tests: generic detection of gadget and kernel snaps

### DIFF
--- a/tests/lib/names.sh
+++ b/tests/lib/names.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 
-gadget_name=$(snap list | sed -n 's/^\(pc\|pi[23]\|dragonboard\|cm3\) .*/\1/p')
-kernel_name=$gadget_name-kernel
-
-if [ "$kernel_name" = "pi3-kernel" ] || [ "$kernel_name" = "cm3-kernel" ]; then
-    kernel_name=pi2-kernel
-fi
+gadget_name=$(snap list | grep gadget | awk '{ print $1 }')
+kernel_name=$(snap list | grep kernel | awk '{ print $1 }')

--- a/tests/lib/names.sh
+++ b/tests/lib/names.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-gadget_name=$(snap list | grep gadget | awk '{ print $1 }')
-kernel_name=$(snap list | grep kernel | awk '{ print $1 }')
+gadget_name=$(snap list | grep 'gadget$' | awk '{ print $1 }')
+kernel_name=$(snap list | grep 'kernel$' | awk '{ print $1 }')


### PR DESCRIPTION
Fix detection of gadget/kernel snap by using the line coming from 'snap list'. This also fixes cases where the kernel name does not match the ${gadget}-kernel pattern.