### PR TITLE
 tests: add test to ensure `snap refresh --amend` works with different channels

### DIFF
--- a/tests/main/refresh-amend/task.yaml
+++ b/tests/main/refresh-amend/task.yaml
@@ -1,22 +1,28 @@
 summary: Ensure that refresh --amend works
 
 restore: |
-    rm -f test-snapd-tools_*.snap
+    rm -f test-snapd-only-in-edge_*.snap
 
 execute: |
     echo "When installing a local snap"
-    snap download test-snapd-tools
-    snap install --dangerous ./test-snapd-tools_*.snap
-    snap list |MATCH "test-snapd-tools.*x1"
+    snap download --edge test-snapd-only-in-edge
+    snap install --dangerous ./test-snapd-only-in-edge_*.snap
+    snap list |MATCH "test-snapd-only-in-edge.*x1"
 
     echo "A normal refresh will not refresh it to the store rev"
-    if snap refresh test-snapd-tools 2> stderr.out; then
+    if snap refresh test-snapd-only-in-edge 2> stderr.out; then
         echo "snap refresh should error but did not"
         exit 1
     fi
-    cat stderr.out | MATCH 'local snap "test-snapd-tools" is unknown to the store'
+    cat stderr.out | MATCH 'local snap "test-snapd-only-in-edge" is unknown to the store'
 
+    echo "A refresh with --amend is not enough, the channel needs to be added"
+    if snap refresh --amend test-snapd-only-in-edge 2> stderr.out; then
+       echo "snap refresh --amend without --edge should error but it did not"
+       exit 1
+    fi
+ 
     echo "A refresh with --amend refreshes it to the store revision"
-    snap refresh --amend test-snapd-tools
+    snap refresh --edge --amend test-snapd-only-in-edge
     echo "And we have a store revision now"
-    snap info test-snapd-tools | MATCH "^snap-id:.*[a-zA-Z0-9]+$"
+    snap info test-snapd-only-in-edge | MATCH "^snap-id:.*[a-zA-Z0-9]+$"


### PR DESCRIPTION
There was a bugreport that `snap refresh --amend` does not work if the snap in question is not available in stable. the #4900 PR fixes this. I added a spread test here to ensure that we don't regress here.

Based on https://github.com/snapcore/snapd/pull/4900

The relevant commit is 35cba2c 