### PR TITLE
ifacestate: only rewrite security profiles if the system-key changes

### DIFF
--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -67,3 +67,16 @@ func (s *systemKeySuite) TestInterfaceSystemKey(c *C) {
 	c.Check(systemKey, Equals, fmt.Sprintf(`build-id: %s
 apparmor-features:%s`, s.buildID, apparmorFeaturesStr))
 }
+
+func (ts *systemKeySuite) TestInterfaceDigest(c *C) {
+	restore := interfaces.MockSystemKey(`build-id: 7a94e9736c091b3984bd63f5aebfc883c4d859e0
+apparmor-features:
+- caps
+- dbus
+`)
+	defer restore()
+
+	systemKey := interfaces.SystemKey()
+	c.Check(systemKey, Matches, "(?sm)^build-id: [a-z0-9]+$")
+	c.Check(systemKey, Matches, "(?sm).*apparmor-features:")
+}

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -21,14 +21,18 @@ package ifacestate
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/policy"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -54,8 +58,10 @@ func (m *InterfaceManager) initialize(extraInterfaces []interfaces.Interface, ex
 	if _, err := m.reloadConnections(""); err != nil {
 		return err
 	}
-	if err := m.regenerateAllSecurityProfiles(); err != nil {
-		return err
+	if m.profilesNeedRegeneration() {
+		if err := m.regenerateAllSecurityProfiles(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -108,14 +114,26 @@ func (m *InterfaceManager) addSnaps() error {
 	return nil
 }
 
-// regenerateAllSecurityProfiles will regenerate the security profiles
-// for apparmor and seccomp. This is needed because:
-// - for seccomp we may have "terms" on disk that the current snap-confine
-//   does not understand (e.g. in a rollback scenario). a refresh ensures
-//   we have a profile that matches what snap-confine understand
-// - for apparmor the kernel 4.4.0-65.86 has an incompatible apparmor
-//   change that breaks existing profiles for installed snaps. With a
-//   refresh those get fixed.
+func (m *InterfaceManager) profilesNeedRegeneration() bool {
+	currentSystemKey := interfaces.SystemKey()
+	if currentSystemKey == "" {
+		logger.Noticef("no system key, forcing re-generation of security profiles")
+		return true
+	}
+
+	onDiskSystemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
+	if os.IsNotExist(err) {
+		return true
+	}
+	if err != nil {
+		logger.Noticef("cannot read system-key file: %s", err)
+		return true
+	}
+
+	return string(onDiskSystemKey) != currentSystemKey
+}
+
+// regenerateAllSecurityProfiles will regenerate all security profiles.
 func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 	// Get all the security backends
 	securityBackends := m.repo.Backends()
@@ -156,7 +174,8 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 		}
 	}
 
-	return nil
+	sk := interfaces.SystemKey()
+	return osutil.AtomicWriteFile(dirs.SnapSystemKeyFile, []byte(sk), 0644, 0)
 }
 
 // renameCorePlugConnection renames one connection from "core-support" plug to

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -1,0 +1,37 @@
+summary: Ensure security profile re-generation works with system-key
+
+execute: |
+    restart_snapd() {
+        systemctl stop snapd.service
+        while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=inactive" ]; do
+            systemctl show -pActiveState snapd.service
+            sleep 1
+        done
+
+        systemctl start snapd.service
+        while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=active" ]; do
+            systemctl show -pActiveState snapd.service
+            sleep 1
+        done
+    }
+
+    echo "Ensure a valid system-key file is on-disk"
+    cat /var/lib/snapd/system-key | MATCH "build-id: [0-9a-z]+"
+    buf="$(stat /var/lib/snapd/system-key)"
+    system_key_content="$(cat /var/lib/snapd/system-key)"
+
+    echo "Ensure that the system-key is not rewritten if system-key is unchanged"
+    restart_snapd
+    buf2="$(stat /var/lib/snapd/system-key)"
+    if [ "$buf" != "$buf2" ]; then
+        echo "system-key got rewriten: $buf != buf2, test broken"
+        exit 1
+    fi
+
+    echo "Ensure that the system-key is rewritten if system-key changes"
+    printf "something: new\n" >> /var/lib/snapd/system-key
+    restart_snapd
+    if grep "something: new" /var/lib/snapd/system-key; then
+        echo "system-key *not* rewriten test broken"
+        exit 1
+    fi


### PR DESCRIPTION
We currently unconditionally rewrite security profiles on each
restart of snapd. However this is not really needed, we only need
to rewrite them if snapd itself changes or if security properties
(like apparmor support in the kernel) changes. This PR addresses
this.
