### PR TITLE
daemon, snap: fix InstallDate, make a method of *snap.Info

### DIFF
--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -22,11 +22,9 @@ package daemon
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
@@ -51,16 +49,6 @@ func snapIcon(info *snap.Info) string {
 	}
 
 	return found[0]
-}
-
-// snapDate returns the time of the snap mount directory.
-func snapDate(info *snap.Info) time.Time {
-	st, err := os.Stat(info.MountDir())
-	if err != nil {
-		return time.Time{}
-	}
-
-	return st.ModTime()
 }
 
 func publisherName(st *state.State, info *snap.Info) (string, error) {
@@ -329,7 +317,7 @@ func mapLocal(about aboutSnap) *client.Snap {
 		Developer:        about.publisher,
 		Icon:             snapIcon(localSnap),
 		ID:               localSnap.SnapID,
-		InstallDate:      snapDate(localSnap),
+		InstallDate:      localSnap.InstallDate(),
 		InstalledSize:    localSnap.Size,
 		Name:             localSnap.Name(),
 		Revision:         localSnap.Revision,

--- a/snap/info.go
+++ b/snap/info.go
@@ -28,6 +28,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil/sys"
@@ -172,7 +173,7 @@ type Info struct {
 	// The information in all the remaining fields is not sourced from the snap blob itself.
 	SideInfo
 
-	// Broken marks if set whether the snap is broken and the reason.
+	// Broken marks whether the snap is broken and the reason.
 	Broken string
 
 	// The information in these fields is ephemeral, available only from the store.
@@ -348,6 +349,22 @@ func (s *Info) ExpandSnapVariables(path string) string {
 		}
 		return ""
 	})
+}
+
+// InstallDate returns the "install date" of the snap.
+//
+// If the snap is not active, it'll return a zero time; otherwise
+// it'll return the modtime of the "current" symlink. Sneaky.
+func (s *Info) InstallDate() time.Time {
+	dir, rev := filepath.Split(s.MountDir())
+	cur := filepath.Join(dir, "current")
+	tag, err := os.Readlink(cur)
+	if err == nil && tag == rev {
+		if st, err := os.Lstat(cur); err == nil {
+			return st.ModTime()
+		}
+	}
+	return time.Time{}
 }
 
 func BadInterfacesSummary(snapInfo *Info) string {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -195,6 +195,20 @@ func (s *infoSuite) TestReadInfo(c *C) {
 	c.Check(snapInfo2, DeepEquals, snapInfo1)
 }
 
+func (s *infoSuite) TestInstallDate(c *C) {
+	si := &snap.SideInfo{Revision: snap.R(1)}
+	info := snaptest.MockSnap(c, sampleYaml, si)
+	// not current -> Zero
+	c.Check(info.InstallDate().IsZero(), Equals, true)
+
+	mountdir := info.MountDir()
+	dir, rev := filepath.Split(mountdir)
+	c.Assert(os.MkdirAll(dir, 0755), IsNil)
+	c.Assert(os.Symlink(rev, filepath.Join(dir, "current")), IsNil)
+
+	c.Check(info.InstallDate().IsZero(), Equals, false)
+}
+
 func (s *infoSuite) TestReadInfoNotFound(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(42), EditedSummary: "esummary"}
 	info, err := snap.ReadInfo("sample", si)


### PR DESCRIPTION
`(client.Snap).InstallDate` was being set from the timestmap of the
toplevel directory of a snap, instead of from the timestamp of the
current symlink.

This is probably a direct consequence of it being tucked away in a
helper function in `daemon/snap.go`. I've made it more visible by making
it a method on snap.Info.
