### PR TITLE
cmd/snap-confine: fix ptrace rule with snap-confine peer (2.32)

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -365,7 +365,7 @@
 
     # workaround for linux 4.13/upstream, see
     # https://forum.snapcraft.io/t/snapd-2-27-6-2-in-debian-sid-blocked-on-apparmor-in-kernel-4-13-0-1/2813/3
-    ptrace (trace, tracedby) peer=@LIBEXECDIR@/snapd/snap-confine,
+    ptrace (trace, tracedby) peer=@LIBEXECDIR@/snap-confine,
 
     # For aa_change_hat() to go into ^mount-namespace-capture-helper
     @{PROC}/[0-9]*/attr/current w,


### PR DESCRIPTION
The current autotools and build setup assumes that LIBEXECDIR=$(libexec)/snapd.
The rule ended up incorrectly pointing to /usr/lib/snapd/snapd/snap-confine.

Signed-off-by: Maciej Borzecki <maciej.zenon.borzecki@canonical.com>

Backport of #4875 for 2.32
