### PR TITLE
tests: fix quoting issues in econnreset test

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -16,14 +16,14 @@ execute: |
     echo "Wait until the download started and downloaded more than 1 MB"
     for i in $(seq 40); do
         if partial=$(ls test-snapd-huge_*.snap.partial | head -1); then
-            if [ $(stat -c%s "$partial") -gt $(( 1024 * 1024 )) ]; then
+            if [ "$(stat -c%s "$partial")" -gt "$(( 1024 * 1024 ))" ]; then
                 break
             fi
         fi
         sleep .5
     done
 
-    if [ ! -f "$partial" ] || [ $(stat -c%s "$partial") -eq 0 ]; then
+    if [ ! -f "$partial" ] || [ "$(stat -c%s "$partial")" -eq 0 ]; then
         echo "Partial file $partial did not start downloading, test broken"
         kill -9 $(pidof snap)
         exit 1


### PR DESCRIPTION
This fixes bad shell code if download fails:

    2018-03-28 14:05:24 Error executing google:ubuntu-14.04-64:tests/main/econnreset :
    -----
    + echo 'Downloading a large snap in the background'
    Downloading a large snap in the background
    + echo 'Wait until the download started and downloaded more than 1 MB'
    Wait until the download started and downloaded more than 1 MB
    ++ seq 40
    + for i in '$(seq 40)'
    + su -c '/usr/bin/env SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log' test
    ++ head -1
    ++ ls 'test-snapd-huge_*.snap.partial'
    ls: cannot access test-snapd-huge_*.snap.partial: No such file or directory
    + partial=
    ++ stat -c%s ''
    stat: cannot stat ââ: No such file or directory
    + '[' -gt 1048576 ']'
    /bin/bash: line 64: [: -gt: unary operator expected
    + sleep .5

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
