### PR TITLE
cmd/snap: user session application autostart v3

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -237,28 +237,16 @@ func antialias(snapApp string, args []string) (string, []string) {
 	return actualApp, argsOut
 }
 
-func getSnapInfo(snapName string, revision snap.Revision) (*snap.Info, error) {
+func getSnapInfo(snapName string, revision snap.Revision) (info *snap.Info, err error) {
 	if revision.Unset() {
-		curFn := filepath.Join(dirs.SnapMountDir, snapName, "current")
-		realFn, err := os.Readlink(curFn)
-		if err != nil {
-			return nil, fmt.Errorf("cannot find current revision for snap %s: %s", snapName, err)
-		}
-		rev := filepath.Base(realFn)
-		revision, err = snap.ParseRevision(rev)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read revision %s: %s", rev, err)
-		}
+		info, err = snap.ReadCurrentInfo(snapName)
+	} else {
+		info, err = snap.ReadInfo(snapName, &snap.SideInfo{
+			Revision: revision,
+		})
 	}
 
-	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
-		Revision: revision,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return info, nil
+	return info, err
 }
 
 func createOrUpdateUserDataSymlink(info *snap.Info, usr *user.User) error {

--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -81,8 +81,7 @@ func (x *cmdUserd) Execute(args []string) error {
 }
 
 func (x *cmdUserd) runAutostart() error {
-	err := userd.AutostartSessionApps()
-	if err != nil {
+	if err := userd.AutostartSessionApps(); err != nil {
 		return fmt.Errorf("autostart failed for the following apps:\n%v", err)
 	}
 	return nil

--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -33,6 +33,8 @@ import (
 
 type cmdUserd struct {
 	userd userd.Userd
+
+	Autostart bool `long:"autostart"`
 }
 
 var shortUserdHelp = i18n.G("Start the userd service")
@@ -46,16 +48,19 @@ func init() {
 		longUserdHelp,
 		func() flags.Commander {
 			return &cmdUserd{}
-		},
-		nil,
-		[]argDesc{},
-	)
+		}, map[string]string{
+			"autostart": i18n.G("Autostart user applications"),
+		}, nil)
 	cmd.hidden = true
 }
 
 func (x *cmdUserd) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
+	}
+
+	if x.Autostart {
+		return x.runAutostart()
 	}
 
 	if err := x.userd.Init(); err != nil {
@@ -73,4 +78,12 @@ func (x *cmdUserd) Execute(args []string) error {
 	}
 
 	return x.userd.Stop()
+}
+
+func (x *cmdUserd) runAutostart() error {
+	err := userd.AutostartSessionApps()
+	if err != nil {
+		return fmt.Errorf("autostart failed for the following apps:\n%v", err)
+	}
+	return nil
 }

--- a/data/Makefile
+++ b/data/Makefile
@@ -2,3 +2,4 @@ all install clean:
 	$(MAKE) -C systemd $@
 	$(MAKE) -C dbus $@
 	$(MAKE) -C env $@
+	$(MAKE) -C desktop $@

--- a/data/desktop/Makefile
+++ b/data/desktop/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+BINDIR := /usr/bin
+DATADIR := /usr/share
+
+SOURCES := $(wildcard *.in)
+DESKTOP_FILES = $(SOURCES:.in=)
+
+.PHONY: all
+all: $(DESKTOP_FILES)
+
+.PHONY: install
+install: $(DESKTOP_FILES)
+	# NOTE: old (e.g. 14.04) GNU coreutils doesn't -D with -t
+	install -d -m 0755 $(DESTDIR)/$(DATADIR)/applications
+	install -m 0644 -t $(DESTDIR)/$(SYSTEMDSYSTEMUNITDIR) $^
+
+.PHONY: clean
+clean:
+	rm -f $(DESKTOP_FILES)
+
+%: %.in
+	cat $< | \
+		sed s:@bindir@:$(BINDIR):g | \
+		cat > $@

--- a/data/desktop/Makefile
+++ b/data/desktop/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Canonical Ltd
+# Copyright (C) 2018 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -13,10 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-BINDIR := /usr/bin
-DATADIR := /usr/share
+BINDIR = /usr/bin
+DATADIR = /usr/share
 
-SOURCES := snap-userd-autostart.desktop.in
+SOURCES = snap-userd-autostart.desktop.in
 DESKTOP_FILES = $(SOURCES:.in=)
 
 .PHONY: all

--- a/data/desktop/Makefile
+++ b/data/desktop/Makefile
@@ -16,7 +16,7 @@
 BINDIR := /usr/bin
 DATADIR := /usr/share
 
-SOURCES := $(wildcard *.in)
+SOURCES := snap-userd-autostart.desktop.in
 DESKTOP_FILES = $(SOURCES:.in=)
 
 .PHONY: all

--- a/data/desktop/Makefile
+++ b/data/desktop/Makefile
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 BINDIR = /usr/bin
-DATADIR = /usr/share
+SYSCONFXDGAUTOSTARTDIR = /etc/xdg/autostart
 
 SOURCES = snap-userd-autostart.desktop.in
 DESKTOP_FILES = $(SOURCES:.in=)
@@ -25,8 +25,8 @@ all: $(DESKTOP_FILES)
 .PHONY: install
 install: $(DESKTOP_FILES)
 	# NOTE: old (e.g. 14.04) GNU coreutils doesn't -D with -t
-	install -d -m 0755 $(DESTDIR)/$(DATADIR)/applications
-	install -m 0644 -t $(DESTDIR)/$(SYSTEMDSYSTEMUNITDIR) $^
+	install -d -m 0755 $(DESTDIR)/$(SYSCONFXDGAUTOSTARTDIR)
+	install -m 0644 -t $(DESTDIR)/$(SYSCONFXDGAUTOSTARTDIR) $^
 
 .PHONY: clean
 clean:

--- a/data/desktop/snap-userd-autostart.desktop.in
+++ b/data/desktop/snap-userd-autostart.desktop.in
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Snap user application autostart helper
+Comment=A snap helper for autostarting user applications
+Exec=@bindir@/snap userd --autostart
+Type=Application

--- a/data/desktop/snap-userd-autostart.desktop.in
+++ b/data/desktop/snap-userd-autostart.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=Snap user application autostart helper
-Comment=A snap helper for autostarting user applications
+Comment=Helper program for launching snap applications that are configured to start automatically.
 Exec=@bindir@/snap userd --autostart
 Type=Application

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -113,6 +113,9 @@ const (
 	// are in the snap confinement environment.
 	CoreLibExecDir   = "/usr/lib/snapd"
 	CoreSnapMountDir = "/snap"
+
+	// Directory with snap data inside user's home
+	UserHomeSnapDir = "snap"
 )
 
 var (
@@ -179,7 +182,7 @@ func SetRootDir(rootdir string) {
 	}
 
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
-	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/snap/")
+	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/", UserHomeSnapDir)
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	SnapConfineAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "snap-confine")
 	AppArmorCacheDir = filepath.Join(rootdir, "/var/cache/apparmor")

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -620,6 +620,7 @@ popd
 %{_datadir}/dbus-1/services/io.snapcraft.Launcher.service
 %{_datadir}/dbus-1/services/io.snapcraft.Settings.service
 %{_datadir}/polkit-1/actions/io.snapcraft.snapd.policy
+%{_sysconfdir}/xdg/autostart/snap-userd-autostart.desktop
 %config(noreplace) %{_sysconfdir}/sysconfig/snapd
 %dir %{_sharedstatedir}/snapd
 %dir %{_sharedstatedir}/snapd/assertions

--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -313,6 +313,7 @@ fi
 %{_mandir}/man1/snap.1.gz
 /usr/share/dbus-1/services/io.snapcraft.Launcher.service
 /usr/share/dbus-1/services/io.snapcraft.Settings.service
+%{_sysconfdir}/xdg/autostart/snap-userd-autostart.desktop
 
 %changelog
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -780,6 +780,22 @@ func ReadInfo(name string, si *SideInfo) (*Info, error) {
 	return info, nil
 }
 
+// ReadCurrentInfo reads the snap information from the installed snap in 'current' revision
+func ReadCurrentInfo(snapName string) (*Info, error) {
+	curFn := filepath.Join(dirs.SnapMountDir, snapName, "current")
+	realFn, err := os.Readlink(curFn)
+	if err != nil {
+		return nil, fmt.Errorf("cannot find current revision for snap %s: %s", snapName, err)
+	}
+	rev := filepath.Base(realFn)
+	revision, err := ParseRevision(rev)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read revision %s: %s", rev, err)
+	}
+
+	return ReadInfo(snapName, &SideInfo{Revision: revision})
+}
+
 // ReadInfoFromSnapFile reads the snap information from the given File
 // and completes it with the given side-info if this is not nil.
 func ReadInfoFromSnapFile(snapf Container, si *SideInfo) (*Info, error) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -304,12 +304,12 @@ func (s *Info) DataDir() string {
 
 // UserDataDir returns the user-specific data directory of the snap.
 func (s *Info) UserDataDir(home string) string {
-	return filepath.Join(home, "snap", s.Name(), s.Revision.String())
+	return filepath.Join(home, dirs.UserHomeSnapDir, s.Name(), s.Revision.String())
 }
 
 // UserCommonDataDir returns the user-specific data directory common across revision of the snap.
 func (s *Info) UserCommonDataDir(home string) string {
-	return filepath.Join(home, "snap", s.Name(), "common")
+	return filepath.Join(home, dirs.UserHomeSnapDir, s.Name(), "common")
 }
 
 // CommonDataDir returns the data directory common across revisions of the snap.

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -195,6 +195,23 @@ func (s *infoSuite) TestReadInfo(c *C) {
 	c.Check(snapInfo2, DeepEquals, snapInfo1)
 }
 
+func (s *infoSuite) TestReadCurrentInfo(c *C) {
+	si := &snap.SideInfo{Revision: snap.R(42)}
+
+	snapInfo1 := snaptest.MockSnapCurrent(c, sampleYaml, si)
+
+	snapInfo2, err := snap.ReadCurrentInfo("sample")
+	c.Assert(err, IsNil)
+
+	c.Check(snapInfo2.Name(), Equals, "sample")
+	c.Check(snapInfo2.Revision, Equals, snap.R(42))
+	c.Check(snapInfo2, DeepEquals, snapInfo1)
+
+	snapInfo3, err := snap.ReadCurrentInfo("not-sample")
+	c.Check(snapInfo3, IsNil)
+	c.Assert(err, ErrorMatches, `cannot find current revision for snap not-sample:.*`)
+}
+
 func (s *infoSuite) TestInstallDate(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(1)}
 	info := snaptest.MockSnap(c, sampleYaml, si)

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -68,6 +68,18 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	return snapInfo
 }
 
+// MockSnapCurrent does the same as MockSnap but additionally creates the
+// 'current' symlink.
+//
+// The caller is responsible for mocking root directory with dirs.SetRootDir()
+// and for altering the overlord state if required.
+func MockSnapCurrent(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
+	si := MockSnap(c, yamlText, sideInfo)
+	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
+	c.Assert(err, check.IsNil)
+	return si
+}
+
 // MockInfo parses the given snap.yaml text and returns a validated snap.Info object including the optional SideInfo.
 //
 // The result is just kept in memory, there is nothing kept on disk. If that is

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -72,6 +72,20 @@ func (s *snapTestSuite) TestMockSnap(c *C) {
 	c.Check(snapInfo.Plugs["network"].Interface, Equals, "network")
 }
 
+func (s *snapTestSuite) TestMockSnapCurrent(c *C) {
+	snapInfo := snaptest.MockSnapCurrent(c, sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
+	// Data from YAML is used
+	c.Check(snapInfo.Name(), Equals, "sample")
+	// Data from SideInfo is used
+	c.Check(snapInfo.Revision, Equals, snap.R(42))
+	// The YAML is placed on disk
+	c.Check(filepath.Join(dirs.SnapMountDir, "sample", "42", "meta", "snap.yaml"),
+		testutil.FileEquals, sampleYaml)
+	link, err := os.Readlink(filepath.Join(dirs.SnapMountDir, "sample", "current"))
+	c.Check(err, IsNil)
+	c.Check(link, Equals, filepath.Join(dirs.SnapMountDir, "sample", "42"))
+}
+
 func (s *snapTestSuite) TestMockInfo(c *C) {
 	snapInfo := snaptest.MockInfo(c, sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
 	// Data from YAML is used

--- a/tests/lib/snaps/test-snapd-xdg-autostart/bin/foobar
+++ b/tests/lib/snaps/test-snapd-xdg-autostart/bin/foobar
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+dump_autostart() {
+    dfpath="$SNAP_USER_DATA/.config/autostart/foo.desktop"
+
+    test -e "$dfpath" && return
+
+    echo "generating autostart file $dfpath"
+
+    mkdir -p $SNAP_USER_DATA/.config/autostart
+    cat <<EOF > $dfpath
+[Desktop Entry]
+Name=foo autostart
+Exec=/foo/bar/baz/bin/foobar --autostart a b c
+EOF
+}
+
+case "$1" in
+    --autostart)
+        echo "autostarting with args '$@'" | tee $SNAP_USER_DATA/foo-autostarted
+        ;;
+    *)
+        echo "regular run with args '$@'"
+        dump_autostart
+        ;;
+esac

--- a/tests/lib/snaps/test-snapd-xdg-autostart/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-xdg-autostart/meta/snap.yaml
@@ -1,0 +1,6 @@
+name: test-snapd-xdg-autostart
+version: 1.0
+apps:
+  foo:
+    command: bin/foobar
+    autostart: foo.desktop

--- a/tests/main/snap-userd-desktop-app-autostart/task.yaml
+++ b/tests/main/snap-userd-desktop-app-autostart/task.yaml
@@ -1,0 +1,29 @@
+summary: Check that snap userd can autostart user session applications
+
+execute: |
+    echo "When the snap is installed"
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-xdg-autostart
+
+    # run the app directly, it will dump a *.desktop file
+    snap run test-snapd-xdg-autostart.foo
+
+    echo "And snap application autostart file exists"
+    test -e ~/snap/test-snapd-xdg-autostart/current/.config/autostart/foo.desktop
+
+    echo "Applications can be automatically started by snap userd --autostart"
+
+    test ! -e ~/snap/test-xdg-snap-autostart/current/foo-autostarted
+    snap userd --autostart > autostart.log 2>&1
+
+    # when app is autostarted it dumps a file at $SNAP_USER_DATA/foo-autostarted,
+    # applications are forked by userd, but userd does not wait for them
+    for i in `seq 20`; do
+        test -e ~/snap/test-snapd-xdg-autostart/current/foo-autostarted && break
+        sleep 1
+    done
+    test -e ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
+
+restore: |
+    rm -f ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
+    rm -f ~/snap/test-snapd-xdg-autostart/current/.config/autostart/foo.desktop

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -125,6 +125,9 @@ func autostartCmd(snapName, desktopFilePath string) (*exec.Cmd, error) {
 		return nil, fmt.Errorf("invalid application startup command: %v", err)
 	}
 
+	// NOTE: Ignore the actual argv[0] in Exec=.. line and replace it with a
+	// command of the snap application. Any arguments passed in the Exec=..
+	// line to the original command are preserved.
 	cmd := exec.Command(app.WrapperPath(), split[1:]...)
 	return cmd, nil
 }

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -61,6 +61,7 @@ func expandDesktopFields(in string) string {
 	return string(out)
 }
 
+// Note: consider wrappers/desktop.go if we start parsing more than Exec line
 func findExec(desktopFileContent []byte) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewBuffer(desktopFileContent))
 	execCmd := ""

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -91,7 +91,7 @@ func autostartCmd(snapName, desktopFilePath string) (*exec.Cmd, error) {
 
 	info, err := snap.ReadCurrentInfo(snapName)
 	if err != nil {
-		return nil, fmt.Errorf("cannot obtain snap information for snap %q: %v", snapName, err)
+		return nil, err
 	}
 
 	var app *snap.AppInfo

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -1,0 +1,177 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package userd
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil/shlex"
+)
+
+var (
+	replacedDesktopKeys = []string{"%f", "%F", "%u", "%U", "%d", "%D",
+		"%n", "%N", "%i", "%c", "%k", "%v", "%m"}
+)
+
+func findExec(desktopFileContent []byte) (string, error) {
+	scanner := bufio.NewScanner(bytes.NewBuffer(desktopFileContent))
+	execCmd := ""
+	for scanner.Scan() {
+		bline := scanner.Bytes()
+
+		if !bytes.HasPrefix(bline, []byte("Exec=")) {
+			continue
+		}
+
+		execCmd = string(bline[len("Exec="):])
+		for _, key := range replacedDesktopKeys {
+			execCmd = strings.Replace(execCmd, key, "", -1)
+		}
+		break
+	}
+
+	execCmd = strings.TrimSpace(execCmd)
+	if execCmd == "" {
+		return "", fmt.Errorf("Exec not found or invalid")
+	}
+	return execCmd, nil
+}
+
+func getCurrentSnapInfo(snapName string) (*snap.Info, error) {
+	curFn := filepath.Join(dirs.SnapMountDir, snapName, "current")
+	realFn, err := os.Readlink(curFn)
+	if err != nil {
+		return nil, fmt.Errorf("cannot find current revision for snap %s: %s", snapName, err)
+	}
+	rev := filepath.Base(realFn)
+	revision, err := snap.ParseRevision(rev)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read revision %s: %s", rev, err)
+	}
+
+	return snap.ReadInfo(snapName, &snap.SideInfo{Revision: revision})
+}
+
+func tryAutostartApp(snapName, desktopFilePath string) (*exec.Cmd, error) {
+	desktopFile := filepath.Base(desktopFilePath)
+
+	info, err := getCurrentSnapInfo(snapName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain snap information for snap %q: %v", snapName, err)
+	}
+
+	var app *snap.AppInfo
+	for _, candidate := range info.Apps {
+		if candidate.Autostart == desktopFile {
+			app = candidate
+			break
+		}
+	}
+	if app == nil {
+		return nil, fmt.Errorf("failed to match desktop file %q with snap %q applications", desktopFile, snapName)
+	}
+
+	content, err := ioutil.ReadFile(desktopFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	command, err := findExec(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine startup command: %v", err)
+	}
+	logger.Debugf("exec line: %v", command)
+
+	split, err := shlex.Split(command)
+	if err != nil {
+		return nil, fmt.Errorf("invalid application startup command: %v", err)
+	}
+
+	cmd := exec.Command(app.WrapperPath(), split[1:]...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to autostart %q: %v", desktopFile, err)
+	}
+	return cmd, nil
+}
+
+type failedAutostartError map[string]error
+
+func (f failedAutostartError) Error() string {
+	var out bytes.Buffer
+	for app, err := range f {
+		fmt.Fprintf(&out, "- %q: %v\n", app, err)
+	}
+	return out.String()
+}
+
+var userCurrent = user.Current
+
+// AutostartSessionApps starts applications which have placed their desktop
+// files in $SNAP_USER_DATA/.config/autostart
+func AutostartSessionApps() error {
+	usr, err := userCurrent()
+	if err != nil {
+		return err
+	}
+
+	usrSnapDir := filepath.Join(usr.HomeDir, "snap")
+
+	glob := filepath.Join(usrSnapDir, "*/current/.config/autostart/*.desktop")
+	matches, err := filepath.Glob(glob)
+	if err != nil {
+		return err
+	}
+
+	failedApps := make(failedAutostartError)
+	for _, desktopFilePath := range matches {
+		desktopFile := filepath.Base(desktopFilePath)
+		logger.Debugf("autostart desktop file %v", desktopFile)
+
+		// /home/foo/snap/some-snap/current/.config/autostart/some-app.desktop ->
+		//    some-snap/current/.config/autostart/some-app.desktop
+		noHomePrefix := strings.TrimPrefix(desktopFilePath, usrSnapDir+"/")
+		// some-snap/current/.config/autostart/some-app.desktop -> some-snap
+		snapName := noHomePrefix[0:strings.IndexByte(noHomePrefix, '/')]
+
+		logger.Debugf("snap name: %q", snapName)
+
+		if _, err := tryAutostartApp(snapName, desktopFilePath); err != nil {
+			logger.Debugf("error encountered when trying to autostart %v for snap %q: %v", desktopFile, snapName, err)
+			failedApps[desktopFile] = err
+		}
+	}
+	if len(failedApps) > 0 {
+		return failedApps
+	}
+	return nil
+}

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -75,6 +75,9 @@ func findExec(desktopFileContent []byte) (string, error) {
 		execCmd = expandDesktopFields(full)
 		break
 	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
 
 	execCmd = strings.TrimSpace(execCmd)
 	if execCmd == "" {

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -159,7 +159,7 @@ func AutostartSessionApps() error {
 		return err
 	}
 
-	usrSnapDir := filepath.Join(usr.HomeDir, "snap")
+	usrSnapDir := filepath.Join(usr.HomeDir, dirs.UserHomeSnapDir)
 
 	glob := filepath.Join(usrSnapDir, "*/current/.config/autostart/*.desktop")
 	matches, err := filepath.Glob(glob)

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -83,25 +83,10 @@ func findExec(desktopFileContent []byte) (string, error) {
 	return execCmd, nil
 }
 
-func getCurrentSnapInfo(snapName string) (*snap.Info, error) {
-	curFn := filepath.Join(dirs.SnapMountDir, snapName, "current")
-	realFn, err := os.Readlink(curFn)
-	if err != nil {
-		return nil, fmt.Errorf("cannot find current revision for snap %s: %s", snapName, err)
-	}
-	rev := filepath.Base(realFn)
-	revision, err := snap.ParseRevision(rev)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read revision %s: %s", rev, err)
-	}
-
-	return snap.ReadInfo(snapName, &snap.SideInfo{Revision: revision})
-}
-
 func autostartCmd(snapName, desktopFilePath string) (*exec.Cmd, error) {
 	desktopFile := filepath.Base(desktopFilePath)
 
-	info, err := getCurrentSnapInfo(snapName)
+	info, err := snap.ReadCurrentInfo(snapName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot obtain snap information for snap %q: %v", snapName, err)
 	}

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -102,7 +102,7 @@ func autostartCmd(snapName, desktopFilePath string) (*exec.Cmd, error) {
 		}
 	}
 	if app == nil {
-		return nil, fmt.Errorf("cannot match desktop file with snap %q applications", snapName)
+		return nil, fmt.Errorf("cannot match desktop file with snap %s applications", snapName)
 	}
 
 	content, err := ioutil.ReadFile(desktopFilePath)
@@ -116,7 +116,7 @@ func autostartCmd(snapName, desktopFilePath string) (*exec.Cmd, error) {
 
 	command, err := findExec(content)
 	if err != nil {
-		return nil, fmt.Errorf("cannot determine startup command: %v", err)
+		return nil, fmt.Errorf("cannot determine startup command for application %s in snap %s: %v", app.Name, snapName, err)
 	}
 	logger.Debugf("exec line: %v", command)
 

--- a/userd/autostart_test.go
+++ b/userd/autostart_test.go
@@ -173,7 +173,7 @@ Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
 
 	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
 	c.Assert(cmd, IsNil)
-	c.Assert(err, ErrorMatches, `cannot match desktop file with snap "snapname" applications`)
+	c.Assert(err, ErrorMatches, `cannot match desktop file with snap snapname applications`)
 }
 
 func (s *autostartSuite) TestTryAutostartAppNoSnap(c *C) {
@@ -199,7 +199,7 @@ Foo=bar
 
 	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
 	c.Assert(cmd, IsNil)
-	c.Assert(err, ErrorMatches, `cannot determine startup command: Exec not found or invalid`)
+	c.Assert(err, ErrorMatches, `cannot determine startup command for application foo in snap snapname: Exec not found or invalid`)
 }
 
 func writeFile(c *C, path string, content []byte) {
@@ -237,8 +237,8 @@ Exec=no-snap
 
 	err := userd.AutostartSessionApps()
 	c.Assert(err, NotNil)
-	c.Check(err, ErrorMatches, `- "foo-stable.desktop": cannot determine startup command: Exec not found or invalid
-- "no-match.desktop": cannot match desktop file with snap "b-foo" applications
+	c.Check(err, ErrorMatches, `- "foo-stable.desktop": cannot determine startup command for application foo in snap a-foo: Exec not found or invalid
+- "no-match.desktop": cannot match desktop file with snap b-foo applications
 - "no-snap.desktop": cannot find current revision for snap c-foo: readlink.*no such file or directory
 `)
 }

--- a/userd/autostart_test.go
+++ b/userd/autostart_test.go
@@ -1,0 +1,263 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package userd_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/userd"
+)
+
+type autostartSuite struct {
+	dir                string
+	autostartDir       string
+	userDir            string
+	userCurrentRestore func()
+}
+
+var _ = Suite(&autostartSuite{})
+
+func (s *autostartSuite) SetUpTest(c *C) {
+	s.dir = c.MkDir()
+	dirs.SetRootDir(s.dir)
+	snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+
+	s.userDir = path.Join(s.dir, "home")
+	s.autostartDir = path.Join(s.userDir, ".config", "autostart")
+	s.userCurrentRestore = userd.MockUserCurrent(func() (*user.User, error) {
+		return &user.User{HomeDir: s.userDir}, nil
+	})
+
+	err := os.MkdirAll(s.autostartDir, 0755)
+	c.Assert(err, IsNil)
+}
+
+func (s *autostartSuite) TearDownTest(c *C) {
+	s.dir = c.MkDir()
+	dirs.SetRootDir("/")
+	if s.userCurrentRestore != nil {
+		s.userCurrentRestore()
+	}
+}
+
+func (s *autostartSuite) TestFindExec(c *C) {
+	allGood := `[Desktop Entry]
+Exec=foo --bar
+`
+	allGoodWithFlags := `[Desktop Entry]
+Exec=foo --bar %U %D +%s
+`
+	noExec := `[Desktop Entry]
+Type=Application
+`
+	emptyExec := `[Desktop Entry]
+Exec=
+`
+	onlySpacesExec := `[Desktop Entry]
+Exec=
+`
+	for i, tc := range []struct {
+		in  string
+		out string
+		err string
+	}{{
+		in:  allGood,
+		out: "foo --bar",
+	}, {
+		in:  noExec,
+		err: "Exec not found or invalid",
+	}, {
+		in:  emptyExec,
+		err: "Exec not found or invalid",
+	}, {
+		in:  onlySpacesExec,
+		err: "Exec not found or invalid",
+	}, {
+		in:  allGoodWithFlags,
+		out: "foo --bar   +%s",
+	}} {
+		c.Logf("tc %d", i)
+
+		cmd, err := userd.FindExec([]byte(tc.in))
+		if tc.err != "" {
+			c.Check(cmd, Equals, "")
+			c.Check(err, ErrorMatches, tc.err)
+		} else {
+			c.Check(err, IsNil)
+			c.Check(cmd, Equals, tc.out)
+		}
+	}
+}
+
+var mockYaml = `name: snapname
+version: 1.0
+apps:
+ foo:
+  command: run-app
+  autostart: foo-stable.desktop
+`
+
+func (s *autostartSuite) TestTryAutostartAppValid(c *C) {
+	si := mockSnapCurrent(c, mockYaml)
+
+	appWrapperPath := si.Apps["foo"].WrapperPath()
+	err := os.MkdirAll(filepath.Dir(appWrapperPath), 0755)
+	c.Assert(err, IsNil)
+
+	appCmd := testutil.MockCommand(c, appWrapperPath, "")
+	defer appCmd.Restore()
+
+	fooDesktopFile := filepath.Join(s.autostartDir, "foo-stable.desktop")
+	writeFile(c, fooDesktopFile,
+		[]byte(`[Desktop Entry]
+Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
+`))
+
+	cmd, err := userd.TryAutostartApp("snapname", fooDesktopFile)
+	c.Assert(err, IsNil)
+	c.Assert(cmd.Path, Equals, appWrapperPath)
+
+	cmd.Wait()
+	c.Assert(appCmd.Calls(), DeepEquals,
+		[][]string{
+			{
+				filepath.Base(appWrapperPath),
+				"-a",
+				"-b",
+				"--foo=a b c",
+				"-z",
+				"dev",
+			},
+		})
+}
+
+func (s *autostartSuite) TestTryAutostartAppNoMatchingApp(c *C) {
+	mockSnapCurrent(c, mockYaml)
+
+	fooDesktopFile := filepath.Join(s.autostartDir, "foo-no-match.desktop")
+	writeFile(c, fooDesktopFile,
+		[]byte(`[Desktop Entry]
+Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
+`))
+
+	cmd, err := userd.TryAutostartApp("snapname", fooDesktopFile)
+	c.Assert(cmd, IsNil)
+	c.Assert(err, ErrorMatches, `failed to match desktop file "foo-no-match.desktop" with snap "snapname" applications`)
+}
+
+func (s *autostartSuite) TestTryAutostartAppNoSnap(c *C) {
+	fooDesktopFile := filepath.Join(s.autostartDir, "foo-stable.desktop")
+	writeFile(c, fooDesktopFile,
+		[]byte(`[Desktop Entry]
+Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
+`))
+
+	cmd, err := userd.TryAutostartApp("snapname", fooDesktopFile)
+	c.Assert(cmd, IsNil)
+	c.Assert(err, ErrorMatches, `failed to obtain snap information for snap "snapname".*`)
+}
+
+func (s *autostartSuite) TestTryAutostartAppBadExec(c *C) {
+	mockSnapCurrent(c, mockYaml)
+
+	fooDesktopFile := filepath.Join(s.autostartDir, "foo-stable.desktop")
+	writeFile(c, fooDesktopFile,
+		[]byte(`[Desktop Entry]
+Foo=bar
+`))
+
+	cmd, err := userd.TryAutostartApp("snapname", fooDesktopFile)
+	c.Assert(cmd, IsNil)
+	c.Assert(err, ErrorMatches, `failed to determine startup command: Exec not found or invalid`)
+}
+
+func mockSnapCurrent(c *C, mockYaml string) *snap.Info {
+	si := snaptest.MockSnap(c, mockYaml, &snap.SideInfo{
+		Revision: snap.R("x2"),
+	})
+	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
+	c.Assert(err, IsNil)
+	return si
+}
+
+func writeFile(c *C, path string, content []byte) {
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(path, content, 0644)
+	c.Assert(err, IsNil)
+}
+
+func (s *autostartSuite) TestTryAutostartMany(c *C) {
+	var mockYamlTemplate = `name: {snap}
+version: 1.0
+apps:
+ foo:
+  command: run-app
+  autostart: foo-stable.desktop
+`
+
+	mockSnapCurrent(c, strings.Replace(mockYamlTemplate, "{snap}", "a-foo", -1))
+	mockSnapCurrent(c, strings.Replace(mockYamlTemplate, "{snap}", "b-foo", -1))
+	writeFile(c, filepath.Join(s.userDir, "snap/a-foo/current/.config/autostart/foo-stable.desktop"),
+		[]byte(`[Desktop Entry]
+Foo=bar
+`))
+	writeFile(c, filepath.Join(s.userDir, "snap/b-foo/current/.config/autostart/no-match.desktop"),
+		[]byte(`[Desktop Entry]
+Exec=no-snap
+`))
+	writeFile(c, filepath.Join(s.userDir, "snap/c-foo/current/.config/autostart/no-snap.desktop"),
+		[]byte(`[Desktop Entry]
+Exec=no-snap
+`))
+
+	err := userd.AutostartSessionApps()
+	c.Assert(err, NotNil)
+	desc := strings.Split(err.Error(), "\n")
+	expected := map[string]int{
+		`- "no-match.desktop": failed to match desktop file`:                      0,
+		`- "no-snap.desktop": failed to obtain snap information for snap "c-foo"`: 0,
+		`- "foo-stable.desktop": failed to determine startup command: Exec`:       0,
+	}
+	for _, e := range desc {
+		if len(e) == 0 {
+			continue
+		}
+		for k := range expected {
+			if strings.HasPrefix(e, k) {
+				expected[k] += 1
+			}
+		}
+	}
+	for k, v := range expected {
+		c.Check(v, Equals, 1, Commentf("expected 1 match of error %q", k))
+	}
+}

--- a/userd/autostart_test.go
+++ b/userd/autostart_test.go
@@ -185,7 +185,7 @@ Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
 
 	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
 	c.Assert(cmd, IsNil)
-	c.Assert(err, ErrorMatches, `cannot obtain snap information for snap "snapname".*`)
+	c.Assert(err, ErrorMatches, `cannot find current revision for snap snapname.*`)
 }
 
 func (s *autostartSuite) TestTryAutostartAppBadExec(c *C) {
@@ -239,6 +239,6 @@ Exec=no-snap
 	c.Assert(err, NotNil)
 	c.Check(err, ErrorMatches, `- "foo-stable.desktop": cannot determine startup command: Exec not found or invalid
 - "no-match.desktop": cannot match desktop file with snap "b-foo" applications
-- "no-snap.desktop": cannot obtain snap information for snap "c-foo": cannot find current revision.*no such file or directory
+- "no-snap.desktop": cannot find current revision for snap c-foo: readlink.*no such file or directory
 `)
 }

--- a/userd/autostart_test.go
+++ b/userd/autostart_test.go
@@ -126,7 +126,7 @@ apps:
 `
 
 func (s *autostartSuite) TestTryAutostartAppValid(c *C) {
-	si := mockSnapCurrent(c, mockYaml)
+	si := snaptest.MockSnapCurrent(c, mockYaml, &snap.SideInfo{Revision: snap.R("x2")})
 
 	appWrapperPath := si.Apps["foo"].WrapperPath()
 	err := os.MkdirAll(filepath.Dir(appWrapperPath), 0755)
@@ -163,7 +163,7 @@ Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
 }
 
 func (s *autostartSuite) TestTryAutostartAppNoMatchingApp(c *C) {
-	mockSnapCurrent(c, mockYaml)
+	snaptest.MockSnapCurrent(c, mockYaml, &snap.SideInfo{Revision: snap.R("x2")})
 
 	fooDesktopFile := filepath.Join(s.autostartDir, "foo-no-match.desktop")
 	writeFile(c, fooDesktopFile,
@@ -189,7 +189,7 @@ Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
 }
 
 func (s *autostartSuite) TestTryAutostartAppBadExec(c *C) {
-	mockSnapCurrent(c, mockYaml)
+	snaptest.MockSnapCurrent(c, mockYaml, &snap.SideInfo{Revision: snap.R("x2")})
 
 	fooDesktopFile := filepath.Join(s.autostartDir, "foo-stable.desktop")
 	writeFile(c, fooDesktopFile,
@@ -200,15 +200,6 @@ Foo=bar
 	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
 	c.Assert(cmd, IsNil)
 	c.Assert(err, ErrorMatches, `cannot determine startup command: Exec not found or invalid`)
-}
-
-func mockSnapCurrent(c *C, mockYaml string) *snap.Info {
-	si := snaptest.MockSnap(c, mockYaml, &snap.SideInfo{
-		Revision: snap.R("x2"),
-	})
-	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
-	c.Assert(err, IsNil)
-	return si
 }
 
 func writeFile(c *C, path string, content []byte) {
@@ -227,8 +218,10 @@ apps:
   autostart: foo-stable.desktop
 `
 
-	mockSnapCurrent(c, strings.Replace(mockYamlTemplate, "{snap}", "a-foo", -1))
-	mockSnapCurrent(c, strings.Replace(mockYamlTemplate, "{snap}", "b-foo", -1))
+	snaptest.MockSnapCurrent(c, strings.Replace(mockYamlTemplate, "{snap}", "a-foo", -1),
+		&snap.SideInfo{Revision: snap.R("x2")})
+	snaptest.MockSnapCurrent(c, strings.Replace(mockYamlTemplate, "{snap}", "b-foo", -1),
+		&snap.SideInfo{Revision: snap.R("x2")})
 	writeFile(c, filepath.Join(s.userDir, "snap/a-foo/current/.config/autostart/foo-stable.desktop"),
 		[]byte(`[Desktop Entry]
 Foo=bar

--- a/userd/autostart_test.go
+++ b/userd/autostart_test.go
@@ -141,11 +141,14 @@ func (s *autostartSuite) TestTryAutostartAppValid(c *C) {
 Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
 `))
 
-	cmd, err := userd.TryAutostartApp("snapname", fooDesktopFile)
+	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
 	c.Assert(err, IsNil)
 	c.Assert(cmd.Path, Equals, appWrapperPath)
 
+	err = cmd.Start()
+	c.Assert(err, IsNil)
 	cmd.Wait()
+
 	c.Assert(appCmd.Calls(), DeepEquals,
 		[][]string{
 			{
@@ -168,7 +171,7 @@ func (s *autostartSuite) TestTryAutostartAppNoMatchingApp(c *C) {
 Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
 `))
 
-	cmd, err := userd.TryAutostartApp("snapname", fooDesktopFile)
+	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
 	c.Assert(cmd, IsNil)
 	c.Assert(err, ErrorMatches, `cannot match desktop file with snap "snapname" applications`)
 }
@@ -180,7 +183,7 @@ func (s *autostartSuite) TestTryAutostartAppNoSnap(c *C) {
 Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
 `))
 
-	cmd, err := userd.TryAutostartApp("snapname", fooDesktopFile)
+	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
 	c.Assert(cmd, IsNil)
 	c.Assert(err, ErrorMatches, `cannot obtain snap information for snap "snapname".*`)
 }
@@ -194,7 +197,7 @@ func (s *autostartSuite) TestTryAutostartAppBadExec(c *C) {
 Foo=bar
 `))
 
-	cmd, err := userd.TryAutostartApp("snapname", fooDesktopFile)
+	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
 	c.Assert(cmd, IsNil)
 	c.Assert(err, ErrorMatches, `cannot determine startup command: Exec not found or invalid`)
 }

--- a/userd/autostart_test.go
+++ b/userd/autostart_test.go
@@ -73,7 +73,7 @@ func (s *autostartSuite) TestFindExec(c *C) {
 Exec=foo --bar
 `
 	allGoodWithFlags := `[Desktop Entry]
-Exec=foo --bar %U %D +%s
+Exec=foo --bar "%%p" %U %D +%s %%
 `
 	noExec := `[Desktop Entry]
 Type=Application
@@ -102,7 +102,7 @@ Exec=
 		err: "Exec not found or invalid",
 	}, {
 		in:  allGoodWithFlags,
-		out: "foo --bar   +%s",
+		out: `foo --bar "%p"   + %`,
 	}} {
 		c.Logf("tc %d", i)
 

--- a/userd/export_test.go
+++ b/userd/export_test.go
@@ -28,8 +28,8 @@ import (
 var (
 	SnapFromPid = snapFromPid
 
-	FindExec        = findExec
-	TryAutostartApp = tryAutostartApp
+	FindExec     = findExec
+	AutostartCmd = autostartCmd
 )
 
 func MockSnapFromSender(f func(*dbus.Conn, dbus.Sender) (string, error)) func() {

--- a/userd/export_test.go
+++ b/userd/export_test.go
@@ -20,11 +20,16 @@
 package userd
 
 import (
+	"os/user"
+
 	"github.com/godbus/dbus"
 )
 
 var (
 	SnapFromPid = snapFromPid
+
+	FindExec        = findExec
+	TryAutostartApp = tryAutostartApp
 )
 
 func MockSnapFromSender(f func(*dbus.Conn, dbus.Sender) (string, error)) func() {
@@ -32,5 +37,13 @@ func MockSnapFromSender(f func(*dbus.Conn, dbus.Sender) (string, error)) func() 
 	snapFromSender = f
 	return func() {
 		snapFromSender = origSnapFromSender
+	}
+}
+
+func MockUserCurrent(f func() (*user.User, error)) func() {
+	origUserCurrent := userCurrent
+	userCurrent = f
+	return func() {
+		userCurrent = origUserCurrent
 	}
 }


### PR DESCRIPTION
3rd iteration of user session applications autostart. Previous 2 attempts were #4759 and #4768. Also dropped refactoring of desktop sanitizers from #4781 in favor of simpler approach.

The PR adds support for `snap user --autostart`. The command is expected to be run as part of user session startup and is responsible for starting snap applications that have placed a proper `*.desktop` file in `$SNAP_USER_DATA/.config/autostart`. The desktop file is matched agains `autostart` declaration in snap's YAML.

For details see https://forum.snapcraft.io/t/development-sprint-march-5th-2018/4345/2