### PR TITLE
cmd/snap: use timeutil.Human to show times in `snap refresh --time`

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -584,6 +584,7 @@ func (x *cmdInstall) Execute([]string) error {
 }
 
 type cmdRefresh struct {
+	timeMixin
 	waitMixin
 
 	channelMixin
@@ -665,13 +666,13 @@ func (x *cmdRefresh) showRefreshTimes() error {
 	} else {
 		return errors.New("internal error: both refresh.timer and refresh.schedule are empty")
 	}
-	if sysinfo.Refresh.Last != "" {
-		fmt.Fprintf(Stdout, "last: %s\n", sysinfo.Refresh.Last)
+	if t, err := time.Parse(time.RFC3339, sysinfo.Refresh.Last); err == nil {
+		fmt.Fprintf(Stdout, "last: %s\n", x.fmtTime(t))
 	} else {
 		fmt.Fprintf(Stdout, "last: n/a\n")
 	}
-	if sysinfo.Refresh.Next != "" {
-		fmt.Fprintf(Stdout, "next: %s\n", sysinfo.Refresh.Next)
+	if t, err := time.Parse(time.RFC3339, sysinfo.Refresh.Next); err == nil {
+		fmt.Fprintf(Stdout, "next: %s\n", x.fmtTime(t))
 	} else {
 		fmt.Fprintf(Stdout, "next: n/a\n")
 	}
@@ -1006,7 +1007,7 @@ func init() {
 			"unaliased":       i18n.G("Install the given snap without enabling its automatic aliases"),
 		}), nil)
 	addCommand("refresh", shortRefreshHelp, longRefreshHelp, func() flags.Commander { return &cmdRefresh{} },
-		waitDescs.also(channelDescs).also(modeDescs).also(map[string]string{
+		waitDescs.also(channelDescs).also(modeDescs).also(timeDescs).also(map[string]string{
 			"amend":             i18n.G("Allow refresh attempt on snap unknown to the store"),
 			"revision":          i18n.G("Refresh to the given revision"),
 			"list":              i18n.G("Show available snaps for refresh but do not perform a refresh"),

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -548,19 +548,19 @@ func (s *SnapSuite) TestRefreshLegacyTime(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/system-info")
-			fmt.Fprintln(w, `{"type": "sync", "status-code": 200, "result": {"refresh": {"schedule": "00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59", "last": "2017-04-25T17:35:00+0200", "next": "2017-04-26T00:58:00+0200"}}}`)
+			fmt.Fprintln(w, `{"type": "sync", "status-code": 200, "result": {"refresh": {"schedule": "00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59", "last": "2017-04-25T17:35:00+02:00", "next": "2017-04-26T00:58:00+02:00"}}}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"refresh", "--time"})
+	rest, err := snap.Parser().ParseArgs([]string{"refresh", "--time", "--abs-time"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `schedule: 00:00-04:59/5:00-10:59/11:00-16:59/17:00-23:59
-last: 2017-04-25T17:35:00+0200
-next: 2017-04-26T00:58:00+0200
+last: 2017-04-25T17:35:00+02:00
+next: 2017-04-26T00:58:00+02:00
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit
@@ -574,19 +574,19 @@ func (s *SnapSuite) TestRefreshTimer(c *check.C) {
 		case 0:
 			c.Check(r.Method, check.Equals, "GET")
 			c.Check(r.URL.Path, check.Equals, "/v2/system-info")
-			fmt.Fprintln(w, `{"type": "sync", "status-code": 200, "result": {"refresh": {"timer": "0:00-24:00/4", "last": "2017-04-25T17:35:00+0200", "next": "2017-04-26T00:58:00+0200"}}}`)
+			fmt.Fprintln(w, `{"type": "sync", "status-code": 200, "result": {"refresh": {"timer": "0:00-24:00/4", "last": "2017-04-25T17:35:00+02:00", "next": "2017-04-26T00:58:00+02:00"}}}`)
 		default:
 			c.Fatalf("expected to get 1 requests, now on %d", n+1)
 		}
 
 		n++
 	})
-	rest, err := snap.Parser().ParseArgs([]string{"refresh", "--time"})
+	rest, err := snap.Parser().ParseArgs([]string{"refresh", "--time", "--abs-time"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, `timer: 0:00-24:00/4
-last: 2017-04-25T17:35:00+0200
-next: 2017-04-26T00:58:00+0200
+last: 2017-04-25T17:35:00+02:00
+next: 2017-04-26T00:58:00+02:00
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -34,7 +34,7 @@ disable_refreshes() {
 
     echo "Minimize risk of hitting refresh schedule"
     snap set core refresh.schedule=00:00-23:59
-    snap refresh --time|MATCH "last: 2[0-9]{3}"
+    snap refresh --time --abs-time | MATCH "last: 2[0-9]{3}"
 
     echo "Ensure jq is gone"
     snap remove jq


### PR DESCRIPTION
based on #4796. This one is the last commit (will rebase or merge once that's landed).