### PR TITLE
osutil,testutil: add symlinkat(2) and readlinkat(2)

### DIFF
--- a/osutil/sys_linux.go
+++ b/osutil/sys_linux.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Symlinkat is a direct pass-through to the symlinkat(2) system call.
+func Symlinkat(target string, dirfd int, linkpath string) error {
+	targetPtr, err := syscall.BytePtrFromString(target)
+	if err != nil {
+		return err
+	}
+	linkpathPtr, err := syscall.BytePtrFromString(linkpath)
+	if err != nil {
+		return err
+	}
+	_, _, errno := syscall.Syscall(syscall.SYS_SYMLINKAT, uintptr(unsafe.Pointer(targetPtr)), uintptr(dirfd), uintptr(unsafe.Pointer(linkpathPtr)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Readlinkat is a direct pass-through to the readlinkat(2) system call.
+func Readlinkat(dirfd int, path string, buf []byte) (n int, err error) {
+	var zero uintptr
+
+	pathPtr, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	var bufPtr unsafe.Pointer
+	if len(buf) > 0 {
+		bufPtr = unsafe.Pointer(&buf[0])
+	} else {
+		bufPtr = unsafe.Pointer(&zero)
+	}
+	r0, _, errno := syscall.Syscall6(syscall.SYS_READLINKAT, uintptr(dirfd), uintptr(unsafe.Pointer(pathPtr)), uintptr(bufPtr), uintptr(len(buf)), 0, 0)
+	n = int(r0)
+	if errno != 0 {
+		return 0, errno
+	}
+	return n, nil
+}

--- a/osutil/sys_linux_test.go
+++ b/osutil/sys_linux_test.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type sysSuite struct{}
+
+var _ = Suite(&sysSuite{})
+
+func (s *sysSuite) TestSymlinkatAndReadlinkat(c *C) {
+	// Create and open a temporary directory.
+	d := c.MkDir()
+	fd, err := syscall.Open(d, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	// Create a symlink relative to the directory file descriptor.
+	err = osutil.Symlinkat("target", fd, "linkpath")
+	c.Assert(err, IsNil)
+
+	// Ensure that the created file is a symlink.
+	fname := filepath.Join(d, "linkpath")
+	fi, err := os.Lstat(fname)
+	c.Assert(err, IsNil)
+	c.Assert(fi.Name(), Equals, "linkpath")
+	c.Assert(fi.Mode()&os.ModeSymlink, Equals, os.ModeSymlink)
+
+	// Ensure that the symlink target is correct.
+	target, err := os.Readlink(fname)
+	c.Assert(err, IsNil)
+	c.Assert(target, Equals, "target")
+
+	// Use readlinkat with a buffer that fits only part of the target path.
+	buf := make([]byte, 2)
+	n, err := osutil.Readlinkat(fd, "linkpath", buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 2)
+	c.Assert(buf, DeepEquals, []byte{'t', 'a'})
+
+	// Use a buffer that fits all of the target path.
+	buf = make([]byte, 100)
+	n, err = osutil.Readlinkat(fd, "linkpath", buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, len("target"))
+	c.Assert(buf[:n], DeepEquals, []byte{'t', 'a', 'r', 'g', 'e', 't'})
+}

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -160,9 +160,10 @@ type SyscallRecorder struct {
 	// Error function for a given system call.
 	errors map[string]func() error
 	// pre-arranged result of lstat, fstat and readdir calls.
-	lstats   map[string]os.FileInfo
-	fstats   map[string]syscall.Stat_t
-	readdirs map[string][]os.FileInfo
+	lstats      map[string]os.FileInfo
+	fstats      map[string]syscall.Stat_t
+	readdirs    map[string][]os.FileInfo
+	readlinkats map[string]string
 	// allocated file descriptors
 	fds map[int]string
 }
@@ -370,6 +371,39 @@ func (sys *SyscallRecorder) ReadDir(dirname string) ([]os.FileInfo, error) {
 func (sys *SyscallRecorder) Symlink(oldname, newname string) error {
 	call := fmt.Sprintf("symlink %q -> %q", newname, oldname)
 	return sys.call(call)
+}
+
+func (sys *SyscallRecorder) Symlinkat(oldname string, dirfd int, newname string) error {
+	call := fmt.Sprintf("symlinkat %q %d %q", oldname, dirfd, newname)
+	if _, ok := sys.fds[dirfd]; !ok {
+		sys.calls = append(sys.calls, call)
+		return fmt.Errorf("attempting to symlinkat with an invalid file descriptor %d", dirfd)
+	}
+	return sys.call(call)
+}
+
+// InsertReadlinkatResult makes given subsequent call to readlinkat return the specified oldname.
+func (sys *SyscallRecorder) InsertReadlinkatResult(call, oldname string) {
+	if sys.readlinkats == nil {
+		sys.readlinkats = make(map[string]string)
+	}
+	sys.readlinkats[call] = oldname
+}
+
+func (sys *SyscallRecorder) Readlinkat(dirfd int, path string, buf []byte) (int, error) {
+	call := fmt.Sprintf("readlinkat %d %q <ptr>", dirfd, path)
+	if _, ok := sys.fds[dirfd]; !ok {
+		sys.calls = append(sys.calls, call)
+		return 0, fmt.Errorf("attempting to readlinkat with an invalid file descriptor %d", dirfd)
+	}
+	if err := sys.call(call); err != nil {
+		return 0, err
+	}
+	if oldname, ok := sys.readlinkats[call]; ok {
+		n := copy(buf, oldname)
+		return n, nil
+	}
+	panic(fmt.Sprintf("one of InsertReadlinkatResult() or InsertFault() for %s must be used", call))
 }
 
 func (sys *SyscallRecorder) Remove(name string) error {

--- a/testutil/lowlevel_test.go
+++ b/testutil/lowlevel_test.go
@@ -399,3 +399,80 @@ func (s *lowLevelSuite) TestRemoveFailure(c *C) {
 	c.Assert(err, ErrorMatches, "operation not permitted")
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`remove "file"`})
 }
+
+func (s *lowLevelSuite) TestSymlinkatBadFd(c *C) {
+	err := s.sys.Symlinkat("/old", 3, "new")
+	c.Assert(err, ErrorMatches, "attempting to symlinkat with an invalid file descriptor 3")
+	c.Assert(s.sys.Calls(), DeepEquals, []string{`symlinkat "/old" 3 "new"`})
+}
+
+func (s *lowLevelSuite) TestSymlinkatSuccess(c *C) {
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+	err = s.sys.Symlinkat("/old", fd, "new")
+	c.Assert(err, IsNil)
+	c.Assert(s.sys.Calls(), DeepEquals, []string{
+		`open "/foo" 0 0`,
+		`symlinkat "/old" 3 "new"`,
+	})
+}
+
+func (s *lowLevelSuite) TestSymlinkatFailure(c *C) {
+	s.sys.InsertFault(`symlinkat "/old" 3 "new"`, syscall.EPERM)
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+	err = s.sys.Symlinkat("/old", fd, "new")
+	c.Assert(err, ErrorMatches, "operation not permitted")
+	c.Assert(s.sys.Calls(), DeepEquals, []string{
+		`open "/foo" 0 0`,
+		`symlinkat "/old" 3 "new"`,
+	})
+}
+
+func (s *lowLevelSuite) TestReadlinkat(c *C) {
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+	buf := make([]byte, 10)
+	c.Assert(func() { s.sys.Readlinkat(fd, "new", buf) }, PanicMatches,
+		`one of InsertReadlinkatResult\(\) or InsertFault\(\) for readlinkat 3 "new" <ptr> must be used`)
+}
+
+func (s *lowLevelSuite) TestReadlinkatBadFd(c *C) {
+	buf := make([]byte, 10)
+	n, err := s.sys.Readlinkat(3, "new", buf)
+	c.Assert(err, ErrorMatches, "attempting to readlinkat with an invalid file descriptor 3")
+	c.Assert(n, Equals, 0)
+	c.Assert(s.sys.Calls(), DeepEquals, []string{`readlinkat 3 "new" <ptr>`})
+}
+
+func (s *lowLevelSuite) TestReadlinkatSuccess(c *C) {
+	s.sys.InsertReadlinkatResult(`readlinkat 3 "new" <ptr>`, "/old")
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+
+	// Buffer has enough room
+	buf := make([]byte, 10)
+	n, err := s.sys.Readlinkat(fd, "new", buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 4)
+	c.Assert(buf, DeepEquals, []byte{'/', 'o', 'l', 'd', 0, 0, 0, 0, 0, 0})
+
+	// Buffer is too short
+	buf = make([]byte, 2)
+	n, err = s.sys.Readlinkat(fd, "new", buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 2)
+	c.Assert(buf, DeepEquals, []byte{'/', 'o'})
+}
+
+func (s *lowLevelSuite) TestReadlinkatFailure(c *C) {
+	s.sys.InsertFault(`readlinkat 3 "new" <ptr>`, syscall.EPERM)
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+
+	buf := make([]byte, 10)
+	n, err := s.sys.Readlinkat(fd, "new", buf)
+	c.Assert(err, ErrorMatches, "operation not permitted")
+	c.Assert(n, Equals, 0)
+	c.Assert(buf, DeepEquals, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+}


### PR DESCRIPTION
This patch adds the symlinkat(2) system call which is not exposed in
golang 1.6. THe implementation uses syscall.Syscall along with
syscall.SYS_SYMLINKAT which is, fortunately, available.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
