### PR TITLE
packaging/arch: sync with snapd/snapd-git from AUR

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -94,13 +94,7 @@ check() {
   export GOPATH="$srcdir/go"
   cd "$GOPATH/src/${_gourl}"
 
-  # XXX: Those files are unknown to gitignore but are checked by run-checks
-  # --static. Before gitignore is updated we just remove the junk one and move
-  # the valuable one aside.
-  rm -f cmd/snap-confine/snap-confine-debug
-  mv data/info $srcdir/xxx-info
-
-  ./run-checks --unit
+  SKIP_UNCLEAN=1 ./run-checks --unit
   # XXX: Static checks choke on autotools generated cruft. Let's not run them
   # here as they are designed to pass on a clean tree, before anything else is
   # done, not after building the tree.

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,30 +1,26 @@
-# $Id$
-# Maintainer: Timothy Redaelli <timothy.redaelli@gmail.com>
+# Maintainer: aimileus <me at aimileus dot nl>
+# Maintainer: Maciej Borzecki <maciek.borzecki@gmail.com>
+# Contributor: Timothy Redaelli <timothy.redaelli@gmail.com>
 # Contributor: Zygmunt Krynicki <me at zygoon dot pl>
-# Contributor: Maciej Borzecki <maciek.borzecki@gmail.com>
 
-pkgbase=snapd
-pkgname=snapd-git
-pkgver=2.31.1
-pkgrel=1
-arch=('i686' 'x86_64')
-url="https://github.com/snapcore/snapd"
-license=('GPL3')
-makedepends=('git' 'go' 'go-tools' 'libseccomp' 'libcap' 'python-docutils' 'systemd' 'xfsprogs' 'libseccomp')
-checkdepends=('python' 'squashfs-tools' 'indent' 'shellcheck')
-
-options=('!strip' 'emptydirs')
-install=snapd.install
-source=("git+https://github.com/snapcore/$pkgbase.git")
-md5sums=('SKIP')
-
+pkgname=snapd
 pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd')
 optdepends=('bash-completion: bash completion support')
-provides=($pkgbase)
-# Community package is split into snapd and snap-confine, make sure we replace
-# both bits
-conflicts=($pkgbase 'snap-confine')
+pkgver=2.31.1.r619.g3c932a4c5
+pkgrel=1
+arch=('x86_64')
+url="https://github.com/snapcore/snapd"
+license=('GPL3')
+makedepends=('git' 'go-pie' 'go-tools' 'libseccomp' 'libcap' 'systemd' 'xfsprogs' 'python-docutils')
+# the following checkdepends are only required for static checks and unit tests,
+# unit tests are currently enabled
+checkdepends=('python' 'squashfs-tools' 'shellcheck')
+conflicts=('snap-confine')
+options=('!strip' 'emptydirs')
+install=snapd.install
+source=("git+https://github.com/snapcore/$pkgname.git")
+sha256sums=('SKIP')
 
 _gourl=github.com/snapcore/snapd
 
@@ -34,39 +30,21 @@ pkgver() {
 }
 
 prepare() {
-  cd "$pkgbase"
+  cd "$pkgname"
 
-  # Use $srcdir/go as our GOPATH
   export GOPATH="$srcdir/go"
   mkdir -p "$GOPATH"
-  # Have snapd checkout appear in a place suitable for subsequent GOPATH This
+
+  # Have snapd checkout appear in a place suitable for subsequent GOPATH. This
   # way we don't have to go get it again and it is exactly what the tag/hash
   # above describes.
   mkdir -p "$(dirname "$GOPATH/src/${_gourl}")"
-  ln --no-target-directory -fs "$srcdir/$pkgbase" "$GOPATH/src/${_gourl}"
-  # Patch snap-seccomp build flags not to link libseccomp statically.
-  sed -i -e 's/-Wl,-Bstatic -lseccomp -Wl,-Bdynamic/-lseccomp/' "$srcdir/$pkgbase/cmd/snap-seccomp/main.go"
+  ln --no-target-directory -fs "$srcdir/$pkgname" "$GOPATH/src/${_gourl}"
 }
 
 build() {
+  cd "$pkgname"
   export GOPATH="$srcdir/go"
-  # Use get-deps.sh provided by upstream to fetch go dependencies using the
-  # godeps tool and dependencies.tsv (maintained upstream).
-  cd "$GOPATH/src/${_gourl}"
-  # Generate version
-  ./mkversion.sh $pkgver-$pkgrel
-
-  # Get golang dependencies
-  XDG_CONFIG_HOME="$srcdir" ./get-deps.sh
-
-  # Generate data files such as real systemd units, dbus service, environment
-  # setup helpers out of the available templates
-  make -C data \
-       BINDIR=/bin \
-       LIBEXECDIR=/usr/lib \
-       SYSTEMDSYSTEMUNITDIR=/usr/lib/systemd/system \
-       SNAP_MOUNT_DIR=/var/lib/snapd/snap \
-       SNAPD_ENVIRONMENT_FILE=/etc/default/snapd
 
   export CGO_ENABLED="1"
   export CGO_CFLAGS="${CFLAGS}"
@@ -74,7 +52,13 @@ build() {
   export CGO_CXXFLAGS="${CXXFLAGS}"
   export CGO_LDFLAGS="${LDFLAGS}"
 
-  # gobuild="go build -pkgdir $GOPATH/pkg -x -v"
+  ./mkversion.sh $pkgver-$pkgrel
+
+  # Use get-deps.sh provided by upstream to fetch go dependencies using the
+  # godeps tool and dependencies.tsv (maintained upstream).
+  cd "$GOPATH/src/${_gourl}"
+  XDG_CONFIG_HOME="$srcdir" ./get-deps.sh
+
   gobuild="go build -x -v"
   # Build/install snap and snapd
   $gobuild -o $GOPATH/bin/snap "${_gourl}/cmd/snap"
@@ -85,9 +69,16 @@ build() {
   $gobuild -o $GOPATH/bin/snap-update-ns -ldflags '-extldflags "-static"' "${_gourl}/cmd/snap-update-ns"
   CGO_ENABLED=0 $gobuild -o $GOPATH/bin/snap-exec "${_gourl}/cmd/snap-exec"
 
-  # Build snap-confine
+  # Generate data files such as real systemd units, dbus service, environment
+  # setup helpers out of the available templates
+  make -C data \
+       BINDIR=/bin \
+       LIBEXECDIR=/usr/lib \
+       SYSTEMDSYSTEMUNITDIR=/usr/lib/systemd/system \
+       SNAP_MOUNT_DIR=/var/lib/snapd/snap \
+       SNAPD_ENVIRONMENT_FILE=/etc/default/snapd
+
   cd cmd
-  # Sync actual parameters with cmd/autogen.sh
   autoreconf -i -f
   ./configure \
     --prefix=/usr \
@@ -97,9 +88,6 @@ build() {
     --enable-nvidia-biarch \
     --enable-merged-usr
   make $MAKEFLAGS
-
-  # generate man-pages for snap
-  $GOPATH/bin/snap help --man > "$srcdir/snap.1"
 }
 
 check() {
@@ -122,40 +110,66 @@ check() {
   mv $srcdir/xxx-info data/info
 }
 
-package_snapd-git() {
+package() {
+  cd "$pkgname"
   export GOPATH="$srcdir/go"
 
-  # Install snap, snapctl, snap-update-ns, snap-seccomp, snap-exec and snapd
-  # executables
-  install -d -m 755 "$pkgdir/usr/bin/"
-  install -m 755 -t "$pkgdir/usr/bin" \
-          "$GOPATH/bin/snap" \
-          "$GOPATH/bin/snapctl"
+  # Install bash completion
+  install -Dm644 data/completion/snap \
+    "$pkgdir/usr/share/bash-completion/completion/snap"
+  install -Dm644 data/completion/complete.sh \
+    "$pkgdir/usr/lib/snapd/complete.sh"
+  install -Dm644 data/completion/etelpmoc.sh \
+    "$pkgdir/usr/lib/snapd/etelpmoc.sh"
 
-  install -d -m 755 "$pkgdir/usr/lib/snapd"
-  install -m 755 -t "$pkgdir/usr/lib/snapd" \
-          "$GOPATH/bin/snap-update-ns" \
-          "$GOPATH/bin/snap-exec" \
-          "$GOPATH/bin/snap-seccomp" \
-          "$GOPATH/bin/snapd"
+  # Install systemd units, dbus services and a script for environment variables
+  make -C data/ install \
+     DBUSSERVICESDIR=/usr/share/dbus-1/services \
+     BINDIR=/usr/bin \
+     SYSTEMDSYSTEMUNITDIR=/usr/lib/systemd/system \
+     SNAP_MOUNT_DIR=/var/lib/snapd/snap \
+     DESTDIR="$pkgdir"
 
-  # Install snap-confine
-  make -C "$srcdir/$pkgbase/cmd" install DESTDIR="$pkgdir"
+  # Install polkit policy
+  install -Dm644 data/polkit/io.snapcraft.snapd.policy \
+    "$pkgdir/usr/share/polkit-1/actions/io.snapcraft.snapd.policy"
 
-  # Install script to export binaries paths of snaps and XDG_DATA_DIRS for their
-  # .desktop files
-  make -C "$srcdir/$pkgbase/data/env" install DESTDIR="$pkgdir"
+  # Install executables
+  install -Dm755 "$GOPATH/bin/snap" "$pkgdir/usr/bin/snap"
+  install -Dm755 "$GOPATH/bin/snapctl" "$pkgdir/usr/bin/snapctl"
+  install -Dm755 "$GOPATH/bin/snapd" "$pkgdir/usr/lib/snapd/snapd"
+  install -Dm755 "$GOPATH/bin/snap-seccomp" "$pkgdir/usr/lib/snapd/snap-seccomp"
+  install -Dm755 "$GOPATH/bin/snap-update-ns" "$pkgdir/usr/lib/snapd/snap-update-ns"
+  install -Dm755 "$GOPATH/bin/snap-exec" "$pkgdir/usr/lib/snapd/snap-exec"
 
-  # Install D-Bus service files
-  make -C "$srcdir/$pkgbase/data/dbus" install \
-       DBUSSERVICESDIR=/usr/share/dbus-1/services \
-       DESTDIR="$pkgdir"
+  # pre-create directories
+  install -dm755 "$pkgdir/var/lib/snapd/snap"
+  install -dm755 "$pkgdir/var/cache/snapd"
+  install -dm755 "$pkgdir/var/lib/snapd/assertions"
+  install -dm755 "$pkgdir/var/lib/snapd/desktop/applications"
+  install -dm755 "$pkgdir/var/lib/snapd/device"
+  install -dm755 "$pkgdir/var/lib/snapd/hostfs"
+  install -dm755 "$pkgdir/var/lib/snapd/mount"
+  install -dm755 "$pkgdir/var/lib/snapd/seccomp/bpf"
+  install -dm755 "$pkgdir/var/lib/snapd/snap/bin"
+  install -dm755 "$pkgdir/var/lib/snapd/snaps"
+  install -dm755 "$pkgdir/var/lib/snapd/lib/gl"
+  install -dm755 "$pkgdir/var/lib/snapd/lib/gl32"
+  install -dm755 "$pkgdir/var/lib/snapd/lib/vulkan"
+  # these dirs have special permissions
+  install -dm000 "$pkgdir/var/lib/snapd/void"
+  install -dm700 "$pkgdir/var/lib/snapd/cookie"
+  install -dm700 "$pkgdir/var/lib/snapd/cache"
 
-  # Install systemd units
-  make -C "$srcdir/$pkgbase/data/systemd" install \
-       BINDIR=/bin \
-       SYSTEMDSYSTEMUNITDIR=/usr/lib/systemd/system \
-       DESTDIR="$pkgdir"
+  make -C cmd install DESTDIR="$pkgdir/"
+
+  # Install man file
+  mkdir -p "$pkgdir/usr/share/man/man1"
+  "$GOPATH/bin/snap" help --man > "$pkgdir/usr/share/man/man1/snap.1"
+
+  # Install the "info" data file with snapd version
+  install -m 644 -D "$GOPATH/src/${_gourl}/data/info" \
+          "$pkgdir/usr/lib/snapd/info"
 
   # Remove snappy core specific units
   rm -fv "$pkgdir/usr/lib/systemd/system/snapd.system-shutdown.service"
@@ -166,46 +180,4 @@ package_snapd-git() {
   rm -fv "$pkgdir/usr/lib/snapd/snapd.core-fixup.sh"
   rm -fv "$pkgdir/usr/bin/ubuntu-core-launcher"
   rm -fv "$pkgdir/usr/lib/snapd/system-shutdown"
-
-
-  # Install the bash tab completion files
-  install -Dm 755 \
-          "$GOPATH/src/${_gourl}/data/completion/snap" \
-          "$pkgdir/usr/share/bash-completion/completions/snap"
-
-  install -D -m 755 -t "$pkgdir/usr/lib/snapd" \
-          "$GOPATH/src/${_gourl}/data/completion/complete.sh" \
-          "$GOPATH/src/${_gourl}/data/completion/etelpmoc.sh"
-
-  # Symlink /var/lib/snapd/snap to /snap so that --classic snaps work
-  ln -s var/lib/snapd/snap "$pkgdir/snap"
-  # and make sure that target exists so that we don't have dangling symlinks
-  # after installing the package
-  install -d -m 755 "$pkgdir/var/lib/snapd/snap"
-
-  # pre-create directories
-  install -d -m 755 "$pkgdir/var/cache/snapd"
-  install -d -m 755 "$pkgdir/var/lib/snapd/assertions"
-  install -d -m 755 "$pkgdir/var/lib/snapd/desktop/applications"
-  install -d -m 755 "$pkgdir/var/lib/snapd/device"
-  install -d -m 755 "$pkgdir/var/lib/snapd/hostfs"
-  install -d -m 755 "$pkgdir/var/lib/snapd/mount"
-  install -d -m 755 "$pkgdir/var/lib/snapd/seccomp/bpf"
-  install -d -m 755 "$pkgdir/var/lib/snapd/snap/bin"
-  install -d -m 755 "$pkgdir/var/lib/snapd/snaps"
-  install -d -m 755 "$pkgdir/var/lib/snapd/lib/gl"
-  install -d -m 755 "$pkgdir/var/lib/snapd/lib/gl32"
-  install -d -m 755 "$pkgdir/var/lib/snapd/lib/vulkan"
-  # these dirs have special permissions
-  install -d -m 000 "$pkgdir/var/lib/snapd/void"
-  install -d -m 700 "$pkgdir/var/lib/snapd/cookie"
-  install -d -m 700 "$pkgdir/var/lib/snapd/cache"
-
-  # Install snap(1) man page
-  install -m 644 -D "$srcdir/snap.1" \
-          "$pkgdir/usr/share/man/man1/snap.1"
-
-  # Install the "info" data file with snapd version
-  install -m 644 -D "$GOPATH/src/${_gourl}/data/info" \
-          "$pkgdir/usr/lib/snapd/info"
 }

--- a/run-checks
+++ b/run-checks
@@ -246,7 +246,8 @@ if [ "$DEPRECATED" = 1 ]; then
 fi
 
 UNCLEAN="$(git status -s|grep '^??')" || true
-if [ -n "$UNCLEAN" ]; then
+SKIP_UNCLEAN=${SKIP_UNCLEAN=}
+if [[ -n "$UNCLEAN" && -z "$SKIP_UNCLEAN" ]]; then
     cat <<EOF
 
 There are files left in the git tree after the tests:


### PR DESCRIPTION
Both AUR packages [snapd](https://aur.archlinux.org/packages/snapd) and [snapd-git](https://aur.archlinux.org/packages/snapd) are mostly in sync with each other, with
the exception of some minor build logging and different `source` and so on.

Sync our in tree recipe with both snapd and snapd-git to the extent that makes
sense. Retain verbose build logs from snapd-git. Keep the check(), along with
running unit tests. Reorder install() section to match both AUR packages and
keep the diffs small.
