### PR TITLE
cmd/snap-confine: attempt to detect if multiarch host uses arch triplets (2.32)

### DIFF
--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -33,13 +33,9 @@ case "$ID" in
 		extra_opts="--libexecdir=/usr/lib/snapd"
 		;;
 	ubuntu)
-		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp"
-		dpkg_architecture=$(which dpkg-architecture 2>/dev/null)
-		if [ -n "$dpkg_architecture" ]; then
-				extra_opts="$extra_opts  --with-host-arch-triplet=$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
-				if [ "$(dpkg-architecture -qDEB_HOST_ARCH)" = "amd64" ]; then
-					extra_opts="$extra_opts --with-host-arch-32bit-triplet=$(dpkg-architecture -ai386 -qDEB_HOST_MULTIARCH)"
-				fi
+		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp --with-host-arch-triplet=$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+		if [ "$(dpkg-architecture -qDEB_HOST_ARCH)" = "amd64" ]; then
+			extra_opts="$extra_opts --with-host-arch-32bit-triplet=$(dpkg-architecture -ai386 -qDEB_HOST_MULTIARCH)"
 		fi
 		;;
 	fedora|centos|rhel)

--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -33,14 +33,7 @@ case "$ID" in
 		extra_opts="--libexecdir=/usr/lib/snapd"
 		;;
 	ubuntu)
-		case "$VERSION_ID" in
-			16.04)
-				extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp"
-				;;
-			*)
-				extra_opts="--libexecdir=/usr/lib/snapd --enable-static-libcap --enable-nvidia-multiarch"
-				;;
-		esac
+		extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp"
 		dpkg_architecture=$(which dpkg-architecture 2>/dev/null)
 		if [ -n "$dpkg_architecture" ]; then
 				extra_opts="$extra_opts  --with-host-arch-triplet=$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
@@ -63,4 +56,4 @@ esac
 echo "Configuring in build directory $BUILD_DIR with: $extra_opts"
 mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
 # shellcheck disable=SC2086
-"${SRC_DIR}/configure" --enable-maintainer-mode --prefix=/usr $extra_opts
+"${SRC_DIR}/configure" --enable-maintainer-mode --prefix=/usr $extra_opts "$@"

--- a/cmd/autogen.sh
+++ b/cmd/autogen.sh
@@ -38,9 +38,16 @@ case "$ID" in
 				extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp"
 				;;
 			*)
-				extra_opts="--libexecdir=/usr/lib/snapd --enable-nvidia-multiarch --enable-static-libcap"
+				extra_opts="--libexecdir=/usr/lib/snapd --enable-static-libcap --enable-nvidia-multiarch"
 				;;
 		esac
+		dpkg_architecture=$(which dpkg-architecture 2>/dev/null)
+		if [ -n "$dpkg_architecture" ]; then
+				extra_opts="$extra_opts  --with-host-arch-triplet=$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+				if [ "$(dpkg-architecture -qDEB_HOST_ARCH)" = "amd64" ]; then
+					extra_opts="$extra_opts --with-host-arch-32bit-triplet=$(dpkg-architecture -ai386 -qDEB_HOST_MULTIARCH)"
+				fi
+		fi
 		;;
 	fedora|centos|rhel)
 		extra_opts="--libexecdir=/usr/libexec/snapd --with-snap-mount-dir=/var/lib/snapd/snap --enable-merged-usr --disable-apparmor"

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -216,5 +216,17 @@ AC_ARG_WITH([32bit-libdir],
 AC_SUBST(LIB32_DIR)
 AC_DEFINE_UNQUOTED([LIB32_DIR], "${LIB32_DIR}", [Location of the lib32 directory])
 
+AC_ARG_WITH([host-arch-triplet],
+    AS_HELP_STRING([--with-host-arch-triplet=triplet], [Arch triplet for host libraries]),
+    [HOST_ARCH_TRIPLET="$withval"])
+AC_SUBST(HOST_ARCH_TRIPLET)
+AC_DEFINE_UNQUOTED([HOST_ARCH_TRIPLET], "${HOST_ARCH_TRIPLET}", [Arch triplet for host libraries])
+
+AC_ARG_WITH([host-arch-32bit-triplet],
+    AS_HELP_STRING([--with-host-arch-32bit-triplet=triplet], [Arch triplet for 32bit libraries]),
+    [HOST_ARCH32_TRIPLET="$withval"])
+AC_SUBST(HOST_ARCH32_TRIPLET)
+AC_DEFINE_UNQUOTED([HOST_ARCH32_TRIPLET], "${HOST_ARCH32_TRIPLET}", [Arch triplet for 32bit libraries])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -447,6 +447,9 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir)
 
 		debug("using arch triplet %s", HOST_ARCH_TRIPLET);
 
+		// sc_mkdir_and_mount_and_glob_files() takes an array of strings, so
+		// initialize native_sources accordingly, but calculate the array length
+		// dynamically to make adjustments to native_sources easier.
 		const char *native_sources[] = { native_libdir };
 		const size_t native_sources_len =
 		    sizeof native_sources / sizeof *native_sources;
@@ -463,6 +466,10 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir)
 
 			debug("using 32-bit arch triplet %s",
 			      HOST_ARCH32_TRIPLET);
+
+			// sc_mkdir_and_mount_and_glob_files() takes an array of strings, so
+			// initialize lib32_sources accordingly, but calculate the array length
+			// dynamically to make adjustments to lib32_sources easier.
 			const char *lib32_sources[] = { lib32_libdir };
 			const size_t lib32_sources_len =
 			    sizeof lib32_sources / sizeof *lib32_sources;

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -439,15 +439,15 @@ static int sc_mount_nvidia_is_driver_in_dir(const char *dir)
 
 static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir)
 {
+	const char *native_libdir = NATIVE_LIBDIR "/" HOST_ARCH_TRIPLET;
+	const char *lib32_libdir = NATIVE_LIBDIR "/" HOST_ARCH32_TRIPLET;
+
 	if ((strlen(HOST_ARCH_TRIPLET) > 0) &&
-	    (sc_mount_nvidia_is_driver_in_dir
-	     (NATIVE_LIBDIR "/" HOST_ARCH_TRIPLET) == 1)) {
+	    (sc_mount_nvidia_is_driver_in_dir(native_libdir) == 1)) {
 
 		debug("using arch triplet %s", HOST_ARCH_TRIPLET);
 
-		const char *native_sources[] = {
-			NATIVE_LIBDIR "/" HOST_ARCH_TRIPLET,
-		};
+		const char *native_sources[] = { native_libdir };
 		const size_t native_sources_len =
 		    sizeof native_sources / sizeof *native_sources;
 		// Primary arch
@@ -459,14 +459,11 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir)
 
 		// Alternative 32-bit support
 		if ((strlen(HOST_ARCH32_TRIPLET) > 0) &&
-		    (sc_mount_nvidia_is_driver_in_dir
-		     (NATIVE_LIBDIR "/" HOST_ARCH32_TRIPLET) == 1)) {
+		    (sc_mount_nvidia_is_driver_in_dir(lib32_libdir) == 1)) {
 
 			debug("using 32-bit arch triplet %s",
 			      HOST_ARCH32_TRIPLET);
-			const char *lib32_sources[] = {
-				NATIVE_LIBDIR "/" HOST_ARCH32_TRIPLET,
-			};
+			const char *lib32_sources[] = { lib32_libdir };
 			const size_t lib32_sources_len =
 			    sizeof lib32_sources / sizeof *lib32_sources;
 			sc_mkdir_and_mount_and_glob_files(rootfs_dir,

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -127,7 +127,6 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 						   const char *glob_list[],
 						   size_t glob_list_len)
 {
-	debug("libgl dir: %s source dir: %s", libgl_dir, source_dir);
 	size_t source_dir_len = strlen(source_dir);
 	glob_t glob_res SC_CLEANUP(globfree) = {
 	.gl_pathv = NULL};
@@ -153,7 +152,6 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 		char symlink_target[512] = { 0 };
 		char prefix_dir[512] = { 0 };
 		const char *pathname = glob_res.gl_pathv[i];
-		debug("pathname: %s", pathname);
 		char *pathname_copy1
 		    SC_CLEANUP(sc_cleanup_string) = strdup(pathname);
 		char *pathname_copy2
@@ -175,7 +173,6 @@ static void sc_populate_libgl_with_hostfs_symlinks(const char *libgl_dir,
 			sc_must_snprintf(prefix_dir, sizeof prefix_dir,
 					 "%s%s", libgl_dir,
 					 &directory_name[source_dir_len]);
-			debug("prefix dir path: %s", prefix_dir);
 			if (sc_nonfatal_mkpath(prefix_dir, 0755) != 0) {
 				die("failed to create prefix path: %s",
 				    prefix_dir);
@@ -445,8 +442,6 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir)
 	if ((strlen(HOST_ARCH_TRIPLET) > 0) &&
 	    (sc_mount_nvidia_is_driver_in_dir(native_libdir) == 1)) {
 
-		debug("using arch triplet %s", HOST_ARCH_TRIPLET);
-
 		// sc_mkdir_and_mount_and_glob_files() takes an array of strings, so
 		// initialize native_sources accordingly, but calculate the array length
 		// dynamically to make adjustments to native_sources easier.
@@ -463,9 +458,6 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir)
 		// Alternative 32-bit support
 		if ((strlen(HOST_ARCH32_TRIPLET) > 0) &&
 		    (sc_mount_nvidia_is_driver_in_dir(lib32_libdir) == 1)) {
-
-			debug("using 32-bit arch triplet %s",
-			      HOST_ARCH32_TRIPLET);
 
 			// sc_mkdir_and_mount_and_glob_files() takes an array of strings, so
 			// initialize lib32_sources accordingly, but calculate the array length

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -38,6 +38,7 @@ const openglConnectedPlugAppArmor = `
 # Bi-arch distribution nvidia support
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcuda*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvidia*.so{,.*} rm,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}tls/libnvidia*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvcuvid.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}lib{GL,EGL}*nvidia.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libGLdispatch.so{,.*} rm,

--- a/packaging/ubuntu-14.04/snapd.dirs
+++ b/packaging/ubuntu-14.04/snapd.dirs
@@ -7,6 +7,8 @@ var/lib/snapd/desktop
 var/lib/snapd/environment
 var/lib/snapd/firstboot
 var/lib/snapd/lib/gl
+var/lib/snapd/lib/gl32
+var/lib/snapd/lib/vulkan
 var/lib/snapd/snaps/partial
 var/lib/snapd/void
 var/snap

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -56,6 +56,8 @@ ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
 	TAGS=-tags withtestkeys
 endif
 
+DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+
 BUILT_USING_PACKAGES=
 # export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 # DPKG_EXPORT_BUILDFLAGS = 1
@@ -72,7 +74,10 @@ ifeq ($(shell dpkg-vendor --query Vendor),Ubuntu)
     # for stability, predicability and easy of deployment. We need to link some
     # things dynamically though: udev has no stable IPC protocol between
     # libudev and udevd so we need to link with it dynamically.
-    VENDOR_ARGS=--enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp
+    VENDOR_ARGS=--enable-nvidia-multiarch --enable-static-libcap --enable-static-libapparmor --enable-static-libseccomp --with-host-arch-triplet=$(DEB_HOST_MULTIARCH)
+ifeq ($(shell dpkg-architecture -qDEB_HOST_ARCH),amd64)
+		VENDOR_ARGS+= --with-host-arch-32bit-triplet=$(shell dpkg-architecture -f -ai386 -qDEB_HOST_MULTIARCH)
+endif
     BUILT_USING_PACKAGES=libcap-dev libapparmor-dev libseccomp-dev
 else
 ifeq ($(shell dpkg-vendor --query Vendor),Debian)

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -1,0 +1,67 @@
+summary: Ensure that basic opengl works with faked nvidia
+
+systems: [ubuntu-14.04-*, ubuntu-16.04-*, ubuntu-18.04-*]
+
+prepare: |
+    # mock nvidia driver
+    mount -t tmpfs tmp /sys/module
+    mkdir -p /sys/module/nvidia
+    echo "123.456" > /sys/module/nvidia/version
+
+    # mock nvidia icd file
+    test ! -d /usr/share/vulkan
+    echo "Test vulkan files access"
+    mkdir -p /usr/share/vulkan/icd.d
+    echo "canary-vulkan" > /usr/share/vulkan/icd.d/nvidia_icd.json
+
+    # mock nvidia libraries
+    if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
+        mkdir -p /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls
+        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libGLX.so.0.0.1
+        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libGLX_nvidia.so.0.0.1
+        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libnvidia-glcore.so.123.456
+        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls/libnvidia-tls.so.123.456
+        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libnvidia-tls.so.123.456
+    fi
+    mkdir -p /usr/lib/nvidia-123/tls
+    echo "canary-legacy" >> /usr/lib/nvidia-123/libGLX.so.0.0.1
+    echo "canary-legacy" >> /usr/lib/nvidia-123/libGLX_nvidia.so.0.0.1
+    echo "canary-legacy" >> /usr/lib/nvidia-123/libnvidia-glcore.so.123.456
+    echo "canary-legacy" >> /usr/lib/nvidia-123/tls/libnvidia-tls.so.123.456
+    echo "canary-legacy" >> /usr/lib/nvidia-123/libnvidia-tls.so.123.456
+
+execute: |
+    . $TESTSLIB/dirs.sh
+    . $TESTSLIB/snaps.sh
+
+    install_local test-snapd-policy-app-consumer
+
+    echo "When the interface is connected"
+    snap connect test-snapd-policy-app-consumer:opengl core:opengl
+
+    echo "App can access nvidia library files"
+    expected="canary-legacy"
+    if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
+        expected="canary-triplet"
+    fi
+    files="libGLX.so.0.0.1 libGLX_nvidia.so.0.0.1 libnvidia-glcore.so.123.456 tls/libnvidia-tls.so.123.456 libnvidia-tls.so.123.456"
+    for f in $files; do
+       snap run test-snapd-policy-app-consumer.opengl -c "cat /var/lib/snapd/lib/gl/$f" | MATCH "$expected"
+    done
+
+    echo "And vulkan ICD file"
+    snap run test-snapd-policy-app-consumer.opengl -c "cat /var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json" | MATCH canary-vulkan
+
+restore: |
+    umount -t tmpfs /sys/module
+    rm -rf /usr/share/vulkan
+
+    if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
+        rm -rf /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls
+        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libGLX.so.0.0.1
+        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libGLX_nvidia.so.0.0.1
+        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libnvidia-glcore.so.123.456
+        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls/libnvidia-tls.so.123.456
+        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libnvidia-tls.so.123.456
+    fi
+    rm -rf /usr/lib/nvidia-123


### PR DESCRIPTION
#4908 backported to 2.32
