### PR TITLE
snapstate: inject autoconnect tasks in doLinkSnap for regular snaps

### DIFF
--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -28,7 +28,6 @@ import (
 
 var (
 	AddImplicitSlots = addImplicitSlots
-	InjectTasks      = injectTasks
 )
 
 // AddForeignTaskHandlers registers handlers for tasks handled outside of the

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2444,76 +2444,7 @@ slots:
 	c.Check(tConnectPlug.Status(), Equals, state.DoneStatus)
 }
 
-func (s *interfaceManagerSuite) TestInjectTasks(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	lane := s.state.NewLane()
-
-	// setup main task and two tasks waiting for it; all part of same change
-	chg := s.state.NewChange("change", "")
-	t0 := s.state.NewTask("task1", "")
-	chg.AddTask(t0)
-	t0.JoinLane(lane)
-	t01 := s.state.NewTask("task1-1", "")
-	t01.WaitFor(t0)
-	chg.AddTask(t01)
-	t02 := s.state.NewTask("task1-2", "")
-	t02.WaitFor(t0)
-	chg.AddTask(t02)
-
-	// setup extra tasks
-	t1 := s.state.NewTask("task2", "")
-	t2 := s.state.NewTask("task3", "")
-	ts := state.NewTaskSet(t1, t2)
-
-	ifacestate.InjectTasks(t0, ts)
-
-	// verify that extra tasks are now part of same change
-	c.Assert(t1.Change().ID(), Equals, t0.Change().ID())
-	c.Assert(t2.Change().ID(), Equals, t0.Change().ID())
-	c.Assert(t1.Change().ID(), Equals, chg.ID())
-
-	c.Assert(t1.Lanes(), DeepEquals, []int{lane})
-
-	// verify that halt tasks of the main task now wait for extra tasks
-	c.Assert(t1.HaltTasks(), HasLen, 2)
-	c.Assert(t2.HaltTasks(), HasLen, 2)
-	c.Assert(t1.HaltTasks(), DeepEquals, t2.HaltTasks())
-
-	ids := []string{t1.HaltTasks()[0].Kind(), t2.HaltTasks()[1].Kind()}
-	sort.Strings(ids)
-	c.Assert(ids, DeepEquals, []string{"task1-1", "task1-2"})
-
-	// verify that extra tasks wait for the main task
-	c.Assert(t1.WaitTasks(), HasLen, 1)
-	c.Assert(t1.WaitTasks()[0].Kind(), Equals, "task1")
-	c.Assert(t2.WaitTasks(), HasLen, 1)
-	c.Assert(t2.WaitTasks()[0].Kind(), Equals, "task1")
-}
-
-func (s *interfaceManagerSuite) TestInjectTasksWithNullChange(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	// setup main task
-	t0 := s.state.NewTask("task1", "")
-	t01 := s.state.NewTask("task1-1", "")
-	t01.WaitFor(t0)
-
-	// setup extra task
-	t1 := s.state.NewTask("task2", "")
-	ts := state.NewTaskSet(t1)
-
-	ifacestate.InjectTasks(t0, ts)
-
-	c.Assert(t1.Lanes(), DeepEquals, []int{0})
-
-	// verify that halt tasks of the main task now wait for extra tasks
-	c.Assert(t1.HaltTasks(), HasLen, 1)
-	c.Assert(t1.HaltTasks()[0].Kind(), Equals, "task1-1")
-}
-
+/*
 func (s *interfaceManagerSuite) TestSetupProfilesInjectsAutoConnectIfMissing(c *C) {
 	mgr := s.manager(c)
 
@@ -2573,6 +2504,7 @@ func (s *interfaceManagerSuite) TestSetupProfilesInjectsAutoConnectIfMissing(c *
 	c.Assert(t.Get("snap-setup", &autoconnectSup), IsNil)
 	c.Assert(autoconnectSup.Name(), Equals, "snap2")
 }
+*/
 
 func (s *interfaceManagerSuite) TestSetupProfilesInjectsAutoConnectIfCore(c *C) {
 	mgr := s.manager(c)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -5192,6 +5192,11 @@ func (s *snapmgrTestSuite) TestEnableRunThrough(c *C) {
 			name: filepath.Join(dirs.SnapMountDir, "some-snap/7"),
 		},
 		{
+			op:    "auto-connect:Doing",
+			name:  "some-snap",
+			revno: snap.R(7),
+		},
+		{
 			op: "update-aliases",
 		},
 	}
@@ -8987,6 +8992,76 @@ func (s *snapmgrTestSuite) TestUpdateManyLayoutsChecksFeatureFlag(c *C) {
 	refreshes, _, err = snapstate.UpdateMany(context.TODO(), s.state, nil, s.user.ID)
 	c.Assert(err, IsNil)
 	c.Assert(refreshes, DeepEquals, []string{"some-snap"})
+}
+
+func (s *snapmgrTestSuite) TestInjectTasks(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	lane := s.state.NewLane()
+
+	// setup main task and two tasks waiting for it; all part of same change
+	chg := s.state.NewChange("change", "")
+	t0 := s.state.NewTask("task1", "")
+	chg.AddTask(t0)
+	t0.JoinLane(lane)
+	t01 := s.state.NewTask("task1-1", "")
+	t01.WaitFor(t0)
+	chg.AddTask(t01)
+	t02 := s.state.NewTask("task1-2", "")
+	t02.WaitFor(t0)
+	chg.AddTask(t02)
+
+	// setup extra tasks
+	t1 := s.state.NewTask("task2", "")
+	t2 := s.state.NewTask("task3", "")
+	ts := state.NewTaskSet(t1, t2)
+
+	snapstate.InjectTasks(t0, ts)
+
+	// verify that extra tasks are now part of same change
+	c.Assert(t1.Change().ID(), Equals, t0.Change().ID())
+	c.Assert(t2.Change().ID(), Equals, t0.Change().ID())
+	c.Assert(t1.Change().ID(), Equals, chg.ID())
+
+	c.Assert(t1.Lanes(), DeepEquals, []int{lane})
+
+	// verify that halt tasks of the main task now wait for extra tasks
+	c.Assert(t1.HaltTasks(), HasLen, 2)
+	c.Assert(t2.HaltTasks(), HasLen, 2)
+	c.Assert(t1.HaltTasks(), DeepEquals, t2.HaltTasks())
+
+	ids := []string{t1.HaltTasks()[0].Kind(), t2.HaltTasks()[1].Kind()}
+	sort.Strings(ids)
+	c.Assert(ids, DeepEquals, []string{"task1-1", "task1-2"})
+
+	// verify that extra tasks wait for the main task
+	c.Assert(t1.WaitTasks(), HasLen, 1)
+	c.Assert(t1.WaitTasks()[0].Kind(), Equals, "task1")
+	c.Assert(t2.WaitTasks(), HasLen, 1)
+	c.Assert(t2.WaitTasks()[0].Kind(), Equals, "task1")
+}
+
+func (s *snapmgrTestSuite) TestInjectTasksWithNullChange(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// setup main task
+	t0 := s.state.NewTask("task1", "")
+	t01 := s.state.NewTask("task1-1", "")
+	t01.WaitFor(t0)
+
+	// setup extra task
+	t1 := s.state.NewTask("task2", "")
+	ts := state.NewTaskSet(t1)
+
+	snapstate.InjectTasks(t0, ts)
+
+	c.Assert(t1.Lanes(), DeepEquals, []int{0})
+
+	// verify that halt tasks of the main task now wait for extra tasks
+	c.Assert(t1.HaltTasks(), HasLen, 1)
+	c.Assert(t1.HaltTasks()[0].Kind(), Equals, "task1-1")
 }
 
 type canDisableSuite struct{}


### PR DESCRIPTION
For core snap inject them after setup-profiles phase 2. Moved inject helpers to snapstate.

This is the 2.32 version of https://github.com/snapcore/snapd/pull/4991
