### PR TITLE
tests: adding checks before stopping snapd service to avoid job canceled on ubuntu 14.04

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -5,24 +5,15 @@ set -e -x
 # shellcheck source=tests/lib/dirs.sh
 . "$TESTSLIB/dirs.sh"
 
+# shellcheck source=tests/lib/systemd.sh
+. "$TESTSLIB/systemd.sh"
+
 reset_classic() {
     # Reload all service units as in some situations the unit might
     # have changed on the disk.
     systemctl daemon-reload
 
-    echo "Ensure the service is active before stopping it"
-    retries=20
-    systemctl status snapd.service snapd.socket || true
-    while systemctl status snapd.service snapd.socket | grep "Active: activating"; do
-        if [ $retries -eq 0 ]; then
-            echo "snapd service or socket not active"
-            exit 1
-        fi
-        retries=$(( $retries - 1 ))
-        sleep 1
-    done
-
-    systemctl stop snapd.service snapd.socket
+    systemd_stop_units snapd.service snapd.socket
 
     case "$SPREAD_SYSTEM" in
         ubuntu-*|debian-*)

--- a/tests/lib/systemd.sh
+++ b/tests/lib/systemd.sh
@@ -36,3 +36,23 @@ wait_for_service() {
     echo "service $service_name did not start"
     exit 1
 }
+
+systemd_stop_units() {
+    for unit in "$@"; do
+        if systemctl is-active "$unit"; then
+            echo "Ensure the service is active before stopping it"
+            retries=20
+            systemctl status "$unit" || true
+            while systemctl status "$unit" | grep "Active: activating"; do
+                if [ $retries -eq 0 ]; then
+                    echo "$unit unit not active"
+                    exit 1
+                fi
+                retries=$(( $retries - 1 ))
+                sleep 1
+            done
+
+            systemctl stop "$unit"
+        fi
+    done
+}

--- a/tests/main/completion/task.yaml
+++ b/tests/main/completion/task.yaml
@@ -9,7 +9,9 @@ environment:
     NAMES: /var/cache/snapd/names
 
 prepare: |
-    systemctl stop snapd.service snapd.socket
+    . "$TESTSLIB/systemd.sh"
+
+    systemd_stop_units snapd.service snapd.socket
     [ -e "$NAMES" ] && mv "$NAMES" "$NAMES.orig"
     cat >"$NAMES" <<EOF
     test-assumes

--- a/tests/main/install-store-laaaarge/task.yaml
+++ b/tests/main/install-store-laaaarge/task.yaml
@@ -1,12 +1,16 @@
 summary: snap install a large snap from the store (bigger than tmpfs)
 
 prepare: |
-    systemctl stop snapd.{service,socket}
+    . "$TESTSLIB/systemd.sh"
+
+    systemd_stop_units snapd.service snapd.socket
     mount -t tmpfs -o rw,nosuid,nodev,size=4 none /tmp
     systemctl start snapd.{socket,service}
 
 restore: |
-    systemctl stop snapd.{service,socket}
+    . "$TESTSLIB/systemd.sh"
+
+    systemd_stop_units snapd.service snapd.socket
     umount /tmp || true
     systemctl start snapd.{socket,service}
 

--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -11,7 +11,10 @@ details: |
 prepare: |
     echo "Ensure an empty state so that installing test-snapd-content-plug"
     echo "will pull in test-snapd-content-slot *and* core"
-    systemctl stop snapd
+
+    . "$TESTSLIB/systemd.sh"
+
+    systemd_stop_units snapd.service
     rm -f /var/lib/snapd/state.json
     systemctl start snapd
 


### PR DESCRIPTION
This is a fix for the error that happens in ubuntu 14.04 when the snapd service is stopped. 
    systemctl stop snapd.service snapd.socket
    Job for snapd.service canceled.

systemd shows that error just on ubuntu trusty when the service which is being stoped is not active yet. 