### PR TITLE
tests: fix dependency for ubuntu artful

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -423,6 +423,11 @@ pkg_dependencies_ubuntu_classic(){
                 xvfb
                 "
             ;;
+        ubuntu-17.10-64)
+            echo "
+                linux-image-extra-4.13.0-16-generic
+                "
+            ;;
         ubuntu-*)
             echo "
                 linux-image-extra-$(uname -r)


### PR DESCRIPTION
This is to avoid an error installing dependencies on ubuntu artful executed for sru validation. 