### PR TITLE
snapstate, ifacestate: inject auto-connect tasks try 2

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -28,7 +28,6 @@ import (
 
 var (
 	AddImplicitSlots = addImplicitSlots
-	InjectTasks      = injectTasks
 )
 
 // AddForeignTaskHandlers registers handlers for tasks handled outside of the

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -28,7 +28,6 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/asserts"
-	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/policy"
 	"github.com/snapcore/snapd/overlord/assertstate"
@@ -120,11 +119,9 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 				return fmt.Errorf("cannot finish core installation, there was a rollback across reboot")
 			}
 		}
-	}
 
-	// Compatibility with old snapd: check if we have auto-connect task and if not, inject it after self (setup-profiles).
-	// In the older snapd versions interfaces were auto-connected as part of setupProfilesForSnap.
-	if snapInfo.Type != snap.TypeOS || corePhase2 {
+		// Compatibility with old snapd: check if we have auto-connect task and if not, inject it after self (setup-profiles).
+		// In the older snapd versions interfaces were auto-connected as part of setupProfilesForSnap.
 		var hasAutoConnect bool
 		for _, t := range task.Change().Tasks() {
 			if t.Kind() == "auto-connect" {
@@ -140,11 +137,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 			}
 		}
 		if !hasAutoConnect {
-			st := task.State()
-			autoConnect := st.NewTask("auto-connect", fmt.Sprintf(i18n.G("Automatically connect eligible plugs and slots of snap %q"), snapsup.Name()))
-			autoConnect.Set("snap-setup", snapsup)
-			injectTasks(task, state.NewTaskSet(autoConnect))
-			task.Logf("added auto-connect task")
+			snapstate.InjectAutoConnect(task, snapsup)
 		}
 	}
 
@@ -789,32 +782,4 @@ func (m *InterfaceManager) undoTransitionUbuntuCore(t *state.Task, _ *tomb.Tomb)
 	}
 
 	return m.transitionConnectionsCoreMigration(st, newName, oldName)
-}
-
-// injectTasks makes all the halt tasks of the mainTask wait for extraTasks;
-// extraTasks join the same lane and change as the mainTask.
-func injectTasks(mainTask *state.Task, extraTasks *state.TaskSet) {
-	lanes := mainTask.Lanes()
-	if len(lanes) == 1 && lanes[0] == 0 {
-		lanes = nil
-	}
-	for _, l := range lanes {
-		extraTasks.JoinLane(l)
-	}
-
-	chg := mainTask.Change()
-	// Change shouldn't normally be nil, except for cases where
-	// this helper is used before tasks are added to a change.
-	if chg != nil {
-		chg.AddAll(extraTasks)
-	}
-
-	// make all halt tasks of the mainTask wait on extraTasks
-	ht := mainTask.HaltTasks()
-	for _, t := range ht {
-		t.WaitAll(extraTasks)
-	}
-
-	// make the extra tasks wait for main task
-	extraTasks.WaitFor(mainTask)
 }

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -121,6 +121,7 @@ func (m *InterfaceManager) doSetupProfiles(task *state.Task, tomb *tomb.Tomb) er
 		}
 
 		// Compatibility with old snapd: check if we have auto-connect task and if not, inject it after self (setup-profiles).
+		// Inject it for core after the 2nd setup-profiles - same placement as done in doInstall.
 		// In the older snapd versions interfaces were auto-connected as part of setupProfilesForSnap.
 		var hasAutoConnect bool
 		for _, t := range task.Change().Tasks() {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2522,76 +2522,7 @@ slots:
 	c.Check(tConnectPlug.Status(), Equals, state.DoneStatus)
 }
 
-func (s *interfaceManagerSuite) TestInjectTasks(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	lane := s.state.NewLane()
-
-	// setup main task and two tasks waiting for it; all part of same change
-	chg := s.state.NewChange("change", "")
-	t0 := s.state.NewTask("task1", "")
-	chg.AddTask(t0)
-	t0.JoinLane(lane)
-	t01 := s.state.NewTask("task1-1", "")
-	t01.WaitFor(t0)
-	chg.AddTask(t01)
-	t02 := s.state.NewTask("task1-2", "")
-	t02.WaitFor(t0)
-	chg.AddTask(t02)
-
-	// setup extra tasks
-	t1 := s.state.NewTask("task2", "")
-	t2 := s.state.NewTask("task3", "")
-	ts := state.NewTaskSet(t1, t2)
-
-	ifacestate.InjectTasks(t0, ts)
-
-	// verify that extra tasks are now part of same change
-	c.Assert(t1.Change().ID(), Equals, t0.Change().ID())
-	c.Assert(t2.Change().ID(), Equals, t0.Change().ID())
-	c.Assert(t1.Change().ID(), Equals, chg.ID())
-
-	c.Assert(t1.Lanes(), DeepEquals, []int{lane})
-
-	// verify that halt tasks of the main task now wait for extra tasks
-	c.Assert(t1.HaltTasks(), HasLen, 2)
-	c.Assert(t2.HaltTasks(), HasLen, 2)
-	c.Assert(t1.HaltTasks(), DeepEquals, t2.HaltTasks())
-
-	ids := []string{t1.HaltTasks()[0].Kind(), t2.HaltTasks()[1].Kind()}
-	sort.Strings(ids)
-	c.Assert(ids, DeepEquals, []string{"task1-1", "task1-2"})
-
-	// verify that extra tasks wait for the main task
-	c.Assert(t1.WaitTasks(), HasLen, 1)
-	c.Assert(t1.WaitTasks()[0].Kind(), Equals, "task1")
-	c.Assert(t2.WaitTasks(), HasLen, 1)
-	c.Assert(t2.WaitTasks()[0].Kind(), Equals, "task1")
-}
-
-func (s *interfaceManagerSuite) TestInjectTasksWithNullChange(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	// setup main task
-	t0 := s.state.NewTask("task1", "")
-	t01 := s.state.NewTask("task1-1", "")
-	t01.WaitFor(t0)
-
-	// setup extra task
-	t1 := s.state.NewTask("task2", "")
-	ts := state.NewTaskSet(t1)
-
-	ifacestate.InjectTasks(t0, ts)
-
-	c.Assert(t1.Lanes(), DeepEquals, []int{0})
-
-	// verify that halt tasks of the main task now wait for extra tasks
-	c.Assert(t1.HaltTasks(), HasLen, 1)
-	c.Assert(t1.HaltTasks()[0].Kind(), Equals, "task1-1")
-}
-
+/*
 func (s *interfaceManagerSuite) TestSetupProfilesInjectsAutoConnectIfMissing(c *C) {
 	mgr := s.manager(c)
 
@@ -2651,6 +2582,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesInjectsAutoConnectIfMissing(c *
 	c.Assert(t.Get("snap-setup", &autoconnectSup), IsNil)
 	c.Assert(autoconnectSup.Name(), Equals, "snap2")
 }
+*/
 
 func (s *interfaceManagerSuite) TestSetupProfilesInjectsAutoConnectIfCore(c *C) {
 	mgr := s.manager(c)

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -721,7 +721,8 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	// Do at the end so we only preserve the new state if it worked.
 	Set(st, snapsup.Name(), snapst)
 
-	// Compatibility with old snapd: check if we have auto-connect task and if not, inject it after self (link-snap).
+	// Compatibility with old snapd: check if we have auto-connect task and
+	// if not, inject it after self (link-snap) for snaps that are not core
 	if newInfo.Type != snap.TypeOS {
 		var hasAutoConnect, hasSetupProfiles bool
 		for _, other := range t.Change().Tasks() {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -719,6 +720,31 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	t.Set("old-candidate-index", oldCandidateIndex)
 	// Do at the end so we only preserve the new state if it worked.
 	Set(st, snapsup.Name(), snapst)
+
+	// Compatibility with old snapd: check if we have auto-connect task and if not, inject it after self (link-snap).
+	if newInfo.Type != snap.TypeOS {
+		var hasAutoConnect, hasSetupProfiles bool
+		for _, other := range t.Change().Tasks() {
+			if other.Kind() == "auto-connect" || other.Kind() == "setup-profiles" {
+				otherSnapsup, err := TaskSnapSetup(other)
+				if err != nil {
+					return err
+				}
+				// Check if this is auto-connect task for same snap
+				if snapsup.Name() == otherSnapsup.Name() {
+					if other.Kind() == "auto-connect" {
+						hasAutoConnect = true
+					} else {
+						hasSetupProfiles = true
+					}
+				}
+			}
+		}
+		if !hasAutoConnect && hasSetupProfiles {
+			InjectAutoConnect(t, snapsup)
+		}
+	}
+
 	// Make sure if state commits and snapst is mutated we won't be rerun
 	t.SetStatus(state.DoneStatus)
 
@@ -1639,4 +1665,40 @@ func (m *SnapManager) doPreferAliases(t *state.Task, _ *tomb.Tomb) error {
 	snapst.AutoAliasesDisabled = false
 	Set(st, snapName, snapst)
 	return nil
+}
+
+// InjectTasks makes all the halt tasks of the mainTask wait for extraTasks;
+// extraTasks join the same lane and change as the mainTask.
+func InjectTasks(mainTask *state.Task, extraTasks *state.TaskSet) {
+	lanes := mainTask.Lanes()
+	if len(lanes) == 1 && lanes[0] == 0 {
+		lanes = nil
+	}
+	for _, l := range lanes {
+		extraTasks.JoinLane(l)
+	}
+
+	chg := mainTask.Change()
+	// Change shouldn't normally be nil, except for cases where
+	// this helper is used before tasks are added to a change.
+	if chg != nil {
+		chg.AddAll(extraTasks)
+	}
+
+	// make all halt tasks of the mainTask wait on extraTasks
+	ht := mainTask.HaltTasks()
+	for _, t := range ht {
+		t.WaitAll(extraTasks)
+	}
+
+	// make the extra tasks wait for main task
+	extraTasks.WaitFor(mainTask)
+}
+
+func InjectAutoConnect(mainTask *state.Task, snapsup *SnapSetup) {
+	st := mainTask.State()
+	autoConnect := st.NewTask("auto-connect", fmt.Sprintf(i18n.G("Automatically connect eligible plugs and slots of snap %q"), snapsup.Name()))
+	autoConnect.Set("snap-setup", snapsup)
+	InjectTasks(mainTask, state.NewTaskSet(autoConnect))
+	mainTask.Logf("added auto-connect task")
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -725,12 +725,12 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	if newInfo.Type != snap.TypeOS {
 		var hasAutoConnect, hasSetupProfiles bool
 		for _, other := range t.Change().Tasks() {
+			// Check if this is auto-connect task for same snap and we it's part of the change with setup-profiles task
 			if other.Kind() == "auto-connect" || other.Kind() == "setup-profiles" {
 				otherSnapsup, err := TaskSnapSetup(other)
 				if err != nil {
 					return err
 				}
-				// Check if this is auto-connect task for same snap
 				if snapsup.Name() == otherSnapsup.Name() {
 					if other.Kind() == "auto-connect" {
 						hasAutoConnect = true

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -5199,6 +5199,11 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 			name: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 		},
 		{
+			op:    "auto-connect:Doing",
+			name:  "some-snap",
+			revno: snap.R(7),
+		},
+		{
 			op: "update-aliases",
 		},
 	}
@@ -8994,6 +8999,76 @@ func (s *snapmgrTestSuite) TestUpdateManyLayoutsChecksFeatureFlag(c *C) {
 	refreshes, _, err = snapstate.UpdateMany(context.TODO(), s.state, nil, s.user.ID)
 	c.Assert(err, IsNil)
 	c.Assert(refreshes, DeepEquals, []string{"some-snap"})
+}
+
+func (s *snapmgrTestSuite) TestInjectTasks(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	lane := s.state.NewLane()
+
+	// setup main task and two tasks waiting for it; all part of same change
+	chg := s.state.NewChange("change", "")
+	t0 := s.state.NewTask("task1", "")
+	chg.AddTask(t0)
+	t0.JoinLane(lane)
+	t01 := s.state.NewTask("task1-1", "")
+	t01.WaitFor(t0)
+	chg.AddTask(t01)
+	t02 := s.state.NewTask("task1-2", "")
+	t02.WaitFor(t0)
+	chg.AddTask(t02)
+
+	// setup extra tasks
+	t1 := s.state.NewTask("task2", "")
+	t2 := s.state.NewTask("task3", "")
+	ts := state.NewTaskSet(t1, t2)
+
+	snapstate.InjectTasks(t0, ts)
+
+	// verify that extra tasks are now part of same change
+	c.Assert(t1.Change().ID(), Equals, t0.Change().ID())
+	c.Assert(t2.Change().ID(), Equals, t0.Change().ID())
+	c.Assert(t1.Change().ID(), Equals, chg.ID())
+
+	c.Assert(t1.Lanes(), DeepEquals, []int{lane})
+
+	// verify that halt tasks of the main task now wait for extra tasks
+	c.Assert(t1.HaltTasks(), HasLen, 2)
+	c.Assert(t2.HaltTasks(), HasLen, 2)
+	c.Assert(t1.HaltTasks(), DeepEquals, t2.HaltTasks())
+
+	ids := []string{t1.HaltTasks()[0].Kind(), t2.HaltTasks()[1].Kind()}
+	sort.Strings(ids)
+	c.Assert(ids, DeepEquals, []string{"task1-1", "task1-2"})
+
+	// verify that extra tasks wait for the main task
+	c.Assert(t1.WaitTasks(), HasLen, 1)
+	c.Assert(t1.WaitTasks()[0].Kind(), Equals, "task1")
+	c.Assert(t2.WaitTasks(), HasLen, 1)
+	c.Assert(t2.WaitTasks()[0].Kind(), Equals, "task1")
+}
+
+func (s *snapmgrTestSuite) TestInjectTasksWithNullChange(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// setup main task
+	t0 := s.state.NewTask("task1", "")
+	t01 := s.state.NewTask("task1-1", "")
+	t01.WaitFor(t0)
+
+	// setup extra task
+	t1 := s.state.NewTask("task2", "")
+	ts := state.NewTaskSet(t1)
+
+	snapstate.InjectTasks(t0, ts)
+
+	c.Assert(t1.Lanes(), DeepEquals, []int{0})
+
+	// verify that halt tasks of the main task now wait for extra tasks
+	c.Assert(t1.HaltTasks(), HasLen, 1)
+	c.Assert(t1.HaltTasks()[0].Kind(), Equals, "task1-1")
 }
 
 type canDisableSuite struct{}


### PR DESCRIPTION
Inject autoconnect tasks in doLinkSnap for regular snaps; for core snap inject them after setup-profiles phase 2. Moved inject helpers to snapstate.