### PR TITLE
interfaces/apparmor: use snap revision with surrounding '.' when replacing in glob

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -186,8 +186,10 @@ func snapConfineFromCoreProfile(coreInfo *snap.Info) (dir, glob string, content 
 	snapConfineInCore := filepath.Join(coreInfo.MountDir(), "usr/lib/snapd/snap-confine")
 	patchedProfileText := bytes.Replace(
 		vanillaProfileText, []byte("/usr/lib/snapd/snap-confine"), []byte(snapConfineInCore), -1)
+	// /snap/core/111/usr/lib/snapd/snap-confine -> snap.core.111.usr.lib.snapd.snap-confine
 	patchedProfileName := strings.Replace(snapConfineInCore[1:], "/", ".", -1)
-	patchedProfileGlob := strings.Replace(patchedProfileName, coreInfo.Revision.String(), "*", 1)
+	// snap.core.111.usr.lib.snapd.snap-confine -> snap.core.*.usr.lib.snapd.snap-confine
+	patchedProfileGlob := strings.Replace(patchedProfileName, "."+coreInfo.Revision.String()+".", ".*.", 1)
 
 	// Return information for EnsureDirState that describes the re-exec profile for snap-confine.
 	content = map[string]*osutil.FileState{


### PR DESCRIPTION
When replacing the snap revision string inside the pattern, make sure to use
".<snap-rev>." as input. Should any component of the path preceding the snap
revision match replaced string we'll a glob that we don't want.

Happened in unit tests, where we tried to replace snap revision '111' in the
following string:

tmp.check-1114575628337396084.0.var.lib.snapd.snap.core.111.usr.lib.snapd.snap-confine

Producing this glob:

  tmp.check-*4575628337396084.0.var.lib.snapd.snap.core.111.usr.lib.snapd.snap-confine

Instead of:

  tmp.check-1114575628337396084.0.var.lib.snapd.snap.core.*.usr.lib.snapd.snap-confine

