### PR TITLE
snap: unify snap name validation w/python; enforce length limit.

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -152,6 +152,12 @@ static void test_sc_snap_name_validate(void)
 	const char *invalid_names[] = {
 		// name cannot be empty
 		"",
+		// names cannot be full
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		"xxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx",
+		"1111111111111111111111111111111111111111x",
+		"x1111111111111111111111111111111111111111",
+		"x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x",
 		// dashes alone are not a name
 		"-", "--",
 		// double dashes in a name are not allowed
@@ -161,7 +167,7 @@ static void test_sc_snap_name_validate(void)
 		// name cannot have any spaces in it
 		"a ", " a", "a a",
 		// a number alone is not a name
-		"0", "123",
+		"0", "123", "1-2-3",
 		// identifier must be plain ASCII
 		"日本語", "한글", "ру́сский язы́к",
 	};
@@ -181,6 +187,17 @@ static void test_sc_snap_name_validate(void)
 	sc_snap_name_validate("123test", &err);
 	g_assert_null(err);
 
+	// In case we switch to a regex, here's a test that could break things.
+	const char *good_bad_name = "u-94903713687486543234157734673284536758";
+	char varname[41] = {0};
+	for (int i = 3; i <= 40; i++ ) {
+		g_assert_nonnull(strncpy(varname, good_bad_name, i));
+		varname[i] = 0;
+		g_test_message("checking valid snap name: >%s<", varname);
+		sc_snap_name_validate(varname, &err);
+		g_assert_null(err);
+		sc_error_free(err);
+	}
 }
 
 static void test_sc_snap_name_validate__respects_error_protocol(void)

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -152,7 +152,7 @@ static void test_sc_snap_name_validate(void)
 	const char *invalid_names[] = {
 		// name cannot be empty
 		"",
-		// names cannot be full
+		// names cannot be too long
 		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 		"xxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx",
 		"1111111111111111111111111111111111111111x",

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -123,15 +123,19 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 		goto out;
 	}
 	bool got_letter = false;
+	int n = 0, m;
 	for (; *p != '\0';) {
-		if (skip_lowercase_letters(&p) > 0) {
+		if ((m = skip_lowercase_letters(&p)) > 0) {
+			n += m;
 			got_letter = true;
 			continue;
 		}
-		if (skip_digits(&p) > 0) {
+		if ((m = skip_digits(&p)) > 0) {
+			n += m;
 			continue;
 		}
 		if (skip_one_char(&p, '-') > 0) {
+			n++;
 			if (*p == '\0') {
 				err =
 				    sc_error_init(SC_SNAP_DOMAIN,
@@ -155,6 +159,10 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 	if (!got_letter) {
 		err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
 				    "snap name must contain at least one letter");
+	}
+	if (n > 40) {
+		err = sc_error_init(SC_SNAP_DOMAIN, SC_SNAP_INVALID_NAME,
+				    "snap name must be shorter than 40 characters");
 	}
 
  out:

--- a/cmd/snap-update-ns/bootstrap.c
+++ b/cmd/snap-update-ns/bootstrap.c
@@ -133,15 +133,19 @@ int validate_snap_name(const char* snap_name)
         return -1;
     }
     bool got_letter = false;
+    int n=0, m;
     for (; *p != '\0';) {
-        if (skip_lowercase_letters(&p) > 0) {
+        if ((m = skip_lowercase_letters(&p)) > 0) {
+            n += m;
             got_letter = true;
             continue;
         }
-        if (skip_digits(&p) > 0) {
+        if ((m = skip_digits(&p)) > 0) {
+            n += m;
             continue;
         }
         if (skip_one_char(&p, '-') > 0) {
+            n++;
             if (*p == '\0') {
                 bootstrap_msg = "snap name cannot end with a dash";
                 return -1;
@@ -157,6 +161,10 @@ int validate_snap_name(const char* snap_name)
     }
     if (!got_letter) {
         bootstrap_msg = "snap name must contain at least one letter";
+        return -1;
+    }
+    if (n > 40) {
+        bootstrap_msg = "snap name must be shorter than 40 characters";
         return -1;
     }
 

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -35,17 +35,38 @@ import (
 )
 
 // Regular expressions describing correct identifiers.
-//
-// validSnapName is also used to validate socket identifiers.
-var validSnapName = regexp.MustCompile("^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$")
 var validHookName = regexp.MustCompile("^[a-z](?:-?[a-z0-9])*$")
+
+// almostValidName is part of snap and socket name validation.
+//   the full regexp we could use, "^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$", is
+//   O(2ⁿ) on the length of the string in python. An equivalent regexp that
+//   doesn't have the nested quantifiers that trip up Python's re would be
+//   "^(?:[a-z0-9]|(?<=[a-z0-9])-)*[a-z](?:[a-z0-9]|-(?=[a-z0-9]))*$", but Go's
+//   regexp package doesn't support look-aheads nor look-behinds, so in order to
+//   have a unified implementation in the Go and Python bits of the project
+//   we're doing it this way instead. Check the length (if applicable), check
+//   this regexp, then check the dashes.
+//   This still leaves sc_snap_name_validate (in cmd/snap-confine/snap.c) and
+//   snap_validate (cmd/snap-update-ns/bootstrap.c) with their own handcrafted
+//   validators.
+var almostValidName = regexp.MustCompile("^[a-z0-9-]*[a-z][a-z0-9-]*$")
+
+// isValidName checks snap and socket socket identifiers.
+func isValidName(name string) bool {
+	if !almostValidName.MatchString(name) {
+		return false
+	}
+	if name[0] == '-' || name[len(name)-1] == '-' || strings.Contains(name, "--") {
+		return false
+	}
+	return true
+}
 
 // ValidateName checks if a string can be used as a snap name.
 func ValidateName(name string) error {
 	// NOTE: This function should be synchronized with the two other
 	// implementations: sc_snap_name_validate and validate_snap_name .
-	valid := validSnapName.MatchString(name)
-	if !valid {
+	if len(name) > 40 || !isValidName(name) {
 		return fmt.Errorf("invalid snap name: %q", name)
 	}
 	return nil
@@ -144,8 +165,7 @@ func ValidateAlias(alias string) error {
 // validateSocketName checks if a string ca be used as a name for a socket (for
 // socket activation).
 func validateSocketName(name string) error {
-	valid := validSnapName.MatchString(name)
-	if !valid {
+	if !isValidName(name) {
 		return fmt.Errorf("invalid socket name: %q", name)
 	}
 	return nil

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -61,6 +61,8 @@ func (s *ValidateSuite) TestValidateName(c *C) {
 		"a-a", "aa-a", "a-aa", "a-b-c",
 		"a0", "a-0", "a-0a",
 		"01game", "1-or-2",
+		// a regexp stresser
+		"u-94903713687486543234157734673284536758",
 	}
 	for _, name := range validNames {
 		err := ValidateName(name)
@@ -69,6 +71,14 @@ func (s *ValidateSuite) TestValidateName(c *C) {
 	invalidNames := []string{
 		// name cannot be empty
 		"",
+		// names cannot be full
+		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		"xxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx",
+		"1111111111111111111111111111111111111111x",
+		"x1111111111111111111111111111111111111111",
+		"x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x",
+		// a regexp stresser
+		"u-9490371368748654323415773467328453675-",
 		// dashes alone are not a name
 		"-", "--",
 		// double dashes in a name are not allowed

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -71,7 +71,7 @@ func (s *ValidateSuite) TestValidateName(c *C) {
 	invalidNames := []string{
 		// name cannot be empty
 		"",
-		// names cannot be full
+		// names cannot be too long
 		"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 		"xxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx",
 		"1111111111111111111111111111111111111111x",


### PR DESCRIPTION
From a comment in the code:

    The full regexp we could use, "^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9])*$", is
    O(2ⁿ) on the length of the string in python. An equivalent regexp that
    doesn't have the nested quantifiers that trip up Python's re would be
    "^(?:[a-z0-9]|(?<=[a-z0-9])-)*[a-z](?:[a-z0-9]|-(?=[a-z0-9]))*$", but Go's
    regexp package doesn't support look-aheads nor look-behinds, so in order to
    have a unified implementation in the Go and Python bits of the project
    we're doing it this way instead. Check the length (if applicable), check
    this regexp, then check the dashes.
    This still leaves sc_snap_name_validate (in cmd/snap-confine/snap.c) and
    snap_validate (cmd/snap-update-ns/bootstrap.c) with their own handcrafted
    validators.

This change also makes the three implementations in snapd verify snap
name length, which they weren't. Also, more tests for all.
