### PR TITLE
cmd/snap-mgmt: remove timers, udev rules, dbus policy files (2.32)

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -97,6 +97,15 @@ purge() {
                         rmdir --ignore-fail-on-non-empty "$d"
                     fi
                 done
+                # udev rules
+                find /etc/udev/rules.d -name "*-snap.${snap}.rules" -print0 | xargs -0 rm -f
+                # dbus policy files
+                find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -print0 | xargs -0 rm -f
+                # timer files
+                find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
+                    systemctl_stop "$(basename $f)"
+                    rm -f "$f"
+                done
             fi
         fi
 

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -98,9 +98,9 @@ purge() {
                     fi
                 done
                 # udev rules
-                find /etc/udev/rules.d -name "*-snap.${snap}.rules" -print0 | xargs -0 rm -f
+                find /etc/udev/rules.d -name "*-snap.${snap}.rules" -execdir rm -f "{}" \;
                 # dbus policy files
-                find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -print0 | xargs -0 rm -f
+                find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
                 # timer files
                 find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
                     systemctl_stop "$(basename $f)"

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -65,6 +65,15 @@ if [ "$1" = "purge" ]; then
                     rmdir --ignore-fail-on-non-empty "$d" || true
                 fi
             done
+            # udev rules
+            find /etc/udev/rules.d -name "*-snap.${snap}.rules" -print0 | xargs -0 rm -f
+            # dbus policy files
+            find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -print0 | xargs -0 rm -f
+            # timer files
+            find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
+                systemctl_stop "$(basename $f)"
+                rm -f "$f"
+            done
         fi
 
         echo "Removing $unit"

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -66,9 +66,9 @@ if [ "$1" = "purge" ]; then
                 fi
             done
             # udev rules
-            find /etc/udev/rules.d -name "*-snap.${snap}.rules" -print0 | xargs -0 rm -f
+            find /etc/udev/rules.d -name "*-snap.${snap}.rules" -execdir rm -f "{}" \;
             # dbus policy files
-            find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -print0 | xargs -0 rm -f
+            find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
             # timer files
             find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
                 systemctl_stop "$(basename $f)"

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -69,9 +69,9 @@ if [ "$1" = "purge" ]; then
                 fi
             done
             # udev rules
-            find /etc/udev/rules.d -name "*-snap.${snap}.rules" -print0 | xargs -0 rm -f
+            find /etc/udev/rules.d -name "*-snap.${snap}.rules" -execdir rm -f "{}" \;
             # dbus policy files
-            find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -print0 | xargs -0 rm -f
+            find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
             # timer files
             find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
                 systemctl_stop "$(basename $f)"

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -68,6 +68,15 @@ if [ "$1" = "purge" ]; then
                     rmdir --ignore-fail-on-non-empty "$d" || true
                 fi
             done
+            # udev rules
+            find /etc/udev/rules.d -name "*-snap.${snap}.rules" -print0 | xargs -0 rm -f
+            # dbus policy files
+            find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -print0 | xargs -0 rm -f
+            # timer files
+            find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
+                systemctl_stop "$(basename $f)"
+                rm -f "$f"
+            done
         fi
 
         echo "Removing $unit"

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -10,8 +10,17 @@ prepare: |
     snap install test-snapd-tools
     snap list | MATCH test-snapd-tools
 
+    # a snap with services
     install_local test-snapd-service
     snap list | MATCH test-snapd-service
+
+    # a snap with timers
+    install_local test-snapd-timer-service
+    snap list | MATCH test-snapd-timer-service
+
+    # a snap with DBus policy files
+    snap install test-snapd-network-status-provider
+    snap list | MATCH test-snapd-network-status-provider
 
     before=$(find ${SNAP_MOUNT_DIR} -type d | wc -l)
     if [ "$before" -lt 2 ]; then
@@ -21,6 +30,11 @@ prepare: |
 
     echo "test service is known to systemd and enabled"
     systemctl list-unit-files --type service --no-legend | MATCH 'snap.test-snapd-service\..*\.service\s+enabled'
+
+    # expecting to find various files that snap installation produced
+    test $(find /etc/udev/rules.d -name '*-snap.*.rules' | wc -l) -gt 0
+    test $(find /etc/dbus-1/system.d -name 'snap.*.conf' | wc -l) -gt 0
+    test $(find /etc/systemd/system -name 'snap.*.timer' | wc -l) -gt 0
 
 execute: |
     echo "Stop snapd before purging"
@@ -62,3 +76,7 @@ execute: |
 
     echo "No dangling service symlinks are left behind"
     test -z "$(find /etc/systemd/system/multi-user.target.wants/ -name 'snap.test-snapd-service.*')"
+
+    test $(find /etc/udev/rules.d -name '*-snap.*.rules' | wc -l) -eq 0
+    test $(find /etc/dbus-1/system.d -name 'snap.*.conf' | wc -l) -eq 0
+    test $(find /etc/systemd/system -name 'snap.*.timer' | wc -l) -eq 0

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -14,10 +14,6 @@ prepare: |
     install_local test-snapd-service
     snap list | MATCH test-snapd-service
 
-    # a snap with timers
-    install_local test-snapd-timer-service
-    snap list | MATCH test-snapd-timer-service
-
     # a snap with DBus policy files
     snap install test-snapd-network-status-provider
     snap list | MATCH test-snapd-network-status-provider
@@ -34,7 +30,6 @@ prepare: |
     # expecting to find various files that snap installation produced
     test $(find /etc/udev/rules.d -name '*-snap.*.rules' | wc -l) -gt 0
     test $(find /etc/dbus-1/system.d -name 'snap.*.conf' | wc -l) -gt 0
-    test $(find /etc/systemd/system -name 'snap.*.timer' | wc -l) -gt 0
 
 execute: |
     echo "Stop snapd before purging"
@@ -79,4 +74,3 @@ execute: |
 
     test $(find /etc/udev/rules.d -name '*-snap.*.rules' | wc -l) -eq 0
     test $(find /etc/dbus-1/system.d -name 'snap.*.conf' | wc -l) -eq 0
-    test $(find /etc/systemd/system -name 'snap.*.timer' | wc -l) -eq 0


### PR DESCRIPTION
#4972 backported to 2.32
