### PR TITLE
daemon: allow `snapctl get` from any uid

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -114,7 +114,10 @@ func (c *Command) canAccess(r *http.Request, user *auth.UserState) accessResult 
 	isSnap := (socket == dirs.SnapSocket)
 
 	// ensure that snaps can only access SnapOK things
-	if isSnap && !c.SnapOK {
+	if isSnap {
+		if c.SnapOK {
+			return accessOK
+		}
 		return accessUnauthorized
 	}
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -172,23 +172,11 @@ func (s *daemonSuite) TestSnapctlAccessSnapOKWithUser(c *check.C) {
 	pst := &http.Request{Method: "POST", RemoteAddr: remoteAddr}
 	del := &http.Request{Method: "DELETE", RemoteAddr: remoteAddr}
 
-	cmd := &Command{d: newTestDaemon(c), SnapOK: true, UserOK: true}
+	cmd := &Command{d: newTestDaemon(c), SnapOK: true}
 	c.Check(cmd.canAccess(get, nil), check.Equals, accessOK)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessUnauthorized)
-
-	cmd = &Command{d: newTestDaemon(c), SnapOK: true, UserOK: false}
-	c.Check(cmd.canAccess(get, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessUnauthorized)
-
-	cmd = &Command{d: newTestDaemon(c), SnapOK: false, UserOK: true}
-	c.Check(cmd.canAccess(get, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessUnauthorized)
+	c.Check(cmd.canAccess(put, nil), check.Equals, accessOK)
+	c.Check(cmd.canAccess(pst, nil), check.Equals, accessOK)
+	c.Check(cmd.canAccess(del, nil), check.Equals, accessOK)
 }
 
 func (s *daemonSuite) TestSnapctlAccessSnapOKWithRoot(c *check.C) {
@@ -198,23 +186,11 @@ func (s *daemonSuite) TestSnapctlAccessSnapOKWithRoot(c *check.C) {
 	pst := &http.Request{Method: "POST", RemoteAddr: remoteAddr}
 	del := &http.Request{Method: "DELETE", RemoteAddr: remoteAddr}
 
-	cmd := &Command{d: newTestDaemon(c), SnapOK: true, UserOK: true}
+	cmd := &Command{d: newTestDaemon(c), SnapOK: true}
 	c.Check(cmd.canAccess(get, nil), check.Equals, accessOK)
 	c.Check(cmd.canAccess(put, nil), check.Equals, accessOK)
 	c.Check(cmd.canAccess(pst, nil), check.Equals, accessOK)
 	c.Check(cmd.canAccess(del, nil), check.Equals, accessOK)
-
-	cmd = &Command{d: newTestDaemon(c), SnapOK: true, UserOK: false}
-	c.Check(cmd.canAccess(get, nil), check.Equals, accessOK)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessOK)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessOK)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessOK)
-
-	cmd = &Command{d: newTestDaemon(c), SnapOK: false, UserOK: true}
-	c.Check(cmd.canAccess(get, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(put, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(pst, nil), check.Equals, accessUnauthorized)
-	c.Check(cmd.canAccess(del, nil), check.Equals, accessUnauthorized)
 }
 
 func (s *daemonSuite) TestUserAccess(c *check.C) {


### PR DESCRIPTION
We have the information what UID has issued a snapctl call now in
the daemon. With that we can allow "get" to be used by anyone.

This fixes a regression in current master where `snapctl get`
is not working when called from with a regular user.
