### PR TITLE
cmd/snap-confine: allow creating missing gl32, gl, vulkan dirs

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -257,12 +257,12 @@
     /usr/** r,
     mount options=(rw bind) /usr/lib{,32}/nvidia-*/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/gl{,32}/,
     mount options=(rw bind) /usr/lib{,32}/nvidia-*/ -> /{tmp/snap.rootfs_*/,}var/lib/snapd/lib/gl{,32}/,
-    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/* w,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/{,*} w,
     mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/,
     mount options=(remount ro) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/,
 
     # Vulkan support
-    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/* w,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/{,*} w,
     mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
     mount options=(remount ro) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
 


### PR DESCRIPTION
This patch adjusts the apparmor profile for snap-confine to be able to
create the aforementioned directories. The bug is subtle as the trailing
slash makes all the difference:

/foo/* w, # this rule won't allow mkdir /foo
/foo/ w,  # this one will

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>

This is https://github.com/snapcore/snapd/pull/4993 for 2.32
