### PR TITLE
overlord/snapstate/backend: perform cleanup if snap setup fails

### DIFF
--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -33,11 +33,9 @@ import (
 func (b Backend) SetupSnap(snapFilePath string, sideInfo *snap.SideInfo, meter progress.Meter) (err error) {
 	// This assumes that the snap was already verified or --dangerous was used.
 
-	var s *snap.Info
-	var snapf snap.Container
-	s, snapf, err = OpenSnapFile(snapFilePath, sideInfo)
-	if err != nil {
-		return err
+	s, snapf, oErr := OpenSnapFile(snapFilePath, sideInfo)
+	if oErr != nil {
+		return oErr
 	}
 	instdir := s.MountDir()
 

--- a/overlord/snapstate/backend/setup.go
+++ b/overlord/snapstate/backend/setup.go
@@ -30,14 +30,26 @@ import (
 )
 
 // SetupSnap does prepare and mount the snap for further processing.
-func (b Backend) SetupSnap(snapFilePath string, sideInfo *snap.SideInfo, meter progress.Meter) error {
+func (b Backend) SetupSnap(snapFilePath string, sideInfo *snap.SideInfo, meter progress.Meter) (err error) {
 	// This assumes that the snap was already verified or --dangerous was used.
 
-	s, snapf, err := OpenSnapFile(snapFilePath, sideInfo)
+	var s *snap.Info
+	var snapf snap.Container
+	s, snapf, err = OpenSnapFile(snapFilePath, sideInfo)
 	if err != nil {
 		return err
 	}
 	instdir := s.MountDir()
+
+	defer func() {
+		if err == nil {
+			return
+		}
+		// XXX: this will also remove the snap from /var/lib/snapd/snaps
+		if e := b.RemoveSnapFiles(s, s.Type, meter); e != nil {
+			meter.Notify(fmt.Sprintf("while trying to clean up due to previous failure: %v", e))
+		}
+	}()
 
 	if err := os.MkdirAll(instdir, 0755); err != nil {
 		return err

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -242,4 +243,34 @@ type: kernel
 
 	l, _ = filepath.Glob(filepath.Join(bootloader.Dir(), "*"))
 	c.Assert(l, HasLen, 0)
+}
+
+func (s *setupSuite) TestSetupCleanupAfterFail(c *C) {
+	snapPath := makeTestSnap(c, helloYaml1)
+
+	si := snap.SideInfo{
+		RealName: "hello",
+		Revision: snap.R(14),
+	}
+
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		// mount unit start fails
+		if len(cmd) >= 2 && cmd[0] == "start" && strings.HasSuffix(cmd[1], ".mount") {
+			return nil, fmt.Errorf("failed")
+		}
+		return []byte("ActiveState=inactive\n"), nil
+	})
+	defer r()
+
+	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	c.Assert(err, ErrorMatches, "failed")
+
+	// everything is gone
+	l, _ := filepath.Glob(filepath.Join(dirs.SnapServicesDir, "*.mount"))
+	c.Check(l, HasLen, 0)
+
+	minInfo := snap.MinimalPlaceInfo("hello", snap.R(14))
+	c.Check(osutil.FileExists(minInfo.MountDir()), Equals, false)
+	c.Check(osutil.FileExists(minInfo.MountFile()), Equals, false)
+	c.Check(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello_14.snap")), Equals, false)
 }


### PR DESCRIPTION
SetupSnap() has side effects such as mount unit files, files copied around. When
the call fails make sure that we clean up. This works with snap setup task where
undo handler is only called if undoing a successfully completed task.
