### PR TITLE
packaging: provide a compat symlink for snappy-app-dev

### DIFF
--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -1,0 +1,1 @@
+/usr/lib/snapd/snappy-app-dev  /lib/udev/snappy-app-dev


### PR DESCRIPTION
Provide a /usr/lib/snapd/snappy-app-dev /lib/udev/snappy-app-dev symlink in core for compatibility if older version of snapd use a newer core snap. This should fix the testsuite failures on the 2.31 branch.