### PR TITLE
advisor: ensure commands.db has mode 0644 and add test

### DIFF
--- a/advisor/backend.go
+++ b/advisor/backend.go
@@ -153,7 +153,7 @@ func (t *writer) done(commit bool) error {
 // DumpCommands returns the whole database as a map. For use in
 // testing and debugging.
 func DumpCommands() (map[string][]string, error) {
-	db, err := bolt.Open(dirs.SnapCommandsDB, 0600, &bolt.Options{
+	db, err := bolt.Open(dirs.SnapCommandsDB, 0644, &bolt.Options{
 		ReadOnly: true,
 		Timeout:  1 * time.Second,
 	})
@@ -188,7 +188,7 @@ type boltFinder struct {
 
 // Open the database for reading.
 func Open() (Finder, error) {
-	db, err := bolt.Open(dirs.SnapCommandsDB, 0600, &bolt.Options{
+	db, err := bolt.Open(dirs.SnapCommandsDB, 0644, &bolt.Options{
 		ReadOnly: true,
 		Timeout:  1 * time.Second,
 	})

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -23,7 +23,12 @@ execute: |
     done
     stat /var/cache/snapd/commands.db
     echo "Ensure the database is readable by a regular user"
-    su -l -c "test -r /var/cache/snapd/commands.db" test
+    if [ $(stat -c "%a" /var/cache/snapd/commands.db) != "644" ]; then
+        echo "incorrect permissions for /var/cache/snapd/commands.db"
+        echo "expected 0644 got:"
+        stat /var/cache/snapd/commands.db
+        exit 1
+    fi
 
     echo "Ensure `snap advise-snap --command` lookup works"
     snap advise-snap --command test-snapd-tools.echo | MATCH test-snapd-tools

--- a/tests/main/snap-advise-command/task.yaml
+++ b/tests/main/snap-advise-command/task.yaml
@@ -22,6 +22,8 @@ execute: |
        sleep 1
     done
     stat /var/cache/snapd/commands.db
+    echo "Ensure the database is readable by a regular user"
+    su -l -c "test -r /var/cache/snapd/commands.db" test
 
     echo "Ensure `snap advise-snap --command` lookup works"
     snap advise-snap --command test-snapd-tools.echo | MATCH test-snapd-tools


### PR DESCRIPTION
When running bolt.Open() even in readonly mode the DB file will
be created if it is missing. Our read-only advisor.Open() uses
mode 0600 to open the Db in read-only mode. This means that if
a root user triggers command-not-found and the DB file is not
yet downloaded the DB is created with 0600. This happend during
manual testing. This PR switches permissions to 0644. It also
adds a test to ensure that the file has the correct permissions.
