### PR TITLE
osutil: parse mount entries without options field

### DIFF
--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -126,8 +126,15 @@ func ParseMountEntry(s string) (MountEntry, error) {
 	var df, cpn int
 	fields := strings.FieldsFunc(s, func(r rune) bool { return r == ' ' || r == '\t' })
 	// do all error checks before any assignments to `e'
-	if len(fields) < 4 || len(fields) > 6 {
-		return e, fmt.Errorf("expected between 4 and 6 fields, found %d", len(fields))
+	if len(fields) < 3 || len(fields) > 6 {
+		return e, fmt.Errorf("expected between 3 and 6 fields, found %d", len(fields))
+	}
+	e.Name = unescape(fields[0])
+	e.Dir = unescape(fields[1])
+	e.Type = unescape(fields[2])
+	// Parse Options if we have at least 4 fields
+	if len(fields) > 3 {
+		e.Options = strings.Split(unescape(fields[3]), ",")
 	}
 	// Parse DumpFrequency if we have at least 5 fields
 	if len(fields) > 4 {
@@ -136,6 +143,7 @@ func ParseMountEntry(s string) (MountEntry, error) {
 			return e, fmt.Errorf("cannot parse dump frequency: %q", fields[4])
 		}
 	}
+	e.DumpFrequency = df
 	// Parse CheckPassNumber if we have at least 6 fields
 	if len(fields) > 5 {
 		cpn, err = strconv.Atoi(fields[5])
@@ -143,11 +151,6 @@ func ParseMountEntry(s string) (MountEntry, error) {
 			return e, fmt.Errorf("cannot parse check pass number: %q", fields[5])
 		}
 	}
-	e.Name = unescape(fields[0])
-	e.Dir = unescape(fields[1])
-	e.Type = unescape(fields[2])
-	e.Options = strings.Split(unescape(fields[3]), ",")
-	e.DumpFrequency = df
 	e.CheckPassNumber = cpn
 	return e, nil
 }

--- a/osutil/mountentry_test.go
+++ b/osutil/mountentry_test.go
@@ -91,6 +91,15 @@ func (s *entrySuite) TestParseMountEntry1(c *C) {
 	c.Assert(e.Options, DeepEquals, []string{"errors=remount-ro"})
 	c.Assert(e.DumpFrequency, Equals, 0)
 	c.Assert(e.CheckPassNumber, Equals, 1)
+
+	e, err = osutil.ParseMountEntry("none /tmp tmpfs")
+	c.Assert(err, IsNil)
+	c.Assert(e.Name, Equals, "none")
+	c.Assert(e.Dir, Equals, "/tmp")
+	c.Assert(e.Type, Equals, "tmpfs")
+	c.Assert(e.Options, IsNil)
+	c.Assert(e.DumpFrequency, Equals, 0)
+	c.Assert(e.CheckPassNumber, Equals, 0)
 }
 
 // Test that options are parsed correctly
@@ -120,10 +129,10 @@ func (s *entrySuite) TestParseMountEntry3(c *C) {
 // Test that number of fields is checked
 func (s *entrySuite) TestParseMountEntry4(c *C) {
 	for _, s := range []string{
-		"", "1", "1 2", "1 2 3" /* skip 4, 5 and 6 fields (valid case) */, "1 2 3 4 5 6 7",
+		"", "1", "1 2" /* skip 3, 4, 5 and 6 fields (valid case) */, "1 2 3 4 5 6 7",
 	} {
 		_, err := osutil.ParseMountEntry(s)
-		c.Assert(err, ErrorMatches, "expected between 4 and 6 fields, found [01237]")
+		c.Assert(err, ErrorMatches, "expected between 3 and 6 fields, found [01237]")
 	}
 }
 


### PR DESCRIPTION
As the name indicates, the options field is *optional* and should not
break parsing. Thanks to John for running into the problem and for
pointing it out.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
