### PR TITLE
debian: undo snap.mount system unit removal

### DIFF
--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -2,8 +2,6 @@
 
 set -e
 
-#DEBHELPER#
-
 
 case "$1" in
     configure)
@@ -30,3 +28,5 @@ case "$1" in
             done
         fi
 esac
+
+#DEBHELPER#

--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -11,4 +11,22 @@ case "$1" in
         if dpkg --compare-versions "$2" lt-nl "2.0.7"; then
             ldconfig
         fi
+
+        # ensure we undo the stopping of the snap.mount unit
+        # that we had in 2.31 and 2.31.1
+        if dpkg --compare-versions "$2" ge-nl "2.31" && \
+                dpkg --compare-versions "$2" lt-nl "2.31.2"; then
+            units=$(systemctl list-unit-files --full | grep '^snap[-.]' | cut -f1 -d ' ' | grep -vF snap.mount.service || true)
+            mounts=$(echo "$units" | grep '^snap[-.].*\.mount$' || true)
+            for unit in $mounts; do
+                # ensure its really a snap mount unit or systemd unit
+                if ! grep -q 'What=/var/lib/snapd/snaps/' "/etc/systemd/system/$unit" && ! grep -q 'X-Snappy=yes' "/etc/systemd/system/$unit"; then
+                    echo "Skipping non-snapd systemd unit $unit"
+                    continue
+                fi
+
+                echo "Starting $unit"
+                systemctl start "$unit"
+            done
+        fi
 esac


### PR DESCRIPTION
Ensure we undo the stopping of the snap.mount unit that we had in 2.31 and 2.31.1