### PR TITLE
many: generate and use per-snap snap-update-ns profile

### DIFF
--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -18,6 +18,8 @@
 #ifndef SNAP_MOUNT_SUPPORT_H
 #define SNAP_MOUNT_SUPPORT_H
 
+#include "apparmor-support.h"
+
 /**
  * Return a file descriptor referencing the snap-update-ns utility
  *
@@ -40,13 +42,13 @@ int sc_open_snap_update_ns(void);
  * The function will also try to preserve the current working directory but if
  * this is impossible it will chdir to SC_VOID_DIR.
  **/
-void sc_populate_mount_ns(int snap_update_ns_fd, const char *base_snap_name,
-			  const char *snap_name);
+void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
+			  const char *base_snap_name, const char *snap_name);
 
 /**
- * Ensure that / or /snap is mounted with the SHARED option. 
+ * Ensure that / or /snap is mounted with the SHARED option.
  *
- * If the system is found to be not having a shared mount for "/" 
+ * If the system is found to be not having a shared mount for "/"
  * snap-confine will create a shared bind mount for "/snap" to
  * ensure that "/snap" is mounted shared. See LP:#1668659
  */

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -436,26 +436,29 @@
     # Allow snap-confine to be killed
     signal (receive) peer=unconfined,
 
+    # Allow switching to snap-update-ns with a per-snap profile.
+    change_profile -> snap-update-ns.*,
+
     # Allow executing snap-update-ns when...
 
     # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the distribution package. This is also the location used when using
     # the core/base snap on all-snap systems. The variants here represent
     # various locations of libexecdir across distributions.
-    /usr/lib{,exec,64}/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /usr/lib{,exec,64}/snapd/snap-update-ns r,
 
     # ...snap-confine is not, conceptually, re-executing and uses
     # snap-update-ns from the distribution package but we are already inside
     # the constructed mount namespace so we must traverse "hostfs". The
     # variants here represent various locations of libexecdir across
     # distributions.
-    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns r,
 
     # ..snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap. Note that the location of the core snap varies from
     # distribution to distribution. The variants here represent different
     # locations of snap mount directory across distributions.
-    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
 
     # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap but we are already inside the constructed mount
@@ -464,145 +467,5 @@
     # "natural" /snap mount entry but we have no control over that.  This is
     # reported as (LP: #1716339). The variants here represent different
     # locations of snap mount directory across distributions.
-    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns Cxr -> snap_update_ns,
-
-    profile snap_update_ns (attach_disconnected) {
-        # The next four rules mirror those above. We want to be able to read
-        # and map snap-update-ns into memory but it may come from a variety of places.
-        /usr/lib{,exec,64}/snapd/snap-update-ns mr,
-        /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns mr,
-        /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
-        /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
-
-        # Allow reading the dynamic linker cache.
-        /etc/ld.so.cache r,
-        # Allow reading, mapping and executing the dynamic linker.
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}ld-*.so mrix,
-        # Allow reading and mapping various parts of the standard library and
-        # dynamically loaded nss modules and what not.
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libc{,-[0-9]*}.so* mr,
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpthread{,-[0-9]*}.so* mr,
-
-        # Allow reading the command line (snap-update-ns uses it in pre-Go bootstrap code).
-        @{PROC}/@{pid}/cmdline r,
-
-        # Allow reading the os-release file (possibly a symlink to /usr/lib).
-        /{etc/,usr/lib/}os-release r,
-
-        # Allow creating/grabbing various snapd lock files.
-        /run/snapd/lock/*.lock rwk,
-
-        # Allow reading stored mount namespaces,
-        /run/snapd/ns/ r,
-        /run/snapd/ns/*.mnt r,
-
-        # Allow reading per-snap desired mount profiles. Those are written by
-        # snapd and represent the desired layout and content connections.
-        /var/lib/snapd/mount/snap.*.fstab r,
-
-        # Allow reading and writing actual per-snap mount profiles. Note that
-        # the second rule is generic to allow our tmpfile-rename approach to
-        # writing them. Those are written by snap-update-ns and represent the
-        # actual layout at a given moment.
-        /run/snapd/ns/*.fstab rw,
-        /run/snapd/ns/*.fstab.* rw,
-
-        # NOTE: at this stage the /snap directory is stable as we have called
-        # pivot_root already.
-
-        # Needed to perform mount/unmounts.
-        capability sys_admin,
-        # Needed for mimic construction.
-        capability chown,
-
-        # Allow freezing and thawing the per-snap cgroup freezers
-        /sys/fs/cgroup/freezer/snap.*/freezer.state rw,
-
-        # Support mount profiles via the content interface. This should correspond
-        # to permutations of $SNAP -> $SNAP for reading and $SNAP_{DATA,COMMON} ->
-        # $SNAP_{DATA,COMMON} for both reading and writing.
-        #
-        # Note that:
-        #   /snap/*/*/**
-        # is meant to mean:
-        #   /snap/$SNAP_NAME/$SNAP_REVISION/and-any-subdirectory
-        # but:
-        #   /var/snap/*/**
-        # is meant to mean:
-        #   /var/snap/$SNAP_NAME/$SNAP_REVISION/
-        mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
-        mount options=(ro bind) /snap/*/** -> /var/snap/*/**,
-        mount options=(rw bind) /var/snap/*/** -> /var/snap/*/**,
-        mount options=(ro bind) /var/snap/*/** -> /var/snap/*/**,
-
-        # Allow creating missing mount directories under $SNAP_DATA.
-        #
-        # The "tree" of permissions is needed for SecureMkdirAll that uses
-        # open(..., O_NOFOLLOW) and mkdirat() using the resulting file
-        # descriptor.
-        / r,
-        /var/ r,
-        /var/snap/{,*/} r,
-        /var/snap/*/**/ rw,
-
-        # Allow creating placeholder directory in /tmp/.snap/ as support for
-        # the writable mimic code that can poke holes in arbitrary read-only
-        # places using tmpfs and bind mounts.
-        /tmp/ r,
-        /tmp/.snap/{,**} rw,
-        # Allow mounting/unmounting any part of $SNAP over to a temporary place
-        # in /tmp/.snap/ during the preparation of a writable mimic.
-        # FIXME: update this with per-snap snap-update-ns profiles
-        mount options=(bind, rw) /** -> /tmp/.snap/**,
-        mount options=(rbind, rw) /** -> /tmp/.snap/**,
-        # Allow mounting tmpfs over the original read-only directory.
-        # FIXME: update this with per-snap snap-update-ns profiles
-        mount fstype=tmpfs options=(rw) tmpfs -> /**,
-        # Allow bind mounting anything from the temporary place in /tmp/.snap/
-        # back to $SNAP/** (to re-construct the data that was there before).
-        # FIXME: update this with per-snap snap-update-ns profiles
-        mount options=(bind, rw) /tmp/.snap/** -> /**,
-        mount options=(rbind, rw) /tmp/.snap/** -> /**,
-        # Allow unmounting the temporary directory in /tmp once it is no longer
-        # necessary.
-        umount /tmp/.snap/**,
-        # Allow unmounting any of the above in case something fails and
-        # we start recovery.
-        umount /**,
-
-        # Allow creating missing directories anywhere under the root directory
-        # (but not in the root directory itself) where they need to be created
-        # as a mount point for layouts or for content sharing. This is a
-        # superset of other cases so they are removed
-        # FIXME: update this with per-snap snap-update-ns profiles
-        / r,
-        /** r,
-        /*/** w,
-
-        # Allow layouts to bind mount *from* $SNAP, $SNAP_DATA and $SNAP_COMMON
-        # *to* anywhere under the root directory. This is safe because the
-        # mounts happen inside an isolated mount namespace (but see below).
-        mount options=(bind) /snap/*/** -> /*/**,
-        mount options=(bind) /var/snap/*/** -> /*/**,
-        # As an exception, don't allow bind mounts to /media which has special
-        # sharing and propagates mount events outside of the snap namespace.
-        audit deny mount -> /media,
-
-        # Allow the content interface to bind fonts from the host filesystem
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
-        # Allow the desktop interface to bind fonts from the host filesystem
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /usr/share/fonts/,
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/local/share/fonts/ -> /usr/local/share/fonts/,
-        mount options=(ro bind) /var/lib/snapd/hostfs/var/cache/fontconfig/ -> /var/cache/fontconfig/,
-
-        # Allow unmounts matching possible mounts listed above.
-        umount /*/**,
-
-        # But we don't want anyone to touch /snap/bin
-        audit deny mount /snap/bin/** -> /**,
-        audit deny mount /** -> /snap/bin/**,
-
-        # Allow the content interface to bind fonts from the host filesystem
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
-    }
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
 }

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -244,7 +244,8 @@ int main(int argc, char **argv)
 				}
 			}
 			if (sc_should_populate_ns_group(group)) {
-				sc_populate_mount_ns(snap_update_ns_fd,
+				sc_populate_mount_ns(&apparmor,
+						     snap_update_ns_fd,
 						     base_snap_name, snap_name);
 				sc_preserve_populated_ns_group(group);
 			}

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -149,7 +149,6 @@ func snippetFromLayout(layout *snap.Layout) string {
 		return fmt.Sprintf("# Layout path: %s\n%s mrwklix,", mountPoint, mountPoint)
 	}
 	return fmt.Sprintf("# Layout path: %s\n# (no extra permissions required for symlink)", mountPoint)
-
 }
 
 func copySnippets(m map[string][]string) map[string][]string {

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -508,3 +508,159 @@ var nfsSnippet = `
   network inet,
   network inet6,
 `
+
+// updateNSTemplate contains an apparmor profile for snap-update-ns.
+// The template contains variable references to encode per-snap layout
+// requirements so that snap-update-ns doesn't need to have broad permissions
+// to write to the whole disk or to mount and unmount anything.
+var updateNSTemplate = `
+# Description: Allows snap-update-ns to construct the mount namespace specific
+# to a particular snap (see the name below). This specifically includes the
+# precise locations of the layout elements.
+
+# vim:syntax=apparmor
+
+#include <tunables/global>
+
+profile snap-update-ns.###SNAP_NAME### (attach_disconnected) {
+  # The next four rules mirror those above. We want to be able to read
+  # and map snap-update-ns into memory but it may come from a variety of places.
+  /usr/lib{,exec,64}/snapd/snap-update-ns mr,
+  /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns mr,
+  /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
+  /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
+
+  # Allow reading the dynamic linker cache.
+  /etc/ld.so.cache r,
+  # Allow reading, mapping and executing the dynamic linker.
+  /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}ld-*.so mrix,
+  # Allow reading and mapping various parts of the standard library and
+  # dynamically loaded nss modules and what not.
+  /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libc{,-[0-9]*}.so* mr,
+  /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpthread{,-[0-9]*}.so* mr,
+
+  # Allow reading the command line (snap-update-ns uses it in pre-Go bootstrap code).
+  @{PROC}/@{pid}/cmdline r,
+
+  # Allow reading the os-release file (possibly a symlink to /usr/lib).
+  /{etc/,usr/lib/}os-release r,
+
+  # Allow creating/grabbing various snapd lock files.
+  /run/snapd/lock/*.lock rwk,
+
+  # Allow reading stored mount namespaces,
+  /run/snapd/ns/ r,
+  /run/snapd/ns/*.mnt r,
+
+  # Allow reading per-snap desired mount profiles. Those are written by
+  # snapd and represent the desired layout and content connections.
+  /var/lib/snapd/mount/snap.*.fstab r,
+
+  # Allow reading and writing actual per-snap mount profiles. Note that
+  # the second rule is generic to allow our tmpfile-rename approach to
+  # writing them. Those are written by snap-update-ns and represent the
+  # actual layout at a given moment.
+  /run/snapd/ns/*.fstab rw,
+  /run/snapd/ns/*.fstab.* rw,
+
+  # NOTE: at this stage the /snap directory is stable as we have called
+  # pivot_root already.
+
+  # Needed to perform mount/unmounts.
+  capability sys_admin,
+  # Needed for mimic construction.
+  capability chown,
+
+  # Allow freezing and thawing the per-snap cgroup freezers
+  /sys/fs/cgroup/freezer/snap.*/freezer.state rw,
+
+  # Support mount profiles via the content interface. This should correspond
+  # to permutations of $SNAP -> $SNAP for reading and $SNAP_{DATA,COMMON} ->
+  # $SNAP_{DATA,COMMON} for both reading and writing.
+  #
+  # Note that:
+  #   /snap/*/*/**
+  # is meant to mean:
+  #   /snap/$SNAP_NAME/$SNAP_REVISION/and-any-subdirectory
+  # but:
+  #   /var/snap/*/**
+  # is meant to mean:
+  #   /var/snap/$SNAP_NAME/$SNAP_REVISION/
+  mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
+  mount options=(ro bind) /snap/*/** -> /var/snap/*/**,
+  mount options=(rw bind) /var/snap/*/** -> /var/snap/*/**,
+  mount options=(ro bind) /var/snap/*/** -> /var/snap/*/**,
+
+  # Allow creating missing mount directories under $SNAP_DATA.
+  #
+  # The "tree" of permissions is needed for SecureMkdirAll that uses
+  # open(..., O_NOFOLLOW) and mkdirat() using the resulting file
+  # descriptor.
+  / r,
+  /var/ r,
+  /var/snap/{,*/} r,
+  /var/snap/*/**/ rw,
+
+  # Allow creating placeholder directory in /tmp/.snap/ as support for
+  # the writable mimic code that can poke holes in arbitrary read-only
+  # places using tmpfs and bind mounts.
+  /tmp/ r,
+  /tmp/.snap/{,**} rw,
+  # Allow mounting/unmounting any part of $SNAP over to a temporary place
+  # in /tmp/.snap/ during the preparation of a writable mimic.
+  # FIXME: update this with per-snap snap-update-ns profiles
+  mount options=(bind, rw) /** -> /tmp/.snap/**,
+  mount options=(rbind, rw) /** -> /tmp/.snap/**,
+  # Allow mounting tmpfs over the original read-only directory.
+  # FIXME: update this with per-snap snap-update-ns profiles
+  mount fstype=tmpfs options=(rw) tmpfs -> /**,
+  # Allow bind mounting anything from the temporary place in /tmp/.snap/
+  # back to $SNAP/** (to re-construct the data that was there before).
+  # FIXME: update this with per-snap snap-update-ns profiles
+  mount options=(bind, rw) /tmp/.snap/** -> /**,
+  mount options=(rbind, rw) /tmp/.snap/** -> /**,
+  # Allow unmounting the temporary directory in /tmp once it is no longer
+  # necessary.
+  umount /tmp/.snap/**,
+  # Allow unmounting any of the above in case something fails and
+  # we start recovery.
+  umount /**,
+
+  # Allow creating missing directories anywhere under the root directory
+  # (but not in the root directory itself) where they need to be created
+  # as a mount point for layouts or for content sharing. This is a
+  # superset of other cases so they are removed
+  # FIXME: update this with per-snap snap-update-ns profiles
+  / r,
+  /** r,
+  /*/** w,
+
+  # Allow layouts to bind mount *from* $SNAP, $SNAP_DATA and $SNAP_COMMON
+  # *to* anywhere under the root directory. This is safe because the
+  # mounts happen inside an isolated mount namespace (but see below).
+  mount options=(bind) /snap/*/** -> /*/**,
+  mount options=(bind) /var/snap/*/** -> /*/**,
+  # As an exception, don't allow bind mounts to /media which has special
+  # sharing and propagates mount events outside of the snap namespace.
+  audit deny mount -> /media,
+
+  # Allow the content interface to bind fonts from the host filesystem
+  mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
+  # Allow the desktop interface to bind fonts from the host filesystem
+  mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /usr/share/fonts/,
+  mount options=(ro bind) /var/lib/snapd/hostfs/usr/local/share/fonts/ -> /usr/local/share/fonts/,
+  mount options=(ro bind) /var/lib/snapd/hostfs/var/cache/fontconfig/ -> /var/cache/fontconfig/,
+
+  # Allow unmounts matching possible mounts listed above.
+  umount /*/**,
+
+  # But we don't want anyone to touch /snap/bin
+  audit deny mount /snap/bin/** -> /**,
+  audit deny mount /** -> /snap/bin/**,
+
+  # Allow the content interface to bind fonts from the host filesystem
+  mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
+
+###SNIPPETS###
+}
+`


### PR DESCRIPTION
This patch extends the apparmor security backend to create a dedicated
snap-update-ns profile for each snap with apps or hooks. That new profile applies to
snap-update-ns when invoked from snap-confine for that specific snap.
The profile exists to express strict mount and write rules that are
required by the layout and avoid the need for generous "you can write
anywhere and mount anywhere" rule.

At this time the mount rules are not any more strict but this will be
easily addressed with subsequent patches that remove generous rules and
add update-ns snippets to compensate.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>