### PR TITLE
many: remove "content" argument from snaptest.MockSnap()

### DIFF
--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -152,7 +152,7 @@ func (s *kernelOSSuite) TestSetNextBootOnClassic(c *C) {
 	defer restore()
 
 	// Create a fake OS snap that we try to update
-	snapInfo := snaptest.MockSnap(c, "name: os\ntype: os", "SNAP", &snap.SideInfo{Revision: snap.R(42)})
+	snapInfo := snaptest.MockSnap(c, "name: os\ntype: os", &snap.SideInfo{Revision: snap.R(42)})
 	err := boot.SetNextBoot(snapInfo)
 	c.Assert(err, IsNil)
 

--- a/cmd/snap-exec/main_test.go
+++ b/cmd/snap-exec/main_test.go
@@ -75,8 +75,6 @@ hooks:
  configure:
 `)
 
-var mockContents = ""
-
 var binaryTemplate = `#!/bin/sh
 echo "$(basename $0)" >> %[1]q
 for arg in "$@"; do
@@ -132,7 +130,7 @@ func (s *snapExecSuite) TestFindCommandNoCommand(c *C) {
 
 func (s *snapExecSuite) TestSnapExecAppIntegration(c *C) {
 	dirs.SetRootDir(c.MkDir())
-	snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R("42"),
 	})
 
@@ -159,7 +157,7 @@ func (s *snapExecSuite) TestSnapExecAppIntegration(c *C) {
 
 func (s *snapExecSuite) TestSnapExecHookIntegration(c *C) {
 	dirs.SetRootDir(c.MkDir())
-	snaptest.MockSnap(c, string(mockHookYaml), string(mockContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(mockHookYaml), &snap.SideInfo{
 		Revision: snap.R("42"),
 	})
 
@@ -181,7 +179,7 @@ func (s *snapExecSuite) TestSnapExecHookIntegration(c *C) {
 
 func (s *snapExecSuite) TestSnapExecHookMissingHookIntegration(c *C) {
 	dirs.SetRootDir(c.MkDir())
-	snaptest.MockSnap(c, string(mockHookYaml), string(mockContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(mockHookYaml), &snap.SideInfo{
 		Revision: snap.R("42"),
 	})
 
@@ -218,7 +216,7 @@ func (s *snapExecSuite) TestSnapExecAppRealIntegration(c *C) {
 	os.Setenv("SNAP_REVISION", "42")
 	defer os.Unsetenv("SNAP_REVISION")
 
-	snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R("42"),
 	})
 
@@ -260,7 +258,7 @@ func (s *snapExecSuite) TestSnapExecHookRealIntegration(c *C) {
 
 	canaryFile := filepath.Join(c.MkDir(), "canary.txt")
 
-	testSnap := snaptest.MockSnap(c, string(mockHookYaml), string(mockContents), &snap.SideInfo{
+	testSnap := snaptest.MockSnap(c, string(mockHookYaml), &snap.SideInfo{
 		Revision: snap.R("42"),
 	})
 	hookPath := filepath.Join("meta", "hooks", "configure")
@@ -296,7 +294,7 @@ func actuallyExec(argv0 string, argv []string, env []string) error {
 
 func (s *snapExecSuite) TestSnapExecShellIntegration(c *C) {
 	dirs.SetRootDir(c.MkDir())
-	snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R("42"),
 	})
 
@@ -321,7 +319,7 @@ func (s *snapExecSuite) TestSnapExecShellIntegration(c *C) {
 
 func (s *snapExecSuite) TestSnapExecAppIntegrationWithVars(c *C) {
 	dirs.SetRootDir(c.MkDir())
-	snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R("42"),
 	})
 

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -45,7 +45,6 @@ apps:
 hooks:
  configure:
 `)
-var mockContents = "SNAP"
 
 func (s *SnapSuite) TestInvalidParameters(c *check.C) {
 	invalidParameters := []string{"run", "--hook=configure", "--command=command-name", "snap-name"}
@@ -67,7 +66,7 @@ func (s *SnapSuite) TestInvalidParameters(c *check.C) {
 
 func (s *SnapSuite) TestSnapRunWhenMissingConfine(c *check.C) {
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -97,7 +96,7 @@ func (s *SnapSuite) TestSnapRunAppIntegration(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -132,7 +131,7 @@ func (s *SnapSuite) TestSnapRunClassicAppIntegration(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml)+"confinement: classic\n", string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml)+"confinement: classic\n", &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -171,7 +170,7 @@ func (s *SnapSuite) TestSnapRunClassicAppIntegrationReexeced(c *check.C) {
 	defer mockSnapConfine(mountedCoreLibExecPath)()
 
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml)+"confinement: classic\n", string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml)+"confinement: classic\n", &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -203,7 +202,7 @@ func (s *SnapSuite) TestSnapRunAppWithCommandIntegration(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -254,7 +253,7 @@ func (s *SnapSuite) TestSnapRunHookIntegration(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -288,7 +287,7 @@ func (s *SnapSuite) TestSnapRunHookUnsetRevisionIntegration(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -323,10 +322,10 @@ func (s *SnapSuite) TestSnapRunHookSpecificRevisionIntegration(c *check.C) {
 
 	// mock installed snap
 	// Create both revisions 41 and 42
-	snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R(41),
 	})
-	snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 
@@ -356,7 +355,7 @@ func (s *SnapSuite) TestSnapRunHookSpecificRevisionIntegration(c *check.C) {
 
 func (s *SnapSuite) TestSnapRunHookMissingRevisionIntegration(c *check.C) {
 	// Only create revision 42
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -382,7 +381,7 @@ func (s *SnapSuite) TestSnapRunHookInvalidRevisionIntegration(c *check.C) {
 
 func (s *SnapSuite) TestSnapRunHookMissingHookIntegration(c *check.C) {
 	// Only create revision 42
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -420,7 +419,7 @@ func (s *SnapSuite) TestSnapRunSaneEnvironmentHandling(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -476,7 +475,7 @@ func (s *SnapSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 	defer mockSnapConfine(filepath.Join(dirs.SnapMountDir, "core", "current", dirs.CoreLibExecDir))()
 
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -525,7 +524,7 @@ func (s *SnapSuite) TestSnapRunXauthorityMigration(c *check.C) {
 
 	// mock installed snap; happily this also gives us a directory
 	// below /tmp which the Xauthority migration expects.
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
 	err = os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
@@ -652,7 +651,7 @@ func (s *SnapSuite) TestSnapRunAppWithStraceIntegration(c *check.C) {
 	defer mockSnapConfine(dirs.DistroLibExecDir)()
 
 	// mock installed snap
-	si := snaptest.MockSnap(c, string(mockYaml), string(mockContents), &snap.SideInfo{
+	si := snaptest.MockSnap(c, string(mockYaml), &snap.SideInfo{
 		Revision: snap.R("x2"),
 	})
 	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -36,7 +36,6 @@ version: 1.0
 hooks:
  configure:
 `)
-var validApplyContents = ""
 
 func (s *SnapSuite) TestInvalidSetParameters(c *check.C) {
 	invalidParameters := []string{"set", "snap-name", "key", "value"}
@@ -46,7 +45,7 @@ func (s *SnapSuite) TestInvalidSetParameters(c *check.C) {
 
 func (s *SnapSuite) TestSnapSetIntegrationString(c *check.C) {
 	// mock installed snap
-	snaptest.MockSnap(c, string(validApplyYaml), string(validApplyContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 
@@ -60,7 +59,7 @@ func (s *SnapSuite) TestSnapSetIntegrationString(c *check.C) {
 
 func (s *SnapSuite) TestSnapSetIntegrationNumber(c *check.C) {
 	// mock installed snap
-	snaptest.MockSnap(c, string(validApplyYaml), string(validApplyContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 
@@ -73,7 +72,7 @@ func (s *SnapSuite) TestSnapSetIntegrationNumber(c *check.C) {
 }
 
 func (s *SnapSuite) TestSnapSetIntegrationBigInt(c *check.C) {
-	snaptest.MockSnap(c, string(validApplyYaml), string(validApplyContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 
@@ -87,7 +86,7 @@ func (s *SnapSuite) TestSnapSetIntegrationBigInt(c *check.C) {
 
 func (s *SnapSuite) TestSnapSetIntegrationJson(c *check.C) {
 	// mock installed snap
-	snaptest.MockSnap(c, string(validApplyYaml), string(validApplyContents), &snap.SideInfo{
+	snaptest.MockSnap(c, string(validApplyYaml), &snap.SideInfo{
 		Revision: snap.R(42),
 	})
 

--- a/daemon/api_mock_test.go
+++ b/daemon/api_mock_test.go
@@ -33,7 +33,7 @@ func (s *apiSuite) mockSnap(c *C, yamlText string) *snap.Info {
 		panic("call s.daemon(c) in your test first")
 	}
 
-	snapInfo := snaptest.MockSnap(c, yamlText, "", &snap.SideInfo{Revision: snap.R(1)})
+	snapInfo := snaptest.MockSnap(c, yamlText, &snap.SideInfo{Revision: snap.R(1)})
 
 	st := s.d.overlord.State()
 

--- a/overlord/configstate/handler_test.go
+++ b/overlord/configstate/handler_test.go
@@ -109,7 +109,7 @@ volumes:
         bootloader: grub
 `)
 
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, "SNAP", &snap.SideInfo{Revision: snap.R(1)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(1)})
 	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
@@ -129,7 +129,7 @@ hooks:
     configure:
 `
 
-	snaptest.MockSnap(c, mockTestSnapYaml, "SNAP", &snap.SideInfo{Revision: snap.R(11)})
+	snaptest.MockSnap(c, mockTestSnapYaml, &snap.SideInfo{Revision: snap.R(11)})
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{
@@ -180,7 +180,7 @@ volumes:
         bootloader: grub
 `)
 
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, "SNAP", &snap.SideInfo{Revision: snap.R(1)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(1)})
 	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -289,7 +289,7 @@ func (s *deviceMgrSuite) setupGadget(c *C, snapYaml string, snapContents string)
 		RealName: "gadget",
 		Revision: snap.R(2),
 	}
-	snaptest.MockSnap(c, snapYaml, snapContents, sideInfoGadget)
+	snaptest.MockSnap(c, snapYaml, sideInfoGadget)
 	snapstate.Set(s.state, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
@@ -303,7 +303,7 @@ func (s *deviceMgrSuite) setupCore(c *C, name, snapYaml string, snapContents str
 		RealName: name,
 		Revision: snap.R(3),
 	}
-	snaptest.MockSnap(c, snapYaml, snapContents, sideInfoCore)
+	snaptest.MockSnap(c, snapYaml, sideInfoCore)
 	snapstate.Set(s.state, name, &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
@@ -2067,7 +2067,7 @@ name: core
 version: 1.0
 slots:
  snapd-control:
-`, "", sideInfoCore11)
+`, sideInfoCore11)
 	c.Assert(core11.Slots, HasLen, 1)
 
 	return core11
@@ -2096,7 +2096,7 @@ func makeInstalledMockSnap(c *C, st *state.State, yml string) *snap.Info {
 		Current:  sideInfo11.Revision,
 		SnapType: "app",
 	})
-	info11 := snaptest.MockSnap(c, yml, "", sideInfo11)
+	info11 := snaptest.MockSnap(c, yml, sideInfo11)
 	c.Assert(info11.Plugs, HasLen, 1)
 
 	return info11

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -135,10 +135,10 @@ func (s *servicectlSuite) SetUpTest(c *C) {
 	snapstate.ReplaceStore(s.st, &s.fakeStore)
 
 	// mock installed snaps
-	info1 := snaptest.MockSnap(c, string(testSnapYaml), "", &snap.SideInfo{
+	info1 := snaptest.MockSnap(c, string(testSnapYaml), &snap.SideInfo{
 		Revision: snap.R(1),
 	})
-	info2 := snaptest.MockSnap(c, string(otherSnapYaml), "", &snap.SideInfo{
+	info2 := snaptest.MockSnap(c, string(otherSnapYaml), &snap.SideInfo{
 		Revision: snap.R(1),
 	})
 	snapstate.Set(s.st, info1.Name(), &snapstate.SnapState{

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -82,8 +82,6 @@ hooks:
     prepare-device:
 `
 
-var snapContents = ""
-
 func (s *hookManagerSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 
@@ -115,7 +113,7 @@ func (s *hookManagerSuite) SetUpTest(c *C) {
 	s.change.AddTask(s.task)
 
 	sideInfo := &snap.SideInfo{RealName: "test-snap", SnapID: "some-snap-id", Revision: snap.R(1)}
-	snaptest.MockSnap(c, snapYaml, snapContents, sideInfo)
+	snaptest.MockSnap(c, snapYaml, sideInfo)
 	snapstate.Set(s.state, "test-snap", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfo},
@@ -874,7 +872,7 @@ func (s *hookManagerSuite) TestHookTasksForDifferentSnapsRunConcurrently(c *C) {
 	s.state.Lock()
 
 	sideInfo := &snap.SideInfo{RealName: "test-snap-1", SnapID: "some-snap-id1", Revision: snap.R(1)}
-	info := snaptest.MockSnap(c, snapYaml1, snapContents, sideInfo)
+	info := snaptest.MockSnap(c, snapYaml1, sideInfo)
 	c.Assert(info.Hooks, HasLen, 1)
 	snapstate.Set(s.state, "test-snap-1", &snapstate.SnapState{
 		Active:   true,
@@ -883,7 +881,7 @@ func (s *hookManagerSuite) TestHookTasksForDifferentSnapsRunConcurrently(c *C) {
 	})
 
 	sideInfo = &snap.SideInfo{RealName: "test-snap-2", SnapID: "some-snap-id2", Revision: snap.R(1)}
-	snaptest.MockSnap(c, snapYaml2, snapContents, sideInfo)
+	snaptest.MockSnap(c, snapYaml2, sideInfo)
 	snapstate.Set(s.state, "test-snap-2", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfo},

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -614,7 +614,7 @@ func (s *interfaceManagerSuite) mockSnap(c *C, yamlText string) *snap.Info {
 	sideInfo := &snap.SideInfo{
 		Revision: snap.R(1),
 	}
-	snapInfo := snaptest.MockSnap(c, yamlText, "", sideInfo)
+	snapInfo := snaptest.MockSnap(c, yamlText, sideInfo)
 	sideInfo.RealName = snapInfo.Name()
 
 	a, err := s.db.FindMany(asserts.SnapDeclarationType, map[string]string{
@@ -643,7 +643,7 @@ func (s *interfaceManagerSuite) mockSnap(c *C, yamlText string) *snap.Info {
 
 func (s *interfaceManagerSuite) mockUpdatedSnap(c *C, yamlText string, revision int) *snap.Info {
 	sideInfo := &snap.SideInfo{Revision: snap.R(revision)}
-	snapInfo := snaptest.MockSnap(c, yamlText, "", sideInfo)
+	snapInfo := snaptest.MockSnap(c, yamlText, sideInfo)
 	sideInfo.RealName = snapInfo.Name()
 
 	s.state.Lock()

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -62,7 +62,6 @@ version: 1.0
 	helloYaml2 = `name: hello
 version: 2.0
 `
-	helloContents = ""
 )
 
 func (s *copydataSuite) TestCopyData(c *C) {
@@ -76,7 +75,7 @@ func (s *copydataSuite) TestCopyData(c *C) {
 
 	canaryData := []byte("ni ni ni")
 
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	// just creates data dirs in this case
 	err = s.be.CopySnapData(v1, nil, progress.Null)
 	c.Assert(err, IsNil)
@@ -92,7 +91,7 @@ func (s *copydataSuite) TestCopyData(c *C) {
 	err = ioutil.WriteFile(filepath.Join(homeCommonData, "canary.common_home"), canaryData, 0644)
 	c.Assert(err, IsNil)
 
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 	err = s.be.CopySnapData(v2, v1, progress.Null)
 	c.Assert(err, IsNil)
 
@@ -123,11 +122,11 @@ func (s *copydataSuite) TestCopyDataBails(c *C) {
 	oldSnapDataHomeGlob := dirs.SnapDataHomeGlob
 	defer func() { dirs.SnapDataHomeGlob = oldSnapDataHomeGlob }()
 
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	c.Assert(s.be.CopySnapData(v1, nil, progress.Null), IsNil)
 	c.Assert(os.Chmod(v1.DataDir(), 0), IsNil)
 
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 	err := s.be.CopySnapData(v2, v1, progress.Null)
 	c.Check(err, ErrorMatches, "cannot copy .*")
 }
@@ -140,7 +139,7 @@ func (s *copydataSuite) TestCopyDataNoUserHomes(c *C) {
 	defer func() { dirs.SnapDataHomeGlob = oldSnapDataHomeGlob }()
 	dirs.SnapDataHomeGlob = filepath.Join(s.tempdir, "no-such-home", "*", "snap")
 
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	err := s.be.CopySnapData(v1, nil, progress.Null)
 	c.Assert(err, IsNil)
 
@@ -151,7 +150,7 @@ func (s *copydataSuite) TestCopyDataNoUserHomes(c *C) {
 	err = ioutil.WriteFile(canaryDataFile, []byte(""), 0644)
 	c.Assert(err, IsNil)
 
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 	err = s.be.CopySnapData(v2, v1, progress.Null)
 	c.Assert(err, IsNil)
 
@@ -197,12 +196,12 @@ func (s copydataSuite) populateHomeData(c *C, user string, revision snap.Revisio
 }
 
 func (s *copydataSuite) TestCopyDataDoUndo(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	s.populateData(c, snap.R(10))
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
 
 	// pretend we install a new version
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
 	// copy data
 	err := s.be.CopySnapData(v2, v1, progress.Null)
@@ -232,11 +231,11 @@ func (s *copydataSuite) TestCopyDataDoUndoNoUserHomes(c *C) {
 	defer func() { dirs.SnapDataHomeGlob = oldSnapDataHomeGlob }()
 	dirs.SnapDataHomeGlob = filepath.Join(s.tempdir, "no-such-home", "*", "snap")
 
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	s.populateData(c, snap.R(10))
 
 	// pretend we install a new version
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
 	// copy data
 	err := s.be.CopySnapData(v2, v1, progress.Null)
@@ -255,7 +254,7 @@ func (s *copydataSuite) TestCopyDataDoUndoNoUserHomes(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataDoUndoFirstInstall(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	// first install
 	err := s.be.CopySnapData(v1, nil, progress.Null)
@@ -274,12 +273,12 @@ func (s *copydataSuite) TestCopyDataDoUndoFirstInstall(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataDoABA(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	s.populateData(c, snap.R(10))
 	c.Check(s.populatedData("10"), Equals, "10\n")
 
 	// pretend we install a new version
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 	// and write our own data to it
 	s.populateData(c, snap.R(20))
 	c.Check(s.populatedData("20"), Equals, "20\n")
@@ -299,12 +298,12 @@ func (s *copydataSuite) TestCopyDataDoABA(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataDoUndoABA(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	s.populateData(c, snap.R(10))
 	c.Check(s.populatedData("10"), Equals, "10\n")
 
 	// pretend we install a new version
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 	// and write our own data to it
 	s.populateData(c, snap.R(20))
 	c.Check(s.populatedData("20"), Equals, "20\n")
@@ -328,13 +327,13 @@ func (s *copydataSuite) TestCopyDataDoUndoABA(c *C) {
 func (s *copydataSuite) TestCopyDataDoIdempotent(c *C) {
 	// make sure that a retry wouldn't stumble on partial work
 
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	s.populateData(c, snap.R(10))
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
 
 	// pretend we install a new version
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
 	// copy data
 	err := s.be.CopySnapData(v2, v1, progress.Null)
@@ -356,12 +355,12 @@ func (s *copydataSuite) TestCopyDataDoIdempotent(c *C) {
 func (s *copydataSuite) TestCopyDataUndoIdempotent(c *C) {
 	// make sure that a retry wouldn't stumble on partial work
 
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	s.populateData(c, snap.R(10))
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
 
 	// pretend we install a new version
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
 	// copy data
 	err := s.be.CopySnapData(v2, v1, progress.Null)
@@ -384,7 +383,7 @@ func (s *copydataSuite) TestCopyDataUndoIdempotent(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataDoFirstInstallIdempotent(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	// first install
 	err := s.be.CopySnapData(v1, nil, progress.Null)
@@ -407,7 +406,7 @@ func (s *copydataSuite) TestCopyDataDoFirstInstallIdempotent(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataUndoFirstInstallIdempotent(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	// first install
 	err := s.be.CopySnapData(v1, nil, progress.Null)
@@ -430,11 +429,11 @@ func (s *copydataSuite) TestCopyDataUndoFirstInstallIdempotent(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataCopyFailure(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	s.populateData(c, snap.R(10))
 
 	// pretend we install a new version
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
 	defer testutil.MockCommand(c, "cp", "echo cp: boom; exit 3").Restore()
 
@@ -448,14 +447,14 @@ func (s *copydataSuite) TestCopyDataCopyFailure(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	s.populateData(c, snap.R(10))
 	homedir1 := s.populateHomeData(c, "user1", snap.R(10))
 	homedir2 := s.populateHomeData(c, "user2", snap.R(10))
 
 	// pretend we install a new version
-	v2 := snaptest.MockSnap(c, helloYaml2, helloContents, &snap.SideInfo{Revision: snap.R(20)})
+	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
 	// sanity check: the 20 dirs don't exist yet (but 10 do)
 	for _, dir := range []string{dirs.SnapDataDir, homedir1, homedir2} {
@@ -477,7 +476,7 @@ func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataSameRevision(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	homedir1 := s.populateHomeData(c, "user1", snap.R(10))
 	homedir2 := s.populateHomeData(c, "user2", snap.R(10))
@@ -513,7 +512,7 @@ func (s *copydataSuite) TestCopyDataSameRevision(c *C) {
 }
 
 func (s *copydataSuite) TestUndoCopyDataSameRevision(c *C) {
-	v1 := snaptest.MockSnap(c, helloYaml1, helloContents, &snap.SideInfo{Revision: snap.R(10)})
+	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	homedir1 := s.populateHomeData(c, "user1", snap.R(10))
 	homedir2 := s.populateHomeData(c, "user2", snap.R(10))

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -71,9 +71,7 @@ apps:
    command: svc
    daemon: simple
 `
-	const contents = ""
-
-	info := snaptest.MockSnap(c, yaml, contents, &snap.SideInfo{Revision: snap.R(11)})
+	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := s.be.LinkSnap(info)
 	c.Assert(err, IsNil)
@@ -103,7 +101,7 @@ version: 1.0
 `
 	const contents = ""
 
-	info := snaptest.MockSnap(c, yaml, contents, &snap.SideInfo{Revision: snap.R(11)})
+	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := s.be.LinkSnap(info)
 	c.Assert(err, IsNil)
@@ -145,7 +143,7 @@ apps:
 `
 	const contents = ""
 
-	info := snaptest.MockSnap(c, yaml, contents, &snap.SideInfo{Revision: snap.R(11)})
+	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := s.be.LinkSnap(info)
 	c.Assert(err, IsNil)
@@ -187,7 +185,7 @@ apps:
 `
 	const contents = ""
 
-	info := snaptest.MockSnap(c, yaml, contents, &snap.SideInfo{Revision: snap.R(11)})
+	info := snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := s.be.LinkSnap(info)
 	c.Assert(err, IsNil)
@@ -245,7 +243,7 @@ apps:
    command: svc
    daemon: simple
 `
-	s.info = snaptest.MockSnap(c, yaml, "", &snap.SideInfo{Revision: snap.R(11)})
+	s.info = snaptest.MockSnap(c, yaml, &snap.SideInfo{Revision: snap.R(11)})
 
 	guiDir := filepath.Join(s.info.MountDir(), "meta", "gui")
 	c.Assert(os.MkdirAll(guiDir, 0755), IsNil)

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -103,8 +103,8 @@ func (bs *bootedSuite) settle() {
 }
 
 func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
-	snaptest.MockSnap(c, "name: core\ntype: os\nversion: 1", "", osSI1)
-	snaptest.MockSnap(c, "name: core\ntype: os\nversion: 2", "", osSI2)
+	snaptest.MockSnap(c, "name: core\ntype: os\nversion: 1", osSI1)
+	snaptest.MockSnap(c, "name: core\ntype: os\nversion: 2", osSI2)
 	snapstate.Set(st, "core", &snapstate.SnapState{
 		SnapType: "os",
 		Active:   true,
@@ -112,8 +112,8 @@ func (bs *bootedSuite) makeInstalledKernelOS(c *C, st *state.State) {
 		Current:  snap.R(2),
 	})
 
-	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 1", "", kernelSI1)
-	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 2", "", kernelSI2)
+	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 1", kernelSI1)
+	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 2", kernelSI2)
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
@@ -221,7 +221,7 @@ func (bs *bootedSuite) TestUpdateBootRevisionsOSErrorsLate(c *C) {
 	defer st.Unlock()
 
 	// have a kernel
-	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 2", "", kernelSI2)
+	snaptest.MockSnap(c, "name: canonical-pc-linux\ntype: os\nversion: 2", kernelSI2)
 	snapstate.Set(st, "canonical-pc-linux", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -246,7 +246,7 @@ func (s *checkSnapSuite) TestCheckSnapGadgetUpdate(c *C) {
 name: gadget
 type: gadget
 version: 1
-`, "", si)
+`, si)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
@@ -288,7 +288,7 @@ func (s *checkSnapSuite) TestCheckSnapGadgetUpdateLocal(c *C) {
 name: gadget
 type: gadget
 version: 1
-`, "", si)
+`, si)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
@@ -330,7 +330,7 @@ func (s *checkSnapSuite) TestCheckSnapGadgetUpdateToUnassertedProhibited(c *C) {
 name: gadget
 type: gadget
 version: 1
-`, "", si)
+`, si)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
@@ -371,7 +371,7 @@ func (s *checkSnapSuite) TestCheckSnapGadgetAdditionProhibited(c *C) {
 name: gadget
 type: gadget
 version: 1
-`, "", si)
+`, si)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
@@ -412,7 +412,7 @@ func (s *checkSnapSuite) TestCheckSnapGadgetAdditionProhibitedBySnapID(c *C) {
 name: gadget
 type: gadget
 version: 1
-`, "", si)
+`, si)
 	snapstate.Set(st, "gadget", &snapstate.SnapState{
 		SnapType: "gadget",
 		Active:   true,
@@ -551,7 +551,7 @@ func (s *checkSnapSuite) TestCheckSnapKernelUpdate(c *C) {
 name: kernel
 type: kernel
 version: 1
-`, "", si)
+`, si)
 	snapstate.Set(st, "kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
@@ -593,7 +593,7 @@ func (s *checkSnapSuite) TestCheckSnapKernelAdditionProhibitedBySnapID(c *C) {
 name: kernel
 type: kernel
 version: 1
-`, "", si)
+`, si)
 	snapstate.Set(st, "kernel", &snapstate.SnapState{
 		SnapType: "kernel",
 		Active:   true,
@@ -657,7 +657,7 @@ func (s *checkSnapSuite) TestCheckSnapBasesHappy(c *C) {
 name: some-base
 type: base
 version: 1
-`, "", si)
+`, si)
 	snapstate.Set(st, "some-base", &snapstate.SnapState{
 		SnapType: "base",
 		Active:   true,

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -5911,12 +5911,12 @@ func (s *snapmgrQuerySuite) SetUpTest(c *C) {
 name: name0
 version: 1.1
 description: |
-    Lots of text`, "", sideInfo11)
+    Lots of text`, sideInfo11)
 	snaptest.MockSnap(c, `
 name: name0
 version: 1.2
 description: |
-    Lots of text`, "", sideInfo12)
+    Lots of text`, sideInfo12)
 	snapstate.Set(st, "name1", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{sideInfo11, sideInfo12},
@@ -6049,7 +6049,7 @@ func (s *snapmgrQuerySuite) TestTypeInfo(c *C) {
 			RealName: x.snapName,
 			Revision: snap.R(2),
 		}
-		snaptest.MockSnap(c, fmt.Sprintf("name: %q\ntype: %q\nversion: %q\n", x.snapName, x.snapType, x.snapName), "", sideInfo)
+		snaptest.MockSnap(c, fmt.Sprintf("name: %q\ntype: %q\nversion: %q\n", x.snapName, x.snapType, x.snapName), sideInfo)
 		snapstate.Set(st, x.snapName, &snapstate.SnapState{
 			SnapType: string(x.snapType),
 			Active:   true,
@@ -6106,7 +6106,7 @@ func (s *snapmgrQuerySuite) TestTypeInfoCore(c *C) {
 				RealName: snapName,
 				Revision: snap.R(1),
 			}
-			snaptest.MockSnap(c, fmt.Sprintf("name: %q\ntype: os\nversion: %q\n", snapName, snapName), "", sideInfo)
+			snaptest.MockSnap(c, fmt.Sprintf("name: %q\ntype: os\nversion: %q\n", snapName, snapName), sideInfo)
 			snapstate.Set(st, snapName, &snapstate.SnapState{
 				SnapType: string(snap.TypeOS),
 				Active:   true,
@@ -7005,7 +7005,7 @@ func (s *snapmgrTestSuite) prepareGadget(c *C) {
 name: the-gadget
 type: gadget
 version: 1.0
-`, "", gadgetSideInfo)
+`, gadgetSideInfo)
 
 	err := ioutil.WriteFile(filepath.Join(gadgetInfo.MountDir(), "meta/gadget.yaml"), []byte(gadgetYaml), 0600)
 	c.Assert(err, IsNil)
@@ -7072,7 +7072,7 @@ volumes:
         bootloader: grub
 `)
 
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, "SNAP", &snap.SideInfo{Revision: snap.R(2)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(2)})
 	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
@@ -7102,7 +7102,7 @@ func makeInstalledMockCoreSnap(c *C) {
 version: 1.0
 type: os
 `
-	snaptest.MockSnap(c, coreSnapYaml, "", &snap.SideInfo{
+	snaptest.MockSnap(c, coreSnapYaml, &snap.SideInfo{
 		RealName: "core",
 		Revision: snap.R(1),
 	})

--- a/snap/gadget_test.go
+++ b/snap/gadget_test.go
@@ -111,8 +111,6 @@ defaults:
       bar: baz
 `)
 
-var mockGadgetSnapContents = "SNAP"
-
 func (s *gadgetYamlTestSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 }
@@ -130,20 +128,20 @@ name: other
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlMissing(c *C) {
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, mockGadgetSnapContents, &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(42)})
 	_, err := snap.ReadGadgetInfo(info, false)
 	c.Assert(err, ErrorMatches, ".*meta/gadget.yaml: no such file or directory")
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOptional(c *C) {
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, mockGadgetSnapContents, &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(42)})
 	gi, err := snap.ReadGadgetInfo(info, true)
 	c.Assert(err, IsNil)
 	c.Check(gi, NotNil)
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicEmptyIsValid(c *C) {
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, mockGadgetSnapContents, &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(42)})
 	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), nil, 0644)
 	c.Assert(err, IsNil)
 
@@ -153,7 +151,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicEmptyIsValid(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOnylDefaultsIsValid(c *C) {
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, mockGadgetSnapContents, &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(42)})
 	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockClassicGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
@@ -168,7 +166,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlOnClassicOnylDefaultsIsValid(c *
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlValid(c *C) {
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, mockGadgetSnapContents, &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(42)})
 	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
@@ -214,7 +212,7 @@ func (s *gadgetYamlTestSuite) TestReadGadgetYamlValid(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadMultiVolumeGadgetYamlValid(c *C) {
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, mockGadgetSnapContents, &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(42)})
 	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), mockMultiVolumeGadgetYaml, 0644)
 	c.Assert(err, IsNil)
 
@@ -266,7 +264,7 @@ func (s *gadgetYamlTestSuite) TestReadMultiVolumeGadgetYamlValid(c *C) {
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlInvalidBootloader(c *C) {
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, mockGadgetSnapContents, &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(42)})
 	mockGadgetYamlBroken := []byte(`
 volumes:
  name:
@@ -281,7 +279,7 @@ volumes:
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlEmptydBootloader(c *C) {
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, mockGadgetSnapContents, &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(42)})
 	mockGadgetYamlBroken := []byte(`
 volumes:
  name:
@@ -296,7 +294,7 @@ volumes:
 }
 
 func (s *gadgetYamlTestSuite) TestReadGadgetYamlMissingBootloader(c *C) {
-	info := snaptest.MockSnap(c, mockGadgetSnapYaml, mockGadgetSnapContents, &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockSnap(c, mockGadgetSnapYaml, &snap.SideInfo{Revision: snap.R(42)})
 
 	err := ioutil.WriteFile(filepath.Join(info.MountDir(), "meta", "gadget.yaml"), nil, 0644)
 	c.Assert(err, IsNil)

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -55,7 +55,7 @@ func (s *infoSimpleSuite) TearDownTest(c *C) {
 
 func (s *infoSimpleSuite) TestReadInfoPanicsIfSanitizeUnset(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(1)}
-	snaptest.MockSnap(c, sampleYaml, sampleContents, si)
+	snaptest.MockSnap(c, sampleYaml, si)
 	c.Assert(func() { snap.ReadInfo("sample", si) }, Panics, `SanitizePlugsSlots function not set`)
 }
 
@@ -173,12 +173,10 @@ apps:
    command: foobar
 `
 
-const sampleContents = "SNAP"
-
 func (s *infoSuite) TestReadInfo(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(42), EditedSummary: "esummary"}
 
-	snapInfo1 := snaptest.MockSnap(c, sampleYaml, sampleContents, si)
+	snapInfo1 := snaptest.MockSnap(c, sampleYaml, si)
 
 	snapInfo2, err := snap.ReadInfo("sample", si)
 	c.Assert(err, IsNil)
@@ -502,7 +500,7 @@ version: 1.0`
 func (s *infoSuite) checkInstalledSnapAndSnapFile(c *C, yaml string, contents string, hooks []string, checker func(c *C, info *snap.Info)) {
 	// First check installed snap
 	sideInfo := &snap.SideInfo{Revision: snap.R(42)}
-	info0 := snaptest.MockSnap(c, yaml, contents, sideInfo)
+	info0 := snaptest.MockSnap(c, yaml, sideInfo)
 	snaptest.PopulateDir(info0.MountDir(), emptyHooks(hooks...))
 	info, err := snap.ReadInfo(info0.Name(), sideInfo)
 	c.Check(err, IsNil)
@@ -661,7 +659,7 @@ func makeFakeDesktopFile(c *C, name, content string) string {
 }
 
 func (s *infoSuite) TestAppDesktopFile(c *C) {
-	snaptest.MockSnap(c, sampleYaml, sampleContents, &snap.SideInfo{})
+	snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{})
 	snapInfo, err := snap.ReadInfo("sample", &snap.SideInfo{})
 	c.Assert(err, IsNil)
 
@@ -695,7 +693,7 @@ func (s *infoSuite) TestReadInfoFromSnapFileRenamesCorePlus(c *C) {
 // reading snap via ReadInfo renames clashing core plugs
 func (s *infoSuite) TestReadInfoRenamesCorePlugs(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(42), RealName: "core"}
-	snaptest.MockSnap(c, coreSnapYaml, sampleContents, si)
+	snaptest.MockSnap(c, coreSnapYaml, si)
 	info, err := snap.ReadInfo("core", si)
 	c.Assert(err, IsNil)
 	c.Check(info.Plugs["network-bind"], IsNil)

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -21,6 +21,7 @@
 package snaptest
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -36,7 +37,7 @@ import (
 //
 // The caller is responsible for mocking root directory with dirs.SetRootDir()
 // and for altering the overlord state if required.
-func MockSnap(c *check.C, yamlText string, snapContents string, sideInfo *snap.SideInfo) *snap.Info {
+func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	c.Assert(sideInfo, check.Not(check.IsNil))
 
 	// Parse the yaml (we need the Name).
@@ -56,6 +57,7 @@ func MockSnap(c *check.C, yamlText string, snapContents string, sideInfo *snap.S
 	// Write the .snap to disk
 	err = os.MkdirAll(filepath.Dir(snapInfo.MountFile()), 0755)
 	c.Assert(err, check.IsNil)
+	snapContents := fmt.Sprintf("%s-%s-%s", sideInfo.RealName, sideInfo.SnapID, sideInfo.Revision)
 	err = ioutil.WriteFile(snapInfo.MountFile(), []byte(snapContents), 0644)
 	c.Assert(err, check.IsNil)
 	snapInfo.Size = int64(len(snapContents))

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -44,7 +44,6 @@ plugs:
  network:
   interface: network
 `
-const sampleContents = ""
 
 type snapTestSuite struct{}
 
@@ -59,7 +58,7 @@ func (s *snapTestSuite) TearDownTest(c *C) {
 }
 
 func (s *snapTestSuite) TestMockSnap(c *C) {
-	snapInfo := snaptest.MockSnap(c, sampleYaml, sampleContents, &snap.SideInfo{Revision: snap.R(42)})
+	snapInfo := snaptest.MockSnap(c, sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
 	// Data from YAML is used
 	c.Check(snapInfo.Name(), Equals, "sample")
 	// Data from SideInfo is used

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -67,7 +67,6 @@ apps:
   post-stop-command: bin/missya
   daemon: forking
 `
-const contentsHello = "HELLO"
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemove(c *C) {
 	// no completers support -> no problem \o/
@@ -96,7 +95,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveWithExistingCompleters(c
 }
 
 func (s *binariesTestSuite) testAddSnapBinariesAndRemove(c *C) {
-	info := snaptest.MockSnap(c, packageHello, contentsHello, &snap.SideInfo{Revision: snap.R(11)})
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(11)})
 	completer := filepath.Join(dirs.CompletersDir, "hello-snap.world")
 	completerExisted := osutil.FileExists(completer)
 
@@ -143,7 +142,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesCleansUpOnFailure(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
  bye:
   command: bin/bye
-`, contentsHello, &snap.SideInfo{Revision: snap.R(11)})
+`, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := wrappers.AddSnapBinaries(info)
 	c.Assert(err, NotNil)

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -70,7 +70,7 @@ func (s *desktopSuite) TestAddPackageDesktopFiles(c *C) {
 	expectedDesktopFilePath := filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar.desktop")
 	c.Assert(osutil.FileExists(expectedDesktopFilePath), Equals, false)
 
-	info := snaptest.MockSnap(c, desktopAppYaml, desktopContents, &snap.SideInfo{Revision: snap.R(11)})
+	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})
 
 	// generate .desktop file in the package baseDir
 	baseDir := info.MountDir()
@@ -113,7 +113,7 @@ func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
 	err := os.MkdirAll(filepath.Join(dirs.SnapDesktopFilesDir, "foo_foobar2.desktop", "potato"), 0755)
 	c.Assert(err, IsNil)
 
-	info := snaptest.MockSnap(c, desktopAppYaml, desktopContents, &snap.SideInfo{Revision: snap.R(11)})
+	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})
 
 	// generate .desktop file in the package baseDir
 	baseDir := info.MountDir()

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -69,7 +69,7 @@ func (s *servicesTestSuite) TestAddSnapServicesAndRemove(c *C) {
 	})
 	defer r()
 
-	info := snaptest.MockSnap(c, packageHello, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	err := wrappers.AddSnapServices(info, nil)
@@ -118,7 +118,7 @@ func (s *servicesTestSuite) TestRemoveSnapWithSocketsRemovesSocketsService(c *C)
       socket-mode: 0666
     sock2:
       listen-stream: $SNAP_COMMON/sock2.socket
-`, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil)
 	c.Assert(err, IsNil)
@@ -158,7 +158,7 @@ apps:
    command: wat
    stop-timeout: 250ms
    daemon: forking
-`, "", &snap.SideInfo{Revision: snap.R(11)})
+`, &snap.SideInfo{Revision: snap.R(11)})
 
 	err := wrappers.AddSnapServices(info, nil)
 	c.Assert(err, IsNil)
@@ -198,7 +198,7 @@ func (s *servicesTestSuite) TestStopServicesWithSockets(c *C) {
       socket-mode: 0666
     sock2:
       listen-stream: $SNAP_DATA/sock2.socket
-`, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil)
 	c.Assert(err, IsNil)
@@ -221,7 +221,7 @@ func (s *servicesTestSuite) TestStartServices(c *C) {
 	})
 	defer r()
 
-	info := snaptest.MockSnap(c, packageHello, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFile := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.service")
 
 	err := wrappers.StartServices(info.Services(), nil)
@@ -246,7 +246,7 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesFailCreateCleanup(c *C) {
 	info := snaptest.MockSnap(c, packageHello+`
  svc2:
   daemon: potato
-`, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil)
 	c.Assert(err, ErrorMatches, ".*potato.*")
@@ -311,7 +311,7 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesFailEnableCleanup(c *C) {
  svc2:
   command: bin/hello
   daemon: simple
-`, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, nil)
 	c.Assert(err, ErrorMatches, "failed")
@@ -359,7 +359,7 @@ func (s *servicesTestSuite) TestAddSnapMultiServicesStartFailOnSystemdReloadClea
  svc2:
   command: bin/hello
   daemon: simple
-`, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.AddSnapServices(info, progress.Null)
 	c.Assert(err, ErrorMatches, "failed")
@@ -396,7 +396,7 @@ func (s *servicesTestSuite) TestAddSnapSocketFiles(c *C) {
       socket-mode: 0666
     sock2:
       listen-stream: $SNAP_DATA/sock2.socket
-`, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	sock1File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.sock1.socket")
 	sock2File := filepath.Join(s.tempdir, "/etc/systemd/system/snap.hello-snap.svc1.sock2.socket")
@@ -457,7 +457,7 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
  svc2:
   command: bin/hello
   daemon: simple
-`, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+`, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.StartServices(info.Services(), nil)
 	c.Assert(err, ErrorMatches, "failed")
@@ -495,7 +495,7 @@ func (s *servicesTestSuite) TestServiceAfterBefore(c *C) {
      - svc2
      - svc3
 `
-	info := snaptest.MockSnap(c, snapYaml, contentsHello, &snap.SideInfo{Revision: snap.R(12)})
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
 
 	checks := []struct {
 		file    string


### PR DESCRIPTION
We currently pass a "content" parameter to MockSnap() which
describes what content the on-disk mocked snap file should
have. This is not used in any test, most tests set it to either
"" or "SNAP". So we just remove it from the API and set the
mocked snap content to "$REALNAME-$SNAPID-$REVNO" which has
the added benefit that the mock snap files on disk all have
different hashes which is useful when working with e.g.
the snap revision assertion.

This is very mechanical and boring.
