### PR TITLE
tests: fixes for autopkgtest in bionic

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -36,3 +36,7 @@ fi
 export GOPATH=/tmp/go
 go get -u github.com/snapcore/spread/cmd/spread
 /tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)"
+
+# store journal info for inspectsion
+journalctl --sync
+journalctl -ab > $ADT_ARTIFACTS/journal.txt

--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -17,6 +17,12 @@ EOF
 fi
 systemctl daemon-reload
 
+# ensure we are not get killed too easily
+echo -950 > /proc/$$/oom_score_adj
+
+# see what mem we have (for debugging)
+cat /proc/meminfo
+
 # ensure we can do a connect to localhost
 echo ubuntu:ubuntu|chpasswd
 sed -i 's/\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config

--- a/spread.yaml
+++ b/spread.yaml
@@ -436,6 +436,9 @@ suites:
         # it disabled. A later PR will enable most tests and
         # drop this blacklist.
         systems: [-ubuntu-core-16-*, -opensuse-*]
+        # autopkgtest runs against localhost which causes problems with
+        # this test prepare
+        backends: [-autopkgtest]
         restore: |
             if [ "$REMOTE_STORE" = staging ]; then
                 echo "skip upgrade tests while talking to the staging store"

--- a/spread.yaml
+++ b/spread.yaml
@@ -115,6 +115,9 @@ backends:
             - ubuntu-18.04-64:
                 username: ubuntu
                 password: ubuntu
+            - ubuntu-18.04-32:
+                username: ubuntu
+                password: ubuntu
             - debian-sid-64:
                 username: debian
                 password: debian

--- a/tests/main/interfaces-alsa/task.yaml
+++ b/tests/main/interfaces-alsa/task.yaml
@@ -43,6 +43,7 @@ execute: |
     fi
 
     echo "Then the snap is able to access snd devices"
+    mkdir -p /dev/snd
     generic-consumer.cmd touch /dev/snd/mysnd-dev
     echo "mysnd-dev-content" | tee /dev/snd/mysnd-dev
     generic-consumer.cmd cat /dev/snd/mysnd-dev | MATCH mysnd-dev-content

--- a/tests/main/interfaces-dbus/task.yaml
+++ b/tests/main/interfaces-dbus/task.yaml
@@ -29,7 +29,7 @@ prepare: |
 restore: |
     rm -f call.error
     . "$TESTSLIB/dbus.sh"
-    stop_dbus_unit
+    stop_dbus_unit || true
 
 execute: |
     CONNECTED_PATTERN="test-snapd-dbus-provider:dbus-test +test-snapd-dbus-consumer"

--- a/tests/main/interfaces-many/task.yaml
+++ b/tests/main/interfaces-many/task.yaml
@@ -3,6 +3,10 @@ summary: Ensure that commands run when their interfaces are connected
 # Start early as it takes a long time.
 priority: 100
 
+debug: |
+    # get the full journal to see any out-of-memory errors
+    journalctl
+
 details: |
     Install a test snap that plugs as many interfaces as is possible and
     verify the command can run (ie, don't test the interface functionality
@@ -19,7 +23,7 @@ details: |
 # - Debian sid amd64 VM
 # - Debian 9 amd64 VM
 # - TODO: All Fedora systems (for classic-only; unrelated error elsewhere)
-systems: [ubuntu-core-16-64, ubuntu-14.04-32, ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-*-amd64, ubuntu-*-armhf, ubuntu-*-arm64, ubuntu-*-i386, ubuntu-*-ppc64el, debian-*]
+systems: [ubuntu-core-16-64, ubuntu-14.04-32, ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-18.04-32, ubuntu-*-amd64, ubuntu-*-armhf, ubuntu-*-arm64, ubuntu-*-i386, ubuntu-*-ppc64el, debian-*]
 
 execute: |
     . $TESTSLIB/dirs.sh

--- a/tests/main/interfaces-many/task.yaml
+++ b/tests/main/interfaces-many/task.yaml
@@ -25,6 +25,9 @@ details: |
 # - TODO: All Fedora systems (for classic-only; unrelated error elsewhere)
 systems: [ubuntu-core-16-64, ubuntu-14.04-32, ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-18.04-32, ubuntu-*-amd64, ubuntu-*-armhf, ubuntu-*-arm64, ubuntu-*-i386, ubuntu-*-ppc64el, debian-*]
 
+# memory issue inside the adt environment
+backends: [-autopkgtest]
+
 execute: |
     . $TESTSLIB/dirs.sh
 

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -1,5 +1,8 @@
 summary: Check snap search
 
+# s390x,ppc64el have nothing featured
+systems: [-ubuntu-*-ppc64el, -ubuntu-*-s390x]
+
 restore: |
     rm -f featured.txt
 

--- a/tests/main/security-device-cgroups/task.yaml
+++ b/tests/main/security-device-cgroups/task.yaml
@@ -21,7 +21,10 @@ environment:
 
 prepare: |
     if [ ! -e /sys/devices/virtual/misc/uinput ]; then
-        modprobe uinput
+        if ! modprobe uinput; then
+            echo "no uinput support, cannot run test"
+            exit 0
+        fi
     fi
     # create nvidia devices if they don't exist
     if [ ! -e /dev/nvidia0 ]; then
@@ -67,6 +70,12 @@ restore: |
     udevadm trigger
 
 execute: |
+    # some systems (like s390x) do not have support for this
+    if [ ! -e /sys/devices/virtual/misc/uinput ]; then
+        echo "no uinput support, cannot run test"
+        exit 0
+    fi
+
     echo "Given a snap is installed"
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools

--- a/tests/regression/lp-1721518/task.yaml
+++ b/tests/regression/lp-1721518/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that interfaces are listed after reboot the machine
 
+# do not run on autopkgtest, we need to reboot here and ADT does
+# not support our reboot logic
+backends: [-autopkgtest]
+
 details: |
     This test checks if the interfaces are listed after the machine
     is rebooted. The test is also checking the interfaces after a 


### PR DESCRIPTION
A bunch of fixes to make sure the autopkgtests work in a bionic environment.