### PR TITLE
tests: skip alsa interface test when the system does not have any audio devices

### DIFF
--- a/tests/main/interfaces-alsa/task.yaml
+++ b/tests/main/interfaces-alsa/task.yaml
@@ -37,6 +37,11 @@ execute: |
     snap connect generic-consumer:alsa
     snap interfaces | MATCH "$CONNECTED_PATTERN"
 
+    if ! [ -d /dev/snd/ ]; then
+        echo "No sound devices available in the system"
+        exit 0
+    fi
+
     echo "Then the snap is able to access snd devices"
     generic-consumer.cmd touch /dev/snd/mysnd-dev
     echo "mysnd-dev-content" | tee /dev/snd/mysnd-dev


### PR DESCRIPTION
This test is failing when snapd tests are being executed using the
linux-azure kernel.

linux-azure was trimmed out to be compiled with only what is supported
in azure (although we might need to disable further configs yet). and it
doesn't support sound devices

Error:
https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac
/autopkgtest-xenial/xenial/amd64/s/snapd/20180201_192738_d770f@/log.gz
