### PR TITLE
wrappers: detect whether systemd-analyze can be used in unit tests

### DIFF
--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -432,8 +432,22 @@ WantedBy=multi-user.target
 
 func (s *servicesWrapperGenSuite) TestTimerGenerateSchedules(c *C) {
 	systemdAnalyzePath, _ := exec.LookPath("systemd-analyze")
+	if systemdAnalyzePath != "" {
+		// systemd-analyze is in the path, but it will fail if the
+		// daemon is not running (as it happens in LP builds) and writes
+		// the following to stderr:
+		//   Failed to create bus connection: No such file or directory
+		cmd := exec.Command(systemdAnalyzePath, "calendar", "12:00")
+		err := cmd.Run()
+		if err != nil {
+			// turns out it's not usable, disable extra verification
+			fmt.Fprintln(os.Stderr, `WARNING: systemd-analyze not usable, cannot validate a known schedule "12:00"`)
+			systemdAnalyzePath = ""
+		}
+	}
+
 	if systemdAnalyzePath == "" {
-		fmt.Fprintln(os.Stderr, "WARNING: generated schedules will not verified by systemd-analyze")
+		fmt.Fprintln(os.Stderr, "WARNING: generated schedules will not be validated by systemd-analyze")
 	}
 
 	for _, t := range []struct {


### PR DESCRIPTION
For some reason systemd-analyze needs to talk to the daemon even if asked to
analyze a calendar schedule. In case of Launchpad builds of edge,
systemd-analyze is available, but when run it fails and writes the following to
stderr:
```
  Failed to create bus connection: No such file or directory
```
