### PR TITLE
wrappers: refactor desktop file sanitizer to support autostart files

### DIFF
--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -102,25 +102,69 @@ var isValidDesktopFileLine = regexp.MustCompile(strings.Join([]string{
 	"^TargetEnvironment=",
 }, "|")).Match
 
-// rewriteExecLine rewrites a "Exec=" line to use the wrapper path for snap application.
-func rewriteExecLine(s *snap.Info, desktopFile, line string) (string, error) {
+type execRewriterImpl struct {
+	// strict enables fallback to matching a desktop file with snap
+	// application using the application's name
+	strict bool
+	// matches matches given app with a desktop file and returns a rewritten
+	// exec line or an empty string
+	matcher func(app *snap.AppInfo, desktopFile, execLine string) string
+}
+
+// appMatcher matches snap app with desktop file and an exec command by looking
+// at snap command wrapper, returns an updated command or an empty string
+func appMatcher(app *snap.AppInfo, desktopFile, execCmd string) string {
 	env := fmt.Sprintf("env BAMF_DESKTOP_FILE_HINT=%s ", desktopFile)
 
+	wrapper := app.WrapperPath()
+	validCmd := filepath.Base(wrapper)
+	// check the prefix to allow %flag style args
+	// this is ok because desktop files are not run through sh
+	// so we don't have to worry about the arguments too much
+	if execCmd == validCmd {
+		return env + wrapper
+	} else if strings.HasPrefix(execCmd, validCmd+" ") {
+		return fmt.Sprintf("%s%s%s", env, wrapper, execCmd[len(validCmd):])
+	}
+	return ""
+}
+
+// appAutostartMatcher matches a snap app with a desktop file and an exec
+// command by inspecting the application's autostart configuration and its command, returns an
+// updated command or an empty string
+func appAutostartMatcher(app *snap.AppInfo, desktopFile, execCmd string) string {
+	if app.Autostart != filepath.Base(desktopFile) {
+		return ""
+	}
+
+	wrapper := app.WrapperPath()
+	cmd := execCmd
+	pos := strings.Index(execCmd, " ")
+	if pos != -1 {
+		cmd = execCmd[0:pos]
+	}
+
+	if !strings.HasSuffix(cmd, app.Command) {
+		return ""
+	}
+
+	return fmt.Sprintf("%s%s", wrapper, execCmd[len(cmd):])
+}
+
+func (e *execRewriterImpl) rewrite(s *snap.Info, desktopFile, line string) (string, error) {
 	cmd := strings.SplitN(line, "=", 2)[1]
 	for _, app := range s.Apps {
-		wrapper := app.WrapperPath()
-		validCmd := filepath.Base(wrapper)
-		// check the prefix to allow %flag style args
-		// this is ok because desktop files are not run through sh
-		// so we don't have to worry about the arguments too much
-		if cmd == validCmd {
-			return "Exec=" + env + wrapper, nil
-		} else if strings.HasPrefix(cmd, validCmd+" ") {
-			return fmt.Sprintf("Exec=%s%s%s", env, wrapper, line[len("Exec=")+len(validCmd):]), nil
+		newCmd := e.matcher(app, desktopFile, cmd)
+		if newCmd != "" {
+			return "Exec=" + newCmd, nil
 		}
 	}
 
-	logger.Noticef("cannot use line %q for desktop file %q (snap %s)", line, desktopFile, s.Name())
+	logger.Noticef("cannot use exec line %q for desktop file %q (snap %s)", line, desktopFile, s.Name())
+	if e.strict {
+		return "", fmt.Errorf("invalid exec command: %q", cmd)
+	}
+
 	// The Exec= line in the desktop file is invalid. Instead of failing
 	// hard we rewrite the Exec= line. The convention is that the desktop
 	// file has the same name as the application we can use this fact here.
@@ -128,6 +172,7 @@ func rewriteExecLine(s *snap.Info, desktopFile, line string) (string, error) {
 	desktopFileApp := strings.TrimSuffix(df, filepath.Ext(df))
 	app, ok := s.Apps[desktopFileApp]
 	if ok {
+		env := fmt.Sprintf("env BAMF_DESKTOP_FILE_HINT=%s ", desktopFile)
 		newExec := fmt.Sprintf("Exec=%s%s", env, app.WrapperPath())
 		logger.Noticef("rewriting desktop file %q to %q", desktopFile, newExec)
 		return newExec, nil
@@ -136,7 +181,26 @@ func rewriteExecLine(s *snap.Info, desktopFile, line string) (string, error) {
 	return "", fmt.Errorf("invalid exec command: %q", cmd)
 }
 
-func sanitizeDesktopFile(s *snap.Info, desktopFile string, rawcontent []byte) []byte {
+// SanitizeAutostartDesktopFile inspects an autostart desktop file and its
+// content, returns an updated content with invalid lines filtered out and Exec
+// line rewritten to match the snap's context
+func SanitizeAutostartDesktopFile(s *snap.Info, desktopFile string, rawcontent []byte) []byte {
+	return sanitizeDesktopFile(s, desktopFile, rawcontent, &execRewriterImpl{strict: true, matcher: appAutostartMatcher})
+}
+
+// SanitizeAutostartDesktopFile inspects an desktop file and its content,
+// returns an updated content with invalid lines filtered out and Exec line
+// rewritten to match the snap's context
+func SanitizeDesktopFile(s *snap.Info, desktopFile string, rawcontent []byte) []byte {
+	return sanitizeDesktopFile(s, desktopFile, rawcontent, &execRewriterImpl{matcher: appMatcher})
+}
+
+type execRewriter interface {
+	// rewrite rewrites a "Exec=" line to use the wrapper path for snap application.
+	rewrite(s *snap.Info, desktopFile, execCmd string) (string, error)
+}
+
+func sanitizeDesktopFile(s *snap.Info, desktopFile string, rawcontent []byte, execRewriter execRewriter) []byte {
 	var newContent bytes.Buffer
 	mountDir := []byte(s.MountDir())
 	scanner := bufio.NewScanner(bytes.NewReader(rawcontent))
@@ -151,7 +215,7 @@ func sanitizeDesktopFile(s *snap.Info, desktopFile string, rawcontent []byte) []
 		// rewrite exec lines to an absolute path for the binary
 		if bytes.HasPrefix(bline, []byte("Exec=")) {
 			var err error
-			line, err := rewriteExecLine(s, desktopFile, string(bline))
+			line, err := execRewriter.rewrite(s, desktopFile, string(bline))
 			if err != nil {
 				// something went wrong, ignore the line
 				continue
@@ -215,7 +279,7 @@ func AddSnapDesktopFiles(s *snap.Info) (err error) {
 		}
 
 		installedDesktopFileName := filepath.Join(dirs.SnapDesktopFilesDir, fmt.Sprintf("%s_%s", s.Name(), filepath.Base(df)))
-		content = sanitizeDesktopFile(s, installedDesktopFileName, content)
+		content = SanitizeDesktopFile(s, installedDesktopFileName, content)
 		if err := osutil.AtomicWriteFile(installedDesktopFileName, content, 0755, 0); err != nil {
 			return err
 		}

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -130,25 +130,19 @@ func appMatcher(app *snap.AppInfo, desktopFile, execCmd string) string {
 }
 
 // appAutostartMatcher matches a snap app with a desktop file and an exec
-// command by inspecting the application's autostart configuration and its command, returns an
+// command by inspecting the application's autostart declaration, returns an
 // updated command or an empty string
 func appAutostartMatcher(app *snap.AppInfo, desktopFile, execCmd string) string {
 	if app.Autostart != filepath.Base(desktopFile) {
 		return ""
 	}
 
-	wrapper := app.WrapperPath()
 	cmd := execCmd
-	pos := strings.Index(execCmd, " ")
-	if pos != -1 {
+	if pos := strings.Index(execCmd, " "); pos != -1 {
 		cmd = execCmd[0:pos]
 	}
 
-	if !strings.HasSuffix(cmd, app.Command) {
-		return ""
-	}
-
-	return fmt.Sprintf("%s%s", wrapper, execCmd[len(cmd):])
+	return fmt.Sprintf("%s%s", app.WrapperPath(), execCmd[len(cmd):])
 }
 
 func (e *execRewriterImpl) rewrite(s *snap.Info, desktopFile, line string) (string, error) {

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -398,7 +398,7 @@ Exec=%s/bin/snap.app --foo bar baz "foo=2"
 `, dirs.SnapMountDir))
 }
 
-func (s *sanitizeDesktopFileSuite) TestSanitizeAutostartNoArgsValid(c *C) {
+func (s *sanitizeDesktopFileSuite) TestSanitizeAutostartNoArgs(c *C) {
 	snap, err := snap.InfoFromSnapYaml([]byte(`
 name: snap
 version: 1.0
@@ -454,7 +454,6 @@ apps:
 	c.Assert(err, IsNil)
 	desktopContent := []byte(`[Desktop Entry]
 Name=foo
-Exec=/snap/foo/current/bin/foo-bad --foo bar baz
 `)
 
 	e := wrappers.SanitizeAutostartDesktopFile(snap, "foo-stable.desktop", desktopContent)
@@ -463,7 +462,7 @@ Name=foo
 `)
 }
 
-func (s *sanitizeDesktopFileSuite) TestSanitizeAutostartBadAutostartDesktop(c *C) {
+func (s *sanitizeDesktopFileSuite) TestSanitizeAutostartDifferentAutostartDesktop(c *C) {
 	snap, err := snap.InfoFromSnapYaml([]byte(`
 name: snap
 version: 1.0

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -21,6 +21,8 @@ package wrappers
 
 import (
 	"time"
+
+	"github.com/snapcore/snapd/snap"
 )
 
 // some internal helper exposed for testing
@@ -30,8 +32,6 @@ var (
 	GenerateSnapTimerFile   = generateSnapTimerFile
 
 	// desktop
-	SanitizeDesktopFile    = sanitizeDesktopFile
-	RewriteExecLine        = rewriteExecLine
 	IsValidDesktopFileLine = isValidDesktopFileLine
 
 	// timers
@@ -44,4 +44,14 @@ func MockKillWait(wait time.Duration) (restore func()) {
 	return func() {
 		killWait = oldKillWait
 	}
+}
+
+func RewriteExecLine(s *snap.Info, desktopFile, line string) (string, error) {
+	r := execRewriterImpl{matcher: appMatcher}
+	return r.rewrite(s, desktopFile, line)
+}
+
+func RewriteAutostartExecLine(s *snap.Info, desktopFile, line string) (string, error) {
+	r := execRewriterImpl{strict: true, matcher: appAutostartMatcher}
+	return r.rewrite(s, desktopFile, line)
 }

--- a/wrappers/export_test.go
+++ b/wrappers/export_test.go
@@ -47,11 +47,11 @@ func MockKillWait(wait time.Duration) (restore func()) {
 }
 
 func RewriteExecLine(s *snap.Info, desktopFile, line string) (string, error) {
-	r := execRewriterImpl{matcher: appMatcher}
+	r := execRewriterImpl{rewriter: appExecRewriter}
 	return r.rewrite(s, desktopFile, line)
 }
 
 func RewriteAutostartExecLine(s *snap.Info, desktopFile, line string) (string, error) {
-	r := execRewriterImpl{strict: true, matcher: appAutostartMatcher}
+	r := execRewriterImpl{strict: true, rewriter: appAutostartExecRewriter}
 	return r.rewrite(s, desktopFile, line)
 }


### PR DESCRIPTION
Refactor the code for sanitizing and rewriting desktop files to accomodate
autostart files. These files are dropped by various applications in
XDG_CONFIG_HOME/autostart for the purpose of enabling their startup when the
desktop session is brought up.

Autostart desktop file is matched with a given snap application if that
application's command is present in the Exec=.. line and the application was
declared to use a desktop file with that name in snap.yaml.

The rules for cleaning up *.desktop files shipped in meta/gui/ remain the same.
