### PR TITLE
Revert "spread.yaml: switch Fedora 27 tests to manual (#4962)"

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -92,8 +92,6 @@ backends:
         systems:
             - fedora-27-64:
                 workers: 4
-                # Fedora CI disabled because of unexplained golang bug breaking every build.
-                manual: true
             - fedora-26-64:
                 workers: 4
                 manual: true


### PR DESCRIPTION
The original issue was traced to messed up packaging of gopkg.in/yaml.v2
where v1 and v2 packages were broken and swapped. Why this resulted in
horrible error messages? We don't know.

This reverts commit 66ef43463d378de76533ec141a2f4931b23ff9db.