### PR TITLE
cmd/snap: add self-strace to `snap run`

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -523,6 +523,11 @@ func (x *cmdRun) runCmdUnderStrace(origCmd, env []string) error {
 	go func() {
 		defer func() { filterDone <- true }()
 
+		if osutil.GetenvBool("SNAP_STRACE_SELF", false) {
+			io.Copy(Stderr, stderr)
+			return
+		}
+
 		r := bufio.NewReader(stderr)
 
 		// The first thing from strace if things work is

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -76,7 +76,7 @@ func init() {
 			"hook":       i18n.G("Hook to run"),
 			"r":          i18n.G("Use a specific snap revision when running hook"),
 			"shell":      i18n.G("Run a shell instead of the command (useful for debugging)"),
-			"strace":     i18n.G("Run the command under strace (useful for debugging). Extra strace options can be specified as well here."),
+			"strace":     i18n.G("Run the command under strace (useful for debugging). Extra strace options can be specified as well here. Pass --raw to strace early snap helpers."),
 			"gdb":        i18n.G("Run the command with gdb"),
 			"parser-ran": "",
 		}, nil)
@@ -258,19 +258,22 @@ func (x *cmdRun) useStrace() bool {
 	return x.ParserRan == 1 && x.Strace != "no-strace"
 }
 
-func (x *cmdRun) straceOpts() []string {
+func (x *cmdRun) straceOpts() (opts []string, raw bool) {
 	if x.Strace == "with-strace" {
-		return nil
+		return nil, false
 	}
 
-	var opts []string
 	// TODO: use shlex?
 	for _, opt := range strings.Split(x.Strace, " ") {
 		if strings.TrimSpace(opt) != "" {
+			if opt == "--raw" {
+				raw = true
+				continue
+			}
 			opts = append(opts, opt)
 		}
 	}
-	return opts
+	return opts, raw
 }
 
 func (x *cmdRun) snapRunApp(snapApp string, args []string) error {
@@ -507,7 +510,8 @@ func (x *cmdRun) runCmdUnderStrace(origCmd, env []string) error {
 	if err != nil {
 		return err
 	}
-	cmd = append(cmd, x.straceOpts()...)
+	straceOpts, raw := x.straceOpts()
+	cmd = append(cmd, straceOpts...)
 	cmd = append(cmd, origCmd...)
 
 	// run with filter
@@ -523,10 +527,11 @@ func (x *cmdRun) runCmdUnderStrace(origCmd, env []string) error {
 	go func() {
 		defer func() { filterDone <- true }()
 
-		// do not filter the initial strace output if SNAP_STRACE_SELF
-		// is set, this is useful when tracking down issues with snap
-		// helpers such as snap-confine, snap-exec ...
-		if osutil.GetenvBool("SNAP_STRACE_SELF", false) {
+		if raw {
+			// Passing --strace='--raw' disables the filtering of
+			// early strace output. This is useful when tracking
+			// down issues with snap helpers such as snap-confine,
+			// snap-exec ...
 			io.Copy(Stderr, stderr)
 			return
 		}

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -523,6 +523,9 @@ func (x *cmdRun) runCmdUnderStrace(origCmd, env []string) error {
 	go func() {
 		defer func() { filterDone <- true }()
 
+		// do not filter the initial strace output if SNAP_STRACE_SELF
+		// is set, this is useful when tracking down issues with snap
+		// helpers such as snap-confine, snap-exec ...
 		if osutil.GetenvBool("SNAP_STRACE_SELF", false) {
 			io.Copy(Stderr, stderr)
 			return


### PR DESCRIPTION
If `SNAP_STRACE_SELF` environment variable is set, `snap run` will not filter the
initial strace output allowing for debugging the early startup. This is useful
when tracking down issues with snap helpers.
