### PR TITLE
cmd/snap: unhide --no-wait; make wait use go via waitMixin

### DIFF
--- a/cmd/snap/cmd_alias.go
+++ b/cmd/snap/cmd_alias.go
@@ -32,6 +32,7 @@ import (
 )
 
 type cmdAlias struct {
+	waitMixin
 	Positionals struct {
 		SnapApp appName `required:"yes"`
 		Alias   string  `required:"yes"`
@@ -50,7 +51,7 @@ Once this manual alias is setup the respective application command can be invoke
 func init() {
 	addCommand("alias", shortAliasHelp, longAliasHelp, func() flags.Commander {
 		return &cmdAlias{}
-	}, nil, []argDesc{
+	}, waitDescs, []argDesc{
 		{name: "<snap.app>"},
 		// TRANSLATORS: This needs to be wrapped in <>s.
 		{name: i18n.G("<alias>")},
@@ -70,16 +71,15 @@ func (x *cmdAlias) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-
-	chg, err := wait(cli, id)
+	chg, err := x.wait(cli, id)
 	if err != nil {
-		return err
-	}
-	if err := showAliasChanges(chg); err != nil {
+		if err == noWait {
+			return nil
+		}
 		return err
 	}
 
-	return nil
+	return showAliasChanges(chg)
 }
 
 type changedAlias struct {

--- a/cmd/snap/cmd_alias_test.go
+++ b/cmd/snap/cmd_alias_test.go
@@ -30,7 +30,7 @@ import (
 
 func (s *SnapSuite) TestAliasHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] alias [<snap.app>] [<alias>]
+  snap.test [OPTIONS] alias [alias-OPTIONS] [<snap.app>] [<alias>]
 
 The alias command aliases the given snap application to the given alias.
 
@@ -42,6 +42,10 @@ Application Options:
 
 Help Options:
   -h, --help            Show this help message
+
+[alias command options]
+          --no-wait     Do not wait for the operation to finish but just print
+                        the change id.
 `
 	rest, err := Parser().ParseArgs([]string{"alias", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/cmd/snap/cmd_connect.go
+++ b/cmd/snap/cmd_connect.go
@@ -26,6 +26,7 @@ import (
 )
 
 type cmdConnect struct {
+	waitMixin
 	Positionals struct {
 		PlugSpec connectPlugSpec `required:"yes"`
 		SlotSpec connectSlotSpec
@@ -56,7 +57,7 @@ the plug name.
 func init() {
 	addCommand("connect", shortConnectHelp, longConnectHelp, func() flags.Commander {
 		return &cmdConnect{}
-	}, nil, []argDesc{
+	}, waitDescs, []argDesc{
 		// TRANSLATORS: This needs to be wrapped in <>s.
 		{name: i18n.G("<snap>:<plug>")},
 		// TRANSLATORS: This needs to be wrapped in <>s.
@@ -82,6 +83,12 @@ func (x *cmdConnect) Execute(args []string) error {
 		return err
 	}
 
-	_, err = wait(cli, id)
-	return err
+	if _, err := x.wait(cli, id); err != nil {
+		if err == noWait {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }

--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -33,7 +33,7 @@ import (
 
 func (s *SnapSuite) TestConnectHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] connect [<snap>:<plug>] [<snap>:<slot>]
+  snap.test [OPTIONS] connect [connect-OPTIONS] [<snap>:<plug>] [<snap>:<slot>]
 
 The connect command connects a plug to a slot.
 It may be called in the following ways:
@@ -58,6 +58,10 @@ Application Options:
 
 Help Options:
   -h, --help               Show this help message
+
+[connect command options]
+          --no-wait        Do not wait for the operation to finish but just
+                           print the change id.
 `
 	rest, err := Parser().ParseArgs([]string{"connect", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/cmd/snap/cmd_disconnect.go
+++ b/cmd/snap/cmd_disconnect.go
@@ -28,6 +28,7 @@ import (
 )
 
 type cmdDisconnect struct {
+	waitMixin
 	Positionals struct {
 		Offer disconnectSlotOrPlugSpec `required:"true"`
 		Use   disconnectSlotSpec
@@ -52,7 +53,7 @@ The snap name may be omitted for the core snap.
 func init() {
 	addCommand("disconnect", shortDisconnectHelp, longDisconnectHelp, func() flags.Commander {
 		return &cmdDisconnect{}
-	}, nil, []argDesc{
+	}, waitDescs, []argDesc{
 		// TRANSLATORS: This needs to be wrapped in <>s.
 		{name: i18n.G("<snap>:<plug>")},
 		// TRANSLATORS: This needs to be wrapped in <>s.
@@ -84,6 +85,12 @@ func (x *cmdDisconnect) Execute(args []string) error {
 		return err
 	}
 
-	_, err = wait(cli, id)
-	return err
+	if _, err := x.wait(cli, id); err != nil {
+		if err == noWait {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -32,7 +32,7 @@ import (
 
 func (s *SnapSuite) TestDisconnectHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] disconnect [<snap>:<plug>] [<snap>:<slot>]
+  snap.test [OPTIONS] disconnect [disconnect-OPTIONS] [<snap>:<plug>] [<snap>:<slot>]
 
 The disconnect command disconnects a plug from a slot.
 It may be called in the following ways:
@@ -51,6 +51,10 @@ Application Options:
 
 Help Options:
   -h, --help               Show this help message
+
+[disconnect command options]
+          --no-wait        Do not wait for the operation to finish but just
+                           print the change id.
 `
 	rest, err := Parser().ParseArgs([]string{"disconnect", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/cmd/snap/cmd_prefer.go
+++ b/cmd/snap/cmd_prefer.go
@@ -26,6 +26,7 @@ import (
 )
 
 type cmdPrefer struct {
+	waitMixin
 	Positionals struct {
 		Snap installedSnapName `required:"yes"`
 	} `positional-args:"true"`
@@ -41,7 +42,7 @@ to conflicting aliases of other snaps whose aliases will be disabled
 func init() {
 	addCommand("prefer", shortPreferHelp, longPreferHelp, func() flags.Commander {
 		return &cmdPrefer{}
-	}, nil, []argDesc{
+	}, waitDescs, []argDesc{
 		{name: "<snap>"},
 	})
 }
@@ -56,14 +57,13 @@ func (x *cmdPrefer) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-
-	chg, err := wait(cli, id)
+	chg, err := x.wait(cli, id)
 	if err != nil {
-		return err
-	}
-	if err := showAliasChanges(chg); err != nil {
+		if err == noWait {
+			return nil
+		}
 		return err
 	}
 
-	return nil
+	return showAliasChanges(chg)
 }

--- a/cmd/snap/cmd_prefer_test.go
+++ b/cmd/snap/cmd_prefer_test.go
@@ -30,17 +30,21 @@ import (
 
 func (s *SnapSuite) TestPreferHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] prefer [<snap>]
+  snap.test [OPTIONS] prefer [prefer-OPTIONS] [<snap>]
 
 The prefer command enables all aliases of the given snap in preference
 to conflicting aliases of other snaps whose aliases will be disabled
 (removed for manual ones).
 
 Application Options:
-      --version     Print the version and exit
+      --version      Print the version and exit
 
 Help Options:
-  -h, --help        Show this help message
+  -h, --help         Show this help message
+
+[prefer command options]
+          --no-wait  Do not wait for the operation to finish but just print the
+                     change id.
 `
 	rest, err := Parser().ParseArgs([]string{"prefer", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -44,6 +44,7 @@ Nested values may be modified via a dotted path:
 `)
 
 type cmdSet struct {
+	waitMixin
 	Positional struct {
 		Snap       installedSnapName
 		ConfValues []string `required:"1"`
@@ -51,7 +52,7 @@ type cmdSet struct {
 }
 
 func init() {
-	addCommand("set", shortSetHelp, longSetHelp, func() flags.Commander { return &cmdSet{} }, nil, []argDesc{
+	addCommand("set", shortSetHelp, longSetHelp, func() flags.Commander { return &cmdSet{} }, waitDescs, []argDesc{
 		{
 			name: "<snap>",
 			// TRANSLATORS: This should probably not start with a lowercase letter.
@@ -81,16 +82,19 @@ func (x *cmdSet) Execute(args []string) error {
 		}
 	}
 
-	return configure(string(x.Positional.Snap), patchValues)
-}
-
-func configure(snapName string, patchValues map[string]interface{}) error {
+	snapName := string(x.Positional.Snap)
 	cli := Client()
 	id, err := cli.SetConf(snapName, patchValues)
 	if err != nil {
 		return err
 	}
 
-	_, err = wait(cli, id)
-	return err
+	if _, err := x.wait(cli, id); err != nil {
+		if err == noWait {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }

--- a/cmd/snap/cmd_unalias.go
+++ b/cmd/snap/cmd_unalias.go
@@ -26,6 +26,7 @@ import (
 )
 
 type cmdUnalias struct {
+	waitMixin
 	Positionals struct {
 		AliasOrSnap aliasOrSnap `required:"yes"`
 	} `positional-args:"true"`
@@ -39,7 +40,7 @@ The unalias command tears down a manual alias when given one or disables all ali
 func init() {
 	addCommand("unalias", shortUnaliasHelp, longUnaliasHelp, func() flags.Commander {
 		return &cmdUnalias{}
-	}, nil, []argDesc{
+	}, waitDescs.also(nil), []argDesc{
 		// TRANSLATORS: This needs to be wrapped in <>s.
 		{name: i18n.G("<alias-or-snap>")},
 	})
@@ -55,14 +56,13 @@ func (x *cmdUnalias) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-
-	chg, err := wait(cli, id)
+	chg, err := x.wait(cli, id)
 	if err != nil {
-		return err
-	}
-	if err := showAliasChanges(chg); err != nil {
+		if err == noWait {
+			return nil
+		}
 		return err
 	}
 
-	return nil
+	return showAliasChanges(chg)
 }

--- a/cmd/snap/cmd_unalias_test.go
+++ b/cmd/snap/cmd_unalias_test.go
@@ -30,7 +30,7 @@ import (
 
 func (s *SnapSuite) TestUnaliasHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] unalias [<alias-or-snap>]
+  snap.test [OPTIONS] unalias [unalias-OPTIONS] [<alias-or-snap>]
 
 The unalias command tears down a manual alias when given one or disables all
 aliases of a snap, removing also all manual ones, when given a snap name.
@@ -40,6 +40,10 @@ Application Options:
 
 Help Options:
   -h, --help                 Show this help message
+
+[unalias command options]
+          --no-wait          Do not wait for the operation to finish but just
+                             print the change id.
 `
 	rest, err := Parser().ParseArgs([]string{"unalias", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/cmd/snap/cmd_watch.go
+++ b/cmd/snap/cmd_watch.go
@@ -51,7 +51,7 @@ func (x *cmdWatch) Execute(args []string) error {
 
 	// this is the only valid use of wait without a waitMixin (ie
 	// without --no-wait), so we fake it here.
-	_, err = waitMixin{}.wait(cli, id)
+	_, err = waitMixin{skipAbort: true}.wait(cli, id)
 
 	return err
 }

--- a/cmd/snap/cmd_watch.go
+++ b/cmd/snap/cmd_watch.go
@@ -48,7 +48,10 @@ func (x *cmdWatch) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	_, err = wait(cli, id)
+
+	// this is the only valid use of wait without a waitMixin (ie
+	// without --no-wait), so we fake it here.
+	_, err = waitMixin{}.wait(cli, id)
 
 	return err
 }

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/store"
 )
@@ -33,7 +34,6 @@ var RunMain = run
 
 var (
 	CreateUserDataDirs = createUserDataDirs
-	Wait               = wait
 	ResolveApp         = resolveApp
 	IsReexeced         = isReexeced
 	MaybePrintServices = maybePrintServices
@@ -152,4 +152,8 @@ func MockTimeutilHuman(h func(time.Time) string) (restore func()) {
 	return func() {
 		timeutilHuman = oldH
 	}
+}
+
+func Wait(cli *client.Client, id string) (*client.Change, error) {
+	return waitMixin{}.wait(cli, id)
 }

--- a/cmd/snap/wait.go
+++ b/cmd/snap/wait.go
@@ -1,0 +1,149 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/progress"
+)
+
+var (
+	maxGoneTime = 5 * time.Second
+	pollTime    = 100 * time.Millisecond
+)
+
+type waitMixin struct {
+	NoWait    bool `long:"no-wait"`
+	skipAbort bool
+}
+
+var waitDescs = mixinDescs{
+	"no-wait": i18n.G("Do not wait for the operation to finish but just print the change id."),
+}
+
+var noWait = errors.New("no wait for op")
+
+func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error) {
+	if wmx.NoWait {
+		fmt.Fprintf(Stdout, "%s\n", id)
+		return nil, noWait
+	}
+	// Intercept sigint
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		sig := <-c
+		// sig is nil if c was closed
+		if sig == nil || wmx.skipAbort {
+			return
+		}
+		cli := Client()
+		_, err := cli.Abort(id)
+		if err != nil {
+			fmt.Fprintf(Stderr, err.Error()+"\n")
+		}
+	}()
+
+	pb := progress.MakeProgressBar()
+	defer func() {
+		pb.Finished()
+		// next two not strictly needed for CLI, but without
+		// them the tests will leak goroutines.
+		signal.Stop(c)
+		close(c)
+	}()
+
+	tMax := time.Time{}
+
+	var lastID string
+	lastLog := map[string]string{}
+	for {
+		chg, err := cli.Change(id)
+		if err != nil {
+			// a client.Error means we were able to communicate with
+			// the server (got an answer)
+			if e, ok := err.(*client.Error); ok {
+				return nil, e
+			}
+
+			// an non-client error here means the server most
+			// likely went away
+			// XXX: it actually can be a bunch of other things; fix client to expose it better
+			now := time.Now()
+			if tMax.IsZero() {
+				tMax = now.Add(maxGoneTime)
+			}
+			if now.After(tMax) {
+				return nil, err
+			}
+			pb.Spin(i18n.G("Waiting for server to restart"))
+			time.Sleep(pollTime)
+			continue
+		}
+		if !tMax.IsZero() {
+			pb.Finished()
+			tMax = time.Time{}
+		}
+
+		for _, t := range chg.Tasks {
+			switch {
+			case t.Status != "Doing":
+				continue
+			case t.Progress.Total == 1:
+				pb.Spin(t.Summary)
+				nowLog := lastLogStr(t.Log)
+				if lastLog[t.ID] != nowLog {
+					pb.Notify(nowLog)
+					lastLog[t.ID] = nowLog
+				}
+			case t.ID == lastID:
+				pb.Set(float64(t.Progress.Done))
+			default:
+				pb.Start(t.Summary, float64(t.Progress.Total))
+				lastID = t.ID
+			}
+			break
+		}
+
+		if chg.Ready {
+			if chg.Status == "Done" {
+				return chg, nil
+			}
+
+			if chg.Err != "" {
+				return chg, errors.New(chg.Err)
+			}
+
+			return nil, fmt.Errorf(i18n.G("change finished in status %q with no error message"), chg.Status)
+		}
+
+		// note this very purposely is not a ticker; we want
+		// to sleep 100ms between calls, not call once every
+		// 100ms.
+		time.Sleep(pollTime)
+	}
+}


### PR DESCRIPTION
With this change, every command that uses wait() is also a waitMixin
(except for `watch`, because that doesn't make sense).

It also unhides --no-wait.