### PR TITLE
debian, snap: only static link libseccomp in snap-seccomp on ubuntu

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -20,8 +20,8 @@
 package main
 
 //#cgo CFLAGS: -D_FILE_OFFSET_BITS=64
-//#cgo pkg-config: --static --cflags libseccomp
-//#cgo LDFLAGS: -Wl,-Bstatic -lseccomp -Wl,-Bdynamic
+//#cgo pkg-config: libseccomp
+//#cgo LDFLAGS:
 //
 //#include <asm/ioctls.h>
 //#include <ctype.h>

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -139,6 +139,15 @@ ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),powerpc)
 	$(shell	if ldd _build/bin/snap-update-ns; then false "need static build"; fi)
 endif
 
+	# ensure snap-seccomp is build with a static libseccomp on Ubuntu
+ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
+	sed -i "s|#cgo LDFLAGS:|#cgo LDFLAGS: /usr/lib/$(shell dpkg-architecture -qDEB_TARGET_MULTIARCH)/libseccomp.a|" _build/src/$(DH_GOPKG)/cmd/snap-seccomp/main.go
+	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_LDFLAGS_ALLOW="/.*/libseccomp.a" go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-seccomp)
+	# ensure that libseccomp is not dynamically linked
+	ldd _build/bin/snap-seccomp
+	test "$$(ldd _build/bin/snap-seccomp | grep libseccomp)" = ""
+endif
+
 	# Build C bits, sadly manually
 	cd cmd && ( autoreconf -i -f )
 	cd cmd && ( ./configure --prefix=/usr --libexecdir=/usr/lib/snapd $(VENDOR_ARGS))

--- a/tests/main/snap-seccomp/task.yaml
+++ b/tests/main/snap-seccomp/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the snap-seccomp bpf handling works
 
 # FIXME: once $(snap debug confinment) can be used (in 2.27+) remove
 #        the systems line
-systems: [ubuntu-*]
+systems: [ubuntu-16*, ubuntu-18*]
 
 # Start early as it takes a long time.
 priority: 100


### PR DESCRIPTION
Rework how we do static linking of libseccomp for the snap-seccomp
helper. The most recent golang change for 1.9 added a whitelist
of allowed things for #cgo LDFLAGS (and #cgo PKG_CONFIG) which
broke out current approach. It seems the only way to get back the
static libseccomp linking is via the CGO_LDFLAGS_ALLOW environment.
So use that during the package build. For the other distros this
is less of an issue, we need the static libseccomp on Ubuntu as
snap-seccomp goes into the core snap and is called if snapd is
re-execing. This means that we cannot have a dynamic libseccomp
there or we might get into libseccomp library compatibility
issues between the host and the core.

This also fixed the build on bionic.