### PR TITLE
strutil: introduce UnsafeString and UnsafeParagraph

### DIFF
--- a/strutil/ctrl16.go
+++ b/strutil/ctrl16.go
@@ -1,0 +1,51 @@
+// +build !go1.7
+
+package strutil
+
+// This is a generated file, editing would be silly.
+// Go edit github.com/chipaca/term/gen/merged_rangetable.go instead.
+
+import "unicode"
+
+// using golang.org/x/text/unicode/rangetable do
+// rangetable.Merge(unicode.Co, unicode.Cf, unicode.Cs, unicode.Noncharacter_Code_Point)
+// (we also care about unicode.Cc but that's handled by hand)
+// this makes the lookup in escape quite a bit faster (over 5×)
+var ctrl = &unicode.RangeTable{
+	R16: []unicode.Range16{
+		{Lo: 0x00ad, Hi: 0x0600, Stride: 1363},
+		{Lo: 0x0601, Hi: 0x0605, Stride: 1},
+		{Lo: 0x061c, Hi: 0x06dd, Stride: 193},
+		{Lo: 0x070f, Hi: 0x180e, Stride: 4351},
+		{Lo: 0x200b, Hi: 0x200f, Stride: 1},
+		{Lo: 0x202a, Hi: 0x202e, Stride: 1},
+		{Lo: 0x2060, Hi: 0x2064, Stride: 1},
+		{Lo: 0x2066, Hi: 0x206f, Stride: 1},
+		{Lo: 0xd800, Hi: 0xf8ff, Stride: 1},
+		{Lo: 0xfdd0, Hi: 0xfdef, Stride: 1},
+		{Lo: 0xfeff, Hi: 0xfff9, Stride: 250},
+		{Lo: 0xfffa, Hi: 0xfffb, Stride: 1},
+		{Lo: 0xfffe, Hi: 0xffff, Stride: 1},
+	},
+	R32: []unicode.Range32{
+		{Lo: 0x110bd, Hi: 0x1bca0, Stride: 44003},
+		{Lo: 0x1bca1, Hi: 0x1bca3, Stride: 1},
+		{Lo: 0x1d173, Hi: 0x1d17a, Stride: 1},
+		{Lo: 0x1fffe, Hi: 0x1ffff, Stride: 1},
+		{Lo: 0x2fffe, Hi: 0x2ffff, Stride: 1},
+		{Lo: 0x3fffe, Hi: 0x3ffff, Stride: 1},
+		{Lo: 0x4fffe, Hi: 0x4ffff, Stride: 1},
+		{Lo: 0x5fffe, Hi: 0x5ffff, Stride: 1},
+		{Lo: 0x6fffe, Hi: 0x6ffff, Stride: 1},
+		{Lo: 0x7fffe, Hi: 0x7ffff, Stride: 1},
+		{Lo: 0x8fffe, Hi: 0x8ffff, Stride: 1},
+		{Lo: 0x9fffe, Hi: 0x9ffff, Stride: 1},
+		{Lo: 0xafffe, Hi: 0xaffff, Stride: 1},
+		{Lo: 0xbfffe, Hi: 0xbffff, Stride: 1},
+		{Lo: 0xcfffe, Hi: 0xcffff, Stride: 1},
+		{Lo: 0xdfffe, Hi: 0xdffff, Stride: 1},
+		{Lo: 0xe0001, Hi: 0xe0020, Stride: 31},
+		{Lo: 0xe0021, Hi: 0xe007f, Stride: 1},
+		{Lo: 0xefffe, Hi: 0x10ffff, Stride: 1},
+	},
+}

--- a/strutil/ctrl17.go
+++ b/strutil/ctrl17.go
@@ -1,0 +1,52 @@
+// +build go1.7
+
+package strutil
+
+// This is a generated file, editing would be silly.
+// Go edit github.com/chipaca/term/gen/merged_rangetable.go instead.
+
+import "unicode"
+
+// using golang.org/x/text/unicode/rangetable do
+// rangetable.Merge(unicode.Co, unicode.Cf, unicode.Cs, unicode.Noncharacter_Code_Point)
+// (we also care about unicode.Cc but that's handled by hand)
+// this makes the lookup in escape quite a bit faster (over 5×)
+var ctrl = &unicode.RangeTable{
+	R16: []unicode.Range16{
+		{Lo: 0x00ad, Hi: 0x0600, Stride: 1363},
+		{Lo: 0x0601, Hi: 0x0605, Stride: 1},
+		{Lo: 0x061c, Hi: 0x06dd, Stride: 193},
+		{Lo: 0x070f, Hi: 0x08e2, Stride: 467},
+		{Lo: 0x180e, Hi: 0x200b, Stride: 2045},
+		{Lo: 0x200c, Hi: 0x200f, Stride: 1},
+		{Lo: 0x202a, Hi: 0x202e, Stride: 1},
+		{Lo: 0x2060, Hi: 0x2064, Stride: 1},
+		{Lo: 0x2066, Hi: 0x206f, Stride: 1},
+		{Lo: 0xd800, Hi: 0xf8ff, Stride: 1},
+		{Lo: 0xfdd0, Hi: 0xfdef, Stride: 1},
+		{Lo: 0xfeff, Hi: 0xfff9, Stride: 250},
+		{Lo: 0xfffa, Hi: 0xfffb, Stride: 1},
+		{Lo: 0xfffe, Hi: 0xffff, Stride: 1},
+	},
+	R32: []unicode.Range32{
+		{Lo: 0x110bd, Hi: 0x1bca0, Stride: 44003},
+		{Lo: 0x1bca1, Hi: 0x1bca3, Stride: 1},
+		{Lo: 0x1d173, Hi: 0x1d17a, Stride: 1},
+		{Lo: 0x1fffe, Hi: 0x1ffff, Stride: 1},
+		{Lo: 0x2fffe, Hi: 0x2ffff, Stride: 1},
+		{Lo: 0x3fffe, Hi: 0x3ffff, Stride: 1},
+		{Lo: 0x4fffe, Hi: 0x4ffff, Stride: 1},
+		{Lo: 0x5fffe, Hi: 0x5ffff, Stride: 1},
+		{Lo: 0x6fffe, Hi: 0x6ffff, Stride: 1},
+		{Lo: 0x7fffe, Hi: 0x7ffff, Stride: 1},
+		{Lo: 0x8fffe, Hi: 0x8ffff, Stride: 1},
+		{Lo: 0x9fffe, Hi: 0x9ffff, Stride: 1},
+		{Lo: 0xafffe, Hi: 0xaffff, Stride: 1},
+		{Lo: 0xbfffe, Hi: 0xbffff, Stride: 1},
+		{Lo: 0xcfffe, Hi: 0xcffff, Stride: 1},
+		{Lo: 0xdfffe, Hi: 0xdffff, Stride: 1},
+		{Lo: 0xe0001, Hi: 0xe0020, Stride: 31},
+		{Lo: 0xe0021, Hi: 0xe007f, Stride: 1},
+		{Lo: 0xefffe, Hi: 0x10ffff, Stride: 1},
+	},
+}

--- a/strutil/escape.go
+++ b/strutil/escape.go
@@ -1,0 +1,78 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// UnsafeString is a string that cannot be shown to the user without
+// further processing, as it might contain control characters.
+type UnsafeString string
+
+// Clean any control characters off the UnsafeString.
+func (un UnsafeString) Clean() string {
+	return clean(string(un), false)
+}
+
+// UnsafeParagraph is a string that cannot be shown to the user without
+// further processing, as it might contain control characters other than \n.
+type UnsafeParagraph string
+
+// Clean any control characters other than \n off the UnsafeParagraph.
+func (un UnsafeParagraph) Clean() string {
+	return clean(string(un), true)
+}
+
+func clean(uns string, paragraph bool) string {
+	// taken with permission from github.com/chipaca/term/escapes
+	out := make([]byte, 0, len(uns))
+	var r rune
+	var c byte
+	var i, j, sz int
+	for j < len(uns) {
+		// 0x80 is utf8.RuneSelf (below that, bytes are runes)
+		if uns[j] < 0x80 {
+			c = uns[j]
+			// 0x00..0x19 and 0x7f is the the first half of Cc
+			// 0x20..0x7e is all of printable ASCII
+			if (paragraph && c == '\n') || 0x20 <= c && c <= 0x7e {
+				out = append(out, c)
+			}
+			j++
+		} else {
+			r, sz = utf8.DecodeRuneInString(uns[j:])
+			if sz == 0 {
+				// end of the line
+				// (shouldn't happen given the loop guard)
+				break
+			}
+			i = j
+			j += sz
+			// 0x80..0x9f is the second half of Cc
+			if r != utf8.RuneError && r > 0x9f && !unicode.Is(ctrl, r) {
+				out = append(out, uns[i:j]...)
+			}
+		}
+	}
+
+	return string(out)
+}

--- a/strutil/escape_test.go
+++ b/strutil/escape_test.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package strutil_test
+
+import (
+	"unicode"
+
+	"gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/strutil"
+)
+
+type escapeSuite struct{}
+
+var _ = check.Suite(escapeSuite{})
+
+func (escapeSuite) TestClean(c *check.C) {
+	for r := rune(0); r <= unicode.MaxRune; r++ {
+		// skip the surrogates as they'er messy
+		s := strutil.UnsafeString([]rune{'a', r, 'z'})
+		notWanted := r == '�' || unicode.In(r,
+			unicode.C,
+			unicode.Noncharacter_Code_Point,
+		)
+		var expected string
+		if notWanted {
+			expected = "az"
+		} else {
+			expected = string(s)
+		}
+		c.Check(s.Clean(), check.Equals, expected, check.Commentf("%t: %#U", notWanted, r))
+	}
+}


### PR DESCRIPTION
In some cases snapd is given a string it can't be sure is safe to print to
the user's terminal.

With this change, strutil will have the tools to deal with that safely.