### PR TITLE
cmd/snap-confine: apparmor: allow creating prefix path for gl/vulkan

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -266,8 +266,15 @@
     mount options=(remount ro) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
 
     # create gl dirs as needed
-    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/ w,
-    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/ w,
+    /tmp/snap.rootfs_*/ r,
+    /tmp/snap.rootfs_*/var/ r,
+    /tmp/snap.rootfs_*/var/lib/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/** rw,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/** rw,
 
     # for chroot on steroids, we use pivot_root as a better chroot that makes
     # apparmor rules behave the same on classic and outside of classic.


### PR DESCRIPTION
Update snap-confine apparmor profile to allow creating a prefix path with
sc_nonfatal_mkpath(). The helper uses a combination of openat() and mkdirat().
Update the profile to allow open in intermediate paths up down to
/var/lib/snapd/lib/{gl,gl32,vulkan} and writes at the paths (and subdirectories)
below.

See https://forum.snapcraft.io/t/all-the-snaps-stopped-working/4650 for information on how it fails.
