### PR TITLE
osutil: add ContextWriter and RunWithContext helpers.

### DIFF
--- a/osutil/context.go
+++ b/osutil/context.go
@@ -73,8 +73,10 @@ func RunWithContext(ctx context.Context, cmd *exec.Cmd) error {
 	close(waitDone)
 	if atomic.LoadUint32(&ctxDone) != 0 {
 		// do one last check to make sure the error from Wait is what we expect from Kill
-		if err, ok := err.(*exec.ExitError); ok && err.ProcessState.Sys() == syscall.WaitStatus(0x9) {
-			return ctx.Err()
+		if err, ok := err.(*exec.ExitError); ok {
+			if ws, ok := err.ProcessState.Sys().(syscall.WaitStatus); ok && ws.Signal() == syscall.SIGKILL {
+				return ctx.Err()
+			}
 		}
 	}
 	return err

--- a/osutil/context.go
+++ b/osutil/context.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"io"
+	"os/exec"
+
+	"golang.org/x/net/context"
+)
+
+// ContextWriter returns a discarding io.Writer which Write method
+// returns an error once the context is done.
+func ContextWriter(ctx context.Context) io.Writer {
+	return ctxWriter{ctx}
+}
+
+type ctxWriter struct {
+	ctx context.Context
+}
+
+func (w ctxWriter) Write(p []byte) (n int, err error) {
+	select {
+	case <-w.ctx.Done():
+		return 0, w.ctx.Err()
+	default:
+	}
+	return len(p), nil
+}
+
+// RunWithContext runs the given command, but kills it if the context
+// becomes done before the command finishes.
+func RunWithContext(ctx context.Context, cmd *exec.Cmd) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	waitDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			cmd.Process.Kill()
+		case <-waitDone:
+		}
+	}()
+
+	err := cmd.Wait()
+	close(waitDone)
+	return err
+}

--- a/osutil/context_test.go
+++ b/osutil/context_test.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type ctxSuite struct{}
+
+type dumbReader struct{}
+
+func (dumbReader) Read([]byte) (int, error) {
+	return 1, nil
+}
+
+var _ = check.Suite(&ctxSuite{})
+
+func (ctxSuite) TestWriter(c *check.C) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second/100)
+	n, err := io.Copy(osutil.ContextWriter(ctx), dumbReader{})
+	c.Assert(err, check.Equals, context.DeadlineExceeded)
+	// but we copied things until the deadline hit
+	c.Check(n, check.Not(check.Equals), int64(0))
+}
+
+func (ctxSuite) TestWriterDone(c *check.C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	n, err := io.Copy(osutil.ContextWriter(ctx), dumbReader{})
+	c.Assert(err, check.Equals, context.Canceled)
+	// and nothing was copied
+	c.Check(n, check.Equals, int64(0))
+}
+
+func (ctxSuite) TestWriterSuccess(c *check.C) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second/100)
+	// check we can copy if we're quick
+	n, err := io.Copy(osutil.ContextWriter(ctx), strings.NewReader("hello"))
+	c.Check(err, check.IsNil)
+	c.Check(n, check.Equals, int64(len("hello")))
+}
+
+func (ctxSuite) TestRun(c *check.C) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second/100)
+	cmd := exec.Command("/bin/sleep", "1")
+	err := osutil.RunWithContext(ctx, cmd)
+	c.Check(err, check.ErrorMatches, "signal: killed")
+}
+
+func (ctxSuite) TestRunDone(c *check.C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd := exec.Command("/bin/sleep", "1")
+	err := osutil.RunWithContext(ctx, cmd)
+	c.Check(err, check.Equals, context.Canceled)
+}
+
+func (ctxSuite) TestRunSuccess(c *check.C) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	cmd := exec.Command("/bin/sleep", "0.01")
+	err := osutil.RunWithContext(ctx, cmd)
+	c.Check(err, check.IsNil)
+}

--- a/osutil/context_test.go
+++ b/osutil/context_test.go
@@ -87,3 +87,10 @@ func (ctxSuite) TestRunSuccess(c *check.C) {
 	err := osutil.RunWithContext(ctx, cmd)
 	c.Check(err, check.IsNil)
 }
+
+func (ctxSuite) TestRunSuccessfulFailure(c *check.C) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	cmd := exec.Command("not/something/you/can/run")
+	err := osutil.RunWithContext(ctx, cmd)
+	c.Check(err, check.ErrorMatches, `fork/exec \S+: no such file or directory`)
+}


### PR DESCRIPTION
`osutil.ContextWriter(ctx)` creates a discarding `io.Writer` which
returns an error once the context is done.

`osutil.RunWithContext(ctx, cmd)` runs the given command, but kills it
if the context becomes done before the command finishes.

These make it easier to make the long-running io-heavy snapshot
commands cancellable (newer go's `os/exec` has `CommandContext`).
