### PR TITLE
asserts: fix flaky storeSuite.TestCheckAuthority

### DIFF
--- a/asserts/store_asserts_test.go
+++ b/asserts/store_asserts_test.go
@@ -166,6 +166,8 @@ func (s *storeSuite) TestCheckAuthority(c *C) {
 	err := db.Add(operator)
 	c.Assert(err, IsNil)
 
+	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
+
 	storeHeaders := map[string]interface{}{
 		"store":       "store1",
 		"operator-id": operator.HeaderString("account-id"),
@@ -173,7 +175,6 @@ func (s *storeSuite) TestCheckAuthority(c *C) {
 	}
 
 	// store signed by some other account fails.
-	otherDB := setup3rdPartySigning(c, "other", storeDB, db)
 	store, err := otherDB.Sign(asserts.StoreType, storeHeaders, nil, "")
 	c.Assert(err, IsNil)
 	err = db.Check(store)


### PR DESCRIPTION
I could not reproduce it here, but the fix is about using a timestamp for the assertion after the signing key creation. If the timestamp is from before it obviously can fall out of the key validity range.
