### PR TITLE
tests: enable content sharing test for $SNAP

### DIFF
--- a/tests/main/interfaces-content-mkdir-writable/task.yaml
+++ b/tests/main/interfaces-content-mkdir-writable/task.yaml
@@ -28,12 +28,6 @@ execute: |
     . $TESTSLIB/dirs.sh
     PATH=$LIBEXECDIR/snapd:$PATH
 
-    # Skip the SNAP variant until the related branch is merged.
-    if [ "$VAR" = "SNAP" ]; then
-        echo "Poking holes in read-only space is not yet supported."
-        exit 0
-    fi
-
     # Test that initially there are no mount points on the plug side (because
     # nothing is connected). All of the plug side target directories are
     # created dynamically when the corresponding content interface connects.


### PR DESCRIPTION
This test can now be enabled because content sharing can now poke
holes into read-only space there.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>