### PR TITLE
configstate: give a chance to immediately recompute the next refresh time when schedules are set (2.32)

### DIFF
--- a/overlord/configstate/configstate_test.go
+++ b/overlord/configstate/configstate_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/configstate"
+	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -170,28 +171,74 @@ func (s *configcoreHijackSuite) SetUpTest(c *C) {
 	configstate.Init(hookMgr)
 }
 
+type witnessManager struct {
+	state     *state.State
+	committed bool
+}
+
+func (m *witnessManager) KnownTaskKinds() []string {
+	return nil
+}
+
+func (wm *witnessManager) Ensure() error {
+	wm.state.Lock()
+	defer wm.state.Unlock()
+	t := config.NewTransaction(wm.state)
+	var witnessCfg bool
+	t.GetMaybe("core", "witness", &witnessCfg)
+	if witnessCfg {
+		wm.committed = true
+	}
+	return nil
+}
+
+func (wm *witnessManager) Stop() {
+}
+
+func (wm *witnessManager) Wait() {
+}
+
 func (s *configcoreHijackSuite) TestHijack(c *C) {
 	configcoreRan := false
+	witnessCfg := false
 	witnessConfigcoreRun := func(conf configcore.Conf) error {
 		// called with no state lock!
 		conf.State().Lock()
 		defer conf.State().Unlock()
+		err := conf.Get("core", "witness", &witnessCfg)
+		c.Assert(err, IsNil)
 		configcoreRan = true
 		return nil
 	}
 	r := configstate.MockConfigcoreRun(witnessConfigcoreRun)
 	defer r()
 
+	witnessMgr := &witnessManager{
+		state: s.state,
+	}
+	s.o.AddManager(witnessMgr)
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	ts := configstate.Configure(s.state, "core", nil, 0)
+	ts := configstate.Configure(s.state, "core", map[string]interface{}{
+		"witness": true,
+	}, 0)
 
 	chg := s.state.NewChange("configure-core", "configure core")
 	chg.AddAll(ts)
 
+	// this will be run by settle helper once no more Ensure are
+	// scheduled, the witnessMgr Ensure would not see the
+	// committed config unless an additional Ensure Loop is
+	// scheduled when committing the configuration
+	observe := func() {
+		c.Check(witnessCfg, Equals, true)
+		c.Check(witnessMgr.committed, Equals, true)
+	}
+
 	s.state.Unlock()
-	err := s.o.Settle(5 * time.Second)
+	err := s.o.SettleObserveBeforeCleanups(5*time.Second, observe)
 	s.state.Lock()
 	c.Assert(err, IsNil)
 

--- a/overlord/configstate/hooks.go
+++ b/overlord/configstate/hooks.go
@@ -51,6 +51,11 @@ func ContextTransaction(context *hookstate.Context) *config.Transaction {
 
 	context.OnDone(func() error {
 		tr.Commit()
+		if context.SnapName() == "core" {
+			// make sure the Ensure logic can process
+			// system configuration changes as soon as possible
+			context.State().EnsureBefore(0)
+		}
 		return nil
 	})
 

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -282,12 +282,7 @@ func (o *Overlord) Stop() error {
 	return err1
 }
 
-// Settle runs first a state engine Ensure and then wait for activities to settle.
-// That's done by waiting for all managers activities to settle while
-// making sure no immediate further Ensure is scheduled. Chiefly for
-// tests.  Cannot be used in conjunction with Loop. If timeout is
-// non-zero and settling takes longer than timeout, returns an error.
-func (o *Overlord) Settle(timeout time.Duration) error {
+func (o *Overlord) settle(timeout time.Duration, beforeCleanups func()) error {
 	func() {
 		o.ensureLock.Lock()
 		defer o.ensureLock.Unlock()
@@ -329,6 +324,10 @@ func (o *Overlord) Settle(timeout time.Duration) error {
 		done = o.ensureNext.Equal(next)
 		o.ensureLock.Unlock()
 		if done {
+			if beforeCleanups != nil {
+				beforeCleanups()
+				beforeCleanups = nil
+			}
 			// we should wait also for cleanup handlers
 			st := o.State()
 			st.Lock()
@@ -345,6 +344,29 @@ func (o *Overlord) Settle(timeout time.Duration) error {
 		return &ensureError{errs}
 	}
 	return nil
+}
+
+// Settle runs first a state engine Ensure and then wait for
+// activities to settle. That's done by waiting for all managers'
+// activities to settle while making sure no immediate further Ensure
+// is scheduled. It then waits similarly for all ready changes to
+// reach the clean state. Chiefly for tests. Cannot be used in
+// conjunction with Loop. If timeout is non-zero and settling takes
+// longer than timeout, returns an error.
+func (o *Overlord) Settle(timeout time.Duration) error {
+	return o.settle(timeout, nil)
+}
+
+// SettleObserveBeforeCleanups runs first a state engine Ensure and
+// then wait for activities to settle. That's done by waiting for all
+// managers' activities to settle while making sure no immediate
+// further Ensure is scheduled. It then waits similarly for all ready
+// changes to reach the clean state, but calls once the provided
+// callback before doing that. Chiefly for tests. Cannot be used in
+// conjunction with Loop. If timeout is non-zero and settling takes
+// longer than timeout, returns an error.
+func (o *Overlord) SettleObserveBeforeCleanups(timeout time.Duration, beforeCleanups func()) error {
+	return o.settle(timeout, beforeCleanups)
 }
 
 // State returns the system state managed by the overlord.


### PR DESCRIPTION
We do this by always triggering an Ensure loop exactly once a system configuration change has been committed.

