### PR TITLE
cmd/snap: fix UX of snap services

### DIFF
--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -81,7 +81,7 @@ func (s *svcStatus) Execute(args []string) error {
 	w := tabWriter()
 	defer w.Flush()
 
-	fmt.Fprintln(w, i18n.G("Snap\tService\tStartup\tCurrent"))
+	fmt.Fprintln(w, i18n.G("Service\tStartup\tCurrent"))
 
 	for _, svc := range services {
 		startup := i18n.G("disabled")
@@ -92,7 +92,7 @@ func (s *svcStatus) Execute(args []string) error {
 		if svc.Active {
 			current = i18n.G("active")
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", svc.Snap, svc.Name, startup, current)
+		fmt.Fprintf(w, "%s.%s\t%s\t%s\n", svc.Snap, svc.Name, startup, current)
 	}
 
 	return nil

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -830,9 +830,7 @@ func (s *SnapOpSuite) TestTryNoSnapDirErrors(c *check.C) {
     "kind":"snap-not-a-snap"
   },
   "status-code": 400
-}
-`)
-
+}`)
 	})
 
 	cmd := []string{"try", "/"}


### PR DESCRIPTION
Every other command uses service names expressed as `<snap>.<app>`, and they name the argument as `<service>` too, including start, stop, snap info, logs, etc, so it's awkward to have the main listing command displaying something wrong to the user as `Service`. While documenting the functionality the  mismatch is obvious.

This may break clients unfortunately, but this functionality is recent enough and the broken experience is bad enough that the trade off seems worth the risk. I will already write the documentation expecting the new format, and will point out that this is changing in 2.32 (I'm hoping we can merge til then).