### PR TITLE
many: delay classic registration until first store interaction

### DIFF
--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -373,8 +374,13 @@ type DeviceAssertions interface {
 	// Serial returns the device serial assertion.
 	Serial() (*asserts.Serial, error)
 
+	// EnsureSerial does a best-effort of triggering and waiting
+	// up to timeout for registration to occur and returns the
+	// serial if now available, or ErrNoState otherwise.
+	EnsureSerial(context.Context, time.Duration) (*asserts.Serial, error)
+
 	// DeviceSessionRequestParams produces a device-session-request with the given nonce, together with other required parameters, the device serial and model assertions.
-	DeviceSessionRequestParams(ctx context.Context, nonce string) (*DeviceSessionRequestParams, error)
+	DeviceSessionRequestParams(nonce string) (*DeviceSessionRequestParams, error)
 	// ProxyStore returns the store assertion for the proxy store if one is set.
 	ProxyStore() (*asserts.Store, error)
 }
@@ -404,7 +410,9 @@ type AuthContext interface {
 
 	StoreID(fallback string) (string, error)
 
-	DeviceSessionRequestParams(ctx context.Context, nonce string) (*DeviceSessionRequestParams, error)
+	EnsureSerial(ctx context.Context, timeout time.Duration) (*asserts.Serial, error)
+
+	DeviceSessionRequestParams(nonce string) (*DeviceSessionRequestParams, error)
 	ProxyStoreParams(defaultURL *url.URL) (proxyStoreID string, proxySroreURL *url.URL, err error)
 
 	CloudInfo() (*CloudInfo, error)
@@ -499,12 +507,26 @@ func (ac *authContext) StoreID(fallback string) (string, error) {
 	return fallback, nil
 }
 
-// DeviceSessionRequestParams produces a device-session-request with the given nonce, together with other required parameters, the device serial and model assertions. It returns ErrNoSerial if the device serial is not yet initialized.
-func (ac *authContext) DeviceSessionRequestParams(ctx context.Context, nonce string) (*DeviceSessionRequestParams, error) {
+// EnsureSerial does a best-effort of triggering and waiting
+// up to timeout for registration to occur and returns the
+// serial if now available, or ErrNoSerial otherwise.
+func (ac *authContext) EnsureSerial(ctx context.Context, timeout time.Duration) (*asserts.Serial, error) {
 	if ac.deviceAsserts == nil {
 		return nil, ErrNoSerial
 	}
-	params, err := ac.deviceAsserts.DeviceSessionRequestParams(ctx, nonce)
+	serial, err := ac.deviceAsserts.EnsureSerial(ctx, timeout)
+	if err == state.ErrNoState {
+		return nil, ErrNoSerial
+	}
+	return serial, err
+}
+
+// DeviceSessionRequestParams produces a device-session-request with the given nonce, together with other required parameters, the device serial and model assertions. It returns ErrNoSerial if the device serial is not yet initialized.
+func (ac *authContext) DeviceSessionRequestParams(nonce string) (*DeviceSessionRequestParams, error) {
+	if ac.deviceAsserts == nil {
+		return nil, ErrNoSerial
+	}
+	params, err := ac.deviceAsserts.DeviceSessionRequestParams(nonce)
 	if err == state.ErrNoState {
 		return nil, ErrNoSerial
 	}

--- a/overlord/auth/auth.go
+++ b/overlord/auth/auth.go
@@ -30,6 +30,7 @@ import (
 	"strconv"
 
 	"golang.org/x/net/context"
+
 	"gopkg.in/macaroon.v1"
 
 	"github.com/snapcore/snapd/asserts"
@@ -373,7 +374,7 @@ type DeviceAssertions interface {
 	Serial() (*asserts.Serial, error)
 
 	// DeviceSessionRequestParams produces a device-session-request with the given nonce, together with other required parameters, the device serial and model assertions.
-	DeviceSessionRequestParams(nonce string) (*DeviceSessionRequestParams, error)
+	DeviceSessionRequestParams(ctx context.Context, nonce string) (*DeviceSessionRequestParams, error)
 	// ProxyStore returns the store assertion for the proxy store if one is set.
 	ProxyStore() (*asserts.Store, error)
 }
@@ -403,7 +404,7 @@ type AuthContext interface {
 
 	StoreID(fallback string) (string, error)
 
-	DeviceSessionRequestParams(nonce string) (*DeviceSessionRequestParams, error)
+	DeviceSessionRequestParams(ctx context.Context, nonce string) (*DeviceSessionRequestParams, error)
 	ProxyStoreParams(defaultURL *url.URL) (proxyStoreID string, proxySroreURL *url.URL, err error)
 
 	CloudInfo() (*CloudInfo, error)
@@ -499,11 +500,11 @@ func (ac *authContext) StoreID(fallback string) (string, error) {
 }
 
 // DeviceSessionRequestParams produces a device-session-request with the given nonce, together with other required parameters, the device serial and model assertions. It returns ErrNoSerial if the device serial is not yet initialized.
-func (ac *authContext) DeviceSessionRequestParams(nonce string) (*DeviceSessionRequestParams, error) {
+func (ac *authContext) DeviceSessionRequestParams(ctx context.Context, nonce string) (*DeviceSessionRequestParams, error) {
 	if ac.deviceAsserts == nil {
 		return nil, ErrNoSerial
 	}
-	params, err := ac.deviceAsserts.DeviceSessionRequestParams(nonce)
+	params, err := ac.deviceAsserts.DeviceSessionRequestParams(ctx, nonce)
 	if err == state.ErrNoState {
 		return nil, ErrNoSerial
 	}

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -548,7 +548,14 @@ func (as *authSuite) TestAuthContextStoreIDFromEnv(c *C) {
 func (as *authSuite) TestAuthContextDeviceSessionRequestParamsNilDeviceAssertions(c *C) {
 	authContext := auth.NewAuthContext(as.state, nil)
 
-	_, err := authContext.DeviceSessionRequestParams(context.TODO(), "NONCE")
+	_, err := authContext.DeviceSessionRequestParams("NONCE")
+	c.Check(err, Equals, auth.ErrNoSerial)
+}
+
+func (as *authSuite) TestAuthContextEnsureSerialNilDeviceAssertions(c *C) {
+	authContext := auth.NewAuthContext(as.state, nil)
+
+	_, err := authContext.EnsureSerial(context.TODO(), 5*time.Second)
 	c.Check(err, Equals, auth.ErrNoSerial)
 }
 
@@ -661,10 +668,14 @@ func (da *testDeviceAssertions) Serial() (*asserts.Serial, error) {
 	return a.(*asserts.Serial), nil
 }
 
-func (da *testDeviceAssertions) DeviceSessionRequestParams(ctx context.Context, nonce string) (*auth.DeviceSessionRequestParams, error) {
+func (da *testDeviceAssertions) EnsureSerial(ctx context.Context, timeout time.Duration) (*asserts.Serial, error) {
 	if ctx == nil {
 		panic("context required")
 	}
+	return da.Serial()
+}
+
+func (da *testDeviceAssertions) DeviceSessionRequestParams(nonce string) (*auth.DeviceSessionRequestParams, error) {
 	if da.nothing {
 		return nil, state.ErrNoState
 	}
@@ -707,7 +718,10 @@ func (as *authSuite) TestAuthContextMissingDeviceAssertions(c *C) {
 	// no assertions in state
 	authContext := auth.NewAuthContext(as.state, &testDeviceAssertions{nothing: true})
 
-	_, err := authContext.DeviceSessionRequestParams(context.TODO(), "NONCE")
+	_, err := authContext.EnsureSerial(context.TODO(), 0)
+	c.Check(err, Equals, auth.ErrNoSerial)
+
+	_, err = authContext.DeviceSessionRequestParams("NONCE")
 	c.Check(err, Equals, auth.ErrNoSerial)
 
 	storeID, err := authContext.StoreID("fallback")
@@ -724,7 +738,11 @@ func (as *authSuite) TestAuthContextWithDeviceAssertions(c *C) {
 	// having assertions in state
 	authContext := auth.NewAuthContext(as.state, &testDeviceAssertions{})
 
-	params, err := authContext.DeviceSessionRequestParams(context.TODO(), "NONCE-1")
+	serialAssert, err := authContext.EnsureSerial(context.TODO(), 0)
+	c.Check(err, IsNil)
+	c.Check(serialAssert.Serial(), Equals, "9999")
+
+	params, err := authContext.DeviceSessionRequestParams("NONCE-1")
 	c.Assert(err, IsNil)
 
 	req := params.EncodedRequest()

--- a/overlord/auth/auth_test.go
+++ b/overlord/auth/auth_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -548,7 +548,7 @@ func (as *authSuite) TestAuthContextStoreIDFromEnv(c *C) {
 func (as *authSuite) TestAuthContextDeviceSessionRequestParamsNilDeviceAssertions(c *C) {
 	authContext := auth.NewAuthContext(as.state, nil)
 
-	_, err := authContext.DeviceSessionRequestParams("NONCE")
+	_, err := authContext.DeviceSessionRequestParams(context.TODO(), "NONCE")
 	c.Check(err, Equals, auth.ErrNoSerial)
 }
 
@@ -661,7 +661,10 @@ func (da *testDeviceAssertions) Serial() (*asserts.Serial, error) {
 	return a.(*asserts.Serial), nil
 }
 
-func (da *testDeviceAssertions) DeviceSessionRequestParams(nonce string) (*auth.DeviceSessionRequestParams, error) {
+func (da *testDeviceAssertions) DeviceSessionRequestParams(ctx context.Context, nonce string) (*auth.DeviceSessionRequestParams, error) {
+	if ctx == nil {
+		panic("context required")
+	}
 	if da.nothing {
 		return nil, state.ErrNoState
 	}
@@ -704,7 +707,7 @@ func (as *authSuite) TestAuthContextMissingDeviceAssertions(c *C) {
 	// no assertions in state
 	authContext := auth.NewAuthContext(as.state, &testDeviceAssertions{nothing: true})
 
-	_, err := authContext.DeviceSessionRequestParams("NONCE")
+	_, err := authContext.DeviceSessionRequestParams(context.TODO(), "NONCE")
 	c.Check(err, Equals, auth.ErrNoSerial)
 
 	storeID, err := authContext.StoreID("fallback")
@@ -721,7 +724,7 @@ func (as *authSuite) TestAuthContextWithDeviceAssertions(c *C) {
 	// having assertions in state
 	authContext := auth.NewAuthContext(as.state, &testDeviceAssertions{})
 
-	params, err := authContext.DeviceSessionRequestParams("NONCE-1")
+	params, err := authContext.DeviceSessionRequestParams(context.TODO(), "NONCE-1")
 	c.Assert(err, IsNil)
 
 	req := params.EncodedRequest()

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -98,14 +98,6 @@ func canAutoRefresh(st *state.State) (bool, error) {
 		return false, nil
 	}
 
-	// XXX: only core
-	// Either we have a serial or we try anyway if we attempted
-	// for a while to get a serial, this would allow us to at
-	// least upgrade core if that can help.
-	if ensureOperationalAttempts(st) >= 3 {
-		return true, nil
-	}
-
 	// Check model exists, for sanity. We always have a model, either
 	// seeded or a generic one that ships with snapd.
 	_, err := Model(st)
@@ -116,7 +108,23 @@ func canAutoRefresh(st *state.State) (bool, error) {
 		return false, err
 	}
 
-	// XXX: only core
+	if release.OnClassic {
+		// On classic the first store interaction (which could
+		// be the first auto-refresh if we have any snaps)
+		// triggers registration.
+		return true, nil
+	}
+
+	// On core registration is started immediately so we wait for
+	// it.
+
+	// Either we have a serial or we try anyway if we attempted
+	// for a while to get a serial, this would allow us to at
+	// least upgrade core if that can help.
+	if ensureOperationalAttempts(st) >= 3 {
+		return true, nil
+	}
+
 	_, err = Serial(st)
 	if err == state.ErrNoState {
 		return false, nil

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -98,6 +98,7 @@ func canAutoRefresh(st *state.State) (bool, error) {
 		return false, nil
 	}
 
+	// XXX: only core
 	// Either we have a serial or we try anyway if we attempted
 	// for a while to get a serial, this would allow us to at
 	// least upgrade core if that can help.
@@ -115,6 +116,7 @@ func canAutoRefresh(st *state.State) (bool, error) {
 		return false, err
 	}
 
+	// XXX: only core
 	_, err = Serial(st)
 	if err == state.ErrNoState {
 		return false, nil

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -466,7 +466,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyClassic(c *C) {
 	becomeOp1 := becomeOperational.ID()
 
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
-	c.Check(becomeOperational.Err(), ErrorMatches, `(?sm).*on classic device registration paused until first store registration.*`)
+	c.Check(becomeOperational.Err(), ErrorMatches, `(?sm).*on classic device registration paused until first store interaction.*`)
 
 	// paused
 	var paused bool
@@ -638,7 +638,7 @@ func (s *deviceMgrSuite) TestDeviceRegistrationClassicFallback(c *C) {
 	c.Assert(becomeOperational, NotNil)
 
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
-	c.Check(becomeOperational.Err(), ErrorMatches, `(?sm).*on classic device registration paused until first store registration.*`)
+	c.Check(becomeOperational.Err(), ErrorMatches, `(?sm).*on classic device registration paused until first store interaction.*`)
 
 	// paused
 	var paused bool

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2131,7 +2131,8 @@ func (s *deviceMgrSuite) TestCanAutoRefreshOnClassic(c *C) {
 	s.state.Set("seeded", true)
 	c.Check(canAutoRefresh(), Equals, false)
 
-	// seeded, model, no serial -> no auto-refresh
+	// seeded, model, no serial -> auto-refresh (which could
+	// trigger registration)
 	auth.SetDevice(s.state, &auth.DeviceState{
 		Brand: "canonical",
 		Model: "pc",
@@ -2139,7 +2140,7 @@ func (s *deviceMgrSuite) TestCanAutoRefreshOnClassic(c *C) {
 	s.makeModelAssertionInState(c, "canonical", "pc", map[string]string{
 		"classic": "true",
 	})
-	c.Check(canAutoRefresh(), Equals, false)
+	c.Check(canAutoRefresh(), Equals, true)
 
 	// seeded, model, serial -> auto-refresh
 	auth.SetDevice(s.state, &auth.DeviceState{

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -465,8 +465,9 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyClassic(c *C) {
 	c.Assert(becomeOperational, NotNil)
 	becomeOp1 := becomeOperational.ID()
 
+	c.Check(becomeOperational.Summary(), Equals, "Prepare device")
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
-	c.Check(becomeOperational.Err(), ErrorMatches, `(?sm).*on classic device registration paused until first store interaction.*`)
+	c.Check(becomeOperational.Err(), IsNil)
 
 	// paused
 	var paused bool
@@ -482,6 +483,8 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyClassic(c *C) {
 	privKey, err := devicestate.KeypairManager(s.mgr).Get(keyID)
 	c.Assert(err, IsNil)
 	c.Check(privKey, NotNil)
+	// we don't have a serial yet
+	c.Check(device.Serial, Equals, "")
 	// attempts were reset
 	c.Check(devicestate.BecomeOperationalBackoff(s.mgr), Equals, 0*time.Second)
 	c.Check(devicestate.EnsureOperationalAttempts(s.state), Equals, 0)
@@ -532,6 +535,7 @@ func (s *deviceMgrSuite) TestFullDeviceRegistrationHappyClassic(c *C) {
 	becomeOperational = s.findBecomeOperationalChange(becomeOp1)
 	c.Assert(becomeOperational, NotNil)
 
+	c.Check(becomeOperational.Summary(), Equals, "Initialize device")
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
 	c.Check(becomeOperational.Err(), IsNil)
 
@@ -638,7 +642,7 @@ func (s *deviceMgrSuite) TestDeviceRegistrationClassicFallback(c *C) {
 	c.Assert(becomeOperational, NotNil)
 
 	c.Check(becomeOperational.Status().Ready(), Equals, true)
-	c.Check(becomeOperational.Err(), ErrorMatches, `(?sm).*on classic device registration paused until first store interaction.*`)
+	c.Check(becomeOperational.Err(), IsNil)
 
 	// paused
 	var paused bool
@@ -651,6 +655,8 @@ func (s *deviceMgrSuite) TestDeviceRegistrationClassicFallback(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(device.Brand, Equals, "generic")
 	c.Check(device.Model, Equals, "generic-classic")
+	// no serial yet
+	c.Check(device.Serial, Equals, "")
 
 	model, err := devicestate.Model(s.state)
 	c.Assert(err, IsNil)

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -21,6 +21,8 @@ package devicestate
 
 import (
 	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/state"
@@ -84,6 +86,18 @@ func BecomeOperationalBackoff(m *DeviceManager) time.Duration {
 
 func SetLastBecomeOperationalAttempt(m *DeviceManager, t time.Time) {
 	m.lastBecomeOperationalAttempt = t
+}
+
+func MockWaitForRegistraionTimeout(timeout time.Duration) (restore func()) {
+	old := waitForRegistrationTimeout
+	waitForRegistrationTimeout = timeout
+	return func() {
+		waitForRegistrationTimeout = old
+	}
+}
+
+func WaitForRegistration(ctx context.Context, m *DeviceManager) (*asserts.Serial, error) {
+	return m.waitForRegistration(ctx)
 }
 
 func MockRepeatRequestSerial(label string) (restore func()) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -22,8 +22,6 @@ package devicestate
 import (
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/state"
 )
@@ -88,16 +86,12 @@ func SetLastBecomeOperationalAttempt(m *DeviceManager, t time.Time) {
 	m.lastBecomeOperationalAttempt = t
 }
 
-func MockWaitForRegistraionTimeout(timeout time.Duration) (restore func()) {
-	old := waitForRegistrationTimeout
-	waitForRegistrationTimeout = timeout
+func MockEnsureRegistrationDefaultTimeout(timeout time.Duration) (restore func()) {
+	old := ensureRegistrationDefaultTimeout
+	ensureRegistrationDefaultTimeout = timeout
 	return func() {
-		waitForRegistrationTimeout = old
+		ensureRegistrationDefaultTimeout = old
 	}
-}
-
-func WaitForRegistration(ctx context.Context, m *DeviceManager) (*asserts.Serial, error) {
-	return m.waitForRegistration(ctx)
 }
 
 func MockRepeatRequestSerial(label string) (restore func()) {

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -454,7 +454,7 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 			paused = true
 		}
 		if paused {
-			return fmt.Errorf("on classic device registration paused until first store registration")
+			return fmt.Errorf("on classic device registration paused until first store interaction")
 		}
 	}
 

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -38,7 +38,6 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/release"
 )
 
 func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
@@ -439,24 +438,6 @@ func (m *DeviceManager) doRequestSerial(t *state.Task, _ *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
 	defer st.Unlock()
-
-	if release.OnClassic {
-		// on classic the first time around we pause the process
-		// until the first store interaction
-		var paused bool
-		err := st.Get("registration-paused", &paused)
-		if err != nil && err != state.ErrNoState {
-			return err
-		}
-		if err == state.ErrNoState {
-			st.Set("registration-paused", true)
-			m.ensureOperationalResetAttempts()
-			paused = true
-		}
-		if paused {
-			return fmt.Errorf("on classic device registration paused until first store interaction")
-		}
-	}
 
 	defer m.markRegistrationFirstAttempt()
 

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -107,6 +107,8 @@ func (m *DeviceManager) doGenerateDeviceKey(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 	t.SetStatus(state.DoneStatus)
+	// make sure we consider the next (split) initialization phase timely
+	st.EnsureBefore(0)
 	return nil
 }
 

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1930,7 +1930,7 @@ func (s *authContextSetupSuite) TestDeviceSessionRequestParams(c *C) {
 	defer st.Unlock()
 
 	st.Unlock()
-	_, err := s.ac.DeviceSessionRequestParams(context.TODO(), "NONCE")
+	_, err := s.ac.DeviceSessionRequestParams("NONCE")
 	st.Lock()
 	c.Check(err, Equals, auth.ErrNoSerial)
 
@@ -1951,13 +1951,18 @@ func (s *authContextSetupSuite) TestDeviceSessionRequestParams(c *C) {
 	})
 
 	st.Unlock()
-	params, err := s.ac.DeviceSessionRequestParams(context.TODO(), "NONCE")
+	params, err := s.ac.DeviceSessionRequestParams("NONCE")
 	st.Lock()
 	c.Assert(err, IsNil)
 	c.Check(strings.HasPrefix(params.EncodedRequest(), "type: device-session-request\n"), Equals, true)
 	c.Check(params.EncodedSerial(), DeepEquals, string(asserts.Encode(s.serial)))
 	c.Check(params.EncodedModel(), DeepEquals, string(asserts.Encode(s.model)))
 
+	st.Unlock()
+	serial, err := s.ac.EnsureSerial(context.TODO(), 10*time.Second)
+	st.Lock()
+	c.Check(err, IsNil)
+	c.Check(serial.Serial(), Equals, "7878")
 }
 
 func (s *authContextSetupSuite) TestProxyStoreParams(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -1930,7 +1930,7 @@ func (s *authContextSetupSuite) TestDeviceSessionRequestParams(c *C) {
 	defer st.Unlock()
 
 	st.Unlock()
-	_, err := s.ac.DeviceSessionRequestParams("NONCE")
+	_, err := s.ac.DeviceSessionRequestParams(context.TODO(), "NONCE")
 	st.Lock()
 	c.Check(err, Equals, auth.ErrNoSerial)
 
@@ -1951,7 +1951,7 @@ func (s *authContextSetupSuite) TestDeviceSessionRequestParams(c *C) {
 	})
 
 	st.Unlock()
-	params, err := s.ac.DeviceSessionRequestParams("NONCE")
+	params, err := s.ac.DeviceSessionRequestParams(context.TODO(), "NONCE")
 	st.Lock()
 	c.Assert(err, IsNil)
 	c.Check(strings.HasPrefix(params.EncodedRequest(), "type: device-session-request\n"), Equals, true)

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -45,7 +47,21 @@ const maxPostponement = 60 * 24 * time.Hour
 var (
 	CanAutoRefresh     func(st *state.State) (bool, error)
 	CanManageRefreshes func(st *state.State) bool
+	EnsureRegistration func(ctx context.Context, st *state.State, opts *EnsureRegistrationOptions) (proceed bool, err error)
 )
+
+type EnsureRegistrationOptions struct {
+	// AfterAttemptsProceedAnyway is the number (if > 0) of
+	// registration attempts after which is preferable to proceed
+	// anyway.  If set to 0 a default number will be
+	// used. Negative means never proceed if not registered.
+	AfterAttemptsProceedAnyway int
+	// CustomStoreOnly means registration is required only with a
+	// custom store.
+	CustomStoreOnly bool
+	// Timeout if waiting for registration.
+	Timeout time.Duration
+}
 
 // refreshRetryDelay specified the minimum time to retry failed refreshes
 var refreshRetryDelay = 10 * time.Minute

--- a/overlord/snapstate/autorefresh.go
+++ b/overlord/snapstate/autorefresh.go
@@ -338,7 +338,19 @@ func (m *autoRefresh) refreshScheduleWithDefaultsFallback() (ts []*timeutil.Sche
 // launchAutoRefresh creates the auto-refresh taskset and a change for it.
 func (m *autoRefresh) launchAutoRefresh() error {
 	m.lastRefreshAttempt = time.Now()
-	updated, tasksets, err := AutoRefresh(auth.EnsureContextTODO(), m.state)
+
+	ctx := auth.EnsureContextTODO()
+	// preferably we should be registered at this point
+	proceed, err := EnsureRegistration(ctx, m.state, nil)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		// try again later
+		return nil
+	}
+
+	updated, tasksets, err := AutoRefresh(ctx, m.state)
 	if err != nil {
 		logger.Noticef("Cannot prepare auto-refresh change: %s", err)
 		return err

--- a/overlord/snapstate/refreshhints.go
+++ b/overlord/snapstate/refreshhints.go
@@ -63,10 +63,21 @@ func (r *refreshHints) needsUpdate() (bool, error) {
 }
 
 func (r *refreshHints) refresh() error {
+	ctx := auth.EnsureContextTODO()
+	// preferably we should be registered at this point
+	proceed, err := EnsureRegistration(ctx, r.state, nil)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		// try again later
+		return nil
+	}
+
 	var refreshManaged bool
 	refreshManaged = refreshScheduleManaged(r.state)
 
-	_, _, _, err := refreshCandidates(auth.EnsureContextTODO(), r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
+	_, _, _, err = refreshCandidates(ctx, r.state, nil, nil, &store.RefreshOptions{RefreshManaged: refreshManaged})
 	// TODO: we currently set last-refresh-hints even when there was an
 	// error. In the future we may retry with a backoff.
 	r.state.Set("last-refresh-hints", time.Now())

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -157,6 +157,10 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil
 	}
+
+	snapstate.EnsureRegistration = func(ctx context.Context, st *state.State, opts *snapstate.EnsureRegistrationOptions) (bool, error) {
+		return true, nil
+	}
 }
 
 func (s *snapmgrTestSuite) TearDownTest(c *C) {
@@ -164,6 +168,7 @@ func (s *snapmgrTestSuite) TearDownTest(c *C) {
 	snapstate.ValidateRefreshes = nil
 	snapstate.AutoAliases = nil
 	snapstate.CanAutoRefresh = nil
+	snapstate.EnsureRegistration = nil
 }
 
 func (s *snapmgrTestSuite) TestKnownTaskKinds(c *C) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -257,7 +257,10 @@ func (ac *testAuthContext) StoreID(fallback string) (string, error) {
 	return fallback, nil
 }
 
-func (ac *testAuthContext) DeviceSessionRequestParams(nonce string) (*auth.DeviceSessionRequestParams, error) {
+func (ac *testAuthContext) DeviceSessionRequestParams(ctx context.Context, nonce string) (*auth.DeviceSessionRequestParams, error) {
+	if ctx == nil {
+		panic("context required")
+	}
 	model, err := asserts.Decode([]byte(exModel))
 	if err != nil {
 		return nil, err

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -225,6 +225,8 @@ type testAuthContext struct {
 	storeID string
 
 	cloudInfo *auth.CloudInfo
+
+	ensuredSerial bool
 }
 
 func (ac *testAuthContext) Device() (*auth.DeviceState, error) {
@@ -257,10 +259,15 @@ func (ac *testAuthContext) StoreID(fallback string) (string, error) {
 	return fallback, nil
 }
 
-func (ac *testAuthContext) DeviceSessionRequestParams(ctx context.Context, nonce string) (*auth.DeviceSessionRequestParams, error) {
+func (ac *testAuthContext) EnsureSerial(ctx context.Context, timeout time.Duration) (*asserts.Serial, error) {
 	if ctx == nil {
 		panic("context required")
 	}
+	ac.ensuredSerial = true
+	return nil, nil
+}
+
+func (ac *testAuthContext) DeviceSessionRequestParams(nonce string) (*auth.DeviceSessionRequestParams, error) {
 	model, err := asserts.Decode([]byte(exModel))
 	if err != nil {
 		return nil, err
@@ -1697,6 +1704,7 @@ func (s *storeTestSuite) TestDoRequestSetsAndRefreshesDeviceAuth(c *C) {
 	c.Check(string(responseData), Equals, "response-data")
 	c.Check(deviceSessionRequested, Equals, true)
 	c.Check(refreshSessionRequested, Equals, true)
+	c.Check(authContext.ensuredSerial, Equals, true)
 }
 
 func (s *storeTestSuite) TestDoRequestSetsAndRefreshesBothAuths(c *C) {

--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -65,6 +65,10 @@ execute: |
     echo "We have a model assertion"
     snap known model|MATCH "model: my-classic-w-gadget"
 
+    echo "Trigger registration by interacting with the store"
+    # FIXME: ignoring errors for now, later teach & use the fakestore instead
+    snap refresh || true
+
     echo "Wait for device initialisation to be done"
     while ! snap changes | grep -q "Done.*Initialize device"; do sleep 1; done
 


### PR DESCRIPTION
XXX UPDATE:
* this always triggers registration once we have a model and its gadget, if specified, is installed, but then pauses it after creating the device key on classic
* the store code then is changed to always trigger/restart registration (for most operations) if there is no serial yet, indirectly via AuthContext and devicestate code, the latter code then does a best-effort of waiting for registration to occur before continuing
* tests/main/classic-custom-device-reg needed adjusting, ideally it should be switched to use the 
  fakestore as well (but it's a larger change because it doesn't support the session endpoints yet and 
  could be done in a follow up)