### PR TITLE
timeutil: fix scheduling on nth weekday of the month

### DIFF
--- a/timeutil/schedule.go
+++ b/timeutil/schedule.go
@@ -129,24 +129,38 @@ func (ws WeekSpan) String() string {
 	return ws.Start.String()
 }
 
+func findNthWeekDay(t time.Time, weekday time.Weekday, nthInMonth uint) time.Time {
+	// move to the beginning of the month
+	t = t.AddDate(0, 0, -t.Day()+1)
+
+	for nth := uint(0); t.Weekday() != weekday || nth != nthInMonth; {
+		t = t.Add(24 * time.Hour)
+		if t.Weekday() == weekday {
+			nth++
+		}
+	}
+	return t
+}
+
 // Match checks if t is within the day span represented by ws.
 func (ws WeekSpan) Match(t time.Time) bool {
 	start, end := ws.Start, ws.End
 	wdStart, wdEnd := start.Weekday, end.Weekday
 
 	if start.Pos != EveryWeek {
-		// is it the right week?
-		week := uint(t.Day()/7) + 1
-
 		if start.Pos == LastWeek {
 			// last week of the month
 			if !isLastWeekdayInMonth(t) {
 				return false
 			}
 		} else {
-			if week < start.Pos || week > end.Pos {
+			startDay := findNthWeekDay(t, start.Weekday, start.Pos)
+			endDay := findNthWeekDay(t, end.Weekday, end.Pos)
+
+			if t.Day() < startDay.Day() || t.Day() > endDay.Day() {
 				return false
 			}
+			return true
 		}
 	}
 

--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -539,6 +539,35 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 			// from now
 			next: "503h-503h",
 		}, {
+			// from last Monday of the month to the Tuesday of
+			// the month, at 10:00
+			schedule: "mon1-tue2,10:00",
+			// Sunday, 22:00
+			last: "2017-02-06 10:00",
+			// first Monday of the month
+			now: "2017-02-07 11:00",
+			// expecting to run the next day at 10:00
+			next: "23h-23h",
+		}, {
+			// from last Monday of the month to the Tuesday of
+			// the month, at 10:00
+			schedule: "mon1-tue2,10:00",
+			last:     "2017-02-01 10:00",
+			// Sunday, 10:00
+			now: "2017-02-05 10:00",
+			// expecting to run the next day at 10:00
+			next: "24h-24h",
+		}, {
+			// from last Monday of the month to the second Tuesday of
+			// the month, at 10:00
+			schedule: "mon1-tue2,10:00",
+			// Sunday, 22:00
+			last: "2017-02-14 22:00",
+			// Thursday, 10:00
+			now: "2017-02-16 10:00",
+			// expecting to run in 18 days
+			next: "432h-432h",
+		}, {
 			// from last Monday of the month to the second Tuesday of
 			// the month, at 10:00
 			schedule: "mon1-tue2,10:00",

--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -519,7 +519,7 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 		}, {
 			// second Monday of the month, at 10:00
 			schedule: "mon2,10:00",
-			// first Monday of the month, 9:00
+			// first Monday of the month, 10:00
 			last: "2017-02-06 10:00",
 			// first Monday of the month, 11:00, right after
 			// 'previous first Monday' run
@@ -530,7 +530,7 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 		}, {
 			// last Monday of the month, at 10:00
 			schedule: "mon5,10:00",
-			// first Monday of the month, 9:00
+			// first Monday of the month, 10:00
 			last: "2017-02-06 10:00",
 			// first Monday of the month, 11:00, right after
 			// 'previous first Monday' run
@@ -539,17 +539,17 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 			// from now
 			next: "503h-503h",
 		}, {
-			// from last Monday of the month to the Tuesday of
+			// from the first Monday of the month to the second Tuesday of
 			// the month, at 10:00
 			schedule: "mon1-tue2,10:00",
-			// Sunday, 22:00
+			// Monday, 10:00
 			last: "2017-02-06 10:00",
-			// first Monday of the month
+			// Tuesday, the day after the first Monday of the month
 			now: "2017-02-07 11:00",
 			// expecting to run the next day at 10:00
 			next: "23h-23h",
 		}, {
-			// from last Monday of the month to the Tuesday of
+			// from the first Monday of the month to the second Tuesday of
 			// the month, at 10:00
 			schedule: "mon1-tue2,10:00",
 			last:     "2017-02-01 10:00",
@@ -558,17 +558,17 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 			// expecting to run the next day at 10:00
 			next: "24h-24h",
 		}, {
-			// from last Monday of the month to the second Tuesday of
+			// from the first Monday of the month to the second Tuesday of
 			// the month, at 10:00
 			schedule: "mon1-tue2,10:00",
-			// Sunday, 22:00
+			// Tuesday, 10:00
 			last: "2017-02-14 22:00",
 			// Thursday, 10:00
 			now: "2017-02-16 10:00",
 			// expecting to run in 18 days
 			next: "432h-432h",
 		}, {
-			// from last Monday of the month to the second Tuesday of
+			// from the first Monday of the month to the second Tuesday of
 			// the month, at 10:00
 			schedule: "mon1-tue2,10:00",
 			// Sunday, 22:00
@@ -578,7 +578,7 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 			// expecting to run the next day at 10:00
 			next: "23h-23h",
 		}, {
-			// from last Monday of the month to the second Tuesday of
+			// from the first Monday of the month to the second Tuesday of
 			// the month, at 10:00
 			schedule: "mon1-tue2,10:00-12:00",
 			// Sunday, 22:00
@@ -588,7 +588,7 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 			// expecting to run now
 			next: "0h-0h",
 		}, {
-			// from last Monday of the month to the second Tuesday of
+			// from the first Monday of the month to the second Tuesday of
 			// the month, at 10:00
 			schedule: "mon1-tue2,10:00~12:00",
 			// Sunday, 22:00


### PR DESCRIPTION
The patch fixes scheduling on nth weekdays of the month. In particular checking
if the date being tested really is the nth occurrence of given weekday weekday
and whether if properly falls into range between nth weekdays.

Consider Feb 2017:
```
       February 2017
   Su Mo Tu We Th Fr Sa
             1  2  3  4
    5  6  7  8  9 10 11
   12 13 14 15 16 17 18
   19 20 21 22 23 24 25
   26 27 28
```
Schedule 'mon1-tue2' would incorrectly include dates 01-05.02, because they are
in the 1st week of the month, but not do not meet the schedule as they are not
'after' the first Monday of the month. Also dates 07-14.02 would be incorrectly
excluded as they are 'after' Tuesday in the 2nd week of the month, while in fact
the dates fall within the range of the schedule as they precede the 2nd Tuesday
of the month.

Address this by changing how the week-span checks are performed. In detail,
replace a simple week-count check with actually finding the nth occurrence of
given weekday in a month,
