### PR TITLE
 tests/main/media-sharing: improve the test to cover /media and /run/media

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -441,7 +441,7 @@ autoreconf --force --install --verbose
     --enable-nvidia-biarch \
     %{?with_multilib:--with-32bit-libdir=%{_prefix}/lib} \
     --with-snap-mount-dir=%{_sharedstatedir}/snapd/snap \
-    --with-merged-usr
+    --enable-merged-usr
 
 %make_build
 popd

--- a/tests/lib/dirs.sh
+++ b/tests/lib/dirs.sh
@@ -2,11 +2,13 @@
 
 export SNAP_MOUNT_DIR=/snap
 export LIBEXECDIR=/usr/lib
+export MEDIA_DIR=/media
 
 case "$SPREAD_SYSTEM" in
     fedora-*)
         export SNAP_MOUNT_DIR=/var/lib/snapd/snap
         export LIBEXECDIR=/usr/libexec
+        export MEDIA_DIR=/run/media
         ;;
     *)
         ;;

--- a/tests/main/media-sharing/task.yaml
+++ b/tests/main/media-sharing/task.yaml
@@ -1,21 +1,25 @@
-summary: The /media directory propagates events outwards
+summary: The media directory propagates events outwards
 details: |
     The /media directory is special in that mount events propagate outward from
-    the mount namespace used by snap applications into the main mount
-    namespace.
+    the mount namespace used by snap applications into the main mount namespace.
+    Fedora and other systems that build udisks without --enable-fsh-media flag
+    use /run/media path instead.
 prepare: |
     . $TESTSLIB/snaps.sh
+    . $TESTSLIB/dirs.sh
     install_local_devmode test-snapd-tools
-    mkdir -p /media/src
-    mkdir -p /media/dst
-    touch /media/src/canary
+    mkdir -p ${MEDIA_DIR}/src
+    mkdir -p ${MEDIA_DIR}/dst
+    touch ${MEDIA_DIR}/src/canary
 execute: |
-    test ! -e /media/dst/canary
-    test-snapd-tools.cmd mount --bind /media/src /media/dst
-    test -e /media/dst/canary
+    . $TESTSLIB/dirs.sh
+    test ! -e ${MEDIA_DIR}/dst/canary
+    test-snapd-tools.cmd mount --bind ${MEDIA_DIR}/src ${MEDIA_DIR}/dst
+    test -e ${MEDIA_DIR}/dst/canary
 restore: |
+    . $TESTSLIB/dirs.sh
     # If this doesn't work maybe it is because the test didn't execute correctly
-    umount /media/dst || true
-    rm -f /media/src/canary
-    rmdir /media/src
-    rmdir /media/dst
+    umount ${MEDIA_DIR}/dst || true
+    rm -f ${MEDIA_DIR}/src/canary
+    rmdir ${MEDIA_DIR}/src
+    rmdir ${MEDIA_DIR}/dst

--- a/tests/main/media-sharing/task.yaml
+++ b/tests/main/media-sharing/task.yaml
@@ -2,7 +2,7 @@ summary: The media directory propagates events outwards
 details: |
     The /media directory is special in that mount events propagate outward from
     the mount namespace used by snap applications into the main mount namespace.
-    Fedora and other systems that build udisks without --enable-fsh-media flag
+    Fedora and other systems that build udisks without --enable-fhs-media flag
     use /run/media path instead.
 prepare: |
     . $TESTSLIB/snaps.sh


### PR DESCRIPTION
#4788 has builds a Fedora package with 'merged usr' enabled, and has uncovered an issue in media-sharing test where a hardcoded `/media` path was used. Attempt to fix it by selecting the media directory path that is appropriate for given system.

@Conan-Kudo ping