### PR TITLE
snap/squashfs: when installing from seed, try symlink before cp

### DIFF
--- a/snap/squashfs/squashfs.go
+++ b/snap/squashfs/squashfs.go
@@ -30,6 +30,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -51,6 +52,8 @@ func (s *Snap) Path() string {
 func New(snapPath string) *Snap {
 	return &Snap{path: snapPath}
 }
+
+var osLink = os.Link
 
 func (s *Snap) Install(targetPath, mountDir string) error {
 
@@ -83,7 +86,13 @@ func (s *Snap) Install(targetPath, mountDir string) error {
 	// link(2) returns EPERM on filesystems that don't support
 	// hard links (like vfat), so checking the error here doesn't
 	// make sense vs just trying to copy it.
-	if err := os.Link(s.path, targetPath); err == nil {
+	if err := osLink(s.path, targetPath); err == nil {
+		return nil
+	}
+
+	// if the file is a seed, but the hardlink failed, symlinking it
+	// saves the copy (which in livecd is expensive) so try that next
+	if filepath.Dir(s.path) == dirs.SnapSeedDir && os.Symlink(s.path, targetPath) == nil {
 		return nil
 	}
 

--- a/snap/squashfs/squashfs_test.go
+++ b/snap/squashfs/squashfs_test.go
@@ -20,6 +20,7 @@
 package squashfs
 
 import (
+	"errors"
 	"io/ioutil"
 	"math"
 	"os"
@@ -31,6 +32,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap/snapdir"
 	"github.com/snapcore/snapd/testutil"
@@ -45,6 +47,11 @@ type SquashfsTestSuite struct {
 var _ = Suite(&SquashfsTestSuite{})
 
 func makeSnap(c *C, manifest, data string) *Snap {
+	cur, _ := os.Getwd()
+	return makeSnapInDir(c, cur, manifest, data)
+}
+
+func makeSnapInDir(c *C, dir, manifest, data string) *Snap {
 	tmp := c.MkDir()
 	err := os.MkdirAll(filepath.Join(tmp, "meta", "hooks", "dir"), 0755)
 	c.Assert(err, IsNil)
@@ -72,8 +79,7 @@ func makeSnap(c *C, manifest, data string) *Snap {
 	c.Assert(err, IsNil)
 
 	// build it
-	cur, _ := os.Getwd()
-	snap := New(filepath.Join(cur, "foo.snap"))
+	snap := New(filepath.Join(dir, "foo.snap"))
 	err = snap.Build(tmp)
 	c.Assert(err, IsNil)
 
@@ -81,31 +87,82 @@ func makeSnap(c *C, manifest, data string) *Snap {
 }
 
 func (s *SquashfsTestSuite) SetUpTest(c *C) {
-	err := os.Chdir(c.MkDir())
+	d := c.MkDir()
+	dirs.SetRootDir(d)
+	err := os.Chdir(d)
 	c.Assert(err, IsNil)
 }
 
-func (s *SquashfsTestSuite) TestInstallSimple(c *C) {
+func (s *SquashfsTestSuite) TestInstallSimpleNoCp(c *C) {
+	// mock cp but still cp
+	cmd := testutil.MockCommand(c, "cp", `#!/bin/sh
+exec /bin/cp "$@"
+`)
+	defer cmd.Restore()
+	// mock link but still link
+	linked := 0
+	r := mockLink(func(a, b string) error {
+		linked++
+		return os.Link(a, b)
+	})
+	defer r()
+
 	snap := makeSnap(c, "name: test", "")
 	targetPath := filepath.Join(c.MkDir(), "target.snap")
 	mountDir := c.MkDir()
 	err := snap.Install(targetPath, mountDir)
 	c.Assert(err, IsNil)
 	c.Check(osutil.FileExists(targetPath), Equals, true)
+	c.Check(linked, Equals, 1)
+	c.Check(cmd.Calls(), HasLen, 0)
+}
+
+func mockLink(newLink func(string, string) error) (restore func()) {
+	oldLink := osLink
+	osLink = newLink
+	return func() {
+		osLink = oldLink
+	}
+}
+
+func noLink() func() {
+	return mockLink(func(string, string) error { return errors.New("no.") })
 }
 
 func (s *SquashfsTestSuite) TestInstallNotCopyTwice(c *C) {
+	// first, disable os.Link
+	defer noLink()()
+
+	// then, mock cp but still cp
+	cmd := testutil.MockCommand(c, "cp", `#!/bin/sh
+exec /bin/cp "$@"
+`)
+	defer cmd.Restore()
+
 	snap := makeSnap(c, "name: test2", "")
 	targetPath := filepath.Join(c.MkDir(), "target.snap")
 	mountDir := c.MkDir()
 	err := snap.Install(targetPath, mountDir)
 	c.Assert(err, IsNil)
+	c.Check(cmd.Calls(), HasLen, 1)
 
-	cmd := testutil.MockCommand(c, "cp", "")
-	defer cmd.Restore()
 	err = snap.Install(targetPath, mountDir)
 	c.Assert(err, IsNil)
-	c.Assert(cmd.Calls(), HasLen, 0)
+	c.Check(cmd.Calls(), HasLen, 1) // and not 2 \o/
+}
+
+func (s *SquashfsTestSuite) TestInstallSeedNoLink(c *C) {
+	defer noLink()()
+
+	c.Assert(os.MkdirAll(dirs.SnapSeedDir, 0755), IsNil)
+	snap := makeSnapInDir(c, dirs.SnapSeedDir, "name: test2", "")
+	targetPath := filepath.Join(c.MkDir(), "target.snap")
+	_, err := os.Lstat(targetPath)
+	c.Check(os.IsNotExist(err), Equals, true)
+
+	err = snap.Install(targetPath, c.MkDir())
+	c.Assert(err, IsNil)
+	c.Check(osutil.IsSymlink(targetPath), Equals, true) // \o/
 }
 
 func (s *SquashfsTestSuite) TestPath(c *C) {


### PR DESCRIPTION
When installing a snap, first we try to link(2) it. If that fails, we
fall back to copying.

If we're installing from the seed directory we can first try a
symlink, as we own both directories. This will save an expensive copy
on the livecd, for example. Huzzah.
