### PR TITLE
data/systemd: for debugging/testing use /etc/environment also for snap-repair runs

### DIFF
--- a/data/systemd/snapd.snap-repair.service.in
+++ b/data/systemd/snapd.snap-repair.service.in
@@ -7,4 +7,5 @@ ConditionKernelCommandLine=snap_core
 [Service]
 Type=oneshot
 ExecStart=@libexecdir@/snapd/snap-repair run
-Environment=SNAP_REAPIR_FROM_TIMER=1
+EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
+Environment=SNAP_REPAIR_FROM_TIMER=1


### PR DESCRIPTION
This is doesn't influence the normal behavior but is useful for testing against staging or debugging.
Also fixes a typo.
