### PR TITLE
tests: fix re-exec profile generation in tests on classic

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -97,11 +97,14 @@ update_core_snap_for_classic_reexec() {
 
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)
+            # remove any generated files and force system key re-generate
+            rm -f /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine*
+            rm -f /var/lib/snapd/system-key
             # and snap-confine's apparmor
             if [ -e /etc/apparmor.d/usr.lib.snapd.snap-confine.real ]; then
                 cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine.real squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine.real
             else
-                cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine      squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine.real
+                cp -a /etc/apparmor.d/usr.lib.snapd.snap-confine squashfs-root/etc/apparmor.d/usr.lib.snapd.snap-confine.real
             fi
             ;;
     esac


### PR DESCRIPTION
When we run tests on a classic system we re-pack the core snap. We
also need to ensure that any already generated apparmor.d profiles
for the snap-confine from core get deleted and re-generated or we
run with a stale snap-confine profile.

This is needed to make profile releated tests more reliable. It is not enough but a first step.