### PR TITLE
interfaces/apparmor: early support for snap-update-ns snippets

### DIFF
--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -30,7 +30,7 @@ import (
 
 // Specification assists in collecting apparmor entries associated with an interface.
 type Specification struct {
-	// context for various Add{...}Snippet functions
+	// scope for various Add{...}Snippet functions
 	securityTags []string
 	snapName     string
 

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -38,9 +38,9 @@ type Specification struct {
 	// for snap application and hook processes. The security tag encodes the identity
 	// of the application or hook.
 	snippets map[string][]string
-	// sunSnippets are indexed by snap name and describe parts of apparmor policy
+	// updateNS are indexed by snap name and describe parts of apparmor policy
 	// for snap-update-ns executing on behalf of a given snap.
-	sunSnippets map[string][]string
+	updateNS map[string][]string
 }
 
 // setScope sets the scope of subsequent AddSnippet family functions.
@@ -68,15 +68,15 @@ func (spec *Specification) AddSnippet(snippet string) {
 	}
 }
 
-// AddSunSnippet adds a new apparmor snippet for the snap-update-ns program.
-func (spec *Specification) AddSunSnippet(snippet string) {
+// AddUpdateNS adds a new apparmor snippet for the snap-update-ns program.
+func (spec *Specification) AddUpdateNS(snippet string) {
 	if spec.snapName == "" {
 		return
 	}
-	if spec.sunSnippets == nil {
-		spec.sunSnippets = make(map[string][]string)
+	if spec.updateNS == nil {
+		spec.updateNS = make(map[string][]string)
 	}
-	spec.sunSnippets[spec.snapName] = append(spec.sunSnippets[spec.snapName], snippet)
+	spec.updateNS[spec.snapName] = append(spec.updateNS[spec.snapName], snippet)
 }
 
 // AddSnapLayout adds apparmor snippets based on the layout of the snap.
@@ -136,9 +136,9 @@ func (spec *Specification) SecurityTags() []string {
 	return tags
 }
 
-// SunSnippets returns a deep copy of all the added snap-update-ns snippets.
-func (spec *Specification) SunSnippets() map[string][]string {
-	return copySnippets(spec.sunSnippets)
+// UpdateNS returns a deep copy of all the added snap-update-ns snippets.
+func (spec *Specification) UpdateNS() map[string][]string {
+	return copySnippets(spec.updateNS)
 }
 
 func snippetFromLayout(layout *snap.Layout) string {

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -115,19 +115,6 @@ func (spec *Specification) AddSnapLayout(si *snap.Info) {
 	}
 }
 
-func snippetFromLayout(layout *snap.Layout) string {
-	mountPoint := layout.Snap.ExpandSnapVariables(layout.Path)
-	return fmt.Sprintf("# Layout path: %[1]s\n%[1]s{,/**} mrwklix,", mountPoint)
-}
-
-func copySnippets(m map[string][]string) map[string][]string {
-	result := make(map[string][]string, len(m))
-	for k, v := range m {
-		result[k] = append([]string(nil), v...)
-	}
-	return result
-}
-
 // Snippets returns a deep copy of all the added application snippets.
 func (spec *Specification) Snippets() map[string][]string {
 	return copySnippets(spec.snippets)
@@ -152,6 +139,19 @@ func (spec *Specification) SecurityTags() []string {
 // SunSnippets returns a deep copy of all the added snap-update-ns snippets.
 func (spec *Specification) SunSnippets() map[string][]string {
 	return copySnippets(spec.sunSnippets)
+}
+
+func snippetFromLayout(layout *snap.Layout) string {
+	mountPoint := layout.Snap.ExpandSnapVariables(layout.Path)
+	return fmt.Sprintf("# Layout path: %[1]s\n%[1]s{,/**} mrwklix,", mountPoint)
+}
+
+func copySnippets(m map[string][]string) map[string][]string {
+	result := make(map[string][]string, len(m))
+	for k, v := range m {
+		result[k] = append([]string(nil), v...)
+	}
+	return result
 }
 
 // Implementation of methods required by interfaces.Specification

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -35,7 +35,7 @@ type Specification struct {
 	snapName     string
 
 	// snippets are indexed by security tag and describe parts of apparmor policy
-	// for snap application and hook processes. The security tag encodes the identify
+	// for snap application and hook processes. The security tag encodes the identity
 	// of the application or hook.
 	snippets map[string][]string
 	// sunSnippets are indexed by snap name and describe parts of apparmor policy

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -54,7 +54,7 @@ func (spec *Specification) setScope(securityTags []string, snapName string) (res
 	}
 }
 
-// AddSnippet adds a new apparmor snippet to all applications using the interface.
+// AddSnippet adds a new apparmor snippet to all applications and hooks using the interface.
 func (spec *Specification) AddSnippet(snippet string) {
 	if len(spec.securityTags) == 0 {
 		return

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -103,7 +103,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 
 // AddSnippet adds a snippet for the given security tag.
 func (s *specSuite) TestAddSnippet(c *C) {
-	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.demo", "snap.demo.service"}, "demo")
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"}, "demo")
 	defer restore()
 
 	// Add two snippets in the context we are in.
@@ -111,27 +111,30 @@ func (s *specSuite) TestAddSnippet(c *C) {
 	s.spec.AddSnippet("snippet 2")
 
 	// The snippets were recorded correctly.
+	c.Assert(s.spec.SunSnippets(), HasLen, 0)
 	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
-		"snap.demo.demo":    {"snippet 1", "snippet 2"},
+		"snap.demo.command": {"snippet 1", "snippet 2"},
 		"snap.demo.service": {"snippet 1", "snippet 2"},
 	})
-	c.Assert(s.spec.SnippetForTag("snap.demo.demo"), Equals, "snippet 1\nsnippet 2")
-	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.demo", "snap.demo.service"})
+	c.Assert(s.spec.SnippetForTag("snap.demo.command"), Equals, "snippet 1\nsnippet 2")
+	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.command", "snap.demo.service"})
 }
 
 // AddSunSnippet adds a snippet for the snap-update-ns profile for a given snap.
 func (s *specSuite) TestAddSunSnippet(c *C) {
-	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.demo", "snap.demo.service"}, "demo")
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"}, "demo")
 	defer restore()
 
 	// Add a two snap-update-ns snippets in the context we are in.
-	s.spec.AddSunSnippet("snippet 1")
-	s.spec.AddSunSnippet("snippet 2")
+	s.spec.AddSunSnippet("s-u-n snippet 1")
+	s.spec.AddSunSnippet("s-u-n snippet 2")
 
-	// The snippets were recorded correctly.
+	// The snippets were recorded correctly and in the right place.
 	c.Assert(s.spec.SunSnippets(), DeepEquals, map[string][]string{
-		"demo": {"snippet 1", "snippet 2"},
+		"demo": {"s-u-n snippet 1", "s-u-n snippet 2"},
 	})
+	c.Assert(s.spec.SnippetForTag("snap.demo.demo"), Equals, "")
+	c.Assert(s.spec.SecurityTags(), HasLen, 0)
 }
 
 const snapWithLayout = `

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -133,7 +133,7 @@ func (s *specSuite) TestAddUpdateNS(c *C) {
 	c.Assert(s.spec.UpdateNS(), DeepEquals, map[string][]string{
 		"demo": {"s-u-n snippet 1", "s-u-n snippet 2"},
 	})
-	c.Assert(s.spec.SnippetForTag("snap.demo.demo"), Equals, "")
+	c.Assert(s.spec.SnippetForTag("snap.demo.command"), Equals, "")
 	c.Assert(s.spec.SecurityTags(), HasLen, 0)
 }
 

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -111,7 +111,7 @@ func (s *specSuite) TestAddSnippet(c *C) {
 	s.spec.AddSnippet("snippet 2")
 
 	// The snippets were recorded correctly.
-	c.Assert(s.spec.SunSnippets(), HasLen, 0)
+	c.Assert(s.spec.UpdateNS(), HasLen, 0)
 	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
 		"snap.demo.command": {"snippet 1", "snippet 2"},
 		"snap.demo.service": {"snippet 1", "snippet 2"},
@@ -120,17 +120,17 @@ func (s *specSuite) TestAddSnippet(c *C) {
 	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.command", "snap.demo.service"})
 }
 
-// AddSunSnippet adds a snippet for the snap-update-ns profile for a given snap.
-func (s *specSuite) TestAddSunSnippet(c *C) {
+// AddUpdateNS adds a snippet for the snap-update-ns profile for a given snap.
+func (s *specSuite) TestAddUpdateNS(c *C) {
 	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"}, "demo")
 	defer restore()
 
 	// Add a two snap-update-ns snippets in the context we are in.
-	s.spec.AddSunSnippet("s-u-n snippet 1")
-	s.spec.AddSunSnippet("s-u-n snippet 2")
+	s.spec.AddUpdateNS("s-u-n snippet 1")
+	s.spec.AddUpdateNS("s-u-n snippet 2")
 
 	// The snippets were recorded correctly and in the right place.
-	c.Assert(s.spec.SunSnippets(), DeepEquals, map[string][]string{
+	c.Assert(s.spec.UpdateNS(), DeepEquals, map[string][]string{
 		"demo": {"s-u-n snippet 1", "s-u-n snippet 2"},
 	})
 	c.Assert(s.spec.SnippetForTag("snap.demo.demo"), Equals, "")

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -99,3 +99,36 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 		"snap.snap2.app2": {"connected-slot", "permanent-slot"},
 	})
 }
+
+// AddSnippet adds a snippet for the given security tag.
+func (s *specSuite) TestAddSnippet(c *C) {
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.demo", "snap.demo.service"}, "demo")
+	defer restore()
+
+	// Add two snippets in the context we are in.
+	s.spec.AddSnippet("snippet 1")
+	s.spec.AddSnippet("snippet 2")
+
+	// The snippets were recorded correctly.
+	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
+		"snap.demo.demo":    {"snippet 1", "snippet 2"},
+		"snap.demo.service": {"snippet 1", "snippet 2"},
+	})
+	c.Assert(s.spec.SnippetForTag("snap.demo.demo"), Equals, "snippet 1\nsnippet 2")
+	c.Assert(s.spec.SecurityTags(), DeepEquals, []string{"snap.demo.demo", "snap.demo.service"})
+}
+
+// AddSunSnippet adds a snippet for the snap-update-ns profile for a given snap.
+func (s *specSuite) TestAddSunSnippet(c *C) {
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.demo", "snap.demo.service"}, "demo")
+	defer restore()
+
+	// Add a two snap-update-ns snippets in the context we are in.
+	s.spec.AddSunSnippet("snippet 1")
+	s.spec.AddSunSnippet("snippet 2")
+
+	// The snippets were recorded correctly.
+	c.Assert(s.spec.SunSnippets(), DeepEquals, map[string][]string{
+		"demo": {"snippet 1", "snippet 2"},
+	})
+}


### PR DESCRIPTION
This patch extends the apparmor backend so that interfaces can now use
apparmor snippets that are destined for the snap-update-ns process that
will execute, confined, to initialize or update the mount namespace.

This is designed so that layout code can generate s-u-n snippets that
describe any writable mimics that may need to be constructed so that
security can be tighter.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
