### PR TITLE
ifacestate: be consistent passing Retry.After as named field

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -577,7 +577,7 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 			}
 			if snapsup, err := snapstate.TaskSnapSetup(t); err == nil {
 				if defaultProviders[snapsup.Name()] {
-					return &state.Retry{contentLinkRetryTimeout}
+					return &state.Retry{After: contentLinkRetryTimeout}
 				}
 			}
 		}


### PR DESCRIPTION
I'm getting a go vet error here about this but also is the preferred/more consistent style even if After is the only field.
