### PR TITLE
tests: check if snapd.socket is active before stoping it

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -12,10 +12,10 @@ reset_classic() {
 
     echo "Ensure the service is active before stopping it"
     retries=20
-    systemctl status snapd.service || true
-    while systemctl status snapd.service | grep "Active: activating"; do
+    systemctl status snapd.service snapd.socket || true
+    while systemctl status snapd.service snapd.socket | grep "Active: activating"; do
         if [ $retries -eq 0 ]; then
-            echo "snapd service not active"
+            echo "snapd service or socket not active"
             exit 1
         fi
         retries=$(( $retries - 1 ))


### PR DESCRIPTION
This is because it is failing to stop the snapd.socket in case it is no
active. So the change is to do the same we did in the past to fix
snapd.service.
