### PR TITLE
snapstate: allow core config via $core

### DIFF
--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -7038,6 +7038,7 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 		Current:  snap.R(11),
 		SnapType: "app",
 	})
+	makeInstalledMockCoreSnap(c)
 
 	defls, err := snapstate.ConfigDefaults(s.state, "some-snap")
 	c.Assert(err, IsNil)

--- a/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
+++ b/tests/main/ubuntu-core-gadget-config-defaults/task.yaml
@@ -27,6 +27,10 @@ prepare: |
        ${TEST_SNAP_ID}:
          a: A
          b: B
+       \$core:
+         service:
+           rsyslog:
+             disable: true
     EOF
     mksquashfs squashfs-root pc_x1.snap -comp xz -no-fragments
     rm -rf squashfs-root
@@ -47,6 +51,11 @@ restore: |
         echo "This test needs test keys to be trusted"
         exit
     fi
+    echo "Undo the rsyslog disable"
+    systemctl unmask rsyslog.service || true
+    systemctl enable rsyslog.service || true
+    systemctl start rsyslog.service || true
+
     . $TESTSLIB/systemd.sh
     systemctl stop snapd.service snapd.socket
     rm -rf /var/lib/snapd/assertions/*
@@ -100,3 +109,8 @@ execute: |
     echo "The configuration defaults from the gadget where applied"
     snap get test-snapd-with-configure a|MATCH "^A$"
     snap get test-snapd-with-configure b|MATCH "^B$"
+
+    echo "The configuration for core is applied"
+    snap get core service.rsyslog.disable|MATCH true
+    echo "And the service is masked"
+    systemctl status rsyslog.service|MATCH masked


### PR DESCRIPTION
This allows using $core to configure the core snap. This means users
can have config defaults for core18 and core without having to
update their gadget.yaml. It also means we can test the firstboot
config settings for core in our integration tests.

If this looks reasonable I will add some more tests (so far its mostly integration tested).