### PR TITLE
tests/lib/prepare: disable snapd.refresh.timer

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -38,6 +38,9 @@ disable_refreshes() {
 
     echo "Ensure jq is gone"
     snap remove jq
+
+    echo "Disable refresh timer"
+    systemctl stop snapd.refresh.timer
 }
 
 setup_systemd_snapd_overrides() {


### PR DESCRIPTION
Disable the refresh timer to rule out the possibility of snapd.refresh.service
activating snapd.service while the test setup or teardown step is being
executed.

