### PR TITLE
progress: tweak ansimeter cvvis use to no longer confuse minicom

### DIFF
--- a/progress/ansimeter.go
+++ b/progress/ansimeter.go
@@ -51,7 +51,7 @@ var (
 	// make cursor invisible
 	cursorInvisible = "\033[?25l"
 	// make cursor visible
-	cursorVisible = "\033[?12;25h"
+	cursorVisible = "\033[?25h"
 	// turn on reverse video
 	enterReverseMode = "\033[7m"
 	// go back to normal video
@@ -152,7 +152,7 @@ func (p *ANSIMeter) Set(current float64) {
 	fmt.Fprint(stdout, "\r", enterReverseMode, string(msg[:i]), exitAttributeMode, string(msg[i:]))
 }
 
-var spinner = []string{".", "o", "O", "o"}
+var spinner = []string{"/", "-", "\\", "|"}
 
 func (p *ANSIMeter) Spin(msgstr string) {
 	msg := []rune(msgstr)


### PR DESCRIPTION
minicom's vt220 implementation was improperly displaying half of
cvvis. It seems it can't handle CPI codes separated by ;, and fails to
ignore the unknown escape.

This simplifies it, but it still does what we want (the cvvis we were
using, taken from terminfo for xterm, was additionally doing an 'echo
on', which we don't need).

Additionally I received feedback about the spinner being nastier than
the old slash-based one, so I moved to that.

... some day I might make that customisable :-)
