### PR TITLE
overlord/configstate/config: make [GS]etSnapConfig use *RawMessage

### DIFF
--- a/overlord/configstate/config/helpers.go
+++ b/overlord/configstate/config/helpers.go
@@ -136,7 +136,7 @@ func GetFromChange(snapName string, subkeys []string, pos int, config map[string
 }
 
 // GetSnapConfig retrieves the raw configuration of a given snap.
-func GetSnapConfig(st *state.State, snapName string) (json.RawMessage, error) {
+func GetSnapConfig(st *state.State, snapName string) (*json.RawMessage, error) {
 	var config map[string]*json.RawMessage
 	err := st.Get("config", &config)
 	if err == state.ErrNoState {
@@ -149,15 +149,16 @@ func GetSnapConfig(st *state.State, snapName string) (json.RawMessage, error) {
 	if !ok {
 		return nil, nil
 	}
-	return *snapcfg, nil
+	return snapcfg, nil
 }
 
 // SetSnapConfig replaces the configuration of a given snap.
-func SetSnapConfig(st *state.State, snapName string, snapcfg json.RawMessage) error {
+func SetSnapConfig(st *state.State, snapName string, snapcfg *json.RawMessage) error {
 	var config map[string]*json.RawMessage
 	err := st.Get("config", &config)
+	isNil := snapcfg == nil || len(*snapcfg) == 0
 	if err == state.ErrNoState {
-		if len(snapcfg) == 0 {
+		if isNil {
 			// bail out early
 			return nil
 		}
@@ -165,10 +166,10 @@ func SetSnapConfig(st *state.State, snapName string, snapcfg json.RawMessage) er
 	} else if err != nil {
 		return err
 	}
-	if len(snapcfg) == 0 {
+	if isNil {
 		delete(config, snapName)
 	} else {
-		config[snapName] = &snapcfg
+		config[snapName] = snapcfg
 	}
 	st.Set("config", config)
 	return nil

--- a/overlord/configstate/config/helpers_test.go
+++ b/overlord/configstate/config/helpers_test.go
@@ -143,7 +143,9 @@ func (s *configHelpersSuite) TestSnapConfig(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	for _, emptyCfg := range [][]byte{nil, {}} {
+	empty1 := json.RawMessage(nil)
+
+	for _, emptyCfg := range []*json.RawMessage{nil, &empty1, {}} {
 		rawCfg, err := config.GetSnapConfig(s.state, "snap1")
 		c.Assert(err, IsNil)
 		c.Check(rawCfg, IsNil)
@@ -154,12 +156,14 @@ func (s *configHelpersSuite) TestSnapConfig(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(rawCfg, IsNil)
 
-		c.Assert(config.SetSnapConfig(s.state, "snap1", json.RawMessage(`{"foo":"bar"}`)), IsNil)
+		cfg := json.RawMessage(`{"foo":"bar"}`)
+		c.Assert(config.SetSnapConfig(s.state, "snap1", &cfg), IsNil)
 
 		// the set sets it
 		rawCfg, err = config.GetSnapConfig(s.state, "snap1")
 		c.Assert(err, IsNil)
-		c.Check(rawCfg, DeepEquals, json.RawMessage(`{"foo":"bar"}`))
+		c.Assert(rawCfg, NotNil)
+		c.Check(*rawCfg, DeepEquals, json.RawMessage(`{"foo":"bar"}`))
 
 		// empty or nil clears it
 		c.Assert(config.SetSnapConfig(s.state, "snap1", emptyCfg), IsNil)


### PR DESCRIPTION
because of [go issue #14493](https://github.com/golang/go/issues/14493) it's best to use `*json.RawMessage` instead of just `json.RawMessage` on go < 1.8. This changes the arity of `GetSnapConfig` and `SetSnapConfig` to help with this.
