### PR TITLE
osutil: allow creating strings out of MountInfoEntry

### DIFF
--- a/osutil/mountinfo.go
+++ b/osutil/mountinfo.go
@@ -57,26 +57,19 @@ func flattenMap(m map[string]string) string {
 	var buf bytes.Buffer
 	for i, key := range keys {
 		if i > 0 {
-			fmt.Fprintf(&buf, ",")
+			buf.WriteString(",")
 		}
 		if m[key] != "" {
 			fmt.Fprintf(&buf, "%s=%s", key, m[key])
 		} else {
-			fmt.Fprintf(&buf, "%s", key)
+			buf.WriteString(key)
 		}
 	}
 	return buf.String()
 }
 
 func flattenList(l []string) string {
-	var buf bytes.Buffer
-	for i, el := range l {
-		if i > 0 {
-			fmt.Fprintf(&buf, ",")
-		}
-		fmt.Fprintf(&buf, "%s", el)
-	}
-	return buf.String()
+	return strings.Join(l, ",")
 }
 
 func (mi *MountInfoEntry) String() string {

--- a/osutil/mountinfo.go
+++ b/osutil/mountinfo.go
@@ -57,19 +57,26 @@ func flattenMap(m map[string]string) string {
 	var buf bytes.Buffer
 	for i, key := range keys {
 		if i > 0 {
-			buf.WriteString(",")
+			buf.WriteRune(',')
 		}
 		if m[key] != "" {
-			fmt.Fprintf(&buf, "%s=%s", key, m[key])
+			fmt.Fprintf(&buf, "%s=%s", escape(key), escape(m[key]))
 		} else {
-			buf.WriteString(key)
+			buf.WriteString(escape(key))
 		}
 	}
 	return buf.String()
 }
 
 func flattenList(l []string) string {
-	return strings.Join(l, ",")
+	var buf bytes.Buffer
+	for i, item := range l {
+		if i > 0 {
+			buf.WriteRune(',')
+		}
+		buf.WriteString(escape(item))
+	}
+	return buf.String()
 }
 
 func (mi *MountInfoEntry) String() string {
@@ -80,7 +87,7 @@ func (mi *MountInfoEntry) String() string {
 	return fmt.Sprintf("%d %d %d:%d %s %s %s %s%s- %s %s %s",
 		mi.MountID, mi.ParentID, mi.DevMajor, mi.DevMinor, escape(mi.Root),
 		escape(mi.MountDir), flattenMap(mi.MountOptions), flattenList(mi.OptionalFields),
-		maybeSpace, mi.FsType, escape(mi.MountSource),
+		maybeSpace, escape(mi.FsType), escape(mi.MountSource),
 		flattenMap(mi.SuperOptions))
 }
 

--- a/osutil/mountinfo.go
+++ b/osutil/mountinfo.go
@@ -21,9 +21,11 @@ package osutil
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -44,6 +46,49 @@ type MountInfoEntry struct {
 	FsType         string
 	MountSource    string
 	SuperOptions   map[string]string
+}
+
+func flattenMap(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	for i, key := range keys {
+		if i > 0 {
+			fmt.Fprintf(&buf, ",")
+		}
+		if m[key] != "" {
+			fmt.Fprintf(&buf, "%s=%s", key, m[key])
+		} else {
+			fmt.Fprintf(&buf, "%s", key)
+		}
+	}
+	return buf.String()
+}
+
+func flattenList(l []string) string {
+	var buf bytes.Buffer
+	for i, el := range l {
+		if i > 0 {
+			fmt.Fprintf(&buf, ",")
+		}
+		fmt.Fprintf(&buf, "%s", el)
+	}
+	return buf.String()
+}
+
+func (mi *MountInfoEntry) String() string {
+	maybeSpace := " "
+	if len(mi.OptionalFields) == 0 {
+		maybeSpace = ""
+	}
+	return fmt.Sprintf("%d %d %d:%d %s %s %s %s%s- %s %s %s",
+		mi.MountID, mi.ParentID, mi.DevMajor, mi.DevMinor, escape(mi.Root),
+		escape(mi.MountDir), flattenMap(mi.MountOptions), flattenList(mi.OptionalFields),
+		maybeSpace, mi.FsType, escape(mi.MountSource),
+		flattenMap(mi.SuperOptions))
 }
 
 // LoadMountInfo loads list of mounted entries from a given file.

--- a/osutil/mountinfo_test.go
+++ b/osutil/mountinfo_test.go
@@ -35,9 +35,12 @@ var _ = Suite(&mountinfoSuite{})
 
 // Check that parsing the example from kernel documentation works correctly.
 func (s *mountinfoSuite) TestParseMountInfoEntry1(c *C) {
-	entry, err := osutil.ParseMountInfoEntry(
-		"36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue")
+	real := "36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue"
+	canonical := "36 35 98:0 /mnt1 /mnt2 noatime,rw master:1 - ext3 /dev/root errors=continue,rw"
+	entry, err := osutil.ParseMountInfoEntry(real)
 	c.Assert(err, IsNil)
+	c.Assert(entry.String(), Equals, canonical)
+
 	c.Assert(entry.MountID, Equals, 36)
 	c.Assert(entry.ParentID, Equals, 35)
 	c.Assert(entry.DevMajor, Equals, 98)
@@ -54,9 +57,12 @@ func (s *mountinfoSuite) TestParseMountInfoEntry1(c *C) {
 // Check that various combinations of optional fields are parsed correctly.
 func (s *mountinfoSuite) TestParseMountInfoEntry2(c *C) {
 	// No optional fields.
-	entry, err := osutil.ParseMountInfoEntry(
-		"36 35 98:0 /mnt1 /mnt2 rw,noatime - ext3 /dev/root rw,errors=continue")
+	real := "36 35 98:0 /mnt1 /mnt2 rw,noatime - ext3 /dev/root rw,errors=continue"
+	canonical := "36 35 98:0 /mnt1 /mnt2 noatime,rw - ext3 /dev/root errors=continue,rw"
+	entry, err := osutil.ParseMountInfoEntry(real)
 	c.Assert(err, IsNil)
+	c.Assert(entry.String(), Equals, canonical)
+
 	c.Assert(entry.MountOptions, DeepEquals, map[string]string{"rw": "", "noatime": ""})
 	c.Assert(entry.OptionalFields, HasLen, 0)
 	c.Assert(entry.FsType, Equals, "ext3")

--- a/osutil/mountinfo_test.go
+++ b/osutil/mountinfo_test.go
@@ -84,9 +84,12 @@ func (s *mountinfoSuite) TestParseMountInfoEntry2(c *C) {
 
 // Check that white-space is unescaped correctly.
 func (s *mountinfoSuite) TestParseMountInfoEntry3(c *C) {
-	entry, err := osutil.ParseMountInfoEntry(
-		`36 35 98:0 /mnt\0401 /mnt\0402 rw\040,noatime mas\040ter:1 - ext\0403 /dev/ro\040ot rw\040,errors=continue`)
+	real := `36 35 98:0 /mnt\0401 /mnt\0402 noatime,rw\040 mas\040ter:1 - ext\0403 /dev/ro\040ot rw\040,errors=continue`
+	canonical := `36 35 98:0 /mnt\0401 /mnt\0402 noatime,rw\040 mas\040ter:1 - ext\0403 /dev/ro\040ot errors=continue,rw\040`
+	entry, err := osutil.ParseMountInfoEntry(real)
 	c.Assert(err, IsNil)
+	c.Assert(entry.String(), Equals, canonical)
+
 	c.Assert(entry.MountID, Equals, 36)
 	c.Assert(entry.ParentID, Equals, 35)
 	c.Assert(entry.DevMajor, Equals, 98)


### PR DESCRIPTION
This is mainly done so that testing and debugging is easier as we never
have to write mountinfo records for data storage.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
