### PR TITLE
interfaces/home: add 'read' attribute to allow non-owner read to @{HOME}

### DIFF
--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -19,6 +19,13 @@
 
 package builtin
 
+import (
+	"fmt"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/snap"
+)
+
 const homeSummary = `allows access to non-hidden files in the home directory`
 
 const homeBaseDeclarationSlots = `
@@ -26,11 +33,17 @@ const homeBaseDeclarationSlots = `
     allow-installation:
       slot-snap-type:
         - core
+    deny-connection:
+      plug-attributes:
+        read: all
     deny-auto-connection:
-      on-classic: false
+      -
+        on-classic: false
+      -
+        plug-attributes:
+          read: all
 `
 
-// http://bazaar.launchpad.net/~ubuntu-security/ubuntu-core-security/trunk/view/head:/data/apparmor/policygroups/ubuntu-core/16.04/home
 const homeConnectedPlugAppArmor = `
 # Description: Can access non-hidden files in user's $HOME. This is restricted
 # because it gives file access to all of the user's $HOME.
@@ -63,8 +76,50 @@ owner /run/user/[0-9]*/gvfs/{,**} r,
 owner /run/user/[0-9]*/gvfs/*/**  w,
 `
 
+const homeConnectedPlugAppArmorWithAllRead = `
+# Allow non-owner read to non-hidden and non-snap files and directories
+@{HOME}/               r,
+@{HOME}/[^s.]**        r,
+@{HOME}/s[^n]**        r,
+@{HOME}/sn[^a]**       r,
+@{HOME}/sna[^p]**      r,
+@{HOME}/snap[^/]**     r,
+@{HOME}/{s,sn,sna}{,/} r,
+`
+
+type homeInterface struct {
+	commonInterface
+}
+
+func (iface *homeInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
+	// It's fine if 'read' isn't specified, but if it is, it needs to be
+	// either 'all' or 'owner'
+	if r, ok := plug.Attrs["read"]; ok {
+		_, ok = r.(string)
+		if !ok || (r != "all" && r != "owner") {
+			return fmt.Errorf(`home plug requires the "read" be either 'all' or 'owner'`)
+		}
+	}
+
+	return nil
+}
+
+func (iface *homeInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	var read string
+	_ = plug.Attr("read", &read)
+	// 'owner' is the standard policy
+	spec.AddSnippet(homeConnectedPlugAppArmor)
+
+	// 'all' grants standard policy plus read access to home without owner
+	// match
+	if read == "all" {
+		spec.AddSnippet(homeConnectedPlugAppArmorWithAllRead)
+	}
+	return nil
+}
+
 func init() {
-	registerIface(&commonInterface{
+	registerIface(&homeInterface{commonInterface{
 		name:                  "home",
 		summary:               homeSummary,
 		implicitOnCore:        true,
@@ -72,5 +127,5 @@ func init() {
 		baseDeclarationSlots:  homeBaseDeclarationSlots,
 		connectedPlugAppArmor: homeConnectedPlugAppArmor,
 		reservedForOS:         true,
-	})
+	}})
 }

--- a/interfaces/builtin/home_test.go
+++ b/interfaces/builtin/home_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -76,17 +76,97 @@ func (s *HomeInterfaceSuite) TestSanitizeSlot(c *C) {
 		"home slots are reserved for the core snap")
 }
 
-func (s *HomeInterfaceSuite) TestSanitizePlug(c *C) {
+func (s *HomeInterfaceSuite) TestSanitizePlugNoAttrib(c *C) {
 	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 }
 
-func (s *HomeInterfaceSuite) TestUsedSecuritySystems(c *C) {
-	// connected plugs have a non-nil security snippet for apparmor
+func (s *HomeInterfaceSuite) TestSanitizePlugWithAttrib(c *C) {
+	const mockSnapYaml = `name: home-plug-snap
+version: 1.0
+plugs:
+ home:
+  read: all
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	plug := info.Plugs["home"]
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), IsNil)
+}
+
+func (s *HomeInterfaceSuite) TestSanitizePlugWithBadAttrib(c *C) {
+	const mockSnapYaml = `name: home-plug-snap
+version: 1.0
+plugs:
+ home:
+  read: bad
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	plug := info.Plugs["home"]
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), ErrorMatches,
+		`home plug requires the "read" be either 'all' or 'owner'`)
+}
+
+func (s *HomeInterfaceSuite) TestSanitizePlugWithEmptyAttrib(c *C) {
+	const mockSnapYaml = `name: home-plug-snap
+version: 1.0
+plugs:
+ home:
+  read: ""
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	plug := info.Plugs["home"]
+	c.Assert(interfaces.BeforePreparePlug(s.iface, plug), ErrorMatches,
+		`home plug requires the "read" be either 'all' or 'owner'`)
+}
+
+func (s *HomeInterfaceSuite) TestConnectedPlugAppArmorWithoutAttrib(c *C) {
 	apparmorSpec := &apparmor.Specification{}
 	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.other.app"})
 	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `owner @{HOME}/ r,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), Not(testutil.Contains), `# Allow non-owner read`)
+}
+
+func (s *HomeInterfaceSuite) TestConnectedPlugAppArmorWithAttribOwner(c *C) {
+	const mockSnapYaml = `name: home-plug-snap
+version: 1.0
+plugs:
+ home:
+  read: owner
+apps:
+ app2:
+  command: foo
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	plug := interfaces.NewConnectedPlug(info.Plugs["home"], nil)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.home-plug-snap.app2"})
+	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `owner @{HOME}/ r,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), Not(testutil.Contains), `# Allow non-owner read`)
+}
+
+func (s *HomeInterfaceSuite) TestConnectedPlugAppArmorWithAttribAll(c *C) {
+	const mockSnapYaml = `name: home-plug-snap
+version: 1.0
+plugs:
+ home:
+  read: all
+apps:
+ app2:
+  command: foo
+`
+	info := snaptest.MockInfo(c, mockSnapYaml, nil)
+	plug := interfaces.NewConnectedPlug(info.Plugs["home"], nil)
+
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.home-plug-snap.app2"})
+	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `owner @{HOME}/ r,`)
+	c.Check(apparmorSpec.SnippetForTag("snap.home-plug-snap.app2"), testutil.Contains, `# Allow non-owner read`)
 }
 
 func (s *HomeInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -219,6 +219,56 @@ func (s *baseDeclSuite) TestInterimAutoConnectionHome(c *C) {
 	release.OnClassic = false
 	err = cand.CheckAutoConnect()
 	c.Check(err, ErrorMatches, `auto-connection denied by slot rule of interface \"home\"`)
+}
+
+func (s *baseDeclSuite) TestHomeReadAll(c *C) {
+	const plugYaml = `name: plug-snap
+version: 0
+plugs:
+  home:
+    read: all
+`
+	restore := release.MockOnClassic(true)
+	defer restore()
+	cand := s.connectCand(c, "home", "", plugYaml)
+	err := cand.Check()
+	c.Check(err, NotNil)
+
+	err = cand.CheckAutoConnect()
+	c.Check(err, NotNil)
+
+	release.OnClassic = false
+	err = cand.Check()
+	c.Check(err, NotNil)
+
+	err = cand.CheckAutoConnect()
+	c.Check(err, NotNil)
+}
+
+func (s *baseDeclSuite) TestHomeReadOwner(c *C) {
+	const plugYaml = `name: plug-snap
+version: 0
+plugs:
+  home:
+    read: owner
+`
+	restore := release.MockOnClassic(true)
+	defer restore()
+	cand := s.connectCand(c, "home", "", plugYaml)
+	err := cand.Check()
+	c.Check(err, IsNil)
+
+	// Same as TestInterimAutoConnectionHome()
+	err = cand.CheckAutoConnect()
+	c.Check(err, IsNil)
+
+	release.OnClassic = false
+	err = cand.Check()
+	c.Check(err, IsNil)
+
+	// Same as TestInterimAutoConnectionHome()
+	err = cand.CheckAutoConnect()
+	c.Check(err, NotNil)
 }
 
 func (s *baseDeclSuite) TestAutoConnectionSnapdControl(c *C) {


### PR DESCRIPTION
If unspecified, 'read' defaults to 'read: owner'. When 'read: all' is
specified, deny connection and auto-connection (thus requiring a manual
review).

References:
https://forum.snapcraft.io/t/home-access-as-root-from-confined-snaps/3802