### PR TITLE
tests: change debug for layout test (2.32)

### DIFF
--- a/tests/main/layout/task.yaml
+++ b/tests/main/layout/task.yaml
@@ -10,13 +10,10 @@ prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-layout
 debug: |
-    # We saw some failures where it looked like we were confined by the most
-    # wrong thing imaginable. To get an idea what is going on let's show
-    # the profile we were using when the test fails.
-    # Before per-snap update-ns profiles are here.
-    cat /etc/apparmor.d/*snap.core.*.usr.lib.snapd.snap-confine* || :
-    # Once per-snap update-ns profiles are here.
-    cat /var/lib/snapd/apparmor/profiles/snap-update-ns.test-snapd-layout || :
+    ls -ld /etc || :
+    ls -ld /etc/demo || :
+    ls -ld /etc/demo.conf || :
+    ls -ld /etc/demo.cfg || :
 execute: |
     . $TESTSLIB/snaps.sh
     for i in $(seq 2); do


### PR DESCRIPTION
We still see a confusing error message sometimes, claiming that /etc
doesn't exist. Let's see if we can use the debug stanza to understand
that better.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>