### PR TITLE
interfaces/apparmor: use a helper to set the scope

### DIFF
--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -102,3 +102,8 @@ func MockClassicTemplate(fakeTemplate string) (restore func()) {
 	classicTemplate = fakeTemplate
 	return func() { classicTemplate = orig }
 }
+
+// SetSpecScope sets the scope of a given specification
+func SetSpecScope(spec *Specification, securityTags []string, snapName string) (restore func()) {
+	return spec.setScope(securityTags, snapName)
+}


### PR DESCRIPTION
The spec.AddSnippet function relies on the under-the-hood scope
information that informs it about the set of security tags that is being
operated on. This makes the interface code straightforward and natural
and is a good thing. This patch refactors how that is done and adds the
name of the snap to the set of scope, contextual information.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
