### PR TITLE
tests: fix snap-run tests when snapd is not running

### DIFF
--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/snapcore/snapd/cmd"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
 	snapdsnap "github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
@@ -77,6 +78,16 @@ func (s *BaseSnapSuite) SetUpTest(c *C) {
 	os.Setenv(TestAuthFileEnvKey, s.AuthFile)
 
 	snapdsnap.MockSanitizePlugsSlots(func(snapInfo *snapdsnap.Info) {})
+
+	err := os.MkdirAll(filepath.Dir(dirs.SnapSystemKeyFile), 0755)
+	c.Assert(err, IsNil)
+	err = interfaces.WriteSystemKey()
+	c.Assert(err, IsNil)
+	interfaces.MockSystemKey(`
+{
+"build-id": "7a94e9736c091b3984bd63f5aebfc883c4d859e0",
+"apparmor-features": ["caps", "dbus"]
+}`)
 }
 
 func (s *BaseSnapSuite) TearDownTest(c *C) {


### PR DESCRIPTION
The new system-key code falls back  to talking to snapd if there is
an error with the system-key comparison. Ensure proper mocking in
the tests so that this is not needed.
