### PR TITLE
snap/squashfs: set timezone when calling unsquashfs to get the build date

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -321,6 +321,7 @@ func BuildDate(path string) time.Time {
 	}
 
 	cmd := exec.Command("unsquashfs", "-s", path)
+	cmd.Env = append(os.Environ(), "TZ=UTC")
 	cmd.Stdout = m
 	cmd.Stderr = m
 	if err := cmd.Run(); err != nil {

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -321,7 +321,7 @@ func BuildDate(path string) time.Time {
 	}
 
 	cmd := exec.Command("unsquashfs", "-s", path)
-	cmd.Env = append(os.Environ(), "TZ=UTC")
+	cmd.Env = []string{"TZ=UTC"}
 	cmd.Stdout = m
 	cmd.Stderr = m
 	if err := cmd.Run(); err != nil {

--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -211,6 +211,7 @@ func (s *Snap) Walk(relative string, walkFn filepath.WalkFunc) error {
 	} else {
 		cmd = exec.Command("unsquashfs", "-no-progress", "-dest", ".", "-ll", s.path, relative)
 	}
+	cmd.Env = []string{"TZ=UTC"}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return walkFn(relative, nil, err)

--- a/snap/squashfs/stat.go
+++ b/snap/squashfs/stat.go
@@ -67,7 +67,7 @@ func fromRaw(raw []byte) (*stat, error) {
 		// next'll come the size or the node type
 		st.parseSize,
 		// and then the time
-		st.parseTime,
+		st.parseTimeUTC,
 		// and finally the path
 		st.parsePath,
 	}
@@ -157,9 +157,9 @@ func errBadPath(raw []byte) statError {
 	}
 }
 
-func (st *stat) parseTime(raw []byte) (int, error) {
+func (st *stat) parseTimeUTC(raw []byte) (int, error) {
 	const timelen = 16
-	t, err := time.ParseInLocation("2006-01-02 15:04", string(raw[:timelen]), time.Local)
+	t, err := time.Parse("2006-01-02 15:04", string(raw[:timelen]))
 	if err != nil {
 		return 0, errBadTime(raw)
 	}

--- a/snap/squashfs/stat_test.go
+++ b/snap/squashfs/stat_test.go
@@ -114,7 +114,7 @@ func (s *SquashfsTestSuite) TestStatUserGroup(c *C) {
 			user:  user,
 			group: group,
 			size:  20,
-			mtime: time.Date(2017, 12, 8, 11, 19, 0, 0, time.Local),
+			mtime: time.Date(2017, 12, 8, 11, 19, 0, 0, time.UTC),
 		}
 
 		com := Commentf("%q", raw)
@@ -142,7 +142,7 @@ func (s *SquashfsTestSuite) TestStatPath(c *C) {
 			user:  "user",
 			group: "group",
 			size:  20,
-			mtime: time.Date(2017, 12, 8, 11, 19, 0, 0, time.Local),
+			mtime: time.Date(2017, 12, 8, 11, 19, 0, 0, time.UTC),
 		}
 
 		com := Commentf("%q", raw)
@@ -161,7 +161,7 @@ func (s *SquashfsTestSuite) TestStatBlock(c *C) {
 		path:  "/dev/loop0",
 		user:  "root",
 		group: "disk",
-		mtime: time.Date(2017, 12, 5, 10, 29, 0, 0, time.Local),
+		mtime: time.Date(2017, 12, 5, 10, 29, 0, 0, time.UTC),
 	})
 	// note the major and minor numbers are ignored (for now)
 }
@@ -175,7 +175,7 @@ func (s *SquashfsTestSuite) TestStatCharacter(c *C) {
 		path:  "/dev/dsp",
 		user:  "root",
 		group: "audio",
-		mtime: time.Date(2017, 12, 5, 10, 29, 0, 0, time.Local),
+		mtime: time.Date(2017, 12, 5, 10, 29, 0, 0, time.UTC),
 	})
 	// note the major and minor numbers are ignored (for now)
 }
@@ -190,7 +190,7 @@ func (s *SquashfsTestSuite) TestStatSymlink(c *C) {
 		user:  "root",
 		group: "root",
 		size:  4,
-		mtime: time.Date(2017, 12, 5, 10, 29, 0, 0, time.Local),
+		mtime: time.Date(2017, 12, 5, 10, 29, 0, 0, time.UTC),
 	})
 }
 
@@ -203,7 +203,7 @@ func (s *SquashfsTestSuite) TestStatNamedPipe(c *C) {
 		path:  "/afifo",
 		user:  "john",
 		group: "john",
-		mtime: time.Date(2018, 1, 9, 10, 24, 0, 0, time.Local),
+		mtime: time.Date(2018, 1, 9, 10, 24, 0, 0, time.UTC),
 	})
 }
 
@@ -216,7 +216,7 @@ func (s *SquashfsTestSuite) TestStatSocket(c *C) {
 		path:  "/asock",
 		user:  "john",
 		group: "john",
-		mtime: time.Date(2018, 1, 9, 10, 24, 0, 0, time.Local),
+		mtime: time.Date(2018, 1, 9, 10, 24, 0, 0, time.UTC),
 	})
 }
 
@@ -235,7 +235,7 @@ func (s *SquashfsTestSuite) TestStatLength(c *C) {
 			user:  "user",
 			group: "group",
 			size:  n,
-			mtime: time.Date(2017, 12, 8, 11, 19, 0, 0, time.Local),
+			mtime: time.Date(2017, 12, 8, 11, 19, 0, 0, time.UTC),
 		}
 
 		com := Commentf("%q", raw)
@@ -255,7 +255,7 @@ func (s *SquashfsTestSuite) TestStatModeBits(c *C) {
 			user:  "user",
 			group: "group",
 			size:  int64(53595),
-			mtime: time.Date(2017, 12, 8, 11, 19, 0, 0, time.Local),
+			mtime: time.Date(2017, 12, 8, 11, 19, 0, 0, time.UTC),
 		}
 
 		com := Commentf("%q vs %o", raw, i)


### PR DESCRIPTION
`unsquashfs -s` returns the last modification time using local timezone. However
its output lacks any indication of the timezone used. Consider these outputs of
`unsquashfs -s`:

CET output:
```
  Found a valid SQUASHFS 4:0 superblock on discord_0.0.4_amd64.snap.
  Creation or last append time Fri Mar  2 13:27:17 2018
```

UTC output:
```
  Found a valid SQUASHFS 4:0 superblock on discord_0.0.4_amd64.snap.
  Creation or last append time Fri Mar  2 12:27:17 2018
```

The time.ANSIC format that we use for parsing does not carry a timezone
placeholder, thus the returned time is always in UTC.

Fortunately unsquashfs respects TZ environment variable. Make sure that when
calling it we force TZ=UTC.
