### PR TITLE
daemon: remove redundant UserOK markings from api commands

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -96,6 +96,7 @@ var api = []*Command{
 }
 
 var (
+	// see daemon.go:canAccess for details how the access is controlled
 	rootCmd = &Command{
 		Path:    "/",
 		GuestOK: true,
@@ -115,9 +116,8 @@ var (
 	}
 
 	logoutCmd = &Command{
-		Path:   "/v2/logout",
-		POST:   logoutUser,
-		UserOK: true,
+		Path: "/v2/logout",
+		POST: logoutUser,
 	}
 
 	appIconCmd = &Command{
@@ -209,21 +209,18 @@ var (
 	}
 
 	createUserCmd = &Command{
-		Path:   "/v2/create-user",
-		UserOK: false,
-		POST:   postCreateUser,
+		Path: "/v2/create-user",
+		POST: postCreateUser,
 	}
 
 	buyCmd = &Command{
-		Path:   "/v2/buy",
-		UserOK: false,
-		POST:   postBuy,
+		Path: "/v2/buy",
+		POST: postBuy,
 	}
 
 	readyToBuyCmd = &Command{
-		Path:   "/v2/buy/ready",
-		UserOK: false,
-		GET:    readyToBuy,
+		Path: "/v2/buy/ready",
+		GET:  readyToBuy,
 	}
 
 	snapctlCmd = &Command{
@@ -233,9 +230,8 @@ var (
 	}
 
 	usersCmd = &Command{
-		Path:   "/v2/users",
-		UserOK: false,
-		GET:    getUsers,
+		Path: "/v2/users",
+		GET:  getUsers,
 	}
 
 	sectionsCmd = &Command{

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -96,6 +96,16 @@ const (
 
 var polkitCheckAuthorizationForPid = polkit.CheckAuthorizationForPid
 
+// canAccess checks the following properties:
+//
+// - if a user is logged in (via `snap login`) everything is allowed
+// - if the user is `root` everything is allowed
+// - POST/PUT/DELETE all require `snap login` or `root`
+//
+// Otherwise for GET requests the following parameters are honored:
+// - GuestOK: anyone can access GET
+// - UserOK: any uid on the local system can access GET
+// - SnapOK: a snap can access this via `snapctl`
 func (c *Command) canAccess(r *http.Request, user *auth.UserState) accessResult {
 	if user != nil {
 		// Authenticated users do anything for now.


### PR DESCRIPTION
We currently have a bunch of Commands in the API that are using
`UserOK:` in a redundant (and for my eyes confusing) way.

The default is `UserOK: false` so we don't need to state it. It
also only applies to `GET` so `UserOK: true` for something that
does not have a `GET` has no effect.

The PR also documents the canAccess() policy.

