### PR TITLE
tests: force profile re-generation via system-key

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -72,6 +72,9 @@ reset_classic() {
         for unit in $mounts $services; do
             systemctl start "$unit"
         done
+
+        # force all profiles to be re-generated
+        rm -f /var/lib/snapd/system-key
     fi
 
     if [ "$1" != "--keep-stopped" ]; then


### PR DESCRIPTION
We do some things behind the back of snapd during the tests. Most importantly, we do change the core snap in potentially incompatible ways during the tests without changing the revision of the core snap. This means that our "system-key" functionality breaks down as it will not re-generate profiles even if it should do so (because from its perspective things have not changed). To ensure this does not cause test problems we force re-generation of the profiles. This fixes the issues that /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine was present with the wrong content (i.e. when a test installed a core snap from a channel and we later restored (via tar) a profile that was generated earlier with the same name and same revision of the core snap).