### PR TITLE
cmd/snap-confine,tests: hide message about stale base snap

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -450,10 +450,6 @@ static int sc_inspect_and_maybe_discard_stale_ns(int mnt_fd,
 		// Some processes are still using the namespace so we cannot discard it
 		// as that would fracture the view that the set of processes inside
 		// have on what is mounted.
-		fprintf(stderr,
-			"snap %s cannot use current base snap %s because "
-			"existing process are still using the old revision\n",
-			snap_name, base_snap_name);
 		return 0;
 	}
 	// The namespace is both stale and empty. We can discard it now.

--- a/tests/main/stale-base-snap/task.yaml
+++ b/tests/main/stale-base-snap/task.yaml
@@ -53,15 +53,6 @@ execute: |
     test-snapd-sh -c "test -e /tmp/stamp"
     test-snapd-sh -c "test ! -e /customized"
 
-    # We are even very vocal about this and leave a message to the
-    # administrator.
-    if test-snapd-sh -c "true" | grep "snap test-snapd-sh cannot use current base snap core because existing process are still using the old revision"; then
-        echo "Expected a warning, got none"
-        kill "$pid" || true
-        wait -n || true
-        exit 1
-    fi
-
     # Kill our helper process.
     kill "$pid" || true
     wait -n || true


### PR DESCRIPTION
The message shows up when, for example, LXD is used after the core
is updated. While we don't have any design on what should happen
in that case we don't want to show a message that users cannot take
realistically action on.

https://forum.snapcraft.io/t/cannot-use-current-base-snap-core/3763
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>