### PR TITLE
tests: define MATCH from spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -347,6 +347,9 @@ prepare: |
         rmdir "$DELTA_PREFIX"
     fi
 
+    # Take the MATCH function from spread and allow our shell scripts to use it.
+    type MATCH | tail -n +2 > $TESTSLIB/spread-funcs.sh
+
     # NOTE: At this stage the source tree is available and no more special
     # considerations apply.
     "$TESTSLIB"/prepare-restore.sh --prepare-project

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -25,6 +25,9 @@ set -o pipefail
 # shellcheck source=tests/lib/random.sh
 . "$TESTSLIB/random.sh"
 
+# shellcheck source=tests/lib/spread-funcs.sh
+. "$TESTSLIB/spread-funcs.sh"
+
 ###
 ### Utility functions reused below.
 ###

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -10,6 +10,8 @@ set -eux
 . "$TESTSLIB/pkgdb.sh"
 # shellcheck source=tests/lib/boot.sh
 . "$TESTSLIB/boot.sh"
+# shellcheck source=tests/lib/spread-funcs.sh
+. "$TESTSLIB/spread-funcs.sh"
 
 disable_kernel_rate_limiting() {
     # kernel rate limiting hinders debugging security policy so turn it off

--- a/tests/lib/spread-funcs.sh
+++ b/tests/lib/spread-funcs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Define MATCH when invoked outside of spread context.
+#
+# The MATCH function is like a super version of grep that prints the input when
+# no match was found. It is used throughout snapd tests. This file is overwritten
+# on project prepare but the function exists for reference and for aid to shellcheck.
+MATCH() {
+	{
+		set +xu
+	} 2> /dev/null
+	[ ${#0} -gt 0 ] || {
+		echo "error: missing regexp argument"
+		return 1
+	}
+	local stdin
+	stdin="$(cat)"
+	echo "$stdin" | grep -q -E "$@" || {
+		echo "error: pattern not found, got
+$stdin" 1>&2
+		return 1
+	}
+}
+

--- a/tests/lib/spread-funcs.sh
+++ b/tests/lib/spread-funcs.sh
@@ -1,24 +1,10 @@
 #!/bin/bash
 
-# Define MATCH when invoked outside of spread context.
+# Define a dummy MATCH function. This file is replaced by the real MATCH
+# function, as defined by spread, on project prepare (in spread.yaml).
 #
-# The MATCH function is like a super version of grep that prints the input when
-# no match was found. It is used throughout snapd tests. This file is overwritten
-# on project prepare but the function exists for reference and for aid to shellcheck.
 MATCH() {
-	{
-		set +xu
-	} 2> /dev/null
-	[ ${#0} -gt 0 ] || {
-		echo "error: missing regexp argument"
-		return 1
-	}
-	local stdin
-	stdin="$(cat)"
-	echo "$stdin" | grep -q -E "$@" || {
-		echo "error: pattern not found, got
-$stdin" 1>&2
-		return 1
-	}
+	echo "dummy MATCH function invoked"
+	false
 }
 


### PR DESCRIPTION
This patch teaches the test suite how to use MATCH in scripts that don't
get sourced from spread.yaml (instead of being executed as regular
programs). This makes it easier to refactor the code and use shellcheck
to look for mistakes.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
