### PR TITLE
 snap: introduce  timer service data types and validation 

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -549,7 +549,7 @@ type HookInfo struct {
 	Slots map[string]*SlotInfo
 }
 
-// File returns the path to the file
+// File returns the path to the *.socket file
 func (socket *SocketInfo) File() string {
 	return filepath.Join(dirs.SnapServicesDir, socket.App.SecurityTag()+"."+socket.Name+".socket")
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -500,6 +500,13 @@ type SocketInfo struct {
 	SocketMode   os.FileMode
 }
 
+// TimerInfo provides information on application timer.
+type TimerInfo struct {
+	App *AppInfo
+
+	Timer string
+}
+
 // AppInfo provides information about a app.
 type AppInfo struct {
 	Snap *Info
@@ -531,6 +538,8 @@ type AppInfo struct {
 	// before
 	After  []string
 	Before []string
+
+	Timer *TimerInfo
 }
 
 // ScreenshotInfo provides information about a screenshot.
@@ -552,6 +561,11 @@ type HookInfo struct {
 // File returns the path to the *.socket file
 func (socket *SocketInfo) File() string {
 	return filepath.Join(dirs.SnapServicesDir, socket.App.SecurityTag()+"."+socket.Name+".socket")
+}
+
+// File returns the path to the *.timer file
+func (timer *TimerInfo) File() string {
+	return filepath.Join(dirs.SnapServicesDir, timer.App.SecurityTag()+".timer")
 }
 
 // SecurityTag returns application-specific security tag.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -80,6 +80,8 @@ type appYaml struct {
 
 	After  []string `yaml:"after,omitempty"`
 	Before []string `yaml:"before,omitempty"`
+
+	Timer string `yaml:"timer,omitempty"`
 }
 
 type hookYaml struct {
@@ -348,6 +350,12 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 				Name:         name,
 				ListenStream: data.ListenStream,
 				SocketMode:   data.SocketMode,
+			}
+		}
+		if yApp.Timer != "" {
+			app.Timer = &TimerInfo{
+				App:   app,
+				Timer: yApp.Timer,
 			}
 		}
 	}

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1628,3 +1628,18 @@ layout:
 		Mode:    0755,
 	})
 }
+
+func (s *YamlSuite) TestSnapYamlAppTimer(c *C) {
+	y := []byte(`name: wat
+version: 42
+apps:
+ foo:
+   daemon: oneshot
+   timer: mon,10:00-12:00
+
+`)
+	info, err := snap.InfoFromSnapYaml(y)
+	c.Assert(err, IsNil)
+	app := info.Apps["foo"]
+	c.Check(app.Timer, DeepEquals, &snap.TimerInfo{App: app, Timer: "mon,10:00-12:00"})
+}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -772,6 +773,22 @@ apps:
 	app := info.Apps["app1"]
 	socket := app.Sockets["sock1"]
 	c.Check(socket.File(), Equals, dirs.GlobalRootDir+"/etc/systemd/system/snap.pans.app1.sock1.socket")
+}
+
+func (s *infoSuite) TestTimerFile(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`name: pans
+apps:
+  app1:
+    daemon: true
+    timer: mon,10:00-12:00
+`))
+
+	c.Assert(err, IsNil)
+
+	app := info.Apps["app1"]
+	timerFile := app.Timer.File()
+	c.Check(timerFile, Equals, dirs.GlobalRootDir+"/etc/systemd/system/snap.pans.app1.timer")
+	c.Check(strings.TrimSuffix(app.ServiceFile(), ".service")+".timer", Equals, timerFile)
 }
 
 func (s *infoSuite) TestLayoutParsing(c *C) {


### PR DESCRIPTION
Introduce basic data types and validation for timer services.

Timer service is defined in snap.yaml as follows:
```
  ..
  apps:
    foo:
      command: bin/foo
      daemon: oneshot          # one of simple|forking|oneshot|dbus|notify
      timer: mon,10:00-12:00   # valid timer specification
```