### PR TITLE
snap: disallow layouts in various special directories

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -536,6 +536,13 @@ func ValidateLayout(layout *Layout, constraints []LayoutConstraint) error {
 		return fmt.Errorf("layout %q uses invalid mount point: must be absolute and clean", layout.Path)
 	}
 
+	for _, path := range []string{"/proc", "/sys", "/dev", "/run", "/boot", "/lost+found", "/media"} {
+		// We use the mountedTree constraint as this has the right semantics.
+		if mountedTree(path).IsOffLimits(mountPoint) {
+			return fmt.Errorf("layout %q in an off-limits area", layout.Path)
+		}
+	}
+
 	for _, constraint := range constraints {
 		if constraint.IsOffLimits(mountPoint) {
 			return fmt.Errorf("layout %q underneath prior layout item %q", layout.Path, constraint)

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -482,7 +482,7 @@ type LayoutConstraint interface {
 // mountedTree represents a mounted file-system tree or a bind-mounted directory.
 type mountedTree string
 
-// IsOffLimits returns true if the mount point is a prefix of a given path.
+// IsOffLimits returns true if the mount point is (perhaps non-proper) prefix of a given path.
 func (mountPoint mountedTree) IsOffLimits(path string) bool {
 	return strings.HasPrefix(path, string(mountPoint)+"/") || path == string(mountPoint)
 }
@@ -490,7 +490,7 @@ func (mountPoint mountedTree) IsOffLimits(path string) bool {
 // mountedFile represents a bind-mounted file.
 type mountedFile string
 
-// IsOffLimits returns true if the mount point is a prefix of a given path.
+// IsOffLimits returns true if the mount point is (perhaps non-proper) prefix of a given path.
 func (mountPoint mountedFile) IsOffLimits(path string) bool {
 	return strings.HasPrefix(path, string(mountPoint)+"/") || path == string(mountPoint)
 }

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -484,7 +484,7 @@ type mountedTree string
 
 // IsOffLimits returns true if the mount point is a prefix of a given path.
 func (mountPoint mountedTree) IsOffLimits(path string) bool {
-	return strings.HasPrefix(path, string(mountPoint)+"/")
+	return strings.HasPrefix(path, string(mountPoint)+"/") || path == string(mountPoint)
 }
 
 // mountedFile represents a bind-mounted file.

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -561,6 +561,23 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo/bar", Bind: "$SNAP/bar/foo"}, []LayoutConstraint{testConstraint("/foo")}),
 		ErrorMatches, `layout "/foo/bar" underneath prior layout item "/foo"`)
 
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/dev", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/dev" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/dev/foo", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/dev/foo" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/proc", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/proc" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/sys", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/sys" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/run", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/run" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/boot", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/boot" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/lost+found", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/lost\+found" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/media", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/media" in an off-limits area`)
+
 	// Several valid layouts.
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Type: "tmpfs", Mode: 01755}, nil), IsNil)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/tmp", Type: "tmpfs"}, nil), IsNil)


### PR DESCRIPTION
The list is made up from the usual suspects (/dev, /sys, /proc) some places that we don't want to wonder about (/run, /boot), some places that are totally odd for apps to touch (/lost+found) and lastly /media which is bi-directionally shared so cannot be allowed.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>