### PR TITLE
snapstate: put layout feature behind feature flag

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -153,6 +153,14 @@ func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 		info.SideInfo.Paid = true
 	case "channel-for-private":
 		info.SideInfo.Private = true
+	case "channel-for-layout":
+		info.Layout = map[string]*snap.Layout{
+			"/usr": {
+				Snap:    info,
+				Path:    "/usr",
+				Symlink: "$SNAP/usr",
+			},
+		}
 	}
 
 	userID := 0
@@ -219,6 +227,16 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 		},
 		Confinement:   confinement,
 		Architectures: []string{"all"},
+	}
+	switch cand.Channel {
+	case "channel-for-layout":
+		info.Layout = map[string]*snap.Layout{
+			"/usr": {
+				Snap:    info,
+				Path:    "/usr",
+				Symlink: "$SNAP/usr",
+			},
+		}
 	}
 
 	var hit snap.Revision

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
@@ -503,6 +504,25 @@ func defaultContentPlugProviders(st *state.State, info *snap.Info) []string {
 	return out
 }
 
+// validateFeatureFlags validates the given snap only uses experimental
+// features that are enabled by the user.
+func validateFeatureFlags(st *state.State, info *snap.Info) error {
+	if len(info.Layout) == 0 {
+		return nil
+	}
+
+	tr := config.NewTransaction(st)
+	var featureFlagLayouts bool
+	if err := tr.GetMaybe("core", "experimental.layouts", &featureFlagLayouts); err != nil {
+		return err
+	}
+	if featureFlagLayouts {
+		return nil
+	}
+
+	return fmt.Errorf("cannot use experimental 'layouts' feature, set option 'experimental.layouts' to true and try again")
+}
+
 // InstallPath returns a set of tasks for installing snap from a file path.
 // Note that the state must be locked by the caller.
 // The provided SideInfo can contain just a name which results in a
@@ -541,6 +561,9 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, channel string, flags
 	}
 
 	if err := validateContainer(container, info, logger.Noticef); err != nil {
+		return nil, err
+	}
+	if err := validateFeatureFlags(st, info); err != nil {
 		return nil, err
 	}
 
@@ -586,6 +609,9 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 	}
 
 	if err := validateInfoAndFlags(info, &snapst, flags); err != nil {
+		return nil, err
+	}
+	if err := validateFeatureFlags(st, info); err != nil {
 		return nil, err
 	}
 
@@ -714,6 +740,13 @@ func doUpdate(st *state.State, names []string, updates []*snap.Info, params func
 		channel, flags, snapst := params(update)
 
 		if err := validateInfoAndFlags(update, snapst, flags); err != nil {
+			if refreshAll {
+				logger.Noticef("cannot update %q: %v", update.Name(), err)
+				continue
+			}
+			return nil, nil, err
+		}
+		if err := validateFeatureFlags(st, update); err != nil {
 			if refreshAll {
 				logger.Noticef("cannot update %q: %v", update.Name(), err)
 				continue

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8805,6 +8805,123 @@ func (s *snapmgrTestSuite) TestSideInfoPrivate(c *C) {
 	c.Check(snapst.CurrentSideInfo().Paid, Equals, false)
 }
 
+func (s *snapmgrTestSuite) TestInstallPathWithLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	mockSnap := makeTestSnap(c, `name: some-snap
+version: 1.0
+layout:
+ /usr:
+  bind: $SNAP/usr
+`)
+	_, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "cannot use experimental 'layouts' feature.*")
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	_, err = snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", snapstate.Flags{})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestInstallLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	_, err := snapstate.Install(s.state, "some-snap", "channel-for-layout", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "cannot use experimental 'layouts' feature.*")
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	_, err = snapstate.Install(s.state, "some-snap", "channel-for-layout", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	_, err := snapstate.Update(s.state, "some-snap", "channel-for-layout", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "cannot use experimental 'layouts' feature.*")
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	_, err = snapstate.Update(s.state, "some-snap", "channel-for-layout", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyExplicitLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:  true,
+		Channel: "channel-for-layout",
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	_, _, err := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	c.Assert(err, ErrorMatches, "cannot use experimental 'layouts' feature.*")
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	_, _, err = snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:  true,
+		Channel: "channel-for-layout",
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	refreshes, _, err := snapstate.UpdateMany(s.state, nil, s.user.ID)
+	c.Assert(err, IsNil)
+	c.Assert(refreshes, HasLen, 0)
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	refreshes, _, err = snapstate.UpdateMany(s.state, nil, s.user.ID)
+	c.Assert(err, IsNil)
+	c.Assert(refreshes, DeepEquals, []string{"some-snap"})
+}
+
 type canDisableSuite struct{}
 
 var _ = Suite(&canDisableSuite{})

--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -5,6 +5,8 @@ details: |
     in the area beyond the $SNAP directory. In addition all applications and
     hooks get permissions to access those areas.
 prepare: |
+    echo "Ensure feature flag is enabled"
+    snap set core experimental.layouts=true
     . $TESTSLIB/snaps.sh
     install_local test-snapd-layout
 debug: |


### PR DESCRIPTION
Install/refresh of snaps with the layout feature will be forbidden
unless "core.experimental.layouts" is set to "true".
