### PR TITLE
ifacestate: don't surface errors from stale connections

### DIFF
--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -265,3 +265,13 @@ func ValidateDBusBusName(busName string) error {
 	}
 	return nil
 }
+
+// UnknownPlugSlotError is an error reported when plug or slot cannot be found.
+type UnknownPlugSlotError struct {
+	Msg string
+}
+
+// Error returns the message associated with unknown plug or slot error.
+func (e *UnknownPlugSlotError) Error() string {
+	return e.Msg
+}

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -28,6 +28,24 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+type NoSuchPlugSlot struct {
+	msg      string
+	Snap     string
+	PlugSlot string
+}
+
+func (e *NoSuchPlugSlot) Error() string {
+	return e.msg
+}
+
+func NewNoSuchPlugSlotError(msg, snap, plugSlot string) *NoSuchPlugSlot {
+	return &NoSuchPlugSlot{
+		msg:      msg,
+		Snap:     snap,
+		PlugSlot: plugSlot,
+	}
+}
+
 // Repository stores all known snappy plugs and slots and ifaces.
 type Repository struct {
 	// Protects the internals from concurrent access.
@@ -553,12 +571,12 @@ func (r *Repository) Connect(ref ConnRef) error {
 	// Ensure that such plug exists
 	plug := r.plugs[plugSnapName][plugName]
 	if plug == nil {
-		return fmt.Errorf("cannot connect plug %q from snap %q, no such plug", plugName, plugSnapName)
+		return NewNoSuchPlugSlotError(fmt.Sprintf("cannot connect plug %q from snap %q, no such plug", plugName, plugSnapName), plugSnapName, plugName)
 	}
 	// Ensure that such slot exists
 	slot := r.slots[slotSnapName][slotName]
 	if slot == nil {
-		return fmt.Errorf("cannot connect plug to slot %q from snap %q, no such slot", slotName, slotSnapName)
+		return NewNoSuchPlugSlotError(fmt.Sprintf("cannot connect plug to slot %q from snap %q, no such slot", slotName, slotSnapName), slotSnapName, slotName)
 	}
 	// Ensure that plug and slot are compatible
 	if slot.Interface != plug.Interface {

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -28,24 +28,6 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-type NoSuchPlugSlot struct {
-	msg      string
-	Snap     string
-	PlugSlot string
-}
-
-func (e *NoSuchPlugSlot) Error() string {
-	return e.msg
-}
-
-func NewNoSuchPlugSlotError(msg, snap, plugSlot string) *NoSuchPlugSlot {
-	return &NoSuchPlugSlot{
-		msg:      msg,
-		Snap:     snap,
-		PlugSlot: plugSlot,
-	}
-}
-
 // Repository stores all known snappy plugs and slots and ifaces.
 type Repository struct {
 	// Protects the internals from concurrent access.
@@ -571,12 +553,12 @@ func (r *Repository) Connect(ref ConnRef) error {
 	// Ensure that such plug exists
 	plug := r.plugs[plugSnapName][plugName]
 	if plug == nil {
-		return NewNoSuchPlugSlotError(fmt.Sprintf("cannot connect plug %q from snap %q, no such plug", plugName, plugSnapName), plugSnapName, plugName)
+		return &UnknownPlugSlotError{Msg: fmt.Sprintf("cannot connect plug %q from snap %q, no such plug", plugName, plugSnapName)}
 	}
 	// Ensure that such slot exists
 	slot := r.slots[slotSnapName][slotName]
 	if slot == nil {
-		return NewNoSuchPlugSlotError(fmt.Sprintf("cannot connect plug to slot %q from snap %q, no such slot", slotName, slotSnapName), slotSnapName, slotName)
+		return &UnknownPlugSlotError{fmt.Sprintf("cannot connect plug to slot %q from snap %q, no such slot", slotName, slotSnapName)}
 	}
 	// Ensure that plug and slot are compatible
 	if slot.Interface != plug.Interface {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -211,8 +211,11 @@ func (m *InterfaceManager) reloadConnections(snapName string) ([]string, error) 
 			continue
 		}
 		if err := m.repo.Connect(connRef); err != nil {
-			// FIXME: we may encounter an error here if there is a stray connection in the state,
-			// they should be cleaned up
+			if _, ok := err.(*interfaces.NoSuchPlugSlot); ok {
+				// FIXME: we may encounter an error here if there is a stray connection in the state,
+				// they should be cleaned up
+				continue
+			}
 			logger.Noticef("%s", err)
 		} else {
 			affected[connRef.PlugRef.Snap] = true

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -211,9 +211,11 @@ func (m *InterfaceManager) reloadConnections(snapName string) ([]string, error) 
 			continue
 		}
 		if err := m.repo.Connect(connRef); err != nil {
-			if _, ok := err.(*interfaces.NoSuchPlugSlot); ok {
-				// FIXME: we may encounter an error here if there is a stray connection in the state,
-				// they should be cleaned up
+			if _, ok := err.(*interfaces.UnknownPlugSlotError); ok {
+				// Some versions of snapd may have left stray connections that
+				// don't have the corresponding plug or slot anymore. Before we
+				// choose how to deal with this data we want to silently ignore
+				// that error not to worry the users.
 				continue
 			}
 			logger.Noticef("%s", err)

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -211,10 +211,13 @@ func (m *InterfaceManager) reloadConnections(snapName string) ([]string, error) 
 			continue
 		}
 		if err := m.repo.Connect(connRef); err != nil {
+			// FIXME: we may encounter an error here if there is a stray connection in the state,
+			// they should be cleaned up
 			logger.Noticef("%s", err)
+		} else {
+			affected[connRef.PlugRef.Snap] = true
+			affected[connRef.SlotRef.Snap] = true
 		}
-		affected[connRef.PlugRef.Snap] = true
-		affected[connRef.SlotRef.Snap] = true
 	}
 	result := make([]string, 0, len(affected))
 	for name := range affected {


### PR DESCRIPTION
This fixes the error reported today when refreshing to beta core:

2018/03/27 14:30:27.014868 cmd.go:212: DEBUG: restarting into "/snap/core/current/usr/bin/snap"
2018-03-27T14:30:41Z ERROR skipping security profiles setup for snap "freechessclub" when handling snap "core": no state entry for key

Full diagnosis is here: https://forum.snapcraft.io/t/please-help-testing-2-32-in-beta/4696

As discussed on IRC this PR only ensures that bad connections don't surface and a fix to weed bad connections from the state will be proposed separately. 

The problem is not new, but it got discovered now because of a change in reloadConnections made in January.
