### PR TITLE
cmd/snap-update-ns: don't fail on existing symlinks

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -135,9 +135,12 @@ func (c *Change) ensureTarget() ([]*Change, error) {
 				err = fmt.Errorf("cannot use %q as mount point: not a regular file", path)
 			}
 		case "symlink":
-			// When we want to create a symlink we just need the empty
-			// space so anything that is in the way is a problem.
-			err = fmt.Errorf("cannot create symlink in %q: existing file in the way", path)
+			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+				// Create path verifies the symlink or fails if it is not what we wanted.
+				_, err = c.createPath(path, false)
+			} else {
+				err = fmt.Errorf("cannot create symlink in %q: existing file in the way", path)
+			}
 		}
 	} else if os.IsNotExist(err) {
 		changes, err = c.createPath(path, true)

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -1314,6 +1314,48 @@ func (s *changeSuite) TestPerformCreateSymlinkWithFileInTheWay(c *C) {
 	})
 }
 
+// Change.Perform wants to create a symlink but a correct symlink is already present.
+func (s *changeSuite) TestPerformCreateSymlinkWithGoodSymlinkPresent(c *C) {
+	s.sys.InsertLstatResult(`lstat "/name"`, testutil.FileInfoSymlink)
+	s.sys.InsertFault(`symlinkat "/oldname" 3 "name"`, syscall.EEXIST)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{Mode: syscall.S_IFLNK})
+	s.sys.InsertReadlinkatResult(`readlinkat 4 "" <ptr>`, "/oldname")
+	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
+	synth, err := chg.Perform()
+	c.Assert(err, IsNil)
+	c.Assert(synth, HasLen, 0)
+	c.Assert(s.sys.Calls(), DeepEquals, []string{
+		`lstat "/name"`,
+		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,   // -> 3
+		`symlinkat "/oldname" 3 "name"`,                 // -> EEXIST
+		`openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, // -> 4
+		`fstat 4 <ptr>`,
+		`readlinkat 4 "" <ptr>`,
+		`close 3`,
+	})
+}
+
+// Change.Perform wants to create a symlink but a incorrect symlink is already present.
+func (s *changeSuite) TestPerformCreateSymlinkWithBadSymlinkPresent(c *C) {
+	s.sys.InsertLstatResult(`lstat "/name"`, testutil.FileInfoSymlink)
+	s.sys.InsertFault(`symlinkat "/oldname" 3 "name"`, syscall.EEXIST)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{Mode: syscall.S_IFLNK})
+	s.sys.InsertReadlinkatResult(`readlinkat 4 "" <ptr>`, "/evil")
+	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
+	synth, err := chg.Perform()
+	c.Assert(err, ErrorMatches, `cannot create path "/name": cannot create symbolic link "name": existing symbolic link in the way`)
+	c.Assert(synth, HasLen, 0)
+	c.Assert(s.sys.Calls(), DeepEquals, []string{
+		`lstat "/name"`,
+		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,   // -> 3
+		`symlinkat "/oldname" 3 "name"`,                 // -> EEXIST
+		`openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, // -> 4
+		`fstat 4 <ptr>`,
+		`readlinkat 4 "" <ptr>`,
+		`close 3`,
+	})
+}
+
 func (s *changeSuite) TestPerformRemoveSymlink(c *C) {
 	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
 	synth, err := chg.Perform()

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"os"
+	"syscall"
 
 	. "gopkg.in/check.v1"
 
@@ -61,6 +62,7 @@ type SystemCalls interface {
 	Open(path string, flags int, mode uint32) (fd int, err error)
 	Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error)
 	Unmount(target string, flags int) error
+	Fstat(fd int, buf *syscall.Stat_t) error
 }
 
 // MockSystemCalls replaces real system calls with those of the argument.
@@ -79,6 +81,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	oldSysUnmount := sysUnmount
 	oldSysSymlinkat := sysSymlinkat
 	oldReadlinkat := sysReadlinkat
+	oldFstat := sysFstat
 
 	// override
 	osLstat = sc.Lstat
@@ -94,6 +97,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	sysUnmount = sc.Unmount
 	sysSymlinkat = sc.Symlinkat
 	sysReadlinkat = sc.Readlinkat
+	sysFstat = sc.Fstat
 
 	return func() {
 		// restore
@@ -110,6 +114,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 		sysUnmount = oldSysUnmount
 		sysSymlinkat = oldSysSymlinkat
 		sysReadlinkat = oldReadlinkat
+		sysFstat = oldFstat
 	}
 }
 

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -222,10 +222,9 @@ func secureMkSymlink(fd int, segments []string, i int, oldname string) error {
 		switch err {
 		case syscall.EEXIST:
 			var objFd int
-			const O_PATH = 010000000
 			// If the file exists then just open it for examination.
 			// Maybe it's the symlink we were hoping to create.
-			objFd, err = sysOpenat(fd, segment, syscall.O_CLOEXEC|O_PATH|syscall.O_NOFOLLOW, 0)
+			objFd, err = sysOpenat(fd, segment, syscall.O_CLOEXEC|sys.O_PATH|syscall.O_NOFOLLOW, 0)
 			if err != nil {
 				return fmt.Errorf("cannot open existing file %q: %v", segment, err)
 			}

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -90,6 +90,10 @@ func formatOpenFlags(flags int) string {
 		flags ^= syscall.O_EXCL
 		fl = append(fl, "O_EXCL")
 	}
+	if flags&sys.O_PATH != 0 {
+		flags ^= sys.O_PATH
+		fl = append(fl, "O_PATH")
+	}
 	if flags != 0 {
 		panic(fmt.Errorf("unrecognized open flags %d", flags))
 	}


### PR DESCRIPTION
There's one more path where we check if a symlink is in place and this
path was not updated to not fail on existing but correct symlinks.

While I'm working on a simplification that drops all of this needless
code I thought about making a quick patch that can land in the next
release safely.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

