### PR TITLE
skip test if no user "daemon" in build jail

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -744,7 +744,10 @@ func (s *snapSeccompSuite) TestRestrictionsWorkingArgsUidGid(c *C) {
 	// while 'root' user usually has uid 0, 'daemon' user uid may vary
 	// across distributions, best lookup the uid directly
 	daemonUid, err := osutil.FindUid("daemon")
-	c.Assert(err, IsNil)
+
+	if err != nil {
+		c.Skip("daemon user not available, perhaps we are in a buildroot jail")
+	}
 
 	for _, t := range []struct {
 		seccompWhitelist string


### PR DESCRIPTION
If the user "daemon" is not available in seccomp/main_test.go , skip the
test, OpenSUSE buildroot jails do not have the standard set of users.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

yes I signed the agreement