### PR TITLE
tests: update tests to deal with s390x quirks

### DIFF
--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -1,6 +1,7 @@
 summary: Ensure that the kernel-module-control interface works.
 
-systems: [-fedora-*, -opensuse-*]
+# the s390x kernel has no minix module
+systems: [-fedora-*, -opensuse-*, -ubuntu-*-s390x]
 
 environment:
     MODULE: minix

--- a/tests/main/interfaces-system-observe/task.yaml
+++ b/tests/main/interfaces-system-observe/task.yaml
@@ -1,5 +1,8 @@
 summary: Ensures that the system-observe interface works.
 
+# on s390x we do not have a serial port to observe
+systems: [-ubuntu-*-s390x]
+
 details: |
     A snap declaring the system-observe plug is defined, its command
     just calls ps -ax.


### PR DESCRIPTION
The s390x system is different in some ways so exclude two more
tests from the autopkgtest runs.
