### PR TITLE
advisor: deal with missing commands.db file

### DIFF
--- a/advisor/backend.go
+++ b/advisor/backend.go
@@ -20,12 +20,14 @@
 package advisor
 
 import (
+	"os"
 	"strings"
 	"time"
 
 	"github.com/snapcore/bolt"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 )
 
 var (
@@ -188,6 +190,9 @@ type boltFinder struct {
 
 // Open the database for reading.
 func Open() (Finder, error) {
+	if !osutil.FileExists(dirs.SnapCommandsDB) {
+		return nil, os.ErrNotExist
+	}
 	db, err := bolt.Open(dirs.SnapCommandsDB, 0644, &bolt.Options{
 		ReadOnly: true,
 		Timeout:  1 * time.Second,

--- a/advisor/cmdfinder.go
+++ b/advisor/cmdfinder.go
@@ -19,6 +19,10 @@
 
 package advisor
 
+import (
+	"os"
+)
+
 type Command struct {
 	Snap    string
 	Command string
@@ -26,6 +30,9 @@ type Command struct {
 
 func FindCommand(command string) ([]Command, error) {
 	finder, err := newFinder()
+	if err != nil && os.IsNotExist(err) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -79,6 +86,9 @@ func FindMisspelledCommand(command string) ([]Command, error) {
 		return nil, nil
 	}
 	finder, err := newFinder()
+	if err != nil && os.IsNotExist(err) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/advisor/cmdfinder_test.go
+++ b/advisor/cmdfinder_test.go
@@ -134,3 +134,20 @@ func (s *cmdfinderSuite) TestDumpCommands(c *C) {
 		"meh": {"foo", "bar"},
 	})
 }
+
+func (s *cmdfinderSuite) TestFindMissingCommandsDB(c *C) {
+	err := os.Remove(dirs.SnapCommandsDB)
+	c.Assert(err, IsNil)
+
+	cmds, err := advisor.FindMisspelledCommand("hello")
+	c.Assert(err, IsNil)
+	c.Check(cmds, HasLen, 0)
+
+	cmds, err = advisor.FindCommand("hello")
+	c.Assert(err, IsNil)
+	c.Check(cmds, HasLen, 0)
+
+	pkg, err := advisor.FindPackage("hello")
+	c.Assert(err, IsNil)
+	c.Check(pkg, IsNil)
+}

--- a/advisor/pkgfinder.go
+++ b/advisor/pkgfinder.go
@@ -19,6 +19,10 @@
 
 package advisor
 
+import (
+	"os"
+)
+
 type Package struct {
 	Snap    string
 	Summary string
@@ -26,6 +30,9 @@ type Package struct {
 
 func FindPackage(pkgName string) (*Package, error) {
 	finder, err := newFinder()
+	if err != nil && os.IsNotExist(err) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If the commands.db file is missing the various advisor commands
should simply return an empty result instead of an error.

See https://forum.snapcraft.io/t/var-cache-snapd-commands-db-permission-denied/4590/8
