### PR TITLE
cmd/snap-update-ns: use syscall.Symlink instead of os.Symlink (2.32)

### DIFF
--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -65,7 +65,6 @@ type SystemCalls interface {
 func MockSystemCalls(sc SystemCalls) (restore func()) {
 	// save
 	oldOsLstat := osLstat
-	oldSymlink := osSymlink
 	oldRemove := osRemove
 	oldIoutilReadDir := ioutilReadDir
 
@@ -76,10 +75,10 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	oldSysOpen := sysOpen
 	oldSysOpenat := sysOpenat
 	oldSysUnmount := sysUnmount
+	oldSysSymlink := sysSymlink
 
 	// override
 	osLstat = sc.Lstat
-	osSymlink = sc.Symlink
 	osRemove = sc.Remove
 	ioutilReadDir = sc.ReadDir
 
@@ -90,11 +89,11 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	sysOpen = sc.Open
 	sysOpenat = sc.Openat
 	sysUnmount = sc.Unmount
+	sysSymlink = sc.Symlink
 
 	return func() {
 		// restore
 		osLstat = oldOsLstat
-		osSymlink = oldSymlink
 		osRemove = oldRemove
 		ioutilReadDir = oldIoutilReadDir
 
@@ -105,6 +104,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 		sysOpen = oldSysOpen
 		sysOpenat = oldSysOpenat
 		sysUnmount = oldSysUnmount
+		sysSymlink = oldSysSymlink
 	}
 }
 

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -41,7 +41,6 @@ const (
 var (
 	osLstat    = os.Lstat
 	osReadlink = os.Readlink
-	osSymlink  = os.Symlink
 	osRemove   = os.Remove
 
 	sysClose   = syscall.Close
@@ -51,6 +50,7 @@ var (
 	sysOpenat  = syscall.Openat
 	sysUnmount = syscall.Unmount
 	sysFchown  = sys.Fchown
+	sysSymlink = syscall.Symlink
 
 	ioutilReadDir = ioutil.ReadDir
 )
@@ -301,7 +301,7 @@ func secureMklinkAll(name string, perm os.FileMode, uid sys.UserID, gid sys.Grou
 		return err
 	}
 	// TODO: roll this uber securely like the code above does using linkat(2).
-	err = osSymlink(oldname, name)
+	err = sysSymlink(oldname, name)
 	if err == syscall.EROFS {
 		return &ReadOnlyFsError{Path: parent}
 	}


### PR DESCRIPTION
We are handling and expecting raw syscall errors, not  the wrapped
variety. This fixes the in-the-wild ability to handle read-only medium
with symlinks. The existing unit tests mocked the return value of
syscall.Symlink, so unit tests did not catch this.

With this patch integration tests now almost passes (it is stopped by
another bug that is fixed separately).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>