### PR TITLE
snap-confine: fallback to /lib/udev/snappy-app-dev if the core is older (2.23)

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -66,6 +66,7 @@
     /etc/udev/udev.conf r,
     /sys/**/uevent r,
     /usr/lib/snapd/snap-device-helper ixr, # drop
+    /lib/udev/snappy-app-dev ixr, # drop
     /run/udev/** rw,
     /{,usr/}bin/tr ixr,
     /usr/lib/locale/** r,

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -61,10 +61,22 @@ _run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
 			sc_must_snprintf(buf, sizeof(buf), "%u:%u", major,
 					 minor);
 		}
-		debug("running snap-device-helper add %s %s %s", udev_s->tagname,
-		      path, buf);
-		execle("/usr/lib/snapd/snap-device-helper", "/usr/lib/snapd/snap-device-helper",
-		       "add", udev_s->tagname, path, buf, NULL, env);
+		debug("running snap-device-helper add %s %s %s",
+		      udev_s->tagname, path, buf);
+                // This code runs inside the core snap. We have two paths
+                // for the udev helper.
+                //
+                // First try new "snap-device-helper" path first but
+                // when running against an older core snap fallback to
+                // the old name.
+		if (access("/usr/lib/snapd/snap-device-helper", X_OK) == 0)
+			execle("/usr/lib/snapd/snap-device-helper",
+			       "/usr/lib/snapd/snap-device-helper", "add",
+			       udev_s->tagname, path, buf, NULL, env);
+		else
+			execle("/lib/udev/snappy-app-dev",
+			       "/lib/udev/snappy-app-dev", "add",
+			       udev_s->tagname, path, buf, NULL, env);
 		die("execl failed");
 	}
 	if (waitpid(pid, &status, 0) < 0)


### PR DESCRIPTION
There is code in snap-confine that runs inside the core snap and runs
our udev helper. We have two paths for the udev helper, the old path
/lib/udev/snappy-appy-dev which we no longer use but may still be
present if the user has an older version of the core snap installed.
And the new path /usr/lib/snapd/snap-device-helper.

This PR changes snap-confine to try /usr/lib/snapd/snap-device-helper
first but fallback to /lib/udev/snappy-app-dev if the new one is not
available.
