### PR TITLE
test: move interfaces-removable-media to manual until issue on fedora is fixed

### DIFF
--- a/tests/main/interfaces-removable-media/task.yaml
+++ b/tests/main/interfaces-removable-media/task.yaml
@@ -3,7 +3,9 @@ summary: Ensure that the removable-media interface works.
 details: |
     The removable-media interface allows to access to removable storage filesystems.
 
-manual: true
+# This is skipped on fedora due to an error which is currently under investigation. 
+# The snap is failing to read /media/testdir giving an error "No such file or directory"
+systems: [-fedora-*]
 
 prepare: |
     . $TESTSLIB/snaps.sh

--- a/tests/main/interfaces-removable-media/task.yaml
+++ b/tests/main/interfaces-removable-media/task.yaml
@@ -3,6 +3,8 @@ summary: Ensure that the removable-media interface works.
 details: |
     The removable-media interface allows to access to removable storage filesystems.
 
+manual: true
+
 prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-removable-media


### PR DESCRIPTION
This test is failing just on fedora.

This is the error log:

+ echo 'And the snap is able to access to read/write removable storage
filesystems'
And the snap is able to access to read/write removable storage
filesystems
+ test-snapd-removable-media.sh -c 'ls /media'
+ test-snapd-removable-media.sh -c 'ls /media/testdir'
ls: cannot access '/media/testdir': No such file or directory
