### PR TITLE
Specify charset in po/snappy.pot

### DIFF
--- a/update-pot
+++ b/update-pot
@@ -24,6 +24,8 @@ find "$HERE" -name "*.go" -type f -print0 | xargs -0 \
     --keyword=i18n.G \
     --keyword-plural=i18n.DG
 
+sed -i 's/charset=CHARSET/charset=UTF-8/' "$OUTPUT"
+
 xgettext "$HERE"/data/polkit/*.policy \
     -o "$OUTPUT" \
     --its="$HERE/po/its/polkit.its" \


### PR DESCRIPTION
https://launchpad.net/bugs/1747272

The new `xgettext()` call in `update-pot` does not work. This entry appears in the buildlog when building on Ubuntu:

`xgettext: input file doesn't contain a header entry with a charset specification`

I think that "input file" refers to the already existing `po/snappy.pot`, which was created right before. When uploading to a PPA including this proposed `sed()` command, there is no complaint in the buildlog about charset.

It would be interesting to test this on a real Ubuntu upload. Possibly we can finally make those strings show up in the translation template.