### PR TITLE
spread: disable StartLimitInterval option on opensuse-42.3

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -44,9 +44,9 @@ disable_refreshes() {
 
 setup_systemd_snapd_overrides() {
     START_LIMIT_INTERVAL="StartLimitInterval=0"
-    if [[ "$SPREAD_SYSTEM" = opensuse-42.2-* ]]; then
+    if [[ "$SPREAD_SYSTEM" =~ opensuse-42.[23]-* ]]; then
         # StartLimitInterval is not supported by the systemd version
-        # openSUSE 42.2 ships.
+        # openSUSE 42.2/3 ship.
         START_LIMIT_INTERVAL=""
     fi
 


### PR DESCRIPTION
This should fix the problem I've just encountered with spread tests:
```
+ [[ opensuse-42.3-64 == ubuntu-core-16-* ]]
+ reset_classic --reuse-core
+ systemctl daemon-reload
+ echo 'Ensure the service is active before stopping it'
Ensure the service is active before stopping it
+ retries=20
+ systemctl status snapd.service snapd.socket
â— snapd.service - Snappy daemon
   Loaded: loaded (/usr/lib/systemd/system/snapd.service; disabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/snapd.service.d
           â””â”€local.conf
   Active: inactive (dead) since Wed 2018-03-28 07:46:18 UTC; 372ms ago
 Main PID: 14489 (code=exited, status=0/SUCCESS)

Mar 28 07:46:18 mar280737-887718 systemd[1]: [/etc/systemd/system/snapd.service.d/local.conf:2] Unknown lvalue 'StartLimitInterval' in section 'Unit'
```