### PR TITLE
cmd/snap-confine: allow mounting anywhere, effectively

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -553,14 +553,14 @@
         # Allow mounting/unmounting any part of $SNAP over to a temporary place
         # in /tmp/.snap/ during the preparation of a writable mimic.
         # FIXME: update this with per-snap snap-update-ns profiles
-        mount options=(bind, rw) /*/** -> /tmp/.snap/**,
-        # Allow mounting tmpfs over the original $SNAP/** directory.
+        mount options=(bind, rw) /** -> /tmp/.snap/**,
+        # Allow mounting tmpfs over the original read-only directory.
         # FIXME: update this with per-snap snap-update-ns profiles
-        mount fstype=tmpfs options=(rw) tmpfs -> /*/**,
+        mount fstype=tmpfs options=(rw) tmpfs -> /**,
         # Allow bind mounting anything from the temporary place in /tmp/.snap/
         # back to $SNAP/** (to re-construct the data that was there before).
         # FIXME: update this with per-snap snap-update-ns profiles
-        mount options=(bind, rw) /tmp/.snap/** -> /*/**,
+        mount options=(bind, rw) /tmp/.snap/** -> /**,
         # Allow unmounting the temporary directory in /tmp once it is no longer
         # necessary.
         umount /tmp/.snap/**,


### PR DESCRIPTION
This should fix a spread test that failed because it could not mount
/tmp/.snap/opt over /opt. The need for broad rules will be undone with
mount hardening that is coming up soon.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
