### PR TITLE
tests/main/user-data-handling: get rid of ordering bug

### DIFF
--- a/tests/main/user-data-handling/task.yaml
+++ b/tests/main/user-data-handling/task.yaml
@@ -3,25 +3,32 @@ summary: Check that the refresh data copy works.
 execute: |
     echo "For an installed snap"
     snap install test-snapd-tools
-    rev=$(snap list|grep test-snapd-tools|tr -s ' '|cut -f3 -d' ')
+    rev=$(snap list test-snapd-tools|tail -n1|tr -s ' '|cut -f3 -d' ')
 
+    homes=(/root/ /home/*/)
     echo "That has some user data"
-    mkdir -p /home/*/snap/test-snapd-tools/$rev/
-    touch /home/*/snap/test-snapd-tools/$rev/mock-data
-    mkdir -p /root/snap/test-snapd-tools/$rev/
-    touch /root/snap/test-snapd-tools/$rev/mock-data
+    for h in "${homes[@]}"; do
+        d="${h}snap/test-snapd-tools/$rev"
+        mkdir -p "$d"
+        touch "$d/mock-data"
+        chown --recursive --reference="$h" "${h}snap/"
+    done
 
     echo "When the snap is refreshed"
     snap refresh --channel=edge test-snapd-tools
-    new_rev=$(snap list|grep test-snapd-tools|tr -s ' '|cut -f3 -d' ')
+    new_rev=$(snap list test-snapd-tools|tail -n1|tr -s ' '|cut -f3 -d' ')
 
     echo "Then the user data gets copied"
-    test -e /home/*/snap/test-snapd-tools/$new_rev/mock-data
-    test -e /root/snap/test-snapd-tools/$new_rev/mock-data
+    for h in "${homes[@]}"; do
+        test -e "${h}snap/test-snapd-tools/$new_rev/mock-data"
+        test -e "${h}snap/test-snapd-tools/$rev/mock-data"
+    done
 
     echo "When the snap is removed"
     snap remove test-snapd-tools
 
     echo "Then all user data and root data is gone"
-    ! test -e /home/*/snap/test-snapd-tools/$new_rev/mock-data
-    ! test -e /root/snap/test-snapd-tools/$new_rev/mock-data
+    for h in "${homes[@]}"; do
+        test ! -e "${h}snap/test-snapd-tools/$new_rev/mock-data"
+        test ! -e "${h}snap/test-snapd-tools/$rev/mock-data"
+    done


### PR DESCRIPTION
the two lines present in the execute script of
`tests/main/user-data-handling`,

```sh
mkdir -p /home/*/snap/test-snapd-tools/$rev/
touch /home/*/snap/test-snapd-tools/$rev/mock-data
```

are problematic, in that depending on what tests have run before,
you'll end up with a directory called `*` in `/home`.

Additionally some of the tests further down would break if there
existed more than one user with a `snap/test-snapd-tools/` directory.

This change aims to fix the problem.
