### PR TITLE
snap: add autostart app property

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -559,6 +559,8 @@ type AppInfo struct {
 	Before []string
 
 	Timer *TimerInfo
+
+	Autostart string
 }
 
 // ScreenshotInfo provides information about a screenshot.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -83,6 +83,8 @@ type appYaml struct {
 	Before []string `yaml:"before,omitempty"`
 
 	Timer string `yaml:"timer,omitempty"`
+
+	Autostart string `yaml:"autostart,omitempty"`
 }
 
 type hookYaml struct {
@@ -299,6 +301,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			RefreshMode:     yApp.RefreshMode,
 			Before:          yApp.Before,
 			After:           yApp.After,
+			Autostart:       yApp.Autostart,
 		}
 		if len(y.Plugs) > 0 || len(yApp.PlugNames) > 0 {
 			app.Plugs = make(map[string]*PlugInfo)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1653,3 +1653,30 @@ apps:
 	app := info.Apps["foo"]
 	c.Check(app.Timer, DeepEquals, &snap.TimerInfo{App: app, Timer: "mon,10:00-12:00"})
 }
+
+func (s *YamlSuite) TestSnapYamlAppAutostart(c *C) {
+	yAutostart := []byte(`name: wat
+version: 42
+apps:
+ foo:
+   command: bin/foo
+   autostart: foo.desktop
+
+`)
+	info, err := snap.InfoFromSnapYaml(yAutostart)
+	c.Assert(err, IsNil)
+	app := info.Apps["foo"]
+	c.Check(app.Autostart, Equals, "foo.desktop")
+
+	yNoAutostart := []byte(`name: wat
+version: 42
+apps:
+ foo:
+   command: bin/foo
+
+`)
+	info, err = snap.InfoFromSnapYaml(yNoAutostart)
+	c.Assert(err, IsNil)
+	app = info.Apps["foo"]
+	c.Check(app.Autostart, Equals, "")
+}


### PR DESCRIPTION
`autostart` property allows to specify the name of desktop file that application
will use for automatic startup in desktop user sessions.

Plan outlined in this forum post: https://forum.snapcraft.io/t/how-to-autostart-a-snap-of-a-desktop-application/2449/19