### PR TITLE
many: propagate contexts enough to be able to mark store operations done from the Ensure loop (2.32)

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -38,6 +38,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/gorilla/mux"
 	"github.com/jessevdk/go-flags"
 
@@ -550,7 +552,8 @@ func getSections(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	theStore := getStore(c)
 
-	sections, err := theStore.Sections(user)
+	// TODO: use a per-request context
+	sections, err := theStore.Sections(context.TODO(), user)
 	switch err {
 	case nil:
 		// pass
@@ -922,7 +925,8 @@ func snapUpdateMany(inst *snapInstruction, st *state.State) (*snapInstructionRes
 		return nil, err
 	}
 
-	updated, tasksets, err := snapstateUpdateMany(st, inst.Snaps, inst.userID)
+	// TODO: use a per-request context
+	updated, tasksets, err := snapstateUpdateMany(context.TODO(), st, inst.Snaps, inst.userID)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strconv"
 
+	"golang.org/x/net/context"
 	"gopkg.in/macaroon.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -542,4 +543,19 @@ func (ac *authContext) CloudInfo() (*CloudInfo, error) {
 		return &cloudInfo, nil
 	}
 	return nil, nil
+}
+
+type ensureContextKey struct{}
+
+// EnsureContextTODO returns a provisional context marked as
+// pertaining to an Ensure loop.
+// TODO: see Overlord.Loop to replace it with a proper context passed to all Ensures.
+func EnsureContextTODO() context.Context {
+	ctx := context.TODO()
+	return context.WithValue(ctx, ensureContextKey{}, struct{}{})
+}
+
+// IsEnsureContext returns whether context was marked as pertaining to an Ensure loop.
+func IsEnsureContext(ctx context.Context) bool {
+	return ctx.Value(ensureContextKey{}) != nil
 }

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	. "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v1"
 
@@ -798,4 +800,16 @@ func (as *authSuite) TestUsers(c *C) {
 	as.state.Unlock()
 	c.Check(err, IsNil)
 	c.Check(users, DeepEquals, []*auth.UserState{user1, user2})
+}
+
+func (as *authSuite) TestEnsureContexts(c *C) {
+	ctx1 := auth.EnsureContextTODO()
+	ctx2 := auth.EnsureContextTODO()
+
+	c.Check(ctx1, Not(Equals), ctx2)
+
+	c.Check(auth.IsEnsureContext(ctx1), Equals, true)
+	c.Check(auth.IsEnsureContext(ctx2), Equals, true)
+
+	c.Check(auth.IsEnsureContext(context.TODO()), Equals, false)
 }

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"sort"
 
+	"golang.org/x/net/context"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
@@ -56,7 +58,7 @@ func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 	}, nil
 }
 
-func (f *fakeStore) ListRefresh(cand []*store.RefreshCandidate, user *auth.UserState, opt *store.RefreshOptions) ([]*snap.Info, error) {
+func (f *fakeStore) ListRefresh(_ context.Context, cand []*store.RefreshCandidate, user *auth.UserState, opt *store.RefreshOptions) ([]*snap.Info, error) {
 	return []*snap.Info{{
 		SideInfo: snap.SideInfo{
 			RealName: "test-snap",
@@ -342,7 +344,7 @@ func (s *servicectlSuite) TestQueuedCommandsUpdateMany(c *C) {
 	s.st.Lock()
 
 	chg := s.st.NewChange("update many change", "update change")
-	installed, tts, err := snapstate.UpdateMany(s.st, []string{"test-snap", "other-snap"}, 0)
+	installed, tts, err := snapstate.UpdateMany(context.TODO(), s.st, []string{"test-snap", "other-snap"}, 0)
 	c.Assert(err, IsNil)
 	sort.Strings(installed)
 	c.Check(installed, DeepEquals, []string{"other-snap", "test-snap"})

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -34,6 +34,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/context"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -838,7 +840,7 @@ version: @VERSION@
 	snapPath, _ = ms.makeStoreTestSnap(c, strings.Replace(snapYamlContent, "@VERSION@", ver, -1), revno)
 	ms.serveSnap(snapPath, revno)
 
-	updated, tss, err := snapstate.UpdateMany(st, []string{"foo"}, 0)
+	updated, tss, err := snapstate.UpdateMany(context.TODO(), st, []string{"foo"}, 0)
 	c.Check(updated, IsNil)
 	c.Check(tss, IsNil)
 	// no validation we, get an error
@@ -858,7 +860,7 @@ version: @VERSION@
 	c.Assert(err, IsNil)
 
 	// ... and try again
-	updated, tss, err = snapstate.UpdateMany(st, []string{"foo"}, 0)
+	updated, tss, err = snapstate.UpdateMany(context.TODO(), st, []string{"foo"}, 0)
 	c.Assert(err, IsNil)
 	c.Assert(updated, DeepEquals, []string{"foo"})
 	c.Assert(tss, HasLen, 1)
@@ -1347,7 +1349,7 @@ apps:
 	ms.serveSnap(fooPath, "15")
 
 	// refresh all
-	updated, tss, err := snapstate.UpdateMany(st, nil, 0)
+	updated, tss, err := snapstate.UpdateMany(context.TODO(), st, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(updated, DeepEquals, []string{"foo"})
 	c.Assert(tss, HasLen, 1)
@@ -1593,7 +1595,7 @@ apps:
 	err = assertstate.RefreshSnapDeclarations(st, 0)
 	c.Assert(err, IsNil)
 
-	updated, tss, err := snapstate.UpdateMany(st, nil, 0)
+	updated, tss, err := snapstate.UpdateMany(context.TODO(), st, nil, 0)
 	c.Assert(err, IsNil)
 	sort.Strings(updated)
 	c.Assert(updated, DeepEquals, []string{"bar", "foo"})

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -255,6 +255,7 @@ func (o *Overlord) Loop() {
 	o.ensureTimerSetup()
 	o.loopTomb.Go(func() error {
 		for {
+			// TODO: pass a proper context into Ensure
 			o.ensureTimerReset()
 			// in case of errors engine logs them,
 			// continue to the next Ensure() try for now

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -321,7 +322,7 @@ func (m *autoRefresh) refreshScheduleWithDefaultsFallback() (ts []*timeutil.Sche
 // launchAutoRefresh creates the auto-refresh taskset and a change for it.
 func (m *autoRefresh) launchAutoRefresh() error {
 	m.lastRefreshAttempt = time.Now()
-	updated, tasksets, err := AutoRefresh(m.state)
+	updated, tasksets, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
 	if err != nil {
 		logger.Noticef("Cannot prepare auto-refresh change: %s", err)
 		return err

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -25,6 +25,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"golang.org/x/net/context"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
@@ -46,7 +48,10 @@ type autoRefreshStore struct {
 	listRefreshErr error
 }
 
-func (r *autoRefreshStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+func (r *autoRefreshStore) ListRefresh(ctx context.Context, cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+	if ctx == nil || !auth.IsEnsureContext(ctx) {
+		panic("Ensure marked context required")
+	}
 	r.ops = append(r.ops, "list-refresh")
 	return nil, r.listRefreshErr
 }

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -37,9 +37,9 @@ type StoreService interface {
 	SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
 	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 	LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info, error)
-	ListRefresh([]*store.RefreshCandidate, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error)
-	Sections(user *auth.UserState) ([]string, error)
-	WriteCatalogs(names io.Writer, adder store.SnapAdder) error
+	ListRefresh(context.Context, []*store.RefreshCandidate, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error)
+	Sections(ctx context.Context, user *auth.UserState) ([]string, error)
+	WriteCatalogs(ctx context.Context, names io.Writer, adder store.SnapAdder) error
 	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error
 
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -264,7 +264,10 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 	return nil, store.ErrNoUpdateAvailable
 }
 
-func (f *fakeStore) ListRefresh(cands []*store.RefreshCandidate, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+func (f *fakeStore) ListRefresh(ctx context.Context, cands []*store.RefreshCandidate, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+	if ctx == nil {
+		panic("context required")
+	}
 	f.pokeStateLock()
 
 	if len(cands) == 0 {
@@ -311,7 +314,10 @@ func (f *fakeStore) Download(ctx context.Context, name, targetFn string, snapInf
 	return nil
 }
 
-func (f *fakeStore) WriteCatalogs(io.Writer, store.SnapAdder) error {
+func (f *fakeStore) WriteCatalogs(ctx context.Context, _ io.Writer, _ store.SnapAdder) error {
+	if ctx == nil {
+		panic("context required")
+	}
 	f.pokeStateLock()
 	f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{
 		op: "x-commands",
@@ -320,7 +326,10 @@ func (f *fakeStore) WriteCatalogs(io.Writer, store.SnapAdder) error {
 	return nil
 }
 
-func (f *fakeStore) Sections(*auth.UserState) ([]string, error) {
+func (f *fakeStore) Sections(ctx context.Context, _ *auth.UserState) ([]string, error) {
+	if ctx == nil {
+		panic("context required")
+	}
 	f.pokeStateLock()
 	f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{
 		op: "x-sections",

--- a/overlord/snapstate/catalogrefresh.go
+++ b/overlord/snapstate/catalogrefresh.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
 )
 
@@ -82,7 +83,7 @@ func refreshCatalogs(st *state.State, theStore StoreService) error {
 		return fmt.Errorf("cannot create directory %q: %v", dirs.SnapCacheDir, err)
 	}
 
-	sections, err := theStore.Sections(nil)
+	sections, err := theStore.Sections(auth.EnsureContextTODO(), nil)
 	if err != nil {
 		return err
 	}
@@ -106,7 +107,7 @@ func refreshCatalogs(st *state.State, theStore StoreService) error {
 	// if all goes well we'll Commit() making this a NOP:
 	defer cmdDB.Rollback()
 
-	if err := theStore.WriteCatalogs(namesFile, cmdDB); err != nil {
+	if err := theStore.WriteCatalogs(auth.EnsureContextTODO(), namesFile, cmdDB); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/catalogrefresh_test.go
+++ b/overlord/snapstate/catalogrefresh_test.go
@@ -23,6 +23,8 @@ import (
 	"io"
 	"time"
 
+	"golang.org/x/net/context"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/advisor"
@@ -42,7 +44,10 @@ type catalogStore struct {
 	ops []string
 }
 
-func (r *catalogStore) WriteCatalogs(w io.Writer, a store.SnapAdder) error {
+func (r *catalogStore) WriteCatalogs(ctx context.Context, w io.Writer, a store.SnapAdder) error {
+	if ctx == nil || !auth.IsEnsureContext(ctx) {
+		panic("Ensure marked context required")
+	}
 	r.ops = append(r.ops, "write-catalog")
 	w.Write([]byte("pkg1\npkg2"))
 	a.AddSnap("foo", "foo summary", []string{"foo", "meh"})
@@ -50,7 +55,10 @@ func (r *catalogStore) WriteCatalogs(w io.Writer, a store.SnapAdder) error {
 	return nil
 }
 
-func (r *catalogStore) Sections(*auth.UserState) ([]string, error) {
+func (r *catalogStore) Sections(ctx context.Context, _ *auth.UserState) ([]string, error) {
+	if ctx == nil || !auth.IsEnsureContext(ctx) {
+		panic("Ensure marked context required")
+	}
 	r.ops = append(r.ops, "sections")
 	return []string{"section1", "section2"}, nil
 }

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -22,6 +22,7 @@ package snapstate
 import (
 	"time"
 
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/store"
@@ -65,7 +66,7 @@ func (r *refreshHints) refresh() error {
 	var refreshManaged bool
 	refreshManaged = refreshScheduleManaged(r.state)
 
-	_, _, _, err := refreshCandidates(r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
+	_, _, _, err := refreshCandidates(auth.EnsureContextTODO(), r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
 	// TODO: we currently set last-refresh-hints even when there was an
 	// error. In the future we may retry with a backoff.
 	r.state.Set("last-refresh-hints", time.Now())

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -22,6 +22,8 @@ package snapstate_test
 import (
 	"time"
 
+	"golang.org/x/net/context"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/overlord/auth"
@@ -39,7 +41,10 @@ type recordingStore struct {
 	ops []string
 }
 
-func (r *recordingStore) ListRefresh(cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+func (r *recordingStore) ListRefresh(ctx context.Context, cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+	if ctx == nil || !auth.IsEnsureContext(ctx) {
+		panic("Ensure marked context required")
+	}
 	r.ops = append(r.ops, "list-refresh")
 	return nil, nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"golang.org/x/net/context"
+
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
@@ -650,7 +652,7 @@ func InstallMany(st *state.State, names []string, userID int) ([]string, []*stat
 // RefreshCandidates gets a list of candidates for update
 // Note that the state must be locked by the caller.
 func RefreshCandidates(st *state.State, user *auth.UserState) ([]*snap.Info, error) {
-	updates, _, _, err := refreshCandidates(st, nil, user, nil)
+	updates, _, _, err := refreshCandidates(context.TODO(), st, nil, user, nil)
 	return updates, err
 }
 
@@ -660,13 +662,13 @@ var ValidateRefreshes func(st *state.State, refreshes []*snap.Info, ignoreValida
 // UpdateMany updates everything from the given list of names that the
 // store says is updateable. If the list is empty, update everything.
 // Note that the state must be locked by the caller.
-func UpdateMany(st *state.State, names []string, userID int) ([]string, []*state.TaskSet, error) {
+func UpdateMany(ctx context.Context, st *state.State, names []string, userID int) ([]string, []*state.TaskSet, error) {
 	user, err := userFromUserID(st, userID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	updates, stateByID, ignoreValidation, err := refreshCandidates(st, names, user, nil)
+	updates, stateByID, ignoreValidation, err := refreshCandidates(ctx, st, names, user, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1084,7 +1086,7 @@ var AutoRefreshAssertions func(st *state.State, userID int) error
 // AutoRefresh is the wrapper that will do a refresh of all the installed
 // snaps on the system. In addition to that it will also refresh important
 // assertions.
-func AutoRefresh(st *state.State) ([]string, []*state.TaskSet, error) {
+func AutoRefresh(ctx context.Context, st *state.State) ([]string, []*state.TaskSet, error) {
 	userID := 0
 
 	if AutoRefreshAssertions != nil {
@@ -1093,7 +1095,7 @@ func AutoRefresh(st *state.State) ([]string, []*state.TaskSet, error) {
 		}
 	}
 
-	return UpdateMany(st, nil, userID)
+	return UpdateMany(ctx, st, nil, userID)
 }
 
 // Enable sets a snap to the active state

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -30,6 +30,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/net/context"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
@@ -694,7 +696,7 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 		SnapType: "app",
 	})
 
-	updates, tts, err := snapstate.UpdateMany(s.state, nil, 0)
+	updates, tts, err := snapstate.UpdateMany(context.TODO(), s.state, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(tts, HasLen, 1)
 	c.Check(updates, DeepEquals, []string{"some-snap"})
@@ -722,7 +724,7 @@ func (s *snapmgrTestSuite) TestUpdateManyDevModeConfinementFiltering(c *C) {
 	})
 
 	// updated snap is devmode, updatemany doesn't update it
-	_, tts, _ := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	_, tts, _ := snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap"}, s.user.ID)
 	// FIXME: UpdateMany will not error out in this case (daemon catches this case, with a weird error)
 	c.Assert(tts, HasLen, 0)
 }
@@ -744,7 +746,7 @@ func (s *snapmgrTestSuite) TestUpdateManyClassicConfinementFiltering(c *C) {
 	})
 
 	// if a snap installed without --classic gets a classic update it isn't installed
-	_, tts, _ := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	_, tts, _ := snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap"}, s.user.ID)
 	// FIXME: UpdateMany will not error out in this case (daemon catches this case, with a weird error)
 	c.Assert(tts, HasLen, 0)
 }
@@ -767,7 +769,7 @@ func (s *snapmgrTestSuite) TestUpdateManyClassic(c *C) {
 	})
 
 	// snap installed with classic: refresh gets classic
-	_, tts, err := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	_, tts, err := snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap"}, s.user.ID)
 	c.Assert(err, IsNil)
 	c.Assert(tts, HasLen, 1)
 }
@@ -786,7 +788,7 @@ func (s *snapmgrTestSuite) TestUpdateManyDevMode(c *C) {
 		SnapType: "app",
 	})
 
-	updates, _, err := snapstate.UpdateMany(s.state, []string{"some-snap"}, 0)
+	updates, _, err := snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap"}, 0)
 	c.Assert(err, IsNil)
 	c.Check(updates, HasLen, 1)
 }
@@ -805,7 +807,7 @@ func (s *snapmgrTestSuite) TestUpdateAllDevMode(c *C) {
 		SnapType: "app",
 	})
 
-	updates, _, err := snapstate.UpdateMany(s.state, nil, 0)
+	updates, _, err := snapstate.UpdateMany(context.TODO(), s.state, nil, 0)
 	c.Assert(err, IsNil)
 	c.Check(updates, HasLen, 0)
 }
@@ -835,7 +837,7 @@ func (s *snapmgrTestSuite) TestUpdateManyValidateRefreshes(c *C) {
 	// hook it up
 	snapstate.ValidateRefreshes = validateRefreshes
 
-	updates, tts, err := snapstate.UpdateMany(s.state, nil, 0)
+	updates, tts, err := snapstate.UpdateMany(context.TODO(), s.state, nil, 0)
 	c.Assert(err, IsNil)
 	c.Assert(tts, HasLen, 1)
 	c.Check(updates, DeepEquals, []string{"some-snap"})
@@ -868,13 +870,13 @@ func (s *snapmgrTestSuite) TestUpdateManyValidateRefreshesUnhappy(c *C) {
 	snapstate.ValidateRefreshes = validateRefreshes
 
 	// refresh all => no error
-	updates, tts, err := snapstate.UpdateMany(s.state, nil, 0)
+	updates, tts, err := snapstate.UpdateMany(context.TODO(), s.state, nil, 0)
 	c.Assert(err, IsNil)
 	c.Check(tts, HasLen, 0)
 	c.Check(updates, HasLen, 0)
 
 	// refresh some-snap => report error
-	updates, tts, err = snapstate.UpdateMany(s.state, []string{"some-snap"}, 0)
+	updates, tts, err = snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap"}, 0)
 	c.Assert(err, Equals, validateErr)
 	c.Check(tts, HasLen, 0)
 	c.Check(updates, HasLen, 0)
@@ -2024,7 +2026,7 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 
 	chg := s.state.NewChange("refresh", "refresh all snaps")
 	// no user is passed to use for UpdateMany
-	updated, tts, err := snapstate.UpdateMany(s.state, nil, 0)
+	updated, tts, err := snapstate.UpdateMany(context.TODO(), s.state, nil, 0)
 	c.Assert(err, IsNil)
 	for _, ts := range tts {
 		chg.AddAll(ts)
@@ -2109,7 +2111,7 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 
 	chg := s.state.NewChange("refresh", "refresh all snaps")
 	// do UpdateMany using user 2 as fallback
-	updated, tts, err := snapstate.UpdateMany(s.state, nil, 2)
+	updated, tts, err := snapstate.UpdateMany(context.TODO(), s.state, nil, 2)
 	c.Assert(err, IsNil)
 	for _, ts := range tts {
 		chg.AddAll(ts)
@@ -2892,7 +2894,7 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 	s.fakeStore.refreshRevnos = map[string]snap.Revision{
 		"some-snap-id": snap.R(12),
 	}
-	_, tts, err := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	_, tts, err := snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap"}, s.user.ID)
 	c.Assert(err, IsNil)
 	c.Check(tts, HasLen, 1)
 
@@ -3076,7 +3078,7 @@ func (s *snapmgrTestSuite) TestMultiUpdateBlockedRevision(c *C) {
 		SnapType: "app",
 	})
 
-	updates, _, err := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	updates, _, err := snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap"}, s.user.ID)
 	c.Assert(err, IsNil)
 	c.Check(updates, DeepEquals, []string{"some-snap"})
 
@@ -3115,7 +3117,7 @@ func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
 		Current:  si7.Revision,
 	})
 
-	updates, _, err := snapstate.UpdateMany(s.state, nil, s.user.ID)
+	updates, _, err := snapstate.UpdateMany(context.TODO(), s.state, nil, s.user.ID)
 	c.Check(err, IsNil)
 	c.Check(updates, HasLen, 0)
 
@@ -3218,7 +3220,7 @@ func (s *snapmgrTestSuite) TestUpdateManyAutoAliasesScenarios(c *C) {
 			snapstate.Set(s.state, snapName, &snapst)
 		}
 
-		updates, tts, err := snapstate.UpdateMany(s.state, scenario.names, s.user.ID)
+		updates, tts, err := snapstate.UpdateMany(context.TODO(), s.state, scenario.names, s.user.ID)
 		c.Check(err, IsNil)
 
 		_, dropped, err := snapstate.AutoAliasesDelta(s.state, []string{"some-snap", "other-snap"})
@@ -8902,7 +8904,7 @@ func (s *snapmgrTestSuite) TestUpdateManyExplicitLayoutsChecksFeatureFlag(c *C) 
 		SnapType: "app",
 	})
 
-	_, _, err := snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	_, _, err := snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap"}, s.user.ID)
 	c.Assert(err, ErrorMatches, "cannot use experimental 'layouts' feature.*")
 
 	// enable layouts
@@ -8910,7 +8912,7 @@ func (s *snapmgrTestSuite) TestUpdateManyExplicitLayoutsChecksFeatureFlag(c *C) 
 	tr.Set("core", "experimental.layouts", true)
 	tr.Commit()
 
-	_, _, err = snapstate.UpdateMany(s.state, []string{"some-snap"}, s.user.ID)
+	_, _, err = snapstate.UpdateMany(context.TODO(), s.state, []string{"some-snap"}, s.user.ID)
 	c.Assert(err, IsNil)
 }
 
@@ -8928,7 +8930,7 @@ func (s *snapmgrTestSuite) TestUpdateManyLayoutsChecksFeatureFlag(c *C) {
 		SnapType: "app",
 	})
 
-	refreshes, _, err := snapstate.UpdateMany(s.state, nil, s.user.ID)
+	refreshes, _, err := snapstate.UpdateMany(context.TODO(), s.state, nil, s.user.ID)
 	c.Assert(err, IsNil)
 	c.Assert(refreshes, HasLen, 0)
 
@@ -8937,7 +8939,7 @@ func (s *snapmgrTestSuite) TestUpdateManyLayoutsChecksFeatureFlag(c *C) {
 	tr.Set("core", "experimental.layouts", true)
 	tr.Commit()
 
-	refreshes, _, err = snapstate.UpdateMany(s.state, nil, s.user.ID)
+	refreshes, _, err = snapstate.UpdateMany(context.TODO(), s.state, nil, s.user.ID)
 	c.Assert(err, IsNil)
 	c.Assert(refreshes, DeepEquals, []string{"some-snap"})
 }

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"sort"
 
+	"golang.org/x/net/context"
+
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -187,7 +189,7 @@ func updateToRevisionInfo(st *state.State, snapst *SnapState, channel string, re
 	return snap, err
 }
 
-func refreshCandidates(st *state.State, names []string, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
+func refreshCandidates(ctx context.Context, st *state.State, names []string, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
 	snapStates, err := All(st)
 	if err != nil {
 		return nil, nil, nil, err
@@ -285,7 +287,7 @@ func refreshCandidates(st *state.State, names []string, user *auth.UserState, fl
 		}
 
 		st.Unlock()
-		updatesForUser, err := theStore.ListRefresh(candidatesInfo, u, flags)
+		updatesForUser, err := theStore.ListRefresh(ctx, candidatesInfo, u, flags)
 		st.Lock()
 		if err != nil {
 			return nil, nil, nil, err

--- a/store/store.go
+++ b/store/store.go
@@ -836,48 +836,53 @@ func (s *Store) retryRequestDecodeJSON(ctx context.Context, reqOptions *requestO
 
 // doRequest does an authenticated request to the store handling a potential macaroon refresh required if needed
 func (s *Store) doRequest(ctx context.Context, client *http.Client, reqOptions *requestOptions, user *auth.UserState) (*http.Response, error) {
-	req, err := s.newRequest(reqOptions, user)
-	if err != nil {
-		return nil, err
-	}
-
-	var resp *http.Response
-	if ctx != nil {
-		resp, err = ctxhttp.Do(ctx, client, req)
-	} else {
-		resp, err = client.Do(req)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	wwwAuth := resp.Header.Get("WWW-Authenticate")
-	if resp.StatusCode == 401 {
-		var refreshNeed authRefreshNeed
-		refresh := false
-		if user != nil && strings.Contains(wwwAuth, "needs_refresh=1") {
-			// refresh user
-			refreshNeed.user = true
-			refresh = true
+	authRefreshes := 0
+	for {
+		req, err := s.newRequest(reqOptions, user)
+		if err != nil {
+			return nil, err
 		}
-		if strings.Contains(wwwAuth, "refresh_device_session=1") {
-			// refresh device session
-			refreshNeed.device = true
-			refresh = true
+
+		var resp *http.Response
+		if ctx != nil {
+			resp, err = ctxhttp.Do(ctx, client, req)
+		} else {
+			resp, err = client.Do(req)
 		}
-		if refresh {
-			err := s.refreshAuth(user, refreshNeed)
-			if err != nil {
-				return nil, err
+		if err != nil {
+			return nil, err
+		}
+
+		wwwAuth := resp.Header.Get("WWW-Authenticate")
+		if resp.StatusCode == 401 && authRefreshes < 4 {
+			// 4 tries: 2 tries for each in case both user
+			// and device need refreshing
+			var refreshNeed authRefreshNeed
+			refresh := false
+			if user != nil && strings.Contains(wwwAuth, "needs_refresh=1") {
+				// refresh user
+				refreshNeed.user = true
+				refresh = true
 			}
-			// close previous response and retry
-			// TODO: make this non-recursive or add a recursion limit
-			resp.Body.Close()
-			return s.doRequest(ctx, client, reqOptions, user)
+			if strings.Contains(wwwAuth, "refresh_device_session=1") {
+				// refresh device session
+				refreshNeed.device = true
+				refresh = true
+			}
+			if refresh {
+				err := s.refreshAuth(user, refreshNeed)
+				if err != nil {
+					return nil, err
+				}
+				// close previous response and retry
+				resp.Body.Close()
+				authRefreshes++
+				continue
+			}
 		}
-	}
 
-	return resp, err
+		return resp, err
+	}
 }
 
 // build a new http.Request with headers for the store

--- a/store/store.go
+++ b/store/store.go
@@ -853,32 +853,23 @@ func (s *Store) doRequest(ctx context.Context, client *http.Client, reqOptions *
 
 	wwwAuth := resp.Header.Get("WWW-Authenticate")
 	if resp.StatusCode == 401 {
-		refreshed := false
+		var refreshNeed authRefreshNeed
+		refresh := false
 		if user != nil && strings.Contains(wwwAuth, "needs_refresh=1") {
 			// refresh user
-			err = s.refreshUser(user)
-			if err != nil {
-				return nil, err
-			}
-			refreshed = true
+			refreshNeed.user = true
+			refresh = true
 		}
 		if strings.Contains(wwwAuth, "refresh_device_session=1") {
 			// refresh device session
-			if s.authContext == nil {
-				return nil, fmt.Errorf("internal error: no authContext")
-			}
-			device, err := s.authContext.Device()
-			if err != nil {
-				return nil, err
-			}
-
-			err = s.refreshDeviceSession(device)
-			if err != nil {
-				return nil, err
-			}
-			refreshed = true
+			refreshNeed.device = true
+			refresh = true
 		}
-		if refreshed {
+		if refresh {
+			err := s.refreshAuth(user, refreshNeed)
+			if err != nil {
+				return nil, err
+			}
 			// close previous response and retry
 			// TODO: make this non-recursive or add a recursion limit
 			resp.Body.Close()
@@ -987,7 +978,37 @@ func (s *Store) cdnHeader(req *http.Request, reqOptions *requestOptions) error {
 
 		req.Header.Set("Snap-CDN", strings.Join(cdnParams, " "))
 	}
+	return nil
+}
 
+type authRefreshNeed struct {
+	device bool
+	user   bool
+}
+
+func (s *Store) refreshAuth(user *auth.UserState, need authRefreshNeed) error {
+	if need.user {
+		// refresh user
+		err := s.refreshUser(user)
+		if err != nil {
+			return err
+		}
+	}
+	if need.device {
+		// refresh device session
+		if s.authContext == nil {
+			return fmt.Errorf("internal error: no authContext")
+		}
+		device, err := s.authContext.Device()
+		if err != nil {
+			return err
+		}
+
+		err = s.refreshDeviceSession(device)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1635,6 +1635,99 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	c.Check(refreshSessionRequested, Equals, true)
 }
 
+func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesBothAuths(c *C) {
+	refresh, err := makeTestRefreshDischargeResponse()
+	c.Assert(err, IsNil)
+	c.Check(t.user.StoreDischarges[0], Not(Equals), refresh)
+
+	// mock refresh response
+	refreshDischargeEndpointHit := false
+	mockSSOServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, fmt.Sprintf(`{"discharge_macaroon": "%s"}`, refresh))
+		refreshDischargeEndpointHit = true
+	}))
+	defer mockSSOServer.Close()
+	UbuntuoneRefreshDischargeAPI = mockSSOServer.URL + "/tokens/refresh"
+
+	refreshSessionRequested := false
+	expiredAuth := `Macaroon root="expired-session-macaroon"`
+	// mock store response
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		switch r.URL.Path {
+		case "/":
+			authorization := r.Header.Get("Authorization")
+			c.Check(authorization, Equals, t.expectedAuthorization(c, t.user))
+			if t.user.StoreDischarges[0] != refresh {
+				w.Header().Set("WWW-Authenticate", "Macaroon needs_refresh=1")
+				w.WriteHeader(401)
+				return
+			}
+
+			devAuthorization := r.Header.Get("X-Device-Authorization")
+			if devAuthorization == "" {
+				c.Fatalf("device authentication missing")
+			} else if devAuthorization == expiredAuth {
+				w.Header().Set("WWW-Authenticate", "Macaroon refresh_device_session=1")
+				w.WriteHeader(401)
+			} else {
+				c.Check(devAuthorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
+				io.WriteString(w, "response-data")
+			}
+		case authNoncesPath:
+			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
+		case authSessionPath:
+			// sanity of request
+			jsonReq, err := ioutil.ReadAll(r.Body)
+			c.Assert(err, IsNil)
+			var req map[string]string
+			err = json.Unmarshal(jsonReq, &req)
+			c.Assert(err, IsNil)
+			c.Check(strings.HasPrefix(req["device-session-request"], "type: device-session-request\n"), Equals, true)
+			c.Check(strings.HasPrefix(req["serial-assertion"], "type: serial\n"), Equals, true)
+			c.Check(strings.HasPrefix(req["model-assertion"], "type: model\n"), Equals, true)
+
+			authorization := r.Header.Get("X-Device-Authorization")
+			if authorization == "" {
+				c.Fatalf("expecting only refresh")
+			} else {
+				c.Check(authorization, Equals, expiredAuth)
+				io.WriteString(w, `{"macaroon": "refreshed-session-macaroon"}`)
+				refreshSessionRequested = true
+			}
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+
+	// make sure device session is expired
+	t.device.SessionMacaroon = "expired-session-macaroon"
+	authContext := &testAuthContext{c: c, device: t.device, user: t.user}
+	repo := New(&Config{
+		StoreBaseURL: mockServerURL,
+	}, authContext)
+	c.Assert(repo, NotNil)
+
+	reqOptions := &requestOptions{Method: "GET", URL: mockServerURL}
+
+	resp, err := repo.doRequest(context.TODO(), repo.client, reqOptions, t.user)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Check(resp.StatusCode, Equals, 200)
+
+	responseData, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	c.Check(string(responseData), Equals, "response-data")
+	c.Check(refreshDischargeEndpointHit, Equals, true)
+	c.Check(refreshSessionRequested, Equals, true)
+}
+
 func (t *remoteRepoTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 	// Custom headers are applied last.
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2653,7 +2653,7 @@ func (t *storeTestSuite) TestStructFields(c *C) {
 	c.Assert(getStructFields(s{}), DeepEquals, []string{"hello", "potato"})
 }
 
-func (s *remoteRepoTestSuite) TestStructFieldsExcept(c *C) {
+func (s *storeTestSuite) TestStructFieldsExcept(c *C) {
 	type aStruct struct {
 		Foo int `json:"hello"`
 		Bar int `json:"potato,stuff"`

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2025,7 +2025,7 @@ const mockSingleOrderJSON = `{
   ]
 }`
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
+func (s *storeTestSuite) TestDetails(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2126,7 +2126,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(slot.Apps["content-plug"].Command, Equals, "bin/content-plug")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryDetailsDefaultChannelIsStable(c *C) {
+func (s *storeTestSuite) TestDetailsDefaultChannelIsStable(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2162,7 +2162,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryDetailsDefaultChannelIsStable(
 	c.Check(result.Channel, Equals, "stable")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryDetails500(c *C) {
+func (s *storeTestSuite) TestDetails500(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
@@ -2194,7 +2194,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryDetails500(c *C) {
 	c.Assert(n, Equals, 5)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryDetails500once(c *C) {
+func (s *storeTestSuite) TestDetails500once(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
@@ -2231,8 +2231,8 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryDetails500once(c *C) {
 	c.Assert(n, Equals, 2)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) {
-	// this test will break and should be melded into TestUbuntuStoreRepositoryDetails,
+func (s *storeTestSuite) TestDetailsAndChannels(c *C) {
+	// this test will break and should be melded into TestDetails,
 	// above, when the store provides the channels as part of details
 
 	n := 0
@@ -2310,7 +2310,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) {
 	c.Check(snap.Validate(result), IsNil)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryNonDefaults(c *C) {
+func (s *storeTestSuite) TestNonDefaults(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 	os.Setenv("SNAPPY_STORE_NO_CDN", "1")
@@ -2359,7 +2359,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryNonDefaults(c *C) {
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryStoreIDFromAuthContext(c *C) {
+func (s *storeTestSuite) TestStoreIDFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		storeID := r.Header.Get("X-Ubuntu-Store")
@@ -2392,7 +2392,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryStoreIDFromAuthContext(c *C) {
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryFullCloudInfoFromAuthContext(c *C) {
+func (s *storeTestSuite) TestFullCloudInfoFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		c.Check(r.Header.Get("Snap-CDN"), Equals, `cloud-name="aws" region="us-east-1" availability-zone="us-east-1c"`)
@@ -2424,7 +2424,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryFullCloudInfoFromAuthContext(c
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryLessDetailedCloudInfoFromAuthContext(c *C) {
+func (s *storeTestSuite) TestLessDetailedCloudInfoFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		c.Check(r.Header.Get("Snap-CDN"), Equals, `cloud-name="openstack" availability-zone="nova"`)
@@ -2456,7 +2456,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryLessDetailedCloudInfoFromAuthC
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContext(c *C) {
+func (s *storeTestSuite) TestProxyStoreFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 
@@ -2491,7 +2491,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContext(c *C
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContextURLFallback(c *C) {
+func (s *storeTestSuite) TestProxyStoreFromAuthContextURLFallback(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 
@@ -2525,7 +2525,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContextURLFa
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryRevision(c *C) {
+func (s *storeTestSuite) TestRevision(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case ordersPath:
@@ -2563,7 +2563,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryRevision(c *C) {
 	c.Check(result.Revision, DeepEquals, snap.R(27))
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryDetailsOopses(c *C) {
+func (s *storeTestSuite) TestDetailsOopses(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		c.Check(r.URL.Path, Matches, ".*/hello-world")
@@ -2613,7 +2613,7 @@ const MockNoDetailsJSON = `{
     "result": "error"
 }`
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
+func (s *storeTestSuite) TestNoDetails(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		c.Check(r.URL.Path, Matches, ".*/no-such-pkg")
@@ -2711,7 +2711,7 @@ const MockSearchJSON = `{
 }
 `
 
-func (s *storeTestSuite) TestUbuntuStoreFindQueries(c *C) {
+func (s *storeTestSuite) TestFindQueries(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
@@ -2797,7 +2797,7 @@ const MockSectionsJSON = `{
 }
 `
 
-func (s *storeTestSuite) TestUbuntuStoreSectionsQuery(c *C) {
+func (s *storeTestSuite) TestSectionsQuery(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", sectionsPath)
@@ -2857,15 +2857,15 @@ const mockNamesJSON = `
   }
 }`
 
-func (s *storeTestSuite) TestUbuntuStoreSnapCommandsOnClassic(c *C) {
-	s.testUbuntuStoreSnapCommands(c, true)
+func (s *storeTestSuite) TestSnapCommandsOnClassic(c *C) {
+	s.testSnapCommands(c, true)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreSnapCommandsOnCore(c *C) {
-	s.testUbuntuStoreSnapCommands(c, false)
+func (s *storeTestSuite) TestSnapCommandsOnCore(c *C) {
+	s.testSnapCommands(c, false)
 }
 
-func (s *storeTestSuite) testUbuntuStoreSnapCommands(c *C, onClassic bool) {
+func (s *storeTestSuite) testSnapCommands(c *C, onClassic bool) {
 	c.Assert(os.MkdirAll(dirs.SnapCacheDir, 0755), IsNil)
 	defer release.MockOnClassic(onClassic)()
 
@@ -2918,7 +2918,7 @@ func (s *storeTestSuite) testUbuntuStoreSnapCommands(c *C, onClassic bool) {
 	})
 }
 
-func (s *storeTestSuite) TestUbuntuStoreFindPrivate(c *C) {
+func (s *storeTestSuite) TestFindPrivate(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
@@ -2963,7 +2963,7 @@ func (s *storeTestSuite) TestUbuntuStoreFindPrivate(c *C) {
 	c.Check(err, Equals, ErrBadQuery)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreFindFailures(c *C) {
+func (s *storeTestSuite) TestFindFailures(c *C) {
 	repo := New(&Config{StoreBaseURL: new(url.URL)}, nil)
 	_, err := repo.Find(&Search{Query: "foo:bar"}, nil)
 	c.Check(err, Equals, ErrBadQuery)
@@ -2971,7 +2971,7 @@ func (s *storeTestSuite) TestUbuntuStoreFindFailures(c *C) {
 	c.Check(err, Equals, ErrBadQuery)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreFindFails(c *C) {
+func (s *storeTestSuite) TestFindFails(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
 		c.Check(r.URL.Query().Get("q"), Equals, "hello")
@@ -2993,7 +2993,7 @@ func (s *storeTestSuite) TestUbuntuStoreFindFails(c *C) {
 	c.Check(snaps, HasLen, 0)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreFindBadContentType(c *C) {
+func (s *storeTestSuite) TestFindBadContentType(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
 		c.Check(r.URL.Query().Get("q"), Equals, "hello")
@@ -3015,7 +3015,7 @@ func (s *storeTestSuite) TestUbuntuStoreFindBadContentType(c *C) {
 	c.Check(snaps, HasLen, 0)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreFindBadBody(c *C) {
+func (s *storeTestSuite) TestFindBadBody(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
 		query := r.URL.Query()
@@ -3039,7 +3039,7 @@ func (s *storeTestSuite) TestUbuntuStoreFindBadBody(c *C) {
 	c.Check(snaps, HasLen, 0)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreFind500(c *C) {
+func (s *storeTestSuite) TestFind500(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
@@ -3062,7 +3062,7 @@ func (s *storeTestSuite) TestUbuntuStoreFind500(c *C) {
 	c.Assert(n, Equals, 5)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreFind500once(c *C) {
+func (s *storeTestSuite) TestFind500once(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
@@ -3092,7 +3092,7 @@ func (s *storeTestSuite) TestUbuntuStoreFind500once(c *C) {
 	c.Assert(n, Equals, 2)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreFindAuthFailed(c *C) {
+func (s *storeTestSuite) TestFindAuthFailed(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case searchPath:
@@ -3277,7 +3277,7 @@ var MockUpdatesJSON = `
 }
 `
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C) {
+func (s *storeTestSuite) TestRefreshForCandidates(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -3335,7 +3335,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C) {
 	c.Assert(results[0].Deltas, HasLen, 0)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesRetriesOnEOF(c *C) {
+func (s *storeTestSuite) TestRefreshForCandidatesRetriesOnEOF(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3386,7 +3386,7 @@ func mockRFC(newRFC func(*Store, []*currentSnapJSON, *auth.UserState, *RefreshOp
 	}
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
+func (s *storeTestSuite) TestLookupRefresh(c *C) {
 	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		c.Check(currentSnaps, DeepEquals, []*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
@@ -3421,7 +3421,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
 	c.Assert(result.Deltas, HasLen, 0)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshIgnoreValidation(c *C) {
+func (s *storeTestSuite) TestLookupRefreshIgnoreValidation(c *C) {
 	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		c.Check(currentSnaps, DeepEquals, []*currentSnapJSON{{
 			SnapID:           helloWorldSnapID,
@@ -3455,7 +3455,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshIgnoreValidation(
 	c.Assert(result.SnapID, Equals, helloWorldSnapID)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c *C) {
+func (s *storeTestSuite) TestLookupRefreshLocalSnap(c *C) {
 	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		panic("unexpected call to refreshForCandidates")
 	})()
@@ -3470,7 +3470,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c *C) {
 	c.Check(err, Equals, ErrLocalSnap)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *C) {
+func (s *storeTestSuite) TestLookupRefreshRFCError(c *C) {
 	anError := errors.New("ouchie")
 	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		return nil, anError
@@ -3487,7 +3487,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *C) {
 	c.Check(err, Equals, anError)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyResponse(c *C) {
+func (s *storeTestSuite) TestLookupRefreshEmptyResponse(c *C) {
 	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		return nil, nil
 	})()
@@ -3503,7 +3503,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyResponse(c *
 	c.Check(err, Equals, ErrSnapNotFound)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshNoUpdate(c *C) {
+func (s *storeTestSuite) TestLookupRefreshNoUpdate(c *C) {
 	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		return []*snapDetails{{
 			SnapID:   helloWorldDeveloperID,
@@ -3522,7 +3522,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshNoUpdate(c *C) {
 	c.Check(err, Equals, ErrNoUpdateAvailable)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
+func (s *storeTestSuite) TestListRefresh(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -3579,7 +3579,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 	c.Assert(results[0].Deltas, HasLen, 0)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshIgnoreValidation(c *C) {
+func (s *storeTestSuite) TestListRefreshIgnoreValidation(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -3635,7 +3635,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshIgnoreValidation(c 
 	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshDefaultChannelIsStable(c *C) {
+func (s *storeTestSuite) TestListRefreshDefaultChannelIsStable(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -3691,7 +3691,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshDefaultChannelIsSta
 	c.Assert(results[0].Deltas, HasLen, 0)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *C) {
+func (s *storeTestSuite) TestListRefreshRetryOnEOF(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3734,7 +3734,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *C) {
 	c.Assert(results[0].Name(), Equals, "hello-world")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
+func (s *storeTestSuite) TestUnexpectedEOFhandling(c *C) {
 	permanentlyBrokenSrvCalls := 0
 	somewhatBrokenSrvCalls := 0
 
@@ -3788,7 +3788,7 @@ func (s *storeTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 	c.Assert(somewhatBrokenSrvCalls, Equals, 4)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c *C) {
+func (s *storeTestSuite) TestRefreshForCandidatesEOF(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3820,7 +3820,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c *C) 
 	c.Assert(n, Equals, 5)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesUnauthorised(c *C) {
+func (s *storeTestSuite) TestRefreshForCandidatesUnauthorised(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
@@ -3939,7 +3939,7 @@ func (s *storeTestSuite) TestAcceptableUpdateSkipsBoth(c *C) {
 	c.Check(acceptableUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("42"), Block: []snap.Revision{snap.R("42")}}), Equals, false)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c *C) {
+func (s *storeTestSuite) TestListRefreshSkipCurrent(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		jsonReq, err := ioutil.ReadAll(r.Body)
@@ -3982,7 +3982,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c *C) {
 	c.Assert(results, HasLen, 0)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshSkipBlocked(c *C) {
+func (s *storeTestSuite) TestListRefreshSkipBlocked(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		jsonReq, err := ioutil.ReadAll(r.Body)
@@ -4084,7 +4084,7 @@ var MockUpdatesWithDeltasJSON = `
 }
 `
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOnly(c *C) {
+func (s *storeTestSuite) TestDefaultsDeltasOnClassicOnly(c *C) {
 	for _, t := range []struct {
 		onClassic      bool
 		deltaFormatStr string
@@ -4116,7 +4116,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOnly(c 
 	}
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *C) {
+func (s *storeTestSuite) TestListRefreshWithDeltas(c *C) {
 	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
 	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
 	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
@@ -4185,7 +4185,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *C) {
 	})
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(c *C) {
+func (s *storeTestSuite) TestListRefreshWithoutDeltas(c *C) {
 	// Verify the X-Delta-Format header is not set.
 	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
 	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
@@ -4237,7 +4237,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(c *C)
 	c.Assert(results[0].Deltas, HasLen, 0)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c *C) {
+func (s *storeTestSuite) TestUpdateNotSendLocalRevs(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Error(r.URL.Path)
 		c.Fatal("no network request expected")
@@ -4261,7 +4261,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryListRefreshOptions(c *C) {
+func (s *storeTestSuite) TestListRefreshOptions(c *C) {
 	for _, t := range []struct {
 		flag   *RefreshOptions
 		header string
@@ -4420,7 +4420,7 @@ T/A8LqZYmIzKRHGwCVucCyAUD8xnwt9nyWLgLB+LLPOVFNK8SR6YyNsX05Yz1BUSndBfaTN8j/k8
 8isKGZE6P0O9ozBbNIAE8v8NMWQegJ4uWuil7D3psLkzQIrxSypk9TrQ2GlIG2hJdUovc5zBuroe
 xS4u9rVT6UY=`
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryAssertion(c *C) {
+func (s *storeTestSuite) TestAssertion(c *C) {
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 88)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4450,7 +4450,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryAssertion(c *C) {
 	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryAssertionProxyStoreFromAuthContext(c *C) {
+func (s *storeTestSuite) TestAssertionProxyStoreFromAuthContext(c *C) {
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 88)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4487,7 +4487,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryAssertionProxyStoreFromAuthCon
 	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryAssertionNotFound(c *C) {
+func (s *storeTestSuite) TestAssertionNotFound(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
 		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
@@ -4517,7 +4517,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryAssertionNotFound(c *C) {
 	})
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositoryAssertion500(c *C) {
+func (s *storeTestSuite) TestAssertion500(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
@@ -4539,7 +4539,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositoryAssertion500(c *C) {
 	c.Assert(n, Equals, 5)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreRepositorySuggestedCurrency(c *C) {
+func (s *storeTestSuite) TestSuggestedCurrency(c *C) {
 	suggestedCurrency := "GBP"
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4583,7 +4583,7 @@ func (s *storeTestSuite) TestUbuntuStoreRepositorySuggestedCurrency(c *C) {
 	c.Check(repo.SuggestedCurrency(), Equals, "EUR")
 }
 
-func (s *storeTestSuite) TestUbuntuStoreDecorateOrders(c *C) {
+func (s *storeTestSuite) TestDecorateOrders(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", ordersPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -4634,7 +4634,7 @@ func (s *storeTestSuite) TestUbuntuStoreDecorateOrders(c *C) {
 	c.Check(otherApp2.MustBuy, Equals, false)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersFailedAccess(c *C) {
+func (s *storeTestSuite) TestDecorateOrdersFailedAccess(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", ordersPath)
 		c.Check(r.Header.Get("Authorization"), Equals, s.expectedAuthorization(c, s.user))
@@ -4683,7 +4683,7 @@ func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersFailedAccess(c *C) {
 	c.Check(otherApp2.MustBuy, Equals, false)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersNoAuth(c *C) {
+func (s *storeTestSuite) TestDecorateOrdersNoAuth(c *C) {
 	cfg := Config{}
 	repo := New(&cfg, nil)
 	c.Assert(repo, NotNil)
@@ -4717,7 +4717,7 @@ func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersNoAuth(c *C) {
 	c.Check(otherApp2.MustBuy, Equals, false)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersAllFree(c *C) {
+func (s *storeTestSuite) TestDecorateOrdersAllFree(c *C) {
 	requestRecieved := false
 
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4754,7 +4754,7 @@ func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersAllFree(c *C) {
 	c.Check(requestRecieved, Equals, false)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersSingle(c *C) {
+func (s *storeTestSuite) TestDecorateOrdersSingle(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Header.Get("Authorization"), Equals, s.expectedAuthorization(c, s.user))
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
@@ -4786,7 +4786,7 @@ func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersSingle(c *C) {
 	c.Check(helloWorld.MustBuy, Equals, false)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersSingleFreeSnap(c *C) {
+func (s *storeTestSuite) TestDecorateOrdersSingleFreeSnap(c *C) {
 	cfg := Config{}
 	repo := New(&cfg, nil)
 	c.Assert(repo, NotNil)
@@ -4801,7 +4801,7 @@ func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersSingleFreeSnap(c *C) {
 	c.Check(helloWorld.MustBuy, Equals, false)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersSingleNotFound(c *C) {
+func (s *storeTestSuite) TestDecorateOrdersSingleNotFound(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", ordersPath)
 		c.Check(r.Header.Get("Authorization"), Equals, s.expectedAuthorization(c, s.user))
@@ -4835,7 +4835,7 @@ func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersSingleNotFound(c *C) {
 	c.Check(helloWorld.MustBuy, Equals, true)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersTokenExpired(c *C) {
+func (s *storeTestSuite) TestDecorateOrdersTokenExpired(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Header.Get("Authorization"), Equals, s.expectedAuthorization(c, s.user))
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
@@ -4868,7 +4868,7 @@ func (s *storeTestSuite) TestUbuntuStoreDecorateOrdersTokenExpired(c *C) {
 	c.Check(helloWorld.MustBuy, Equals, true)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreMustBuy(c *C) {
+func (s *storeTestSuite) TestMustBuy(c *C) {
 	// Never need to buy a free snap.
 	c.Check(mustBuy(false, true), Equals, false)
 	c.Check(mustBuy(false, false), Equals, false)
@@ -4960,7 +4960,7 @@ var buyTests = []struct {
 	},
 }
 
-func (s *storeTestSuite) TestUbuntuStoreBuy500(c *C) {
+func (s *storeTestSuite) TestBuy500(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -4994,7 +4994,7 @@ func (s *storeTestSuite) TestUbuntuStoreBuy500(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *storeTestSuite) TestUbuntuStoreBuy(c *C) {
+func (s *storeTestSuite) TestBuy(c *C) {
 	for _, test := range buyTests {
 		searchServerCalled := false
 		purchaseServerGetCalled := false
@@ -5098,7 +5098,7 @@ func (s *storeTestSuite) TestUbuntuStoreBuy(c *C) {
 	}
 }
 
-func (s *storeTestSuite) TestUbuntuStoreBuyFailArgumentChecking(c *C) {
+func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
 	repo := New(&Config{}, nil)
 	c.Assert(repo, NotNil)
 
@@ -5254,7 +5254,7 @@ var readyToBuyTests = []struct {
 	},
 }
 
-func (s *storeTestSuite) TestUbuntuStoreReadyToBuy(c *C) {
+func (s *storeTestSuite) TestReadyToBuy(c *C) {
 	for _, test := range readyToBuyTests {
 		purchaseServerGetCalled := 0
 		mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -148,7 +148,7 @@ func assertRequest(c *C, r *http.Request, method, pathPattern string) {
 	}
 }
 
-type remoteRepoTestSuite struct {
+type storeTestSuite struct {
 	testutil.BaseTest
 	store     *Store
 	logbuf    *bytes.Buffer
@@ -162,7 +162,7 @@ type remoteRepoTestSuite struct {
 	restoreLogger func()
 }
 
-var _ = Suite(&remoteRepoTestSuite{})
+var _ = Suite(&storeTestSuite{})
 
 const (
 	exModel = `type: model
@@ -348,7 +348,7 @@ func createTestDevice() *auth.DeviceState {
 	}
 }
 
-func (t *remoteRepoTestSuite) SetUpTest(c *C) {
+func (t *storeTestSuite) SetUpTest(c *C) {
 	t.store = New(nil, nil)
 	t.origDownloadFunc = download
 	dirs.SetRootDir(c.MkDir())
@@ -381,13 +381,13 @@ func (t *remoteRepoTestSuite) SetUpTest(c *C) {
 	)))
 }
 
-func (t *remoteRepoTestSuite) TearDownTest(c *C) {
+func (t *storeTestSuite) TearDownTest(c *C) {
 	download = t.origDownloadFunc
 	t.mockXDelta.Restore()
 	t.restoreLogger()
 }
 
-func (t *remoteRepoTestSuite) expectedAuthorization(c *C, user *auth.UserState) string {
+func (t *storeTestSuite) expectedAuthorization(c *C, user *auth.UserState) string {
 	var buf bytes.Buffer
 
 	root, err := auth.MacaroonDeserialize(user.StoreMacaroon)
@@ -405,7 +405,7 @@ func (t *remoteRepoTestSuite) expectedAuthorization(c *C, user *auth.UserState) 
 	return buf.String()
 }
 
-func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
+func (t *storeTestSuite) TestDownloadOK(c *C) {
 	expectedContent := []byte("I was downloaded")
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		c.Check(url, Equals, "anon-url")
@@ -427,7 +427,7 @@ func (t *remoteRepoTestSuite) TestDownloadOK(c *C) {
 	c.Assert(path, testutil.FileEquals, expectedContent)
 }
 
-func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
+func (t *storeTestSuite) TestDownloadRangeRequest(c *C) {
 	partialContentStr := "partial content "
 	missingContentStr := "was downloaded"
 	expectedContentStr := partialContentStr + missingContentStr
@@ -456,7 +456,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequest(c *C) {
 	c.Assert(targetFn, testutil.FileEquals, expectedContentStr)
 }
 
-func (t *remoteRepoTestSuite) TestResumeOfCompleted(c *C) {
+func (t *storeTestSuite) TestResumeOfCompleted(c *C) {
 	expectedContentStr := "nothing downloaded"
 
 	download = nil
@@ -478,7 +478,7 @@ func (t *remoteRepoTestSuite) TestResumeOfCompleted(c *C) {
 	c.Assert(targetFn, testutil.FileEquals, expectedContentStr)
 }
 
-func (t *remoteRepoTestSuite) TestDownloadEOFHandlesResumeHashCorrectly(c *C) {
+func (t *storeTestSuite) TestDownloadEOFHandlesResumeHashCorrectly(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 
@@ -519,7 +519,7 @@ func (t *remoteRepoTestSuite) TestDownloadEOFHandlesResumeHashCorrectly(c *C) {
 	c.Assert(t.logbuf.String(), Matches, "(?s).*Retrying .* attempt 2, .*")
 }
 
-func (t *remoteRepoTestSuite) TestDownloadRetryHashErrorIsFullyRetried(c *C) {
+func (t *storeTestSuite) TestDownloadRetryHashErrorIsFullyRetried(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 
@@ -565,7 +565,7 @@ func (t *remoteRepoTestSuite) TestDownloadRetryHashErrorIsFullyRetried(c *C) {
 	c.Assert(t.logbuf.String(), Matches, "(?s).*Retrying .* attempt 2, .*")
 }
 
-func (t *remoteRepoTestSuite) TestResumeOfCompletedRetriedOnHashFailure(c *C) {
+func (t *storeTestSuite) TestResumeOfCompletedRetriedOnHashFailure(c *C) {
 	var mockServer *httptest.Server
 
 	// our mock download content
@@ -602,7 +602,7 @@ func (t *remoteRepoTestSuite) TestResumeOfCompletedRetriedOnHashFailure(c *C) {
 	c.Assert(t.logbuf.String(), Matches, "(?s).*sha3-384 mismatch.*")
 }
 
-func (t *remoteRepoTestSuite) TestDownloadRetryHashErrorIsFullyRetriedOnlyOnce(c *C) {
+func (t *storeTestSuite) TestDownloadRetryHashErrorIsFullyRetriedOnlyOnce(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 
@@ -630,7 +630,7 @@ func (t *remoteRepoTestSuite) TestDownloadRetryHashErrorIsFullyRetriedOnlyOnce(c
 	c.Assert(n, Equals, 2)
 }
 
-func (t *remoteRepoTestSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {
+func (t *storeTestSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {
 	expectedContentStr := "file was downloaded from scratch"
 	partialContentStr := "partial content "
 
@@ -664,7 +664,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequestRetryOnHashError(c *C) {
 	c.Assert(targetFn, testutil.FileEquals, expectedContentStr)
 }
 
-func (t *remoteRepoTestSuite) TestDownloadRangeRequestFailOnHashError(c *C) {
+func (t *storeTestSuite) TestDownloadRangeRequestFailOnHashError(c *C) {
 	partialContentStr := "partial content "
 
 	n := 0
@@ -690,7 +690,7 @@ func (t *remoteRepoTestSuite) TestDownloadRangeRequestFailOnHashError(c *C) {
 	c.Assert(n, Equals, 2)
 }
 
-func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
+func (t *storeTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 	expectedContent := []byte("I was downloaded")
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		// check user is pass and auth url is used
@@ -715,7 +715,7 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDownloadDoesNotUseAnonURL(c *C) {
 	c.Assert(path, testutil.FileEquals, expectedContent)
 }
 
-func (t *remoteRepoTestSuite) TestAuthenticatedDeviceDoesNotUseAnonURL(c *C) {
+func (t *storeTestSuite) TestAuthenticatedDeviceDoesNotUseAnonURL(c *C) {
 	expectedContent := []byte("I was downloaded")
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		// check auth url is used
@@ -743,7 +743,7 @@ func (t *remoteRepoTestSuite) TestAuthenticatedDeviceDoesNotUseAnonURL(c *C) {
 	c.Assert(path, testutil.FileEquals, expectedContent)
 }
 
-func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
+func (t *storeTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
 	expectedContentStr := "I was downloaded"
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		c.Check(url, Equals, "anon-url")
@@ -766,7 +766,7 @@ func (t *remoteRepoTestSuite) TestLocalUserDownloadUsesAnonURL(c *C) {
 	c.Assert(path, testutil.FileEquals, expectedContentStr)
 }
 
-func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
+func (t *storeTestSuite) TestDownloadFails(c *C) {
 	var tmpfile *os.File
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		tmpfile = w.(*os.File)
@@ -786,7 +786,7 @@ func (t *remoteRepoTestSuite) TestDownloadFails(c *C) {
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
 }
 
-func (t *remoteRepoTestSuite) TestDownloadSyncFails(c *C) {
+func (t *storeTestSuite) TestDownloadSyncFails(c *C) {
 	var tmpfile *os.File
 	download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, s *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 		tmpfile = w.(*os.File)
@@ -810,7 +810,7 @@ func (t *remoteRepoTestSuite) TestDownloadSyncFails(c *C) {
 	c.Assert(osutil.FileExists(tmpfile.Name()), Equals, false)
 }
 
-func (t *remoteRepoTestSuite) TestActualDownload(c *C) {
+func (t *storeTestSuite) TestActualDownload(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -829,7 +829,7 @@ func (t *remoteRepoTestSuite) TestActualDownload(c *C) {
 	c.Check(n, Equals, 1)
 }
 
-func (t *remoteRepoTestSuite) TestDownloadCancellation(c *C) {
+func (t *storeTestSuite) TestDownloadCancellation(c *C) {
 	// the channel used by mock server to request cancellation from the test
 	syncCh := make(chan struct{})
 
@@ -871,7 +871,7 @@ func (nopeSeeker) Seek(int64, int) (int64, error) {
 	return -1, errors.New("what is this, quidditch?")
 }
 
-func (t *remoteRepoTestSuite) TestActualDownloadNonPurchased402(c *C) {
+func (t *storeTestSuite) TestActualDownloadNonPurchased402(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -890,7 +890,7 @@ func (t *remoteRepoTestSuite) TestActualDownloadNonPurchased402(c *C) {
 	c.Check(n, Equals, 1)
 }
 
-func (t *remoteRepoTestSuite) TestActualDownload404(c *C) {
+func (t *storeTestSuite) TestActualDownload404(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -908,7 +908,7 @@ func (t *remoteRepoTestSuite) TestActualDownload404(c *C) {
 	c.Check(n, Equals, 1)
 }
 
-func (t *remoteRepoTestSuite) TestActualDownload500(c *C) {
+func (t *storeTestSuite) TestActualDownload500(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -926,7 +926,7 @@ func (t *remoteRepoTestSuite) TestActualDownload500(c *C) {
 	c.Check(n, Equals, 5)
 }
 
-func (t *remoteRepoTestSuite) TestActualDownload500Once(c *C) {
+func (t *storeTestSuite) TestActualDownload500Once(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -995,7 +995,7 @@ func (sb *SillyBuffer) String() string {
 	return string(sb.buf[0:sb.pos])
 }
 
-func (t *remoteRepoTestSuite) TestActualDownloadResume(c *C) {
+func (t *storeTestSuite) TestActualDownloadResume(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n++
@@ -1016,7 +1016,7 @@ func (t *remoteRepoTestSuite) TestActualDownloadResume(c *C) {
 	c.Check(n, Equals, 1)
 }
 
-func (t *remoteRepoTestSuite) TestUseDeltas(c *C) {
+func (t *storeTestSuite) TestUseDeltas(c *C) {
 	origPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", origPath)
 	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
@@ -1136,7 +1136,7 @@ var deltaTests = []struct {
 	expectedContent: "full-snap-url-content",
 }}
 
-func (t *remoteRepoTestSuite) TestDownloadWithDelta(c *C) {
+func (t *storeTestSuite) TestDownloadWithDelta(c *C) {
 	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
 	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
 	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
@@ -1264,7 +1264,7 @@ var downloadDeltaTests = []struct {
 	expectError:   true,
 }}
 
-func (t *remoteRepoTestSuite) TestDownloadDelta(c *C) {
+func (t *storeTestSuite) TestDownloadDelta(c *C) {
 	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
 	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
 	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
@@ -1337,7 +1337,7 @@ var applyDeltaTests = []struct {
 	error:           "cannot apply unsupported delta format \"nodelta\" (only xdelta3 currently)",
 }}
 
-func (t *remoteRepoTestSuite) TestApplyDelta(c *C) {
+func (t *storeTestSuite) TestApplyDelta(c *C) {
 	for _, testCase := range applyDeltaTests {
 		name := "foo"
 		currentSnapName := fmt.Sprintf("%s_%d.snap", name, testCase.currentRevision)
@@ -1384,7 +1384,7 @@ var (
 	userAgent = httputil.UserAgent()
 )
 
-func (t *remoteRepoTestSuite) TestDoRequestSetsAuth(c *C) {
+func (t *storeTestSuite) TestDoRequestSetsAuth(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.UserAgent(), Equals, userAgent)
 		// check user authorization is set
@@ -1415,7 +1415,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAuth(c *C) {
 	c.Check(string(responseData), Equals, "response-data")
 }
 
-func (t *remoteRepoTestSuite) TestDoRequestDoesNotSetAuthForLocalOnlyUser(c *C) {
+func (t *storeTestSuite) TestDoRequestDoesNotSetAuthForLocalOnlyUser(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.UserAgent(), Equals, userAgent)
 		// check no user authorization is set
@@ -1446,7 +1446,7 @@ func (t *remoteRepoTestSuite) TestDoRequestDoesNotSetAuthForLocalOnlyUser(c *C) 
 	c.Check(string(responseData), Equals, "response-data")
 }
 
-func (t *remoteRepoTestSuite) TestDoRequestAuthNoSerial(c *C) {
+func (t *storeTestSuite) TestDoRequestAuthNoSerial(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.UserAgent(), Equals, userAgent)
 		// check user authorization is set
@@ -1480,7 +1480,7 @@ func (t *remoteRepoTestSuite) TestDoRequestAuthNoSerial(c *C) {
 	c.Check(string(responseData), Equals, "response-data")
 }
 
-func (t *remoteRepoTestSuite) TestDoRequestRefreshesAuth(c *C) {
+func (t *storeTestSuite) TestDoRequestRefreshesAuth(c *C) {
 	refresh, err := makeTestRefreshDischargeResponse()
 	c.Assert(err, IsNil)
 	c.Check(t.user.StoreDischarges[0], Not(Equals), refresh)
@@ -1527,7 +1527,7 @@ func (t *remoteRepoTestSuite) TestDoRequestRefreshesAuth(c *C) {
 	c.Check(refreshDischargeEndpointHit, Equals, true)
 }
 
-func (t *remoteRepoTestSuite) TestDoRequestForwardsRefreshAuthFailure(c *C) {
+func (t *storeTestSuite) TestDoRequestForwardsRefreshAuthFailure(c *C) {
 	// mock refresh response
 	refreshDischargeEndpointHit := false
 	mockSSOServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1563,7 +1563,7 @@ func (t *remoteRepoTestSuite) TestDoRequestForwardsRefreshAuthFailure(c *C) {
 	c.Check(refreshDischargeEndpointHit, Equals, true)
 }
 
-func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
+func (t *storeTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	deviceSessionRequested := false
 	refreshSessionRequested := false
 	expiredAuth := `Macaroon root="expired-session-macaroon"`
@@ -1635,7 +1635,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	c.Check(refreshSessionRequested, Equals, true)
 }
 
-func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesBothAuths(c *C) {
+func (t *storeTestSuite) TestDoRequestSetsAndRefreshesBothAuths(c *C) {
 	refresh, err := makeTestRefreshDischargeResponse()
 	c.Assert(err, IsNil)
 	c.Check(t.user.StoreDischarges[0], Not(Equals), refresh)
@@ -1728,7 +1728,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsAndRefreshesBothAuths(c *C) {
 	c.Check(refreshSessionRequested, Equals, true)
 }
 
-func (t *remoteRepoTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
+func (t *storeTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 	// Custom headers are applied last.
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.UserAgent(), Equals, `customAgent`)
@@ -1763,7 +1763,7 @@ func (t *remoteRepoTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 	c.Check(string(responseData), Equals, "response-data")
 }
 
-func (t *remoteRepoTestSuite) TestLoginUser(c *C) {
+func (t *storeTestSuite) TestLoginUser(c *C) {
 	macaroon, err := makeTestMacaroon()
 	c.Assert(err, IsNil)
 	serializedMacaroon, err := auth.MacaroonSerialize(macaroon)
@@ -1795,7 +1795,7 @@ func (t *remoteRepoTestSuite) TestLoginUser(c *C) {
 	c.Check(userDischarge, Equals, serializedDischarge)
 }
 
-func (t *remoteRepoTestSuite) TestLoginUserDeveloperAPIError(c *C) {
+func (t *storeTestSuite) TestLoginUserDeveloperAPIError(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		io.WriteString(w, "{}")
@@ -1811,7 +1811,7 @@ func (t *remoteRepoTestSuite) TestLoginUserDeveloperAPIError(c *C) {
 	c.Check(userDischarge, Equals, "")
 }
 
-func (t *remoteRepoTestSuite) TestLoginUserSSOError(c *C) {
+func (t *storeTestSuite) TestLoginUserSSOError(c *C) {
 	macaroon, err := makeTestMacaroon()
 	c.Assert(err, IsNil)
 	serializedMacaroon, err := auth.MacaroonSerialize(macaroon)
@@ -2025,7 +2025,7 @@ const mockSingleOrderJSON = `{
   ]
 }`
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2126,7 +2126,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails(c *C) {
 	c.Check(slot.Apps["content-plug"].Command, Equals, "bin/content-plug")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsDefaultChannelIsStable(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryDetailsDefaultChannelIsStable(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2162,7 +2162,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsDefaultChannelIsSt
 	c.Check(result.Channel, Equals, "stable")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails500(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryDetails500(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
@@ -2194,7 +2194,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails500(c *C) {
 	c.Assert(n, Equals, 5)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails500once(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryDetails500once(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
@@ -2231,7 +2231,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetails500once(c *C) {
 	c.Assert(n, Equals, 2)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) {
 	// this test will break and should be melded into TestUbuntuStoreRepositoryDetails,
 	// above, when the store provides the channels as part of details
 
@@ -2310,7 +2310,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsAndChannels(c *C) 
 	c.Check(snap.Validate(result), IsNil)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNonDefaults(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryNonDefaults(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 	os.Setenv("SNAPPY_STORE_NO_CDN", "1")
@@ -2359,7 +2359,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNonDefaults(c *C) {
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryStoreIDFromAuthContext(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryStoreIDFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		storeID := r.Header.Get("X-Ubuntu-Store")
@@ -2392,7 +2392,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryStoreIDFromAuthContext(c 
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryFullCloudInfoFromAuthContext(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryFullCloudInfoFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		c.Check(r.Header.Get("Snap-CDN"), Equals, `cloud-name="aws" region="us-east-1" availability-zone="us-east-1c"`)
@@ -2424,7 +2424,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryFullCloudInfoFromAuthCont
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLessDetailedCloudInfoFromAuthContext(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryLessDetailedCloudInfoFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		c.Check(r.Header.Get("Snap-CDN"), Equals, `cloud-name="openstack" availability-zone="nova"`)
@@ -2456,7 +2456,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLessDetailedCloudInfoFrom
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContext(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 
@@ -2491,7 +2491,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContext
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContextURLFallback(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContextURLFallback(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 
@@ -2525,7 +2525,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryProxyStoreFromAuthContext
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRevision(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryRevision(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case ordersPath:
@@ -2563,7 +2563,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRevision(c *C) {
 	c.Check(result.Revision, DeepEquals, snap.R(27))
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDetailsOopses(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryDetailsOopses(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		c.Check(r.URL.Path, Matches, ".*/hello-world")
@@ -2613,7 +2613,7 @@ const MockNoDetailsJSON = `{
     "result": "error"
 }`
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
 		c.Check(r.URL.Path, Matches, ".*/no-such-pkg")
@@ -2645,7 +2645,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryNoDetails(c *C) {
 	c.Assert(result, IsNil)
 }
 
-func (t *remoteRepoTestSuite) TestStructFields(c *C) {
+func (t *storeTestSuite) TestStructFields(c *C) {
 	type s struct {
 		Foo int `json:"hello"`
 		Bar int `json:"potato,stuff"`
@@ -2711,7 +2711,7 @@ const MockSearchJSON = `{
 }
 `
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreFindQueries(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreFindQueries(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
@@ -2797,7 +2797,7 @@ const MockSectionsJSON = `{
 }
 `
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreSectionsQuery(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreSectionsQuery(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", sectionsPath)
@@ -2857,15 +2857,15 @@ const mockNamesJSON = `
   }
 }`
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreSnapCommandsOnClassic(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreSnapCommandsOnClassic(c *C) {
 	t.testUbuntuStoreSnapCommands(c, true)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreSnapCommandsOnCore(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreSnapCommandsOnCore(c *C) {
 	t.testUbuntuStoreSnapCommands(c, false)
 }
 
-func (t *remoteRepoTestSuite) testUbuntuStoreSnapCommands(c *C, onClassic bool) {
+func (t *storeTestSuite) testUbuntuStoreSnapCommands(c *C, onClassic bool) {
 	c.Assert(os.MkdirAll(dirs.SnapCacheDir, 0755), IsNil)
 	defer release.MockOnClassic(onClassic)()
 
@@ -2918,7 +2918,7 @@ func (t *remoteRepoTestSuite) testUbuntuStoreSnapCommands(c *C, onClassic bool) 
 	})
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreFindPrivate(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreFindPrivate(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
@@ -2963,7 +2963,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindPrivate(c *C) {
 	c.Check(err, Equals, ErrBadQuery)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreFindFailures(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreFindFailures(c *C) {
 	repo := New(&Config{StoreBaseURL: new(url.URL)}, nil)
 	_, err := repo.Find(&Search{Query: "foo:bar"}, nil)
 	c.Check(err, Equals, ErrBadQuery)
@@ -2971,7 +2971,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindFailures(c *C) {
 	c.Check(err, Equals, ErrBadQuery)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreFindFails(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreFindFails(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
 		c.Check(r.URL.Query().Get("q"), Equals, "hello")
@@ -2993,7 +2993,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindFails(c *C) {
 	c.Check(snaps, HasLen, 0)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreFindBadContentType(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreFindBadContentType(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
 		c.Check(r.URL.Query().Get("q"), Equals, "hello")
@@ -3015,7 +3015,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindBadContentType(c *C) {
 	c.Check(snaps, HasLen, 0)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreFindBadBody(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreFindBadBody(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
 		query := r.URL.Query()
@@ -3039,7 +3039,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindBadBody(c *C) {
 	c.Check(snaps, HasLen, 0)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreFind500(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreFind500(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
@@ -3062,7 +3062,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFind500(c *C) {
 	c.Assert(n, Equals, 5)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreFind500once(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreFind500once(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
@@ -3092,7 +3092,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFind500once(c *C) {
 	c.Assert(n, Equals, 2)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreFindAuthFailed(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreFindAuthFailed(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case searchPath:
@@ -3143,7 +3143,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreFindAuthFailed(c *C) {
 	c.Check(snaps[0].MustBuy, Equals, true)
 }
 
-func (t *remoteRepoTestSuite) TestCurrentSnap(c *C) {
+func (t *storeTestSuite) TestCurrentSnap(c *C) {
 	cand := &RefreshCandidate{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
@@ -3160,7 +3160,7 @@ func (t *remoteRepoTestSuite) TestCurrentSnap(c *C) {
 	c.Check(t.logbuf.String(), Equals, "")
 }
 
-func (t *remoteRepoTestSuite) TestCurrentSnapIgnoreValidation(c *C) {
+func (t *storeTestSuite) TestCurrentSnapIgnoreValidation(c *C) {
 	cand := &RefreshCandidate{
 		SnapID:           helloWorldSnapID,
 		Channel:          "stable",
@@ -3178,7 +3178,7 @@ func (t *remoteRepoTestSuite) TestCurrentSnapIgnoreValidation(c *C) {
 	c.Check(t.logbuf.String(), Equals, "")
 }
 
-func (t *remoteRepoTestSuite) TestCurrentSnapNoChannel(c *C) {
+func (t *storeTestSuite) TestCurrentSnapNoChannel(c *C) {
 	cand := &RefreshCandidate{
 		SnapID:   helloWorldSnapID,
 		Revision: snap.R(1),
@@ -3193,7 +3193,7 @@ func (t *remoteRepoTestSuite) TestCurrentSnapNoChannel(c *C) {
 	c.Check(t.logbuf.String(), Equals, "")
 }
 
-func (t *remoteRepoTestSuite) TestCurrentSnapNilNoID(c *C) {
+func (t *storeTestSuite) TestCurrentSnapNilNoID(c *C) {
 	cand := &RefreshCandidate{
 		SnapID:   "",
 		Revision: snap.R(1),
@@ -3203,7 +3203,7 @@ func (t *remoteRepoTestSuite) TestCurrentSnapNilNoID(c *C) {
 	c.Check(t.logbuf.String(), Matches, "(?m).* an empty SnapID but a store revision!")
 }
 
-func (t *remoteRepoTestSuite) TestCurrentSnapNilLocalRevision(c *C) {
+func (t *storeTestSuite) TestCurrentSnapNilLocalRevision(c *C) {
 	cand := &RefreshCandidate{
 		SnapID:   helloWorldSnapID,
 		Revision: snap.R("x1"),
@@ -3213,7 +3213,7 @@ func (t *remoteRepoTestSuite) TestCurrentSnapNilLocalRevision(c *C) {
 	c.Check(t.logbuf.String(), Matches, "(?m).* a non-empty SnapID but a non-store revision!")
 }
 
-func (t *remoteRepoTestSuite) TestCurrentSnapNilLocalRevisionNoID(c *C) {
+func (t *storeTestSuite) TestCurrentSnapNilLocalRevisionNoID(c *C) {
 	cand := &RefreshCandidate{
 		SnapID:   "",
 		Revision: snap.R("x1"),
@@ -3223,7 +3223,7 @@ func (t *remoteRepoTestSuite) TestCurrentSnapNilLocalRevisionNoID(c *C) {
 	c.Check(t.logbuf.String(), Equals, "")
 }
 
-func (t *remoteRepoTestSuite) TestCurrentSnapRevLocalRevWithAmendHappy(c *C) {
+func (t *storeTestSuite) TestCurrentSnapRevLocalRevWithAmendHappy(c *C) {
 	cand := &RefreshCandidate{
 		SnapID:   helloWorldSnapID,
 		Revision: snap.R("x1"),
@@ -3277,7 +3277,7 @@ var MockUpdatesJSON = `
 }
 `
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -3335,7 +3335,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidates(c *C
 	c.Assert(results[0].Deltas, HasLen, 0)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesRetriesOnEOF(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesRetriesOnEOF(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3386,7 +3386,7 @@ func mockRFC(newRFC func(*Store, []*currentSnapJSON, *auth.UserState, *RefreshOp
 	}
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
 	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		c.Check(currentSnaps, DeepEquals, []*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
@@ -3421,7 +3421,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefresh(c *C) {
 	c.Assert(result.Deltas, HasLen, 0)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshIgnoreValidation(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshIgnoreValidation(c *C) {
 	defer mockRFC(func(_ *Store, currentSnaps []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		c.Check(currentSnaps, DeepEquals, []*currentSnapJSON{{
 			SnapID:           helloWorldSnapID,
@@ -3455,7 +3455,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshIgnoreValida
 	c.Assert(result.SnapID, Equals, helloWorldSnapID)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c *C) {
 	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		panic("unexpected call to refreshForCandidates")
 	})()
@@ -3470,7 +3470,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshLocalSnap(c 
 	c.Check(err, Equals, ErrLocalSnap)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *C) {
 	anError := errors.New("ouchie")
 	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		return nil, anError
@@ -3487,7 +3487,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshRFCError(c *
 	c.Check(err, Equals, anError)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyResponse(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyResponse(c *C) {
 	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		return nil, nil
 	})()
@@ -3503,7 +3503,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshEmptyRespons
 	c.Check(err, Equals, ErrSnapNotFound)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshNoUpdate(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryLookupRefreshNoUpdate(c *C) {
 	defer mockRFC(func(_ *Store, _ []*currentSnapJSON, _ *auth.UserState, _ *RefreshOptions) ([]*snapDetails, error) {
 		return []*snapDetails{{
 			SnapID:   helloWorldDeveloperID,
@@ -3522,7 +3522,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryLookupRefreshNoUpdate(c *
 	c.Check(err, Equals, ErrNoUpdateAvailable)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -3579,7 +3579,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefresh(c *C) {
 	c.Assert(results[0].Deltas, HasLen, 0)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshIgnoreValidation(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryListRefreshIgnoreValidation(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -3635,7 +3635,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshIgnoreValidati
 	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshDefaultChannelIsStable(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryListRefreshDefaultChannelIsStable(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -3691,7 +3691,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshDefaultChannel
 	c.Assert(results[0].Deltas, HasLen, 0)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3734,7 +3734,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshRetryOnEOF(c *
 	c.Assert(results[0].Name(), Equals, "hello-world")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 	permanentlyBrokenSrvCalls := 0
 	somewhatBrokenSrvCalls := 0
 
@@ -3788,7 +3788,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreUnexpectedEOFhandling(c *C) {
 	c.Assert(somewhatBrokenSrvCalls, Equals, 4)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c *C) {
 	n := 0
 	var mockServer *httptest.Server
 	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3820,7 +3820,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesEOF(c
 	c.Assert(n, Equals, 5)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesUnauthorised(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesUnauthorised(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
@@ -3851,7 +3851,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryRefreshForCandidatesUnaut
 	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 401 via POST to "http://.*?/metadata"`)
 }
 
-func (t *remoteRepoTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
+func (t *storeTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
 	baseURL, err := url.Parse("http://nonexistingserver909123.com/")
 	c.Assert(err, IsNil)
 	cfg := Config{
@@ -3870,7 +3870,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (t *remoteRepoTestSuite) TestRefreshForCandidates500(c *C) {
+func (t *storeTestSuite) TestRefreshForCandidates500(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
@@ -3897,7 +3897,7 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500(c *C) {
 	c.Assert(n, Equals, 5)
 }
 
-func (t *remoteRepoTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) {
+func (t *storeTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
@@ -3925,21 +3925,21 @@ func (t *remoteRepoTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) 
 	c.Assert(n, Equals, 1)
 }
 
-func (t *remoteRepoTestSuite) TestAcceptableUpdateWorks(c *C) {
+func (t *storeTestSuite) TestAcceptableUpdateWorks(c *C) {
 	c.Check(acceptableUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("1")}), Equals, true)
 }
-func (t *remoteRepoTestSuite) TestAcceptableUpdateSkipsCurrent(c *C) {
+func (t *storeTestSuite) TestAcceptableUpdateSkipsCurrent(c *C) {
 	c.Check(acceptableUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("42")}), Equals, false)
 }
-func (t *remoteRepoTestSuite) TestAcceptableUpdateSkipsBlocked(c *C) {
+func (t *storeTestSuite) TestAcceptableUpdateSkipsBlocked(c *C) {
 	c.Check(acceptableUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("1"), Block: []snap.Revision{snap.R("42")}}), Equals, false)
 }
-func (t *remoteRepoTestSuite) TestAcceptableUpdateSkipsBoth(c *C) {
+func (t *storeTestSuite) TestAcceptableUpdateSkipsBoth(c *C) {
 	// belts-and-suspenders
 	c.Check(acceptableUpdate(&snapDetails{Revision: 42}, &RefreshCandidate{Revision: snap.R("42"), Block: []snap.Revision{snap.R("42")}}), Equals, false)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		jsonReq, err := ioutil.ReadAll(r.Body)
@@ -3982,7 +3982,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipCurrent(c 
 	c.Assert(results, HasLen, 0)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshSkipBlocked(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryListRefreshSkipBlocked(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", metadataPath)
 		jsonReq, err := ioutil.ReadAll(r.Body)
@@ -4084,7 +4084,7 @@ var MockUpdatesWithDeltasJSON = `
 }
 `
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOnly(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOnly(c *C) {
 	for _, t := range []struct {
 		onClassic      bool
 		deltaFormatStr string
@@ -4116,7 +4116,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryDefaultsDeltasOnClassicOn
 	}
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *C) {
 	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
 	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
 	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
@@ -4185,7 +4185,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithDeltas(c *
 	})
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(c *C) {
 	// Verify the X-Delta-Format header is not set.
 	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
 	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
@@ -4237,7 +4237,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshWithoutDeltas(
 	c.Assert(results[0].Deltas, HasLen, 0)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Error(r.URL.Path)
 		c.Fatal("no network request expected")
@@ -4261,7 +4261,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryUpdateNotSendLocalRevs(c 
 	c.Assert(err, IsNil)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshOptions(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryListRefreshOptions(c *C) {
 	for _, t := range []struct {
 		flag   *RefreshOptions
 		header string
@@ -4300,7 +4300,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryListRefreshOptions(c *C) 
 	}
 }
 
-func (t *remoteRepoTestSuite) TestStructFieldsSurvivesNoTag(c *C) {
+func (t *storeTestSuite) TestStructFieldsSurvivesNoTag(c *C) {
 	type s struct {
 		Foo int `json:"hello"`
 		Bar int
@@ -4308,7 +4308,7 @@ func (t *remoteRepoTestSuite) TestStructFieldsSurvivesNoTag(c *C) {
 	c.Assert(getStructFields(s{}), DeepEquals, []string{"hello"})
 }
 
-func (t *remoteRepoTestSuite) TestAuthLocationDependsOnEnviron(c *C) {
+func (t *storeTestSuite) TestAuthLocationDependsOnEnviron(c *C) {
 	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
 	before := authLocation()
 
@@ -4319,7 +4319,7 @@ func (t *remoteRepoTestSuite) TestAuthLocationDependsOnEnviron(c *C) {
 	c.Check(before, Not(Equals), after)
 }
 
-func (t *remoteRepoTestSuite) TestAuthURLDependsOnEnviron(c *C) {
+func (t *storeTestSuite) TestAuthURLDependsOnEnviron(c *C) {
 	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
 	before := authURL()
 
@@ -4330,7 +4330,7 @@ func (t *remoteRepoTestSuite) TestAuthURLDependsOnEnviron(c *C) {
 	c.Check(before, Not(Equals), after)
 }
 
-func (t *remoteRepoTestSuite) TestApiURLDependsOnEnviron(c *C) {
+func (t *storeTestSuite) TestApiURLDependsOnEnviron(c *C) {
 	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
 	before := apiURL()
 
@@ -4341,7 +4341,7 @@ func (t *remoteRepoTestSuite) TestApiURLDependsOnEnviron(c *C) {
 	c.Check(before, Not(Equals), after)
 }
 
-func (t *remoteRepoTestSuite) TestStoreURLDependsOnEnviron(c *C) {
+func (t *storeTestSuite) TestStoreURLDependsOnEnviron(c *C) {
 	// This also depends on the API URL, but that's tested separately (see
 	// TestApiURLDependsOnEnviron).
 	api := apiURL()
@@ -4368,21 +4368,21 @@ func (t *remoteRepoTestSuite) TestStoreURLDependsOnEnviron(c *C) {
 	c.Check(u.String(), Matches, "https://force-cpi.local/.*")
 }
 
-func (t *remoteRepoTestSuite) TestStoreURLBadEnvironAPI(c *C) {
+func (t *storeTestSuite) TestStoreURLBadEnvironAPI(c *C) {
 	c.Assert(os.Setenv("SNAPPY_FORCE_API_URL", "://force-api.local/"), IsNil)
 	defer os.Setenv("SNAPPY_FORCE_API_URL", "")
 	_, err := storeURL(apiURL())
 	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_API_URL: parse ://force-api.local/: missing protocol scheme")
 }
 
-func (t *remoteRepoTestSuite) TestStoreURLBadEnvironCPI(c *C) {
+func (t *storeTestSuite) TestStoreURLBadEnvironCPI(c *C) {
 	c.Assert(os.Setenv("SNAPPY_FORCE_CPI_URL", "://force-cpi.local/api/v1/"), IsNil)
 	defer os.Setenv("SNAPPY_FORCE_CPI_URL", "")
 	_, err := storeURL(apiURL())
 	c.Check(err, ErrorMatches, "invalid SNAPPY_FORCE_CPI_URL: parse ://force-cpi.local/: missing protocol scheme")
 }
 
-func (t *remoteRepoTestSuite) TestStoreDeveloperURLDependsOnEnviron(c *C) {
+func (t *storeTestSuite) TestStoreDeveloperURLDependsOnEnviron(c *C) {
 	c.Assert(os.Setenv("SNAPPY_USE_STAGING_STORE", ""), IsNil)
 	before := storeDeveloperURL()
 
@@ -4393,12 +4393,12 @@ func (t *remoteRepoTestSuite) TestStoreDeveloperURLDependsOnEnviron(c *C) {
 	c.Check(before, Not(Equals), after)
 }
 
-func (t *remoteRepoTestSuite) TestDefaultConfig(c *C) {
+func (t *storeTestSuite) TestDefaultConfig(c *C) {
 	c.Check(defaultConfig.StoreBaseURL.String(), Equals, "https://api.snapcraft.io/")
 	c.Check(defaultConfig.AssertionsBaseURL, IsNil)
 }
 
-func (t *remoteRepoTestSuite) TestNew(c *C) {
+func (t *storeTestSuite) TestNew(c *C) {
 	aStore := New(nil, nil)
 	// check for fields
 	c.Check(aStore.detailFields, DeepEquals, detailFields)
@@ -4420,7 +4420,7 @@ T/A8LqZYmIzKRHGwCVucCyAUD8xnwt9nyWLgLB+LLPOVFNK8SR6YyNsX05Yz1BUSndBfaTN8j/k8
 8isKGZE6P0O9ozBbNIAE8v8NMWQegJ4uWuil7D3psLkzQIrxSypk9TrQ2GlIG2hJdUovc5zBuroe
 xS4u9rVT6UY=`
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertion(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryAssertion(c *C) {
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 88)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4450,7 +4450,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertion(c *C) {
 	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionProxyStoreFromAuthContext(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryAssertionProxyStoreFromAuthContext(c *C) {
 	restore := asserts.MockMaxSupportedFormat(asserts.SnapDeclarationType, 88)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4487,7 +4487,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionProxyStoreFromAu
 	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionNotFound(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryAssertionNotFound(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
 		c.Check(r.Header.Get("Accept"), Equals, "application/x.ubuntu.assertion")
@@ -4517,7 +4517,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertionNotFound(c *C) {
 	})
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertion500(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositoryAssertion500(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", "/api/v1/snaps/assertions/.*")
@@ -4539,7 +4539,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositoryAssertion500(c *C) {
 	c.Assert(n, Equals, 5)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreRepositorySuggestedCurrency(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreRepositorySuggestedCurrency(c *C) {
 	suggestedCurrency := "GBP"
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4583,7 +4583,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreRepositorySuggestedCurrency(c *C) {
 	c.Check(repo.SuggestedCurrency(), Equals, "EUR")
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrders(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreDecorateOrders(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", ordersPath)
 		// check device authorization is set, implicitly checking doRequest was used
@@ -4634,7 +4634,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrders(c *C) {
 	c.Check(otherApp2.MustBuy, Equals, false)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersFailedAccess(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreDecorateOrdersFailedAccess(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", ordersPath)
 		c.Check(r.Header.Get("Authorization"), Equals, t.expectedAuthorization(c, t.user))
@@ -4683,7 +4683,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersFailedAccess(c *C) {
 	c.Check(otherApp2.MustBuy, Equals, false)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersNoAuth(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreDecorateOrdersNoAuth(c *C) {
 	cfg := Config{}
 	repo := New(&cfg, nil)
 	c.Assert(repo, NotNil)
@@ -4717,7 +4717,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersNoAuth(c *C) {
 	c.Check(otherApp2.MustBuy, Equals, false)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersAllFree(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreDecorateOrdersAllFree(c *C) {
 	requestRecieved := false
 
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -4754,7 +4754,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersAllFree(c *C) {
 	c.Check(requestRecieved, Equals, false)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersSingle(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreDecorateOrdersSingle(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Header.Get("Authorization"), Equals, t.expectedAuthorization(c, t.user))
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
@@ -4786,7 +4786,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersSingle(c *C) {
 	c.Check(helloWorld.MustBuy, Equals, false)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersSingleFreeSnap(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreDecorateOrdersSingleFreeSnap(c *C) {
 	cfg := Config{}
 	repo := New(&cfg, nil)
 	c.Assert(repo, NotNil)
@@ -4801,7 +4801,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersSingleFreeSnap(c *C) 
 	c.Check(helloWorld.MustBuy, Equals, false)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersSingleNotFound(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreDecorateOrdersSingleNotFound(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", ordersPath)
 		c.Check(r.Header.Get("Authorization"), Equals, t.expectedAuthorization(c, t.user))
@@ -4835,7 +4835,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersSingleNotFound(c *C) 
 	c.Check(helloWorld.MustBuy, Equals, true)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersTokenExpired(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreDecorateOrdersTokenExpired(c *C) {
 	mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Header.Get("Authorization"), Equals, t.expectedAuthorization(c, t.user))
 		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
@@ -4868,7 +4868,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreDecorateOrdersTokenExpired(c *C) {
 	c.Check(helloWorld.MustBuy, Equals, true)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreMustBuy(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreMustBuy(c *C) {
 	// Never need to buy a free snap.
 	c.Check(mustBuy(false, true), Equals, false)
 	c.Check(mustBuy(false, false), Equals, false)
@@ -4960,7 +4960,7 @@ var buyTests = []struct {
 	},
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreBuy500(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreBuy500(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -4994,7 +4994,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuy500(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreBuy(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreBuy(c *C) {
 	for _, test := range buyTests {
 		searchServerCalled := false
 		purchaseServerGetCalled := false
@@ -5098,7 +5098,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreBuy(c *C) {
 	}
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreBuyFailArgumentChecking(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreBuyFailArgumentChecking(c *C) {
 	repo := New(&Config{}, nil)
 	c.Assert(repo, NotNil)
 
@@ -5254,7 +5254,7 @@ var readyToBuyTests = []struct {
 	},
 }
 
-func (t *remoteRepoTestSuite) TestUbuntuStoreReadyToBuy(c *C) {
+func (t *storeTestSuite) TestUbuntuStoreReadyToBuy(c *C) {
 	for _, test := range readyToBuyTests {
 		purchaseServerGetCalled := 0
 		mockPurchasesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -5290,7 +5290,7 @@ func (t *remoteRepoTestSuite) TestUbuntuStoreReadyToBuy(c *C) {
 	}
 }
 
-func (t *remoteRepoTestSuite) TestDoRequestSetRangeHeaderOnRedirect(c *C) {
+func (t *storeTestSuite) TestDoRequestSetRangeHeaderOnRedirect(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch n {
@@ -5343,7 +5343,7 @@ func (co *cacheObserver) Put(cacheKey, sourcePath string) error {
 	return nil
 }
 
-func (t *remoteRepoTestSuite) TestDownloadCacheHit(c *C) {
+func (t *storeTestSuite) TestDownloadCacheHit(c *C) {
 	oldCache := t.store.cacher
 	defer func() { t.store.cacher = oldCache }()
 	obs := &cacheObserver{inCache: map[string]bool{"the-snaps-sha3_384": true}}
@@ -5365,7 +5365,7 @@ func (t *remoteRepoTestSuite) TestDownloadCacheHit(c *C) {
 	c.Check(obs.puts, IsNil)
 }
 
-func (t *remoteRepoTestSuite) TestDownloadCacheMiss(c *C) {
+func (t *storeTestSuite) TestDownloadCacheMiss(c *C) {
 	oldCache := t.store.cacher
 	defer func() { t.store.cacher = oldCache }()
 	obs := &cacheObserver{inCache: map[string]bool{}}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -732,11 +732,11 @@ func (s *storeTestSuite) TestAuthenticatedDeviceDoesNotUseAnonURL(c *C) {
 	snap.Size = int64(len(expectedContent))
 
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&Config{}, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&Config{}, authContext)
+	c.Assert(sto, NotNil)
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
-	err := repo.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, nil)
+	err := sto.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, nil)
 	c.Assert(err, IsNil)
 	defer os.Remove(path)
 
@@ -1270,10 +1270,10 @@ func (s *storeTestSuite) TestDownloadDelta(c *C) {
 	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
 
 	authContext := &testAuthContext{c: c}
-	repo := New(nil, authContext)
+	sto := New(nil, authContext)
 
 	for _, testCase := range downloadDeltaTests {
-		repo.deltaFormat = testCase.format
+		sto.deltaFormat = testCase.format
 		download = func(ctx context.Context, name, sha3, url string, user *auth.UserState, _ *Store, w io.ReadWriteSeeker, resume int64, pbar progress.Meter) error {
 			expectedUser := s.user
 			if testCase.useLocalUser {
@@ -1305,7 +1305,7 @@ func (s *storeTestSuite) TestDownloadDelta(c *C) {
 			authedUser = nil
 		}
 
-		err = repo.downloadDelta("snapname", &testCase.info, w, nil, authedUser)
+		err = sto.downloadDelta("snapname", &testCase.info, w, nil, authedUser)
 
 		if testCase.expectError {
 			c.Assert(err, NotNil)
@@ -1400,13 +1400,13 @@ func (s *storeTestSuite) TestDoRequestSetsAuth(c *C) {
 	defer mockServer.Close()
 
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
-	repo := New(&Config{}, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&Config{}, authContext)
+	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, s.user)
+	response, err := sto.doRequest(context.TODO(), sto.client, reqOptions, s.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1431,13 +1431,13 @@ func (s *storeTestSuite) TestDoRequestDoesNotSetAuthForLocalOnlyUser(c *C) {
 	defer mockServer.Close()
 
 	authContext := &testAuthContext{c: c, device: s.device, user: s.localUser}
-	repo := New(&Config{}, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&Config{}, authContext)
+	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, s.localUser)
+	response, err := sto.doRequest(context.TODO(), sto.client, reqOptions, s.localUser)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1465,13 +1465,13 @@ func (s *storeTestSuite) TestDoRequestAuthNoSerial(c *C) {
 	s.device.Serial = ""
 	s.device.SessionMacaroon = ""
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
-	repo := New(&Config{}, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&Config{}, authContext)
+	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, s.user)
+	response, err := sto.doRequest(context.TODO(), sto.client, reqOptions, s.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1511,13 +1511,13 @@ func (s *storeTestSuite) TestDoRequestRefreshesAuth(c *C) {
 	defer mockServer.Close()
 
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
-	repo := New(&Config{}, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&Config{}, authContext)
+	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, s.user)
+	response, err := sto.doRequest(context.TODO(), sto.client, reqOptions, s.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -1551,13 +1551,13 @@ func (s *storeTestSuite) TestDoRequestForwardsRefreshAuthFailure(c *C) {
 	defer mockServer.Close()
 
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
-	repo := New(&Config{}, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&Config{}, authContext)
+	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
 
-	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, s.user)
+	response, err := sto.doRequest(context.TODO(), sto.client, reqOptions, s.user)
 	c.Assert(err, Equals, ErrInvalidCredentials)
 	c.Check(response, IsNil)
 	c.Check(refreshDischargeEndpointHit, Equals, true)
@@ -1617,14 +1617,14 @@ func (s *storeTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	// make sure device session is not set
 	s.device.SessionMacaroon = ""
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
-	repo := New(&Config{
+	sto := New(&Config{
 		StoreBaseURL: mockServerURL,
 	}, authContext)
-	c.Assert(repo, NotNil)
+	c.Assert(sto, NotNil)
 
 	reqOptions := &requestOptions{Method: "GET", URL: mockServerURL}
 
-	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, s.user)
+	response, err := sto.doRequest(context.TODO(), sto.client, reqOptions, s.user)
 	c.Assert(err, IsNil)
 	defer response.Body.Close()
 
@@ -1708,14 +1708,14 @@ func (s *storeTestSuite) TestDoRequestSetsAndRefreshesBothAuths(c *C) {
 	// make sure device session is expired
 	s.device.SessionMacaroon = "expired-session-macaroon"
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
-	repo := New(&Config{
+	sto := New(&Config{
 		StoreBaseURL: mockServerURL,
 	}, authContext)
-	c.Assert(repo, NotNil)
+	c.Assert(sto, NotNil)
 
 	reqOptions := &requestOptions{Method: "GET", URL: mockServerURL}
 
-	resp, err := repo.doRequest(context.TODO(), repo.client, reqOptions, s.user)
+	resp, err := sto.doRequest(context.TODO(), sto.client, reqOptions, s.user)
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 
@@ -1740,8 +1740,8 @@ func (s *storeTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 	c.Assert(mockServer, NotNil)
 	defer mockServer.Close()
 
-	repo := New(&Config{}, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&Config{}, nil)
+	c.Assert(sto, NotNil)
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{
 		Method: "GET",
@@ -1754,7 +1754,7 @@ func (s *storeTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 		},
 	}
 
-	response, err := repo.doRequest(context.TODO(), repo.client, reqOptions, s.user)
+	response, err := sto.doRequest(context.TODO(), sto.client, reqOptions, s.user)
 	defer response.Body.Close()
 	c.Assert(err, IsNil)
 
@@ -2065,8 +2065,8 @@ func (s *storeTestSuite) TestDetails(c *C) {
 		DetailFields: []string{"abc", "def"},
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2074,7 +2074,7 @@ func (s *storeTestSuite) TestDetails(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 	c.Check(result.Architectures, DeepEquals, []string{"all"})
@@ -2103,7 +2103,7 @@ func (s *storeTestSuite) TestDetails(c *C) {
 	// Make sure the epoch (currently not sent by the store) defaults to "0"
 	c.Check(result.Epoch.String(), Equals, "0")
 
-	c.Check(repo.SuggestedCurrency(), Equals, "GBP")
+	c.Check(sto.SuggestedCurrency(), Equals, "GBP")
 
 	// skip this one until the store supports it
 	// c.Check(result.Private, Equals, true)
@@ -2148,14 +2148,14 @@ func (s *storeTestSuite) TestDetailsDefaultChannelIsStable(c *C) {
 		DetailFields: []string{"abc", "def"},
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
 		Name: "hello-world",
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 	c.Check(result.SnapID, Equals, helloWorldSnapID)
@@ -2179,8 +2179,8 @@ func (s *storeTestSuite) TestDetails500(c *C) {
 		DetailFields: []string{},
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2188,7 +2188,7 @@ func (s *storeTestSuite) TestDetails500(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	_, err := repo.SnapInfo(spec, nil)
+	_, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot get details for snap "hello-world" in channel "edge": got unexpected HTTP status code 500 via GET to "http://.*?/details/hello-world\?channel=edge"`)
 	c.Assert(n, Equals, 5)
@@ -2216,8 +2216,8 @@ func (s *storeTestSuite) TestDetails500once(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2225,7 +2225,7 @@ func (s *storeTestSuite) TestDetails500once(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 	c.Assert(n, Equals, 2)
@@ -2260,15 +2260,15 @@ func (s *storeTestSuite) TestDetailsAndChannels(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
 		Name:       "hello-world",
 		AnyChannel: true,
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 1)
 	c.Check(result.Name(), Equals, "hello-world")
@@ -2345,8 +2345,8 @@ func (s *storeTestSuite) TestNonDefaults(c *C) {
 	cfg.Series = "21"
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "foo"
-	repo := New(cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(cfg, nil)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2354,7 +2354,7 @@ func (s *storeTestSuite) TestNonDefaults(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 }
@@ -2378,8 +2378,8 @@ func (s *storeTestSuite) TestStoreIDFromAuthContext(c *C) {
 	cfg.Series = "21"
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "fallback"
-	repo := New(cfg, &testAuthContext{c: c, device: s.device, storeID: "my-brand-store-id"})
-	c.Assert(repo, NotNil)
+	sto := New(cfg, &testAuthContext{c: c, device: s.device, storeID: "my-brand-store-id"})
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2387,7 +2387,7 @@ func (s *storeTestSuite) TestStoreIDFromAuthContext(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 }
@@ -2410,8 +2410,8 @@ func (s *storeTestSuite) TestFullCloudInfoFromAuthContext(c *C) {
 	cfg.Series = "21"
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "fallback"
-	repo := New(cfg, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "aws", Region: "us-east-1", AvailabilityZone: "us-east-1c"}})
-	c.Assert(repo, NotNil)
+	sto := New(cfg, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "aws", Region: "us-east-1", AvailabilityZone: "us-east-1c"}})
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2419,7 +2419,7 @@ func (s *storeTestSuite) TestFullCloudInfoFromAuthContext(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 }
@@ -2442,8 +2442,8 @@ func (s *storeTestSuite) TestLessDetailedCloudInfoFromAuthContext(c *C) {
 	cfg.Series = "21"
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "fallback"
-	repo := New(cfg, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "openstack", Region: "", AvailabilityZone: "nova"}})
-	c.Assert(repo, NotNil)
+	sto := New(cfg, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "openstack", Region: "", AvailabilityZone: "nova"}})
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2451,7 +2451,7 @@ func (s *storeTestSuite) TestLessDetailedCloudInfoFromAuthContext(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 }
@@ -2472,13 +2472,13 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContext(c *C) {
 	c.Assert(err, IsNil)
 	cfg := DefaultConfig()
 	cfg.StoreBaseURL = nowhereURL
-	repo := New(cfg, &testAuthContext{
+	sto := New(cfg, &testAuthContext{
 		c:             c,
 		device:        s.device,
 		proxyStoreID:  "foo",
 		proxyStoreURL: mockServerURL,
 	})
-	c.Assert(repo, NotNil)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2486,7 +2486,7 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContext(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 }
@@ -2505,14 +2505,14 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContextURLFallback(c *C) {
 	mockServerURL, _ := url.Parse(mockServer.URL)
 	cfg := DefaultConfig()
 	cfg.StoreBaseURL = mockServerURL
-	repo := New(cfg, &testAuthContext{
+	sto := New(cfg, &testAuthContext{
 		c:      c,
 		device: s.device,
 		// mock an assertion that has id but no url
 		proxyStoreID:  "foo",
 		proxyStoreURL: nil,
 	})
-	c.Assert(repo, NotNil)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2520,7 +2520,7 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContextURLFallback(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 }
@@ -2548,8 +2548,8 @@ func (s *storeTestSuite) TestRevision(c *C) {
 	cfg := DefaultConfig()
 	cfg.StoreBaseURL = mockServerURL
 	cfg.DetailFields = []string{}
-	repo := New(cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(cfg, nil)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2557,7 +2557,7 @@ func (s *storeTestSuite) TestRevision(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(26),
 	}
-	result, err := repo.SnapInfo(spec, s.user)
+	result, err := sto.SnapInfo(spec, s.user)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 	c.Check(result.Revision, DeepEquals, snap.R(27))
@@ -2582,8 +2582,8 @@ func (s *storeTestSuite) TestDetailsOopses(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2591,7 +2591,7 @@ func (s *storeTestSuite) TestDetailsOopses(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	_, err := repo.SnapInfo(spec, nil)
+	_, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, ErrorMatches, `cannot get details for snap "hello-world" in channel "edge": got unexpected HTTP status code 5.. via GET to "http://\S+" \[OOPS-[[:xdigit:]]*\]`)
 }
 
@@ -2631,8 +2631,8 @@ func (s *storeTestSuite) TestNoDetails(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2640,7 +2640,7 @@ func (s *storeTestSuite) TestNoDetails(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, NotNil)
 	c.Assert(result, IsNil)
 }
@@ -2762,8 +2762,8 @@ func (s *storeTestSuite) TestFindQueries(c *C) {
 		DetailFields: []string{"abc", "def"},
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	for _, query := range []Search{
 		{Query: "hello", Prefix: true},
@@ -2771,7 +2771,7 @@ func (s *storeTestSuite) TestFindQueries(c *C) {
 		{Section: "db"},
 		{Query: "hello", Section: "db"},
 	} {
-		repo.Find(&query, nil)
+		sto.Find(&query, nil)
 	}
 }
 
@@ -2820,10 +2820,10 @@ func (s *storeTestSuite) TestSectionsQuery(c *C) {
 	cfg := Config{
 		StoreBaseURL: serverURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	sections, err := repo.Sections(s.user)
+	sections, err := sto.Sections(s.user)
 	c.Check(err, IsNil)
 	c.Check(sections, DeepEquals, []string{"featured", "database"})
 }
@@ -2895,15 +2895,15 @@ func (s *storeTestSuite) testSnapCommands(c *C, onClassic bool) {
 	defer mockServer.Close()
 
 	serverURL, _ := url.Parse(mockServer.URL)
-	repo := New(&Config{StoreBaseURL: serverURL}, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&Config{StoreBaseURL: serverURL}, nil)
+	c.Assert(sto, NotNil)
 
 	db, err := advisor.Create()
 	c.Assert(err, IsNil)
 	defer db.Rollback()
 
 	var bufNames bytes.Buffer
-	err = repo.WriteCatalogs(&bufNames, db)
+	err = sto.WriteCatalogs(&bufNames, db)
 	c.Assert(err, IsNil)
 	db.Commit()
 	c.Check(bufNames.String(), Equals, "bar\nfoo\n")
@@ -2950,24 +2950,24 @@ func (s *storeTestSuite) TestFindPrivate(c *C) {
 	cfg := Config{
 		StoreBaseURL: serverURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	_, err := repo.Find(&Search{Query: "foo", Private: true}, s.user)
+	_, err := sto.Find(&Search{Query: "foo", Private: true}, s.user)
 	c.Check(err, IsNil)
 
-	_, err = repo.Find(&Search{Query: "foo", Private: true}, nil)
+	_, err = sto.Find(&Search{Query: "foo", Private: true}, nil)
 	c.Check(err, Equals, ErrUnauthenticated)
 
-	_, err = repo.Find(&Search{Query: "name:foo", Private: true}, s.user)
+	_, err = sto.Find(&Search{Query: "name:foo", Private: true}, s.user)
 	c.Check(err, Equals, ErrBadQuery)
 }
 
 func (s *storeTestSuite) TestFindFailures(c *C) {
-	repo := New(&Config{StoreBaseURL: new(url.URL)}, nil)
-	_, err := repo.Find(&Search{Query: "foo:bar"}, nil)
+	sto := New(&Config{StoreBaseURL: new(url.URL)}, nil)
+	_, err := sto.Find(&Search{Query: "foo:bar"}, nil)
 	c.Check(err, Equals, ErrBadQuery)
-	_, err = repo.Find(&Search{Query: "foo", Private: true, Prefix: true}, s.user)
+	_, err = sto.Find(&Search{Query: "foo", Private: true, Prefix: true}, s.user)
 	c.Check(err, Equals, ErrBadQuery)
 }
 
@@ -2985,10 +2985,10 @@ func (s *storeTestSuite) TestFindFails(c *C) {
 		StoreBaseURL: mockServerURL,
 		DetailFields: []string{}, // make the error less noisy
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	snaps, err := repo.Find(&Search{Query: "hello"}, nil)
+	snaps, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `cannot search: got unexpected HTTP status code 418 via GET to "http://\S+[?&]q=hello.*"`)
 	c.Check(snaps, HasLen, 0)
 }
@@ -3007,10 +3007,10 @@ func (s *storeTestSuite) TestFindBadContentType(c *C) {
 		StoreBaseURL: mockServerURL,
 		DetailFields: []string{}, // make the error less noisy
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	snaps, err := repo.Find(&Search{Query: "hello"}, nil)
+	snaps, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `received an unexpected content type \("text/plain[^"]+"\) when trying to search via "http://\S+[?&]q=hello.*"`)
 	c.Check(snaps, HasLen, 0)
 }
@@ -3031,10 +3031,10 @@ func (s *storeTestSuite) TestFindBadBody(c *C) {
 		StoreBaseURL: mockServerURL,
 		DetailFields: []string{}, // make the error less noisy
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	snaps, err := repo.Find(&Search{Query: "hello"}, nil)
+	snaps, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `invalid character '<' looking for beginning of value`)
 	c.Check(snaps, HasLen, 0)
 }
@@ -3054,10 +3054,10 @@ func (s *storeTestSuite) TestFind500(c *C) {
 		StoreBaseURL: mockServerURL,
 		DetailFields: []string{},
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	_, err := repo.Find(&Search{Query: "hello"}, nil)
+	_, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `cannot search: got unexpected HTTP status code 500 via GET to "http://\S+[?&]q=hello.*"`)
 	c.Assert(n, Equals, 5)
 }
@@ -3083,10 +3083,10 @@ func (s *storeTestSuite) TestFind500once(c *C) {
 		StoreBaseURL: mockServerURL,
 		DetailFields: []string{},
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	snaps, err := repo.Find(&Search{Query: "hello"}, nil)
+	snaps, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, IsNil)
 	c.Assert(snaps, HasLen, 1)
 	c.Assert(n, Equals, 2)
@@ -3127,10 +3127,10 @@ func (s *storeTestSuite) TestFindAuthFailed(c *C) {
 		StoreBaseURL: mockServerURL,
 		DetailFields: []string{}, // make the error less noisy
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	snaps, err := repo.Find(&Search{Query: "foo"}, s.user)
+	snaps, err := sto.Find(&Search{Query: "foo"}, s.user)
 	c.Assert(err, IsNil)
 
 	// Check that we log an error.
@@ -3314,10 +3314,10 @@ func (s *storeTestSuite) TestRefreshForCandidates(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.refreshForCandidates([]*currentSnapJSON{
+	results, err := sto.refreshForCandidates([]*currentSnapJSON{
 		{
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
@@ -3364,10 +3364,10 @@ func (s *storeTestSuite) TestRefreshForCandidatesRetriesOnEOF(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.refreshForCandidates([]*currentSnapJSON{{
+	results, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
@@ -3403,10 +3403,10 @@ func (s *storeTestSuite) TestLookupRefresh(c *C) {
 		}}, nil
 	})()
 
-	repo := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(repo, NotNil)
+	sto := New(nil, &testAuthContext{c: c, device: s.device})
+	c.Assert(sto, NotNil)
 
-	result, err := repo.LookupRefresh(&RefreshCandidate{
+	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
@@ -3439,10 +3439,10 @@ func (s *storeTestSuite) TestLookupRefreshIgnoreValidation(c *C) {
 		}}, nil
 	})()
 
-	repo := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(repo, NotNil)
+	sto := New(nil, &testAuthContext{c: c, device: s.device})
+	c.Assert(sto, NotNil)
 
-	result, err := repo.LookupRefresh(&RefreshCandidate{
+	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:           helloWorldSnapID,
 		Channel:          "stable",
 		Revision:         snap.R(1),
@@ -3460,10 +3460,10 @@ func (s *storeTestSuite) TestLookupRefreshLocalSnap(c *C) {
 		panic("unexpected call to refreshForCandidates")
 	})()
 
-	repo := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(repo, NotNil)
+	sto := New(nil, &testAuthContext{c: c, device: s.device})
+	c.Assert(sto, NotNil)
 
-	result, err := repo.LookupRefresh(&RefreshCandidate{
+	result, err := sto.LookupRefresh(&RefreshCandidate{
 		Revision: snap.R("x1"),
 	}, nil)
 	c.Assert(result, IsNil)
@@ -3476,10 +3476,10 @@ func (s *storeTestSuite) TestLookupRefreshRFCError(c *C) {
 		return nil, anError
 	})()
 
-	repo := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(repo, NotNil)
+	sto := New(nil, &testAuthContext{c: c, device: s.device})
+	c.Assert(sto, NotNil)
 
-	result, err := repo.LookupRefresh(&RefreshCandidate{
+	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:   helloWorldDeveloperID,
 		Revision: snap.R(1),
 	}, nil)
@@ -3492,10 +3492,10 @@ func (s *storeTestSuite) TestLookupRefreshEmptyResponse(c *C) {
 		return nil, nil
 	})()
 
-	repo := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(repo, NotNil)
+	sto := New(nil, &testAuthContext{c: c, device: s.device})
+	c.Assert(sto, NotNil)
 
-	result, err := repo.LookupRefresh(&RefreshCandidate{
+	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:   helloWorldDeveloperID,
 		Revision: snap.R(1),
 	}, nil)
@@ -3511,10 +3511,10 @@ func (s *storeTestSuite) TestLookupRefreshNoUpdate(c *C) {
 		}}, nil
 	})()
 
-	repo := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(repo, NotNil)
+	sto := New(nil, &testAuthContext{c: c, device: s.device})
+	c.Assert(sto, NotNil)
 
-	result, err := repo.LookupRefresh(&RefreshCandidate{
+	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:   helloWorldDeveloperID,
 		Revision: snap.R(1),
 	}, nil)
@@ -3559,10 +3559,10 @@ func (s *storeTestSuite) TestListRefresh(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.ListRefresh([]*RefreshCandidate{
+	results, err := sto.ListRefresh([]*RefreshCandidate{
 		{
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
@@ -3617,10 +3617,10 @@ func (s *storeTestSuite) TestListRefreshIgnoreValidation(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.ListRefresh([]*RefreshCandidate{
+	results, err := sto.ListRefresh([]*RefreshCandidate{
 		{
 			SnapID:           helloWorldSnapID,
 			Channel:          "stable",
@@ -3672,10 +3672,10 @@ func (s *storeTestSuite) TestListRefreshDefaultChannelIsStable(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.ListRefresh([]*RefreshCandidate{
+	results, err := sto.ListRefresh([]*RefreshCandidate{
 		{
 			SnapID:   helloWorldSnapID,
 			Revision: snap.R(1),
@@ -3720,10 +3720,10 @@ func (s *storeTestSuite) TestListRefreshRetryOnEOF(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.ListRefresh([]*RefreshCandidate{{
+	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(1),
@@ -3762,10 +3762,10 @@ func (s *storeTestSuite) TestUnexpectedEOFhandling(c *C) {
 			StoreBaseURL: mockServerURL,
 		}
 		authContext := &testAuthContext{c: c, device: s.device}
-		repo := New(&cfg, authContext)
-		c.Assert(repo, NotNil)
+		sto := New(&cfg, authContext)
+		c.Assert(sto, NotNil)
 
-		_, err := repo.refreshForCandidates([]*currentSnapJSON{{
+		_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
@@ -3807,10 +3807,10 @@ func (s *storeTestSuite) TestRefreshForCandidatesEOF(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	_, err := repo.refreshForCandidates([]*currentSnapJSON{{
+	_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 1,
@@ -3839,10 +3839,10 @@ func (s *storeTestSuite) TestRefreshForCandidatesUnauthorised(c *C) {
 	}
 
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	_, err := repo.refreshForCandidates([]*currentSnapJSON{{
+	_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
@@ -3858,10 +3858,10 @@ func (s *storeTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
 		StoreBaseURL: baseURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	_, err = repo.refreshForCandidates([]*currentSnapJSON{{
+	_, err = sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
@@ -3885,10 +3885,10 @@ func (s *storeTestSuite) TestRefreshForCandidates500(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	_, err := repo.refreshForCandidates([]*currentSnapJSON{{
+	_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
@@ -3913,10 +3913,10 @@ func (s *storeTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
-	_, err := repo.refreshForCandidates([]*currentSnapJSON{{
+	_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: 24,
@@ -3970,10 +3970,10 @@ func (s *storeTestSuite) TestListRefreshSkipCurrent(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.ListRefresh([]*RefreshCandidate{{
+	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(26),
@@ -4014,10 +4014,10 @@ func (s *storeTestSuite) TestListRefreshSkipBlocked(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.ListRefresh([]*RefreshCandidate{{
+	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(25),
@@ -4105,10 +4105,10 @@ func (s *storeTestSuite) TestDefaultsDeltasOnClassicOnly(c *C) {
 		cfg := Config{
 			StoreBaseURL: mockServerURL,
 		}
-		repo := New(&cfg, nil)
-		c.Assert(repo, NotNil)
+		sto := New(&cfg, nil)
+		c.Assert(sto, NotNil)
 
-		repo.refreshForCandidates([]*currentSnapJSON{{
+		sto.refreshForCandidates([]*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: 1,
@@ -4154,10 +4154,10 @@ func (s *storeTestSuite) TestListRefreshWithDeltas(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.ListRefresh([]*RefreshCandidate{{
+	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
@@ -4224,10 +4224,10 @@ func (s *storeTestSuite) TestListRefreshWithoutDeltas(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	results, err := repo.ListRefresh([]*RefreshCandidate{{
+	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(24),
@@ -4250,10 +4250,10 @@ func (s *storeTestSuite) TestUpdateNotSendLocalRevs(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
-	_, err := repo.ListRefresh([]*RefreshCandidate{{
+	_, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
 		Channel:  "stable",
 		Revision: snap.R(-2),
@@ -4287,10 +4287,10 @@ func (s *storeTestSuite) TestListRefreshOptions(c *C) {
 		cfg := Config{
 			StoreBaseURL: mockServerURL,
 		}
-		repo := New(&cfg, nil)
-		c.Assert(repo, NotNil)
+		sto := New(&cfg, nil)
+		c.Assert(sto, NotNil)
 
-		_, err := repo.ListRefresh([]*RefreshCandidate{{
+		_, err := sto.ListRefresh([]*RefreshCandidate{{
 			SnapID:   helloWorldSnapID,
 			Channel:  "stable",
 			Revision: snap.R(24),
@@ -4442,9 +4442,9 @@ func (s *storeTestSuite) TestAssertion(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
-	repo := New(&cfg, authContext)
+	sto := New(&cfg, authContext)
 
-	a, err := repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
+	a, err := sto.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
 	c.Assert(err, IsNil)
 	c.Check(a, NotNil)
 	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
@@ -4479,9 +4479,9 @@ func (s *storeTestSuite) TestAssertionProxyStoreFromAuthContext(c *C) {
 		proxyStoreID:  "foo",
 		proxyStoreURL: mockServerURL,
 	}
-	repo := New(&cfg, authContext)
+	sto := New(&cfg, authContext)
 
-	a, err := repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
+	a, err := sto.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
 	c.Assert(err, IsNil)
 	c.Check(a, NotNil)
 	c.Check(a.Type(), Equals, asserts.SnapDeclarationType)
@@ -4504,9 +4504,9 @@ func (s *storeTestSuite) TestAssertionNotFound(c *C) {
 	cfg := Config{
 		AssertionsBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
+	sto := New(&cfg, nil)
 
-	_, err := repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
+	_, err := sto.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
 	c.Check(asserts.IsNotFound(err), Equals, true)
 	c.Check(err, DeepEquals, &asserts.NotFoundError{
 		Type: asserts.SnapDeclarationType,
@@ -4532,9 +4532,9 @@ func (s *storeTestSuite) TestAssertion500(c *C) {
 	cfg := Config{
 		AssertionsBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
+	sto := New(&cfg, nil)
 
-	_, err := repo.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
+	_, err := sto.Assertion(asserts.SnapDeclarationType, []string{"16", "snapidfoo"}, nil)
 	c.Assert(err, ErrorMatches, `cannot fetch assertion: got unexpected HTTP status code 500 via .+`)
 	c.Assert(n, Equals, 5)
 }
@@ -4557,11 +4557,11 @@ func (s *storeTestSuite) TestSuggestedCurrency(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
 	// the store doesn't know the currency until after the first search, so fall back to dollars
-	c.Check(repo.SuggestedCurrency(), Equals, "USD")
+	c.Check(sto.SuggestedCurrency(), Equals, "USD")
 
 	// we should soon have a suggested currency
 	spec := SnapSpec{
@@ -4569,18 +4569,18 @@ func (s *storeTestSuite) TestSuggestedCurrency(c *C) {
 		Channel:  "edge",
 		Revision: snap.R(0),
 	}
-	result, err := repo.SnapInfo(spec, nil)
+	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Assert(result, NotNil)
-	c.Check(repo.SuggestedCurrency(), Equals, "GBP")
+	c.Check(sto.SuggestedCurrency(), Equals, "GBP")
 
 	suggestedCurrency = "EUR"
 
 	// checking the currency updates
-	result, err = repo.SnapInfo(spec, nil)
+	result, err = sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Assert(result, NotNil)
-	c.Check(repo.SuggestedCurrency(), Equals, "EUR")
+	c.Check(sto.SuggestedCurrency(), Equals, "EUR")
 }
 
 func (s *storeTestSuite) TestDecorateOrders(c *C) {
@@ -4602,8 +4602,8 @@ func (s *storeTestSuite) TestDecorateOrders(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4625,7 +4625,7 @@ func (s *storeTestSuite) TestDecorateOrders(c *C) {
 
 	snaps := []*snap.Info{helloWorld, funkyApp, otherApp, otherApp2}
 
-	err := repo.decorateOrders(snaps, s.user)
+	err := sto.decorateOrders(snaps, s.user)
 	c.Assert(err, IsNil)
 
 	c.Check(helloWorld.MustBuy, Equals, false)
@@ -4651,8 +4651,8 @@ func (s *storeTestSuite) TestDecorateOrdersFailedAccess(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4674,7 +4674,7 @@ func (s *storeTestSuite) TestDecorateOrdersFailedAccess(c *C) {
 
 	snaps := []*snap.Info{helloWorld, funkyApp, otherApp, otherApp2}
 
-	err := repo.decorateOrders(snaps, s.user)
+	err := sto.decorateOrders(snaps, s.user)
 	c.Assert(err, NotNil)
 
 	c.Check(helloWorld.MustBuy, Equals, true)
@@ -4685,8 +4685,8 @@ func (s *storeTestSuite) TestDecorateOrdersFailedAccess(c *C) {
 
 func (s *storeTestSuite) TestDecorateOrdersNoAuth(c *C) {
 	cfg := Config{}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4708,7 +4708,7 @@ func (s *storeTestSuite) TestDecorateOrdersNoAuth(c *C) {
 
 	snaps := []*snap.Info{helloWorld, funkyApp, otherApp, otherApp2}
 
-	err := repo.decorateOrders(snaps, nil)
+	err := sto.decorateOrders(snaps, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(helloWorld.MustBuy, Equals, true)
@@ -4735,8 +4735,8 @@ func (s *storeTestSuite) TestDecorateOrdersAllFree(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
 	// This snap is free
 	helloWorld := &snap.Info{}
@@ -4749,7 +4749,7 @@ func (s *storeTestSuite) TestDecorateOrdersAllFree(c *C) {
 	snaps := []*snap.Info{helloWorld, funkyApp}
 
 	// There should be no request to the purchase server.
-	err := repo.decorateOrders(snaps, s.user)
+	err := sto.decorateOrders(snaps, s.user)
 	c.Assert(err, IsNil)
 	c.Check(requestRecieved, Equals, false)
 }
@@ -4771,8 +4771,8 @@ func (s *storeTestSuite) TestDecorateOrdersSingle(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4781,22 +4781,22 @@ func (s *storeTestSuite) TestDecorateOrdersSingle(c *C) {
 
 	snaps := []*snap.Info{helloWorld}
 
-	err := repo.decorateOrders(snaps, s.user)
+	err := sto.decorateOrders(snaps, s.user)
 	c.Assert(err, IsNil)
 	c.Check(helloWorld.MustBuy, Equals, false)
 }
 
 func (s *storeTestSuite) TestDecorateOrdersSingleFreeSnap(c *C) {
 	cfg := Config{}
-	repo := New(&cfg, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, nil)
+	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
 
 	snaps := []*snap.Info{helloWorld}
 
-	err := repo.decorateOrders(snaps, s.user)
+	err := sto.decorateOrders(snaps, s.user)
 	c.Assert(err, IsNil)
 	c.Check(helloWorld.MustBuy, Equals, false)
 }
@@ -4820,8 +4820,8 @@ func (s *storeTestSuite) TestDecorateOrdersSingleNotFound(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4830,7 +4830,7 @@ func (s *storeTestSuite) TestDecorateOrdersSingleNotFound(c *C) {
 
 	snaps := []*snap.Info{helloWorld}
 
-	err := repo.decorateOrders(snaps, s.user)
+	err := sto.decorateOrders(snaps, s.user)
 	c.Assert(err, NotNil)
 	c.Check(helloWorld.MustBuy, Equals, true)
 }
@@ -4853,8 +4853,8 @@ func (s *storeTestSuite) TestDecorateOrdersTokenExpired(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4863,7 +4863,7 @@ func (s *storeTestSuite) TestDecorateOrdersTokenExpired(c *C) {
 
 	snaps := []*snap.Info{helloWorld}
 
-	err := repo.decorateOrders(snaps, s.user)
+	err := sto.decorateOrders(snaps, s.user)
 	c.Assert(err, NotNil)
 	c.Check(helloWorld.MustBuy, Equals, true)
 }
@@ -4982,15 +4982,15 @@ func (s *storeTestSuite) TestBuy500(c *C) {
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
 	}
-	repo := New(&cfg, authContext)
-	c.Assert(repo, NotNil)
+	sto := New(&cfg, authContext)
+	c.Assert(sto, NotNil)
 
 	buyOptions := &BuyOptions{
 		SnapID:   helloWorldSnapID,
 		Currency: "USD",
 		Price:    1,
 	}
-	_, err := repo.Buy(buyOptions, s.user)
+	_, err := sto.Buy(buyOptions, s.user)
 	c.Assert(err, NotNil)
 }
 
@@ -5055,8 +5055,8 @@ func (s *storeTestSuite) TestBuy(c *C) {
 		cfg := Config{
 			StoreBaseURL: mockServerURL,
 		}
-		repo := New(&cfg, authContext)
-		c.Assert(repo, NotNil)
+		sto := New(&cfg, authContext)
+		c.Assert(sto, NotNil)
 
 		// Find the snap first
 		spec := SnapSpec{
@@ -5064,14 +5064,14 @@ func (s *storeTestSuite) TestBuy(c *C) {
 			Channel:  "edge",
 			Revision: snap.R(0),
 		}
-		snap, err := repo.SnapInfo(spec, s.user)
+		snap, err := sto.SnapInfo(spec, s.user)
 		c.Assert(snap, NotNil)
 		c.Assert(err, IsNil)
 
 		buyOptions := &BuyOptions{
 			SnapID:   snap.SnapID,
-			Currency: repo.SuggestedCurrency(),
-			Price:    snap.Prices[repo.SuggestedCurrency()],
+			Currency: sto.SuggestedCurrency(),
+			Price:    snap.Prices[sto.SuggestedCurrency()],
 		}
 		if test.snapID != "" {
 			buyOptions.SnapID = test.snapID
@@ -5082,7 +5082,7 @@ func (s *storeTestSuite) TestBuy(c *C) {
 		if test.price > 0 {
 			buyOptions.Price = test.price
 		}
-		result, err := repo.Buy(buyOptions, s.user)
+		result, err := sto.Buy(buyOptions, s.user)
 
 		c.Check(result, DeepEquals, test.expectedResult)
 		if test.expectedError == "" {
@@ -5099,11 +5099,11 @@ func (s *storeTestSuite) TestBuy(c *C) {
 }
 
 func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
-	repo := New(&Config{}, nil)
-	c.Assert(repo, NotNil)
+	sto := New(&Config{}, nil)
+	c.Assert(sto, NotNil)
 
 	// no snap ID
-	result, err := repo.Buy(&BuyOptions{
+	result, err := sto.Buy(&BuyOptions{
 		Price:    1.0,
 		Currency: "USD",
 	}, s.user)
@@ -5112,7 +5112,7 @@ func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
 	c.Check(err.Error(), Equals, "cannot buy snap: snap ID missing")
 
 	// no price
-	result, err = repo.Buy(&BuyOptions{
+	result, err = sto.Buy(&BuyOptions{
 		SnapID:   "snap ID",
 		Currency: "USD",
 	}, s.user)
@@ -5121,7 +5121,7 @@ func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
 	c.Check(err.Error(), Equals, "cannot buy snap: invalid expected price")
 
 	// no currency
-	result, err = repo.Buy(&BuyOptions{
+	result, err = sto.Buy(&BuyOptions{
 		SnapID: "snap ID",
 		Price:  1.0,
 	}, s.user)
@@ -5130,7 +5130,7 @@ func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
 	c.Check(err.Error(), Equals, "cannot buy snap: currency missing")
 
 	// no user
-	result, err = repo.Buy(&BuyOptions{
+	result, err = sto.Buy(&BuyOptions{
 		SnapID:   "snap ID",
 		Price:    1.0,
 		Currency: "USD",
@@ -5281,10 +5281,10 @@ func (s *storeTestSuite) TestReadyToBuy(c *C) {
 		cfg := Config{
 			StoreBaseURL: mockServerURL,
 		}
-		repo := New(&cfg, authContext)
-		c.Assert(repo, NotNil)
+		sto := New(&cfg, authContext)
+		c.Assert(sto, NotNil)
 
-		err := repo.ReadyToBuy(s.user)
+		err := sto.ReadyToBuy(s.user)
 		test.Test(c, err)
 		c.Check(purchaseServerGetCalled, Equals, test.NumOfCalls)
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -733,7 +733,6 @@ func (s *storeTestSuite) TestAuthenticatedDeviceDoesNotUseAnonURL(c *C) {
 
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&Config{}, authContext)
-	c.Assert(sto, NotNil)
 
 	path := filepath.Join(c.MkDir(), "downloaded-file")
 	err := sto.Download(context.TODO(), "foo", path, &snap.DownloadInfo, nil, nil)
@@ -1401,7 +1400,6 @@ func (s *storeTestSuite) TestDoRequestSetsAuth(c *C) {
 
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
 	sto := New(&Config{}, authContext)
-	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
@@ -1432,7 +1430,6 @@ func (s *storeTestSuite) TestDoRequestDoesNotSetAuthForLocalOnlyUser(c *C) {
 
 	authContext := &testAuthContext{c: c, device: s.device, user: s.localUser}
 	sto := New(&Config{}, authContext)
-	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
@@ -1466,7 +1463,6 @@ func (s *storeTestSuite) TestDoRequestAuthNoSerial(c *C) {
 	s.device.SessionMacaroon = ""
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
 	sto := New(&Config{}, authContext)
-	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
@@ -1512,7 +1508,6 @@ func (s *storeTestSuite) TestDoRequestRefreshesAuth(c *C) {
 
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
 	sto := New(&Config{}, authContext)
-	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
@@ -1552,7 +1547,6 @@ func (s *storeTestSuite) TestDoRequestForwardsRefreshAuthFailure(c *C) {
 
 	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
 	sto := New(&Config{}, authContext)
-	c.Assert(sto, NotNil)
 
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{Method: "GET", URL: endpoint}
@@ -1620,7 +1614,6 @@ func (s *storeTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	sto := New(&Config{
 		StoreBaseURL: mockServerURL,
 	}, authContext)
-	c.Assert(sto, NotNil)
 
 	reqOptions := &requestOptions{Method: "GET", URL: mockServerURL}
 
@@ -1711,7 +1704,6 @@ func (s *storeTestSuite) TestDoRequestSetsAndRefreshesBothAuths(c *C) {
 	sto := New(&Config{
 		StoreBaseURL: mockServerURL,
 	}, authContext)
-	c.Assert(sto, NotNil)
 
 	reqOptions := &requestOptions{Method: "GET", URL: mockServerURL}
 
@@ -1741,7 +1733,6 @@ func (s *storeTestSuite) TestDoRequestSetsExtraHeaders(c *C) {
 	defer mockServer.Close()
 
 	sto := New(&Config{}, nil)
-	c.Assert(sto, NotNil)
 	endpoint, _ := url.Parse(mockServer.URL)
 	reqOptions := &requestOptions{
 		Method: "GET",
@@ -2066,7 +2057,6 @@ func (s *storeTestSuite) TestDetails(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2149,7 +2139,6 @@ func (s *storeTestSuite) TestDetailsDefaultChannelIsStable(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2180,7 +2169,6 @@ func (s *storeTestSuite) TestDetails500(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2217,7 +2205,6 @@ func (s *storeTestSuite) TestDetails500once(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2261,7 +2248,6 @@ func (s *storeTestSuite) TestDetailsAndChannels(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2346,7 +2332,6 @@ func (s *storeTestSuite) TestNonDefaults(c *C) {
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "foo"
 	sto := New(cfg, nil)
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2379,7 +2364,6 @@ func (s *storeTestSuite) TestStoreIDFromAuthContext(c *C) {
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "fallback"
 	sto := New(cfg, &testAuthContext{c: c, device: s.device, storeID: "my-brand-store-id"})
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2411,7 +2395,6 @@ func (s *storeTestSuite) TestFullCloudInfoFromAuthContext(c *C) {
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "fallback"
 	sto := New(cfg, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "aws", Region: "us-east-1", AvailabilityZone: "us-east-1c"}})
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2443,7 +2426,6 @@ func (s *storeTestSuite) TestLessDetailedCloudInfoFromAuthContext(c *C) {
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "fallback"
 	sto := New(cfg, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "openstack", Region: "", AvailabilityZone: "nova"}})
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2478,7 +2460,6 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContext(c *C) {
 		proxyStoreID:  "foo",
 		proxyStoreURL: mockServerURL,
 	})
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2512,7 +2493,6 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContextURLFallback(c *C) {
 		proxyStoreID:  "foo",
 		proxyStoreURL: nil,
 	})
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2549,7 +2529,6 @@ func (s *storeTestSuite) TestRevision(c *C) {
 	cfg.StoreBaseURL = mockServerURL
 	cfg.DetailFields = []string{}
 	sto := New(cfg, nil)
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2583,7 +2562,6 @@ func (s *storeTestSuite) TestDetailsOopses(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2632,7 +2610,6 @@ func (s *storeTestSuite) TestNoDetails(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	// the actual test
 	spec := SnapSpec{
@@ -2763,7 +2740,6 @@ func (s *storeTestSuite) TestFindQueries(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	for _, query := range []Search{
 		{Query: "hello", Prefix: true},
@@ -2821,7 +2797,6 @@ func (s *storeTestSuite) TestSectionsQuery(c *C) {
 		StoreBaseURL: serverURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	sections, err := sto.Sections(s.user)
 	c.Check(err, IsNil)
@@ -2896,7 +2871,6 @@ func (s *storeTestSuite) testSnapCommands(c *C, onClassic bool) {
 
 	serverURL, _ := url.Parse(mockServer.URL)
 	sto := New(&Config{StoreBaseURL: serverURL}, nil)
-	c.Assert(sto, NotNil)
 
 	db, err := advisor.Create()
 	c.Assert(err, IsNil)
@@ -2951,7 +2925,6 @@ func (s *storeTestSuite) TestFindPrivate(c *C) {
 		StoreBaseURL: serverURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	_, err := sto.Find(&Search{Query: "foo", Private: true}, s.user)
 	c.Check(err, IsNil)
@@ -2986,7 +2959,6 @@ func (s *storeTestSuite) TestFindFails(c *C) {
 		DetailFields: []string{}, // make the error less noisy
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	snaps, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `cannot search: got unexpected HTTP status code 418 via GET to "http://\S+[?&]q=hello.*"`)
@@ -3008,7 +2980,6 @@ func (s *storeTestSuite) TestFindBadContentType(c *C) {
 		DetailFields: []string{}, // make the error less noisy
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	snaps, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `received an unexpected content type \("text/plain[^"]+"\) when trying to search via "http://\S+[?&]q=hello.*"`)
@@ -3032,7 +3003,6 @@ func (s *storeTestSuite) TestFindBadBody(c *C) {
 		DetailFields: []string{}, // make the error less noisy
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	snaps, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `invalid character '<' looking for beginning of value`)
@@ -3055,7 +3025,6 @@ func (s *storeTestSuite) TestFind500(c *C) {
 		DetailFields: []string{},
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	_, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, ErrorMatches, `cannot search: got unexpected HTTP status code 500 via GET to "http://\S+[?&]q=hello.*"`)
@@ -3084,7 +3053,6 @@ func (s *storeTestSuite) TestFind500once(c *C) {
 		DetailFields: []string{},
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	snaps, err := sto.Find(&Search{Query: "hello"}, nil)
 	c.Check(err, IsNil)
@@ -3128,7 +3096,6 @@ func (s *storeTestSuite) TestFindAuthFailed(c *C) {
 		DetailFields: []string{}, // make the error less noisy
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	snaps, err := sto.Find(&Search{Query: "foo"}, s.user)
 	c.Assert(err, IsNil)
@@ -3315,7 +3282,6 @@ func (s *storeTestSuite) TestRefreshForCandidates(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.refreshForCandidates([]*currentSnapJSON{
 		{
@@ -3365,7 +3331,6 @@ func (s *storeTestSuite) TestRefreshForCandidatesRetriesOnEOF(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
@@ -3404,7 +3369,6 @@ func (s *storeTestSuite) TestLookupRefresh(c *C) {
 	})()
 
 	sto := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(sto, NotNil)
 
 	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:   helloWorldSnapID,
@@ -3440,7 +3404,6 @@ func (s *storeTestSuite) TestLookupRefreshIgnoreValidation(c *C) {
 	})()
 
 	sto := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(sto, NotNil)
 
 	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:           helloWorldSnapID,
@@ -3461,7 +3424,6 @@ func (s *storeTestSuite) TestLookupRefreshLocalSnap(c *C) {
 	})()
 
 	sto := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(sto, NotNil)
 
 	result, err := sto.LookupRefresh(&RefreshCandidate{
 		Revision: snap.R("x1"),
@@ -3477,7 +3439,6 @@ func (s *storeTestSuite) TestLookupRefreshRFCError(c *C) {
 	})()
 
 	sto := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(sto, NotNil)
 
 	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:   helloWorldDeveloperID,
@@ -3493,7 +3454,6 @@ func (s *storeTestSuite) TestLookupRefreshEmptyResponse(c *C) {
 	})()
 
 	sto := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(sto, NotNil)
 
 	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:   helloWorldDeveloperID,
@@ -3512,7 +3472,6 @@ func (s *storeTestSuite) TestLookupRefreshNoUpdate(c *C) {
 	})()
 
 	sto := New(nil, &testAuthContext{c: c, device: s.device})
-	c.Assert(sto, NotNil)
 
 	result, err := sto.LookupRefresh(&RefreshCandidate{
 		SnapID:   helloWorldDeveloperID,
@@ -3560,7 +3519,6 @@ func (s *storeTestSuite) TestListRefresh(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.ListRefresh([]*RefreshCandidate{
 		{
@@ -3618,7 +3576,6 @@ func (s *storeTestSuite) TestListRefreshIgnoreValidation(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.ListRefresh([]*RefreshCandidate{
 		{
@@ -3673,7 +3630,6 @@ func (s *storeTestSuite) TestListRefreshDefaultChannelIsStable(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.ListRefresh([]*RefreshCandidate{
 		{
@@ -3721,7 +3677,6 @@ func (s *storeTestSuite) TestListRefreshRetryOnEOF(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
@@ -3763,7 +3718,6 @@ func (s *storeTestSuite) TestUnexpectedEOFhandling(c *C) {
 		}
 		authContext := &testAuthContext{c: c, device: s.device}
 		sto := New(&cfg, authContext)
-		c.Assert(sto, NotNil)
 
 		_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
@@ -3808,7 +3762,6 @@ func (s *storeTestSuite) TestRefreshForCandidatesEOF(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
@@ -3840,7 +3793,6 @@ func (s *storeTestSuite) TestRefreshForCandidatesUnauthorised(c *C) {
 
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
@@ -3859,7 +3811,6 @@ func (s *storeTestSuite) TestRefreshForCandidatesFailOnDNS(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	_, err = sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
@@ -3886,7 +3837,6 @@ func (s *storeTestSuite) TestRefreshForCandidates500(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
@@ -3914,7 +3864,6 @@ func (s *storeTestSuite) TestRefreshForCandidates500DurationExceeded(c *C) {
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	_, err := sto.refreshForCandidates([]*currentSnapJSON{{
 		SnapID:   helloWorldSnapID,
@@ -3971,7 +3920,6 @@ func (s *storeTestSuite) TestListRefreshSkipCurrent(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
@@ -4015,7 +3963,6 @@ func (s *storeTestSuite) TestListRefreshSkipBlocked(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
@@ -4106,7 +4053,6 @@ func (s *storeTestSuite) TestDefaultsDeltasOnClassicOnly(c *C) {
 			StoreBaseURL: mockServerURL,
 		}
 		sto := New(&cfg, nil)
-		c.Assert(sto, NotNil)
 
 		sto.refreshForCandidates([]*currentSnapJSON{{
 			SnapID:   helloWorldSnapID,
@@ -4155,7 +4101,6 @@ func (s *storeTestSuite) TestListRefreshWithDeltas(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
@@ -4225,7 +4170,6 @@ func (s *storeTestSuite) TestListRefreshWithoutDeltas(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	results, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
@@ -4251,7 +4195,6 @@ func (s *storeTestSuite) TestUpdateNotSendLocalRevs(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	_, err := sto.ListRefresh([]*RefreshCandidate{{
 		SnapID:   helloWorldSnapID,
@@ -4288,7 +4231,6 @@ func (s *storeTestSuite) TestListRefreshOptions(c *C) {
 			StoreBaseURL: mockServerURL,
 		}
 		sto := New(&cfg, nil)
-		c.Assert(sto, NotNil)
 
 		_, err := sto.ListRefresh([]*RefreshCandidate{{
 			SnapID:   helloWorldSnapID,
@@ -4400,6 +4342,7 @@ func (s *storeTestSuite) TestDefaultConfig(c *C) {
 
 func (s *storeTestSuite) TestNew(c *C) {
 	aStore := New(nil, nil)
+	c.Assert(aStore, NotNil)
 	// check for fields
 	c.Check(aStore.detailFields, DeepEquals, detailFields)
 }
@@ -4558,7 +4501,6 @@ func (s *storeTestSuite) TestSuggestedCurrency(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	// the store doesn't know the currency until after the first search, so fall back to dollars
 	c.Check(sto.SuggestedCurrency(), Equals, "USD")
@@ -4603,7 +4545,6 @@ func (s *storeTestSuite) TestDecorateOrders(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4652,7 +4593,6 @@ func (s *storeTestSuite) TestDecorateOrdersFailedAccess(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4686,7 +4626,6 @@ func (s *storeTestSuite) TestDecorateOrdersFailedAccess(c *C) {
 func (s *storeTestSuite) TestDecorateOrdersNoAuth(c *C) {
 	cfg := Config{}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4736,7 +4675,6 @@ func (s *storeTestSuite) TestDecorateOrdersAllFree(c *C) {
 	}
 
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	// This snap is free
 	helloWorld := &snap.Info{}
@@ -4772,7 +4710,6 @@ func (s *storeTestSuite) TestDecorateOrdersSingle(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4789,7 +4726,6 @@ func (s *storeTestSuite) TestDecorateOrdersSingle(c *C) {
 func (s *storeTestSuite) TestDecorateOrdersSingleFreeSnap(c *C) {
 	cfg := Config{}
 	sto := New(&cfg, nil)
-	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4821,7 +4757,6 @@ func (s *storeTestSuite) TestDecorateOrdersSingleNotFound(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4854,7 +4789,6 @@ func (s *storeTestSuite) TestDecorateOrdersTokenExpired(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	helloWorld := &snap.Info{}
 	helloWorld.SnapID = helloWorldSnapID
@@ -4983,7 +4917,6 @@ func (s *storeTestSuite) TestBuy500(c *C) {
 		StoreBaseURL: mockServerURL,
 	}
 	sto := New(&cfg, authContext)
-	c.Assert(sto, NotNil)
 
 	buyOptions := &BuyOptions{
 		SnapID:   helloWorldSnapID,
@@ -5056,7 +4989,6 @@ func (s *storeTestSuite) TestBuy(c *C) {
 			StoreBaseURL: mockServerURL,
 		}
 		sto := New(&cfg, authContext)
-		c.Assert(sto, NotNil)
 
 		// Find the snap first
 		spec := SnapSpec{
@@ -5100,7 +5032,6 @@ func (s *storeTestSuite) TestBuy(c *C) {
 
 func (s *storeTestSuite) TestBuyFailArgumentChecking(c *C) {
 	sto := New(&Config{}, nil)
-	c.Assert(sto, NotNil)
 
 	// no snap ID
 	result, err := sto.Buy(&BuyOptions{
@@ -5282,7 +5213,6 @@ func (s *storeTestSuite) TestReadyToBuy(c *C) {
 			StoreBaseURL: mockServerURL,
 		}
 		sto := New(&cfg, authContext)
-		c.Assert(sto, NotNil)
 
 		err := sto.ReadyToBuy(s.user)
 		test.Test(c, err)

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -53,7 +53,7 @@ func (Store) LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info
 	panic("Store.LookupRefresh not expected")
 }
 
-func (Store) ListRefresh([]*store.RefreshCandidate, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error) {
+func (Store) ListRefresh(context.Context, []*store.RefreshCandidate, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error) {
 	panic("Store.ListRefresh not expected")
 }
 
@@ -73,7 +73,7 @@ func (Store) ReadyToBuy(*auth.UserState) error {
 	panic("Store.ReadyToBuy not expected")
 }
 
-func (Store) Sections(*auth.UserState) ([]string, error) {
+func (Store) Sections(context.Context, *auth.UserState) ([]string, error) {
 	panic("Store.Sections not expected")
 }
 
@@ -81,6 +81,6 @@ func (Store) Assertion(*asserts.AssertionType, []string, *auth.UserState) (asser
 	panic("Store.Assertion not expected")
 }
 
-func (Store) WriteCatalogs(io.Writer, store.SnapAdder) error {
+func (Store) WriteCatalogs(context.Context, io.Writer, store.SnapAdder) error {
 	panic("fakeStore.WriteCatalogs not expected")
 }


### PR DESCRIPTION
This is a minimal sufficient first step, see the TODO in overlord.go for the proper thing when we have more time.
