### PR TITLE
interfaces/hostname-control: allow setting the hostname via syscall and systemd

### DIFF
--- a/interfaces/builtin/hostname_control.go
+++ b/interfaces/builtin/hostname_control.go
@@ -1,0 +1,89 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const hostnameControlSummary = `allows configuring the system hostname`
+
+const hostnameControlBaseDeclarationSlots = `
+  hostname-control:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const hostnameControlConnectedPlugAppArmor = `
+# Description: Can configure the system hostname.
+# /{,usr/}bin/hostname ixr, # already allowed by default
+/etc/hostname w,            # read allowed by default
+
+#include <abstractions/dbus-strict>
+/{,usr/}{,s}bin/hostnamectl           ixr,
+
+# Allow access to hostname system service
+dbus (send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.DBus.Properties
+    member="Get{,All}"
+    peer=(label=unconfined),
+dbus (receive)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.DBus.Properties
+    member=PropertiesChanged
+    peer=(label=unconfined),
+dbus (send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+dbus(receive, send)
+    bus=system
+    path=/org/freedesktop/hostname1
+    interface=org.freedesktop.hostname1
+    member=Set{,Pretty,Static}Hostname
+    peer=(label=unconfined),
+
+# Needed to use 'sethostname'. See man 7 capabilities
+capability sys_admin,
+# Needed to use 'hostnamectl set-hostname'
+capability sys_admin,
+`
+
+const hostnameControlConnectedPlugSecComp = `
+# Description: Can configure the system hostname.
+sethostname
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "hostname-control",
+		summary:               hostnameControlSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  hostnameControlBaseDeclarationSlots,
+		connectedPlugAppArmor: hostnameControlConnectedPlugAppArmor,
+		connectedPlugSecComp:  hostnameControlConnectedPlugSecComp,
+		reservedForOS:         true,
+	})
+
+}

--- a/interfaces/builtin/hostname_control_test.go
+++ b/interfaces/builtin/hostname_control_test.go
@@ -1,0 +1,111 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type HostnameControlInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&HostnameControlInterfaceSuite{
+	iface: builtin.MustInterface("hostname-control"),
+})
+
+const hostnameControlConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [hostname-control]
+`
+
+const hostnameControlCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  hostname-control:
+`
+
+func (s *HostnameControlInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, hostnameControlConsumerYaml, nil, "hostname-control")
+	s.slot, s.slotInfo = MockConnectedSlot(c, hostnameControlCoreYaml, nil, "hostname-control")
+}
+
+func (s *HostnameControlInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "hostname-control")
+}
+
+func (s *HostnameControlInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "hostname-control",
+		Interface: "hostname-control",
+	}
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		"hostname-control slots are reserved for the core snap")
+}
+
+func (s *HostnameControlInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *HostnameControlInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/{,usr/}{,s}bin/hostnamectl")
+}
+
+func (s *HostnameControlInterfaceSuite) TestSecCompSpec(c *C) {
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "sethostname\n")
+}
+
+func (s *HostnameControlInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows configuring the system hostname`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "hostname-control")
+}
+
+func (s *HostnameControlInterfaceSuite) TestAutoConnect(c *C) {
+	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
+	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+}
+func (s *HostnameControlInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -113,6 +113,9 @@ apps:
   home:
     command: bin/run
     plugs: [ home ]
+  hostname-control:
+    command: bin/run
+    plugs: [ hostname-control ]
   io-ports-control:
     command: bin/run
     plugs: [ io-ports-control ]


### PR DESCRIPTION
Reference: https://forum.snapcraft.io/t/set-hostname-from-with-in-a-snap/4225/3