### PR TITLE
cmd/snap-seccomp: Cancel the atomic file on error, not just Close

### DIFF
--- a/cmd/snap-seccomp/main.go
+++ b/cmd/snap-seccomp/main.go
@@ -711,7 +711,8 @@ func compile(content []byte, out string) error {
 	if err != nil {
 		return err
 	}
-	defer fout.Close()
+	// Cancel once Committed is a NOP
+	defer fout.Cancel()
 
 	if err := secFilter.ExportBPF(fout.File); err != nil {
 		return err


### PR DESCRIPTION
We had a minor bug in `cmd/snap-seccomp/main.go`, where we did essentially
```go
	fout, _ := osutil.NewAtomicFile(...)
	defer fout.Close()

	if err := doStuff(fout); err != nil {
		return err
	}
	return fout.Commit()
```
which, on error, would leave the tempfile lying around. This changes
the `Close` to a `Cancel`, which does the right thing on error (and
becomes a NOP once the atomic file is successfully committed).
