### PR TITLE
cmd/snap-confine: ignore missing cgroups in snap-device-helper (2.32)

### DIFF
--- a/cmd/snap-confine/snap-device-helper
+++ b/cmd/snap-confine/snap-device-helper
@@ -18,6 +18,13 @@ MAJMIN="$4"
 APPNAME="$( echo "$APPNAME" | tr '_' '.' )"
 app_dev_cgroup="/sys/fs/cgroup/devices/$APPNAME"
 
+# The cgroup is only present after snap start so ignore any cgroup changes
+# (eg, 'add' on boot, hotplug, hotunplug) when the cgroup doesn't exist
+# yet. LP: #1762182.
+if [ ! -e "$app_dev_cgroup" ]; then
+    exit 0
+fi
+
 # check if it's a block or char dev
 if [ "${DEVPATH#*/block/}" != "$DEVPATH" ]; then
     type="b"


### PR DESCRIPTION
Don't attempt to modify cgroups that don't exist.

The snap-device-helper script is invoked by udev as a result of a
snapd-generated udev rule. When a device is tagged to be visible to a
given snap the tag is picked up by snap-confine and placed into the
device cgroup on application startup.

Long running applications have their cgroups modified by the very same
udev rule, because apart from tagging the rule runs the
snap-device-helper script to alter the cgroup.

Prior to this patch the modification was done regardless if the cgroup
existed or not, resulting in repeated error messages:

     Apr 08 15:23:32 vougeot systemd-udevd[919]: Process
     '/usr/lib/snapd/snap-device-helper add snap_vlc_vlc
     /devices/pci0000:00/0000:00:02.0/drm/card0 226:0' failed with exit code
     2.

Fixes: https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1762182
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>