### PR TITLE
debian: add gbp.conf script to build snapd via `gbp buildpackage`

### DIFF
--- a/packaging/ubuntu-16.04/gbp.conf
+++ b/packaging/ubuntu-16.04/gbp.conf
@@ -1,0 +1,7 @@
+[buildpackage]
+# use a build area relative to the git repository
+export-dir = ../build-area
+# disable the since the sources are being exported first
+cleaner =
+# post export script that gets the vendored dependencies
+postexport = ./get-deps.sh


### PR DESCRIPTION
This provides a clean way to build the source package with the
right vendored dependencies. It requires a fixed git-buildpackage
though, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894790
for details.

