### PR TITLE
interfaces/apparmor: ensure snap-confine profile for reexec is current

### DIFF
--- a/interfaces/apparmor/apparmor.go
+++ b/interfaces/apparmor/apparmor.go
@@ -42,9 +42,20 @@ import (
 // If no such profile was previously loaded then it is simply added to the kernel.
 // If there was a profile with the same name before, that profile is replaced.
 func LoadProfile(fname string) error {
+	return loadProfile(fname, dirs.AppArmorCacheDir)
+}
+
+// UnloadProfile removes the named profile from the running kernel.
+//
+// The operation is done with: apparmor_parser --remove $name
+// The binary cache file is removed from /var/cache/apparmor
+func UnloadProfile(name string) error {
+	return unloadProfile(name, dirs.AppArmorCacheDir)
+}
+
+func loadProfile(fname, cacheDir string) error {
 	// Use no-expr-simplify since expr-simplify is actually slower on armhf (LP: #1383858)
-	args := []string{"--replace", "--write-cache", "-O", "no-expr-simplify",
-		fmt.Sprintf("--cache-loc=%s", dirs.AppArmorCacheDir)}
+	args := []string{"--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s", cacheDir)}
 	if !osutil.GetenvBool("SNAPD_DEBUG") {
 		args = append(args, "--quiet")
 	}
@@ -57,16 +68,12 @@ func LoadProfile(fname string) error {
 	return nil
 }
 
-// UnloadProfile removes the named profile from the running kernel.
-//
-// The operation is done with: apparmor_parser --remove $name
-// The binary cache file is removed from /var/cache/apparmor
-func UnloadProfile(name string) error {
+func unloadProfile(name, cacheDir string) error {
 	output, err := exec.Command("apparmor_parser", "--remove", name).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("cannot unload apparmor profile: %s\napparmor_parser output:\n%s", err, string(output))
 	}
-	err = os.Remove(filepath.Join(dirs.AppArmorCacheDir, name))
+	err = os.Remove(filepath.Join(cacheDir, name))
 	// It is not an error if the cache file wasn't there to remove.
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("cannot remove apparmor profile cache: %s", err)

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -217,6 +217,18 @@ func setupSnapConfineReexec(coreInfo *snap.Info) error {
 	}
 
 	changed, removed, errEnsure := osutil.EnsureDirState(dir, glob, content)
+	if len(changed) == 0 {
+		// XXX: because NFS workaround is handled separately the same correct
+		// snap-confine profile may need to be re-loaded. This is because the
+		// profile contains include directives and those load a second file
+		// that has changed outside of the scope of EnsureDirState.
+		//
+		// To counter that, always reload the profile by pretending it had
+		// changed.
+		for fname := range content {
+			changed = append(changed, fname)
+		}
+	}
 	errReload := reloadProfiles(changed, dir, cache)
 	errUnload := unloadProfiles(removed, cache)
 	if errEnsure != nil {

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -410,6 +410,7 @@ func unloadProfiles(profiles []string) error {
 	return nil
 }
 
+// NewSpecification returns a new, empty apparmor specification.
 func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -290,8 +290,8 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		all = append(all, name)
 	}
 	sort.Strings(all)
-	errReload := reloadProfiles(all)
-	errUnload := unloadProfiles(removed)
+	errReload := reloadProfiles(all, dirs.SnapAppArmorDir, dirs.AppArmorCacheDir)
+	errUnload := unloadProfiles(removed, dirs.AppArmorCacheDir)
 	if errEnsure != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, errEnsure)
 	}
@@ -305,7 +305,7 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 func (b *Backend) Remove(snapName string) error {
 	glob := fmt.Sprintf("snap*.%s*", snapName)
 	_, removed, errEnsure := osutil.EnsureDirState(dirs.SnapAppArmorDir, glob, nil)
-	errUnload := unloadProfiles(removed)
+	errUnload := unloadProfiles(removed, dirs.AppArmorCacheDir)
 	if errEnsure != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, errEnsure)
 	}
@@ -390,10 +390,9 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 	}
 }
 
-func reloadProfiles(profiles []string) error {
+func reloadProfiles(profiles []string, profileDir, cacheDir string) error {
 	for _, profile := range profiles {
-		fname := filepath.Join(dirs.SnapAppArmorDir, profile)
-		err := LoadProfile(fname)
+		err := loadProfile(filepath.Join(profileDir, profile), cacheDir)
 		if err != nil {
 			return fmt.Errorf("cannot load apparmor profile %q: %s", profile, err)
 		}
@@ -401,9 +400,9 @@ func reloadProfiles(profiles []string) error {
 	return nil
 }
 
-func unloadProfiles(profiles []string) error {
+func unloadProfiles(profiles []string, cacheDir string) error {
 	for _, profile := range profiles {
-		if err := UnloadProfile(profile); err != nil {
+		if err := unloadProfile(profile, cacheDir); err != nil {
 			return fmt.Errorf("cannot unload apparmor profile %q: %s", profile, err)
 		}
 	}

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -69,7 +69,7 @@ while [ -n "$1" ]; do
 		--write-cache)
 			write=yes
 			;;
-		--replace|--remove)
+		--quiet|--replace|--remove)
 			# Ignore
 			;;
 		-O)
@@ -414,11 +414,7 @@ const coreYaml = `name: core
 version: 1
 `
 
-func (s *backendSuite) TestSnapConfineProfile(c *C) {
-	// Let's say we're working with the core snap at revision 111.
-	coreInfo := snaptest.MockInfo(c, coreYaml, &snap.SideInfo{Revision: snap.R(111)})
-
-	// The apparmor profile would normally be here. Let's write one there.
+func (s *backendSuite) writeVanillaSnapConfineProfile(c *C, coreInfo *snap.Info) {
 	vanillaProfilePath := filepath.Join(coreInfo.MountDir(), "/etc/apparmor.d/usr.lib.snapd.snap-confine.real")
 	vanillaProfileText := []byte(`#include <tunables/global>
 /usr/lib/snapd/snap-confine (attach_disconnected) {
@@ -427,10 +423,15 @@ func (s *backendSuite) TestSnapConfineProfile(c *C) {
     /etc/ld.so.cache r,
 }
 `)
-	//c.Assert(os.MkdirAll(dirs.SystemApparmorDir, 0755), IsNil)
+	c.Assert(os.MkdirAll(dirs.SystemApparmorDir, 0755), IsNil)
 	c.Assert(os.MkdirAll(filepath.Dir(vanillaProfilePath), 0755), IsNil)
 	c.Assert(ioutil.WriteFile(vanillaProfilePath, vanillaProfileText, 0644), IsNil)
+}
 
+func (s *backendSuite) TestSnapConfineProfile(c *C) {
+	// Let's say we're working with the core snap at revision 111.
+	coreInfo := snaptest.MockInfo(c, coreYaml, &snap.SideInfo{Revision: snap.R(111)})
+	s.writeVanillaSnapConfineProfile(c, coreInfo)
 	// We expect to see the same profile, just anchored at a different directory.
 	expectedProfileDir := filepath.Join(dirs.GlobalRootDir, "/etc/apparmor.d")
 	expectedProfileName := strings.Replace(filepath.Join(coreInfo.MountDir(), "usr/lib/snapd/snap-confine")[1:], "/", ".", -1)
@@ -464,6 +465,9 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecCleans(c *C) {
 	restorer = release.MockForcedDevmode(false)
 	defer restorer()
 
+	coreInfo := snaptest.MockInfo(c, coreYaml, &snap.SideInfo{Revision: snap.R(111)})
+	s.writeVanillaSnapConfineProfile(c, coreInfo)
+
 	canaryName := strings.Replace(filepath.Join(dirs.SnapMountDir, "/core/2718/usr/lib/snapd/snap-confine"), "/", ".", -1)[1:]
 	canary := filepath.Join(dirs.SystemApparmorDir, canaryName)
 	err := os.MkdirAll(filepath.Dir(canary), 0755)
@@ -475,8 +479,8 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecCleans(c *C) {
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, coreYaml, 111)
 
 	c.Check(osutil.FileExists(canary), Equals, false)
-	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "-R", canaryName},
+	c.Check(s.parserCmd.Calls(), testutil.DeepContains, []string{
+		"apparmor_parser", "--remove", canaryName,
 	})
 }
 
@@ -486,29 +490,8 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 	restorer = release.MockForcedDevmode(false)
 	defer restorer()
 
-	cmd := testutil.MockCommand(c, "apparmor_parser", "")
-	defer cmd.Restore()
-
-	var mockAA = []byte(`# Author: Jamie Strandboge <jamie@canonical.com>
-#include <tunables/global>
-
-/usr/lib/snapd/snap-confine (attach_disconnected) {
-    # We run privileged, so be fanatical about what we include and don't use
-    # any abstractions
-    /etc/ld.so.cache r,
-}
-`)
-
-	err := os.MkdirAll(dirs.SystemApparmorDir, 0755)
-	c.Assert(err, IsNil)
-
-	// meh, the paths/filenames are all complicated :/
-	coreRoot := filepath.Join(dirs.SnapMountDir, "/core/111")
-	snapConfineApparmorInCore := filepath.Join(coreRoot, "/etc/apparmor.d/usr.lib.snapd.snap-confine.real")
-	err = os.MkdirAll(filepath.Dir(snapConfineApparmorInCore), 0755)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(snapConfineApparmorInCore, mockAA, 0644)
-	c.Assert(err, IsNil)
+	coreInfo := snaptest.MockInfo(c, coreYaml, &snap.SideInfo{Revision: snap.R(111)})
+	s.writeVanillaSnapConfineProfile(c, coreInfo)
 
 	// install the new core snap on classic triggers a new snap-confine
 	// for this snap-confine on core
@@ -516,7 +499,6 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 
 	newAA, err := filepath.Glob(filepath.Join(dirs.SystemApparmorDir, "*"))
 	c.Assert(err, IsNil)
-
 	c.Assert(newAA, HasLen, 1)
 	c.Check(newAA[0], Matches, `.*/etc/apparmor.d/.*.snap.core.111.usr.lib.snapd.snap-confine`)
 
@@ -525,9 +507,7 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 	// this is the key, rewriting "/usr/lib/snapd/snap-confine
 	c.Check(string(content), testutil.Contains, "/snap/core/111/usr/lib/snapd/snap-confine (attach_disconnected) {")
 	// no other changes other than that to the input
-	c.Check(string(content), Equals, fmt.Sprintf(`# Author: Jamie Strandboge <jamie@canonical.com>
-#include <tunables/global>
-
+	c.Check(string(content), Equals, fmt.Sprintf(`#include <tunables/global>
 %s/core/111/usr/lib/snapd/snap-confine (attach_disconnected) {
     # We run privileged, so be fanatical about what we include and don't use
     # any abstractions
@@ -535,14 +515,14 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 }
 `, dirs.SnapMountDir))
 
-	c.Check(cmd.Calls(), DeepEquals, [][]string{
-		{"apparmor_parser", "--replace", "--write-cache", newAA[0], "--cache-loc", dirs.SystemApparmorCacheDir},
-	})
+	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{{
+		"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify",
+		fmt.Sprintf("--cache-loc=%s", dirs.SystemApparmorCacheDir), "--quiet", newAA[0],
+	}})
 
 	// snap-confine directory was created
 	_, err = os.Stat(dirs.SnapConfineAppArmorDir)
 	c.Check(err, IsNil)
-
 }
 
 func (s *backendSuite) TestCoreOnCoreCleansApparmorCache(c *C) {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -410,7 +410,7 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 	}
 }
 
-var coreYaml string = `name: core
+const coreYaml = `name: core
 version: 1
 `
 

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -25,6 +25,10 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
+var (
+	SnapConfineFromCoreProfile = snapConfineFromCoreProfile
+)
+
 // MockProcSelfExe mocks the location of /proc/self/exe read by setupSnapConfineGeneratedPolicy.
 func MockProcSelfExe(symlink string) (restore func()) {
 	old := procSelfExe


### PR DESCRIPTION
This branch changes how snap-confine apparmor profile for re-execution is
generated. Before we would only consider the generating and loading profile if
it was absent. Now the logic is split into "generate" and "ensure" stages. The
generate stage is fully functional, depending only on the snap.Info of the
desired core snap. The ensure stage is far simplified as it got reduced to the
ensure-dir-state + load/unload calls that are already done by the apparmor
backend.

The branch contains some misc cleanups and generalisation of the apparmor
helper functions.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>