### PR TITLE
snap: sort layout elements before validating

### DIFF
--- a/snap/export_test.go
+++ b/snap/export_test.go
@@ -20,8 +20,9 @@
 package snap
 
 var (
-	NewHookType        = newHookType
-	ValidateSocketName = validateSocketName
+	NewHookType                  = newHookType
+	ValidateSocketName           = validateSocketName
+	InfoFromSnapYamlWithSideInfo = infoFromSnapYamlWithSideInfo
 )
 
 func MockSupportedHookTypes(hookTypes []*HookType) (restore func()) {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -225,8 +226,19 @@ func Validate(info *Info) error {
 		return err
 	}
 
+	return ValidateLayoutAll(info)
+}
+
+// ValidateLayoutAll validates the consistency of all the layout elements in a snap.
+func ValidateLayoutAll(info *Info) error {
 	blacklist := make([]string, 0, len(info.Layout))
+	paths := make([]string, 0, len(info.Layout))
 	for _, layout := range info.Layout {
+		paths = append(paths, layout.Path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		layout := info.Layout[path]
 		if err := ValidateLayout(layout, blacklist); err != nil {
 			return err
 		}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -574,10 +574,21 @@ layout:
   /usr/foo/bar:
     type: tmpfs
 `
-	info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml1), &SideInfo{Revision: R(42)})
-	c.Assert(err, IsNil)
-	err = ValidateLayoutAll(info)
-	c.Assert(err, ErrorMatches, `layout "/usr/foo/bar" underneath prior layout item "/usr/foo"`)
+	const yaml1rev = `
+name: broken-layout-1
+layout:
+  /usr/foo/bar:
+    type: tmpfs
+  /usr/foo:
+    type: tmpfs
+`
+
+	for _, yaml := range []string{yaml1, yaml1rev} {
+		info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml), &SideInfo{Revision: R(42)})
+		c.Assert(err, IsNil)
+		err = ValidateLayoutAll(info)
+		c.Assert(err, ErrorMatches, `layout "/usr/foo/bar" underneath prior layout item "/usr/foo"`)
+	}
 
 	// Same as above but with bind-mounts instead of filesystem mounts.
 	const yaml2 = `
@@ -588,10 +599,20 @@ layout:
   /usr/foo/bar:
     bind: $SNAP
 `
-	info, err = InfoFromSnapYamlWithSideInfo([]byte(yaml2), &SideInfo{Revision: R(42)})
-	c.Assert(err, IsNil)
-	err = ValidateLayoutAll(info)
-	c.Assert(err, ErrorMatches, `layout "/usr/foo/bar" underneath prior layout item "/usr/foo"`)
+	const yaml2rev = `
+name: broken-layout-2
+layout:
+  /usr/foo/bar:
+    bind: $SNAP
+  /usr/foo:
+    bind: $SNAP
+`
+	for _, yaml := range []string{yaml2, yaml2rev} {
+		info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml), &SideInfo{Revision: R(42)})
+		c.Assert(err, IsNil)
+		err = ValidateLayoutAll(info)
+		c.Assert(err, ErrorMatches, `layout "/usr/foo/bar" underneath prior layout item "/usr/foo"`)
+	}
 }
 
 func (s *ValidateSuite) TestValidateSocketName(c *C) {


### PR DESCRIPTION
snap: sort layout elements before validating

We should sort layout elements and validate them by name so that we can
give correct validation errors reliably. If /foo and /foo/bar are two
layout elements then the error should always say that /foo/bar is
underneath /foo, irrespective or runtime map ordering.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>