### PR TITLE
interfaces/serial: change pattern not to exclude /dev/ttymxc*

### DIFF
--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -69,7 +69,8 @@ func (iface *serialPortInterface) String() string {
 //  - ttyXRUSBx  (Exar Corp. USB UART devices)
 //  - ttySX (UART serial ports)
 //  - ttyOX (UART serial ports on ARM)
-var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(USB|ACM|AMA|XRUSB|S|O)[0-9]+$")
+//  - ttymxcX (serial ports on i.mx6UL)
+var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(mxc|USB|ACM|AMA|XRUSB|S|O)[0-9]+$")
 
 // Pattern that is considered valid for the udev symlink to the serial device,
 // path attributes will be compared to this for validity when usb vid and pid


### PR DESCRIPTION
The currently available regexp that is using for telling if the serial
port node name is allowed is too tight. We have found a number of cases
where itdisallowed a valid serial device like for example /dev/ttymxc3
on i.MX6UL based devices.

This commit changes the mask to basically allow everything that starts
with tty and ends with a number.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
