### PR TITLE
cmd/snap-seccomp: graceful handling of non-multilib host

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -47,6 +47,7 @@ func Test(t *testing.T) { TestingT(t) }
 type snapSeccompSuite struct {
 	seccompBpfLoader     string
 	seccompSyscallRunner string
+	canCheckCompatArch   bool
 }
 
 var _ = Suite(&snapSeccompSuite{})
@@ -177,10 +178,13 @@ func (s *snapSeccompSuite) SetUpSuite(c *C) {
 	err = cmd.Run()
 	c.Assert(err, IsNil)
 
+	// Amazon Linux 2 is 64bit only and there is no multilib support
+	s.canCheckCompatArch = !release.DistroLike("amzn")
+
 	// Build 32bit runner on amd64 to test non-native syscall handling.
 	// Ideally we would build for ppc64el->powerpc and arm64->armhf but
 	// it seems tricky to find the right gcc-multilib for this.
-	if arch.UbuntuArchitecture() == "amd64" {
+	if arch.UbuntuArchitecture() == "amd64" && s.canCheckCompatArch {
 		cmd = exec.Command(cmd.Args[0], cmd.Args[1:]...)
 		cmd.Args = append(cmd.Args, "-m32")
 		for i, k := range cmd.Args {
@@ -771,6 +775,9 @@ func (s *snapSeccompSuite) TestRestrictionsWorkingArgsUidGid(c *C) {
 }
 
 func (s *snapSeccompSuite) TestCompatArchWorks(c *C) {
+	if !s.canCheckCompatArch {
+		c.Skip("multi-lib syscall runner not supported by this host")
+	}
 	for _, t := range []struct {
 		arch             string
 		seccompWhitelist string


### PR DESCRIPTION
Some hosts may not have multilib support at all, in which case any attempt to
build the multilib syscall-runner will fail. Try to handle such case and
skip the unit tests accordingly. Since there is not much we can do about the
host just skip the test.

Example test failure on such host:
```
=== RUN   Test
cannot build multi-lib syscall runner: exit status 1
In file included from /usr/include/features.h:447:0,
                 from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdlib.h:25,
                 from /tmp/check-2039432933516484279/1/seccomp_syscall_runner.c:3:
/usr/include/gnu/stubs.h:7:11: fatal error: gnu/stubs-32.h: No such file or directory
 # include <gnu/stubs-32.h>
           ^~~~~~~~~~~~~~~~
compilation terminated.

----------------------------------------------------------------------
FAIL: main_test.go:769: snapSeccompSuite.TestCompatArchWorks

main_test.go:791:
    s.runBpf(c, t.seccompWhitelist, t.bpfInput, t.expected)
main_test.go:316:
    c.Fatalf("unexpected error for %q (failed to run %q): %s", seccompWhitelist, lastKmsg(), err)
... Error: unexpected error for "read" (failed to run "Showing last 10 lines of dmesg:\n[ 3484.534825] NET: Registered protocol family 24\n[ 3484.583121] NET: Registered protocol family 21\n[ 3484.651176] NET: Registered protocol family 33
\n[ 3484.651792] Key type rxrpc registered\n[ 3484.652292] Key type rxrpc_s registered\n[ 3484.741025] Guest personality initialized and is inactive\n[ 3484.741932] VMCI host device registered (name=vmci, major=10, minor=58)\n[ 3484.742623
] Initialized host personality\n[ 3484.748088] NET: Registered protocol family 40\n"): signal: bad system call

OOPS: 12 passed, 1 FAILED
```
