### PR TITLE
overlord/snapstate: verify that default schedule is randomized and is  not a single time

### DIFF
--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/storetest"
+	"github.com/snapcore/snapd/timeutil"
 )
 
 type autoRefreshStore struct {
@@ -159,4 +160,18 @@ func (s *autoRefreshTestSuite) TestRefreshBackoff(c *C) {
 	err = af.Ensure()
 	c.Check(err, ErrorMatches, "random store error")
 	c.Check(s.store.ops, HasLen, 2)
+}
+
+func (s *autoRefreshTestSuite) TestDefaultScheduleIsRandomized(c *C) {
+	schedule, err := timeutil.ParseSchedule(snapstate.DefaultRefreshSchedule)
+	c.Assert(err, IsNil)
+
+	for _, sched := range schedule {
+		for _, span := range sched.ClockSpans {
+			c.Check(span.Start == span.End, Equals, false,
+				Commentf("clock span %v is a single time, expected an actual span", span))
+			c.Check(span.Spread, Equals, true,
+				Commentf("clock span %v is not randomized", span))
+		}
+	}
 }


### PR DESCRIPTION
Make sure that we do not break the backend again and verify that the default
schedule is randomized and is an actual time span (i.e. not a single time).
