### PR TITLE
cmd/snap-confine: make /run/media an alias of /media

### DIFF
--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -319,7 +319,7 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			die("cannot lstat %s", dst);
 		}
 		if ((stat_buf.st_mode & S_IFMT) == S_IFLNK) {
-			die("cannot bind mount over a symlink: %s", dst);
+			die("cannot bind mount alternate path over a symlink: %s", dst);
 		}
 		sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND, NULL);
 		if (!mnt->is_bidirectional) {

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -199,9 +199,9 @@ static void sc_setup_mount_profiles(struct sc_apparmor *apparmor,
 struct sc_mount {
 	const char *path;
 	bool is_bidirectional;
-	// Alias defines the rbind mount "alias" of path. It exists mainly for
-	// /media <=> /run/media equivalence.
-	const char *alias;
+	// Alternate path defines the rbind mount "alternative" of path.
+	// It exists so that we can make /media on systems that use /run/media.
+	const char *altpath;
 };
 
 struct sc_mount_config {
@@ -307,13 +307,13 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			// from that of its own snap.
 			sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
 		}
-		if (mnt->alias == NULL) {
+		if (mnt->altpath == NULL) {
 			continue;
 		}
-		// An alias of mnt->path is provided at another location.
+		// An alternate path of mnt->path is provided at another location.
 		// It should behave exactly the same as the original.
 		sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir,
-				 mnt->alias);
+				 mnt->altpath);
 		sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND, NULL);
 		if (!mnt->is_bidirectional) {
 			sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -199,6 +199,9 @@ static void sc_setup_mount_profiles(struct sc_apparmor *apparmor,
 struct sc_mount {
 	const char *path;
 	bool is_bidirectional;
+	// Alias defines the rbind mount "alias" of path. It exists mainly for
+	// /media <=> /run/media equivalence.
+	const char *alias;
 };
 
 struct sc_mount_config {
@@ -302,6 +305,17 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 			// Mount events will only propagate inwards to the namespace. This
 			// way the running application cannot alter any global state apart
 			// from that of its own snap.
+			sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
+		}
+		if (mnt->alias == NULL) {
+			continue;
+		}
+		// An alias of mnt->path is provided at another location.
+		// It should behave exactly the same as the original.
+		sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir,
+				 mnt->alias);
+		sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND, NULL);
+		if (!mnt->is_bidirectional) {
 			sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);
 		}
 	}
@@ -603,7 +617,7 @@ void sc_populate_mount_ns(struct sc_apparmor *apparmor, int snap_update_ns_fd,
 			{"/usr/src"},	// FIXME: move to SecurityMounts in system-trace interface
 			{"/var/log"},	// FIXME: move to SecurityMounts in log-observe interface
 #ifdef MERGED_USR
-			{"/run/media", true},	// access to the users removable devices
+			{"/run/media", true, "/media"},	// access to the users removable devices
 #else
 			{"/media", true},	// access to the users removable devices
 #endif				// MERGED_USR

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -314,6 +314,13 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config)
 		// It should behave exactly the same as the original.
 		sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir,
 				 mnt->altpath);
+		struct stat stat_buf;
+		if (lstat(dst, &stat_buf) < 0) {
+			die("cannot lstat %s", dst);
+		}
+		if ((stat_buf.st_mode & S_IFMT) == S_IFLNK) {
+			die("cannot bind mount over a symlink: %s", dst);
+		}
 		sc_do_mount(mnt->path, dst, NULL, MS_REC | MS_BIND, NULL);
 		if (!mnt->is_bidirectional) {
 			sc_do_mount("none", dst, NULL, MS_REC | MS_SLAVE, NULL);

--- a/tests/main/interfaces-removable-media/task.yaml
+++ b/tests/main/interfaces-removable-media/task.yaml
@@ -3,10 +3,6 @@ summary: Ensure that the removable-media interface works.
 details: |
     The removable-media interface allows to access to removable storage filesystems.
 
-# This is skipped on fedora due to an error which is currently under investigation. 
-# The snap is failing to read /media/testdir giving an error "No such file or directory"
-systems: [-fedora-*]
-
 prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-removable-media


### PR DESCRIPTION
    
This patch makes it so that inside the execution environment, the /media
directory always corresponds to the correct directory on the host
(either /media or /run/media).
   
This makes the execution environment more portable across systems, for
snap developers the programmatic difference between /media and
/run/media no longer exists. Snap applications can always rely on
/media.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>