### PR TITLE
xdgopenproxy: integrate xdg-open implementation into snapctl

### DIFF
--- a/cmd/snapctl/main.go
+++ b/cmd/snapctl/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/xdgopenproxy"
 )
 
 var clientConfig = client.Config{
@@ -45,6 +46,13 @@ func main() {
 			fmt.Fprintf(os.Stderr, "no internal core configuration anymore")
 			os.Exit(1)
 		}
+	}
+	if len(os.Args) == 3 && os.Args[1] == "user-open" {
+		if err := xdgopenproxy.Run(os.Args[2]); err != nil {
+			fmt.Fprintf(os.Stderr, "user-open error: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	// no internal command, route via snapd

--- a/xdgopenproxy/export_test.go
+++ b/xdgopenproxy/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package xdgopenproxy
+
+var Launch = launch

--- a/xdgopenproxy/export_test.go
+++ b/xdgopenproxy/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/xdgopenproxy/xdgopenproxy.go
+++ b/xdgopenproxy/xdgopenproxy.go
@@ -1,0 +1,63 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package xdgopenproxy provides a client for snap userd's xdg-open D-Bus proxy
+package xdgopenproxy
+
+import (
+	"net/url"
+	"syscall"
+
+	"github.com/godbus/dbus"
+)
+
+func Run(urlOrFile string) error {
+	bus, err := dbus.SessionBus()
+	if err != nil {
+		return err
+	}
+	defer bus.Close()
+	launcher := bus.Object("io.snapcraft.Launcher", "/io/snapcraft/Launcher")
+	return launch(launcher, urlOrFile)
+}
+
+func launch(launcher dbus.BusObject, urlOrFile string) error {
+	if u, err := url.Parse(urlOrFile); err == nil {
+		if u.Scheme == "file" {
+			return openFile(launcher, u.Path)
+		} else if u.Scheme != "" {
+			return openUrl(launcher, urlOrFile)
+		}
+	}
+	return openFile(launcher, urlOrFile)
+}
+
+func openUrl(launcher dbus.BusObject, url string) error {
+	return launcher.Call("io.snapcraft.Launcher.OpenURL", 0, url).Err
+}
+
+func openFile(launcher dbus.BusObject, filename string) error {
+	fd, err := syscall.Open(filename, syscall.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(fd)
+
+	return launcher.Call("io.snapcraft.Launcher.OpenFile", 0, "", dbus.UnixFD(fd)).Err
+}

--- a/xdgopenproxy/xdgopenproxy.go
+++ b/xdgopenproxy/xdgopenproxy.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/xdgopenproxy/xdgopenproxy_test.go
+++ b/xdgopenproxy/xdgopenproxy_test.go
@@ -1,0 +1,139 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package xdgopenproxy_test
+
+import (
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/godbus/dbus"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/xdgopenproxy"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type xdgOpenSuite struct{}
+
+var _ = Suite(&xdgOpenSuite{})
+
+func (s *xdgOpenSuite) TestOpenURL(c *C) {
+	launcher := fakeBusObject(func(method string, args ...interface{}) error {
+		c.Check(method, Equals, "io.snapcraft.Launcher.OpenURL")
+		c.Check(args, DeepEquals, []interface{}{"http://example.org"})
+		return nil
+	})
+	c.Check(xdgopenproxy.Launch(launcher, "http://example.org"), IsNil)
+}
+
+func (s *xdgOpenSuite) TestOpenFile(c *C) {
+	path := filepath.Join(c.MkDir(), "test.txt")
+	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
+
+	launcher := fakeBusObject(func(method string, args ...interface{}) error {
+		c.Check(method, Equals, "io.snapcraft.Launcher.OpenFile")
+		c.Assert(args, HasLen, 2)
+		c.Check(args[0], Equals, "")
+		//c.Check(args[1], Equals, ???)
+		return nil
+	})
+	c.Check(xdgopenproxy.Launch(launcher, path), IsNil)
+}
+
+func (s *xdgOpenSuite) TestOpenFileURL(c *C) {
+	path := filepath.Join(c.MkDir(), "test.txt")
+	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
+
+	launcher := fakeBusObject(func(method string, args ...interface{}) error {
+		c.Check(method, Equals, "io.snapcraft.Launcher.OpenFile")
+		c.Assert(args, HasLen, 2)
+		c.Check(args[0], Equals, "")
+		//c.Check(args[1], Equals, ???)
+		return nil
+	})
+
+	u := url.URL{Scheme: "file", Path: path}
+	c.Check(xdgopenproxy.Launch(launcher, u.String()), IsNil)
+}
+
+func (s *xdgOpenSuite) TestOpenDir(c *C) {
+	dir := c.MkDir()
+
+	launcher := fakeBusObject(func(method string, args ...interface{}) error {
+		c.Check(method, Equals, "io.snapcraft.Launcher.OpenFile")
+		c.Assert(args, HasLen, 2)
+		c.Check(args[0], Equals, "")
+		//c.Check(args[1], Equals, ???)
+		return nil
+	})
+	c.Check(xdgopenproxy.Launch(launcher, dir), IsNil)
+}
+
+func (s *xdgOpenSuite) TestOpenMissingFile(c *C) {
+	path := filepath.Join(c.MkDir(), "no-such-file.txt")
+
+	launcher := fakeBusObject(func(method string, args ...interface{}) error {
+		c.Error("unexpected D-Bus call")
+		return nil
+	})
+	c.Check(xdgopenproxy.Launch(launcher, path), ErrorMatches, "no such file or directory")
+}
+
+func (s *xdgOpenSuite) TestOpenUnreadableFile(c *C) {
+	path := filepath.Join(c.MkDir(), "test.txt")
+	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
+	c.Assert(os.Chmod(path, 0), IsNil)
+
+	launcher := fakeBusObject(func(method string, args ...interface{}) error {
+		c.Error("unexpected D-Bus call")
+		return nil
+	})
+	c.Check(xdgopenproxy.Launch(launcher, path), ErrorMatches, "permission denied")
+}
+
+// fakeBusObject is a dbus.BusObject implementation that forwards
+// Call invocations
+type fakeBusObject func(method string, args ...interface{}) error
+
+func (f fakeBusObject) Call(method string, flags dbus.Flags, args ...interface{}) *dbus.Call {
+	err := f(method, args...)
+	return &dbus.Call{Err: err}
+}
+
+func (f fakeBusObject) Go(method string, flags dbus.Flags, ch chan *dbus.Call, args ...interface{}) *dbus.Call {
+	return nil
+}
+
+func (f fakeBusObject) GetProperty(prop string) (dbus.Variant, error) {
+	return dbus.Variant{}, nil
+}
+
+func (f fakeBusObject) Destination() string {
+	return ""
+}
+
+func (f fakeBusObject) Path() dbus.ObjectPath {
+	return ""
+}

--- a/xdgopenproxy/xdgopenproxy_test.go
+++ b/xdgopenproxy/xdgopenproxy_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as


### PR DESCRIPTION
This branch integrates an implementation of the sandboxed `/usr/bin/xdg-open` into the `snapctl` utility, including support for opening local files, as requested by @niemeyer.

With this in place, `/usr/bin/xdg-open` can be replaced with a shell script like:

    #!/bin/sh
    snapctl user-open "$@"