### PR TITLE
errtracker: respect the /etc/whoopsie configuration

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -64,20 +64,22 @@ var (
 )
 
 func whoopsieEnabled() bool {
+	dflt := true
+
 	cfg := goconfigparser.New()
 	err := cfg.ReadFile(whoopsiePreferences)
 	if os.IsNotExist(err) {
-		return true
+		return dflt
 	}
 	if err != nil {
 		logger.Noticef("cannot read whoopsie config %q: %v", whoopsiePreferences, err)
-		return true
+		return dflt
 	}
 
 	reportMetricsEnabled, err := cfg.Getbool("General", "report_metrics")
 	if err != nil {
 		logger.Noticef("cannot parse whoopsie config %q: %v", whoopsiePreferences, err)
-		return true
+		return dflt
 	}
 	return reportMetricsEnabled
 }

--- a/errtracker/export_test.go
+++ b/errtracker/export_test.go
@@ -70,3 +70,11 @@ func MockReExec(f func() string) (restorer func()) {
 		didSnapdReExec = oldDidSnapdReExec
 	}
 }
+
+func MockWhoopsiePreferences(path string) (restorer func()) {
+	old := whoopsiePreferences
+	whoopsiePreferences = path
+	return func() {
+		whoopsiePreferences = old
+	}
+}


### PR DESCRIPTION
We must support the settings of the user about sending problem
reports. This is implemented on Ubuntu via the /etc/whoopsie
configuration and that config is controllable via the
gnome-control-center.

We should probably also have our own internal configuration
(snapd.problem_reports={true,false}?). But that will be a
followup PR.
