### PR TITLE
tests: disable 18.04 spread tests in google for now

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -53,9 +53,10 @@ backends:
                 workers: 6
             - ubuntu-16.04-64:
                 workers: 8
-            - ubuntu-18.04-64:
-                image: ubuntu-os-cloud-devel/ubuntu-1804-lts
-                workers: 6
+            # disabled because of: cannot connect: cannot connect to google:ubuntu-18.04-64 (mar200647-634341): ssh: handshake failed: EOF
+            #- ubuntu-18.04-64:
+            #    image: ubuntu-os-cloud-devel/ubuntu-1804-lts
+            #    workers: 6
 
             - ubuntu-core-16-64:
                 image: ubuntu-16.04-64


### PR DESCRIPTION
This unblocks master again, we currently see every test failing
because:
```
2018-03-20 06:49:53 Discarding google:ubuntu-18.04-64 (mar200647-634350), cannot connect: cannot connect to google:ubuntu-18.04-64 (mar200647-634350): ssh: handshake failed: EOF
```

At least this is my theory :)