### PR TITLE
overlord: test fix, address corner case (2.32)

### DIFF
--- a/overlord/devicestate/handlers.go
+++ b/overlord/devicestate/handlers.go
@@ -47,6 +47,9 @@ func (m *DeviceManager) doMarkSeeded(t *state.Task, _ *tomb.Tomb) error {
 
 	st.Set("seed-time", time.Now())
 	st.Set("seeded", true)
+	// make sure we setup a fallback model/consider the next phase
+	// (registration) timely
+	st.EnsureBefore(0)
 	return nil
 }
 

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -207,6 +207,9 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 	c.Assert(err, IsNil)
 
 	markSeeded(o)
+	// make sure we don't try to talk to the store
+	snapstate.CanAutoRefresh = nil
+
 	o.Loop()
 
 	err = o.Stop()


### PR DESCRIPTION
* fix a test that was triggering store-talking code
* address a corner case: make sure there's no gap between trivial seeding and setting up a fallback model (this is admittedly a rare scenario)
