### PR TITLE
overlord/snapstate: block install of "system"

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -297,6 +297,10 @@ func (x *infoCmd) Execute([]string) error {
 		if i > 0 {
 			fmt.Fprintln(w, "---")
 		}
+		if snapName == "system" {
+			fmt.Fprintln(w, "system: You can't have it.")
+			continue
+		}
 
 		if tryDirect(w, snapName, x.Verbose) {
 			noneOK = false

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -60,6 +60,9 @@ func needsMaybeCore(typ snap.Type) int {
 }
 
 func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int) (*state.TaskSet, error) {
+	if snapsup.Name() == "system" {
+		return nil, fmt.Errorf("cannot install reserved snap name 'system'")
+	}
 	if snapst.IsInstalled() && !snapst.Active {
 		return nil, fmt.Errorf("cannot update disabled snap %q", snapsup.Name())
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -654,6 +654,13 @@ func (s snapmgrTestSuite) TestInstallFailsOnDisabledSnap(c *C) {
 	c.Assert(err, ErrorMatches, `cannot update disabled snap "some-snap"`)
 }
 
+func (s snapmgrTestSuite) TestInstallFailsOnSystem(c *C) {
+	snapsup := &snapstate.SnapSetup{SideInfo: &snap.SideInfo{RealName: "system", SnapID: "some-snap-id", Revision: snap.R(1)}}
+	_, err := snapstate.DoInstall(s.state, nil, snapsup, 0)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `cannot install reserved snap name 'system'`)
+}
+
 func (s *snapmgrTestSuite) TestUpdateCreatesDiscardAfterCurrentTasks(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
`system` is going to have a special meaning soon, so we're blocking use of it as a snap name.