### PR TITLE
cmd/snap: also include tracking channel in list output.

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -237,6 +237,8 @@ func maybePrintServices(w io.Writer, snapName string, allApps []client.AppInfo, 
 	}
 }
 
+var channelRisks = []string{"stable", "candidate", "beta", "edge"}
+
 // displayChannels displays channels and tracks in the right order
 func displayChannels(w io.Writer, remote *client.Snap) {
 	// \t\t\t so we get "installed" lined up with "channels"
@@ -245,7 +247,7 @@ func displayChannels(w io.Writer, remote *client.Snap) {
 	// order by tracks
 	for _, tr := range remote.Tracks {
 		trackHasOpenChannel := false
-		for _, risk := range []string{"stable", "candidate", "beta", "edge"} {
+		for _, risk := range channelRisks {
 			chName := fmt.Sprintf("%s/%s", tr, risk)
 			ch, ok := remote.Channels[chName]
 			if tr == "latest" {

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -56,7 +56,7 @@ func (s *SnapSuite) TestList(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
 			c.Check(r.URL.RawQuery, check.Equals, "")
-			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17}]}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17, "tracking-channel": "potatoes"}]}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -66,8 +66,8 @@ func (s *SnapSuite) TestList(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"list"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Developer +Notes
-foo +4.2 +17 +bar +-
+	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Tracking +Developer +Notes
+foo +4.2 +17 +potatoes +bar +-
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -80,7 +80,7 @@ func (s *SnapSuite) TestListAll(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
 			c.Check(r.URL.RawQuery, check.Equals, "select=all")
-			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17}]}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17, "tracking-channel": "stable"}]}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -90,8 +90,8 @@ func (s *SnapSuite) TestListAll(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"list", "--all"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Developer +Notes
-foo +4.2 +17 +bar +-
+	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Tracking +Developer +Notes
+foo +4.2 +17 +stable +bar +-
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -162,7 +162,7 @@ func (s *SnapSuite) TestListWithQuery(c *check.C) {
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/snaps")
 			c.Check(r.URL.Query().Get("snaps"), check.Equals, "foo")
-			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17}]}`)
+			fmt.Fprintln(w, `{"type": "sync", "result": [{"name": "foo", "status": "active", "version": "4.2", "developer": "bar", "revision":17, "tracking-channel": "1.10/stable/fix1234"}]}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
@@ -172,8 +172,8 @@ func (s *SnapSuite) TestListWithQuery(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"list", "foo"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Developer +Notes
-foo +4.2 +17 +bar +-
+	c.Check(s.Stdout(), check.Matches, `Name +Version +Rev +Tracking +Developer +Notes
+foo +4.2 +17 +1\.10/stable/… +bar +-
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
@@ -202,10 +202,49 @@ func (s *SnapSuite) TestListWithNotes(c *check.C) {
 	rest, err := snap.Parser().ParseArgs([]string{"list"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
-	c.Check(s.Stdout(), check.Matches, `(?ms)^Name +Version +Rev +Developer +Notes$`)
-	c.Check(s.Stdout(), check.Matches, `(?ms).*^foo +4.2 +17 +bar +try$`)
+	c.Check(s.Stdout(), check.Matches, `(?ms)^Name +Version +Rev +Tracking +Developer +Notes$`)
+	c.Check(s.Stdout(), check.Matches, `(?ms).*^foo +4.2 +17 +- +bar +try$`)
 	c.Check(s.Stdout(), check.Matches, `(?ms).*^dm1 +.* +devmode$`)
 	c.Check(s.Stdout(), check.Matches, `(?ms).*^dm2 +.* +devmode$`)
 	c.Check(s.Stdout(), check.Matches, `(?ms).*^cf1 +.* +jailmode$`)
 	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *SnapSuite) TestFormatChannel(c *check.C) {
+	type tableT struct {
+		channel  string
+		expected string
+	}
+	for _, t := range []tableT{
+		{"", "-"},
+		{"stable", "stable"},
+		{"edge", "edge"},
+		{"foo/stable", "foo"},
+		{"foo/edge", "foo/edge"},
+		{"foo", "foo"},
+		{"foo/stable/bar", "foo/stable/…"},
+		{"foo/edge/bar", "foo/edge/…"},
+		{"stable/bar", "stable/…"},
+		{"edge/bar", "edge/…"},
+	} {
+		c.Check(snap.FormatChannel(t.channel), check.Equals, t.expected, check.Commentf(t.channel))
+	}
+
+	// and some SISO tests just to check it doesn't panic nor return empty string
+	// (the former would break scripts)
+	for _, ch := range []string{
+		"",
+		"\x00",
+		"/",
+		"//",
+		"///",
+		"////",
+		"a/",
+		"/b",
+		"a//b",
+		"/stable",
+		"/edge",
+	} {
+		c.Check(snap.FormatChannel(ch), check.Not(check.Equals), "", check.Commentf(ch))
+	}
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -40,6 +40,8 @@ var (
 	MaybePrintCommands = maybePrintCommands
 	SortByPath         = sortByPath
 	AdviseCommand      = adviseCommand
+	Antialias          = antialias
+	FormatChannel      = fmtChannel
 )
 
 func MockPollTime(d time.Duration) (restore func()) {
@@ -135,5 +137,3 @@ func MockIsTerminal(t bool) (restore func()) {
 		isTerminal = oldIsTerminal
 	}
 }
-
-var Antialias = antialias

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -12,17 +12,17 @@ execute: |
     # *current* edge also has .git. and a hash snippet, so add an optional .git.[0-9a-f]+ to the already optional timestamp
     if [ "$SPREAD_BACKEND" = "linode" -o "$SPREAD_BACKEND" == "qemu" ] && [ "$SPREAD_SYSTEM" = "ubuntu-core-16-64" ]; then
         echo "With customized images the core snap is sideloaded"
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +core *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +x[0-9]+ +- +- +core *$'
     elif [ "$SRU_VALIDATION" = "1" ]; then
         echo "When sru validation is done the core snap is installed from the store"
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +core *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +stable +canonical +core *$'
     else
-        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +canonical +core *$'
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +edge +canonical +core *$'
     fi
     snap list | MATCH "$expected"
 
     echo "List prints installed snap version"
-    snap list | MATCH '^test-snapd-tools +[0-9]+(\.[0-9]+)* +x[0-9]+ +- *$'
+    snap list | MATCH '^test-snapd-tools +[0-9]+(\.[0-9]+)* +x[0-9]+ +- +- +- *$'
 
     echo "Install test-snapd-tools again"
     . $TESTSLIB/snaps.sh

--- a/tests/main/local-install-w-metadata/task.yaml
+++ b/tests/main/local-install-w-metadata/task.yaml
@@ -17,7 +17,7 @@ execute: |
     snap install test-snapd-tools_*.snap
 
     echo "The revision is not a local revision"
-    snap list|MATCH '^test-snapd-tools.* [0-9]+\s+canonical'
+    snap list|MATCH '^test-snapd-tools.* [0-9]+\s+-\s+canonical'
 
     echo "Test it"
     test-snapd-tools.success


### PR DESCRIPTION
This adds a "Tracking" column to `snap list`, which lists an
abbreviated form of the tracking channel of the snap.

If there is no tracking channel (because it's a local snap), this will
show '-' instead; I also made 'Developer' show up as '-' in this case;
this'll avoid breaking scripts in future.

The abbreviation consists of ellipsising the branch, and dropping the
"stable" from a track/stable channel.