### PR TITLE
snap: improve validation of snap layouts

### DIFF
--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -122,14 +122,14 @@ layout:
     type: tmpfs
     mode: 1777
   /mylink:
-    symlink: /link/target
+    symlink: $SNAP/link/target
 `
 
 func (s *specSuite) TestMountEntryFromLayout(c *C) {
 	snapInfo := snaptest.MockInfo(c, snapWithLayout, &snap.SideInfo{Revision: snap.R(42)})
 	s.spec.AddSnapLayout(snapInfo)
 	c.Assert(s.spec.MountEntries(), DeepEquals, []mount.Entry{
-		{Dir: "/mylink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/link/target"}},
+		{Dir: "/mylink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/vanguard/42/link/target"}},
 		{Name: "tmpfs", Dir: "/mytmp", Type: "tmpfs", Options: []string{"x-snapd.mode=01777"}},
 		{Name: "/snap/vanguard/42/usr", Dir: "/usr", Options: []string{"bind", "rw"}},
 	})

--- a/snap/info.go
+++ b/snap/info.go
@@ -330,6 +330,25 @@ func (s *Info) Services() []*AppInfo {
 	return svcs
 }
 
+// ExpandSnapVariables resolves $SNAP, $SNAP_DATA and $SNAP_COMMON.
+func (s *Info) ExpandSnapVariables(path string) string {
+	return os.Expand(path, func(v string) string {
+		switch v {
+		case "SNAP":
+			// NOTE: We use dirs.CoreSnapMountDir here as the path used will be always
+			// inside the mount namespace snap-confine creates and there we will
+			// always have a /snap directory available regardless if the system
+			// we're running on supports this or not.
+			return filepath.Join(dirs.CoreSnapMountDir, s.Name(), s.Revision.String())
+		case "SNAP_DATA":
+			return s.DataDir()
+		case "SNAP_COMMON":
+			return s.CommonDataDir()
+		}
+		return ""
+	})
+}
+
 func BadInterfacesSummary(snapInfo *Info) string {
 	inverted := make(map[string][]string)
 	for name, reason := range snapInfo.BadInterfaces {

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1598,3 +1598,33 @@ apps:
 		},
 	})
 }
+
+func (s *YamlSuite) TestLayout(c *C) {
+	y := []byte(`
+name: foo
+version: 1.0
+layout:
+  /usr/share/foo:
+    bind: $SNAP/usr/share/foo
+  /usr/share/bar:
+    symlink: $SNAP/usr/share/bar
+`)
+	info, err := snap.InfoFromSnapYaml(y)
+	c.Assert(err, IsNil)
+	c.Assert(info.Layout["/usr/share/foo"], DeepEquals, &snap.Layout{
+		Snap:  info,
+		Path:  "/usr/share/foo",
+		Bind:  "$SNAP/usr/share/foo",
+		User:  "root",
+		Group: "root",
+		Mode:  0755,
+	})
+	c.Assert(info.Layout["/usr/share/bar"], DeepEquals, &snap.Layout{
+		Snap:    info,
+		Path:    "/usr/share/bar",
+		Symlink: "$SNAP/usr/share/bar",
+		User:    "root",
+		Group:   "root",
+		Mode:    0755,
+	})
+}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -859,3 +859,14 @@ func (s *infoSuite) TestSlotInfoAttr(c *C) {
 	c.Check(slot.Attr("unknown", &val), ErrorMatches, `snap "snap" does not have attribute "unknown" for interface "interface"`)
 	c.Check(slot.Attr("key", intVal), ErrorMatches, `internal error: cannot get "key" attribute of interface "interface" with non-pointer value`)
 }
+
+func (s *infoSuite) TestExpandSnapVariables(c *C) {
+	dirs.SetRootDir("")
+	info, err := snap.InfoFromSnapYaml([]byte(`name: foo`))
+	c.Assert(err, IsNil)
+	info.Revision = snap.R(42)
+	c.Assert(info.ExpandSnapVariables("$SNAP/stuff"), Equals, "/snap/foo/42/stuff")
+	c.Assert(info.ExpandSnapVariables("$SNAP_DATA/stuff"), Equals, "/var/snap/foo/42/stuff")
+	c.Assert(info.ExpandSnapVariables("$SNAP_COMMON/stuff"), Equals, "/var/snap/foo/common/stuff")
+	c.Assert(info.ExpandSnapVariables("$GARBAGE/rocks"), Equals, "/rocks")
+}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -232,10 +232,12 @@ func Validate(info *Info) error {
 		return err
 	}
 
+	blacklist := make([]string, 0, len(info.Layout))
 	for _, layout := range info.Layout {
-		if err := ValidateLayout(layout); err != nil {
+		if err := ValidateLayout(layout, blacklist); err != nil {
 			return err
 		}
+		blacklist = append(blacklist, info.ExpandSnapVariables(layout.Path))
 	}
 	return nil
 }
@@ -443,7 +445,14 @@ func isAbsAndClean(path string) bool {
 }
 
 // ValidateLayout ensures that the given layout contains only valid subset of constructs.
-func ValidateLayout(layout *Layout) error {
+func ValidateLayout(layout *Layout, blacklist []string) error {
+	si := layout.Snap
+	// Rules for validating layouts:
+	//
+	// * source of mount --bind must be in on of $SNAP, $SNAP_DATA or $SNAP_COMMON
+	// * target of symlink must in in one of $SNAP, $SNAP_DATA, or $SNAP_COMMON
+	// * may not mount on top of an existing layout mountpoint
+
 	mountPoint := layout.Path
 
 	if mountPoint == "" {
@@ -453,8 +462,14 @@ func ValidateLayout(layout *Layout) error {
 	if err := ValidatePathVariables(mountPoint); err != nil {
 		return fmt.Errorf("layout %q uses invalid mount point: %s", layout.Path, err)
 	}
+	mountPoint = si.ExpandSnapVariables(mountPoint)
 	if !isAbsAndClean(mountPoint) {
 		return fmt.Errorf("layout %q uses invalid mount point: must be absolute and clean", layout.Path)
+	}
+	for i := range blacklist {
+		if strings.HasPrefix(mountPoint, blacklist[i]) {
+			return fmt.Errorf("layout %q underneath prior layout item %q", layout.Path, blacklist[i])
+		}
 	}
 
 	var nused int
@@ -476,8 +491,17 @@ func ValidateLayout(layout *Layout) error {
 		if err := ValidatePathVariables(mountSource); err != nil {
 			return fmt.Errorf("layout %q uses invalid bind mount source %q: %s", layout.Path, mountSource, err)
 		}
+		mountSource = si.ExpandSnapVariables(mountSource)
 		if !isAbsAndClean(mountSource) {
 			return fmt.Errorf("layout %q uses invalid bind mount source %q: must be absolute and clean", layout.Path, mountSource)
+		}
+		// Bind mounts *must* use $SNAP, $SNAP_DATA or $SNAP_COMMON as bind
+		// mount source. This is done so that snaps cannot bypass restrictions
+		// by mounting something outside into their own space.
+		if !strings.HasPrefix(mountSource, si.ExpandSnapVariables("$SNAP")) &&
+			!strings.HasPrefix(mountSource, si.ExpandSnapVariables("$SNAP_DATA")) &&
+			!strings.HasPrefix(mountSource, si.ExpandSnapVariables("$SNAP_COMMON")) {
+			return fmt.Errorf("layout %q uses invalid bind mount source %q: must start with $SNAP, $SNAP_DATA or $SNAP_COMMON", layout.Path, mountSource)
 		}
 	}
 
@@ -494,8 +518,17 @@ func ValidateLayout(layout *Layout) error {
 		if err := ValidatePathVariables(oldname); err != nil {
 			return fmt.Errorf("layout %q uses invalid symlink old name %q: %s", layout.Path, oldname, err)
 		}
+		oldname = si.ExpandSnapVariables(oldname)
 		if !isAbsAndClean(oldname) {
 			return fmt.Errorf("layout %q uses invalid symlink old name %q: must be absolute and clean", layout.Path, oldname)
+		}
+		// Symlinks *must* use $SNAP, $SNAP_DATA or $SNAP_COMMON as oldname.
+		// This is done so that snaps cannot attempt to bypass restrictions
+		// by mounting something outside into their own space.
+		if !strings.HasPrefix(oldname, si.ExpandSnapVariables("$SNAP")) &&
+			!strings.HasPrefix(oldname, si.ExpandSnapVariables("$SNAP_DATA")) &&
+			!strings.HasPrefix(oldname, si.ExpandSnapVariables("$SNAP_COMMON")) {
+			return fmt.Errorf("layout %q uses invalid symlink old name %q: must start with $SNAP, $SNAP_DATA or $SNAP_COMMON", layout.Path, oldname)
 		}
 	}
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -516,45 +516,52 @@ func (s *ValidateSuite) TestValidateAlias(c *C) {
 }
 
 func (s *ValidateSuite) TestValidateLayout(c *C) {
+	si := &Info{SuggestedName: "foo"}
 	// Several invalid layouts.
-	c.Check(ValidateLayout(&Layout{}),
+	c.Check(ValidateLayout(&Layout{Snap: si}, nil),
 		ErrorMatches, "layout cannot use an empty path")
-	c.Check(ValidateLayout(&Layout{Path: "/foo"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo"}, nil),
 		ErrorMatches, `layout "/foo" must define a bind mount, a filesystem mount or a symlink`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "/bar", Type: "tmpfs"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Bind: "/bar", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/foo" must define a bind mount, a filesystem mount or a symlink`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "/bar", Symlink: "/froz"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Bind: "/bar", Symlink: "/froz"}, nil),
 		ErrorMatches, `layout "/foo" must define a bind mount, a filesystem mount or a symlink`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Symlink: "/froz"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Type: "tmpfs", Symlink: "/froz"}, nil),
 		ErrorMatches, `layout "/foo" must define a bind mount, a filesystem mount or a symlink`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "ext4"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Type: "ext4"}, nil),
 		ErrorMatches, `layout "/foo" uses invalid filesystem "ext4"`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo/bar", Type: "tmpfs", User: "foo"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo/bar", Type: "tmpfs", User: "foo"}, nil),
 		ErrorMatches, `layout "/foo/bar" uses invalid user "foo"`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo/bar", Type: "tmpfs", Group: "foo"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo/bar", Type: "tmpfs", Group: "foo"}, nil),
 		ErrorMatches, `layout "/foo/bar" uses invalid group "foo"`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Mode: 02755}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Type: "tmpfs", Mode: 02755}, nil),
 		ErrorMatches, `layout "/foo" uses invalid mode 02755`)
-	c.Check(ValidateLayout(&Layout{Path: "$FOO", Type: "tmpfs"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "$FOO", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "\$FOO" uses invalid mount point: reference to unknown variable "\$FOO"`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo", Bind: "$BAR"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Bind: "$BAR"}, nil),
 		ErrorMatches, `layout "/foo" uses invalid bind mount source "\$BAR": reference to unknown variable "\$BAR"`)
-	c.Check(ValidateLayout(&Layout{Path: "/foo", Symlink: "$BAR"}),
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "$SNAP/evil", Bind: "/etc"}, nil),
+		ErrorMatches, `layout "\$SNAP/evil" uses invalid bind mount source "/etc": must start with \$SNAP, \$SNAP_DATA or \$SNAP_COMMON`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Symlink: "$BAR"}, nil),
 		ErrorMatches, `layout "/foo" uses invalid symlink old name "\$BAR": reference to unknown variable "\$BAR"`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "$SNAP/evil", Symlink: "/etc"}, nil),
+		ErrorMatches, `layout "\$SNAP/evil" uses invalid symlink old name "/etc": must start with \$SNAP, \$SNAP_DATA or \$SNAP_COMMON`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo/bar", Bind: "$SNAP/bar/foo"}, []string{"/foo"}),
+		ErrorMatches, `layout "/foo/bar" underneath prior layout item "/foo"`)
 	// Several valid layouts.
-	c.Check(ValidateLayout(&Layout{Path: "/foo", Type: "tmpfs", Mode: 01755}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/tmp", Type: "tmpfs"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/usr", Bind: "$SNAP/usr"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/var", Bind: "$SNAP_DATA/var"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/var", Bind: "$SNAP_COMMON/var"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/etc/foo.conf", Symlink: "$SNAP_DATA/etc/foo.conf"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", User: "root"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", Group: "root"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/a/b", Type: "tmpfs", Mode: 0655}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/usr", Symlink: "$SNAP/usr"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/var", Symlink: "$SNAP_DATA/var"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "/var", Symlink: "$SNAP_COMMON/var"}), IsNil)
-	c.Check(ValidateLayout(&Layout{Path: "$SNAP/data", Symlink: "$SNAP_DATA"}), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Type: "tmpfs", Mode: 01755}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/tmp", Type: "tmpfs"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/usr", Bind: "$SNAP/usr"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var", Bind: "$SNAP_DATA/var"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var", Bind: "$SNAP_COMMON/var"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/etc/foo.conf", Symlink: "$SNAP_DATA/etc/foo.conf"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/a/b", Type: "tmpfs", User: "root"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/a/b", Type: "tmpfs", Group: "root"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/a/b", Type: "tmpfs", Mode: 0655}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/usr", Symlink: "$SNAP/usr"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var", Symlink: "$SNAP_DATA/var"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var", Symlink: "$SNAP_COMMON/var"}, nil), IsNil)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "$SNAP/data", Symlink: "$SNAP_DATA"}, nil), IsNil)
 }
 
 func (s *ValidateSuite) TestValidateSocketName(c *C) {


### PR DESCRIPTION
Rules for validating layouts:

* source of mount --bind must be in on of $SNAP, $SNAP_DATA or $SNAP_COMMON
* target of symlink must in in one of $SNAP, $SNAP_DATA, or $SNAP_COMMON
* may not mount on top of an existing layout mountpoint

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>