### PR TITLE
interfaces: harden snap-update-ns profile (2.32)

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -157,9 +157,6 @@ static void sc_setup_mount_profiles(struct sc_apparmor *apparmor,
 		die("cannot fork to run snap-update-ns");
 	}
 	if (child == 0) {
-		// NOTE: This code is temporarily disabled for the 2.32 release so that
-		// we can approach this with less urgency for 2.33.
-#if 0
 		// We are the child, execute snap-update-ns under a dedicated profile.
 		char profile[PATH_MAX] = { 0 };
 		sc_must_snprintf(profile, sizeof profile, "snap-update-ns.%s",
@@ -167,7 +164,6 @@ static void sc_setup_mount_profiles(struct sc_apparmor *apparmor,
 		debug("launching snap-update-ns under per-snap profile %s",
 		      profile);
 		sc_maybe_aa_change_onexec(apparmor, profile);
-#endif
 		char *snap_name_copy SC_CLEANUP(sc_cleanup_string) = NULL;
 		snap_name_copy = strdup(snap_name);
 		if (snap_name_copy == NULL) {

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -446,20 +446,20 @@
     # from the distribution package. This is also the location used when using
     # the core/base snap on all-snap systems. The variants here represent
     # various locations of libexecdir across distributions.
-    /usr/lib{,exec,64}/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /usr/lib{,exec,64}/snapd/snap-update-ns r,
 
     # ...snap-confine is not, conceptually, re-executing and uses
     # snap-update-ns from the distribution package but we are already inside
     # the constructed mount namespace so we must traverse "hostfs". The
     # variants here represent various locations of libexecdir across
     # distributions.
-    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns r,
 
     # ..snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap. Note that the location of the core snap varies from
     # distribution to distribution. The variants here represent different
     # locations of snap mount directory across distributions.
-    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns Cxr -> snap_update_ns,
+    /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
 
     # ...snap-confine is, conceptually, re-executing and uses snap-update-ns
     # from the core snap but we are already inside the constructed mount
@@ -468,145 +468,5 @@
     # "natural" /snap mount entry but we have no control over that.  This is
     # reported as (LP: #1716339). The variants here represent different
     # locations of snap mount directory across distributions.
-	/var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns Cxr -> snap_update_ns,
-
-    profile snap_update_ns (attach_disconnected) {
-        # The next four rules mirror those above. We want to be able to read
-        # and map snap-update-ns into memory but it may come from a variety of places.
-        /usr/lib{,exec,64}/snapd/snap-update-ns mr,
-        /var/lib/snapd/hostfs/usr/lib{,exec,64}/snapd/snap-update-ns mr,
-        /{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
-        /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns mr,
-
-        # Allow reading the dynamic linker cache.
-        /etc/ld.so.cache r,
-        # Allow reading, mapping and executing the dynamic linker.
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}ld-*.so mrix,
-        # Allow reading and mapping various parts of the standard library and
-        # dynamically loaded nss modules and what not.
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libc{,-[0-9]*}.so* mr,
-        /{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libpthread{,-[0-9]*}.so* mr,
-
-        # Allow reading the command line (snap-update-ns uses it in pre-Go bootstrap code).
-        @{PROC}/@{pid}/cmdline r,
-
-        # Allow reading the os-release file (possibly a symlink to /usr/lib).
-        /{etc/,usr/lib/}os-release r,
-
-        # Allow creating/grabbing various snapd lock files.
-        /run/snapd/lock/*.lock rwk,
-
-        # Allow reading stored mount namespaces,
-        /run/snapd/ns/ r,
-        /run/snapd/ns/*.mnt r,
-
-        # Allow reading per-snap desired mount profiles. Those are written by
-        # snapd and represent the desired layout and content connections.
-        /var/lib/snapd/mount/snap.*.fstab r,
-
-        # Allow reading and writing actual per-snap mount profiles. Note that
-        # the second rule is generic to allow our tmpfile-rename approach to
-        # writing them. Those are written by snap-update-ns and represent the
-        # actual layout at a given moment.
-        /run/snapd/ns/*.fstab rw,
-        /run/snapd/ns/*.fstab.* rw,
-
-        # NOTE: at this stage the /snap directory is stable as we have called
-        # pivot_root already.
-
-        # Needed to perform mount/unmounts.
-        capability sys_admin,
-        # Needed for mimic construction.
-        capability chown,
-
-        # Allow freezing and thawing the per-snap cgroup freezers
-        /sys/fs/cgroup/freezer/snap.*/freezer.state rw,
-
-        # Support mount profiles via the content interface. This should correspond
-        # to permutations of $SNAP -> $SNAP for reading and $SNAP_{DATA,COMMON} ->
-        # $SNAP_{DATA,COMMON} for both reading and writing.
-        #
-        # Note that:
-        #   /snap/*/*/**
-        # is meant to mean:
-        #   /snap/$SNAP_NAME/$SNAP_REVISION/and-any-subdirectory
-        # but:
-        #   /var/snap/*/**
-        # is meant to mean:
-        #   /var/snap/$SNAP_NAME/$SNAP_REVISION/
-        mount options=(ro bind) /snap/*/** -> /snap/*/*/**,
-        mount options=(ro bind) /snap/*/** -> /var/snap/*/**,
-        mount options=(rw bind) /var/snap/*/** -> /var/snap/*/**,
-        mount options=(ro bind) /var/snap/*/** -> /var/snap/*/**,
-
-        # Allow creating missing mount directories under $SNAP_DATA.
-        #
-        # The "tree" of permissions is needed for SecureMkdirAll that uses
-        # open(..., O_NOFOLLOW) and mkdirat() using the resulting file
-        # descriptor.
-        / r,
-        /var/ r,
-        /var/snap/{,*/} r,
-        /var/snap/*/**/ rw,
-
-        # Allow creating placeholder directory in /tmp/.snap/ as support for
-        # the writable mimic code that can poke holes in arbitrary read-only
-        # places using tmpfs and bind mounts.
-        /tmp/ r,
-        /tmp/.snap/{,**} rw,
-        # Allow mounting/unmounting any part of $SNAP over to a temporary place
-        # in /tmp/.snap/ during the preparation of a writable mimic.
-        # FIXME: update this with per-snap snap-update-ns profiles
-        mount options=(bind, rw) /** -> /tmp/.snap/**,
-        mount options=(rbind, rw) /** -> /tmp/.snap/**,
-        # Allow mounting tmpfs over the original read-only directory.
-        # FIXME: update this with per-snap snap-update-ns profiles
-        mount fstype=tmpfs options=(rw) tmpfs -> /**,
-        # Allow bind mounting anything from the temporary place in /tmp/.snap/
-        # back to $SNAP/** (to re-construct the data that was there before).
-        # FIXME: update this with per-snap snap-update-ns profiles
-        mount options=(bind, rw) /tmp/.snap/** -> /**,
-        mount options=(rbind, rw) /tmp/.snap/** -> /**,
-        # Allow unmounting the temporary directory in /tmp once it is no longer
-        # necessary.
-        umount /tmp/.snap/**,
-        # Allow unmounting any of the above in case something fails and
-        # we start recovery.
-        umount /**,
-
-        # Allow creating missing directories anywhere under the root directory
-        # (but not in the root directory itself) where they need to be created
-        # as a mount point for layouts or for content sharing. This is a
-        # superset of other cases so they are removed
-        # FIXME: update this with per-snap snap-update-ns profiles
-        / r,
-        /** r,
-        /*/** w,
-
-        # Allow layouts to bind mount *from* $SNAP, $SNAP_DATA and $SNAP_COMMON
-        # *to* anywhere under the root directory. This is safe because the
-        # mounts happen inside an isolated mount namespace (but see below).
-        mount options=(bind) /snap/*/** -> /*/**,
-        mount options=(bind) /var/snap/*/** -> /*/**,
-        # As an exception, don't allow bind mounts to /media which has special
-        # sharing and propagates mount events outside of the snap namespace.
-        audit deny mount -> /media,
-
-        # Allow the content interface to bind fonts from the host filesystem
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
-        # Allow the desktop interface to bind fonts from the host filesystem
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /usr/share/fonts/,
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/local/share/fonts/ -> /usr/local/share/fonts/,
-        mount options=(ro bind) /var/lib/snapd/hostfs/var/cache/fontconfig/ -> /var/cache/fontconfig/,
-
-        # Allow unmounts matching possible mounts listed above.
-        umount /*/**,
-
-        # But we don't want anyone to touch /snap/bin
-        audit deny mount /snap/bin/** -> /**,
-        audit deny mount /** -> /snap/bin/**,
-
-        # Allow the content interface to bind fonts from the host filesystem
-        mount options=(ro bind) /var/lib/snapd/hostfs/usr/share/fonts/ -> /snap/*/*/**,
-    }
+    /var/lib/snapd/hostfs/{,var/lib/snapd/}snap/core/*/usr/lib/snapd/snap-update-ns r,
 }

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -271,7 +271,12 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	if err != nil {
 		return fmt.Errorf("cannot obtain apparmor specification for snap %q: %s", snapName, err)
 	}
-	spec.(*Specification).snapName = snapInfo.Name()
+
+	// Set the snapName for AddUpdateNS snippet.
+	//
+	// TODO: remove this along with Specification.snapName as it is not really
+	// needed in practice and the corresponding code can be simplified away.
+	spec.(*Specification).snapName = snapName
 	spec.(*Specification).AddSnapLayout(snapInfo)
 	spec.(*Specification).snapName = ""
 

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -271,7 +271,9 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	if err != nil {
 		return fmt.Errorf("cannot obtain apparmor specification for snap %q: %s", snapName, err)
 	}
+	spec.(*Specification).snapName = snapInfo.Name()
 	spec.(*Specification).AddSnapLayout(snapInfo)
+	spec.(*Specification).snapName = ""
 
 	// core on classic is special
 	if snapName == "core" && release.OnClassic && release.AppArmorLevel() != release.NoAppArmor {

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -145,7 +145,7 @@ func (spec *Specification) AddSnapLayout(si *snap.Info) {
 			WritableProfile(&buf, path)
 		case l.Symlink != "":
 			// Allow constructing writable mimic to symlink parent directory.
-			fmt.Fprintf(&buf, "  %s rwl,\n", path)
+			fmt.Fprintf(&buf, "  %s rw,\n", path)
 			WritableProfile(&buf, path)
 		}
 		spec.AddUpdateNS(buf.String())

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -20,7 +20,9 @@
 package apparmor
 
 import (
+	"bytes"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -85,14 +87,14 @@ func (spec *Specification) AddSnapLayout(si *snap.Info) {
 		return
 	}
 
-	// walk the layout elements in deterministic order, by mount point name
+	// Walk the layout elements in deterministic order, by mount point name.
 	paths := make([]string, 0, len(si.Layout))
 	for path := range si.Layout {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
 
-	// get tags describing all apps and hooks
+	// Get tags describing all apps and hooks.
 	tags := make([]string, 0, len(si.Apps)+len(si.Hooks))
 	for _, app := range si.Apps {
 		tags = append(tags, app.SecurityTag())
@@ -101,7 +103,7 @@ func (spec *Specification) AddSnapLayout(si *snap.Info) {
 		tags = append(tags, hook.SecurityTag())
 	}
 
-	// append layout snippets to all tags; the layout applies equally to the
+	// Append layout snippets to all tags; the layout applies equally to the
 	// entire snap as the entire snap uses one mount namespace.
 	if spec.snippets == nil {
 		spec.snippets = make(map[string][]string)
@@ -113,6 +115,127 @@ func (spec *Specification) AddSnapLayout(si *snap.Info) {
 		}
 		sort.Strings(spec.snippets[tag])
 	}
+	// Append update-ns snippets that allow constructing the layout.
+	for _, path := range paths {
+		var buf bytes.Buffer
+		l := si.Layout[path]
+		fmt.Fprintf(&buf, "  # Layout %s\n", l)
+		path := si.ExpandSnapVariables(l.Path)
+		switch {
+		case l.Bind != "":
+			bind := si.ExpandSnapVariables(l.Bind)
+			// Allow bind mounting the layout element.
+			fmt.Fprintf(&buf, "  mount options=(rbind, rw) %s/ -> %s/,\n", bind, path)
+			fmt.Fprintf(&buf, "  umount %s/,\n", path)
+			// Allow constructing writable mimic in both bind-mount source and mount point.
+			WritableProfile(&buf, path)
+			WritableProfile(&buf, bind)
+		case l.BindFile != "":
+			bindFile := si.ExpandSnapVariables(l.BindFile)
+			// Allow bind mounting the layout element.
+			fmt.Fprintf(&buf, "  mount options=(bind, rw) %s -> %s,\n", bindFile, path)
+			fmt.Fprintf(&buf, "  umount %s,\n", path)
+			// Allow constructing writable mimic in both bind-mount source and mount point.
+			WritableFileProfile(&buf, path)
+			WritableFileProfile(&buf, bindFile)
+		case l.Type == "tmpfs":
+			fmt.Fprintf(&buf, "  mount fstype=tmpfs tmpfs -> %s/,\n", path)
+			fmt.Fprintf(&buf, "  umount %s/,\n", path)
+			// Allow constructing writable mimic to mount point.
+			WritableProfile(&buf, path)
+		case l.Symlink != "":
+			// Allow constructing writable mimic to symlink parent directory.
+			fmt.Fprintf(&buf, "  %s rwl,\n", path)
+			WritableProfile(&buf, path)
+		}
+		spec.AddUpdateNS(buf.String())
+	}
+}
+
+func isProbablyWritable(path string) bool {
+	return strings.HasPrefix(path, "/var/snap/") || strings.HasPrefix(path, "/home/") || strings.HasPrefix(path, "/root/")
+}
+
+// WritableFileProfile writes a profile for snap-update-ns for making given file writable.
+func WritableFileProfile(buf *bytes.Buffer, path string) {
+	if path == "/" {
+		return
+	}
+	if isProbablyWritable(path) {
+		fmt.Fprintf(buf, "  # Writable file %s\n", path)
+		fmt.Fprintf(buf, "  %s rw,\n", path)
+		for p := parent(path); p != "/"; p = parent(p) {
+			fmt.Fprintf(buf, "  %s/ rw,\n", p)
+		}
+	} else {
+		parentPath := parent(path)
+		fmt.Fprintf(buf, "  # Writable mimic %s\n", parentPath)
+		// Allow setting the read-only directory aside via a bind mount.
+		fmt.Fprintf(buf, "  mount options=(rbind, rw) %s/ -> /tmp/.snap%s/,\n", parentPath, parentPath)
+		// Allow mounting tmpfs over the read-only directory.
+		fmt.Fprintf(buf, "  mount fstype=tmpfs options=(rw) tmpfs -> %s/,\n", parentPath)
+		// Allow bind mounting things to reconstruct the now-writable parent directory.
+		fmt.Fprintf(buf, "  mount options=(rbind, rw) /tmp/.snap%s/** -> %s/**,\n", parentPath, parentPath)
+		fmt.Fprintf(buf, "  mount options=(bind, rw) /tmp/.snap%s/* -> %s/*,\n", parentPath, parentPath)
+		// Allow unmounting the temporary directory.
+		fmt.Fprintf(buf, "  umount /tmp/.snap%s/,\n", parentPath)
+		// Allow unmounting the destination directory as well as anything inside.
+		// This lets us perform the undo plan in case the writable mimic fails.
+		fmt.Fprintf(buf, "  umount %s{,/**},\n", parentPath)
+		// Allow creating directories on demand.
+		fmt.Fprintf(buf, "  %s/** rw,\n", parentPath)
+		for p := parentPath; p != "/"; p = parent(p) {
+			fmt.Fprintf(buf, "  %s/ rw,\n", p)
+		}
+		fmt.Fprintf(buf, "  /tmp/.snap%s/** rw,\n", parentPath)
+		for p := filepath.Join("/tmp/.snap/", parentPath); p != "/"; p = parent(p) {
+			fmt.Fprintf(buf, "  %s/ rw,\n", p)
+		}
+	}
+}
+
+// WritableProfile writes a profile for snap-update-ns for making given directory writable.
+func WritableProfile(buf *bytes.Buffer, path string) {
+	if path == "/" {
+		return
+	}
+	if isProbablyWritable(path) {
+		fmt.Fprintf(buf, "  # Writable directory %s\n", path)
+		for p := path; p != "/"; p = parent(p) {
+			fmt.Fprintf(buf, "  %s/ rw,\n", p)
+		}
+	} else {
+		parentPath := parent(path)
+		fmt.Fprintf(buf, "  # Writable mimic %s\n", parentPath)
+		// Allow setting the read-only directory aside via a bind mount.
+		fmt.Fprintf(buf, "  mount options=(rbind, rw) %s/ -> /tmp/.snap%s/,\n", parentPath, parentPath)
+		// Allow mounting tmpfs over the read-only directory.
+		fmt.Fprintf(buf, "  mount fstype=tmpfs options=(rw) tmpfs -> %s/,\n", parentPath)
+		// Allow bind mounting things to reconstruct the now-writable parent directory.
+		fmt.Fprintf(buf, "  mount options=(rbind, rw) /tmp/.snap%s/** -> %s/**,\n", parentPath, parentPath)
+		fmt.Fprintf(buf, "  mount options=(bind, rw) /tmp/.snap%s/* -> %s/*,\n", parentPath, parentPath)
+		// Allow unmounting the temporary directory.
+		fmt.Fprintf(buf, "  umount /tmp/.snap%s/,\n", parentPath)
+		// Allow unmounting the destination directory as well as anything inside.
+		// This lets us perform the undo plan in case the writable mimic fails.
+		fmt.Fprintf(buf, "  umount %s{,/**},\n", parentPath)
+		// Allow creating directories on demand.
+		fmt.Fprintf(buf, "  %s/** rw,\n", parentPath)
+		for p := parentPath; p != "/"; p = parent(p) {
+			fmt.Fprintf(buf, "  %s/ rw,\n", p)
+		}
+		fmt.Fprintf(buf, "  /tmp/.snap%s/** rw,\n", parentPath)
+		for p := filepath.Join("/tmp/.snap/", parentPath); p != "/"; p = parent(p) {
+			fmt.Fprintf(buf, "  %s/ rw,\n", p)
+		}
+	}
+}
+
+// parent returns the parent directory of a given path.
+func parent(path string) string {
+	result, _ := filepath.Split(path)
+	result = filepath.Clean(result)
+	return result
 }
 
 // Snippets returns a deep copy of all the added application snippets.

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -82,6 +82,22 @@ func (spec *Specification) AddUpdateNS(snippet string) {
 }
 
 // AddSnapLayout adds apparmor snippets based on the layout of the snap.
+//
+// The per-snap snap-update-ns profiles are composed via a template and
+// snippets for the snap. The snippets may allow (depending on the snippet):
+// - mount profiles via the content interface
+// - creating missing mount point directories under $SNAP* (the 'tree'
+//   of permissions is needed for SecureMkDirAll that uses
+//   open(..., O_NOFOLLOW) and mkdirat() using the resulting file descriptor)
+// - creating a placeholder directory in /tmp/.snap/ in the per-snap mount
+//   namespace to support writable mimic which uses tmpfs and bind mount to
+//   poke holes in arbitrary read-only locations
+// - mounting/unmounting any part of $SNAP into placeholder directory
+// - mounting/unmounting tmpfs over the original $SNAP/** location
+// - mounting/unmounting from placeholder back to $SNAP/** (for reconstructing
+//   the data)
+// Importantly, the above mount operations are happening within the per-snap
+// mount namespace.
 func (spec *Specification) AddSnapLayout(si *snap.Info) {
 	if len(si.Layout) == 0 {
 		return

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -191,11 +191,9 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   umount /tmp/.snap/etc/,
   umount /etc{,/**},
   /etc/** rw,
-  /etc/ rw,
   /tmp/.snap/etc/** rw,
   /tmp/.snap/etc/ rw,
   /tmp/.snap/ rw,
-  /tmp/ rw,
   # Writable mimic /snap/vanguard/42
   mount options=(rbind, rw) /snap/vanguard/42/ -> /tmp/.snap/snap/vanguard/42/,
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/vanguard/42/,
@@ -206,13 +204,11 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   /snap/vanguard/42/** rw,
   /snap/vanguard/42/ rw,
   /snap/vanguard/ rw,
-  /snap/ rw,
   /tmp/.snap/snap/vanguard/42/** rw,
   /tmp/.snap/snap/vanguard/42/ rw,
   /tmp/.snap/snap/vanguard/ rw,
   /tmp/.snap/snap/ rw,
   /tmp/.snap/ rw,
-  /tmp/ rw,
 `
 	profile1 := `  # Layout /usr/foo: bind $SNAP/usr/foo
   mount options=(rbind, rw) /snap/vanguard/42/usr/foo/ -> /usr/foo/,
@@ -225,11 +221,9 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   umount /tmp/.snap/usr/,
   umount /usr{,/**},
   /usr/** rw,
-  /usr/ rw,
   /tmp/.snap/usr/** rw,
   /tmp/.snap/usr/ rw,
   /tmp/.snap/ rw,
-  /tmp/ rw,
   # Writable mimic /snap/vanguard/42/usr
   mount options=(rbind, rw) /snap/vanguard/42/usr/ -> /tmp/.snap/snap/vanguard/42/usr/,
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/vanguard/42/usr/,
@@ -241,14 +235,12 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   /snap/vanguard/42/usr/ rw,
   /snap/vanguard/42/ rw,
   /snap/vanguard/ rw,
-  /snap/ rw,
   /tmp/.snap/snap/vanguard/42/usr/** rw,
   /tmp/.snap/snap/vanguard/42/usr/ rw,
   /tmp/.snap/snap/vanguard/42/ rw,
   /tmp/.snap/snap/vanguard/ rw,
   /tmp/.snap/snap/ rw,
   /tmp/.snap/ rw,
-  /tmp/ rw,
 `
 	profile2 := `  # Layout /var/cache/mylink: symlink $SNAP_DATA/link/target
   /var/cache/mylink rw,
@@ -261,12 +253,10 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   umount /var/cache{,/**},
   /var/cache/** rw,
   /var/cache/ rw,
-  /var/ rw,
   /tmp/.snap/var/cache/** rw,
   /tmp/.snap/var/cache/ rw,
   /tmp/.snap/var/ rw,
   /tmp/.snap/ rw,
-  /tmp/ rw,
 `
 	profile3 := `  # Layout /var/tmp: type tmpfs, mode: 01777
   mount fstype=tmpfs tmpfs -> /var/tmp/,
@@ -279,11 +269,9 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   umount /tmp/.snap/var/,
   umount /var{,/**},
   /var/** rw,
-  /var/ rw,
   /tmp/.snap/var/** rw,
   /tmp/.snap/var/ rw,
   /tmp/.snap/ rw,
-  /tmp/ rw,
 `
 	updateNS := s.spec.UpdateNS()["vanguard"]
 	c.Assert(updateNS[0], Equals, profile0)

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -251,7 +251,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   /tmp/ rw,
 `
 	profile2 := `  # Layout /var/cache/mylink: symlink $SNAP_DATA/link/target
-  /var/cache/mylink rwl,
+  /var/cache/mylink rw,
   # Writable mimic /var/cache
   mount options=(rbind, rw) /var/cache/ -> /tmp/.snap/var/cache/,
   mount fstype=tmpfs options=(rw) tmpfs -> /var/cache/,

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -154,26 +154,141 @@ apps:
   vanguard:
     command: vanguard
 layout:
-  /usr:
-    bind: $SNAP/usr
-  /mytmp:
+  /usr/foo:
+    bind: $SNAP/usr/foo
+  /var/tmp:
     type: tmpfs
     mode: 1777
-  /mylink:
-    symlink: $SNAP/link/target
+  /var/cache/mylink:
+    symlink: $SNAP_DATA/link/target
   /etc/foo.conf:
     bind-file: $SNAP/foo.conf
 `
 
 func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
 	snapInfo := snaptest.MockInfo(c, snapWithLayout, &snap.SideInfo{Revision: snap.R(42)})
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.vanguard.vanguard"}, "vanguard")
+	defer restore()
+
 	s.spec.AddSnapLayout(snapInfo)
 	c.Assert(s.spec.Snippets(), DeepEquals, map[string][]string{
 		"snap.vanguard.vanguard": {
 			"# Layout path: /etc/foo.conf\n/etc/foo.conf mrwklix,",
-			"# Layout path: /mylink\n# (no extra permissions required for symlink)",
-			"# Layout path: /mytmp\n/mytmp{,/**} mrwklix,",
-			"# Layout path: /usr\n/usr{,/**} mrwklix,",
+			"# Layout path: /usr/foo\n/usr/foo{,/**} mrwklix,",
+			"# Layout path: /var/cache/mylink\n# (no extra permissions required for symlink)",
+			"# Layout path: /var/tmp\n/var/tmp{,/**} mrwklix,",
 		},
 	})
+
+	profile0 := `  # Layout /etc/foo.conf: bind-file $SNAP/foo.conf
+  mount options=(bind, rw) /snap/vanguard/42/foo.conf -> /etc/foo.conf,
+  umount /etc/foo.conf,
+  # Writable mimic /etc
+  mount options=(rbind, rw) /etc/ -> /tmp/.snap/etc/,
+  mount fstype=tmpfs options=(rw) tmpfs -> /etc/,
+  mount options=(rbind, rw) /tmp/.snap/etc/** -> /etc/**,
+  mount options=(bind, rw) /tmp/.snap/etc/* -> /etc/*,
+  umount /tmp/.snap/etc/,
+  umount /etc{,/**},
+  /etc/** rw,
+  /etc/ rw,
+  /tmp/.snap/etc/** rw,
+  /tmp/.snap/etc/ rw,
+  /tmp/.snap/ rw,
+  /tmp/ rw,
+  # Writable mimic /snap/vanguard/42
+  mount options=(rbind, rw) /snap/vanguard/42/ -> /tmp/.snap/snap/vanguard/42/,
+  mount fstype=tmpfs options=(rw) tmpfs -> /snap/vanguard/42/,
+  mount options=(rbind, rw) /tmp/.snap/snap/vanguard/42/** -> /snap/vanguard/42/**,
+  mount options=(bind, rw) /tmp/.snap/snap/vanguard/42/* -> /snap/vanguard/42/*,
+  umount /tmp/.snap/snap/vanguard/42/,
+  umount /snap/vanguard/42{,/**},
+  /snap/vanguard/42/** rw,
+  /snap/vanguard/42/ rw,
+  /snap/vanguard/ rw,
+  /snap/ rw,
+  /tmp/.snap/snap/vanguard/42/** rw,
+  /tmp/.snap/snap/vanguard/42/ rw,
+  /tmp/.snap/snap/vanguard/ rw,
+  /tmp/.snap/snap/ rw,
+  /tmp/.snap/ rw,
+  /tmp/ rw,
+`
+	profile1 := `  # Layout /usr/foo: bind $SNAP/usr/foo
+  mount options=(rbind, rw) /snap/vanguard/42/usr/foo/ -> /usr/foo/,
+  umount /usr/foo/,
+  # Writable mimic /usr
+  mount options=(rbind, rw) /usr/ -> /tmp/.snap/usr/,
+  mount fstype=tmpfs options=(rw) tmpfs -> /usr/,
+  mount options=(rbind, rw) /tmp/.snap/usr/** -> /usr/**,
+  mount options=(bind, rw) /tmp/.snap/usr/* -> /usr/*,
+  umount /tmp/.snap/usr/,
+  umount /usr{,/**},
+  /usr/** rw,
+  /usr/ rw,
+  /tmp/.snap/usr/** rw,
+  /tmp/.snap/usr/ rw,
+  /tmp/.snap/ rw,
+  /tmp/ rw,
+  # Writable mimic /snap/vanguard/42/usr
+  mount options=(rbind, rw) /snap/vanguard/42/usr/ -> /tmp/.snap/snap/vanguard/42/usr/,
+  mount fstype=tmpfs options=(rw) tmpfs -> /snap/vanguard/42/usr/,
+  mount options=(rbind, rw) /tmp/.snap/snap/vanguard/42/usr/** -> /snap/vanguard/42/usr/**,
+  mount options=(bind, rw) /tmp/.snap/snap/vanguard/42/usr/* -> /snap/vanguard/42/usr/*,
+  umount /tmp/.snap/snap/vanguard/42/usr/,
+  umount /snap/vanguard/42/usr{,/**},
+  /snap/vanguard/42/usr/** rw,
+  /snap/vanguard/42/usr/ rw,
+  /snap/vanguard/42/ rw,
+  /snap/vanguard/ rw,
+  /snap/ rw,
+  /tmp/.snap/snap/vanguard/42/usr/** rw,
+  /tmp/.snap/snap/vanguard/42/usr/ rw,
+  /tmp/.snap/snap/vanguard/42/ rw,
+  /tmp/.snap/snap/vanguard/ rw,
+  /tmp/.snap/snap/ rw,
+  /tmp/.snap/ rw,
+  /tmp/ rw,
+`
+	profile2 := `  # Layout /var/cache/mylink: symlink $SNAP_DATA/link/target
+  /var/cache/mylink rwl,
+  # Writable mimic /var/cache
+  mount options=(rbind, rw) /var/cache/ -> /tmp/.snap/var/cache/,
+  mount fstype=tmpfs options=(rw) tmpfs -> /var/cache/,
+  mount options=(rbind, rw) /tmp/.snap/var/cache/** -> /var/cache/**,
+  mount options=(bind, rw) /tmp/.snap/var/cache/* -> /var/cache/*,
+  umount /tmp/.snap/var/cache/,
+  umount /var/cache{,/**},
+  /var/cache/** rw,
+  /var/cache/ rw,
+  /var/ rw,
+  /tmp/.snap/var/cache/** rw,
+  /tmp/.snap/var/cache/ rw,
+  /tmp/.snap/var/ rw,
+  /tmp/.snap/ rw,
+  /tmp/ rw,
+`
+	profile3 := `  # Layout /var/tmp: type tmpfs, mode: 01777
+  mount fstype=tmpfs tmpfs -> /var/tmp/,
+  umount /var/tmp/,
+  # Writable mimic /var
+  mount options=(rbind, rw) /var/ -> /tmp/.snap/var/,
+  mount fstype=tmpfs options=(rw) tmpfs -> /var/,
+  mount options=(rbind, rw) /tmp/.snap/var/** -> /var/**,
+  mount options=(bind, rw) /tmp/.snap/var/* -> /var/*,
+  umount /tmp/.snap/var/,
+  umount /var{,/**},
+  /var/** rw,
+  /var/ rw,
+  /tmp/.snap/var/** rw,
+  /tmp/.snap/var/ rw,
+  /tmp/.snap/ rw,
+  /tmp/ rw,
+`
+	updateNS := s.spec.UpdateNS()["vanguard"]
+	c.Assert(updateNS[0], Equals, profile0)
+	c.Assert(updateNS[1], Equals, profile1)
+	c.Assert(updateNS[2], Equals, profile2)
+	c.Assert(updateNS[3], Equals, profile3)
+	c.Assert(updateNS, DeepEquals, []string{profile0, profile1, profile2, profile3})
 }

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -569,11 +569,10 @@ profile snap-update-ns.###SNAP_NAME### (attach_disconnected) {
   /var/lib/snapd/mount/snap.###SNAP_NAME###.fstab r,
 
   # Allow reading and writing actual per-snap mount profiles. Note that
-  # the second rule is generic to allow our tmpfile-rename approach to
-  # writing them. Those are written by snap-update-ns and represent the
-  # actual layout at a given moment.
-  /run/snapd/ns/snap.###SNAP_NAME###.fstab rw,
-  /run/snapd/ns/snap.###SNAP_NAME###.fstab.* rw,
+  # the wildcard in the rule to allow an atomic write + rename strategy.
+  # Those files are written by snap-update-ns and represent the actual
+  # mount profile at a given moment.
+  /run/snapd/ns/snap.###SNAP_NAME###.fstab{,.*} rw,
 
   # NOTE: at this stage the /snap directory is stable as we have called
   # pivot_root already.

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -520,10 +520,16 @@ var overlayRootSnippet = `
   "###UPPERDIR###/{,**/}" r,
 `
 
-// updateNSTemplate contains an apparmor profile for snap-update-ns.
-// The template contains variable references to encode per-snap layout
-// requirements so that snap-update-ns doesn't need to have broad permissions
-// to write to the whole disk or to mount and unmount anything.
+// updateNSTemplate defines the apparmor profile for per-snap snap-update-ns.
+//
+// The per-snap snap-update-ns profiles are composed via a template and
+// snippets for the snap. The template allows:
+// - accesses to libraries, files and /proc entries required to run
+// - using global and per-snap lock files
+// - reading per-snap mount namespaces and mount profiles
+// - managing per-snap freezer state files
+// - per-snap mounting/unmounting fonts from the host
+// - denying mounts to restricted places (eg, /snap/bin and /media)
 var updateNSTemplate = `
 # Description: Allows snap-update-ns to construct the mount namespace specific
 # to a particular snap (see the name below). This specifically includes the

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -603,9 +603,15 @@ profile snap-update-ns.###SNAP_NAME### (attach_disconnected) {
   mount options=(ro bind) /var/lib/snapd/hostfs/var/cache/fontconfig/ -> /var/cache/fontconfig/,
   umount /var/cache/fontconfig/,
 
-  # Allow traversing from the root directory.
+  # Allow traversing from the root directory and several well-known places.
   # Specific directory permissions are added by snippets below.
   / r,
+  /etc/ r,
+  /snap/ r,
+  /tmp/ r,
+  /usr/ r,
+  /var/ r,
+  /var/snap/ r,
 
   # Allow reading timezone data.
   /usr/share/zoneinfo/** r,

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -186,11 +186,7 @@ func resolveSpecialVariable(path string, snapInfo *snap.Info) string {
 	return filepath.Join(filepath.Join(dirs.CoreSnapMountDir, snapInfo.Name(), snapInfo.Revision.String()), path)
 }
 
-func mountEntry(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string, extraOptions ...string) osutil.MountEntry {
-	options := make([]string, 0, len(extraOptions)+1)
-	options = append(options, "bind")
-	options = append(options, extraOptions...)
-
+func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string) (string, string) {
 	var target string
 	// The 'target' attribute has already been verified in BeforePreparePlug.
 	_ = plug.Attr("target", &target)
@@ -203,7 +199,14 @@ func mountEntry(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, 
 		_, sourceName := filepath.Split(source)
 		target = filepath.Join(target, sourceName)
 	}
+	return source, target
+}
 
+func mountEntry(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string, extraOptions ...string) osutil.MountEntry {
+	options := make([]string, 0, len(extraOptions)+1)
+	options = append(options, "bind")
+	options = append(options, extraOptions...)
+	source, target := sourceTarget(plug, slot, relSrc)
 	return osutil.MountEntry{
 		Name:    source,
 		Dir:     target,
@@ -222,9 +225,17 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 # are needed for using named sockets within the exported
 # directory.
 `)
-		for _, w := range writePaths {
+		for i, w := range writePaths {
 			fmt.Fprintf(contentSnippet, "%s/** mrwklix,\n",
 				resolveSpecialVariable(w, slot.Snap()))
+			source, target := sourceTarget(plug, slot, w)
+			var buf bytes.Buffer
+			fmt.Fprintf(&buf, "  # Read-write content sharing %s -> %s (w#%d)\n", plug.Ref(), slot.Ref(), i)
+			fmt.Fprintf(&buf, "  mount options=(bind, rw) %s/ -> %s/,\n", source, target)
+			fmt.Fprintf(&buf, "  umount %s/,\n", target)
+			apparmor.WritableProfile(&buf, source)
+			apparmor.WritableProfile(&buf, target)
+			spec.AddUpdateNS(buf.String())
 		}
 	}
 
@@ -235,9 +246,18 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 # snaps may directly access the slot implementation's files
 # read-only.
 `)
-		for _, r := range readPaths {
+		for i, r := range readPaths {
 			fmt.Fprintf(contentSnippet, "%s/** mrkix,\n",
 				resolveSpecialVariable(r, slot.Snap()))
+
+			source, target := sourceTarget(plug, slot, r)
+			var buf bytes.Buffer
+			fmt.Fprintf(&buf, "  # Read-only content sharing %s -> %s (r#%d)\n", plug.Ref(), slot.Ref(), i)
+			fmt.Fprintf(&buf, "  mount options=(bind, ro) %s/ -> %s/,\n", source, target)
+			fmt.Fprintf(&buf, "  umount %s/,\n", target)
+			apparmor.WritableProfile(&buf, source)
+			apparmor.WritableProfile(&buf, target)
+			spec.AddUpdateNS(buf.String())
 		}
 	}
 

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -322,13 +322,11 @@ slots:
   /snap/producer/5/** rw,
   /snap/producer/5/ rw,
   /snap/producer/ rw,
-  /snap/ rw,
   /tmp/.snap/snap/producer/5/** rw,
   /tmp/.snap/snap/producer/5/ rw,
   /tmp/.snap/snap/producer/ rw,
   /tmp/.snap/snap/ rw,
   /tmp/.snap/ rw,
-  /tmp/ rw,
   # Writable mimic /snap/consumer/7
   mount options=(rbind, rw) /snap/consumer/7/ -> /tmp/.snap/snap/consumer/7/,
   mount fstype=tmpfs options=(rw) tmpfs -> /snap/consumer/7/,
@@ -339,13 +337,11 @@ slots:
   /snap/consumer/7/** rw,
   /snap/consumer/7/ rw,
   /snap/consumer/ rw,
-  /snap/ rw,
   /tmp/.snap/snap/consumer/7/** rw,
   /tmp/.snap/snap/consumer/7/ rw,
   /tmp/.snap/snap/consumer/ rw,
   /tmp/.snap/snap/ rw,
   /tmp/.snap/ rw,
-  /tmp/ rw,
 `
 	c.Assert(updateNS["consumer"][0], Equals, profile0)
 	c.Assert(updateNS, DeepEquals, map[string][]string{"consumer": {profile0}})
@@ -405,14 +401,10 @@ slots:
   /var/snap/producer/5/export/ rw,
   /var/snap/producer/5/ rw,
   /var/snap/producer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
   # Writable directory /var/snap/consumer/7/import
   /var/snap/consumer/7/import/ rw,
   /var/snap/consumer/7/ rw,
   /var/snap/consumer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
 `
 	c.Assert(updateNS["consumer"][0], Equals, profile0)
 	c.Assert(updateNS, DeepEquals, map[string][]string{"consumer": {profile0}})
@@ -472,14 +464,10 @@ slots:
   /var/snap/producer/common/export/ rw,
   /var/snap/producer/common/ rw,
   /var/snap/producer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
   # Writable directory /var/snap/consumer/common/import
   /var/snap/consumer/common/import/ rw,
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
 `
 	c.Assert(updateNS["consumer"][0], Equals, profile0)
 	c.Assert(updateNS, DeepEquals, map[string][]string{"consumer": {profile0}})
@@ -574,15 +562,11 @@ slots:
   /var/snap/producer/common/write-common/ rw,
   /var/snap/producer/common/ rw,
   /var/snap/producer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
   # Writable directory /var/snap/consumer/common/import/write-common
   /var/snap/consumer/common/import/write-common/ rw,
   /var/snap/consumer/common/import/ rw,
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
 `
 	profile1 := `  # Read-write content sharing consumer:content -> producer:content (w#1)
   mount options=(bind, rw) /var/snap/producer/2/write-data/ -> /var/snap/consumer/common/import/write-data/,
@@ -591,15 +575,11 @@ slots:
   /var/snap/producer/2/write-data/ rw,
   /var/snap/producer/2/ rw,
   /var/snap/producer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
   # Writable directory /var/snap/consumer/common/import/write-data
   /var/snap/consumer/common/import/write-data/ rw,
   /var/snap/consumer/common/import/ rw,
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
 `
 	profile2 := `  # Read-only content sharing consumer:content -> producer:content (r#0)
   mount options=(bind, ro) /var/snap/producer/common/read-common/ -> /var/snap/consumer/common/import/read-common/,
@@ -608,15 +588,11 @@ slots:
   /var/snap/producer/common/read-common/ rw,
   /var/snap/producer/common/ rw,
   /var/snap/producer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
   # Writable directory /var/snap/consumer/common/import/read-common
   /var/snap/consumer/common/import/read-common/ rw,
   /var/snap/consumer/common/import/ rw,
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
 `
 	profile3 := `  # Read-only content sharing consumer:content -> producer:content (r#1)
   mount options=(bind, ro) /var/snap/producer/2/read-data/ -> /var/snap/consumer/common/import/read-data/,
@@ -625,15 +601,11 @@ slots:
   /var/snap/producer/2/read-data/ rw,
   /var/snap/producer/2/ rw,
   /var/snap/producer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
   # Writable directory /var/snap/consumer/common/import/read-data
   /var/snap/consumer/common/import/read-data/ rw,
   /var/snap/consumer/common/import/ rw,
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
 `
 	profile4 := `  # Read-only content sharing consumer:content -> producer:content (r#2)
   mount options=(bind, ro) /snap/producer/2/read-snap/ -> /var/snap/consumer/common/import/read-snap/,
@@ -648,20 +620,16 @@ slots:
   /snap/producer/2/** rw,
   /snap/producer/2/ rw,
   /snap/producer/ rw,
-  /snap/ rw,
   /tmp/.snap/snap/producer/2/** rw,
   /tmp/.snap/snap/producer/2/ rw,
   /tmp/.snap/snap/producer/ rw,
   /tmp/.snap/snap/ rw,
   /tmp/.snap/ rw,
-  /tmp/ rw,
   # Writable directory /var/snap/consumer/common/import/read-snap
   /var/snap/consumer/common/import/read-snap/ rw,
   /var/snap/consumer/common/import/ rw,
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
-  /var/snap/ rw,
-  /var/ rw,
 `
 	c.Assert(updateNS["consumer"][0], Equals, profile0)
 	c.Assert(updateNS["consumer"][1], Equals, profile1)

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -61,7 +61,7 @@ func mountEntryFromLayout(layout *snap.Layout) osutil.MountEntry {
 	// XXX: what about ro mounts?
 	if layout.Bind != "" {
 		mountSource := layout.Snap.ExpandSnapVariables(layout.Bind)
-		entry.Options = []string{"bind", "rw"}
+		entry.Options = []string{"rbind", "rw"}
 		entry.Name = mountSource
 	}
 	if layout.BindFile != "" {

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -160,6 +160,6 @@ func (s *specSuite) TestMountEntryFromLayout(c *C) {
 		{Dir: "/etc/foo.conf", Name: "/snap/vanguard/42/foo.conf", Options: []string{"bind", "rw", "x-snapd.kind=file", "x-snapd.origin=layout"}},
 		{Dir: "/mylink", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/snap/vanguard/42/link/target", "x-snapd.origin=layout"}},
 		{Dir: "/mytmp", Name: "tmpfs", Type: "tmpfs", Options: []string{"x-snapd.mode=01777", "x-snapd.origin=layout"}},
-		{Dir: "/usr", Name: "/snap/vanguard/42/usr", Options: []string{"bind", "rw", "x-snapd.origin=layout"}},
+		{Dir: "/usr", Name: "/snap/vanguard/42/usr", Options: []string{"rbind", "rw", "x-snapd.origin=layout"}},
 	})
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -211,6 +211,34 @@ type Layout struct {
 	Symlink  string      `json:"symlink,omitempty"`
 }
 
+// String returns a simple textual representation of a layout.
+func (l *Layout) String() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%s: ", l.Path)
+	switch {
+	case l.Bind != "":
+		fmt.Fprintf(&buf, "bind %s", l.Bind)
+	case l.BindFile != "":
+		fmt.Fprintf(&buf, "bind-file %s", l.BindFile)
+	case l.Symlink != "":
+		fmt.Fprintf(&buf, "symlink %s", l.Symlink)
+	case l.Type != "":
+		fmt.Fprintf(&buf, "type %s", l.Type)
+	default:
+		fmt.Fprintf(&buf, "???")
+	}
+	if l.User != "root" && l.User != "" {
+		fmt.Fprintf(&buf, ", user: %s", l.User)
+	}
+	if l.Group != "root" && l.Group != "" {
+		fmt.Fprintf(&buf, ", group: %s", l.Group)
+	}
+	if l.Mode != 0755 {
+		fmt.Fprintf(&buf, ", mode: %#o", l.Mode)
+	}
+	return buf.String()
+}
+
 // ChannelSnapInfo is the minimum information that can be used to clearly
 // distinguish different revisions of the same snap.
 type ChannelSnapInfo struct {


### PR DESCRIPTION
This is a backport of for https://github.com/snapcore/snapd/pull/4765 for the 2.32 release

This branch hardens the snap-update-ns apparmor profile (per snap) to
include precise snap and directory names instead of wild-cards for:

 - content interface mounts
 - host font sharing
 - layouts mounts and symlinks
 - lock files
 - mount profiles
 - preserved mount namespace files
 - writable directory creation
 -  writable mimic construction

This patch also tweaks layout to use recursive bind mounts for
directories. This allows replicating existing mounts in a new location.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>