### PR TITLE
Revert "snapstate: fix `snap refresh --amend` when the snap is not av…

### DIFF
--- a/tests/main/refresh-amend/task.yaml
+++ b/tests/main/refresh-amend/task.yaml
@@ -1,28 +1,22 @@
 summary: Ensure that refresh --amend works
 
 restore: |
-    rm -f test-snapd-only-in-edge_*.snap
+    rm -f test-snapd-tools_*.snap
 
 execute: |
     echo "When installing a local snap"
-    snap download --edge test-snapd-only-in-edge
-    snap install --dangerous ./test-snapd-only-in-edge_*.snap
-    snap list |MATCH "test-snapd-only-in-edge.*x1"
+    snap download test-snapd-tools
+    snap install --dangerous ./test-snapd-tools_*.snap
+    snap list |MATCH "test-snapd-tools.*x1"
 
     echo "A normal refresh will not refresh it to the store rev"
-    if snap refresh test-snapd-only-in-edge 2> stderr.out; then
+    if snap refresh test-snapd-tools 2> stderr.out; then
         echo "snap refresh should error but did not"
         exit 1
     fi
-    cat stderr.out | MATCH 'local snap "test-snapd-only-in-edge" is unknown to the store'
-
-    echo "A refresh with --amend is not enough, the channel needs to be added"
-    if snap refresh --amend test-snapd-only-in-edge 2> stderr.out; then
-       echo "snap refresh --amend without --edge should error but it did not"
-       exit 1
-    fi
+    cat stderr.out | MATCH 'local snap "test-snapd-tools" is unknown to the store'
 
     echo "A refresh with --amend refreshes it to the store revision"
-    snap refresh --edge --amend test-snapd-only-in-edge
+    snap refresh --amend test-snapd-tools
     echo "And we have a store revision now"
-    snap info test-snapd-only-in-edge | MATCH "^snap-id:.*[a-zA-Z0-9]+$"
+    snap info test-snapd-tools | MATCH "^snap-id:.*[a-zA-Z0-9]+$"


### PR DESCRIPTION
…ailable in stable"

This reverts commit 73f59f7d484b5b0676e45cf107accfba3ad4c5fe.

We are reverting this because a more complete fix is coming and it would conflict with this patch.