### PR TITLE
tests: disable interfaces-location-control on s390x

### DIFF
--- a/tests/main/interfaces-location-control/task.yaml
+++ b/tests/main/interfaces-location-control/task.yaml
@@ -9,7 +9,8 @@ details: |
     The snap is also declaring a plug on this interface must be able to ask for its properties.
 
 # dbus-launch not supported in ubuntu-core
-systems: [-ubuntu-core-16-*]
+# s390x does not support locationd
+systems: [-ubuntu-core-16-*, -ubuntu-*-s390x]
 
 prepare: |
     . "$TESTSLIB/dbus.sh"


### PR DESCRIPTION
Trivial PR to disable the locationd test on s390x. This snap is not available there and arguable a mainframe does not change location that often. This is the only(!) failing test on s390x in autopkgtest.

LP: #1750856