### PR TITLE
snap-seccomp: fix cgo pkg-config and LDFLAGS

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -20,8 +20,8 @@
 package main
 
 //#cgo CFLAGS: -D_FILE_OFFSET_BITS=64
-//#cgo pkg-config: --static --cflags libseccomp
-//#cgo LDFLAGS: -Wl,-Bstatic -lseccomp -Wl,-Bdynamic
+//#cgo pkg-config: libseccomp
+//#cgo LDFLAGS: -lseccomp
 //
 //#include <asm/ioctls.h>
 //#include <ctype.h>


### PR DESCRIPTION
Without this change, the package does not build for me:

    go build github.com/snapcore/snapd/cmd/snap-seccomp: invalid pkg-config package name: --static
    go build github.com/snapcore/snapd/cmd/snap-seccomp: invalid flag in #cgo LDFLAGS: -Wl,-Bstatic

See also https://golang.org/cmd/cgo/
