### PR TITLE
errtracker: make TestJournalErrorSilentError work on gccgo

### DIFF
--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -426,7 +426,7 @@ func (s *ErrtrackerTestSuite) TestJournalError(c *C) {
 func (s *ErrtrackerTestSuite) TestJournalErrorSilentError(c *C) {
 	jctl := testutil.MockCommand(c, "journalctl", "kill $$")
 	defer jctl.Restore()
-	c.Check(errtracker.JournalError(), Equals, "error: signal: terminated")
+	c.Check(errtracker.JournalError(), Matches, "error: signal: [Tt]erminated")
 	c.Check(jctl.Calls(), DeepEquals, [][]string{
 		{"journalctl", "-b", "--priority=warning..err", "--lines=1000"},
 	})


### PR DESCRIPTION
The error from SIGTERM is slightly different with gccgo so we
need to adjust the TestJournalErrorSilentError test for this

See
https://launchpadlibrarian.net/363432841/buildlog_ubuntu-xenial-powerpc.snapd_2.32.3_BUILDING.txt.gz
for the powerpc build failure.