### PR TITLE
overlord/configstate: change how ssh is stopped/started (2.32)

### DIFF
--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -21,6 +21,9 @@ package configcore
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
@@ -37,22 +40,41 @@ func (l *sysdLogger) Notify(status string) {
 // where "true" means disabled and "false" means enabled.
 func switchDisableService(serviceName, value string) error {
 	sysd := systemd.New(dirs.GlobalRootDir, &sysdLogger{})
+	sshCanary := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_not_to_be_run")
 
 	switch value {
 	case "true":
-		if err := sysd.Disable(serviceName); err != nil {
-			return err
-		}
-		if err := sysd.Mask(serviceName); err != nil {
-			return err
+		if serviceName == "ssh.service" {
+			if err := ioutil.WriteFile(sshCanary, []byte("SSH has been disabled by snapd system configuration\n"), 0644); err != nil {
+				return err
+			}
+		} else {
+			if err := sysd.Disable(serviceName); err != nil {
+				return err
+			}
+			if err := sysd.Mask(serviceName); err != nil {
+				return err
+			}
 		}
 		return sysd.Stop(serviceName, 5*time.Minute)
 	case "false":
-		if err := sysd.Unmask(serviceName); err != nil {
-			return err
-		}
-		if err := sysd.Enable(serviceName); err != nil {
-			return err
+		if serviceName == "ssh.service" {
+			err := os.Remove(sshCanary)
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			// Unmask both sshd.service and ssh.service and ignore the
+			// errors, if any. This undoes the damage done by earlier
+			// versions of snapd.
+			sysd.Unmask("sshd.service")
+			sysd.Unmask("ssh.service")
+		} else {
+			if err := sysd.Unmask(serviceName); err != nil {
+				return err
+			}
+			if err := sysd.Enable(serviceName); err != nil {
+				return err
+			}
 		}
 		return sysd.Start(serviceName)
 	default:
@@ -63,7 +85,7 @@ func switchDisableService(serviceName, value string) error {
 // services that can be disabled
 func handleServiceDisableConfiguration(tr Conf) error {
 	var services = []struct{ configName, systemdName string }{
-		{"ssh", "sshd.service"},
+		{"ssh", "ssh.service"},
 		{"rsyslog", "rsyslog.service"},
 	}
 	for _, service := range services {

--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -66,7 +66,11 @@ func switchDisableSSHService(serviceName, value string) error {
 
 // switchDisableTypicalService switches a service in/out of disabled state
 // where "true" means disabled and "false" means enabled.
-func switchDisableTypicalService(serviceName, value string) error {
+func switchDisableService(serviceName, value string) error {
+	if serviceName == "ssh.service" {
+		return switchDisableSSHService(serviceName, value)
+	}
+
 	sysd := systemd.New(dirs.GlobalRootDir, &sysdLogger{})
 
 	switch value {
@@ -89,13 +93,6 @@ func switchDisableTypicalService(serviceName, value string) error {
 	default:
 		return fmt.Errorf("option %q has invalid value %q", serviceName, value)
 	}
-}
-
-func switchDisableService(serviceName, value string) error {
-	if serviceName == "ssh.service" {
-		return switchDisableSSHService(serviceName, value)
-	}
-	return switchDisableTypicalService(serviceName, value)
 }
 
 // services that can be disabled

--- a/overlord/configstate/configcore/services_test.go
+++ b/overlord/configstate/configcore/services_test.go
@@ -83,11 +83,14 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/ssh"), 0755)
+	c.Assert(err, IsNil)
+
 	for _, service := range []struct {
 		cfgName     string
 		systemdName string
 	}{
-		{"ssh", "sshd.service"},
+		{"ssh", "ssh.service"},
 		{"rsyslog", "rsyslog.service"},
 	} {
 		s.systemctlArgs = nil
@@ -99,12 +102,23 @@ func (s *servicesSuite) TestConfigureServiceDisabledIntegration(c *C) {
 		})
 		c.Assert(err, IsNil)
 		srv := service.systemdName
-		c.Check(s.systemctlArgs, DeepEquals, [][]string{
-			{"--root", dirs.GlobalRootDir, "disable", srv},
-			{"--root", dirs.GlobalRootDir, "mask", srv},
-			{"stop", srv},
-			{"show", "--property=ActiveState", srv},
-		})
+		if service.cfgName == "ssh" {
+			// SSH is special cased
+			sshCanary := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_not_to_be_run")
+			_, err := os.Stat(sshCanary)
+			c.Assert(err, IsNil)
+			c.Check(s.systemctlArgs, DeepEquals, [][]string{
+				{"stop", srv},
+				{"show", "--property=ActiveState", srv},
+			})
+		} else {
+			c.Check(s.systemctlArgs, DeepEquals, [][]string{
+				{"--root", dirs.GlobalRootDir, "disable", srv},
+				{"--root", dirs.GlobalRootDir, "mask", srv},
+				{"stop", srv},
+				{"show", "--property=ActiveState", srv},
+			})
+		}
 	}
 }
 
@@ -112,11 +126,14 @@ func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 
+	err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/etc/ssh"), 0755)
+	c.Assert(err, IsNil)
+
 	for _, service := range []struct {
 		cfgName     string
 		systemdName string
 	}{
-		{"ssh", "sshd.service"},
+		{"ssh", "ssh.service"},
 		{"rsyslog", "rsyslog.service"},
 	} {
 		s.systemctlArgs = nil
@@ -128,11 +145,23 @@ func (s *servicesSuite) TestConfigureServiceEnableIntegration(c *C) {
 
 		c.Assert(err, IsNil)
 		srv := service.systemdName
-		c.Check(s.systemctlArgs, DeepEquals, [][]string{
-			{"--root", dirs.GlobalRootDir, "unmask", srv},
-			{"--root", dirs.GlobalRootDir, "enable", srv},
-			{"start", srv},
-		})
+		if service.cfgName == "ssh" {
+			// SSH is special cased
+			c.Check(s.systemctlArgs, DeepEquals, [][]string{
+				{"--root", dirs.GlobalRootDir, "unmask", "sshd.service"},
+				{"--root", dirs.GlobalRootDir, "unmask", "ssh.service"},
+				{"start", srv},
+			})
+			sshCanary := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_not_to_be_run")
+			_, err := os.Stat(sshCanary)
+			c.Assert(err, ErrorMatches, ".* no such file or directory")
+		} else {
+			c.Check(s.systemctlArgs, DeepEquals, [][]string{
+				{"--root", dirs.GlobalRootDir, "unmask", srv},
+				{"--root", dirs.GlobalRootDir, "enable", srv},
+				{"start", srv},
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
The ssh.service has an alias of sshd.service and so we must operate on
the main file ssh.service for enable/disable operations as aliases do
not exist when the main unit is disabled.

Due to some unfortunate use of writable paths we cannot mask ssh.service
and have that unit stay gone on reboot. To work around that use the fact
that the unit is conditional of non-existence of /etc/ssh/sshd_not_to_be_run

The patch also unmasks sshd.service in case it was masked by earlier
snapd.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>