### PR TITLE
snap: understand directories in layout blacklist

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -452,7 +452,7 @@ type LayoutConstraint interface {
 	IsOffLimits(path string) bool
 }
 
-// mountedDirectory represents a mounted file-system tree or a bind-mounted directory.
+// mountedTree represents a mounted file-system tree or a bind-mounted directory.
 type mountedTree string
 
 // IsOffLimits returns true if the mount point s a prefix of a given path.

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -231,18 +231,19 @@ func Validate(info *Info) error {
 
 // ValidateLayoutAll validates the consistency of all the layout elements in a snap.
 func ValidateLayoutAll(info *Info) error {
-	blacklist := make([]string, 0, len(info.Layout))
 	paths := make([]string, 0, len(info.Layout))
 	for _, layout := range info.Layout {
 		paths = append(paths, layout.Path)
 	}
 	sort.Strings(paths)
+
+	constraints := make([]LayoutConstraint, 0, len(info.Layout))
 	for _, path := range paths {
 		layout := info.Layout[path]
-		if err := ValidateLayout(layout, blacklist); err != nil {
+		if err := ValidateLayout(layout, constraints); err != nil {
 			return err
 		}
-		blacklist = append(blacklist, layout.effectivePath())
+		constraints = append(constraints, layout.constraint())
 	}
 	return nil
 }
@@ -446,16 +447,37 @@ func isAbsAndClean(path string) bool {
 	return (filepath.IsAbs(path) || strings.HasPrefix(path, "$")) && filepath.Clean(path) == path
 }
 
-func (layout *Layout) effectivePath() string {
+// LayoutConstraint abstracts validation of conflicting layout elements.
+type LayoutConstraint interface {
+	IsOffLimits(path string) bool
+}
+
+// mountedDirectory represents a mounted file-system tree or a bind-mounted directory.
+type mountedTree string
+
+// IsOffLimits returns true if the mount point s a prefix of a given path.
+func (mountPoint mountedTree) IsOffLimits(path string) bool {
+	return strings.HasPrefix(path, string(mountPoint)+"/")
+}
+
+// symlinkFile represents a layout using symbolic link.
+type symlinkFile string
+
+// IsOffLimits returns true for mounted files  if a path is identical to the path of the mount point.
+func (mountPoint symlinkFile) IsOffLimits(path string) bool {
+	return strings.HasPrefix(path, string(mountPoint)+"/") || path == string(mountPoint)
+}
+
+func (layout *Layout) constraint() LayoutConstraint {
 	path := layout.Snap.ExpandSnapVariables(layout.Path)
-	if (layout.Bind != "" || layout.Type != "") && !strings.HasSuffix(path, "/") {
-		path += "/"
+	if layout.Symlink != "" {
+		return symlinkFile(path)
 	}
-	return path
+	return mountedTree(path)
 }
 
 // ValidateLayout ensures that the given layout contains only valid subset of constructs.
-func ValidateLayout(layout *Layout, blacklist []string) error {
+func ValidateLayout(layout *Layout, constraints []LayoutConstraint) error {
 	si := layout.Snap
 	// Rules for validating layouts:
 	//
@@ -477,11 +499,9 @@ func ValidateLayout(layout *Layout, blacklist []string) error {
 		return fmt.Errorf("layout %q uses invalid mount point: must be absolute and clean", layout.Path)
 	}
 
-	// effective path contains a trailing slash for directory-like mount entries.
-	effectivePath := layout.effectivePath()
-	for i := range blacklist {
-		if (strings.HasSuffix(blacklist[i], "/") && strings.HasPrefix(effectivePath, blacklist[i])) || effectivePath == blacklist[i] {
-			return fmt.Errorf("layout %q underneath prior layout item %q", layout.Path, blacklist[i])
+	for _, constraint := range constraints {
+		if constraint.IsOffLimits(mountPoint) {
+			return fmt.Errorf("layout %q underneath prior layout item %q", layout.Path, constraint)
 		}
 	}
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -546,8 +546,9 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 		ErrorMatches, `layout "/foo" uses invalid symlink old name "\$BAR": reference to unknown variable "\$BAR"`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "$SNAP/evil", Symlink: "/etc"}, nil),
 		ErrorMatches, `layout "\$SNAP/evil" uses invalid symlink old name "/etc": must start with \$SNAP, \$SNAP_DATA or \$SNAP_COMMON`)
-	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo/bar", Bind: "$SNAP/bar/foo"}, []string{"/foo"}),
-		ErrorMatches, `layout "/foo/bar" underneath prior layout item "/foo"`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo/bar", Bind: "$SNAP/bar/foo"}, []string{"/foo/"}),
+		ErrorMatches, `layout "/foo/bar" underneath prior layout item "/foo/"`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foobar", Bind: "$SNAP/bar/foo"}, []string{"/foo"}), IsNil)
 	// Several valid layouts.
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Type: "tmpfs", Mode: 01755}, nil), IsNil)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/tmp", Type: "tmpfs"}, nil), IsNil)
@@ -587,7 +588,7 @@ layout:
 		info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml), &SideInfo{Revision: R(42)})
 		c.Assert(err, IsNil)
 		err = ValidateLayoutAll(info)
-		c.Assert(err, ErrorMatches, `layout "/usr/foo/bar" underneath prior layout item "/usr/foo"`)
+		c.Assert(err, ErrorMatches, `layout "/usr/foo/bar" underneath prior layout item "/usr/foo/"`)
 	}
 
 	// Same as above but with bind-mounts instead of filesystem mounts.
@@ -611,7 +612,55 @@ layout:
 		info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml), &SideInfo{Revision: R(42)})
 		c.Assert(err, IsNil)
 		err = ValidateLayoutAll(info)
-		c.Assert(err, ErrorMatches, `layout "/usr/foo/bar" underneath prior layout item "/usr/foo"`)
+		c.Assert(err, ErrorMatches, `layout "/usr/foo/bar" underneath prior layout item "/usr/foo/"`)
+	}
+
+	// /etc/foo (directory) is not clashing with /etc/foo.conf (file)
+	const yaml3 = `
+name: valid-layout-1
+layout:
+  /etc/foo:
+    bind: $SNAP_DATA/foo
+  /etc/foo.conf:
+    symlink: $SNAP_DATA/foo.conf
+`
+	const yaml3rev = `
+name: valid-layout-1
+layout:
+  /etc/foo.conf:
+    symlink: $SNAP_DATA/foo.conf
+  /etc/foo:
+    bind: $SNAP_DATA/foo
+`
+	for _, yaml := range []string{yaml3, yaml3rev} {
+		info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml), &SideInfo{Revision: R(42)})
+		c.Assert(err, IsNil)
+		err = ValidateLayoutAll(info)
+		c.Assert(err, IsNil)
+	}
+
+	// /etc/foo file is not clashing with /etc/foobar
+	const yaml4 = `
+name: valid-layout-2
+layout:
+  /etc/foo:
+    symlink: $SNAP_DATA/foo
+  /etc/foobar:
+    symlink: $SNAP_DATA/foobar
+`
+	const yaml4rev = `
+name: valid-layout-2
+layout:
+  /etc/foobar:
+    symlink: $SNAP_DATA/foobar
+  /etc/foo:
+    symlink: $SNAP_DATA/foo
+`
+	for _, yaml := range []string{yaml4, yaml4rev} {
+		info, err := InfoFromSnapYamlWithSideInfo([]byte(yaml), &SideInfo{Revision: R(42)})
+		c.Assert(err, IsNil)
+		err = ValidateLayoutAll(info)
+		c.Assert(err, IsNil)
 	}
 }
 


### PR DESCRIPTION
The layout blacklist contains string prefixes that are forbidden in
subsequent layout elements. The prefixes are just paths of each layout
elements. To work correctly a layout element that describes a directory
(vs a file) needs to contain the trailing slash. In other words, this
layout is valid:

 - directory /etc/demo (blacklist contribution: /etc/demo/)
 - file /etc/demo.conf (blacklist contribution: /etc/demo.conf)

Because /etc/demo.conf is not a prefix of /etc/demo/, this should be
allowed by the validator.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
