### PR TITLE
[RFC] snap application autostart support

### DIFF
--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -20,19 +20,29 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
+	"os/user"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/userd"
 )
 
 type cmdUserd struct {
 	userd userd.Userd
+
+	Autostart bool `long:"autostart"`
 }
 
 var shortUserdHelp = i18n.G("Start the userd service")
@@ -44,16 +54,19 @@ func init() {
 		longUserdHelp,
 		func() flags.Commander {
 			return &cmdUserd{}
-		},
-		nil,
-		[]argDesc{},
-	)
+		}, map[string]string{
+			"autostart": i18n.G("Autostart user applications"),
+		}, nil)
 	cmd.hidden = true
 }
 
 func (x *cmdUserd) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
+	}
+
+	if x.Autostart {
+		return x.runAutostart()
 	}
 
 	if err := x.userd.Init(); err != nil {
@@ -71,4 +84,84 @@ func (x *cmdUserd) Execute(args []string) error {
 	}
 
 	return x.userd.Stop()
+}
+
+var (
+	replacedDesktopKeys = []string{"%f", "%F", "%u", "%U", "%d", "%D",
+		"%n", "%N", "%i", "%c", "%k", "%v", "%m"}
+)
+
+func findExec(desktopFilePath string) (string, error) {
+	f, err := os.Open(desktopFilePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "Exec=") {
+			continue
+		}
+
+		execCmd := strings.Split(line, "Exec=")[1]
+		for _, key := range replacedDesktopKeys {
+			execCmd = strings.Replace(execCmd, key, "", -1)
+		}
+		return execCmd, nil
+	}
+	return "", nil
+}
+
+func (x *cmdUserd) runAutostart() error {
+	logger.Debugf("autostart")
+	usr, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	usrSnapDir := filepath.Join(usr.HomeDir, "snap")
+
+	glob := filepath.Join(usrSnapDir, "*/current/.config/autostart/*.desktop")
+	matches, err := filepath.Glob(glob)
+	if err != nil {
+		return err
+	}
+
+	for _, desktopFile := range matches {
+		logger.Debugf("autostart desktop file %v", desktopFile)
+		// /home/foo/snap/some-snap/current/.config/autostart/some-app.desktop ->
+		//    some-snap/current/.config/autostart/some-app.desktop
+		noPrefix := strings.TrimPrefix(desktopFile, usrSnapDir+"/")
+		// some-snap/current/.config/autostart/some-app.desktop -> some-snap
+		snapName := noPrefix[0:strings.IndexByte(noPrefix, '/')]
+		logger.Debugf("snap name: %v", snapName)
+		info, err := getSnapInfo(snapName, snap.R(0))
+		if err != nil {
+			logger.Noticef("failed to obtain snap information for snap %q: %v", snapName, err)
+			continue
+		}
+		// use the sanitized desktop file
+		snapAppDesktop := filepath.Join(dirs.SnapDesktopFilesDir,
+			fmt.Sprintf("%s_%s", info.Name(), filepath.Base(desktopFile)))
+		command, err := findExec(snapAppDesktop)
+		if err != nil {
+			logger.Noticef("failed to locate app command for %v: %v", filepath.Base(desktopFile), err)
+			continue
+		}
+		if command == "" {
+			logger.Noticef("Exec= line not found in desktop file %v", snapAppDesktop)
+			continue
+		}
+		logger.Debugf("exec line: %v", command)
+
+		// TODO: shlex
+		split := strings.Split(command, " ")
+		cmd := exec.Command(split[0], split[1:]...)
+		if err := cmd.Start(); err != nil {
+			logger.Noticef("failed to start %q: %v", command, err)
+		}
+	}
+	return nil
 }

--- a/data/desktop/Makefile
+++ b/data/desktop/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+BINDIR := /usr/bin
+DATADIR := /usr/share
+
+SOURCES := $(wildcard *.in)
+DESKTOP_FILES = $(SOURCES:.in=)
+
+.PHONY: all
+all: $(DESKTOP_FILES)
+
+.PHONY: install
+install: $(DESKTOP_FILES)
+	# NOTE: old (e.g. 14.04) GNU coreutils doesn't -D with -t
+	install -d -m 0755 $(DESTDIR)/$(DATADIR)/applications
+	install -m 0644 -t $(DESTDIR)/$(SYSTEMDSYSTEMUNITDIR) $^
+
+.PHONY: clean
+clean:
+	rm -f $(DESKTOP_FILES)
+
+%: %.in
+	cat $< | \
+		sed s:@bindir@:$(BINDIR):g | \
+		cat > $@

--- a/data/desktop/snap-userd-autostart.desktop
+++ b/data/desktop/snap-userd-autostart.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Snap user application autostart helper
+Comment=A snap helper for autostarting user applications
+Exec=/usr/bin/snap userd --autostart
+Type=Application

--- a/data/desktop/snap-userd-autostart.desktop.in
+++ b/data/desktop/snap-userd-autostart.desktop.in
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Snap user application autostart helper
+Comment=A snap helper for autostarting user applications
+Exec=@bindir@/snap userd --autostart
+Type=Application


### PR DESCRIPTION
Opening early in hope of attracting reviews and comments on the matter.

When the applications drop a `*.desktop` file under `~/snap/*/current/.config/autostart/`, we expect the file to have the same name as the `app` declaration in `snap.yaml`. Also the snap must provide a desktop file for that application under `meta/gui`. Under this assumption, we will pick the right, and sanitized, desktop file for the app and use its `Exec=..` line as a startup command. More details in the forum topic https://forum.snapcraft.io/t/how-to-autostart-a-snap-of-a-desktop-application/2449