### PR TITLE
tests: adjust canonical-livepatch test on GCE

### DIFF
--- a/tests/main/canonical-livepatch/task.yaml
+++ b/tests/main/canonical-livepatch/task.yaml
@@ -16,4 +16,13 @@ execute: |
     done
 
     echo "And ensure we get the expected status"
-    canonical-livepatch status | MATCH "Machine is not enabled"
+    case "$(uname -r)" in
+        *-gcp)
+            # Google compute platform kernels are not supported by Canonical Live Patch system.
+            # The error message goes to stderr, hence the extra redirect magic.
+            ( canonical-livepatch status 2>&1 ) | MATCH -- '-gcp" is not eligible for livepatch updates'
+            ;;
+        *)
+            ( canonical-livepatch status 2>&1 ) | MATCH "Machine is not enabled"
+            ;;
+    esac


### PR DESCRIPTION
On Google compute engine/platform we are relying on the google-provided
kernel. This kernel is not supported by the Canonical Live Patch service
and we get an error message when trying.

Adjust the livepatch test to handle this case.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com