### PR TITLE
snap: fix `snap advise-snap --command` output to match spec

### DIFF
--- a/cmd/snap/cmd_advise.go
+++ b/cmd/snap/cmd_advise.go
@@ -59,19 +59,28 @@ func init() {
 }
 
 func outputAdviseExactText(command string, result []advisor.Command) error {
-	fmt.Fprintf(Stdout, i18n.G("The program %q can be found in the following snaps:\n"), command)
+	fmt.Fprintf(Stdout, "\n")
+	fmt.Fprintf(Stdout, i18n.G("Command %q not found, but can be installed with:\n"), command)
+	fmt.Fprintf(Stdout, "\n")
 	for _, snap := range result {
-		fmt.Fprintf(Stdout, " * %s\n", snap.Snap)
+		fmt.Fprintf(Stdout, "sudo snap install %s\n", snap.Snap)
 	}
-	fmt.Fprintf(Stdout, i18n.G("Try: snap install <selected snap>\n"))
+	fmt.Fprintf(Stdout, "\n")
+	fmt.Fprintf(Stdout, "See 'snap info <snap name>' for additional versions.\n")
+	fmt.Fprintf(Stdout, "\n")
 	return nil
 }
 
 func outputAdviseMisspellText(command string, result []advisor.Command) error {
-	fmt.Fprintf(Stdout, i18n.G("No command %q found, did you mean:\n"), command)
+	fmt.Fprintf(Stdout, "\n")
+	fmt.Fprintf(Stdout, i18n.G("Command %q not found, did you mean:\n"), command)
+	fmt.Fprintf(Stdout, "\n")
 	for _, snap := range result {
-		fmt.Fprintf(Stdout, " Command %q from snap %q\n", snap.Command, snap.Snap)
+		fmt.Fprintf(Stdout, " command %q from snap %q\n", snap.Command, snap.Snap)
 	}
+	fmt.Fprintf(Stdout, "\n")
+	fmt.Fprintf(Stdout, "See 'snap info <snap name>' for additional versions.\n")
+	fmt.Fprintf(Stdout, "\n")
 	return nil
 }
 

--- a/cmd/snap/cmd_advise_test.go
+++ b/cmd/snap/cmd_advise_test.go
@@ -68,10 +68,14 @@ func (s *SnapSuite) TestAdviseCommandHappyText(c *C) {
 	rest, err := snap.Parser().ParseArgs([]string{"advise-snap", "--command", "hello"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, DeepEquals, []string{})
-	c.Assert(s.Stdout(), Equals, `The program "hello" can be found in the following snaps:
- * hello
- * hello-wcm
-Try: snap install <selected snap>
+	c.Assert(s.Stdout(), Equals, `
+Command "hello" not found, but can be installed with:
+
+sudo snap install hello
+sudo snap install hello-wcm
+
+See 'snap info <snap name>' for additional versions.
+
 `)
 	c.Assert(s.Stderr(), Equals, "")
 }
@@ -94,9 +98,14 @@ func (s *SnapSuite) TestAdviseCommandMisspellText(c *C) {
 	for _, misspelling := range []string{"helo", "0hello", "hell0", "hello0"} {
 		err := snap.AdviseCommand(misspelling, "pretty")
 		c.Assert(err, IsNil)
-		c.Assert(s.Stdout(), Equals, fmt.Sprintf(`No command "%s" found, did you mean:
- Command "hello" from snap "hello"
- Command "hello" from snap "hello-wcm"
+		c.Assert(s.Stdout(), Equals, fmt.Sprintf(`
+Command "%s" not found, did you mean:
+
+ command "hello" from snap "hello"
+ command "hello" from snap "hello-wcm"
+
+See 'snap info <snap name>' for additional versions.
+
 `, misspelling))
 		c.Assert(s.Stderr(), Equals, "")
 


### PR DESCRIPTION
The latest agreements on command-not-found output are now implemented
in the command-not-found package. We also need to update the
`snap advise-snap --command` output because this is what we use
on the core snap.
