### PR TITLE
systemd, wrappers: start all snap services in one systemctl call

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -103,7 +103,7 @@ type Systemd interface {
 	DaemonReload() error
 	Enable(service string) error
 	Disable(service string) error
-	Start(service string) error
+	Start(service ...string) error
 	Stop(service string, timeout time.Duration) error
 	Kill(service, signal string) error
 	Restart(service string, timeout time.Duration) error
@@ -172,9 +172,9 @@ func (s *systemd) Mask(serviceName string) error {
 	return err
 }
 
-// Start the given service
-func (*systemd) Start(serviceName string) error {
-	_, err := systemctlCmd("start", serviceName)
+// Start the given service or services
+func (*systemd) Start(serviceNames ...string) error {
+	_, err := systemctlCmd(append([]string{"start"}, serviceNames...)...)
 	return err
 }
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -148,6 +148,12 @@ func (s *SystemdTestSuite) TestStart(c *C) {
 	c.Check(s.argses, DeepEquals, [][]string{{"start", "foo"}})
 }
 
+func (s *SystemdTestSuite) TestStartMany(c *C) {
+	err := New("", s.rep).Start("foo", "bar", "baz")
+	c.Assert(err, IsNil)
+	c.Check(s.argses, DeepEquals, [][]string{{"start", "foo", "bar", "baz"}})
+}
+
 func (s *SystemdTestSuite) TestStop(c *C) {
 	restore := MockStopDelays(time.Millisecond, 25*time.Second)
 	defer restore()


### PR DESCRIPTION
Try to address the problem raised in https://forum.snapcraft.io/t/snap-service-start-ordering/1470/21 and if a snap carries more than one service, have them started in one call to systemctl. This should give systemd a chance to enforce the After/Before rules.