### PR TITLE
interfaces: add xdg-desktop-portal support to desktop interface

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -174,6 +174,23 @@ dbus (send)
     interface=io.snapcraft.Settings
     member={Check,Get,Set}
     peer=(label=unconfined),
+
+## Allow access to xdg-document-portal file system.  Access control is
+## handled by bind mounting a snap-specific sub-tree to this location.
+#owner /run/user/[0-9]*/doc/** rw,
+
+# Allow access to xdg-desktop-portal and xdg-document-portal
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.portal.*
+    path=/org/freedesktop/portal/{desktop,documents}
+    peer=(label=unconfined),
+
+dbus (receive, send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/freedesktop/portal/{desktop,documents}
+    peer=(label=unconfined),
 `
 
 type desktopInterface struct{}
@@ -226,6 +243,16 @@ func (iface *desktopInterface) MountConnectedPlug(spec *mount.Specification, plu
 			Options: []string{"bind", "ro"},
 		})
 	}
+
+	/*
+		appId := "snap.pkg." + plug.Snap.Name()
+		spec.AddUserMount(mount.Entry{
+			Name: "$XDG_RUNTIME_DIR/doc/by-app/" + appId,
+			Dir: "$XDG_RUNTIME_DIR/doc",
+			Options: []string{"bind", "rw"},
+		})
+	*/
+
 	return nil
 }
 

--- a/interfaces/builtin/desktop_test.go
+++ b/interfaces/builtin/desktop_test.go
@@ -99,6 +99,7 @@ func (s *DesktopInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Description: Can access basic graphical desktop resources")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "#include <abstractions/fonts>")
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/etc/gtk-3.0/settings.ini r,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "# Allow access to xdg-desktop-portal and xdg-document-portal")
 
 	// connected plug to core slot
 	spec = &apparmor.Specification{}


### PR DESCRIPTION
This branch is the first stage of adding support for xdg-desktop-portal to snapd.

As discussed earlier, I'm adding this to the existing `desktop` interface rather than creating a new one, since most desktop apps will likely require some portal features, and xdg-desktop-portal acts as a trusted helper with just-in-time approval prompts to the user.

This branch is not complete, since it doesn't mount the document portal.  That feature depends on user mounts.

It also isn't safe to use on systems with an old version of xdg-desktop-portal, since they will not identify snaps as confined apps.  I'm not sure what the best way to handle that is.  We could have "Conflicts: ..." lines in the Debian and RPM packaging, but that doesn't cover every deployment target for snapd.