### PR TITLE
wrappers: do not start oneshot services

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -100,6 +100,14 @@ func StartServices(apps []*snap.AppInfo, inter interacter) (err error) {
 			continue
 		}
 
+		// skip oneshot services, as:
+		// - they may hang indefinitely
+		// - they have TimeoutStartSec disabled by default
+		// - we do not really know when is the good time to start them
+		if app.Daemon == "oneshot" {
+			continue
+		}
+
 		defer func(app *snap.AppInfo) {
 			if err == nil {
 				return

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -453,6 +453,9 @@ func (s *servicesTestSuite) TestStartSnapMultiServicesFailStartCleanup(c *C) {
  svc2:
   command: bin/hello
   daemon: simple
+ svc3:
+  command: bin/oneshot
+  daemon: oneshot
 `, &snap.SideInfo{Revision: snap.R(12)})
 
 	err := wrappers.StartServices(info.Services(), nil)


### PR DESCRIPTION
When a snap is installed, all services defined in snap.yaml are started in
start-snap-services task. The code does a runs `systemctl start <services>` and
waits for it to exit.

There is a peculiar case of 'oneshot' type services, where `systemctl start`,
unless called with --no-block, will block until the service exits. If the
service takes a long time to do its work, or is badly written and will hang
indefinitely, the snap installation process will stall [1].

If we try the --no-block approach, we will not be able to report if service was
actually started (those are only queued for startup). Setting TimeoutStartSec to
some value, feels a bit arbitrary. For instance, ssh key generation is usually
done in a oneshot service and it may take a considerable amount of time.

As a proposed workaround do not start 'oneshot' services at all on the premise
that we cannot guess the proper timeout and in fact do not know when it is the
right time to start the service (eg. the 'daemon' service generates data in
common snap data, oneshot service peeks into the data and fails with non-0 exit
code if it isn't there, causing snap installation to fail).

[1]. https://forum.snapcraft.io/t/oneshot-daemon-freezes-install-on-start-snap-foo-unset-services/3894
