### PR TITLE
tests: force profile re-generation via system-key

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -72,7 +72,10 @@ reset_classic() {
         for unit in $mounts $services; do
             systemctl start "$unit"
         done
-    fi
+
+        # force all profiles to be re-generated
+        rm -f /var/lib/snapd/system-key
+     fi
 
     if [ "$1" != "--keep-stopped" ]; then
         systemctl start snapd.socket


### PR DESCRIPTION
Tests may change profiles (e.g. via installing a core snap) which bypasses the new system-key mechanism. So force the re-generation of the profiles (most notably /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine).