### PR TITLE
tests: update kill-timeout focused on making tests pass on boards

### DIFF
--- a/tests/main/snap-service/task.yaml
+++ b/tests/main/snap-service/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that `snap run --command=reload` works
 
-kill-timeout: 3m
+kill-timeout: 5m
+
 execute: |
     echo "When the service snap is installed"
     . $TESTSLIB/snaps.sh

--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that own services can be controlled by snapctl
 
-kill-timeout: 3m
+kill-timeout: 5m
+
 environment:
     SERVICEOPTIONFILE: /var/snap/test-snapd-service/current/service-option
 


### PR DESCRIPTION
This is happening that the prepare phase takes about 2.5 to 3 minutes in
a dragonboard in case the sd card is not fast enough. This is making the
test suite fail during the prepare phase when we test the new core on
edge channel and beta channel.

The idea is to move from 3m to 5m the kill-timeout to avoid this kind of
issues.

Example: https://paste.ubuntu.com/26506907/


