### PR TITLE
many: support holding refreshes by setting refresh.hold

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -402,6 +402,7 @@ type RefreshInfo struct {
 	// Schedule contains the legacy refresh.schedule setting.
 	Schedule string `json:"schedule,omitempty"`
 	Last     string `json:"last,omitempty"`
+	Hold     string `json:"hold,omitempty"`
 	Next     string `json:"next,omitempty"`
 }
 

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -670,6 +670,9 @@ func (x *cmdRefresh) showRefreshTimes() error {
 	} else {
 		fmt.Fprintf(Stdout, "last: n/a\n")
 	}
+	if sysinfo.Refresh.Hold != "" {
+		fmt.Fprintf(Stdout, "hold: %s\n", sysinfo.Refresh.Hold)
+	}
 	if sysinfo.Refresh.Next != "" {
 		fmt.Fprintf(Stdout, "next: %s\n", sysinfo.Refresh.Next)
 	} else {

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -266,6 +266,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	defer st.Unlock()
 	nextRefresh := snapMgr.NextRefresh()
 	lastRefresh, _ := snapMgr.LastRefresh()
+	refreshHold, _ := snapMgr.EffectiveRefreshHold()
 	refreshScheduleStr, legacySchedule, err := snapMgr.RefreshSchedule()
 	if err != nil {
 		return InternalError("cannot get refresh schedule: %s", err)
@@ -277,6 +278,7 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	refreshInfo := client.RefreshInfo{
 		Last: formatRefreshTime(lastRefresh),
+		Hold: formatRefreshTime(refreshHold),
 		Next: formatRefreshTime(nextRefresh),
 	}
 	if !legacySchedule {

--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -21,6 +21,7 @@ package configcore
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/timeutil"
@@ -36,6 +37,16 @@ func validateRefreshSchedule(tr Conf) error {
 		// refresh.timer is not set
 		if _, err = timeutil.ParseSchedule(refreshTimerStr); err != nil {
 			return err
+		}
+	}
+
+	refreshHoldStr, err := coreCfg(tr, "refresh.hold")
+	if err != nil {
+		return err
+	}
+	if refreshHoldStr != "" {
+		if _, err := time.Parse(time.RFC3339, refreshHoldStr); err != nil {
+			return fmt.Errorf("refresh.hold cannot be parsed: %v", err)
 		}
 	}
 

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -79,3 +79,23 @@ func (s *refreshSuite) TestConfigureLegacyRefreshScheduleRejected(c *C) {
 	})
 	c.Assert(err, ErrorMatches, `cannot parse "8:00~12:00": not a valid interval`)
 }
+
+func (s *refreshSuite) TestConfigureRefreshHoldHappy(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"refresh.hold": "2018-08-18T15:00:00Z",
+		},
+	})
+	c.Assert(err, IsNil)
+}
+
+func (s *refreshSuite) TestConfigureRefreshHoldInvalid(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"refresh.hold": "invalid",
+		},
+	})
+	c.Assert(err, ErrorMatches, `refresh\.hold cannot be parsed:.*`)
+}

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -527,6 +527,12 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedHappy(c *C) {
 	err = state.Get("seeded", &seeded)
 	c.Assert(err, IsNil)
 	c.Check(seeded, Equals, true)
+
+	// check we set seed-time
+	var seedTime time.Time
+	err = state.Get("seed-time", &seedTime)
+	c.Assert(err, IsNil)
+	c.Check(seedTime.IsZero(), Equals, false)
 }
 
 func (s *FirstBootTestSuite) TestPopulateFromSeedMissingBootloader(c *C) {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -45,6 +45,7 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
+	st.Set("seed-time", time.Now())
 	st.Set("seeded", true)
 	return nil
 }

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -34,6 +34,9 @@ import (
 // the default refresh pattern
 const defaultRefreshSchedule = "00:00~24:00/4"
 
+// cannot keep without refreshing for more than maxPostponement
+const maxPostponement = 60 * 24 * time.Hour
+
 // hooks setup by devicestate
 var (
 	CanAutoRefresh     func(st *state.State) (bool, error)
@@ -135,7 +138,7 @@ func (m *autoRefresh) Ensure() error {
 	if m.nextRefresh.IsZero() {
 		// store attempts in memory so that we can backoff
 		if !lastRefresh.IsZero() {
-			delta := timeutil.Next(refreshSchedule, lastRefresh)
+			delta := timeutil.Next(refreshSchedule, lastRefresh, maxPostponement)
 			m.nextRefresh = time.Now().Add(delta)
 		} else {
 			// immediate

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -200,7 +200,13 @@ func (m *autoRefresh) Ensure() error {
 		return nil
 	}
 	if !holdTime.IsZero() {
+		// expired hold case
 		m.clearRefreshHold()
+		if !m.nextRefresh.After(holdTime) {
+			// next refresh is obsolete, compute the next one
+			delta := timeutil.Next(refreshSchedule, holdTime, maxPostponement)
+			m.nextRefresh = time.Now().Add(delta)
+		}
 	}
 
 	// do refresh attempt (if needed)

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -144,6 +144,14 @@ var (
 	NewCatalogRefresh = newCatalogRefresh
 )
 
+func MockNextRefresh(ar *autoRefresh, when time.Time) {
+	ar.nextRefresh = when
+}
+
+func MockLastRefreshSchedule(ar *autoRefresh, schedule string) {
+	ar.lastRefreshSchedule = schedule
+}
+
 func MockCatalogRefreshNextRefresh(cr *catalogRefresh, when time.Time) {
 	cr.nextCatalogRefresh = when
 }

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -368,6 +368,14 @@ func (m *SnapManager) NextRefresh() time.Time {
 	return m.autoRefresh.NextRefresh()
 }
 
+// EffectiveRefreshHold returns the time until to which refreshes are
+// held if refresh.hold configuration is set and accounting for the
+// max postponement since the last refresh.
+// The caller should be holding the state lock.
+func (m *SnapManager) EffectiveRefreshHold() (time.Time, error) {
+	return m.autoRefresh.EffectiveRefreshHold()
+}
+
 // LastRefresh returns the time the last snap update.
 // The caller should be holding the state lock.
 func (m *SnapManager) LastRefresh() (time.Time, error) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -131,6 +131,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	s.user2, err = auth.NewUser(s.state, "username2", "email2@test.com", "macaroon2", []string{"discharge2"})
 	c.Assert(err, IsNil)
 
+	s.state.Set("seed-time", time.Now())
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active: true,
 		Sequence: []*snap.SideInfo{

--- a/snap/info.go
+++ b/snap/info.go
@@ -785,6 +785,18 @@ func ReadInfoFromSnapFile(snapf Container, si *SideInfo) (*Info, error) {
 	return info, nil
 }
 
+// InstallDate returns the "install date" of the snap.
+//
+// If the snap is not active, it'll return a zero time; otherwise
+// it'll return the modtime of the "current" symlink.
+func InstallDate(name string) time.Time {
+	cur := filepath.Join(dirs.SnapMountDir, name, "current")
+	if st, err := os.Lstat(cur); err == nil {
+		return st.ModTime()
+	}
+	return time.Time{}
+}
+
 // SplitSnapApp will split a string of the form `snap.app` into
 // the `snap` and the `app` part. It also deals with the special
 // case of snapName == appName.

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -200,13 +200,21 @@ func (s *infoSuite) TestInstallDate(c *C) {
 	info := snaptest.MockSnap(c, sampleYaml, si)
 	// not current -> Zero
 	c.Check(info.InstallDate().IsZero(), Equals, true)
+	c.Check(snap.InstallDate(info.Name()).IsZero(), Equals, true)
 
 	mountdir := info.MountDir()
 	dir, rev := filepath.Split(mountdir)
 	c.Assert(os.MkdirAll(dir, 0755), IsNil)
-	c.Assert(os.Symlink(rev, filepath.Join(dir, "current")), IsNil)
+	cur := filepath.Join(dir, "current")
+	c.Assert(os.Symlink(rev, cur), IsNil)
+	st, err := os.Lstat(cur)
+	c.Assert(err, IsNil)
+	instTime := st.ModTime()
+	// sanity
+	c.Check(instTime.IsZero(), Equals, false)
 
-	c.Check(info.InstallDate().IsZero(), Equals, false)
+	c.Check(info.InstallDate().Equal(instTime), Equals, true)
+	c.Check(snap.InstallDate(info.Name()).Equal(instTime), Equals, true)
 }
 
 func (s *infoSuite) TestReadInfoNotFound(c *C) {

--- a/timeutil/schedule.go
+++ b/timeutil/schedule.go
@@ -397,9 +397,6 @@ func randDur(a, b time.Time) time.Duration {
 
 var (
 	timeNow = time.Now
-
-	// FIMXE: pass in as a parameter for next
-	maxDuration = 60 * 24 * time.Hour
 )
 
 func init() {
@@ -407,8 +404,8 @@ func init() {
 }
 
 // Next returns the earliest event after last according to the provided
-// schedule.
-func Next(schedule []*Schedule, last time.Time) time.Duration {
+// schedule but no later than maxDuration since last.
+func Next(schedule []*Schedule, last time.Time, maxDuration time.Duration) time.Duration {
 	now := timeNow()
 
 	window := ScheduleWindow{

--- a/timeutil/schedule_test.go
+++ b/timeutil/schedule_test.go
@@ -210,6 +210,10 @@ func parse(c *C, s string) (time.Duration, time.Duration) {
 	return a, b
 }
 
+const (
+	maxDuration = 60 * 24 * time.Hour
+)
+
 func (ts *timeutilSuite) TestLegacyScheduleNext(c *C) {
 	const shortForm = "2006-01-02 15:04"
 
@@ -303,7 +307,7 @@ func (ts *timeutilSuite) TestLegacyScheduleNext(c *C) {
 		c.Assert(err, IsNil)
 		minDist, maxDist := parse(c, t.next)
 
-		next := timeutil.Next(sched, last)
+		next := timeutil.Next(sched, last, maxDuration)
 		c.Check(next >= minDist && next <= maxDist, Equals, true, Commentf("invalid  distance for schedule %q with last refresh %q, now %q, expected %v, got %v", t.schedule, t.last, t.now, t.next, next))
 	}
 
@@ -757,7 +761,7 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 		calls := 2
 
 		for i := 0; i < calls; i++ {
-			next := timeutil.Next(sched, last)
+			next := timeutil.Next(sched, last, maxDuration)
 			if t.randomized {
 				c.Check(next, Not(Equals), previous)
 			} else if previous != 0 {


### PR DESCRIPTION
This also introduces setting seed-time, to have an anchor point if using refresh.hold before the first refresh. 