### PR TITLE
tests: add support for external backend executions on listing test

### DIFF
--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -16,6 +16,8 @@ execute: |
     elif [ "$SRU_VALIDATION" = "1" ]; then
         echo "When sru validation is done the core snap is installed from the store"
         expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+[0-9]+\.[0-9a-f]+)? +[0-9]+ +stable +canonical +core *$'
+    elif [ "$SPREAD_BACKEND" = "external" ]; then
+        expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +(edge|beta|candidate|stable) +canonical +core *$'
     else
         expected='^core .* [0-9]{2}-[0-9.]+(~[a-z0-9]+)?(\+git[0-9]+\.[0-9a-f]+)? +[0-9]+ +edge +canonical +core *$'
     fi


### PR DESCRIPTION
This change is to support when the channel is not edge, as it happens
when we run beta validation.
