### PR TITLE
interfaces/time-control,netlink-audit: adjust for util-linux compiled with libaudit - 2.31

### DIFF
--- a/interfaces/builtin/netlink_audit.go
+++ b/interfaces/builtin/netlink_audit.go
@@ -45,6 +45,10 @@ capability net_admin,
 # CAP_AUDIT_READ required to read the audit log via the netlink multicast socket
 # per 'man 7 capabilities'
 capability audit_read,
+
+# CAP_AUDIT_WRITE required to write to the audit log via the netlink multicast
+# socket per 'man 7 capabilities'
+capability audit_write,
 `
 
 func init() {

--- a/interfaces/builtin/netlink_audit_test.go
+++ b/interfaces/builtin/netlink_audit_test.go
@@ -23,8 +23,8 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"

--- a/interfaces/builtin/netlink_audit_test.go
+++ b/interfaces/builtin/netlink_audit_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -81,12 +82,20 @@ func (s *NetlinkAuditInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 }
 
-func (s *NetlinkAuditInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	seccompSpec := &seccomp.Specification{}
-	err := seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+func (s *NetlinkAuditInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
-	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
-	c.Check(seccompSpec.SnippetForTag("snap.other.app2"), testutil.Contains, "socket AF_NETLINK - NETLINK_AUDIT\n")
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "capability audit_write,\n")
+}
+
+func (s *NetlinkAuditInterfaceSuite) TestSecCompSpec(c *C) {
+	spec := &seccomp.Specification{}
+	err := spec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.other.app2"})
+	c.Check(spec.SnippetForTag("snap.other.app2"), testutil.Contains, "socket AF_NETLINK - NETLINK_AUDIT\n")
 }
 
 func (s *NetlinkAuditInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -97,8 +97,8 @@ capability sys_time,
 # clients to use it now that they have access to the relevant
 # device nodes. Note: some invocations of hwclock will try to
 # write to the audit subsystem. We omit 'capability audit_write'
-# and 'capability net_admin' here. Applications requiring
-# logging should plugs 'netlink-audit'.
+# and 'capability net_admin' here. Applications requiring audit
+# logging should plug 'netlink-audit'.
 /sbin/hwclock ixr,
 `
 

--- a/interfaces/builtin/time_control.go
+++ b/interfaces/builtin/time_control.go
@@ -95,8 +95,24 @@ capability sys_time,
 
 # As the core snap ships the hwclock utility we can also allow
 # clients to use it now that they have access to the relevant
-# device nodes.
+# device nodes. Note: some invocations of hwclock will try to
+# write to the audit subsystem. We omit 'capability audit_write'
+# and 'capability net_admin' here. Applications requiring
+# logging should plugs 'netlink-audit'.
 /sbin/hwclock ixr,
+`
+
+const timeControlConnectedPlugSecComp = `
+# Description: Can set time and date via systemd' timedated D-Bus interface.
+# Can read all properties of /org/freedesktop/timedate1 D-Bus object; see
+# https://www.freedesktop.org/wiki/Software/systemd/timedated/; This also
+# gives full access to the RTC device nodes and relevant parts of sysfs.
+
+# util-linux built with libaudit tries to write to the audit subsystem. We
+# allow the socket call here to avoid seccomp kill, but omit the AppArmor
+# capability rules.
+bind
+socket AF_NETLINK - NETLINK_AUDIT
 `
 
 var timeControlConnectedPlugUDev = []string{`SUBSYSTEM=="rtc"`}
@@ -109,6 +125,7 @@ func init() {
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  timeControlBaseDeclarationSlots,
 		connectedPlugAppArmor: timeControlConnectedPlugAppArmor,
+		connectedPlugSecComp:  timeControlConnectedPlugSecComp,
 		connectedPlugUDev:     timeControlConnectedPlugUDev,
 		reservedForOS:         true,
 	})

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
@@ -83,6 +84,13 @@ func (s *TimeControlInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "org/freedesktop/timedate1")
+}
+
+func (s *TimeControlInterfaceSuite) TestSecCompSpec(c *C) {
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Check(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "socket AF_NETLINK - NETLINK_AUDIT")
 }
 
 func (s *TimeControlInterfaceSuite) TestUDevSpec(c *C) {

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
-	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -94,6 +94,9 @@ update_core_snap_for_classic_reexec() {
     cp -a "$LIBEXECDIR"/snapd/* squashfs-root/usr/lib/snapd/
     # also the binaries themselves
     cp -a /usr/bin/{snap,snapctl} squashfs-root/usr/bin/
+    # clean and install the udev helper
+    rm -f squashfs-root//lib/udev/snappy-app-dev
+    cp -a /lib/udev/snappy-app-dev squashfs-root/lib/udev/
 
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)

--- a/tests/lib/snaps/test-snapd-timedate-control-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-timedate-control-consumer/meta/snap.yaml
@@ -15,4 +15,4 @@ apps:
         plugs: [timezone-control]
     hwclock-time:
         command: bin/hwclock
-        plugs: [time-control]
+        plugs: [time-control, netlink-audit]

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -25,13 +25,18 @@ execute: |
     CONNECTED_PATTERN=":time-control +test-snapd-timedate-control-consumer"
     DISCONNECTED_PATTERN="\- +test-snapd-timedate-control-consumer:time-control"
 
+    # hwclock with libaudit (ie, core 16) also needs netlink-audit connected.
+    # This interface is tested elsewhere, so simply connect it here so we can
+    # test the time-control interface in isolation.
+    snap connect test-snapd-timedate-control-consumer:netlink-audit
+
     # Check the interface is disconnected by detault
     snap interfaces | MATCH "$DISCONNECTED_PATTERN"
 
     # Connect the interface and check it is connected
     snap connect test-snapd-timedate-control-consumer:time-control
     snap interfaces | MATCH "$CONNECTED_PATTERN"
-    
+
     # Read/write to hwclock access should be possible
     test-snapd-timedate-control-consumer.hwclock-time -r -f /dev/rtc
     test-snapd-timedate-control-consumer.hwclock-time --systohc -f /dev/rtc

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -5,7 +5,7 @@ details: |
     can access the /dev/rtc device node exposed by a slot on the OS
     snap properly.
 
-systems: [-opensuse-*,-fedora-*,-ubuntu-core-*]
+systems: [-opensuse-*,-fedora-*,-ubuntu-core-*,-ubuntu-14.04-*]
 
 prepare: |
     . $TESTSLIB/snaps.sh


### PR DESCRIPTION
https://github.com/snapcore/snapd/pull/4683 for 2.31