### PR TITLE
osutil: DropPrivs morphs an *exec.Cmd to drop privileges

### DIFF
--- a/osutil/export_test.go
+++ b/osutil/export_test.go
@@ -145,3 +145,17 @@ func MockEtcFstab(text string) (restore func()) {
 		etcFstab = old
 	}
 }
+
+func MockSysGetuid(uid sys.UserID) func() {
+	real := sysGetuid
+	sysGetuid = func() sys.UserID { return uid }
+
+	return func() { sysGetuid = real }
+}
+
+func MockSysChownPath(mock func(string, sys.UserID, sys.GroupID) error) func() {
+	real := sysChownPath
+	sysChownPath = mock
+
+	return func() { sysChownPath = real }
+}

--- a/osutil/mockable.go
+++ b/osutil/mockable.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"os/user"
 	"syscall"
+
+	"github.com/snapcore/snapd/osutil/sys"
 )
 
 const (
@@ -36,6 +38,8 @@ var (
 
 	osReadlink = os.Readlink
 
+	sysGetuid      = sys.Getuid
+	sysChownPath   = sys.ChownPath
 	syscallKill    = syscall.Kill
 	syscallGetpgid = syscall.Getpgid
 

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -669,6 +669,10 @@ popd
 %endif
 
 %post
+getent group snappypkg >/dev/null || groupadd -r snappypkg
+getent passwd snappypkg >/dev/null || \
+    useradd -r -g snappypkg -d /nonexistent -s /sbin/nologin \
+    -c "Unprivileged account for insecure snap inspection" snappypkg
 %systemd_post %{snappy_svcs}
 # If install, test if snapd socket and timer are enabled.
 # If enabled, then attempt to start them. This will silently fail

--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -242,6 +242,10 @@ mv %{buildroot}%{_libexecdir}/snapd/snapd-generator %{buildroot}/lib/systemd/sys
 %service_add_pre %{systemd_services_list}
 
 %post
+getent group snappypkg >/dev/null || groupadd -r snappypkg
+getent passwd snappypkg >/dev/null || \
+    useradd -r -g snappypkg -d /nonexistent -s /sbin/nologin \
+    -c "Unprivileged account for insecure snap inspection" snappypkg
 %set_permissions %{_libexecdir}/snapd/snap-confine
 %service_add_post %{systemd_services_list}
 case ":$PATH:" in

--- a/packaging/ubuntu-14.04/snapd.postinst
+++ b/packaging/ubuntu-14.04/snapd.postinst
@@ -11,6 +11,12 @@ case "$1" in
         if dpkg --compare-versions "$2" lt-nl "2.0.7"; then
             ldconfig
         fi
+        adduser --system \
+            --disabled-password \
+            --home /nonexistent \
+            --no-create-home \
+            --group \
+            snappypkg
         # start required services
         if [ -d /run/systemd/system ]; then
             systemctl daemon-reload

--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -11,4 +11,10 @@ case "$1" in
         if dpkg --compare-versions "$2" lt-nl "2.0.7"; then
             ldconfig
         fi
+        adduser --system \
+            --disabled-password \
+            --home /nonexistent \
+            --no-create-home \
+            --group \
+            snappypkg
 esac


### PR DESCRIPTION
This is not our old friend “drop privileges in Go using Setuid”; this is its
humbler sibling, “drop privileges using sudo when running a command”.

Just in case that's too cryptic, this PR also uses `osutil.DropPrivs` to drop
privileges in `snap/squashfs`, so you can see it in action.

The immediate driver for this is that dropping to an unprivileged user
before running unsquashfs to e.g. read the snap.yaml will let us
postpone hashing the file without worrying about that attack vector.

It resurrects the user "snappypkg" for this. It's not a very nice name, but
has the advantage of already existing in core.

~~This'll need tweaks to all the packaging flavours.~~ Patches welcome...
