### PR TITLE
tests: adding ubuntu-14.04-64 to the google backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -50,6 +50,8 @@ backends:
         systems:
             - ubuntu-16.04-64:
                 workers: 8
+            - ubuntu-14.04-64:
+                workers: 6
 
     linode:
         key: "$(HOST: echo $SPREAD_LINODE_KEY)"
@@ -65,9 +67,6 @@ backends:
             HTTPS_PROXY: null
         systems:
             - ubuntu-16.04-32:
-                kernel: GRUB 2
-                workers: 6
-            - ubuntu-14.04-64:
                 kernel: GRUB 2
                 workers: 6
 


### PR DESCRIPTION
First step on the migration from linode to google. 