### PR TITLE
cmd/snap: tweaks to 'snap info' output

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -26,10 +26,10 @@ import (
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
-
-	"gopkg.in/yaml.v2"
+	"time"
 
 	"github.com/jessevdk/go-flags"
+	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
@@ -281,6 +281,13 @@ func formatSummary(raw string) string {
 func (x *infoCmd) Execute([]string) error {
 	cli := Client()
 
+	termWidth, _ := termSize()
+	termWidth -= 3
+	if termWidth > 100 {
+		// any wider than this and it gets hard to read
+		termWidth = 100
+	}
+
 	w := tabwriter.NewWriter(Stdout, 2, 2, 1, ' ', 0)
 
 	noneOK := true
@@ -323,11 +330,7 @@ func (x *infoCmd) Execute([]string) error {
 		}
 		fmt.Fprintf(w, "license:\t%s\n", license)
 		maybePrintPrice(w, remote, resInfo)
-		// FIXME: find out for real
-		termWidth := 77
 		fmt.Fprintf(w, "description: |\n%s\n", formatDescr(both.Description, termWidth))
-		maybePrintType(w, both.Type)
-		maybePrintID(w, both)
 		maybePrintCommands(w, snapName, both.Apps, termWidth)
 		maybePrintServices(w, snapName, both.Apps, termWidth)
 
@@ -337,8 +340,8 @@ func (x *infoCmd) Execute([]string) error {
 			fmt.Fprintf(w, "  confinement:\t%s\n", both.Confinement)
 		}
 
+		var notes *Notes
 		if local != nil {
-			var notes *Notes
 			if x.Verbose {
 				jailMode := local.Confinement == client.DevModeConfinement && !local.DevMode
 				fmt.Fprintf(w, "  devmode:\t%t\n", local.DevMode)
@@ -355,10 +358,18 @@ func (x *infoCmd) Execute([]string) error {
 			} else {
 				notes = NotesFromLocal(local)
 			}
-
+		}
+		// stops the notes etc trying to be aligned with channels
+		w.Flush()
+		maybePrintType(w, both.Type)
+		maybePrintID(w, both)
+		if local != nil {
 			fmt.Fprintf(w, "tracking:\t%s\n", local.TrackingChannel)
+			fmt.Fprintf(w, "refreshed:\t%s\n", local.InstallDate.Format(time.RFC3339))
+		}
+		w.Flush()
+		if local != nil {
 			fmt.Fprintf(w, "installed:\t%s\t(%s)\t%s\t%s\n", local.Version, local.Revision, strutil.SizeToStr(local.InstalledSize), notes)
-			fmt.Fprintf(w, "refreshed:\t%s\n", local.InstallDate)
 		}
 
 		if remote != nil && remote.Channels != nil && remote.Tracks != nil {

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -270,8 +270,8 @@ description: |
   https://snapcraft.io/
 snap-id:   mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:  beta
+refreshed: 0001-01-01T00:00:00Z
 installed: 2.10 (1) 1kB disabled
-refreshed: 0001-01-01 00:00:00 +0000 UTC
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -306,8 +306,8 @@ description: |
   https://snapcraft.io/
 snap-id:   mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:  beta
+refreshed: 0001-01-01T00:00:00Z
 installed: 2.10 (1) 1kB disabled
-refreshed: 0001-01-01 00:00:00 +0000 UTC
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }


### PR DESCRIPTION
Three changes to 'snap info':

 * time was being output in something that wasn't RFC3339; fixed that.
 * terminal width was hardcoded at 77; changed to detect (but clamp to 100; text
   that's too wide is too hard to read). Still not perfect as it's counting
   bytes, but better.
 * reorded some fields, and added Flush() calls to the tabwriter, to improve
   alignment of the values.

here's before:

    name:      core
    summary:   snapd runtime environment
    publisher: canonical
    contact:   snappy-canonical-storeaccount@canonical.com
    license:   unknown
    description: |
      The core runtime environment for snapd
    type:        core
    snap-id:     99T7MUlRhtI3U0QFgl5mXXESAiSwt776
    tracking:    candidate
    installed:   16-2.31 (4017) 85MB core
    refreshed:   2018-02-06 15:18:04 +0000 UTC
    channels:
      stable:    16-2.30                (3887) 85MB -
      candidate: 16-2.31                (4017) 85MB -
      beta:      16-2.31                (4017) 85MB -
      edge:      16-2.31+git575.9a84813 (4083) 85MB -

here's after:

    name:      core
    summary:   snapd runtime environment
    publisher: canonical
    contact:   snappy-canonical-storeaccount@canonical.com
    license:   unknown
    description: |
      The core runtime environment for snapd
    type:      core
    snap-id:   99T7MUlRhtI3U0QFgl5mXXESAiSwt776
    tracking:  candidate
    refreshed: 2018-02-06T15:18:04Z
    installed:   16-2.31                (4017) 85MB core
    channels:
      stable:    16-2.30                (3887) 85MB -
      candidate: 16-2.31                (4017) 85MB -
      beta:      16-2.31                (4017) 85MB -
      edge:      16-2.31+git575.9a84813 (4083) 85MB -
