### PR TITLE
devicestate: fix autopkgtest failure in TestDoRequestSerialErrorsOnNoHost

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -771,6 +771,10 @@ version: gadget
 }
 
 func (s *deviceMgrSuite) TestDoRequestSerialErrorsOnNoHost(c *C) {
+	if os.Getenv("http_proxy") != "" {
+		c.Skip("cannot run test when http proxy is in use, the error pattern is different")
+	}
+
 	privKey, _ := assertstest.GenerateKey(testKeyLength)
 
 	nowhere := "http://nowhere.nowhere.test"


### PR DESCRIPTION
The autopkgtest environment uses a http_proxy during the tests. This
means that the invalid host in the test will not be looked up
directly but instead passed to the proxy. The proxy will return
a 503 which will be retried. So the error pattern is different.

For now the test is skipped when a http_proxy is set, we could
add a new test that checks the proxy behaviour.

