### PR TITLE
snap: don't create empty Change with "Hold" state on disconnect

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -375,7 +375,8 @@ const (
 
 	ErrorKindNotSnap = "snap-not-a-snap"
 
-	ErrorKindNetworkTimeout = "network-timeout"
+	ErrorKindNetworkTimeout      = "network-timeout"
+	ErrorKindInterfacesUnchanged = "interfaces-unchanged"
 )
 
 // IsTwoFactorError returns whether the given error is due to problems
@@ -387,6 +388,16 @@ func IsTwoFactorError(err error) bool {
 	}
 
 	return e.Kind == ErrorKindTwoFactorFailed || e.Kind == ErrorKindTwoFactorRequired
+}
+
+// IsInterfacesUnchangedError returns whether the given error means the requested
+// change to interfaces was not made, because there was nothing to do.
+func IsInterfacesUnchangedError(err error) bool {
+	e, ok := err.(*Error)
+	if !ok || e == nil {
+		return false
+	}
+	return e.Kind == ErrorKindInterfacesUnchanged
 }
 
 // OSRelease contains information about the system extracted from /etc/os-release.

--- a/cmd/snap/cmd_disconnect.go
+++ b/cmd/snap/cmd_disconnect.go
@@ -22,6 +22,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 
 	"github.com/jessevdk/go-flags"
@@ -81,6 +82,11 @@ func (x *cmdDisconnect) Execute(args []string) error {
 	cli := Client()
 	id, err := cli.Disconnect(offer.Snap, offer.Name, use.Snap, use.Name)
 	if err != nil {
+		if client.IsInterfacesUnchangedError(err) {
+			fmt.Fprintf(Stdout, i18n.G("No connections to disconnect"))
+			fmt.Fprintf(Stdout, "\n")
+			return nil
+		}
 		return err
 	}
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1846,7 +1846,10 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 		repo := c.d.overlord.InterfaceManager().Repository()
 		summary = fmt.Sprintf("Disconnect %s:%s from %s:%s", a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
 		conns, err = repo.ResolveDisconnect(a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
-		if err == nil && len(conns) > 0 {
+		if err == nil {
+			if len(conns) == 0 {
+				return InterfacesUnchanged("nothing to do")
+			}
 			for _, connRef := range conns {
 				var ts *state.TaskSet
 				ts, err = ifacestate.Disconnect(st, connRef.PlugRef.Snap, connRef.PlugRef.Name, connRef.SlotRef.Snap, connRef.SlotRef.Name)
@@ -1864,12 +1867,6 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 	}
 
 	change := newChange(st, a.Action+"-snap", summary, tasksets, affected)
-	// Special case for disconnect: if no connections exist, we just report Done.
-	// Note that for every other case ResolveDisconnect will give an error.
-	if len(tasksets) == 0 {
-		change.SetStatus(state.DoneStatus)
-	}
-
 	st.EnsureBefore(0)
 
 	return AsyncResponse(nil, &Meta{Change: change.ID()})

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1864,8 +1864,8 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 	}
 
 	change := newChange(st, a.Action+"-snap", summary, tasksets, affected)
-	// Special case for disconnect: if no connections exit, we don't want to error out and just report Done.
-	// Note that for every other case (invalid snap/plug/slot names ResolveDisconnect will report a clear error that we report above)
+	// Special case for disconnect: if no connections exist, we just report Done.
+	// Note that for every other case ResolveDisconnect will give an error.
 	if len(tasksets) == 0 {
 		change.SetStatus(state.DoneStatus)
 	}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1846,7 +1846,7 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 		repo := c.d.overlord.InterfaceManager().Repository()
 		summary = fmt.Sprintf("Disconnect %s:%s from %s:%s", a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
 		conns, err = repo.ResolveDisconnect(a.Plugs[0].Snap, a.Plugs[0].Name, a.Slots[0].Snap, a.Slots[0].Name)
-		if err == nil {
+		if err == nil && len(conns) > 0 {
 			for _, connRef := range conns {
 				var ts *state.TaskSet
 				ts, err = ifacestate.Disconnect(st, connRef.PlugRef.Snap, connRef.PlugRef.Name, connRef.SlotRef.Snap, connRef.SlotRef.Name)
@@ -1864,6 +1864,11 @@ func changeInterfaces(c *Command, r *http.Request, user *auth.UserState) Respons
 	}
 
 	change := newChange(st, a.Action+"-snap", summary, tasksets, affected)
+	// Special case for disconnect: if no connections exit, we don't want to error out and just report Done.
+	// Note that for every other case (invalid snap/plug/slot names ResolveDisconnect will report a clear error that we report above)
+	if len(tasksets) == 0 {
+		change.SetStatus(state.DoneStatus)
+	}
 
 	st.EnsureBefore(0)
 

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -145,7 +145,8 @@ const (
 
 	errorKindBadQuery = errorKind("bad-query")
 
-	errorKindNetworkTimeout = errorKind("network-timeout")
+	errorKindNetworkTimeout      = errorKind("network-timeout")
+	errorKindInterfacesUnchanged = errorKind("interfaces-unchanged")
 )
 
 type errorValue interface{}
@@ -284,6 +285,20 @@ func AssertResponse(asserts []asserts.Assertion, bundle bool) Response {
 		bundle = true
 	}
 	return &assertResponse{assertions: asserts, bundle: bundle}
+}
+
+// InterfacesUnchanged is an error responder used when an operation
+// that would normally change interfaces finds it has nothing to do
+func InterfacesUnchanged(format string, v ...interface{}) Response {
+	res := &errorResult{
+		Message: fmt.Sprintf(format, v...),
+		Kind:    errorKindInterfacesUnchanged,
+	}
+	return &resp{
+		Type:   ResponseTypeError,
+		Result: res,
+		Status: 400,
+	}
 }
 
 func (ar assertResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -40,3 +40,7 @@ execute: |
     snap connect home-consumer:home core:home
     snap disconnect home-consumer:home :home
     snap interfaces | grep -Pzqe "$DISCONNECTED_PATTERN"
+
+    echo "Disconnecting again using abbreviated form doesn't fail"
+    snap disconnect home-consumer:home
+    snap changes | tail -n2 | MATCH "Done.*Disconnect.*"

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -41,6 +41,5 @@ execute: |
     snap disconnect home-consumer:home :home
     snap interfaces | grep -Pzqe "$DISCONNECTED_PATTERN"
 
-    echo "Disconnecting again using abbreviated form doesn't fail"
-    snap disconnect home-consumer:home
-    snap changes | tail -n2 | MATCH "Done.*Disconnect.*"
+    echo "Disconnecting again using abbreviated form is handled"
+    snap disconnect home-consumer:home 2>&1 | MATCH "nothing to do"

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -42,4 +42,4 @@ execute: |
     snap interfaces | grep -Pzqe "$DISCONNECTED_PATTERN"
 
     echo "Disconnecting again using abbreviated form is handled"
-    snap disconnect home-consumer:home | MATCH "nothing to do"
+    snap disconnect home-consumer:home | MATCH "No connections to disconnect"

--- a/tests/main/snap-disconnect/task.yaml
+++ b/tests/main/snap-disconnect/task.yaml
@@ -42,4 +42,4 @@ execute: |
     snap interfaces | grep -Pzqe "$DISCONNECTED_PATTERN"
 
     echo "Disconnecting again using abbreviated form is handled"
-    snap disconnect home-consumer:home 2>&1 | MATCH "nothing to do"
+    snap disconnect home-consumer:home | MATCH "nothing to do"


### PR DESCRIPTION
When using the abbreviated form of `snap disconnect snap:<plug|slot>` and there are no connections, we create an empty change with no tasks, and it remains in Hold state and produces the following error:
```
$ snap disconnect spotify:x11                                                 
error: change finished in status "Hold" with no error message
```
This PR fixes it. snap disconnect will not report any error if there are no connections for given plug or slot and an empty Change with Done status will be created. Note that in any other case (invalid plug or slot) we report an error.