### PR TITLE
osutil: handle file being matched by multiple patterns (2.32)

### DIFF
--- a/osutil/syncdir.go
+++ b/osutil/syncdir.go
@@ -100,21 +100,24 @@ func EnsureDirStateGlobs(dir string, globs []string, content map[string]*FileSta
 		changed = append(changed, baseName)
 	}
 	// Delete phase (remove files matching the glob that are not in content)
-	var matches []string
+	matches := make(map[string]bool)
 	for _, glob := range globs {
 		m, err := filepath.Glob(filepath.Join(dir, glob))
 		if err != nil {
 			sort.Strings(changed)
 			return changed, nil, err
 		}
-		matches = append(matches, m...)
+		for _, path := range m {
+			matches[path] = true
+		}
 	}
-	for _, filePath := range matches {
-		baseName := filepath.Base(filePath)
+
+	for path := range matches {
+		baseName := filepath.Base(path)
 		if content[baseName] != nil {
 			continue
 		}
-		err := os.Remove(filePath)
+		err := os.Remove(path)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err

--- a/osutil/syncdir_test.go
+++ b/osutil/syncdir_test.go
@@ -90,6 +90,17 @@ func (s *EnsureDirStateSuite) TestTwoPatterns(c *C) {
 	c.Assert(stat.Mode().Perm(), Equals, os.FileMode(0600))
 }
 
+func (s *EnsureDirStateSuite) TestMultipleMatches(c *C) {
+	name := filepath.Join(s.dir, "foo")
+	err := ioutil.WriteFile(name, []byte("content"), 0600)
+	c.Assert(err, IsNil)
+	// When a file is matched by multiple globs it removed correctly.
+	changed, removed, err := osutil.EnsureDirStateGlobs(s.dir, []string{"foo", "f*"}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(changed, HasLen, 0)
+	c.Assert(removed, DeepEquals, []string{"foo"})
+}
+
 func (s *EnsureDirStateSuite) TestCreatesMissingFiles(c *C) {
 	name := filepath.Join(s.dir, "missing.snap")
 	changed, removed, err := osutil.EnsureDirState(s.dir, s.glob, map[string]*osutil.FileState{


### PR DESCRIPTION
When EnsureDirStateGlobs has more than one pattern matching a single
file the loop would naively encounter ENOENT error on the second attempt
to remove the file. This patch fixes the loop to remove each file at
most once.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
