### PR TITLE
overlord/configstate: change how ssh is stopped/started (#4912)

### DIFF
--- a/overlord/configstate/configcore/services.go
+++ b/overlord/configstate/configcore/services.go
@@ -21,6 +21,9 @@ package configcore
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
@@ -33,9 +36,41 @@ func (l *sysdLogger) Notify(status string) {
 	fmt.Fprintf(Stderr, "sysd: %s\n", status)
 }
 
-// swtichDisableService switches a service in/out of disabled state
+// switchDisableSSHService handles the special case of disabling/enabling ssh
+// service on core devices.
+func switchDisableSSHService(serviceName, value string) error {
+	sysd := systemd.New(dirs.GlobalRootDir, &sysdLogger{})
+	sshCanary := filepath.Join(dirs.GlobalRootDir, "/etc/ssh/sshd_not_to_be_run")
+
+	switch value {
+	case "true":
+		if err := ioutil.WriteFile(sshCanary, []byte("SSH has been disabled by snapd system configuration\n"), 0644); err != nil {
+			return err
+		}
+		return sysd.Stop(serviceName, 5*time.Minute)
+	case "false":
+		err := os.Remove(sshCanary)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		// Unmask both sshd.service and ssh.service and ignore the
+		// errors, if any. This undoes the damage done by earlier
+		// versions of snapd.
+		sysd.Unmask("sshd.service")
+		sysd.Unmask("ssh.service")
+		return sysd.Start(serviceName)
+	default:
+		return fmt.Errorf("option %q has invalid value %q", serviceName, value)
+	}
+}
+
+// switchDisableTypicalService switches a service in/out of disabled state
 // where "true" means disabled and "false" means enabled.
 func switchDisableService(serviceName, value string) error {
+	if serviceName == "ssh.service" {
+		return switchDisableSSHService(serviceName, value)
+	}
+
 	sysd := systemd.New(dirs.GlobalRootDir, &sysdLogger{})
 
 	switch value {
@@ -63,7 +98,7 @@ func switchDisableService(serviceName, value string) error {
 // services that can be disabled
 func handleServiceDisableConfiguration(tr Conf) error {
 	var services = []struct{ configName, systemdName string }{
-		{"ssh", "sshd.service"},
+		{"ssh", "ssh.service"},
 		{"rsyslog", "rsyslog.service"},
 	}
 	for _, service := range services {


### PR DESCRIPTION
* overlord/configstate: change how ssh is stopped/started

The ssh.service has an alias of sshd.service and so we must operate on
the main file ssh.service for enable/disable operations as aliases do
not exist when the main unit is disabled.

Due to some unfortunate use of writable paths we cannot mask ssh.service
and have that unit stay gone on reboot. To work around that use the fact
that the unit is conditional of non-existence of /etc/ssh/sshd_not_to_be_run

The patch also unmasks ssh{,d}.service in case it was masked by earlier
snapd.

The master version of #4912 