### PR TITLE
many: simplify mocking of home-on-NFS

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -57,10 +57,11 @@ import (
 )
 
 var (
-	procSelfExe = "/proc/self/exe"
+	procSelfExe    = "/proc/self/exe"
+	isHomeUsingNFS = osutil.IsHomeUsingNFS
 )
 
-// Backend is responsible for maintaining apparmor profiles for ubuntu-core-launcher.
+// Backend is responsible for maintaining apparmor profiles for snaps and parts of snapd.
 type Backend struct{}
 
 // Name returns the name of the backend.
@@ -99,7 +100,7 @@ func (b *Backend) Initialize() error {
 	// Check if NFS is mounted at or under $HOME. Because NFS is not
 	// transparent to apparmor we must alter our profile to counter that and
 	// allow snap-confine to work.
-	if nfs, err := osutil.IsHomeUsingNFS(); err != nil {
+	if nfs, err := isHomeUsingNFS(); err != nil {
 		logger.Noticef("cannot determine if NFS is in use: %v", err)
 	} else if nfs {
 		policy["nfs-support"] = &osutil.FileState{
@@ -388,7 +389,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 				// transparent to apparmor we must alter the profile to counter that and
 				// allow access to SNAP_USER_* files.
 				tagSnippets = snippetForTag
-				if nfs, _ := osutil.IsHomeUsingNFS(); nfs {
+				if nfs, _ := isHomeUsingNFS(); nfs {
 					tagSnippets += nfsSnippet
 				}
 			}

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -29,6 +29,15 @@ var (
 	SnapConfineFromCoreProfile = snapConfineFromCoreProfile
 )
 
+// MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS
+func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
+	old := isHomeUsingNFS
+	isHomeUsingNFS = new
+	return func() {
+		isHomeUsingNFS = old
+	}
+}
+
 // MockProcSelfExe mocks the location of /proc/self/exe read by setupSnapConfineGeneratedPolicy.
 func MockProcSelfExe(symlink string) (restore func()) {
 	old := procSelfExe

--- a/interfaces/export_test.go
+++ b/interfaces/export_test.go
@@ -74,3 +74,12 @@ func (c BySlotInfo) Swap(i, j int)      { bySlotInfo(c).Swap(i, j) }
 func (c BySlotInfo) Less(i, j int) bool { return bySlotInfo(c).Less(i, j) }
 
 var CopyAttributes = copyAttributes
+
+// MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS
+func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
+	old := isHomeUsingNFS
+	isHomeUsingNFS = new
+	return func() {
+		isHomeUsingNFS = old
+	}
+}

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -42,7 +42,10 @@ type systemKey struct {
 	Core             string   `yaml:"core,omitempty"`
 }
 
-var mockedSystemKey *systemKey
+var (
+	isHomeUsingNFS  = osutil.IsHomeUsingNFS
+	mockedSystemKey *systemKey
+)
 
 func generateSystemKey() *systemKey {
 	// for testing only
@@ -63,7 +66,7 @@ func generateSystemKey() *systemKey {
 	// Add if home is using NFS, if so we need to have a different
 	// security profile and if this changes we need to change our
 	// profile.
-	sk.NFSHome, err = osutil.IsHomeUsingNFS()
+	sk.NFSHome, err = isHomeUsingNFS()
 	if err != nil {
 		logger.Noticef("cannot determine nfs usage in generateSystemKey: %v", err)
 	}

--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -20,7 +20,9 @@
 package osutil
 
 import (
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -105,4 +107,41 @@ func MockOsReadlink(f func(string) (string, error)) func() {
 	osReadlink = f
 
 	return func() { osReadlink = realOsReadlink }
+}
+
+//MockMountInfo mocks content of /proc/self/mountinfo read by IsHomeUsingNFS
+func MockMountInfo(text string) (restore func()) {
+	old := procSelfMountInfo
+	f, err := ioutil.TempFile("", "mountinfo")
+	if err != nil {
+		panic(fmt.Errorf("cannot open temporary file: %s", err))
+	}
+	if err := ioutil.WriteFile(f.Name(), []byte(text), 0644); err != nil {
+		panic(fmt.Errorf("cannot write mock mountinfo file: %s", err))
+	}
+	procSelfMountInfo = f.Name()
+	return func() {
+		os.Remove(procSelfMountInfo)
+		procSelfMountInfo = old
+	}
+}
+
+// MockEtcFstab mocks content of /etc/fstab read by IsHomeUsingNFS
+func MockEtcFstab(text string) (restore func()) {
+	old := etcFstab
+	f, err := ioutil.TempFile("", "fstab")
+	if err != nil {
+		panic(fmt.Errorf("cannot open temporary file: %s", err))
+	}
+	if err := ioutil.WriteFile(f.Name(), []byte(text), 0644); err != nil {
+		panic(fmt.Errorf("cannot write mock fstab file: %s", err))
+	}
+	etcFstab = f.Name()
+	return func() {
+		if etcFstab == "/etc/fstab" {
+			panic("respectfully refusing to remove /etc/fstab")
+		}
+		os.Remove(etcFstab)
+		etcFstab = old
+	}
 }

--- a/osutil/mockable.go
+++ b/osutil/mockable.go
@@ -20,8 +20,6 @@
 package osutil
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"syscall"
@@ -45,40 +43,3 @@ var (
 	etcFstab          = "/etc/fstab"
 	sudoersDotD       = "/etc/sudoers.d"
 )
-
-//MockMountInfo mocks content of /proc/self/mountinfo read by IsHomeUsingNFS
-func MockMountInfo(text string) (restore func()) {
-	old := procSelfMountInfo
-	f, err := ioutil.TempFile("", "mountinfo")
-	if err != nil {
-		panic(fmt.Errorf("cannot open temporary file: %s", err))
-	}
-	if err := ioutil.WriteFile(f.Name(), []byte(text), 0644); err != nil {
-		panic(fmt.Errorf("cannot write mock mountinfo file: %s", err))
-	}
-	procSelfMountInfo = f.Name()
-	return func() {
-		os.Remove(procSelfMountInfo)
-		procSelfMountInfo = old
-	}
-}
-
-// MockEtcFstab mocks content of /etc/fstab read by IsHomeUsingNFS
-func MockEtcFstab(text string) (restore func()) {
-	old := etcFstab
-	f, err := ioutil.TempFile("", "fstab")
-	if err != nil {
-		panic(fmt.Errorf("cannot open temporary file: %s", err))
-	}
-	if err := ioutil.WriteFile(f.Name(), []byte(text), 0644); err != nil {
-		panic(fmt.Errorf("cannot write mock fstab file: %s", err))
-	}
-	etcFstab = f.Name()
-	return func() {
-		if etcFstab == "/etc/fstab" {
-			panic("respectfully refusing to remove /etc/fstab")
-		}
-		os.Remove(etcFstab)
-		etcFstab = old
-	}
-}


### PR DESCRIPTION
The function that determines if /home is on an NFS filesystem is
provided by the osutil module and is tested there. We don't need to mock
the data it uses to compute the result but rather the result itself.
This simplifies mocking, removes unneeded, exported mock functions,
removes redundant tests and shortens the code overall.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
