### PR TITLE
cmd/snap: add completion conversion helper to increase DRY

### DIFF
--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -59,12 +59,7 @@ func (x *cmdList) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	names := make([]string, len(x.Positional.Snaps))
-	for i, name := range x.Positional.Snaps {
-		names[i] = string(name)
-	}
-
-	return listSnaps(names, x.All)
+	return listSnaps(installedSnapNames(x.Positional.Snaps), x.All)
 }
 
 var ErrNoMatchingSnaps = errors.New(i18n.G("no matching snaps installed"))

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -229,11 +229,7 @@ func (x *cmdRemove) removeOne(opts *client.SnapOptions) error {
 }
 
 func (x *cmdRemove) removeMany(opts *client.SnapOptions) error {
-	names := make([]string, len(x.Positional.Snaps))
-	for i, s := range x.Positional.Snaps {
-		names[i] = string(s)
-	}
-
+	names := installedSnapNames(x.Positional.Snaps)
 	cli := Client()
 	changeID, err := cli.RemoveMany(names, opts)
 	if err != nil {
@@ -575,11 +571,7 @@ func (x *cmdInstall) Execute([]string) error {
 	}
 	x.setModes(opts)
 
-	names := make([]string, len(x.Positional.Snaps))
-	for i, name := range x.Positional.Snaps {
-		names[i] = string(name)
-	}
-
+	names := remoteSnapNames(x.Positional.Snaps)
 	if len(names) == 1 {
 		return x.installOne(names[0], opts)
 	}
@@ -740,11 +732,8 @@ func (x *cmdRefresh) Execute([]string) error {
 		return nil
 	}
 
-	names := make([]string, len(x.Positional.Snaps))
-	for i, name := range x.Positional.Snaps {
-		names[i] = string(name)
-	}
-	if len(x.Positional.Snaps) == 1 {
+	names := installedSnapNames(x.Positional.Snaps)
+	if len(names) == 1 {
 		opts := &client.SnapOptions{
 			Amend:            x.Amend,
 			Channel:          x.Channel,

--- a/cmd/snap/complete.go
+++ b/cmd/snap/complete.go
@@ -51,6 +51,15 @@ func (s installedSnapName) Complete(match string) []flags.Completion {
 	return ret
 }
 
+func installedSnapNames(snaps []installedSnapName) []string {
+	names := make([]string, len(snaps))
+	for i, name := range snaps {
+		names[i] = string(name)
+	}
+
+	return names
+}
+
 func completeFromSortedFile(filename, match string) ([]flags.Completion, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -106,6 +115,15 @@ func (s remoteSnapName) Complete(match string) []flags.Completion {
 		ret[i] = flags.Completion{Item: snap.Name}
 	}
 	return ret
+}
+
+func remoteSnapNames(snaps []remoteSnapName) []string {
+	names := make([]string, len(snaps))
+	for i, name := range snaps {
+		names[i] = string(name)
+	}
+
+	return names
 }
 
 type anySnapName string


### PR DESCRIPTION
snap commands that used e.g. []installedSnapName to get tab completion
were then converting those to []string themselves, repeatedly. This
moves that to a helper and avoids the duplication.
