### PR TITLE
systemd: add default target for timers

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -126,6 +126,9 @@ const (
 
 	// the default target for systemd socket units that we generate
 	SocketsTarget = "sockets.target"
+
+	// the default target for systemd timer units that we generate
+	TimersTarget = "timers.target"
 )
 
 type reporter interface {


### PR DESCRIPTION
Add a const for the default target for *.timers. To be used as a value in
`WantedBy` in timer units.
