### PR TITLE
snapctl: allow `snapctl get` from any uid

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2490,11 +2490,15 @@ func runSnapctl(c *Command, r *http.Request, user *auth.UserState) Response {
 	if len(snapctlOptions.Args) == 0 {
 		return BadRequest("snapctl cannot run without args")
 	}
+	_, uid, _, err := ucrednetGet(r.RemoteAddr)
+	if err != nil {
+		return Forbidden("cannot get remote user: %s", err)
+	}
 
 	// Ignore missing context error to allow 'snapctl -h' without a context;
 	// Actual context is validated later by get/set.
 	context, _ := c.d.overlord.HookManager().Context(snapctlOptions.ContextID)
-	stdout, stderr, err := ctlcmd.Run(context, snapctlOptions.Args)
+	stdout, stderr, err := ctlcmd.Run(context, uid, snapctlOptions.Args)
 	if err != nil {
 		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
 			stdout = []byte(e.Error())

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -111,10 +111,13 @@ func (c *Command) canAccess(r *http.Request, user *auth.UserState) accessResult 
 		logger.Noticef("unexpected error when attempting to get UID: %s", err)
 		return accessForbidden
 	}
-	isSnap := (socket == dirs.SnapSocket)
 
 	// ensure that snaps can only access SnapOK things
-	if isSnap && !c.SnapOK {
+	isSnap := (socket == dirs.SnapSocket)
+	if isSnap {
+		if c.SnapOK {
+			return accessOK
+		}
 		return accessUnauthorized
 	}
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -172,23 +172,11 @@ func (s *daemonSuite) TestSnapctlAccessSnapOKWithUser(c *check.C) {
 	pst := &http.Request{Method: "POST", RemoteAddr: remoteAddr}
 	del := &http.Request{Method: "DELETE", RemoteAddr: remoteAddr}
 
-	cmd := &Command{d: newTestDaemon(c), SnapOK: true, UserOK: true}
+	cmd := &Command{d: newTestDaemon(c), SnapOK: true}
 	c.Check(cmd.canAccess(get, nil), check.Equals, accessOK)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessUnauthorized)
-
-	cmd = &Command{d: newTestDaemon(c), SnapOK: true, UserOK: false}
-	c.Check(cmd.canAccess(get, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessUnauthorized)
-
-	cmd = &Command{d: newTestDaemon(c), SnapOK: false, UserOK: true}
-	c.Check(cmd.canAccess(get, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessUnauthorized)
+	c.Check(cmd.canAccess(put, nil), check.Equals, accessOK)
+	c.Check(cmd.canAccess(pst, nil), check.Equals, accessOK)
+	c.Check(cmd.canAccess(del, nil), check.Equals, accessOK)
 }
 
 func (s *daemonSuite) TestSnapctlAccessSnapOKWithRoot(c *check.C) {
@@ -198,23 +186,11 @@ func (s *daemonSuite) TestSnapctlAccessSnapOKWithRoot(c *check.C) {
 	pst := &http.Request{Method: "POST", RemoteAddr: remoteAddr}
 	del := &http.Request{Method: "DELETE", RemoteAddr: remoteAddr}
 
-	cmd := &Command{d: newTestDaemon(c), SnapOK: true, UserOK: true}
+	cmd := &Command{d: newTestDaemon(c), SnapOK: true}
 	c.Check(cmd.canAccess(get, nil), check.Equals, accessOK)
 	c.Check(cmd.canAccess(put, nil), check.Equals, accessOK)
 	c.Check(cmd.canAccess(pst, nil), check.Equals, accessOK)
 	c.Check(cmd.canAccess(del, nil), check.Equals, accessOK)
-
-	cmd = &Command{d: newTestDaemon(c), SnapOK: true, UserOK: false}
-	c.Check(cmd.canAccess(get, nil), check.Equals, accessOK)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessOK)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessOK)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessOK)
-
-	cmd = &Command{d: newTestDaemon(c), SnapOK: false, UserOK: true}
-	c.Check(cmd.canAccess(get, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessUnauthorized)
 }
 
 func (s *daemonSuite) TestUserAccess(c *check.C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -975,24 +975,24 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyPrepareDeviceHook(c *C) 
 		c.Assert(ctx.HookName(), Equals, "prepare-device")
 
 		// snapctl set the registration params
-		_, _, err := ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("device-service.url=%q", mockServer.URL+"/svc/")})
+		_, _, err := ctlcmd.Run(ctx, 0, []string{"set", fmt.Sprintf("device-service.url=%q", mockServer.URL+"/svc/")})
 		c.Assert(err, IsNil)
 
 		h, err := json.Marshal(map[string]string{
 			"x-extra-header": "extra",
 		})
 		c.Assert(err, IsNil)
-		_, _, err = ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("device-service.headers=%s", string(h))})
+		_, _, err = ctlcmd.Run(ctx, 0, []string{"set", fmt.Sprintf("device-service.headers=%s", string(h))})
 		c.Assert(err, IsNil)
 
-		_, _, err = ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("registration.proposed-serial=%q", "Y9999")})
+		_, _, err = ctlcmd.Run(ctx, 0, []string{"set", fmt.Sprintf("registration.proposed-serial=%q", "Y9999")})
 		c.Assert(err, IsNil)
 
 		d, err := yaml.Marshal(map[string]string{
 			"mac": "00:00:00:00:ff:00",
 		})
 		c.Assert(err, IsNil)
-		_, _, err = ctlcmd.Run(ctx, []string{"set", fmt.Sprintf("registration.body=%q", d)})
+		_, _, err = ctlcmd.Run(ctx, 0, []string{"set", fmt.Sprintf("registration.body=%q", d)})
 		c.Assert(err, IsNil)
 
 		return nil, nil

--- a/overlord/hookstate/ctlcmd/ctlcmd_test.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd_test.go
@@ -55,7 +55,7 @@ func (s *ctlcmdSuite) SetUpTest(c *C) {
 }
 
 func (s *ctlcmdSuite) TestNonExistingCommand(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"foo"})
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, 0, []string{"foo"})
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
 	c.Check(err, ErrorMatches, ".*[Uu]nknown command.*")
@@ -68,7 +68,7 @@ func (s *ctlcmdSuite) TestCommandOutput(c *C) {
 	mockCommand.FakeStdout = "test stdout"
 	mockCommand.FakeStderr = "test stderr"
 
-	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"mock", "foo"})
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, 0, []string{"mock", "foo"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "test stdout")
 	c.Check(string(stderr), Equals, "test stderr")

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -135,7 +135,7 @@ func (s *getSuite) TestGetTests(c *C) {
 
 		state.Unlock()
 
-		stdout, stderr, err := ctlcmd.Run(mockContext, strings.Fields(test.args))
+		stdout, stderr, err := ctlcmd.Run(mockContext, 0, strings.Fields(test.args))
 		if test.error != "" {
 			c.Check(err, ErrorMatches, test.error)
 		} else {
@@ -147,7 +147,7 @@ func (s *getSuite) TestGetTests(c *C) {
 }
 
 func (s *getSuite) TestCommandWithoutContext(c *C) {
-	_, _, err := ctlcmd.Run(nil, []string{"get", "foo"})
+	_, _, err := ctlcmd.Run(nil, 0, []string{"get", "foo"})
 	c.Check(err, ErrorMatches, ".*cannot get without a context.*")
 }
 
@@ -206,52 +206,52 @@ func (s *getAttrSuite) SetUpTest(c *C) {
 }
 
 func (s *getAttrSuite) TestGetPlugAttributesInPlugHook(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, []string{"get", ":aplug", "aattr"})
+	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, 0, []string{"get", ":aplug", "aattr"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "foo\n")
 	c.Check(string(stderr), Equals, "")
 
-	stdout, stderr, err = ctlcmd.Run(s.mockPlugHookContext, []string{"get", "-d", ":aplug", "baz"})
+	stdout, stderr, err = ctlcmd.Run(s.mockPlugHookContext, 0, []string{"get", "-d", ":aplug", "baz"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "{\n\t\"baz\": [\n\t\t\"a\",\n\t\t\"b\"\n\t]\n}\n")
 	c.Check(string(stderr), Equals, "")
 
 	// The --plug parameter doesn't do anything if used on plug side
-	stdout, stderr, err = ctlcmd.Run(s.mockPlugHookContext, []string{"get", "--plug", ":aplug", "aattr"})
+	stdout, stderr, err = ctlcmd.Run(s.mockPlugHookContext, 0, []string{"get", "--plug", ":aplug", "aattr"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "foo\n")
 	c.Check(string(stderr), Equals, "")
 }
 
 func (s *getAttrSuite) TestGetSlotAttributesInSlotHook(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, []string{"get", ":bslot", "battr"})
+	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, 0, []string{"get", ":bslot", "battr"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "bar\n")
 	c.Check(string(stderr), Equals, "")
 
 	// The --slot parameter doesn't do anything if used on slot side
-	stdout, stderr, err = ctlcmd.Run(s.mockSlotHookContext, []string{"get", "--slot", ":bslot", "battr"})
+	stdout, stderr, err = ctlcmd.Run(s.mockSlotHookContext, 0, []string{"get", "--slot", ":bslot", "battr"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "bar\n")
 	c.Check(string(stderr), Equals, "")
 }
 
 func (s *getAttrSuite) TestGetSlotAttributeInPlugHook(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, []string{"get", "--slot", ":aplug", "battr"})
+	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, 0, []string{"get", "--slot", ":aplug", "battr"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "bar\n")
 	c.Check(string(stderr), Equals, "")
 }
 
 func (s *getAttrSuite) TestGetPlugAttributeInSlotHook(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, []string{"get", "--plug", ":bslot", "aattr"})
+	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, 0, []string{"get", "--plug", ":bslot", "aattr"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "foo\n")
 	c.Check(string(stderr), Equals, "")
 }
 
 func (s *getAttrSuite) TestUnknownPlugAttribute(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, []string{"get", ":aplug", "x"})
+	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, 0, []string{"get", ":aplug", "x"})
 	c.Check(err, NotNil)
 	c.Check(err.Error(), Equals, `unknown attribute "x"`)
 	c.Check(string(stdout), Equals, "")
@@ -259,7 +259,7 @@ func (s *getAttrSuite) TestUnknownPlugAttribute(c *C) {
 }
 
 func (s *getAttrSuite) TestUnknownSlotAttribute(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, []string{"get", ":bslot", "x"})
+	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, 0, []string{"get", ":bslot", "x"})
 	c.Check(err, NotNil)
 	c.Check(err.Error(), Equals, `unknown attribute "x"`)
 	c.Check(string(stdout), Equals, "")
@@ -267,7 +267,7 @@ func (s *getAttrSuite) TestUnknownSlotAttribute(c *C) {
 }
 
 func (s *getAttrSuite) TestUsingPlugNameInSlotHookFails(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, []string{"get", ":aplug", "x"})
+	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, 0, []string{"get", ":aplug", "x"})
 	c.Check(err, NotNil)
 	c.Check(err.Error(), Equals, `unknown plug or slot "aplug"`)
 	c.Check(string(stdout), Equals, "")
@@ -275,7 +275,7 @@ func (s *getAttrSuite) TestUsingPlugNameInSlotHookFails(c *C) {
 }
 
 func (s *getAttrSuite) TestUsingSlotNameInPlugHookFails(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, []string{"get", ":bslot", "x"})
+	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, 0, []string{"get", ":bslot", "x"})
 	c.Check(err, NotNil)
 	c.Check(err.Error(), Equals, `unknown plug or slot "bslot"`)
 	c.Check(string(stdout), Equals, "")
@@ -283,7 +283,7 @@ func (s *getAttrSuite) TestUsingSlotNameInPlugHookFails(c *C) {
 }
 
 func (s *getAttrSuite) TestForcePlugOrSlotMutuallyExclusive(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, []string{"get", "--slot", "--plug", ":aplug", "x"})
+	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, 0, []string{"get", "--slot", "--plug", ":aplug", "x"})
 	c.Check(err, NotNil)
 	c.Check(err.Error(), Equals, `cannot use --plug and --slot together`)
 	c.Check(string(stdout), Equals, "")
@@ -291,17 +291,17 @@ func (s *getAttrSuite) TestForcePlugOrSlotMutuallyExclusive(c *C) {
 }
 
 func (s *getAttrSuite) TestPlugOrSlotEmpty(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, []string{"get", ":", "foo"})
+	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, 0, []string{"get", ":", "foo"})
 	c.Check(err.Error(), Equals, "plug or slot name not provided")
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
 }
 
 func (s *setSuite) TestNull(c *C) {
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"set", "foo=null"})
+	_, _, err := ctlcmd.Run(s.mockContext, 0, []string{"set", "foo=null"})
 	c.Check(err, IsNil)
 
-	_, _, err = ctlcmd.Run(s.mockContext, []string{"set", `bar=[null]`})
+	_, _, err = ctlcmd.Run(s.mockContext, 0, []string{"set", `bar=[null]`})
 	c.Check(err, IsNil)
 
 	// Notify the context that we're done. This should save the config.

--- a/overlord/hookstate/ctlcmd/restart.go
+++ b/overlord/hookstate/ctlcmd/restart.go
@@ -20,6 +20,8 @@
 package ctlcmd
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/servicestate"
@@ -45,6 +47,10 @@ type restartCommand struct {
 }
 
 func (c *restartCommand) Execute(args []string) error {
+	if c.getUid() != 0 {
+		return fmt.Errorf("cannot use \"restart\" with uid %d, try with sudo", c.getUid())
+	}
+
 	inst := servicestate.Instruction{
 		Action: "restart",
 		Names:  c.Positional.ServiceNames,

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -192,7 +192,7 @@ func (s *servicectlSuite) TestStopCommand(c *C) {
 		)
 	})
 	defer restore()
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"stop", "test-snap.test-service"})
+	_, _, err := ctlcmd.Run(s.mockContext, 0, []string{"stop", "test-snap.test-service"})
 	c.Assert(err, NotNil)
 	c.Check(err, ErrorMatches, "forced error")
 	c.Assert(serviceChangeFuncCalled, Equals, true)
@@ -204,7 +204,7 @@ func (s *servicectlSuite) TestStopCommandUnknownService(c *C) {
 		serviceChangeFuncCalled = true
 	})
 	defer restore()
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"stop", "test-snap.fooservice"})
+	_, _, err := ctlcmd.Run(s.mockContext, 0, []string{"stop", "test-snap.fooservice"})
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `unknown service: "test-snap.fooservice"`)
 	c.Assert(serviceChangeFuncCalled, Equals, false)
@@ -217,7 +217,7 @@ func (s *servicectlSuite) TestStopCommandFailsOnOtherSnap(c *C) {
 	})
 	defer restore()
 	// verify that snapctl is not allowed to control services of other snaps (only the one of its hook)
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"stop", "other-snap.test-service"})
+	_, _, err := ctlcmd.Run(s.mockContext, 0, []string{"stop", "other-snap.test-service"})
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, `unknown service: "other-snap.test-service"`)
 	c.Assert(serviceChangeFuncCalled, Equals, false)
@@ -239,7 +239,7 @@ func (s *servicectlSuite) TestStartCommand(c *C) {
 		)
 	})
 	defer restore()
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"start", "test-snap.test-service"})
+	_, _, err := ctlcmd.Run(s.mockContext, 0, []string{"start", "test-snap.test-service"})
 	c.Check(err, NotNil)
 	c.Check(err, ErrorMatches, "forced error")
 	c.Assert(serviceChangeFuncCalled, Equals, true)
@@ -261,7 +261,7 @@ func (s *servicectlSuite) TestRestartCommand(c *C) {
 		)
 	})
 	defer restore()
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"restart", "test-snap.test-service"})
+	_, _, err := ctlcmd.Run(s.mockContext, 0, []string{"restart", "test-snap.test-service"})
 	c.Check(err, NotNil)
 	c.Check(err, ErrorMatches, "forced error")
 	c.Assert(serviceChangeFuncCalled, Equals, true)
@@ -282,7 +282,7 @@ func (s *servicectlSuite) TestConflictingChange(c *C) {
 	chg.AddTask(task)
 	s.st.Unlock()
 
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"start", "test-snap.test-service"})
+	_, _, err := ctlcmd.Run(s.mockContext, 0, []string{"start", "test-snap.test-service"})
 	c.Check(err, NotNil)
 	c.Check(err, ErrorMatches, `snap "test-snap" has "conflicting change" change in progress`)
 }
@@ -311,11 +311,11 @@ func (s *servicectlSuite) TestQueuedCommands(c *C) {
 		context, err := hookstate.NewContext(task, task.State(), setup, s.mockHandler, "")
 		c.Assert(err, IsNil)
 
-		_, _, err = ctlcmd.Run(context, []string{"stop", "test-snap.test-service"})
+		_, _, err = ctlcmd.Run(context, 0, []string{"stop", "test-snap.test-service"})
 		c.Check(err, IsNil)
-		_, _, err = ctlcmd.Run(context, []string{"start", "test-snap.test-service"})
+		_, _, err = ctlcmd.Run(context, 0, []string{"start", "test-snap.test-service"})
 		c.Check(err, IsNil)
-		_, _, err = ctlcmd.Run(context, []string{"restart", "test-snap.test-service"})
+		_, _, err = ctlcmd.Run(context, 0, []string{"restart", "test-snap.test-service"})
 		c.Check(err, IsNil)
 	}
 
@@ -363,11 +363,11 @@ func (s *servicectlSuite) TestQueuedCommandsUpdateMany(c *C) {
 		context, err := hookstate.NewContext(task, task.State(), setup, s.mockHandler, "")
 		c.Assert(err, IsNil)
 
-		_, _, err = ctlcmd.Run(context, []string{"stop", "test-snap.test-service"})
+		_, _, err = ctlcmd.Run(context, 0, []string{"stop", "test-snap.test-service"})
 		c.Check(err, IsNil)
-		_, _, err = ctlcmd.Run(context, []string{"start", "test-snap.test-service"})
+		_, _, err = ctlcmd.Run(context, 0, []string{"start", "test-snap.test-service"})
 		c.Check(err, IsNil)
-		_, _, err = ctlcmd.Run(context, []string{"restart", "test-snap.test-service"})
+		_, _, err = ctlcmd.Run(context, 0, []string{"restart", "test-snap.test-service"})
 		c.Check(err, IsNil)
 	}
 
@@ -403,11 +403,11 @@ func (s *servicectlSuite) TestQueuedCommandsSingleLane(c *C) {
 	context, err := hookstate.NewContext(task, task.State(), setup, s.mockHandler, "")
 	c.Assert(err, IsNil)
 
-	_, _, err = ctlcmd.Run(context, []string{"stop", "test-snap.test-service"})
+	_, _, err = ctlcmd.Run(context, 0, []string{"stop", "test-snap.test-service"})
 	c.Check(err, IsNil)
-	_, _, err = ctlcmd.Run(context, []string{"start", "test-snap.test-service"})
+	_, _, err = ctlcmd.Run(context, 0, []string{"start", "test-snap.test-service"})
 	c.Check(err, IsNil)
-	_, _, err = ctlcmd.Run(context, []string{"restart", "test-snap.test-service"})
+	_, _, err = ctlcmd.Run(context, 0, []string{"restart", "test-snap.test-service"})
 	c.Check(err, IsNil)
 
 	s.st.Lock()

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -70,6 +70,9 @@ func (s *setCommand) Execute(args []string) error {
 	if context == nil {
 		return fmt.Errorf("cannot set without a context")
 	}
+	if s.getUid() != 0 {
+		return fmt.Errorf("cannot use \"set\" with uid %d, try with sudo", s.getUid())
+	}
 
 	// treat PlugOrSlotSpec argument as key=value if it contans '=' or doesn't contain ':' - this is to support
 	// values such as "device-service.url=192.168.0.1:5555" and error out on invalid key=value if only "key" is given.

--- a/overlord/hookstate/ctlcmd/set_test.go
+++ b/overlord/hookstate/ctlcmd/set_test.go
@@ -63,16 +63,16 @@ func (s *setSuite) SetUpTest(c *C) {
 }
 
 func (s *setSuite) TestInvalidArguments(c *C) {
-	_, _, err := ctlcmd.Run(s.mockContext, []string{"set"})
+	_, _, err := ctlcmd.Run(s.mockContext, 0, []string{"set"})
 	c.Check(err, ErrorMatches, "set which option.*")
-	_, _, err = ctlcmd.Run(s.mockContext, []string{"set", "foo", "bar"})
+	_, _, err = ctlcmd.Run(s.mockContext, 0, []string{"set", "foo", "bar"})
 	c.Check(err, ErrorMatches, ".*invalid parameter.*want key=value.*")
-	_, _, err = ctlcmd.Run(s.mockContext, []string{"set", ":foo", "bar=baz"})
+	_, _, err = ctlcmd.Run(s.mockContext, 0, []string{"set", ":foo", "bar=baz"})
 	c.Check(err, ErrorMatches, ".*interface attributes can only be set during the execution of prepare hooks.*")
 }
 
 func (s *setSuite) TestCommand(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "foo=bar", "baz=qux"})
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, 0, []string{"set", "foo=bar", "baz=qux"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
@@ -99,7 +99,7 @@ func (s *setSuite) TestCommand(c *C) {
 }
 
 func (s *setSuite) TestSetConfigOptionWithColon(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "device-service.url=192.168.0.1:5555"})
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, 0, []string{"set", "device-service.url=192.168.0.1:5555"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
@@ -117,7 +117,7 @@ func (s *setSuite) TestSetConfigOptionWithColon(c *C) {
 }
 
 func (s *setSuite) TestSetNumbers(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "foo=1234567890", "bar=123456.7890"})
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, 0, []string{"set", "foo=1234567890", "bar=123456.7890"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
@@ -146,7 +146,7 @@ func (s *setSuite) TestCommandSavesDeltasOnly(c *C) {
 	tr.Commit()
 	s.mockContext.State().Unlock()
 
-	stdout, stderr, err := ctlcmd.Run(s.mockContext, []string{"set", "test-key2=test-value3"})
+	stdout, stderr, err := ctlcmd.Run(s.mockContext, 0, []string{"set", "test-key2=test-value3"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
@@ -166,7 +166,7 @@ func (s *setSuite) TestCommandSavesDeltasOnly(c *C) {
 }
 
 func (s *setSuite) TestCommandWithoutContext(c *C) {
-	_, _, err := ctlcmd.Run(nil, []string{"set", "foo=bar"})
+	_, _, err := ctlcmd.Run(nil, 0, []string{"set", "foo=bar"})
 	c.Check(err, ErrorMatches, ".*cannot set without a context.*")
 }
 
@@ -220,7 +220,7 @@ func (s *setAttrSuite) SetUpTest(c *C) {
 }
 
 func (s *setAttrSuite) TestSetPlugAttributesInPlugHook(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, []string{"set", ":aplug", "foo=bar"})
+	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, 0, []string{"set", ":aplug", "foo=bar"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
@@ -237,7 +237,7 @@ func (s *setAttrSuite) TestSetPlugAttributesInPlugHook(c *C) {
 }
 
 func (s *setAttrSuite) TestSetSlotAttributesInSlotHook(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, []string{"set", ":bslot", "foo=bar"})
+	stdout, stderr, err := ctlcmd.Run(s.mockSlotHookContext, 0, []string{"set", ":bslot", "foo=bar"})
 	c.Check(err, IsNil)
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
@@ -254,7 +254,7 @@ func (s *setAttrSuite) TestSetSlotAttributesInSlotHook(c *C) {
 }
 
 func (s *setAttrSuite) TestPlugOrSlotEmpty(c *C) {
-	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, []string{"set", ":", "foo=bar"})
+	stdout, stderr, err := ctlcmd.Run(s.mockPlugHookContext, 0, []string{"set", ":", "foo=bar"})
 	c.Check(err.Error(), Equals, "plug or slot name not provided")
 	c.Check(string(stdout), Equals, "")
 	c.Check(string(stderr), Equals, "")
@@ -273,7 +273,7 @@ func (s *setAttrSuite) TestSetCommandFailsOutsideOfValidContext(c *C) {
 	mockContext, err = hookstate.NewContext(task, task.State(), setup, s.mockHandler, "")
 	c.Assert(err, IsNil)
 
-	stdout, stderr, err := ctlcmd.Run(mockContext, []string{"set", ":aplug", "foo=bar"})
+	stdout, stderr, err := ctlcmd.Run(mockContext, 0, []string{"set", ":aplug", "foo=bar"})
 	c.Check(err, NotNil)
 	c.Check(err.Error(), Equals, `interface attributes can only be set during the execution of prepare hooks`)
 	c.Check(string(stdout), Equals, "")

--- a/overlord/hookstate/ctlcmd/start.go
+++ b/overlord/hookstate/ctlcmd/start.go
@@ -20,6 +20,8 @@
 package ctlcmd
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/servicestate"
@@ -45,6 +47,10 @@ type startCommand struct {
 }
 
 func (c *startCommand) Execute(args []string) error {
+	if c.getUid() != 0 {
+		return fmt.Errorf("cannot use \"restart\" with uid %d, try with sudo", c.getUid())
+	}
+
 	inst := servicestate.Instruction{
 		Action: "start",
 		Names:  c.Positional.ServiceNames,

--- a/overlord/hookstate/ctlcmd/stop.go
+++ b/overlord/hookstate/ctlcmd/stop.go
@@ -20,6 +20,8 @@
 package ctlcmd
 
 import (
+	"fmt"
+
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/servicestate"
@@ -45,6 +47,10 @@ func init() {
 }
 
 func (c *stopCommand) Execute(args []string) error {
+	if c.getUid() != 0 {
+		return fmt.Errorf("cannot use \"restart\" with uid %d, try with sudo", c.getUid())
+	}
+
 	inst := servicestate.Instruction{
 		Action: "stop",
 		Names:  c.Positional.ServiceNames,


### PR DESCRIPTION
We have the information what UID has issued a snapctl call now in
the daemon. With that we can allow "get" to be used by anyone.