### PR TITLE
tests: store journal in autopkgtest artiffacts and add 18.04-32 to qemu

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -36,3 +36,7 @@ fi
 export GOPATH=/tmp/go
 go get -u github.com/snapcore/spread/cmd/spread
 /tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)"
+
+# store journal info for inspectsion
+journalctl --sync
+journalctl -ab > $ADT_ARTIFACTS/journal.txt

--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -17,6 +17,12 @@ EOF
 fi
 systemctl daemon-reload
 
+# ensure we are not get killed too easily
+echo -950 > /proc/$$/oom_score_adj
+
+# see what mem we have (for debugging)
+cat /proc/meminfo
+
 # ensure we can do a connect to localhost
 echo ubuntu:ubuntu|chpasswd
 sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config

--- a/spread.yaml
+++ b/spread.yaml
@@ -115,6 +115,9 @@ backends:
             - ubuntu-18.04-64:
                 username: ubuntu
                 password: ubuntu
+            - ubuntu-18.04-32:
+                username: ubuntu
+                password: ubuntu
             - debian-sid-64:
                 username: debian
                 password: debian


### PR DESCRIPTION
Trivial PR to (hopefully) improve the autopkgtest debug by giving us the systemd journal via the artefacts mechanism of autopkgtest.