### PR TITLE
osutil: reimplement IsMounted with LoadMountInfo

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -51,13 +51,6 @@ func MockSudoersDotD(mockDir string) func() {
 	return func() { sudoersDotD = realSudoersD }
 }
 
-func MockMountInfoPath(mockMountInfoPath string) func() {
-	realMountInfoPath := mountInfoPath
-	mountInfoPath = mockMountInfoPath
-
-	return func() { mountInfoPath = realMountInfoPath }
-}
-
 func MockSyscallKill(f func(int, syscall.Signal) error) func() {
 	oldSyscallKill := syscallKill
 	syscallKill = f


### PR DESCRIPTION
We now have full mountinfo parser available at our disposal so
we don't need a second implementation around.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
