### PR TITLE
tests: add workaround for s390x failure

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -16,6 +16,16 @@ else
     goctest="go test"
 fi
 COVERMODE=${COVERMODE:-atomic}
+
+# add workaround for https://github.com/golang/go/issues/24449
+if [ "$(uname -m)" = "s390x" ]; then
+    if go version | grep -q go1.10; then
+        echo "covermode 'atomic' crashes on s390x with go1.10, reseting "
+        echo "to 'set'. see https://github.com/golang/go/issues/24449"
+        COVERMODE="set"
+    fi
+fi
+
 export GOPATH="${GOPATH:-$(realpath "$(dirname "$0")"/../../../../)}"
 export PATH="$PATH:${GOPATH%%:*}/bin"
 


### PR DESCRIPTION
The -covermode 'atomic' switch makes tests on s390x with go1.10 fail.
See https://github.com/golang/go/issues/24449 