### PR TITLE
snap: remove underscore from version validator regexp

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -51,7 +51,7 @@ func ValidateName(name string) error {
 }
 
 // NB keep this in sync with snapcraft and the review tools :-)
-var isValidVersion = regexp.MustCompile("^[a-zA-Z0-9](?:[a-zA-Z0-9:.+~_-]{0,30}[a-zA-Z0-9+~])?$").MatchString
+var isValidVersion = regexp.MustCompile("^[a-zA-Z0-9](?:[a-zA-Z0-9:.+~-]{0,30}[a-zA-Z0-9+~])?$").MatchString
 
 // ValidateVersion checks if a string is a valid snap version.
 func ValidateVersion(version string) error {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -93,7 +93,7 @@ func (s *ValidateSuite) TestValidateVersion(c *C) {
 		"0", "v1.0", "0.12+16.04.20160126-0ubuntu1",
 		"1:6.0.1+r16-3", "1.0~", "1.0+", "README.~1~",
 		"a+++++++++++++++++++++++++++++++",
-		"AZaz:.+~_-123",
+		"AZaz:.+~-123",
 	}
 	for _, version := range validVersions {
 		err := ValidateVersion(version)
@@ -103,9 +103,9 @@ func (s *ValidateSuite) TestValidateVersion(c *C) {
 		// can't have non-whitelisted symbols
 		"v1.3([<$$$>])", "what even _is_ a version",
 		// can't start with whitelisted symbls
-		":", ".", "+", "~", "_", "-",
+		":", ".", "+", "~", "-",
 		// can't end with most whitelisted symbols
-		"a:", "a.", "a_", "a-",
+		"a:", "a.", "a-",
 		// version must be plain ASCII
 		"árbol", "日本語", "한글", "ру́сский язы́к",
 	}

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -101,7 +101,7 @@ func (s *ValidateSuite) TestValidateVersion(c *C) {
 	}
 	invalidVersions := []string{
 		// can't have non-whitelisted symbols
-		"v1.3([<$$$>])", "what even _is_ a version",
+		"v1.3([<$$$>])", "what even _is_ a version", "horrible_underscores",
 		// can't start with whitelisted symbls
 		":", ".", "+", "~", "-",
 		// can't end with most whitelisted symbols


### PR DESCRIPTION
rationale: underscores are used in many places to separate components
of a filename that includes the version. Having underscores in
versions makes it a lot tricker to parse them.
