### PR TITLE
cmd/snap-update-ns: small refactor for upcoming per-user mounts

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -563,7 +563,8 @@ int sc_open_snap_update_ns(void)
 	return fd;
 }
 
-void sc_populate_mount_ns(const char *base_snap_name, const char *snap_name)
+void sc_populate_mount_ns(int snap_update_ns_fd, const char *base_snap_name,
+			  const char *snap_name)
 {
 	// Get the current working directory before we start fiddling with
 	// mounts and possibly pivot_root.  At the end of the whole process, we
@@ -573,10 +574,6 @@ void sc_populate_mount_ns(const char *base_snap_name, const char *snap_name)
 	if (vanilla_cwd == NULL) {
 		die("cannot get the current working directory");
 	}
-	// Find and open snap-update-ns from the same path as where we
-	// (snap-confine) were called.
-	int snap_update_ns_fd SC_CLEANUP(sc_cleanup_close) = -1;
-	snap_update_ns_fd = sc_open_snap_update_ns();
 
 	bool on_classic_distro = is_running_on_classic_distribution();
 	// on classic or with alternative base snaps we need to setup

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -535,7 +535,7 @@ static bool __attribute__ ((used))
 	return false;
 }
 
-static int sc_open_snap_update_ns(void)
+int sc_open_snap_update_ns(void)
 {
 	// +1 is for the case where the link is exactly PATH_MAX long but we also
 	// want to store the terminating '\0'. The readlink system call doesn't add

--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -19,6 +19,15 @@
 #define SNAP_MOUNT_SUPPORT_H
 
 /**
+ * Return a file descriptor referencing the snap-update-ns utility
+ *
+ * By calling this prior to changing the mount namespace, it is
+ * possible to execute the utility even if a different version is now
+ * mounted at the expected location.
+ **/
+int sc_open_snap_update_ns(void);
+
+/**
  * Assuming a new mountspace, populate it accordingly.
  *
  * This function performs many internal tasks:

--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -40,7 +40,8 @@ int sc_open_snap_update_ns(void);
  * The function will also try to preserve the current working directory but if
  * this is impossible it will chdir to SC_VOID_DIR.
  **/
-void sc_populate_mount_ns(const char *base_snap_name, const char *snap_name);
+void sc_populate_mount_ns(int snap_update_ns_fd, const char *base_snap_name,
+			  const char *snap_name);
 
 /**
  * Ensure that / or /snap is mounted with the SHARED option. 

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -219,6 +219,12 @@ int main(int argc, char **argv)
 			sc_initialize_ns_groups();
 			sc_unlock_global(global_lock_fd);
 
+			// Find and open snap-update-ns from the same
+			// path as where we (snap-confine) were
+			// called.
+			int snap_update_ns_fd SC_CLEANUP(sc_cleanup_close) = -1;
+			snap_update_ns_fd = sc_open_snap_update_ns();
+
 			// Do per-snap initialization.
 			int snap_lock_fd = sc_lock(snap_name);
 			debug("initializing mount namespace: %s", snap_name);
@@ -238,7 +244,8 @@ int main(int argc, char **argv)
 				}
 			}
 			if (sc_should_populate_ns_group(group)) {
-				sc_populate_mount_ns(base_snap_name, snap_name);
+				sc_populate_mount_ns(snap_update_ns_fd,
+						     base_snap_name, snap_name);
 				sc_preserve_populated_ns_group(group);
 			}
 			sc_close_ns_group(group);


### PR DESCRIPTION
This small branch sets the stage in anticipation of the second call to snap-update-ns.