### PR TITLE
many: at seeding try to capture cloud information into core config under "cloud"

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -85,7 +85,8 @@ var (
 	SystemApparmorDir      string
 	SystemApparmorCacheDir string
 
-	CloudMetaDataFile string
+	CloudMetaDataFile     string
+	CloudInstanceDataFile string
 
 	ClassicDir string
 
@@ -224,6 +225,7 @@ func SetRootDir(rootdir string) {
 	SystemApparmorCacheDir = filepath.Join(rootdir, "/etc/apparmor.d/cache")
 
 	CloudMetaDataFile = filepath.Join(rootdir, "/var/lib/cloud/seed/nocloud-net/meta-data")
+	CloudInstanceDataFile = filepath.Join(rootdir, "/run/cloud-init/instance-data.json")
 
 	SnapUdevRulesDir = filepath.Join(rootdir, "/etc/udev/rules.d")
 

--- a/overlord/configstate/configcore/cloud.go
+++ b/overlord/configstate/configcore/cloud.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// CloudInfo holds the content for the optional "cloud" entry of core config
+// that reflects cloud information for the system if available.
+type CloudInfo struct {
+	Name             string `json:"name"`
+	Region           string `json:"region,omitempty"`
+	AvailabilityZone string `json:"availability-zone,omitempty"`
+}
+
+func alreadySeeded(tr Conf) (bool, error) {
+	st := tr.State()
+	st.Lock()
+	defer st.Unlock()
+	var seeded bool
+	err := tr.State().Get("seeded", &seeded)
+	if err != nil && err != state.ErrNoState {
+		return false, err
+	}
+	return seeded, nil
+}
+
+func handleCloud(tr Conf) error {
+	// if we are during seeding try to capture cloud information
+	seeded, err := alreadySeeded(tr)
+	if err != nil {
+		return err
+	}
+	if seeded {
+		// already done
+		return nil
+	}
+
+	data, err := ioutil.ReadFile(dirs.CloudInstanceDataFile)
+	if os.IsNotExist(err) {
+		// nothing to do
+		return nil
+	}
+	if err != nil {
+		logger.Noticef("cannot read cloud instance information %q: %v", dirs.CloudInstanceDataFile, err)
+		return nil
+	}
+	var instanceData struct {
+		V1 struct {
+			Name             string `json:"cloud-name"`
+			Region           string `json:"region"`
+			AvailabilityZone string `json:"availability-zone"`
+		} `json:"v1"`
+	}
+	err = json.Unmarshal(data, &instanceData)
+	if err != nil {
+		logger.Noticef("cannot unmarshal cloud instance information %q: %v", dirs.CloudInstanceDataFile, err)
+		return nil
+	}
+
+	cloudName := instanceData.V1.Name
+	if cloudName == "" || cloudName == "nocloud" || cloudName == "none" {
+		// not a cloud
+		return nil
+	}
+
+	tr.Set("core", "cloud", CloudInfo{
+		Name:             cloudName,
+		Region:           instanceData.V1.Region,
+		AvailabilityZone: instanceData.V1.AvailabilityZone,
+	})
+	return nil
+}

--- a/overlord/configstate/configcore/cloud.go
+++ b/overlord/configstate/configcore/cloud.go
@@ -49,7 +49,7 @@ func alreadySeeded(tr Conf) (bool, error) {
 	return seeded, nil
 }
 
-func handleCloud(tr Conf) error {
+func setCloudInfoWhenSeeding(tr Conf) error {
 	// if we are during seeding try to capture cloud information
 	seeded, err := alreadySeeded(tr)
 	if err != nil {

--- a/overlord/configstate/configcore/cloud_test.go
+++ b/overlord/configstate/configcore/cloud_test.go
@@ -1,0 +1,162 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+)
+
+type cloudSuite struct {
+	configcoreSuite
+}
+
+var _ = Suite(&cloudSuite{})
+
+func (s *cloudSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *cloudSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *cloudSuite) TestHandleCloud(c *C) {
+	tests := []struct {
+		instData         string
+		name             string
+		region           string
+		availabilityZone string
+	}{
+		{"", "", "", ""},
+		{`{
+}`, "", "", ""},
+		{"{", "", "", ""},
+		{`{
+ "v1": {
+  "availability-zone": "us-east-2b",
+  "cloud-name": "aws",
+  "instance-id": "i-03bdbe0d89f4c8ec9",
+  "local-hostname": "ip-10-41-41-143",
+  "region": "us-east-2"
+ }
+}`, "aws", "us-east-2", "us-east-2b"},
+		{`{
+"v1": {
+  "availability-zone": null,
+  "cloud-name": "azure",
+  "instance-id": "1C63DFBB-46A0-7243-A11F-5A1F6EAEBCCB",
+  "public-hostname": "my-b1",
+  "public-ipv4-address": null,
+  "public-ipv6-address": null,
+  "region": null
+ }
+}`, "azure", "", ""},
+		{`{
+ "v1": {
+  "availability-zone": "nova",
+  "cloud-name": "openstack",
+  "instance-id": "3e39d278-0644-4728-9479-678f9212d8f0",
+  "local-hostname": "xenial-test",
+  "region": null
+ }
+}`, "openstack", "", "nova"},
+		{`{
+ "v1": {
+  "availability-zone": null,
+  "cloud-name": "nocloud",
+  "instance-id": "b5",
+  "local-hostname": "b5",
+  "region": null
+ }
+}`, "", "", ""},
+		{},
+		{`{
+  "v1": null,
+}`, "", "", ""},
+		{`{
+ "v1": {
+   "cloud-name": "none"
+ }
+}`, "", "", ""},
+	}
+
+	err := os.MkdirAll(filepath.Dir(dirs.CloudInstanceDataFile), 0755)
+	c.Assert(err, IsNil)
+
+	for _, t := range tests {
+		os.Remove(dirs.CloudInstanceDataFile)
+		if t.instData != "" {
+			err = ioutil.WriteFile(dirs.CloudInstanceDataFile, []byte(t.instData), 0600)
+			c.Assert(err, IsNil)
+		}
+
+		tr := &mockConf{
+			state: s.state,
+		}
+		err := configcore.Run(tr)
+		c.Assert(err, IsNil)
+
+		var cloudInfo configcore.CloudInfo
+		tr.Get("core", "cloud", &cloudInfo)
+
+		c.Check(cloudInfo.Name, Equals, t.name)
+		c.Check(cloudInfo.Region, Equals, t.region)
+		c.Check(cloudInfo.AvailabilityZone, Equals, t.availabilityZone)
+	}
+}
+
+func (s *cloudSuite) TestHandleCloudAlreadySeeded(c *C) {
+	instData := `{
+ "v1": {
+  "availability-zone": "us-east-2b",
+  "cloud-name": "aws",
+  "instance-id": "i-03bdbe0d89f4c8ec9",
+  "local-hostname": "ip-10-41-41-143",
+  "region": "us-east-2"
+ }
+}`
+
+	err := os.MkdirAll(filepath.Dir(dirs.CloudInstanceDataFile), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(dirs.CloudInstanceDataFile, []byte(instData), 0600)
+	c.Assert(err, IsNil)
+
+	s.state.Lock()
+	s.state.Set("seeded", true)
+	s.state.Unlock()
+	tr := &mockConf{
+		state: s.state,
+	}
+	err = configcore.Run(tr)
+	c.Assert(err, IsNil)
+
+	var cloudInfo configcore.CloudInfo
+	tr.Get("core", "cloud", &cloudInfo)
+
+	c.Check(cloudInfo.Name, Equals, "")
+}

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -35,6 +35,7 @@ var (
 
 type Conf interface {
 	Get(snapName, key string, result interface{}) error
+	Set(snapName, key string, value interface{}) error
 	State() *state.State
 }
 
@@ -54,6 +55,11 @@ func Run(tr Conf) error {
 		return err
 	}
 	if err := validateRefreshSchedule(tr); err != nil {
+		return err
+	}
+
+	// capture cloud information
+	if err := handleCloud(tr); err != nil {
 		return err
 	}
 

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -59,7 +59,7 @@ func Run(tr Conf) error {
 	}
 
 	// capture cloud information
-	if err := handleCloud(tr); err != nil {
+	if err := setCloudInfoWhenSeeding(tr); err != nil {
 		return err
 	}
 

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -50,6 +50,17 @@ func (cfg *mockConf) Get(snapName, key string, result interface{}) error {
 	return cfg.err
 }
 
+func (cfg *mockConf) Set(snapName, key string, v interface{}) error {
+	if snapName != "core" {
+		return fmt.Errorf("mockConf only knows about core")
+	}
+	if cfg.conf == nil {
+		cfg.conf = make(map[string]interface{})
+	}
+	cfg.conf[key] = v
+	return nil
+}
+
 func (cfg *mockConf) State() *state.State {
 	return cfg.state
 }

--- a/overlord/configstate/configcore/picfg_test.go
+++ b/overlord/configstate/configcore/picfg_test.go
@@ -51,6 +51,7 @@ unrelated_options=are-kept
 `
 
 func (s *piCfgSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc"), 0755), IsNil)
 
@@ -134,6 +135,7 @@ func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
 	defer restore()
 
 	err := configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"pi-config.disable-overscan": 1,
 		},
@@ -144,6 +146,7 @@ func (s *piCfgSuite) TestConfigurePiConfigIntegration(c *C) {
 	s.checkMockConfig(c, expected)
 
 	err = configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"pi-config.disable-overscan": "",
 		},

--- a/overlord/configstate/configcore/powerbtn_test.go
+++ b/overlord/configstate/configcore/powerbtn_test.go
@@ -41,6 +41,7 @@ type powerbtnSuite struct {
 var _ = Suite(&powerbtnSuite{})
 
 func (s *powerbtnSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc"), 0755), IsNil)
 
@@ -63,6 +64,7 @@ func (s *powerbtnSuite) TestConfigurePowerIntegration(c *C) {
 	for _, action := range []string{"ignore", "poweroff", "reboot", "halt", "kexec", "suspend", "hibernate", "hybrid-sleep", "lock"} {
 
 		err := configcore.Run(&mockConf{
+			state: s.state,
 			conf: map[string]interface{}{
 				"system.power-key-action": action,
 			},

--- a/overlord/configstate/configcore/proxy_test.go
+++ b/overlord/configstate/configcore/proxy_test.go
@@ -91,6 +91,7 @@ func (s *proxySuite) TestConfigureProxy(c *C) {
 		s.makeMockEtcEnvironment(c)
 
 		err := configcore.Run(&mockConf{
+			state: s.state,
 			conf: map[string]interface{}{
 				fmt.Sprintf("proxy.%s", proto): fmt.Sprintf("%s://example.com", proto),
 			},
@@ -112,6 +113,7 @@ func (s *proxySuite) TestConfigureNoProxy(c *C) {
 	// populate with content
 	s.makeMockEtcEnvironment(c)
 	err := configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"proxy.no-proxy": "example.com,bar.com",
 		},
@@ -128,6 +130,7 @@ no_proxy=example.com,bar.com`)
 func (s *proxySuite) TestConfigureProxyStore(c *C) {
 	// set to ""
 	err := configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"proxy.store": "",
 		},

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -33,6 +33,7 @@ var _ = Suite(&refreshSuite{})
 
 func (s *refreshSuite) TestConfigureRefreshTimerHappy(c *C) {
 	err := configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.timer": "8:00~12:00/2",
 		},
@@ -42,6 +43,7 @@ func (s *refreshSuite) TestConfigureRefreshTimerHappy(c *C) {
 
 func (s *refreshSuite) TestConfigureRefreshTimerRejected(c *C) {
 	err := configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.timer": "invalid",
 		},
@@ -51,6 +53,7 @@ func (s *refreshSuite) TestConfigureRefreshTimerRejected(c *C) {
 
 func (s *refreshSuite) TestConfigureLegacyRefreshScheduleHappy(c *C) {
 	err := configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.schedule": "8:00-12:00",
 		},
@@ -60,6 +63,7 @@ func (s *refreshSuite) TestConfigureLegacyRefreshScheduleHappy(c *C) {
 
 func (s *refreshSuite) TestConfigureLegacyRefreshScheduleRejected(c *C) {
 	err := configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.schedule": "invalid",
 		},
@@ -68,6 +72,7 @@ func (s *refreshSuite) TestConfigureLegacyRefreshScheduleRejected(c *C) {
 
 	// check that refresh.schedule is verified against legacy parser
 	err = configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"refresh.schedule": "8:00~12:00/2",
 		},

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -42,6 +42,7 @@ var _ = Suite(&servicesSuite{})
 
 func (s *servicesSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.configcoreSuite.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
 	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc"), 0755), IsNil)
 	s.systemctlArgs = nil
@@ -87,6 +88,7 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 		s.systemctlArgs = nil
 
 		err := configcore.Run(&mockConf{
+			state: s.state,
 			conf: map[string]interface{}{
 				fmt.Sprintf("service.%s.disable", srvName): true,
 			},
@@ -109,6 +111,7 @@ func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
 	for _, srvName := range []string{"ssh", "rsyslog"} {
 		s.systemctlArgs = nil
 		err := configcore.Run(&mockConf{
+			state: s.state,
 			conf: map[string]interface{}{
 				fmt.Sprintf("service.%s.disable", srvName): false,
 			},
@@ -129,6 +132,7 @@ func (s *servicesSuite) TestConfigureServiceUnsupportedService(c *C) {
 	defer restore()
 
 	err := configcore.Run(&mockConf{
+		state: s.state,
 		conf: map[string]interface{}{
 			"service.snapd.disable": true,
 		},

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -70,6 +70,13 @@ func installSeedSnap(st *state.State, sn *snap.SeedSnap, flags snapstate.Flags) 
 	return snapstate.InstallPath(st, &sideInfo, path, sn.Channel, flags)
 }
 
+func trivialSeeding(st *state.State, markSeeded *state.Task) []*state.TaskSet {
+	// give a chance to internal core config to run
+	configTs := snapstate.ConfigureSnap(st, "core", 0)
+	markSeeded.WaitAll(configTs)
+	return []*state.TaskSet{configTs, state.NewTaskSet(markSeeded)}
+}
+
 func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 	// check that the state is empty
 	var seeded bool
@@ -86,7 +93,7 @@ func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 	// ack all initial assertions
 	model, err := importAssertionsFromSeed(st)
 	if err == errNothingToDo {
-		return []*state.TaskSet{state.NewTaskSet(markSeeded)}, nil
+		return trivialSeeding(st, markSeeded), nil
 	}
 	if err != nil {
 		return nil, err
@@ -95,7 +102,7 @@ func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 	seedYamlFile := filepath.Join(dirs.SnapSeedDir, "seed.yaml")
 	if release.OnClassic && !osutil.FileExists(seedYamlFile) {
 		// on classic it is ok to not seed any snaps
-		return []*state.TaskSet{state.NewTaskSet(markSeeded)}, nil
+		return trivialSeeding(st, markSeeded), nil
 	}
 
 	seed, err := snap.ReadSeedYaml(seedYamlFile)


### PR DESCRIPTION
This is done from the running of the internal core configure code at that time.