### PR TITLE
 daemon: improve ucrednet code for the snap.socket

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2278,7 +2278,7 @@ func setupLocalUser(st *state.State, username, email string) error {
 }
 
 func postCreateUser(c *Command, r *http.Request, user *auth.UserState) Response {
-	_, uid, err := postCreateUserUcrednetGet(r.RemoteAddr)
+	_, uid, _, err := postCreateUserUcrednetGet(r.RemoteAddr)
 	if err != nil {
 		return BadRequest("cannot get ucrednet uid: %v", err)
 	}
@@ -2499,7 +2499,7 @@ func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
 }
 
 func getUsers(c *Command, r *http.Request, user *auth.UserState) Response {
-	_, uid, err := postCreateUserUcrednetGet(r.RemoteAddr)
+	_, uid, _, err := postCreateUserUcrednetGet(r.RemoteAddr)
 	if err != nil {
 		return BadRequest("cannot get ucrednet uid: %v", err)
 	}

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4779,8 +4779,8 @@ func (s *postCreateUserSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
 
 	s.daemon(c)
-	postCreateUserUcrednetGet = func(string) (uint32, uint32, error) {
-		return 100, 0, nil
+	postCreateUserUcrednetGet = func(string) (uint32, uint32, string, error) {
+		return 100, 0, dirs.SnapdSocket, nil
 	}
 	s.mockUserHome = c.MkDir()
 	userLookup = mkUserLookup(s.mockUserHome)
@@ -5145,8 +5145,8 @@ func (s *postCreateUserSuite) TestPostCreateUserFromAssertionAllKnownClassicErro
 
 	s.makeSystemUsers(c, []map[string]interface{}{goodUser})
 
-	postCreateUserUcrednetGet = func(string) (uint32, uint32, error) {
-		return 100, 0, nil
+	postCreateUserUcrednetGet = func(string) (uint32, uint32, string, error) {
+		return 100, 0, dirs.SnapdSocket, nil
 	}
 	defer func() {
 		postCreateUserUcrednetGet = ucrednetGet

--- a/daemon/ucrednet_test.go
+++ b/daemon/ucrednet_test.go
@@ -74,7 +74,7 @@ func (s *ucrednetSuite) TestAcceptConnRemoteAddrString(c *check.C) {
 
 	remoteAddr := conn.RemoteAddr().String()
 	c.Check(remoteAddr, check.Matches, "pid=100;uid=42;.*")
-	pid, uid, err := ucrednetGet(remoteAddr)
+	pid, uid, _, err := ucrednetGet(remoteAddr)
 	c.Check(pid, check.Equals, uint32(100))
 	c.Check(uid, check.Equals, uint32(42))
 	c.Check(err, check.IsNil)
@@ -101,7 +101,7 @@ func (s *ucrednetSuite) TestNonUnix(c *check.C) {
 
 	remoteAddr := conn.RemoteAddr().String()
 	c.Check(remoteAddr, check.Matches, "pid=;uid=;.*")
-	pid, uid, err := ucrednetGet(remoteAddr)
+	pid, uid, _, err := ucrednetGet(remoteAddr)
 	c.Check(pid, check.Equals, ucrednetNoProcess)
 	c.Check(uid, check.Equals, ucrednetNobody)
 	c.Check(err, check.Equals, errNoID)
@@ -144,36 +144,37 @@ func (s *ucrednetSuite) TestUcredErrors(c *check.C) {
 }
 
 func (s *ucrednetSuite) TestGetNoUid(c *check.C) {
-	pid, uid, err := ucrednetGet("pid=100;uid=;")
+	pid, uid, _, err := ucrednetGet("pid=100;uid=;")
 	c.Check(err, check.Equals, errNoID)
 	c.Check(pid, check.Equals, uint32(100))
 	c.Check(uid, check.Equals, ucrednetNobody)
 }
 
 func (s *ucrednetSuite) TestGetBadUid(c *check.C) {
-	pid, uid, err := ucrednetGet("pid=100;uid=hello;")
+	pid, uid, _, err := ucrednetGet("pid=100;uid=hello;")
 	c.Check(err, check.NotNil)
 	c.Check(pid, check.Equals, uint32(100))
 	c.Check(uid, check.Equals, ucrednetNobody)
 }
 
 func (s *ucrednetSuite) TestGetNonUcrednet(c *check.C) {
-	pid, uid, err := ucrednetGet("hello")
+	pid, uid, _, err := ucrednetGet("hello")
 	c.Check(err, check.Equals, errNoID)
 	c.Check(pid, check.Equals, ucrednetNoProcess)
 	c.Check(uid, check.Equals, ucrednetNobody)
 }
 
 func (s *ucrednetSuite) TestGetNothing(c *check.C) {
-	pid, uid, err := ucrednetGet("")
+	pid, uid, _, err := ucrednetGet("")
 	c.Check(err, check.Equals, errNoID)
 	c.Check(pid, check.Equals, ucrednetNoProcess)
 	c.Check(uid, check.Equals, ucrednetNobody)
 }
 
 func (s *ucrednetSuite) TestGet(c *check.C) {
-	pid, uid, err := ucrednetGet("pid=100;uid=42;")
+	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket")
 	c.Check(err, check.IsNil)
 	c.Check(pid, check.Equals, uint32(100))
 	c.Check(uid, check.Equals, uint32(42))
+	c.Check(socket, check.Equals, "/run/snap.socket")
 }


### PR DESCRIPTION
The old code did not get the pid/uid of the "other side" for
daemon connections that originate from a snap (via snapctl).
But we still need this information to make proper access
decisions. This PR extends the snap(ctl) socket to also transmit
pid/uid information and adds some more tests. 

The changes as small as possible, but I want to do a followup that makes `canAccess` a bit easier to read.
