### PR TITLE
interfaces/apparmor: simplify UpdateNS internals

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -273,13 +273,8 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		return fmt.Errorf("cannot obtain apparmor specification for snap %q: %s", snapName, err)
 	}
 
-	// Set the snapName for AddUpdateNS snippet.
-	//
-	// TODO: remove this along with Specification.snapName as it is not really
-	// needed in practice and the corresponding code can be simplified away.
-	spec.(*Specification).snapName = snapName
+	// Add snippets derived from the layout definition.
 	spec.(*Specification).AddSnapLayout(snapInfo)
-	spec.(*Specification).snapName = ""
 
 	// core on classic is special
 	if snapName == "core" && release.OnClassic && release.AppArmorLevel() != release.NoAppArmor {
@@ -373,7 +368,7 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts i
 	// If we have neither then we don't have any need to create an executing environment.
 	// This applies to, for example, kernel snaps or gadget snaps (unless they have hooks).
 	if len(content) > 0 {
-		snippets := strings.Join(spec.UpdateNS()[snapInfo.Name()], "\n")
+		snippets := strings.Join(spec.UpdateNS(), "\n")
 		addUpdateNSProfile(snapInfo, opts, snippets, content)
 	}
 

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -83,6 +83,6 @@ func MockClassicTemplate(fakeTemplate string) (restore func()) {
 }
 
 // SetSpecScope sets the scope of a given specification
-func SetSpecScope(spec *Specification, securityTags []string, snapName string) (restore func()) {
-	return spec.setScope(securityTags, snapName)
+func SetSpecScope(spec *Specification, securityTags []string) (restore func()) {
+	return spec.setScope(securityTags)
 }

--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -39,8 +39,8 @@ type Specification struct {
 	// for snap application and hook processes. The security tag encodes the identity
 	// of the application or hook.
 	snippets map[string][]string
-	// updateNS are indexed by snap name and describe parts of apparmor policy
-	// for snap-update-ns executing on behalf of a given snap.
+	// updateNS describe parts of apparmor policy for snap-update-ns executing
+	// on behalf of a given snap.
 	updateNS []string
 }
 

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -103,7 +103,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 
 // AddSnippet adds a snippet for the given security tag.
 func (s *specSuite) TestAddSnippet(c *C) {
-	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"}, "demo")
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})
 	defer restore()
 
 	// Add two snippets in the context we are in.
@@ -122,7 +122,7 @@ func (s *specSuite) TestAddSnippet(c *C) {
 
 // AddUpdateNS adds a snippet for the snap-update-ns profile for a given snap.
 func (s *specSuite) TestAddUpdateNS(c *C) {
-	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"}, "demo")
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.demo.command", "snap.demo.service"})
 	defer restore()
 
 	// Add a two snap-update-ns snippets in the context we are in.
@@ -130,8 +130,8 @@ func (s *specSuite) TestAddUpdateNS(c *C) {
 	s.spec.AddUpdateNS("s-u-n snippet 2")
 
 	// The snippets were recorded correctly and in the right place.
-	c.Assert(s.spec.UpdateNS(), DeepEquals, map[string][]string{
-		"demo": {"s-u-n snippet 1", "s-u-n snippet 2"},
+	c.Assert(s.spec.UpdateNS(), DeepEquals, []string{
+		"s-u-n snippet 1", "s-u-n snippet 2",
 	})
 	c.Assert(s.spec.SnippetForTag("snap.demo.command"), Equals, "")
 	c.Assert(s.spec.SecurityTags(), HasLen, 0)
@@ -157,7 +157,7 @@ layout:
 
 func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
 	snapInfo := snaptest.MockInfo(c, snapWithLayout, &snap.SideInfo{Revision: snap.R(42)})
-	restore := apparmor.SetSpecScope(s.spec, []string{"snap.vanguard.vanguard"}, "vanguard")
+	restore := apparmor.SetSpecScope(s.spec, []string{"snap.vanguard.vanguard"})
 	defer restore()
 
 	s.spec.AddSnapLayout(snapInfo)
@@ -263,7 +263,7 @@ func (s *specSuite) TestApparmorSnippetsFromLayout(c *C) {
   /tmp/.snap/var/ rw,
   /tmp/.snap/ rw,
 `
-	updateNS := s.spec.UpdateNS()["vanguard"]
+	updateNS := s.spec.UpdateNS()
 	c.Assert(updateNS[0], Equals, profile0)
 	c.Assert(updateNS[1], Equals, profile1)
 	c.Assert(updateNS[2], Equals, profile2)

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -343,8 +343,8 @@ slots:
   /tmp/.snap/snap/ rw,
   /tmp/.snap/ rw,
 `
-	c.Assert(updateNS["consumer"][0], Equals, profile0)
-	c.Assert(updateNS, DeepEquals, map[string][]string{"consumer": {profile0}})
+	c.Assert(updateNS[0], Equals, profile0)
+	c.Assert(updateNS, DeepEquals, []string{profile0})
 }
 
 // Check that sharing of writable data is possible
@@ -406,8 +406,8 @@ slots:
   /var/snap/consumer/7/ rw,
   /var/snap/consumer/ rw,
 `
-	c.Assert(updateNS["consumer"][0], Equals, profile0)
-	c.Assert(updateNS, DeepEquals, map[string][]string{"consumer": {profile0}})
+	c.Assert(updateNS[0], Equals, profile0)
+	c.Assert(updateNS, DeepEquals, []string{profile0})
 }
 
 // Check that sharing of writable common data is possible
@@ -469,8 +469,8 @@ slots:
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
 `
-	c.Assert(updateNS["consumer"][0], Equals, profile0)
-	c.Assert(updateNS, DeepEquals, map[string][]string{"consumer": {profile0}})
+	c.Assert(updateNS[0], Equals, profile0)
+	c.Assert(updateNS, DeepEquals, []string{profile0})
 }
 
 func (s *ContentSuite) TestInterfaces(c *C) {
@@ -631,12 +631,12 @@ slots:
   /var/snap/consumer/common/ rw,
   /var/snap/consumer/ rw,
 `
-	c.Assert(updateNS["consumer"][0], Equals, profile0)
-	c.Assert(updateNS["consumer"][1], Equals, profile1)
-	c.Assert(updateNS["consumer"][2], Equals, profile2)
-	c.Assert(updateNS["consumer"][3], Equals, profile3)
-	c.Assert(updateNS["consumer"][4], Equals, profile4)
-	c.Assert(updateNS, DeepEquals, map[string][]string{"consumer": {profile0, profile1, profile2, profile3, profile4}})
+	c.Assert(updateNS[0], Equals, profile0)
+	c.Assert(updateNS[1], Equals, profile1)
+	c.Assert(updateNS[2], Equals, profile2)
+	c.Assert(updateNS[3], Equals, profile3)
+	c.Assert(updateNS[4], Equals, profile4)
+	c.Assert(updateNS, DeepEquals, []string{profile0, profile1, profile2, profile3, profile4})
 }
 
 func (s *ContentSuite) TestModernContentInterfacePlugins(c *C) {


### PR DESCRIPTION
This patch drops the snap name from internal state of apparmor.Snippet.
The variable only held one snap name and it is not needed in practice.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>