### PR TITLE
cmd: make fmt (indent 2.2.11)

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -189,8 +189,8 @@ static void test_sc_snap_name_validate(void)
 
 	// In case we switch to a regex, here's a test that could break things.
 	const char *good_bad_name = "u-94903713687486543234157734673284536758";
-	char varname[41] = {0};
-	for (int i = 3; i <= 40; i++ ) {
+	char varname[41] = { 0 };
+	for (int i = 3; i <= 40; i++) {
 		g_assert_nonnull(strncpy(varname, good_bad_name, i));
 		varname[i] = 0;
 		g_test_message("checking valid snap name: >%s<", varname);

--- a/cmd/snap-confine/seccomp-support.c
+++ b/cmd/snap-confine/seccomp-support.c
@@ -218,7 +218,8 @@ int sc_apply_seccomp_bpf(const char *filter_profile)
 		.len = num_read / sizeof(struct sock_filter),
 		.filter = (struct sock_filter *)bpf,
 	};
-	if (seccomp(SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_LOG, &prog) != 0) {
+	if (seccomp(SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_LOG, &prog) !=
+	    0) {
 		if (errno == ENOSYS) {
 			debug("kernel doesn't support the seccomp(2) syscall");
 		} else if (errno == EINVAL) {

--- a/cmd/snap-confine/udev-support.c
+++ b/cmd/snap-confine/udev-support.c
@@ -63,12 +63,12 @@ _run_snappy_app_dev_add_majmin(struct snappy_udev *udev_s,
 		}
 		debug("running snap-device-helper add %s %s %s",
 		      udev_s->tagname, path, buf);
-                // This code runs inside the core snap. We have two paths
-                // for the udev helper.
-                //
-                // First try new "snap-device-helper" path first but
-                // when running against an older core snap fallback to
-                // the old name.
+		// This code runs inside the core snap. We have two paths
+		// for the udev helper.
+		//
+		// First try new "snap-device-helper" path first but
+		// when running against an older core snap fallback to
+		// the old name.
 		if (access("/usr/lib/snapd/snap-device-helper", X_OK) == 0)
 			execle("/usr/lib/snapd/snap-device-helper",
 			       "/usr/lib/snapd/snap-device-helper", "add",

--- a/cmd/system-shutdown/system-shutdown.c
+++ b/cmd/system-shutdown/system-shutdown.c
@@ -65,10 +65,10 @@ int main(int argc, char *argv[])
 	   before doing whatever we were told to do, in which case there's
 	   nothing left to sync.
 
-           1) ... apart from the third way that we never talk about: we somehow
-	      are unable to umount everything cleanly, but go ahead with the
-	      reboot anyway because no error was returned. That's the only path
-	      we need to sync on explicitly.
+	   1) ... apart from the third way that we never talk about: we somehow
+	   are unable to umount everything cleanly, but go ahead with the
+	   reboot anyway because no error was returned. That's the only path
+	   we need to sync on explicitly.
 	 */
 
 	if (mkdir("/writable", 0755) < 0) {
@@ -87,12 +87,12 @@ int main(int argc, char *argv[])
 			die("cannot move writable out of the way");
 		}
 
-                if (umount_all()) {
-                        kmsg("- was able to unmount writable cleanly");
-                } else {
-                        kmsg("* was *NOT* able to unmount writable cleanly");
-                        sync(); // we don't know what happened but we're going ahead
-                }
+		if (umount_all()) {
+			kmsg("- was able to unmount writable cleanly");
+		} else {
+			kmsg("* was *NOT* able to unmount writable cleanly");
+			sync();	// we don't know what happened but we're going ahead
+		}
 	}
 
 	// argv[1] can be one of at least: halt, reboot, poweroff.


### PR DESCRIPTION
A while ago we disabled the format check for C code because indent started to produce different
output. Some code merged since could use "make fmt" to make it less annoying to work on changes.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>