### PR TITLE
tests: make tests run with specific bionic release avoiding take the last one

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -53,10 +53,9 @@ backends:
                 workers: 6
             - ubuntu-16.04-64:
                 workers: 8
-            # disabled because of: cannot connect: cannot connect to google:ubuntu-18.04-64 (mar200647-634341): ssh: handshake failed: EOF
-            #- ubuntu-18.04-64:
-            #    image: ubuntu-os-cloud-devel/ubuntu-1804-lts
-            #    workers: 6
+            - ubuntu-18.04-64:
+                image: ubuntu-os-cloud-devel/daily-ubuntu-1804-bionic-v20180315
+                workers: 6
 
             - ubuntu-core-16-64:
                 image: ubuntu-16.04-64


### PR DESCRIPTION
The last bionic version uploaded yesterday doesn't see to be working properly "cannot connect: cannot connect to google:ubuntu-18.04-64 (mar200647-634341): ssh: handshake failed: EOF"
I fixed the bionic image that we are going to use for testing, the update will be done manually once we are sure the image is working properly.