### PR TITLE
interfaces: misc updates for default, firewall-control, fuse-support and process-control

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -134,6 +134,7 @@ var defaultTemplate = `
   /{,usr/}bin/find ixr,
   /{,usr/}bin/flock ixr,
   /{,usr/}bin/fmt ixr,
+  /{,usr/}bin/getconf ixr,
   /{,usr/}bin/getent ixr,
   /{,usr/}bin/getopt ixr,
   /{,usr/}bin/groups ixr,

--- a/interfaces/builtin/firewall_control.go
+++ b/interfaces/builtin/firewall_control.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -125,6 +125,7 @@ unix (bind) type=stream addr="@xtables",
 @{PROC}/sys/net/ipv4/conf/*/log_martians w,
 @{PROC}/sys/net/ipv4/tcp_syncookies w,
 @{PROC}/sys/net/ipv6/conf/*/forwarding w,
+@{PROC}/sys/net/netfilter/nf_conntrack_helper rw,
 `
 
 // http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/seccomp/policygroups/ubuntu-core/16.04/firewall-control

--- a/interfaces/builtin/fuse_support.go
+++ b/interfaces/builtin/fuse_support.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -54,7 +54,7 @@ capability sys_admin,
 # Allow mounts to our snap-specific writable directories
 # Note 1: fstype is 'fuse.<command>', eg 'fuse.sshfs'
 # Note 2: due to LP: #1612393 - @{HOME} can't be used in mountpoint
-# Note 3: local fuse mounts of filesystem directories are mediated by 
+# Note 3: local fuse mounts of filesystem directories are mediated by
 #         AppArmor. The actual underlying file in the source directory is
 #         mediated, not the presentation layer of the target directory, so
 #         we can safely allow all local mounts to our snap-specific writable
@@ -67,6 +67,10 @@ mount fstype=fuse.* options=(ro,nosuid,nodev) ** -> /home/*/snap/@{SNAP_NAME}/@{
 mount fstype=fuse.* options=(rw,nosuid,nodev) ** -> /home/*/snap/@{SNAP_NAME}/@{SNAP_REVISION}/{,**/},
 mount fstype=fuse.* options=(ro,nosuid,nodev) ** -> /var/snap/@{SNAP_NAME}/@{SNAP_REVISION}/{,**/},
 mount fstype=fuse.* options=(rw,nosuid,nodev) ** -> /var/snap/@{SNAP_NAME}/@{SNAP_REVISION}/{,**/},
+mount fstype=fuse.* options=(ro,nosuid,nodev) ** -> /home/*/snap/@{SNAP_NAME}/common/{,**/},
+mount fstype=fuse.* options=(rw,nosuid,nodev) ** -> /home/*/snap/@{SNAP_NAME}/common/{,**/},
+mount fstype=fuse.* options=(ro,nosuid,nodev) ** -> /var/snap/@{SNAP_NAME}/common/{,**/},
+mount fstype=fuse.* options=(rw,nosuid,nodev) ** -> /var/snap/@{SNAP_NAME}/common/{,**/},
 
 # Explicitly deny reads to /etc/fuse.conf. We do this to ensure that
 # the safe defaults of fuse are used (which are enforced by our mount

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -31,11 +31,13 @@ const processControlBaseDeclarationSlots = `
 
 const processControlConnectedPlugAppArmor = `
 # Description: This interface allows for controlling other processes via
-# signals and nice. This is reserved because it grants privileged access to
-# all processes under root or processes running under the same UID otherwise.
+# signals, cpu affinity and nice. This is reserved because it grants privileged
+# access to all processes under root or processes running under the same UID
+# otherwise.
 
-# /{,usr/}bin/nice is already in default policy, so just allow renice here
+# /{,usr/}bin/nice is already in default policy
 /{,usr/}bin/renice ixr,
+/{,usr/}bin/taskset ixr,
 
 capability sys_resource,
 capability sys_nice,
@@ -45,8 +47,9 @@ signal,
 
 const processControlConnectedPlugSecComp = `
 # Description: This interface allows for controlling other processes via
-# signals and nice. This is reserved because it grants privileged access to
-# all processes under root or processes running under the same UID otherwise.
+# signals, cpu affinity and nice. This is reserved because it grants privileged
+# access to all processes under root or processes running under the same UID
+# otherwise.
 
 # Allow setting the nice value/priority for any process
 nice


### PR DESCRIPTION
* interfaces/process-control: allow using taskset for CPU affinity
* interfaces/fuse-support: also allow mounts on SNAP_COMMON and SNAP_USER_COMMON
* interfaces/firewall-control: allow rw on net/netfilter/nf_conntrack_helper
* interfaces: allow use of getconf by default