### PR TITLE
debian/rules: workaround for https://github.com/golang/go/issues/23721

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -46,6 +46,8 @@ GOOS := $(shell go env GOOS)
 BUILDFLAGS:=
 GCCGOFLAGS=-gccgoflags="-I $(CURDIR)/_build/pkg/gccgo_$(GOOS)_$(GOARCH)/$(DH_GOPKG)/vendor"
 export DH_GOLANG_GO_GENERATE=0
+# workaround for https://github.com/golang/go/issues/23721
+export GOMAXPROCS=2
 endif
 
 # check if we need to include the testkeys in the binary


### PR DESCRIPTION
gccgo seems to have a bug where in some cases a goroutine never gets
to run. The issue can be worked around by having setting GOMAXPROCS to
something bigger than 1, so this change does that.

If do io copies on things that don't actually involve the operating
system we might bite the same issue outside of the tests, so if we
have gccgo-built binaries in production we probably want to set
GOMAXPROCS there as well.
