### PR TITLE
httputil: include Go runtime version in user agent string

### DIFF
--- a/httputil/useragent.go
+++ b/httputil/useragent.go
@@ -21,6 +21,7 @@ package httputil
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/snapcore/snapd/arch"
@@ -60,10 +61,10 @@ func SetUserAgentFromVersion(version string, extraProds ...string) {
 	// xxx this assumes ReleaseInfo's ID and VersionID don't have weird characters
 	// (see rfc 7231 for values of weird)
 	// assumption checks out in practice, q.v. https://github.com/zyga/os-release-zoo
-	userAgent = fmt.Sprintf("snapd/%v (%s)%s %s/%s (%s) linux/%s", version,
+	userAgent = fmt.Sprintf("snapd/%v (%s)%s %s/%s (%s) linux/%s %s", version,
 		strings.Join(extras, "; "), extraProdStr, release.ReleaseInfo.ID,
 		release.ReleaseInfo.VersionID, string(arch.UbuntuArchitecture()),
-		sanitizeKernelVersion(release.KernelVersion()))
+		sanitizeKernelVersion(release.KernelVersion()), runtime.Version())
 }
 
 func sanitizeKernelVersion(in string) string {


### PR DESCRIPTION
Given that Go runtime changes over time with bugs being fixed/added it's useful to have it in the logs.
