### PR TITLE
snap: pass full timer spec in `snap run --timer`

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -603,6 +603,9 @@ func (app *AppInfo) launcherCommand(command string) string {
 
 // LauncherCommand returns the launcher command line to use when invoking the app binary.
 func (app *AppInfo) LauncherCommand() string {
+	if app.Timer != nil {
+		return app.launcherCommand(fmt.Sprintf("--timer=%q", app.Timer.Timer))
+	}
 	return app.launcherCommand("")
 }
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -152,6 +152,9 @@ apps:
      command: foo-bin
    bar:
      command: bar-bin -x
+   baz:
+     command: bar-bin -x
+     timer: 10:00-12:00,,mon,12:00~14:00
 `))
 	c.Assert(err, IsNil)
 	info.Revision = snap.R(42)
@@ -160,6 +163,7 @@ apps:
 	c.Check(info.Apps["bar"].LauncherReloadCommand(), Equals, "/usr/bin/snap run --command=reload foo.bar")
 	c.Check(info.Apps["bar"].LauncherPostStopCommand(), Equals, "/usr/bin/snap run --command=post-stop foo.bar")
 	c.Check(info.Apps["foo"].LauncherCommand(), Equals, "/usr/bin/snap run foo")
+	c.Check(info.Apps["baz"].LauncherCommand(), Equals, `/usr/bin/snap run --timer="10:00-12:00,,mon,12:00~14:00" foo.baz`)
 }
 
 const sampleYaml = `


### PR DESCRIPTION
`snap run --timer` expects a full timer specification to be passed in the
command line.

Related `snap` command change is #4677 

