### PR TITLE
wrappers: services which are socket or timer activated should not be started during boot

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -235,8 +235,11 @@ func AddSnapServices(s *snap.Info, inter interacter) (err error) {
 				return err
 			}
 			written = append(written, path)
-			// service is activated via timers only and not during
-			// the boot
+		}
+
+		if app.Timer != nil || len(app.Sockets) != 0 {
+			// service is socket or timer activated, not during the
+			// boot
 			continue
 		}
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -889,3 +889,48 @@ apps:
 		c.Check(reloads >= 1, Equals, true, Commentf("test-case %v did not reload services as expected", i))
 	}
 }
+
+func (s *servicesTestSuite) TestSnapServicesActivation(c *C) {
+	const snapYaml = `name: hello-snap
+version: 1.10
+summary: hello
+description: Hello...
+apps:
+ svc1:
+  command: bin/hello
+  daemon: simple
+  plugs: [network-bind]
+  sockets:
+    sock1:
+      listen-stream: $SNAP_COMMON/sock1.socket
+      socket-mode: 0666
+ svc2:
+  command: bin/hello
+  daemon: oneshot
+  timer: 10:00-12:00
+ svc3:
+  command: bin/hello
+  daemon: simple
+`
+
+	var sysdLog [][]string
+	r := systemd.MockSystemctl(func(cmd ...string) ([]byte, error) {
+		sysdLog = append(sysdLog, cmd)
+		return []byte("ActiveState=inactive\n"), nil
+	})
+	defer r()
+
+	svc3Name := "snap.hello-snap.svc3.service"
+
+	info := snaptest.MockSnap(c, snapYaml, &snap.SideInfo{Revision: snap.R(12)})
+
+	// fix the apps order to make the test stable
+	err := wrappers.AddSnapServices(info, nil)
+	c.Assert(err, IsNil)
+	c.Assert(sysdLog, HasLen, 2, Commentf("len: %v calls: %v", len(sysdLog), sysdLog))
+	c.Check(sysdLog, DeepEquals, [][]string{
+		// only svc3 gets started during boot
+		{"--root", dirs.GlobalRootDir, "enable", svc3Name},
+		{"daemon-reload"},
+	}, Commentf("calls: %v", sysdLog))
+}


### PR DESCRIPTION
Fix socket activated service handling by not enabling them, so that they
start as a result of the actual event rather than at boot time.