### PR TITLE
many: record if snap was installed with --dangerous, snow relevant annotation in `snap info` and `snap list`

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -54,6 +54,7 @@ type Snap struct {
 	DevMode          bool          `json:"devmode"`
 	JailMode         bool          `json:"jailmode"`
 	TryMode          bool          `json:"trymode,omitempty"`
+	DangerousMode    bool          `json:"dangerousmode,omitempty"`
 	Apps             []AppInfo     `json:"apps,omitempty"`
 	Broken           string        `json:"broken,omitempty"`
 	Contact          string        `json:"contact"`

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -350,6 +350,9 @@ func (x *infoCmd) Execute([]string) error {
 				} else {
 					fmt.Fprintf(w, "  broken:\t%t (%s)\n", true, local.Broken)
 				}
+				if local.DangerousMode {
+					fmt.Fprintf(w, "  dangerous:\t%t\n", true)
+				}
 
 				fmt.Fprintf(w, "  ignore-validation:\t%t\n", local.IgnoreValidation)
 			} else {

--- a/cmd/snap/notes.go
+++ b/cmd/snap/notes.go
@@ -61,6 +61,7 @@ type Notes struct {
 	Disabled         bool
 	Broken           bool
 	IgnoreValidation bool
+	DangerousMode    bool
 }
 
 func NotesFromChannelSnapInfo(ref *snap.ChannelSnapInfo) *Notes {
@@ -95,6 +96,7 @@ func NotesFromLocal(snp *client.Snap) *Notes {
 		Disabled:         snp.Status != client.StatusActive,
 		Broken:           snp.Broken != "",
 		IgnoreValidation: snp.IgnoreValidation,
+		DangerousMode:    snp.DangerousMode,
 	}
 }
 
@@ -159,6 +161,10 @@ func (n *Notes) String() string {
 
 	if n.IgnoreValidation {
 		ns = append(ns, i18n.G("ignore-validation"))
+	}
+
+	if n.DangerousMode {
+		ns = append(ns, "dangerous")
 	}
 
 	if len(ns) == 0 {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1420,6 +1420,7 @@ func postSnaps(c *Command, r *http.Request, user *auth.UserState) Response {
 	if err != nil {
 		return BadRequest(err.Error())
 	}
+	flags.DangerousMode = dangerousOK
 
 	if len(form.Value["action"]) > 0 && form.Value["action"][0] == "try" {
 		if len(form.Value["snap-path"]) == 0 {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -2157,7 +2157,7 @@ func (s *apiSuite) TestSideloadSnapOnNonDevModeDistro(c *check.C) {
 	// try a multipart/form-data upload
 	body := sideLoadBodyWithoutDevMode
 	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
-	chgSummary := s.sideloadCheck(c, body, head, snapstate.Flags{RemoveSnapPath: true})
+	chgSummary := s.sideloadCheck(c, body, head, snapstate.Flags{RemoveSnapPath: true, DangerousMode: true})
 	c.Check(chgSummary, check.Equals, `Install "local" snap from file "a/b/local.snap"`)
 }
 
@@ -2167,7 +2167,7 @@ func (s *apiSuite) TestSideloadSnapOnDevModeDistro(c *check.C) {
 	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
 	restore := release.MockForcedDevmode(true)
 	defer restore()
-	flags := snapstate.Flags{RemoveSnapPath: true}
+	flags := snapstate.Flags{RemoveSnapPath: true, DangerousMode: true}
 	chgSummary := s.sideloadCheck(c, body, head, flags)
 	c.Check(chgSummary, check.Equals, `Install "local" snap from file "a/b/local.snap"`)
 }
@@ -2208,7 +2208,7 @@ func (s *apiSuite) TestSideloadSnapJailMode(c *check.C) {
 		"----hello--\r\n"
 	head := map[string]string{"Content-Type": "multipart/thing; boundary=--hello--"}
 	// try a multipart/form-data upload
-	flags := snapstate.Flags{JailMode: true, RemoveSnapPath: true}
+	flags := snapstate.Flags{JailMode: true, RemoveSnapPath: true, DangerousMode: true}
 	chgSummary := s.sideloadCheck(c, body, head, flags)
 	c.Check(chgSummary, check.Equals, `Install "local" snap from file "x"`)
 }

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -344,6 +344,7 @@ func mapLocal(about aboutSnap) *client.Snap {
 		DevMode:          snapst.DevMode,
 		TryMode:          snapst.TryMode,
 		JailMode:         snapst.JailMode,
+		DangerousMode:    snapst.DangerousMode,
 		Private:          localSnap.Private,
 		Apps:             apps,
 		Broken:           localSnap.Broken,

--- a/overlord/snapstate/flags.go
+++ b/overlord/snapstate/flags.go
@@ -57,6 +57,10 @@ type Flags struct {
 	// Amend allows refreshing out of a snap unknown to the store
 	// and into one that is known.
 	Amend bool `json:"amend,omitempty"`
+
+	// DangerousMode is set if user has installed the snap directly from
+	// unknown file
+	DangerousMode bool `json:"dangerousmode,omitempty"`
 }
 
 // DevModeAllowed returns whether a snap can be installed with devmode confinement (either set or overridden)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -601,6 +601,8 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.DevMode = snapsup.DevMode
 	oldJailMode := snapst.JailMode
 	snapst.JailMode = snapsup.JailMode
+	oldDangerousMode := snapst.DangerousMode
+	snapst.DangerousMode = snapsup.DangerousMode
 	oldClassic := snapst.Classic
 	snapst.Classic = snapsup.Classic
 	if snapsup.Required { // set only on install and left alone on refresh
@@ -662,6 +664,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	t.Set("old-trymode", oldTryMode)
 	t.Set("old-devmode", oldDevMode)
 	t.Set("old-jailmode", oldJailMode)
+	t.Set("old-dangerousmode", oldDangerousMode)
 	t.Set("old-classic", oldClassic)
 	t.Set("old-ignore-validation", oldIgnoreValidation)
 	t.Set("old-channel", oldChannel)
@@ -728,6 +731,12 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if err != nil {
 		return err
 	}
+	var oldDangerousMode bool
+	err = t.Get("old-dangerousmode", &oldDangerousMode)
+	if err != nil {
+		return err
+	}
+
 	var oldClassic bool
 	err = t.Get("old-classic", &oldClassic)
 	if err != nil {


### PR DESCRIPTION
A quick followup on https://forum.snapcraft.io/t/how-to-check-if-a-snap-is-installed-in-dangerous-mode/3968. A simple attempt to record if snap was installed with 'dangerous' mode enabled or not. Updated `snap info` and `snap list` to show the relevant information in such case.

```
$ snap download test-snapd-tools
Fetching snap "test-snapd-tools"
Fetching assertions for "test-snapd-tools"
Install the snap with:
   snap ack test-snapd-tools_6.assert
   snap install test-snapd-tools_6.snap

$ sudo snap install --dangerous test-snapd-tools_6.snap
test-snapd-tools 1.0 installed

$ snap list                           
Name              Version  Rev   Developer     Notes
core              16-2.30  3887  canonical     core
hello-world       6.3      27    canonical     -
ohmygiraffe       1.1.0a   3     popey         -
test-snapd-tools  1.0      x1                  dangerous
wormhole          0.10.3   23    snapcrafters  -

$ snap info --verbose test-snapd-tools
name:      test-snapd-tools
summary:   ""
publisher: 
license:   unknown
description: |
  
commands:
  - test-snapd-tools.block
  - test-snapd-tools.cat
  - test-snapd-tools.cmd
  - test-snapd-tools.echo
  - test-snapd-tools.env
  - test-snapd-tools.fail
  - test-snapd-tools.head
  - test-snapd-tools.sh
  - test-snapd-tools.success
notes:               
  private:           false
  confinement:       strict
  devmode:           false
  jailmode:          false
  trymode:           false
  enabled:           true
  broken:            false
  dangerous:         true
  ignore-validation: false
tracking:            
installed:           1.0 (x1) 8kB 
refreshed:           2017-03-14 10:46:14 +0100 CET
channels:                          
  stable:            1.0       (6) 8kB -
  candidate:         ↑                 
  beta:              ↑                 
  edge:              1.0+fake1 (5) 8kB -
```

