### PR TITLE
userd: add an OpenFile method for launching local files with xdg-open

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -139,7 +139,7 @@ dbus (send)
     bus=session
     path=/io/snapcraft/Launcher
     interface=io.snapcraft.Launcher
-    member=OpenURL
+    member={OpenURL,OpenFile}
     peer=(label=unconfined),
 
 # Allow checking status, activating and locking the screensaver

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -112,7 +112,7 @@ dbus (send)
     bus=session
     path=/io/snapcraft/Launcher
     interface=io.snapcraft.Launcher
-    member=OpenURL
+    member={OpenURL,OpenFile}
     peer=(label=unconfined),
 
 # Allow use of snapd's internal 'xdg-settings'

--- a/osutil/sys/syscall.go
+++ b/osutil/sys/syscall.go
@@ -95,3 +95,15 @@ func FchownAt(dirfd uintptr, path string, uid UserID, gid GroupID, flags int) er
 	}
 	return errno
 }
+
+// As of Go 1.9, the O_PATH constant does not seem to be declared
+// uniformly over all archtiectures.
+const O_PATH = 0x200000
+
+func FcntlGetFl(fd int) (int, error) {
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_GETFL), 0)
+	if errno != 0 {
+		return 0, errno
+	}
+	return int(flags), nil
+}

--- a/userd/launcher.go
+++ b/userd/launcher.go
@@ -128,11 +128,11 @@ func fdToFilename(fd int) (string, error) {
 		return "", err
 	}
 
-	var fdStat, fileStat syscall.Stat_t
-	if err := syscall.Fstat(fd, &fdStat); err != nil {
+	var fileStat, fdStat syscall.Stat_t
+	if err := syscall.Stat(filename, &fileStat); err != nil {
 		return "", err
 	}
-	if err := syscall.Stat(filename, &fileStat); err != nil {
+	if err := syscall.Fstat(fd, &fdStat); err != nil {
 		return "", err
 	}
 

--- a/userd/launcher.go
+++ b/userd/launcher.go
@@ -22,10 +22,16 @@ package userd
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
+	"syscall"
+	"time"
 
 	"github.com/godbus/dbus"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/strutil"
+	"github.com/snapcore/snapd/userd/ui"
 )
 
 const launcherIntrospectionXML = `
@@ -39,6 +45,9 @@ const launcherIntrospectionXML = `
 <interface name='io.snapcraft.Launcher'>
 	<method name='OpenURL'>
 		<arg type='s' name='url' direction='in'/>
+	</method>
+	<method name="OpenFile">
+		<arg type="h" name="fd" direction="in"/>
 	</method>
 </interface>`
 
@@ -88,6 +97,81 @@ func (s *Launcher) OpenURL(addr string) *dbus.Error {
 	}
 
 	if err = exec.Command("xdg-open", addr).Run(); err != nil {
+		return dbus.MakeFailedError(fmt.Errorf("cannot open supplied URL"))
+	}
+
+	return nil
+}
+
+func fdToFilename(fd int) (string, error) {
+	flags, err := sys.FcntlGetFl(fd)
+	if err != nil {
+		return "", err
+	}
+	// File descriptors opened with O_PATH do not imply access to
+	// the file in question.
+	if flags&sys.O_PATH != 0 {
+		return "", fmt.Errorf("bad file descriptor")
+	}
+
+	// Determine the file name associated with the passed file descriptor.
+	filename, err := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", fd))
+	if err != nil {
+		return "", err
+	}
+
+	var fdStat, fileStat syscall.Stat_t
+	if err := syscall.Fstat(fd, &fdStat); err != nil {
+		return "", err
+	}
+	if err := syscall.Stat(filename, &fileStat); err != nil {
+		return "", err
+	}
+
+	// Sanity check to ensure we've got the right file
+	if fdStat.Dev != fileStat.Dev || fdStat.Ino != fileStat.Ino {
+		return "", fmt.Errorf("could not determine file name")
+	}
+
+	fileType := fileStat.Mode & syscall.S_IFMT
+	if fileType != syscall.S_IFREG && fileType != syscall.S_IFDIR {
+		return "", fmt.Errorf("can only open regular files and directories")
+	}
+
+	return filename, nil
+}
+
+func (s *Launcher) OpenFile(clientFd dbus.UnixFD, sender dbus.Sender) *dbus.Error {
+	// godbus transfers ownership of this file descriptor to us
+	fd := int(clientFd)
+	defer syscall.Close(fd)
+
+	filename, err := fdToFilename(fd)
+	if err != nil {
+		return dbus.MakeFailedError(err)
+	}
+
+	snap, err := snapFromSender(s.conn, sender)
+	if err != nil {
+		return dbus.MakeFailedError(err)
+	}
+	dialog, err := ui.New()
+	if err != nil {
+		return dbus.MakeFailedError(err)
+	}
+	answeredYes := dialog.YesNo(
+		i18n.G("Allow open file?"),
+		fmt.Sprintf(i18n.G("Allow snap %q to open file %q ?"), snap, filename),
+		&ui.DialogOptions{
+			Timeout: 5 * 60 * time.Second,
+			Footer:  i18n.G("This dialog will close automatically after 5 minutes of inactivity."),
+		},
+	)
+	if !answeredYes {
+		return dbus.MakeFailedError(fmt.Errorf("permission denied"))
+	}
+
+	if err = exec.Command("xdg-open", filename).Run(); err != nil {
 		return dbus.MakeFailedError(fmt.Errorf("cannot open supplied URL"))
 	}
 

--- a/userd/launcher.go
+++ b/userd/launcher.go
@@ -47,6 +47,7 @@ const launcherIntrospectionXML = `
 		<arg type='s' name='url' direction='in'/>
 	</method>
 	<method name="OpenFile">
+		<arg type="s" name="parent_window" direction="in"/>
 		<arg type="h" name="fd" direction="in"/>
 	</method>
 </interface>`
@@ -148,7 +149,7 @@ func fdToFilename(fd int) (string, error) {
 	return filename, nil
 }
 
-func (s *Launcher) OpenFile(clientFd dbus.UnixFD, sender dbus.Sender) *dbus.Error {
+func (s *Launcher) OpenFile(parentWindow string, clientFd dbus.UnixFD, sender dbus.Sender) *dbus.Error {
 	// godbus transfers ownership of this file descriptor to us
 	fd := int(clientFd)
 	defer syscall.Close(fd)

--- a/userd/launcher.go
+++ b/userd/launcher.go
@@ -103,6 +103,13 @@ func (s *Launcher) OpenURL(addr string) *dbus.Error {
 	return nil
 }
 
+// fdToFilename determines the path associated with an open file descriptor.
+//
+// The file descriptor cannot be opened using O_PATH and must refer to
+// a regular file or to a directory. The symlink at /proc/self/fd/<fd>
+// is read to determine the filename. The descriptor is also fstat'ed
+// and the resulting device number and inode number are compared to
+// stat on the path determined earlier. The numbers must match.
 func fdToFilename(fd int) (string, error) {
 	flags, err := sys.FcntlGetFl(fd)
 	if err != nil {
@@ -111,7 +118,7 @@ func fdToFilename(fd int) (string, error) {
 	// File descriptors opened with O_PATH do not imply access to
 	// the file in question.
 	if flags&sys.O_PATH != 0 {
-		return "", fmt.Errorf("bad file descriptor")
+		return "", fmt.Errorf("cannot use file descriptors opened using O_PATH")
 	}
 
 	// Determine the file name associated with the passed file descriptor.
@@ -130,12 +137,12 @@ func fdToFilename(fd int) (string, error) {
 
 	// Sanity check to ensure we've got the right file
 	if fdStat.Dev != fileStat.Dev || fdStat.Ino != fileStat.Ino {
-		return "", fmt.Errorf("could not determine file name")
+		return "", fmt.Errorf("cannot determine file name")
 	}
 
 	fileType := fileStat.Mode & syscall.S_IFMT
 	if fileType != syscall.S_IFREG && fileType != syscall.S_IFDIR {
-		return "", fmt.Errorf("can only open regular files and directories")
+		return "", fmt.Errorf("cannot open anything other than regular files or directories")
 	}
 
 	return filename, nil
@@ -160,8 +167,8 @@ func (s *Launcher) OpenFile(clientFd dbus.UnixFD, sender dbus.Sender) *dbus.Erro
 		return dbus.MakeFailedError(err)
 	}
 	answeredYes := dialog.YesNo(
-		i18n.G("Allow open file?"),
-		fmt.Sprintf(i18n.G("Allow snap %q to open file %q ?"), snap, filename),
+		i18n.G("Allow opening file?"),
+		fmt.Sprintf(i18n.G("Allow snap %q to open file %q?"), snap, filename),
 		&ui.DialogOptions{
 			Timeout: 5 * 60 * time.Second,
 			Footer:  i18n.G("This dialog will close automatically after 5 minutes of inactivity."),

--- a/userd/launcher_test.go
+++ b/userd/launcher_test.go
@@ -20,12 +20,17 @@
 package userd_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/godbus/dbus"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/userd"
 )
@@ -35,7 +40,8 @@ func Test(t *testing.T) { TestingT(t) }
 type launcherSuite struct {
 	launcher *userd.Launcher
 
-	mockXdgOpen *testutil.MockCmd
+	mockXdgOpen           *testutil.MockCmd
+	restoreSnapFromSender func()
 }
 
 var _ = Suite(&launcherSuite{})
@@ -43,10 +49,14 @@ var _ = Suite(&launcherSuite{})
 func (s *launcherSuite) SetUpTest(c *C) {
 	s.launcher = &userd.Launcher{}
 	s.mockXdgOpen = testutil.MockCommand(c, "xdg-open", "")
+	s.restoreSnapFromSender = userd.MockSnapFromSender(func(*dbus.Conn, dbus.Sender) (string, error) {
+		return "some-snap", nil
+	})
 }
 
 func (s *launcherSuite) TearDownTest(c *C) {
 	s.mockXdgOpen.Restore()
+	s.restoreSnapFromSender()
 }
 
 func (s *launcherSuite) TestOpenURLWithNotAllowedScheme(c *C) {
@@ -82,4 +92,99 @@ func (s *launcherSuite) TestOpenURLWithFailingXdgOpen(c *C) {
 	err := s.launcher.OpenURL("https://snapcraft.io")
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "cannot open supplied URL")
+}
+
+func (s *launcherSuite) TestOpenFileUserAccepts(c *C) {
+	mockZenity := testutil.MockCommand(c, "zenity", "true")
+	defer mockZenity.Restore()
+
+	path := filepath.Join(c.MkDir(), "test.txt")
+	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
+
+	file, err := os.Open(path)
+	c.Assert(err, IsNil)
+	defer file.Close()
+
+	dupFd, err := syscall.Dup(int(file.Fd()))
+	c.Assert(err, IsNil)
+
+	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	c.Assert(err, IsNil)
+	c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{
+		{"xdg-open", path},
+	})
+}
+
+func (s *launcherSuite) TestOpenFileUserDeclines(c *C) {
+	mockZenity := testutil.MockCommand(c, "zenity", "false")
+	defer mockZenity.Restore()
+
+	path := filepath.Join(c.MkDir(), "test.txt")
+	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
+
+	file, err := os.Open(path)
+	c.Assert(err, IsNil)
+	defer file.Close()
+
+	dupFd, err := syscall.Dup(int(file.Fd()))
+	c.Assert(err, IsNil)
+
+	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "permission denied")
+	c.Assert(s.mockXdgOpen.Calls(), IsNil)
+}
+
+func (s *launcherSuite) TestOpenFileSucceedsWithDirectory(c *C) {
+	mockZenity := testutil.MockCommand(c, "zenity", "true")
+	defer mockZenity.Restore()
+
+	dir := c.MkDir()
+	fd, err := syscall.Open(dir, syscall.O_RDONLY|syscall.O_DIRECTORY, 0755)
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	dupFd, err := syscall.Dup(fd)
+	c.Assert(err, IsNil)
+
+	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	c.Assert(err, IsNil)
+	c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{
+		{"xdg-open", dir},
+	})
+}
+
+func (s *launcherSuite) TestOpenFileFailsWithDeviceFile(c *C) {
+	mockZenity := testutil.MockCommand(c, "zenity", "true")
+	defer mockZenity.Restore()
+
+	file, err := os.Open("/dev/null")
+	c.Assert(err, IsNil)
+	defer file.Close()
+
+	dupFd, err := syscall.Dup(int(file.Fd()))
+	c.Assert(err, IsNil)
+
+	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "can only open regular files and directories")
+	c.Assert(s.mockXdgOpen.Calls(), IsNil)
+}
+
+func (s *launcherSuite) TestOpenFileFailsWithPathDescriptor(c *C) {
+	mockZenity := testutil.MockCommand(c, "zenity", "true")
+	defer mockZenity.Restore()
+
+	dir := c.MkDir()
+	fd, err := syscall.Open(dir, sys.O_PATH, 0755)
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	dupFd, err := syscall.Dup(fd)
+	c.Assert(err, IsNil)
+
+	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "bad file descriptor")
+	c.Assert(s.mockXdgOpen.Calls(), IsNil)
 }

--- a/userd/launcher_test.go
+++ b/userd/launcher_test.go
@@ -167,7 +167,7 @@ func (s *launcherSuite) TestOpenFileFailsWithDeviceFile(c *C) {
 
 	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, "can only open regular files and directories")
+	c.Assert(err, ErrorMatches, "cannot open anything other than regular files or directories")
 	c.Assert(s.mockXdgOpen.Calls(), IsNil)
 }
 
@@ -185,6 +185,6 @@ func (s *launcherSuite) TestOpenFileFailsWithPathDescriptor(c *C) {
 
 	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, "bad file descriptor")
+	c.Assert(err, ErrorMatches, "cannot use file descriptors opened using O_PATH")
 	c.Assert(s.mockXdgOpen.Calls(), IsNil)
 }

--- a/userd/launcher_test.go
+++ b/userd/launcher_test.go
@@ -108,7 +108,7 @@ func (s *launcherSuite) TestOpenFileUserAccepts(c *C) {
 	dupFd, err := syscall.Dup(int(file.Fd()))
 	c.Assert(err, IsNil)
 
-	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	err = s.launcher.OpenFile("", dbus.UnixFD(dupFd), ":some-dbus-sender")
 	c.Assert(err, IsNil)
 	c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{
 		{"xdg-open", path},
@@ -129,7 +129,7 @@ func (s *launcherSuite) TestOpenFileUserDeclines(c *C) {
 	dupFd, err := syscall.Dup(int(file.Fd()))
 	c.Assert(err, IsNil)
 
-	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	err = s.launcher.OpenFile("", dbus.UnixFD(dupFd), ":some-dbus-sender")
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "permission denied")
 	c.Assert(s.mockXdgOpen.Calls(), IsNil)
@@ -147,7 +147,7 @@ func (s *launcherSuite) TestOpenFileSucceedsWithDirectory(c *C) {
 	dupFd, err := syscall.Dup(fd)
 	c.Assert(err, IsNil)
 
-	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	err = s.launcher.OpenFile("", dbus.UnixFD(dupFd), ":some-dbus-sender")
 	c.Assert(err, IsNil)
 	c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{
 		{"xdg-open", dir},
@@ -165,7 +165,7 @@ func (s *launcherSuite) TestOpenFileFailsWithDeviceFile(c *C) {
 	dupFd, err := syscall.Dup(int(file.Fd()))
 	c.Assert(err, IsNil)
 
-	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	err = s.launcher.OpenFile("", dbus.UnixFD(dupFd), ":some-dbus-sender")
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "cannot open anything other than regular files or directories")
 	c.Assert(s.mockXdgOpen.Calls(), IsNil)
@@ -183,7 +183,7 @@ func (s *launcherSuite) TestOpenFileFailsWithPathDescriptor(c *C) {
 	dupFd, err := syscall.Dup(fd)
 	c.Assert(err, IsNil)
 
-	err = s.launcher.OpenFile(dbus.UnixFD(dupFd), ":some-dbus-sender")
+	err = s.launcher.OpenFile("", dbus.UnixFD(dupFd), ":some-dbus-sender")
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "cannot use file descriptors opened using O_PATH")
 	c.Assert(s.mockXdgOpen.Calls(), IsNil)


### PR DESCRIPTION
This is the snapd side of work to make the xdg-open proxy handle local files.  Similar to the xdg-settings D-Bus interface, it prompts the user before opening the file.

Similar to xdg-desktop-portal's OpenFile interface, this takes a file descriptor as proof of access.  While the x-d-p implementation expects an `O_PATH` file descriptor, I'm explicitly checking that it isn't `O_PATH`: I believe that logic doesn't make sense because it is possible to create `O_PATH` file descriptors for files a process can't access (https://github.com/flatpak/xdg-desktop-portal/issues/167).  I also check to make sure the it is a regular file or directory.

The file name to open is determined by looking in `/proc/self/fd/$fd`, and checking that it refers to the same file.  We never try to perform reads or writes on the file descriptor because the confined app shares control of it.

This work will need some matching changes to the xdg-open proxy in the core snap, but this side should be landable on its own.  This Python script can be used for ad-hoc testing: https://paste.ubuntu.com/p/r8KGvHqrVF/