### PR TITLE
devicestate: fix the TestDoRequestSerialErrorsOnNoHost failing on artful/bionic

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -773,7 +773,7 @@ version: gadget
 func (s *deviceMgrSuite) TestDoRequestSerialErrorsOnNoHost(c *C) {
 	privKey, _ := assertstest.GenerateKey(testKeyLength)
 
-	nowhere := "http://nowhere.nowhere.test"
+	nowhere := "http://nowhere.nowhere.really-nowhere.com"
 
 	mockRequestIDURL := nowhere + requestIDURLPath
 	restore := devicestate.MockRequestIDURL(mockRequestIDURL)


### PR DESCRIPTION
We also see this in the autopkgtest failures for the 2.31 bionic upload. We need to pull this in for 2.31.1.