### PR TITLE
tests: make restore of interfaces-password-manager-service more robust

### DIFF
--- a/tests/main/interfaces-password-manager-service/task.yaml
+++ b/tests/main/interfaces-password-manager-service/task.yaml
@@ -10,7 +10,9 @@ prepare: |
 
 restore: |
     . $TESTSLIB/pkgdb.sh
-    kill $(cat dbus-launch.pid)
+    if [ -f dbus-launch.pid ]; then
+        kill $(cat dbus-launch.pid)
+    fi
     rm -f  dbus-launch.pid
 
 execute: |


### PR DESCRIPTION
Trivial drive-by fix, the suite failed in restore on s390x.