### PR TITLE
debian: run snap.mount upgrade fixup *before* debhelper

### DIFF
--- a/packaging/ubuntu-16.04/snapd.postinst
+++ b/packaging/ubuntu-16.04/snapd.postinst
@@ -2,8 +2,6 @@
 
 set -e
 
-#DEBHELPER#
-
 
 case "$1" in
     configure)
@@ -37,3 +35,5 @@ case "$1" in
             done
         fi
 esac
+
+#DEBHELPER#


### PR DESCRIPTION
When undoing the snap.mount unit stopping, do that before snapd is started.