### PR TITLE
spread: use more recent bionic snapshot

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -56,7 +56,7 @@ backends:
             - ubuntu-16.04-64:
                 workers: 8
             - ubuntu-18.04-64:
-                image: ubuntu-os-cloud-devel/daily-ubuntu-1804-bionic-v20180315
+                image: ubuntu-os-cloud-devel/daily-ubuntu-1804-bionic-v20180327
                 workers: 6
 
             - ubuntu-core-16-64:


### PR DESCRIPTION
The currently used snapshot is has a kernel -12 but there are no longer
modules for the -12 kernel in the archive. We must use a more recent
snapshot to keep the booted kernel in sync with the moving archive.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
