### PR TITLE
tests: add a detector for kernel bug https://pad.lv/1755563

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -346,6 +346,17 @@ restore_project_each() {
         echo "Invalid udev file detected, test most likely broke it"
         exit 1
     fi
+
+    # Sometimes (unclear when) the sysfs representation of apparmor profiles is
+    # broken and has dangling symbolic links. To collect more data about this,
+    # look for broken symlinks after each test.
+    find /sys/kernel/security/apparmor/policy/profiles -type l -exec sh -c "file -b {} | grep -q ^broken" \; -print >/tmp/bug-1755563.txt
+    if [ -s /tmp/bug-1755563.txt ]; then
+        echo "Kernel bug detected: https://pad.lv/1755563"
+        echo
+        cat /tmp/bug-1755563.txt
+        exit 1
+    fi
 }
 
 restore_project() {


### PR DESCRIPTION
We noticed that in certain cases the kernel shows dangling symlinks in
the syfs filesystem, where there should be none. Those may be related to
an apparmor-related bug we are chasing. To know more we now look for
this bug after each test.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
