### PR TITLE
cmd/snap-update-ns: use x-snapd.{synthetic,needed-by} in practice (2.32)

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -94,7 +94,7 @@ func (c *Change) createPath(path string, pokeHoles bool) ([]*Change, error) {
 	if err2, ok := err.(*ReadOnlyFsError); ok && pokeHoles {
 		// If the writing failed because the underlying file-system is read-only
 		// we can construct a writable mimic to fix that.
-		changes, err = createWritableMimic(err2.Path)
+		changes, err = createWritableMimic(err2.Path, path)
 		if err != nil {
 			err = fmt.Errorf("cannot create writable mimic over %q: %s", err2.Path, err)
 		} else {

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -390,7 +390,10 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 	synth, err := chg.Perform()
 	c.Assert(err, IsNil)
 	c.Assert(synth, DeepEquals, []*update.Change{
-		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/rofs", Type: "tmpfs"}},
+		{Action: update.Mount, Entry: osutil.MountEntry{
+			Name: "tmpfs", Dir: "/rofs", Type: "tmpfs",
+			Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/rofs/target"}},
+		},
 	})
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		// sniff mount target
@@ -746,7 +749,10 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyB
 	synth, err := chg.Perform()
 	c.Assert(err, IsNil)
 	c.Assert(synth, DeepEquals, []*update.Change{
-		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/rofs", Type: "tmpfs"}},
+		{Action: update.Mount, Entry: osutil.MountEntry{
+			Name: "tmpfs", Dir: "/rofs", Type: "tmpfs",
+			Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/rofs/target"}},
+		},
 	})
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		// sniff mount target
@@ -1021,7 +1027,10 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPointAndReadOnlyBase(c
 	synth, err := chg.Perform()
 	c.Assert(err, IsNil)
 	c.Assert(synth, DeepEquals, []*update.Change{
-		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/rofs", Type: "tmpfs"}},
+		{Action: update.Mount, Entry: osutil.MountEntry{
+			Name: "tmpfs", Dir: "/rofs", Type: "tmpfs",
+			Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/rofs/target"}},
+		},
 	})
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		// sniff mount target
@@ -1253,7 +1262,10 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 	synth, err := chg.Perform()
 	c.Assert(err, IsNil)
 	c.Assert(synth, DeepEquals, []*update.Change{
-		{Action: update.Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: "/rofs", Type: "tmpfs"}},
+		{Action: update.Mount, Entry: osutil.MountEntry{
+			Name: "tmpfs", Dir: "/rofs", Type: "tmpfs",
+			Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/rofs/name"}},
+		},
 	})
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		// sniff symlink name

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -319,7 +319,7 @@ func secureMklinkAll(name string, perm os.FileMode, uid sys.UserID, gid sys.Grou
 // be used with. Since the original directory is hidden the algorithm relies on
 // a temporary directory where the original is bind-mounted during the
 // progression of the algorithm.
-func planWritableMimic(dir string) ([]*Change, error) {
+func planWritableMimic(dir, neededBy string) ([]*Change, error) {
 	// We need a place for "safe keeping" of what is present in the original
 	// directory as we are about to attach a tmpfs there, which will hide
 	// everything inside.
@@ -349,7 +349,10 @@ func planWritableMimic(dir string) ([]*Change, error) {
 	})
 	// Mount tmpfs over the original directory, hiding its contents.
 	changes = append(changes, &Change{
-		Action: Mount, Entry: osutil.MountEntry{Name: "tmpfs", Dir: dir, Type: "tmpfs"},
+		Action: Mount, Entry: osutil.MountEntry{
+			Name: "tmpfs", Dir: dir, Type: "tmpfs",
+			Options: []string{"x-snapd.synthetic", fmt.Sprintf("x-snapd.needed-by=%s", neededBy)},
+		},
 	})
 	// Iterate over the items in the original directory (nothing is mounted _yet_).
 	entries, err := ioutilReadDir(dir)
@@ -368,18 +371,21 @@ func planWritableMimic(dir string) ([]*Change, error) {
 		switch {
 		case m.IsDir():
 			ch.Entry.Options = []string{"rbind"}
-			changes = append(changes, ch)
 		case m.IsRegular():
 			ch.Entry.Options = []string{"bind", "x-snapd.kind=file"}
-			changes = append(changes, ch)
 		case m&os.ModeSymlink != 0:
 			if target, err := osReadlink(filepath.Join(dir, fi.Name())); err == nil {
 				ch.Entry.Options = []string{"x-snapd.kind=symlink", fmt.Sprintf("x-snapd.symlink=%s", target)}
-				changes = append(changes, ch)
+			} else {
+				continue
 			}
 		default:
 			logger.Noticef("skipping unsupported file %s", fi)
+			continue
 		}
+		ch.Entry.Options = append(ch.Entry.Options, "x-snapd.synthetic")
+		ch.Entry.Options = append(ch.Entry.Options, fmt.Sprintf("x-snapd.needed-by=%s", neededBy))
+		changes = append(changes, ch)
 	}
 	// Finally unbind the safe-keeping directory as we don't need it anymore.
 	changes = append(changes, &Change{
@@ -490,8 +496,8 @@ func execWritableMimic(plan []*Change) ([]*Change, error) {
 	return undoChanges, nil
 }
 
-func createWritableMimic(dir string) ([]*Change, error) {
-	plan, err := planWritableMimic(dir)
+func createWritableMimic(dir, neededBy string) ([]*Change, error) {
+	plan, err := planWritableMimic(dir, neededBy)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -18,40 +18,48 @@ debug: |
     # Once per-snap update-ns profiles are here.
     cat /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-layout || :
 execute: |
-    echo "snap declaring layouts doesn't explode on startup"
-    test-snapd-layout.sh -c "true"
-    
-    echo "layout declarations are honored"
+    . $TESTSLIB/snaps.sh
+    for i in $(seq 2); do
+        if [ "$i" -eq 2 ]; then
+            echo "The snap works across refreshes"
+            install_local test-snapd-layout
+        fi
 
-    test-snapd-layout.sh -c "test -d /etc/demo"
-    test-snapd-layout.sh -c "test -f /etc/demo.conf"
-    test-snapd-layout.sh -c "test -h /etc/demo.cfg"
-    test "$(test-snapd-layout.sh -c "readlink /etc/demo.cfg")" = "$(test-snapd-layout.sh -c 'echo $SNAP_COMMON/etc/demo.conf')"
-    test-snapd-layout.sh -c "test -d /usr/share/demo"
-    test-snapd-layout.sh -c "test -d /var/lib/demo"
-    test-snapd-layout.sh -c "test -d /var/cache/demo"
-    test-snapd-layout.sh -c "test -d /opt/demo"
+        echo "snap declaring layouts doesn't explode on startup"
+        test-snapd-layout.sh -c "true"
 
-    echo "layout locations pointing to SNAP_DATA and SNAP_COMMON are writable"
-    echo "and the writes go to the right place in the backing store"
+        echo "layout declarations are honored"
 
-    test-snapd-layout.sh -c "echo foo-1 > /etc/demo/writable"
-    test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo/writable')" = "foo-1"
+        test-snapd-layout.sh -c "test -d /etc/demo"
+        test-snapd-layout.sh -c "test -f /etc/demo.conf"
+        test-snapd-layout.sh -c "test -h /etc/demo.cfg"
+        test "$(test-snapd-layout.sh -c "readlink /etc/demo.cfg")" = "$(test-snapd-layout.sh -c 'echo $SNAP_COMMON/etc/demo.conf')"
+        test-snapd-layout.sh -c "test -d /usr/share/demo"
+        test-snapd-layout.sh -c "test -d /var/lib/demo"
+        test-snapd-layout.sh -c "test -d /var/cache/demo"
+        test-snapd-layout.sh -c "test -d /opt/demo"
 
-    test-snapd-layout.sh -c "echo foo-2 > /etc/demo.conf"
-    test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo.conf')" = "foo-2"
+        echo "layout locations pointing to SNAP_DATA and SNAP_COMMON are writable"
+        echo "and the writes go to the right place in the backing store"
 
-    # NOTE: this is a symlink to demo.conf, effectively
-    test-snapd-layout.sh -c "echo foo-3 > /etc/demo.cfg"
-    test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo.conf')" = "foo-3"
+        test-snapd-layout.sh -c "echo foo-1 > /etc/demo/writable"
+        test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo/writable')" = "foo-1"
 
-    test-snapd-layout.sh -c "echo foo-4 > /var/lib/demo/writable"
-    test "$(test-snapd-layout.sh -c 'cat $SNAP_DATA/var/lib/demo/writable')" = "foo-4"
+        test-snapd-layout.sh -c "echo foo-2 > /etc/demo.conf"
+        test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo.conf')" = "foo-2"
 
-    test-snapd-layout.sh -c "echo foo-5 > /var/cache/demo/writable"
-    test "$(test-snapd-layout.sh -c 'cat $SNAP_DATA/var/cache/demo/writable')" = "foo-5"
+        # NOTE: this is a symlink to demo.conf, effectively
+        test-snapd-layout.sh -c "echo foo-3 > /etc/demo.cfg"
+        test "$(test-snapd-layout.sh -c 'cat $SNAP_COMMON/etc/demo.conf')" = "foo-3"
 
-    echo "layout locations pointing to SNAP are readable"
+        test-snapd-layout.sh -c "echo foo-4 > /var/lib/demo/writable"
+        test "$(test-snapd-layout.sh -c 'cat $SNAP_DATA/var/lib/demo/writable')" = "foo-4"
 
-    test-snapd-layout.sh -c "test -r /usr/share/demo/file"
-    test-snapd-layout.sh -c "test -r /opt/demo/file"
+        test-snapd-layout.sh -c "echo foo-5 > /var/cache/demo/writable"
+        test "$(test-snapd-layout.sh -c 'cat $SNAP_DATA/var/cache/demo/writable')" = "foo-5"
+
+        echo "layout locations pointing to SNAP are readable"
+
+        test-snapd-layout.sh -c "test -r /usr/share/demo/file"
+        test-snapd-layout.sh -c "test -r /opt/demo/file"
+    done


### PR DESCRIPTION
The mount diff/update mechanism had a simple idea on how to handle
updates when faced with synthesized mount entries. The synthetic mount
entries were tagged with the x-snapd.synthetic and
x-snapd.needed-by=something tags and the update mechanism would
understand them and keep the synthetic entires around for as long as the
real entry that referred to them was kept.

The problem is this was never really done in practice. The mimic code
never generated the tags. Thus mimic code would cause issues when
refreshing snaps.

This patch makes the prepareWritableMimic emit the right tags and
updates the tests to match. The spread test for layout is tweaked
to run twice.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>