### PR TITLE
interfaces/screen-inhibit-control,network-status: fix dbus path and interface typos - 2.31

### DIFF
--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -81,7 +81,7 @@ const networkStatusConnectedPlugAppArmor = `
 # Allow all access to NetworkingStatus service
 dbus (send)
     bus=system
-    interface=com.ubuntu.connectivity1.NetworkingStatus{,/**}
+    interface=com.ubuntu.connectivity1.NetworkingStatus{,*}
     path=/com/ubuntu/connectivity1/NetworkingStatus
     peer=(label=###SLOT_SECURITY_TAGS###),
 

--- a/interfaces/builtin/network_status_test.go
+++ b/interfaces/builtin/network_status_test.go
@@ -76,7 +76,7 @@ func (s *NetworkStatusSuite) TestAppArmorConnectedPlug(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `peer=(label="snap.provider.app"`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "interface=com.ubuntu.connectivity1.NetworkingStatus{,/**}")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "interface=com.ubuntu.connectivity1.NetworkingStatus{,*}")
 }
 
 func (s *NetworkStatusSuite) TestAppArmorConnectedSlot(c *C) {

--- a/interfaces/builtin/screen_inhibit_control.go
+++ b/interfaces/builtin/screen_inhibit_control.go
@@ -67,7 +67,7 @@ dbus (send)
 # API rule
 dbus (send)
     bus=session
-    path=/{,org/freedesktop/,org.gnome/}ScreenSaver
+    path=/{,org/freedesktop/,org/gnome/}ScreenSaver
     interface=org.freedesktop.ScreenSaver
     member={Inhibit,UnInhibit,SimulateUserActivity}
     peer=(label=unconfined),


### PR DESCRIPTION
https://github.com/snapcore/snapd/pull/4733 for 2.31.