### PR TITLE
tests/main/ubuntu-core-services: enable snapd.refresh.timer for the test

### DIFF
--- a/tests/main/ubuntu-core-services/task.yaml
+++ b/tests/main/ubuntu-core-services/task.yaml
@@ -2,6 +2,10 @@ summary: Ensure all services on Core are active
 
 systems: [ubuntu-core-*]
 
+prepare: |
+    # the timer is disabled by default to not interfere with the
+    # tests and  cleanups
+    systemctl start snapd.refresh.timer
 execute: |
     echo "Ensure one-shot services are working"
     for oneshot in snapd.autoimport.service snapd.sshd-keygen.service; do
@@ -15,3 +19,5 @@ execute: |
     for timer in snapd.refresh.timer snapd.snap-repair.timer; do
         systemctl is-active $timer
     done
+restore: |
+    systemctl stop snapd.refresh.timer


### PR DESCRIPTION
snapd.refresh.timer is stopped in project prepare so that it does not interfere
with tests or the cleanup. We need to explicitly start if for the purpose of
this test.
