### PR TITLE
skip test that requires internet when not present

### DIFF
--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -801,9 +802,17 @@ func (s *deviceMgrSuite) TestDoRequestSerialErrorsOnNoHost(c *C) {
 		c.Skip("cannot run test when http proxy is in use, the error pattern is different")
 	}
 
+	const nonexistent_host = "nowhere.nowhere.test"
+
+	// check internet access
+	_, err := net.LookupHost(nonexistent_host)
+	if netErr, ok := err.(net.Error); !ok || netErr.Temporary() {
+		c.Skip("cannot run test with no internet access, the error pattern is different")
+	}
+
 	privKey, _ := assertstest.GenerateKey(testKeyLength)
 
-	nowhere := "http://nowhere.nowhere.test"
+	nowhere := "http://" + nonexistent_host
 
 	mockRequestIDURL := nowhere + requestIDURLPath
 	restore := devicestate.MockRequestIDURL(mockRequestIDURL)


### PR DESCRIPTION
Do a host lookup on "www.google.com" to check for presence of internet
access in a devicestate test that requires it, skip the test if not
present.

Buildroot jails such as those used by OpenSUSE disable internet access.

(agreement signed)

I tried to think of a way to check for internet access in a way that doesn't actually access the internet, but could not find a good solution, as it is disabled in a variety of ways. Hopefully a host lookup is harmless enough.