### PR TITLE
tests: a bunch of test fixes for s390x from looking at the autopkgtest logs

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -502,9 +502,16 @@ func straceCmd() ([]string, error) {
 		return nil, fmt.Errorf("cannot use strace without sudo: %s", err)
 	}
 
-	// try strace from the snap first, we use new syscalls like
+	// Try strace from the snap first, we use new syscalls like
 	// "_newselect" that are known to not work with the strace of e.g.
-	// ubuntu 14.04
+	// ubuntu 14.04.
+	//
+	// TODO: some architectures do not have some syscalls (e.g.
+	// s390x does not have _newselect). In
+	// https://github.com/strace/strace/issues/57 options are
+	// discussed.  We could use "-e trace=?syscall" but that is
+	// only available since strace 4.17 which is not even in
+	// ubutnu 17.10.
 	var stracePath string
 	cand := filepath.Join(dirs.SnapMountDir, "strace-static", "current", "bin", "strace")
 	if osutil.FileExists(cand) {

--- a/tests/lib/dbus.sh
+++ b/tests/lib/dbus.sh
@@ -30,6 +30,6 @@ stop_dbus_unit(){
         stop dbus-provider
         rm -f /etc/init/dbus-provider.conf
     else
-        systemctl stop dbus-provider
+        systemctl stop dbus-provider || true
     fi
 }

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -5,7 +5,8 @@ details: |
     can access the /dev/rtc device node exposed by a slot on the OS
     snap properly.
 
-systems: [-opensuse-*,-fedora-*,-ubuntu-core-*,-ubuntu-14.04-*]
+# s390x virtualization does not support hwclock
+systems: [-opensuse-*,-fedora-*,-ubuntu-core-*,-ubuntu-14.04-*,-*-s390x]
 
 prepare: |
     . $TESTSLIB/snaps.sh

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -17,7 +17,7 @@ execute: |
     test-snapd-tools.env | egrep '^(SNAP|PATH|HOME)=' | sort > misc-vars.txt
 
     echo "Ensure that SNAP environment variables are what we expect"
-    MATCH '^SNAP_ARCH=(amd64|i386|arm64|armhf|ppc64el)$'                  < snap-vars.txt
+    MATCH '^SNAP_ARCH=(amd64|i386|arm64|armhf|ppc64el|s390x)$'            < snap-vars.txt
     MATCH '^SNAP_COMMON=/var/snap/test-snapd-tools/common$'               < snap-vars.txt
     MATCH '^SNAP_DATA=/var/snap/test-snapd-tools/x1$'                     < snap-vars.txt
     MATCH '^SNAP_LIBRARY_PATH=/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void$' < snap-vars.txt

--- a/tests/main/snap-run/task.yaml
+++ b/tests/main/snap-run/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that `snap run` runs
 
+# strace does not support _newselect on s390x
+# (https://github.com/strace/strace/issues/57)
+systems: [-*-s390x]
+
 prepare: |
     . $TESTSLIB/snaps.sh
     install_local basic-run


### PR DESCRIPTION
This is the first iteration of fixes for s390x. We will probably need more but the suite aborted when the restore task for dbus failed (this is also fixed as part of this PR).

Please squash when merging.