### PR TITLE
overlord/configstate/config: make SetSnapConfig delete on empty

### DIFF
--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -157,11 +157,19 @@ func SetSnapConfig(st *state.State, snapName string, snapcfg json.RawMessage) er
 	var config map[string]*json.RawMessage
 	err := st.Get("config", &config)
 	if err == state.ErrNoState {
+		if len(snapcfg) == 0 {
+			// bail out early
+			return nil
+		}
 		config = make(map[string]*json.RawMessage, 1)
 	} else if err != nil {
 		return err
 	}
-	config[snapName] = &snapcfg
+	if len(snapcfg) == 0 {
+		delete(config, snapName)
+	} else {
+		config[snapName] = &snapcfg
+	}
 	st.Set("config", config)
 	return nil
 }

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -143,13 +143,28 @@ func (s *configHelpersSuite) TestSnapConfig(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	rawCfg, err := config.GetSnapConfig(s.state, "snap1")
-	c.Assert(err, IsNil)
-	c.Check(rawCfg, IsNil)
+	for _, emptyCfg := range [][]byte{nil, {}} {
+		rawCfg, err := config.GetSnapConfig(s.state, "snap1")
+		c.Assert(err, IsNil)
+		c.Check(rawCfg, IsNil)
 
-	c.Assert(config.SetSnapConfig(s.state, "snap1", json.RawMessage(`{"foo":"bar"}`)), IsNil)
+		// can set to empty when empty and it's fine
+		c.Assert(config.SetSnapConfig(s.state, "snap1", emptyCfg), IsNil)
+		rawCfg, err = config.GetSnapConfig(s.state, "snap1")
+		c.Assert(err, IsNil)
+		c.Check(rawCfg, IsNil)
 
-	rawCfg, err = config.GetSnapConfig(s.state, "snap1")
-	c.Assert(err, IsNil)
-	c.Check(rawCfg, DeepEquals, json.RawMessage(`{"foo":"bar"}`))
+		c.Assert(config.SetSnapConfig(s.state, "snap1", json.RawMessage(`{"foo":"bar"}`)), IsNil)
+
+		// the set sets it
+		rawCfg, err = config.GetSnapConfig(s.state, "snap1")
+		c.Assert(err, IsNil)
+		c.Check(rawCfg, DeepEquals, json.RawMessage(`{"foo":"bar"}`))
+
+		// empty or nil clears it
+		c.Assert(config.SetSnapConfig(s.state, "snap1", emptyCfg), IsNil)
+		rawCfg, err = config.GetSnapConfig(s.state, "snap1")
+		c.Assert(err, IsNil)
+		c.Check(rawCfg, IsNil)
+	}
 }


### PR DESCRIPTION
With the previous `SetSnapConfig` it wasn't possible to pass in an empty
(`nil` or `[]byte{}`) raw config; the serialisation would fail. It also
wasn't possible to unset a config; at best you could set it to `"{}"`.

This addresses both issues: a `nil` or empty config can now be used to
clear the config.

This makes using it very natural, as when the config isn't set,
`GetSnapConfig` will return a `nil` (raw) config as well. The caller can
treat the returned raw config as an opaque blob, as intended.
