### PR TITLE
snap: make `snap run` look at the system-key for security profiles

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -91,6 +92,33 @@ and environment.
 		}, nil)
 }
 
+func maybeWaitForSecurityProfileRegeneration() error {
+	// check if the security profiles key has changed, if so, we need
+	// to wait for snapd to re-generate all profiles
+	//
+	// (wait up to 1500 * 200ms = 300s)
+	timeout := 1500
+	if timeoutEnv := os.Getenv("SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT"); timeoutEnv != "" {
+		if i, err := strconv.Atoi(timeoutEnv); err == nil {
+			timeout = i
+		}
+	}
+	for i := 0; i < timeout; i++ {
+		mismatch, err := interfaces.SystemKeyMismatch()
+		if err != nil {
+			// there is nothing we can do
+			logger.Debugf("SystemKeyMismatch returned an error: %v", err)
+			return nil
+		}
+		if !mismatch {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return fmt.Errorf("timeout waiting for snap system profiles to get updated")
+}
+
 func (x *cmdRun) Execute(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf(i18n.G("need the application to run as argument"))
@@ -115,6 +143,10 @@ func (x *cmdRun) Execute(args []string) error {
 	if x.HookName != "" && len(args) > 0 {
 		// TRANSLATORS: %q is the hook name; %s a space-separated list of extra arguments
 		return fmt.Errorf(i18n.G("too many arguments for hook %q: %s"), x.HookName, strings.Join(args, " "))
+	}
+
+	if err := maybeWaitForSecurityProfileRegeneration(); err != nil {
+		return err
 	}
 
 	// Now actually handle the dispatching

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -95,12 +95,11 @@ and environment.
 func maybeWaitForSecurityProfileRegeneration() error {
 	// check if the security profiles key has changed, if so, we need
 	// to wait for snapd to re-generate all profiles
-	//
-	// (wait up to 1500 * 200ms = 300s)
-	timeout := 1500
-	if timeoutEnv := os.Getenv("SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT"); timeoutEnv != "" {
+	sleep := 200 * time.Millisecond
+	timeout := int(300 * time.Second / sleep)
+	if timeoutEnv := os.Getenv("SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT_SEC"); timeoutEnv != "" {
 		if i, err := strconv.Atoi(timeoutEnv); err == nil {
-			timeout = i
+			timeout = int(time.Duration(i) * time.Second / sleep)
 		}
 	}
 	for i := 0; i < timeout; i++ {
@@ -113,7 +112,7 @@ func maybeWaitForSecurityProfileRegeneration() error {
 		if !mismatch {
 			return nil
 		}
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(sleep)
 	}
 
 	return fmt.Errorf("timeout waiting for snap system profiles to get updated")

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -109,11 +109,12 @@ func maybeWaitForSecurityProfileRegeneration() error {
 	// We have a mismatch, try to connect to snapd, once we can
 	// connect we just continue because that means snapd has
 	// generated new profiles.
-	sleep := 200 * time.Millisecond
-	timeout := int(300 * time.Second / sleep)
-	if timeoutEnv := os.Getenv("SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT_SEC"); timeoutEnv != "" {
+	//
+	// connect timeout is 5s
+	timeout := 12
+	if timeoutEnv := os.Getenv("SNAPD_DEBUG_SYSTEM_KEY_RETRY"); timeoutEnv != "" {
 		if i, err := strconv.Atoi(timeoutEnv); err == nil {
-			timeout = int(time.Duration(i) * time.Second / sleep)
+			timeout = i
 		}
 	}
 
@@ -122,7 +123,6 @@ func maybeWaitForSecurityProfileRegeneration() error {
 		if _, err := cli.SysInfo(); err == nil {
 			return nil
 		}
-		time.Sleep(sleep)
 	}
 
 	return fmt.Errorf("timeout waiting for snap system profiles to get updated")

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -106,8 +106,16 @@ func maybeWaitForSecurityProfileRegeneration() error {
 	}
 
 	// We have a mismatch, try to connect to snapd, once we can
-	// connect we just continue because that means snapd has
-	// generated new profiles.
+	// connect we just continue because that usually means that
+	// a new snapd is ready and has generated profiles.
+	//
+	// There is a corner case if an upgrade leaves the old snapd
+	// running and we connect to the old snapd. Handling this
+	// correctly is tricky because our "snap run" pipeline may
+	// depend on profiles written by the new snapd. So for now we
+	// just continue and hope for the best. The real fix for this
+	// is to fix the packaging so that snapd is stopped, upgraded
+	// and started.
 	//
 	// connect timeout for client is 5s on each try, so 12*5s = 60s
 	timeout := 12

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -57,11 +57,11 @@ type systemKey struct {
 	// IMPORTANT: when adding new inputs bump this version
 	Version int `json:"version"`
 
-	BuildID          string   `json:"build_id"`
-	AppArmorFeatures []string `json:"apparmor_features"`
-	NFSHome          bool     `json:"nfs_home"`
-	OverlayRoot      string   `json:"overlay_root"`
-	SecCompActions   []string `json:"seccomp_features"`
+	BuildID          string   `json:"build-id"`
+	AppArmorFeatures []string `json:"apparmor-features"`
+	NFSHome          bool     `json:"nfs-home"`
+	OverlayRoot      string   `json:"overlay-root"`
+	SecCompActions   []string `json:"seccomp-features"`
 }
 
 var (
@@ -72,7 +72,7 @@ var (
 func findSnapdPath() (string, error) {
 	snapdPath := filepath.Join(dirs.DistroLibExecDir, "snapd")
 
-	// find the right snapdPath
+	// find the right snapdPath by looking if we are re-execing or not
 	exe, err := os.Readlink("/proc/self/exe")
 	if err != nil {
 		return "", err

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -20,10 +20,11 @@
 package interfaces
 
 import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
@@ -31,17 +32,35 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
+// ErrSystemKeyIncomparableVersions indicates that the system-key
+// on disk and the system-key calculated from generateSystemKey
+// have different inputs and are therefor incomparable.
+//
+// This means:
+// - "snapd" needs to re-generate security profiles
+// - "snap run" cannot wait for those security profiles
+var (
+	ErrSystemKeyIncomparableVersions = errors.New("system-key version mismatch")
+	ErrSystemKeyMissing              = errors.New("system-key missing on disk")
+)
+
 // systemKey describes the environment for which security profiles
 // have been generated. It is useful to compare if the current
 // running system is similar enough to the generated profiles or
 // if the profiles need to be re-generated to match the new system.
+//
+// Note that this key gets generated on *each* `snap run` - so it
+// *must* be cheap to calculate it (no hashes of big binaries etc).
 type systemKey struct {
-	BuildID          string   `yaml:"build-id"`
-	AppArmorFeatures []string `yaml:"apparmor-features"`
-	NFSHome          bool     `yaml:"nfs-home"`
-	OverlayRoot      string   `yaml:"overlay-root"`
-	Core             string   `yaml:"core,omitempty"`
-	SecCompActions   []string `yaml:"seccomp-features"`
+	// IMPORTANT: when adding new inputs bump this version
+	Version string `json:"version"`
+
+	BuildID          string   `json:"build_id"`
+	AppArmorFeatures []string `json:"apparmor_features"`
+	NFSHome          bool     `json:"nfs_home"`
+	OverlayRoot      string   `json:"overlay_root"`
+	Core             string   `json:"core,omitempty"`
+	SecCompActions   []string `json:"seccomp_features"`
 }
 
 var (
@@ -56,6 +75,7 @@ func generateSystemKey() *systemKey {
 	}
 
 	var sk systemKey
+	sk.Version = "1"
 	buildID, err := osutil.MyBuildID()
 	if err != nil {
 		buildID = ""
@@ -93,26 +113,79 @@ func generateSystemKey() *systemKey {
 	return &sk
 }
 
-// SystemKey outputs a string that identifies what security profiles
-// environment this snapd is using. Security profiles that were generated
-// with a different Systemkey should be re-generated.
-func SystemKey() string {
+// WriteSystemKey will write the current system-key to disk
+func WriteSystemKey() error {
 	sk := generateSystemKey()
 
 	// special case: unknown build-ids always trigger a rebuild
 	if sk.BuildID == "" {
-		return ""
+		return nil
 	}
-	sks, err := yaml.Marshal(sk)
+	sks, err := json.Marshal(sk)
 	if err != nil {
 		panic(err)
 	}
-	return string(sks)
+	return osutil.AtomicWriteFile(dirs.SnapSystemKeyFile, sks, 0644, 0)
+}
+
+// SystemKeyMismatch checks if the running binary expects a different
+// system-key than what is on disk.
+//
+// This is used in two places:
+// - snap run: when there is a mismatch it will wait for snapd
+//             to re-generate the security profiles
+// - snapd: on startup it checks if the system-key has changed and
+//          if so re-generate the security profiles
+//
+// This ensures that "snap run" and "snapd" have a consistent set
+// of security profiles. Without it we may have the following
+// scenario:
+// 1. snapd gets refreshed and snaps need updated security profiles
+//    to work (e.g. because snap-exec needs a new permission)
+// 2. The system reboots to start the new snapd. At this point
+//    the old security profiles are on disk (because the new
+//    snapd did not run yet)
+// 3. Snaps that run as daemon get started during boot by systemd
+//    (e.g. network-manager). This may happen before snapd had a
+//    chance to refresh the security profiles.
+// 4. Because the security profiles are for the old version of
+//    the snaps that run before snapd fail to start. For e.g.
+//    network-manager this is of course catastrophic.
+// To prevent this, in step(4) we have this wait-for-snapd
+// step to ensure the expected profiles are on disk.
+func SystemKeyMismatch() (bool, error) {
+	mySystemKey := generateSystemKey()
+
+	raw, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
+	if err != nil && os.IsNotExist(err) {
+		return false, ErrSystemKeyMissing
+	}
+	if err != nil {
+		return false, err
+	}
+	var diskSystemKey systemKey
+	if err := json.Unmarshal(raw, &diskSystemKey); err != nil {
+		return false, err
+	}
+	// deal with the race that "snap run" may start, then snapd
+	// is upgraded and generates a new system-key with different
+	// inputs than the "snap run" in memory. In this case we
+	// should be fine because new security profiles will also
+	// have been written to disk.
+	if mySystemKey.Version != diskSystemKey.Version {
+		return false, ErrSystemKeyIncomparableVersions
+	}
+	mySystemKeyJSON, err := json.Marshal(mySystemKey)
+	if err != nil {
+		return false, err
+	}
+
+	return string(mySystemKeyJSON) != string(raw), nil
 }
 
 func MockSystemKey(s string) func() {
 	var sk systemKey
-	err := yaml.Unmarshal([]byte(s), &sk)
+	err := json.Unmarshal([]byte(s), &sk)
 	if err != nil {
 		panic(err)
 	}

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -85,7 +85,7 @@ func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
 
 	overlayRoot, err := osutil.IsRootWritableOverlay()
 	c.Assert(err, IsNil)
-	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":"1","build_id":"%s","apparmor_features":%s,"nfs_home":%v,"overlay_root":%q,"seccomp_features":%s}`, s.buildID, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
+	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":"1","build_ids":{"host_snapd":"","core_snap_snapd":""},"apparmor_features":%s,"nfs_home":%v,"overlay_root":%q,"seccomp_features":%s}`, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
 }
 
 func (s *systemKeySuite) TestInterfaceSystemKeyMismatchHappy(c *C) {

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -85,7 +85,7 @@ func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
 
 	overlayRoot, err := osutil.IsRootWritableOverlay()
 	c.Assert(err, IsNil)
-	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build_ids":{"host_snapd":"","core_snap_snapd":""},"apparmor_features":%s,"nfs_home":%v,"overlay_root":%q,"seccomp_features":%s}`, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
+	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build_id":"","apparmor_features":%s,"nfs_home":%v,"overlay_root":%q,"seccomp_features":%s}`, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
 }
 
 func (s *systemKeySuite) TestInterfaceSystemKeyMismatchHappy(c *C) {

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -85,7 +85,7 @@ func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
 
 	overlayRoot, err := osutil.IsRootWritableOverlay()
 	c.Assert(err, IsNil)
-	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":"1","build_ids":{"host_snapd":"","core_snap_snapd":""},"apparmor_features":%s,"nfs_home":%v,"overlay_root":%q,"seccomp_features":%s}`, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
+	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build_ids":{"host_snapd":"","core_snap_snapd":""},"apparmor_features":%s,"nfs_home":%v,"overlay_root":%q,"seccomp_features":%s}`, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
 }
 
 func (s *systemKeySuite) TestInterfaceSystemKeyMismatchHappy(c *C) {
@@ -124,13 +124,13 @@ func (s *systemKeySuite) TestInterfaceSystemKeyMismatchVersions(c *C) {
 	// we calculcate v1
 	s.AddCleanup(interfaces.MockSystemKey(`
 {
-"version":"1",
+"version":1,
 "build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
 }`))
 	// and the on-disk version is v2
 	err := ioutil.WriteFile(dirs.SnapSystemKeyFile, []byte(`
 {
-"version":"2",
+"version":2,
 "build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
 }`), 0644)
 	c.Assert(err, IsNil)

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -20,9 +20,11 @@
 package interfaces_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
-	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -30,9 +32,12 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type systemKeySuite struct {
+	testutil.BaseTest
+
 	tmp              string
 	apparmorFeatures string
 	buildID          string
@@ -41,65 +46,96 @@ type systemKeySuite struct {
 var _ = Suite(&systemKeySuite{})
 
 func (s *systemKeySuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
 	s.tmp = c.MkDir()
 	dirs.SetRootDir(s.tmp)
-	s.apparmorFeatures = filepath.Join(s.tmp, "/sys/kernel/security/apparmor/features")
+	os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
 
+	s.apparmorFeatures = filepath.Join(s.tmp, "/sys/kernel/security/apparmor/features")
 	id, err := osutil.MyBuildID()
 	c.Assert(err, IsNil)
 	s.buildID = id
+
+	s.AddCleanup(interfaces.MockIsHomeUsingNFS(func() (bool, error) { return false, nil }))
+	s.AddCleanup(release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"}))
 }
 
 func (s *systemKeySuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+
 	dirs.SetRootDir("/")
 }
 
-func (s *systemKeySuite) TestInterfaceSystemKey(c *C) {
-	restore := interfaces.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
-	defer restore()
+func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
+	err := interfaces.WriteSystemKey()
+	c.Assert(err, IsNil)
 
-	restore2 := release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"})
-	defer restore2()
+	systemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
+	c.Assert(err, IsNil)
 
-	systemKey := interfaces.SystemKey()
+	apparmorFeaturesStr, err := json.Marshal(release.AppArmorFeatures())
+	c.Assert(err, IsNil)
 
-	apparmorFeatures := release.AppArmorFeatures()
-	var apparmorFeaturesStr string
-	if len(apparmorFeatures) == 0 {
-		apparmorFeaturesStr = " []\n"
-	} else {
-		apparmorFeaturesStr = "\n- " + strings.Join(apparmorFeatures, "\n- ") + "\n"
-	}
-
-	seccompActions := release.SecCompActions
-	var seccompActionsStr string
-	if len(seccompActions) == 0 {
-		seccompActionsStr = " []\n"
-	} else {
-		seccompActionsStr = "\n- " + strings.Join(seccompActions, "\n- ") + "\n"
-	}
+	seccompActionsStr, err := json.Marshal(release.SecCompActions)
+	c.Assert(err, IsNil)
 
 	nfsHome, err := osutil.IsHomeUsingNFS()
 	c.Assert(err, IsNil)
+
 	overlayRoot, err := osutil.IsRootWritableOverlay()
 	c.Assert(err, IsNil)
-	c.Check(systemKey, Equals, fmt.Sprintf(`build-id: %s
-apparmor-features:%snfs-home: %v
-overlay-root: "%v"
-seccomp-features:%s`, s.buildID, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
+	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":"1","build_id":"%s","apparmor_features":%s,"nfs_home":%v,"overlay_root":%q,"seccomp_features":%s}`, s.buildID, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
 }
 
-func (ts *systemKeySuite) TestInterfaceDigest(c *C) {
-	restore := interfaces.MockSystemKey(`build-id: 7a94e9736c091b3984bd63f5aebfc883c4d859e0
-apparmor-features:
-- caps
-- dbus
-`)
-	defer restore()
-	restore = interfaces.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
-	defer restore()
+func (s *systemKeySuite) TestInterfaceSystemKeyMismatchHappy(c *C) {
+	s.AddCleanup(interfaces.MockSystemKey(`
+{
+"build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor_features": ["caps", "dbus"]
+}
+`))
 
-	systemKey := interfaces.SystemKey()
-	c.Check(systemKey, Matches, "(?sm)^build-id: [a-z0-9]+$")
-	c.Check(systemKey, Matches, "(?sm).*apparmor-features:")
+	// no system-key yet -> Error
+	c.Assert(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)
+	_, err := interfaces.SystemKeyMismatch()
+	c.Assert(err, Equals, interfaces.ErrSystemKeyMissing)
+
+	// create a system-key -> no mismatch anymore
+	err = interfaces.WriteSystemKey()
+	c.Assert(err, IsNil)
+	mismatch, err := interfaces.SystemKeyMismatch()
+	c.Assert(err, IsNil)
+	c.Check(mismatch, Equals, false)
+
+	// change our system-key to have more apparmor features
+	s.AddCleanup(interfaces.MockSystemKey(`
+{
+"build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor_features": ["caps", "dbus", "more", "and", "more"]
+}
+`))
+	mismatch, err = interfaces.SystemKeyMismatch()
+	c.Assert(err, IsNil)
+	c.Check(mismatch, Equals, true)
+}
+
+func (s *systemKeySuite) TestInterfaceSystemKeyMismatchVersions(c *C) {
+	// we calculcate v1
+	s.AddCleanup(interfaces.MockSystemKey(`
+{
+"version":"1",
+"build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
+}`))
+	// and the on-disk version is v2
+	err := ioutil.WriteFile(dirs.SnapSystemKeyFile, []byte(`
+{
+"version":"2",
+"build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
+}`), 0644)
+	c.Assert(err, IsNil)
+
+	// when we encounter different versions we get the right error
+	_, err = interfaces.SystemKeyMismatch()
+	c.Assert(err, Equals, interfaces.ErrSystemKeyIncomparableVersions)
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -85,14 +85,14 @@ func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
 
 	overlayRoot, err := osutil.IsRootWritableOverlay()
 	c.Assert(err, IsNil)
-	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build_id":"","apparmor_features":%s,"nfs_home":%v,"overlay_root":%q,"seccomp_features":%s}`, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
+	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build-id":"","apparmor-features":%s,"nfs-home":%v,"overlay-root":%q,"seccomp-features":%s}`, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
 }
 
 func (s *systemKeySuite) TestInterfaceSystemKeyMismatchHappy(c *C) {
 	s.AddCleanup(interfaces.MockSystemKey(`
 {
-"build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
-"apparmor_features": ["caps", "dbus"]
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus"]
 }
 `))
 
@@ -111,7 +111,7 @@ func (s *systemKeySuite) TestInterfaceSystemKeyMismatchHappy(c *C) {
 	// change our system-key to have more apparmor features
 	s.AddCleanup(interfaces.MockSystemKey(`
 {
-"build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
 "apparmor_features": ["caps", "dbus", "more", "and", "more"]
 }
 `))
@@ -125,13 +125,13 @@ func (s *systemKeySuite) TestInterfaceSystemKeyMismatchVersions(c *C) {
 	s.AddCleanup(interfaces.MockSystemKey(`
 {
 "version":1,
-"build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
 }`))
 	// and the on-disk version is v2
 	err := ioutil.WriteFile(dirs.SnapSystemKeyFile, []byte(`
 {
 "version":2,
-"build_id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
 }`), 0644)
 	c.Assert(err, IsNil)
 

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/httputil"
-	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -46,7 +45,6 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
-	interfaces.WriteSystemKey()
 	st.Set("seed-time", time.Now())
 	st.Set("seeded", true)
 	return nil

--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/httputil"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -45,6 +46,7 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 	st.Lock()
 	defer st.Unlock()
 
+	interfaces.WriteSystemKey()
 	st.Set("seed-time", time.Now())
 	st.Set("seeded", true)
 	return nil

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -21,17 +21,13 @@ package ifacestate
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/policy"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -114,22 +110,12 @@ func (m *InterfaceManager) addSnaps() error {
 }
 
 func (m *InterfaceManager) profilesNeedRegeneration() bool {
-	currentSystemKey := interfaces.SystemKey()
-	if currentSystemKey == "" {
-		logger.Noticef("no system key, forcing re-generation of security profiles")
-		return true
-	}
-
-	onDiskSystemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
-	if os.IsNotExist(err) {
-		return true
-	}
+	mismatch, err := interfaces.SystemKeyMismatch()
 	if err != nil {
-		logger.Noticef("cannot read system-key file: %s", err)
+		logger.Noticef("error trying to compare the snap system key: %v", err)
 		return true
 	}
-
-	return string(onDiskSystemKey) != currentSystemKey
+	return mismatch
 }
 
 // regenerateAllSecurityProfiles will regenerate all security profiles.
@@ -173,8 +159,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 		}
 	}
 
-	sk := interfaces.SystemKey()
-	return osutil.AtomicWriteFile(dirs.SnapSystemKeyFile, []byte(sk), 0644, 0)
+	return interfaces.WriteSystemKey()
 }
 
 // renameCorePlugConnection renames one connection from "core-support" plug to

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2350,7 +2350,7 @@ func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKey
 	c.Assert(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)
 
 	_ = s.manager(c)
-	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, `{.*"build_id":.*`)
+	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, `{.*"build-id":.*`)
 
 	stat, err := os.Stat(dirs.SnapSystemKeyFile)
 	c.Assert(err, IsNil)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2357,6 +2357,7 @@ func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKey
 
 	// run manager again, but this time the snapsystemkey file should
 	// not be rewriten as the systemKey inputs have not changed
+	time.Sleep(20 * time.Millisecond)
 	s.privateMgr = nil
 	_ = s.manager(c)
 	stat2, err := os.Stat(dirs.SnapSystemKeyFile)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2342,7 +2342,7 @@ func (s *interfaceManagerSuite) TestConnectHandlesAutoconnect(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKeyFile(c *C) {
-	restore := interfaces.MockSystemKey(`{"build_id": "something"}`)
+	restore := interfaces.MockSystemKey(`{"core": "123"}`)
 	defer restore()
 
 	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
@@ -2350,7 +2350,7 @@ func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKey
 	c.Assert(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)
 
 	_ = s.manager(c)
-	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, `{.*"build_id":.*`)
+	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, `{.*"core":"123".*`)
 
 	stat, err := os.Stat(dirs.SnapSystemKeyFile)
 	c.Assert(err, IsNil)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2342,7 +2342,7 @@ func (s *interfaceManagerSuite) TestConnectHandlesAutoconnect(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKeyFile(c *C) {
-	restore := interfaces.MockSystemKey("build-id: something")
+	restore := interfaces.MockSystemKey(`{"build_id": "something"}`)
 	defer restore()
 
 	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
@@ -2350,7 +2350,7 @@ func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKey
 	c.Assert(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)
 
 	_ = s.manager(c)
-	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, "(?sm).*build-id:.*")
+	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, `{.*"build_id":.*`)
 
 	stat, err := os.Stat(dirs.SnapSystemKeyFile)
 	c.Assert(err, IsNil)

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2350,7 +2350,7 @@ func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKey
 	c.Assert(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)
 
 	_ = s.manager(c)
-	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, `{.*"core":"123".*`)
+	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, `{.*"build_id":.*`)
 
 	stat, err := os.Stat(dirs.SnapSystemKeyFile)
 	c.Assert(err, IsNil)

--- a/tests/main/snap-confine/task.yaml
+++ b/tests/main/snap-confine/task.yaml
@@ -18,16 +18,19 @@ restore: |
 execute: |
     . $TESTSLIB/dirs.sh
 
-    echo "Simulating broken current symlink for core"
-    mv $SNAP_MOUNT_DIR/core/current $SNAP_MOUNT_DIR/core/current.renamed
-
-    if test-snapd-tools.echo hello 2>snap-confine.stderr; then
-        echo "test-snapd-tools.echo should fail to run, test broken"
-    fi
-    cat snap-confine.stderr | MATCH 'cannot locate the core or legacy core snap \(current symlink missing\?\):'
+    # With system-key a broken current symlink will force snap-run to
+    # wait for snapd to be ready - so this part of the test is disabled
+    # for now.
+    #
+    #echo "Simulating broken current symlink for core"
+    #mv $SNAP_MOUNT_DIR/core/current $SNAP_MOUNT_DIR/core/current.renamed
+    #if test-snapd-tools.echo hello 2>snap-confine.stderr; then
+    #    echo "test-snapd-tools.echo should fail to run, test broken"
+    #fi
+    #cat snap-confine.stderr | MATCH 'cannot locate the core or legacy core snap \(current symlink missing\?\):'
+    #mv $SNAP_MOUNT_DIR/core/current.renamed $SNAP_MOUNT_DIR/core/current
 
     echo "Test nvidia device fix"
-    mv $SNAP_MOUNT_DIR/core/current.renamed $SNAP_MOUNT_DIR/core/current
     # For https://github.com/snapcore/snapd/pull/4042
     echo "Simulate nvidia device tags"
     mkdir -p /run/udev/tags/snap_test-snapd-tools_echo

--- a/tests/main/snap-confine/task.yaml
+++ b/tests/main/snap-confine/task.yaml
@@ -18,17 +18,13 @@ restore: |
 execute: |
     . $TESTSLIB/dirs.sh
 
-    # With system-key a broken current symlink will force snap-run to
-    # wait for snapd to be ready - so this part of the test is disabled
-    # for now.
-    #
-    #echo "Simulating broken current symlink for core"
-    #mv $SNAP_MOUNT_DIR/core/current $SNAP_MOUNT_DIR/core/current.renamed
-    #if test-snapd-tools.echo hello 2>snap-confine.stderr; then
-    #    echo "test-snapd-tools.echo should fail to run, test broken"
-    #fi
-    #cat snap-confine.stderr | MATCH 'cannot locate the core or legacy core snap \(current symlink missing\?\):'
-    #mv $SNAP_MOUNT_DIR/core/current.renamed $SNAP_MOUNT_DIR/core/current
+    echo "Simulating broken current symlink for core"
+    mv $SNAP_MOUNT_DIR/core/current $SNAP_MOUNT_DIR/core/current.renamed
+    if test-snapd-tools.echo hello 2>snap-confine.stderr; then
+        echo "test-snapd-tools.echo should fail to run, test broken"
+    fi
+    cat snap-confine.stderr | MATCH 'cannot locate the core or legacy core snap \(current symlink missing\?\):'
+    mv $SNAP_MOUNT_DIR/core/current.renamed $SNAP_MOUNT_DIR/core/current
 
     echo "Test nvidia device fix"
     # For https://github.com/snapcore/snapd/pull/4042

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -16,7 +16,8 @@ execute: |
     }
 
     echo "Ensure a valid system-key file is on-disk"
-    cat /var/lib/snapd/system-key | MATCH '"build_id":"[0-9a-z]+"'
+    cat /var/lib/snapd/system-key | MATCH '"host_snapd":"[0-9a-z]+"'
+    cat /var/lib/snapd/system-key | MATCH '"core_snap_snapd":"[0-9a-z]+"'
     buf="$(stat /var/lib/snapd/system-key)"
     system_key_content="$(cat /var/lib/snapd/system-key)"
 

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -30,9 +30,9 @@ execute: |
     fi
 
     echo "Ensure that the system-key is rewritten if system-key changes"
-    printf "something: new\n" >> /var/lib/snapd/system-key
+    printf '{"version":1}' > /var/lib/snapd/system-key
     restart_snapd
-    if grep "something: new" /var/lib/snapd/system-key; then
+    if grep '{"version":1}' /var/lib/snapd/system-key; then
         echo "system-key *not* rewriten test broken"
         exit 1
     fi
@@ -40,7 +40,7 @@ execute: |
     echo "Ensure snap run waits for system key updates"
     snap install test-snapd-tools
     echo "Change system-key, this ensure that snap run will wait"
-    printf "something: new\n" >> /var/lib/snapd/system-key
+    printf '{"version":1}' > /var/lib/snapd/system-key
     if SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT_SEC=5 test-snapd-tools.echo bad; then
         echo "snap run should have errored because of changed system-key"
         exit 1

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -21,7 +21,7 @@ execute: |
     }
 
     echo "Ensure a valid system-key file is on-disk"
-    cat /var/lib/snapd/system-key | MATCH '"build_id":"[0-9a-z]+"'
+    cat /var/lib/snapd/system-key | MATCH '"build-id":"[0-9a-z]+"'
     buf="$(stat /var/lib/snapd/system-key)"
     system_key_content="$(cat /var/lib/snapd/system-key)"
 

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -1,18 +1,23 @@
 summary: Ensure security profile re-generation works with system-key
 
 execute: |
-    restart_snapd() {
+    stop_snapd() {
         systemctl stop snapd.service
         while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=inactive" ]; do
             systemctl show -pActiveState snapd.service
             sleep 1
         done
-
+    }
+    start_snapd() {
         systemctl start snapd.service
         while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=active" ]; do
             systemctl show -pActiveState snapd.service
             sleep 1
         done
+    }
+    restart_snapd() {
+        stop_snapd
+        start_snapd
     }
 
     echo "Ensure a valid system-key file is on-disk"
@@ -40,11 +45,22 @@ execute: |
     snap install test-snapd-tools
     echo "Change system-key, this ensure that snap run will wait"
     printf '{"version":1}' > /var/lib/snapd/system-key
+    stop_snapd
     if SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT_SEC=5 test-snapd-tools.echo bad; then
         echo "snap run should have errored because of changed system-key"
         exit 1
     fi
+    start_snapd
 
+    echo "Ensure snap run does not wait when it can talk to snapd"
+    echo "Change system-key, with running snapd"
+    printf '{"version":1}' > /var/lib/snapd/system-key
+    test-snapd-tools.echo good
+    
     echo "Things work again after a restart of snapd"
     restart_snapd
-    test-snapd-tools.echo good
+    test-snapd-tools.echo good-again
+    if grep '{"version":1}' /var/lib/snapd/system-key; then
+        echo "system-key *not* rewriten test broken"
+        exit 1
+    fi

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -16,8 +16,7 @@ execute: |
     }
 
     echo "Ensure a valid system-key file is on-disk"
-    cat /var/lib/snapd/system-key | MATCH '"host_snapd":"[0-9a-z]+"'
-    cat /var/lib/snapd/system-key | MATCH '"core_snap_snapd":"[0-9a-z]+"'
+    cat /var/lib/snapd/system-key | MATCH '"build_id":"[0-9a-z]+"'
     buf="$(stat /var/lib/snapd/system-key)"
     system_key_content="$(cat /var/lib/snapd/system-key)"
 

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -41,7 +41,7 @@ execute: |
     snap install test-snapd-tools
     echo "Change system-key, this ensure that snap run will wait"
     printf "something: new\n" >> /var/lib/snapd/system-key
-    if SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT=5 test-snapd-tools.echo bad; then
+    if SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT_SEC=5 test-snapd-tools.echo bad; then
         echo "snap run should have errored because of changed system-key"
         exit 1
     fi

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -2,14 +2,14 @@ summary: Ensure security profile re-generation works with system-key
 
 execute: |
     stop_snapd() {
-        systemctl stop snapd.service
+        systemctl stop snapd.service snapd.socket
         while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=inactive" ]; do
             systemctl show -pActiveState snapd.service
             sleep 1
         done
     }
     start_snapd() {
-        systemctl start snapd.service
+        systemctl start snapd.service snapd.socket
         while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=active" ]; do
             systemctl show -pActiveState snapd.service
             sleep 1
@@ -46,7 +46,7 @@ execute: |
     echo "Change system-key, this ensure that snap run will wait"
     printf '{"version":1}' > /var/lib/snapd/system-key
     stop_snapd
-    if SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT_SEC=5 test-snapd-tools.echo bad; then
+    if SNAPD_DEBUG_SYSTEM_KEY_RETRY=1 test-snapd-tools.echo bad; then
         echo "snap run should have errored because of changed system-key"
         exit 1
     fi

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -16,7 +16,7 @@ execute: |
     }
 
     echo "Ensure a valid system-key file is on-disk"
-    cat /var/lib/snapd/system-key | MATCH "build-id: [0-9a-z]+"
+    cat /var/lib/snapd/system-key | MATCH '"build_id":"[0-9a-z]+"'
     buf="$(stat /var/lib/snapd/system-key)"
     system_key_content="$(cat /var/lib/snapd/system-key)"
 
@@ -35,3 +35,16 @@ execute: |
         echo "system-key *not* rewriten test broken"
         exit 1
     fi
+
+    echo "Ensure snap run waits for system key updates"
+    snap install test-snapd-tools
+    echo "Change system-key, this ensure that snap run will wait"
+    printf "something: new\n" >> /var/lib/snapd/system-key
+    if SNAPD_DEBUG_SYSTEM_KEY_WAIT_TIMEOUT=5 test-snapd-tools.echo bad; then
+        echo "snap run should have errored because of changed system-key"
+        exit 1
+    fi
+
+    echo "Things work again after a restart of snapd"
+    restart_snapd
+    test-snapd-tools.echo good


### PR DESCRIPTION
many: make `snap run` look at the system-key for security profiles

If the system-key for the security profiles does not match, wait and
eventually timeout if snapd is not generating the profiles we need.

Without it we may have the following scenario:

1. snapd gets refreshed and snaps need updated security profiles
   to work (e.g. because snap-confine needs new generated
   snap-update-ns profiles on disk)
2. The system reboots to start the new snapd. At this point
   the old security profiles are on disk (because the new
   snapd did not run yet) and nothing new is there yet.
3. Snaps that run as daemon get started during boot by systemd
   (e.g. network-manager). This may happen before snapd had a
   chance to refresh the security profiles.
4. Because the security profiles are for the old version of
   the snaps that run before snapd starts and generates the
   missing security profiles will fail to start. For e.g.
   network-manager this is of course catastrophic as it
   leaves the machine without networking.

To prevent this, in step(4) we have this wait-for-snapd
step to ensure the expected profiles are on disk.

This PR also switches the system-key to json to make the
parsing a lot quicker.

It also introduces a new version key into the system-key.
This version key is important because there is a race when
a) the sytem-key gets new inputs
b) old `snap run` is executed and slow to load
c) new snapd with new inputs run at exactly the same time and
   write a new system-key to disk
In this case (b) will have calculated a profile without the new
inputs and eventually timeout. The new code will just continue
if there is a version mismatch (which is fine because it means
new profiles are on disk so no need to wait).

