### PR TITLE
packaging: create /var/lib/snapd/lib/{gl,gl32,vulkan} as part of packaging

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -125,12 +125,6 @@ check() {
 package_snapd-git() {
   export GOPATH="$srcdir/go"
 
-  # Ensure that we have /var/lib/snapd/{hostfs,lib/gl}/ as they are required by
-  # snap-confine for constructing some bind mounts around.
-  install -d -m 755 \
-            "$pkgdir/var/lib/snapd/hostfs/" \
-            "$pkgdir/var/lib/snapd/lib/gl/"
-
   # Install snap, snapctl, snap-update-ns, snap-seccomp, snap-exec and snapd
   # executables
   install -d -m 755 "$pkgdir/usr/bin/"
@@ -200,6 +194,8 @@ package_snapd-git() {
   install -d -m 755 "$pkgdir/var/lib/snapd/snap/bin"
   install -d -m 755 "$pkgdir/var/lib/snapd/snaps"
   install -d -m 755 "$pkgdir/var/lib/snapd/lib/gl"
+  install -d -m 755 "$pkgdir/var/lib/snapd/lib/gl32"
+  install -d -m 755 "$pkgdir/var/lib/snapd/lib/vulkan"
   # these dirs have special permissions
   install -d -m 000 "$pkgdir/var/lib/snapd/void"
   install -d -m 700 "$pkgdir/var/lib/snapd/cookie"

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -465,6 +465,9 @@ install -d -p %{buildroot}%{_sharedstatedir}/snapd/hostfs
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/mount
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/seccomp/bpf
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/snaps
+install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/gl
+install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/gl32
+install -d -p %{buildroot}%{_sharedstatedir}/snapd/lib/vulkan
 install -d -p %{buildroot}%{_sharedstatedir}/snapd/snap/bin
 install -d -p %{buildroot}%{_localstatedir}/snap
 install -d -p %{buildroot}%{_localstatedir}/cache/snapd
@@ -613,6 +616,10 @@ popd
 %dir %{_sharedstatedir}/snapd/mount
 %dir %{_sharedstatedir}/snapd/seccomp
 %dir %{_sharedstatedir}/snapd/seccomp/bpf
+%dir %{_sharedstatedir}/snapd/lib
+%dir %{_sharedstatedir}/snapd/lib/gl
+%dir %{_sharedstatedir}/snapd/lib/gl32
+%dir %{_sharedstatedir}/snapd/lib/vulkan
 %dir %{_sharedstatedir}/snapd/snaps
 %dir %{_sharedstatedir}/snapd/snap
 %ghost %dir %{_sharedstatedir}/snapd/snap/bin

--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -203,6 +203,8 @@ rm -f %{?buildroot}/usr/bin/ubuntu-core-launcher
 rm -f %{?buildroot}%{_libexecdir}/snapd/system-shutdown
 # Install the directories that snapd creates by itself so that they can be a part of the package
 install -d %buildroot/var/lib/snapd/{assertions,desktop/applications,device,hostfs,mount,apparmor/profiles,seccomp/bpf,snaps}
+
+install -d %buildroot/var/lib/snapd/{lib/gl,lib/gl32,lib/vulkan}
 install -d %buildroot/var/cache/snapd
 install -d %buildroot/snap/bin
 # Install local permissions policy for snap-confine. This should be removed
@@ -278,6 +280,10 @@ fi
 %dir /var/lib/snapd/seccomp
 %dir /var/lib/snapd/seccomp/bpf
 %dir /var/lib/snapd/snaps
+%dir /var/lib/snapd/lib
+%dir /var/lib/snapd/lib/gl
+%dir /var/lib/snapd/lib/gl32
+%dir /var/lib/snapd/lib/vulkan
 %dir /var/cache/snapd
 %verify(not user group mode) %attr(06755,root,root) %{_libexecdir}/snapd/snap-confine
 %{_mandir}/man1/snap-confine.1.gz


### PR DESCRIPTION
All those dirs are needed for snap-confine when setting up the mount namespace. ` /var/lib/snapd/lib/vulkan` was added recently, but only Ubunt/Debian packaging got updated.

Related forum topic: https://forum.snapcraft.io/t/spotify-cannot-create-tmpfs-target/3805

@Conan-Kudo would it be possible for you to apply a similar change in Fedora package?