### PR TITLE
osutil: use tilde suffix for temporary files used for atomic replacement

### DIFF
--- a/osutil/io.go
+++ b/osutil/io.go
@@ -86,7 +86,14 @@ func NewAtomicFile(filename string, perm os.FileMode, flags AtomicWriteFlags, ui
 			}
 		}
 	}
-	tmp := filename + "." + strutil.MakeRandomString(12)
+	// The tilde is appended so that programs that inspect all files in some
+	// directory are more likely to ignore this file as an editor backup file.
+	//
+	// This fixes an issue in apparmor-utils package, specifically in
+	// aa-enforce. Tools from this package enumerate all profiles by loading
+	// parsing any file found in /etc/apparmor.d/, skipping only very specific
+	// suffixes, such as the one we selected below.
+	tmp := filename + "." + strutil.MakeRandomString(12) + "~"
 
 	fd, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
 	if err != nil {

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -155,7 +155,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) 
 	tmpdir := c.MkDir()
 	// ensure we always get the same result
 	rand.Seed(1)
-	expectedRandomness := strutil.MakeRandomString(12)
+	expectedRandomness := strutil.MakeRandomString(12) + "~"
 	// ensure we always get the same result
 	rand.Seed(1)
 


### PR DESCRIPTION
This patch changes the temporary files used for, amongst other, apparmor
profiles with ~ (tilde) so that they are ignored by apparmor tools in an
unlikely but real case when snapd is killed after creating the temporary
file but before removing it or renaming it over to something else.

Tilde is the best suffix for this choice as other suffixes that are
ignored include packaging specific semantics (like .dpkg-new) or have
well-known meaning (.rej, .orig).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>