### PR TITLE
snap: fix command-not-found on core devices

### DIFF
--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -124,5 +124,5 @@ func adviseCommand(cmd string, format string) error {
 		}
 	}
 
-	return fmt.Errorf("%s command not found", cmd)
+	return fmt.Errorf("%s: command not found", cmd)
 }

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -286,7 +286,15 @@ func main() {
 			Command: true,
 			Format:  "pretty",
 		}
-		cmd.Positionals.CommandOrPkg = os.Args[1]
+		// the bash.bashrc handler runs:
+		//    /usr/lib/command-not-found -- "$1"
+		// so skip over any "--"
+		for _, arg := range os.Args[1:] {
+			if arg != "--" {
+				cmd.Positionals.CommandOrPkg = arg
+				break
+			}
+		}
 		if err := cmd.Execute(nil); err != nil {
 			fmt.Fprintf(Stderr, "%s\n", err)
 		}


### PR DESCRIPTION
This tiny PR fixes two issues on core:
- command-not-found is run as `/usr/lib/command-not-found -- "$1"` which means that we need to deal with the `--` in our symlink detection code
- the output of c-n-f should be `foo: command not found` but currently the `:` is missing