### PR TITLE
tests: avoid removing preinstalled snaps on core

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -42,6 +42,7 @@ environment:
     NEW_CORE_CHANNEL: "$(HOST: echo $SPREAD_NEW_CORE_CHANNEL)"
     SRU_VALIDATION: "$(HOST: echo ${SPREAD_SRU_VALIDATION:-0})"
     PRE_CACHE_SNAPS: core ubuntu-core test-snapd-tools
+    SKIP_REMOVE_SNAPS: "$(HOST: echo ${SKIP_REMOVE_SNAPS:-})"
 
 backends:
     linode:

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -97,7 +97,9 @@ reset_all_snap() {
             "bin" | "$gadget_name" | "$kernel_name" | core | README)
                 ;;
             *)
-                snap remove "$snap"
+                if ! echo "$SKIP_REMOVE_SNAPS" | grep -q -w $snap; then
+                    snap remove "$snap"
+                fi
                 ;;
         esac
     done

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -97,7 +97,7 @@ reset_all_snap() {
             "bin" | "$gadget_name" | "$kernel_name" | core | README)
                 ;;
             *)
-                if ! echo "$SKIP_REMOVE_SNAPS" | grep -q -w $snap; then
+                if ! echo "$SKIP_REMOVE_SNAPS" | grep -w "$snap"; then
                     snap remove "$snap"
                 fi
                 ;;


### PR DESCRIPTION
This change prevents to remove preinstalled snaps. This is usefull to
test gadgets such as the caracalla.

i.e. when the modem-manager snap is removed, it is causing the
connection to the device is broken in the caracalla.
