### PR TITLE
tests: disentangle etc vs extrausers in core tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -363,7 +363,7 @@ restore: |
 restore-each: |
     "$TESTSLIB"/prepare-restore.sh --restore-project-each
     # XXX: something is hosing the filesystem so look for signs of that
-    ! grep -F //deleted /proc/self/mountinfo
+    ! grep -F "//deleted /etc" /proc/self/mountinfo
 
 suites:
     tests/main/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -362,6 +362,8 @@ restore: |
     "$TESTSLIB"/prepare-restore.sh --restore-project
 restore-each: |
     "$TESTSLIB"/prepare-restore.sh --restore-project-each
+    # XXX: something is hosing the filesystem so look for signs of that
+    ! grep -F //deleted /proc/self/mountinfo
 
 suites:
     tests/main/:


### PR DESCRIPTION
This changes how we get the spread root user to work on core, instead of bind mounting /var/lib/extrausers/* over /etc/*,  we setup a separate set of files in /root/test-etc/ and read-only bind mount those instead.

The cons of the old approach:
* making /var/lib/extrausers/* the same as /etc/* means all our account related tests were not very realistic
* /etc/passwd etc are read-only on core but /var/lib/extrausers/* is meant to be mutable/mutated and it is by tests and in some cases the bind mount got into a //deleted state, this seems to be main source of the annoying tests/main/layout /etc failures

We still need to sync over /var/lib/extrausers/* and make sure the test user is there, this is consistent with new users being there on core but is not ideal, and is needed only for the classic snap test; we end doing what writeable path does at boot. Something maybe we can revisit later.