### PR TITLE
overlord,interfaces: be more vocal about broken snaps and read errors (2.32)

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -808,6 +808,9 @@ func (r *Repository) SnapSpecification(securitySystem SecuritySystem, snapName s
 // Unknown interfaces and plugs/slots that don't validate are not added.
 // Information about those failures are returned to the caller.
 func (r *Repository) AddSnap(snapInfo *snap.Info) error {
+	if snapInfo.Broken != "" {
+		return fmt.Errorf("snap is broken: %s", snapInfo.Broken)
+	}
 	err := snap.Validate(snapInfo)
 	if err != nil {
 		return err

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -103,7 +103,7 @@ func (m *InterfaceManager) addSnaps() error {
 	for _, snapInfo := range snaps {
 		addImplicitSlots(snapInfo)
 		if err := m.repo.AddSnap(snapInfo); err != nil {
-			logger.Noticef("%s", err)
+			logger.Noticef("cannot add snap %q to interface repository: %s", snapInfo.Name(), err)
 		}
 	}
 	return nil

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/errtracker"
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -215,6 +216,9 @@ var readInfo = readInfoAnyway
 
 func readInfoAnyway(name string, si *snap.SideInfo) (*snap.Info, error) {
 	info, err := snap.ReadInfo(name, si)
+	if err != nil {
+		logger.Noticef("cannot read snap info of snap %q at revision %s: %s", name, si.Revision, err)
+	}
 	if _, ok := err.(*snap.NotFoundError); ok {
 		reason := fmt.Sprintf("cannot read snap %q: %s", name, err)
 		info := &snap.Info{


### PR DESCRIPTION
This patch adds some verbose-y logs whenever we read or try to use
broken snaps. Snaps may be "broken" when we cannot read the
meta/snap.yaml file. Using broken snaps can have undesired consequences
as they don't carry any plugs or slots, but still carry the right name
and often revision.

The interface repository will now refuse to add broken snaps, leading
to an explicit error message when such operation is attempted.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>