### PR TITLE
tests: make sure snapd is running before attempting to remove leftover snaps

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -97,6 +97,10 @@ reset_all_snap() {
             "bin" | "$gadget_name" | "$kernel_name" | core | README)
                 ;;
             *)
+                # make sure snapd is running before we attempt to remove snaps, in case a test stopped it
+                if ! systemctl status snapd.service snapd.socket; then
+                    systemctl start snapd.service snapd.socket
+                fi
                 snap remove "$snap"
                 ;;
         esac


### PR DESCRIPTION
Make sure snapd is running when attempting 'snap remove ...' in `reset_all_snap()`.

This is something I hit with a new spread test in my other branch: if the test leaves installed snaps around and stops snapd at the end of the test, then reset code fails in the **next** test, but since `reset_all_snap` is only run on `ubuntu-core-16-*` it might be a little puzzling as to where the cause is.