### PR TITLE
tests: add arch to CI

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -2,6 +2,9 @@
 # Maintainer: Maciej Borzecki <maciek.borzecki@gmail.com>
 # Contributor: Timothy Redaelli <timothy.redaelli@gmail.com>
 # Contributor: Zygmunt Krynicki <me at zygoon dot pl>
+#
+# Environment variables that can set by CI:
+# - WITH_TEST_KEYS=1 - enable use of testing keys
 
 pkgname=snapd
 pkgdesc="Service and tools for management of snap packages."
@@ -46,6 +49,12 @@ build() {
   cd "$pkgname"
   export GOPATH="$srcdir/go"
 
+  # GOFLAGS may be modified by CI tools
+  GOFLAGS=""
+  if [[ "$WITH_TEST_KEYS" == 1 ]]; then
+      GOFLAGS="$GOFLAGS -tags withtestkeys"
+  fi
+
   export CGO_ENABLED="1"
   export CGO_CFLAGS="${CFLAGS}"
   export CGO_CPPFLAGS="${CPPFLAGS}"
@@ -61,13 +70,13 @@ build() {
 
   gobuild="go build -x -v"
   # Build/install snap and snapd
-  $gobuild -o $GOPATH/bin/snap "${_gourl}/cmd/snap"
-  $gobuild -o $GOPATH/bin/snapctl "${_gourl}/cmd/snapctl"
-  $gobuild -o $GOPATH/bin/snapd "${_gourl}/cmd/snapd"
-  $gobuild -o $GOPATH/bin/snap-seccomp "${_gourl}/cmd/snap-seccomp"
+  $gobuild -o $GOPATH/bin/snap $GOFLAGS "${_gourl}/cmd/snap"
+  $gobuild -o $GOPATH/bin/snapctl $GOFLAGS "${_gourl}/cmd/snapctl"
+  $gobuild -o $GOPATH/bin/snapd $GOFLAGS "${_gourl}/cmd/snapd"
+  $gobuild -o $GOPATH/bin/snap-seccomp $GOFLAGS "${_gourl}/cmd/snap-seccomp"
   # build snap-exec and snap-update-ns completely static for base snaps
-  $gobuild -o $GOPATH/bin/snap-update-ns -ldflags '-extldflags "-static"' "${_gourl}/cmd/snap-update-ns"
-  CGO_ENABLED=0 $gobuild -o $GOPATH/bin/snap-exec "${_gourl}/cmd/snap-exec"
+  $gobuild -o $GOPATH/bin/snap-update-ns -ldflags '-extldflags "-static"' $GOFLAGS "${_gourl}/cmd/snap-update-ns"
+  CGO_ENABLED=0 $gobuild -o $GOPATH/bin/snap-exec $GOFLAGS "${_gourl}/cmd/snap-exec"
 
   # Generate data files such as real systemd units, dbus service, environment
   # setup helpers out of the available templates

--- a/spread.yaml
+++ b/spread.yaml
@@ -76,8 +76,7 @@ backends:
             - opensuse-42.3-64:
                 image: opensuse-cloud/opensuse-leap-42-3-v20180116
                 workers: 4
-            - arch-64:
-                image: arch-linux-64-v20180110
+            - arch-linux-64:
                 workers: 4
 
     linode:

--- a/spread.yaml
+++ b/spread.yaml
@@ -454,7 +454,7 @@ suites:
         # Test cases are not yet ported to Fedora/openSUSE that is why
         # we keep them disabled. A later PR will enable most tests and
         # drop this blacklist.
-        systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*]
+        systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
         # unittests are run as part of the autopkgtest build already
         backends: [-autopkgtest]
         environment:
@@ -493,10 +493,10 @@ suites:
     tests/nightly/:
         summary: Suite for nightly, expensive, tests
         manual: true
-        # Test cases are not yet ported to Fedora/openSUSE that is why
+        # Test cases are not yet ported to Fedora/openSUSE/Arch that is why
         # we keep them disabled. A later PR will enable most tests and
         # drop this blacklist.
-        systems: [-fedora-*, -opensuse-*]
+        systems: [-fedora-*, -opensuse-*, -arch-*]
         prepare: |
             . $TESTSLIB/prepare.sh
             if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then

--- a/spread.yaml
+++ b/spread.yaml
@@ -345,6 +345,12 @@ prepare: |
                 zypper -q --gpg-auto-import-keys refresh
                 zypper -q install -y xdelta3 curl &> "$tf" || (cat "$tf"; exit 1)
                 ;;
+            arch-*)
+                # NOTE: we ought to do pacman -Syu, but this may update the
+                # kernel which we will not detect at this stage and fail to
+                # reboot; actual distro upgrade is done later in prepare
+                pacman -Sy --noconfirm xdelta3 curl &> "$tf" || (cat "$tf"; exit 1)
+                ;;
         esac
         rm -f "$tf"
         curl -sS -o - "https://codeload.github.com/snapcore/snapd/tar.gz/$DELTA_REF" | gunzip > delta-ref.tar

--- a/spread.yaml
+++ b/spread.yaml
@@ -453,7 +453,7 @@ suites:
 
     tests/unit/:
         summary: Suite to run unit tests (non-go and different go runtimes)
-        # Test cases are not yet ported to Fedora/openSUSE that is why
+        # Test cases are not yet ported to Fedora/openSUSE/Arch that is why
         # we keep them disabled. A later PR will enable most tests and
         # drop this blacklist.
         systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]

--- a/spread.yaml
+++ b/spread.yaml
@@ -478,7 +478,17 @@ suites:
         restore: |
             $TESTSLIB/reset.sh --store
             . $TESTSLIB/pkgdb.sh
-            distro_purge_package snapd snap-confine ubuntu-core-launcher
+
+            distro_purge_package snapd
+            case "$SPREAD_SYSTEM" in
+                arch-*)
+                    # there is no snap-confine and ubuntu-core-launcher
+                    # in Arch
+                    ;;
+                *)
+                    distro_purge_package snap-confine ubuntu-core-launcher
+                    ;;
+            esac
 
     tests/nightly/:
         summary: Suite for nightly, expensive, tests

--- a/spread.yaml
+++ b/spread.yaml
@@ -76,6 +76,9 @@ backends:
             - opensuse-42.3-64:
                 image: opensuse-cloud/opensuse-leap-42-3-v20180116
                 workers: 4
+            - arch-64:
+                image: arch-linux-64-v20180110
+                workers: 4
 
     linode:
         key: "$(HOST: echo $SPREAD_LINODE_KEY)"

--- a/tests/lib/dirs.sh
+++ b/tests/lib/dirs.sh
@@ -10,6 +10,10 @@ case "$SPREAD_SYSTEM" in
         export LIBEXECDIR=/usr/libexec
         export MEDIA_DIR=/run/media
         ;;
+    arch-*)
+        export SNAP_MOUNT_DIR=/var/lib/snapd/snap
+        export MEDIA_DIR=/run/media
+        ;;
     *)
         ;;
 esac

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -599,3 +599,18 @@ install_pkg_dependencies(){
     # shellcheck disable=SC2086
     distro_install_package $pkgs
 }
+
+# upgrade distribution and indicate if reboot is needed by outputting 'reboot'
+# to stdout
+distro_upgrade() {
+    case "$SPREAD_SYSTEM" in
+        arch-*)
+            if pacman -Syu --noconfirm 2>&1 | grep -q "there is nothing to do" ; then
+                echo "reboot"
+            fi
+            ;;
+        *)
+            echo "WARNING: distro upgrade not supported on $SPREAD_SYSTEM"
+            ;;
+    esac
+}

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -390,6 +390,12 @@ distro_install_build_snapd(){
         # shellcheck disable=SC2086
         distro_install_local_package $packages
 
+        if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
+            # Arch policy does not allow calling daemon-reloads in package
+            # install scripts
+            systemctl daemon-reload
+        fi
+
         # On some distributions the snapd.socket is not yet automatically
         # enabled as we don't have a systemd present configuration approved
         # by the distribution for it in place yet.

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -611,7 +611,23 @@ install_pkg_dependencies(){
 distro_upgrade() {
     case "$SPREAD_SYSTEM" in
         arch-*)
-            if pacman -Syu --noconfirm 2>&1 | grep -q "there is nothing to do" ; then
+            # Arch does not support partial upgrades. On top of this, the image
+            # we are running in may have been built some time ago and we need to
+            # upgrade so that the tests are run with the same package versions
+            # as the users will have. We basically need to run pacman -Syu.
+            # Since there is no way to tell if we can continue after upgrading
+            # (eg. the kernel package or systemd got updated ) issue a reboot
+            # instead.
+            #
+            # pacman -Syu --noconfirm on an updated system:
+            # :: Synchronizing package databases...
+            #  core is up to date
+            #  extra is up to date
+            #  community is up to date
+            #  multilib is up to date
+            # :: Starting full system upgrade...
+            #  there is nothing to do  <--- needle
+            if ! pacman -Syu --noconfirm 2>&1 | grep -q "there is nothing to do" ; then
                 echo "reboot"
             fi
             ;;

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -148,11 +148,11 @@ build_arch_pkg() {
     archive_name=snapd-$version.tar
 
     rm -rf /tmp/pkg
-    mkdir -p "/tmp/pkg/sources/snapd"
-    cp -ra -- * "/tmp/pkg/sources/snapd/"
+    mkdir -p /tmp/pkg/sources/snapd
+    cp -ra -- * /tmp/pkg/sources/snapd/
 
     # shellcheck disable=SC2086
-    (tar -C /tmp/pkg/sources -cf "/tmp/pkg/$archive_name" "snapd")
+    tar -C /tmp/pkg/sources -cf "/tmp/pkg/$archive_name" "snapd"
     cp "$packaging_path"/* "/tmp/pkg"
 
     # fixup PKGBUILD which builds a package named snapd-git with dynamic version

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -167,6 +167,8 @@ build_arch_pkg() {
         -e "s/pkgver=.*/pkgver=$version/" \
         -e "s/package_snapd-git()/package_snapd()/" \
         /tmp/pkg/PKGBUILD
+    # comment out automatic package version update block `pkgver() { ... }` as
+    # it's only useful when building the package manually
     awk '
     /BEGIN/ { strip = 0; last = 0 }
     /pkgver\(\)/ { strip = 1 }
@@ -434,7 +436,7 @@ restore_suite() {
         . $TESTSLIB/pkgdb.sh
         distro_purge_package snapd
         if [[ "$SPREAD_SYSTEM" != opensuse-* && "$SPREAD_SYSTEM" != arch-* ]]; then
-            # A snap-confine package never existed on openSUSE
+            # A snap-confine package never existed on openSUSE or Arch
             distro_purge_package snap-confine
         fi
     fi

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -44,7 +44,7 @@ create_test_user(){
                 # unlikely to ever clash with anything, and easy to remember.
                 quiet adduser --uid 12345 --gid 12345 --disabled-password --gecos '' test
                 ;;
-            debian-*|fedora-*|opensuse-*)
+            debian-*|fedora-*|opensuse-*|arch-*)
                 quiet useradd -m --uid 12345 --gid 12345 test
                 ;;
             *)
@@ -141,6 +141,46 @@ build_rpm() {
     fi
 }
 
+build_arch_pkg() {
+    base_version="$(head -1 debian/changelog | awk -F '[()]' '{print $2}')"
+    version="1337.$base_version"
+    packaging_path=packaging/arch
+    archive_name=snapd-$version.tar
+
+    rm -rf /tmp/pkg
+    mkdir -p "/tmp/pkg/sources/snapd"
+    cp -ra -- * "/tmp/pkg/sources/snapd/"
+
+    # shellcheck disable=SC2086
+    (tar -C /tmp/pkg/sources -cf "/tmp/pkg/$archive_name" "snapd")
+    cp "$packaging_path"/* "/tmp/pkg"
+
+    # fixup PKGBUILD which builds a package named snapd-git with dynamic version
+    #  - update pkgname to use snapd
+    #  - kill dynamic version
+    #  - packaging functions are named package_<pkgname>(), update it to package_snapd()
+    #  - update source path to point to local archive instead of git
+    #  - fix package version to $version
+    sed -i \
+        -e "s/^source=.*/source=(\"$archive_name\")/" \
+        -e "s/pkgname=snapd.*/pkgname=snapd/" \
+        -e "s/pkgver=.*/pkgver=$version/" \
+        -e "s/package_snapd-git()/package_snapd()/" \
+        /tmp/pkg/PKGBUILD
+    awk '
+    /BEGIN/ { strip = 0; last = 0 }
+    /pkgver\(\)/ { strip = 1 }
+    /^}/ { if (strip) last = 1 }
+    // { if (strip) { print "#" $0; if (last) { last = 0; strip = 0}} else { print $0}}
+    ' < /tmp/pkg/PKGBUILD > /tmp/pkg/PKGBUILD.tmp
+    mv /tmp/pkg/PKGBUILD.tmp /tmp/pkg/PKGBUILD
+
+    chown -R test:test /tmp/pkg
+    su -l -c "cd /tmp/pkg && WITH_TEST_KEYS=1 makepkg -f --nocheck" test
+
+    cp /tmp/pkg/snapd*.pkg.tar.xz "$GOPATH"
+}
+
 download_from_published(){
     local published_version="$1"
 
@@ -217,6 +257,27 @@ prepare_project() {
 
     distro_update_package_db
 
+    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
+        # perform system upgrade on Arch so that we run with most recent kernel
+        # and userspace
+        if [[ "$SPREAD_REBOOT" == 0 ]]; then
+            if distro_upgrade | MATCH "reboot"; then
+                echo "system upgraded, reboot required"
+                REBOOT
+            fi
+            # arch uses a single kernel package which could have gotten updated
+            # just now, reboot in case we're still on the old kernel
+            if [ ! -d "/lib/modules/$(uname -r)" ]; then
+                echo "rebooting to new kernel"
+                REBOOT
+            fi
+        fi
+        if [[ "$SPREAD_REBOOT" != 1 ]]; then
+            echo "reboot did not work"
+            exit 1
+        fi
+    fi
+
     if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
         if [ ! -d packaging/ubuntu-14.04 ]; then
             echo "no packaging/ubuntu-14.04/ directory "
@@ -265,6 +326,9 @@ prepare_project() {
                 ;;
             fedora-*|opensuse-*)
                 build_rpm
+                ;;
+            arch-*)
+                build_arch_pkg
                 ;;
             *)
                 echo "ERROR: No build instructions available for system $SPREAD_SYSTEM"

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -433,7 +433,7 @@ restore_suite() {
         # shellcheck source=tests/lib/pkgdb.sh
         . $TESTSLIB/pkgdb.sh
         distro_purge_package snapd
-        if [[ "$SPREAD_SYSTEM" != opensuse-* ]]; then
+        if [[ "$SPREAD_SYSTEM" != opensuse-* && "$SPREAD_SYSTEM" != arch-* ]]; then
             # A snap-confine package never existed on openSUSE
             distro_purge_package snap-confine
         fi

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -261,6 +261,14 @@ prepare_classic() {
     fi
 
     disable_kernel_rate_limiting
+
+    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
+        # Arch packages do not ship empty directories by default, hence there is
+        # no /etc/dbus-1/system.d what prevents dbus from properly establishing
+        # inotify watch on that path
+        mkdir -p /etc/dbus-1/system.d
+        systemctl reload dbus.service
+    fi
 }
 
 setup_reflash_magic() {

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -31,7 +31,7 @@ reset_classic() {
         ubuntu-*|debian-*)
             sh -x "${SPREAD_PATH}/debian/snapd.postrm" purge
             ;;
-        fedora-*|opensuse-*)
+        fedora-*|opensuse-*|arch-*)
             # We don't know if snap-mgmt was built, so call the *.in file
             # directly and pass arguments that will override the placeholders
             sh -x "${SPREAD_PATH}/cmd/snap-mgmt/snap-mgmt.sh.in" \

--- a/tests/main/classic-confinement/task.yaml
+++ b/tests/main/classic-confinement/task.yaml
@@ -11,7 +11,7 @@ prepare: |
     . $TESTSLIB/dirs.sh
     snap pack "$TESTSLIB/snaps/$CLASSIC_SNAP/"
 
-    if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
+    if [[ "$SPREAD_SYSTEM" == fedora-* || "$SPREAD_SYSTEM" == arch-* ]]; then
         # although classic snaps do not work out of the box on fedora,
         # we still want to verify if the basics do work if the user
         # symlinks /snap to $SNAP_MOUNT_DIR themselves
@@ -49,6 +49,6 @@ execute: |
     "$CLASSIC_SNAP" | MATCH lala
 
 restore: |
-    if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
+    if [[ "$SPREAD_SYSTEM" == fedora-* || "$SPREAD_SYSTEM" == arch-* ]]; then
         rm -f /snap
     fi

--- a/tests/main/classic-custom-device-reg/task.yaml
+++ b/tests/main/classic-custom-device-reg/task.yaml
@@ -1,6 +1,9 @@
 summary: |
    Test gadget customized device initialisation and registration also on classic
-systems: [-ubuntu-core-16-*]
+systems:
+    - -ubuntu-core-16-*
+    # The test fails on Arch right now, disable it temporarily
+    - -arch-*
 environment:
     SEED_DIR: /var/lib/snapd/seed
 prepare: |

--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -2,9 +2,9 @@ summary: Ensure that the ubuntu-core -> core transition works with auth.json
 
 # we never test on core because the transition can only happen on "classic"
 # we disable on ppc64el because the downloads are very slow there
-# Both Fedora and openSUSE are disabled at the moment as there is something
+# Fedora, openSUSE and Arch are disabled at the moment as there is something
 # fishy going on and the snapd service gets terminated during the process.
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -arch-*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -2,9 +2,9 @@ summary: Ensure that the ubuntu-core -> core transition works
 
 # we never test on core because the transition can only happen on "classic"
 # we disable on ppc64el because the downloads are very slow there
-# Both Fedora and openSUSE are disabled at the moment as there is something
+# Fedora, openSUSE and Arch are disabled at the moment as there is something
 # fishy going on and the snapd service gets terminated during the process.
-systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -ubuntu-*-i386]
+systems: [-ubuntu-core-16-*, -ubuntu-*-ppc64el, -fedora-*, -opensuse-*, -ubuntu-*-i386, -arch-*]
 
 # autopkgtest run only a subset of tests that deals with the integration
 # with the distro

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -37,6 +37,6 @@ execute: |
 
 restore: |
     snap remove test-snapd-hello-classic
-    if [[ "$SPREAD_SYSTEM" == fedora-* || "SPREAD_SYSTEM" == arch-* ]]; then
+    if [[ "$SPREAD_SYSTEM" == fedora-* || "$SPREAD_SYSTEM" == arch-* ]]; then
         rm -f /snap
     fi

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -10,7 +10,7 @@ details: |
 
 prepare: |
     . $TESTSLIB/dirs.sh
-    if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
+    if [[ "$SPREAD_SYSTEM" == fedora-* || "$SPREAD_SYSTEM" == arch-* ]]; then
         # although classic snaps do not work out of the box on fedora,
         # we still want to verify if the basics do work if the user
         # symlinks /snap to $SNAP_MOUNT_DIR themselves
@@ -37,6 +37,6 @@ execute: |
 
 restore: |
     snap remove test-snapd-hello-classic
-    if [[ "$SPREAD_SYSTEM" == fedora-* ]]; then
+    if [[ "$SPREAD_SYSTEM" == fedora-* || "SPREAD_SYSTEM" == arch-* ]]; then
         rm -f /snap
     fi

--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure create-user functionality
 
 # Disabled for Fedora, openSUSE as both have not all options for add user
 # available the `snap create-user` command requires. Needs code rework.
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*]
+systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
 
 environment:
     USER_EMAIL: mvo@ubuntu.com

--- a/tests/main/create-user/task.yaml
+++ b/tests/main/create-user/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure create-user functionality
 
-# Disabled for Fedora, openSUSE as both have not all options for add user
-# available the `snap create-user` command requires. Needs code rework.
+# Disabled for Fedora, openSUSE and Arch as none have all options for add user
+# the `snap create-user` command requires. Needs code rework.
 systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
 
 environment:

--- a/tests/main/debs-have-built-using/task.yaml
+++ b/tests/main/debs-have-built-using/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that our debs have the "built-using" header
 
-systems: [-ubuntu-core-*, -fedora-*, -opensuse-*]
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*]
 
 execute: |
     out=$(dpkg -I $GOHOME/snapd_*.deb)

--- a/tests/main/dirs-not-shared-with-host/task.yaml
+++ b/tests/main/dirs-not-shared-with-host/task.yaml
@@ -12,6 +12,16 @@ prepare: |
     echo "Having installed the test snap"
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
+    # Arch does not use /etc/alternatives
+    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
+        mkdir /etc/alternatives
+    fi
+restore: |
+    # Arch does not use /etc/alternatives
+    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
+        rmdir /etc/alternatives
+    fi
+
 environment:
     DIRECTORY/alternatives: /etc/alternatives
     DIRECTORY/ssl: /etc/ssl

--- a/tests/main/interfaces-avahi-observe/task.yaml
+++ b/tests/main/interfaces-avahi-observe/task.yaml
@@ -1,6 +1,6 @@
 summary: check that avahi-observe interface works
 
-systems: [-ubuntu-core-*, -fedora-*, -opensuse-*]
+systems: [-ubuntu-core-*, -fedora-*, -opensuse-*, -arch-*]
 
 prepare: |
     echo "Given a snap with an avahi-observe interface plug is installed"

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -2,7 +2,7 @@ summary: Ensure that the cups interface works.
 
 # Default cups/cups-pdf configuration on these distributions isn't
 # working yet without further tweaks.
-systems: [-ubuntu-core-16-*, -opensuse-*, -fedora-*]
+systems: [-ubuntu-core-16-*, -opensuse-*, -fedora-*, -arch-*]
 
 details: |
     The cups-control interface allows a snap to access the locale configuration.

--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that the firewall-control interface works.
 
-systems: [-fedora-*, -opensuse-*]
+systems: [-fedora-*, -opensuse-*, -arch-*]
 
 details: |
     The firewall-control interface allows a snap to configure the firewall.

--- a/tests/main/interfaces-hardware-random-control/task.yaml
+++ b/tests/main/interfaces-hardware-random-control/task.yaml
@@ -10,8 +10,8 @@ summary: |
     A snap declaring a plug on this interface must be able to read files in
     /sys/class/misc/hw_random/{rng_available,rng_current} and write /dev/hwrng
 
-# Execution skipped on debian due to device /dev/hwrng not created by default
-systems: [-debian-*]
+# Execution skipped on debian and arch due to device /dev/hwrng not created by default
+systems: [-debian-*, -arch-*]
 
 prepare: |
     . "$TESTSLIB/snaps.sh"

--- a/tests/main/interfaces-hardware-random-observe/task.yaml
+++ b/tests/main/interfaces-hardware-random-observe/task.yaml
@@ -10,8 +10,8 @@ summary: |
     A snap declaring a plug on this interface must be able to read files in
     /sys/class/misc/hw_random/{rng_available,rng_current} and /dev/hwrng
 
-# Execution skipped on debian due to device /dev/hwrng not created by default
-systems: [-debian-*]
+# Execution skipped on debian and arch due to device /dev/hwrng not created by default
+systems: [-debian-*, -arch-*]
 
 prepare: |
     . "$TESTSLIB/snaps.sh"

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -1,7 +1,7 @@
 summary: Ensure that the kernel-module-control interface works.
 
 # the s390x kernel has no minix module
-systems: [-fedora-*, -opensuse-*, -ubuntu-*-s390x]
+systems: [-fedora-*, -opensuse-*, -ubuntu-*-s390x, -arch-*]
 
 environment:
     MODULE: minix

--- a/tests/main/interfaces-locale-control/task.yaml
+++ b/tests/main/interfaces-locale-control/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that the locale-control interface works.
 
-systems: [-fedora-*, -opensuse-*]
+systems: [-fedora-*, -opensuse-*, -arch-*]
 
 summary: |
     The locale-control interface allows a snap to access the locale configuration.

--- a/tests/main/interfaces-netlink-audit/task.yaml
+++ b/tests/main/interfaces-netlink-audit/task.yaml
@@ -7,7 +7,8 @@ details: |
 
 # Ubuntu 14.04-64 is skipped due to the capability CAP_AUDIT_READ
 # is not available in its kernel
-systems: [-ubuntu-14.04-*]
+# arch: CONFIG_AUDIT is not enabled in the default kernel
+systems: [-ubuntu-14.04-*, -arch-*]
 
 prepare: |
     . $TESTSLIB/snaps.sh

--- a/tests/main/interfaces-openvswitch-support/task.yaml
+++ b/tests/main/interfaces-openvswitch-support/task.yaml
@@ -5,7 +5,8 @@ details: |
 
 # ubuntu-core, ubuntu-14 and fedora are skipped due to /run/uuidd/request file does not
 # exist. On those systems different files are being used instead.
-systems: [-ubuntu-14.04-*,-ubuntu-core-16-*,-fedora-*]
+# arch: uses /run/run/uuidd/request, filed a bug report https://bugs.archlinux.org/task/58122
+systems: [-ubuntu-14.04-*,-ubuntu-core-16-*,-fedora-*, -arch-*]
 
 prepare: |
     snap install test-snapd-openvswitch-support

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -6,7 +6,7 @@ details: |
     snap properly.
 
 # s390x virtualization does not support hwclock
-systems: [-opensuse-*,-fedora-*,-ubuntu-core-*,-ubuntu-14.04-*,-*-s390x]
+systems: [-opensuse-*,-fedora-*,-ubuntu-core-*,-ubuntu-14.04-*,-*-s390x,-arch-*]
 
 prepare: |
     . $TESTSLIB/snaps.sh

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -5,6 +5,7 @@ systems:
     - -ubuntu-*-ppc64el
     - -fedora-*
     - -opensuse-*
+    - -arch-*
 
 details: |
     The upower-observe interface allows a snap to query UPower for power devices, history

--- a/tests/main/manpages/task.yaml
+++ b/tests/main/manpages/task.yaml
@@ -11,9 +11,9 @@ execute: |
     # to the machine or force a cache consistency calling the man page with '-u'
     # This issue happens with any package, not just with snap related ones
     # The command "man snap" works well in this case (man 2.6.6)
-    if [[ "$SPREAD_SYSTEM" == opensuse-* ]]; then
+    if [[ "$SPREAD_SYSTEM" == opensuse-* || "$SPREAD_SYSTEM" == arch-* ]]; then
         for manpage in snap snap-confine snap-discard-ns; do
-            if ! LC_ALL=C man --where $manpage; then
+            if ! LC_ALL=C man -u --where $manpage; then
                 echo "Expected to see manual page path for $manpage"
                 exit 1
             fi

--- a/tests/main/prepare-image-grub/task.yaml
+++ b/tests/main/prepare-image-grub/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that prepare-image works for grub-systems
 
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*]
+systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
 
 backends: [-autopkgtest]
 

--- a/tests/main/refresh/task.yaml
+++ b/tests/main/refresh/task.yaml
@@ -30,7 +30,7 @@ prepare: |
     flags=
     if [[ $SNAP_NAME =~ classic ]]; then
         case "$SPREAD_SYSTEM" in
-            ubuntu-core-*|fedora-*)
+            ubuntu-core-*|fedora-*|arch-*)
                 exit
                 ;;
         esac
@@ -76,7 +76,7 @@ execute: |
 
     if [[ $SNAP_NAME =~ classic ]]; then
         case "$SPREAD_SYSTEM" in
-            ubuntu-core-*|fedora-*)
+            ubuntu-core-*|fedora-*|arch-*)
                 exit
                 ;;
         esac

--- a/tests/main/security-device-cgroups-classic/task.yaml
+++ b/tests/main/security-device-cgroups-classic/task.yaml
@@ -7,7 +7,7 @@ details: |
 
 # Disabled on Fedora and Ubuntu Core because they don't support classic
 # confinement.
-systems: [-fedora-*, -ubuntu-core-*]
+systems: [-fedora-*, -ubuntu-core-*, -arch-*]
 
 prepare: |
     # Create framebuffer device node and give it some content we can verify

--- a/tests/main/security-device-cgroups-classic/task.yaml
+++ b/tests/main/security-device-cgroups-classic/task.yaml
@@ -5,7 +5,7 @@ details: |
     sure that other devices are still accessible (ie, the cgroup is not in
     effect).
 
-# Disabled on Fedora and Ubuntu Core because they don't support classic
+# Disabled on Fedora, Ubuntu Core and Arch because they don't support classic
 # confinement.
 systems: [-fedora-*, -ubuntu-core-*, -arch-*]
 

--- a/tests/main/security-device-cgroups-jailmode/task.yaml
+++ b/tests/main/security-device-cgroups-jailmode/task.yaml
@@ -6,7 +6,7 @@ details: |
     still accessible (ie, the cgroup is not in effect).
 
 # None of those systems support strict confinement which is required to formally enable jailmode.
-systems: [-fedora-*, -opensuse-*, -debian-*]
+systems: [-fedora-*, -opensuse-*, -debian-*, -arch-*]
 
 prepare: |
     # Create framebuffer device node and give it some content we can verify

--- a/tests/main/security-device-cgroups-strict/task.yaml
+++ b/tests/main/security-device-cgroups-strict/task.yaml
@@ -5,7 +5,7 @@ details: |
     sure that other devices not included in the snap's plugged interfaces are
     still accessible (ie, the cgroup is not in effect).
 
-systems: [-fedora-*, -opensuse-*,-debian-*]
+systems: [-fedora-*, -opensuse-*,-debian-*, -arch-*]
 
 prepare: |
     # Create framebuffer device node and give it some content we can verify

--- a/tests/main/security-setuid-root/task.yaml
+++ b/tests/main/security-setuid-root/task.yaml
@@ -5,6 +5,7 @@ systems:
     - -debian-*
     - -fedora-*
     - -opensuse-*
+    - -arch-*
 
 details: |
     snap-confine is setuid root but is only confined with an apparmor profile

--- a/tests/main/server-snap/task.yaml
+++ b/tests/main/server-snap/task.yaml
@@ -1,6 +1,7 @@
 summary: Check snap web servers
 
-systems: [-fedora-*, -opensuse-*]
+# arch: there is no ip6-localhost
+systems: [-fedora-*, -opensuse-*, -arch-*]
 
 environment:
     SNAP_NAME/pythonServer: test-snapd-python-webserver

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -1,7 +1,7 @@
 summary: Test that snap-confine is run from core on re-exec
 
-# Disable for Fedora, openSUSE as re-exec is not support there yet
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*]
+# Disable for Fedora, openSUSE and Arch as re-exec is not support there yet
+systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
 
 prepare: |
     echo "Installing test-snapd-tools"

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -22,7 +22,7 @@ execute: |
     snap info /etc/passwd && exit 1 || true
 
     snap info basic_1.0_all.snap $TESTSLIB/snaps/basic-desktop test-snapd-tools test-snapd-devmode core /etc/passwd test-snapd-python-webserver > out
-    python3 check.py < out
+    PYTHONIOENCODING=utf8 python3 check.py < out
 
     . $TESTSLIB/snaps.sh
     snap info --verbose $TESTSLIB/snaps/basic-desktop|MATCH "path: "

--- a/tests/main/snap-repair/task.yaml
+++ b/tests/main/snap-repair/task.yaml
@@ -1,6 +1,6 @@
 summary: Ensure that snap-repair is available
 
-systems: [-fedora-*, -opensuse-*]
+systems: [-fedora-*, -opensuse-*, -arch-*]
 
 execute: |
     . $TESTSLIB/dirs.sh

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -1,6 +1,6 @@
 summary: Test that snapd reexecs itself into core
 
-# Disable for Fedora, openSUSE as re-exec is not support there yet
+# Disable for Fedora, openSUSE and Arch as re-exec is not support there yet
 systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
 
 restore: |

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -1,7 +1,7 @@
 summary: Test that snapd reexecs itself into core
 
 # Disable for Fedora, openSUSE as re-exec is not support there yet
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*]
+systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
 
 restore: |
     . $TESTSLIB/dirs.sh

--- a/tests/main/try/task.yaml
+++ b/tests/main/try/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that try command works
 
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*]
+systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
 
 environment:
     PORT: 8081

--- a/tests/regression/lp-1595444/task.yaml
+++ b/tests/regression/lp-1595444/task.yaml
@@ -11,6 +11,7 @@ systems:
     - -debian-*
     - -fedora-*
     - -opensuse-*
+    - -arch-*
 
 prepare: |
     echo "Having installed the test snap"

--- a/tests/regression/lp-1597839/task.yaml
+++ b/tests/regression/lp-1597839/task.yaml
@@ -1,6 +1,6 @@
 summary: Regression check for https://bugs.launchpad.net/snap-confine/+bug/1597839
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-*, -fedora-*]
+systems: [-ubuntu-core-16-*, -fedora-*, -arch-*]
 details: |
     The snappy execution environment should contain the /lib/modules directory
     from the host filesystem when running on a classic distribution

--- a/tests/regression/lp-1597842/task.yaml
+++ b/tests/regression/lp-1597842/task.yaml
@@ -4,7 +4,7 @@ details: |
     directory from the classic distribution. Certain snaps may use that to
     access kernel sources.
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-*, -fedora-*]
+systems: [-ubuntu-core-16-*, -fedora-*, -arch-*]
 prepare: |
     echo "Having installed the test snap"
     . "$TESTSLIB/snaps.sh"

--- a/tests/regression/lp-1599891/task.yaml
+++ b/tests/regression/lp-1599891/task.yaml
@@ -4,6 +4,7 @@ systems:
     - -debian-*
     - -fedora-*
     - -opensuse-*
+    - -arch-*
 execute: |
     snap_confine=/usr/lib/snapd/snap-confine
     echo "Seeing that snap-confine is in $snap_confine"

--- a/tests/regression/lp-1613845/task.yaml
+++ b/tests/regression/lp-1613845/task.yaml
@@ -5,7 +5,7 @@ details: |
     the host filesystem. While this would never work in an all-snap image it is
     still important to ensure that it works in classic devmode environment.
 # This test only applies to classic systems
-systems: [-ubuntu-core-16-*, -fedora-*]
+systems: [-ubuntu-core-16-*, -fedora-*, -arch-*]
 prepare: |
     echo "Having installed the test snap in devmode"
     . "$TESTSLIB/snaps.sh"

--- a/tests/regression/lp-1618683/task.yaml
+++ b/tests/regression/lp-1618683/task.yaml
@@ -1,4 +1,8 @@
-summary: Check that user namespace can be unshared within snap apps 
+summary: Check that user namespace can be unshared within snap apps
+systems:
+    # Arch does not have CONFIG_USER_NS in the default kernel (yet!), see
+    # https://bugs.archlinux.org/index.php?do=details&task_id=36969 for details
+    - arch-*
 details: |
     Snap-confine used to "leak" the root filesystem directory across the
     pivot_root call. This caused checks in the kernel to fail and resulted in

--- a/tests/regression/lp-1618683/task.yaml
+++ b/tests/regression/lp-1618683/task.yaml
@@ -2,7 +2,7 @@ summary: Check that user namespace can be unshared within snap apps
 systems:
     # Arch does not have CONFIG_USER_NS in the default kernel (yet!), see
     # https://bugs.archlinux.org/index.php?do=details&task_id=36969 for details
-    - arch-*
+    - -arch-*
 details: |
     Snap-confine used to "leak" the root filesystem directory across the
     pivot_root call. This caused checks in the kernel to fail and resulted in

--- a/tests/regression/lp-1641885/task.yaml
+++ b/tests/regression/lp-1641885/task.yaml
@@ -4,6 +4,7 @@ systems:
     - -debian-*
     - -fedora-*
     - -opensuse-*
+    - -arch-*
 details: |
     Users found that a snap that uses "confinement: devmode", even when
     installed with "snap install --jailmode" is effectively in devmode (the

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that upgrade works
 
-systems: [-debian-sid-*]
+# arch: there is no snapd in arch repos
+systems: [-debian-sid-*, -arch-*]
 
 restore: |
     if [ "$REMOTE_STORE" = staging ]; then

--- a/tests/upgrade/basic/task.yaml
+++ b/tests/upgrade/basic/task.yaml
@@ -26,6 +26,13 @@ execute: |
     echo "Install previous snapd version from the store"
     distro_install_package snap-confine snapd
 
+    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
+        # Services are not auto enabled or started on Arch
+        systemctl daemon-reload
+        systemctl restart snapd.socket
+        systemctl enable snapd.socket
+    fi
+
     prevsnapdver=$(snap --version|grep "snapd ")
 
     if [[ "$SPREAD_SYSTEM" = debian-* ]] ; then
@@ -54,7 +61,17 @@ execute: |
     # allow-downgrades prevents errors when new versions hit the archive, for instance,
     # trying to install 2.11ubuntu1 over 2.11+0.16.04
     pkg_extension="$(distro_get_package_extension)"
-    distro_install_local_package --allow-downgrades "$GOHOME"/snap*."$pkg_extension"
+    if [[ "$SPREAD_SYSTEM" == arch-* ]]; then
+        # Arch's pacman is a bit funky here, the command that's run is:
+        #    pacman -U --noconfirm --force /home/gopath/snapd-*.pkg.tar.xz
+        # The official repo package contains snapd and snap-confine. The local test package
+        # conflicts with snap-confine, thus pacman will ask to remove snap-confine, displaying
+        # a question, but at the same time it completely ignores --noconfirm and aborts the upgrade.
+        # As a workaround, drop --noconfirm and pass 'y' to all the questions.
+        yes | pacman -U "$GOHOME"/snap*."$pkg_extension"
+    else
+        distro_install_local_package --allow-downgrades "$GOHOME"/snap*."$pkg_extension"
+    fi
 
     snapdver=$(snap --version|grep "snapd ")
     [ "$snapdver" != "$prevsnapdver" ]

--- a/tests/upgrade/snapd-xdg-open/task.yaml
+++ b/tests/upgrade/snapd-xdg-open/task.yaml
@@ -5,7 +5,7 @@ description: |
     the snapd-xdg-open package from the archive is properly replaced.
 # Test case only applies to Ubuntu as that is the only distribution where
 # we had a snapd-xdg-open package ever.
-systems: [-ubuntu-core-*, -debian-*, -ubuntu-14.04-*, -fedora-*]
+systems: [-ubuntu-core-*, -debian-*, -ubuntu-14.04-*, -fedora-*, -arch-*]
 restore: |
     . "$TESTSLIB/pkgdb.sh"
     if [ "$REMOTE_STORE" = staging ]; then


### PR DESCRIPTION
Resurrected #4285. All enabled tests should be green now.

There are some ugly workarounds for Arch specific issues.