### PR TITLE
[2.32] wrappers: services which are socket or timer activated should not be started during boot

### DIFF
--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -198,6 +198,11 @@ func AddSnapServices(s *snap.Info, inter interacter) (err error) {
 			written = append(written, path)
 		}
 
+		if len(app.Sockets) != 0 {
+			// service is socket activated, not during the boot
+			continue
+		}
+
 		svcName := app.ServiceName()
 		if err := sysd.Enable(svcName); err != nil {
 			return err


### PR DESCRIPTION
Fix socket activated service handling by not enabling them, so that they
start as a result of the actual event rather than at boot time.

