### PR TITLE
osutil: allow using many globs in EnsureDirState

### DIFF
--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -67,12 +67,12 @@ func EnsureDirStateGlobs(dir string, globs []string, content map[string]*FileSta
 	// Check syntax before doing anything.
 	for _, glob := range globs {
 		if _, err := filepath.Match(glob, "foo"); err != nil {
-			panic(fmt.Sprintf("EnsureDirState got invalid pattern %q: %s", glob, err))
+			panic(fmt.Sprintf("internal error: EnsureDirState got invalid pattern %q: %s", glob, err))
 		}
 	}
 	for baseName := range content {
 		if filepath.Base(baseName) != baseName {
-			panic(fmt.Sprintf("EnsureDirState got filename %q which has a path component", baseName))
+			panic(fmt.Sprintf("internal error: EnsureDirState got filename %q which has a path component", baseName))
 		}
 		sane := false
 		for _, glob := range globs {
@@ -83,9 +83,9 @@ func EnsureDirStateGlobs(dir string, globs []string, content map[string]*FileSta
 		}
 		if !sane {
 			if len(globs) == 1 {
-				panic(fmt.Sprintf("EnsureDirState got filename %q which doesn't match the glob pattern %q", baseName, globs[0]))
+				panic(fmt.Sprintf("internal error: EnsureDirState got filename %q which doesn't match the glob pattern %q", baseName, globs[0]))
 			}
-			panic(fmt.Sprintf("EnsureDirState got filename %q which doesn't match any glob patterns %q", baseName, globs))
+			panic(fmt.Sprintf("internal error: EnsureDirState got filename %q which doesn't match any glob patterns %q", baseName, globs))
 		}
 	}
 	// Change phase (create/change files described by content)

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -37,15 +37,15 @@ type FileState struct {
 // ErrSameState is returned when the state of a file has not changed.
 var ErrSameState = fmt.Errorf("file state has not changed")
 
-// EnsureDirState ensures that directory content matches expectations.
+// EnsureDirStateMany ensures that directory content matches expectations.
 //
-// EnsureDirState enumerates all the files in the specified directory that
-// match the provided pattern (glob). Each enumerated file is checked to ensure
-// that the contents, permissions are what is desired. Unexpected files are
-// removed. Missing files are created and differing files are corrected.  Files
-// not matching the pattern are ignored.
+// EnsureDirStateMany enumerates all the files in the specified directory that
+// match the provided set of pattern (globs). Each enumerated file is checked
+// to ensure that the contents, permissions are what is desired. Unexpected
+// files are removed. Missing files are created and differing files are
+// corrected. Files not matching any pattern are ignored.
 //
-// Note that EnsureDirState only checks for permissions and content. Other
+// Note that EnsureDirStateMany only checks for permissions and content. Other
 // security mechanisms, including file ownership and extended attributes are
 // *not* supported.
 //
@@ -53,7 +53,7 @@ var ErrSameState = fmt.Errorf("file state has not changed")
 // the directory.  Map keys must be file names relative to the directory.
 // Sub-directories in the name are not allowed.
 //
-// If writing any of the files fails, EnsureDirState switches to erase mode
+// If writing any of the files fails, EnsureDirStateMany switches to erase mode
 // where *all* of the files managed by the glob pattern are removed (including
 // those that may have been already written). The return value is an empty list
 // of changed files, the real list of removed files and the first error.
@@ -63,16 +63,28 @@ var ErrSameState = fmt.Errorf("file state has not changed")
 // exhausted.
 //
 // In all cases, the function returns the first error it has encountered.
-func EnsureDirState(dir, glob string, content map[string]*FileState) (changed, removed []string, err error) {
-	if _, err := filepath.Match(glob, "foo"); err != nil {
-		panic(fmt.Sprintf("EnsureDirState got invalid pattern %q: %s", glob, err))
+func EnsureDirStateMany(dir string, globs []string, content map[string]*FileState) (changed, removed []string, err error) {
+	for _, glob := range globs {
+		if _, err := filepath.Match(glob, "foo"); err != nil {
+			panic(fmt.Sprintf("EnsureDirState got invalid pattern %q: %s", glob, err))
+		}
 	}
 	for baseName := range content {
 		if filepath.Base(baseName) != baseName {
 			panic(fmt.Sprintf("EnsureDirState got filename %q which has a path component", baseName))
 		}
-		if ok, _ := filepath.Match(glob, baseName); !ok {
-			panic(fmt.Sprintf("EnsureDirState got filename %q which doesn't match the glob pattern %q", baseName, glob))
+		sane := false
+		for _, glob := range globs {
+			if ok, _ := filepath.Match(glob, baseName); ok {
+				sane = true
+				break
+			}
+		}
+		if !sane {
+			if len(globs) == 1 {
+				panic(fmt.Sprintf("EnsureDirState got filename %q which doesn't match the glob pattern %q", baseName, globs[0]))
+			}
+			panic(fmt.Sprintf("EnsureDirState got filename %q which doesn't match any glob patterns %q", baseName, globs))
 		}
 	}
 	// Change phase (create/change files described by content)
@@ -96,10 +108,14 @@ func EnsureDirState(dir, glob string, content map[string]*FileState) (changed, r
 		changed = append(changed, baseName)
 	}
 	// Delete phase (remove files matching the glob that are not in content)
-	matches, err := filepath.Glob(filepath.Join(dir, glob))
-	if err != nil {
-		sort.Strings(changed)
-		return changed, nil, err
+	var matches []string
+	for _, glob := range globs {
+		m, err := filepath.Glob(filepath.Join(dir, glob))
+		if err != nil {
+			sort.Strings(changed)
+			return changed, nil, err
+		}
+		matches = append(matches, m...)
 	}
 	for _, filePath := range matches {
 		baseName := filepath.Base(filePath)
@@ -118,6 +134,13 @@ func EnsureDirState(dir, glob string, content map[string]*FileState) (changed, r
 	sort.Strings(changed)
 	sort.Strings(removed)
 	return changed, removed, firstErr
+}
+
+// EnsureDirState ensures that directory content matches expectations.
+//
+// This is like EnsureDirStateMany but it only supports one glob at a time.
+func EnsureDirState(dir string, glob string, content map[string]*FileState) (changed, removed []string, err error) {
+	return EnsureDirStateMany(dir, []string{glob}, content)
 }
 
 // EnsureFileState ensures that the file is in the expected state. It will not attempt

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -67,12 +67,12 @@ func EnsureDirStateGlobs(dir string, globs []string, content map[string]*FileSta
 	// Check syntax before doing anything.
 	for _, glob := range globs {
 		if _, err := filepath.Match(glob, "foo"); err != nil {
-			panic(fmt.Sprintf("internal error: EnsureDirState got invalid pattern %q: %s", glob, err))
+			return nil, nil, fmt.Errorf("internal error: EnsureDirState got invalid pattern %q: %s", glob, err)
 		}
 	}
 	for baseName := range content {
 		if filepath.Base(baseName) != baseName {
-			panic(fmt.Sprintf("internal error: EnsureDirState got filename %q which has a path component", baseName))
+			return nil, nil, fmt.Errorf("internal error: EnsureDirState got filename %q which has a path component", baseName)
 		}
 		sane := false
 		for _, glob := range globs {
@@ -83,9 +83,9 @@ func EnsureDirStateGlobs(dir string, globs []string, content map[string]*FileSta
 		}
 		if !sane {
 			if len(globs) == 1 {
-				panic(fmt.Sprintf("internal error: EnsureDirState got filename %q which doesn't match the glob pattern %q", baseName, globs[0]))
+				return nil, nil, fmt.Errorf("internal error: EnsureDirState got filename %q which doesn't match the glob pattern %q", baseName, globs[0])
 			}
-			panic(fmt.Sprintf("internal error: EnsureDirState got filename %q which doesn't match any glob patterns %q", baseName, globs))
+			return nil, nil, fmt.Errorf("internal error: EnsureDirState got filename %q which doesn't match any glob patterns %q", baseName, globs)
 		}
 	}
 	// Change phase (create/change files described by content)

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -64,6 +64,7 @@ var ErrSameState = fmt.Errorf("file state has not changed")
 //
 // In all cases, the function returns the first error it has encountered.
 func EnsureDirStateMany(dir string, globs []string, content map[string]*FileState) (changed, removed []string, err error) {
+	// Check syntax before doing anything.
 	for _, glob := range globs {
 		if _, err := filepath.Match(glob, "foo"); err != nil {
 			panic(fmt.Sprintf("EnsureDirState got invalid pattern %q: %s", glob, err))

--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -37,15 +37,15 @@ type FileState struct {
 // ErrSameState is returned when the state of a file has not changed.
 var ErrSameState = fmt.Errorf("file state has not changed")
 
-// EnsureDirStateMany ensures that directory content matches expectations.
+// EnsureDirStateGlobs ensures that directory content matches expectations.
 //
-// EnsureDirStateMany enumerates all the files in the specified directory that
+// EnsureDirStateGlobs enumerates all the files in the specified directory that
 // match the provided set of pattern (globs). Each enumerated file is checked
 // to ensure that the contents, permissions are what is desired. Unexpected
 // files are removed. Missing files are created and differing files are
 // corrected. Files not matching any pattern are ignored.
 //
-// Note that EnsureDirStateMany only checks for permissions and content. Other
+// Note that EnsureDirStateGlobs only checks for permissions and content. Other
 // security mechanisms, including file ownership and extended attributes are
 // *not* supported.
 //
@@ -53,7 +53,7 @@ var ErrSameState = fmt.Errorf("file state has not changed")
 // the directory.  Map keys must be file names relative to the directory.
 // Sub-directories in the name are not allowed.
 //
-// If writing any of the files fails, EnsureDirStateMany switches to erase mode
+// If writing any of the files fails, EnsureDirStateGlobs switches to erase mode
 // where *all* of the files managed by the glob pattern are removed (including
 // those that may have been already written). The return value is an empty list
 // of changed files, the real list of removed files and the first error.
@@ -63,7 +63,7 @@ var ErrSameState = fmt.Errorf("file state has not changed")
 // exhausted.
 //
 // In all cases, the function returns the first error it has encountered.
-func EnsureDirStateMany(dir string, globs []string, content map[string]*FileState) (changed, removed []string, err error) {
+func EnsureDirStateGlobs(dir string, globs []string, content map[string]*FileState) (changed, removed []string, err error) {
 	// Check syntax before doing anything.
 	for _, glob := range globs {
 		if _, err := filepath.Match(glob, "foo"); err != nil {
@@ -139,9 +139,9 @@ func EnsureDirStateMany(dir string, globs []string, content map[string]*FileStat
 
 // EnsureDirState ensures that directory content matches expectations.
 //
-// This is like EnsureDirStateMany but it only supports one glob at a time.
+// This is like EnsureDirStateGlobs but it only supports one glob at a time.
 func EnsureDirState(dir string, glob string, content map[string]*FileState) (changed, removed []string, err error) {
-	return EnsureDirStateMany(dir, []string{glob}, content)
+	return EnsureDirStateGlobs(dir, []string{glob}, content)
 }
 
 // EnsureFileState ensures that the file is in the expected state. It will not attempt

--- a/osutil/syncdir_test.go
+++ b/osutil/syncdir_test.go
@@ -208,20 +208,18 @@ func (s *EnsureDirStateSuite) TestFixesFilesWithBadPermissions(c *C) {
 }
 
 func (s *EnsureDirStateSuite) TestReportsAbnormalFileLocation(c *C) {
-	c.Assert(func() {
-		osutil.EnsureDirState(s.dir, s.glob, map[string]*osutil.FileState{"subdir/file.snap": {}})
-	}, PanicMatches, `internal error: EnsureDirState got filename "subdir/file.snap" which has a path component`)
+	_, _, err := osutil.EnsureDirState(s.dir, s.glob, map[string]*osutil.FileState{"subdir/file.snap": {}})
+	c.Assert(err, ErrorMatches, `internal error: EnsureDirState got filename "subdir/file.snap" which has a path component`)
 }
 
 func (s *EnsureDirStateSuite) TestReportsAbnormalFileName(c *C) {
-	c.Assert(func() {
-		osutil.EnsureDirState(s.dir, s.glob, map[string]*osutil.FileState{"without-namespace": {}})
-	}, PanicMatches, `internal error: EnsureDirState got filename "without-namespace" which doesn't match the glob pattern "\*\.snap"`)
+	_, _, err := osutil.EnsureDirState(s.dir, s.glob, map[string]*osutil.FileState{"without-namespace": {}})
+	c.Assert(err, ErrorMatches, `internal error: EnsureDirState got filename "without-namespace" which doesn't match the glob pattern "\*\.snap"`)
 }
 
 func (s *EnsureDirStateSuite) TestReportsAbnormalPatterns(c *C) {
-	c.Assert(func() { osutil.EnsureDirState(s.dir, "[", nil) },
-		PanicMatches, `internal error: EnsureDirState got invalid pattern "\[": syntax error in pattern`)
+	_, _, err := osutil.EnsureDirState(s.dir, "[", nil)
+	c.Assert(err, ErrorMatches, `internal error: EnsureDirState got invalid pattern "\[": syntax error in pattern`)
 }
 
 func (s *EnsureDirStateSuite) TestRemovesAllManagedFilesOnError(c *C) {

--- a/osutil/syncdir_test.go
+++ b/osutil/syncdir_test.go
@@ -210,18 +210,18 @@ func (s *EnsureDirStateSuite) TestFixesFilesWithBadPermissions(c *C) {
 func (s *EnsureDirStateSuite) TestReportsAbnormalFileLocation(c *C) {
 	c.Assert(func() {
 		osutil.EnsureDirState(s.dir, s.glob, map[string]*osutil.FileState{"subdir/file.snap": {}})
-	}, PanicMatches, `EnsureDirState got filename "subdir/file.snap" which has a path component`)
+	}, PanicMatches, `internal error: EnsureDirState got filename "subdir/file.snap" which has a path component`)
 }
 
 func (s *EnsureDirStateSuite) TestReportsAbnormalFileName(c *C) {
 	c.Assert(func() {
 		osutil.EnsureDirState(s.dir, s.glob, map[string]*osutil.FileState{"without-namespace": {}})
-	}, PanicMatches, `EnsureDirState got filename "without-namespace" which doesn't match the glob pattern "\*\.snap"`)
+	}, PanicMatches, `internal error: EnsureDirState got filename "without-namespace" which doesn't match the glob pattern "\*\.snap"`)
 }
 
 func (s *EnsureDirStateSuite) TestReportsAbnormalPatterns(c *C) {
 	c.Assert(func() { osutil.EnsureDirState(s.dir, "[", nil) },
-		PanicMatches, `EnsureDirState got invalid pattern "\[": syntax error in pattern`)
+		PanicMatches, `internal error: EnsureDirState got invalid pattern "\[": syntax error in pattern`)
 }
 
 func (s *EnsureDirStateSuite) TestRemovesAllManagedFilesOnError(c *C) {

--- a/osutil/syncdir_test.go
+++ b/osutil/syncdir_test.go
@@ -71,7 +71,7 @@ func (s *EnsureDirStateSuite) TestTwoPatterns(c *C) {
 	err = ioutil.WriteFile(name2, []byte("expected-2"), 0600)
 	c.Assert(err, IsNil)
 
-	changed, removed, err := osutil.EnsureDirStateMany(s.dir, []string{"*.snap", "*.snap-update-ns"}, map[string]*osutil.FileState{
+	changed, removed, err := osutil.EnsureDirStateGlobs(s.dir, []string{"*.snap", "*.snap-update-ns"}, map[string]*osutil.FileState{
 		"expected.snap":           {Content: []byte("expected-1"), Mode: 0600},
 		"expected.snap-update-ns": {Content: []byte("expected-2"), Mode: 0600},
 	})

--- a/osutil/syncdir_test.go
+++ b/osutil/syncdir_test.go
@@ -62,6 +62,39 @@ func (s *EnsureDirStateSuite) TestVerifiesExpectedFiles(c *C) {
 	c.Assert(stat.Mode().Perm(), Equals, os.FileMode(0600))
 }
 
+func (s *EnsureDirStateSuite) TestTwoPatterns(c *C) {
+	name1 := filepath.Join(s.dir, "expected.snap")
+	err := ioutil.WriteFile(name1, []byte("expected-1"), 0600)
+	c.Assert(err, IsNil)
+
+	name2 := filepath.Join(s.dir, "expected.snap-update-ns")
+	err = ioutil.WriteFile(name2, []byte("expected-2"), 0600)
+	c.Assert(err, IsNil)
+
+	changed, removed, err := osutil.EnsureDirStateMany(s.dir, []string{"*.snap", "*.snap-update-ns"}, map[string]*osutil.FileState{
+		"expected.snap":           {Content: []byte("expected-1"), Mode: 0600},
+		"expected.snap-update-ns": {Content: []byte("expected-2"), Mode: 0600},
+	})
+	c.Assert(err, IsNil)
+	// Report says that nothing has changed
+	c.Assert(changed, HasLen, 0)
+	c.Assert(removed, HasLen, 0)
+	// The content is correct
+	content, err := ioutil.ReadFile(name1)
+	c.Assert(err, IsNil)
+	c.Assert(content, DeepEquals, []byte("expected-1"))
+	content, err = ioutil.ReadFile(name2)
+	c.Assert(err, IsNil)
+	c.Assert(content, DeepEquals, []byte("expected-2"))
+	// The permissions are correct
+	stat, err := os.Stat(name1)
+	c.Assert(err, IsNil)
+	c.Assert(stat.Mode().Perm(), Equals, os.FileMode(0600))
+	stat, err = os.Stat(name2)
+	c.Assert(err, IsNil)
+	c.Assert(stat.Mode().Perm(), Equals, os.FileMode(0600))
+}
+
 func (s *EnsureDirStateSuite) TestCreatesMissingFiles(c *C) {
 	name := filepath.Join(s.dir, "missing.snap")
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]*osutil.FileState{


### PR DESCRIPTION
This patch simply extends the directory synchronizer to allow more than
one glob to be used. This will come in handy when we want to provide
more than one kind of content for a given snap and then the
prefix/suffix (that is expressed as a glob) cannot capture that if only
one glob is available.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>