### PR TITLE
cmd/snap: use proper help strings for `snap userd --help`

### DIFF
--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -40,8 +40,8 @@ var longUserdHelp = i18n.G("The userd command starts the snap user session servi
 
 func init() {
 	cmd := addCommand("userd",
-		shortAbortHelp,
-		longAbortHelp,
+		shortUserdHelp,
+		longUserdHelp,
 		func() flags.Commander {
 			return &cmdUserd{}
 		},


### PR DESCRIPTION
We are currently showing the help strings for `snap abort` command. Found with gometalinter:
```
cmd_userd.go:38:1:warning: shortUserdHelp is unused (deadcode)
cmd_userd.go:39:1:warning: longUserdHelp is unused (deadcode)
```
