### PR TITLE
cmd/snap: tweak and polish help strings

### DIFF
--- a/cmd/snap/cmd_ack.go
+++ b/cmd/snap/cmd_ack.go
@@ -34,11 +34,11 @@ type cmdAck struct {
 	} `positional-args:"true" required:"true"`
 }
 
-var shortAckHelp = i18n.G("Adds an assertion to the system")
+var shortAckHelp = i18n.G("Add an assertion to the system")
 var longAckHelp = i18n.G(`
 The ack command tries to add an assertion to the system assertion database.
 
-The assertion may also be a newer revision of a preexisting assertion that it
+The assertion may also be a newer revision of a pre-existing assertion that it
 will replace.
 
 To succeed the assertion must be valid, its signature verified with a known

--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -34,13 +34,16 @@ type cmdAdviseSnap struct {
 		CommandOrPkg string `required:"yes"`
 	} `positional-args:"true"`
 
-	Format  string `long:"format" default:"pretty"`
+	Format  string `long:"format" default:"pretty" choice:"pretty" choice:"json"`
 	Command bool   `long:"command"`
 }
 
 var shortAdviseSnapHelp = i18n.G("Advise on available snaps")
 var longAdviseSnapHelp = i18n.G(`
-The advise-snap command shows what snaps with the given command are available.
+The advise-snap command searches for and suggests the installation of snaps.
+
+If --command is given, it suggests snaps that provide the given command.
+Otherwise it suggests snaps with the given name.
 `)
 
 func init() {
@@ -48,7 +51,7 @@ func init() {
 		return &cmdAdviseSnap{}
 	}, map[string]string{
 		"command": i18n.G("Advise on snaps that provide the given command"),
-		"format":  i18n.G("Use the given output format (pretty or json)"),
+		"format":  i18n.G("Use the given output format"),
 	}, []argDesc{
 		{name: "<command or pkg>"},
 	})

--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -38,10 +38,9 @@ type cmdAdviseSnap struct {
 	Command bool   `long:"command"`
 }
 
-var shortAdviseSnapHelp = i18n.G("Advise on available snaps.")
+var shortAdviseSnapHelp = i18n.G("Advise on available snaps")
 var longAdviseSnapHelp = i18n.G(`
-The advise-snap command shows what snaps with the given command are
-available.
+The advise-snap command shows what snaps with the given command are available.
 `)
 
 func init() {

--- a/cmd/snap/cmd_alias.go
+++ b/cmd/snap/cmd_alias.go
@@ -41,11 +41,12 @@ type cmdAlias struct {
 
 // TODO: implement a completer for snapApp
 
-var shortAliasHelp = i18n.G("Sets up a manual alias")
+var shortAliasHelp = i18n.G("Set up a manual alias")
 var longAliasHelp = i18n.G(`
 The alias command aliases the given snap application to the given alias.
 
-Once this manual alias is setup the respective application command can be invoked just using the alias.
+Once this manual alias is setup the respective application command can be
+invoked just using the alias.
 `)
 
 func init() {

--- a/cmd/snap/cmd_alias_test.go
+++ b/cmd/snap/cmd_alias_test.go
@@ -30,18 +30,12 @@ import (
 
 func (s *SnapSuite) TestAliasHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] alias [alias-OPTIONS] [<snap.app>] [<alias>]
+  snap.test alias [alias-OPTIONS] [<snap.app>] [<alias>]
 
 The alias command aliases the given snap application to the given alias.
 
 Once this manual alias is setup the respective application command can be
 invoked just using the alias.
-
-Application Options:
-      --version         Print the version and exit
-
-Help Options:
-  -h, --help            Show this help message
 
 [alias command options]
           --no-wait     Do not wait for the operation to finish but just print

--- a/cmd/snap/cmd_aliases.go
+++ b/cmd/snap/cmd_aliases.go
@@ -45,8 +45,8 @@ $ snap aliases <snap>
 Lists only the aliases defined by the specified snap.
 
 An alias noted as undefined means it was explicitly enabled or disabled but is
-not defined in the current revision of the snap; possibly temporarily (e.g.
-because of a revert), if not this can be cleared with 'snap alias --reset'.
+not defined in the current revision of the snap, possibly temporarily (e.g.
+because of a revert). In any case you can clear this with 'snap alias --reset'.
 `)
 
 func init() {

--- a/cmd/snap/cmd_aliases.go
+++ b/cmd/snap/cmd_aliases.go
@@ -46,7 +46,7 @@ Lists only the aliases defined by the specified snap.
 
 An alias noted as undefined means it was explicitly enabled or disabled but is
 not defined in the current revision of the snap, possibly temporarily (e.g.
-because of a revert). In any case you can clear this with 'snap alias --reset'.
+because of a revert). This can cleared with 'snap alias --reset'.
 `)
 
 func init() {
@@ -140,7 +140,7 @@ func (x *cmdAliases) Execute(args []string) error {
 		} else {
 			fmt.Fprintln(Stderr, i18n.G("No aliases are currently defined."))
 		}
-		fmt.Fprintln(Stderr, i18n.G("\nUse snap alias --help to learn how to create aliases manually."))
+		fmt.Fprintln(Stderr, i18n.G("\nUse 'snap help alias' to learn how to create aliases manually."))
 	}
 	return nil
 }

--- a/cmd/snap/cmd_aliases.go
+++ b/cmd/snap/cmd_aliases.go
@@ -36,7 +36,7 @@ type cmdAliases struct {
 	} `positional-args:"true"`
 }
 
-var shortAliasesHelp = i18n.G("Lists aliases in the system")
+var shortAliasesHelp = i18n.G("List aliases in the system")
 var longAliasesHelp = i18n.G(`
 The aliases command lists all aliases available in the system and their status.
 
@@ -45,8 +45,8 @@ $ snap aliases <snap>
 Lists only the aliases defined by the specified snap.
 
 An alias noted as undefined means it was explicitly enabled or disabled but is
-not defined in the current revision of the snap; possibly temporarely (e.g
-because of a revert), if not this can be cleared with snap alias --reset.
+not defined in the current revision of the snap; possibly temporarily (e.g.
+because of a revert), if not this can be cleared with 'snap alias --reset'.
 `)
 
 func init() {

--- a/cmd/snap/cmd_aliases_test.go
+++ b/cmd/snap/cmd_aliases_test.go
@@ -41,7 +41,7 @@ Lists only the aliases defined by the specified snap.
 
 An alias noted as undefined means it was explicitly enabled or disabled but is
 not defined in the current revision of the snap; possibly temporarily (e.g.
-because of a revert), if not this can be cleared with 'snap alias --reset'.
+because of a revert). In any case you can clear this with 'snap alias --reset'.
 `
 	rest, err := Parser().ParseArgs([]string{"aliases", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/cmd/snap/cmd_aliases_test.go
+++ b/cmd/snap/cmd_aliases_test.go
@@ -40,8 +40,8 @@ $ snap aliases <snap>
 Lists only the aliases defined by the specified snap.
 
 An alias noted as undefined means it was explicitly enabled or disabled but is
-not defined in the current revision of the snap; possibly temporarily (e.g.
-because of a revert). In any case you can clear this with 'snap alias --reset'.
+not defined in the current revision of the snap, possibly temporarily (e.g.
+because of a revert). This can cleared with 'snap alias --reset'.
 `
 	rest, err := Parser().ParseArgs([]string{"aliases", "--help"})
 	c.Assert(err.Error(), Equals, msg)
@@ -131,7 +131,7 @@ func (s *SnapSuite) TestAliasesNone(c *C) {
 	_, err := Parser().ParseArgs([]string{"aliases"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "")
-	c.Assert(s.Stderr(), Equals, "No aliases are currently defined.\n\nUse snap alias --help to learn how to create aliases manually.\n")
+	c.Assert(s.Stderr(), Equals, "No aliases are currently defined.\n\nUse 'snap help alias' to learn how to create aliases manually.\n")
 }
 
 func (s *SnapSuite) TestAliasesNoneFilterSnap(c *C) {
@@ -152,7 +152,7 @@ func (s *SnapSuite) TestAliasesNoneFilterSnap(c *C) {
 	_, err := Parser().ParseArgs([]string{"aliases", "not-bar"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "")
-	c.Assert(s.Stderr(), Equals, "No aliases are currently defined for snap \"not-bar\".\n\nUse snap alias --help to learn how to create aliases manually.\n")
+	c.Assert(s.Stderr(), Equals, "No aliases are currently defined for snap \"not-bar\".\n\nUse 'snap help alias' to learn how to create aliases manually.\n")
 }
 
 func (s *SnapSuite) TestAliasesSorting(c *C) {

--- a/cmd/snap/cmd_aliases_test.go
+++ b/cmd/snap/cmd_aliases_test.go
@@ -31,7 +31,7 @@ import (
 
 func (s *SnapSuite) TestAliasesHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] aliases [<snap>]
+  snap.test aliases [<snap>]
 
 The aliases command lists all aliases available in the system and their status.
 
@@ -40,14 +40,8 @@ $ snap aliases <snap>
 Lists only the aliases defined by the specified snap.
 
 An alias noted as undefined means it was explicitly enabled or disabled but is
-not defined in the current revision of the snap; possibly temporarely (e.g
-because of a revert), if not this can be cleared with snap alias --reset.
-
-Application Options:
-      --version     Print the version and exit
-
-Help Options:
-  -h, --help        Show this help message
+not defined in the current revision of the snap; possibly temporarily (e.g.
+because of a revert), if not this can be cleared with 'snap alias --reset'.
 `
 	rest, err := Parser().ParseArgs([]string{"aliases", "--help"})
 	c.Assert(err.Error(), Equals, msg)

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -219,7 +219,7 @@ type cmdAutoImport struct {
 	ForceClassic bool `long:"force-classic"`
 }
 
-var shortAutoImportHelp = i18n.G("Inspects devices for actionable information")
+var shortAutoImportHelp = i18n.G("Inspect devices for actionable information")
 
 var longAutoImportHelp = i18n.G(`
 The auto-import command searches available mounted devices looking for

--- a/cmd/snap/cmd_auto_import.go
+++ b/cmd/snap/cmd_auto_import.go
@@ -226,11 +226,11 @@ The auto-import command searches available mounted devices looking for
 assertions that are signed by trusted authorities, and potentially
 performs system changes based on them.
 
-If one or more device paths are provided via --mount, these are temporariy
+If one or more device paths are provided via --mount, these are temporarily
 mounted to be inspected as well. Even in that case the command will still
 consider all available mounted devices for inspection.
 
-Imported assertions must be made available in the auto-import.assert file
+Assertions to be imported must be made available in the auto-import.assert file
 in the root of the filesystem.
 `)
 

--- a/cmd/snap/cmd_booted.go
+++ b/cmd/snap/cmd_booted.go
@@ -29,8 +29,8 @@ type cmdBooted struct{}
 
 func init() {
 	cmd := addCommand("booted",
-		"internal",
-		"internal",
+		"Internal",
+		"The booted command is only retained for backwards compatibility.",
 		func() flags.Commander {
 			return &cmdBooted{}
 		}, nil, nil)

--- a/cmd/snap/cmd_buy.go
+++ b/cmd/snap/cmd_buy.go
@@ -30,7 +30,7 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-var shortBuyHelp = i18n.G("Buys a snap")
+var shortBuyHelp = i18n.G("Buy a snap")
 var longBuyHelp = i18n.G(`
 The buy command buys a snap from the store.
 `)

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -34,9 +34,12 @@ import (
 var shortChangesHelp = i18n.G("List system changes")
 var shortTasksHelp = i18n.G("List a change's tasks")
 var longChangesHelp = i18n.G(`
-The changes command displays a summary of the recent system changes performed.`)
+The changes command displays a summary of the recent system changes performed.
+`)
 var longTasksHelp = i18n.G(`
-The tasks command displays a summary of tasks associated to an individual change.`)
+The tasks command displays a summary of tasks associated to an
+individual change.
+`)
 
 type cmdChanges struct {
 	Positional struct {

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -34,7 +34,7 @@ import (
 var shortChangesHelp = i18n.G("List system changes")
 var shortTasksHelp = i18n.G("List a change's tasks")
 var longChangesHelp = i18n.G(`
-The changes command displays a summary of the recent system changes performed.
+The changes command displays a summary of system changes performed recently.
 `)
 var longTasksHelp = i18n.G(`
 The tasks command displays a summary of tasks associated to an

--- a/cmd/snap/cmd_changes.go
+++ b/cmd/snap/cmd_changes.go
@@ -37,8 +37,8 @@ var longChangesHelp = i18n.G(`
 The changes command displays a summary of system changes performed recently.
 `)
 var longTasksHelp = i18n.G(`
-The tasks command displays a summary of tasks associated to an
-individual change.
+The tasks command displays a summary of tasks associated with an individual
+change.
 `)
 
 type cmdChanges struct {
@@ -72,8 +72,8 @@ func (c *cmdChanges) Execute(args []string) error {
 	}
 
 	if allDigits(c.Positional.Snap) {
-		// TRANSLATORS: the %s is the argument given by the user to "snap changes"
-		return fmt.Errorf(i18n.G(`"snap changes" command expects a snap name, try: "snap tasks %s"`), c.Positional.Snap)
+		// TRANSLATORS: the %s is the argument given by the user to 'snap changes'
+		return fmt.Errorf(i18n.G(`'snap changes' command expects a snap name, try 'snap tasks %s'`), c.Positional.Snap)
 	}
 
 	if c.Positional.Snap == "everything" {

--- a/cmd/snap/cmd_confinement.go
+++ b/cmd/snap/cmd_confinement.go
@@ -27,10 +27,10 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-var shortConfinementHelp = i18n.G("Prints the confinement mode the system operates in")
+var shortConfinementHelp = i18n.G("Print the confinement mode the system operates in")
 var longConfinementHelp = i18n.G(`
-The confinement command will print the confinement mode (strict, partial or none)
-the system operates in.
+The confinement command will print the confinement mode (strict,
+partial or none) the system operates in.
 `)
 
 type cmdConfinement struct{}

--- a/cmd/snap/cmd_connect.go
+++ b/cmd/snap/cmd_connect.go
@@ -33,7 +33,7 @@ type cmdConnect struct {
 	} `positional-args:"true"`
 }
 
-var shortConnectHelp = i18n.G("Connects a plug to a slot")
+var shortConnectHelp = i18n.G("Connect a plug to a slot")
 var longConnectHelp = i18n.G(`
 The connect command connects a plug to a slot.
 It may be called in the following ways:

--- a/cmd/snap/cmd_connect_test.go
+++ b/cmd/snap/cmd_connect_test.go
@@ -33,7 +33,7 @@ import (
 
 func (s *SnapSuite) TestConnectHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] connect [connect-OPTIONS] [<snap>:<plug>] [<snap>:<slot>]
+  snap.test connect [connect-OPTIONS] [<snap>:<plug>] [<snap>:<slot>]
 
 The connect command connects a plug to a slot.
 It may be called in the following ways:
@@ -52,12 +52,6 @@ $ snap connect <snap>:<plug>
 
 Connects the provided plug to the slot in the core snap with a name matching
 the plug name.
-
-Application Options:
-      --version            Print the version and exit
-
-Help Options:
-  -h, --help               Show this help message
 
 [connect command options]
           --no-wait        Do not wait for the operation to finish but just

--- a/cmd/snap/cmd_create_key.go
+++ b/cmd/snap/cmd_create_key.go
@@ -39,7 +39,10 @@ type cmdCreateKey struct {
 func init() {
 	cmd := addCommand("create-key",
 		i18n.G("Create cryptographic key pair"),
-		i18n.G("Create a cryptographic key pair that can be used for signing assertions."),
+		i18n.G(`
+The create-key command creates a cryptographic key pair that can be
+used for signing assertions.
+`),
 		func() flags.Commander {
 			return &cmdCreateKey{}
 		}, nil, []argDesc{{

--- a/cmd/snap/cmd_create_user.go
+++ b/cmd/snap/cmd_create_user.go
@@ -29,7 +29,7 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-var shortCreateUserHelp = i18n.G("Creates a local system user")
+var shortCreateUserHelp = i18n.G("Create a local system user")
 var longCreateUserHelp = i18n.G(`
 The create-user command creates a local system user with the username and SSH
 keys registered on the store account identified by the provided email address.

--- a/cmd/snap/cmd_debug.go
+++ b/cmd/snap/cmd_debug.go
@@ -25,7 +25,7 @@ import (
 
 type cmdDebug struct{}
 
-var shortDebugHelp = i18n.G("Runs debug commands")
+var shortDebugHelp = i18n.G("Run debug commands")
 var longDebugHelp = i18n.G(`
 The debug command contains a selection of additional sub-commands.
 

--- a/cmd/snap/cmd_delete_key.go
+++ b/cmd/snap/cmd_delete_key.go
@@ -35,7 +35,10 @@ type cmdDeleteKey struct {
 func init() {
 	cmd := addCommand("delete-key",
 		i18n.G("Delete cryptographic key pair"),
-		i18n.G("Delete the local cryptographic key pair with the given name."),
+		i18n.G(`
+The delete-key command deletes the local cryptographic key pair with
+the given name.
+`),
 		func() flags.Commander {
 			return &cmdDeleteKey{}
 		}, nil, []argDesc{{

--- a/cmd/snap/cmd_disconnect.go
+++ b/cmd/snap/cmd_disconnect.go
@@ -35,7 +35,7 @@ type cmdDisconnect struct {
 	} `positional-args:"true"`
 }
 
-var shortDisconnectHelp = i18n.G("Disconnects a plug from a slot")
+var shortDisconnectHelp = i18n.G("Disconnect a plug from a slot")
 var longDisconnectHelp = i18n.G(`
 The disconnect command disconnects a plug from a slot.
 It may be called in the following ways:

--- a/cmd/snap/cmd_disconnect_test.go
+++ b/cmd/snap/cmd_disconnect_test.go
@@ -32,7 +32,7 @@ import (
 
 func (s *SnapSuite) TestDisconnectHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] disconnect [disconnect-OPTIONS] [<snap>:<plug>] [<snap>:<slot>]
+  snap.test disconnect [disconnect-OPTIONS] [<snap>:<plug>] [<snap>:<slot>]
 
 The disconnect command disconnects a plug from a slot.
 It may be called in the following ways:
@@ -45,12 +45,6 @@ $ snap disconnect <snap>:<slot or plug>
 
 Disconnects everything from the provided plug or slot.
 The snap name may be omitted for the core snap.
-
-Application Options:
-      --version            Print the version and exit
-
-Help Options:
-  -h, --help               Show this help message
 
 [disconnect command options]
           --no-wait        Do not wait for the operation to finish but just

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -46,7 +46,7 @@ type cmdDownload struct {
 var shortDownloadHelp = i18n.G("Download the given snap")
 var longDownloadHelp = i18n.G(`
 The download command downloads the given snap and its supporting assertions
-to the current directory under .snap and .assert file extensions, respectively.
+to the current directory with .snap and .assert file extensions, respectively.
 `)
 
 func init() {

--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -43,7 +43,7 @@ type cmdDownload struct {
 	} `positional-args:"true" required:"true"`
 }
 
-var shortDownloadHelp = i18n.G("Downloads the given snap")
+var shortDownloadHelp = i18n.G("Download the given snap")
 var longDownloadHelp = i18n.G(`
 The download command downloads the given snap and its supporting assertions
 to the current directory under .snap and .assert file extensions, respectively.

--- a/cmd/snap/cmd_ensure_state_soon.go
+++ b/cmd/snap/cmd_ensure_state_soon.go
@@ -27,8 +27,8 @@ type cmdEnsureStateSoon struct{}
 
 func init() {
 	cmd := addDebugCommand("ensure-state-soon",
-		"(internal) trigger an ensure runn in the state engine",
-		"(internal) trigger an ensure runn in the state engine",
+		"(internal) trigger an ensure run in the state engine",
+		"(internal) trigger an ensure run in the state engine",
 		func() flags.Commander {
 			return &cmdEnsureStateSoon{}
 		})

--- a/cmd/snap/cmd_export_key.go
+++ b/cmd/snap/cmd_export_key.go
@@ -39,7 +39,10 @@ type cmdExportKey struct {
 func init() {
 	cmd := addCommand("export-key",
 		i18n.G("Export cryptographic public key"),
-		i18n.G("Export a public key assertion body that may be imported by other systems."),
+		i18n.G(`
+The export-key command exports a public key assertion body that may be
+imported by other systems.
+`),
 		func() flags.Commander {
 			return &cmdExportKey{}
 		}, map[string]string{

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -39,6 +39,11 @@ import (
 var shortFindHelp = i18n.G("Find packages to install")
 var longFindHelp = i18n.G(`
 The find command queries the store for available packages in the stable channel.
+
+With the --private flag, which requires the user to be logged-in to the store
+(see 'snap help login'), it instead searches for private snaps that the user
+has developer access to, either directly or through the store's collaboration
+feature.
 `)
 
 func getPrice(prices map[string]float64, currency string) (float64, string, error) {
@@ -123,7 +128,7 @@ func showSections() error {
 	for _, sec := range sections {
 		fmt.Fprintf(Stdout, " * %s\n", sec)
 	}
-	fmt.Fprintf(Stdout, i18n.G("Please try: snap find --section=<selected section>\n"))
+	fmt.Fprintf(Stdout, i18n.G("Please try 'snap find --section=<selected section>'\n"))
 	return nil
 }
 

--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -36,7 +36,7 @@ import (
 	"github.com/snapcore/snapd/strutil"
 )
 
-var shortFindHelp = i18n.G("Finds packages to install")
+var shortFindHelp = i18n.G("Find packages to install")
 var longFindHelp = i18n.G(`
 The find command queries the store for available packages in the stable channel.
 `)

--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -422,7 +422,7 @@ func (s *SnapSuite) TestFindSnapSectionOverview(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, `No section specified. Available sections:
  * sec1
  * sec2
-Please try: snap find --section=<selected section>
+Please try 'snap find --section=<selected section>'
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 
@@ -508,7 +508,7 @@ func (s *SnapSuite) TestFindSnapCachedSection(c *check.C) {
  * sec1
  * sec2
  * sec3
-Please try: snap find --section=<selected section>
+Please try 'snap find --section=<selected section>'
 `)
 
 	s.ResetStdStreams()

--- a/cmd/snap/cmd_first_boot.go
+++ b/cmd/snap/cmd_first_boot.go
@@ -29,8 +29,9 @@ type cmdInternalFirstBoot struct{}
 
 func init() {
 	cmd := addCommand("firstboot",
-		"internal",
-		"internal", func() flags.Commander {
+		"Internal",
+		"The firstboot command is only retained for backwards compatibility.",
+		func() flags.Commander {
 			return &cmdInternalFirstBoot{}
 		}, nil, nil)
 	cmd.hidden = true

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -32,7 +32,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-var shortGetHelp = i18n.G("Prints configuration options")
+var shortGetHelp = i18n.G("Print configuration options")
 var longGetHelp = i18n.G(`
 The get command prints configuration options for the provided snap.
 

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -210,7 +210,7 @@ func (x *cmdGet) outputDefault(conf map[string]interface{}, snapName string, con
 
 		// TODO: remove this conditional and the warning below
 		// after a transition period.
-		fmt.Fprintf(Stderr, i18n.G(`WARNING: The output of "snap get" will become a list with columns - use -d or -l to force the output format.\n`))
+		fmt.Fprintf(Stderr, i18n.G(`WARNING: The output of 'snap get' will become a list with columns - use -d or -l to force the output format.\n`))
 		return x.outputJson(confToPrint)
 	}
 

--- a/cmd/snap/cmd_get_test.go
+++ b/cmd/snap/cmd_get_test.go
@@ -66,7 +66,7 @@ var getTests = []getCmdArgs{{
 	stdout: "Key        Value\ntest-key1  test-value1\ntest-key2  2\n",
 }, {
 	args:   "get snapname document",
-	stderr: `WARNING: The output of "snap get" will become a list with columns - use -d or -l to force the output format.\n`,
+	stderr: `WARNING: The output of 'snap get' will become a list with columns - use -d or -l to force the output format.\n`,
 	stdout: "{\n\t\"document\": {\n\t\t\"key1\": \"value1\",\n\t\t\"key2\": \"value2\"\n\t}\n}\n",
 }, {
 	isTerminal: true,
@@ -98,7 +98,7 @@ var getTests = []getCmdArgs{{
 	isTerminal: false,
 	args:       "get snapname  test-key1 test-key2",
 	stdout:     "{\n\t\"test-key1\": \"test-value1\",\n\t\"test-key2\": 2\n}\n",
-	stderr:     `WARNING: The output of "snap get" will become a list with columns - use -d or -l to force the output format.\n`,
+	stderr:     `WARNING: The output of 'snap get' will become a list with columns - use -d or -l to force the output format.\n`,
 },
 }
 

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -20,6 +20,8 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 
 	"github.com/snapcore/snapd/i18n"
@@ -27,14 +29,41 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-var shortHelpHelp = i18n.G("Help")
+var shortHelpHelp = i18n.G("Show help about a command")
 var longHelpHelp = i18n.G(`
-The help command shows helpful information. Unlike this. ;-)
+The help command displays information about snap commands.
 `)
 
+// addHelp adds --help like what go-flags would do for us, but hidden
+func addHelp(parser *flags.Parser) error {
+	var help struct {
+		ShowHelp func() error `short:"h" long:"help"`
+	}
+	help.ShowHelp = func() error {
+		var buf bytes.Buffer
+		parser.WriteHelp(&buf)
+		return &flags.Error{
+			Type:    flags.ErrHelp,
+			Message: buf.String(),
+		}
+	}
+	hlp, err := parser.AddGroup("Help Options", "", &help)
+	if err != nil {
+		return err
+	}
+	parser.FindOptionByLongName("help").Description = i18n.G("Show this help message")
+	hlp.Hidden = true
+
+	return nil
+}
+
 type cmdHelp struct {
-	Manpage bool `long:"man"`
-	parser  *flags.Parser
+	Manpage    bool `long:"man"`
+	Positional struct {
+		// TODO: find a way to make Command tab-complete
+		Sub string `positional-arg-name:"<command>"`
+	} `positional-args:"yes"`
+	parser *flags.Parser
 }
 
 func init() {
@@ -50,7 +79,13 @@ func (cmd cmdHelp) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
-
+	if cmd.Positional.Sub != "" {
+		subcmd := cmd.parser.Find(cmd.Positional.Sub)
+		if subcmd == nil {
+			return fmt.Errorf(i18n.G("Unknown command %q. Try 'snap help'."), cmd.Positional.Sub)
+		}
+		cmd.parser.Command.Active = subcmd
+	}
 	if cmd.Manpage {
 		cmd.parser.WriteManPage(Stdout)
 		os.Exit(0)

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -47,11 +47,13 @@ func addHelp(parser *flags.Parser) error {
 			Message: buf.String(),
 		}
 	}
-	hlp, err := parser.AddGroup("Help Options", "", &help)
+	hlpgrp, err := parser.AddGroup("Help Options", "", &help)
 	if err != nil {
 		return err
 	}
-	parser.FindOptionByLongName("help").Description = i18n.G("Show this help message")
+	hlpgrp.Hidden = true
+	hlp := parser.FindOptionByLongName("help")
+	hlp.Description = i18n.G("Show this help message")
 	hlp.Hidden = true
 
 	return nil

--- a/cmd/snap/cmd_help.go
+++ b/cmd/snap/cmd_help.go
@@ -58,7 +58,7 @@ func addHelp(parser *flags.Parser) error {
 }
 
 type cmdHelp struct {
-	Manpage    bool `long:"man"`
+	Manpage    bool `long:"man" hidden:"true"`
 	Positional struct {
 		// TODO: find a way to make Command tab-complete
 		Sub string `positional-arg-name:"<command>"`

--- a/cmd/snap/cmd_help_test.go
+++ b/cmd/snap/cmd_help_test.go
@@ -41,7 +41,7 @@ func (s *SnapSuite) TestHelpPrintsHelp(c *check.C) {
 		err := snap.RunMain()
 		c.Assert(err, check.IsNil)
 		c.Check(s.Stdout(), check.Matches, `(?smU)Usage:
- +snap \[OPTIONS\] <command>
+ +snap <command>
 
 Install, configure, refresh and remove snap packages. Snaps are
 'universal' packages that work across many different Linux systems,
@@ -50,13 +50,6 @@ cloud, servers, desktops and the internet of things.
 
 This is the CLI for snapd, a background service that takes care of
 snaps on the system. Start with 'snap list' to see installed snaps.
-
-
-Application Options:
- +--version +Print the version and exit
-
-Help Options:
- +-h, --help +Show this help message
 
 Available commands:
  +abort.*
@@ -74,7 +67,7 @@ func (s *SnapSuite) TestSubCommandHelpPrintsHelp(c *check.C) {
 	err := snap.RunMain()
 	c.Assert(err, check.IsNil)
 	c.Check(s.Stdout(), check.Matches, `(?smU)Usage:
- +snap \[OPTIONS\] install \[install-OPTIONS\] <snap>...
+ +snap install \[install-OPTIONS\] <snap>...
 .*
 `)
 	c.Check(s.Stderr(), check.Equals, "")

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -47,9 +47,15 @@ type infoCmd struct {
 	} `positional-args:"yes" required:"yes"`
 }
 
-var shortInfoHelp = i18n.G("Show detailed information about a snap")
+var shortInfoHelp = i18n.G("Show detailed information about snaps")
 var longInfoHelp = i18n.G(`
-The info command shows detailed information about a snap, be it by name or by path.`)
+The info command shows detailed information about snaps.
+
+The snaps can be specified by name or by path; names are looked for both in the
+store and in the installed snaps; paths can refer to a .snap file, or to a
+directory that contains an unpacked snap suitable for 'snap try' (like the
+'prime' directory snapcraft produces).
+`)
 
 func init() {
 	addCommand("info",

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -53,8 +53,8 @@ The info command shows detailed information about snaps.
 
 The snaps can be specified by name or by path; names are looked for both in the
 store and in the installed snaps; paths can refer to a .snap file, or to a
-directory that contains an unpacked snap suitable for 'snap try' (like the
-'prime' directory snapcraft produces).
+directory that contains an unpacked snap suitable for 'snap try' (an example
+of this would be the 'prime' directory snapcraft produces).
 `)
 
 func init() {

--- a/cmd/snap/cmd_interface.go
+++ b/cmd/snap/cmd_interface.go
@@ -39,7 +39,7 @@ type cmdInterface struct {
 	} `positional-args:"true"`
 }
 
-var shortInterfaceHelp = i18n.G("Lists snap interfaces")
+var shortInterfaceHelp = i18n.G("List snap interfaces")
 var longInterfaceHelp = i18n.G(`
 The interface command shows details of snap interfaces.
 

--- a/cmd/snap/cmd_interface_test.go
+++ b/cmd/snap/cmd_interface_test.go
@@ -33,18 +33,12 @@ import (
 
 func (s *SnapSuite) TestInterfaceHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] interface [interface-OPTIONS] [<interface>]
+  snap.test interface [interface-OPTIONS] [<interface>]
 
 The interface command shows details of snap interfaces.
 
 If no interface name is provided, a list of interface names with at least
 one connection is shown, or a list of all interfaces if --all is provided.
-
-Application Options:
-      --version          Print the version and exit
-
-Help Options:
-  -h, --help             Show this help message
 
 [interface command options]
           --attrs        Show interface attributes

--- a/cmd/snap/cmd_interfaces.go
+++ b/cmd/snap/cmd_interfaces.go
@@ -34,12 +34,12 @@ type cmdInterfaces struct {
 	} `positional-args:"true"`
 }
 
-var shortInterfacesHelp = i18n.G("Lists interfaces in the system")
+var shortInterfacesHelp = i18n.G("List interfaces in the system")
 var longInterfacesHelp = i18n.G(`
 The interfaces command lists interfaces available in the system.
 
 By default all slots and plugs, used and offered by all snaps, are displayed.
- 
+
 $ snap interfaces <snap>:<slot or plug>
 
 Lists only the specified slot or plug.
@@ -50,7 +50,8 @@ Lists the slots offered and plugs used by the specified snap.
 
 $ snap interfaces -i=<interface> [<snap>]
 
-Filters the complete output so only plugs and/or slots matching the provided details are listed.
+Filters the complete output so only plugs and/or slots matching the provided
+details are listed.
 `)
 
 func init() {

--- a/cmd/snap/cmd_keys.go
+++ b/cmd/snap/cmd_keys.go
@@ -36,7 +36,10 @@ type cmdKeys struct {
 func init() {
 	cmd := addCommand("keys",
 		i18n.G("List cryptographic keys"),
-		i18n.G("List cryptographic keys that can be used for signing assertions."),
+		i18n.G(`
+The keys command lists cryptographic keys that can be used for signing
+assertions.
+`),
 		func() flags.Commander {
 			return &cmdKeys{}
 		}, map[string]string{"json": i18n.G("Output results in JSON format")}, nil)

--- a/cmd/snap/cmd_known.go
+++ b/cmd/snap/cmd_known.go
@@ -41,7 +41,7 @@ type cmdKnown struct {
 	Remote bool `long:"remote"`
 }
 
-var shortKnownHelp = i18n.G("Shows known assertions of the provided type")
+var shortKnownHelp = i18n.G("Show known assertions of the provided type")
 var longKnownHelp = i18n.G(`
 The known command shows known assertions of the provided type.
 If header=value pairs are provided after the assertion type, the assertions

--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -109,7 +109,7 @@ func listSnaps(names []string, all bool) error {
 	if err != nil {
 		if err == client.ErrNoSnapsInstalled {
 			if len(names) == 0 {
-				fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet. Try \"snap install hello-world\"."))
+				fmt.Fprintln(Stderr, i18n.G("No snaps are installed yet. Try 'snap install hello-world'."))
 				return nil
 			} else {
 				return ErrNoMatchingSnaps

--- a/cmd/snap/cmd_list.go
+++ b/cmd/snap/cmd_list.go
@@ -35,7 +35,8 @@ import (
 
 var shortListHelp = i18n.G("List installed snaps")
 var longListHelp = i18n.G(`
-The list command displays a summary of snaps installed in the current system.`)
+The list command displays a summary of snaps installed in the current system.
+`)
 
 type cmdList struct {
 	Positional struct {

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -30,15 +30,9 @@ import (
 
 func (s *SnapSuite) TestListHelp(c *check.C) {
 	msg := `Usage:
-  snap.test [OPTIONS] list [list-OPTIONS] [<snap>...]
+  snap.test list [list-OPTIONS] [<snap>...]
 
 The list command displays a summary of snaps installed in the current system.
-
-Application Options:
-      --version     Print the version and exit
-
-Help Options:
-  -h, --help        Show this help message
 
 [list command options]
           --all     Show all revisions

--- a/cmd/snap/cmd_list_test.go
+++ b/cmd/snap/cmd_list_test.go
@@ -108,7 +108,7 @@ func (s *SnapSuite) TestListEmpty(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Equals, "")
-	c.Check(s.Stderr(), check.Equals, "No snaps are installed yet. Try \"snap install hello-world\".\n")
+	c.Check(s.Stderr(), check.Equals, "No snaps are installed yet. Try 'snap install hello-world'.\n")
 }
 
 func (s *SnapSuite) TestListEmptyWithQuery(c *check.C) {

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -36,14 +36,16 @@ type cmdLogin struct {
 	} `positional-args:"yes"`
 }
 
-var shortLoginHelp = i18n.G("Authenticates on snapd and the store")
+var shortLoginHelp = i18n.G("Authenticate to snapd and the store")
 
 var longLoginHelp = i18n.G(`
-The login command authenticates on snapd and the snap store and saves credentials
-into the ~/.snap/auth.json file. Further communication with snapd will then be made
-using those credentials.
+The login command authenticates the user to snapd and the snap store, and saves
+credentials into the ~/.snap/auth.json file. Further communication with snapd
+will then be made using those credentials.
 
-Login only works for local users in the sudo, admin or wheel groups.
+You don't need to login to interact with snapd, unless you are publishing your
+own snaps and are wishinng to install unpublished revisions, or private snaps
+you have access to, or you wish to buy snaps.
 
 An account can be setup at https://login.ubuntu.com
 `)

--- a/cmd/snap/cmd_login.go
+++ b/cmd/snap/cmd_login.go
@@ -43,11 +43,11 @@ The login command authenticates the user to snapd and the snap store, and saves
 credentials into the ~/.snap/auth.json file. Further communication with snapd
 will then be made using those credentials.
 
-You don't need to login to interact with snapd, unless you are publishing your
-own snaps and are wishinng to install unpublished revisions, or private snaps
-you have access to, or you wish to buy snaps.
+It's not necessary to log in to interact with snapd. Doing so, however, enables
+purchasing of snaps using 'snap buy', as well as some some developer-oriented
+features as detailed in the help for the find, install and refresh commands.
 
-An account can be setup at https://login.ubuntu.com
+An account can be set up at https://login.ubuntu.com
 `)
 
 func init() {

--- a/cmd/snap/cmd_logout.go
+++ b/cmd/snap/cmd_logout.go
@@ -29,7 +29,9 @@ type cmdLogout struct{}
 
 var shortLogoutHelp = i18n.G("Log out of the store")
 
-var longLogoutHelp = i18n.G("This command logs the current user out of the store")
+var longLogoutHelp = i18n.G(`
+The logout command logs the current user out of the store.
+`)
 
 func init() {
 	addCommand("logout",

--- a/cmd/snap/cmd_logout.go
+++ b/cmd/snap/cmd_logout.go
@@ -27,10 +27,10 @@ import (
 
 type cmdLogout struct{}
 
-var shortLogoutHelp = i18n.G("Log out of the store")
+var shortLogoutHelp = i18n.G("Log out of snapd and the store")
 
 var longLogoutHelp = i18n.G(`
-The logout command logs the current user out of the store.
+The logout command logs the current user out of snapd and the store.
 `)
 
 func init() {

--- a/cmd/snap/cmd_managed.go
+++ b/cmd/snap/cmd_managed.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-var shortIsManagedHelp = i18n.G("Prints whether system is managed")
+var shortIsManagedHelp = i18n.G("Print whether the system is managed")
 var longIsManagedHelp = i18n.G(`
 The managed command will print true or false informing whether
 snapd has registered users.

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -37,7 +37,8 @@ type packCmd struct {
 
 var shortPackHelp = i18n.G("Pack the given target dir as a snap")
 var longPackHelp = i18n.G(`
-The pack command packs the given snap-dir as a snap.`)
+The pack command packs the given snap-dir as a snap.
+`)
 
 func init() {
 	addCommand("pack",

--- a/cmd/snap/cmd_prefer.go
+++ b/cmd/snap/cmd_prefer.go
@@ -36,7 +36,7 @@ var shortPreferHelp = i18n.G("Prefer aliases from a snap and disable conflicts")
 var longPreferHelp = i18n.G(`
 The prefer command enables all aliases of the given snap in preference
 to conflicting aliases of other snaps whose aliases will be disabled
-(removed for manual ones).
+(or removed, for manual ones).
 `)
 
 func init() {

--- a/cmd/snap/cmd_prefer_test.go
+++ b/cmd/snap/cmd_prefer_test.go
@@ -30,17 +30,11 @@ import (
 
 func (s *SnapSuite) TestPreferHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] prefer [prefer-OPTIONS] [<snap>]
+  snap.test prefer [prefer-OPTIONS] [<snap>]
 
 The prefer command enables all aliases of the given snap in preference
 to conflicting aliases of other snaps whose aliases will be disabled
 (removed for manual ones).
-
-Application Options:
-      --version      Print the version and exit
-
-Help Options:
-  -h, --help         Show this help message
 
 [prefer command options]
           --no-wait  Do not wait for the operation to finish but just print the

--- a/cmd/snap/cmd_prefer_test.go
+++ b/cmd/snap/cmd_prefer_test.go
@@ -34,7 +34,7 @@ func (s *SnapSuite) TestPreferHelp(c *C) {
 
 The prefer command enables all aliases of the given snap in preference
 to conflicting aliases of other snaps whose aliases will be disabled
-(removed for manual ones).
+(or removed, for manual ones).
 
 [prefer command options]
           --no-wait  Do not wait for the operation to finish but just print the

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -40,10 +40,10 @@ type cmdPrepareImage struct {
 
 func init() {
 	cmd := addCommand("prepare-image",
-		i18n.G("Prepare a snappy device image"),
+		i18n.G("Prepare a core device image"),
 		i18n.G(`
-The prepare-image command is used by ubuntu-image in building a snappy device
-image.
+The prepare-image command performs some of the steps necessary for creating
+core device images.
 `),
 		func() flags.Commander {
 			return &cmdPrepareImage{}

--- a/cmd/snap/cmd_prepare_image.go
+++ b/cmd/snap/cmd_prepare_image.go
@@ -40,8 +40,11 @@ type cmdPrepareImage struct {
 
 func init() {
 	cmd := addCommand("prepare-image",
-		i18n.G("Prepare a snappy image"),
-		i18n.G("Prepare a snappy image"),
+		i18n.G("Prepare a snappy device image"),
+		i18n.G(`
+The prepare-image command is used by ubuntu-image in building a snappy device
+image.
+`),
 		func() flags.Commander {
 			return &cmdPrepareImage{}
 		}, map[string]string{

--- a/cmd/snap/cmd_repair_repairs.go
+++ b/cmd/snap/cmd_repair_repairs.go
@@ -54,7 +54,7 @@ type cmdShowRepair struct {
 	} `positional-args:"yes"`
 }
 
-var shortRepairHelp = i18n.G("Shows specific repairs")
+var shortRepairHelp = i18n.G("Show specific repairs")
 var longRepairHelp = i18n.G(`
 The repair command shows the details about one or multiple repairs.
 `)

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -509,7 +509,7 @@ func straceCmd() ([]string, error) {
 	if stracePath == "" {
 		stracePath, err = exec.LookPath("strace")
 		if err != nil {
-			return nil, fmt.Errorf("cannot find an installed strace, please try: `snap install strace-static`")
+			return nil, fmt.Errorf("cannot find an installed strace, please try 'snap install strace-static'")
 		}
 	}
 

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -72,7 +72,10 @@ type cmdRun struct {
 func init() {
 	addCommand("run",
 		i18n.G("Run the given snap command"),
-		i18n.G("Run the given snap command with the right confinement and environment"),
+		i18n.G(`
+The run command executes the given snap command with the right confinement
+and environment.
+`),
 		func() flags.Commander {
 			return &cmdRun{}
 		}, map[string]string{

--- a/cmd/snap/cmd_services.go
+++ b/cmd/snap/cmd_services.go
@@ -46,11 +46,13 @@ type svcLogs struct {
 var (
 	shortServicesHelp = i18n.G("Query the status of services")
 	longServicesHelp  = i18n.G(`
-The services command lists information about the services specified, or about the services in all currently installed snaps.
+The services command lists information about the services specified, or about
+the services in all currently installed snaps.
 `)
 	shortLogsHelp = i18n.G("Retrieve logs of services")
 	longLogsHelp  = i18n.G(`
-The logs command fetches logs of the given services and displays them in chronological order.
+The logs command fetches logs of the given services and displays them in
+chronological order.
 `)
 	shortStartHelp = i18n.G("Start services")
 	longStartHelp  = i18n.G(`
@@ -64,7 +66,8 @@ The stop command stops, and optionally disables, the given services.
 	longRestartHelp  = i18n.G(`
 The restart command restarts the given services.
 
-If the --reload option is given, for each service whose app has a reload command, a reload is performed instead of a restart.
+If the --reload option is given, for each service whose app has a reload
+command, a reload is performed instead of a restart.
 `)
 )
 

--- a/cmd/snap/cmd_set.go
+++ b/cmd/snap/cmd_set.go
@@ -29,7 +29,7 @@ import (
 	"github.com/snapcore/snapd/jsonutil"
 )
 
-var shortSetHelp = i18n.G("Changes configuration options")
+var shortSetHelp = i18n.G("Change configuration options")
 var longSetHelp = i18n.G(`
 The set command changes the provided configuration options as requested.
 

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -33,7 +33,7 @@ import (
 var shortSignHelp = i18n.G("Sign an assertion")
 var longSignHelp = i18n.G(`
 The sign command signs an assertion using the specified key, using the
-input for headers from a JSON mapping provided through stdin, the body
+input for headers from a JSON mapping provided through stdin. The body
 of the assertion can be specified through a "body" pseudo-header.
 `)
 

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -31,7 +31,10 @@ import (
 )
 
 var shortSignHelp = i18n.G("Sign an assertion")
-var longSignHelp = i18n.G(`Sign an assertion using the specified key, using the input for headers from a JSON mapping provided through stdin, the body of the assertion can be specified through a "body" pseudo-header.
+var longSignHelp = i18n.G(`
+The sign command signs an assertion using the specified key, using the
+input for headers from a JSON mapping provided through stdin, the body
+of the assertion can be specified through a "body" pseudo-header.
 `)
 
 type cmdSign struct {

--- a/cmd/snap/cmd_sign_build.go
+++ b/cmd/snap/cmd_sign_build.go
@@ -43,8 +43,11 @@ type cmdSignBuild struct {
 	Grade       string  `long:"grade" choice:"devel" choice:"stable" default:"stable"`
 }
 
-var shortSignBuildHelp = i18n.G("Create snap build assertion")
-var longSignBuildHelp = i18n.G("Create snap-build assertion for the provided snap file.")
+var shortSignBuildHelp = i18n.G("Create a snap-build assertion")
+var longSignBuildHelp = i18n.G(`
+The sign-build command creates a snap-build assertion for the provided
+snap file.
+`)
 
 func init() {
 	cmd := addCommand("sign-build",

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -42,12 +42,12 @@ func lastLogStr(logs []string) string {
 }
 
 var (
-	shortInstallHelp = i18n.G("Installs a snap to the system")
-	shortRemoveHelp  = i18n.G("Removes a snap from the system")
-	shortRefreshHelp = i18n.G("Refreshes a snap in the system")
-	shortTryHelp     = i18n.G("Tests a snap in the system")
-	shortEnableHelp  = i18n.G("Enables a snap in the system")
-	shortDisableHelp = i18n.G("Disables a snap in the system")
+	shortInstallHelp = i18n.G("Install a snap to the system")
+	shortRemoveHelp  = i18n.G("Remove a snap from the system")
+	shortRefreshHelp = i18n.G("Refresh a snap in the system")
+	shortTryHelp     = i18n.G("Test a snap in the system")
+	shortEnableHelp  = i18n.G("Enable a snap in the system")
+	shortDisableHelp = i18n.G("Disable a snap in the system")
 )
 
 var longInstallHelp = i18n.G(`
@@ -57,9 +57,9 @@ The install command installs the named snap in the system.
 var longRemoveHelp = i18n.G(`
 The remove command removes the named snap from the system.
 
-By default all the snap revisions are removed, including their data and the common
-data directory. When a --revision option is passed only the specified revision is
-removed.
+By default all the snap revisions are removed, including their data and the
+common data directory. When a --revision option is passed only the specified
+revision is removed.
 `)
 
 var longRefreshHelp = i18n.G(`
@@ -83,7 +83,7 @@ The enable command enables a snap that was previously disabled.
 
 var longDisableHelp = i18n.G(`
 The disable command disables a snap. The binaries and services of the
-snap will no longer be available. But all the data is still available
+snap will no longer be available, but all the data is still available
 and the snap can easily be enabled again.
 `)
 

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -51,7 +51,19 @@ var (
 )
 
 var longInstallHelp = i18n.G(`
-The install command installs the named snap in the system.
+The install command installs the named snaps in the system.
+
+With no further options, the snaps are installed tracking the stable channel,
+with strict security confinement.
+
+Revision choice via the --revision override is limited to those that are the
+current revision of a channel.
+If the snap is one the user has developer access to, either directly or through
+the store's collaboration feature, then logging in (see 'snap help login')
+lifts this restriction.
+
+Note a later refresh will typically undo a revision override, taking the snap
+back to the current revision of the channel it's tracking.
 `)
 
 var longRemoveHelp = i18n.G(`
@@ -63,7 +75,19 @@ revision is removed.
 `)
 
 var longRefreshHelp = i18n.G(`
-The refresh command refreshes (updates) the named snap.
+The refresh command updates the specified snaps, or all snaps in the system if
+none are specified.
+
+With no further options, the snaps are refreshed to the current revision of the
+channel they're tracking, preserving their confinement options.
+
+Revision choice via the --revision override is limited to those that are the
+current revision of a channel.
+If the snap is one the user has developer access to, either directly or through
+the store's collaboration feature, then logging in (see 'snap help login')
+lifts this restriction.
+
+Note a later refresh will typically undo a revision override.
 `)
 
 var longTryHelp = i18n.G(`
@@ -683,7 +707,7 @@ func (x *cmdTry) Execute([]string) error {
 	if e, ok := err.(*client.Error); ok && e.Kind == client.ErrorKindNotSnap {
 		return fmt.Errorf(i18n.G(`%q does not contain an unpacked snap.
 
-Try "snapcraft prime" in your project directory, then "snap try" again.`), path)
+Try "snapcraft prime" in your project directory, then 'snap try' again.`), path)
 	}
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -707,7 +707,7 @@ func (x *cmdTry) Execute([]string) error {
 	if e, ok := err.(*client.Error); ok && e.Kind == client.ErrorKindNotSnap {
 		return fmt.Errorf(i18n.G(`%q does not contain an unpacked snap.
 
-Try "snapcraft prime" in your project directory, then 'snap try' again.`), path)
+Try 'snapcraft prime' in your project directory, then 'snap try' again.`), path)
 	}
 	if err != nil {
 		return err

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -842,7 +842,7 @@ func (s *SnapOpSuite) TestTryNoSnapDirErrors(c *check.C) {
 	_, err := snap.Parser().ParseArgs(cmd)
 	c.Assert(err, check.ErrorMatches, `"/" does not contain an unpacked snap.
 
-Try "snapcraft prime" in your project directory, then "snap try" again.`)
+Try 'snapcraft prime' in your project directory, then 'snap try' again.`)
 }
 
 func (s *SnapSuite) TestInstallChannelDuplicationError(c *check.C) {

--- a/cmd/snap/cmd_unalias.go
+++ b/cmd/snap/cmd_unalias.go
@@ -34,8 +34,9 @@ type cmdUnalias struct {
 
 var shortUnaliasHelp = i18n.G("Unalias a manual alias or an entire snap")
 var longUnaliasHelp = i18n.G(`
-The unalias command tears down a manual alias when given one or disables all
-aliases of a snap, removing also all manual ones, when given a snap name.
+The unalias command removes a single alias if the provided argument is a manual
+alias, or disables all aliases of a snap, including manual ones, if the
+argument is a snap name.
 `)
 
 func init() {

--- a/cmd/snap/cmd_unalias.go
+++ b/cmd/snap/cmd_unalias.go
@@ -34,7 +34,8 @@ type cmdUnalias struct {
 
 var shortUnaliasHelp = i18n.G("Unalias a manual alias or an entire snap")
 var longUnaliasHelp = i18n.G(`
-The unalias command tears down a manual alias when given one or disables all aliases of a snap, removing also all manual ones, when given a snap name.
+The unalias command tears down a manual alias when given one or disables all
+aliases of a snap, removing also all manual ones, when given a snap name.
 `)
 
 func init() {

--- a/cmd/snap/cmd_unalias_test.go
+++ b/cmd/snap/cmd_unalias_test.go
@@ -30,16 +30,10 @@ import (
 
 func (s *SnapSuite) TestUnaliasHelp(c *C) {
 	msg := `Usage:
-  snap.test [OPTIONS] unalias [unalias-OPTIONS] [<alias-or-snap>]
+  snap.test unalias [unalias-OPTIONS] [<alias-or-snap>]
 
 The unalias command tears down a manual alias when given one or disables all
 aliases of a snap, removing also all manual ones, when given a snap name.
-
-Application Options:
-      --version              Print the version and exit
-
-Help Options:
-  -h, --help                 Show this help message
 
 [unalias command options]
           --no-wait          Do not wait for the operation to finish but just

--- a/cmd/snap/cmd_unalias_test.go
+++ b/cmd/snap/cmd_unalias_test.go
@@ -32,8 +32,9 @@ func (s *SnapSuite) TestUnaliasHelp(c *C) {
 	msg := `Usage:
   snap.test unalias [unalias-OPTIONS] [<alias-or-snap>]
 
-The unalias command tears down a manual alias when given one or disables all
-aliases of a snap, removing also all manual ones, when given a snap name.
+The unalias command removes a single alias if the provided argument is a manual
+alias, or disables all aliases of a snap, including manual ones, if the
+argument is a snap name.
 
 [unalias command options]
           --no-wait          Do not wait for the operation to finish but just

--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -36,7 +36,9 @@ type cmdUserd struct {
 }
 
 var shortUserdHelp = i18n.G("Start the userd service")
-var longUserdHelp = i18n.G("The userd command starts the snap user session service.")
+var longUserdHelp = i18n.G(`
+The userd command starts the snap user session service.
+`)
 
 func init() {
 	cmd := addCommand("userd",

--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -29,7 +29,7 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-var shortVersionHelp = i18n.G("Shows version details")
+var shortVersionHelp = i18n.G("Show version details")
 var longVersionHelp = i18n.G(`
 The version command displays the versions of the running client, server,
 and operating system.

--- a/cmd/snap/cmd_whoami.go
+++ b/cmd/snap/cmd_whoami.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-var shortWhoAmIHelp = i18n.G("Prints the email the user is logged in with")
+var shortWhoAmIHelp = i18n.G("Print the email the user is logged in with")
 var longWhoAmIHelp = i18n.G(`
 The whoami command prints the email the user is logged in with.
 `)

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -122,7 +122,7 @@ func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (stri
 		}
 	case client.ErrorKindSnapAlreadyInstalled:
 		isError = false
-		msg = i18n.G(`snap %q is already installed, see "snap refresh --help"`)
+		msg = i18n.G(`snap %q is already installed, see 'snap help refresh'`)
 	case client.ErrorKindSnapNeedsDevMode:
 		msg = i18n.G(`
 The publisher of snap %q has indicated that they do not consider this revision
@@ -147,7 +147,7 @@ If you understand and want to proceed repeat the command including --classic.
 		u, _ := user.Current()
 		if u != nil && u.Username == "root" {
 			// TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
-			msg = fmt.Sprintf(i18n.G(`%s (see "snap login --help")`), err.Message)
+			msg = fmt.Sprintf(i18n.G(`%s (see 'snap help login')`), err.Message)
 		} else {
 			// TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 			msg = fmt.Sprintf(i18n.G(`%s (try with sudo)`), err.Message)

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -165,7 +165,7 @@ func Parser() *flags.Parser {
 		printVersions()
 		panic(&exitStatus{0})
 	}
-	parser := flags.NewParser(&optionsData, flags.HelpFlag|flags.PassDoubleDash|flags.PassAfterNonOption)
+	parser := flags.NewParser(&optionsData, flags.PassDoubleDash|flags.PassAfterNonOption)
 	parser.ShortDescription = i18n.G("Tool to interact with snaps")
 	parser.LongDescription = i18n.G(`
 Install, configure, refresh and remove snap packages. Snaps are
@@ -174,9 +174,15 @@ enabling secure distribution of the latest apps and utilities for
 cloud, servers, desktops and the internet of things.
 
 This is the CLI for snapd, a background service that takes care of
-snaps on the system. Start with 'snap list' to see installed snaps.
-`)
-	parser.FindOptionByLongName("version").Description = i18n.G("Print the version and exit")
+snaps on the system. Start with 'snap list' to see installed snaps.`)
+	// hide the unhelpful "[OPTIONS]" from help output
+	parser.Usage = ""
+	if version := parser.FindOptionByLongName("version"); version != nil {
+		version.Description = i18n.G("Print the version and exit")
+		version.Hidden = true
+	}
+	// add --help like what go-flags would do for us, but hidden
+	addHelp(parser)
 
 	// Add all regular commands
 	for _, c := range commands {
@@ -358,7 +364,7 @@ func run() error {
 				return nil
 			}
 			if e.Type == flags.ErrUnknownCommand {
-				return fmt.Errorf(i18n.G(`unknown command %q, see "snap --help"`), os.Args[1])
+				return fmt.Errorf(i18n.G(`unknown command %q, see "snap help"`), os.Args[1])
 			}
 		}
 

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -201,11 +201,8 @@ snaps on the system. Start with 'snap list' to see installed snaps.`)
 		}
 
 		opts := cmd.Options()
-		for _, grp := range cmd.Groups() {
-			opts = append(opts, grp.Options()...)
-		}
 		if c.optDescs != nil && len(opts) != len(c.optDescs) {
-			logger.Noticef("wrong number of option descriptions for %s: expected %d, got %d", c.name, len(opts), len(c.optDescs))
+			logger.Panicf("wrong number of option descriptions for %s: expected %d, got %d", c.name, len(opts), len(c.optDescs))
 		}
 		for _, opt := range opts {
 			name := opt.LongName

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -201,8 +201,11 @@ snaps on the system. Start with 'snap list' to see installed snaps.`)
 		}
 
 		opts := cmd.Options()
+		for _, grp := range cmd.Groups() {
+			opts = append(opts, grp.Options()...)
+		}
 		if c.optDescs != nil && len(opts) != len(c.optDescs) {
-			logger.Panicf("wrong number of option descriptions for %s: expected %d, got %d", c.name, len(opts), len(c.optDescs))
+			logger.Noticef("wrong number of option descriptions for %s: expected %d, got %d", c.name, len(opts), len(c.optDescs))
 		}
 		for _, opt := range opts {
 			name := opt.LongName
@@ -364,7 +367,7 @@ func run() error {
 				return nil
 			}
 			if e.Type == flags.ErrUnknownCommand {
-				return fmt.Errorf(i18n.G(`unknown command %q, see "snap help"`), os.Args[1])
+				return fmt.Errorf(i18n.G(`unknown command %q, see 'snap help'`), os.Args[1])
 			}
 		}
 

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -243,7 +243,7 @@ func (s *SnapSuite) TestUnknownCommand(c *C) {
 	defer restore()
 
 	err := snap.RunMain()
-	c.Assert(err, ErrorMatches, `unknown command "unknowncmd", see "snap --help"`)
+	c.Assert(err, ErrorMatches, `unknown command "unknowncmd", see "snap help"`)
 }
 
 func (s *SnapSuite) TestResolveApp(c *C) {

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -243,7 +243,7 @@ func (s *SnapSuite) TestUnknownCommand(c *C) {
 	defer restore()
 
 	err := snap.RunMain()
-	c.Assert(err, ErrorMatches, `unknown command "unknowncmd", see "snap help"`)
+	c.Assert(err, ErrorMatches, `unknown command "unknowncmd", see 'snap help'`)
 }
 
 func (s *SnapSuite) TestResolveApp(c *C) {

--- a/tests/main/completion/toplevel.exp
+++ b/tests/main/completion/toplevel.exp
@@ -1,11 +1,5 @@
 source lib.exp0
 
-# --help completes
-chat "snap --h\t" "snap --help $" true
-# but no more
-chat "\t\t" "snap --help $"
-cancel
-
 # commands complete
 rechat "snap in\t\t" "\[\n ]info\[\r ]" true
 rechat "" "\[\n ]install\[\r ]" true

--- a/tests/main/completion/toplevel.exp
+++ b/tests/main/completion/toplevel.exp
@@ -6,12 +6,6 @@ chat "snap --h\t" "snap --help $" true
 chat "\t\t" "snap --help $"
 cancel
 
-# --version completes
-chat "snap --v\t" "snap --version $" true
-# but no more
-chat "\t\t" "snap --version $"
-cancel
-
 # commands complete
 rechat "snap in\t\t" "\[\n ]info\[\r ]" true
 rechat "" "\[\n ]install\[\r ]" true

--- a/tests/main/help/task.yaml
+++ b/tests/main/help/task.yaml
@@ -1,13 +1,22 @@
 summary: Check commands help
 systems: [+fedora-*]
-environment:
-    CMD/abort: abort
-    CMD/changes: changes
-    CMD/find: find
-    CMD/install: install
-    CMD/interfaces: interfaces
-    CMD/remove: remove
 execute: |
-    echo "Checking help for command $CMD"
-    expected="(?s)Usage:\n  snap \[OPTIONS\] $CMD.*?\n\nThe $CMD command .*?\nHelp Options:\n  -h, --help +Show this help message\n.*?"
-    snap $CMD --help | grep -Pzq "$expected"
+    bad=""
+    for CMD in $( GO_FLAGS_COMPLETION=1 snap | grep -vFx help ); do
+        printf "Checking help for command %-16s" "'$CMD':"
+        expected="Usage:\n\\s+snap $CMD\\b.*\n\nThe $CMD command (?s).*\.\n"
+        actual="$( snap $CMD --help )"
+        if ! grep -Pzq "$expected" <<<"$actual"; then
+            bad=1
+            echo
+            echo "The output of 'snap $CMD --help' does not match the regular expression"
+            echo "'$expected':"
+            echo
+            echo "----------------"
+            echo "$actual"
+            echo "----------------"
+        else
+            echo " Ok."
+        fi
+    done
+    test ! "$bad"


### PR DESCRIPTION
* make every short help be imperative

* make every long help be indicative and start with 'The foo command',
  including hidden or internal ones as a user can still stumble upon
  these (but not including debug commands).

* hide the --version and --help options all over the place (make
  manpage better)

* make the help spread test test every command
