### PR TITLE
cmd/snapd: make sure signal handlers are established during early daemon startup

### DIFF
--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -56,6 +56,9 @@ func run() error {
 	t0 := time.Now().Truncate(time.Millisecond)
 	httputil.SetUserAgentFromVersion(cmd.Version)
 
+	ch := make(chan os.Signal)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+
 	d, err := daemon.New()
 	if err != nil {
 		return err
@@ -71,8 +74,6 @@ func run() error {
 	systemd.SdNotify("READY=1")
 	logger.Debugf("activation done in %v", time.Now().Truncate(time.Millisecond).Sub(t0))
 
-	ch := make(chan os.Signal)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	select {
 	case sig := <-ch:
 		logger.Noticef("Exiting on %s signal.\n", sig)


### PR DESCRIPTION
Signal handlers for SIGTERM & SIGINT were only added once the daemon
initialization phase has completed. Given that the init phase does a fair amount
of work, SIGTERM or SIGINT received at this time would terminate the process,
without any chance for performing cleanup.

The problem would manifest itself as a failure in tests/main/snap-confine,
and one or more temporary files of snap-confine being left behind. This was
logged as:
```
   + aa-enforce /etc/apparmor.d/usr.lib.snapd.snap-confine.real

   ERROR: Conflicting profiles for /snap/core/4321/usr/lib/snapd/snap-confine defined in two files:
   - /etc/apparmor.d/snap.core.4321.usr.lib.snapd.snap-confine
   - /etc/apparmor.d/snap.core.4321.usr.lib.snapd.snap-confine.5GrtGCJBj87S
```
