### PR TITLE
store: revert PR#4532 and do not display displayname

### DIFF
--- a/store/details.go
+++ b/store/details.go
@@ -39,13 +39,15 @@ type snapDetails struct {
 	LastUpdated      string             `json:"last_updated,omitempty"`
 	Name             string             `json:"package_name"`
 	Prices           map[string]float64 `json:"prices,omitempty"`
-	Publisher        string             `json:"publisher,omitempty"`
-	RatingsAverage   float64            `json:"ratings_average,omitempty"`
-	Revision         int                `json:"revision"` // store revisions are ints starting at 1
-	ScreenshotURLs   []string           `json:"screenshot_urls,omitempty"`
-	SnapID           string             `json:"snap_id"`
-	License          string             `json:"license,omitempty"`
-	Base             string             `json:"base,omitempty"`
+	// Note that the publisher is really the "display name" of the
+	// publisher
+	Publisher      string   `json:"publisher,omitempty"`
+	RatingsAverage float64  `json:"ratings_average,omitempty"`
+	Revision       int      `json:"revision"` // store revisions are ints starting at 1
+	ScreenshotURLs []string `json:"screenshot_urls,omitempty"`
+	SnapID         string   `json:"snap_id"`
+	License        string   `json:"license,omitempty"`
+	Base           string   `json:"base,omitempty"`
 
 	// FIXME: the store should send "contact" here, once it does we
 	//        can remove support_url

--- a/store/store.go
+++ b/store/store.go
@@ -96,9 +96,16 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.EditedTitle = d.Title
 	info.EditedSummary = d.Summary
 	info.EditedDescription = d.Description
-	// FIXME: should this be publisherID?
+	// Note that the store side is using confusing terminology here.
+	// What the store calls "developer" is actually the publisher
+	// username.
+	//
+	// It also sends "publisher" which is the "publisher display name"
+	// which we cannot use currently because it is not validated
+	// (i.e. the publisher could put anything in there and mislead
+	// the users this way).
+	info.Publisher = d.Developer
 	info.PublisherID = d.DeveloperID
-	info.Publisher = d.Publisher
 	info.Channel = d.Channel
 	info.Sha3_384 = d.DownloadSha3_384
 	info.Size = d.DownloadSize

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2003,7 +2003,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(result.Architectures, DeepEquals, []string{"all"})
 	c.Check(result.Revision, Equals, snap.R(27))
 	c.Check(result.SnapID, Equals, helloWorldSnapID)
-	c.Check(result.Publisher, Equals, "Canonical")
+	c.Check(result.Publisher, Equals, "canonical")
 	c.Check(result.Version, Equals, "6.3")
 	c.Check(result.Sha3_384, Matches, `[[:xdigit:]]{96}`)
 	c.Check(result.Size, Equals, int64(20480))

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -133,7 +133,7 @@ check("error", res[5],
 # not installed snaps have "contact" information
 check("test-snapd-python-webserver", res[6],
    ("name", equals, "test-snapd-python-webserver"),
-   ("publisher", equals, "Canonical"),
+   ("publisher", equals, "canonical"),
    ("contact", equals, "snappy-canonical-storeaccount@canonical.com"),
    ("summary", exists),
    ("description", exists),


### PR DESCRIPTION
The current store API is sending data with a confusing terminology.
What is called "developer" in the API is in reality the publisher
username.

This unfixes https://bugs.launchpad.net/ubuntu/+source/gnome-software/+bug/1742637