### PR TITLE
tests: make autopkgtest tests more targeted

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -439,6 +439,8 @@ suites:
         # we keep them disabled. A later PR will enable most tests and
         # drop this blacklist.
         systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*]
+        # unittests are run as part of the autopkgtest build already
+        backends: [-autopkgtest]
         environment:
             # env vars required for coverage reporting from a spread task
             TRAVIS_BUILD_NUMBER: "$(HOST: echo $TRAVIS_BUILD_NUMBER)"

--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -6,6 +6,10 @@ summary: Ensure that the ubuntu-core -> core transition works with auth.json
 # fishy going on and the snapd service gets terminated during the process.
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*]
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 warn-timeout: 1m
 kill-timeout: 5m
 debug: |

--- a/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -4,6 +4,10 @@ summary: Ensure that the ubuntu-core -> core transition works with two cores
 # we disable on ppc64el because the downloads are very slow there
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el]
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 warn-timeout: 1m
 kill-timeout: 5m
 debug: |

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -6,6 +6,10 @@ summary: Ensure that the ubuntu-core -> core transition works
 # fishy going on and the snapd service gets terminated during the process.
 systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -ubuntu-*-i386]
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 warn-timeout: 1m
 kill-timeout: 5m
 

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -5,6 +5,10 @@ restore: |
 
     rm -f test-snapd-huge_*
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 execute: |
     echo "Downloading a large snap in the background"
     su -c "/usr/bin/env SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &

--- a/tests/main/listing/task.yaml
+++ b/tests/main/listing/task.yaml
@@ -4,8 +4,11 @@ prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
 
-execute: |
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
 
+execute: |
     echo "List prints core snap version"
     # most core versions should be like "16-2", so [0-9]{2}-[0-9.]+
     # but edge will have a timestamp in there, "16.2+201701010932", so add an optional \+[0-9]+ to the end

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -7,6 +7,10 @@ summary: Ensure that lxd works
 # FIXME LXD has some issue on Google images.
 systems: [ubuntu-16.04-32, ubuntu-core-*]
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 # lxd downloads can be quite slow
 kill-timeout: 25m
 

--- a/tests/main/prepare-image-uboot/task.yaml
+++ b/tests/main/prepare-image-uboot/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that prepare-image works for uboot-systems
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 environment:
     ROOT: /home/test/tmp/
     IMAGE: /home/test/tmp/image

--- a/tests/main/searching/task.yaml
+++ b/tests/main/searching/task.yaml
@@ -3,6 +3,10 @@ summary: Check snap search
 # s390x,ppc64el have nothing featured
 systems: [-ubuntu-*-ppc64el, -ubuntu-*-s390x]
 
+# autopkgtest run only a subset of tests that deals with the integration
+# with the distro
+backends: [-autopkgtest]
+
 restore: |
     rm -f featured.txt
 


### PR DESCRIPTION
The autopkgtest tests run in a different environment/lifecycle than
most of the other spread backends. An autopkgtest may run weeks
after the actual release as part of a reverse dependency test for
a different package that snapd uses. For this reason we exclude
some tests have external inputs (like the store search test).

The autopkgtest environment is also slower and more restricted than
our regular spread machines. This means that some expensive tests
(like lxd or core transition) should not be run there as this may
lead to timeouts on the autopkgtest side.

And finally the regular deb is build as part of the autopkgtest
run. Here the unittests are already run so we can skip the
tests/unit part of spread.