### PR TITLE
many: backported fixes for layouts and symlinks (2.32)

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -135,9 +135,12 @@ func (c *Change) ensureTarget() ([]*Change, error) {
 				err = fmt.Errorf("cannot use %q as mount point: not a regular file", path)
 			}
 		case "symlink":
-			// When we want to create a symlink we just need the empty
-			// space so anything that is in the way is a problem.
-			err = fmt.Errorf("cannot create symlink in %q: existing file in the way", path)
+			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+				// Create path verifies the symlink or fails if it is not what we wanted.
+				_, err = c.createPath(path, false)
+			} else {
+				err = fmt.Errorf("cannot create symlink in %q: existing file in the way", path)
+			}
 		}
 	} else if os.IsNotExist(err) {
 		changes, err = c.createPath(path, true)

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -88,7 +88,7 @@ func (c *Change) createPath(path string, pokeHoles bool) ([]*Change, error) {
 		if target == "" {
 			err = fmt.Errorf("cannot create symlink with empty target")
 		} else {
-			err = secureMklinkAll(path, mode, uid, gid, target)
+			err = secureMksymlinkAll(path, mode, uid, gid, target)
 		}
 	}
 	if err2, ok := err.(*ReadOnlyFsError); ok && pokeHoles {

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -1172,24 +1172,24 @@ func (s *changeSuite) TestPerformCreateSymlink(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`lstat "/name"`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
+		`symlinkat "/oldname" 3 "name"`,
 		`close 3`,
-		`symlink "/name" -> "/oldname"`,
 	})
 }
 
 // Change.Perform wants to create a symlink but it fails.
 func (s *changeSuite) TestPerformCreateSymlinkWithError(c *C) {
 	s.sys.InsertFault(`lstat "/name"`, syscall.ENOENT)
-	s.sys.InsertFault(`symlink "/name" -> "/oldname"`, errTesting)
+	s.sys.InsertFault(`symlinkat "/oldname" 3 "name"`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
 	synth, err := chg.Perform()
-	c.Assert(err, ErrorMatches, `cannot create path "/name": testing`)
+	c.Assert(err, ErrorMatches, `cannot create path "/name": cannot create symlink "name": testing`)
 	c.Assert(synth, HasLen, 0)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`lstat "/name"`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
+		`symlinkat "/oldname" 3 "name"`,
 		`close 3`,
-		`symlink "/name" -> "/oldname"`,
 	})
 }
 
@@ -1218,9 +1218,9 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDir(c *C) {
 		`mkdirat 3 "base" 0755`,
 		`openat 3 "base" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
 		`fchown 4 0 0`,
-		`close 4`,
 		`close 3`,
-		`symlink "/base/name" -> "/oldname"`,
+		`symlinkat "/oldname" 4 "name"`,
+		`close 4`,
 	})
 }
 
@@ -1244,8 +1244,8 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirWithErrors(c *C) {
 func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C) {
 	s.sys.InsertFault(`lstat "/rofs/name"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "rofs" 0755`, syscall.EEXIST)
-	s.sys.InsertFault(`symlink "/rofs/name" -> "/oldname"`, syscall.EROFS, nil) // works on 2nd try
-	s.sys.InsertReadDirResult(`readdir "/rofs"`, nil)                           // pretend /rofs is empty.
+	s.sys.InsertFault(`symlinkat "/oldname" 4 "name"`, syscall.EROFS, nil) // works on 2nd try
+	s.sys.InsertReadDirResult(`readdir "/rofs"`, nil)                      // pretend /rofs is empty.
 	s.sys.InsertFault(`lstat "/tmp/.snap/rofs"`, syscall.ENOENT)
 	s.sys.InsertLstatResult(`lstat "/rofs"`, testutil.FileInfoDir)
 
@@ -1260,14 +1260,13 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 		`lstat "/rofs/name"`,
 
 		// create base name (/rofs)
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
+		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, // -> 3
 		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 4`,
+		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, // -> 4
 		`close 3`,
-
 		// create symlink
-		`symlink "/rofs/name" -> "/oldname"`,
+		`symlinkat "/oldname" 4 "name"`, // (inserted fault happens here)
+		`close 4`,
 
 		// error, read only filesystem, create a mimic
 		`readdir "/rofs"`,
@@ -1296,11 +1295,10 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
 		`mkdirat 3 "rofs" 0755`,
 		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 4`,
 		`close 3`,
-
 		// create symlink
-		`symlink "/rofs/name" -> "/oldname"`,
+		`symlinkat "/oldname" 4 "name"`, // (inserted fault happens here)
+		`close 4`,
 	})
 }
 

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -1314,6 +1314,48 @@ func (s *changeSuite) TestPerformCreateSymlinkWithFileInTheWay(c *C) {
 	})
 }
 
+// Change.Perform wants to create a symlink but a correct symlink is already present.
+func (s *changeSuite) TestPerformCreateSymlinkWithGoodSymlinkPresent(c *C) {
+	s.sys.InsertLstatResult(`lstat "/name"`, testutil.FileInfoSymlink)
+	s.sys.InsertFault(`symlinkat "/oldname" 3 "name"`, syscall.EEXIST)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{Mode: syscall.S_IFLNK})
+	s.sys.InsertReadlinkatResult(`readlinkat 4 "" <ptr>`, "/oldname")
+	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
+	synth, err := chg.Perform()
+	c.Assert(err, IsNil)
+	c.Assert(synth, HasLen, 0)
+	c.Assert(s.sys.Calls(), DeepEquals, []string{
+		`lstat "/name"`,
+		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,   // -> 3
+		`symlinkat "/oldname" 3 "name"`,                 // -> EEXIST
+		`openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, // -> 4
+		`fstat 4 <ptr>`,
+		`readlinkat 4 "" <ptr>`,
+		`close 3`,
+	})
+}
+
+// Change.Perform wants to create a symlink but a incorrect symlink is already present.
+func (s *changeSuite) TestPerformCreateSymlinkWithBadSymlinkPresent(c *C) {
+	s.sys.InsertLstatResult(`lstat "/name"`, testutil.FileInfoSymlink)
+	s.sys.InsertFault(`symlinkat "/oldname" 3 "name"`, syscall.EEXIST)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{Mode: syscall.S_IFLNK})
+	s.sys.InsertReadlinkatResult(`readlinkat 4 "" <ptr>`, "/evil")
+	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
+	synth, err := chg.Perform()
+	c.Assert(err, ErrorMatches, `cannot create path "/name": cannot create symbolic link "name": existing symbolic link in the way`)
+	c.Assert(synth, HasLen, 0)
+	c.Assert(s.sys.Calls(), DeepEquals, []string{
+		`lstat "/name"`,
+		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,   // -> 3
+		`symlinkat "/oldname" 3 "name"`,                 // -> EEXIST
+		`openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, // -> 4
+		`fstat 4 <ptr>`,
+		`readlinkat 4 "" <ptr>`,
+		`close 3`,
+	})
+}
+
 func (s *changeSuite) TestPerformRemoveSymlink(c *C) {
 	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "unused", Dir: "/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
 	synth, err := chg.Perform()

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"os"
+	"syscall"
 
 	. "gopkg.in/check.v1"
 
@@ -61,6 +62,7 @@ type SystemCalls interface {
 	Open(path string, flags int, mode uint32) (fd int, err error)
 	Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error)
 	Unmount(target string, flags int) error
+	Fstat(fd int, buf *syscall.Stat_t) error
 }
 
 // MockSystemCalls replaces real system calls with those of the argument.
@@ -79,6 +81,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	oldSysUnmount := sysUnmount
 	oldSysSymlinkat := sysSymlinkat
 	oldReadlinkat := sysReadlinkat
+	oldFstat := sysFstat
 
 	// override
 	osLstat = sc.Lstat
@@ -94,6 +97,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	sysUnmount = sc.Unmount
 	sysSymlinkat = sc.Symlinkat
 	sysReadlinkat = sc.Readlinkat
+	sysFstat = sc.Fstat
 
 	return func() {
 		// restore
@@ -110,6 +114,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 		sysUnmount = oldSysUnmount
 		sysSymlinkat = oldSysSymlinkat
 		sysReadlinkat = oldReadlinkat
+		sysFstat = oldFstat
 	}
 }
 

--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -35,11 +35,12 @@ var (
 	FreezeSnapProcesses = freezeSnapProcesses
 	ThawSnapProcesses   = thawSnapProcesses
 	// utils
-	PlanWritableMimic = planWritableMimic
-	ExecWritableMimic = execWritableMimic
-	SecureMkdirAll    = secureMkdirAll
-	SecureMkfileAll   = secureMkfileAll
-	SplitIntoSegments = splitIntoSegments
+	PlanWritableMimic  = planWritableMimic
+	ExecWritableMimic  = execWritableMimic
+	SecureMkdirAll     = secureMkdirAll
+	SecureMkfileAll    = secureMkfileAll
+	SecureMksymlinkAll = secureMksymlinkAll
+	SplitIntoSegments  = splitIntoSegments
 
 	// main
 	ComputeAndSaveChanges = computeAndSaveChanges
@@ -49,7 +50,8 @@ var (
 type SystemCalls interface {
 	Lstat(name string) (os.FileInfo, error)
 	ReadDir(dirname string) ([]os.FileInfo, error)
-	Symlink(oldname, newname string) error
+	Symlinkat(oldname string, dirfd int, newname string) error
+	Readlinkat(dirfd int, path string, buf []byte) (int, error)
 	Remove(name string) error
 
 	Close(fd int) error
@@ -75,7 +77,8 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	oldSysOpen := sysOpen
 	oldSysOpenat := sysOpenat
 	oldSysUnmount := sysUnmount
-	oldSysSymlink := sysSymlink
+	oldSysSymlinkat := sysSymlinkat
+	oldReadlinkat := sysReadlinkat
 
 	// override
 	osLstat = sc.Lstat
@@ -89,7 +92,8 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	sysOpen = sc.Open
 	sysOpenat = sc.Openat
 	sysUnmount = sc.Unmount
-	sysSymlink = sc.Symlink
+	sysSymlinkat = sc.Symlinkat
+	sysReadlinkat = sc.Readlinkat
 
 	return func() {
 		// restore
@@ -104,7 +108,8 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 		sysOpen = oldSysOpen
 		sysOpenat = oldSysOpenat
 		sysUnmount = oldSysUnmount
-		sysSymlink = oldSysSymlink
+		sysSymlinkat = oldSysSymlinkat
+		sysReadlinkat = oldReadlinkat
 	}
 }
 

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -222,10 +222,9 @@ func secureMkSymlink(fd int, segments []string, i int, oldname string) error {
 		switch err {
 		case syscall.EEXIST:
 			var objFd int
-			const O_PATH = 010000000
 			// If the file exists then just open it for examination.
 			// Maybe it's the symlink we were hoping to create.
-			objFd, err = sysOpenat(fd, segment, syscall.O_CLOEXEC|O_PATH|syscall.O_NOFOLLOW, 0)
+			objFd, err = sysOpenat(fd, segment, syscall.O_CLOEXEC|sys.O_PATH|syscall.O_NOFOLLOW, 0)
 			if err != nil {
 				return fmt.Errorf("cannot open existing file %q: %v", segment, err)
 			}

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -43,14 +43,16 @@ var (
 	osReadlink = os.Readlink
 	osRemove   = os.Remove
 
-	sysClose   = syscall.Close
-	sysMkdirat = syscall.Mkdirat
-	sysMount   = syscall.Mount
-	sysOpen    = syscall.Open
-	sysOpenat  = syscall.Openat
-	sysUnmount = syscall.Unmount
-	sysFchown  = sys.Fchown
-	sysSymlink = syscall.Symlink
+	sysClose      = syscall.Close
+	sysMkdirat    = syscall.Mkdirat
+	sysMount      = syscall.Mount
+	sysOpen       = syscall.Open
+	sysOpenat     = syscall.Openat
+	sysUnmount    = syscall.Unmount
+	sysFchown     = sys.Fchown
+	sysFstat      = syscall.Fstat
+	sysSymlinkat  = osutil.Symlinkat
+	sysReadlinkat = osutil.Readlinkat
 
 	ioutilReadDir = ioutil.ReadDir
 )
@@ -202,6 +204,63 @@ func secureMkFile(fd int, segments []string, i int, perm os.FileMode, uid sys.Us
 	return nil
 }
 
+// secureMkSymlink creates a symlink at i-th entry of absolute path represented by
+// segments. This function is meant to be used to create the leaf symlink.
+// Existing and identical symlinks are reused without errors.
+func secureMkSymlink(fd int, segments []string, i int, oldname string) error {
+	logger.Debugf("secure-mk-symlink %d %q %d %q", fd, segments, i, oldname)
+	segment := segments[i]
+	var err error
+
+	// Open the final path segment as a file. Try to create the file (so that
+	// we know if we need to chown it) but fall back to just opening an
+	// existing one.
+
+	// TODO: don't write links outside of tmpfs or $SNAP_{,USER_}{DATA,COMMON}
+	err = sysSymlinkat(oldname, fd, segment)
+	if err != nil {
+		switch err {
+		case syscall.EEXIST:
+			var objFd int
+			const O_PATH = 010000000
+			// If the file exists then just open it for examination.
+			// Maybe it's the symlink we were hoping to create.
+			objFd, err = sysOpenat(fd, segment, syscall.O_CLOEXEC|O_PATH|syscall.O_NOFOLLOW, 0)
+			if err != nil {
+				return fmt.Errorf("cannot open existing file %q: %v", segment, err)
+			}
+			var statBuf syscall.Stat_t
+			err = sysFstat(objFd, &statBuf)
+			if err != nil {
+				return fmt.Errorf("cannot inspect existing file %q: %v", segment, err)
+			}
+			if statBuf.Mode&syscall.S_IFLNK != syscall.S_IFLNK {
+				return fmt.Errorf("cannot create symbolic link %q: existing file in the way", segment)
+			}
+			var n int
+			buf := make([]byte, len(oldname)+2)
+			n, err = sysReadlinkat(objFd, "", buf)
+			if err != nil {
+				return fmt.Errorf("cannot read symbolic link %q: %v", segment, err)
+			}
+			if string(buf[:n]) != oldname {
+				return fmt.Errorf("cannot create symbolic link %q: existing symbolic link in the way", segment)
+			}
+			return nil
+		case syscall.EROFS:
+			// Treat EROFS specially: this is a hint that we have to poke a
+			// hole using tmpfs. The path below is the location where we
+			// need to poke the hole.
+			p := "/" + strings.Join(segments[:i], "/")
+			return &ReadOnlyFsError{Path: p}
+		default:
+			return fmt.Errorf("cannot create symlink %q: %v", segment, err)
+		}
+	}
+
+	return nil
+}
+
 func splitIntoSegments(name string) ([]string, error) {
 	if name != filepath.Clean(name) {
 		return nil, fmt.Errorf("cannot split unclean path %q", name)
@@ -294,16 +353,35 @@ func secureMkfileAll(name string, perm os.FileMode, uid sys.UserID, gid sys.Grou
 	return err
 }
 
-func secureMklinkAll(name string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, oldname string) error {
-	parent := filepath.Dir(name)
-	err := secureMkdirAll(parent, perm, uid, gid)
+func secureMksymlinkAll(name string, perm os.FileMode, uid sys.UserID, gid sys.GroupID, oldname string) error {
+	logger.Debugf("secure-mksymlink-all %q %q %d %d %q", name, perm, uid, gid, oldname)
+
+	// Only support absolute paths to avoid bugs in snap-confine when
+	// called from anywhere.
+	if !filepath.IsAbs(name) {
+		return fmt.Errorf("cannot create symlink with relative path: %q", name)
+	}
+	// Only support file names, not directory names.
+	if strings.HasSuffix(name, "/") {
+		return fmt.Errorf("cannot create non-file path: %q", name)
+	}
+
+	// Split the path into segments.
+	segments, err := splitIntoSegments(name)
 	if err != nil {
 		return err
 	}
-	// TODO: roll this uber securely like the code above does using linkat(2).
-	err = sysSymlink(oldname, name)
-	if err == syscall.EROFS {
-		return &ReadOnlyFsError{Path: parent}
+
+	// Create the prefix.
+	fd, err := secureMkPrefix(segments, perm, uid, gid)
+	if err != nil {
+		return err
+	}
+	defer sysClose(fd)
+
+	if len(segments) > 0 {
+		// Create the final segment as a symlink.
+		err = secureMkSymlink(fd, segments, len(segments)-1, oldname)
 	}
 	return err
 }

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -648,6 +648,48 @@ func (s *realSystemSuite) TestSecureMkfileAllForReal(c *C) {
 	c.Check(fi.Mode().Perm(), Equals, os.FileMode(0750))
 }
 
+// Check that we can actually create symlinks.
+// This doesn't test the chown logic as that requires root.
+func (s *realSystemSuite) TestSecureMksymlinkAllForReal(c *C) {
+	d := c.MkDir()
+
+	// Create symlink f1 that points to "oldname" and check that it
+	// is correct. Note that symlink permissions are always set to 0777
+	f1 := filepath.Join(d, "symlink")
+	err := update.SecureMksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "oldname")
+	c.Assert(err, IsNil)
+	fi, err := os.Lstat(f1)
+	c.Assert(err, IsNil)
+	c.Check(fi.Mode()&os.ModeSymlink, Equals, os.ModeSymlink)
+	c.Check(fi.Mode().Perm(), Equals, os.FileMode(0777))
+
+	target, err := os.Readlink(f1)
+	c.Assert(err, IsNil)
+	c.Check(target, Equals, "oldname")
+
+	// Create an identical symlink to see that it doesn't fail.
+	err = update.SecureMksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "oldname")
+	c.Assert(err, IsNil)
+
+	// Create a different symlink and see that it fails now
+	err = update.SecureMksymlinkAll(f1, 0755, sys.FlagID, sys.FlagID, "other")
+	c.Assert(err, ErrorMatches, `cannot create symbolic link "symlink": existing symbolic link in the way`)
+
+	// Create an file and check that it clashes with a symlink we attempt to create.
+	f2 := filepath.Join(d, "file")
+	err = update.SecureMkfileAll(f2, 0755, sys.FlagID, sys.FlagID)
+	c.Assert(err, IsNil)
+	err = update.SecureMksymlinkAll(f2, 0755, sys.FlagID, sys.FlagID, "oldname")
+	c.Assert(err, ErrorMatches, `cannot create symbolic link "file": existing file in the way`)
+
+	// Create an file and check that it clashes with a symlink we attempt to create.
+	f3 := filepath.Join(d, "dir")
+	err = update.SecureMkdirAll(f3, 0755, sys.FlagID, sys.FlagID)
+	c.Assert(err, IsNil)
+	err = update.SecureMksymlinkAll(f3, 0755, sys.FlagID, sys.FlagID, "oldname")
+	c.Assert(err, ErrorMatches, `cannot create symbolic link "dir": existing file in the way`)
+}
+
 func (s *utilsSuite) TestCleanTrailingSlash(c *C) {
 	// This is a sanity test for the use of filepath.Clean in secureMk{dir,file}All
 	c.Assert(filepath.Clean("/path/"), Equals, "/path")

--- a/osutil/sys_linux.go
+++ b/osutil/sys_linux.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Symlinkat is a direct pass-through to the symlinkat(2) system call.
+func Symlinkat(target string, dirfd int, linkpath string) error {
+	targetPtr, err := syscall.BytePtrFromString(target)
+	if err != nil {
+		return err
+	}
+	linkpathPtr, err := syscall.BytePtrFromString(linkpath)
+	if err != nil {
+		return err
+	}
+	_, _, errno := syscall.Syscall(syscall.SYS_SYMLINKAT, uintptr(unsafe.Pointer(targetPtr)), uintptr(dirfd), uintptr(unsafe.Pointer(linkpathPtr)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// Readlinkat is a direct pass-through to the readlinkat(2) system call.
+func Readlinkat(dirfd int, path string, buf []byte) (n int, err error) {
+	var zero uintptr
+
+	pathPtr, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	var bufPtr unsafe.Pointer
+	if len(buf) > 0 {
+		bufPtr = unsafe.Pointer(&buf[0])
+	} else {
+		bufPtr = unsafe.Pointer(&zero)
+	}
+	r0, _, errno := syscall.Syscall6(syscall.SYS_READLINKAT, uintptr(dirfd), uintptr(unsafe.Pointer(pathPtr)), uintptr(bufPtr), uintptr(len(buf)), 0, 0)
+	n = int(r0)
+	if errno != 0 {
+		return 0, errno
+	}
+	return n, nil
+}

--- a/osutil/sys_linux_test.go
+++ b/osutil/sys_linux_test.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+type sysSuite struct{}
+
+var _ = Suite(&sysSuite{})
+
+func (s *sysSuite) TestSymlinkatAndReadlinkat(c *C) {
+	// Create and open a temporary directory.
+	d := c.MkDir()
+	fd, err := syscall.Open(d, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	// Create a symlink relative to the directory file descriptor.
+	err = osutil.Symlinkat("target", fd, "linkpath")
+	c.Assert(err, IsNil)
+
+	// Ensure that the created file is a symlink.
+	fname := filepath.Join(d, "linkpath")
+	fi, err := os.Lstat(fname)
+	c.Assert(err, IsNil)
+	c.Assert(fi.Name(), Equals, "linkpath")
+	c.Assert(fi.Mode()&os.ModeSymlink, Equals, os.ModeSymlink)
+
+	// Ensure that the symlink target is correct.
+	target, err := os.Readlink(fname)
+	c.Assert(err, IsNil)
+	c.Assert(target, Equals, "target")
+
+	// Use readlinkat with a buffer that fits only part of the target path.
+	buf := make([]byte, 2)
+	n, err := osutil.Readlinkat(fd, "linkpath", buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 2)
+	c.Assert(buf, DeepEquals, []byte{'t', 'a'})
+
+	// Use a buffer that fits all of the target path.
+	buf = make([]byte, 100)
+	n, err = osutil.Readlinkat(fd, "linkpath", buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, len("target"))
+	c.Assert(buf[:n], DeepEquals, []byte{'t', 'a', 'r', 'g', 'e', 't'})
+}

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -90,6 +90,10 @@ func formatOpenFlags(flags int) string {
 		flags ^= syscall.O_EXCL
 		fl = append(fl, "O_EXCL")
 	}
+	if flags&sys.O_PATH != 0 {
+		flags ^= sys.O_PATH
+		fl = append(fl, "O_PATH")
+	}
 	if flags != 0 {
 		panic(fmt.Errorf("unrecognized open flags %d", flags))
 	}

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -159,8 +159,9 @@ type SyscallRecorder struct {
 	calls []string
 	// Error function for a given system call.
 	errors map[string]func() error
-	// pre-arranged result of lstat and readdir calls
+	// pre-arranged result of lstat, fstat and readdir calls.
 	lstats   map[string]os.FileInfo
+	fstats   map[string]syscall.Stat_t
 	readdirs map[string][]os.FileInfo
 	// allocated file descriptors
 	fds map[int]string
@@ -321,6 +322,30 @@ func (sys *SyscallRecorder) Lstat(name string) (os.FileInfo, error) {
 		return fi, nil
 	}
 	panic(fmt.Sprintf("one of InsertLstatResult() or InsertFault() for %s must be used", call))
+}
+
+// InsertFstatResult makes given subsequent call fstat return the specified stat buffer.
+func (sys *SyscallRecorder) InsertFstatResult(call string, buf syscall.Stat_t) {
+	if sys.fstats == nil {
+		sys.fstats = make(map[string]syscall.Stat_t)
+	}
+	sys.fstats[call] = buf
+}
+
+func (sys *SyscallRecorder) Fstat(fd int, buf *syscall.Stat_t) error {
+	call := fmt.Sprintf("fstat %d <ptr>", fd)
+	if _, ok := sys.fds[fd]; !ok {
+		sys.calls = append(sys.calls, call)
+		return fmt.Errorf("attempting to fstat with an invalid file descriptor %d", fd)
+	}
+	if err := sys.call(call); err != nil {
+		return err
+	}
+	if b, ok := sys.fstats[call]; ok {
+		*buf = b
+		return nil
+	}
+	panic(fmt.Sprintf("one of InsertFstatResult() or InsertFault() for %s must be used", call))
 }
 
 // InsertReadDirResult makes given subsequent call readdir return the specified fake file infos.

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -160,9 +160,10 @@ type SyscallRecorder struct {
 	// Error function for a given system call.
 	errors map[string]func() error
 	// pre-arranged result of lstat, fstat and readdir calls.
-	lstats   map[string]os.FileInfo
-	fstats   map[string]syscall.Stat_t
-	readdirs map[string][]os.FileInfo
+	lstats      map[string]os.FileInfo
+	fstats      map[string]syscall.Stat_t
+	readdirs    map[string][]os.FileInfo
+	readlinkats map[string]string
 	// allocated file descriptors
 	fds map[int]string
 }
@@ -370,6 +371,39 @@ func (sys *SyscallRecorder) ReadDir(dirname string) ([]os.FileInfo, error) {
 func (sys *SyscallRecorder) Symlink(oldname, newname string) error {
 	call := fmt.Sprintf("symlink %q -> %q", newname, oldname)
 	return sys.call(call)
+}
+
+func (sys *SyscallRecorder) Symlinkat(oldname string, dirfd int, newname string) error {
+	call := fmt.Sprintf("symlinkat %q %d %q", oldname, dirfd, newname)
+	if _, ok := sys.fds[dirfd]; !ok {
+		sys.calls = append(sys.calls, call)
+		return fmt.Errorf("attempting to symlinkat with an invalid file descriptor %d", dirfd)
+	}
+	return sys.call(call)
+}
+
+// InsertReadlinkatResult makes given subsequent call to readlinkat return the specified oldname.
+func (sys *SyscallRecorder) InsertReadlinkatResult(call, oldname string) {
+	if sys.readlinkats == nil {
+		sys.readlinkats = make(map[string]string)
+	}
+	sys.readlinkats[call] = oldname
+}
+
+func (sys *SyscallRecorder) Readlinkat(dirfd int, path string, buf []byte) (int, error) {
+	call := fmt.Sprintf("readlinkat %d %q <ptr>", dirfd, path)
+	if _, ok := sys.fds[dirfd]; !ok {
+		sys.calls = append(sys.calls, call)
+		return 0, fmt.Errorf("attempting to readlinkat with an invalid file descriptor %d", dirfd)
+	}
+	if err := sys.call(call); err != nil {
+		return 0, err
+	}
+	if oldname, ok := sys.readlinkats[call]; ok {
+		n := copy(buf, oldname)
+		return n, nil
+	}
+	panic(fmt.Sprintf("one of InsertReadlinkatResult() or InsertFault() for %s must be used", call))
 }
 
 func (sys *SyscallRecorder) Remove(name string) error {

--- a/testutil/lowlevel_test.go
+++ b/testutil/lowlevel_test.go
@@ -399,3 +399,80 @@ func (s *lowLevelSuite) TestRemoveFailure(c *C) {
 	c.Assert(err, ErrorMatches, "operation not permitted")
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`remove "file"`})
 }
+
+func (s *lowLevelSuite) TestSymlinkatBadFd(c *C) {
+	err := s.sys.Symlinkat("/old", 3, "new")
+	c.Assert(err, ErrorMatches, "attempting to symlinkat with an invalid file descriptor 3")
+	c.Assert(s.sys.Calls(), DeepEquals, []string{`symlinkat "/old" 3 "new"`})
+}
+
+func (s *lowLevelSuite) TestSymlinkatSuccess(c *C) {
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+	err = s.sys.Symlinkat("/old", fd, "new")
+	c.Assert(err, IsNil)
+	c.Assert(s.sys.Calls(), DeepEquals, []string{
+		`open "/foo" 0 0`,
+		`symlinkat "/old" 3 "new"`,
+	})
+}
+
+func (s *lowLevelSuite) TestSymlinkatFailure(c *C) {
+	s.sys.InsertFault(`symlinkat "/old" 3 "new"`, syscall.EPERM)
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+	err = s.sys.Symlinkat("/old", fd, "new")
+	c.Assert(err, ErrorMatches, "operation not permitted")
+	c.Assert(s.sys.Calls(), DeepEquals, []string{
+		`open "/foo" 0 0`,
+		`symlinkat "/old" 3 "new"`,
+	})
+}
+
+func (s *lowLevelSuite) TestReadlinkat(c *C) {
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+	buf := make([]byte, 10)
+	c.Assert(func() { s.sys.Readlinkat(fd, "new", buf) }, PanicMatches,
+		`one of InsertReadlinkatResult\(\) or InsertFault\(\) for readlinkat 3 "new" <ptr> must be used`)
+}
+
+func (s *lowLevelSuite) TestReadlinkatBadFd(c *C) {
+	buf := make([]byte, 10)
+	n, err := s.sys.Readlinkat(3, "new", buf)
+	c.Assert(err, ErrorMatches, "attempting to readlinkat with an invalid file descriptor 3")
+	c.Assert(n, Equals, 0)
+	c.Assert(s.sys.Calls(), DeepEquals, []string{`readlinkat 3 "new" <ptr>`})
+}
+
+func (s *lowLevelSuite) TestReadlinkatSuccess(c *C) {
+	s.sys.InsertReadlinkatResult(`readlinkat 3 "new" <ptr>`, "/old")
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+
+	// Buffer has enough room
+	buf := make([]byte, 10)
+	n, err := s.sys.Readlinkat(fd, "new", buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 4)
+	c.Assert(buf, DeepEquals, []byte{'/', 'o', 'l', 'd', 0, 0, 0, 0, 0, 0})
+
+	// Buffer is too short
+	buf = make([]byte, 2)
+	n, err = s.sys.Readlinkat(fd, "new", buf)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 2)
+	c.Assert(buf, DeepEquals, []byte{'/', 'o'})
+}
+
+func (s *lowLevelSuite) TestReadlinkatFailure(c *C) {
+	s.sys.InsertFault(`readlinkat 3 "new" <ptr>`, syscall.EPERM)
+	fd, err := s.sys.Open("/foo", syscall.O_RDONLY, 0)
+	c.Assert(err, IsNil)
+
+	buf := make([]byte, 10)
+	n, err := s.sys.Readlinkat(fd, "new", buf)
+	c.Assert(err, ErrorMatches, "operation not permitted")
+	c.Assert(n, Equals, 0)
+	c.Assert(buf, DeepEquals, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+}


### PR DESCRIPTION
This branch contains a number of cherry-picks for bugfixes related to symlinks
and layouts.  In a brief sense the symlinks are now created the same way files
and directories are, using openat(2) family of functions, some of which had to
be done directly using syscall.Syscall. There are support patches for testing
in the testutil package.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>