### PR TITLE
osutil: fix fstab parser to allow for # in field values

### DIFF
--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -127,7 +127,14 @@ func ParseMountEntry(s string) (MountEntry, error) {
 	var err error
 	var df, cpn int
 	fields := strings.FieldsFunc(s, func(r rune) bool { return r == ' ' || r == '\t' })
-	// do all error checks before any assignments to `e'
+	// Look for any inline comments. The first field that starts with '#' is a comment.
+	for i, field := range fields {
+		if strings.HasPrefix(field, "#") {
+			fields = fields[:i]
+			break
+		}
+	}
+	// Do all error checks before any assignments to `e'
 	if len(fields) < 3 || len(fields) > 6 {
 		return e, fmt.Errorf("expected between 3 and 6 fields, found %d", len(fields))
 	}

--- a/osutil/mountentry_test.go
+++ b/osutil/mountentry_test.go
@@ -102,6 +102,18 @@ func (s *entrySuite) TestParseMountEntry1(c *C) {
 	c.Assert(e.CheckPassNumber, Equals, 0)
 }
 
+// Test that hash inside a field value is supported.
+func (s *entrySuite) TestHashInFieldValue(c *C) {
+	e, err := osutil.ParseMountEntry("mhddfs#/mnt/dir1,/mnt/dir2 /mnt/dir fuse defaults,allow_other 0 0")
+	c.Assert(err, IsNil)
+	c.Assert(e.Name, Equals, "mhddfs#/mnt/dir1,/mnt/dir2")
+	c.Assert(e.Dir, Equals, "/mnt/dir")
+	c.Assert(e.Type, Equals, "fuse")
+	c.Assert(e.Options, DeepEquals, []string{"defaults", "allow_other"})
+	c.Assert(e.DumpFrequency, Equals, 0)
+	c.Assert(e.CheckPassNumber, Equals, 0)
+}
+
 // Test that options are parsed correctly
 func (s *entrySuite) TestParseMountEntry2(c *C) {
 	e, err := osutil.ParseMountEntry("name dir type options,comma,separated 0 0")

--- a/osutil/mountprofile.go
+++ b/osutil/mountprofile.go
@@ -66,10 +66,15 @@ func ReadMountProfile(reader io.Reader) (*MountProfile, error) {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		s := scanner.Text()
-		if i := strings.IndexByte(s, '#'); i != -1 {
-			s = s[0:i]
-		}
 		s = strings.TrimSpace(s)
+		// Skip lines that only contain a comment, that is, those that start
+		// with the '#' character (ignoring leading spaces). This specifically
+		// allows us to parse '#' inside individual fields, which the fstab(5)
+		// specification allows.
+		if strings.IndexByte(s, '#') == 0 {
+			continue
+		}
+		// Skip lines that are totally empty
 		if s == "" {
 			continue
 		}

--- a/osutil/mountprofile_test.go
+++ b/osutil/mountprofile_test.go
@@ -58,6 +58,26 @@ func (s *profileSuite) TestLoadMountProfile2(c *C) {
 	})
 }
 
+// Test that loading profile with various comments works as expected.
+func (s *profileSuite) TestLoadMountProfile3(c *C) {
+	dir := c.MkDir()
+	fname := filepath.Join(dir, "existing")
+	err := ioutil.WriteFile(fname, []byte(`
+   # comment with leading spaces
+name#-1 dir#-1 type#-1 options#-1 1 1 # inline comment
+# comment without leading spaces
+
+
+`), 0644)
+	c.Assert(err, IsNil)
+	p, err := osutil.LoadMountProfile(fname)
+	c.Assert(err, IsNil)
+	c.Assert(p.Entries, HasLen, 1)
+	c.Assert(p.Entries, DeepEquals, []osutil.MountEntry{
+		{Name: "name#-1", Dir: "dir#-1", Type: "type#-1", Options: []string{"options#-1"}, DumpFrequency: 1, CheckPassNumber: 1},
+	})
+}
+
 // Test that saving a profile to a file works correctly.
 func (s *profileSuite) TestSaveMountProfile1(c *C) {
 	dir := c.MkDir()


### PR DESCRIPTION
This patch changes the fstab parser to allow the-hash-or-pound sign to
be used inside field values, as long as it is not the first character.

This specifically allows us to parse this mount entry:

    mhddfs#/mnt/hdd1,/mnt/hdd2,/mnt/hdd3 /mnt/virtual fuse defaults,allow_other 0 0

The parser no longer strips off first encountered '#' sign. Instead
comments are differentiated into full comments and inline comments. Full
comments have '#' as the first non-whitespace character of a given line
and are stripped out by the fstab file parser and don't reach the fstab
entry parser. Inline comments are stripped after fstab-entry field
separation and must contain '#' as the first character of a field. This
combination allows '#' to be safely used inside individual fields, as
long as it is not the first character.

Fixes: https://bugs.launchpad.net/snappy/+bug/1760841
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>