### PR TITLE
spread,tests: move suite-level prepare/restore to central script

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -365,45 +365,25 @@ suites:
     tests/main/:
         summary: Full-system tests for snapd
         prepare: |
-            . $TESTSLIB/prepare.sh
-            if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
-                prepare_all_snap
-            else
-                prepare_classic
-            fi
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
-            $TESTSLIB/reset.sh --reuse-core
-            . $TESTSLIB/prepare.sh
-            if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then
-                prepare_each_classic
-            fi
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
+        restore-each: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
         restore: |
-            $TESTSLIB/reset.sh --store
-            if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then
-                . $TESTSLIB/pkgdb.sh
-                distro_purge_package snapd
-                if [[ "$SPREAD_SYSTEM" != opensuse-* ]]; then
-                    # A snap-confine package never existed on openSUSE
-                    distro_purge_package snap-confine
-                fi
-            fi
-
+            "$TESTSLIB"/prepare-restore.sh --restore-suite
     tests/completion/:
         summary: completion tests
         # ppc64el disabled because of https://bugs.launchpad.net/snappy/+bug/1655594
         systems: [-ubuntu-core-*, -ubuntu-*-ppc64el]
         prepare: |
-            . $TESTSLIB/prepare.sh
-            prepare_classic
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
-            $TESTSLIB/reset.sh --reuse-core
-            . $TESTSLIB/prepare.sh
-            prepare_each_classic
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
+        restore-each: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
         restore: |
-            $TESTSLIB/reset.sh --store
-            . $TESTSLIB/pkgdb.sh
-            distro_purge_package snapd
-
+            "$TESTSLIB"/prepare-restore.sh --restore-suite
         environment:
           _/plain: _
           _/plain_plusdirs: _
@@ -422,20 +402,13 @@ suites:
     tests/regression/:
         summary: Regression tests for snapd
         prepare: |
-            . $TESTSLIB/prepare.sh
-            if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
-                prepare_all_snap
-            else
-                prepare_classic
-            fi
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite
         prepare-each: |
-            $TESTSLIB/reset.sh --reuse-core
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
+        restore-each: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
         restore: |
-            $TESTSLIB/reset.sh
-            if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then
-                . $TESTSLIB/pkgdb.sh
-                distro_purge_package snapd
-            fi
+            "$TESTSLIB"/prepare-restore.sh --restore-suite
 
     tests/upgrade/:
         summary: Tests for snapd upgrade

--- a/spread.yaml
+++ b/spread.yaml
@@ -347,8 +347,9 @@ prepare: |
         rmdir "$DELTA_PREFIX"
     fi
 
-    # Take the MATCH function from spread and allow our shell scripts to use it.
+    # Take the MATCH and REBOOT functions from spread and allow our shell scripts to use them.
     type MATCH | tail -n +2 > $TESTSLIB/spread-funcs.sh
+    type REBOOT | tail -n +2 >> $TESTSLIB/spread-funcs.sh
 
     # NOTE: At this stage the source tree is available and no more special
     # considerations apply.

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -338,6 +338,44 @@ prepare_project_each() {
     fixup_dev_random
 }
 
+prepare_suite() {
+    # shellcheck source=tests/lib/prepare.sh
+    . "$TESTSLIB"/prepare.sh
+    if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
+        prepare_all_snap
+    else
+        prepare_classic
+    fi
+}
+
+prepare_suite_each() {
+    # shellcheck source=tests/lib/reset.sh
+    "$TESTSLIB"/reset.sh --reuse-core
+    # shellcheck source=tests/lib/prepare.sh
+    . "$TESTSLIB"/prepare.sh
+    if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then
+        prepare_each_classic
+    fi
+}
+
+restore_suite_each() {
+    true
+}
+
+restore_suite() {
+    # shellcheck source=tests/lib/reset.sh
+    "$TESTSLIB"/reset.sh --store
+    if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then
+        # shellcheck source=tests/lib/pkgdb.sh
+        . $TESTSLIB/pkgdb.sh
+        distro_purge_package snapd
+        if [[ "$SPREAD_SYSTEM" != opensuse-* ]]; then
+            # A snap-confine package never existed on openSUSE
+            distro_purge_package snap-confine
+        fi
+    fi
+}
+
 restore_project_each() {
     restore_dev_random
 
@@ -375,6 +413,18 @@ case "$1" in
     --prepare-project-each)
         prepare_project_each
         ;;
+    --prepare-suite)
+        prepare_suite
+        ;;
+    --prepare-suite-each)
+        prepare_suite_each
+        ;;
+    --restore-suite-each)
+        restore_suite_each
+        ;;
+    --restore-suite)
+        restore_suite
+        ;;
     --restore-project-each)
         restore_project_each
         ;;
@@ -383,7 +433,7 @@ case "$1" in
         ;;
     *)
         echo "unsupported argument: $1"
-        echo "try one of --{prepare,restore}-project{,-each}"
+        echo "try one of --{prepare,restore}-{project,suite}{,-each}"
         exit 1
         ;;
 esac

--- a/tests/lib/spread-funcs.sh
+++ b/tests/lib/spread-funcs.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-# Define a dummy MATCH function. This file is replaced by the real MATCH
-# function, as defined by spread, on project prepare (in spread.yaml).
-#
+# Define a dummy MATCH and REBOOT functions. This file is replaced by real
+# functions, as defined by spread, on project prepare (in spread.yaml).
+
 MATCH() {
 	echo "dummy MATCH function invoked"
 	false
 }
 
+REBOOT() {
+	echo "dummy REBOOT function invoked"
+	false
+}


### PR DESCRIPTION
The test suite now uses centrally managed prepare-restore code. This is
just a first step towards moving all the prepare-restore code there,
done in a way that can be tested easily.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
