### PR TITLE
store: parse the JSON format used by the coming new store API to convey snap information

### DIFF
--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -68,7 +68,7 @@ type storeSnapDelta struct {
 	Size     int64  `json:"size"`
 	Source   int    `json:"source"`
 	Target   int    `json:"target"`
-	URL      string `json:"url,omitempty"`
+	URL      string `json:"url"`
 }
 
 type storeAccount struct {

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -1,0 +1,177 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+// storeSnap holds the information sent as JSON by the store for a snap.
+type storeSnap struct {
+	Architectures []string          `json:"architectures"`
+	Base          string            `json:"base"`
+	Confinement   string            `json:"confinement"`
+	Contact       string            `json:"contact"`
+	CreatedAt     string            `json:"created-at"` // revision timestamp
+	Description   string            `json:"description"`
+	Download      storeSnapDownload `json:"download"`
+	Epoch         snap.Epoch        `json:"epoch"`
+	License       string            `json:"license"`
+	Name          string            `json:"name"`
+	Prices        map[string]string `json:"prices"` // currency->price,  free: {"USD": "0"}
+	Private       bool              `json:"private"`
+	Publisher     storeAccount      `json:"publisher"`
+	Revision      int               `json:"revision"` // store revisions are ints starting at 1
+	SnapID        string            `json:"snap-id"`
+	SnapYAML      string            `json:"snap-yaml"` // optional
+	Summary       string            `json:"summary"`
+	Title         string            `json:"title"`
+	Type          snap.Type         `json:"type"`
+	Version       string            `json:"version"`
+
+	// TODO: not yet defined: channel map
+
+	// media
+	Media []storeSnapMedia `json:"media"`
+}
+
+type storeSnapDownload struct {
+	Sha3_384 string           `json:"sha3-384"`
+	Size     int64            `json:"size"`
+	URL      string           `json:"url"`
+	Deltas   []storeSnapDelta `json:"deltas"`
+}
+
+type storeSnapDelta struct {
+	Format   string `json:"format"`
+	Sha3_384 string `json:"sha3-384"`
+	Size     int64  `json:"size"`
+	Source   int    `json:"source"`
+	Target   int    `json:"target"`
+	URL      string `json:"url,omitempty"`
+}
+
+type storeAccount struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`  // aka username
+	Title string `json:"title"` // aka display-name
+}
+
+type storeSnapMedia struct {
+	Type   string `json:"type"` // icon/screenshot
+	URL    string `json:"url"`
+	Width  int64  `json:"width"`
+	Height int64  `json:"height"`
+}
+
+func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
+	info := &snap.Info{}
+	info.RealName = d.Name
+	info.Revision = snap.R(d.Revision)
+	info.SnapID = d.SnapID
+	info.EditedTitle = d.Title
+	info.EditedSummary = d.Summary
+	info.EditedDescription = d.Description
+	info.Private = d.Private
+	info.Contact = d.Contact
+	info.Architectures = d.Architectures
+	info.Type = d.Type
+	info.Version = d.Version
+	info.Epoch = d.Epoch
+	info.Confinement = snap.ConfinementType(d.Confinement)
+	info.Base = d.Base
+	info.License = d.License
+	info.PublisherID = d.Publisher.ID
+	info.Publisher = d.Publisher.Name
+	info.DownloadURL = d.Download.URL
+	info.Size = d.Download.Size
+	info.Sha3_384 = d.Download.Sha3_384
+	if len(d.Download.Deltas) > 0 {
+		deltas := make([]snap.DeltaInfo, len(d.Download.Deltas))
+		for i, d := range d.Download.Deltas {
+			deltas[i] = snap.DeltaInfo{
+				FromRevision: d.Source,
+				ToRevision:   d.Target,
+				Format:       d.Format,
+				DownloadURL:  d.URL,
+				Size:         d.Size,
+				Sha3_384:     d.Sha3_384,
+			}
+		}
+		info.Deltas = deltas
+	}
+
+	// fill in the plug/slot data
+	if rawYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {
+		if info.Plugs == nil {
+			info.Plugs = make(map[string]*snap.PlugInfo)
+		}
+		for k, v := range rawYamlInfo.Plugs {
+			info.Plugs[k] = v
+			info.Plugs[k].Snap = info
+		}
+		if info.Slots == nil {
+			info.Slots = make(map[string]*snap.SlotInfo)
+		}
+		for k, v := range rawYamlInfo.Slots {
+			info.Slots[k] = v
+			info.Slots[k].Snap = info
+		}
+	}
+
+	// convert prices
+	if len(d.Prices) > 0 {
+		prices := make(map[string]float64, len(d.Prices))
+		for currency, priceStr := range d.Prices {
+			price, err := strconv.ParseFloat(priceStr, 64)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse snap price: %v", err)
+			}
+			prices[currency] = price
+		}
+		info.Paid = true
+		info.Prices = prices
+	}
+
+	// media
+	screenshots := make([]snap.ScreenshotInfo, 0, len(d.Media))
+	for _, mediaObj := range d.Media {
+		switch mediaObj.Type {
+		case "icon":
+			if info.IconURL == "" {
+				info.IconURL = mediaObj.URL
+			}
+		case "screenshot":
+			screenshots = append(screenshots, snap.ScreenshotInfo{
+				URL:    mediaObj.URL,
+				Width:  mediaObj.Width,
+				Height: mediaObj.Height,
+			})
+		}
+	}
+	if len(screenshots) > 0 {
+		info.Screenshots = screenshots
+	}
+
+	return info, nil
+}

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -72,9 +72,9 @@ type storeSnapDelta struct {
 }
 
 type storeAccount struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`  // aka username
-	Title string `json:"title"` // aka display-name
+	ID          string `json:"id"`
+	Username    string `json:"username"`
+	DisplayName string `json:"display-name"`
 }
 
 type storeSnapMedia struct {
@@ -102,7 +102,7 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	info.Base = d.Base
 	info.License = d.License
 	info.PublisherID = d.Publisher.ID
-	info.Publisher = d.Publisher.Name
+	info.Publisher = d.Publisher.Username
 	info.DownloadURL = d.Download.URL
 	info.Size = d.Download.Size
 	info.Sha3_384 = d.Download.Sha3_384

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -61,8 +61,8 @@ const (
   "private": false,
   "publisher": {
      "id": "canonical",
-     "name": "canonical",
-     "title": "Canonical"
+     "username": "canonical",
+     "display-name": "Canonical"
   },
   "revision": 3887,
   "snap-id": "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
@@ -107,8 +107,8 @@ const (
   "private": false,
   "publisher": {
      "id": "ZvtzsxbsHivZLdvzrt0iqW529riGLfXJ",
-     "name": "thingyinc",
-     "title": "Thingy Inc."
+     "username": "thingyinc",
+     "display-name": "Thingy Inc."
   },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -1,0 +1,250 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store
+
+import (
+	"encoding/json"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+type detailsV2Suite struct{}
+
+var _ = Suite(&detailsV2Suite{})
+
+const (
+	coreStoreJSON = `{
+  "architectures": [
+    "amd64"
+  ],
+  "base": null,
+  "confinement": "strict",
+  "contact": "mailto:snappy-canonical-storeaccount@canonical.com",
+  "created-at": "2018-01-22T07:49:19.440720+00:00",
+  "description": "The core runtime environment for snapd",
+  "download": {
+     "sha3-384": "b691f6dde3d8022e4db563840f0ef82320cb824b6292ffd027dbc838535214dac31c3512c619beaf73f1aeaf35ac62d5",
+     "size": 85291008,
+     "url": "https://api.snapcraft.io/api/v1/snaps/download/99T7MUlRhtI3U0QFgl5mXXESAiSwt776_3887.snap",
+     "deltas": []
+  },
+  "epoch": {
+     "read": [0],
+     "write": [0]
+  },
+  "license": null,
+  "name": "core",
+  "prices": {},
+  "private": false,
+  "publisher": {
+     "id": "canonical",
+     "name": "canonical",
+     "title": "Canonical"
+  },
+  "revision": 3887,
+  "snap-id": "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
+  "summary": "snapd runtime environment",
+  "title": "core",
+  "type": "os",
+  "version": "16-2.30",
+  "media": []
+}`
+
+	thingyStoreJSON = `{
+  "architectures": [
+    "amd64"
+  ],
+  "base": "base-18",
+  "confinement": "strict",
+  "contact": "https://thingy.com",
+  "created-at": "2018-01-26T11:38:35.536410+00:00",
+  "description": "Useful thingy for thinging",
+  "download": {
+     "sha3-384": "a29f8d894c92ad19bb943764eb845c6bd7300f555ee9b9dbb460599fecf712775c0f3e2117b5c56b08fcb9d78fc8ae4d",
+     "size": 10000021,
+     "url": "https://api.snapcraft.io/api/v1/snaps/download/XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap",
+     "deltas": [
+       {
+         "format": "xdelta3",
+         "source": 19,
+         "target": 21,
+         "url": "https://api.snapcraft.io/api/v1/snaps/download/XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV_19_21_xdelta3.delta",
+         "size": 9999,
+         "sha3-384": "29f8d894c92ad19bb943764eb845c6bd7300f555ee9b9dbb460599fecf712775c0f3e2117b5c56b08fcb9d78fc8ae4df"
+       }
+     ]
+  },
+  "epoch": {
+     "read": [0,1],
+     "write": [1]
+  },
+  "license": "Proprietary",
+  "name": "thingy",
+  "prices": {"USD": "9.99"},
+  "private": false,
+  "publisher": {
+     "id": "ZvtzsxbsHivZLdvzrt0iqW529riGLfXJ",
+     "name": "thingyinc",
+     "title": "Thingy Inc."
+  },
+  "revision": 21,
+  "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
+  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\napps:\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\n",
+  "summary": "useful thingy",
+  "title": "thingy",
+  "type": "app",
+  "version": "9.50",
+  "media": [
+     {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Thingy.png"},
+     {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
+     {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", "width": 600, "height": 200}
+  ]
+}`
+)
+
+func (s *detailsV2Suite) TestInfoFromStoreSnapSimple(c *C) {
+	var snp storeSnap
+	err := json.Unmarshal([]byte(coreStoreJSON), &snp)
+	c.Assert(err, IsNil)
+
+	info, err := infoFromStoreSnap(&snp)
+	c.Assert(err, IsNil)
+	c.Check(snap.Validate(info), IsNil)
+
+	c.Check(info, DeepEquals, &snap.Info{
+		Architectures: []string{"amd64"},
+		SideInfo: snap.SideInfo{
+			RealName:          "core",
+			SnapID:            "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
+			Revision:          snap.R(3887),
+			Contact:           "mailto:snappy-canonical-storeaccount@canonical.com",
+			EditedTitle:       "core",
+			EditedSummary:     "snapd runtime environment",
+			EditedDescription: "The core runtime environment for snapd",
+			Private:           false,
+			Paid:              false,
+		},
+		Epoch:       *snap.E("0"),
+		Type:        snap.TypeOS,
+		Version:     "16-2.30",
+		Confinement: snap.StrictConfinement,
+		PublisherID: "canonical",
+		Publisher:   "canonical",
+		DownloadInfo: snap.DownloadInfo{
+			DownloadURL: "https://api.snapcraft.io/api/v1/snaps/download/99T7MUlRhtI3U0QFgl5mXXESAiSwt776_3887.snap",
+			Sha3_384:    "b691f6dde3d8022e4db563840f0ef82320cb824b6292ffd027dbc838535214dac31c3512c619beaf73f1aeaf35ac62d5",
+			Size:        85291008,
+		},
+		Plugs: make(map[string]*snap.PlugInfo),
+		Slots: make(map[string]*snap.SlotInfo),
+	})
+}
+
+func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
+	var snp storeSnap
+	// base, prices, media
+	err := json.Unmarshal([]byte(thingyStoreJSON), &snp)
+	c.Assert(err, IsNil)
+
+	info, err := infoFromStoreSnap(&snp)
+	c.Assert(err, IsNil)
+	c.Check(snap.Validate(info), IsNil)
+
+	info2 := *info
+	// clear recursive bits
+	info2.Plugs = nil
+	info2.Slots = nil
+	c.Check(&info2, DeepEquals, &snap.Info{
+		Architectures: []string{"amd64"},
+		Base:          "base-18",
+		SideInfo: snap.SideInfo{
+			RealName:          "thingy",
+			SnapID:            "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
+			Revision:          snap.R(21),
+			Contact:           "https://thingy.com",
+			EditedTitle:       "thingy",
+			EditedSummary:     "useful thingy",
+			EditedDescription: "Useful thingy for thinging",
+			Private:           false,
+			Paid:              true,
+		},
+		Epoch: snap.Epoch{
+			Read:  []uint32{0, 1},
+			Write: []uint32{1},
+		},
+		Type:        snap.TypeApp,
+		Version:     "9.50",
+		Confinement: snap.StrictConfinement,
+		License:     "Proprietary",
+		PublisherID: "ZvtzsxbsHivZLdvzrt0iqW529riGLfXJ",
+		Publisher:   "thingyinc",
+		DownloadInfo: snap.DownloadInfo{
+			DownloadURL: "https://api.snapcraft.io/api/v1/snaps/download/XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap",
+			Sha3_384:    "a29f8d894c92ad19bb943764eb845c6bd7300f555ee9b9dbb460599fecf712775c0f3e2117b5c56b08fcb9d78fc8ae4d",
+			Size:        10000021,
+			Deltas: []snap.DeltaInfo{
+				{
+					Format:       "xdelta3",
+					FromRevision: 19,
+					ToRevision:   21,
+					DownloadURL:  "https://api.snapcraft.io/api/v1/snaps/download/XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV_19_21_xdelta3.delta",
+					Size:         9999,
+					Sha3_384:     "29f8d894c92ad19bb943764eb845c6bd7300f555ee9b9dbb460599fecf712775c0f3e2117b5c56b08fcb9d78fc8ae4df",
+				},
+			},
+		},
+		Prices: map[string]float64{
+			"USD": 9.99,
+		},
+		IconURL: "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Thingy.png",
+		Screenshots: []snap.ScreenshotInfo{
+			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
+			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", Width: 600, Height: 200},
+		},
+	})
+
+	// validate the plugs/slots
+	c.Assert(info.Plugs, HasLen, 1)
+	plug := info.Plugs["shared-content-plug"]
+	c.Check(plug.Name, Equals, "shared-content-plug")
+	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Apps, HasLen, 1)
+	c.Check(plug.Apps["content-plug"].Command, Equals, "bin/content-plug")
+
+	c.Assert(info.Slots, HasLen, 1)
+	slot := info.Slots["shared-content-slot"]
+	c.Check(slot.Name, Equals, "shared-content-slot")
+	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Apps, HasLen, 1)
+	c.Check(slot.Apps["content-plug"].Command, Equals, "bin/content-plug")
+
+	// private
+	err = json.Unmarshal([]byte(strings.Replace(thingyStoreJSON, `"private": false`, `"private": true`, 1)), &snp)
+	c.Assert(err, IsNil)
+
+	info, err = infoFromStoreSnap(&snp)
+	c.Assert(err, IsNil)
+	c.Check(snap.Validate(info), IsNil)
+
+	c.Check(info.Private, Equals, true)
+}


### PR DESCRIPTION
Because is not needed for install/refresh how to format the channel map is not defined yet.

Most field names match snapd own REST API, there is a bit of nesting/grouping to make the pieces of information more modular.