### PR TITLE
many: generate and use per-snap snap-update-ns profile (2.32)

### DIFF
--- a/cmd/snap-confine/mount-support.h
+++ b/cmd/snap-confine/mount-support.h
@@ -18,6 +18,8 @@
 #ifndef SNAP_MOUNT_SUPPORT_H
 #define SNAP_MOUNT_SUPPORT_H
 
+#include "apparmor-support.h"
+
 /**
  * Return a file descriptor referencing the snap-update-ns utility
  *
@@ -40,13 +42,13 @@ int sc_open_snap_update_ns(void);
  * The function will also try to preserve the current working directory but if
  * this is impossible it will chdir to SC_VOID_DIR.
  **/
-void sc_populate_mount_ns(int snap_update_ns_fd, const char *base_snap_name,
-			  const char *snap_name);
+void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
+			  const char *base_snap_name, const char *snap_name);
 
 /**
- * Ensure that / or /snap is mounted with the SHARED option. 
+ * Ensure that / or /snap is mounted with the SHARED option.
  *
- * If the system is found to be not having a shared mount for "/" 
+ * If the system is found to be not having a shared mount for "/"
  * snap-confine will create a shared bind mount for "/snap" to
  * ensure that "/snap" is mounted shared. See LP:#1668659
  */

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -436,26 +436,29 @@
     # Allow snap-confine to be killed
     signal (receive) peer=unconfined,
 
+    # Allow switching to snap-update-ns with a per-snap profile.
+    change_profile -> snap-update-ns.*,
+
     # Allow executing snap-update-ns when...
 
     # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the distribution package. This is also the location used when using
     # the core/base snap on all-snap systems. The variants here represent
     # various locations of libexecdir across distributions.
-    /usr/lib{,exec,64}/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /usr/lib{,exec,64}/snapd/snap-update-ns r,
 
     # ...snap-confine is not, conceptually, re-executing and uses
     # snap-update-ns from the distribution package but we are already inside
     # the constructed mount namespace so we must traverse "hostfs". The
     # variants here represent various locations of libexecdir across
     # distributions.
-    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns r,
 
     # ..snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap. Note that the location of the core snap varies from
     # distribution to distribution. The variants here represent different
     # locations of snap mount directory across distributions.
-    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
 
     # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap but we are already inside the constructed mount
@@ -464,145 +467,5 @@
     # "natural" /snap mount entry but we have no control over that.  This is
     # reported as (LP: #1716339). The variants here represent different
     # locations of snap mount directory across distributions.
-    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns Cxr -> snap_update_ns,
-
-    profile snap_update_ns (attach_disconnected) {
-        # The next four rules mirror those above. We want to be able to read
-        # and map snap-update-ns into memory but it may come from a variety of places.
-        /usr/lib{,exec,64}/snapd/snap-update-ns mr,
-        /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns mr,
-        /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
-        /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
-
-        # Allow reading the dynamic linker cache.
-        /etc/ld.so.cache r,
-        # Allow reading, mapping and executing the dynamic linker.
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}ld-*.so mrix,
-        # Allow reading and mapping various parts of the standard library and
-        # dynamically loaded nss modules and what not.
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libc{,-[0-9]*}.so* mr,
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpthread{,-[0-9]*}.so* mr,
-
-        # Allow reading the command line (snap-update-ns uses it in pre-Go bootstrap code).
-        @{PROC}/@{pid}/cmdline r,
-
-        # Allow reading the os-release file (possibly a symlink to /usr/lib).
-        /{etc/,usr/lib/}os-release r,
-
-        # Allow creating/grabbing various snapd lock files.
-        /run/snapd/lock/*.lock rwk,
-
-        # Allow reading stored mount namespaces,
-        /run/snapd/ns/ r,
-        /run/snapd/ns/*.mnt r,
-
-        # Allow reading per-snap desired mount profiles. Those are written by
-        # snapd and represent the desired layout and content connections.
-        /var/lib/snapd/mount/snap.*.fstab r,
-
-        # Allow reading and writing actual per-snap mount profiles. Note that
-        # the second rule is generic to allow our tmpfile-rename approach to
-        # writing them. Those are written by snap-update-ns and represent the
-        # actual layout at a given moment.
-        /run/snapd/ns/*.fstab rw,
-        /run/snapd/ns/*.fstab.* rw,
-
-        # NOTE: at this stage the /snap directory is stable as we have called
-        # pivot_root already.
-
-        # Needed to perform mount/unmounts.
-        capability sys_admin,
-        # Needed for mimic construction.
-        capability chown,
-
-        # Allow freezing and thawing the per-snap cgroup freezers
-        /sys/fs/cgroup/freezer/snap.*/freezer.state rw,
-
-        # Support mount profiles via the content interface. This should correspond
-        # to permutations of $SNAP -> $SNAP for reading and $SNAP_{DATA,COMMON} ->
-        # $SNAP_{DATA,COMMON} for both reading and writing.
-        #
-        # Note that:
-        #   /snap/*/*/**
-        # is meant to mean:
-        #   /snap/$SNAP_NAME/$SNAP_REVISION/and-any-subdirectory
-        # but:
-        #   /var/snap/*/**
-        # is meant to mean:
-        #   /var/snap/$SNAP_NAME/$SNAP_REVISION/
-        mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
-        mount options=(ro bind) /snap/*/** -> /var/snap/*/**,
-        mount options=(rw bind) /var/snap/*/** -> /var/snap/*/**,
-        mount options=(ro bind) /var/snap/*/** -> /var/snap/*/**,
-
-        # Allow creating missing mount directories under $SNAP_DATA.
-        #
-        # The "tree" of permissions is needed for SecureMkdirAll that uses
-        # open(..., O_NOFOLLOW) and mkdirat() using the resulting file
-        # descriptor.
-        / r,
-        /var/ r,
-        /var/snap/{,*/} r,
-        /var/snap/*/**/ rw,
-
-        # Allow creating placeholder directory in /tmp/.snap/ as support for
-        # the writable mimic code that can poke holes in arbitrary read-only
-        # places using tmpfs and bind mounts.
-        /tmp/ r,
-        /tmp/.snap/{,**} rw,
-        # Allow mounting/unmounting any part of $SNAP over to a temporary place
-        # in /tmp/.snap/ during the preparation of a writable mimic.
-        # FIXME: update this with per-snap snap-update-ns profiles
-        mount options=(bind, rw) /** -> /tmp/.snap/**,
-        mount options=(rbind, rw) /** -> /tmp/.snap/**,
-        # Allow mounting tmpfs over the original read-only directory.
-        # FIXME: update this with per-snap snap-update-ns profiles
-        mount fstype=tmpfs options=(rw) tmpfs -> /**,
-        # Allow bind mounting anything from the temporary place in /tmp/.snap/
-        # back to $SNAP/** (to re-construct the data that was there before).
-        # FIXME: update this with per-snap snap-update-ns profiles
-        mount options=(bind, rw) /tmp/.snap/** -> /**,
-        mount options=(rbind, rw) /tmp/.snap/** -> /**,
-        # Allow unmounting the temporary directory in /tmp once it is no longer
-        # necessary.
-        umount /tmp/.snap/**,
-        # Allow unmounting any of the above in case something fails and
-        # we start recovery.
-        umount /**,
-
-        # Allow creating missing directories anywhere under the root directory
-        # (but not in the root directory itself) where they need to be created
-        # as a mount point for layouts or for content sharing. This is a
-        # superset of other cases so they are removed
-        # FIXME: update this with per-snap snap-update-ns profiles
-        / r,
-        /** r,
-        /*/** w,
-
-        # Allow layouts to bind mount *from* $SNAP, $SNAP_DATA and $SNAP_COMMON
-        # *to* anywhere under the root directory. This is safe because the
-        # mounts happen inside an isolated mount namespace (but see below).
-        mount options=(bind) /snap/*/** -> /*/**,
-        mount options=(bind) /var/snap/*/** -> /*/**,
-        # As an exception, don't allow bind mounts to /media which has special
-        # sharing and propagates mount events outside of the snap namespace.
-        audit deny mount -> /media,
-
-        # Allow the content interface to bind fonts from the host filesystem
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
-        # Allow the desktop interface to bind fonts from the host filesystem
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /usr/share/fonts/,
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/local/share/fonts/ -> /usr/local/share/fonts/,
-        mount options=(ro bind) /var/lib/snapd/hostfs/var/cache/fontconfig/ -> /var/cache/fontconfig/,
-
-        # Allow unmounts matching possible mounts listed above.
-        umount /*/**,
-
-        # But we don't want anyone to touch /snap/bin
-        audit deny mount /snap/bin/** -> /**,
-        audit deny mount /** -> /snap/bin/**,
-
-        # Allow the content interface to bind fonts from the host filesystem
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
-    }
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
 }

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -244,7 +244,8 @@ int main(int argc, char **argv)
 				}
 			}
 			if (sc_should_populate_ns_group(group)) {
-				sc_populate_mount_ns(snap_update_ns_fd,
+				sc_populate_mount_ns(&apparmor,
+						     snap_update_ns_fd,
 						     base_snap_name, snap_name);
 				sc_preserve_populated_ns_group(group);
 			}

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -301,12 +301,13 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapName, err)
 	}
 	dir := dirs.SnapAppArmorDir
-	glob := interfaces.SecurityTagGlob(snapInfo.Name())
+	glob1 := fmt.Sprintf("snap*.%s*", snapInfo.Name())
+	glob2 := fmt.Sprintf("snap-update-ns.%s", snapInfo.Name())
 	cache := dirs.AppArmorCacheDir
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("cannot create directory for apparmor profiles %q: %s", dir, err)
 	}
-	_, removed, errEnsure := osutil.EnsureDirState(dir, glob, content)
+	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dir, []string{glob1, glob2}, content)
 	// NOTE: load all profiles instead of just the changed profiles.  We're
 	// relying on apparmor cache to make this efficient. This gives us
 	// certainty that each call to Setup ends up with working profiles.
@@ -329,9 +330,10 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 // Remove removes and unloads apparmor profiles of a given snap.
 func (b *Backend) Remove(snapName string) error {
 	dir := dirs.SnapAppArmorDir
-	glob := fmt.Sprintf("snap*.%s*", snapName)
+	glob1 := fmt.Sprintf("snap*.%s*", snapName)
+	glob2 := fmt.Sprintf("snap-update-ns.%s", snapName)
 	cache := dirs.AppArmorCacheDir
-	_, removed, errEnsure := osutil.EnsureDirState(dir, glob, nil)
+	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dir, []string{glob1, glob2}, nil)
 	errUnload := unloadProfiles(removed, cache)
 	if errEnsure != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, errEnsure)
@@ -340,30 +342,59 @@ func (b *Backend) Remove(snapName string) error {
 }
 
 var (
-	templatePattern = regexp.MustCompile("(###[A-Z]+###)")
+	templatePattern = regexp.MustCompile("(###[A-Z_]+###)")
 	attachPattern   = regexp.MustCompile(`\(attach_disconnected\)`)
 )
 
 const attachComplain = "(attach_disconnected,complain)"
 
 func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts interfaces.ConfinementOptions) (content map[string]*osutil.FileState, err error) {
+	content = make(map[string]*osutil.FileState, len(snapInfo.Apps)+len(snapInfo.Hooks)+1)
+
+	// Add profile for each app.
 	for _, appInfo := range snapInfo.Apps {
-		if content == nil {
-			content = make(map[string]*osutil.FileState)
-		}
 		securityTag := appInfo.SecurityTag()
 		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content)
 	}
-
+	// Add profile for each hook.
 	for _, hookInfo := range snapInfo.Hooks {
-		if content == nil {
-			content = make(map[string]*osutil.FileState)
-		}
 		securityTag := hookInfo.SecurityTag()
 		addContent(securityTag, snapInfo, opts, spec.SnippetForTag(securityTag), content)
 	}
+	// Add profile for snap-update-ns if we have any apps or hooks.
+	// If we have neither then we don't have any need to create an executing environment.
+	// This applies to, for example, kernel snaps or gadget snaps (unless they have hooks).
+	if len(content) > 0 {
+		snippets := strings.Join(spec.UpdateNS()[snapInfo.Name()], "\n")
+		addUpdateNSProfile(snapInfo, opts, snippets, content)
+	}
 
 	return content, nil
+}
+
+// addUpdateNSProfile adds an apparmor profile for snap-update-ns, tailored to a specific snap.
+//
+// This profile exists so that snap-update-ns doens't need to carry very wide, open permissions
+// that are suitable for poking holes (and writing) in nearly arbitrary places. Instead the profile
+// contains just the permissions needed to poke a hole and write to the layout-specific paths.
+func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippets string, content map[string]*osutil.FileState) {
+	// Compute the template by injecting special updateNS snippets.
+	policy := templatePattern.ReplaceAllStringFunc(updateNSTemplate, func(placeholder string) string {
+		switch placeholder {
+		case "###SNAP_NAME###":
+			return snapInfo.Name()
+		case "###SNIPPETS###":
+			return snippets
+		}
+		return ""
+	})
+
+	// Ensure that the snap-update-ns profile is on disk.
+	profileName := fmt.Sprintf("snap-update-ns.%s", snapInfo.Name())
+	content[profileName] = &osutil.FileState{
+		Content: []byte(policy),
+		Mode:    0644,
+	}
 }
 
 func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState) {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -116,12 +116,14 @@ func (s *backendSuite) TestName(c *C) {
 
 func (s *backendSuite) TestInstallingSnapWritesAndLoadsProfiles(c *C) {
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, ifacetest.SambaYamlV1, 1)
+	updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
 	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 	// file called "snap.sambda.smbd" was created
 	_, err := os.Stat(profile)
 	c.Check(err, IsNil)
 	// apparmor_parser was used to load that file
 	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
 		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", profile},
 	})
 }
@@ -129,14 +131,56 @@ func (s *backendSuite) TestInstallingSnapWritesAndLoadsProfiles(c *C) {
 func (s *backendSuite) TestInstallingSnapWithHookWritesAndLoadsProfiles(c *C) {
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, ifacetest.HookYaml, 1)
 	profile := filepath.Join(dirs.SnapAppArmorDir, "snap.foo.hook.configure")
+	updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.foo")
 
 	// Verify that profile "snap.foo.hook.configure" was created
 	_, err := os.Stat(profile)
 	c.Check(err, IsNil)
 	// apparmor_parser was used to load that file
 	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
 		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", profile},
 	})
+}
+
+const layoutYaml = `name: myapp
+version: 1
+apps:
+  myapp:
+    command: myapp
+layout:
+  /usr/share/myapp:
+    bind: $SNAP/usr/share/myapp
+`
+
+func (s *backendSuite) TestInstallingSnapWithLayoutWritesAndLoadsProfiles(c *C) {
+	s.InstallSnap(c, interfaces.ConfinementOptions{}, layoutYaml, 1)
+	appProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.myapp.myapp")
+	updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.myapp")
+	// both profiles were created
+	_, err := os.Stat(appProfile)
+	c.Check(err, IsNil)
+	_, err = os.Stat(updateNSProfile)
+	c.Check(err, IsNil)
+	// TODO: check for layout snippets inside the generated file once we have some snippets to check for.
+	// apparmor_parser was used to load them
+	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
+		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", appProfile},
+	})
+}
+
+const gadgetYaml = `name: mydevice
+type: gadget
+version: 1
+`
+
+func (s *backendSuite) TestInstallingSnapWithoutAppsOrHooksDoesntAddProfiles(c *C) {
+	// Installing a snap that doesn't have either hooks or apps doesn't generate
+	// any apparmor profiles because there is no executable content that would need
+	// an execution environment and the corresponding mount namespace.
+	s.InstallSnap(c, interfaces.ConfinementOptions{}, gadgetYaml, 1)
+	c.Check(s.parserCmd.Calls(), HasLen, 0)
 }
 
 func (s *backendSuite) TestProfilesAreAlwaysLoaded(c *C) {
@@ -145,8 +189,10 @@ func (s *backendSuite) TestProfilesAreAlwaysLoaded(c *C) {
 		s.parserCmd.ForgetCalls()
 		err := s.Backend.Setup(snapInfo, opts, s.Repo)
 		c.Assert(err, IsNil)
+		updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
 		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", profile},
 		})
 		s.RemoveSnap(c, snapInfo)
@@ -168,6 +214,7 @@ func (s *backendSuite) TestRemovingSnapRemovesAndUnloadsProfiles(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor_parser was used to unload the profile
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+			{"apparmor_parser", "--remove", "snap-update-ns.samba"},
 			{"apparmor_parser", "--remove", "snap.samba.smbd"},
 		})
 	}
@@ -188,6 +235,7 @@ func (s *backendSuite) TestRemovingSnapWithHookRemovesAndUnloadsProfiles(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor_parser was used to unload the profile
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+			{"apparmor_parser", "--remove", "snap-update-ns.foo"},
 			{"apparmor_parser", "--remove", "snap.foo.hook.configure"},
 		})
 	}
@@ -198,10 +246,12 @@ func (s *backendSuite) TestUpdatingSnapMakesNeccesaryChanges(c *C) {
 		snapInfo := s.InstallSnap(c, opts, ifacetest.SambaYamlV1, 1)
 		s.parserCmd.ForgetCalls()
 		snapInfo = s.UpdateSnap(c, snapInfo, opts, ifacetest.SambaYamlV1, 2)
+		updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
 		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 		// apparmor_parser was used to reload the profile because snap revision
 		// is inside the generated policy.
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", profile},
 		})
 		s.RemoveSnap(c, snapInfo)
@@ -214,6 +264,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 		s.parserCmd.ForgetCalls()
 		// NOTE: the revision is kept the same to just test on the new application being added
 		snapInfo = s.UpdateSnap(c, snapInfo, opts, ifacetest.SambaYamlV1WithNmbd, 1)
+		updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
 		smbdProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 		nmbdProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.nmbd")
 		// file called "snap.sambda.nmbd" was created
@@ -221,6 +272,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 		c.Check(err, IsNil)
 		// apparmor_parser was used to load the both profiles
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", nmbdProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", smbdProfile},
 		})
@@ -234,6 +286,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreHooks(c *C) {
 		s.parserCmd.ForgetCalls()
 		// NOTE: the revision is kept the same to just test on the new application being added
 		snapInfo = s.UpdateSnap(c, snapInfo, opts, ifacetest.SambaYamlWithHook, 1)
+		updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
 		smbdProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 		nmbdProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.nmbd")
 		hookProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.hook.configure")
@@ -241,8 +294,9 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreHooks(c *C) {
 		// Verify that profile "snap.samba.hook.configure" was created
 		_, err := os.Stat(hookProfile)
 		c.Check(err, IsNil)
-		// apparmor_parser was used to load the both profiles
+		// apparmor_parser was used to load all the profiles
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", hookProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", nmbdProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", smbdProfile},
@@ -257,6 +311,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerApps(c *C) {
 		s.parserCmd.ForgetCalls()
 		// NOTE: the revision is kept the same to just test on the application being removed
 		snapInfo = s.UpdateSnap(c, snapInfo, opts, ifacetest.SambaYamlV1, 1)
+		updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
 		smbdProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 		nmbdProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.nmbd")
 		// file called "snap.sambda.nmbd" was removed
@@ -264,6 +319,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerApps(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor_parser was used to remove the unused profile
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", smbdProfile},
 			{"apparmor_parser", "--remove", "snap.samba.nmbd"},
 		})
@@ -277,6 +333,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerHooks(c *C) {
 		s.parserCmd.ForgetCalls()
 		// NOTE: the revision is kept the same to just test on the application being removed
 		snapInfo = s.UpdateSnap(c, snapInfo, opts, ifacetest.SambaYamlV1WithNmbd, 1)
+		updateNSProfile := filepath.Join(dirs.SnapAppArmorDir, "snap-update-ns.samba")
 		smbdProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 		nmbdProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.nmbd")
 		hookProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.hook.configure")
@@ -286,6 +343,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerHooks(c *C) {
 		c.Check(os.IsNotExist(err), Equals, true)
 		// apparmor_parser was used to remove the unused profile
 		c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", updateNSProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", nmbdProfile},
 			{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s/var/cache/apparmor", s.RootDir), "--quiet", smbdProfile},
 			{"apparmor_parser", "--remove", "snap.samba.hook.configure"},
@@ -496,7 +554,7 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 	coreInfo := snaptest.MockInfo(c, coreYaml, &snap.SideInfo{Revision: snap.R(111)})
 	s.writeVanillaSnapConfineProfile(c, coreInfo)
 
-	// install the new core snap on classic triggers a new snap-confine
+	// Install the new core snap on classic triggers a new snap-confine
 	// for this snap-confine on core
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, coreYaml, 111)
 
@@ -505,9 +563,9 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 	c.Assert(newAA, HasLen, 1)
 	c.Check(newAA[0], Matches, `.*/etc/apparmor.d/.*.snap.core.111.usr.lib.snapd.snap-confine`)
 
-	// this is the key, rewriting "/usr/lib/snapd/snap-confine
+	// This is the key, rewriting "/usr/lib/snapd/snap-confine
 	c.Check(newAA[0], testutil.FileContains, "/snap/core/111/usr/lib/snapd/snap-confine (attach_disconnected) {")
-	// no other changes other than that to the input
+	// No other changes other than that to the input
 	c.Check(newAA[0], testutil.FileEquals, fmt.Sprintf(`#include <tunables/global>
 %s/core/111/usr/lib/snapd/snap-confine (attach_disconnected) {
     # We run privileged, so be fanatical about what we include and don't use
@@ -516,10 +574,9 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 }
 `, dirs.SnapMountDir))
 
-	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{{
-		"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify",
-		fmt.Sprintf("--cache-loc=%s", dirs.SystemApparmorCacheDir), "--quiet", newAA[0],
-	}})
+	c.Check(s.parserCmd.Calls(), DeepEquals, [][]string{
+		{"apparmor_parser", "--replace", "--write-cache", "-O", "no-expr-simplify", fmt.Sprintf("--cache-loc=%s", dirs.SystemApparmorCacheDir), "--quiet", newAA[0]},
+	})
 
 	// snap-confine directory was created
 	_, err = os.Stat(dirs.SnapConfineAppArmorDir)

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -149,7 +149,6 @@ func snippetFromLayout(layout *snap.Layout) string {
 		return fmt.Sprintf("# Layout path: %s\n%s mrwklix,", mountPoint, mountPoint)
 	}
 	return fmt.Sprintf("# Layout path: %s\n# (no extra permissions required for symlink)", mountPoint)
-
 }
 
 func copySnippets(m map[string][]string) map[string][]string {

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -519,3 +519,159 @@ var overlayRootSnippet = `
   # details see: https://bugs.launchpad.net/apparmor/+bug/1703674
   "###UPPERDIR###/{,**/}" r,
 `
+
+// updateNSTemplate contains an apparmor profile for snap-update-ns.
+// The template contains variable references to encode per-snap layout
+// requirements so that snap-update-ns doesn't need to have broad permissions
+// to write to the whole disk or to mount and unmount anything.
+var updateNSTemplate = `
+# Description: Allows snap-update-ns to construct the mount namespace specific
+# to a particular snap (see the name below). This specifically includes the
+# precise locations of the layout elements.
+
+# vim:syntax=apparmor
+
+#include <tunables/global>
+
+profile snap-update-ns.###SNAP_NAME### (attach_disconnected) {
+  # The next four rules mirror those above. We want to be able to read
+  # and map snap-update-ns into memory but it may come from a variety of places.
+  /usr/lib{,exec,64}/snapd/snap-update-ns mr,
+  /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns mr,
+  /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
+  /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
+
+  # Allow reading the dynamic linker cache.
+  /etc/ld.so.cache r,
+  # Allow reading, mapping and executing the dynamic linker.
+  /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}ld-*.so mrix,
+  # Allow reading and mapping various parts of the standard library and
+  # dynamically loaded nss modules and what not.
+  /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libc{,-[0-9]*}.so* mr,
+  /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpthread{,-[0-9]*}.so* mr,
+
+  # Allow reading the command line (snap-update-ns uses it in pre-Go bootstrap code).
+  @{PROC}/@{pid}/cmdline r,
+
+  # Allow reading the os-release file (possibly a symlink to /usr/lib).
+  /{etc/,usr/lib/}os-release r,
+
+  # Allow creating/grabbing various snapd lock files.
+  /run/snapd/lock/*.lock rwk,
+
+  # Allow reading stored mount namespaces,
+  /run/snapd/ns/ r,
+  /run/snapd/ns/*.mnt r,
+
+  # Allow reading per-snap desired mount profiles. Those are written by
+  # snapd and represent the desired layout and content connections.
+  /var/lib/snapd/mount/snap.*.fstab r,
+
+  # Allow reading and writing actual per-snap mount profiles. Note that
+  # the second rule is generic to allow our tmpfile-rename approach to
+  # writing them. Those are written by snap-update-ns and represent the
+  # actual layout at a given moment.
+  /run/snapd/ns/*.fstab rw,
+  /run/snapd/ns/*.fstab.* rw,
+
+  # NOTE: at this stage the /snap directory is stable as we have called
+  # pivot_root already.
+
+  # Needed to perform mount/unmounts.
+  capability sys_admin,
+  # Needed for mimic construction.
+  capability chown,
+
+  # Allow freezing and thawing the per-snap cgroup freezers
+  /sys/fs/cgroup/freezer/snap.*/freezer.state rw,
+
+  # Support mount profiles via the content interface. This should correspond
+  # to permutations of $SNAP -> $SNAP for reading and $SNAP_{DATA,COMMON} ->
+  # $SNAP_{DATA,COMMON} for both reading and writing.
+  #
+  # Note that:
+  #   /snap/*/*/**
+  # is meant to mean:
+  #   /snap/$SNAP_NAME/$SNAP_REVISION/and-any-subdirectory
+  # but:
+  #   /var/snap/*/**
+  # is meant to mean:
+  #   /var/snap/$SNAP_NAME/$SNAP_REVISION/
+  mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
+  mount options=(ro bind) /snap/*/** -> /var/snap/*/**,
+  mount options=(rw bind) /var/snap/*/** -> /var/snap/*/**,
+  mount options=(ro bind) /var/snap/*/** -> /var/snap/*/**,
+
+  # Allow creating missing mount directories under $SNAP_DATA.
+  #
+  # The "tree" of permissions is needed for SecureMkdirAll that uses
+  # open(..., O_NOFOLLOW) and mkdirat() using the resulting file
+  # descriptor.
+  / r,
+  /var/ r,
+  /var/snap/{,*/} r,
+  /var/snap/*/**/ rw,
+
+  # Allow creating placeholder directory in /tmp/.snap/ as support for
+  # the writable mimic code that can poke holes in arbitrary read-only
+  # places using tmpfs and bind mounts.
+  /tmp/ r,
+  /tmp/.snap/{,**} rw,
+  # Allow mounting/unmounting any part of $SNAP over to a temporary place
+  # in /tmp/.snap/ during the preparation of a writable mimic.
+  # FIXME: update this with per-snap snap-update-ns profiles
+  mount options=(bind, rw) /** -> /tmp/.snap/**,
+  mount options=(rbind, rw) /** -> /tmp/.snap/**,
+  # Allow mounting tmpfs over the original read-only directory.
+  # FIXME: update this with per-snap snap-update-ns profiles
+  mount fstype=tmpfs options=(rw) tmpfs -> /**,
+  # Allow bind mounting anything from the temporary place in /tmp/.snap/
+  # back to $SNAP/** (to re-construct the data that was there before).
+  # FIXME: update this with per-snap snap-update-ns profiles
+  mount options=(bind, rw) /tmp/.snap/** -> /**,
+  mount options=(rbind, rw) /tmp/.snap/** -> /**,
+  # Allow unmounting the temporary directory in /tmp once it is no longer
+  # necessary.
+  umount /tmp/.snap/**,
+  # Allow unmounting any of the above in case something fails and
+  # we start recovery.
+  umount /**,
+
+  # Allow creating missing directories anywhere under the root directory
+  # (but not in the root directory itself) where they need to be created
+  # as a mount point for layouts or for content sharing. This is a
+  # superset of other cases so they are removed
+  # FIXME: update this with per-snap snap-update-ns profiles
+  / r,
+  /** r,
+  /*/** w,
+
+  # Allow layouts to bind mount *from* $SNAP, $SNAP_DATA and $SNAP_COMMON
+  # *to* anywhere under the root directory. This is safe because the
+  # mounts happen inside an isolated mount namespace (but see below).
+  mount options=(bind) /snap/*/** -> /*/**,
+  mount options=(bind) /var/snap/*/** -> /*/**,
+  # As an exception, don't allow bind mounts to /media which has special
+  # sharing and propagates mount events outside of the snap namespace.
+  audit deny mount -> /media,
+
+  # Allow the content interface to bind fonts from the host filesystem
+  mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
+  # Allow the desktop interface to bind fonts from the host filesystem
+  mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /usr/share/fonts/,
+  mount options=(ro bind) /var/lib/snapd/hostfs/usr/local/share/fonts/ -> /usr/local/share/fonts/,
+  mount options=(ro bind) /var/lib/snapd/hostfs/var/cache/fontconfig/ -> /var/cache/fontconfig/,
+
+  # Allow unmounts matching possible mounts listed above.
+  umount /*/**,
+
+  # But we don't want anyone to touch /snap/bin
+  audit deny mount /snap/bin/** -> /**,
+  audit deny mount /** -> /snap/bin/**,
+
+  # Allow the content interface to bind fonts from the host filesystem
+  mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
+
+###SNIPPETS###
+}
+`


### PR DESCRIPTION
This patch extends the apparmor security backend to create a dedicated
snap-update-ns profile for each snap. That new profile applies to
snap-update-ns when invoked from snap-confine for that specific snap.
The profile exists to express strict mount and write rules that are
required by the layout and avoid the need for generous "you can write
anywhere and mount anywhere" rule.

At this time the mount rules are not any more strict but this will be
easily addressed with subsequent patches that remove generous rules and
add update-ns snippets to compensate.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
