### PR TITLE
interfaces: add /var/lib/snapd/snap to @{INSTALL_DIR}

### DIFF
--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -384,7 +384,7 @@ const commonPrefix = `
 @{SNAP_NAME}="samba"
 @{SNAP_REVISION}="1"
 @{PROFILE_DBUS}="snap_2esamba_2esmbd"
-@{INSTALL_DIR}="/{,var/lib/snapd/}snap""`
+@{INSTALL_DIR}="/{,var/lib/snapd/}snap"`
 
 var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// By default apparmor is enforcing mode.

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -384,7 +384,7 @@ const commonPrefix = `
 @{SNAP_NAME}="samba"
 @{SNAP_REVISION}="1"
 @{PROFILE_DBUS}="snap_2esamba_2esmbd"
-@{INSTALL_DIR}="/snap"`
+@{INSTALL_DIR}="{/snap,/var/lib/snapd/snap}"`
 
 var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// By default apparmor is enforcing mode.

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -384,7 +384,7 @@ const commonPrefix = `
 @{SNAP_NAME}="samba"
 @{SNAP_REVISION}="1"
 @{PROFILE_DBUS}="snap_2esamba_2esmbd"
-@{INSTALL_DIR}="{/snap,/var/lib/snapd/snap}"`
+@{INSTALL_DIR}="/{,var/lib/snapd/}snap""`
 
 var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// By default apparmor is enforcing mode.

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/snap"
 )
@@ -35,6 +36,6 @@ func templateVariables(info *snap.Info, securityTag string) string {
 	fmt.Fprintf(&buf, "@{SNAP_REVISION}=\"%s\"\n", info.Revision)
 	fmt.Fprintf(&buf, "@{PROFILE_DBUS}=\"%s\"\n",
 		dbus.SafePath(securityTag))
-	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"/snap\"")
+	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"{/snap,%s}\"", dirs.SnapMountDir)
 	return buf.String()
 }

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/snap"
 )
@@ -36,6 +35,6 @@ func templateVariables(info *snap.Info, securityTag string) string {
 	fmt.Fprintf(&buf, "@{SNAP_REVISION}=\"%s\"\n", info.Revision)
 	fmt.Fprintf(&buf, "@{PROFILE_DBUS}=\"%s\"\n",
 		dbus.SafePath(securityTag))
-	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"{/snap,%s}\"", dirs.SnapMountDir)
+	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"/{,var/lib/snapd/}snap\"")
 	return buf.String()
 }


### PR DESCRIPTION
This fixes issue where snap.yaml is accessed under /var/lib/snapd/snap instead of /snap. This occurs in Archlinux. Fix is based on https://forum.snapcraft.io/t/apparmor-issues-with-default-install-dir/4568/2 .

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
