### PR TITLE
cmd/snap-update-ns: fix creation of layout symlinks

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -88,7 +88,7 @@ func (c *Change) createPath(path string, pokeHoles bool) ([]*Change, error) {
 		if target == "" {
 			err = fmt.Errorf("cannot create symlink with empty target")
 		} else {
-			err = secureMklinkAll(path, mode, uid, gid, target)
+			err = secureMksymlinkAll(path, mode, uid, gid, target)
 		}
 	}
 	if err2, ok := err.(*ReadOnlyFsError); ok && pokeHoles {

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -1172,24 +1172,24 @@ func (s *changeSuite) TestPerformCreateSymlink(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`lstat "/name"`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
+		`symlinkat "/oldname" 3 "name"`,
 		`close 3`,
-		`symlink "/name" -> "/oldname"`,
 	})
 }
 
 // Change.Perform wants to create a symlink but it fails.
 func (s *changeSuite) TestPerformCreateSymlinkWithError(c *C) {
 	s.sys.InsertFault(`lstat "/name"`, syscall.ENOENT)
-	s.sys.InsertFault(`symlink "/name" -> "/oldname"`, errTesting)
+	s.sys.InsertFault(`symlinkat "/oldname" 3 "name"`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
 	synth, err := chg.Perform()
-	c.Assert(err, ErrorMatches, `cannot create path "/name": testing`)
+	c.Assert(err, ErrorMatches, `cannot create path "/name": cannot create symlink "name": testing`)
 	c.Assert(synth, HasLen, 0)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`lstat "/name"`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
+		`symlinkat "/oldname" 3 "name"`,
 		`close 3`,
-		`symlink "/name" -> "/oldname"`,
 	})
 }
 
@@ -1218,9 +1218,9 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDir(c *C) {
 		`mkdirat 3 "base" 0755`,
 		`openat 3 "base" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
 		`fchown 4 0 0`,
-		`close 4`,
 		`close 3`,
-		`symlink "/base/name" -> "/oldname"`,
+		`symlinkat "/oldname" 4 "name"`,
+		`close 4`,
 	})
 }
 
@@ -1244,8 +1244,8 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirWithErrors(c *C) {
 func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C) {
 	s.sys.InsertFault(`lstat "/rofs/name"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
-	s.sys.InsertFault(`symlink "/rofs/name" -> "/oldname"`, syscall.EROFS, nil) // works on 2nd try
-	s.sys.InsertReadDirResult(`readdir "/rofs"`, nil)                           // pretend /rofs is empty.
+	s.sys.InsertFault(`symlinkat "/oldname" 4 "name"`, syscall.EROFS, nil) // works on 2nd try
+	s.sys.InsertReadDirResult(`readdir "/rofs"`, nil)                      // pretend /rofs is empty.
 	s.sys.InsertFault(`lstat "/tmp/.snap/rofs"`, syscall.ENOENT)
 	s.sys.InsertLstatResult(`lstat "/rofs"`, testutil.FileInfoDir)
 
@@ -1260,14 +1260,13 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 		`lstat "/rofs/name"`,
 
 		// create base name (/rofs)
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
+		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, // -> 3
 		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 4`,
+		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, // -> 4
 		`close 3`,
-
 		// create symlink
-		`symlink "/rofs/name" -> "/oldname"`,
+		`symlinkat "/oldname" 4 "name"`, // (inserted fault happens here)
+		`close 4`,
 
 		// error, read only filesystem, create a mimic
 		`readdir "/rofs"`,
@@ -1296,11 +1295,10 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
 		`mkdirat 3 "rofs" 0755`,
 		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 4`,
 		`close 3`,
-
 		// create symlink
-		`symlink "/rofs/name" -> "/oldname"`,
+		`symlinkat "/oldname" 4 "name"`, // (inserted fault happens here)
+		`close 4`,
 	})
 }
 

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -35,11 +35,12 @@ var (
 	FreezeSnapProcesses = freezeSnapProcesses
 	ThawSnapProcesses   = thawSnapProcesses
 	// utils
-	PlanWritableMimic = planWritableMimic
-	ExecWritableMimic = execWritableMimic
-	SecureMkdirAll    = secureMkdirAll
-	SecureMkfileAll   = secureMkfileAll
-	SplitIntoSegments = splitIntoSegments
+	PlanWritableMimic  = planWritableMimic
+	ExecWritableMimic  = execWritableMimic
+	SecureMkdirAll     = secureMkdirAll
+	SecureMkfileAll    = secureMkfileAll
+	SecureMksymlinkAll = secureMksymlinkAll
+	SplitIntoSegments  = splitIntoSegments
 
 	// main
 	ComputeAndSaveChanges = computeAndSaveChanges
@@ -49,7 +50,8 @@ var (
 type SystemCalls interface {
 	Lstat(name string) (os.FileInfo, error)
 	ReadDir(dirname string) ([]os.FileInfo, error)
-	Symlink(oldname, newname string) error
+	Symlinkat(oldname string, dirfd int, newname string) error
+	Readlinkat(dirfd int, path string, buf []byte) (int, error)
 	Remove(name string) error
 
 	Close(fd int) error
@@ -75,7 +77,8 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	oldSysOpen := sysOpen
 	oldSysOpenat := sysOpenat
 	oldSysUnmount := sysUnmount
-	oldSysSymlink := sysSymlink
+	oldSysSymlinkat := sysSymlinkat
+	oldReadlinkat := sysReadlinkat
 
 	// override
 	osLstat = sc.Lstat
@@ -89,7 +92,8 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	sysOpen = sc.Open
 	sysOpenat = sc.Openat
 	sysUnmount = sc.Unmount
-	sysSymlink = sc.Symlink
+	sysSymlinkat = sc.Symlinkat
+	sysReadlinkat = sc.Readlinkat
 
 	return func() {
 		// restore
@@ -104,7 +108,8 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 		sysOpen = oldSysOpen
 		sysOpenat = oldSysOpenat
 		sysUnmount = oldSysUnmount
-		sysSymlink = oldSysSymlink
+		sysSymlinkat = oldSysSymlinkat
+		sysReadlinkat = oldReadlinkat
 	}
 }
 

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -43,14 +43,16 @@ var (
 	osReadlink = os.Readlink
 	osRemove   = os.Remove
 
-	sysClose   = syscall.Close
-	sysMkdirat = syscall.Mkdirat
-	sysMount   = syscall.Mount
-	sysOpen    = syscall.Open
-	sysOpenat  = syscall.Openat
-	sysUnmount = syscall.Unmount
-	sysFchown  = sys.Fchown
-	sysSymlink = syscall.Symlink
+	sysClose      = syscall.Close
+	sysMkdirat    = syscall.Mkdirat
+	sysMount      = syscall.Mount
+	sysOpen       = syscall.Open
+	sysOpenat     = syscall.Openat
+	sysUnmount    = syscall.Unmount
+	sysFchown     = sys.Fchown
+	sysFstat      = syscall.Fstat
+	sysSymlinkat  = osutil.Symlinkat
+	sysReadlinkat = osutil.Readlinkat
 
 	ioutilReadDir = ioutil.ReadDir
 )
@@ -202,6 +204,63 @@ func secureMkFile(fd int, segments []string, i int, perm os.FileMode, uid sys.Us
 	return nil
 }
 
+// secureMkSymlink creates a symlink at i-th entry of absolute path represented by
+// segments. This function is meant to be used to create the leaf symlink.
+// Existing and identical symlinks are reused without errors.
+func secureMkSymlink(fd int, segments []string, i int, oldname string) error {
+	logger.Debugf("secure-mk-symlink %d %q %d %q", fd, segments, i, oldname)
+	segment := segments[i]
+	var err error
+
+	// Open the final path segment as a file. Try to create the file (so that
+	// we know if we need to chown it) but fall back to just opening an
+	// existing one.
+
+	// TODO: don't write links outside of tmpfs or $SNAP_{,USER_}{DATA,COMMON}
+	err = sysSymlinkat(oldname, fd, segment)
+	if err != nil {
+		switch err {
+		case syscall.EEXIST:
+			var objFd int
+			const O_PATH = 010000000
+			// If the file exists then just open it for examination.
+			// Maybe it's the symlink we were hoping to create.
+			objFd, err = sysOpenat(fd, segment, syscall.O_CLOEXEC|O_PATH|syscall.O_NOFOLLOW, 0)
+			if err != nil {
+				return fmt.Errorf("cannot open existing file %q: %v", segment, err)
+			}
+			var statBuf syscall.Stat_t
+			err = sysFstat(objFd, &statBuf)
+			if err != nil {
+				return fmt.Errorf("cannot inspect existing file %q: %v", segment, err)
+			}
+			if statBuf.Mode&syscall.S_IFLNK != syscall.S_IFLNK {
+				return fmt.Errorf("cannot create symbolic link %q: existing file in the way", segment)
+			}
+			var n int
+			buf := make([]byte, len(oldname)+2)
+			n, err = sysReadlinkat(objFd, "", buf)
+			if err != nil {
+				return fmt.Errorf("cannot read symbolic link %q: %v", segment, err)
+			}
+			if string(buf[:n]) != oldname {
+				return fmt.Errorf("cannot create symbolic link %q: existing symbolic link in the way", segment)
+			}
+			return nil
+		case syscall.EROFS:
+			// Treat EROFS specially: this is a hint that we have to poke a
+			// hole using tmpfs. The path below is the location where we
+			// need to poke the hole.
+			p := "/" + strings.Join(segments[:i], "/")
+			return &ReadOnlyFsError{Path: p}
+		default:
+			return fmt.Errorf("cannot create symlink %q: %v", segment, err)
+		}
+	}
+
+	return nil
+}
+
 func splitIntoSegments(name string) ([]string, error) {
 	if name != filepath.Clean(name) {
 		return nil, fmt.Errorf("cannot split unclean path %q", name)
@@ -294,16 +353,35 @@ func secureMkfileAll(name string, perm os.FileMode, uid sys.UserID, gid sys.Grou
 	return err
 }
 
-func secureMklinkAll(name string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, oldname string) error {
-	parent := filepath.Dir(name)
-	err := secureMkdirAll(parent, perm, uid, gid)
+func secureMksymlinkAll(name string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, oldname string) error {
+	logger.Debugf("secure-mksymlink-all %q %q %d %d %q", name, perm, uid, gid, oldname)
+
+	// Only support absolute paths to avoid bugs in snap-confine when
+	// called from anywhere.
+	if !filepath.IsAbs(name) {
+		return fmt.Errorf("cannot create symlink with relative path: %q", name)
+	}
+	// Only support file names, not directory names.
+	if strings.HasSuffix(name, "/") {
+		return fmt.Errorf("cannot create non-file path: %q", name)
+	}
+
+	// Split the path into segments.
+	segments, err := splitIntoSegments(name)
 	if err != nil {
 		return err
 	}
-	// TODO: roll this uber securely like the code above does using linkat(2).
-	err = sysSymlink(oldname, name)
-	if err == syscall.EROFS {
-		return &ReadOnlyFsError{Path: parent}
+
+	// Create the prefix.
+	fd, err := secureMkPrefix(segments, perm, uid, gid)
+	if err != nil {
+		return err
+	}
+	defer sysClose(fd)
+
+	if len(segments) > 0 {
+		// Create the final segment as a symlink.
+		err = secureMkSymlink(fd, segments, len(segments)-1, oldname)
 	}
 	return err
 }

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -648,6 +648,48 @@ func (s *realSystemSuite) TestSecureMkfileAllForReal(c *C) {
 	c.Check(fi.Mode().Perm(), Equals, os.FileMode(0750))
 }
 
+// Check that we can actually create symlinks.
+// This doesn't test the chown logic as that requires root.
+func (s *realSystemSuite) TestSecureMksymlinkAllForReal(c *C) {
+	d := c.MkDir()
+
+	// Create symlink f1 that points to "oldname" and check that it
+	// is correct. Note that symlink permissions are always set to 0777
+	f1 := filepath.Join(d, "symlink")
+	err := update.SecureMksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "oldname")
+	c.Assert(err, IsNil)
+	fi, err := os.Lstat(f1)
+	c.Assert(err, IsNil)
+	c.Check(fi.Mode()&os.ModeSymlink, Equals, os.ModeSymlink)
+	c.Check(fi.Mode().Perm(), Equals, os.FileMode(0777))
+
+	target, err := os.Readlink(f1)
+	c.Assert(err, IsNil)
+	c.Check(target, Equals, "oldname")
+
+	// Create an identical symlink to see that it doesn't fail.
+	err = update.SecureMksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "oldname")
+	c.Assert(err, IsNil)
+
+	// Create a different symlink and see that it fails now
+	err = update.SecureMksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "other")
+	c.Assert(err, ErrorMatches, `cannot create symbolic link "symlink": existing symbolic link in the way`)
+
+	// Create an file and check that it clashes with a symlink we attempt to create.
+	f2 := filepath.Join(d, "file")
+	err = update.SecureMkfileAll(f2, 0755, sys.FlagID, sys.FlagID)
+	c.Assert(err, IsNil)
+	err = update.SecureMksymlinkAll(f2, 0755, sys.FlagID, sys.FlagID, "oldname")
+	c.Assert(err, ErrorMatches, `cannot create symbolic link "file": existing file in the way`)
+
+	// Create an file and check that it clashes with a symlink we attempt to create.
+	f3 := filepath.Join(d, "dir")
+	err = update.SecureMkdirAll(f3, 0755, sys.FlagID, sys.FlagID)
+	c.Assert(err, IsNil)
+	err = update.SecureMksymlinkAll(f3, 0755, sys.FlagID, sys.FlagID, "oldname")
+	c.Assert(err, ErrorMatches, `cannot create symbolic link "dir": existing file in the way`)
+}
+
 func (s *utilsSuite) TestCleanTrailingSlash(c *C) {
 	// This is a sanity test for the use of filepath.Clean in secureMk{dir,file}All
 	c.Assert(filepath.Clean("/path/"), Equals, "/path")


### PR DESCRIPTION
This patch addresses two issues with layout symlinks:

 - symlinks were not created in a secure way, because symlinkat(2) and
   readlinkat(2) were not available
 - attempting to create a symlink where one would be present and had
   the right target would fail

This addresses the first half of the layout feature that sometimes
breaks in spread tests because existing symbolic links are not
inspected.

As a small tweak the secureMklinkAll function was renamed to
secureMksymlinkAll. In case we ever want to create hard links the name
will be less confusing.

The new function is covered with some unit tests and some non-mocked
real tests, ensuring that it is fully tested without extensive (long)
set of mocked unit tests.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
