### PR TITLE
spread.yaml: switch Fedora 27 tests to manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -92,6 +92,8 @@ backends:
         systems:
             - fedora-27-64:
                 workers: 4
+                # Fedora CI disabled because of unexplained golang bug breaking every build.
+                manual: true
             - fedora-26-64:
                 workers: 4
                 manual: true


### PR DESCRIPTION
Fedora is affected by what looks like a compiler issue where the build
terminates without any useful diagnostic message:
```
    r -p $WORK/golang.org/x/net/context/
    cd /usr/share/gocode/src/golang.org/x/net/context/ctxhttp
    /usr/lib/golang/pkg/tool/linux_amd64/compile -o $WORK/golang.org/x/net/context/ctxhttp.a -trimpath $WORK -shared -goversion go1.9.4 -p golang.org/x/net/context/ctxhttp -complete -installsuffix shared -buildid ab9e3e1669ce2ef40183ac44ed64b157e02355b9 -D _/usr/share/gocode/src/golang.org/x/net/context/ctxhttp -I $WORK -I /usr/share/gocode/pkg/linux_amd64_shared -pack ./ctxhttp.go
    error: Bad exit status from /var/tmp/rpm-tmp.iLEs6F (%build)
	Bad exit status from /var/tmp/rpm-tmp.iLEs6F (%build)
    RPM build errors:
    Child return code was: 1
    EXCEPTION: [Error()]
    Traceback (most recent call last):
      File "/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py", line 89, in trace
	result = func(*args, **kw)
      File "/usr/lib/python3.6/site-packages/mockbuild/util.py", line 582, in do
	raise exception.Error("Command failed. See logs for output.\n # %s" % (command,), child.returncode)
    mockbuild.exception.Error: Command failed. See logs for output.
     # bash --login -c /usr/bin/rpmbuild -bb --target x86_64 --nodeps /builddir/build/SPECS/snapd.spec
```
Some additional investigation uncovered what looks like an unexpanded RPM macro
%{go_import_path} which hints at a broken RPM helper for golang as the culprit.
This patch should be reverted once the situation stabilizes and a fix is in place.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
