### PR TITLE
packaging: fix build on sbuild

### DIFF
--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -141,6 +141,8 @@ endif
 
 	# ensure snap-seccomp is build with a static libseccomp on Ubuntu
 ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
+	# (static linking on powerpc with cgo is broken)
+ ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),powerpc)
 	sed -i "s|#cgo LDFLAGS:|#cgo LDFLAGS: /usr/lib/$(shell dpkg-architecture -qDEB_TARGET_MULTIARCH)/libseccomp.a|" _build/src/$(DH_GOPKG)/cmd/snap-seccomp/main.go
 	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_LDFLAGS_ALLOW="/.*/libseccomp.a" go build $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-seccomp)
 	# ensure that libseccomp is not dynamically linked
@@ -148,7 +150,7 @@ ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
 	test "$$(ldd _build/bin/snap-seccomp | grep libseccomp)" = ""
 	# revert again so that the subsequent tests work
 	sed -i "s|#cgo LDFLAGS: /usr/lib/$(shell dpkg-architecture -qDEB_TARGET_MULTIARCH)/libseccomp.a|#cgo LDFLAGS:|" _build/src/$(DH_GOPKG)/cmd/snap-seccomp/main.go
-
+ endif
 endif
 
 	# Build C bits, sadly manually

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -146,6 +146,9 @@ ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
 	# ensure that libseccomp is not dynamically linked
 	ldd _build/bin/snap-seccomp
 	test "$$(ldd _build/bin/snap-seccomp | grep libseccomp)" = ""
+	# revert again so that the subsequent tests work
+	sed -i "s|#cgo LDFLAGS: /usr/lib/$(shell dpkg-architecture -qDEB_TARGET_MULTIARCH)/libseccomp.a|#cgo LDFLAGS:|" _build/src/$(DH_GOPKG)/cmd/snap-seccomp/main.go
+
 endif
 
 	# Build C bits, sadly manually


### PR DESCRIPTION
This PR contains two fixes:
- do not try to static link on powerpc, that is broken
- revert the rewrite of LDFLAGS after snap-seccomp was build (otherwise the subsequent unit tests will fail because they will try to build snap-seccomp again for testing and that will choke on the LDFLAGS line)