### PR TITLE
Expose payment and account URLs in /v2/system-info

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -405,6 +405,14 @@ type RefreshInfo struct {
 	Next     string `json:"next,omitempty"`
 }
 
+// URLInfo contains information about URLs the client might need the user to use.
+type URLInfo struct {
+	AccountCreate         string `json:"account-create"`
+	AccountForgotPassword string `json:"account-forgot-password"`
+	PaymentSetup          string `json:"payment-setup"`
+	PaymentTOS            string `json:"payment-tos"`
+}
+
 // SysInfo holds system information
 type SysInfo struct {
 	Series    string    `json:"series,omitempty"`
@@ -416,6 +424,7 @@ type SysInfo struct {
 	KernelVersion string `json:"kernel-version,omitempty"`
 
 	Refresh     RefreshInfo `json:"refresh,omitempty"`
+	URLs        URLInfo     `json:"urls,omitempty"`
 	Confinement string      `json:"confinement"`
 }
 

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -90,18 +90,23 @@ func buySnap(snapName string) error {
 		return fmt.Errorf(i18n.G("cannot buy snap: it has already been bought"))
 	}
 
+	sysinfo, err := cli.SysInfo()
+	if err != nil {
+		return err
+	}
+
 	err = cli.ReadyToBuy()
 	if err != nil {
 		if e, ok := err.(*client.Error); ok {
 			switch e.Kind {
 			case client.ErrorKindNoPaymentMethods:
-				return fmt.Errorf(i18n.G(`You need to have a payment method associated with your account in order to buy a snap, please visit https://my.ubuntu.com/payment/edit to add one.
+				return fmt.Errorf(i18n.G(`You need to have a payment method associated with your account in order to buy a snap, please visit %q to add one.
 
-Once you’ve added your payment details, you just need to run 'snap buy %s' again.`), snap.Name)
+Once you’ve added your payment details, you just need to run 'snap buy %s' again.`), sysinfo.URLs.paymentSetup, snap.Name)
 			case client.ErrorKindTermsNotAccepted:
-				return fmt.Errorf(i18n.G(`In order to buy %q, you need to agree to the latest terms and conditions. Please visit https://my.ubuntu.com/payment/edit to do this.
+				return fmt.Errorf(i18n.G(`In order to buy %q, you need to agree to the latest terms and conditions. Please visit %q to do this.
 
-Once completed, return here and run 'snap buy %s' again.`), snap.Name, snap.Name)
+Once completed, return here and run 'snap buy %s' again.`), snap.Name, sysinfo.URLs.paymentTOS, snap.Name)
 			}
 		}
 		return err
@@ -123,7 +128,7 @@ for %s. Press ctrl-c to cancel.`), snap.Name, snap.Developer, formatPrice(opts.P
 			switch e.Kind {
 			case client.ErrorKindPaymentDeclined:
 				return fmt.Errorf(i18n.G(`Sorry, your payment method has been declined by the issuer. Please review your
-payment details at https://my.ubuntu.com/payment/edit and try again.`))
+payment details at %q and try again.`), sysinfo.URLs.paymentSetup)
 			}
 		}
 		return err

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -301,6 +301,12 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 			"snap-bin-dir":   dirs.SnapBinariesDir,
 		},
 		"refresh": refreshInfo,
+		"urls": map[string]interface{}{
+			"account-create":          "https://login.ubuntu.com/+login",
+			"account-forgot-password": "https://login.ubuntu.com/+forgot_password",
+			"payment-setup":           "https://my.ubuntu.com/payment/edit",
+			"payment-tos":             "https://my.ubuntu.com/payment/edit",
+		},
 	}
 	// NOTE: Right now we don't have a good way to differentiate if we
 	// only have partial confinement (ala AppArmor disabled and Seccomp

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -812,6 +812,12 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 			// only the "timer" field
 			"timer": "8:00~9:00/2",
 		},
+		"urls": map[string]interface{}{
+			"account-create":          "https://login.ubuntu.com/+login",
+			"account-forgot-password": "https://login.ubuntu.com/+forgot_password",
+			"payment-setup":           "https://my.ubuntu.com/payment/edit",
+			"payment-tos":             "https://my.ubuntu.com/payment/edit",
+		},
 		"confinement": "partial",
 	}
 	var rsp resp
@@ -867,6 +873,12 @@ func (s *apiSuite) TestSysInfoLegacyRefresh(c *check.C) {
 		"refresh": map[string]interface{}{
 			// only the "schedule" field
 			"schedule": "00:00-9:00/12:00-13:00",
+		},
+		"urls": map[string]interface{}{
+			"account-create":          "https://login.ubuntu.com/+login",
+			"account-forgot-password": "https://login.ubuntu.com/+forgot_password",
+			"payment-setup":           "https://my.ubuntu.com/payment/edit",
+			"payment-tos":             "https://my.ubuntu.com/payment/edit",
 		},
 		"confinement": "partial",
 	}


### PR DESCRIPTION
This allows clients to avoid hard-coding these values. They can then be updated
in one location / vary if different backends are used.
