### PR TITLE
strutil, cmd/snap: drop strutil.WordWrap, first pass at replacement

### DIFF
--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -442,3 +442,35 @@ installed:    2.10 (1) 1kB disabled
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 }
+
+func (infoSuite) TestDescr(c *check.C) {
+	for k, v := range map[string]string{
+		"": "  \n",
+		`one:
+ * two three four five six  
+   * seven height nine ten
+`: `  one:
+   * two three four
+   five six
+     * seven height
+     nine ten
+`,
+		"abcdefghijklm nopqrstuvwxyz ABCDEFGHIJKLMNOPQR STUVWXYZ": `
+  abcdefghijklm
+  nopqrstuvwxyz
+  ABCDEFGHIJKLMNOPQR
+  STUVWXYZ
+`[1:],
+		// not much we can do when it won't fit
+		"abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ": `
+  abcdefghijklmnopqr
+  stuvwxyz
+  ABCDEFGHIJKLMNOPQR
+  STUVWXYZ
+`[1:],
+	} {
+		var buf bytes.Buffer
+		snap.PrintDescr(&buf, k, 20)
+		c.Check(buf.String(), check.Equals, v, check.Commentf("%q", k))
+	}
+}

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -42,6 +42,7 @@ var (
 	AdviseCommand      = adviseCommand
 	Antialias          = antialias
 	FormatChannel      = fmtChannel
+	PrintDescr         = printDescr
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -20,7 +20,6 @@
 package strutil
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -70,41 +69,6 @@ func Quoted(names []string) string {
 	}
 
 	return strings.Join(quoted, ", ")
-}
-
-// WordWrap takes a input string and word wraps after `n` chars
-// into a new slice.
-//
-// Caveats:
-// - If a single word that is biger than max will not get wrapped
-// - Extra whitespace will be removed
-func WordWrap(s string, max int) []string {
-	n := 0
-
-	var out []string
-	line := bytes.NewBuffer(nil)
-	// FIXME: we want to be smarter here. to quote Gustavo: "The
-	// logic here is corrupting the spacing of the original line,
-	// which means indentation and tabling will be gone. A better
-	// approach would be finding the break point and then using
-	// the original content instead of rewriting it."
-	for _, word := range strings.Fields(s) {
-		if n+len(word) > max && n > 0 {
-			out = append(out, line.String())
-			line.Truncate(0)
-			n = 0
-		} else if n > 0 {
-			fmt.Fprintf(line, " ")
-			n += 1
-		}
-		fmt.Fprintf(line, word)
-		n += len(word)
-	}
-	if line.Len() > 0 {
-		out = append(out, line.String())
-	}
-
-	return out
 }
 
 // ListContains determines whether the given string is contained in the

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -83,26 +83,6 @@ func (ts *strutilSuite) TestSizeToStr(c *check.C) {
 	}
 }
 
-func (ts *strutilSuite) TestWordWrap(c *check.C) {
-	for _, t := range []struct {
-		in  string
-		out []string
-		n   int
-	}{
-		// pathological
-		{"12345", []string{"12345"}, 3},
-		{"123 456789", []string{"123", "456789"}, 3},
-		// valid
-		{"abc def ghi", []string{"abc", "def", "ghi"}, 3},
-		{"a b c d e f", []string{"a b", "c d", "e f"}, 3},
-		{"ab cd ef", []string{"ab cd", "ef"}, 5},
-		// intentional (but slightly strange)
-		{"ab            cd", []string{"ab", "cd"}, 2},
-	} {
-		c.Check(strutil.WordWrap(t.in, t.n), check.DeepEquals, t.out)
-	}
-}
-
 func (ts *strutilSuite) TestListContains(c *check.C) {
 	for _, xs := range [][]string{
 		{},


### PR DESCRIPTION
strutil.WordWrap was rather buggy, so it's getting replaced.

This is the first pass at that, which is already good enough that I
think this should land, but it does have more work to be done. Gustavo
would like to find a heuristic for line folding; I'd like to make it
more aware of unicode widths.

In any case once we're happy with it we should probably move the
reusable parts to strutil.
