### PR TITLE
vendor: update github.com/mvo5/libseccomp-golang

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -49,10 +49,10 @@
 			"revisionTime": "2015-02-12T09:37:50Z"
 		},
 		{
-			"checksumSHA1": "qUzU7BwMvcmsdozh1XVd0SAarAY=",
+			"checksumSHA1": "uSjL89zodhV0X/LvyZ67FlKYKvg=",
 			"path": "github.com/mvo5/libseccomp-golang",
-			"revision": "e0e036d8f7d25f0c63e96896b99547e9d5f71617",
-			"revisionTime": "2017-10-05T08:38:35Z"
+			"revision": "f4de83b52afb3c19190eb65cc92429feaaf0e8b6",
+			"revisionTime": "2018-03-08T15:25:21Z"
 		},
 		{
 			"checksumSHA1": "lG6diF/yE9cGgQIKRAlsaeYAjO4=",


### PR DESCRIPTION
This update brings in fixes to the vendored libseccomp bindings.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>