### PR TITLE
many: drop snaps' InstallDate, introduce Updated

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -20,7 +20,6 @@
 package client
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -39,7 +38,7 @@ type Snap struct {
 	DownloadSize     int64         `json:"download-size,omitempty"`
 	Icon             string        `json:"icon,omitempty"`
 	InstalledSize    int64         `json:"installed-size,omitempty"`
-	InstallDate      time.Time     `json:"install-date,omitempty"`
+	Updated          *time.Time    `json:"updated,omitempty"`
 	Name             string        `json:"name"`
 	Developer        string        `json:"developer"`
 	Status           string        `json:"status"`
@@ -67,21 +66,6 @@ type Snap struct {
 
 	// The ordered list of tracks that contains channels
 	Tracks []string `json:"tracks,omitempty"`
-}
-
-func (s *Snap) MarshalJSON() ([]byte, error) {
-	type auxSnap Snap // use auxiliary type so that Go does not call Snap.MarshalJSON()
-	// separate type just for marshalling
-	m := struct {
-		auxSnap
-		InstallDate *time.Time `json:"install-date,omitempty"`
-	}{
-		auxSnap: auxSnap(*s),
-	}
-	if !s.InstallDate.IsZero() {
-		m.InstallDate = &s.InstallDate
-	}
-	return json.Marshal(&m)
 }
 
 type Screenshot struct {

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -182,7 +182,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 			"download-size": 6930947,
 			"icon": "/v2/icons/chatroom.ogra/icon",
 			"installed-size": 18976651,
-			"install-date": "2016-01-02T15:04:05Z",
+			"updated": "2016-01-02T15:04:05Z",
 			"license": "GPL-3.0",
 			"name": "chatroom",
 			"developer": "ogra",
@@ -204,6 +204,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 	c.Assert(cs.req.Method, check.Equals, "GET")
 	c.Assert(cs.req.URL.Path, check.Equals, fmt.Sprintf("/v2/snaps/%s", pkgName))
 	c.Assert(err, check.IsNil)
+	date := time.Date(2016, 1, 2, 15, 4, 5, 0, time.UTC)
 	c.Assert(pkg, check.DeepEquals, &client.Snap{
 		ID:            "funky-snap-id",
 		Summary:       "bla bla",
@@ -212,7 +213,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 		DownloadSize:  6930947,
 		Icon:          "/v2/icons/chatroom.ogra/icon",
 		InstalledSize: 18976651,
-		InstallDate:   time.Date(2016, 1, 2, 15, 4, 5, 0, time.UTC),
+		Updated:       &date,
 		License:       "GPL-3.0",
 		Name:          "chatroom",
 		Developer:     "ogra",

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -367,15 +367,16 @@ func (x *infoCmd) Execute([]string) error {
 		maybePrintID(w, both)
 		if local != nil {
 			fmt.Fprintf(w, "tracking:\t%s\n", local.TrackingChannel)
-			fmt.Fprintf(w, "refreshed:\t%s\n", local.InstallDate.Format(time.RFC3339))
 		}
-		w.Flush()
+		if !(both.Updated == nil || both.Updated.IsZero()) {
+			fmt.Fprintf(w, "refreshed:\t%s\n", both.Updated.Format(time.RFC3339))
+		}
+		if remote != nil && remote.Channels != nil && remote.Tracks != nil {
+			w.Flush()
+			displayChannels(w, remote)
+		}
 		if local != nil {
 			fmt.Fprintf(w, "installed:\t%s\t(%s)\t%s\t%s\n", local.Version, local.Revision, strutil.SizeToStr(local.InstalledSize), notes)
-		}
-
-		if remote != nil && remote.Channels != nil && remote.Tracks != nil {
-			displayChannels(w, remote)
 		}
 
 	}

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -270,7 +270,6 @@ description: |
   https://snapcraft.io/
 snap-id:   mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:  beta
-refreshed: 0001-01-01T00:00:00Z
 installed: 2.10 (1) 1kB disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
@@ -306,7 +305,6 @@ description: |
   https://snapcraft.io/
 snap-id:   mVyGrEwiqSi5PugCwyH7WgpoQLemtTd6
 tracking:  beta
-refreshed: 0001-01-01T00:00:00Z
 installed: 2.10 (1) 1kB disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -564,8 +564,8 @@ UnitFileState=potatoes
 	c.Check(m.InstalledSize, check.FitsTypeOf, int64(0))
 	m.InstalledSize = 0
 	// ditto install-date
-	c.Check(m.InstallDate, check.FitsTypeOf, time.Time{})
-	m.InstallDate = time.Time{}
+	c.Check(m.Updated, check.FitsTypeOf, &time.Time{})
+	m.Updated = nil
 
 	meta := &Meta{}
 	expected := &resp{

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -22,11 +22,9 @@ package daemon
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
@@ -51,16 +49,6 @@ func snapIcon(info *snap.Info) string {
 	}
 
 	return found[0]
-}
-
-// snapDate returns the time of the snap mount directory.
-func snapDate(info *snap.Info) time.Time {
-	st, err := os.Stat(info.MountDir())
-	if err != nil {
-		return time.Time{}
-	}
-
-	return st.ModTime()
 }
 
 func publisherName(st *state.State, info *snap.Info) (string, error) {
@@ -324,12 +312,13 @@ func mapLocal(about aboutSnap) *client.Snap {
 
 	// TODO: expose aliases information and state?
 
+	updated := localSnap.Updated
 	result := &client.Snap{
 		Description:      localSnap.Description(),
 		Developer:        about.publisher,
 		Icon:             snapIcon(localSnap),
 		ID:               localSnap.SnapID,
-		InstallDate:      snapDate(localSnap),
+		Updated:          &updated,
 		InstalledSize:    localSnap.Size,
 		Name:             localSnap.Name(),
 		Revision:         localSnap.Revision,
@@ -375,10 +364,12 @@ func mapRemote(remoteSnap *snap.Info) *client.Snap {
 		}
 	}
 
+	updated := remoteSnap.Updated
 	result := &client.Snap{
 		Description:  remoteSnap.Description(),
 		Developer:    remoteSnap.Publisher,
 		DownloadSize: remoteSnap.Size,
+		Updated:      &updated,
 		Icon:         snapIcon(remoteSnap),
 		ID:           remoteSnap.SnapID,
 		Name:         remoteSnap.Name(),

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1681,6 +1681,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 		SnapPath: filepath.Join(dirs.SnapBlobDir, "some-snap_42.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
+			Updated:     snapsup.DownloadInfo.Updated,
 		},
 		SideInfo: snapsup.SideInfo,
 	})
@@ -1869,6 +1870,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 		SnapPath: filepath.Join(dirs.SnapBlobDir, "services-snap_11.snap"),
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
+			Updated:     snapsup.DownloadInfo.Updated,
 		},
 		SideInfo: snapsup.SideInfo,
 	})

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -60,7 +60,11 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	snapContents := fmt.Sprintf("%s-%s-%s", sideInfo.RealName, sideInfo.SnapID, sideInfo.Revision)
 	err = ioutil.WriteFile(snapInfo.MountFile(), []byte(snapContents), 0644)
 	c.Assert(err, check.IsNil)
-	snapInfo.Size = int64(len(snapContents))
+	st, err := os.Stat(snapInfo.MountFile())
+	c.Assert(err, check.IsNil)
+	c.Assert(int64(len(snapContents)), check.Equals, st.Size())
+	snapInfo.Size = st.Size()
+	snapInfo.Updated = st.ModTime()
 
 	return snapInfo
 }

--- a/store/details.go
+++ b/store/details.go
@@ -21,6 +21,7 @@ package store
 
 import (
 	"github.com/snapcore/snapd/snap"
+	"time"
 )
 
 // snapDetails encapsulates the data sent to us from the store as JSON.
@@ -36,7 +37,7 @@ type snapDetails struct {
 	DownloadURL      string             `json:"download_url,omitempty"`
 	Epoch            snap.Epoch         `json:"epoch"`
 	IconURL          string             `json:"icon_url"`
-	LastUpdated      string             `json:"last_updated,omitempty"`
+	LastUpdated      time.Time          `json:"last_updated,omitempty"`
 	Name             string             `json:"package_name"`
 	Prices           map[string]float64 `json:"prices,omitempty"`
 	// Note that the publisher is really the "display name" of the

--- a/store/store.go
+++ b/store/store.go
@@ -109,6 +109,7 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.Channel = d.Channel
 	info.Sha3_384 = d.DownloadSha3_384
 	info.Size = d.DownloadSize
+	info.Updated = d.LastUpdated
 	info.IconURL = d.IconURL
 	info.AnonDownloadURL = d.AnonDownloadURL
 	info.DownloadURL = d.DownloadURL

--- a/tests/main/snap-info/check.py
+++ b/tests/main/snap-info/check.py
@@ -140,4 +140,5 @@ check("test-snapd-python-webserver", res[6],
    ("channels", exists),
    ("snap-id", equals, snap_ids["test-snapd-python-webserver"]),
    ("license", equals, "Other Open Source"),
+   ("refreshed", exists),
 )


### PR DESCRIPTION
Before this change, snaps would have an `InstallDate` attribute
in the client API (`"install-date"` in the JSON). The field would
not be present for 'remote' snaps (so, not in `/v2/find`
results), only in 'local' (`/v2/snaps`) snaps, and it was wrong:
the value returned was the timestmap of the toplevel directory of
the snap, which is not the install date of the snap.

The *actual* install date is also probably confusing to users, as
the date it was installed could be interpreted as the date the
user did `snap install`, or as of was when _this revision_ was
installed (FWIW it was meant to be the latter). In `snap info`,
for example, we call this time `refreshed` time (oblivious to the
fact that it was wrong much of the time).

As far as I know (I checked in 16.04's GNOME's software; maybe
@ikeydoherty and @robert-ancell can confirm) GUI software stores
aren't using the timestamp; snapd-glib will return `NULL` for
snapd_snap_get_install_date, and because in searches it won't be
there clients will have had to handle that `NULL`.

Between it not always being there, it being wrong when it is, and
it being called an ambiguous thing even if it weren't, I think
the best thing we can do is just drop it.

This change drops `InstallDate`, and adds `Updated` in its place.

* for 'remote' snaps, `Updated` is populated from the store's
  `LastUpdated` field.

* for 'local' snaps, `Updated` is populated from the timestamp of
  the thing we put in `/var/lib/snapd/snaps` (that'd be the
  `.snap` for regular snaps, or a symlink to the thing for `try`
  snaps -- so we use `lstat`, fwiw). It being called something
  different from `Refreshed` avoids it causing confusion when
  it's found to be different from timestamps in `snap changes`.

This will still leave a small element of possible confusion, in
that `Updated` will not update on revert, but hopefully this is
minor (and if it isn't, needs addressing separately; it isn't a
problem introduced by this change).

There is also another timestamp that would be quite useful to
report, for local squashfs snaps, and that's the one of the
squash's creation. This might follow in a separate PR.

> #### open question:
> In both cases, `snap info` will list this as `refreshed`, which
> is a little weird for remote snaps (and leaves open the
> possibility of confusion with what `snap changes` reports). I
> could change it to say `updated`, but I don't know how well
> that'd fly.
