### PR TITLE
 snap: Call SanitizePlugsSlots from InfoFromSnapYaml (2.32)

### DIFF
--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/snap"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -35,7 +37,9 @@ var (
 	_ = Suite(&plugSlotRulesSuite{})
 )
 
-type attrConstraintsSuite struct{}
+type attrConstraintsSuite struct {
+	testutil.BaseTest
+}
 
 func attrs(yml string) map[string]interface{} {
 	var attrs map[string]interface{}
@@ -57,6 +61,15 @@ func attrs(yml string) map[string]interface{} {
 		panic(err)
 	}
 	return info.Plugs["plug"].Attrs
+}
+
+func (s *attrConstraintsSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *attrConstraintsSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 }
 
 func (s *attrConstraintsSuite) TestSimple(c *C) {

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -39,18 +39,22 @@ import (
 func TestBoot(t *testing.T) { TestingT(t) }
 
 type kernelOSSuite struct {
+	testutil.BaseTest
 	bootloader *boottest.MockBootloader
 }
 
 var _ = Suite(&kernelOSSuite{})
 
 func (s *kernelOSSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 	dirs.SetRootDir(c.MkDir())
 	s.bootloader = boottest.NewMockBootloader("mock", c.MkDir())
 	partition.ForceBootloader(s.bootloader)
 }
 
 func (s *kernelOSSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 	dirs.SetRootDir("")
 	partition.ForceBootloader(nil)
 }

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -104,6 +104,8 @@ type apiBaseSuite struct {
 	jctlFollows        []bool
 	jctlRCs            []io.ReadCloser
 	jctlErrs           []error
+
+	restoreSanitize func()
 }
 
 func (s *apiBaseSuite) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
@@ -165,6 +167,7 @@ func (s *apiBaseSuite) SetUpSuite(c *check.C) {
 	s.restoreRelease = release.MockForcedDevmode(false)
 	s.systemctlRestorer = systemd.MockSystemctl(s.systemctl)
 	s.journalctlRestorer = systemd.MockJournalctl(s.journalctl)
+	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 }
 
 func (s *apiBaseSuite) TearDownSuite(c *check.C) {
@@ -172,6 +175,7 @@ func (s *apiBaseSuite) TearDownSuite(c *check.C) {
 	s.restoreRelease()
 	s.systemctlRestorer()
 	s.journalctlRestorer()
+	s.restoreSanitize()
 }
 
 func (s *apiBaseSuite) systemctl(args ...string) (buf []byte, err error) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -64,6 +64,7 @@ func (s *emptyStore) Assertion(assertType *asserts.AssertionType, primaryKey []s
 func Test(t *testing.T) { TestingT(t) }
 
 type imageSuite struct {
+	testutil.BaseTest
 	root       string
 	bootloader *boottest.MockBootloader
 
@@ -86,6 +87,9 @@ func (s *imageSuite) SetUpTest(c *C) {
 	s.root = c.MkDir()
 	s.bootloader = boottest.NewMockBootloader("grub", c.MkDir())
 	partition.ForceBootloader(s.bootloader)
+
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
 	s.stdout = &bytes.Buffer{}
 	image.Stdout = s.stdout
@@ -159,6 +163,7 @@ func (s *imageSuite) addSystemSnapAssertions(c *C, snapName string, publisher st
 }
 
 func (s *imageSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 	partition.ForceBootloader(nil)
 	image.Stdout = os.Stdout
 	image.Stderr = os.Stderr

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -27,9 +27,12 @@ import (
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 type specSuite struct {
+	testutil.BaseTest
 	iface    *ifacetest.TestInterface
 	spec     *apparmor.Specification
 	plugInfo *snap.PlugInfo
@@ -83,9 +86,16 @@ var _ = Suite(&specSuite{
 })
 
 func (s *specSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+
 	s.spec = &apparmor.Specification{}
 	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil)
 	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil)
+}
+
+func (s *specSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 }
 
 // The spec.Specification can be used through the interfaces.Specification interface

--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -517,11 +517,8 @@ func (s *AllSuite) TestSanitizeErrorsOnInvalidPlugNames(c *C) {
 }
 
 func (s *AllSuite) TestSanitizeErrorsOnInvalidSlotInterface(c *C) {
-	snapInfo := snaptest.MockInfo(c, testInvalidSlotInterfaceYaml, nil)
-	c.Check(snapInfo.Apps["app"].Slots, HasLen, 1)
-	c.Check(snapInfo.Hooks["install"].Slots, HasLen, 1)
-	c.Check(snapInfo.Slots, HasLen, 1)
-	snap.SanitizePlugsSlots(snapInfo)
+	snapInfo, err := snap.InfoFromSnapYaml([]byte(testInvalidSlotInterfaceYaml))
+	c.Assert(err, IsNil)
 	c.Check(snapInfo.Apps["app"].Slots, HasLen, 0)
 	c.Check(snapInfo.Hooks["install"].Slots, HasLen, 0)
 	c.Assert(snapInfo.BadInterfaces, HasLen, 1)

--- a/interfaces/builtin/dbus_test.go
+++ b/interfaces/builtin/dbus_test.go
@@ -143,68 +143,64 @@ func (s *DbusInterfaceSuite) TestName(c *C) {
 }
 
 func (s *DbusInterfaceSuite) TestValidSessionBusName(c *C) {
-	var mockSnapYaml = []byte(`name: dbus-snap
+	var mockSnapYaml = `name: dbus-snap
 version: 1.0
 slots:
  dbus-slot:
   interface: dbus
   bus: session
   name: org.dbus-snap.session-a
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	slot := info.Slots["dbus-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestValidSystemBusName(c *C) {
-	var mockSnapYaml = []byte(`name: dbus-snap
+	var mockSnapYaml = `name: dbus-snap
 version: 1.0
 slots:
  dbus-slot:
   interface: dbus
   bus: system
   name: org.dbus-snap.system-a
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	slot := info.Slots["dbus-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestValidFullBusName(c *C) {
-	var mockSnapYaml = []byte(`name: dbus-snap
+	var mockSnapYaml = `name: dbus-snap
 version: 1.0
 slots:
  dbus-slot:
   interface: dbus
   bus: system
   name: org.dbus-snap.foo.bar.baz.n0rf_qux
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	slot := info.Slots["dbus-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestNonexistentBusName(c *C) {
-	var mockSnapYaml = []byte(`name: dbus-snap
+	var mockSnapYaml = `name: dbus-snap
 version: 1.0
 slots:
  dbus-slot:
   interface: dbus
   bus: nonexistent
   name: org.dbus-snap
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	slot := info.Slots["dbus-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches, "bus 'nonexistent' must be one of 'session' or 'system'")
@@ -213,85 +209,80 @@ slots:
 // If this test is failing, be sure to verify the AppArmor rules for binding to
 // a well-known name to avoid overlaps.
 func (s *DbusInterfaceSuite) TestInvalidBusNameEndsWithDashInt(c *C) {
-	var mockSnapYaml = []byte(`name: dbus-snap
+	var mockSnapYaml = `name: dbus-snap
 version: 1.0
 slots:
  dbus-slot:
   interface: dbus
   bus: session
   name: org.dbus-snap.session-12345
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	slot := info.Slots["dbus-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches, "DBus bus name must not end with -NUMBER")
 }
 
 func (s *DbusInterfaceSuite) TestSanitizeSlotSystem(c *C) {
-	var mockSnapYaml = []byte(`name: dbus-snap
+	var mockSnapYaml = `name: dbus-snap
 version: 1.0
 slots:
  dbus-slot:
   interface: dbus
   bus: system
   name: org.dbus-snap.system
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	slot := info.Slots["dbus-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestSanitizeSlotSession(c *C) {
-	var mockSnapYaml = []byte(`name: dbus-snap
+	var mockSnapYaml = `name: dbus-snap
 version: 1.0
 slots:
  dbus-slot:
   interface: dbus
   bus: session
   name: org.dbus-snap.session
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	slot := info.Slots["dbus-slot"]
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestSanitizePlugSystem(c *C) {
-	var mockSnapYaml = []byte(`name: dbus-snap
+	var mockSnapYaml = `name: dbus-snap
 version: 1.0
 plugs:
  dbus-plug:
   interface: dbus
   bus: system
   name: org.dbus-snap.system
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	plug := info.Plugs["dbus-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), IsNil)
 }
 
 func (s *DbusInterfaceSuite) TestSanitizePlugSession(c *C) {
-	var mockSnapYaml = []byte(`name: dbus-snap
+	var mockSnapYaml = `name: dbus-snap
 version: 1.0
 plugs:
  dbus-plug:
   interface: dbus
   bus: session
   name: org.dbus-snap.session
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	plug := info.Plugs["dbus-plug"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), IsNil)

--- a/interfaces/builtin/docker_support_test.go
+++ b/interfaces/builtin/docker_support_test.go
@@ -172,16 +172,15 @@ apps:
 }
 
 func (s *DockerSupportInterfaceSuite) TestSanitizePlugWithPrivilegedBad(c *C) {
-	var mockSnapYaml = []byte(`name: docker
+	var mockSnapYaml = `name: docker
 version: 1.0
 plugs:
  privileged:
   interface: docker-support
   privileged-containers: bad
-`)
+`
 
-	info, err := snap.InfoFromSnapYaml(mockSnapYaml)
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
 
 	plug := info.Plugs["privileged"]
 	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), ErrorMatches, "docker-support plug requires bool with 'privileged-containers'")

--- a/interfaces/connection_test.go
+++ b/interfaces/connection_test.go
@@ -24,9 +24,11 @@ import (
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type connSuite struct {
+	testutil.BaseTest
 	plug *snap.PlugInfo
 	slot *snap.SlotInfo
 }
@@ -34,6 +36,8 @@ type connSuite struct {
 var _ = Suite(&connSuite{})
 
 func (s *connSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 	consumer := snaptest.MockInfo(c, `
 name: consumer
 version: 0
@@ -56,6 +60,10 @@ slots:
         attr: value
 `, nil)
 	s.slot = producer.Slots["slot"]
+}
+
+func (s *connSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 }
 
 // Make sure ConnectedPlug,ConnectedSlot, PlugInfo, SlotInfo implement Attrer.

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -29,15 +29,27 @@ import (
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func Test(t *testing.T) {
 	TestingT(t)
 }
 
-type CoreSuite struct{}
+type CoreSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&CoreSuite{})
+
+func (s *CoreSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *CoreSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
 
 func (s *CoreSuite) TestValidateName(c *C) {
 	validNames := []string{

--- a/interfaces/ifacetest/backendtest.go
+++ b/interfaces/ifacetest/backendtest.go
@@ -29,10 +29,11 @@ import (
 )
 
 type BackendSuite struct {
-	Backend interfaces.SecurityBackend
-	Repo    *interfaces.Repository
-	Iface   *TestInterface
-	RootDir string
+	Backend         interfaces.SecurityBackend
+	Repo            *interfaces.Repository
+	Iface           *TestInterface
+	RootDir         string
+	restoreSanitize func()
 }
 
 func (s *BackendSuite) SetUpTest(c *C) {
@@ -44,10 +45,13 @@ func (s *BackendSuite) SetUpTest(c *C) {
 	s.Iface = &TestInterface{InterfaceName: "iface"}
 	err := s.Repo.AddInterface(s.Iface)
 	c.Assert(err, IsNil)
+
+	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 }
 
 func (s *BackendSuite) TearDownTest(c *C) {
 	dirs.SetRootDir("/")
+	s.restoreSanitize()
 }
 
 // Tests for Setup() and Remove()

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -37,13 +37,19 @@ import (
 )
 
 type baseDeclSuite struct {
-	baseDecl *asserts.BaseDeclaration
+	baseDecl        *asserts.BaseDeclaration
+	restoreSanitize func()
 }
 
 var _ = Suite(&baseDeclSuite{})
 
 func (s *baseDeclSuite) SetUpSuite(c *C) {
+	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 	s.baseDecl = asserts.BuiltinBaseDeclaration()
+}
+
+func (s *baseDeclSuite) TearDownSuite(c *C) {
+	s.restoreSanitize()
 }
 
 func (s *baseDeclSuite) connectCand(c *C, iface, slotYaml, plugYaml string) *policy.ConnectCandidate {

--- a/interfaces/policy/policy_test.go
+++ b/interfaces/policy/policy_test.go
@@ -45,11 +45,14 @@ type policySuite struct {
 
 	randomSnap *snap.Info
 	randomDecl *asserts.SnapDeclaration
+
+	restoreSanitize func()
 }
 
 var _ = Suite(&policySuite{})
 
 func (s *policySuite) SetUpSuite(c *C) {
+	s.restoreSanitize = snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 	a, err := asserts.Decode([]byte(`type: base-declaration
 authority-id: canonical
 series: 16
@@ -702,6 +705,10 @@ sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQ
 AXNpZw==`))
 	c.Assert(err, IsNil)
 	s.randomDecl = a.(*asserts.SnapDeclaration)
+}
+
+func (s *policySuite) TearDownSuite(c *C) {
+	s.restoreSanitize()
 }
 
 func (s *policySuite) TestBaselineDefaultIsAllow(c *C) {

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 type RepositorySuite struct {
+	testutil.BaseTest
 	iface     Interface
 	plug      *snap.PlugInfo
 	slot      *snap.SlotInfo
@@ -48,6 +49,9 @@ var _ = Suite(&RepositorySuite{
 })
 
 func (s *RepositorySuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+
 	consumer := snaptest.MockInfo(c, `
 name: consumer
 version: 0
@@ -91,6 +95,10 @@ slots:
 	s.testRepo = NewRepository()
 	err := s.testRepo.AddInterface(s.iface)
 	c.Assert(err, IsNil)
+}
+
+func (s *RepositorySuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 }
 
 func addPlugsSlots(c *C, repo *Repository, yamls ...string) []*snap.Info {
@@ -1488,12 +1496,16 @@ plugs:
 // Tests for AddSnap and RemoveSnap
 
 type AddRemoveSuite struct {
+	testutil.BaseTest
 	repo *Repository
 }
 
 var _ = Suite(&AddRemoveSuite{})
 
 func (s *AddRemoveSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+
 	s.repo = NewRepository()
 	err := s.repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "iface"})
 	c.Assert(err, IsNil)
@@ -1503,6 +1515,10 @@ func (s *AddRemoveSuite) SetUpTest(c *C) {
 		BeforePrepareSlotCallback: func(slot *snap.SlotInfo) error { return fmt.Errorf("slot is invalid") },
 	})
 	c.Assert(err, IsNil)
+}
+
+func (s *AddRemoveSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 }
 
 const testConsumerYaml = `
@@ -1632,6 +1648,7 @@ func (s *AddRemoveSuite) TestRemoveSnapErrorsOnStillConnectedSlot(c *C) {
 }
 
 type DisconnectSnapSuite struct {
+	testutil.BaseTest
 	repo   *Repository
 	s1, s2 *snap.Info
 }
@@ -1639,6 +1656,9 @@ type DisconnectSnapSuite struct {
 var _ = Suite(&DisconnectSnapSuite{})
 
 func (s *DisconnectSnapSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+
 	s.repo = NewRepository()
 
 	err := s.repo.AddInterface(&ifacetest.TestInterface{InterfaceName: "iface-a"})
@@ -1668,6 +1688,10 @@ slots:
 	c.Assert(err, IsNil)
 	err = s.repo.AddSnap(s.s2)
 	c.Assert(err, IsNil)
+}
+
+func (s *DisconnectSnapSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 }
 
 func (s *DisconnectSnapSuite) TestNotConnected(c *C) {

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -747,6 +747,10 @@ slots:
 	err = assertstate.Add(st, snapDecl)
 	c.Assert(err, IsNil)
 
+	// mock SanitizePlugsSlots so that unknown interfaces are not rejected
+	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	defer restoreSanitize()
+
 	ts, err := snapstate.InstallPath(st, si, snapPath, "", snapstate.Flags{DevMode: true})
 	c.Assert(err, IsNil)
 	chg := st.NewChange("install-snap", "...")

--- a/overlord/snapstate/backend/backend_test.go
+++ b/overlord/snapstate/backend/backend_test.go
@@ -29,13 +29,13 @@ import (
 	"github.com/snapcore/snapd/snap/squashfs"
 
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
+	"github.com/snapcore/snapd/testutil"
 )
 
 func TestBackend(t *testing.T) { TestingT(t) }
 
 func makeTestSnap(c *C, snapYamlContent string) string {
-	info, err := snap.InfoFromSnapYaml([]byte(snapYamlContent))
-	c.Assert(err, IsNil)
+	info := snaptest.MockInfo(c, snapYamlContent, nil)
 	var files [][]string
 	for _, app := range info.Apps {
 		// files is a list of (filename, content)
@@ -44,9 +44,20 @@ func makeTestSnap(c *C, snapYamlContent string) string {
 	return snaptest.MakeTestSnapWithFiles(c, snapYamlContent, files)
 }
 
-type backendSuite struct{}
+type backendSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&backendSuite{})
+
+func (s *backendSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *backendSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
 
 func (s *backendSuite) TestOpenSnapFile(c *C) {
 	const yaml = `name: hello

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -40,6 +40,7 @@ import (
 )
 
 type setupSuite struct {
+	testutil.BaseTest
 	be                backend.Backend
 	umount            *testutil.MockCmd
 	systemctlRestorer func()
@@ -48,6 +49,9 @@ type setupSuite struct {
 var _ = Suite(&setupSuite{})
 
 func (s *setupSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+
 	dirs.SetRootDir(c.MkDir())
 
 	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc", "systemd", "system", "multi-user.target.wants"), 0755)
@@ -61,6 +65,7 @@ func (s *setupSuite) SetUpTest(c *C) {
 }
 
 func (s *setupSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 	dirs.SetRootDir("")
 	partition.ForceBootloader(nil)
 	s.umount.Restore()

--- a/snap/container_test.go
+++ b/snap/container_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapdir"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 type FileSuite struct{}
@@ -55,12 +57,22 @@ func (s *FileSuite) TestFileOpenForSnapDirErrors(c *C) {
 }
 
 type validateSuite struct {
+	testutil.BaseTest
 	log func(string, ...interface{})
 }
 
 var _ = Suite(&validateSuite{})
 
 func discard(string, ...interface{}) {}
+
+func (s *validateSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *validateSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
 
 func (s *validateSuite) TestValidateContainerReallyEmptyFails(c *C) {
 	const yaml = `name: empty-snap

--- a/snap/info.go
+++ b/snap/info.go
@@ -731,8 +731,6 @@ func ReadInfo(name string, si *SideInfo) (*Info, error) {
 		return nil, err
 	}
 
-	SanitizePlugsSlots(info)
-
 	return info, nil
 }
 

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -180,6 +180,7 @@ func InfoFromSnapYaml(yamlData []byte) (*Info, error) {
 	snap.renameClashingCorePlugs()
 
 	snap.BadInterfaces = make(map[string]string)
+	SanitizePlugsSlots(snap)
 
 	// FIXME: validation of the fields
 	return snap, nil

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -29,12 +29,16 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timeout"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 // Hook up check.v1 into the "go test" runner
 func Test(t *testing.T) { TestingT(t) }
 
-type InfoSnapYamlTestSuite struct{}
+type InfoSnapYamlTestSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&InfoSnapYamlTestSuite{})
 
@@ -42,6 +46,15 @@ var mockYaml = []byte(`name: foo
 version: 1.0
 type: app
 `)
+
+func (s *InfoSnapYamlTestSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *InfoSnapYamlTestSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
 
 func (s *InfoSnapYamlTestSuite) TestSimple(c *C) {
 	info, err := snap.InfoFromSnapYaml(mockYaml)
@@ -58,16 +71,20 @@ func (s *InfoSnapYamlTestSuite) TestFail(c *C) {
 
 type YamlSuite struct {
 	restore func()
+	testutil.BaseTest
 }
 
 var _ = Suite(&YamlSuite{})
 
 func (s *YamlSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 	hookType := snap.NewHookType(regexp.MustCompile(".*"))
 	s.restore = snap.MockSupportedHookTypes([]*snap.HookType{hookType})
 }
 
 func (s *YamlSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 	s.restore()
 }
 

--- a/snap/pack/pack_test.go
+++ b/snap/pack/pack_test.go
@@ -48,6 +48,7 @@ var _ = Suite(&packSuite{})
 
 func (s *packSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 
 	// chdir into a tempdir
 	pwd, err := os.Getwd()
@@ -58,6 +59,10 @@ func (s *packSuite) SetUpTest(c *C) {
 
 	// use fake root
 	dirs.SetRootDir(c.MkDir())
+}
+
+func (s *packSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 }
 
 func makeExampleSnapSourceDir(c *C, snapYamlContent string) string {

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -68,6 +68,15 @@ var mockClassicSnapInfo = &snap.Info{
 	Confinement: snap.ClassicConfinement,
 }
 
+func (s *HTestSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *HTestSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
+
 func (ts *HTestSuite) TestBasic(c *C) {
 	env := basicEnv(mockSnapInfo)
 

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -40,6 +40,9 @@ import (
 func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	c.Assert(sideInfo, check.Not(check.IsNil))
 
+	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	defer restoreSanitize()
+
 	// Parse the yaml (we need the Name).
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(yamlText))
 	c.Assert(err, check.IsNil)
@@ -75,8 +78,8 @@ func MockInfo(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	}
 
 	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	defer restoreSanitize()
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(yamlText))
-	restoreSanitize()
 	c.Assert(err, check.IsNil)
 	snapInfo.SideInfo = *sideInfo
 	err = snap.Validate(snapInfo)
@@ -92,6 +95,9 @@ func MockInvalidInfo(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap
 	if sideInfo == nil {
 		sideInfo = &snap.SideInfo{}
 	}
+
+	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	defer restoreSanitize()
 
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(yamlText))
 	c.Assert(err, check.IsNil)
@@ -136,6 +142,9 @@ func MakeTestSnapWithFiles(c *check.C, snapYamlContent string, files [][]string)
 	}
 
 	PopulateDir(snapSource, files)
+
+	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	defer restoreSanitize()
 
 	err = osutil.ChDir(snapSource, func() error {
 		var err error

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -74,7 +74,9 @@ func MockInfo(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 		sideInfo = &snap.SideInfo{}
 	}
 
+	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
 	snapInfo, err := snap.InfoFromSnapYaml([]byte(yamlText))
+	restoreSanitize()
 	c.Assert(err, check.IsNil)
 	snapInfo.SideInfo = *sideInfo
 	err = snap.Validate(snapInfo)

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -27,9 +27,13 @@ import (
 	. "gopkg.in/check.v1"
 
 	. "github.com/snapcore/snapd/snap"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
-type ValidateSuite struct{}
+type ValidateSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&ValidateSuite{})
 
@@ -53,6 +57,15 @@ func createSampleApp() *AppInfo {
 	}
 	socket.App = app
 	return app
+}
+
+func (s *ValidateSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(MockSanitizePlugsSlots(func(snapInfo *Info) {}))
+}
+
+func (s *ValidateSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 }
 
 func (s *ValidateSuite) TestValidateName(c *C) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -349,6 +349,9 @@ func createTestDevice() *auth.DeviceState {
 }
 
 func (s *storeTestSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+
 	s.store = New(nil, nil)
 	s.origDownloadFunc = download
 	dirs.SetRootDir(c.MkDir())
@@ -385,6 +388,7 @@ func (s *storeTestSuite) TearDownTest(c *C) {
 	download = s.origDownloadFunc
 	s.mockXDelta.Restore()
 	s.restoreLogger()
+	s.BaseTest.TearDownTest(c)
 }
 
 func (s *storeTestSuite) expectedAuthorization(c *C, user *auth.UserState) string {

--- a/tests/lib/fakestore/store/store.go
+++ b/tests/lib/fakestore/store/store.go
@@ -180,6 +180,9 @@ func snapEssentialInfo(w http.ResponseWriter, fn, snapID string, bs asserts.Back
 		return nil, errInfo
 	}
 
+	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	defer restoreSanitize()
+
 	info, err := snap.ReadInfoFromSnapFile(snapFile, nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("can get info for: %v: %v", fn, err), 400)
@@ -311,6 +314,9 @@ func (s *Store) collectSnaps() (map[string]string, error) {
 	}
 
 	snaps := map[string]string{}
+
+	restoreSanitize := snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+	defer restoreSanitize()
 
 	for _, fn := range snapFns {
 		snapFile, err := snap.Open(fn)

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 type desktopSuite struct {
+	testutil.BaseTest
 	tempdir string
 
 	mockUpdateDesktopDatabase *testutil.MockCmd
@@ -44,6 +45,8 @@ type desktopSuite struct {
 var _ = Suite(&desktopSuite{})
 
 func (s *desktopSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
 	s.tempdir = c.MkDir()
 	dirs.SetRootDir(s.tempdir)
 
@@ -51,6 +54,7 @@ func (s *desktopSuite) SetUpTest(c *C) {
 }
 
 func (s *desktopSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
 	s.mockUpdateDesktopDatabase.Restore()
 	dirs.SetRootDir("")
 }
@@ -133,9 +137,20 @@ func (s *desktopSuite) TestAddPackageDesktopFilesCleanup(c *C) {
 
 // sanitize
 
-type sanitizeDesktopFileSuite struct{}
+type sanitizeDesktopFileSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&sanitizeDesktopFileSuite{})
+
+func (s *sanitizeDesktopFileSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *sanitizeDesktopFileSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
 
 func (s *sanitizeDesktopFileSuite) TestSanitizeIgnoreNotWhitelisted(c *C) {
 	snap := &snap.Info{SideInfo: snap.SideInfo{RealName: "foo", Revision: snap.R(12)}}

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -29,11 +29,14 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
 	"github.com/snapcore/snapd/timeout"
 	"github.com/snapcore/snapd/wrappers"
 )
 
-type servicesWrapperGenSuite struct{}
+type servicesWrapperGenSuite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&servicesWrapperGenSuite{})
 
@@ -92,6 +95,15 @@ Type=%s
 %s`
 	expectedTypeForkingWrapper = fmt.Sprintf(expectedServiceWrapperFmt, mountUnitPrefix, mountUnitPrefix, "forking", "\n[Install]\nWantedBy=multi-user.target\n")
 )
+
+func (s *servicesWrapperGenSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *servicesWrapperGenSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
 
 func (s *servicesWrapperGenSuite) TestGenerateSnapServiceFile(c *C) {
 	yamlText := `


### PR DESCRIPTION
This is #4890 backported to 2.32 - there was one conflict so this cannot be cherry-picked.