### PR TITLE
many: allow constructing layouts (phase 1)

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -512,7 +512,7 @@
 
         # Needed to perform mount/unmounts.
         capability sys_admin,
-        # Needed to chown files for writable mimic.
+        # Needed for mimic construction.
         capability chown,
 
         # Allow freezing and thawing the per-snap cgroup freezers
@@ -552,22 +552,36 @@
         /tmp/.snap/{,**} rw,
         # Allow mounting/unmounting any part of $SNAP over to a temporary place
         # in /tmp/.snap/ during the preparation of a writable mimic.
-        mount options=(bind, rw) /snap/*/** -> /tmp/.snap/**,
+        # FIXME: update this with per-snap snap-update-ns profiles
+        mount options=(bind, rw) /*/** -> /tmp/.snap/**,
         # Allow mounting tmpfs over the original $SNAP/** directory.
-        mount fstype=tmpfs options=(rw) tmpfs -> /snap/*/**,
+        # FIXME: update this with per-snap snap-update-ns profiles
+        mount fstype=tmpfs options=(rw) tmpfs -> /*/**,
         # Allow bind mounting anything from the temporary place in /tmp/.snap/
         # back to $SNAP/** (to re-construct the data that was there before).
-        mount options=(bind, rw) /tmp/.snap/** -> /snap/*/**,
+        # FIXME: update this with per-snap snap-update-ns profiles
+        mount options=(bind, rw) /tmp/.snap/** -> /*/**,
         # Allow unmounting the temporary directory in /tmp once it is no longer
         # necessary.
         umount /tmp/.snap/**,
 
-        # Allow creating missing directories under $SNAP once the writable
-        # mimic is ready.
+        # Allow creating missing directories anywhere under the root directory
+        # (but not in the root directory itself) where they need to be created
+        # as a mount point for layouts or for content sharing. This is a
+        # superset of other cases so they are removed
+        # FIXME: update this with per-snap snap-update-ns profiles
         / r,
-        /snap/ r,
-        /snap/{,**} r,
-        /snap/*/** w,
+        /** r,
+        /*/** w,
+
+        # Allow layouts to bind mount *from* $SNAP, $SNAP_DATA and $SNAP_COMMON
+        # *to* anywhere under the root directory. This is safe because the
+        # mounts happen inside an isolated mount namespace (but see below).
+        mount options=(bind) /snap/*/** -> /*/**,
+        mount options=(bind) /var/snap/*/** -> /*/**,
+        # As an exception, don't allow bind mounts to /media which has special
+        # sharing and propagates mount events outside of the snap namespace.
+        audit deny mount -> /media,
 
         # Allow the content interface to bind fonts from the host filesystem
         mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
@@ -577,11 +591,7 @@
         mount options=(ro bind) /var/lib/snapd/hostfs/var/cache/fontconfig/ -> /var/cache/fontconfig/,
 
         # Allow unmounts matching possible mounts listed above.
-        umount /snap/*/*/**,
-        umount /var/snap/*/**,
-        umount /usr/share/fonts,
-        umount /usr/local/share/fonts,
-        umount /var/cache/fontconfig,
+        umount /*/**,
 
         # But we don't want anyone to touch /snap/bin
         audit deny mount /snap/bin/** -> /**,

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -277,6 +277,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	if err != nil {
 		return fmt.Errorf("cannot obtain apparmor specification for snap %q: %s", snapName, err)
 	}
+	spec.(*Specification).AddSnapLayout(snapInfo)
 
 	// core on classic is special
 	if snapName == "core" && release.OnClassic && release.AppArmorLevel() != release.NoAppArmor {
@@ -332,8 +333,9 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 
 // Remove removes and unloads apparmor profiles of a given snap.
 func (b *Backend) Remove(snapName string) error {
-	glob := interfaces.SecurityTagGlob(snapName)
-	_, removed, errEnsure := osutil.EnsureDirState(dirs.SnapAppArmorDir, glob, nil)
+	glob1 := fmt.Sprintf("snap*.%s*", snapName)
+	glob2 := fmt.Sprintf("snap-update-ns.%s", snapName)
+	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dirs.SnapAppArmorDir, []string{glob1, glob2}, nil)
 	errUnload := unloadProfiles(removed)
 	if errEnsure != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, errEnsure)


### PR DESCRIPTION
This patch implements the first phase of layouts agreed with jdstrand.

The requirements for this phase are:
 * source of mount --bind must be in one of $SNAP, $SNAP_DATA or $SNAP_COMMON
 * target of symlink must in in one of $SNAP, $SNAP_DATA, or $SNAP_COMMON
 * may not mount on top of an existing layout mountpoint

The first and rules are implemented with an apparmor profile. All three
rules are implemented with additional snapd-side validation. As an extra
sanity check mounts over /media are denied as that directory is setup
with bidirectional mount event propagation.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>