### PR TITLE
release-tools: add repack-debian-tarball.sh

### DIFF
--- a/release-tools/repack-debian-tarball.sh
+++ b/release-tools/repack-debian-tarball.sh
@@ -20,7 +20,7 @@
 set -ue
 
 # Get the filename from argv[1]
-debian_tarball="$1"
+debian_tarball="${1:-}"
 if [ "$debian_tarball" = "" ]; then
 	echo "Usage: repack-debian-tarball.sh <snapd-debian-tarball>"
 	exit 1

--- a/release-tools/repack-debian-tarball.sh
+++ b/release-tools/repack-debian-tarball.sh
@@ -17,7 +17,7 @@
 # - snapd_2.31.2.no-vendor.tar.xz
 # - snapd_2.31.2.vendor.tar.xz
 # - snapd_2.31.2.only-vendor.xz
-set -xue
+set -ue
 
 # Get the filename from argv[1]
 debian_tarball="$1"

--- a/release-tools/repack-debian-tarball.sh
+++ b/release-tools/repack-debian-tarball.sh
@@ -26,6 +26,11 @@ if [ "$debian_tarball" = "" ]; then
 	exit 1
 fi
 
+if [ ! -f "$debian_tarball" ]; then
+	echo "cannot operate on $debian_tarball, no such file"
+	exit 1
+fi
+
 # Extract the upstream version from the filename.
 # For example: snapd_2.31.2-1.tar.xz => 2.32.2
 upstream_version="$(echo "$debian_tarball" | cut -d _ -f 2 | sed -e 's/\.tar\..*//')"

--- a/release-tools/repack-debian-tarball.sh
+++ b/release-tools/repack-debian-tarball.sh
@@ -32,7 +32,8 @@ if [ ! -f "$debian_tarball" ]; then
 fi
 
 # Extract the upstream version from the filename.
-# For example: snapd_2.31.2-1.tar.xz => 2.32.2
+# For example: snapd_2.31.2.tar.xz => 2.32.2
+# NOTE: There is no dash (-) in the version because snapd is a native Debian package.
 upstream_version="$(echo "$debian_tarball" | cut -d _ -f 2 | sed -e 's/\.tar\..*//')"
 
 # Scratch directory is where the original tarball is unpacked.

--- a/release-tools/repack-debian-tarball.sh
+++ b/release-tools/repack-debian-tarball.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# This script is used to re-pack the "orig" tarball from the Debian package
+# into a suitable upstream release. There are two changes applied: The Debian
+# tarball contains the directory snapd.upstream/ which needs to become
+# snapd-$VERSION. The Debian tarball contains the vendor/ directory which must
+# be removed from one of those.
+#
+# Example usage:
+#
+# $ wget https://launchpad.net/ubuntu/+archive/primary/+files/snapd_2.31.2.tar.xz 
+# $ repack-debian-tarball.sh snapd_2.31.2.tar.xz
+#
+# This will produce three files that need to be added to the github release page:
+#
+# - snapd_2.31.2.no-vendor.tar.xz
+# - snapd_2.31.2.vendor.tar.xz
+# - snapd_2.31.2.only-vendor.xz
+set -xue
+
+# Get the filename from argv[1]
+debian_tarball="$1"
+if [ "$debian_tarball" = "" ]; then
+	echo "Usage: repack-debian-tarball.sh <snapd-debian-tarball>"
+	exit 1
+fi
+
+# Extract the upstream version from the filename.
+# For example: snapd_2.31.2-1.tar.xz => 2.32.2
+upstream_version="$(echo "$debian_tarball" | cut -d _ -f 2 | sed -e 's/\.tar\..*//')"
+
+# Scratch directory is where the original tarball is unpacked.
+scratch_dir="$(mktemp -d)"
+cleanup() {
+	rm -rf "$scratch_dir"
+}
+trap cleanup EXIT
+
+# Unpack the original with fakeroot (to preserve ownership of files). 
+fakeroot tar \
+	--auto-compress \
+	--extract \
+	--file="$debian_tarball" \
+	--directory="$scratch_dir/"
+
+# Pack a fully copy with vendor tree
+fakeroot tar \
+	--create \
+	--transform="s/snapd.upstream/snapd-$upstream_version/" \
+	--file=snapd_"$upstream_version".vendor.tar.xz \
+	--auto-compress \
+	--directory="$scratch_dir/" snapd.upstream
+
+# Pack a copy without vendor tree
+fakeroot tar \
+	--create \
+	--transform="s/snapd.upstream/snapd-$upstream_version/" \
+	--exclude='snapd*/vendor/*' \
+	--file=snapd_"$upstream_version".no-vendor.tar.xz \
+	--auto-compress \
+	--directory="$scratch_dir/" snapd.upstream
+
+# Pack a copy of the vendor tree
+fakeroot tar \
+	--create \
+	--transform="s/snapd.upstream/snapd-$upstream_version/" \
+	--file=snapd_"$upstream_version".only-vendor.tar.xz \
+	--auto-compress \
+	--directory="$scratch_dir/" snapd.upstream/vendor/ 


### PR DESCRIPTION
This patch adds first a several release scripts used by the release
manager to prepare snapd releases. The script takes a Debian tarball and
creates three separate tarballs with correctly named (and versioned)
directory.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
