### PR TITLE
[2.31] timeutil: account for 24h wrap when flattening clock spans

### DIFF
--- a/timeutil/export_test.go
+++ b/timeutil/export_test.go
@@ -21,6 +21,10 @@ package timeutil
 
 import "time"
 
+var (
+	ParseClockSpan = parseClockSpan
+)
+
 func MockTimeNow(f func() time.Time) (restorer func()) {
 	origTimeNow := timeNow
 	timeNow = f

--- a/timeutil/schedule.go
+++ b/timeutil/schedule.go
@@ -46,7 +46,11 @@ func (t Clock) String() string {
 func (t Clock) Sub(other Clock) time.Duration {
 	t1 := time.Duration(t.Hour)*time.Hour + time.Duration(t.Minute)*time.Minute
 	t2 := time.Duration(other.Hour)*time.Hour + time.Duration(other.Minute)*time.Minute
-	return t1 - t2
+	dur := t1 - t2
+	if dur < 0 {
+		dur = -(dur + 24*time.Hour)
+	}
+	return dur
 }
 
 // Add adds given duration to t and returns a new Clock
@@ -225,6 +229,9 @@ func (ts ClockSpan) ClockSpans() []ClockSpan {
 	}
 
 	span := ts.End.Sub(ts.Start)
+	if span < 0 {
+		span = -span
+	}
 	step := span / time.Duration(ts.Split)
 
 	spans := make([]ClockSpan, ts.Split)


### PR DESCRIPTION
When flattening a clock span such as 23:00-01:00/2, the code would incorrectly
generate spans: 23:00-12:00, 12:00-01:00. This is caused by the fact that
01:00.Sub(23:00) incorrectly returns -22h instead of -2h and that the flattening
function does not account for the 24h wraparound.
