### PR TITLE
snapstate: put layout feature behind feature flag (2.32)

### DIFF
--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -153,6 +153,14 @@ func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 		info.SideInfo.Paid = true
 	case "channel-for-private":
 		info.SideInfo.Private = true
+	case "channel-for-layout":
+		info.Layout = map[string]*snap.Layout{
+			"/usr": {
+				Snap:    info,
+				Path:    "/usr",
+				Symlink: "$SNAP/usr",
+			},
+		}
 	}
 
 	userID := 0
@@ -219,6 +227,16 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 		},
 		Confinement:   confinement,
 		Architectures: []string{"all"},
+	}
+	switch cand.Channel {
+	case "channel-for-layout":
+		info.Layout = map[string]*snap.Layout{
+			"/usr": {
+				Snap:    info,
+				Path:    "/usr",
+				Symlink: "$SNAP/usr",
+			},
+		}
 	}
 
 	var hit snap.Revision

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
@@ -500,6 +501,25 @@ func defaultContentPlugProviders(st *state.State, info *snap.Info) []string {
 	return out
 }
 
+// validateFeatureFlags validates the given snap only uses experimental
+// features that are enabled by the user.
+func validateFeatureFlags(st *state.State, info *snap.Info) error {
+	if len(info.Layout) == 0 {
+		return nil
+	}
+
+	tr := config.NewTransaction(st)
+	var featureFlagLayouts bool
+	if err := tr.GetMaybe("core", "experimental.layouts", &featureFlagLayouts); err != nil {
+		return err
+	}
+	if featureFlagLayouts {
+		return nil
+	}
+
+	return fmt.Errorf("cannot use experimental 'layouts' feature, set option 'experimental.layouts' to true and try again")
+}
+
 // InstallPath returns a set of tasks for installing snap from a file path.
 // Note that the state must be locked by the caller.
 // The provided SideInfo can contain just a name which results in a
@@ -538,6 +558,9 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, channel string, flags
 	}
 
 	if err := validateContainer(container, info, logger.Noticef); err != nil {
+		return nil, err
+	}
+	if err := validateFeatureFlags(st, info); err != nil {
 		return nil, err
 	}
 
@@ -583,6 +606,9 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 	}
 
 	if err := validateInfoAndFlags(info, &snapst, flags); err != nil {
+		return nil, err
+	}
+	if err := validateFeatureFlags(st, info); err != nil {
 		return nil, err
 	}
 
@@ -711,6 +737,13 @@ func doUpdate(st *state.State, names []string, updates []*snap.Info, params func
 		channel, flags, snapst := params(update)
 
 		if err := validateInfoAndFlags(update, snapst, flags); err != nil {
+			if refreshAll {
+				logger.Noticef("cannot update %q: %v", update.Name(), err)
+				continue
+			}
+			return nil, nil, err
+		}
+		if err := validateFeatureFlags(st, update); err != nil {
 			if refreshAll {
 				logger.Noticef("cannot update %q: %v", update.Name(), err)
 				continue

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8798,6 +8798,123 @@ func (s *snapmgrTestSuite) TestSideInfoPrivate(c *C) {
 	c.Check(snapst.CurrentSideInfo().Paid, Equals, false)
 }
 
+func (s *snapmgrTestSuite) TestInstallPathWithLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	mockSnap := makeTestSnap(c, `name: some-snap
+version: 1.0
+layout:
+ /usr:
+  bind: $SNAP/usr
+`)
+	_, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "cannot use experimental 'layouts' feature.*")
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	_, err = snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(8)}, mockSnap, "", snapstate.Flags{})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestInstallLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	_, err := snapstate.Install(s.state, "some-snap", "channel-for-layout", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "cannot use experimental 'layouts' feature.*")
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	_, err = snapstate.Install(s.state, "some-snap", "channel-for-layout", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	_, err := snapstate.Update(s.state, "some-snap", "channel-for-layout", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, "cannot use experimental 'layouts' feature.*")
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	_, err = snapstate.Update(s.state, "some-snap", "channel-for-layout", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyExplicitLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:  true,
+		Channel: "channel-for-layout",
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	_, _, err := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	c.Assert(err, ErrorMatches, "cannot use experimental 'layouts' feature.*")
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	_, _, err = snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	c.Assert(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyLayoutsChecksFeatureFlag(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:  true,
+		Channel: "channel-for-layout",
+		Sequence: []*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	refreshes, _, err := snapstate.UpdateMany(s.state, nil, s.user.ID)
+	c.Assert(err, IsNil)
+	c.Assert(refreshes, HasLen, 0)
+
+	// enable layouts
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.layouts", true)
+	tr.Commit()
+
+	refreshes, _, err = snapstate.UpdateMany(s.state, nil, s.user.ID)
+	c.Assert(err, IsNil)
+	c.Assert(refreshes, DeepEquals, []string{"some-snap"})
+}
+
 type canDisableSuite struct{}
 
 var _ = Suite(&canDisableSuite{})

--- a/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-layout/meta/snap.yaml
@@ -1,0 +1,25 @@
+name: test-snapd-layout
+version: 1.0
+summary: Sample illustrating very basic layout support
+apps:
+    sh:
+        command: ../../../bin/sh
+layout:
+  # Layouts can be used to inject configuration files and directories.
+  /etc/demo:
+    bind: $SNAP_COMMON/etc/demo
+  /etc/demo.conf:
+    bind-file: $SNAP_COMMON/etc/demo.conf
+  /etc/demo.cfg:
+    symlink: $SNAP_COMMON/etc/demo.conf
+  # Layouts can be used to remap $SNAP paths to work around hard-coded locations.
+  /usr/share/demo:
+    bind: $SNAP/usr/share/demo
+  # Layouts can be used to remap $SNAP_DATA to work around hard-coded locations
+  /var/lib/demo:
+    bind: $SNAP_DATA/var/lib/demo
+  /var/cache/demo:
+    bind: $SNAP_DATA/var/cache/demo
+  # Layouts can help with applications designed for /opt
+  /opt/demo:
+    bind: $SNAP/opt/demo

--- a/tests/lib/snaps/test-snapd-layout/opt/demo/file
+++ b/tests/lib/snaps/test-snapd-layout/opt/demo/file
@@ -1,0 +1,1 @@
+content-of-file

--- a/tests/lib/snaps/test-snapd-layout/usr/share/demo/file
+++ b/tests/lib/snaps/test-snapd-layout/usr/share/demo/file
@@ -1,0 +1,1 @@
+content-of-file

--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -1,0 +1,57 @@
+summary: Ensure that snap layouts are applied
+details: |
+    This test installs a test snap that uses layout declarations.
+    The layout changes which directories and files exist in the filesystem
+    in the area beyond the $SNAP directory. In addition all applications and
+    hooks get permissions to access those areas.
+prepare: |
+    echo "Ensure feature flag is enabled"
+    snap set core experimental.layouts=true
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-layout
+debug: |
+    # We saw some failures where it looked like we were confined by the most
+    # wrong thing imaginable. To get an idea what is going on let's show
+    # the profile we were using when the test fails.
+    # Before per-snap update-ns profiles are here.
+    cat /etc/apparmor.d/*snap.core.*.usr.lib.snapd.snap-confine* || :
+    # Once per-snap update-ns profiles are here.
+    cat /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-layout || :
+execute: |
+    echo "snap declaring layouts doesn't explode on startup"
+    test-snapd-layout.sh -c "true"
+    
+    echo "layout declarations are honored"
+
+    test-snapd-layout.sh -c "test -d /etc/demo"
+    test-snapd-layout.sh -c "test -f /etc/demo.conf"
+    test-snapd-layout.sh -c "test -h /etc/demo.cfg"
+    test "$(test-snapd-layout.sh -c "readlink /etc/demo.cfg")" = "$(test-snapd-layout.sh -c 'echo $SNAP_COMMON/etc/demo.conf')"
+    test-snapd-layout.sh -c "test -d /usr/share/demo"
+    test-snapd-layout.sh -c "test -d /var/lib/demo"
+    test-snapd-layout.sh -c "test -d /var/cache/demo"
+    test-snapd-layout.sh -c "test -d /opt/demo"
+
+    echo "layout locations pointing to SNAP_DATA and SNAP_COMMON are writable"
+    echo "and the writes go to the right place in the backing store"
+
+    test-snapd-layout.sh -c "echo foo-1 > /etc/demo/writable"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo/writable')" = "foo-1"
+
+    test-snapd-layout.sh -c "echo foo-2 > /etc/demo.conf"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo.conf')" = "foo-2"
+
+    # NOTE: this is a symlink to demo.conf, effectively
+    test-snapd-layout.sh -c "echo foo-3 > /etc/demo.cfg"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo.conf')" = "foo-3"
+
+    test-snapd-layout.sh -c "echo foo-4 > /var/lib/demo/writable"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_DATA/var/lib/demo/writable')" = "foo-4"
+
+    test-snapd-layout.sh -c "echo foo-5 > /var/cache/demo/writable"
+    test "$(test-snapd-layout.sh -c 'cat $SNAP_DATA/var/cache/demo/writable')" = "foo-5"
+
+    echo "layout locations pointing to SNAP are readable"
+
+    test-snapd-layout.sh -c "test -r /usr/share/demo/file"
+    test-snapd-layout.sh -c "test -r /opt/demo/file"


### PR DESCRIPTION
Install/refresh of snaps with the layout feature will be forbidden
unless "core.experimental.layouts" is set to "true"