### PR TITLE
cmd/snap-confine: allow snap-update-ns to chown things

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -512,6 +512,8 @@
 
         # Needed to perform mount/unmounts.
         capability sys_admin,
+        # Needed to chown files for writable mimic.
+        capability chown,
 
         # Allow freezing and thawing the per-snap cgroup freezers
         /sys/fs/cgroup/freezer/snap.*/freezer.state rw,


### PR DESCRIPTION
This is used by the writable mimic code but was not caught by spread
tests because they run as root. Minimal patch for 2.31.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>