### PR TITLE
all: snap versions are now validated

### DIFF
--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -139,6 +139,7 @@ func (s *specSuite) TestAddUpdateNS(c *C) {
 
 const snapWithLayout = `
 name: vanguard
+version: 0
 apps:
   vanguard:
     command: vanguard

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -444,6 +444,7 @@ func (s *AllSuite) TestRegisterIface(c *C) {
 
 const testConsumerInvalidSlotNameYaml = `
 name: consumer
+version: 0
 slots:
  ttyS5:
   interface: iface
@@ -454,6 +455,7 @@ apps:
 
 const testConsumerInvalidPlugNameYaml = `
 name: consumer
+version: 0
 plugs:
  ttyS3:
   interface: iface
@@ -464,6 +466,7 @@ apps:
 
 const testInvalidSlotInterfaceYaml = `
 name: testsnap
+version: 0
 slots:
  iface:
   interface: iface
@@ -477,6 +480,7 @@ hooks:
 
 const testInvalidPlugInterfaceYaml = `
 name: testsnap
+version: 0
 plugs:
  iface:
   interface: iface

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&AlsaInterfaceSuite{
 })
 
 const alsaConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [alsa]
 `
 
 const alsaCoreYaml = `name: core
+version: 0
 type: os
 slots:
   alsa:

--- a/interfaces/builtin/avahi_control_test.go
+++ b/interfaces/builtin/avahi_control_test.go
@@ -46,18 +46,21 @@ var _ = Suite(&AvahiControlInterfaceSuite{
 })
 
 const avahiControlConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [avahi-control]
 `
 
 const avahiControlProducerYaml = `name: producer
+version: 0
 apps:
  app:
   slots: [avahi-control]
 `
 
 const avahiControlCoreYaml = `name: core
+version: 0
 slots:
   avahi-control:
 `

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -46,18 +46,21 @@ var _ = Suite(&AvahiObserveInterfaceSuite{
 })
 
 const avahiObserveConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [avahi-observe]
 `
 
 const avahiObserveProducerYaml = `name: producer
+version: 0
 apps:
  app:
   slots: [avahi-observe]
 `
 
 const avahiObserveCoreYaml = `name: core
+version: 0
 slots:
   avahi-observe:
 `

--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -48,12 +48,14 @@ var _ = Suite(&BluezInterfaceSuite{
 })
 
 const bluezConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [bluez]
 `
 
 const bluezConsumerTwoAppsYaml = `name: consumer
+version: 0
 apps:
  app1:
   plugs: [bluez]
@@ -62,6 +64,7 @@ apps:
 `
 
 const bluezConsumerThreeAppsYaml = `name: consumer
+version: 0
 apps:
  app1:
   plugs: [bluez]
@@ -71,12 +74,14 @@ apps:
 `
 
 const bluezProducerYaml = `name: producer
+version: 0
 apps:
  app:
   slots: [bluez]
 `
 
 const bluezProducerTwoAppsYaml = `name: producer
+version: 0
 apps:
  app1:
   slots: [bluez]
@@ -85,6 +90,7 @@ apps:
 `
 
 const bluezProducerThreeAppsYaml = `name: producer
+version: 0
 apps:
  app1:
   slots: [bluez]
@@ -94,6 +100,7 @@ apps:
 `
 
 const bluezCoreYaml = `name: core
+version: 0
 slots:
   bluez:
 `

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -68,6 +68,7 @@ var _ = Suite(&BoolFileInterfaceSuite{
 func (s *BoolFileInterfaceSuite) SetUpTest(c *C) {
 	plugSnapinfo := snaptest.MockInfo(c, `
 name: other
+version: 0
 plugs:
  plug: bool-file
 apps:
@@ -76,6 +77,7 @@ apps:
 `, nil)
 	info := snaptest.MockInfo(c, `
 name: ubuntu-core
+version: 0
 slots:
     gpio:
         interface: bool-file

--- a/interfaces/builtin/broadcom_asic_control_test.go
+++ b/interfaces/builtin/broadcom_asic_control_test.go
@@ -46,6 +46,7 @@ var _ = Suite(&BroadcomAsicControlSuite{
 
 func (s *BroadcomAsicControlSuite) SetUpTest(c *C) {
 	const producerYaml = `name: core
+version: 0
 type: os
 slots:
   broadcom-asic-control:
@@ -55,6 +56,7 @@ slots:
 	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil)
 
 	const consumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [broadcom-asic-control]

--- a/interfaces/builtin/camera_test.go
+++ b/interfaces/builtin/camera_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&CameraInterfaceSuite{
 })
 
 const cameraConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [camera]
 `
 
 const cameraCoreYaml = `name: core
+version: 0
 type: os
 slots:
   camera:

--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -33,6 +33,7 @@ var _ = Suite(&commonIfaceSuite{})
 func (s *commonIfaceSuite) TestUDevSpec(c *C) {
 	plug, _ := MockConnectedPlug(c, `
 name: consumer
+version: 0
 apps:
   app-a:
     plugs: [common]
@@ -42,6 +43,7 @@ apps:
 `, nil, "common")
 	slot, _ := MockConnectedSlot(c, `
 name: producer
+version: 0
 slots:
   common:
 `, nil, "common")

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -123,6 +123,7 @@ slots:
 
 func (s *ContentSuite) TestSanitizeSlotSourceAndLegacy(c *C) {
 	slot := MockSlot(c, `name: snap
+version: 0
 slots:
   content:
     source:
@@ -131,6 +132,7 @@ slots:
 `, nil, "content")
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches, `move the "read" attribute into the "source" section`)
 	slot = MockSlot(c, `name: snap
+version: 0
 slots:
   content:
     source:
@@ -222,7 +224,7 @@ apps:
 }
 
 func (s *ContentSuite) TestResolveSpecialVariable(c *C) {
-	info := snaptest.MockInfo(c, "name: name", &snap.SideInfo{Revision: snap.R(42)})
+	info := snaptest.MockInfo(c, "{name: name, version: 0}", &snap.SideInfo{Revision: snap.R(42)})
 	c.Check(builtin.ResolveSpecialVariable("foo", info), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
 	c.Check(builtin.ResolveSpecialVariable("$SNAP/foo", info), Equals, filepath.Join(dirs.CoreSnapMountDir, "name/42/foo"))
 	c.Check(builtin.ResolveSpecialVariable("$SNAP_DATA/foo", info), Equals, "/var/snap/name/42/foo")
@@ -235,6 +237,7 @@ func (s *ContentSuite) TestResolveSpecialVariable(c *C) {
 // Check that legacy syntax works and allows sharing read-only snap content
 func (s *ContentSuite) TestConnectedPlugSnippetSharingLegacy(c *C) {
 	const consumerYaml = `name: consumer 
+version: 0
 plugs:
  content:
   target: import
@@ -242,6 +245,7 @@ plugs:
 	consumerInfo := snaptest.MockInfo(c, consumerYaml, &snap.SideInfo{Revision: snap.R(7)})
 	plug := interfaces.NewConnectedPlug(consumerInfo.Plugs["content"], nil)
 	const producerYaml = `name: producer
+version: 0
 slots:
  content:
   read:
@@ -263,6 +267,7 @@ slots:
 // Check that sharing of read-only snap content is possible
 func (s *ContentSuite) TestConnectedPlugSnippetSharingSnap(c *C) {
 	const consumerYaml = `name: consumer 
+version: 0
 plugs:
  content:
   target: $SNAP/import
@@ -273,6 +278,7 @@ apps:
 	consumerInfo := snaptest.MockInfo(c, consumerYaml, &snap.SideInfo{Revision: snap.R(7)})
 	plug := interfaces.NewConnectedPlug(consumerInfo.Plugs["content"], nil)
 	const producerYaml = `name: producer
+version: 0
 slots:
  content:
   read:
@@ -306,6 +312,7 @@ slots:
 // Check that sharing of writable data is possible
 func (s *ContentSuite) TestConnectedPlugSnippetSharingSnapData(c *C) {
 	const consumerYaml = `name: consumer 
+version: 0
 plugs:
  content:
   target: $SNAP_DATA/import
@@ -316,6 +323,7 @@ apps:
 	consumerInfo := snaptest.MockInfo(c, consumerYaml, &snap.SideInfo{Revision: snap.R(7)})
 	plug := interfaces.NewConnectedPlug(consumerInfo.Plugs["content"], nil)
 	const producerYaml = `name: producer
+version: 0
 slots:
  content:
   write:
@@ -351,6 +359,7 @@ slots:
 // Check that sharing of writable common data is possible
 func (s *ContentSuite) TestConnectedPlugSnippetSharingSnapCommon(c *C) {
 	const consumerYaml = `name: consumer 
+version: 0
 plugs:
  content:
   target: $SNAP_COMMON/import
@@ -361,6 +370,7 @@ apps:
 	consumerInfo := snaptest.MockInfo(c, consumerYaml, &snap.SideInfo{Revision: snap.R(7)})
 	plug := interfaces.NewConnectedPlug(consumerInfo.Plugs["content"], nil)
 	const producerYaml = `name: producer
+version: 0
 slots:
  content:
   write:
@@ -399,6 +409,7 @@ func (s *ContentSuite) TestInterfaces(c *C) {
 
 func (s *ContentSuite) TestModernContentInterface(c *C) {
 	plug := MockPlug(c, `name: consumer
+version: 0
 plugs:
  content:
   target: $SNAP_COMMON/import
@@ -409,6 +420,7 @@ apps:
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil)
 
 	slot := MockSlot(c, `name: producer
+version: 0
 slots:
  content:
   source:
@@ -476,6 +488,7 @@ slots:
 func (s *ContentSuite) TestModernContentInterfacePlugins(c *C) {
 	// Define one app snap and two snaps plugin snaps.
 	plug := MockPlug(c, `name: app
+version: 0
 plugs:
  plugins:
   interface: content
@@ -491,6 +504,7 @@ apps:
 	// XXX: realistically the plugin may be a single file and we don't support
 	// those very well.
 	slotOne := MockSlot(c, `name: plugin-one
+version: 0
 slots:
  plugin-for-app:
   interface: content
@@ -500,6 +514,7 @@ slots:
 	connectedSlotOne := interfaces.NewConnectedSlot(slotOne, nil)
 
 	slotTwo := MockSlot(c, `name: plugin-two
+version: 0
 slots:
  plugin-for-app:
   interface: content
@@ -551,6 +566,7 @@ slots:
 
 func (s *ContentSuite) TestModernContentSameReadAndWriteClash(c *C) {
 	plug := MockPlug(c, `name: consumer
+version: 0
 plugs:
  content:
   target: $SNAP_COMMON/import
@@ -561,6 +577,7 @@ apps:
 	connectedPlug := interfaces.NewConnectedPlug(plug, nil)
 
 	slot := MockSlot(c, `name: producer
+version: 0
 slots:
  content:
   source:

--- a/interfaces/builtin/dbus_test.go
+++ b/interfaces/builtin/dbus_test.go
@@ -65,6 +65,7 @@ var _ = Suite(&DbusInterfaceSuite{
 func (s *DbusInterfaceSuite) SetUpSuite(c *C) {
 	s.snapInfo = snaptest.MockInfo(c, `
 name: test-dbus
+version: 0
 slots:
   test-session-slot:
     interface: dbus

--- a/interfaces/builtin/dcdbas_control_test.go
+++ b/interfaces/builtin/dcdbas_control_test.go
@@ -45,6 +45,7 @@ var _ = Suite(&DcdbasControlInterfaceSuite{
 func (s *DcdbasControlInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
 name: other
+version: 0
 apps:
  app:
     command: foo

--- a/interfaces/builtin/desktop_legacy_test.go
+++ b/interfaces/builtin/desktop_legacy_test.go
@@ -42,12 +42,14 @@ var _ = Suite(&DesktopLegacyInterfaceSuite{
 })
 
 const desktopLegacyConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [desktop-legacy]
 `
 
 const desktopLegacyCoreYaml = `name: core
+version: 0
 type: os
 slots:
   desktop-legacy:

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -48,12 +48,14 @@ var _ = Suite(&DesktopInterfaceSuite{
 })
 
 const desktopConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [desktop]
 `
 
 const desktopCoreYaml = `name: core
+version: 0
 type: os
 slots:
   desktop:

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -40,12 +40,14 @@ type FirewallControlInterfaceSuite struct {
 }
 
 const firewallControlConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [firewall-control]
 `
 
 const firewallControlCoreYaml = `name: core
+version: 0
 type: os
 slots:
   firewall-control:

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -40,6 +40,7 @@ type FramebufferInterfaceSuite struct {
 
 const framebufferConsumerYaml = `
 name: consumer
+version: 0
 apps:
   app:
     plugs: [framebuffer]
@@ -47,6 +48,7 @@ apps:
 
 const framebufferOsYaml = `
 name: core
+version: 0
 type: os
 slots:
   framebuffer:

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -41,12 +41,14 @@ type FuseSupportInterfaceSuite struct {
 }
 
 const fuseSupportConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [fuse-support]
 `
 
 const fuseSupportCoreYaml = `name: core
+version: 0
 type: os
 slots:
   fuse-support:

--- a/interfaces/builtin/gpg_keys_test.go
+++ b/interfaces/builtin/gpg_keys_test.go
@@ -42,12 +42,14 @@ var _ = Suite(&GpgKeysInterfaceSuite{
 })
 
 const gpgKeysConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
    plugs: [gpg-keys]
    `
 
 const gpgKeysCoreYaml = `name: core
+version: 0
 type: os
 slots:
   gpg-keys:

--- a/interfaces/builtin/gpg_public_keys_test.go
+++ b/interfaces/builtin/gpg_public_keys_test.go
@@ -42,12 +42,14 @@ var _ = Suite(&GpgPublicKeysInterfaceSuite{
 })
 
 const gpgPublicKeysConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
    plugs: [gpg-public-keys]
    `
 
 const gpgPublicKeysCoreYaml = `name: core
+version: 0
 type: os
 slots:
   gpg-public-keys:

--- a/interfaces/builtin/gpio_memory_control_test.go
+++ b/interfaces/builtin/gpio_memory_control_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&GpioMemoryControlInterfaceSuite{
 })
 
 const gpioMemoryControlConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [gpio-memory-control]
 `
 
 const gpioMemoryControlCoreYaml = `name: core
+version: 0
 type: os
 slots:
   gpio-memory-control:

--- a/interfaces/builtin/gpio_test.go
+++ b/interfaces/builtin/gpio_test.go
@@ -57,6 +57,7 @@ var _ = Suite(&GpioInterfaceSuite{
 func (s *GpioInterfaceSuite) SetUpTest(c *C) {
 	gadgetInfo := snaptest.MockInfo(c, `
 name: my-device
+version: 0
 type: gadget
 slots:
     my-pin:
@@ -87,6 +88,7 @@ plugs:
 
 	osInfo := snaptest.MockInfo(c, `
 name: my-core
+version: 0
 type: os
 slots:
     my-pin:
@@ -99,6 +101,7 @@ slots:
 
 	appInfo := snaptest.MockInfo(c, `
 name: my-app
+version: 0
 slots:
     my-pin:
         interface: gpio

--- a/interfaces/builtin/hardware_random_control_test.go
+++ b/interfaces/builtin/hardware_random_control_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&HardwareRandomControlInterfaceSuite{
 })
 
 const hardwareRandomControlConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [hardware-random-control]
 `
 
 const hardwareRandomControlCoreYaml = `name: core
+version: 0
 type: os
 slots:
   hardware-random-control:

--- a/interfaces/builtin/hardware_random_observe_test.go
+++ b/interfaces/builtin/hardware_random_observe_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&HardwareRandomObserveInterfaceSuite{
 })
 
 const hardwareRandomObserveConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [hardware-random-observe]
 `
 
 const hardwareRandomObserveCoreYaml = `name: core
+version: 0
 type: os
 slots:
   hardware-random-observe:

--- a/interfaces/builtin/hidraw_test.go
+++ b/interfaces/builtin/hidraw_test.go
@@ -79,6 +79,7 @@ var _ = Suite(&HidrawInterfaceSuite{
 func (s *HidrawInterfaceSuite) SetUpTest(c *C) {
 	osSnapInfo := snaptest.MockInfo(c, `
 name: ubuntu-core
+version: 0
 type: os
 slots:
     test-port-1:
@@ -116,6 +117,7 @@ slots:
 
 	gadgetSnapInfo := snaptest.MockInfo(c, `
 name: some-device
+version: 0
 type: gadget
 slots:
   test-udev-1:
@@ -157,6 +159,7 @@ slots:
 
 	consumingSnapInfo := snaptest.MockInfo(c, `
 name: client-snap
+version: 0
 plugs:
     plug-for-device-1:
         interface: hidraw

--- a/interfaces/builtin/i2c_test.go
+++ b/interfaces/builtin/i2c_test.go
@@ -76,6 +76,7 @@ func (s *I2cInterfaceSuite) SetUpTest(c *C) {
 	// Mock for OS Snap
 	osSnapInfo := snaptest.MockInfo(c, `
 name: ubuntu-core
+version: 0
 type: os
 slots:
   test-port-1:
@@ -87,6 +88,7 @@ slots:
 	// Mock for Gadget Snap
 	gadgetSnapInfo := snaptest.MockInfo(c, `
 name: some-device
+version: 0
 type: gadget
 slots:
   test-udev-1:
@@ -146,6 +148,7 @@ slots:
 	// Snap Consumers
 	consumingSnapInfo := snaptest.MockInfo(c, `
 name: client-snap
+version: 0
 plugs:
   plug-for-port-1:
     interface: i2c

--- a/interfaces/builtin/iio_test.go
+++ b/interfaces/builtin/iio_test.go
@@ -78,6 +78,7 @@ func (s *IioInterfaceSuite) SetUpTest(c *C) {
 	// Mock for OS Snap
 	osSnapInfo := snaptest.MockInfo(c, `
 name: ubuntu-core
+version: 0
 type: os
 slots:
   test-port-1:
@@ -89,6 +90,7 @@ slots:
 	// Mock for Gadget Snap
 	gadgetSnapInfo := snaptest.MockInfo(c, `
 name: some-device
+version: 0
 type: gadget
 slots:
   test-udev-1:
@@ -154,6 +156,7 @@ slots:
 	// Snap Consumers
 	consumingSnapInfo := snaptest.MockInfo(c, `
 name: client-snap
+version: 0
 plugs:
   plug-for-port-1:
     interface: iio

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -44,12 +44,14 @@ var _ = Suite(&ioPortsControlInterfaceSuite{
 })
 
 const ioPortsControlConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [io-ports-control]
 `
 
 const ioPortsControlCoreYaml = `name: core
+version: 0
 type: os
 slots:
   io-ports-control:

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&JoystickInterfaceSuite{
 })
 
 const joystickConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [joystick]
 `
 
 const joystickCoreYaml = `name: core
+version: 0
 type: os
 slots:
   joystick:

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -44,12 +44,14 @@ var _ = Suite(&KernelModuleControlInterfaceSuite{
 })
 
 const kernelmodctlConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [kernel-module-control]
 `
 
 const kernelmodctlCoreYaml = `name: core
+version: 0
 type: os
 slots:
   kernel-module-control:

--- a/interfaces/builtin/kvm_test.go
+++ b/interfaces/builtin/kvm_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&kvmInterfaceSuite{
 })
 
 const kvmConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [kvm]
 `
 
 const kvmCoreYaml = `name: core
+version: 0
 type: os
 slots:
   kvm:

--- a/interfaces/builtin/lxd_support_test.go
+++ b/interfaces/builtin/lxd_support_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&LxdSupportInterfaceSuite{
 })
 
 const lxdSupportConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [lxd-support]
 `
 
 const lxdSupportCoreYaml = `name: core
+version: 0
 type: os
 slots:
   lxd-support:

--- a/interfaces/builtin/lxd_test.go
+++ b/interfaces/builtin/lxd_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&LxdInterfaceSuite{
 })
 
 const lxdConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [lxd]
 `
 
 const lxdCoreYaml = `name: core
+version: 0
 type: os
 slots:
   lxd:

--- a/interfaces/builtin/mir_test.go
+++ b/interfaces/builtin/mir_test.go
@@ -49,6 +49,7 @@ var _ = Suite(&MirInterfaceSuite{
 func (s *MirInterfaceSuite) SetUpTest(c *C) {
 	// a pulseaudio slot on the core snap (as automatically added on classic)
 	const mirMockClassicSlotSnapInfoYaml = `name: core
+version: 0
 type: os
 slots:
  mir:

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -44,12 +44,14 @@ var _ = Suite(&NetworkControlInterfaceSuite{
 })
 
 const networkControlConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [network-control]
 `
 
 const networkControlCoreYaml = `name: core
+version: 0
 type: os
 slots:
   network-control:

--- a/interfaces/builtin/network_setup_control_test.go
+++ b/interfaces/builtin/network_setup_control_test.go
@@ -45,6 +45,7 @@ var _ = Suite(&NetworkSetupControlInterfaceSuite{
 func (s *NetworkSetupControlInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
 name: other
+version: 0
 apps:
  app:
     command: foo

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&OpenglInterfaceSuite{
 })
 
 const openglConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [opengl]
 `
 
 const openglCoreYaml = `name: core
+version: 0
 type: os
 slots:
   opengl:

--- a/interfaces/builtin/optical_drive_test.go
+++ b/interfaces/builtin/optical_drive_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&OpticalDriveInterfaceSuite{
 })
 
 const opticalDriveConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [optical-drive]
 `
 
 const opticalDriveCoreYaml = `name: core
+version: 0
 type: os
 slots:
   optical-drive:

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&PhysicalMemoryControlInterfaceSuite{
 })
 
 const physicalMemoryControlConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [physical-memory-control]
 `
 
 const physicalMemoryControlCoreYaml = `name: core
+version: 0
 type: os
 slots:
   physical-memory-control:

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -44,12 +44,14 @@ var _ = Suite(&PhysicalMemoryObserveInterfaceSuite{
 })
 
 const physicalMemoryObserveConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [physical-memory-observe]
 `
 
 const physicalMemoryObserveCoreYaml = `name: core
+version: 0
 type: os
 slots:
   physical-memory-observe:

--- a/interfaces/builtin/ppp_test.go
+++ b/interfaces/builtin/ppp_test.go
@@ -44,12 +44,14 @@ var _ = Suite(&PppInterfaceSuite{
 })
 
 const pppConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [ppp]
 `
 
 const pppCoreYaml = `name: core
+version: 0
 type: os
 slots:
   ppp:

--- a/interfaces/builtin/pulseaudio_test.go
+++ b/interfaces/builtin/pulseaudio_test.go
@@ -64,6 +64,7 @@ apps:
 
 // a pulseaudio slot on the core snap (as automatically added on classic)
 const pulseaudioMockClassicSlotSnapInfoYaml = `name: core
+version: 0
 type: os
 slots:
  pulseaudio:

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&RawUsbInterfaceSuite{
 })
 
 const rawusbConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [raw-usb]
 `
 
 const rawusbCoreYaml = `name: core
+version: 0
 type: os
 slots:
   raw-usb:

--- a/interfaces/builtin/removable_media_test.go
+++ b/interfaces/builtin/removable_media_test.go
@@ -45,6 +45,7 @@ var _ = Suite(&RemovableMediaInterfaceSuite{
 func (s *RemovableMediaInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
 name: client-snap
+version: 0
 apps:
   other:
     command: foo

--- a/interfaces/builtin/serial_port_test.go
+++ b/interfaces/builtin/serial_port_test.go
@@ -109,6 +109,7 @@ var _ = Suite(&SerialPortInterfaceSuite{
 func (s *SerialPortInterfaceSuite) SetUpTest(c *C) {
 	osSnapInfo := snaptest.MockInfo(c, `
 name: ubuntu-core
+version: 0
 type: os
 slots:
     test-port-1:
@@ -206,6 +207,7 @@ slots:
 
 	gadgetSnapInfo := snaptest.MockInfo(c, `
 name: some-device
+version: 0
 type: gadget
 slots:
   test-udev-1:
@@ -271,6 +273,7 @@ slots:
 
 	consumingSnapInfo := snaptest.MockInfo(c, `
 name: client-snap
+version: 0
 plugs:
     plug-for-port-1:
         interface: serial-port

--- a/interfaces/builtin/shutdown_test.go
+++ b/interfaces/builtin/shutdown_test.go
@@ -45,6 +45,7 @@ var _ = Suite(&ShutdownInterfaceSuite{
 func (s *ShutdownInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
 name: other
+version: 0
 apps:
  app:
     command: foo

--- a/interfaces/builtin/snapd_control_test.go
+++ b/interfaces/builtin/snapd_control_test.go
@@ -45,6 +45,7 @@ var _ = Suite(&SnapdControlInterfaceSuite{
 func (s *SnapdControlInterfaceSuite) SetUpTest(c *C) {
 	consumingSnapInfo := snaptest.MockInfo(c, `
 name: other
+version: 0
 apps:
  app:
     command: foo

--- a/interfaces/builtin/spi_test.go
+++ b/interfaces/builtin/spi_test.go
@@ -70,6 +70,7 @@ var _ = Suite(&spiInterfaceSuite{
 func (s *spiInterfaceSuite) SetUpTest(c *C) {
 	info := snaptest.MockInfo(c, `
 name: core
+version: 0
 type: os
 slots:
   spi-1:
@@ -86,6 +87,7 @@ slots:
 
 	info = snaptest.MockInfo(c, `
 name: gadget
+version: 0
 type: gadget
 slots:
   spi-1:
@@ -131,6 +133,7 @@ slots:
 
 	info = snaptest.MockInfo(c, `
 name: consumer
+version: 0
 plugs:
   spi-1:
     interface: spi

--- a/interfaces/builtin/ssh_keys_test.go
+++ b/interfaces/builtin/ssh_keys_test.go
@@ -42,12 +42,14 @@ var _ = Suite(&SshKeysInterfaceSuite{
 })
 
 const sshKeysConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
    plugs: [ssh-keys]
    `
 
 const sshKeysCoreYaml = `name: core
+version: 0
 type: os
 slots:
   ssh-keys:

--- a/interfaces/builtin/ssh_public_keys_test.go
+++ b/interfaces/builtin/ssh_public_keys_test.go
@@ -42,12 +42,14 @@ var _ = Suite(&SshPublicKeysInterfaceSuite{
 })
 
 const sshPublicKeysConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
    plugs: [ssh-public-keys]
    `
 
 const sshPublicKeysCoreYaml = `name: core
+version: 0
 type: os
 slots:
   ssh-public-keys:

--- a/interfaces/builtin/thumbnailer_service_test.go
+++ b/interfaces/builtin/thumbnailer_service_test.go
@@ -55,6 +55,7 @@ apps:
 `
 	// a thumbnailer-service slot on the core snap (as automatically added on classic)
 	const thumbnailerServiceMockClassicSlotSnapInfoYaml = `name: core
+version: 0
 type: os
 slots:
  thumbnailer-service:

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&TimeControlInterfaceSuite{
 })
 
 const timectlConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [time-control]
 `
 
 const timectlCoreYaml = `name: core
+version: 0
 type: os
 slots:
   time-control:

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -43,12 +43,14 @@ var _ = Suite(&TpmInterfaceSuite{
 })
 
 const tpmConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [tpm]
 `
 
 const tpmCoreYaml = `name: core
+version: 0
 type: os
 slots:
   tpm:

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -45,12 +45,14 @@ var _ = Suite(&UDisks2InterfaceSuite{
 })
 
 const udisks2ConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [udisks2]
 `
 
 const udisks2ConsumerTwoAppsYaml = `name: consumer
+version: 0
 apps:
  app1:
   plugs: [udisks2]
@@ -59,6 +61,7 @@ apps:
 `
 
 const udisks2ConsumerThreeAppsYaml = `name: consumer
+version: 0
 apps:
  app1:
   plugs: [udisks2]
@@ -68,12 +71,14 @@ apps:
 `
 
 const udisks2ProducerYaml = `name: producer
+version: 0
 apps:
  app:
   slots: [udisks2]
 `
 
 const udisks2ProducerTwoAppsYaml = `name: producer
+version: 0
 apps:
  app1:
   slots: [udisks2]
@@ -82,6 +87,7 @@ apps:
 `
 
 const udisks2ProducerThreeAppsYaml = `name: producer
+version: 0
 apps:
  app1:
   slots: [udisks2]

--- a/interfaces/builtin/uhid_test.go
+++ b/interfaces/builtin/uhid_test.go
@@ -42,12 +42,14 @@ var _ = Suite(&UhidInterfaceSuite{
 })
 
 const uhidConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [uhid]
 `
 
 const uhidCoreYaml = `name: core
+version: 0
 type: os
 slots:
   uhid:

--- a/interfaces/builtin/upower_observe_test.go
+++ b/interfaces/builtin/upower_observe_test.go
@@ -55,6 +55,7 @@ apps:
   plugs: [upower-observe]
 `
 	const upowerMockClassicSlotSnapInfoYaml = `name: core
+version: 0
 type: os
 slots:
  upower-observe:

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -47,6 +47,7 @@ var _ = Suite(&WaylandInterfaceSuite{
 })
 
 const waylandConsumerYaml = `name: consumer
+version: 0
 apps:
  app:
   plugs: [wayland]
@@ -54,6 +55,7 @@ apps:
 
 // a wayland slot on a wayland snap (as installed on a core/all-snap system)
 const waylandCoreYaml = `name: wayland
+version: 0
 apps:
  app1:
   slots: [wayland]
@@ -61,6 +63,7 @@ apps:
 
 // a wayland slot on the core snap (as automatically added on classic)
 const waylandClassicYaml = `name: core
+version: 0
 type: os
 slots:
  wayland:

--- a/interfaces/connection_test.go
+++ b/interfaces/connection_test.go
@@ -36,6 +36,7 @@ var _ = Suite(&connSuite{})
 func (s *connSuite) SetUpTest(c *C) {
 	consumer := snaptest.MockInfo(c, `
 name: consumer
+version: 0
 apps:
     app:
 plugs:
@@ -46,6 +47,7 @@ plugs:
 	s.plug = consumer.Plugs["plug"]
 	producer := snaptest.MockInfo(c, `
 name: producer
+version: 0
 apps:
     app:
 slots:

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -184,6 +184,7 @@ func (s *CoreSuite) TestParseConnRef(c *C) {
 func (s *CoreSuite) TestSanitizePlug(c *C) {
 	info := snaptest.MockInfo(c, `
 name: snap
+version: 0
 plugs:
   plug:
     interface: iface
@@ -204,6 +205,7 @@ plugs:
 func (s *CoreSuite) TestSanitizeSlot(c *C) {
 	info := snaptest.MockInfo(c, `
 name: snap
+version: 0
 slots:
   slot:
     interface: iface

--- a/interfaces/ifacetest/backendtest.go
+++ b/interfaces/ifacetest/backendtest.go
@@ -99,6 +99,7 @@ slots:
 `
 const SambaYamlWithHook = `
 name: samba
+version: 0
 apps:
     smbd:
     nmbd:

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -116,6 +116,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 
 const snapWithLayout = `
 name: vanguard
+version: 0
 layout:
   /usr:
     bind: $SNAP/usr

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -49,12 +49,14 @@ func (s *baseDeclSuite) SetUpSuite(c *C) {
 func (s *baseDeclSuite) connectCand(c *C, iface, slotYaml, plugYaml string) *policy.ConnectCandidate {
 	if slotYaml == "" {
 		slotYaml = fmt.Sprintf(`name: slot-snap
+version: 0
 slots:
   %s:
 `, iface)
 	}
 	if plugYaml == "" {
 		plugYaml = fmt.Sprintf(`name: plug-snap
+version: 0
 plugs:
   %s:
 `, iface)
@@ -71,6 +73,7 @@ plugs:
 func (s *baseDeclSuite) installSlotCand(c *C, iface string, snapType snap.Type, yaml string) *policy.InstallCandidate {
 	if yaml == "" {
 		yaml = fmt.Sprintf(`name: install-slot-snap
+version: 0
 type: %s
 slots:
   %s:
@@ -86,6 +89,7 @@ slots:
 func (s *baseDeclSuite) installPlugCand(c *C, iface string, snapType snap.Type, yaml string) *policy.InstallCandidate {
 	if yaml == "" {
 		yaml = fmt.Sprintf(`name: install-plug-snap
+version: 0
 type: %s
 plugs:
   %s:
@@ -243,12 +247,14 @@ func (s *baseDeclSuite) TestAutoConnectionContent(c *C) {
 	// same publisher, same content
 	cand = s.connectCand(c, "stuff", `
 name: slot-snap
+version: 0
 slots:
   stuff:
     interface: content
     content: mk1
 `, `
 name: plug-snap
+version: 0
 plugs:
   stuff:
     interface: content
@@ -267,12 +273,14 @@ plugs:
 
 	// same publisher, different content
 	cand = s.connectCand(c, "stuff", `name: slot-snap
+version: 0
 slots:
   stuff:
     interface: content
     content: mk1
 `, `
 name: plug-snap
+version: 0
 plugs:
   stuff:
     interface: content
@@ -740,12 +748,14 @@ func (s *baseDeclSuite) TestConnectionContent(c *C) {
 
 	// same publisher, same content
 	cand = s.connectCand(c, "stuff", `name: slot-snap
+version: 0
 slots:
   stuff:
     interface: content
     content: mk1
 `, `
 name: plug-snap
+version: 0
 plugs:
   stuff:
     interface: content
@@ -765,12 +775,14 @@ plugs:
 	// same publisher, different content
 	cand = s.connectCand(c, "stuff", `
 name: slot-snap
+version: 0
 slots:
   stuff:
     interface: content
     content: mk1
 `, `
 name: plug-snap
+version: 0
 plugs:
   stuff:
     interface: content
@@ -795,6 +807,7 @@ revision: 0
 
 func (s *baseDeclSuite) TestBrowserSupportAllowSandbox(c *C) {
 	const plugYaml = `name: plug-snap
+version: 0
 plugs:
   browser-support:
    allow-sandbox: true

--- a/interfaces/policy/policy_test.go
+++ b/interfaces/policy/policy_test.go
@@ -283,6 +283,7 @@ AXNpZw==`))
 
 	s.plugSnap = snaptest.MockInfo(c, `
 name: plug-snap
+version: 0
 plugs:
    random:
    mismatchy:
@@ -443,6 +444,7 @@ plugs:
 
 	s.slotSnap = snaptest.MockInfo(c, `
 name: slot-snap
+version: 0
 slots:
    random:
    mismatchy:
@@ -676,6 +678,7 @@ AXNpZw==`))
 
 	s.randomSnap = snaptest.MockInfo(c, `
 name: random-snap
+version: 0
 plugs:
   precise-plug-snap-id:
   checked-plug-publisher-id:
@@ -875,6 +878,7 @@ func (s *policySuite) TestSnapDeclAllowDenyAutoConnection(c *C) {
 func (s *policySuite) TestSnapTypeCheckConnection(c *C) {
 	gadgetSnap := snaptest.MockInfo(c, `
 name: gadget
+version: 0
 type: gadget
 plugs:
    gadgethelp:
@@ -884,6 +888,7 @@ slots:
 
 	coreSnap := snaptest.MockInfo(c, `
 name: core
+version: 0
 type: os
 slots:
    gadgethelp:
@@ -1078,6 +1083,7 @@ func (s *policySuite) TestDollarPlugPublisherIDCheckConnection(c *C) {
 	// slot publisher id == plug publisher id
 	samePubSlotSnap := snaptest.MockInfo(c, `
 name: same-pub-slot-snap
+version: 0
 slots:
   same-plug-publisher-id:
 `, nil)
@@ -1136,6 +1142,7 @@ func (s *policySuite) TestDollarSlotPublisherIDCheckConnection(c *C) {
 	// plug publisher id == slot publisher id
 	samePubPlugSnap := snaptest.MockInfo(c, `
 name: same-pub-plug-snap
+version: 0
 plugs:
   same-slot-publisher-id:
 `, nil)
@@ -1166,6 +1173,7 @@ AXNpZw==`))
 func (s *policySuite) TestBaselineDefaultIsAllowInstallation(c *C) {
 	installSnap := snaptest.MockInfo(c, `
 name: install-slot-snap
+version: 0
 slots:
   random1:
 plugs:
@@ -1187,62 +1195,75 @@ func (s *policySuite) TestBaseDeclAllowDenyInstallation(c *C) {
 		expected    string // "" => no error
 	}{
 		{`name: install-snap
+version: 0
 slots:
   innocuous:
   install-slot-coreonly:
 `, `installation not allowed by "install-slot-coreonly" slot rule of interface "install-slot-coreonly"`},
 		{`name: install-snap
+version: 0
 slots:
   install-slot-attr-ok:
     attr: ok
 `, ""},
 		{`name: install-snap
+version: 0
 slots:
   install-slot-attr-deny:
     trust: trusted
 `, `installation denied by "install-slot-attr-deny" slot rule of interface "install-slot-attr-deny"`},
 		{`name: install-snap
+version: 0
 plugs:
   install-plug-attr-ok:
     attr: ok
 `, ""},
 		{`name: install-snap
+version: 0
 plugs:
   install-plug-attr-ok:
     attr: not-ok
 `, `installation not allowed by "install-plug-attr-ok" plug rule of interface "install-plug-attr-ok"`},
 		{`name: install-snap
+version: 0
 plugs:
   install-plug-gadget-only:
 `, `installation not allowed by "install-plug-gadget-only" plug rule of interface "install-plug-gadget-only"`},
 		{`name: install-gadget
+version: 0
 type: gadget
 plugs:
   install-plug-gadget-only:
 `, ""},
 		{`name: install-gadget
+version: 0
 type: gadget
 plugs:
   install-plug-or:
      p: P2`, `installation denied by "install-plug-or" plug rule.*`},
 		{`name: install-snap
+version: 0
 plugs:
   install-plug-or:
      p: P1`, `installation denied by "install-plug-or" plug rule.*`},
 		{`name: install-snap
+version: 0
 plugs:
   install-plug-or:
      p: P3`, ""},
 		{`name: install-gadget
+version: 0
 type: gadget
 slots:
   install-slot-or:
      p: P2`, `installation denied by "install-slot-or" slot rule.*`},
 		{`name: install-snap
+version: 0
 slots:
   install-slot-or:
      p: P1`, `installation denied by "install-slot-or" slot rule.*`},
 		{`name: install-snap
+version: 0
 slots:
   install-slot-or:
      p: P3`, ""},
@@ -1273,6 +1294,7 @@ func (s *policySuite) TestSnapDeclAllowDenyInstallation(c *C) {
 		expected    string // "" => no error
 	}{
 		{`name: install-snap
+version: 0
 slots:
   install-slot-base-allow-snap-deny:
     have: yes # bool
@@ -1283,6 +1305,7 @@ slots:
         have: true
 `, `installation denied by "install-slot-base-allow-snap-deny" slot rule of interface "install-slot-base-allow-snap-deny" for "install-snap" snap`},
 		{`name: install-snap
+version: 0
 slots:
   install-slot-base-allow-snap-not-allow:
     have: yes # bool
@@ -1293,6 +1316,7 @@ slots:
         have: false
 `, `installation not allowed by "install-slot-base-allow-snap-not-allow" slot rule of interface "install-slot-base-allow-snap-not-allow" for "install-snap" snap`},
 		{`name: install-snap
+version: 0
 slots:
   install-slot-base-deny-snap-allow:
     have: yes
@@ -1301,6 +1325,7 @@ slots:
     allow-installation: true
 `, ""},
 		{`name: install-snap
+version: 0
 plugs:
   install-plug-base-allow-snap-deny:
     attr: give-me
@@ -1311,6 +1336,7 @@ plugs:
         attr: .*
 `, `installation denied by "install-plug-base-allow-snap-deny" plug rule of interface "install-plug-base-allow-snap-deny" for "install-snap" snap`},
 		{`name: install-snap
+version: 0
 plugs:
   install-plug-base-allow-snap-not-allow:
     attr: give-me
@@ -1321,6 +1347,7 @@ plugs:
         attr: minimal
 `, `installation not allowed by "install-plug-base-allow-snap-not-allow" plug rule of interface "install-plug-base-allow-snap-not-allow" for "install-snap" snap`},
 		{`name: install-snap
+version: 0
 plugs:
   install-plug-base-deny-snap-allow:
     attr: attrvalue
@@ -1464,15 +1491,19 @@ func (s *policySuite) TestOnClassicInstallation(c *C) {
 		err         string // "" => no error
 	}{
 		{"", `name: install-snap
+version: 0
 slots:
   install-slot-on-classic-distros:`, `installation not allowed by "install-slot-on-classic-distros" slot rule.*`},
 		{"debian", `name: install-snap
+version: 0
 slots:
   install-slot-on-classic-distros:`, ""},
 		{"", `name: install-snap
+version: 0
 plugs:
   install-plug-on-classic-distros:`, `installation not allowed by "install-plug-on-classic-distros" plug rule.*`},
 		{"debian", `name: install-snap
+version: 0
 plugs:
   install-plug-on-classic-distros:`, ""},
 	}

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -50,6 +50,7 @@ var _ = Suite(&RepositorySuite{
 func (s *RepositorySuite) SetUpTest(c *C) {
 	consumer := snaptest.MockInfo(c, `
 name: consumer
+version: 0
 apps:
     app:
 hooks:
@@ -63,6 +64,7 @@ plugs:
 	s.plug = consumer.Plugs["plug"]
 	producer := snaptest.MockInfo(c, `
 name: producer
+version: 0
 apps:
     app:
 hooks:
@@ -79,6 +81,7 @@ slots:
 	// have at least one interface.
 	s.coreSnap = snaptest.MockInfo(c, `
 name: core
+version: 0
 type: os
 slots:
     network:
@@ -259,12 +262,14 @@ func (s *RepositorySuite) TestPlug(c *C) {
 func (s *RepositorySuite) TestPlugSearch(c *C) {
 	addPlugsSlots(c, s.testRepo, `
 name: x
+version: 0
 plugs:
     a: interface
     b: interface
     c: interface
 `, `
 name: y
+version: 0
 plugs:
     a: interface
     b: interface
@@ -315,10 +320,12 @@ func (s *RepositorySuite) TestRemovePlugFailsWhenPlugIsConnected(c *C) {
 func (s *RepositorySuite) TestAllPlugsWithoutInterfaceName(c *C) {
 	snaps := addPlugsSlots(c, s.testRepo, `
 name: snap-a
+version: 0
 plugs:
     name-a: interface
 `, `
 name: snap-b
+version: 0
 plugs:
     name-a: interface
     name-b: interface
@@ -339,10 +346,12 @@ func (s *RepositorySuite) TestAllPlugsWithInterfaceName(c *C) {
 	c.Assert(err, IsNil)
 	snaps := addPlugsSlots(c, s.testRepo, `
 name: snap-a
+version: 0
 plugs:
     name-a: interface
 `, `
 name: snap-b
+version: 0
 plugs:
     name-a: interface
     name-b: other-interface
@@ -356,10 +365,12 @@ plugs:
 func (s *RepositorySuite) TestPlugs(c *C) {
 	snaps := addPlugsSlots(c, s.testRepo, `
 name: snap-a
+version: 0
 plugs:
     name-a: interface
 `, `
 name: snap-b
+version: 0
 plugs:
     name-a: interface
     name-b: interface
@@ -382,11 +393,13 @@ func (s *RepositorySuite) TestAllSlots(c *C) {
 	c.Assert(err, IsNil)
 	snaps := addPlugsSlots(c, s.testRepo, `
 name: snap-a
+version: 0
 slots:
     name-a: interface
     name-b: interface
 `, `
 name: snap-b
+version: 0
 slots:
     name-a: other-interface
 `)
@@ -407,11 +420,13 @@ slots:
 func (s *RepositorySuite) TestSlots(c *C) {
 	snaps := addPlugsSlots(c, s.testRepo, `
 name: snap-a
+version: 0
 slots:
     name-a: interface
     name-b: interface
 `, `
 name: snap-b
+version: 0
 slots:
     name-a: interface
 `)
@@ -563,6 +578,7 @@ func (s *RepositorySuite) TestResolveConnectExplicit(c *C) {
 func (s *RepositorySuite) TestResolveConnectImplicitCoreSlot(c *C) {
 	coreSnap := snaptest.MockInfo(c, `
 name: core
+version: 0
 type: os
 slots:
     slot:
@@ -582,6 +598,7 @@ slots:
 func (s *RepositorySuite) TestResolveConnectImplicitUbuntuCoreSlot(c *C) {
 	ubuntuCoreSnap := snaptest.MockInfo(c, `
 name: ubuntu-core
+version: 0
 type: os
 slots:
     slot:
@@ -601,6 +618,7 @@ slots:
 func (s *RepositorySuite) TestResolveConnectImplicitSlotPrefersCore(c *C) {
 	coreSnap := snaptest.MockInfo(c, `
 name: core
+version: 0
 type: os
 slots:
     slot:
@@ -608,6 +626,7 @@ slots:
 `, nil)
 	ubuntuCoreSnap := snaptest.MockInfo(c, `
 name: ubuntu-core
+version: 0
 type: os
 slots:
     slot:
@@ -627,6 +646,7 @@ func (s *RepositorySuite) TestResolveConnectNoImplicitCandidates(c *C) {
 	c.Assert(err, IsNil)
 	coreSnap := snaptest.MockInfo(c, `
 name: core
+version: 0
 type: os
 slots:
     slot:
@@ -643,6 +663,7 @@ slots:
 func (s *RepositorySuite) TestResolveConnectAmbiguity(c *C) {
 	coreSnap := snaptest.MockInfo(c, `
 name: core
+version: 0
 type: os
 slots:
     slot-a:
@@ -1371,12 +1392,14 @@ func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlots(c *C) {
 	// Add a pair of snaps with plugs/slots using those two interfaces
 	consumer := snaptest.MockInfo(c, `
 name: consumer
+version: 0
 plugs:
     auto:
     manual:
 `, nil)
 	producer := snaptest.MockInfo(c, `
 name: producer
+version: 0
 type: os
 slots:
     auto:
@@ -1413,6 +1436,7 @@ func (s *RepositorySuite) TestAutoConnectCandidatePlugsAndSlotsSymmetry(c *C) {
 	// Add a producer snap for "auto"
 	producer := snaptest.MockInfo(c, `
 name: producer
+version: 0
 type: os
 slots:
     auto:
@@ -1423,6 +1447,7 @@ slots:
 	// Add two consumers snaps for "auto"
 	consumer1 := snaptest.MockInfo(c, `
 name: consumer1
+version: 0
 plugs:
     auto:
 `, nil)
@@ -1433,6 +1458,7 @@ plugs:
 	// Add two consumers snaps for "auto"
 	consumer2 := snaptest.MockInfo(c, `
 name: consumer2
+version: 0
 plugs:
     auto:
 `, nil)
@@ -1481,12 +1507,14 @@ func (s *AddRemoveSuite) SetUpTest(c *C) {
 
 const testConsumerYaml = `
 name: consumer
+version: 0
 apps:
     app:
         plugs: [iface]
 `
 const testProducerYaml = `
 name: producer
+version: 0
 apps:
     app:
         slots: [iface]
@@ -1494,6 +1522,7 @@ apps:
 
 const testConsumerInvalidSlotNameYaml = `
 name: consumer
+version: 0
 slots:
  ttyS5:
   interface: iface
@@ -1504,6 +1533,7 @@ apps:
 
 const testConsumerInvalidPlugNameYaml = `
 name: consumer
+version: 0
 plugs:
  ttyS3:
   interface: iface
@@ -1548,6 +1578,7 @@ func (s *AddRemoveSuite) TestAddSnapErrorsOnExistingSnapSlots(c *C) {
 func (s *AddRemoveSuite) TestAddSnapSkipsUnknownInterfaces(c *C) {
 	info, err := s.addSnap(c, `
 name: bogus
+version: 0
 plugs:
   bogus-plug:
 slots:
@@ -1617,6 +1648,7 @@ func (s *DisconnectSnapSuite) SetUpTest(c *C) {
 
 	s.s1 = snaptest.MockInfo(c, `
 name: s1
+version: 0
 plugs:
     iface-a:
 slots:
@@ -1627,6 +1659,7 @@ slots:
 
 	s.s2 = snaptest.MockInfo(c, `
 name: s2
+version: 0
 plugs:
     iface-b:
 slots:
@@ -1698,6 +1731,7 @@ func makeContentConnectionTestSnaps(c *C, plugContentToken, slotContentToken str
 
 	plugSnap := snaptest.MockInfo(c, fmt.Sprintf(`
 name: content-plug-snap
+version: 0
 plugs:
   imported-content:
     interface: content
@@ -1705,6 +1739,7 @@ plugs:
 `, plugContentToken), nil)
 	slotSnap := snaptest.MockInfo(c, fmt.Sprintf(`
 name: content-slot-snap
+version: 0
 slots:
   exported-content:
     interface: content
@@ -1773,6 +1808,7 @@ func (s *RepositorySuite) TestInfo(c *C) {
 	// Add some test snaps.
 	s1 := snaptest.MockInfo(c, fmt.Sprintf(`
 name: s1
+version: 0
 apps:
   s1:
     plugs: [i1, i2]
@@ -1781,6 +1817,7 @@ apps:
 
 	s2 := snaptest.MockInfo(c, fmt.Sprintf(`
 name: s2
+version: 0
 apps:
   s2:
     slots: [i1, i3]
@@ -1789,6 +1826,7 @@ apps:
 
 	s3 := snaptest.MockInfo(c, fmt.Sprintf(`
 name: s3
+version: 0
 type: os
 slots:
   i2:

--- a/interfaces/udev/spec_test.go
+++ b/interfaces/udev/spec_test.go
@@ -62,6 +62,7 @@ var _ = Suite(&specSuite{
 
 func (s *specSuite) SetUpSuite(c *C) {
 	info1 := snaptest.MockInfo(c, `name: snap1
+version: 0
 plugs:
     name:
         interface: test
@@ -72,6 +73,7 @@ hooks:
     configure:
 `, nil)
 	info2 := snaptest.MockInfo(c, `name: snap2
+version: 0
 slots:
     name:
         interface: test

--- a/overlord/assertstate/assertstate_test.go
+++ b/overlord/assertstate/assertstate_test.go
@@ -1015,6 +1015,7 @@ func (s *assertMgrSuite) TestAutoAliasesTemporaryFallback(c *C) {
 
 	info := snaptest.MockInfo(c, `
 name: foo
+version: 0
 apps:
    cmd1:
      aliases: [alias1]

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1634,8 +1634,7 @@ func (s *deviceMgrSuite) TestCheckGadget(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	// nothing is setup
-	gadgetInfo := snaptest.MockInfo(c, `type: gadget
-name: other-gadget`, nil)
+	gadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: other-gadget, version: 0}", nil)
 
 	err := devicestate.CheckGadgetOrKernel(s.state, gadgetInfo, nil, snapstate.Flags{})
 	c.Check(err, ErrorMatches, `cannot install gadget without model assertion`)
@@ -1666,26 +1665,17 @@ name: other-gadget`, nil)
 
 	// brand gadget
 	s.setupSnapDecl(c, "gadget", "brand-gadget-id", "my-brand")
-	brandGadgetInfo := snaptest.MockInfo(c, `
-type: gadget
-name: gadget
-`, nil)
+	brandGadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: gadget, version: 0}", nil)
 	brandGadgetInfo.SnapID = "brand-gadget-id"
 
 	// canonical gadget
 	s.setupSnapDecl(c, "gadget", "canonical-gadget-id", "canonical")
-	canonicalGadgetInfo := snaptest.MockInfo(c, `
-type: gadget
-name: gadget
-`, nil)
+	canonicalGadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: gadget, version: 0}", nil)
 	canonicalGadgetInfo.SnapID = "canonical-gadget-id"
 
 	// other gadget
 	s.setupSnapDecl(c, "gadget", "other-gadget-id", "other-brand")
-	otherGadgetInfo := snaptest.MockInfo(c, `
-type: gadget
-name: gadget
-`, nil)
+	otherGadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: gadget, version: 0}", nil)
 	otherGadgetInfo.SnapID = "other-gadget-id"
 
 	// install brand gadget ok
@@ -1712,8 +1702,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassic(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	gadgetInfo := snaptest.MockInfo(c, `type: gadget
-name: other-gadget`, nil)
+	gadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: other-gadget, version: 0}", nil)
 
 	// setup model assertion
 	s.setupBrands(c)
@@ -1740,26 +1729,17 @@ name: other-gadget`, nil)
 
 	// brand gadget
 	s.setupSnapDecl(c, "gadget", "brand-gadget-id", "my-brand")
-	brandGadgetInfo := snaptest.MockInfo(c, `
-type: gadget
-name: gadget
-`, nil)
+	brandGadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: gadget, version: 0}", nil)
 	brandGadgetInfo.SnapID = "brand-gadget-id"
 
 	// canonical gadget
 	s.setupSnapDecl(c, "gadget", "canonical-gadget-id", "canonical")
-	canonicalGadgetInfo := snaptest.MockInfo(c, `
-type: gadget
-name: gadget
-`, nil)
+	canonicalGadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: gadget, version: 0}", nil)
 	canonicalGadgetInfo.SnapID = "canonical-gadget-id"
 
 	// other gadget
 	s.setupSnapDecl(c, "gadget", "other-gadget-id", "other-brand")
-	otherGadgetInfo := snaptest.MockInfo(c, `
-type: gadget
-name: gadget
-`, nil)
+	otherGadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: gadget, version: 0}", nil)
 	otherGadgetInfo.SnapID = "other-gadget-id"
 
 	// install brand gadget ok
@@ -1786,8 +1766,7 @@ func (s *deviceMgrSuite) TestCheckGadgetOnClassicGadgetNotSpecified(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	gadgetInfo := snaptest.MockInfo(c, `type: gadget
-name: gadget`, nil)
+	gadgetInfo := snaptest.MockInfo(c, "{type: gadget, name: gadget, version: 0}", nil)
 
 	// setup model assertion
 	s.setupBrands(c)
@@ -1815,8 +1794,7 @@ name: gadget`, nil)
 func (s *deviceMgrSuite) TestCheckKernel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-	kernelInfo := snaptest.MockInfo(c, `type: kernel
-name: lnrk`, nil)
+	kernelInfo := snaptest.MockInfo(c, "{type: kernel, name: lnrk, version: 0}", nil)
 
 	// not on classic
 	release.OnClassic = true
@@ -1854,26 +1832,17 @@ name: lnrk`, nil)
 
 	// brand kernel
 	s.setupSnapDecl(c, "krnl", "brand-krnl-id", "my-brand")
-	brandKrnlInfo := snaptest.MockInfo(c, `
-type: kernel
-name: krnl
-`, nil)
+	brandKrnlInfo := snaptest.MockInfo(c, "{type: kernel, name: krnl, version: 0}", nil)
 	brandKrnlInfo.SnapID = "brand-krnl-id"
 
 	// canonical kernel
 	s.setupSnapDecl(c, "krnl", "canonical-krnl-id", "canonical")
-	canonicalKrnlInfo := snaptest.MockInfo(c, `
-type: kernel
-name: krnl
-`, nil)
+	canonicalKrnlInfo := snaptest.MockInfo(c, "{type: kernel, name: krnl, version: 0}", nil)
 	canonicalKrnlInfo.SnapID = "canonical-krnl-id"
 
 	// other kernel
 	s.setupSnapDecl(c, "krnl", "other-krnl-id", "other-brand")
-	otherKrnlInfo := snaptest.MockInfo(c, `
-type: kernel
-name: krnl
-`, nil)
+	otherKrnlInfo := snaptest.MockInfo(c, "{type: kernel, name: krnl, version: 0}", nil)
 	otherKrnlInfo.SnapID = "other-krnl-id"
 
 	// install brand kernel ok

--- a/overlord/ifacestate/implicit_test.go
+++ b/overlord/ifacestate/implicit_test.go
@@ -35,7 +35,7 @@ func (implicitSuite) TestAddImplicitSlotsOnCore(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
-	info := snaptest.MockInfo(c, "name: core\ntype: os\n", nil)
+	info := snaptest.MockInfo(c, "{name: core, type: os, version: 0}", nil)
 	ifacestate.AddImplicitSlots(info)
 	// Ensure that some slots that exist in core systems are present.
 	for _, name := range []string{"network"} {
@@ -57,7 +57,7 @@ func (implicitSuite) TestAddImplicitSlotsOnClassic(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
-	info := snaptest.MockInfo(c, "name: core\ntype: os\n", nil)
+	info := snaptest.MockInfo(c, "{name: core, type: os, version: 0}", nil)
 	ifacestate.AddImplicitSlots(info)
 	// Ensure that some slots that exist in classic systems are present.
 	for _, name := range []string{"network", "unity7"} {

--- a/overlord/snapstate/aliasesv2_test.go
+++ b/overlord/snapstate/aliasesv2_test.go
@@ -285,6 +285,7 @@ func (s *snapmgrTestSuite) TestRefreshAliases(c *C) {
 
 	info := snaptest.MockInfo(c, `
 name: alias-snap
+version: 0
 apps:
     cmd1:
     cmd2:

--- a/overlord/snapstate/backend/backend_test.go
+++ b/overlord/snapstate/backend/backend_test.go
@@ -66,6 +66,7 @@ apps:
 
 func (s *backendSuite) TestOpenSnapFilebSideInfo(c *C) {
 	const yaml = `name: foo
+version: 0
 apps:
  bar:
   command: bin/bar

--- a/snap/broken_test.go
+++ b/snap/broken_test.go
@@ -74,6 +74,7 @@ func (s *brokenSuite) TestGuessAppsForBrokenServices(c *C) {
 
 func (s *brokenSuite) TestRenamePlug(c *C) {
 	snapInfo := snaptest.MockInvalidInfo(c, `name: core
+version: 0
 plugs:
   old:
     interface: iface

--- a/snap/gadget_test.go
+++ b/snap/gadget_test.go
@@ -122,6 +122,7 @@ func (s *gadgetYamlTestSuite) TearDownTest(c *C) {
 func (s *gadgetYamlTestSuite) TestReadGadgetNotAGadget(c *C) {
 	info := snaptest.MockInfo(c, `
 name: other
+version: 0
 `, &snap.SideInfo{Revision: snap.R(42)})
 	_, err := snap.ReadGadgetInfo(info, false)
 	c.Assert(err, ErrorMatches, "cannot read gadget snap details: not a gadget snap")

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -669,6 +669,7 @@ func (s *infoSuite) TestAppDesktopFile(c *C) {
 }
 
 const coreSnapYaml = `name: core
+version: 0
 type: os
 plugs:
   network-bind:

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -105,7 +105,7 @@ printf "hello world"
 }
 
 func (s *packSuite) TestPackNoManifestFails(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, "name: hello")
+	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	c.Assert(os.Remove(filepath.Join(sourceDir, "meta", "snap.yaml")), IsNil)
 	_, err := pack.Snap(sourceDir, "")
 	c.Assert(err, ErrorMatches, `.*/meta/snap\.yaml: no such file or directory`)
@@ -113,6 +113,7 @@ func (s *packSuite) TestPackNoManifestFails(c *C) {
 
 func (s *packSuite) TestPackMissingAppFails(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, `name: hello
+version: 0
 apps:
  foo:
   command: bin/hello-world
@@ -123,7 +124,7 @@ apps:
 }
 
 func (s *packSuite) TestCopyCopies(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, "name: hello")
+	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	// actually this'll be on /tmp so it'll be a link
 	target := c.MkDir()
 	c.Assert(pack.CopyToBuildDir(sourceDir, target), IsNil)
@@ -133,7 +134,7 @@ func (s *packSuite) TestCopyCopies(c *C) {
 }
 
 func (s *packSuite) TestCopyActuallyCopies(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, "name: hello")
+	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 
 	// hoping to get the non-linking behaviour via /dev/shm
 	target, err := ioutil.TempDir("/dev/shm", "copy")
@@ -151,7 +152,7 @@ func (s *packSuite) TestCopyActuallyCopies(c *C) {
 }
 
 func (s *packSuite) TestCopyExcludesBackups(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, "name: hello")
+	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	target := c.MkDir()
 	// add a backup file
 	c.Assert(ioutil.WriteFile(filepath.Join(sourceDir, "foo~"), []byte("hi"), 0755), IsNil)
@@ -164,7 +165,7 @@ func (s *packSuite) TestCopyExcludesBackups(c *C) {
 }
 
 func (s *packSuite) TestCopyExcludesTopLevelDEBIAN(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, "name: hello")
+	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	target := c.MkDir()
 	// add a toplevel DEBIAN
 	c.Assert(os.MkdirAll(filepath.Join(sourceDir, "DEBIAN", "foo"), 0755), IsNil)
@@ -181,7 +182,7 @@ func (s *packSuite) TestCopyExcludesTopLevelDEBIAN(c *C) {
 }
 
 func (s *packSuite) TestCopyExcludesWholeDirs(c *C) {
-	sourceDir := makeExampleSnapSourceDir(c, "name: hello")
+	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	target := c.MkDir()
 	// add a file inside a skipped dir
 	c.Assert(os.Mkdir(filepath.Join(sourceDir, ".bzr"), 0755), IsNil)


### PR DESCRIPTION
As I said over in [the forum](https://forum.snapcraft.io/t/3974),

> For historically reasons snapd has been very lax about validation of
> the version string of snaps. However, the time seems right to make it
> consistent with what snapcraft and the review tools check. In doing
> this work we found that those two had diverging opinions on what
> constituted a valid version, so we’ve fixed this as well.

the regexp it validates is now the same between the three projects,
`^[a-zA-Z0-9](?:[a-zA-Z0-9:.+~_-]{0,30}[a-zA-Z0-9+~])?$`.
