### PR TITLE
userd/tests: Test kdialog calls and mock kdialog too to make tests work in KDE

### DIFF
--- a/userd/ui/ui.go
+++ b/userd/ui/ui.go
@@ -46,11 +46,35 @@ type DialogOptions struct {
 	Timeout time.Duration
 }
 
+var hasZenityExecutable = func() bool {
+	return osutil.ExecutableExists("zenity")
+}
+
+var hasKDialogExecutable = func() bool {
+	return osutil.ExecutableExists("kdialog")
+}
+
+func MockHasZenityExecutable(f func() bool) func() {
+	oldHasZenityExecutable := hasZenityExecutable
+	hasZenityExecutable := f
+	return func() {
+		hasZenityExecutable = oldHasZenityExecutable
+	}
+}
+
+func MockHasKDialogExecutable(f func() bool) func() {
+	oldHasKDialogExecutable := hasKDialogExecutable
+	hasKDialogExecutable := f
+	return func() {
+		hasKDialogExecutable = oldHasKDialogExecutable
+	}
+}
+
 // New returns the best matching UI interface for the given system
 // or an error if no ui can be created.
 func New() (UI, error) {
-	hasZenity := osutil.ExecutableExists("zenity")
-	hasKDialog := osutil.ExecutableExists("kdialog")
+	hasZenity := hasZenityExecutable()
+	hasKDialog := hasKDialogExecutable()
 
 	switch {
 	case hasZenity && hasKDialog:


### PR DESCRIPTION
On KDE we invoke the real kdialog because it wasn't mocked and the tests fail.
This PR fixes it and also makes the test check both kdialog and zenity code paths.