### PR TITLE
interfaces/serial: change pattern not to exclude /dev/ttymxc (2.32)

### DIFF
--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -69,7 +69,8 @@ func (iface *serialPortInterface) String() string {
 //  - ttyXRUSBx  (Exar Corp. USB UART devices)
 //  - ttySX (UART serial ports)
 //  - ttyOX (UART serial ports on ARM)
-var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(USB|ACM|AMA|XRUSB|S|O)[0-9]+$")
+//  - ttymxcX (serial ports on i.mx6UL)
+var serialDeviceNodePattern = regexp.MustCompile("^/dev/tty(mxc|USB|ACM|AMA|XRUSB|S|O)[0-9]+$")
 
 // Pattern that is considered valid for the udev symlink to the serial device,
 // path attributes will be compared to this for validity when usb vid and pid

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -201,10 +201,10 @@
 			"revisionTime": "2016-08-29T01:00:30Z"
 		},
 		{
-			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
+			"checksumSHA1": "HmUAWd1Jm25cGH4Pyf3Zgp2RhkI=",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b",
-			"revisionTime": "2017-04-07T17:21:22Z"
+			"revision": "86f5ed62f8a0ee96bd888d2efdfd6d4fb100a4eb",
+			"revisionTime": "2018-03-26T05:07:29Z"
 		}
 	],
 	"rootPath": "github.com/snapcore/snapd"


### PR DESCRIPTION
This is a backport of #4819 for 2.32