### PR TITLE
many: cherry-pick relevent `go vet` 1.10 fixes to 2.32

### DIFF
--- a/advisor/backend.go
+++ b/advisor/backend.go
@@ -183,7 +183,7 @@ func DumpCommands() (map[string][]string, error) {
 }
 
 type boltFinder struct {
-	bolt.DB
+	*bolt.DB
 }
 
 // Open the database for reading.
@@ -196,7 +196,7 @@ func Open() (Finder, error) {
 		return nil, err
 	}
 
-	return &boltFinder{*db}, nil
+	return &boltFinder{db}, nil
 }
 
 func (f *boltFinder) FindCommand(command string) ([]Command, error) {

--- a/cmd/snap/interfaces_common_test.go
+++ b/cmd/snap/interfaces_common_test.go
@@ -65,8 +65,8 @@ func (s *AttributePairSuite) TestUnmarshalFlagAttributePair(c *C) {
 
 func (s *AttributePairSuite) TestAttributePairSliceToMap(c *C) {
 	attrs := []AttributePair{
-		{"key1", "value1"},
-		{"key2", "value2"},
+		{Key: "key1", Value: "value1"},
+		{Key: "key2", Value: "value2"},
 	}
 	m := AttributePairSliceToMap(attrs)
 	c.Check(m, DeepEquals, map[string]string{

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -70,19 +70,19 @@ func MockMaxTentatives(max int) (restore func()) {
 	}
 }
 
-func (m *DeviceManager) KeypairManager() asserts.KeypairManager {
+func KeypairManager(m *DeviceManager) asserts.KeypairManager {
 	return m.keypairMgr
 }
 
-func (m *DeviceManager) EnsureOperationalShouldBackoff(now time.Time) bool {
+func EnsureOperationalShouldBackoff(m *DeviceManager, now time.Time) bool {
 	return m.ensureOperationalShouldBackoff(now)
 }
 
-func (m *DeviceManager) BecomeOperationalBackoff() time.Duration {
+func BecomeOperationalBackoff(m *DeviceManager) time.Duration {
 	return m.becomeOperationalBackoff
 }
 
-func (m *DeviceManager) SetLastBecomeOperationalAttempt(t time.Time) {
+func SetLastBecomeOperationalAttempt(m *DeviceManager, t time.Time) {
 	m.lastBecomeOperationalAttempt = t
 }
 
@@ -94,7 +94,7 @@ func MockRepeatRequestSerial(label string) (restore func()) {
 	}
 }
 
-func (m *DeviceManager) EnsureSeedYaml() error {
+func EnsureSeedYaml(m *DeviceManager) error {
 	return m.ensureSeedYaml()
 }
 
@@ -108,11 +108,11 @@ func MockPopulateStateFromSeed(f func(*state.State) ([]*state.TaskSet, error)) (
 	}
 }
 
-func (m *DeviceManager) EnsureBootOk() error {
+func EnsureBootOk(m *DeviceManager) error {
 	return m.ensureBootOk()
 }
 
-func (m *DeviceManager) SetBootOkRan(b bool) {
+func SetBootOkRan(m *DeviceManager, b bool) {
 	m.bootOkRan = b
 }
 

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -32,7 +32,7 @@ var (
 
 // AddForeignTaskHandlers registers handlers for tasks handled outside of the
 // InterfaceManager.
-func (m *InterfaceManager) AddForeignTaskHandlers() {
+func AddForeignTaskHandlers(m *InterfaceManager) {
 	// Add handler to test full aborting of changes
 	erroringHandler := func(task *state.Task, _ *tomb.Tomb) error {
 		return errors.New("error out")

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -117,7 +117,7 @@ func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {
 	if s.privateMgr == nil {
 		mgr, err := ifacestate.Manager(s.state, s.hookManager(c), s.extraIfaces, s.extraBackends)
 		c.Assert(err, IsNil)
-		mgr.AddForeignTaskHandlers()
+		ifacestate.AddForeignTaskHandlers(mgr)
 		s.privateMgr = mgr
 		s.o.AddManager(mgr)
 

--- a/run-checks
+++ b/run-checks
@@ -79,7 +79,7 @@ addtrap endmsg
 append_coverage() (
     profile="$1"
     if [ -f "$profile" ]; then
-        grep -v "^mode:" -- "$profile" >> .coverage/coverage.out
+        grep -v "^mode:" -- "$profile" >> .coverage/coverage.out || true
         rm "$profile"
     fi
 )
@@ -215,11 +215,15 @@ if [ "$UNIT" = 1 ]; then
 
     # tests
     echo Running tests from "$PWD"
-    for pkg in $(go list ./... | grep -v '/vendor/' ); do
-        go test -i "$pkg"
-        $goctest -v -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
-        append_coverage .coverage/profile.out
-    done
+    if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
+        $goctest -v -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
+    else
+        for pkg in $(go list ./... | grep -v '/vendor/' ); do
+            go test -i "$pkg"
+            $goctest -v -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
+            append_coverage .coverage/profile.out
+        done
+    fi
 
     # upload to codecov.io if on travis
     if [ "${TRAVIS_BUILD_NUMBER:-}" ]; then

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -491,7 +491,7 @@ func ExampleSplitSnapApp() {
 	// Output: hello-world env
 }
 
-func ExampleSplitSnapAppShort() {
+func ExampleSplitSnapApp_short() {
 	fmt.Println(snap.SplitSnapApp("hello-world"))
 	// Output: hello-world hello-world
 }


### PR DESCRIPTION
Backport the relevant bits from #4837