### PR TITLE
tests: drop old debug code

### DIFF
--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -9,14 +9,6 @@ prepare: |
     snap set core experimental.layouts=true
     . $TESTSLIB/snaps.sh
     install_local test-snapd-layout
-debug: |
-    # We saw some failures where it looked like we were confined by the most
-    # wrong thing imaginable. To get an idea what is going on let's show
-    # the profile we were using when the test fails.
-    # Before per-snap update-ns profiles are here.
-    cat /etc/apparmor.d/*snap.core.*.usr.lib.snapd.snap-confine* || :
-    # Once per-snap update-ns profiles are here.
-    cat /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-layout || :
 execute: |
     echo "snap declaring layouts doesn't explode on startup"
     test-snapd-layout.sh -c "true"


### PR DESCRIPTION
We now understand what has caused the issues and don't need to keep the
debug code around anymore. In retrospective the code was misguided too.
    
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>