### PR TITLE
packaging: recommend "gnupg" instead of "gnupg1 | gnupg"

### DIFF
--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -70,7 +70,7 @@ Depends: adduser,
          ${shlibs:Depends}
 Replaces: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
 Breaks: ubuntu-snappy (<< 1.9), ubuntu-snappy-cli (<< 1.9), snap-confine (<< 2.23), ubuntu-core-launcher (<< 2.22), snapd-xdg-open (<= 0.0.0)
-Recommends: gnupg1 | gnupg
+Recommends: gnupg
 Conflicts: snap (<< 2013-11-29-1ubuntu1)
 Built-Using: ${Built-Using} ${misc:Built-Using}
 Description: Daemon and tooling that enable snap packages


### PR DESCRIPTION
This means we will get gnupg1 on xenial and gnupg2 on bionic. This
is what the distro asked for, i.e. they want to stop supporting
gpg1 in 18.04 and move it to universe.

