### PR TITLE
timeutil: account for 24h wrap when flattening clock spans

### DIFF
--- a/timeutil/export_test.go
+++ b/timeutil/export_test.go
@@ -21,6 +21,10 @@ package timeutil
 
 import "time"
 
+var (
+	ParseClockSpan = parseClockSpan
+)
+
 func MockTimeNow(f func() time.Time) (restorer func()) {
 	origTimeNow := timeNow
 	timeNow = f

--- a/timeutil/schedule.go
+++ b/timeutil/schedule.go
@@ -46,7 +46,11 @@ func (t Clock) String() string {
 func (t Clock) Sub(other Clock) time.Duration {
 	t1 := time.Duration(t.Hour)*time.Hour + time.Duration(t.Minute)*time.Minute
 	t2 := time.Duration(other.Hour)*time.Hour + time.Duration(other.Minute)*time.Minute
-	return t1 - t2
+	dur := t1 - t2
+	if dur < 0 {
+		dur = -(dur + 24*time.Hour)
+	}
+	return dur
 }
 
 // Add adds given duration to t and returns a new Clock
@@ -225,6 +229,9 @@ func (ts ClockSpan) ClockSpans() []ClockSpan {
 	}
 
 	span := ts.End.Sub(ts.Start)
+	if span < 0 {
+		span = -span
+	}
 	step := span / time.Duration(ts.Split)
 
 	spans := make([]ClockSpan, ts.Split)

--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -44,6 +44,20 @@ func (ts *timeutilSuite) TestClock(c *C) {
 
 	td = timeutil.Clock{Hour: 10, Minute: 1}
 	c.Check(td.Sub(timeutil.Clock{Hour: 10, Minute: 0}), Equals, time.Minute)
+
+	td = timeutil.Clock{Hour: 23, Minute: 0}
+	c.Check(td.Add(time.Hour), Equals, timeutil.Clock{Hour: 0, Minute: 0})
+	c.Check(td.Add(2*time.Hour), Equals, timeutil.Clock{Hour: 1, Minute: 0})
+	c.Check(td.Sub(timeutil.Clock{Hour: 1, Minute: 0}), Equals, 22*time.Hour)
+	c.Check(td.Sub(timeutil.Clock{Hour: 0, Minute: 0}), Equals, 23*time.Hour)
+
+	td = timeutil.Clock{Hour: 1, Minute: 0}
+	c.Check(td.Sub(timeutil.Clock{Hour: 23, Minute: 0}), Equals, -2*time.Hour)
+	c.Check(td.Sub(timeutil.Clock{Hour: 1, Minute: 0}), Equals, time.Duration(0))
+
+	td = timeutil.Clock{Hour: 0, Minute: 0}
+	c.Check(td.Sub(timeutil.Clock{Hour: 23, Minute: 0}), Equals, -1*time.Hour)
+	c.Check(td.Sub(timeutil.Clock{Hour: 1, Minute: 0}), Equals, -23*time.Hour)
 }
 
 func (ts *timeutilSuite) TestParseClock(c *C) {
@@ -903,5 +917,35 @@ func (ts *timeutilSuite) TestScheduleIncludes(c *C) {
 
 		c.Check(timeutil.Includes(sched, now), Equals, t.expecting,
 			Commentf("unexpected result for schedule %v and time %v", t.schedule, now))
+	}
+}
+
+func (ts *timeutilSuite) TestClockSpans(c *C) {
+	const shortForm = "2006-01-02 15:04:05"
+
+	for _, t := range []struct {
+		clockspan  string
+		flattenend []string
+	}{
+		{
+			clockspan:  "23:00-01:00/2",
+			flattenend: []string{"23:00-00:00", "00:00-01:00"},
+		}, {
+			clockspan:  "23:00-01:00/4",
+			flattenend: []string{"23:00-23:30", "23:30-00:00", "00:00-00:30", "00:30-01:00"},
+		},
+	} {
+		c.Logf("trying %+v", t)
+		spans, err := timeutil.ParseClockSpan(t.clockspan)
+		c.Assert(err, IsNil)
+
+		spanStrings := make([]string, len(t.flattenend))
+		flattened := spans.ClockSpans()
+		c.Assert(flattened, HasLen, len(t.flattenend))
+		for i := range flattened {
+			spanStrings[i] = flattened[i].String()
+		}
+
+		c.Assert(spanStrings, DeepEquals, t.flattenend)
 	}
 }


### PR DESCRIPTION
When flattening a clock span such as `23:00-01:00/2`, the code would incorrectly
generate spans: `23:00-12:00`, `12:00-01:00`. This is caused by the fact that
01:00.Sub(23:00) incorrectly returns -22h instead of -2h and that the flattening
function does not account for the 24h wraparound.
