### PR TITLE
snap: exclude `gettimeofday` from `snap run --strace`

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -461,7 +461,7 @@ func straceCmd() ([]string, error) {
 		stracePath,
 		"-u", current.Username,
 		"-f",
-		"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid",
+		"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid,gettimeofday",
 	}, nil
 }
 

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -461,6 +461,8 @@ func straceCmd() ([]string, error) {
 		stracePath,
 		"-u", current.Username,
 		"-f",
+		// these syscalls are excluded because they make strace hang
+		// on all or some architectures (gettimeofday on arm64)
 		"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid,gettimeofday",
 	}, nil
 }

--- a/cmd/snap/cmd_run_test.go
+++ b/cmd/snap/cmd_run_test.go
@@ -688,7 +688,7 @@ echo "stdout output 2"
 			filepath.Join(straceCmd.BinDir(), "strace"),
 			"-u", user.Username,
 			"-f",
-			"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid",
+			"-e", "!select,pselect6,_newselect,clock_gettime,sigaltstack,gettid,gettimeofday",
 			filepath.Join(dirs.DistroLibExecDir, "snap-confine"),
 			"snap.snapname.app",
 			filepath.Join(dirs.CoreLibExecDir, "snap-exec"),


### PR DESCRIPTION
There are reported hangs on arm64 with the strace test. It appears
the gettimeofday is making the system hang. Blacklisting it from
the syscalls we trace by default.
