### PR TITLE
interfaces/mount: generate per-user mount profiles

### DIFF
--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -90,38 +90,30 @@ func (b *Backend) Remove(snapName string) error {
 	return nil
 }
 
+// addMountProfile adds a mount profile with the given name, based on the given entries.
+//
+// If there are no entries no profile is generated.
+func addMountProfile(content map[string]*osutil.FileState, fname string, entries []osutil.MountEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	var buffer bytes.Buffer
+	for _, entry := range entries {
+		fmt.Fprintf(&buffer, "%s\n", entry)
+	}
+	content[fname] = &osutil.FileState{Content: buffer.Bytes(), Mode: 0644}
+}
+
 // deriveContent computes .fstab tables based on requests made to the specification.
 func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.FileState {
 	content := make(map[string]*osutil.FileState, 2)
-	mountEntries := spec.MountEntries()
-	userMountEntries := spec.UserMountEntries()
 	snapName := snapInfo.Name()
-
-	if len(mountEntries) != 0 {
-		// Compute the contents of the fstab file. It should
-		// contain all the mount rules collected by the
-		// backend controller.
-		var buffer bytes.Buffer
-		for _, entry := range mountEntries {
-			fmt.Fprintf(&buffer, "%s\n", entry)
-		}
-		fstate := &osutil.FileState{Content: buffer.Bytes(), Mode: 0644}
-		// Add the per-snap fstab file. This file is read by
-		// snap-update-ns in the global pass.
-		content[fmt.Sprintf("snap.%s.fstab", snapName)] = fstate
-	}
-
-	if len(userMountEntries) != 0 {
-		// Compute the contents of the user-fstab file.
-		var buffer bytes.Buffer
-		for _, entry := range userMountEntries {
-			fmt.Fprintf(&buffer, "%s\n", entry)
-		}
-		fstate := &osutil.FileState{Content: buffer.Bytes(), Mode: 0644}
-		// Add the per-snap user-fstab file. This file will be
-		// read by snap-update-ns in the per-user pass.
-		content[fmt.Sprintf("snap.%s.user-fstab", snapName)] = fstate
-	}
+	// Add the per-snap fstab file.
+	// This file is read by snap-update-ns in the global pass.
+	addMountProfile(content, fmt.Sprintf("snap.%s.fstab", snapName), spec.MountEntries())
+	// Add the per-snap user-fstab file.
+	// This file will be read by snap-update-ns in the per-user pass.
+	addMountProfile(content, fmt.Sprintf("snap.%s.user-fstab", snapName), spec.UserMountEntries())
 	return content
 }
 

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -127,10 +127,14 @@ slots:
 func (s *backendSuite) TestSetupSetsupSimple(c *C) {
 	fsEntry1 := osutil.MountEntry{Name: "/src-1", Dir: "/dst-1", Type: "none", Options: []string{"bind", "ro"}, DumpFrequency: 0, CheckPassNumber: 0}
 	fsEntry2 := osutil.MountEntry{Name: "/src-2", Dir: "/dst-2", Type: "none", Options: []string{"bind", "ro"}, DumpFrequency: 0, CheckPassNumber: 0}
+	fsEntry3 := osutil.MountEntry{Name: "/src-3", Dir: "/dst-3", Type: "none", Options: []string{"bind", "ro"}, DumpFrequency: 0, CheckPassNumber: 0}
 
 	// Give the plug a permanent effect
 	s.Iface.MountPermanentPlugCallback = func(spec *mount.Specification, plug *snap.PlugInfo) error {
-		return spec.AddMountEntry(fsEntry1)
+		if err := spec.AddMountEntry(fsEntry1); err != nil {
+			return err
+		}
+		return spec.AddUserMountEntry(fsEntry3)
 	}
 	// Give the slot a permanent effect
 	s.iface2.MountPermanentSlotCallback = func(spec *mount.Specification, slot *snap.SlotInfo) error {
@@ -151,6 +155,12 @@ func (s *backendSuite) TestSetupSetsupSimple(c *C) {
 	got := strings.Split(string(content), "\n")
 	sort.Strings(got)
 	c.Check(got, DeepEquals, expected)
+
+	// Check that the user-fstab file was written with the user mount
+	fn = filepath.Join(dirs.SnapMountPolicyDir, "snap.snap-name.user-fstab")
+	content, err = ioutil.ReadFile(fn)
+	c.Assert(err, IsNil, Commentf("Expected user mount profile for the whole snap"))
+	c.Check(string(content), Equals, fsEntry3.String()+"\n")
 }
 
 func (s *backendSuite) TestSetupSetsupWithoutDir(c *C) {


### PR DESCRIPTION
This patch complements the mount specification change and allows the
backend to create per-user mount profiles. The profiles look exactly
the same as the global profiles but are designed to be processed
in a new stage, coming in an upcoming change in snap-update-ns and
snap-confine.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
