### PR TITLE
cmd/snap-confine: fix read-only filesystem when mounting nvidia files in biarch

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -271,6 +271,7 @@ static void sc_mount_nvidia_driver_biarch(const char *rootfs_dir)
 	    sizeof native_sources / sizeof *native_sources;
 
 #if UINTPTR_MAX == 0xffffffffffffffff
+	// Alternative 32-bit support
 	const char *lib32_sources[] = {
 		LIB32_DIR,
 		LIB32_DIR "/nvidia*",


### PR DESCRIPTION
The last operation of sc_mkdir_and_mount_and_glob_files() is to remount the
target directory as read-only. This will cause all subsequent attempts to
link/mount files inside that path to fail. Specifically it will not be possible
to pick up the files from /usr/lib/nvidia*/ and /usr/lib32/nvidia*/ as this is
attempted once /var/lib/snapd/lib/gl[32] has been remounted read-only.


