### PR TITLE
polkit: ensure error is properly set if dialog is dismissed

### DIFF
--- a/polkit/authority.go
+++ b/polkit/authority.go
@@ -49,7 +49,7 @@ func checkAuthorization(subject authSubject, actionId string, details map[string
 	err = authority.Call(
 		"org.freedesktop.PolicyKit1.Authority.CheckAuthorization", 0,
 		subject, actionId, details, flags, "").Store(&result)
-	if err != nil && !result.IsAuthorized {
+	if err != nil || !result.IsAuthorized {
 		if result.IsChallenge {
 			err = ErrInteraction
 		} else if result.Details["polkit.dismissed"] != "" {

--- a/polkit/authority.go
+++ b/polkit/authority.go
@@ -49,7 +49,10 @@ func checkAuthorization(subject authSubject, actionId string, details map[string
 	err = authority.Call(
 		"org.freedesktop.PolicyKit1.Authority.CheckAuthorization", 0,
 		subject, actionId, details, flags, "").Store(&result)
-	if err != nil || !result.IsAuthorized {
+	if err != nil {
+		return false, err
+	}
+	if !result.IsAuthorized {
 		if result.IsChallenge {
 			err = ErrInteraction
 		} else if result.Details["polkit.dismissed"] != "" {


### PR DESCRIPTION
Make sure error is properly set if polkit dialog is dismissed. This is required to fix https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1721735