### PR TITLE
cmd/snap-confine: nvidia: add tls/libnvidia-tls.so* glob

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -99,6 +99,7 @@ static const char *nvidia_globs[] = {
 	"libnvidia-ml.so*",
 	"libnvidia-ptxjitcompiler.so*",
 	"libnvidia-tls.so*",
+	"tls/libnvidia-tls.so*",
 	"vdpau/libvdpau_nvidia.so*",
 };
 


### PR DESCRIPTION
Make sure that we pick up nvidia TLS libs otherwise applications using libGLX
will fail in most mysterious ways.

The problem was debugged in detail in this forum topic [1].

A simple test case using glxinfo would segfault both inside the snap mount namespace
and in chroot, the backtrace pointing back to pthread_mutex_lock():
```
   (gdb) bt
   #0  0x00007ffff7559fb4 in pthread_mutex_lock () from target:/lib/x86_64-linux-gnu/libc.so.6
   #1  0x00007ffff6f5eddb in mt_mutex_lock (mutex=0x7ffff71e5180 <dispatchLock>) at glvnd_pthread.c:317
   #2  0x00007ffff6f23f77 in LockDispatch () at GLdispatch.c:144
   #3  0x00007ffff6f24115 in __glDispatchNewVendorID () at GLdispatch.c:198
   #4  0x00007ffff7212607 in __glXLookupVendorByName (vendorName=0x60d160 "nvidia") at libglxmapping.c:442
   #5  0x00007ffff7213811 in __glXLookupVendorByScreen (dpy=0x60aab0, screen=0) at libglxmapping.c:574
   #6  0x00007ffff7213966 in __glXGetDynDispatch (dpy=0x60aab0, screen=0) at libglxmapping.c:608
   #7  0x00007ffff7209563 in glXChooseVisual (dpy=0x60aab0, screen=0, attrib_list=0x609200) at libglx.c:215
   #8  0x00007ffff7b89d58 in glXChooseVisual (dpy=0x60aab0, screen=0, attribList=0x609200) at g_libglglxwrapper.c:183
   #9  0x0000000000401741 in ?? ()
   #10 0x00007ffff7465830 in __libc_start_main () from target:/lib/x86_64-linux-gnu/libc.so.6
   #11 0x0000000000401ea9 in ?? ()
```

Further debugging revealed that this may be related to libc/pthread & TLS handling.

[1]. https://forum.snapcraft.io/t/nvidia-acceleration-on-chrome-and-firefox/4532/

