### PR TITLE
tests: use root path to /home/test/tmp to avoid lack of space issue

### DIFF
--- a/tests/main/prepare-image-uboot/task.yaml
+++ b/tests/main/prepare-image-uboot/task.yaml
@@ -1,13 +1,17 @@
 summary: Check that prepare-image works for uboot-systems
+
 environment:
-    ROOT: /tmp/root
-    IMAGE: /tmp/root/image
-    GADGET: /tmp/root/gadget
+    ROOT: /home/test/tmp/
+    IMAGE: /home/test/tmp/image
+    GADGET: /home/test/tmp/gadget
+
 prepare: |
     mkdir -p $ROOT
     chown test:test $ROOT
+
 restore: |
     rm -rf $ROOT
+
 execute: |
     # TODO: switch to a prebuilt properly signed model assertion once we can do that consistently
     echo Creating model assertion


### PR DESCRIPTION
This change is because in some boards like the dragonboard there is not
enough space in /tmp to unpack the snaps. Because of that, the
kernel.img is not in $IMAGE/boot/uboot/pi2-kernel_49.snap/ making the
test prepare-image-uboot fail.

It is still missing a research about why the command "snap prepare-
image" is not failing and making the test fail when the board goes out
of space.

Error log: https://paste.ubuntu.com/26509491/