### PR TITLE
snap: use custom unsquashfsStderrWriter for unsquashfs error detection

### DIFF
--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -331,7 +331,7 @@ func (s *SquashfsTestSuite) TestUnsquashfsStderrWriter(c *C) {
 		},
 		{
 			inp:         []string{"failed 1\nfailed 2\n3 failed\n"},
-			expectedErr: `"failed: "failed 1", "failed 2", and "3 failed"`,
+			expectedErr: `failed: "failed 1", "failed 2", and "3 failed"`,
 		},
 		{
 			inp:         []string{"failed 1\nfailed 2\n3 Failed\n4 Failed\n"},
@@ -347,7 +347,7 @@ func (s *SquashfsTestSuite) TestUnsquashfsStderrWriter(c *C) {
 			usw.Write([]byte(l))
 		}
 		if t.expectedErr != "" {
-			c.Check(usw.Err(), ErrorMatches, t.expectedErr)
+			c.Check(usw.Err(), ErrorMatches, t.expectedErr, Commentf("inp: %q failed", t.inp))
 		} else {
 			c.Check(usw.Err(), IsNil)
 		}


### PR DESCRIPTION
This addresses a review feedback suggestion from John in PR#4605
to keep the amount of error output we keep in memory smaller.
    
unsquahfs will potentially return an error for each file it tries to
unpack (e.g. on out of disk space) - so potentially a lot of output.

This PR creates a custom writer to minimize the impact. There is a
tradeoff here, the code is not as easy anymore, feedback welcome.
    
We might consider keeping the simplistic approach because we generally
do not unpack many files in snapd (bootloader asserts, kernel/initramfs)
so we shouldn't generate insane amount of output (currently at least).
