### PR TITLE
cmd/snap-update-ns: use recursive bind mounts for writable mimic

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -554,6 +554,7 @@
         # in /tmp/.snap/ during the preparation of a writable mimic.
         # FIXME: update this with per-snap snap-update-ns profiles
         mount options=(bind, rw) /** -> /tmp/.snap/**,
+        mount options=(rbind, rw) /** -> /tmp/.snap/**,
         # Allow mounting tmpfs over the original read-only directory.
         # FIXME: update this with per-snap snap-update-ns profiles
         mount fstype=tmpfs options=(rw) tmpfs -> /**,
@@ -561,9 +562,13 @@
         # back to $SNAP/** (to re-construct the data that was there before).
         # FIXME: update this with per-snap snap-update-ns profiles
         mount options=(bind, rw) /tmp/.snap/** -> /**,
+        mount options=(rbind, rw) /tmp/.snap/** -> /**,
         # Allow unmounting the temporary directory in /tmp once it is no longer
         # necessary.
         umount /tmp/.snap/**,
+        # Allow unmounting any of the above in case something fails and
+        # we start recovery.
+        umount /**,
 
         # Allow creating missing directories anywhere under the root directory
         # (but not in the root directory itself) where they need to be created

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -252,7 +252,11 @@ func (c *Change) lowLevelPerform() error {
 			err = osRemove(c.Entry.Dir)
 			logger.Debugf("remove %q (error: %v)", c.Entry.Dir, err)
 		case "", "file":
-			err = sysUnmount(c.Entry.Dir, umountNoFollow)
+			flags := umountNoFollow
+			if c.Entry.OptBool("x-snapd.detach") {
+				flags |= syscall.MNT_DETACH
+			}
+			err = sysUnmount(c.Entry.Dir, flags)
 			logger.Debugf("umount %q (error: %v)", c.Entry.Dir, err)
 		}
 		return err

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -422,10 +422,10 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 		`close 3`,
 		`close 5`,
 		`lstat "/rofs"`,
-		`mount "/rofs" "/tmp/.snap/rofs" "" MS_BIND ""`,
+		`mount "/rofs" "/tmp/.snap/rofs" "" MS_BIND|MS_REC ""`,
 		`lstat "/rofs"`,
 		`mount "tmpfs" "/rofs" "tmpfs" 0 ""`,
-		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW`,
+		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`,
 
 		// mimic ready, re-try initial mkdir
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
@@ -547,6 +547,15 @@ func (s *changeSuite) TestPerformFilesystemUnmount(c *C) {
 	synth, err := chg.Perform()
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "/target" UMOUNT_NOFOLLOW`})
+	c.Assert(synth, HasLen, 0)
+}
+
+// Change.Perform wants to detach a bind mount.
+func (s *changeSuite) TestPerformFilesystemDetch(c *C) {
+	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "/something", Dir: "/target", Options: []string{"x-snapd.detach"}}}
+	synth, err := chg.Perform()
+	c.Assert(err, IsNil)
+	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "/target" UMOUNT_NOFOLLOW|MNT_DETACH`})
 	c.Assert(synth, HasLen, 0)
 }
 
@@ -769,10 +778,10 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyB
 		`close 3`,
 		`close 5`,
 		`lstat "/rofs"`,
-		`mount "/rofs" "/tmp/.snap/rofs" "" MS_BIND ""`,
+		`mount "/rofs" "/tmp/.snap/rofs" "" MS_BIND|MS_REC ""`,
 		`lstat "/rofs"`,
 		`mount "tmpfs" "/rofs" "tmpfs" 0 ""`,
-		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW`,
+		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`,
 
 		// mimic ready, re-try initial mkdir
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
@@ -1044,10 +1053,10 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPointAndReadOnlyBase(c
 		`close 3`,
 		`close 5`,
 		`lstat "/rofs"`,
-		`mount "/rofs" "/tmp/.snap/rofs" "" MS_BIND ""`,
+		`mount "/rofs" "/tmp/.snap/rofs" "" MS_BIND|MS_REC ""`,
 		`lstat "/rofs"`,
 		`mount "tmpfs" "/rofs" "tmpfs" 0 ""`,
-		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW`,
+		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`,
 
 		// mimic ready, re-try initial mkdir
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
@@ -1278,10 +1287,10 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 		`close 3`,
 		`close 5`,
 		`lstat "/rofs"`,
-		`mount "/rofs" "/tmp/.snap/rofs" "" MS_BIND ""`,
+		`mount "/rofs" "/tmp/.snap/rofs" "" MS_BIND|MS_REC ""`,
 		`lstat "/rofs"`,
 		`mount "tmpfs" "/rofs" "tmpfs" 0 ""`,
-		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW`,
+		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`,
 
 		// mimic ready, re-try initial base mkdir
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -336,7 +336,7 @@ func planWritableMimic(dir string) ([]*Change, error) {
 			// parsing the mount table and exploring what is really
 			// there and this is not how the undo logic is
 			// designed.
-			Name: dir, Dir: safeKeepingDir, Options: []string{"bind"}},
+			Name: dir, Dir: safeKeepingDir, Options: []string{"rbind"}},
 	})
 	// Mount tmpfs over the original directory, hiding its contents.
 	changes = append(changes, &Change{
@@ -349,9 +349,8 @@ func planWritableMimic(dir string) ([]*Change, error) {
 	}
 	for _, fi := range entries {
 		ch := &Change{Action: Mount, Entry: osutil.MountEntry{
-			Name:    filepath.Join(safeKeepingDir, fi.Name()),
-			Dir:     filepath.Join(dir, fi.Name()),
-			Options: []string{"bind"},
+			Name: filepath.Join(safeKeepingDir, fi.Name()),
+			Dir:  filepath.Join(dir, fi.Name()),
 		}}
 		// Bind mount each element from the safe-keeping directory into the
 		// tmpfs. Our Change.Perform() engine can create the missing
@@ -359,9 +358,10 @@ func planWritableMimic(dir string) ([]*Change, error) {
 		m := fi.Mode()
 		switch {
 		case m.IsDir():
+			ch.Entry.Options = []string{"rbind"}
 			changes = append(changes, ch)
 		case m.IsRegular():
-			ch.Entry.Options = append(ch.Entry.Options, "x-snapd.kind=file")
+			ch.Entry.Options = []string{"bind", "x-snapd.kind=file"}
 			changes = append(changes, ch)
 		case m&os.ModeSymlink != 0:
 			if target, err := osReadlink(filepath.Join(dir, fi.Name())); err == nil {
@@ -374,7 +374,7 @@ func planWritableMimic(dir string) ([]*Change, error) {
 	}
 	// Finally unbind the safe-keeping directory as we don't need it anymore.
 	changes = append(changes, &Change{
-		Action: Unmount, Entry: osutil.MountEntry{Name: "none", Dir: safeKeepingDir},
+		Action: Unmount, Entry: osutil.MountEntry{Name: "none", Dir: safeKeepingDir, Options: []string{"x-snapd.detach"}},
 	})
 	return changes, nil
 }
@@ -430,6 +430,9 @@ func execWritableMimic(plan []*Change) ([]*Change, error) {
 				// The "undo plan" is "a plan that can be undone" not "the plan
 				// for how to undo" so we need to flip the actions.
 				recoveryUndoChange.Action = Unmount
+				if recoveryUndoChange.Entry.OptBool("rbind") {
+					recoveryUndoChange.Entry.Options = append(recoveryUndoChange.Entry.Options, "x-snapd.detach")
+				}
 				if _, err2 := changePerform(recoveryUndoChange); err2 != nil {
 					// Drat, we failed when trying to recover from an error.
 					// We cannot do anything at this stage.
@@ -451,9 +454,15 @@ func execWritableMimic(plan []*Change) ([]*Change, error) {
 
 		}
 		// Store an undo change for the change we just performed.
+		undoOpts := change.Entry.Options
+		if change.Entry.OptBool("rbind") {
+			undoOpts = make([]string, 0, len(change.Entry.Options)+1)
+			undoOpts = append(undoOpts, change.Entry.Options...)
+			undoOpts = append(undoOpts, "x-snapd.detach")
+		}
 		undoChange := &Change{
 			Action: Mount,
-			Entry:  osutil.MountEntry{Dir: change.Entry.Dir, Name: change.Entry.Name, Type: change.Entry.Type, Options: change.Entry.Options},
+			Entry:  osutil.MountEntry{Dir: change.Entry.Dir, Name: change.Entry.Name, Type: change.Entry.Type, Options: undoOpts},
 		}
 		// Because of the use of a temporary bind mount (aka the safe-keeping
 		// directory) we cannot represent bind mounts fully (the temporary bind
@@ -464,7 +473,7 @@ func execWritableMimic(plan []*Change) ([]*Change, error) {
 		// directory or file in the same path, with the tmpfs in place already)
 		// but this is closer to the truth and more in line with the idea that
 		// this is just a plan for undoing the operation.
-		if undoChange.Entry.OptBool("bind") {
+		if undoChange.Entry.OptBool("bind") || undoChange.Entry.OptBool("rbind") {
 			undoChange.Entry.Name = undoChange.Entry.Dir
 		}
 		undoChanges = append(undoChanges, undoChange)

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -256,18 +256,18 @@ func (s *utilsSuite) TestPlanWritableMimic(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(changes, DeepEquals, []*update.Change{
 		// Store /foo in /tmp/.snap/foo while we set things up
-		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"rbind"}}, Action: update.Mount},
 		// Put a tmpfs over /foo
 		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/foo", Type: "tmpfs"}, Action: update.Mount},
 		// Bind mount files and directories over. Note that files are identified by x-snapd.kind=file option.
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/file", Dir: "/foo/file", Options: []string{"bind", "x-snapd.kind=file"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"rbind"}}, Action: update.Mount},
 		// Create symlinks.
 		// Bad symlinks and all other file types are skipped and not
 		// recorded in mount changes.
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/symlink", Dir: "/foo/symlink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=target"}}, Action: update.Mount},
 		// Unmount the safe-keeping directory
-		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo"}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
 	})
 }
 
@@ -290,12 +290,12 @@ func (s *utilsSuite) TestPlanWritableMimicErrors(c *C) {
 func (s *utilsSuite) TestExecWirableMimicSuccess(c *C) {
 	// This plan is the same as in the test above. This is what comes out of planWritableMimic.
 	plan := []*update.Change{
-		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"rbind"}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/foo", Type: "tmpfs"}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/file", Dir: "/foo/file", Options: []string{"bind", "x-snapd.kind=file"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"rbind"}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/symlink", Dir: "/foo/symlink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=target"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo"}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
 	}
 
 	// Mock the act of performing changes, each of the change we perform is coming from the plan.
@@ -311,20 +311,20 @@ func (s *utilsSuite) TestExecWirableMimicSuccess(c *C) {
 	c.Assert(undoPlan, DeepEquals, []*update.Change{
 		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/foo", Type: "tmpfs"}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "/foo/file", Dir: "/foo/file", Options: []string{"bind", "x-snapd.kind=file"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "/foo/dir", Dir: "/foo/dir", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/foo/dir", Dir: "/foo/dir", Options: []string{"rbind", "x-snapd.detach"}}, Action: update.Mount},
 	})
 }
 
 func (s *utilsSuite) TestExecWirableMimicErrorWithRecovery(c *C) {
 	// This plan is the same as in the test above. This is what comes out of planWritableMimic.
 	plan := []*update.Change{
-		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"rbind"}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/foo", Type: "tmpfs"}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/file", Dir: "/foo/file", Options: []string{"bind", "x-snapd.kind=file"}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/symlink", Dir: "/foo/symlink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=target"}}, Action: update.Mount},
 		// NOTE: the next perform will fail. Notably the symlink did not fail.
-		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"bind"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo"}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"rbind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
 	}
 
 	// Mock the act of performing changes. Before we inject a failure we ensure
@@ -357,19 +357,19 @@ func (s *utilsSuite) TestExecWirableMimicErrorWithRecovery(c *C) {
 		// NOTE: there is no symlink undo entry as it is implicitly undone by unmounting the tmpfs.
 		{Entry: osutil.MountEntry{Name: "/foo/file", Dir: "/foo/file", Options: []string{"bind", "x-snapd.kind=file"}}, Action: update.Unmount},
 		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/foo", Type: "tmpfs"}, Action: update.Unmount},
-		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"bind"}}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"rbind", "x-snapd.detach"}}, Action: update.Unmount},
 	})
 }
 
 func (s *utilsSuite) TestExecWirableMimicErrorNothingDone(c *C) {
 	// This plan is the same as in the test above. This is what comes out of planWritableMimic.
 	plan := []*update.Change{
-		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"rbind"}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/foo", Type: "tmpfs"}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/file", Dir: "/foo/file", Options: []string{"bind", "x-snapd.kind=file"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"rbind"}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/symlink", Dir: "/foo/symlink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=target"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo"}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
 	}
 
 	// Mock the act of performing changes and just fail on any request.
@@ -387,12 +387,12 @@ func (s *utilsSuite) TestExecWirableMimicErrorNothingDone(c *C) {
 func (s *utilsSuite) TestExecWirableMimicErrorCannotUndo(c *C) {
 	// This plan is the same as in the test above. This is what comes out of planWritableMimic.
 	plan := []*update.Change{
-		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/foo", Dir: "/tmp/.snap/foo", Options: []string{"rbind"}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/foo", Type: "tmpfs"}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/file", Dir: "/foo/file", Options: []string{"bind", "x-snapd.kind=file"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"bind"}}, Action: update.Mount},
+		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/dir", Dir: "/foo/dir", Options: []string{"rbind"}}, Action: update.Mount},
 		{Entry: osutil.MountEntry{Name: "/tmp/.snap/foo/symlink", Dir: "/foo/symlink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=target"}}, Action: update.Mount},
-		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo"}, Action: update.Unmount},
+		{Entry: osutil.MountEntry{Name: "none", Dir: "/tmp/.snap/foo", Options: []string{"x-snapd.detach"}}, Action: update.Unmount},
 	}
 
 	// Mock the act of performing changes. After performing the first change

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -136,6 +136,10 @@ func formatUnmountFlags(flags int) string {
 		flags ^= UMOUNT_NOFOLLOW
 		fl = append(fl, "UMOUNT_NOFOLLOW")
 	}
+	if flags&syscall.MNT_DETACH == syscall.MNT_DETACH {
+		flags ^= syscall.MNT_DETACH
+		fl = append(fl, "MNT_DETACH")
+	}
 	if flags != 0 {
 		panic(fmt.Errorf("unrecognized unmount flags %d", flags))
 	}

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -109,6 +109,10 @@ func formatMountFlags(flags int) string {
 		flags ^= syscall.MS_BIND
 		fl = append(fl, "MS_BIND")
 	}
+	if flags&syscall.MS_REC == syscall.MS_REC {
+		flags ^= syscall.MS_REC
+		fl = append(fl, "MS_REC")
+	}
 	if flags&syscall.MS_RDONLY == syscall.MS_RDONLY {
 		flags ^= syscall.MS_RDONLY
 		fl = append(fl, "MS_RDONLY")

--- a/testutil/lowlevel_test.go
+++ b/testutil/lowlevel_test.go
@@ -265,10 +265,10 @@ func (s *lowLevelSuite) TestMkdiratBadFd(c *C) {
 }
 
 func (s *lowLevelSuite) TestMountSuccess(c *C) {
-	err := s.sys.Mount("source", "target", "fstype", syscall.MS_BIND|syscall.MS_RDONLY, "")
+	err := s.sys.Mount("source", "target", "fstype", syscall.MS_BIND|syscall.MS_REC|syscall.MS_RDONLY, "")
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`mount "source" "target" "fstype" MS_BIND|MS_RDONLY ""`,
+		`mount "source" "target" "fstype" MS_BIND|MS_REC|MS_RDONLY ""`,
 	})
 }
 

--- a/testutil/lowlevel_test.go
+++ b/testutil/lowlevel_test.go
@@ -282,9 +282,9 @@ func (s *lowLevelSuite) TestMountFailure(c *C) {
 }
 
 func (s *lowLevelSuite) TestUnmountSuccess(c *C) {
-	err := s.sys.Unmount("target", testutil.UMOUNT_NOFOLLOW)
+	err := s.sys.Unmount("target", testutil.UMOUNT_NOFOLLOW|syscall.MNT_DETACH)
 	c.Assert(err, IsNil)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "target" UMOUNT_NOFOLLOW`})
+	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "target" UMOUNT_NOFOLLOW|MNT_DETACH`})
 }
 
 func (s *lowLevelSuite) TestUnmountFailure(c *C) {


### PR DESCRIPTION
This branch fixes a bug where poking writable holes in places with
existing bind mounts would "undo" those bind mounts because only the
first layer would be "copied" by a bind mount. Recursive bind mount
will transfer all of the directory and file bind mounts over.

With this change we must also switch to lazy unmount (MNT_DETACH) on
the undo operation. This is required because otherwise we would have
to iterate the mount table and figure out which mount entries to
remove. Using MNT_DETACH simply makes the kernel do that for us.

To convey the new unmount flag we now have "x-snapd.detach" mount option
on some generated unmount changes.

The apparmor profile for snap-update-ns has been updated to include
the new rbind permissions (both bind and rbind are now required).
In addition, testing this has uncovered that we didn't have enough
permissions to undo the writable mimic plan in case of failures
(we lacked appropriate umount permission). This is now fixed.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>