### PR TITLE
tests: ensure disabled services are masked

### DIFF
--- a/tests/main/snapctl-configure-core/task.yaml
+++ b/tests/main/snapctl-configure-core/task.yaml
@@ -23,8 +23,8 @@ execute: |
     systemctl status rsyslog.service|MATCH "Active: active"
     snap set core service.rsyslog.disable=true
     systemctl status rsyslog.service|MATCH "Active: inactive"
+    systemctl status rsyslog.service|MATCH "Loaded: masked"
     snap set core service.rsyslog.disable=false
-
     
     echo "Check that powerkey handling works"
     snap set core system.power-key-action=reboot


### PR DESCRIPTION
When we disable built-in core services like rsyslog we also mask them to avoid that they get re-added via the "writable-path" magic (the /etc/systemd/system directory in mode "sync" so that means that the enable symlinks that are on our core snap would simply be re-created if we only remove the unit).

To ensure this really works add an extra check to the existing integration test.