### PR TITLE
tests/lib/prepare-restore: sync journal before rotating and vacuuming

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -319,6 +319,8 @@ prepare_project_each() {
             systemctl start systemd-journald.service
             ;;
         *)
+            # rotate and sync 'override' each other if used in a single command
+            journalctl --sync
             journalctl --rotate
             sleep .1
             journalctl --vacuum-time=1ms

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -319,7 +319,9 @@ prepare_project_each() {
             systemctl start systemd-journald.service
             ;;
         *)
-            # rotate and sync 'override' each other if used in a single command
+            # per journalctl's implementation, --rotate and --sync 'override'
+            # each other if used in a single command, with the one appearing
+            # later being effective
             journalctl --sync
             journalctl --rotate
             sleep .1


### PR DESCRIPTION
Attempt to sync the journal before rotating. This should cause all in-flight
logs to be be written to the backing store. Thus when we rotate and vacuum, the
removed journals will have all the logs from previous test runs and the 'old'
logs should not be present during current test run. This is important if the
test is using the same snap with services as the previous one.
