### PR TITLE
 many: add interfaces.SystemKey() helper

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -64,7 +64,8 @@ var (
 	SnapTrustedAccountKey string
 	SnapAssertsSpoolDir   string
 
-	SnapStateFile string
+	SnapStateFile     string
+	SnapSystemKeyFile string
 
 	SnapRepairDir        string
 	SnapRepairStateFile  string
@@ -201,6 +202,7 @@ func SetRootDir(rootdir string) {
 	SnapAssertsSpoolDir = filepath.Join(rootdir, "run/snapd/auto-import")
 
 	SnapStateFile = filepath.Join(rootdir, snappyDir, "state.json")
+	SnapSystemKeyFile = filepath.Join(rootdir, snappyDir, "system-key")
 
 	SnapCacheDir = filepath.Join(rootdir, "/var/cache/snapd")
 	SnapNamesFile = filepath.Join(SnapCacheDir, "names")

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+// systemKey describes the environment for which security profiles
+// have been generated. It is useful to compare if the current
+// running system is similar enough to the generated profiles or
+// if the profiles need to be re-generated to match the new system.
+type systemKey struct {
+	BuildID          string   `yaml:"build-id"`
+	ApparmorFeatures []string `yaml:"apparmor-features"`
+}
+
+var mySystemKey systemKey
+
+func init() {
+	// add build-id
+	buildID, err := osutil.MyBuildID()
+	if err != nil {
+		buildID = "unknown"
+	}
+	mySystemKey.BuildID = buildID
+
+	// add apparmor-feature, note that ioutil.ReadDir() is already sorted
+	if dentries, err := ioutil.ReadDir("/sys/kernel/security/apparmor/features"); err == nil {
+		mySystemKey.ApparmorFeatures = make([]string, len(dentries))
+		for i, f := range dentries {
+			mySystemKey.ApparmorFeatures[i] = f.Name()
+		}
+	}
+}
+
+// SystemKey outputs a string that identifies what security profiles
+// environment this snapd is using. Security profiles that were generated
+// with a different Systemkey should be re-generated.
+func SystemKey() string {
+	sk, err := yaml.Marshal(mySystemKey)
+	if err != nil {
+		panic(err)
+	}
+	return string(sk)
+}

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -48,7 +48,10 @@ func generateSystemKey() *systemKey {
 	}
 	mySystemKey.BuildID = buildID
 
-	// add apparmor-feature, note that ioutil.ReadDir() is already sorted
+	// Add apparmor-feature, note that ioutil.ReadDir() is already sorted.
+	//
+	// We prefix the dirs.GlobalRootDir (which is usually "/") to make
+	// this testable.
 	if dentries, err := ioutil.ReadDir(filepath.Join(dirs.GlobalRootDir, "/sys/kernel/security/apparmor/features")); err == nil {
 		mySystemKey.AppArmorFeatures = make([]string, len(dentries))
 		for i, f := range dentries {

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -1,0 +1,36 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package interfaces_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+)
+
+type systemKeySuite struct{}
+
+var _ = Suite(&systemKeySuite{})
+
+func (ts *systemKeySuite) TestInterfaceDigest(c *C) {
+	systemKey := interfaces.SystemKey()
+	c.Check(systemKey, Matches, "(?sm)^build-id: (unknown|[a-z0-9]+)$")
+	c.Check(systemKey, Matches, "(?sm).*apparmor-features:")
+}

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -53,7 +53,7 @@ func (s *systemKeySuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
 }
 
-func (s *systemKeySuite) TestInterfaceSystemKeyEmpty(c *C) {
+func (s *systemKeySuite) TestInterfaceSystemKeyNoApparmor(c *C) {
 	systemKey := interfaces.SystemKey()
 	c.Check(systemKey, Equals, fmt.Sprintf(`build-id: %s
 apparmor-features: []

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -20,17 +20,55 @@
 package interfaces_test
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/osutil"
 )
 
-type systemKeySuite struct{}
+type systemKeySuite struct {
+	tmp              string
+	apparmorFeatures string
+	buildID          string
+}
 
 var _ = Suite(&systemKeySuite{})
 
-func (ts *systemKeySuite) TestInterfaceDigest(c *C) {
+func (s *systemKeySuite) SetUpTest(c *C) {
+	s.tmp = c.MkDir()
+	dirs.SetRootDir(s.tmp)
+	s.apparmorFeatures = filepath.Join(s.tmp, "/sys/kernel/security/apparmor/features")
+
+	id, err := osutil.MyBuildID()
+	c.Assert(err, IsNil)
+	s.buildID = id
+}
+
+func (s *systemKeySuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *systemKeySuite) TestInterfaceSystemKeyEmpty(c *C) {
 	systemKey := interfaces.SystemKey()
-	c.Check(systemKey, Matches, "(?sm)^build-id: (unknown|[a-z0-9]+)$")
-	c.Check(systemKey, Matches, "(?sm).*apparmor-features:")
+	c.Check(systemKey, Equals, fmt.Sprintf(`build-id: %s
+apparmor-features: []
+`, s.buildID))
+}
+
+func (s *systemKeySuite) TestInterfaceSystemKey(c *C) {
+	err := os.MkdirAll(s.apparmorFeatures, 0755)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(filepath.Join(s.apparmorFeatures, "policy"), 0755)
+	c.Assert(err, IsNil)
+
+	systemKey := interfaces.SystemKey()
+	c.Check(systemKey, Equals, fmt.Sprintf(`build-id: %s
+apparmor-features:
+- policy
+`, s.buildID))
 }

--- a/osutil/buildid.go
+++ b/osutil/buildid.go
@@ -27,6 +27,8 @@ import (
 	"os"
 )
 
+var osReadlink = os.Readlink
+
 // ErrNoBuildID is returned when an executable does not contain a Build-ID
 var ErrNoBuildID = errors.New("executable does not contain a build ID")
 
@@ -98,4 +100,14 @@ func ReadBuildID(fname string) (string, error) {
 		return hex.EncodeToString(noteData), nil
 	}
 	return "", ErrNoBuildID
+}
+
+// MyBuildID return the build-id of the currently running executable
+func MyBuildID() (string, error) {
+	exe, err := osReadlink("/proc/self/exe")
+	if err != nil {
+		return "", err
+	}
+
+	return ReadBuildID(exe)
 }

--- a/osutil/buildid_test.go
+++ b/osutil/buildid_test.go
@@ -86,3 +86,14 @@ func (s *buildIDSuite) TestReadBuildIDmd5(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(id, Equals, buildID(c, md5Truth))
 }
+
+func (s *buildIDSuite) TestMyBuildID(c *C) {
+	restore := osutil.MockOsReadlink(func(string) (string, error) {
+		return truePath, nil
+	})
+	defer restore()
+
+	id, err := osutil.MyBuildID()
+	c.Assert(err, IsNil)
+	c.Check(id, Equals, buildID(c, truePath))
+}

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -106,3 +106,10 @@ func SetUnsafeIO(b bool) func() {
 		snapdUnsafeIO = oldSnapdUnsafeIO
 	}
 }
+
+func MockOsReadlink(f func(string) (string, error)) func() {
+	realOsReadlink := osReadlink
+	osReadlink = f
+
+	return func() { osReadlink = realOsReadlink }
+}


### PR DESCRIPTION
This PR implements a new interfaces.SystemKey() helper as discussed in https://forum.snapcraft.io/t/827/23

The SystemKey describes the system environment for which security profiles are valid. Right now the inputs are the build-id of snapd itself and the apparmor capabilities from the kernel. Adding extra inputs (like seccomp capabilities once we have those) is trivial and will result in a different SystemKey which is desirable.

Note that the SystemKey() string is currently the yaml that describes the system. We discussed hashing it but it seems like its actually nicer to keep it a string to make debugging easier and we can always change it, the signature of SystemKey() is a string (but happy to change to a digest again if that is preferred).

This is just the first step (I split it up for easier reviewing), the next steps are:

*    only re-generate security profiles if the system-key changes (#3460)
*    make snap run wait for security profile generation if the system-key changes (#3471)

This is a cleaned up PR from the originalhttps://github.com/snapcore/snapd/pull/3456 - all review feedback is addressed here.