### PR TITLE
tests: add integration for local snap licenses

### DIFF
--- a/tests/lib/snaps/basic-desktop/meta/snap.yaml
+++ b/tests/lib/snaps/basic-desktop/meta/snap.yaml
@@ -1,5 +1,6 @@
 name: basic-desktop
 version: 1.0
+license: GPL-3.0
 apps:
  echo:
   command: bin/echo

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -24,7 +24,11 @@ execute: |
     snap info basic_1.0_all.snap $TESTSLIB/snaps/basic-desktop test-snapd-tools test-snapd-devmode core /etc/passwd test-snapd-python-webserver > out
     python3 check.py < out
 
-    snap info --verbose $TESTSLIB/snaps/basic-desktop
+    . $TESTSLIB/snaps.sh
+    snap info --verbose $TESTSLIB/snaps/basic-desktop|MATCH "path: "
+    install_local basic-desktop
+    snap info basic-desktop|MATCH "license:[ ]+GPL-3.0"
+
     snap info --verbose basic_1.0_all.snap|MATCH "sha3-384:"
     snap info --verbose test-snapd-tools|MATCH "  ignore-validation:"
 


### PR DESCRIPTION
Not all snaps have a "license: ..." field currently, but this
integration test ensures that we show it if we have it.

