### PR TITLE
many: add `core.problem-reports.disabled` option

### DIFF
--- a/overlord/configstate/settings/settings.go
+++ b/overlord/configstate/settings/settings.go
@@ -1,0 +1,41 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package settings
+
+import (
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// ProblemReportsDisabled returns true if the problem reports are disabled
+// via the "core.problem-reports.disabled" settings.
+//
+// The state must be locked when this is called.
+func ProblemReportsDisabled(st *state.State) bool {
+	var disableProblemReports bool
+
+	tr := config.NewTransaction(st)
+	if err := tr.GetMaybe("core", "problem-reports.disabled", &disableProblemReports); err != nil {
+		logger.Noticef("cannot get problem report setting: %v", err)
+	}
+
+	return disableProblemReports
+}

--- a/overlord/configstate/settings/settings_test.go
+++ b/overlord/configstate/settings/settings_test.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package settings_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/configstate/settings"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestT(t *testing.T) { TestingT(t) }
+
+type settingsSuite struct {
+	state *state.State
+}
+
+var _ = Suite(&settingsSuite{})
+
+func (s *settingsSuite) SetUpTest(c *C) {
+	s.state = state.New(nil)
+}
+
+func (s *settingsSuite) TestSettingProblemReportsDisableDefault(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(settings.ProblemReportsDisabled(s.state), Equals, false)
+}
+
+func (s *settingsSuite) TestSettingProblemReportsDisable(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "problem-reports.disabled", true)
+	tr.Commit()
+
+	c.Check(settings.ProblemReportsDisabled(s.state), Equals, true)
+}

--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/errtracker"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/configstate/settings"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -396,10 +397,16 @@ func trackHookError(context *Context, output []byte, err error) {
 	if context.setup.IgnoreError {
 		extra["IgnoreError"] = "1"
 	}
-	oopsid, err := errtrackerReport(context.SnapName(), errmsg, dupSig, extra)
-	if err == nil {
-		logger.Noticef("Reported hook failure from %q for snap %q as %s", context.HookName(), context.SnapName(), oopsid)
-	} else {
-		logger.Debugf("Cannot report hook failure: %s", err)
+
+	context.state.Lock()
+	problemReportsDisabled := settings.ProblemReportsDisabled(context.state)
+	context.state.Unlock()
+	if !problemReportsDisabled {
+		oopsid, err := errtrackerReport(context.SnapName(), errmsg, dupSig, extra)
+		if err == nil {
+			logger.Noticef("Reported hook failure from %q for snap %q as %s", context.HookName(), context.SnapName(), oopsid)
+		} else {
+			logger.Debugf("Cannot report hook failure: %s", err)
+		}
 	}
 }

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -780,6 +781,35 @@ func (s *hookManagerSuite) TestHookTaskHandlerReportsErrorIfRequested(c *C) {
 	defer s.state.Unlock()
 
 	c.Check(errtrackerCalled, Equals, true)
+}
+
+func (s *hookManagerSuite) TestHookTaskHandlerReportsErrorDisabled(c *C) {
+	s.state.Lock()
+	var hooksup hookstate.HookSetup
+	s.task.Get("hook-setup", &hooksup)
+	hooksup.TrackError = true
+	s.task.Set("hook-setup", &hooksup)
+
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "problem-reports.disabled", true)
+	tr.Commit()
+	s.state.Unlock()
+
+	hookstate.MockErrtrackerReport(func(snap, errmsg, dupSig string, extra map[string]string) (string, error) {
+		c.Fatalf("no error reports should be generated")
+		return "", nil
+	})
+
+	// Force the snap command to exit 1, and print something to stderr
+	cmd := testutil.MockCommand(
+		c, "snap", ">&2 echo 'hook failed at user request'; exit 1")
+	defer cmd.Restore()
+
+	s.manager.Ensure()
+	s.manager.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
 }
 
 func (s *hookManagerSuite) TestHookTasksForSameSnapAreSerialized(c *C) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/configstate/settings"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -350,13 +351,15 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 		extra["UbuntuCoreTransitionCount"] = strconv.Itoa(ubuntuCoreTransitionCount)
 	}
 
-	st.Unlock()
-	oopsid, err := errtrackerReport(snapsup.SideInfo.RealName, strings.Join(logMsg, "\n"), strings.Join(dupSig, "\n"), extra)
-	st.Lock()
-	if err == nil {
-		logger.Noticef("Reported install problem for %q as %s", snapsup.SideInfo.RealName, oopsid)
-	} else {
-		logger.Debugf("Cannot report problem: %s", err)
+	if !settings.ProblemReportsDisabled(st) {
+		st.Unlock()
+		oopsid, err := errtrackerReport(snapsup.SideInfo.RealName, strings.Join(logMsg, "\n"), strings.Join(dupSig, "\n"), extra)
+		st.Lock()
+		if err == nil {
+			logger.Noticef("Reported install problem for %q as %s", snapsup.SideInfo.RealName, oopsid)
+		} else {
+			logger.Debugf("Cannot report problem: %s", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This allows disable problem reports via the core config. It only
looks at the internal option.

An alternative approach would be to make overlord/configstate/configcore
write /etc/whoopsie and let PR#4839 pick that setting up.
