### PR TITLE
tests: add support for phased prepare-restore logic

### DIFF
--- a/tests/lib/prepare-restore.d/00-EXAMPLE.sh
+++ b/tests/lib/prepare-restore.d/00-EXAMPLE.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# This directory can contain any number of files that assist in the
+# prepare-restore process.  Each file should be named NN-purpose.sh where NN is
+# a two-digit priority code. Lower priority codes have an opportunity to run
+# first.
+#
+# Each file is a shell script that is sourced in a private shell. The script can define
+# any number of functions named on_{prepare,restore}_{project,suite}{,_each}. All such
+# functions are optional.
+#
+# If a function is present it will be called at the right time, as if the same
+# shell code was present in the appropriate stanza in spread.yaml.
+#
+# The main idea is that this design increases modularity and helps to make the
+# code manageable as code responsible for a given task, that spans many phases,
+# can be placed next to each other in one file, and not have to be scattered in
+# one huge file somewhere.
+
+# == Project prepare/restore ==
+
+on_prepare_project() {
+    # This phase runs once, when the whole project is prepared.
+    echo "PHASE: prepare project"
+}
+
+on_restore_project() {
+    # This phase runs once, when the whole project is restored.
+    echo "PHASE: restore project"
+}
+
+# == Project wide task prepare/restore ==
+
+on_prepare_project_each() {
+    # This phase runs once for each task but is affecting the whole
+    # project, not just individual suite or task.
+    echo "PHASE: prepare project each"
+}
+
+on_restore_project_each() {
+    # This phase runs once for each task but is affecting the whole
+    # project, not just individual suite or task.
+    echo "PHASE: restore project each"
+}
+
+# == Suite level prepare/restore ==
+
+on_prepare_suite() {
+    # This phase runs when a specific suite is prepared
+    echo "PHASE: prepare suite"
+}
+
+on_restore_suite() {
+    # This phase runs when a specific suite is restored
+    echo "PHASE: restore suite"
+}
+
+# == Task level prepare/restore ==
+
+on_prepare_suite_each() {
+    # This phase runs when each task in a given suite is prepared.
+    echo "PHASE: prepare suite each"
+}
+
+on_restore_suite_each() {
+    # This phase runs when each task in a given suite is restored.
+    echo "PHASE: restore suite each"
+}
+

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -32,6 +32,25 @@ set -o pipefail
 ### Utility functions reused below.
 ###
 
+# Run a set of scripts in the prepare-restore.d directory. From each
+# script run, if present, the function on_$phase, where phase is one of
+# {prepare,restore}_{project,suite}{,_each}.
+do_phase() {
+    phase="$1" && shift
+    for module in "$TESTSLIB"/prepare-restore.d/*.sh; do
+        (
+            set -u
+            set -e
+            # shellcheck disable=SC1090
+            . "$module"
+            if [ "$(type -t "on_$phase")" = "function" ]; then
+                "on_$phase"
+            fi
+        )
+    done
+}
+
+
 create_test_user(){
    if ! id test >& /dev/null; then
         quiet groupadd --gid 12345 test
@@ -169,6 +188,8 @@ install_dependencies_from_published(){
 ###
 
 prepare_project() {
+    do_phase prepare_project
+
     # Check if running inside a container.
     # The testsuite will not work in such an environment
     if systemd-detect-virt -c; then
@@ -300,6 +321,8 @@ EOF
 }
 
 prepare_project_each() {
+    do_phase prepare_project_each
+
     # We want to rotate the logs so that when inspecting or dumping them we
     # will just see logs since the test has started.
 
@@ -339,6 +362,8 @@ prepare_project_each() {
 }
 
 prepare_suite() {
+    do_phase prepare_suite
+
     # shellcheck source=tests/lib/prepare.sh
     . "$TESTSLIB"/prepare.sh
     if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
@@ -349,6 +374,8 @@ prepare_suite() {
 }
 
 prepare_suite_each() {
+    do_phase prepare_suite_each
+
     # shellcheck source=tests/lib/reset.sh
     "$TESTSLIB"/reset.sh --reuse-core
     # shellcheck source=tests/lib/prepare.sh
@@ -359,10 +386,12 @@ prepare_suite_each() {
 }
 
 restore_suite_each() {
-    true
+    do_phase restore_suite_each
 }
 
 restore_suite() {
+    do_phase restore_suite
+
     # shellcheck source=tests/lib/reset.sh
     "$TESTSLIB"/reset.sh --store
     if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then
@@ -377,6 +406,8 @@ restore_suite() {
 }
 
 restore_project_each() {
+    do_phase restore_project_each
+
     restore_dev_random
 
     # Udev rules are notoriously hard to write and seemingly correct but subtly
@@ -390,6 +421,8 @@ restore_project_each() {
 }
 
 restore_project() {
+    do_phase restore_project
+
     # We use a trick to accelerate prepare/restore code in certain suites. That
     # code uses a tarball to store the vanilla state. Here we just remove this
     # tarball.


### PR DESCRIPTION
This patch adds a simple system where prepare/restore code
can be placed in individual modules that are executed with a given
priority and can affect each of the phases of the test.

The phases are:
 - prepare_project (only once)
 - restore_project
 - prepare_project_each (for each task in the whole project)
 - restore_project_each
 - prepare_suite (for each suite)
 - restore_suite
 - prepare_suite_each (for each task in a given suite)
 - restore_suite_each

An example module is added along with echo's in each of the phases.
This patch will help to modularize the prepare/restore logic and
hopefully make it more testable and easy to reason about.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
