### PR TITLE
interfaces/desktop-legacy: allow access to gnome-shell screenshot/screencast

### DIFF
--- a/interfaces/builtin/desktop_legacy.go
+++ b/interfaces/builtin/desktop_legacy.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -34,7 +34,7 @@ const desktopLegacyBaseDeclarationSlots = `
 
 const desktopLegacyConnectedPlugAppArmor = `
 # Description: Can access common desktop legacy methods. This gives privileged
-# access to the user's input.
+# access to the user's input and screen output.
 
 # accessibility (a11y)
 #include <abstractions/dbus-session-strict>
@@ -224,6 +224,19 @@ dbus (send)
     path=/org/gtk/vfs/mounttracker
     interface=org.gtk.vfs.MountTracker
     member=LookupMount,
+
+# gnome-shell screenshot and screencast
+dbus (send)
+    bus=session
+    path=/org/gnome/Shell/Screen{cast,shot}
+    interface=org.freedesktop.DBus.Properties
+    member=Get{,All}
+    peer=(label=unconfined),
+dbus (send)
+    bus=session
+    path=/org/gnome/Shell/Screen{cast,shot}
+    interface=org.gnome.Shell.Screen{cast,shot}
+    peer=(label=unconfined),
 `
 
 const desktopLegacyConnectedPlugSecComp = `


### PR DESCRIPTION
gnome-shell currently provides the org.gnome.Shell.Screencast and
org.gnome.Shell.Screenshot interfaces which is currently the only way that
the gnome-shell on wayland can perform screenshots and screencasts. See:
https://help.gnome.org/users/gnome-help/stable/screen-shot-record.html

Implement this as part of desktop-legacy for a number of reasons:
- desktop-legacy is the place for temporary or unsafe APIs until a suitable
  safe replacement is found
- screencast and screenshot would ideally be handled by a dedicated service.
  For GNOME applications, that would be the Pipewire (aka pulsevideo) as
  surfaced by portals. Not all systems will have this portal, so put in
  desktop-legacy until it is widely available
- desktop-legacy already has an expansive surface via the accessibility bus
  and input methods, which already allows access to all user input. The
  screencast and screenshot methods expand this surface to what is displayed
  on the screen, though gnome-shell will indicate that screen recording is
  taking place and play a sound when a screen shot is taken (though the sound
  can be subverted via the gsettings interface)