### PR TITLE
interfaces/desktop-legacy,unity7: support gtk2/gvfs gtk_show_uri() for 2.31

### DIFF
--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -212,6 +212,18 @@ dbus send
     interface=org.freedesktop.DBus.Properties
     member=GetAll
     peer=(label=unconfined),
+
+# gtk2/gvfs gtk_show_uri()
+dbus (send)
+    bus=session
+    path=/org/gtk/vfs/mounttracker
+    interface=org.gtk.vfs.MountTracker
+    member=ListMountableInfo,
+dbus (send)
+    bus=session
+    path=/org/gtk/vfs/mounttracker
+    interface=org.gtk.vfs.MountTracker
+    member=LookupMount,
 `
 
 const desktopLegacyConnectedPlugSecComp = `

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -598,6 +598,18 @@ dbus (receive)
     interface=org.freedesktop.DBus.Introspectable
     member=Introspect
     peer=(label=unconfined),
+
+# gtk2/gvfs gtk_show_uri()
+dbus (send)
+    bus=session
+    path=/org/gtk/vfs/mounttracker
+    interface=org.gtk.vfs.MountTracker
+    member=ListMountableInfo,
+dbus (send)
+    bus=session
+    path=/org/gtk/vfs/mounttracker
+    interface=org.gtk.vfs.MountTracker
+    member=LookupMount,
 `
 
 const unity7ConnectedPlugSeccomp = `


### PR DESCRIPTION
https://github.com/snapcore/snapd/pull/4591 for 2.31. I'm requesting this for 2.31 since it will allow a new high profile snap to run in strict mode.

cc @popey