### PR TITLE
snap/pack, cmd/snap: add `snap pack --check-skeleton`

### DIFF
--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -49,7 +49,6 @@ valid snap metadata and raises an error otherwise. Application commands listed
 in snap metadata file, but appearing with incorrect permission bits result in an
 error. Commands that are missing from snap-dir are listed in diagnostic
 messages.
- `)
 `)
 
 func init() {

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -46,10 +46,10 @@ the current directory.
 
 When used with --check-skeleton, pack only checks whether snap-dir contains
 valid snap metadata and raises an error otherwise. Application commands listed
-in snap metadata file, but appearing with incorrect permission bits or missing
-from snap-dir are signaled through diagnostic messages and do not result in an
-error.
-`)
+in snap metadata file, but appearing with incorrect permission bits result in an
+error. Commands that are missing from snap-dir are listed in diagnostic
+messages.
+ `)
 
 func init() {
 	addCommand("pack",

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -37,9 +37,19 @@ type packCmd struct {
 	} `positional-args:"yes"`
 }
 
-var shortPackHelp = i18n.G("Pack the given target dir as a snap")
+var shortPackHelp = i18n.G("Pack the given directory as a snap")
 var longPackHelp = i18n.G(`
-The pack command packs the given snap-dir as a snap.`)
+The pack command packs the given snap-dir as a snap and writes the result to
+target-dir. If target-dir is omitted, the result is written to current
+directory. If both source-dir and target-dir are omitted, the pack command packs
+the current directory.
+
+When used with --check-skeleton, pack only checks whether snap-dir contains
+valid snap metadata and raises an error otherwise. Application commands listed
+in snap metadata file, but appearing with incorrect permission bits or missing
+from snap-dir are signaled through diagnostic messages and do not result in an
+error.
+`)
 
 func init() {
 	addCommand("pack",
@@ -48,7 +58,7 @@ func init() {
 		func() flags.Commander {
 			return &packCmd{}
 		}, map[string]string{
-			"check-skeleton": i18n.G("Validate snap directory only"),
+			"check-skeleton": i18n.G("Validate snap-dir metadata only"),
 		}, nil)
 }
 

--- a/cmd/snap/cmd_pack.go
+++ b/cmd/snap/cmd_pack.go
@@ -61,7 +61,7 @@ func (x *packCmd) Execute([]string) error {
 	}
 
 	if x.CheckSkeleton {
-		_, err := pack.LoadValidate(x.Positional.SnapDir)
+		err := pack.CheckSkeleton(x.Positional.SnapDir)
 		if err == snap.ErrMissingPaths {
 			return nil
 		}

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -1,0 +1,80 @@
+package main_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/check.v1"
+
+	snaprun "github.com/snapcore/snapd/cmd/snap"
+)
+
+const packSnapYaml = `name: hello
+version: 1.0.1
+apps:
+ app:
+  command: bin/hello
+`
+
+func makeSnapDirForPack(c *check.C, snapYaml string) string {
+	tempdir := c.MkDir()
+	c.Assert(os.Chmod(tempdir, 0755), check.IsNil)
+
+	// use meta/snap.yaml
+	metaDir := filepath.Join(tempdir, "meta")
+	err := os.Mkdir(metaDir, 0755)
+	c.Assert(err, check.IsNil)
+	err = ioutil.WriteFile(filepath.Join(metaDir, "snap.yaml"), []byte(snapYaml), 0644)
+	c.Assert(err, check.IsNil)
+
+	return tempdir
+}
+
+func (s *SnapSuite) TestPackCheckSkeletonNoAppFiles(c *check.C) {
+	snapDir := makeSnapDirForPack(c, packSnapYaml)
+
+	// check-skeleton does not fail due to missing files
+	_, err := snaprun.Parser().ParseArgs([]string{"pack", "--check-skeleton", snapDir})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *SnapSuite) TestPackCheckSkeletonBadMeta(c *check.C) {
+	// no snap name
+	snapYaml := `
+version: foobar
+apps:
+`
+	snapDir := makeSnapDirForPack(c, snapYaml)
+
+	_, err := snaprun.Parser().ParseArgs([]string{"pack", "--check-skeleton", snapDir})
+	c.Assert(err, check.ErrorMatches, "snap name cannot be empty")
+}
+
+func (s *SnapSuite) TestPackPacksFailsForMissingPaths(c *check.C) {
+	snapDir := makeSnapDirForPack(c, packSnapYaml)
+
+	_, err := snaprun.Parser().ParseArgs([]string{"pack", snapDir, snapDir})
+	c.Assert(err, check.ErrorMatches, ".* snap is unusable due to missing files")
+}
+
+func (s *SnapSuite) TestPackPacksASnap(c *check.C) {
+	snapDir := makeSnapDirForPack(c, packSnapYaml)
+
+	const helloBinContent = `#!/bin/sh
+printf "hello world"
+`
+	// an example binary
+	binDir := filepath.Join(snapDir, "bin")
+	err := os.Mkdir(binDir, 0755)
+	c.Assert(err, check.IsNil)
+	err = ioutil.WriteFile(filepath.Join(binDir, "hello"), []byte(helloBinContent), 0755)
+	c.Assert(err, check.IsNil)
+
+	_, err = snaprun.Parser().ParseArgs([]string{"pack", snapDir, snapDir})
+	c.Assert(err, check.IsNil)
+
+	matches, err := filepath.Glob(snapDir + "/hello*.snap")
+	c.Assert(err, check.IsNil)
+	c.Assert(matches, check.HasLen, 1)
+}

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -211,8 +211,13 @@ func copyToBuildDir(sourceDir, buildDir string) error {
 	})
 }
 
-// LoadValidate attempts to load and validate  snap data from source directory
-func LoadValidate(sourceDir string) (*snap.Info, error) {
+// CheckSkeleton attempts to validate snap data in source directory
+func CheckSkeleton(sourceDir string) error {
+	_, err := loadAndValidate(sourceDir)
+	return err
+}
+
+func loadAndValidate(sourceDir string) (*snap.Info, error) {
 	// ensure we have valid content
 	yaml, err := ioutil.ReadFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
 	if err != nil {
@@ -235,7 +240,7 @@ func LoadValidate(sourceDir string) (*snap.Info, error) {
 }
 
 func prepare(sourceDir, targetDir, buildDir string) (snapName string, err error) {
-	info, err := LoadValidate(sourceDir)
+	info, err := loadAndValidate(sourceDir)
 	if err != nil {
 		return "", err
 	}

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -211,24 +211,31 @@ func copyToBuildDir(sourceDir, buildDir string) error {
 	})
 }
 
-func prepare(sourceDir, targetDir, buildDir string) (snapName string, err error) {
+// LoadValidate attempts to load and validate  snap data from source directory
+func LoadValidate(sourceDir string) (*snap.Info, error) {
 	// ensure we have valid content
 	yaml, err := ioutil.ReadFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	info, err := snap.InfoFromSnapYaml(yaml)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	err = snap.Validate(info)
-	if err != nil {
-		return "", err
+	if err := snap.Validate(info); err != nil {
+		return nil, err
 	}
 
-	err = snap.ValidateContainer(snapdir.New(sourceDir), info, logger.Noticef)
+	if err := snap.ValidateContainer(snapdir.New(sourceDir), info, logger.Noticef); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+func prepare(sourceDir, targetDir, buildDir string) (snapName string, err error) {
+	info, err := LoadValidate(sourceDir)
 	if err != nil {
 		return "", err
 	}

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -131,7 +131,7 @@ apps:
   command: bin/hello-world
 `)
 	c.Assert(os.Remove(filepath.Join(sourceDir, "bin", "hello-world")), IsNil)
-	_, err := pack.LoadValidate(sourceDir)
+	err := pack.CheckSkeleton(sourceDir)
 	c.Assert(err, Equals, snap.ErrMissingPaths)
 }
 

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -123,6 +123,18 @@ apps:
 	c.Assert(err, Equals, snap.ErrMissingPaths)
 }
 
+func (s *packSuite) TestValidateMissingAppFailsWithErrMissingPaths(c *C) {
+	sourceDir := makeExampleSnapSourceDir(c, `name: hello
+version: 0
+apps:
+ foo:
+  command: bin/hello-world
+`)
+	c.Assert(os.Remove(filepath.Join(sourceDir, "bin", "hello-world")), IsNil)
+	_, err := pack.LoadValidate(sourceDir)
+	c.Assert(err, Equals, snap.ErrMissingPaths)
+}
+
 func (s *packSuite) TestCopyCopies(c *C) {
 	sourceDir := makeExampleSnapSourceDir(c, "{name: hello, version: 0}")
 	// actually this'll be on /tmp so it'll be a link


### PR DESCRIPTION
Add support for `snap pack --check-skeleton`. Extend `snap pack` test suite.
