### PR TITLE
interfaces,release: probe seccomp features lazily

### DIFF
--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -88,7 +88,7 @@ func generateSystemKey() *systemKey {
 	sk.Core, _ = os.Readlink(filepath.Join(dirs.SnapMountDir, "core/current"))
 
 	// Add seccomp-features
-	sk.SecCompActions = release.SecCompActions
+	sk.SecCompActions = release.SecCompActions()
 
 	return &sk
 }

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -71,7 +71,7 @@ func (s *systemKeySuite) TestInterfaceSystemKey(c *C) {
 		apparmorFeaturesStr = "\n- " + strings.Join(apparmorFeatures, "\n- ") + "\n"
 	}
 
-	seccompActions := release.SecCompActions
+	seccompActions := release.SecCompActions()
 	var seccompActionsStr string
 	if len(seccompActions) == 0 {
 		seccompActionsStr = " []\n"

--- a/release/seccomp_test.go
+++ b/release/seccomp_test.go
@@ -32,11 +32,11 @@ var _ = Suite(&seccompSuite{})
 func (s *seccompSuite) TestInterfaceSystemKey(c *C) {
 	reset := release.MockSecCompActions([]string{})
 	defer reset()
-	c.Check(release.SecCompActions, DeepEquals, []string{})
+	c.Check(release.SecCompActions(), DeepEquals, []string{})
 
 	reset = release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"})
 	defer reset()
-	c.Check(release.SecCompActions, DeepEquals, []string{"allow", "errno", "kill", "log", "trace", "trap"})
+	c.Check(release.SecCompActions(), DeepEquals, []string{"allow", "errno", "kill", "log", "trace", "trap"})
 }
 
 func (s *seccompSuite) TestSecCompSupportsAction(c *C) {


### PR DESCRIPTION
This is PR #4913 for master:

This patch changes the release module not to eagerly probe available
seccomp features. Since this is only needed to compute the system key
and the file read from proc is normally denied by confinement this
should limit confusing denials people see while using snaps.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
