### PR TITLE
Do not auto-import from loop/ram devices

### DIFF
--- a/data/udev/rules.d/66-snapd-autoimport.rules
+++ b/data/udev/rules.d/66-snapd-autoimport.rules
@@ -1,3 +1,3 @@
 # probe for assertions, must run before udisks2
-ACTION=="add", SUBSYSTEM=="block" \
+ACTION=="add", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*" \
     RUN+="/usr/bin/unshare -m /usr/bin/snap auto-import --mount=/dev/%k"


### PR DESCRIPTION
snap auto-import takes a noticeable time on boot, and with this we
reduce that time. Also, it does not really make sense to import
assertions from these virtual devices.