### PR TITLE
wrappers: cleanup enabled service sockets

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -100,6 +100,21 @@ func StartServices(apps []*snap.AppInfo, inter interacter) (err error) {
 			continue
 		}
 
+		defer func(app *snap.AppInfo) {
+			if err == nil {
+				return
+			}
+			if e := stopService(sysd, app, inter); e != nil {
+				inter.Notify(fmt.Sprintf("While trying to stop previously started service %q: %v", app.ServiceName(), e))
+			}
+			for _, socket := range app.Sockets {
+				socketService := filepath.Base(socket.File())
+				if e := sysd.Disable(socketService); e != nil {
+					inter.Notify(fmt.Sprintf("While trying to disable previously enabled socket service %q: %v", socketService, e))
+				}
+			}
+		}(app)
+
 		if len(app.Sockets) == 0 {
 			services = append(services, app.ServiceName())
 		}
@@ -111,28 +126,11 @@ func StartServices(apps []*snap.AppInfo, inter interacter) (err error) {
 				return err
 			}
 
-			defer func(socketService string) {
-				if err == nil {
-					return
-				}
-				if e := sysd.Disable(socketService); e != nil {
-					inter.Notify(fmt.Sprintf("While trying to disable previously enabled socket service %q: %v", socketService, e))
-				}
-			}(socketService)
-
 			if err := sysd.Start(socketService); err != nil {
 				return err
 			}
 		}
 
-		defer func(app *snap.AppInfo) {
-			if err == nil {
-				return
-			}
-			if e := stopService(sysd, app, inter); e != nil {
-				inter.Notify(fmt.Sprintf("While trying to stop previously started service %q: %v", app.ServiceName(), e))
-			}
-		}(app)
 	}
 
 	if len(services) > 0 {

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -111,6 +111,15 @@ func StartServices(apps []*snap.AppInfo, inter interacter) (err error) {
 				return err
 			}
 
+			defer func(socketService string) {
+				if err == nil {
+					return
+				}
+				if e := sysd.Disable(socketService); e != nil {
+					inter.Notify(fmt.Sprintf("While trying to disable previously enabled socket service %q: %v", socketService, e))
+				}
+			}(socketService)
+
 			if err := sysd.Start(socketService); err != nil {
 				return err
 			}

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -457,15 +457,72 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
 
 	err := wrappers.StartServices(info.Services(), nil)
 	c.Assert(err, ErrorMatches, "failed")
-
-	c.Assert(sysdLog, HasLen, 5)
+	c.Assert(sysdLog, HasLen, 5, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"start", svc1Name, svc2Name}, // one of the services fails
 		{"stop", svc2Name},
 		{"show", "--property=ActiveState", svc2Name},
 		{"stop", svc1Name},
 		{"show", "--property=ActiveState", svc1Name},
+	}, Commentf("calls: %v", sysdLog))
+}
+
+func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSockets(c *C) {
+	var sysdLog [][]string
+	svc1Name := "snap.hello-snap.svc1.service"
+	svc2Name := "snap.hello-snap.svc2.service"
+	svc2SocketName := "snap.hello-snap.svc2.sock1.socket"
+	svc3SocketName := "snap.hello-snap.svc3.sock1.socket"
+
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		sysdLog = append(sysdLog, cmd)
+		c.Logf("call: %v", cmd)
+		if len(cmd) >= 2 && cmd[0] == "start" && cmd[1] == svc3SocketName {
+			// svc2 socket fails
+			return nil, fmt.Errorf("failed")
+		}
+		return []byte("ActiveState=inactive\n"), nil
 	})
+	defer r()
+
+	info := snaptest.MockSnap(c, packageHello+`
+ svc2:
+  command: bin/hello
+  daemon: simple
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+ svc3:
+  command: bin/hello
+  daemon: simple
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+`, &snap.SideInfo{Revision: snap.R(12)})
+
+	// ensure desired order
+	apps := []*snap.AppInfo{info.Apps["svc1"], info.Apps["svc2"], info.Apps["svc3"]}
+
+	err := wrappers.StartServices(apps, nil)
+	c.Assert(err, ErrorMatches, "failed")
+	c.Logf("sysdlog: %v", sysdLog)
+	c.Assert(sysdLog, HasLen, 12, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Check(sysdLog, DeepEquals, [][]string{
+		{"--root", s.tempdir, "enable", svc2SocketName},
+		{"start", svc2SocketName},
+		{"--root", s.tempdir, "enable", svc3SocketName},
+		{"start", svc3SocketName}, // start failed, what follows is the cleanup
+		{"--root", s.tempdir, "disable", svc3SocketName},
+		{"stop", svc2SocketName},
+		{"show", "--property=ActiveState", svc2SocketName},
+		{"stop", svc2Name},
+		{"show", "--property=ActiveState", svc2Name},
+		{"--root", s.tempdir, "disable", svc2SocketName},
+		{"stop", svc1Name},
+		{"show", "--property=ActiveState", svc1Name},
+	}, Commentf("calls: %v", sysdLog))
 }
 
 func (s *servicesTestSuite) TestServiceAfterBefore(c *C) {

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -472,6 +472,7 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	svc1Name := "snap.hello-snap.svc1.service"
 	svc2Name := "snap.hello-snap.svc2.service"
 	svc2SocketName := "snap.hello-snap.svc2.sock1.socket"
+	svc3Name := "snap.hello-snap.svc3.service"
 	svc3SocketName := "snap.hello-snap.svc3.sock1.socket"
 
 	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
@@ -508,12 +509,16 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanupWithSocket
 	err := wrappers.StartServices(apps, nil)
 	c.Assert(err, ErrorMatches, "failed")
 	c.Logf("sysdlog: %v", sysdLog)
-	c.Assert(sysdLog, HasLen, 12, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Assert(sysdLog, HasLen, 16, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
 	c.Check(sysdLog, DeepEquals, [][]string{
 		{"--root", s.tempdir, "enable", svc2SocketName},
 		{"start", svc2SocketName},
 		{"--root", s.tempdir, "enable", svc3SocketName},
 		{"start", svc3SocketName}, // start failed, what follows is the cleanup
+		{"stop", svc3SocketName},
+		{"show", "--property=ActiveState", svc3SocketName},
+		{"stop", svc3Name},
+		{"show", "--property=ActiveState", svc3Name},
 		{"--root", s.tempdir, "disable", svc3SocketName},
 		{"stop", svc2SocketName},
 		{"show", "--property=ActiveState", svc2SocketName},


### PR DESCRIPTION
When starting the services, the sockets are handled in 2 steps, first getting
enabled followed by starting the actual socket. When the start step of a socket
or a service fails, the sockets do not get disabled.

