### PR TITLE
tests: add a spread test for layouts

### DIFF
--- a/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
@@ -1,0 +1,25 @@
+name: test-snapd-layout
+version: 1.0
+summary: Sample illustrating very basic layout support
+apps:
+    sh:
+        command: ../../../bin/sh
+layout:
+  # Layouts can be used to inject configuration files and directories.
+  /etc/demo:
+    bind: $SNAP_COMMON/etc/demo
+  /etc/demo.conf:
+    bind-file: $SNAP_COMMON/etc/demo.conf
+  /etc/demo.cfg:
+    symlink: $SNAP_COMMON/etc/demo.conf
+  # Layouts can be used to remap $SNAP paths to work around hard-coded locations.
+  /usr/share/demo:
+    bind: $SNAP/usr/share/demo
+  # Layouts can be used to remap $SNAP_DATA to work around hard-coded locations
+  /var/lib/demo:
+    bind: $SNAP_DATA/var/lib/demo
+  /var/cache/demo:
+    bind: $SNAP_DATA/var/cache/demo
+  # Layouts can help with applications designed for /opt
+  /opt/demo:
+    bind: $SNAP/opt/demo

--- a/tests/lib/snaps/test-snapd-layout/opt/demo/file
+++ b/tests/lib/snaps/test-snapd-layout/opt/demo/file
@@ -1,0 +1,1 @@
+content-of-file

--- a/tests/lib/snaps/test-snapd-layout/usr/share/demo/file
+++ b/tests/lib/snaps/test-snapd-layout/usr/share/demo/file
@@ -1,0 +1,1 @@
+content-of-file

--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -1,0 +1,47 @@
+summary: Ensure that snap layouts are applied
+details: |
+    This test installs a test snap that uses layout declarations.
+    The layout changes which directories and files exist in the filesystem
+    in the area beyond the $SNAP directory. In addition all applications and
+    hooks get permissions to access those areas.
+prepare: |
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-layout    
+execute: |
+    echo "snap declaring layouts doesn't explode on startup"
+    test-snapd-layout.sh -c "true"
+    
+    echo "layout declarations are honored"
+
+    test-snapd-layout.sh -c "test -d /etc/demo"
+    test-snapd-layout.sh -c "test -f /etc/demo.conf"
+    test-snapd-layout.sh -c "test -h /etc/demo.cfg"
+    test "$(test-snapd-layout.sh -c "readlink /etc/demo.cfg")" = "$(test-snapd-layout.sh -c 'echo $SNAP_COMMON/etc/demo.conf')"
+    test-snapd-layout.sh -c "test -d /usr/share/demo"
+    test-snapd-layout.sh -c "test -d /var/lib/demo"
+    test-snapd-layout.sh -c "test -d /var/cache/demo"
+    test-snapd-layout.sh -c "test -d /opt/demo"
+
+    echo "layout locations pointing to SNAP_DATA and SNAP_COMMON are writable"
+    echo "and the writes go to the right place in the backing store"
+
+    test-snapd-layout.sh -c "echo foo-1 > /etc/demo/writable"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo/writable')" = "foo-1"
+
+    test-snapd-layout.sh -c "echo foo-2 > /etc/demo.conf"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo.conf')" = "foo-2"
+
+    # NOTE: this is a symlink to demo.conf, effectively
+    test-snapd-layout.sh -c "echo foo-3 > /etc/demo.cfg"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo.conf')" = "foo-3"
+
+    test-snapd-layout.sh -c "echo foo-4 > /var/lib/demo/writable"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_DATA/var/lib/demo/writable')" = "foo-4"
+
+    test-snapd-layout.sh -c "echo foo-5 > /var/cache/demo/writable"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_DATA/var/cache/demo/writable')" = "foo-5"
+
+    echo "layout locations pointing to SNAP are readable"
+
+    test-snapd-layout.sh -c "test -r /usr/share/demo/file"
+    test-snapd-layout.sh -c "test -r /opt/demo/file"


### PR DESCRIPTION
The test uses a new snap that declares a powerful but conservative
layout and checks that it operates as desired. The test is conservative
as it does not interact with "problematic" locations like
/var/lib/snapd, /var/snap, /usr/lib/snapd and /usr/bin where hiding
access to snapd state or programs could cause complications.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
