### PR TITLE
snap: make `snap run` look at the system-key for security profiles (2.32)

### DIFF
--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -20,10 +20,13 @@
 package interfaces
 
 import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"gopkg.in/yaml.v2"
+	"reflect"
+	"strings"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
@@ -31,31 +34,75 @@ import (
 	"github.com/snapcore/snapd/release"
 )
 
+// ErrSystemKeyIncomparableVersions indicates that the system-key
+// on disk and the system-key calculated from generateSystemKey
+// have different inputs and are therefore incomparable.
+//
+// This means:
+// - "snapd" needs to re-generate security profiles
+// - "snap run" cannot wait for those security profiles
+var (
+	ErrSystemKeyVersion = errors.New("system-key versions not comparable")
+	ErrSystemKeyMissing = errors.New("system-key missing on disk")
+)
+
 // systemKey describes the environment for which security profiles
 // have been generated. It is useful to compare if the current
 // running system is similar enough to the generated profiles or
 // if the profiles need to be re-generated to match the new system.
+//
+// Note that this key gets generated on *each* `snap run` - so it
+// *must* be cheap to calculate it (no hashes of big binaries etc).
 type systemKey struct {
-	BuildID          string   `yaml:"build-id"`
-	AppArmorFeatures []string `yaml:"apparmor-features"`
-	NFSHome          bool     `yaml:"nfs-home"`
-	OverlayRoot      string   `yaml:"overlay-root"`
-	Core             string   `yaml:"core,omitempty"`
-	SecCompActions   []string `yaml:"seccomp-features"`
+	// IMPORTANT: when adding new inputs bump this version
+	Version int `json:"version"`
+
+	// This is the build-id of the snapd that generated the profiles.
+	BuildID string `json:"build-id"`
+
+	// These inputs come from the host environment via e.g.
+	// kernel version or similar settings. If those change we may
+	// need to change the generated profiles (e.g. when the user
+	// boots into a more featureful seccomp).
+	AppArmorFeatures []string `json:"apparmor-features"`
+	NFSHome          bool     `json:"nfs-home"`
+	OverlayRoot      string   `json:"overlay-root"`
+	SecCompActions   []string `json:"seccomp-features"`
 }
 
 var mockedSystemKey *systemKey
 
-func generateSystemKey() *systemKey {
-	// for testing only
-	if mockedSystemKey != nil {
-		return mockedSystemKey
+func findSnapdPath() (string, error) {
+	snapdPath := filepath.Join(dirs.DistroLibExecDir, "snapd")
+
+	// find the right snapdPath by looking if we are re-execing or not
+	exe, err := os.Readlink("/proc/self/exe")
+	if err != nil {
+		return "", err
 	}
 
-	var sk systemKey
-	buildID, err := osutil.MyBuildID()
+	if strings.HasPrefix(exe, dirs.SnapMountDir) {
+		return filepath.Join(dirs.SnapMountDir, "core/current/usr/lib/snapd/snapd"), nil
+	}
+	return snapdPath, nil
+}
+
+func generateSystemKey() (*systemKey, error) {
+	// for testing only
+	if mockedSystemKey != nil {
+		return mockedSystemKey, nil
+	}
+
+	sk := &systemKey{
+		Version: 1,
+	}
+	snapdPath, err := findSnapdPath()
 	if err != nil {
-		buildID = ""
+		return nil, err
+	}
+	buildID, err := osutil.ReadBuildID(snapdPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
 	}
 	sk.BuildID = buildID
 
@@ -68,6 +115,7 @@ func generateSystemKey() *systemKey {
 	sk.NFSHome, err = osutil.IsHomeUsingNFS()
 	if err != nil {
 		logger.Noticef("cannot determine nfs usage in generateSystemKey: %v", err)
+		return nil, err
 	}
 
 	// Add if '/' is on overlayfs so we can add AppArmor rules for
@@ -75,41 +123,97 @@ func generateSystemKey() *systemKey {
 	sk.OverlayRoot, err = osutil.IsRootWritableOverlay()
 	if err != nil {
 		logger.Noticef("cannot determine root filesystem on overlay in generateSystemKey: %v", err)
+		return nil, err
 	}
-
-	// Add the current Core path, we need this because we call helpers
-	// like snap-confine from core that will need an updated profile
-	// if it changes
-	//
-	// FIXME: what about core18? the snapd snap?
-	sk.Core, _ = os.Readlink(filepath.Join(dirs.SnapMountDir, "core/current"))
 
 	// Add seccomp-features
 	sk.SecCompActions = release.SecCompActions()
 
-	return &sk
+	return sk, nil
 }
 
-// SystemKey outputs a string that identifies what security profiles
-// environment this snapd is using. Security profiles that were generated
-// with a different Systemkey should be re-generated.
-func SystemKey() string {
-	sk := generateSystemKey()
-
-	// special case: unknown build-ids always trigger a rebuild
-	if sk.BuildID == "" {
-		return ""
-	}
-	sks, err := yaml.Marshal(sk)
+// WriteSystemKey will write the current system-key to disk
+func WriteSystemKey() error {
+	sk, err := generateSystemKey()
 	if err != nil {
-		panic(err)
+		return err
 	}
-	return string(sks)
+	sks, err := json.Marshal(sk)
+	if err != nil {
+		return err
+	}
+	return osutil.AtomicWriteFile(dirs.SnapSystemKeyFile, sks, 0644, 0)
+}
+
+// SystemKeyMismatch checks if the running binary expects a different
+// system-key than what is on disk.
+//
+// This is used in two places:
+// - snap run: when there is a mismatch it will wait for snapd
+//             to re-generate the security profiles
+// - snapd: on startup it checks if the system-key has changed and
+//          if so re-generate the security profiles
+//
+// This ensures that "snap run" and "snapd" have a consistent set
+// of security profiles. Without it we may have the following
+// scenario:
+// 1. snapd gets refreshed and snaps need updated security profiles
+//    to work (e.g. because snap-exec needs a new permission)
+// 2. The system reboots to start the new snapd. At this point
+//    the old security profiles are on disk (because the new
+//    snapd did not run yet)
+// 3. Snaps that run as daemon get started during boot by systemd
+//    (e.g. network-manager). This may happen before snapd had a
+//    chance to refresh the security profiles.
+// 4. Because the security profiles are for the old version of
+//    the snaps that run before snapd fail to start. For e.g.
+//    network-manager this is of course catastrophic.
+// To prevent this, in step(4) we have this wait-for-snapd
+// step to ensure the expected profiles are on disk.
+func SystemKeyMismatch() (bool, error) {
+	mySystemKey, err := generateSystemKey()
+	if err != nil {
+		return false, err
+	}
+
+	raw, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
+	if err != nil && os.IsNotExist(err) {
+		return false, ErrSystemKeyMissing
+	}
+	if err != nil {
+		return false, err
+	}
+	var diskSystemKey systemKey
+	if err := json.Unmarshal(raw, &diskSystemKey); err != nil {
+		return false, err
+	}
+	// deal with the race that "snap run" may start, then snapd
+	// is upgraded and generates a new system-key with different
+	// inputs than the "snap run" in memory. In this case we
+	// should be fine because new security profiles will also
+	// have been written to disk.
+	if mySystemKey.Version != diskSystemKey.Version {
+		return false, ErrSystemKeyVersion
+	}
+
+	// special case to detect local runs
+	if mockedSystemKey == nil {
+		if exe, err := os.Readlink("/proc/self/exe"); err == nil {
+			// detect running local local builds
+			if !strings.HasPrefix(exe, "/usr") && !strings.HasPrefix(exe, "/snap") {
+				logger.Noticef("running from non-installed location %s: ignoring system-key", exe)
+				return false, ErrSystemKeyVersion
+			}
+		}
+	}
+
+	// TODO: write custom struct compare
+	return !reflect.DeepEqual(mySystemKey, &diskSystemKey), nil
 }
 
 func MockSystemKey(s string) func() {
 	var sk systemKey
-	err := yaml.Unmarshal([]byte(s), &sk)
+	err := json.Unmarshal([]byte(s), &sk)
 	if err != nil {
 		panic(err)
 	}

--- a/interfaces/system_key_test.go
+++ b/interfaces/system_key_test.go
@@ -20,9 +20,11 @@
 package interfaces_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
-	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -30,9 +32,12 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/testutil"
 )
 
 type systemKeySuite struct {
+	testutil.BaseTest
+
 	tmp              string
 	apparmorFeatures string
 	buildID          string
@@ -42,67 +47,109 @@ type systemKeySuite struct {
 var _ = Suite(&systemKeySuite{})
 
 func (s *systemKeySuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
 	s.tmp = c.MkDir()
 	dirs.SetRootDir(s.tmp)
-	s.apparmorFeatures = filepath.Join(s.tmp, "/sys/kernel/security/apparmor/features")
+	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
+	c.Assert(err, IsNil)
+	err = os.MkdirAll(dirs.DistroLibExecDir, 0755)
+	c.Assert(err, IsNil)
+	err = os.Symlink("/proc/self/exe", filepath.Join(dirs.DistroLibExecDir, "snapd"))
+	c.Assert(err, IsNil)
 
+	s.apparmorFeatures = filepath.Join(s.tmp, "/sys/kernel/security/apparmor/features")
 	id, err := osutil.MyBuildID()
 	c.Assert(err, IsNil)
 	s.buildID = id
 
 	s.restorers = []func(){
 		osutil.MockMountInfo(""), osutil.MockEtcFstab(""),
+		release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"}),
 	}
 }
 
 func (s *systemKeySuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+
 	dirs.SetRootDir("/")
 	for _, fn := range s.restorers {
 		fn()
 	}
 }
 
-func (s *systemKeySuite) TestInterfaceSystemKey(c *C) {
-	restore := release.MockSecCompActions([]string{"allow", "errno", "kill", "log", "trace", "trap"})
-	defer restore()
+func (s *systemKeySuite) TestInterfaceWriteSystemKey(c *C) {
+	err := interfaces.WriteSystemKey()
+	c.Assert(err, IsNil)
 
-	systemKey := interfaces.SystemKey()
+	systemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
+	c.Assert(err, IsNil)
 
-	apparmorFeatures := release.AppArmorFeatures()
-	var apparmorFeaturesStr string
-	if len(apparmorFeatures) == 0 {
-		apparmorFeaturesStr = " []\n"
-	} else {
-		apparmorFeaturesStr = "\n- " + strings.Join(apparmorFeatures, "\n- ") + "\n"
-	}
+	apparmorFeaturesStr, err := json.Marshal(release.AppArmorFeatures())
+	c.Assert(err, IsNil)
 
-	seccompActions := release.SecCompActions()
-	var seccompActionsStr string
-	if len(seccompActions) == 0 {
-		seccompActionsStr = " []\n"
-	} else {
-		seccompActionsStr = "\n- " + strings.Join(seccompActions, "\n- ") + "\n"
-	}
+	seccompActionsStr, err := json.Marshal(release.SecCompActions())
+	c.Assert(err, IsNil)
 
 	nfsHome, err := osutil.IsHomeUsingNFS()
 	c.Assert(err, IsNil)
+
+	buildID, err := osutil.ReadBuildID("/proc/self/exe")
+	c.Assert(err, IsNil)
+
 	overlayRoot, err := osutil.IsRootWritableOverlay()
 	c.Assert(err, IsNil)
-	c.Check(systemKey, Equals, fmt.Sprintf(`build-id: %s
-apparmor-features:%snfs-home: %v
-overlay-root: "%v"
-seccomp-features:%s`, s.buildID, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
+	c.Check(string(systemKey), Equals, fmt.Sprintf(`{"version":1,"build-id":"%s","apparmor-features":%s,"nfs-home":%v,"overlay-root":%q,"seccomp-features":%s}`, buildID, apparmorFeaturesStr, nfsHome, overlayRoot, seccompActionsStr))
 }
 
-func (ts *systemKeySuite) TestInterfaceDigest(c *C) {
-	restore := interfaces.MockSystemKey(`build-id: 7a94e9736c091b3984bd63f5aebfc883c4d859e0
-apparmor-features:
-- caps
-- dbus
-`)
-	defer restore()
+func (s *systemKeySuite) TestInterfaceSystemKeyMismatchHappy(c *C) {
+	s.AddCleanup(interfaces.MockSystemKey(`
+{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus"]
+}
+`))
 
-	systemKey := interfaces.SystemKey()
-	c.Check(systemKey, Matches, "(?sm)^build-id: [a-z0-9]+$")
-	c.Check(systemKey, Matches, "(?sm).*apparmor-features:")
+	// no system-key yet -> Error
+	c.Assert(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)
+	_, err := interfaces.SystemKeyMismatch()
+	c.Assert(err, Equals, interfaces.ErrSystemKeyMissing)
+
+	// create a system-key -> no mismatch anymore
+	err = interfaces.WriteSystemKey()
+	c.Assert(err, IsNil)
+	mismatch, err := interfaces.SystemKeyMismatch()
+	c.Assert(err, IsNil)
+	c.Check(mismatch, Equals, false)
+
+	// change our system-key to have more apparmor features
+	s.AddCleanup(interfaces.MockSystemKey(`
+{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor_features": ["caps", "dbus", "more", "and", "more"]
+}
+`))
+	mismatch, err = interfaces.SystemKeyMismatch()
+	c.Assert(err, IsNil)
+	c.Check(mismatch, Equals, true)
+}
+
+func (s *systemKeySuite) TestInterfaceSystemKeyMismatchVersions(c *C) {
+	// we calculcate v1
+	s.AddCleanup(interfaces.MockSystemKey(`
+{
+"version":1,
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
+}`))
+	// and the on-disk version is v2
+	err := ioutil.WriteFile(dirs.SnapSystemKeyFile, []byte(`
+{
+"version":2,
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0"
+}`), 0644)
+	c.Assert(err, IsNil)
+
+	// when we encounter different versions we get the right error
+	_, err = interfaces.SystemKeyMismatch()
+	c.Assert(err, Equals, interfaces.ErrSystemKeyVersion)
 }

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -21,17 +21,13 @@ package ifacestate
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/backends"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/policy"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -114,22 +110,12 @@ func (m *InterfaceManager) addSnaps() error {
 }
 
 func (m *InterfaceManager) profilesNeedRegeneration() bool {
-	currentSystemKey := interfaces.SystemKey()
-	if currentSystemKey == "" {
-		logger.Noticef("no system key, forcing re-generation of security profiles")
-		return true
-	}
-
-	onDiskSystemKey, err := ioutil.ReadFile(dirs.SnapSystemKeyFile)
-	if os.IsNotExist(err) {
-		return true
-	}
+	mismatch, err := interfaces.SystemKeyMismatch()
 	if err != nil {
-		logger.Noticef("cannot read system-key file: %s", err)
+		logger.Noticef("error trying to compare the snap system key: %v", err)
 		return true
 	}
-
-	return string(onDiskSystemKey) != currentSystemKey
+	return mismatch
 }
 
 // regenerateAllSecurityProfiles will regenerate all security profiles.
@@ -173,8 +159,7 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 		}
 	}
 
-	sk := interfaces.SystemKey()
-	return osutil.AtomicWriteFile(dirs.SnapSystemKeyFile, []byte(sk), 0644, 0)
+	return interfaces.WriteSystemKey()
 }
 
 // renameCorePlugConnection renames one connection from "core-support" plug to

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2342,7 +2342,7 @@ func (s *interfaceManagerSuite) TestConnectHandlesAutoconnect(c *C) {
 }
 
 func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKeyFile(c *C) {
-	restore := interfaces.MockSystemKey("build-id: something")
+	restore := interfaces.MockSystemKey(`{"core": "123"}`)
 	defer restore()
 
 	s.mockIface(c, &ifacetest.TestInterface{InterfaceName: "test"})
@@ -2350,13 +2350,14 @@ func (s *interfaceManagerSuite) TestRegenerateAllSecurityProfilesWritesSystemKey
 	c.Assert(osutil.FileExists(dirs.SnapSystemKeyFile), Equals, false)
 
 	_ = s.manager(c)
-	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, "(?sm).*build-id:.*")
+	c.Check(dirs.SnapSystemKeyFile, testutil.FileMatches, `{.*"build-id":.*`)
 
 	stat, err := os.Stat(dirs.SnapSystemKeyFile)
 	c.Assert(err, IsNil)
 
 	// run manager again, but this time the snapsystemkey file should
 	// not be rewriten as the systemKey inputs have not changed
+	time.Sleep(20 * time.Millisecond)
 	s.privateMgr = nil
 	_ = s.manager(c)
 	stat2, err := os.Stat(dirs.SnapSystemKeyFile)

--- a/tests/main/snap-confine/task.yaml
+++ b/tests/main/snap-confine/task.yaml
@@ -20,14 +20,13 @@ execute: |
 
     echo "Simulating broken current symlink for core"
     mv $SNAP_MOUNT_DIR/core/current $SNAP_MOUNT_DIR/core/current.renamed
-
     if test-snapd-tools.echo hello 2>snap-confine.stderr; then
         echo "test-snapd-tools.echo should fail to run, test broken"
     fi
     cat snap-confine.stderr | MATCH 'cannot locate the core or legacy core snap \(current symlink missing\?\):'
+    mv $SNAP_MOUNT_DIR/core/current.renamed $SNAP_MOUNT_DIR/core/current
 
     echo "Test nvidia device fix"
-    mv $SNAP_MOUNT_DIR/core/current.renamed $SNAP_MOUNT_DIR/core/current
     # For https://github.com/snapcore/snapd/pull/4042
     echo "Simulate nvidia device tags"
     mkdir -p /run/udev/tags/snap_test-snapd-tools_echo

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -1,22 +1,27 @@
 summary: Ensure security profile re-generation works with system-key
 
 execute: |
-    restart_snapd() {
-        systemctl stop snapd.service
+    stop_snapd() {
+        systemctl stop snapd.service snapd.socket
         while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=inactive" ]; do
             systemctl show -pActiveState snapd.service
             sleep 1
         done
-
-        systemctl start snapd.service
+    }
+    start_snapd() {
+        systemctl start snapd.service snapd.socket
         while [ "$(systemctl show -pActiveState snapd.service)" != "ActiveState=active" ]; do
             systemctl show -pActiveState snapd.service
             sleep 1
         done
     }
+    restart_snapd() {
+        stop_snapd
+        start_snapd
+    }
 
     echo "Ensure a valid system-key file is on-disk"
-    cat /var/lib/snapd/system-key | MATCH "build-id: [0-9a-z]+"
+    cat /var/lib/snapd/system-key | MATCH '"build-id":"[0-9a-z]+"'
     buf="$(stat /var/lib/snapd/system-key)"
     system_key_content="$(cat /var/lib/snapd/system-key)"
 
@@ -29,9 +34,33 @@ execute: |
     fi
 
     echo "Ensure that the system-key is rewritten if system-key changes"
-    printf "something: new\n" >> /var/lib/snapd/system-key
+    printf '{"version":1}' > /var/lib/snapd/system-key
     restart_snapd
-    if grep "something: new" /var/lib/snapd/system-key; then
+    if grep '{"version":1}' /var/lib/snapd/system-key; then
+        echo "system-key *not* rewriten test broken"
+        exit 1
+    fi
+
+    echo "Ensure snap run waits for system key updates"
+    snap install test-snapd-tools
+    echo "Change system-key, this ensure that snap run will wait"
+    printf '{"version":1}' > /var/lib/snapd/system-key
+    stop_snapd
+    if SNAPD_DEBUG_SYSTEM_KEY_RETRY=1 test-snapd-tools.echo bad; then
+        echo "snap run should have errored because of changed system-key"
+        exit 1
+    fi
+    start_snapd
+
+    echo "Ensure snap run does not wait when it can talk to snapd"
+    echo "Change system-key, with running snapd"
+    printf '{"version":1}' > /var/lib/snapd/system-key
+    test-snapd-tools.echo good
+    
+    echo "Things work again after a restart of snapd"
+    restart_snapd
+    test-snapd-tools.echo good-again
+    if grep '{"version":1}' /var/lib/snapd/system-key; then
         echo "system-key *not* rewriten test broken"
         exit 1
     fi


### PR DESCRIPTION
many: make `snap run` look at the system-key for security profiles

If the system-key for the security profiles does not match, wait and
eventually timeout if snapd is not generating the profiles we need.

Without it we may have the following scenario:

1. snapd gets refreshed and snaps need updated security profiles
   to work (e.g. because snap-confine needs new generated
   snap-update-ns profiles on disk)
2. The system reboots to start the new snapd. At this point
   the old security profiles are on disk (because the new
   snapd did not run yet) and nothing new is there yet.
3. Snaps that run as daemon get started during boot by systemd
   (e.g. network-manager). This may happen before snapd had a
   chance to refresh the security profiles.
4. Because the security profiles are for the old version of
   the snaps that run before snapd starts and generates the
   missing security profiles will fail to start. For e.g.
   network-manager this is of course catastrophic as it
   leaves the machine without networking.

To prevent this, in step(4) we have this wait-for-snapd
step to ensure the expected profiles are on disk.

This PR also switches the system-key to json to make the
parsing a lot quicker.

It also introduces a new version key into the system-key.
This version key is important because there is a race when
a) the sytem-key gets new inputs
b) old `snap run` is executed and slow to load
c) new snapd with new inputs run at exactly the same time and
   write a new system-key to disk
In this case (b) will have calculated a profile without the new
inputs and eventually timeout. The new code will just continue
if there is a version mismatch if it can reach snapd.

