### PR TITLE
interfaces: make system-key more robust against invalid fstab entries (2.32)

### DIFF
--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -116,6 +116,7 @@ func generateSystemKey() (*systemKey, error) {
 	if err != nil {
 		// just log the error here
 		logger.Noticef("cannot determine nfs usage in generateSystemKey: %v", err)
+		return nil, err
 	}
 
 	// Add if '/' is on overlayfs so we can add AppArmor rules for
@@ -124,6 +125,7 @@ func generateSystemKey() (*systemKey, error) {
 	if err != nil {
 		// just log the error here
 		logger.Noticef("cannot determine root filesystem on overlay in generateSystemKey: %v", err)
+		return nil, err
 	}
 
 	// Add seccomp-features

--- a/interfaces/system_key.go
+++ b/interfaces/system_key.go
@@ -114,16 +114,16 @@ func generateSystemKey() (*systemKey, error) {
 	// profile.
 	sk.NFSHome, err = osutil.IsHomeUsingNFS()
 	if err != nil {
+		// just log the error here
 		logger.Noticef("cannot determine nfs usage in generateSystemKey: %v", err)
-		return nil, err
 	}
 
 	// Add if '/' is on overlayfs so we can add AppArmor rules for
 	// upperdir such that if this changes, we change our profile.
 	sk.OverlayRoot, err = osutil.IsRootWritableOverlay()
 	if err != nil {
+		// just log the error here
 		logger.Noticef("cannot determine root filesystem on overlay in generateSystemKey: %v", err)
-		return nil, err
 	}
 
 	// Add seccomp-features

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -159,7 +159,10 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles() error {
 		}
 	}
 
-	return interfaces.WriteSystemKey()
+	if err := interfaces.WriteSystemKey(); err != nil {
+		logger.Noticef("cannot write system key: %v", err)
+	}
+	return nil
 }
 
 // renameCorePlugConnection renames one connection from "core-support" plug to

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -1,10 +1,11 @@
 summary: Ensure security profile re-generation works with system-key
 prepare: |
     echo "Make backup of fstab"
-    cp /etc/fstab /etc/fstab.save
+    cp /etc/fstab /tmp/fstab.save
 restore: |
     echo "Restore fstab copy"
-    mv /etc/fstab.save /etc/fstab
+    cp /tmp/fstab.save /etc/fstab
+    rm -f /tmp/fstab.save
 execute: |
     stop_snapd() {
         systemctl stop snapd.service snapd.socket

--- a/tests/main/snap-system-key/task.yaml
+++ b/tests/main/snap-system-key/task.yaml
@@ -1,5 +1,10 @@
 summary: Ensure security profile re-generation works with system-key
-
+prepare: |
+    echo "Make backup of fstab"
+    cp /etc/fstab /etc/fstab.save
+restore: |
+    echo "Restore fstab copy"
+    mv /etc/fstab.save /etc/fstab
 execute: |
     stop_snapd() {
         systemctl stop snapd.service snapd.socket
@@ -64,3 +69,9 @@ execute: |
         echo "system-key *not* rewriten test broken"
         exit 1
     fi
+
+    echo "Ensure snapd works even with invalid /etc/fstab (LP: #1760841)"
+    echo "invalid so very invalid so invalid" >> /etc/fstab
+    restart_snapd
+    echo "Ensure snap commands still work"
+    snap list


### PR DESCRIPTION
This is https://github.com/snapcore/snapd/pull/4969 for the 2.32 branch.