### PR TITLE
osutil: aggregate mockable symbols

### DIFF
--- a/osutil/buildid.go
+++ b/osutil/buildid.go
@@ -27,8 +27,6 @@ import (
 	"os"
 )
 
-var osReadlink = os.Readlink
-
 // ErrNoBuildID is returned when an executable does not contain a Build-ID
 var ErrNoBuildID = errors.New("executable does not contain a build ID")
 

--- a/osutil/exec.go
+++ b/osutil/exec.go
@@ -140,12 +140,7 @@ func CommandFromCore(name string, cmdArgs ...string) (*exec.Cmd, error) {
 	return exec.Command(coreLdSo, allArgs...), nil
 }
 
-var (
-	syscallKill    = syscall.Kill
-	syscallGetpgid = syscall.Getpgid
-
-	cmdWaitTimeout = 5 * time.Second
-)
+var cmdWaitTimeout = 5 * time.Second
 
 // KillProcessGroup kills the process group associated with the given command.
 //

--- a/osutil/mockable.go
+++ b/osutil/mockable.go
@@ -1,0 +1,84 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"syscall"
+)
+
+const (
+	// ProcSelfMountInfo is a path to the mountinfo table of the current process.
+	ProcSelfMountInfo = "/proc/self/mountinfo"
+)
+
+var (
+	userLookup  = user.Lookup
+	userCurrent = user.Current
+
+	osReadlink = os.Readlink
+
+	syscallKill    = syscall.Kill
+	syscallGetpgid = syscall.Getpgid
+
+	procSelfMountInfo = ProcSelfMountInfo
+	etcFstab          = "/etc/fstab"
+	sudoersDotD       = "/etc/sudoers.d"
+)
+
+//MockMountInfo mocks content of /proc/self/mountinfo read by IsHomeUsingNFS
+func MockMountInfo(text string) (restore func()) {
+	old := procSelfMountInfo
+	f, err := ioutil.TempFile("", "mountinfo")
+	if err != nil {
+		panic(fmt.Errorf("cannot open temporary file: %s", err))
+	}
+	if err := ioutil.WriteFile(f.Name(), []byte(text), 0644); err != nil {
+		panic(fmt.Errorf("cannot write mock mountinfo file: %s", err))
+	}
+	procSelfMountInfo = f.Name()
+	return func() {
+		os.Remove(procSelfMountInfo)
+		procSelfMountInfo = old
+	}
+}
+
+// MockEtcFstab mocks content of /etc/fstab read by IsHomeUsingNFS
+func MockEtcFstab(text string) (restore func()) {
+	old := etcFstab
+	f, err := ioutil.TempFile("", "fstab")
+	if err != nil {
+		panic(fmt.Errorf("cannot open temporary file: %s", err))
+	}
+	if err := ioutil.WriteFile(f.Name(), []byte(text), 0644); err != nil {
+		panic(fmt.Errorf("cannot write mock fstab file: %s", err))
+	}
+	etcFstab = f.Name()
+	return func() {
+		if etcFstab == "/etc/fstab" {
+			panic("respectfully refusing to remove /etc/fstab")
+		}
+		os.Remove(etcFstab)
+		etcFstab = old
+	}
+}

--- a/osutil/mountinfo.go
+++ b/osutil/mountinfo.go
@@ -46,9 +46,6 @@ type MountInfoEntry struct {
 	SuperOptions   map[string]string
 }
 
-// ProcSelfMountInfo is a path to the mountinfo table of the current process.
-const ProcSelfMountInfo = "/proc/self/mountinfo"
-
 // LoadMountInfo loads list of mounted entries from a given file.
 //
 // The file is typically ProcSelfMountInfo but any other process mount table

--- a/osutil/nfs.go
+++ b/osutil/nfs.go
@@ -21,14 +21,7 @@ package osutil
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strings"
-)
-
-var (
-	procSelfMountInfo = ProcSelfMountInfo
-	etcFstab          = "/etc/fstab"
 )
 
 // IsHomeUsingNFS returns true if NFS mounts are defined or mounted under /home.
@@ -56,41 +49,4 @@ func IsHomeUsingNFS() (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-//MockMountInfo mocks content of /proc/self/mountinfo read by IsHomeUsingNFS
-func MockMountInfo(text string) (restore func()) {
-	old := procSelfMountInfo
-	f, err := ioutil.TempFile("", "mountinfo")
-	if err != nil {
-		panic(fmt.Errorf("cannot open temporary file: %s", err))
-	}
-	if err := ioutil.WriteFile(f.Name(), []byte(text), 0644); err != nil {
-		panic(fmt.Errorf("cannot write mock mountinfo file: %s", err))
-	}
-	procSelfMountInfo = f.Name()
-	return func() {
-		os.Remove(procSelfMountInfo)
-		procSelfMountInfo = old
-	}
-}
-
-// MockEtcFstab mocks content of /etc/fstab read by IsHomeUsingNFS
-func MockEtcFstab(text string) (restore func()) {
-	old := etcFstab
-	f, err := ioutil.TempFile("", "fstab")
-	if err != nil {
-		panic(fmt.Errorf("cannot open temporary file: %s", err))
-	}
-	if err := ioutil.WriteFile(f.Name(), []byte(text), 0644); err != nil {
-		panic(fmt.Errorf("cannot write mock fstab file: %s", err))
-	}
-	etcFstab = f.Name()
-	return func() {
-		if etcFstab == "/etc/fstab" {
-			panic("respectfully refusing to remove /etc/fstab")
-		}
-		os.Remove(etcFstab)
-		etcFstab = old
-	}
 }

--- a/osutil/user.go
+++ b/osutil/user.go
@@ -32,10 +32,6 @@ import (
 	"github.com/snapcore/snapd/osutil/sys"
 )
 
-var userLookup = user.Lookup
-
-var sudoersDotD = "/etc/sudoers.d"
-
 var sudoersTemplate = `
 # Created by snap create-user
 
@@ -123,8 +119,6 @@ func AddUser(name string, opts *AddUserOptions) error {
 
 	return nil
 }
-
-var userCurrent = user.Current
 
 // RealUser finds the user behind a sudo invocation when root, if applicable
 // and possible.


### PR DESCRIPTION
This will help in upcoming improvements to mocking. As more things are
added to osutil it is sometimes unclear what is being mocked and how.
This patch should help to improve the situation.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>