### PR TITLE
cmd/snap-confine: create lib/{gl,gl32,vulkan} under /var/lib/snapd and chown as root:root

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -39,9 +39,10 @@
 // note: if the parent dir changes to something other than
 // the current /var/lib/snapd/lib then sc_mkdir_and_mount_and_bind
 // and sc_mkdir_and_mount_and_bind need updating.
-#define SC_LIBGL_DIR   "/var/lib/snapd/lib/gl"
-#define SC_LIBGL32_DIR "/var/lib/snapd/lib/gl32"
-#define SC_VULKAN_DIR  "/var/lib/snapd/lib/vulkan"
+#define SC_LIB "/var/lib/snapd/lib"
+#define SC_LIBGL_DIR   SC_LIB "/gl"
+#define SC_LIBGL32_DIR SC_LIB "/gl32"
+#define SC_VULKAN_DIR  SC_LIB "/vulkan"
 
 #define SC_VULKAN_SOURCE_DIR "/usr/share/vulkan"
 
@@ -222,6 +223,10 @@ static void sc_mkdir_and_mount_and_glob_files(const char *rootfs_dir,
 	if (res != 0 && errno != EEXIST) {
 		die("cannot create tmpfs target %s", libgl_dir);
 	}
+	if (res == 0 && (chown(libgl_dir, 0, 0) < 0)) {
+		// Adjust the ownership only if we created the directory.
+		die("cannot change ownership of %s", libgl_dir);
+	}
 
 	debug("mounting tmpfs at %s", libgl_dir);
 	if (mount("none", libgl_dir, "tmpfs", MS_NODEV | MS_NOEXEC, NULL) != 0) {
@@ -361,6 +366,10 @@ static void sc_mkdir_and_mount_and_bind(const char *rootfs_dir,
 	if (res != 0 && errno != EEXIST) {
 		die("cannot create directory %s", dst);
 	}
+	if (res == 0 && (chown(libgl_dir, 0, 0) < 0)) {
+		// Adjust the ownership only if we created the directory.
+		die("cannot change ownership of %s", libgl_dir);
+	}
 	// Bind mount the binary nvidia driver into $tgt_dir (i.e. /var/lib/snapd/lib/gl).
 	debug("bind mounting nvidia driver %s -> %s", src, dst);
 	if (mount(src, dst, NULL, MS_BIND, NULL) != 0) {
@@ -397,6 +406,15 @@ void sc_mount_nvidia_driver(const char *rootfs_dir)
 	/* If NVIDIA module isn't loaded, don't attempt to mount the drivers */
 	if (access(SC_NVIDIA_DRIVER_VERSION_FILE, F_OK) != 0) {
 		return;
+	}
+
+	int res = mkdir(SC_LIB, 0755);
+	if (res != 0 && errno != EEXIST) {
+		die("cannot create " SC_LIB);
+	}
+	if (res == 0 && (chown(SC_LIB, 0, 0) < 0)) {
+		// Adjust the ownership only if we created the directory.
+		die("cannot change ownership of " SC_LIB);
 	}
 #ifdef NVIDIA_MULTIARCH
 	sc_mount_nvidia_driver_multiarch(rootfs_dir);

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -366,9 +366,9 @@ static void sc_mkdir_and_mount_and_bind(const char *rootfs_dir,
 	if (res != 0 && errno != EEXIST) {
 		die("cannot create directory %s", dst);
 	}
-	if (res == 0 && (chown(libgl_dir, 0, 0) < 0)) {
+	if (res == 0 && (chown(dst, 0, 0) < 0)) {
 		// Adjust the ownership only if we created the directory.
-		die("cannot change ownership of %s", libgl_dir);
+		die("cannot change ownership of %s", dst);
 	}
 	// Bind mount the binary nvidia driver into $tgt_dir (i.e. /var/lib/snapd/lib/gl).
 	debug("bind mounting nvidia driver %s -> %s", src, dst);


### PR DESCRIPTION
Create the whole lib/{gl,gl32,vulkan} path under /var/lib/snapd to account for
potential packaging errors. Attempt to chown to root:root only if we created the
directory, otherwise assume that the packager has adjusted the ownership as
required.

