### PR TITLE
many: go vet cleanups

### DIFF
--- a/advisor/backend.go
+++ b/advisor/backend.go
@@ -183,7 +183,7 @@ func DumpCommands() (map[string][]string, error) {
 }
 
 type boltFinder struct {
-	bolt.DB
+	*bolt.DB
 }
 
 // Open the database for reading.
@@ -196,7 +196,7 @@ func Open() (Finder, error) {
 		return nil, err
 	}
 
-	return &boltFinder{*db}, nil
+	return &boltFinder{db}, nil
 }
 
 func (f *boltFinder) FindCommand(command string) ([]Command, error) {

--- a/cmd/snap/interfaces_common_test.go
+++ b/cmd/snap/interfaces_common_test.go
@@ -65,8 +65,8 @@ func (s *AttributePairSuite) TestUnmarshalFlagAttributePair(c *C) {
 
 func (s *AttributePairSuite) TestAttributePairSliceToMap(c *C) {
 	attrs := []AttributePair{
-		{"key1", "value1"},
-		{"key2", "value2"},
+		{Key: "key1", Value: "value1"},
+		{Key: "key2", Value: "value2"},
 	}
 	m := AttributePairSliceToMap(attrs)
 	c.Check(m, DeepEquals, map[string]string{

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -70,19 +70,19 @@ func MockMaxTentatives(max int) (restore func()) {
 	}
 }
 
-func (m *DeviceManager) KeypairManager() asserts.KeypairManager {
+func KeypairManager(m *DeviceManager) asserts.KeypairManager {
 	return m.keypairMgr
 }
 
-func (m *DeviceManager) EnsureOperationalShouldBackoff(now time.Time) bool {
+func EnsureOperationalShouldBackoff(m *DeviceManager, now time.Time) bool {
 	return m.ensureOperationalShouldBackoff(now)
 }
 
-func (m *DeviceManager) BecomeOperationalBackoff() time.Duration {
+func BecomeOperationalBackoff(m *DeviceManager) time.Duration {
 	return m.becomeOperationalBackoff
 }
 
-func (m *DeviceManager) SetLastBecomeOperationalAttempt(t time.Time) {
+func SetLastBecomeOperationalAttempt(m *DeviceManager, t time.Time) {
 	m.lastBecomeOperationalAttempt = t
 }
 
@@ -94,7 +94,7 @@ func MockRepeatRequestSerial(label string) (restore func()) {
 	}
 }
 
-func (m *DeviceManager) EnsureSeedYaml() error {
+func EnsureSeedYaml(m *DeviceManager) error {
 	return m.ensureSeedYaml()
 }
 
@@ -108,11 +108,11 @@ func MockPopulateStateFromSeed(f func(*state.State) ([]*state.TaskSet, error)) (
 	}
 }
 
-func (m *DeviceManager) EnsureBootOk() error {
+func EnsureBootOk(m *DeviceManager) error {
 	return m.ensureBootOk()
 }
 
-func (m *DeviceManager) SetBootOkRan(b bool) {
+func SetBootOkRan(m *DeviceManager, b bool) {
 	m.bootOkRan = b
 }
 

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -32,7 +32,7 @@ var (
 
 // AddForeignTaskHandlers registers handlers for tasks handled outside of the
 // InterfaceManager.
-func (m *InterfaceManager) AddForeignTaskHandlers() {
+func AddForeignTaskHandlers(m *InterfaceManager) {
 	// Add handler to test full aborting of changes
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {
 		return errors.New("error out")

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -117,7 +117,7 @@ func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {
 	if s.privateMgr == nil {
 		mgr, err := ifacestate.Manager(s.state, s.hookManager(c), s.extraIfaces, s.extraBackends)
 		c.Assert(err, IsNil)
-		mgr.AddForeignTaskHandlers()
+		ifacestate.AddForeignTaskHandlers(mgr)
 		s.privateMgr = mgr
 		s.o.AddManager(mgr)
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -493,7 +493,7 @@ func ExampleSplitSnapApp() {
 	// Output: hello-world env
 }
 
-func ExampleSplitSnapAppShort() {
+func ExampleSplitSnapApp_short() {
 	fmt.Println(snap.SplitSnapApp("hello-world"))
 	// Output: hello-world hello-world
 }

--- a/userd/ui/ui.go
+++ b/userd/ui/ui.go
@@ -56,7 +56,7 @@ var hasKDialogExecutable = func() bool {
 
 func MockHasZenityExecutable(f func() bool) func() {
 	oldHasZenityExecutable := hasZenityExecutable
-	hasZenityExecutable := f
+	hasZenityExecutable = f
 	return func() {
 		hasZenityExecutable = oldHasZenityExecutable
 	}
@@ -64,7 +64,7 @@ func MockHasZenityExecutable(f func() bool) func() {
 
 func MockHasKDialogExecutable(f func() bool) func() {
 	oldHasKDialogExecutable := hasKDialogExecutable
-	hasKDialogExecutable := f
+	hasKDialogExecutable = f
 	return func() {
 		hasKDialogExecutable = oldHasKDialogExecutable
 	}


### PR DESCRIPTION
Cleaning up most of `go vet` 1.10 issues. 

These 2 problems remain unresolved though:
```
# github.com/snapcore/snapd/overlord/ifacestate_test                 
overlord/ifacestate/ifacestate_test.go:120:29: internal compiler error: no function definition for [0xc421125440] FUNC-method(*ifacestate.InterfaceManager) func()                                                                            
                                                                            
                                                                                                                                                                
Please file a bug report including a short program that triggers the error.                                                         
https://golang.org/issue/new                                                                                                                                      
# github.com/snapcore/snapd/overlord/devicestate_test                                                                                                                                                                                         
overlord/devicestate/devicestate_test.go:403:38: internal compiler error: no function definition for [0xc420e1aba0] FUNC-method(*devicestate.DeviceManager) func() asserts.KeypairManager
                                                                                                                                   
                                                                                                                                                                                                                                              
Please file a bug report including a short program that triggers the error.                                                         
https://golang.org/issue/new                                                                                                                                                          
```

