### PR TITLE
 overlord/snapstate: on multi-snap refresh make sure bases and core are finished before dependent snaps (2.32)

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -373,7 +373,7 @@ func showDone(names []string, op string) error {
 		default:
 			fmt.Fprintf(Stdout, "internal error: unknown op %q", op)
 		}
-		if snap.TrackingChannel != snap.Channel {
+		if snap.TrackingChannel != snap.Channel && snap.Channel != "" {
 			// TRANSLATORS: first %s is a snap name, following %s is a channel name
 			fmt.Fprintf(Stdout, i18n.G("Snap %s is no longer tracking %s.\n"), snap.Name, snap.TrackingChannel)
 		}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1165,7 +1165,13 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 	var snapName string
 
 	switch err {
-	case store.ErrSnapNotFound:
+	case store.ErrSnapNotFound, store.ErrRevisionNotAvailable:
+		// TODO: treating ErrRevisionNotAvailable the same as
+		// ErrSnapNotFound preserves the old error handling
+		// behavior of the REST API and the snap command.  We
+		// should revisit this once the store returns more
+		// precise errors and makes it possible to distinguish
+		// the why a revision wasn't available.
 		switch len(inst.Snaps) {
 		case 1:
 			return SnapNotFound(inst.Snaps[0], err)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -86,7 +86,8 @@ type apiBaseSuite struct {
 	d                 *Daemon
 	user              *auth.UserState
 	restoreBackends   func()
-	refreshCandidates []*store.RefreshCandidate
+	currentSnaps      []*store.CurrentSnap
+	actions           []*store.SnapAction
 	buyOptions        *store.BuyOptions
 	buyResult         *store.BuyResult
 	storeSigning      *assertstest.StoreStack
@@ -126,18 +127,12 @@ func (s *apiBaseSuite) Find(search *store.Search, user *auth.UserState) ([]*snap
 	return s.rsnaps, s.err
 }
 
-func (s *apiBaseSuite) LookupRefresh(snap *store.RefreshCandidate, user *auth.UserState) (*snap.Info, error) {
-	s.refreshCandidates = []*store.RefreshCandidate{snap}
-	s.user = user
-
-	return s.rsnaps[0], s.err
-}
-
-func (s *apiBaseSuite) ListRefresh(ctx context.Context, snaps []*store.RefreshCandidate, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+func (s *apiBaseSuite) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
 	if ctx == nil {
 		panic("context required")
 	}
-	s.refreshCandidates = snaps
+	s.currentSnaps = currentSnaps
+	s.actions = actions
 	s.user = user
 
 	return s.rsnaps, s.err
@@ -232,7 +227,8 @@ func (s *apiBaseSuite) SetUpTest(c *check.C) {
 	s.vars = nil
 	s.user = nil
 	s.d = nil
-	s.refreshCandidates = nil
+	s.currentSnaps = nil
+	s.actions = nil
 	// Disable real security backends for all API tests
 	s.restoreBackends = ifacestate.MockSecurityBackends(nil)
 
@@ -1502,7 +1498,8 @@ func (s *apiSuite) TestFind(c *check.C) {
 	c.Check(rsp.SuggestedCurrency, check.Equals, "EUR")
 
 	c.Check(s.storeSearch, check.DeepEquals, store.Search{Query: "hi"})
-	c.Check(s.refreshCandidates, check.HasLen, 0)
+	c.Check(s.currentSnaps, check.HasLen, 0)
+	c.Check(s.actions, check.HasLen, 0)
 }
 
 func (s *apiSuite) TestFindRefreshes(c *check.C) {
@@ -1525,7 +1522,8 @@ func (s *apiSuite) TestFindRefreshes(c *check.C) {
 	snaps := snapList(rsp.Result)
 	c.Assert(snaps, check.HasLen, 1)
 	c.Assert(snaps[0]["name"], check.Equals, "store")
-	c.Check(s.refreshCandidates, check.HasLen, 1)
+	c.Check(s.currentSnaps, check.HasLen, 1)
+	c.Check(s.actions, check.HasLen, 1)
 }
 
 func (s *apiSuite) TestFindRefreshSideloaded(c *check.C) {
@@ -1561,9 +1559,9 @@ func (s *apiSuite) TestFindRefreshSideloaded(c *check.C) {
 	rsp := searchStore(findCmd, req, nil).(*resp)
 
 	snaps := snapList(rsp.Result)
-	c.Assert(snaps, check.HasLen, 1)
-	c.Assert(snaps[0]["name"], check.Equals, "store")
-	c.Check(s.refreshCandidates, check.HasLen, 0)
+	c.Assert(snaps, check.HasLen, 0)
+	c.Check(s.currentSnaps, check.HasLen, 0)
+	c.Check(s.actions, check.HasLen, 0)
 }
 
 func (s *apiSuite) TestFindPrivate(c *check.C) {
@@ -6471,6 +6469,7 @@ func (s *appSuite) TestErrToResponseNoSnapsDoesNotPanic(c *check.C) {
 	si := &snapInstruction{Action: "frobble"}
 	errors := []error{
 		store.ErrSnapNotFound,
+		store.ErrRevisionNotAvailable,
 		store.ErrNoUpdateAvailable,
 		store.ErrLocalSnap,
 		&snap.AlreadyInstalledError{Snap: "foo"},

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -47,18 +47,18 @@ type fakeStore struct {
 	storetest.Store
 }
 
-func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
-	return &snap.Info{
-		SideInfo: snap.SideInfo{
-			RealName: spec.Name,
-			Revision: snap.R(2),
-		},
-		Publisher:     "foo",
-		Architectures: []string{"all"},
-	}, nil
-}
+func (f *fakeStore) SnapAction(_ context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+	if len(actions) == 1 && actions[0].Action == "install" {
+		return []*snap.Info{{
+			SideInfo: snap.SideInfo{
+				RealName: actions[0].Name,
+				Revision: snap.R(2),
+			},
+			Publisher:     "foo",
+			Architectures: []string{"all"},
+		}}, nil
+	}
 
-func (f *fakeStore) ListRefresh(_ context.Context, cand []*store.RefreshCandidate, user *auth.UserState, opt *store.RefreshOptions) ([]*snap.Info, error) {
 	return []*snap.Info{{
 		SideInfo: snap.SideInfo{
 			RealName: "test-snap",

--- a/overlord/managers_test.go
+++ b/overlord/managers_test.go
@@ -360,6 +360,29 @@ const (
 	"summary": "Foo",
 	"version": "@VERSION@"
 }`
+
+	snapV2 = `{
+	"architectures": [
+	    "all"
+	],
+        "download": {
+            "url": "@URL@"
+        },
+        "type": "app",
+	"name": "@NAME@",
+	"revision": @REVISION@,
+	"snap-id": "@SNAPID@",
+	"summary": "Foo",
+	"description": "this is a description",
+	"version": "@VERSION@",
+        "publisher": {
+           "id": "devdevdev",
+           "name": "bar"
+         },
+         "media": [
+            {"type": "icon", "url": "@ICON@"}
+         ]
+}`
 )
 
 var fooSnapID = fakeSnapID("foo")
@@ -416,7 +439,7 @@ func (ms *mgrsSuite) makeStoreTestSnap(c *C, snapYaml string, revno string) (pat
 
 func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 	var baseURL *url.URL
-	fillHit := func(name string) string {
+	fillHit := func(hitTemplate, name string) string {
 		snapf, err := snap.Open(ms.serveSnapPath[name])
 		if err != nil {
 			panic(err)
@@ -425,7 +448,7 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 		if err != nil {
 			panic(err)
 		}
-		hit := strings.Replace(searchHit, "@URL@", baseURL.String()+"/api/v1/snaps/download/"+name, -1)
+		hit := strings.Replace(hitTemplate, "@URL@", baseURL.String()+"/api/v1/snaps/download/"+name, -1)
 		hit = strings.Replace(hit, "@NAME@", name, -1)
 		hit = strings.Replace(hit, "@SNAPID@", fakeSnapID(name), -1)
 		hit = strings.Replace(hit, "@ICON@", baseURL.String()+"/icon", -1)
@@ -435,13 +458,25 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 	}
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// all URLS are /api/v1/snaps/... so check the url is sane and discard
-		// the common prefix to simplify indexing into the comps slice.
+		// all URLS are /api/v1/snaps/... or /v2/snaps/... so
+		// check the url is sane and discard the common prefix
+		// to simplify indexing into the comps slice.
 		comps := strings.Split(r.URL.Path, "/")
-		if len(comps) <= 4 {
+		if len(comps) < 2 {
 			panic("unexpected url path: " + r.URL.Path)
 		}
-		comps = comps[4:]
+		if comps[1] == "api" { //v1
+			if len(comps) <= 4 {
+				panic("unexpected url path: " + r.URL.Path)
+			}
+			comps = comps[4:]
+		} else { // v2
+			if len(comps) <= 3 {
+				panic("unexpected url path: " + r.URL.Path)
+			}
+			comps = comps[3:]
+			comps[0] = "v2:" + comps[0]
+		}
 
 		switch comps[0] {
 		case "assertions":
@@ -465,7 +500,7 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 			return
 		case "details":
 			w.WriteHeader(200)
-			io.WriteString(w, fillHit(comps[1]))
+			io.WriteString(w, fillHit(searchHit, comps[1]))
 		case "metadata":
 			dec := json.NewDecoder(r.Body)
 			var input struct {
@@ -484,7 +519,7 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 				if snap.R(s.Revision) == snap.R(ms.serveRevision[name]) {
 					continue
 				}
-				hits = append(hits, json.RawMessage(fillHit(name)))
+				hits = append(hits, json.RawMessage(fillHit(searchHit, name)))
 			}
 			w.WriteHeader(200)
 			output, err := json.Marshal(map[string]interface{}{
@@ -506,6 +541,50 @@ func (ms *mgrsSuite) mockStore(c *C) *httptest.Server {
 				panic(err)
 			}
 			io.Copy(w, snapR)
+		case "v2:refresh":
+			dec := json.NewDecoder(r.Body)
+			var input struct {
+				Actions []struct {
+					Action string `json:"action"`
+					SnapID string `json:"snap-id"`
+					Name   string `json:"name"`
+				} `json:"actions"`
+			}
+			if err := dec.Decode(&input); err != nil {
+				panic(err)
+			}
+			type resultJSON struct {
+				Result string          `json:"result"`
+				SnapID string          `json:"snap-id"`
+				Name   string          `json:"name"`
+				Snap   json.RawMessage `json:"snap"`
+			}
+			var results []resultJSON
+			for _, a := range input.Actions {
+				name := ms.serveIDtoName[a.SnapID]
+				if a.Action == "install" {
+					name = a.Name
+				}
+				if ms.serveSnapPath[name] == "" {
+					// no match
+					continue
+				}
+				results = append(results, resultJSON{
+					Result: a.Action,
+					SnapID: a.SnapID,
+					Name:   name,
+					Snap:   json.RawMessage(fillHit(snapV2, name)),
+				})
+			}
+			w.WriteHeader(200)
+			output, err := json.Marshal(map[string]interface{}{
+				"results": results,
+			})
+			if err != nil {
+				panic(err)
+			}
+			w.Write(output)
+
 		default:
 			panic("unexpected url path: " + r.URL.Path)
 		}

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -51,6 +51,22 @@ type autoRefreshStore struct {
 func (r *autoRefreshStore) ListRefresh(ctx context.Context, cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
 	if ctx == nil || !auth.IsEnsureContext(ctx) {
 		panic("Ensure marked context required")
+	}
+	r.ops = append(r.ops, "list-refresh")
+	return nil, r.listRefreshErr
+}
+
+func (r *autoRefreshStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+	if ctx == nil || !auth.IsEnsureContext(ctx) {
+		panic("Ensure marked context required")
+	}
+	if len(currentSnaps) != len(actions) || len(currentSnaps) == 0 {
+		panic("expected in test one action for each current snaps, and at least one snap")
+	}
+	for _, a := range actions {
+		if a.Action != "refresh" {
+			panic("expected refresh actions")
+		}
 	}
 	r.ops = append(r.ops, "list-refresh")
 	return nil, r.listRefreshErr

--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -37,9 +37,13 @@ type StoreService interface {
 	SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error)
 	Find(search *store.Search, user *auth.UserState) ([]*snap.Info, error)
 	LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info, error)
+
 	ListRefresh(context.Context, []*store.RefreshCandidate, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error)
+	SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error)
+
 	Sections(ctx context.Context, user *auth.UserState) ([]string, error)
 	WriteCatalogs(ctx context.Context, names io.Writer, adder store.SnapAdder) error
+
 	Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error
 
 	Assertion(assertType *asserts.AssertionType, primaryKey []string, user *auth.UserState) (asserts.Assertion, error)

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -47,7 +47,9 @@ type fakeOp struct {
 	revno   snap.Revision
 	sinfo   snap.SideInfo
 	stype   snap.Type
-	cand    store.RefreshCandidate
+
+	curSnaps []store.CurrentSnap
+	action   store.SnapAction
 
 	old string
 
@@ -93,6 +95,29 @@ type fakeDownload struct {
 	macaroon string
 }
 
+type byName []store.CurrentSnap
+
+func (bna byName) Len() int      { return len(bna) }
+func (bna byName) Swap(i, j int) { bna[i], bna[j] = bna[j], bna[i] }
+func (bna byName) Less(i, j int) bool {
+	return bna[i].Name < bna[j].Name
+}
+
+type byAction []*store.SnapAction
+
+func (ba byAction) Len() int      { return len(ba) }
+func (ba byAction) Swap(i, j int) { ba[i], ba[j] = ba[j], ba[i] }
+func (ba byAction) Less(i, j int) bool {
+	if ba[i].Action == ba[j].Action {
+		if ba[i].Action == "refresh" {
+			return ba[i].SnapID < ba[j].SnapID
+		} else {
+			return ba[i].Name < ba[j].Name
+		}
+	}
+	return ba[i].Action < ba[j].Action
+}
+
 type fakeStore struct {
 	storetest.Store
 
@@ -114,6 +139,18 @@ func (f *fakeStore) pokeStateLock() {
 func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
 	f.pokeStateLock()
 
+	info, err := f.snapInfo(spec, user)
+
+	userID := 0
+	if user != nil {
+		userID = user.ID
+	}
+	f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{op: "storesvc-snap", name: spec.Name, revno: info.Revision, userID: userID})
+
+	return info, err
+}
+
+func (f *fakeStore) snapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
 	if spec.Revision.Unset() {
 		spec.Revision = snap.R(11)
 		if spec.Channel == "channel-for-7" {
@@ -126,6 +163,10 @@ func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 	typ := snap.TypeApp
 	if spec.Name == "some-core" {
 		typ = snap.TypeOS
+	}
+
+	if spec.Name == "snap-unknown" {
+		return nil, store.ErrSnapNotFound
 	}
 
 	info := &snap.Info{
@@ -163,27 +204,23 @@ func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 		}
 	}
 
-	userID := 0
-	if user != nil {
-		userID = user.ID
-	}
-	f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{op: "storesvc-snap", name: spec.Name, revno: spec.Revision, userID: userID})
-
 	return info, nil
 }
 
-func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserState) (*snap.Info, error) {
-	f.pokeStateLock()
+type refreshCand struct {
+	snapID           string
+	channel          string
+	revision         snap.Revision
+	block            []snap.Revision
+	ignoreValidation bool
+}
 
-	if cand == nil {
-		panic("LookupRefresh called with no candidate")
-	}
-
+func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	var name string
 
-	switch cand.SnapID {
+	switch cand.snapID {
 	case "":
-		return nil, store.ErrLocalSnap
+		panic("store refresh APIs expect snap-ids")
 	case "other-snap-id":
 		return nil, store.ErrNoUpdateAvailable
 	case "fakestore-please-error-on-refresh":
@@ -196,16 +233,20 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 		name = "core"
 	case "snap-with-snapd-control-id":
 		name = "snap-with-snapd-control"
+	case "producer-id":
+		name = "producer"
+	case "consumer-id":
+		name = "consumer"
 	default:
-		panic(fmt.Sprintf("ListRefresh: unknown snap-id: %s", cand.SnapID))
+		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}
 
 	revno := snap.R(11)
-	if r := f.refreshRevnos[cand.SnapID]; !r.Unset() {
+	if r := f.refreshRevnos[cand.snapID]; !r.Unset() {
 		revno = r
 	}
 	confinement := snap.StrictConfinement
-	switch cand.Channel {
+	switch cand.channel {
 	case "channel-for-7":
 		revno = snap.R(7)
 	case "channel-for-classic":
@@ -217,8 +258,8 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 	info := &snap.Info{
 		SideInfo: snap.SideInfo{
 			RealName: name,
-			Channel:  cand.Channel,
-			SnapID:   cand.SnapID,
+			Channel:  cand.channel,
+			SnapID:   cand.snapID,
 			Revision: revno,
 		},
 		Version: name,
@@ -228,7 +269,7 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 		Confinement:   confinement,
 		Architectures: []string{"all"},
 	}
-	switch cand.Channel {
+	switch cand.channel {
 	case "channel-for-layout":
 		info.Layout = map[string]*snap.Layout{
 			"/usr": {
@@ -240,22 +281,15 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 	}
 
 	var hit snap.Revision
-	if cand.Revision != revno {
+	if cand.revision != revno {
 		hit = revno
 	}
-	for _, blocked := range cand.Block {
+	for _, blocked := range cand.block {
 		if blocked == revno {
 			hit = snap.Revision{}
 			break
 		}
 	}
-
-	userID := 0
-	if user != nil {
-		userID = user.ID
-	}
-	// TODO: move this back to ListRefresh
-	f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{op: "storesvc-list-refresh", cand: *cand, revno: hit, userID: userID})
 
 	if !hit.Unset() {
 		return info, nil
@@ -264,26 +298,134 @@ func (f *fakeStore) LookupRefresh(cand *store.RefreshCandidate, user *auth.UserS
 	return nil, store.ErrNoUpdateAvailable
 }
 
-func (f *fakeStore) ListRefresh(ctx context.Context, cands []*store.RefreshCandidate, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
+func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
 	if ctx == nil {
 		panic("context required")
 	}
 	f.pokeStateLock()
 
-	if len(cands) == 0 {
+	if len(currentSnaps) == 0 && len(actions) == 0 {
 		return nil, nil
 	}
-	if len(cands) > 3 {
-		panic("fake ListRefresh unexpectedly called with more than 3 candidates")
+	if len(actions) > 3 {
+		panic("fake SnapAction unexpectedly called with more than 3 actions")
 	}
 
+	curByID := make(map[string]*store.CurrentSnap, len(currentSnaps))
+	curSnaps := make(byName, len(currentSnaps))
+	for i, cur := range currentSnaps {
+		if cur.Name == "" || cur.SnapID == "" || cur.Revision.Unset() {
+			return nil, fmt.Errorf("internal error: incomplete current snap info")
+		}
+		curByID[cur.SnapID] = cur
+		curSnaps[i] = *cur
+	}
+	sort.Sort(curSnaps)
+
+	userID := 0
+	if user != nil {
+		userID = user.ID
+	}
+	if len(curSnaps) == 0 {
+		curSnaps = nil
+	}
+	f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{op: "storesvc-snap-action", curSnaps: curSnaps, userID: userID})
+
+	sorted := make(byAction, len(actions))
+	copy(sorted, actions)
+	sort.Sort(sorted)
+
+	refreshErrors := make(map[string]error)
+	installErrors := make(map[string]error)
 	var res []*snap.Info
-	for _, cand := range cands {
-		info, err := f.LookupRefresh(cand, user)
-		if err == store.ErrLocalSnap || err == store.ErrNoUpdateAvailable {
+	for _, a := range sorted {
+		if a.Action != "install" && a.Action != "refresh" {
+			panic("not supported")
+		}
+
+		if a.Action == "install" {
+			spec := store.SnapSpec{
+				Name:     a.Name,
+				Channel:  a.Channel,
+				Revision: a.Revision,
+			}
+			info, err := f.snapInfo(spec, user)
+			if err != nil {
+				installErrors[a.Name] = err
+				continue
+			}
+			f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{
+				op:     "storesvc-snap-action:action",
+				action: *a,
+				revno:  info.Revision,
+				userID: userID,
+			})
+			if !a.Revision.Unset() {
+				info.Channel = ""
+			}
+			res = append(res, info)
 			continue
 		}
+
+		// refresh
+
+		cur := curByID[a.SnapID]
+		channel := a.Channel
+		if channel == "" {
+			channel = cur.TrackingChannel
+		}
+		ignoreValidation := cur.IgnoreValidation
+		if a.Flags&store.SnapActionIgnoreValidation != 0 {
+			ignoreValidation = true
+		} else if a.Flags&store.SnapActionEnforceValidation != 0 {
+			ignoreValidation = false
+		}
+		cand := refreshCand{
+			snapID:           a.SnapID,
+			channel:          channel,
+			revision:         cur.Revision,
+			block:            cur.Block,
+			ignoreValidation: ignoreValidation,
+		}
+		info, err := f.lookupRefresh(cand)
+		var hit snap.Revision
+		if info != nil {
+			if !a.Revision.Unset() {
+				info.Revision = a.Revision
+			}
+			hit = info.Revision
+		}
+		f.fakeBackend.ops = append(f.fakeBackend.ops, fakeOp{
+			op:     "storesvc-snap-action:action",
+			action: *a,
+			revno:  hit,
+			userID: userID,
+		})
+		if err == store.ErrNoUpdateAvailable {
+			refreshErrors[cur.Name] = err
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if !a.Revision.Unset() {
+			info.Channel = ""
+		}
 		res = append(res, info)
+	}
+
+	if len(refreshErrors)+len(installErrors) > 0 || len(res) == 0 {
+		if len(refreshErrors) == 0 {
+			refreshErrors = nil
+		}
+		if len(installErrors) == 0 {
+			installErrors = nil
+		}
+		return res, &store.SnapActionError{
+			NoResults: len(refreshErrors)+len(installErrors)+len(res) == 0,
+			Refresh:   refreshErrors,
+			Install:   installErrors,
+		}
 	}
 
 	return res, nil

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -218,6 +218,7 @@ type refreshCand struct {
 func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	var name string
 
+	typ := snap.TypeApp
 	switch cand.snapID {
 	case "":
 		panic("store refresh APIs expect snap-ids")
@@ -231,12 +232,16 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		name = "some-snap"
 	case "core-snap-id":
 		name = "core"
+		typ = snap.TypeOS
 	case "snap-with-snapd-control-id":
 		name = "snap-with-snapd-control"
 	case "producer-id":
 		name = "producer"
 	case "consumer-id":
 		name = "consumer"
+	case "some-base-id":
+		name = "some-base"
+		typ = snap.TypeBase
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}
@@ -256,6 +261,7 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 	}
 
 	info := &snap.Info{
+		Type: typ,
 		SideInfo: snap.SideInfo{
 			RealName: name,
 			Channel:  cand.channel,
@@ -278,6 +284,8 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 				Symlink: "$SNAP/usr",
 			},
 		}
+	case "channel-for-base":
+		info.Base = "some-base"
 	}
 
 	var hit snap.Revision

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -89,6 +89,15 @@ func MockReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, error))
 	return func() { readInfo = old }
 }
 
+func MockRevisionDate(mock func(info *snap.Info) time.Time) (restore func()) {
+	old := revisionDate
+	if mock == nil {
+		mock = revisionDateImpl
+	}
+	revisionDate = mock
+	return func() { revisionDate = old }
+}
+
 func MockOpenSnapFile(mock func(path string, si *snap.SideInfo) (*snap.Info, snap.Container, error)) (restore func()) {
 	prevOpenSnapFile := openSnapFile
 	openSnapFile = mock

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -21,6 +21,7 @@ package snapstate
 
 import (
 	"errors"
+	"sort"
 	"time"
 
 	"gopkg.in/tomb.v2"
@@ -171,4 +172,9 @@ func MockRefreshRetryDelay(d time.Duration) func() {
 	return func() {
 		refreshRetryDelay = origRefreshRetryDelay
 	}
+}
+
+func ByKindOrder(snaps ...*snap.Info) []*snap.Info {
+	sort.Sort(byKind(snaps))
+	return snaps
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -37,7 +37,6 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/store"
 )
 
 // TaskSnapSetup returns the SnapSetup with task params hold by or referred to by the the task.
@@ -363,6 +362,12 @@ func (m *SnapManager) undoPrepareSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
+func installInfoUnlocked(st *state.State, snapsup *SnapSetup) (*snap.Info, error) {
+	st.Lock()
+	defer st.Unlock()
+	return installInfo(st, snapsup.Name(), snapsup.Channel, snapsup.Revision(), snapsup.UserID)
+}
+
 func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	st := t.State()
 	st.Lock()
@@ -387,12 +392,7 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		// COMPATIBILITY - this task was created from an older version
 		// of snapd that did not store the DownloadInfo in the state
 		// yet.
-		spec := store.SnapSpec{
-			Name:     snapsup.Name(),
-			Channel:  snapsup.Channel,
-			Revision: snapsup.Revision(),
-		}
-		storeInfo, err = theStore.SnapInfo(spec, user)
+		storeInfo, err = installInfoUnlocked(st, snapsup)
 		if err != nil {
 			return err
 		}

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
 )
 
 type downloadSnapSuite struct {
@@ -90,8 +91,15 @@ func (s *downloadSnapSuite) TestDoDownloadSnapCompatbility(c *C) {
 	// the compat code called the store "Snap" endpoint
 	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op:    "storesvc-snap",
-			name:  "foo",
+			op: "storesvc-snap-action",
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "install",
+				Name:    "foo",
+				Channel: "some-channel",
+			},
 			revno: snap.R(11),
 		},
 		{

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
 )
 
 type prereqSuite struct {
@@ -123,18 +124,39 @@ func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {
 	defer s.state.Unlock()
 	c.Assert(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
-			op:    "storesvc-snap",
-			name:  "prereq1",
+			op: "storesvc-snap-action",
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "install",
+				Name:    "prereq1",
+				Channel: "stable",
+			},
 			revno: snap.R(11),
 		},
 		{
-			op:    "storesvc-snap",
-			name:  "prereq2",
+			op: "storesvc-snap-action",
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "install",
+				Name:    "prereq2",
+				Channel: "stable",
+			},
 			revno: snap.R(11),
 		},
 		{
-			op:    "storesvc-snap",
-			name:  "some-base",
+			op: "storesvc-snap-action",
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "install",
+				Name:    "some-base",
+				Channel: "stable",
+			},
 			revno: snap.R(11),
 		},
 	})

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -44,6 +44,22 @@ type recordingStore struct {
 func (r *recordingStore) ListRefresh(ctx context.Context, cands []*store.RefreshCandidate, _ *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, error) {
 	if ctx == nil || !auth.IsEnsureContext(ctx) {
 		panic("Ensure marked context required")
+	}
+	r.ops = append(r.ops, "list-refresh")
+	return nil, nil
+}
+
+func (r *recordingStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+	if ctx == nil || !auth.IsEnsureContext(ctx) {
+		panic("Ensure marked context required")
+	}
+	if len(currentSnaps) != len(actions) || len(currentSnaps) == 0 {
+		panic("expected in test one action for each current snaps, and at least one snap")
+	}
+	for _, a := range actions {
+		if a.Action != "refresh" {
+			panic("expected refresh actions")
+		}
 	}
 	r.ops = append(r.ops, "list-refresh")
 	return nil, nil

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -234,6 +234,17 @@ func readInfoAnyway(name string, si *snap.SideInfo) (*snap.Info, error) {
 	return info, err
 }
 
+var revisionDate = revisionDateImpl
+
+// revisionDate returns a good approximation of when a revision reached the system.
+func revisionDateImpl(info *snap.Info) time.Time {
+	fi, err := os.Lstat(info.MountFile())
+	if err != nil {
+		return time.Time{}
+	}
+	return fi.ModTime()
+}
+
 // CurrentInfo returns the information about the current active revision or the last active revision (if the snap is inactive). It returns the ErrNoCurrent error if snapst.Current is unset.
 func (snapst *SnapState) CurrentInfo() (*snap.Info, error) {
 	cur := snapst.CurrentSideInfo()

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -607,7 +607,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		return nil, &snap.AlreadyInstalledError{Snap: name}
 	}
 
-	info, err := snapInfo(st, name, channel, revision, userID)
+	info, err := installInfo(st, name, channel, revision, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -637,6 +637,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 func InstallMany(st *state.State, names []string, userID int) ([]string, []*state.TaskSet, error) {
 	installed := make([]string, 0, len(names))
 	tasksets := make([]*state.TaskSet, 0, len(names))
+	// TODO: this could be reorged to do one single store call
 	for _, name := range names {
 		ts, err := Install(st, name, "", snap.R(0), userID, Flags{})
 		// FIXME: is this expected behavior?
@@ -1077,7 +1078,7 @@ func infoForUpdate(st *state.State, snapst *SnapState, name, channel string, rev
 	}
 	if sideInfo == nil {
 		// refresh from given revision from store
-		return updateToRevisionInfo(st, snapst, channel, revision, userID)
+		return updateToRevisionInfo(st, snapst, revision, userID)
 	}
 
 	// refresh-to-local
@@ -1514,12 +1515,6 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 		return nil, fmt.Errorf("cannot transition snap %q: not installed", oldName)
 	}
 
-	var userID int
-	newInfo, err := snapInfo(st, newName, oldSnapst.Channel, snap.R(0), userID)
-	if err != nil {
-		return nil, err
-	}
-
 	var all []*state.TaskSet
 	// install new core (if not already installed)
 	err = Get(st, newName, &newSnapst)
@@ -1527,6 +1522,12 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 		return nil, err
 	}
 	if !newSnapst.IsInstalled() {
+		var userID int
+		newInfo, err := installInfo(st, newName, oldSnapst.Channel, snap.R(0), userID)
+		if err != nil {
+			return nil, err
+		}
+
 		// start by instaling the new snap
 		tsInst, err := doInstall(st, &newSnapst, &SnapSetup{
 			Channel:      oldSnapst.Channel,

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -78,6 +78,8 @@ func (s *snapmgrTestSuite) settle(c *C) {
 
 var _ = Suite(&snapmgrTestSuite{})
 
+var fakeRevDateEpoch = time.Date(2018, 1, 0, 0, 0, 0, 0, time.UTC)
+
 func (s *snapmgrTestSuite) SetUpTest(c *C) {
 	s.BaseTest.SetUpTest(c)
 	dirs.SetRootDir(c.MkDir())
@@ -116,6 +118,14 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 
 	s.BaseTest.AddCleanup(snapstate.MockReadInfo(s.fakeBackend.ReadInfo))
 	s.BaseTest.AddCleanup(snapstate.MockOpenSnapFile(s.fakeBackend.OpenSnapFile))
+	revDate := func(info *snap.Info) time.Time {
+		if info.Revision.Local() {
+			panic("no local revision should reach revisionDate")
+		}
+		// for convenience a date derived from the revision
+		return fakeRevDateEpoch.AddDate(0, 0, info.Revision.N)
+	}
+	s.BaseTest.AddCleanup(snapstate.MockRevisionDate(revDate))
 
 	s.BaseTest.AddCleanup(func() {
 		snapstate.SetupInstallHook = oldSetupInstallHook
@@ -1127,7 +1137,7 @@ type sneakyStore struct {
 	state *state.State
 }
 
-func (s sneakyStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
+func (s sneakyStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
 	s.state.Lock()
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
 		Active:   true,
@@ -1137,7 +1147,7 @@ func (s sneakyStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.
 		SnapType: "app",
 	})
 	s.state.Unlock()
-	return s.fakeStore.SnapInfo(spec, user)
+	return s.fakeStore.SnapAction(ctx, currentSnaps, actions, user, opts)
 }
 
 func (s *snapmgrTestSuite) TestInstallStateConflict(c *C) {
@@ -1567,6 +1577,163 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	defer s.state.Unlock()
 
 	chg := s.state.NewChange("install", "install a snap")
+	ts, err := snapstate.Install(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	chg.AddAll(ts)
+
+	s.state.Unlock()
+	defer s.snapmgr.Stop()
+	s.settle(c)
+	s.state.Lock()
+
+	// ensure all our tasks ran
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, true)
+	c.Check(snapstate.Installing(s.state), Equals, false)
+	c.Check(s.fakeStore.downloads, DeepEquals, []fakeDownload{{
+		macaroon: s.user.StoreMacaroon,
+		name:     "some-snap",
+	}})
+	expected := fakeOps{
+		{
+			op:     "storesvc-snap-action",
+			userID: 1,
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "install",
+				Name:    "some-snap",
+				Channel: "some-channel",
+			},
+			revno:  snap.R(11),
+			userID: 1,
+		},
+		{
+			op:   "storesvc-download",
+			name: "some-snap",
+		},
+		{
+			op:    "validate-snap:Doing",
+			name:  "some-snap",
+			revno: snap.R(11),
+		},
+		{
+			op:  "current",
+			old: "<no-current>",
+		},
+		{
+			op:   "open-snap-file",
+			name: filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
+			sinfo: snap.SideInfo{
+				RealName: "some-snap",
+				SnapID:   "some-snap-id",
+				Channel:  "some-channel",
+				Revision: snap.R(11),
+			},
+		},
+		{
+			op:    "setup-snap",
+			name:  filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
+			revno: snap.R(11),
+		},
+		{
+			op:   "copy-data",
+			name: filepath.Join(dirs.SnapMountDir, "some-snap/11"),
+			old:  "<no-old>",
+		},
+		{
+			op:    "setup-profiles:Doing",
+			name:  "some-snap",
+			revno: snap.R(11),
+		},
+		{
+			op: "candidate",
+			sinfo: snap.SideInfo{
+				RealName: "some-snap",
+				SnapID:   "some-snap-id",
+				Channel:  "some-channel",
+				Revision: snap.R(11),
+			},
+		},
+		{
+			op:   "link-snap",
+			name: filepath.Join(dirs.SnapMountDir, "some-snap/11"),
+		},
+		{
+			op:    "auto-connect:Doing",
+			name:  "some-snap",
+			revno: snap.R(11),
+		},
+		{
+			op: "update-aliases",
+		},
+		{
+			op:    "cleanup-trash",
+			name:  "some-snap",
+			revno: snap.R(11),
+		},
+	}
+	// start with an easier-to-read error if this fails:
+	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
+
+	// check progress
+	ta := ts.Tasks()
+	task := ta[1]
+	_, cur, total := task.Progress()
+	c.Assert(cur, Equals, s.fakeStore.fakeCurrentProgress)
+	c.Assert(total, Equals, s.fakeStore.fakeTotalProgress)
+	c.Check(task.Summary(), Equals, `Download snap "some-snap" (11) from channel "some-channel"`)
+
+	// check link/start snap summary
+	linkTask := ta[len(ta)-7]
+	c.Check(linkTask.Summary(), Equals, `Make snap "some-snap" (11) available to the system`)
+	startTask := ta[len(ta)-2]
+	c.Check(startTask.Summary(), Equals, `Start snap "some-snap" (11) services`)
+
+	// verify snap-setup in the task state
+	var snapsup snapstate.SnapSetup
+	err = task.Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
+		Channel:  "some-channel",
+		UserID:   s.user.ID,
+		SnapPath: filepath.Join(dirs.SnapBlobDir, "some-snap_11.snap"),
+		DownloadInfo: &snap.DownloadInfo{
+			DownloadURL: "https://some-server.com/some/path.snap",
+		},
+		SideInfo: snapsup.SideInfo,
+	})
+	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
+		RealName: "some-snap",
+		Channel:  "some-channel",
+		Revision: snap.R(11),
+		SnapID:   "some-snap-id",
+	})
+
+	// verify snaps in the system state
+	var snaps map[string]*snapstate.SnapState
+	err = s.state.Get("snaps", &snaps)
+	c.Assert(err, IsNil)
+
+	snapst := snaps["some-snap"]
+	c.Assert(snapst.Active, Equals, true)
+	c.Assert(snapst.Channel, Equals, "some-channel")
+	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Channel:  "some-channel",
+		Revision: snap.R(11),
+	})
+	c.Assert(snapst.Required, Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	chg := s.state.NewChange("install", "install a snap")
 	ts, err := snapstate.Install(s.state, "some-snap", "some-channel", snap.R(42), s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
@@ -1586,8 +1753,16 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	}})
 	expected := fakeOps{
 		{
-			op:     "storesvc-snap",
-			name:   "some-snap",
+			op:     "storesvc-snap-action",
+			userID: 1,
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:   "install",
+				Name:     "some-snap",
+				Revision: snap.R(42),
+			},
 			revno:  snap.R(42),
 			userID: 1,
 		},
@@ -1609,7 +1784,6 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 			name: filepath.Join(dirs.SnapBlobDir, "some-snap_42.snap"),
 			sinfo: snap.SideInfo{
 				RealName: "some-snap",
-				Channel:  "some-channel",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(42),
 			},
@@ -1633,7 +1807,6 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 			op: "candidate",
 			sinfo: snap.SideInfo{
 				RealName: "some-snap",
-				Channel:  "some-channel",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(42),
 			},
@@ -1690,7 +1863,6 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
 		Revision: snap.R(42),
-		Channel:  "some-channel",
 		SnapID:   "some-snap-id",
 	})
 
@@ -1704,7 +1876,6 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 	c.Assert(snapst.Channel, Equals, "some-channel")
 	c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
-		Channel:  "some-channel",
 		SnapID:   "some-snap-id",
 		Revision: snap.R(42),
 	})
@@ -1732,6 +1903,13 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 		Revision: snap.R(7),
 		SnapID:   "services-snap-id",
 	}
+	snaptest.MockSnap(c, `name: services-snap`, &si)
+	fi, err := os.Stat(snap.MountFile("services-snap", si.Revision))
+	c.Assert(err, IsNil)
+	refreshedDate := fi.ModTime()
+	// look at disk
+	r := snapstate.MockRevisionDate(nil)
+	defer r()
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -1741,6 +1919,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 		Sequence: []*snap.SideInfo{&si},
 		Current:  si.Revision,
 		SnapType: "app",
+		Channel:  "stable",
 	})
 
 	chg := s.state.NewChange("refresh", "refresh a snap")
@@ -1755,11 +1934,23 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 
 	expected := fakeOps{
 		{
-			op: "storesvc-list-refresh",
-			cand: store.RefreshCandidate{
-				Channel:  "some-channel",
-				SnapID:   "services-snap-id",
-				Revision: snap.R(7),
+			op: "storesvc-snap-action",
+			curSnaps: []store.CurrentSnap{{
+				Name:            "services-snap",
+				SnapID:          "services-snap-id",
+				Revision:        snap.R(7),
+				TrackingChannel: "stable",
+				RefreshedDate:   refreshedDate,
+			}},
+			userID: 1,
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "refresh",
+				SnapID:  "services-snap-id",
+				Channel: "some-channel",
+				Flags:   store.SnapActionEnforceValidation,
 			},
 			revno:  snap.R(11),
 			userID: 1,
@@ -1940,7 +2131,7 @@ func (s *snapmgrTestSuite) TestUpdateRememberedUserRunThrough(c *C) {
 
 	for _, op := range s.fakeBackend.ops {
 		switch op.op {
-		case "storesvc-list-refresh":
+		case "storesvc-snap-action":
 			c.Check(op.userID, Equals, 1)
 		case "storesvc-download":
 			snapName := op.name
@@ -1981,7 +2172,7 @@ func (s *snapmgrTestSuite) TestUpdateToRevisionRememberedUserRunThrough(c *C) {
 
 	for _, op := range s.fakeBackend.ops {
 		switch op.op {
-		case "storesvc-snap":
+		case "storesvc-snap-action:action":
 			c.Check(op.userID, Equals, 1)
 		case "storesvc-download":
 			snapName := op.name
@@ -2052,11 +2243,19 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 		userID int
 	}
 	seen := make(map[snapIDuserID]bool)
+	ir := 0
 	di := 0
 	for _, op := range s.fakeBackend.ops {
 		switch op.op {
-		case "storesvc-list-refresh":
-			snapID := op.cand.SnapID
+		case "storesvc-snap-action":
+			ir++
+			c.Check(op.curSnaps, DeepEquals, []store.CurrentSnap{
+				{Name: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
+				{Name: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2)},
+				{Name: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5)},
+			})
+		case "storesvc-snap-action:action":
+			snapID := op.action.SnapID
 			seen[snapIDuserID{snapID: snapID, userID: op.userID}] = true
 		case "storesvc-download":
 			snapName := op.name
@@ -2067,13 +2266,11 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsNoUserRunThrough(c *C) {
 			di++
 		}
 	}
+	c.Check(ir, Equals, 3)
 	// we check all snaps with each user
 	c.Check(seen, DeepEquals, map[snapIDuserID]bool{
-		{snapID: "core-snap-id", userID: 1}:     true,
+		{snapID: "core-snap-id", userID: 0}:     true,
 		{snapID: "some-snap-id", userID: 1}:     true,
-		{snapID: "services-snap-id", userID: 1}: true,
-		{snapID: "core-snap-id", userID: 2}:     true,
-		{snapID: "some-snap-id", userID: 2}:     true,
 		{snapID: "services-snap-id", userID: 2}: true,
 	})
 }
@@ -2137,11 +2334,19 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 		userID int
 	}
 	seen := make(map[snapIDuserID]bool)
+	ir := 0
 	di := 0
 	for _, op := range s.fakeBackend.ops {
 		switch op.op {
-		case "storesvc-list-refresh":
-			snapID := op.cand.SnapID
+		case "storesvc-snap-action":
+			ir++
+			c.Check(op.curSnaps, DeepEquals, []store.CurrentSnap{
+				{Name: "core", SnapID: "core-snap-id", Revision: snap.R(1), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
+				{Name: "services-snap", SnapID: "services-snap-id", Revision: snap.R(2), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 2)},
+				{Name: "some-snap", SnapID: "some-snap-id", Revision: snap.R(5), RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 5)},
+			})
+		case "storesvc-snap-action:action":
+			snapID := op.action.SnapID
 			seen[snapIDuserID{snapID: snapID, userID: op.userID}] = true
 		case "storesvc-download":
 			snapName := op.name
@@ -2152,13 +2357,11 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserRunThrough(c *C) {
 			di++
 		}
 	}
+	c.Check(ir, Equals, 2)
 	// we check all snaps with each user
 	c.Check(seen, DeepEquals, map[snapIDuserID]bool{
-		{snapID: "core-snap-id", userID: 1}:     true,
-		{snapID: "some-snap-id", userID: 1}:     true,
-		{snapID: "services-snap-id", userID: 1}: true,
 		{snapID: "core-snap-id", userID: 2}:     true,
-		{snapID: "some-snap-id", userID: 2}:     true,
+		{snapID: "some-snap-id", userID: 1}:     true,
 		{snapID: "services-snap-id", userID: 2}: true,
 	})
 
@@ -2208,11 +2411,22 @@ func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 
 	expected := fakeOps{
 		{
-			op: "storesvc-list-refresh",
-			cand: store.RefreshCandidate{
-				Channel:  "some-channel",
-				SnapID:   "some-snap-id",
-				Revision: snap.R(7),
+			op: "storesvc-snap-action",
+			curSnaps: []store.CurrentSnap{{
+				Name:          "some-snap",
+				SnapID:        "some-snap-id",
+				Revision:      snap.R(7),
+				RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+			}},
+			userID: 1,
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "refresh",
+				SnapID:  "some-snap-id",
+				Channel: "some-channel",
+				Flags:   store.SnapActionEnforceValidation,
 			},
 			revno:  snap.R(11),
 			userID: 1,
@@ -2368,11 +2582,23 @@ func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
 
 	expected := fakeOps{
 		{
-			op: "storesvc-list-refresh",
-			cand: store.RefreshCandidate{
-				Channel:  "some-channel",
-				SnapID:   "some-snap-id",
-				Revision: snap.R(7),
+			op: "storesvc-snap-action",
+			curSnaps: []store.CurrentSnap{{
+				Name:            "some-snap",
+				SnapID:          "some-snap-id",
+				Revision:        snap.R(7),
+				TrackingChannel: "stable",
+				RefreshedDate:   fakeRevDateEpoch.AddDate(0, 0, 7),
+			}},
+			userID: 1,
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "refresh",
+				SnapID:  "some-snap-id",
+				Channel: "some-channel",
+				Flags:   store.SnapActionEnforceValidation,
 			},
 			revno:  snap.R(11),
 			userID: 1,
@@ -2523,6 +2749,41 @@ func (s *snapmgrTestSuite) TestUpdateSameRevision(c *C) {
 	c.Assert(err, Equals, store.ErrNoUpdateAvailable)
 }
 
+// A noResultsStore returns no results for install/refresh requests
+type noResultsStore struct {
+	*fakeStore
+}
+
+func (n noResultsStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+	return nil, &store.SnapActionError{NoResults: true}
+}
+
+func (s *snapmgrTestSuite) TestUpdateNoStoreResults(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.ReplaceStore(s.state, noResultsStore{fakeStore: s.fakeStore})
+
+	// this is an atypical case in which the store didn't return
+	// an error nor a result, we are defensive and return
+	// a reasonable error
+	si := snap.SideInfo{
+		RealName: "some-snap",
+		SnapID:   "some-snap-id",
+		Revision: snap.R(7),
+	}
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si},
+		Channel:  "channel-for-7",
+		Current:  si.Revision,
+	})
+
+	_, err := snapstate.Update(s.state, "some-snap", "channel-for-7", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, Equals, store.ErrNoUpdateAvailable)
+}
+
 func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchesChannel(c *C) {
 	si := snap.SideInfo{
 		RealName: "some-snap",
@@ -2601,15 +2862,28 @@ func (s *snapmgrTestSuite) TestUpdateSameRevisionSwitchChannelRunThrough(c *C) {
 	s.state.Lock()
 
 	expected := fakeOps{
-		// we just expect the "storesvc-list-refresh" op, we
+		// we just expect the "storesvc-snap-action" ops, we
 		// don't have a fakeOp for switchChannel because it has
 		// not a backend method, it just manipulates the state
 		{
-			op: "storesvc-list-refresh",
-			cand: store.RefreshCandidate{
-				Channel:  "channel-for-7",
-				SnapID:   "some-snap-id",
-				Revision: snap.R(7),
+			op: "storesvc-snap-action",
+			curSnaps: []store.CurrentSnap{{
+				Name:            "some-snap",
+				SnapID:          "some-snap-id",
+				Revision:        snap.R(7),
+				TrackingChannel: "other-channel",
+				RefreshedDate:   fakeRevDateEpoch.AddDate(0, 0, 7),
+			}},
+			userID: 1,
+		},
+
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "refresh",
+				SnapID:  "some-snap-id",
+				Channel: "channel-for-7",
+				Flags:   store.SnapActionEnforceValidation,
 			},
 			userID: 1,
 		},
@@ -2864,13 +3138,24 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(s.fakeBackend.ops[0], DeepEquals, fakeOp{
-		op:    "storesvc-list-refresh",
-		revno: snap.R(11),
-		cand: store.RefreshCandidate{
+		op: "storesvc-snap-action",
+		curSnaps: []store.CurrentSnap{{
+			Name:             "some-snap",
 			SnapID:           "some-snap-id",
 			Revision:         snap.R(7),
-			Channel:          "stable",
-			IgnoreValidation: true,
+			IgnoreValidation: false,
+			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 7),
+		}},
+		userID: 1,
+	})
+	c.Check(s.fakeBackend.ops[1], DeepEquals, fakeOp{
+		op:    "storesvc-snap-action:action",
+		revno: snap.R(11),
+		action: store.SnapAction{
+			Action:  "refresh",
+			SnapID:  "some-snap-id",
+			Channel: "stable",
+			Flags:   store.SnapActionIgnoreValidation,
 		},
 		userID: 1,
 	})
@@ -2899,13 +3184,24 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 	c.Check(tts, HasLen, 1)
 
 	c.Check(s.fakeBackend.ops[0], DeepEquals, fakeOp{
-		op:    "storesvc-list-refresh",
-		revno: snap.R(12),
-		cand: store.RefreshCandidate{
+		op: "storesvc-snap-action",
+		curSnaps: []store.CurrentSnap{{
+			Name:             "some-snap",
 			SnapID:           "some-snap-id",
 			Revision:         snap.R(11),
-			Channel:          "stable",
+			TrackingChannel:  "stable",
 			IgnoreValidation: true,
+			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 11),
+		}},
+		userID: 1,
+	})
+	c.Check(s.fakeBackend.ops[1], DeepEquals, fakeOp{
+		op:    "storesvc-snap-action:action",
+		revno: snap.R(12),
+		action: store.SnapAction{
+			Action: "refresh",
+			SnapID: "some-snap-id",
+			Flags:  0,
 		},
 		userID: 1,
 	})
@@ -2939,13 +3235,25 @@ func (s *snapmgrTestSuite) TestUpdateIgnoreValidationSticky(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(s.fakeBackend.ops[0], DeepEquals, fakeOp{
-		op:    "storesvc-list-refresh",
-		revno: snap.R(11),
-		cand: store.RefreshCandidate{
+		op: "storesvc-snap-action",
+		curSnaps: []store.CurrentSnap{{
+			Name:             "some-snap",
 			SnapID:           "some-snap-id",
 			Revision:         snap.R(12),
-			Channel:          "stable",
-			IgnoreValidation: false,
+			TrackingChannel:  "stable",
+			IgnoreValidation: true,
+			RefreshedDate:    fakeRevDateEpoch.AddDate(0, 0, 12),
+		}},
+		userID: 1,
+	})
+	c.Check(s.fakeBackend.ops[1], DeepEquals, fakeOp{
+		op:    "storesvc-snap-action:action",
+		revno: snap.R(11),
+		action: store.SnapAction{
+			Action:  "refresh",
+			SnapID:  "some-snap-id",
+			Channel: "stable",
+			Flags:   store.SnapActionEnforceValidation,
 		},
 		userID: 1,
 	})
@@ -3012,7 +3320,26 @@ func (s *snapmgrTestSuite) TestUpdateAmend(c *C) {
 	err = tasks[1].Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Check(snapsup.Revision(), Equals, snap.R(7))
+}
 
+func (s *snapmgrTestSuite) TestUpdateAmendSnapNotFound(c *C) {
+	si := snap.SideInfo{
+		RealName: "snap-unknown",
+		Revision: snap.R("x1"),
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snap-unknown", &snapstate.SnapState{
+		Active:   true,
+		Sequence: []*snap.SideInfo{&si},
+		Channel:  "stable",
+		Current:  si.Revision,
+	})
+
+	_, err := snapstate.Update(s.state, "snap-unknown", "stable", snap.R(0), s.user.ID, snapstate.Flags{Amend: true})
+	c.Assert(err, Equals, store.ErrSnapNotFound)
 }
 
 func (s *snapmgrTestSuite) TestSingleUpdateBlockedRevision(c *C) {
@@ -3041,18 +3368,17 @@ func (s *snapmgrTestSuite) TestSingleUpdateBlockedRevision(c *C) {
 	_, err := snapstate.Update(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 
-	c.Assert(s.fakeBackend.ops, HasLen, 1)
+	c.Assert(s.fakeBackend.ops, HasLen, 2)
 	c.Check(s.fakeBackend.ops[0], DeepEquals, fakeOp{
-		op:    "storesvc-list-refresh",
-		revno: snap.R(11),
-		cand: store.RefreshCandidate{
-			SnapID:   "some-snap-id",
-			Revision: snap.R(7),
-			Channel:  "some-channel",
-		},
+		op: "storesvc-snap-action",
+		curSnaps: []store.CurrentSnap{{
+			Name:          "some-snap",
+			SnapID:        "some-snap-id",
+			Revision:      snap.R(7),
+			RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+		}},
 		userID: 1,
 	})
-
 }
 
 func (s *snapmgrTestSuite) TestMultiUpdateBlockedRevision(c *C) {
@@ -3082,17 +3408,17 @@ func (s *snapmgrTestSuite) TestMultiUpdateBlockedRevision(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(updates, DeepEquals, []string{"some-snap"})
 
-	c.Assert(s.fakeBackend.ops, HasLen, 1)
+	c.Assert(s.fakeBackend.ops, HasLen, 2)
 	c.Check(s.fakeBackend.ops[0], DeepEquals, fakeOp{
-		op:    "storesvc-list-refresh",
-		revno: snap.R(11),
-		cand: store.RefreshCandidate{
-			SnapID:   "some-snap-id",
-			Revision: snap.R(7),
-		},
+		op: "storesvc-snap-action",
+		curSnaps: []store.CurrentSnap{{
+			Name:          "some-snap",
+			SnapID:        "some-snap-id",
+			Revision:      snap.R(7),
+			RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+		}},
 		userID: 1,
 	})
-
 }
 
 func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
@@ -3121,17 +3447,18 @@ func (s *snapmgrTestSuite) TestAllUpdateBlockedRevision(c *C) {
 	c.Check(err, IsNil)
 	c.Check(updates, HasLen, 0)
 
-	c.Assert(s.fakeBackend.ops, HasLen, 1)
+	c.Assert(s.fakeBackend.ops, HasLen, 2)
 	c.Check(s.fakeBackend.ops[0], DeepEquals, fakeOp{
-		op: "storesvc-list-refresh",
-		cand: store.RefreshCandidate{
-			SnapID:   "some-snap-id",
-			Revision: snap.R(7),
-			Block:    []snap.Revision{snap.R(11)},
-		},
+		op: "storesvc-snap-action",
+		curSnaps: []store.CurrentSnap{{
+			Name:          "some-snap",
+			SnapID:        "some-snap-id",
+			Revision:      snap.R(7),
+			RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 7),
+			Block:         []snap.Revision{snap.R(11)},
+		}},
 		userID: 1,
 	})
-
 }
 
 var orthogonalAutoAliasesScenarios = []struct {
@@ -5351,8 +5678,16 @@ func (s *snapmgrTestSuite) TestUndoMountSnapFailsInCopyData(c *C) {
 
 	expected := fakeOps{
 		{
-			op:     "storesvc-snap",
-			name:   "some-snap",
+			op:     "storesvc-snap-action",
+			userID: 1,
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "install",
+				Name:    "some-snap",
+				Channel: "some-channel",
+			},
 			revno:  snap.R(11),
 			userID: 1,
 		},
@@ -7402,6 +7737,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 		Sequence: []*snap.SideInfo{{RealName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
 		SnapType: "os",
+		Channel:  "beta",
 	})
 
 	chg := s.state.NewChange("transition-ubuntu-core", "...")
@@ -7426,8 +7762,18 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 	}})
 	expected := fakeOps{
 		{
-			op:    "storesvc-snap",
-			name:  "core",
+			op: "storesvc-snap-action",
+			curSnaps: []store.CurrentSnap{
+				{Name: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1), TrackingChannel: "beta", RefreshedDate: fakeRevDateEpoch.AddDate(0, 0, 1)},
+			},
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "install",
+				Name:    "core",
+				Channel: "beta",
+			},
 			revno: snap.R(11),
 		},
 		{
@@ -7449,6 +7795,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 			sinfo: snap.SideInfo{
 				RealName: "core",
 				SnapID:   "core-id",
+				Channel:  "beta",
 				Revision: snap.R(11),
 			},
 		},
@@ -7472,6 +7819,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 			sinfo: snap.SideInfo{
 				RealName: "core",
 				SnapID:   "core-id",
+				Channel:  "beta",
 				Revision: snap.R(11),
 			},
 		},
@@ -7540,6 +7888,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThrough(c *C) {
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
 }
+
 func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -7549,12 +7898,14 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 		Sequence: []*snap.SideInfo{{RealName: "ubuntu-core", SnapID: "ubuntu-core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
 		SnapType: "os",
+		Channel:  "stable",
 	})
 	snapstate.Set(s.state, "core", &snapstate.SnapState{
 		Active:   true,
 		Sequence: []*snap.SideInfo{{RealName: "core", SnapID: "core-snap-id", Revision: snap.R(1)}},
 		Current:  snap.R(1),
 		SnapType: "os",
+		Channel:  "stable",
 	})
 
 	chg := s.state.NewChange("transition-ubuntu-core", "...")
@@ -7574,11 +7925,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 	c.Assert(chg.IsReady(), Equals, true)
 	c.Check(s.fakeStore.downloads, HasLen, 0)
 	expected := fakeOps{
-		{
-			op:    "storesvc-snap",
-			name:  "core",
-			revno: snap.R(11),
-		},
 		{
 			op:   "transition-ubuntu-core:Doing",
 			name: "ubuntu-core",
@@ -7621,7 +7967,6 @@ func (s *snapmgrTestSuite) TestTransitionCoreRunThroughWithCore(c *C) {
 	// start with an easier-to-read error if this fails:
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
-
 }
 
 func (s *snapmgrTestSuite) TestTransitionCoreStartsAutomatically(c *C) {
@@ -8053,16 +8398,32 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 	expected := fakeOps{
 		// we check the snap
 		{
-			op:     "storesvc-snap",
-			name:   "some-snap",
+			op:     "storesvc-snap-action",
+			userID: 1,
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:   "install",
+				Name:     "some-snap",
+				Revision: snap.R(42),
+			},
 			revno:  snap.R(42),
 			userID: 1,
 		},
 		// then we check core because its not installed already
 		// and continue with that
 		{
-			op:     "storesvc-snap",
-			name:   "core",
+			op:     "storesvc-snap-action",
+			userID: 1,
+		},
+		{
+			op: "storesvc-snap-action:action",
+			action: store.SnapAction{
+				Action:  "install",
+				Name:    "core",
+				Channel: "stable",
+			},
 			revno:  snap.R(11),
 			userID: 1,
 		},
@@ -8144,7 +8505,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 			name: filepath.Join(dirs.SnapBlobDir, "some-snap_42.snap"),
 			sinfo: snap.SideInfo{
 				RealName: "some-snap",
-				Channel:  "some-channel",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(42),
 			},
@@ -8168,7 +8528,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 			op: "candidate",
 			sinfo: snap.SideInfo{
 				RealName: "some-snap",
-				Channel:  "some-channel",
 				SnapID:   "some-snap-id",
 				Revision: snap.R(42),
 			},
@@ -8320,7 +8679,6 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 
 		// ensure we have both core and snap2
 		var snapst snapstate.SnapState
-
 		err = snapstate.Get(s.state, "core", &snapst)
 		c.Assert(err, IsNil)
 		c.Assert(snapst.Active, Equals, true)
@@ -8332,14 +8690,15 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsWithFailureRunThrough(c
 			Revision: snap.R(11),
 		})
 
-		err = snapstate.Get(s.state, "snap2", &snapst)
+		var snapst2 snapstate.SnapState
+		err = snapstate.Get(s.state, "snap2", &snapst2)
 		c.Assert(err, IsNil)
-		c.Assert(snapst.Active, Equals, true)
-		c.Assert(snapst.Sequence, HasLen, 1)
-		c.Assert(snapst.Sequence[0], DeepEquals, &snap.SideInfo{
+		c.Assert(snapst2.Active, Equals, true)
+		c.Assert(snapst2.Sequence, HasLen, 1)
+		c.Assert(snapst2.Sequence[0], DeepEquals, &snap.SideInfo{
 			RealName: "snap2",
 			SnapID:   "snap2-id",
-			Channel:  "some-other-channel",
+			Channel:  "",
 			Revision: snap.R(21),
 		})
 
@@ -8355,8 +8714,8 @@ type behindYourBackStore struct {
 	chg                  *state.Change
 }
 
-func (s behindYourBackStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
-	if spec.Name == "core" {
+func (s behindYourBackStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+	if len(actions) == 1 && actions[0].Action == "install" && actions[0].Name == "core" {
 		s.state.Lock()
 		if !s.coreInstallRequested {
 			s.coreInstallRequested = true
@@ -8390,7 +8749,7 @@ func (s behindYourBackStore) SnapInfo(spec store.SnapSpec, user *auth.UserState)
 		s.state.Unlock()
 	}
 
-	return s.fakeStore.SnapInfo(spec, user)
+	return s.fakeStore.SnapAction(ctx, currentSnaps, actions, user, opts)
 }
 
 // this test the scenario that some-snap gets installed and during the
@@ -8412,7 +8771,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 
 	// now install a snap that will pull in core
 	chg := s.state.NewChange("install", "install a snap on a system without core")
-	ts, err := snapstate.Install(s.state, "some-snap", "some-channel", snap.R(42), s.user.ID, snapstate.Flags{})
+	ts, err := snapstate.Install(s.state, "some-snap", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -8469,7 +8828,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreConflictingInstall(c *C) {
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
 		Channel:  "some-channel",
-		Revision: snap.R(42),
+		Revision: snap.R(11),
 	})
 }
 
@@ -8478,9 +8837,13 @@ type contentStore struct {
 	state *state.State
 }
 
-func (s contentStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
-	info, err := s.fakeStore.SnapInfo(spec, user)
-	switch spec.Name {
+func (s contentStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, error) {
+	snaps, err := s.fakeStore.SnapAction(ctx, currentSnaps, actions, user, opts)
+	if len(snaps) != 1 {
+		panic("expected to be queried for install of only one snap at a time")
+	}
+	info := snaps[0]
+	switch info.Name() {
 	case "snap-content-plug":
 		info.Plugs = map[string]*snap.PlugInfo{
 			"some-plug": {
@@ -8562,7 +8925,7 @@ func (s contentStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap
 		}
 	}
 
-	return info, err
+	return []*snap.Info{info}, err
 }
 
 func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
@@ -8575,7 +8938,7 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 	ifacerepo.Replace(s.state, repo)
 
 	chg := s.state.NewChange("install", "install a snap")
-	ts, err := snapstate.Install(s.state, "snap-content-plug", "some-channel", snap.R(42), s.user.ID, snapstate.Flags{})
+	ts, err := snapstate.Install(s.state, "snap-content-plug", "stable", snap.R(42), s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 	chg.AddAll(ts)
 
@@ -8588,13 +8951,27 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 	c.Assert(chg.Err(), IsNil)
 	c.Assert(chg.IsReady(), Equals, true)
 	expected := fakeOps{{
-		op:     "storesvc-snap",
-		name:   "snap-content-plug",
+		op:     "storesvc-snap-action",
+		userID: 1,
+	}, {
+		op: "storesvc-snap-action:action",
+		action: store.SnapAction{
+			Action:   "install",
+			Name:     "snap-content-plug",
+			Revision: snap.R(42),
+		},
 		revno:  snap.R(42),
 		userID: 1,
 	}, {
-		op:     "storesvc-snap",
-		name:   "snap-content-slot",
+		op:     "storesvc-snap-action",
+		userID: 1,
+	}, {
+		op: "storesvc-snap-action:action",
+		action: store.SnapAction{
+			Action:  "install",
+			Name:    "snap-content-slot",
+			Channel: "stable",
+		},
 		revno:  snap.R(11),
 		userID: 1,
 	}, {
@@ -8660,7 +9037,6 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 		name: filepath.Join(dirs.SnapBlobDir, "snap-content-plug_42.snap"),
 		sinfo: snap.SideInfo{
 			RealName: "snap-content-plug",
-			Channel:  "some-channel",
 			SnapID:   "snap-content-plug-id",
 			Revision: snap.R(42),
 		},
@@ -8680,7 +9056,6 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 		op: "candidate",
 		sinfo: snap.SideInfo{
 			RealName: "snap-content-plug",
-			Channel:  "some-channel",
 			SnapID:   "snap-content-plug-id",
 			Revision: snap.R(42),
 		},
@@ -8707,7 +9082,7 @@ func (s *snapmgrTestSuite) TestInstallDefaultProviderRunThrough(c *C) {
 	// do a simple c.Check(ops, DeepEquals, fakeOps{...})
 	c.Check(len(s.fakeBackend.ops), Equals, len(expected))
 	for _, op := range expected {
-		c.Check(s.fakeBackend.ops, testutil.DeepContains, op)
+		c.Assert(s.fakeBackend.ops, testutil.DeepContains, op)
 	}
 }
 

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -25,6 +25,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -90,29 +91,39 @@ func userFromUserIDOrFallback(st *state.State, userID int, fallbackUser *auth.Us
 	return fallbackUser, nil
 }
 
-func snapNameToID(st *state.State, name string, user *auth.UserState) (string, error) {
-	theStore := Store(st)
-	st.Unlock()
-	info, err := theStore.SnapInfo(store.SnapSpec{Name: name}, user)
-	st.Lock()
-	return info.SnapID, err
-}
+func installInfo(st *state.State, name, channel string, revision snap.Revision, userID int) (*snap.Info, error) {
+	// TODO: support ignore-validation?
 
-func snapInfo(st *state.State, name, channel string, revision snap.Revision, userID int) (*snap.Info, error) {
+	curSnaps, err := currentSnaps(st)
+	if err != nil {
+		return nil, err
+	}
+
 	user, err := userFromUserID(st, userID)
 	if err != nil {
 		return nil, err
 	}
-	theStore := Store(st)
-	st.Unlock() // calls to the store should be done without holding the state lock
-	spec := store.SnapSpec{
-		Name:     name,
-		Channel:  channel,
+
+	// cannot specify both with the API
+	if !revision.Unset() {
+		channel = ""
+	}
+
+	action := &store.SnapAction{
+		Action: "install",
+		Name:   name,
+		// the desired channel
+		Channel: channel,
+		// the desired revision
 		Revision: revision,
 	}
-	snap, err := theStore.SnapInfo(spec, user)
+
+	theStore := Store(st)
+	st.Unlock() // calls to the store should be done without holding the state lock
+	res, err := theStore.SnapAction(context.TODO(), curSnaps, []*store.SnapAction{action}, user, nil)
 	st.Lock()
-	return snap, err
+
+	return singleActionResult(name, action.Action, res, err)
 }
 
 func updateInfo(st *state.State, snapst *SnapState, opts *updateInfoOpts, userID int) (*snap.Info, error) {
@@ -120,26 +131,42 @@ func updateInfo(st *state.State, snapst *SnapState, opts *updateInfoOpts, userID
 		opts = &updateInfoOpts{}
 	}
 
+	curSnaps, err := currentSnaps(st)
+	if err != nil {
+		return nil, err
+	}
+
 	curInfo, user, err := preUpdateInfo(st, snapst, opts.amend, userID)
 	if err != nil {
 		return nil, err
 	}
 
-	refreshCand := &store.RefreshCandidate{
+	var flags store.SnapActionFlags
+	if opts.ignoreValidation {
+		flags = store.SnapActionIgnoreValidation
+	} else {
+		flags = store.SnapActionEnforceValidation
+	}
+
+	action := &store.SnapAction{
+		Action: "refresh",
+		SnapID: curInfo.SnapID,
 		// the desired channel
-		Channel:          opts.channel,
-		SnapID:           curInfo.SnapID,
-		Revision:         curInfo.Revision,
-		Epoch:            curInfo.Epoch,
-		IgnoreValidation: opts.ignoreValidation,
-		Amend:            opts.amend,
+		Channel: opts.channel,
+		Flags:   flags,
+	}
+
+	if curInfo.SnapID == "" { // amend
+		action.Action = "install"
+		action.Name = curInfo.Name()
 	}
 
 	theStore := Store(st)
 	st.Unlock() // calls to the store should be done without holding the state lock
-	res, err := theStore.LookupRefresh(refreshCand, user)
+	res, err := theStore.SnapAction(context.TODO(), curSnaps, []*store.SnapAction{action}, user, nil)
 	st.Lock()
-	return res, err
+
+	return singleActionResult(curInfo.Name(), action.Action, res, err)
 }
 
 func preUpdateInfo(st *state.State, snapst *SnapState, amend bool, userID int) (*snap.Info, *auth.UserState, error) {
@@ -157,39 +184,130 @@ func preUpdateInfo(st *state.State, snapst *SnapState, amend bool, userID int) (
 		if !amend {
 			return nil, nil, store.ErrLocalSnap
 		}
-
-		// in amend mode we need to move to the store rev
-		id, err := snapNameToID(st, curInfo.Name(), user)
-		if err != nil {
-			return nil, nil, fmt.Errorf("cannot get snap ID for %q: %v", curInfo.Name(), err)
-		}
-		curInfo.SnapID = id
-		// set revision to "unknown"
-		curInfo.Revision = snap.R(0)
 	}
 
 	return curInfo, user, nil
 }
 
-func updateToRevisionInfo(st *state.State, snapst *SnapState, channel string, revision snap.Revision, userID int) (*snap.Info, error) {
+func singleActionResult(name, action string, results []*snap.Info, e error) (info *snap.Info, err error) {
+	if len(results) > 1 {
+		return nil, fmt.Errorf("internal error: multiple store results for a single snap op")
+	}
+	if len(results) > 0 {
+		// TODO: if we also have an error log/warn about it
+		return results[0], nil
+	}
+
+	if saErr, ok := e.(*store.SnapActionError); ok {
+		if len(saErr.Other) != 0 {
+			return nil, saErr
+		}
+
+		var snapErr error
+		switch action {
+		case "refresh":
+			snapErr = saErr.Refresh[name]
+		case "install":
+			snapErr = saErr.Install[name]
+		}
+		if snapErr != nil {
+			return nil, snapErr
+		}
+
+		// no result, atypical case
+		if saErr.NoResults {
+			switch action {
+			case "refresh":
+				return nil, store.ErrNoUpdateAvailable
+			case "install":
+				return nil, store.ErrSnapNotFound
+			}
+		}
+	}
+
+	return nil, e
+}
+
+func updateToRevisionInfo(st *state.State, snapst *SnapState, revision snap.Revision, userID int) (*snap.Info, error) {
+	// TODO: support ignore-validation?
+
+	curSnaps, err := currentSnaps(st)
+	if err != nil {
+		return nil, err
+	}
+
 	curInfo, user, err := preUpdateInfo(st, snapst, false, userID)
 	if err != nil {
 		return nil, err
 	}
 
-	theStore := Store(st)
-	st.Unlock() // calls to the store should be done without holding the state lock
-	spec := store.SnapSpec{
-		Name:     curInfo.Name(),
-		Channel:  channel,
+	action := &store.SnapAction{
+		Action: "refresh",
+		SnapID: curInfo.SnapID,
+		// the desired revision
 		Revision: revision,
 	}
-	snap, err := theStore.SnapInfo(spec, user)
+
+	theStore := Store(st)
+	st.Unlock() // calls to the store should be done without holding the state lock
+	res, err := theStore.SnapAction(context.TODO(), curSnaps, []*store.SnapAction{action}, user, nil)
 	st.Lock()
-	return snap, err
+
+	return singleActionResult(curInfo.Name(), action.Action, res, err)
 }
 
-func refreshCandidates(ctx context.Context, st *state.State, names []string, user *auth.UserState, flags *store.RefreshOptions) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
+func currentSnaps(st *state.State) ([]*store.CurrentSnap, error) {
+	snapStates, err := All(st)
+	if err != nil {
+		return nil, err
+	}
+
+	curSnaps := collectCurrentSnaps(snapStates, nil)
+	return curSnaps, nil
+}
+
+func collectCurrentSnaps(snapStates map[string]*SnapState, consider func(*store.CurrentSnap, *SnapState)) (curSnaps []*store.CurrentSnap) {
+	curSnaps = make([]*store.CurrentSnap, 0, len(snapStates))
+
+	for snapName, snapst := range snapStates {
+		if snapst.TryMode {
+			// try mode snaps are completely local and
+			// irrelevant for the operation
+			continue
+		}
+
+		snapInfo, err := snapst.CurrentInfo()
+		if err != nil {
+			continue
+		}
+
+		if snapInfo.SnapID == "" {
+			// the store won't be able to tell what this
+			// is and so cannot include it in the
+			// operation
+			continue
+		}
+
+		installed := &store.CurrentSnap{
+			Name:   snapName,
+			SnapID: snapInfo.SnapID,
+			// the desired channel (not snapInfo.Channel!)
+			TrackingChannel:  snapst.Channel,
+			Revision:         snapInfo.Revision,
+			RefreshedDate:    revisionDate(snapInfo),
+			IgnoreValidation: snapst.IgnoreValidation,
+		}
+		curSnaps = append(curSnaps, installed)
+
+		if consider != nil {
+			consider(installed, snapst)
+		}
+	}
+
+	return curSnaps
+}
+
+func refreshCandidates(ctx context.Context, st *state.State, names []string, user *auth.UserState, opts *store.RefreshOptions) ([]*snap.Info, map[string]*SnapState, map[string]bool, error) {
 	snapStates, err := All(st)
 	if err != nil {
 		return nil, nil, nil, err
@@ -204,93 +322,69 @@ func refreshCandidates(ctx context.Context, st *state.State, names []string, use
 
 	sort.Strings(names)
 
+	actionsByUserID := make(map[int][]*store.SnapAction)
 	stateByID := make(map[string]*SnapState, len(snapStates))
-	candidatesInfo := make([]*store.RefreshCandidate, 0, len(snapStates))
 	ignoreValidation := make(map[string]bool)
-	userIDs := make(map[int]bool)
-	for _, snapst := range snapStates {
-		if len(names) == 0 && (snapst.TryMode || snapst.DevMode) {
-			// no auto-refresh for trymode nor devmode
-			continue
-		}
+	fallbackID := idForUser(user)
+	nCands := 0
 
+	addCand := func(installed *store.CurrentSnap, snapst *SnapState) {
 		// FIXME: snaps that are not active are skipped for now
 		//        until we know what we want to do
 		if !snapst.Active {
-			continue
+			return
 		}
 
-		snapInfo, err := snapst.CurrentInfo()
-		if err != nil {
-			// log something maybe?
-			continue
+		if len(names) == 0 && snapst.DevMode {
+			// no auto-refresh for devmode
+			return
 		}
 
-		if snapInfo.SnapID == "" {
-			// no refresh for sideloaded
-			continue
+		if len(names) > 0 && !strutil.SortedListContains(names, installed.Name) {
+			return
 		}
 
-		if len(names) > 0 && !strutil.SortedListContains(names, snapInfo.Name()) {
-			continue
-		}
-
-		stateByID[snapInfo.SnapID] = snapst
-
-		// get confinement preference from the snapstate
-		candidateInfo := &store.RefreshCandidate{
-			// the desired channel (not info.Channel!)
-			Channel:          snapst.Channel,
-			SnapID:           snapInfo.SnapID,
-			Revision:         snapInfo.Revision,
-			Epoch:            snapInfo.Epoch,
-			IgnoreValidation: snapst.IgnoreValidation,
-		}
+		stateByID[installed.SnapID] = snapst
 
 		if len(names) == 0 {
-			candidateInfo.Block = snapst.Block()
+			installed.Block = snapst.Block()
 		}
 
-		candidatesInfo = append(candidatesInfo, candidateInfo)
-		if snapst.UserID != 0 {
-			userIDs[snapst.UserID] = true
+		userID := snapst.UserID
+		if userID == 0 {
+			userID = fallbackID
 		}
+		actionsByUserID[userID] = append(actionsByUserID[userID], &store.SnapAction{
+			Action: "refresh",
+			SnapID: installed.SnapID,
+		})
 		if snapst.IgnoreValidation {
-			ignoreValidation[snapInfo.SnapID] = true
+			ignoreValidation[installed.SnapID] = true
 		}
+		nCands++
 	}
+	// determine current snaps and collect candidates for refresh
+	curSnaps := collectCurrentSnaps(snapStates, addCand)
 
 	theStore := Store(st)
 
-	// TODO: we query for all snaps for each user so that the
-	// store can take into account validation constraints, we can
-	// do better with coming APIs
-	updatesInfo := make(map[string]*snap.Info, len(candidatesInfo))
-	fallbackUsed := false
-	fallbackID := idForUser(user)
-	if len(userIDs) == 0 {
-		// none of the snaps had an installed user set, just
-		// use the fallbackID
-		userIDs[fallbackID] = true
-	}
-	for userID := range userIDs {
+	updatesInfo := make(map[string]*snap.Info, nCands)
+	for userID, actions := range actionsByUserID {
 		u, err := userFromUserIDOrFallback(st, userID, user)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		// consider the fallback user at most once
-		if idForUser(u) == fallbackID {
-			if fallbackUsed {
-				continue
-			}
-			fallbackUsed = true
-		}
 
 		st.Unlock()
-		updatesForUser, err := theStore.ListRefresh(ctx, candidatesInfo, u, flags)
+		updatesForUser, err := theStore.SnapAction(ctx, curSnaps, actions, u, opts)
 		st.Lock()
 		if err != nil {
-			return nil, nil, nil, err
+			saErr, ok := err.(*store.SnapActionError)
+			if !ok {
+				return nil, nil, nil, err
+			}
+			// TODO: use the warning infra here when we have it
+			logger.Noticef("%v", saErr)
 		}
 
 		for _, snapInfo := range updatesForUser {

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -68,7 +68,7 @@ type storeSnapDelta struct {
 	Size     int64  `json:"size"`
 	Source   int    `json:"source"`
 	Target   int    `json:"target"`
-	URL      string `json:"url,omitempty"`
+	URL      string `json:"url"`
 }
 
 type storeAccount struct {

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -1,0 +1,177 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+// storeSnap holds the information sent as JSON by the store for a snap.
+type storeSnap struct {
+	Architectures []string          `json:"architectures"`
+	Base          string            `json:"base"`
+	Confinement   string            `json:"confinement"`
+	Contact       string            `json:"contact"`
+	CreatedAt     string            `json:"created-at"` // revision timestamp
+	Description   string            `json:"description"`
+	Download      storeSnapDownload `json:"download"`
+	Epoch         snap.Epoch        `json:"epoch"`
+	License       string            `json:"license"`
+	Name          string            `json:"name"`
+	Prices        map[string]string `json:"prices"` // currency->price,  free: {"USD": "0"}
+	Private       bool              `json:"private"`
+	Publisher     storeAccount      `json:"publisher"`
+	Revision      int               `json:"revision"` // store revisions are ints starting at 1
+	SnapID        string            `json:"snap-id"`
+	SnapYAML      string            `json:"snap-yaml"` // optional
+	Summary       string            `json:"summary"`
+	Title         string            `json:"title"`
+	Type          snap.Type         `json:"type"`
+	Version       string            `json:"version"`
+
+	// TODO: not yet defined: channel map
+
+	// media
+	Media []storeSnapMedia `json:"media"`
+}
+
+type storeSnapDownload struct {
+	Sha3_384 string           `json:"sha3-384"`
+	Size     int64            `json:"size"`
+	URL      string           `json:"url"`
+	Deltas   []storeSnapDelta `json:"deltas"`
+}
+
+type storeSnapDelta struct {
+	Format   string `json:"format"`
+	Sha3_384 string `json:"sha3-384"`
+	Size     int64  `json:"size"`
+	Source   int    `json:"source"`
+	Target   int    `json:"target"`
+	URL      string `json:"url,omitempty"`
+}
+
+type storeAccount struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`  // aka username
+	Title string `json:"title"` // aka display-name
+}
+
+type storeSnapMedia struct {
+	Type   string `json:"type"` // icon/screenshot
+	URL    string `json:"url"`
+	Width  int64  `json:"width"`
+	Height int64  `json:"height"`
+}
+
+func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
+	info := &snap.Info{}
+	info.RealName = d.Name
+	info.Revision = snap.R(d.Revision)
+	info.SnapID = d.SnapID
+	info.EditedTitle = d.Title
+	info.EditedSummary = d.Summary
+	info.EditedDescription = d.Description
+	info.Private = d.Private
+	info.Contact = d.Contact
+	info.Architectures = d.Architectures
+	info.Type = d.Type
+	info.Version = d.Version
+	info.Epoch = d.Epoch
+	info.Confinement = snap.ConfinementType(d.Confinement)
+	info.Base = d.Base
+	info.License = d.License
+	info.PublisherID = d.Publisher.ID
+	info.Publisher = d.Publisher.Name
+	info.DownloadURL = d.Download.URL
+	info.Size = d.Download.Size
+	info.Sha3_384 = d.Download.Sha3_384
+	if len(d.Download.Deltas) > 0 {
+		deltas := make([]snap.DeltaInfo, len(d.Download.Deltas))
+		for i, d := range d.Download.Deltas {
+			deltas[i] = snap.DeltaInfo{
+				FromRevision: d.Source,
+				ToRevision:   d.Target,
+				Format:       d.Format,
+				DownloadURL:  d.URL,
+				Size:         d.Size,
+				Sha3_384:     d.Sha3_384,
+			}
+		}
+		info.Deltas = deltas
+	}
+
+	// fill in the plug/slot data
+	if rawYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {
+		if info.Plugs == nil {
+			info.Plugs = make(map[string]*snap.PlugInfo)
+		}
+		for k, v := range rawYamlInfo.Plugs {
+			info.Plugs[k] = v
+			info.Plugs[k].Snap = info
+		}
+		if info.Slots == nil {
+			info.Slots = make(map[string]*snap.SlotInfo)
+		}
+		for k, v := range rawYamlInfo.Slots {
+			info.Slots[k] = v
+			info.Slots[k].Snap = info
+		}
+	}
+
+	// convert prices
+	if len(d.Prices) > 0 {
+		prices := make(map[string]float64, len(d.Prices))
+		for currency, priceStr := range d.Prices {
+			price, err := strconv.ParseFloat(priceStr, 64)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse snap price: %v", err)
+			}
+			prices[currency] = price
+		}
+		info.Paid = true
+		info.Prices = prices
+	}
+
+	// media
+	screenshots := make([]snap.ScreenshotInfo, 0, len(d.Media))
+	for _, mediaObj := range d.Media {
+		switch mediaObj.Type {
+		case "icon":
+			if info.IconURL == "" {
+				info.IconURL = mediaObj.URL
+			}
+		case "screenshot":
+			screenshots = append(screenshots, snap.ScreenshotInfo{
+				URL:    mediaObj.URL,
+				Width:  mediaObj.Width,
+				Height: mediaObj.Height,
+			})
+		}
+	}
+	if len(screenshots) > 0 {
+		info.Screenshots = screenshots
+	}
+
+	return info, nil
+}

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -72,9 +72,9 @@ type storeSnapDelta struct {
 }
 
 type storeAccount struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`  // aka username
-	Title string `json:"title"` // aka display-name
+	ID          string `json:"id"`
+	Username    string `json:"username"`
+	DisplayName string `json:"display-name"`
 }
 
 type storeSnapMedia struct {
@@ -102,7 +102,7 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	info.Base = d.Base
 	info.License = d.License
 	info.PublisherID = d.Publisher.ID
-	info.Publisher = d.Publisher.Name
+	info.Publisher = d.Publisher.Username
 	info.DownloadURL = d.Download.URL
 	info.Size = d.Download.Size
 	info.Sha3_384 = d.Download.Sha3_384

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -61,8 +61,8 @@ const (
   "private": false,
   "publisher": {
      "id": "canonical",
-     "name": "canonical",
-     "title": "Canonical"
+     "username": "canonical",
+     "display-name": "Canonical"
   },
   "revision": 3887,
   "snap-id": "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
@@ -107,8 +107,8 @@ const (
   "private": false,
   "publisher": {
      "id": "ZvtzsxbsHivZLdvzrt0iqW529riGLfXJ",
-     "name": "thingyinc",
-     "title": "Thingy Inc."
+     "username": "thingyinc",
+     "display-name": "Thingy Inc."
   },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -1,0 +1,250 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package store
+
+import (
+	"encoding/json"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+type detailsV2Suite struct{}
+
+var _ = Suite(&detailsV2Suite{})
+
+const (
+	coreStoreJSON = `{
+  "architectures": [
+    "amd64"
+  ],
+  "base": null,
+  "confinement": "strict",
+  "contact": "mailto:snappy-canonical-storeaccount@canonical.com",
+  "created-at": "2018-01-22T07:49:19.440720+00:00",
+  "description": "The core runtime environment for snapd",
+  "download": {
+     "sha3-384": "b691f6dde3d8022e4db563840f0ef82320cb824b6292ffd027dbc838535214dac31c3512c619beaf73f1aeaf35ac62d5",
+     "size": 85291008,
+     "url": "https://api.snapcraft.io/api/v1/snaps/download/99T7MUlRhtI3U0QFgl5mXXESAiSwt776_3887.snap",
+     "deltas": []
+  },
+  "epoch": {
+     "read": [0],
+     "write": [0]
+  },
+  "license": null,
+  "name": "core",
+  "prices": {},
+  "private": false,
+  "publisher": {
+     "id": "canonical",
+     "name": "canonical",
+     "title": "Canonical"
+  },
+  "revision": 3887,
+  "snap-id": "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
+  "summary": "snapd runtime environment",
+  "title": "core",
+  "type": "os",
+  "version": "16-2.30",
+  "media": []
+}`
+
+	thingyStoreJSON = `{
+  "architectures": [
+    "amd64"
+  ],
+  "base": "base-18",
+  "confinement": "strict",
+  "contact": "https://thingy.com",
+  "created-at": "2018-01-26T11:38:35.536410+00:00",
+  "description": "Useful thingy for thinging",
+  "download": {
+     "sha3-384": "a29f8d894c92ad19bb943764eb845c6bd7300f555ee9b9dbb460599fecf712775c0f3e2117b5c56b08fcb9d78fc8ae4d",
+     "size": 10000021,
+     "url": "https://api.snapcraft.io/api/v1/snaps/download/XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap",
+     "deltas": [
+       {
+         "format": "xdelta3",
+         "source": 19,
+         "target": 21,
+         "url": "https://api.snapcraft.io/api/v1/snaps/download/XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV_19_21_xdelta3.delta",
+         "size": 9999,
+         "sha3-384": "29f8d894c92ad19bb943764eb845c6bd7300f555ee9b9dbb460599fecf712775c0f3e2117b5c56b08fcb9d78fc8ae4df"
+       }
+     ]
+  },
+  "epoch": {
+     "read": [0,1],
+     "write": [1]
+  },
+  "license": "Proprietary",
+  "name": "thingy",
+  "prices": {"USD": "9.99"},
+  "private": false,
+  "publisher": {
+     "id": "ZvtzsxbsHivZLdvzrt0iqW529riGLfXJ",
+     "name": "thingyinc",
+     "title": "Thingy Inc."
+  },
+  "revision": 21,
+  "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
+  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\napps:\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\n",
+  "summary": "useful thingy",
+  "title": "thingy",
+  "type": "app",
+  "version": "9.50",
+  "media": [
+     {"type": "icon", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Thingy.png"},
+     {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
+     {"type": "screenshot", "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", "width": 600, "height": 200}
+  ]
+}`
+)
+
+func (s *detailsV2Suite) TestInfoFromStoreSnapSimple(c *C) {
+	var snp storeSnap
+	err := json.Unmarshal([]byte(coreStoreJSON), &snp)
+	c.Assert(err, IsNil)
+
+	info, err := infoFromStoreSnap(&snp)
+	c.Assert(err, IsNil)
+	c.Check(snap.Validate(info), IsNil)
+
+	c.Check(info, DeepEquals, &snap.Info{
+		Architectures: []string{"amd64"},
+		SideInfo: snap.SideInfo{
+			RealName:          "core",
+			SnapID:            "99T7MUlRhtI3U0QFgl5mXXESAiSwt776",
+			Revision:          snap.R(3887),
+			Contact:           "mailto:snappy-canonical-storeaccount@canonical.com",
+			EditedTitle:       "core",
+			EditedSummary:     "snapd runtime environment",
+			EditedDescription: "The core runtime environment for snapd",
+			Private:           false,
+			Paid:              false,
+		},
+		Epoch:       *snap.E("0"),
+		Type:        snap.TypeOS,
+		Version:     "16-2.30",
+		Confinement: snap.StrictConfinement,
+		PublisherID: "canonical",
+		Publisher:   "canonical",
+		DownloadInfo: snap.DownloadInfo{
+			DownloadURL: "https://api.snapcraft.io/api/v1/snaps/download/99T7MUlRhtI3U0QFgl5mXXESAiSwt776_3887.snap",
+			Sha3_384:    "b691f6dde3d8022e4db563840f0ef82320cb824b6292ffd027dbc838535214dac31c3512c619beaf73f1aeaf35ac62d5",
+			Size:        85291008,
+		},
+		Plugs: make(map[string]*snap.PlugInfo),
+		Slots: make(map[string]*snap.SlotInfo),
+	})
+}
+
+func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
+	var snp storeSnap
+	// base, prices, media
+	err := json.Unmarshal([]byte(thingyStoreJSON), &snp)
+	c.Assert(err, IsNil)
+
+	info, err := infoFromStoreSnap(&snp)
+	c.Assert(err, IsNil)
+	c.Check(snap.Validate(info), IsNil)
+
+	info2 := *info
+	// clear recursive bits
+	info2.Plugs = nil
+	info2.Slots = nil
+	c.Check(&info2, DeepEquals, &snap.Info{
+		Architectures: []string{"amd64"},
+		Base:          "base-18",
+		SideInfo: snap.SideInfo{
+			RealName:          "thingy",
+			SnapID:            "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
+			Revision:          snap.R(21),
+			Contact:           "https://thingy.com",
+			EditedTitle:       "thingy",
+			EditedSummary:     "useful thingy",
+			EditedDescription: "Useful thingy for thinging",
+			Private:           false,
+			Paid:              true,
+		},
+		Epoch: snap.Epoch{
+			Read:  []uint32{0, 1},
+			Write: []uint32{1},
+		},
+		Type:        snap.TypeApp,
+		Version:     "9.50",
+		Confinement: snap.StrictConfinement,
+		License:     "Proprietary",
+		PublisherID: "ZvtzsxbsHivZLdvzrt0iqW529riGLfXJ",
+		Publisher:   "thingyinc",
+		DownloadInfo: snap.DownloadInfo{
+			DownloadURL: "https://api.snapcraft.io/api/v1/snaps/download/XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV_21.snap",
+			Sha3_384:    "a29f8d894c92ad19bb943764eb845c6bd7300f555ee9b9dbb460599fecf712775c0f3e2117b5c56b08fcb9d78fc8ae4d",
+			Size:        10000021,
+			Deltas: []snap.DeltaInfo{
+				{
+					Format:       "xdelta3",
+					FromRevision: 19,
+					ToRevision:   21,
+					DownloadURL:  "https://api.snapcraft.io/api/v1/snaps/download/XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV_19_21_xdelta3.delta",
+					Size:         9999,
+					Sha3_384:     "29f8d894c92ad19bb943764eb845c6bd7300f555ee9b9dbb460599fecf712775c0f3e2117b5c56b08fcb9d78fc8ae4df",
+				},
+			},
+		},
+		Prices: map[string]float64{
+			"USD": 9.99,
+		},
+		IconURL: "https://dashboard.snapcraft.io/site_media/appmedia/2017/12/Thingy.png",
+		Screenshots: []snap.ScreenshotInfo{
+			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
+			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", Width: 600, Height: 200},
+		},
+	})
+
+	// validate the plugs/slots
+	c.Assert(info.Plugs, HasLen, 1)
+	plug := info.Plugs["shared-content-plug"]
+	c.Check(plug.Name, Equals, "shared-content-plug")
+	c.Check(plug.Snap, Equals, info)
+	c.Check(plug.Apps, HasLen, 1)
+	c.Check(plug.Apps["content-plug"].Command, Equals, "bin/content-plug")
+
+	c.Assert(info.Slots, HasLen, 1)
+	slot := info.Slots["shared-content-slot"]
+	c.Check(slot.Name, Equals, "shared-content-slot")
+	c.Check(slot.Snap, Equals, info)
+	c.Check(slot.Apps, HasLen, 1)
+	c.Check(slot.Apps["content-plug"].Command, Equals, "bin/content-plug")
+
+	// private
+	err = json.Unmarshal([]byte(strings.Replace(thingyStoreJSON, `"private": false`, `"private": true`, 1)), &snp)
+	c.Assert(err, IsNil)
+
+	info, err = infoFromStoreSnap(&snp)
+	c.Assert(err, IsNil)
+	c.Check(snap.Validate(info), IsNil)
+
+	c.Check(info.Private, Equals, true)
+}

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -31,7 +31,9 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
-type detailsV2Suite struct{}
+type detailsV2Suite struct {
+	testutil.BaseTest
+}
 
 var _ = Suite(&detailsV2Suite{})
 
@@ -124,6 +126,15 @@ const (
   ]
 }`
 )
+
+func (s *detailsV2Suite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
+}
+
+func (s *detailsV2Suite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+}
 
 func (s *detailsV2Suite) TestInfoFromStoreSnapSimple(c *C) {
 	var snp storeSnap

--- a/store/errors.go
+++ b/store/errors.go
@@ -182,9 +182,6 @@ var (
 func translateSnapActionError(action, code, message string) error {
 	switch code {
 	case "revision-not-found":
-		if action == "refresh" {
-			return ErrNoUpdateAvailable
-		}
 		return ErrRevisionNotAvailable
 	case "id-not-found", "name-not-found":
 		return ErrSnapNotFound

--- a/store/errors.go
+++ b/store/errors.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -61,6 +61,9 @@ var (
 
 	// ErrNoUpdateAvailable is returned when an update is attempetd for a snap that has no update available.
 	ErrNoUpdateAvailable = errors.New("snap has no updates available")
+
+	// ErrRevisionNotAvailable is returned when an install is attempted for a snap but the/a revision is not available (given install constraints)
+	ErrRevisionNotAvailable = errors.New("no snap revision given constraints")
 )
 
 // DownloadError represents a download error
@@ -106,4 +109,90 @@ func (e InvalidAuthDataError) Error() string {
 	//      full sentences (with periods and capitalization)
 	//      (empirically this checks out)
 	return strings.Join(es, "  ")
+}
+
+// SnapActionError conveys errors that were reported on otherwise overall successful snap action (install/refresh) request.
+type SnapActionError struct {
+	// NoResults is set if the there were no results in the response
+	NoResults bool
+	// Refresh errors by snap name.
+	Refresh map[string]error
+	// Install errors by snap name.
+	Install map[string]error
+	// Other errors.
+	Other []error
+}
+
+func (e SnapActionError) Error() string {
+	nRefresh := len(e.Refresh)
+	nInstall := len(e.Install)
+	nOther := len(e.Other)
+
+	// single error
+	if nRefresh+nInstall+nOther == 1 {
+		if nOther == 0 {
+			op := "refresh"
+			errs := e.Refresh
+			if nInstall > 0 {
+				op = "install"
+				errs = e.Install
+			}
+			for name, e := range errs {
+				return fmt.Sprintf("cannot %s snap %q: %v", op, name, e)
+			}
+		} else {
+			return fmt.Sprintf("cannot refresh or install: %v", e.Other[0])
+		}
+	}
+
+	header := "cannot refresh:"
+	if nInstall > 0 {
+		header = "cannot install:"
+	}
+	if nOther > 0 || (nInstall > 0 && nRefresh > 0) {
+		header = "cannot refresh or install:"
+	}
+	es := []string{header}
+
+	for name, e := range e.Refresh {
+		es = append(es, fmt.Sprintf("snap %q: %v", name, e))
+	}
+
+	for name, e := range e.Install {
+		es = append(es, fmt.Sprintf("snap %q: %v", name, e))
+	}
+
+	for _, e := range e.Other {
+		es = append(es, fmt.Sprintf("* %v", e))
+	}
+
+	if e.NoResults && len(es) == 1 {
+		// this is an atypical result
+		return "no install/refresh information results from the store"
+	}
+	return strings.Join(es, "\n")
+}
+
+// Authorization soft-expiry errors that get handled automatically.
+var (
+	errUserAuthorizationNeedsRefresh   = errors.New("soft-expired user authorization needs refresh")
+	errDeviceAuthorizationNeedsRefresh = errors.New("soft-expired device authorization needs refresh")
+)
+
+func translateSnapActionError(action, code, message string) error {
+	switch code {
+	case "revision-not-found":
+		if action == "refresh" {
+			return ErrNoUpdateAvailable
+		}
+		return ErrRevisionNotAvailable
+	case "id-not-found", "name-not-found":
+		return ErrSnapNotFound
+	case "user-authorization-needs-refresh":
+		return errUserAuthorizationNeedsRefresh
+	case "device-authorization-needs-refresh":
+		return errDeviceAuthorizationNeedsRefresh
+	default:
+		return fmt.Errorf("%v", message)
+	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2017 Canonical Ltd
+ * Copyright (C) 2014-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -333,6 +333,7 @@ func apiURL() *url.URL {
 func storeURL(api *url.URL) (*url.URL, error) {
 	var override string
 	var overrideName string
+	// XXX: time to drop FORCE_CPI support
 	// XXX: Deprecated but present for backward-compatibility: this used
 	// to be "Click Package Index".  Remove this once people have got
 	// used to SNAPPY_FORCE_API_URL instead.
@@ -489,6 +490,8 @@ const (
 	customersMeEndpPath = "api/v1/snaps/purchases/customers/me"
 	sectionsEndpPath    = "api/v1/snaps/sections"
 	commandsEndpPath    = "api/v1/snaps/names"
+	// v2
+	snapActionEndpPath = "v2/snaps/refresh"
 
 	deviceNonceEndpPath   = "api/v1/snaps/auth/nonces"
 	deviceSessionEndpPath = "api/v1/snaps/auth/sessions"
@@ -693,13 +696,13 @@ func (s *Store) refreshDeviceSession(device *auth.DeviceState) error {
 }
 
 // authenticateDevice will add the store expected Macaroon X-Device-Authorization header for device
-func authenticateDevice(r *http.Request, device *auth.DeviceState) {
+func authenticateDevice(r *http.Request, device *auth.DeviceState, apiLevel apiLevel) {
 	if device.SessionMacaroon != "" {
-		r.Header.Set("X-Device-Authorization", fmt.Sprintf(`Macaroon root="%s"`, device.SessionMacaroon))
+		r.Header.Set(hdrSnapDeviceAuthorization[apiLevel], fmt.Sprintf(`Macaroon root="%s"`, device.SessionMacaroon))
 	}
 }
 
-func (s *Store) setStoreID(r *http.Request) (customStore bool) {
+func (s *Store) setStoreID(r *http.Request, apiLevel apiLevel) (customStore bool) {
 	storeID := s.fallbackStoreID
 	if s.authContext != nil {
 		cand, err := s.authContext.StoreID(storeID)
@@ -710,11 +713,26 @@ func (s *Store) setStoreID(r *http.Request) (customStore bool) {
 		}
 	}
 	if storeID != "" {
-		r.Header.Set("X-Ubuntu-Store", storeID)
+		r.Header.Set(hdrSnapDeviceStore[apiLevel], storeID)
 		return true
 	}
 	return false
 }
+
+type apiLevel int
+
+const (
+	apiV1Endps apiLevel = 0 // api/v1 endpoints
+	apiV2Endps apiLevel = 1 // v2 endpoints
+)
+
+var (
+	hdrSnapDeviceAuthorization = []string{"X-Device-Authorization", "Snap-Device-Authorization"}
+	hdrSnapDeviceStore         = []string{"X-Ubuntu-Store", "Snap-Device-Store"}
+	hdrSnapDeviceSeries        = []string{"X-Ubuntu-Series", "Snap-Device-Series"}
+	hdrSnapDeviceArchitecture  = []string{"X-Ubuntu-Architecture", "Snap-Device-Architecture"}
+	hdrSnapClassic             = []string{"X-Ubuntu-Classic", "Snap-Classic"}
+)
 
 type deviceAuthNeed int
 
@@ -729,6 +747,7 @@ type requestOptions struct {
 	URL          *url.URL
 	Accept       string
 	ContentType  string
+	APILevel     apiLevel
 	ExtraHeaders map[string]string
 	Data         []byte
 
@@ -874,18 +893,15 @@ func (s *Store) doRequest(ctx context.Context, client *http.Client, reqOptions *
 			// 4 tries: 2 tries for each in case both user
 			// and device need refreshing
 			var refreshNeed authRefreshNeed
-			refresh := false
 			if user != nil && strings.Contains(wwwAuth, "needs_refresh=1") {
 				// refresh user
 				refreshNeed.user = true
-				refresh = true
 			}
 			if strings.Contains(wwwAuth, "refresh_device_session=1") {
 				// refresh device session
 				refreshNeed.device = true
-				refresh = true
 			}
-			if refresh {
+			if refreshNeed.needed() {
 				err := s.refreshAuth(user, refreshNeed)
 				if err != nil {
 					return nil, err
@@ -901,110 +917,13 @@ func (s *Store) doRequest(ctx context.Context, client *http.Client, reqOptions *
 	}
 }
 
-// build a new http.Request with headers for the store
-func (s *Store) newRequest(reqOptions *requestOptions, user *auth.UserState) (*http.Request, error) {
-	var body io.Reader
-	if reqOptions.Data != nil {
-		body = bytes.NewBuffer(reqOptions.Data)
-	}
-
-	req, err := http.NewRequest(reqOptions.Method, reqOptions.URL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	customStore := s.setStoreID(req)
-
-	if s.authContext != nil && (customStore || reqOptions.DeviceAuthNeed != deviceAuthCustomStoreOnly) {
-		device, err := s.authContext.Device()
-		if err != nil {
-			return nil, err
-		}
-		// we don't have a session yet but have a serial, try
-		// to get a session
-		if device.SessionMacaroon == "" && device.Serial != "" {
-			err = s.refreshDeviceSession(device)
-			if err == auth.ErrNoSerial {
-				// missing serial assertion, log and continue without device authentication
-				logger.Debugf("cannot set device session: %v", err)
-			}
-			if err != nil && err != auth.ErrNoSerial {
-				return nil, err
-			}
-		}
-		authenticateDevice(req, device)
-	}
-
-	// only set user authentication if user logged in to the store
-	if hasStoreAuth(user) {
-		authenticateUser(req, user)
-	}
-
-	req.Header.Set("User-Agent", httputil.UserAgent())
-	req.Header.Set("Accept", reqOptions.Accept)
-	req.Header.Set("X-Ubuntu-Architecture", s.architecture)
-	req.Header.Set("X-Ubuntu-Series", s.series)
-	req.Header.Set("X-Ubuntu-Classic", strconv.FormatBool(release.OnClassic))
-	req.Header.Set("X-Ubuntu-Wire-Protocol", UbuntuCoreWireProtocol)
-	// still send this for now
-	req.Header.Set("X-Ubuntu-No-CDN", strconv.FormatBool(s.noCDN))
-	// TODO: do this only for download
-	err = s.cdnHeader(req, reqOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	if reqOptions.ContentType != "" {
-		req.Header.Set("Content-Type", reqOptions.ContentType)
-	}
-
-	for header, value := range reqOptions.ExtraHeaders {
-		req.Header.Set(header, value)
-	}
-
-	return req, nil
-}
-
-func (s *Store) cdnHeader(req *http.Request, reqOptions *requestOptions) error {
-	if s.noCDN {
-		req.Header.Set("Snap-CDN", "none")
-		return nil
-	}
-
-	if s.authContext == nil {
-		return nil
-	}
-
-	// set Snap-CDN from cloud instance information
-	// if available
-
-	// TODO: do we want a more complex retry strategy
-	// where we first to send this header and if the
-	// operation fails that way to even get the connection
-	// then we retry without sending this?
-
-	cloudInfo, err := s.authContext.CloudInfo()
-	if err != nil {
-		return err
-	}
-
-	if cloudInfo != nil {
-		cdnParams := []string{fmt.Sprintf("cloud-name=%q", cloudInfo.Name)}
-		if cloudInfo.Region != "" {
-			cdnParams = append(cdnParams, fmt.Sprintf("region=%q", cloudInfo.Region))
-		}
-		if cloudInfo.AvailabilityZone != "" {
-			cdnParams = append(cdnParams, fmt.Sprintf("availability-zone=%q", cloudInfo.AvailabilityZone))
-		}
-
-		req.Header.Set("Snap-CDN", strings.Join(cdnParams, " "))
-	}
-	return nil
-}
-
 type authRefreshNeed struct {
 	device bool
 	user   bool
+}
+
+func (rn *authRefreshNeed) needed() bool {
+	return rn.device || rn.user
 }
 
 func (s *Store) refreshAuth(user *auth.UserState, need authRefreshNeed) error {
@@ -1031,6 +950,102 @@ func (s *Store) refreshAuth(user *auth.UserState, need authRefreshNeed) error {
 		}
 	}
 	return nil
+}
+
+// build a new http.Request with headers for the store
+func (s *Store) newRequest(reqOptions *requestOptions, user *auth.UserState) (*http.Request, error) {
+	var body io.Reader
+	if reqOptions.Data != nil {
+		body = bytes.NewBuffer(reqOptions.Data)
+	}
+
+	req, err := http.NewRequest(reqOptions.Method, reqOptions.URL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	customStore := s.setStoreID(req, reqOptions.APILevel)
+
+	if s.authContext != nil && (customStore || reqOptions.DeviceAuthNeed != deviceAuthCustomStoreOnly) {
+		device, err := s.authContext.Device()
+		if err != nil {
+			return nil, err
+		}
+		// we don't have a session yet but have a serial, try
+		// to get a session
+		if device.SessionMacaroon == "" && device.Serial != "" {
+			err = s.refreshDeviceSession(device)
+			if err == auth.ErrNoSerial {
+				// missing serial assertion, log and continue without device authentication
+				logger.Debugf("cannot set device session: %v", err)
+			}
+			if err != nil && err != auth.ErrNoSerial {
+				return nil, err
+			}
+		}
+		authenticateDevice(req, device, reqOptions.APILevel)
+	}
+
+	// only set user authentication if user logged in to the store
+	if hasStoreAuth(user) {
+		authenticateUser(req, user)
+	}
+
+	req.Header.Set("User-Agent", httputil.UserAgent())
+	req.Header.Set("Accept", reqOptions.Accept)
+	req.Header.Set(hdrSnapDeviceArchitecture[reqOptions.APILevel], s.architecture)
+	req.Header.Set(hdrSnapDeviceSeries[reqOptions.APILevel], s.series)
+	req.Header.Set(hdrSnapClassic[reqOptions.APILevel], strconv.FormatBool(release.OnClassic))
+	if reqOptions.APILevel == apiV1Endps {
+		req.Header.Set("X-Ubuntu-Wire-Protocol", UbuntuCoreWireProtocol)
+	}
+
+	if reqOptions.ContentType != "" {
+		req.Header.Set("Content-Type", reqOptions.ContentType)
+	}
+
+	for header, value := range reqOptions.ExtraHeaders {
+		req.Header.Set(header, value)
+	}
+
+	return req, nil
+}
+
+func (s *Store) cdnHeader() (string, error) {
+	if s.noCDN {
+		return "none", nil
+	}
+
+	if s.authContext == nil {
+		return "", nil
+	}
+
+	// set Snap-CDN from cloud instance information
+	// if available
+
+	// TODO: do we want a more complex retry strategy
+	// where we first to send this header and if the
+	// operation fails that way to even get the connection
+	// then we retry without sending this?
+
+	cloudInfo, err := s.authContext.CloudInfo()
+	if err != nil {
+		return "", err
+	}
+
+	if cloudInfo != nil {
+		cdnParams := []string{fmt.Sprintf("cloud-name=%q", cloudInfo.Name)}
+		if cloudInfo.Region != "" {
+			cdnParams = append(cdnParams, fmt.Sprintf("region=%q", cloudInfo.Region))
+		}
+		if cloudInfo.AvailabilityZone != "" {
+			cdnParams = append(cdnParams, fmt.Sprintf("availability-zone=%q", cloudInfo.AvailabilityZone))
+		}
+
+		return strings.Join(cdnParams, " "), nil
+	}
+
+	return "", nil
 }
 
 func (s *Store) extractSuggestedCurrency(resp *http.Response) {
@@ -1674,21 +1689,29 @@ var download = func(ctx context.Context, name, sha3_384, downloadURL string, use
 		return err
 	}
 
+	cdnHeader, err := s.cdnHeader()
+	if err != nil {
+		return err
+	}
+
 	var finalErr error
 	startTime := time.Now()
 	for attempt := retry.Start(defaultRetryStrategy, nil); attempt.Next(); {
 		reqOptions := &requestOptions{
-			Method: "GET",
-			URL:    storeURL,
+			Method:       "GET",
+			URL:          storeURL,
+			ExtraHeaders: make(map[string]string),
 		}
+		if cdnHeader != "" {
+			reqOptions.ExtraHeaders["Snap-CDN"] = cdnHeader
+		}
+
 		httputil.MaybeLogRetryAttempt(reqOptions.URL.String(), attempt, startTime)
 
 		h := crypto.SHA3_384.New()
 
 		if resume > 0 {
-			reqOptions.ExtraHeaders = map[string]string{
-				"Range": fmt.Sprintf("bytes=%d-", resume),
-			}
+			reqOptions.ExtraHeaders["Range"] = fmt.Sprintf("bytes=%d-", resume)
 			// seed the sha3 with the already local file
 			if _, err := w.Seek(0, os.SEEK_SET); err != nil {
 				return err
@@ -2142,4 +2165,297 @@ func (s *Store) SetCacheDownloads(fileCount int) {
 	} else {
 		s.cacher = &nullCache{}
 	}
+}
+
+// snap action: install/refresh
+
+type CurrentSnap struct {
+	Name             string
+	SnapID           string
+	Revision         snap.Revision
+	TrackingChannel  string
+	RefreshedDate    time.Time
+	IgnoreValidation bool
+	Block            []snap.Revision
+}
+
+type currentSnapV2JSON struct {
+	SnapID           string     `json:"snap-id"`
+	InstanceKey      string     `json:"instance-key"`
+	Revision         int        `json:"revision"`
+	TrackingChannel  string     `json:"tracking-channel"`
+	RefreshedDate    *time.Time `json:"refreshed-date,omitempty"`
+	IgnoreValidation bool       `json:"ignore-validation,omitempty"`
+}
+
+type SnapActionFlags int
+
+const (
+	SnapActionIgnoreValidation SnapActionFlags = 1 << iota
+	SnapActionEnforceValidation
+)
+
+type SnapAction struct {
+	Action   string
+	Name     string
+	SnapID   string
+	Channel  string
+	Revision snap.Revision
+	Flags    SnapActionFlags
+	Epoch    *snap.Epoch
+}
+
+type snapActionJSON struct {
+	Action           string      `json:"action"`
+	InstanceKey      string      `json:"instance-key"`
+	Name             string      `json:"name,omitempty"`
+	SnapID           string      `json:"snap-id,omitempty"`
+	Channel          string      `json:"channel,omitempty"`
+	Revision         int         `json:"revision,omitempty"`
+	Epoch            *snap.Epoch `json:"epoch,omitempty"`
+	IgnoreValidation *bool       `json:"ignore-validation,omitempty"`
+}
+
+type snapActionResult struct {
+	Result           string    `json:"result"`
+	InstanceKey      string    `json:"instance-key"`
+	SnapID           string    `json:"snap-id,omitempy"`
+	Name             string    `json:"name,omitempty"`
+	Snap             storeSnap `json:"snap"`
+	EffectiveChannel string    `json:"effective-channel,omitempty"`
+	Error            struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type snapActionRequest struct {
+	Context []*currentSnapV2JSON `json:"context"`
+	Actions []*snapActionJSON    `json:"actions"`
+	Fields  []string             `json:"fields"`
+}
+
+type snapActionResultList struct {
+	Results   []*snapActionResult `json:"results"`
+	ErrorList []struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error-list"`
+}
+
+var snapActionFields = getStructFields(storeSnap{})
+
+// SnapAction queries the store for snap information for the given
+// install/refresh actions, given the context information about
+// current installed snaps in currentSnaps. If the request was overall
+// successul (200) but there were reported errors it will return both
+// the snap infos and an SnapActionError.
+func (s *Store) SnapAction(ctx context.Context, currentSnaps []*CurrentSnap, actions []*SnapAction, user *auth.UserState, opts *RefreshOptions) ([]*snap.Info, error) {
+	if opts == nil {
+		opts = &RefreshOptions{}
+	}
+
+	if len(currentSnaps) == 0 && len(actions) == 0 {
+		// nothing to do
+		return nil, &SnapActionError{NoResults: true}
+	}
+
+	authRefreshes := 0
+	for {
+		snaps, err := s.snapAction(ctx, currentSnaps, actions, user, opts)
+
+		if saErr, ok := err.(*SnapActionError); ok && authRefreshes < 2 && len(saErr.Other) > 0 {
+			// do we need to try to refresh auths?, 2 tries
+			var refreshNeed authRefreshNeed
+			for _, otherErr := range saErr.Other {
+				switch otherErr {
+				case errUserAuthorizationNeedsRefresh:
+					refreshNeed.user = true
+				case errDeviceAuthorizationNeedsRefresh:
+					refreshNeed.device = true
+				}
+			}
+			if refreshNeed.needed() {
+				err := s.refreshAuth(user, refreshNeed)
+				if err != nil {
+					// best effort
+					logger.Noticef("cannot refresh soft-expired authorisation: %v", err)
+				}
+				authRefreshes++
+				// TODO: we could avoid retrying here
+				// if refreshAuth gave no error we got
+				// as many non-error results from the
+				// store as actions anyway
+				continue
+			}
+		}
+
+		return snaps, err
+	}
+}
+
+func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, actions []*SnapAction, user *auth.UserState, opts *RefreshOptions) ([]*snap.Info, error) {
+
+	// TODO: the store already requires instance-key but doesn't
+	// yet support repeating in context or sending actions for the
+	// same snap-id, for now we keep instance-key handling internal
+
+	curSnaps := make(map[string]*CurrentSnap, len(currentSnaps))
+	curSnapJSONs := make([]*currentSnapV2JSON, len(currentSnaps))
+	for i, curSnap := range currentSnaps {
+		if curSnap.SnapID == "" || curSnap.Name == "" || curSnap.Revision.Unset() {
+			return nil, fmt.Errorf("internal error: invalid current snap information")
+		}
+		curSnaps[curSnap.SnapID] = curSnap
+		channel := curSnap.TrackingChannel
+		if channel == "" {
+			channel = "stable"
+		}
+		var refreshedDate *time.Time
+		if !curSnap.RefreshedDate.IsZero() {
+			refreshedDate = &curSnap.RefreshedDate
+		}
+		curSnapJSONs[i] = &currentSnapV2JSON{
+			SnapID:           curSnap.SnapID,
+			InstanceKey:      curSnap.SnapID,
+			Revision:         curSnap.Revision.N,
+			TrackingChannel:  channel,
+			IgnoreValidation: curSnap.IgnoreValidation,
+			RefreshedDate:    refreshedDate,
+		}
+	}
+
+	installNum := 0
+	installKeys := make(map[string]bool, len(actions))
+	actionJSONs := make([]*snapActionJSON, len(actions))
+	for i, a := range actions {
+		var ignoreValidation *bool
+		if a.Flags&SnapActionIgnoreValidation != 0 {
+			var t = true
+			ignoreValidation = &t
+		} else if a.Flags&SnapActionEnforceValidation != 0 {
+			var f = false
+			ignoreValidation = &f
+		}
+
+		instanceKey := a.SnapID
+		if a.Action == "install" {
+			installNum++
+			instanceKey = fmt.Sprintf("install-%d", installNum)
+			installKeys[instanceKey] = true
+		}
+
+		aJSON := &snapActionJSON{
+			Action:           a.Action,
+			InstanceKey:      instanceKey,
+			SnapID:           a.SnapID,
+			Name:             a.Name,
+			Channel:          a.Channel,
+			Revision:         a.Revision.N,
+			Epoch:            a.Epoch,
+			IgnoreValidation: ignoreValidation,
+		}
+		actionJSONs[i] = aJSON
+	}
+
+	// build input for the install/refresh endpoint
+	jsonData, err := json.Marshal(snapActionRequest{
+		Context: curSnapJSONs,
+		Actions: actionJSONs,
+		Fields:  snapActionFields,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	reqOptions := &requestOptions{
+		Method:      "POST",
+		URL:         s.endpointURL(snapActionEndpPath, nil),
+		Accept:      jsonContentType,
+		ContentType: jsonContentType,
+		Data:        jsonData,
+		APILevel:    apiV2Endps,
+	}
+
+	if useDeltas() {
+		logger.Debugf("Deltas enabled. Adding header Snap-Accept-Delta-Format: %v", s.deltaFormat)
+		reqOptions.addHeader("Snap-Accept-Delta-Format", s.deltaFormat)
+	}
+	if opts.RefreshManaged {
+		reqOptions.addHeader("Snap-Refresh-Managed", "true")
+	}
+
+	var results snapActionResultList
+	resp, err := s.retryRequestDecodeJSON(ctx, reqOptions, user, &results, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, respToError(resp, "query the store for updates")
+	}
+
+	s.extractSuggestedCurrency(resp)
+
+	refreshErrors := make(map[string]error)
+	installErrors := make(map[string]error)
+	var otherErrors []error
+
+	var snaps []*snap.Info
+	for _, res := range results.Results {
+		if res.Result == "error" {
+			if installKeys[res.InstanceKey] {
+				if res.Name != "" {
+					installErrors[res.Name] = translateSnapActionError("install", res.Error.Code, res.Error.Message)
+					continue
+				}
+			} else {
+				if cur := curSnaps[res.InstanceKey]; cur != nil {
+					refreshErrors[cur.Name] = translateSnapActionError("refresh", res.Error.Code, res.Error.Message)
+					continue
+				}
+			}
+			otherErrors = append(otherErrors, translateSnapActionError("-", res.Error.Code, res.Error.Message))
+			continue
+		}
+		snapInfo, err := infoFromStoreSnap(&res.Snap)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected invalid install/refresh API result: %v", err)
+		}
+		snapInfo.Channel = res.EffectiveChannel
+		if res.Result == "refresh" {
+			cur := curSnaps[res.SnapID]
+			if cur == nil {
+				return nil, fmt.Errorf("unexpected invalid install/refresh API result: unexpected refresh")
+			}
+			rrev := snap.R(res.Snap.Revision)
+			if rrev == cur.Revision || findRev(rrev, cur.Block) {
+				refreshErrors[cur.Name] = ErrNoUpdateAvailable
+				continue
+			}
+		}
+		snaps = append(snaps, snapInfo)
+	}
+
+	for _, errObj := range results.ErrorList {
+		otherErrors = append(otherErrors, translateSnapActionError("-", errObj.Code, errObj.Message))
+	}
+
+	if len(refreshErrors)+len(installErrors) != 0 || len(results.Results) == 0 || len(otherErrors) != 0 {
+		// normalize empty maps
+		if len(refreshErrors) == 0 {
+			refreshErrors = nil
+		}
+		if len(installErrors) == 0 {
+			installErrors = nil
+		}
+		return snaps, &SnapActionError{
+			NoResults: len(results.Results) == 0,
+			Refresh:   refreshErrors,
+			Install:   installErrors,
+			Other:     otherErrors,
+		}
+	}
+
+	return snaps, nil
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -6547,7 +6547,7 @@ func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
 	c.Assert(results, HasLen, 0)
 	c.Check(err, DeepEquals, &SnapActionError{
 		Refresh: map[string]error{
-			"hello-world": ErrNoUpdateAvailable,
+			"hello-world": ErrRevisionNotAvailable,
 		},
 		Install: map[string]error{
 			"foo": ErrRevisionNotAvailable,

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -131,6 +131,8 @@ const (
 	ordersPath         = "/api/v1/snaps/purchases/orders"
 	searchPath         = "/api/v1/snaps/search"
 	sectionsPath       = "/api/v1/snaps/sections"
+	// v2
+	snapActionPath = "/v2/snaps/refresh"
 )
 
 // Build details path for a snap name.
@@ -816,6 +818,7 @@ func (s *storeTestSuite) TestDownloadSyncFails(c *C) {
 func (s *storeTestSuite) TestActualDownload(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Snap-CDN"), Equals, "")
 		n++
 		io.WriteString(w, "response-data")
 	}))
@@ -830,6 +833,64 @@ func (s *storeTestSuite) TestActualDownload(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(buf.String(), Equals, "response-data")
 	c.Check(n, Equals, 1)
+}
+
+func (s *storeTestSuite) TestActualDownloadNoCDN(c *C) {
+	os.Setenv("SNAPPY_STORE_NO_CDN", "1")
+	defer os.Unsetenv("SNAPPY_STORE_NO_CDN")
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Snap-CDN"), Equals, "none")
+		io.WriteString(w, "response-data")
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	theStore := New(&Config{}, nil)
+	var buf SillyBuffer
+	// keep tests happy
+	sha3 := ""
+	err := download(context.TODO(), "foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(buf.String(), Equals, "response-data")
+}
+
+func (s *storeTestSuite) TestActualDownloadFullCloudInfoFromAuthContext(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Snap-CDN"), Equals, `cloud-name="aws" region="us-east-1" availability-zone="us-east-1c"`)
+
+		io.WriteString(w, "response-data")
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	theStore := New(&Config{}, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "aws", Region: "us-east-1", AvailabilityZone: "us-east-1c"}})
+
+	var buf SillyBuffer
+	// keep tests happy
+	sha3 := ""
+	err := download(context.TODO(), "foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(buf.String(), Equals, "response-data")
+}
+
+func (s *storeTestSuite) TestActualDownloadLessDetailedCloudInfoFromAuthContext(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Header.Get("Snap-CDN"), Equals, `cloud-name="openstack" availability-zone="nova"`)
+
+		io.WriteString(w, "response-data")
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	theStore := New(&Config{}, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "openstack", Region: "", AvailabilityZone: "nova"}})
+
+	var buf SillyBuffer
+	// keep tests happy
+	sha3 := ""
+	err := download(context.TODO(), "foo", sha3, mockServer.URL, nil, theStore, &buf, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(buf.String(), Equals, "response-data")
 }
 
 func (s *storeTestSuite) TestDownloadCancellation(c *C) {
@@ -2303,8 +2364,6 @@ func (s *storeTestSuite) TestDetailsAndChannels(c *C) {
 func (s *storeTestSuite) TestNonDefaults(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
-	os.Setenv("SNAPPY_STORE_NO_CDN", "1")
-	defer os.Unsetenv("SNAPPY_STORE_NO_CDN")
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", detailsPathPattern)
@@ -2318,9 +2377,6 @@ func (s *storeTestSuite) TestNonDefaults(c *C) {
 		c.Check(r.Header.Get("X-Ubuntu-Series"), Equals, "21")
 		c.Check(r.Header.Get("X-Ubuntu-Architecture"), Equals, "archXYZ")
 		c.Check(r.Header.Get("X-Ubuntu-Classic"), Equals, "true")
-		// for now we have both
-		c.Check(r.Header.Get("X-Ubuntu-No-CDN"), Equals, "true")
-		c.Check(r.Header.Get("Snap-CDN"), Equals, "none")
 
 		w.WriteHeader(200)
 		io.WriteString(w, MockDetailsJSON)
@@ -2368,68 +2424,6 @@ func (s *storeTestSuite) TestStoreIDFromAuthContext(c *C) {
 	cfg.Architecture = "archXYZ"
 	cfg.StoreID = "fallback"
 	sto := New(cfg, &testAuthContext{c: c, device: s.device, storeID: "my-brand-store-id"})
-
-	// the actual test
-	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
-	}
-	result, err := sto.SnapInfo(spec, nil)
-	c.Assert(err, IsNil)
-	c.Check(result.Name(), Equals, "hello-world")
-}
-
-func (s *storeTestSuite) TestFullCloudInfoFromAuthContext(c *C) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
-		c.Check(r.Header.Get("Snap-CDN"), Equals, `cloud-name="aws" region="us-east-1" availability-zone="us-east-1c"`)
-
-		w.WriteHeader(200)
-		io.WriteString(w, MockDetailsJSON)
-	}))
-
-	c.Assert(mockServer, NotNil)
-	defer mockServer.Close()
-
-	mockServerURL, _ := url.Parse(mockServer.URL)
-	cfg := DefaultConfig()
-	cfg.StoreBaseURL = mockServerURL
-	cfg.Series = "21"
-	cfg.Architecture = "archXYZ"
-	cfg.StoreID = "fallback"
-	sto := New(cfg, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "aws", Region: "us-east-1", AvailabilityZone: "us-east-1c"}})
-
-	// the actual test
-	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
-	}
-	result, err := sto.SnapInfo(spec, nil)
-	c.Assert(err, IsNil)
-	c.Check(result.Name(), Equals, "hello-world")
-}
-
-func (s *storeTestSuite) TestLessDetailedCloudInfoFromAuthContext(c *C) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
-		c.Check(r.Header.Get("Snap-CDN"), Equals, `cloud-name="openstack" availability-zone="nova"`)
-
-		w.WriteHeader(200)
-		io.WriteString(w, MockDetailsJSON)
-	}))
-
-	c.Assert(mockServer, NotNil)
-	defer mockServer.Close()
-
-	mockServerURL, _ := url.Parse(mockServer.URL)
-	cfg := DefaultConfig()
-	cfg.StoreBaseURL = mockServerURL
-	cfg.Series = "21"
-	cfg.Architecture = "archXYZ"
-	cfg.StoreID = "fallback"
-	sto := New(cfg, &testAuthContext{c: c, device: s.device, cloudInfo: &auth.CloudInfo{Name: "openstack", Region: "", AvailabilityZone: "nova"}})
 
 	// the actual test
 	spec := SnapSpec{
@@ -5360,4 +5354,1567 @@ func (s *storeTestSuite) TestDownloadCacheMiss(c *C) {
 
 	c.Check(obs.gets, DeepEquals, []string{fmt.Sprintf("the-snaps-sha3_384:%s", path)})
 	c.Check(obs.puts, DeepEquals, []string{fmt.Sprintf("the-snaps-sha3_384:%s", path)})
+}
+
+var (
+	helloRefreshedDateStr = "2018-02-27T11:00:00Z"
+	helloRefreshedDate    time.Time
+)
+
+func init() {
+	t, err := time.Parse(time.RFC3339, helloRefreshedDateStr)
+	if err != nil {
+		panic(err)
+	}
+	helloRefreshedDate = t
+}
+
+func (s *storeTestSuite) TestSnapAction(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		c.Check(r.Header.Get("Snap-Refresh-Managed"), Equals, "")
+
+		// no store ID by default
+		storeID := r.Header.Get("Snap-Device-Store")
+		c.Check(storeID, Equals, "")
+
+		c.Check(r.Header.Get("Snap-Device-Series"), Equals, release.Series)
+		c.Check(r.Header.Get("Snap-Device-Architecture"), Equals, arch.UbuntuArchitecture())
+		c.Check(r.Header.Get("Snap-Classic"), Equals, "false")
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Fields  []string                 `json:"fields"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Check(req.Fields, DeepEquals, snapActionFields)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(1),
+			"tracking-channel": "beta",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "beta",
+			Revision:        snap.R(1),
+			RefreshedDate:   helloRefreshedDate,
+		},
+	}, []*SnapAction{
+		{
+			Action: "refresh",
+			SnapID: helloWorldSnapID,
+		},
+	}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(26))
+	c.Assert(results[0].Version, Equals, "6.1")
+	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
+	c.Assert(results[0].PublisherID, Equals, helloWorldDeveloperID)
+	c.Assert(results[0].Deltas, HasLen, 0)
+}
+
+func (s *storeTestSuite) TestSnapActionNoResults(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(1),
+			"tracking-channel": "beta",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 0)
+		io.WriteString(w, `{
+  "results": []
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "beta",
+			Revision:        snap.R(1),
+			RefreshedDate:   helloRefreshedDate,
+		},
+	}, nil, nil, nil)
+	c.Check(results, HasLen, 0)
+	c.Check(err, DeepEquals, &SnapActionError{NoResults: true})
+
+	// local no-op
+	results, err = sto.SnapAction(context.TODO(), nil, nil, nil, nil)
+	c.Check(results, HasLen, 0)
+	c.Check(err, DeepEquals, &SnapActionError{NoResults: true})
+
+	c.Check(err.Error(), Equals, "no install/refresh information results from the store")
+}
+
+func (s *storeTestSuite) TestSnapActionRefreshedDateIsOptional(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":      helloWorldSnapID,
+			"instance-key": helloWorldSnapID,
+
+			"revision":         float64(1),
+			"tracking-channel": "beta",
+		})
+		c.Assert(req.Actions, HasLen, 0)
+		io.WriteString(w, `{
+  "results": []
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "beta",
+			Revision:        snap.R(1),
+		},
+	}, nil, nil, nil)
+	c.Check(results, HasLen, 0)
+	c.Check(err, DeepEquals, &SnapActionError{NoResults: true})
+}
+
+func (s *storeTestSuite) TestSnapActionSkipBlocked(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(1),
+			"tracking-channel": "stable",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+			"channel":      "stable",
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "stable",
+			Revision:        snap.R(1),
+			RefreshedDate:   helloRefreshedDate,
+			Block:           []snap.Revision{snap.R(26)},
+		},
+	}, []*SnapAction{
+		{
+			Action:  "refresh",
+			SnapID:  helloWorldSnapID,
+			Channel: "stable",
+		},
+	}, nil, nil)
+	c.Assert(results, HasLen, 0)
+	c.Check(err, DeepEquals, &SnapActionError{
+		Refresh: map[string]error{
+			"hello-world": ErrNoUpdateAvailable,
+		},
+	})
+}
+
+func (s *storeTestSuite) TestSnapActionSkipCurrent(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(26),
+			"tracking-channel": "stable",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+			"channel":      "stable",
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "stable",
+			Revision:        snap.R(26),
+			RefreshedDate:   helloRefreshedDate,
+		},
+	}, []*SnapAction{
+		{
+			Action:  "refresh",
+			SnapID:  helloWorldSnapID,
+			Channel: "stable",
+		},
+	}, nil, nil)
+	c.Assert(results, HasLen, 0)
+	c.Check(err, DeepEquals, &SnapActionError{
+		Refresh: map[string]error{
+			"hello-world": ErrNoUpdateAvailable,
+		},
+	})
+}
+
+func (s *storeTestSuite) TestSnapActionRetryOnEOF(c *C) {
+	n := 0
+	var mockServer *httptest.Server
+	mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		n++
+		if n < 4 {
+			io.WriteString(w, "{")
+			mockServer.CloseClientConnections()
+			return
+		}
+
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err := json.NewDecoder(r.Body).Decode(&req)
+		c.Assert(err, IsNil)
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Actions, HasLen, 1)
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "stable",
+			Revision:        snap.R(1),
+		},
+	}, []*SnapAction{
+		{
+			Action:  "refresh",
+			SnapID:  helloWorldSnapID,
+			Channel: "stable",
+		},
+	}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 4)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+}
+
+func (s *storeTestSuite) TestSnapActionIgnoreValidation(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":           helloWorldSnapID,
+			"instance-key":      helloWorldSnapID,
+			"revision":          float64(1),
+			"tracking-channel":  "stable",
+			"refreshed-date":    helloRefreshedDateStr,
+			"ignore-validation": true,
+		})
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":            "refresh",
+			"instance-key":      helloWorldSnapID,
+			"snap-id":           helloWorldSnapID,
+			"channel":           "stable",
+			"ignore-validation": false,
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:             "hello-world",
+			SnapID:           helloWorldSnapID,
+			TrackingChannel:  "stable",
+			Revision:         snap.R(1),
+			RefreshedDate:    helloRefreshedDate,
+			IgnoreValidation: true,
+		},
+	}, []*SnapAction{
+		{
+			Action:  "refresh",
+			SnapID:  helloWorldSnapID,
+			Channel: "stable",
+			Flags:   SnapActionEnforceValidation,
+		},
+	}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(26))
+}
+
+func (s *storeTestSuite) TestInstallFallbackChannelIsStable(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(1),
+			"tracking-channel": "stable",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:          "hello-world",
+			SnapID:        helloWorldSnapID,
+			RefreshedDate: helloRefreshedDate,
+			Revision:      snap.R(1),
+		},
+	}, []*SnapAction{
+		{
+			Action: "refresh",
+			SnapID: helloWorldSnapID,
+		},
+	}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(26))
+	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
+}
+
+func (s *storeTestSuite) TestSnapActionNonDefaultsHeaders(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		storeID := r.Header.Get("Snap-Device-Store")
+		c.Check(storeID, Equals, "foo")
+
+		c.Check(r.Header.Get("Snap-Device-Series"), Equals, "21")
+		c.Check(r.Header.Get("Snap-Device-Architecture"), Equals, "archXYZ")
+		c.Check(r.Header.Get("Snap-Classic"), Equals, "true")
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(1),
+			"tracking-channel": "beta",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := DefaultConfig()
+	cfg.StoreBaseURL = mockServerURL
+	cfg.Series = "21"
+	cfg.Architecture = "archXYZ"
+	cfg.StoreID = "foo"
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "beta",
+			RefreshedDate:   helloRefreshedDate,
+			Revision:        snap.R(1),
+		},
+	}, []*SnapAction{
+		{
+			Action: "refresh",
+			SnapID: helloWorldSnapID,
+		},
+	}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(26))
+	c.Assert(results[0].Version, Equals, "6.1")
+	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
+	c.Assert(results[0].PublisherID, Equals, helloWorldDeveloperID)
+	c.Assert(results[0].Deltas, HasLen, 0)
+}
+
+func (s *storeTestSuite) TestSnapActionWithDeltas(c *C) {
+	origUseDeltas := os.Getenv("SNAPD_USE_DELTAS_EXPERIMENTAL")
+	defer os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", origUseDeltas)
+	c.Assert(os.Setenv("SNAPD_USE_DELTAS_EXPERIMENTAL", "1"), IsNil)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		c.Check(r.Header.Get("Snap-Accept-Delta-Format"), Equals, "xdelta3")
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(1),
+			"tracking-channel": "beta",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "beta",
+			Revision:        snap.R(1),
+			RefreshedDate:   helloRefreshedDate,
+		},
+	}, []*SnapAction{
+		{
+			Action: "refresh",
+			SnapID: helloWorldSnapID,
+		},
+	}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(26))
+}
+
+func (s *storeTestSuite) TestSnapActionOptions(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		c.Check(r.Header.Get("Snap-Refresh-Managed"), Equals, "true")
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(1),
+			"tracking-channel": "stable",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+			"channel":      "stable",
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "stable",
+			Revision:        snap.R(1),
+			RefreshedDate:   helloRefreshedDate,
+		},
+	}, []*SnapAction{
+		{
+			Action:  "refresh",
+			SnapID:  helloWorldSnapID,
+			Channel: "stable",
+		},
+	}, nil, &RefreshOptions{RefreshManaged: true})
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(26))
+}
+
+func (s *storeTestSuite) TestSnapActionInstall(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		c.Check(r.Header.Get("Snap-Refresh-Managed"), Equals, "")
+
+		// no store ID by default
+		storeID := r.Header.Get("Snap-Device-Store")
+		c.Check(storeID, Equals, "")
+
+		c.Check(r.Header.Get("Snap-Device-Series"), Equals, release.Series)
+		c.Check(r.Header.Get("Snap-Device-Architecture"), Equals, arch.UbuntuArchitecture())
+		c.Check(r.Header.Get("Snap-Classic"), Equals, "false")
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 0)
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "install",
+			"instance-key": "install-1",
+			"name":         "hello-world",
+			"channel":      "beta",
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "install",
+     "instance-key": "install-1",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "effective-channel": "candidate",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), nil,
+		[]*SnapAction{
+			{
+				Action:  "install",
+				Name:    "hello-world",
+				Channel: "beta",
+			},
+		}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(26))
+	c.Assert(results[0].Version, Equals, "6.1")
+	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
+	c.Assert(results[0].PublisherID, Equals, helloWorldDeveloperID)
+	c.Assert(results[0].Deltas, HasLen, 0)
+	// effective-channel
+	c.Assert(results[0].Channel, Equals, "candidate")
+}
+
+func (s *storeTestSuite) TestSnapActionInstallWithRevision(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		c.Check(r.Header.Get("Snap-Refresh-Managed"), Equals, "")
+
+		// no store ID by default
+		storeID := r.Header.Get("Snap-Device-Store")
+		c.Check(storeID, Equals, "")
+
+		c.Check(r.Header.Get("Snap-Device-Series"), Equals, release.Series)
+		c.Check(r.Header.Get("Snap-Device-Architecture"), Equals, arch.UbuntuArchitecture())
+		c.Check(r.Header.Get("Snap-Classic"), Equals, "false")
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 0)
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "install",
+			"instance-key": "install-1",
+			"name":         "hello-world",
+			"revision":     float64(28),
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "install",
+     "instance-key": "install-1",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 28,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), nil,
+		[]*SnapAction{
+			{
+				Action:   "install",
+				Name:     "hello-world",
+				Revision: snap.R(28),
+			},
+		}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+	c.Assert(results[0].Revision, Equals, snap.R(28))
+	c.Assert(results[0].Version, Equals, "6.1")
+	c.Assert(results[0].SnapID, Equals, helloWorldSnapID)
+	c.Assert(results[0].PublisherID, Equals, helloWorldDeveloperID)
+	c.Assert(results[0].Deltas, HasLen, 0)
+	// effective-channel is not set
+	c.Assert(results[0].Channel, Equals, "")
+}
+
+func (s *storeTestSuite) TestSnapActionRevisionNotAvailable(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(26),
+			"tracking-channel": "stable",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 2)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+			"channel":      "stable",
+		})
+		c.Assert(req.Actions[1], DeepEquals, map[string]interface{}{
+			"action":       "install",
+			"instance-key": "install-1",
+			"name":         "foo",
+			"channel":      "stable",
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "error",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "error": {
+       "code": "revision-not-found",
+       "message": "msg1"
+     }
+  }, {
+     "result": "error",
+     "instance-key": "install-1",
+     "snap-id": "foo-id",
+     "name": "foo",
+     "error": {
+       "code": "revision-not-found",
+       "message": "msg2"
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "stable",
+			Revision:        snap.R(26),
+			RefreshedDate:   helloRefreshedDate,
+		},
+	}, []*SnapAction{
+		{
+			Action:  "refresh",
+			SnapID:  helloWorldSnapID,
+			Channel: "stable",
+		}, {
+			Action:  "install",
+			Name:    "foo",
+			Channel: "stable",
+		},
+	}, nil, nil)
+	c.Assert(results, HasLen, 0)
+	c.Check(err, DeepEquals, &SnapActionError{
+		Refresh: map[string]error{
+			"hello-world": ErrNoUpdateAvailable,
+		},
+		Install: map[string]error{
+			"foo": ErrRevisionNotAvailable,
+		},
+	})
+}
+
+func (s *storeTestSuite) TestSnapActionSnapNotFound(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 1)
+		c.Assert(req.Context[0], DeepEquals, map[string]interface{}{
+			"snap-id":          helloWorldSnapID,
+			"instance-key":     helloWorldSnapID,
+			"revision":         float64(26),
+			"tracking-channel": "stable",
+			"refreshed-date":   helloRefreshedDateStr,
+		})
+		c.Assert(req.Actions, HasLen, 2)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "refresh",
+			"instance-key": helloWorldSnapID,
+			"snap-id":      helloWorldSnapID,
+			"channel":      "stable",
+		})
+		c.Assert(req.Actions[1], DeepEquals, map[string]interface{}{
+			"action":       "install",
+			"instance-key": "install-1",
+			"name":         "foo",
+			"channel":      "stable",
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "error",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "error": {
+       "code": "id-not-found",
+       "message": "msg1"
+     }
+  }, {
+     "result": "error",
+     "instance-key": "install-1",
+     "name": "foo",
+     "error": {
+       "code": "name-not-found",
+       "message": "msg2"
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "stable",
+			Revision:        snap.R(26),
+			RefreshedDate:   helloRefreshedDate,
+		},
+	}, []*SnapAction{
+		{
+			Action:  "refresh",
+			SnapID:  helloWorldSnapID,
+			Channel: "stable",
+		}, {
+			Action:  "install",
+			Name:    "foo",
+			Channel: "stable",
+		},
+	}, nil, nil)
+	c.Assert(results, HasLen, 0)
+	c.Check(err, DeepEquals, &SnapActionError{
+		Refresh: map[string]error{
+			"hello-world": ErrSnapNotFound,
+		},
+		Install: map[string]error{
+			"foo": ErrSnapNotFound,
+		},
+	})
+}
+
+func (s *storeTestSuite) TestSnapActionOtherErrors(c *C) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		// check device authorization is set, implicitly checking doRequest was used
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+
+		jsonReq, err := ioutil.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		var req struct {
+			Context []map[string]interface{} `json:"context"`
+			Actions []map[string]interface{} `json:"actions"`
+		}
+
+		err = json.Unmarshal(jsonReq, &req)
+		c.Assert(err, IsNil)
+
+		c.Assert(req.Context, HasLen, 0)
+		c.Assert(req.Actions, HasLen, 1)
+		c.Assert(req.Actions[0], DeepEquals, map[string]interface{}{
+			"action":       "install",
+			"instance-key": "install-1",
+			"name":         "foo",
+			"channel":      "stable",
+		})
+
+		io.WriteString(w, `{
+  "results": [{
+     "result": "error",
+     "error": {
+       "code": "other1",
+       "message": "other error one"
+     }
+  }],
+  "error-list": [
+     {"code": "global-error", "message": "global error"}
+  ]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: mockServerURL,
+	}
+	authContext := &testAuthContext{c: c, device: s.device}
+	sto := New(&cfg, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), nil, []*SnapAction{
+		{
+			Action:  "install",
+			Name:    "foo",
+			Channel: "stable",
+		},
+	}, nil, nil)
+	c.Assert(results, HasLen, 0)
+	c.Check(err, DeepEquals, &SnapActionError{
+		Other: []error{
+			fmt.Errorf("other error one"),
+			fmt.Errorf("global error"),
+		},
+	})
+}
+
+func (s *storeTestSuite) TestSnapActionErrorError(c *C) {
+	e := &SnapActionError{Refresh: map[string]error{
+		"foo": fmt.Errorf("sad refresh"),
+	}}
+	c.Check(e.Error(), Equals, `cannot refresh snap "foo": sad refresh`)
+
+	e = &SnapActionError{Refresh: map[string]error{
+		"foo": fmt.Errorf("sad refresh 1"),
+		"bar": fmt.Errorf("sad refresh 2"),
+	}}
+	errMsg := e.Error()
+	c.Check(strings.HasPrefix(errMsg, "cannot refresh:\n"), Equals, true)
+	c.Check(errMsg, testutil.Contains, "\nsnap \"foo\": sad refresh 1")
+	c.Check(errMsg, testutil.Contains, "\nsnap \"bar\": sad refresh 2")
+
+	e = &SnapActionError{Install: map[string]error{
+		"foo": fmt.Errorf("sad install"),
+	}}
+	c.Check(e.Error(), Equals, `cannot install snap "foo": sad install`)
+
+	e = &SnapActionError{Install: map[string]error{
+		"foo": fmt.Errorf("sad install 1"),
+		"bar": fmt.Errorf("sad install 2"),
+	}}
+	errMsg = e.Error()
+	c.Check(strings.HasPrefix(errMsg, "cannot install:\n"), Equals, true)
+	c.Check(errMsg, testutil.Contains, "\nsnap \"foo\": sad install 1")
+	c.Check(errMsg, testutil.Contains, "\nsnap \"bar\": sad install 2")
+
+	e = &SnapActionError{Refresh: map[string]error{
+		"foo": fmt.Errorf("sad refresh 1"),
+	},
+		Install: map[string]error{
+			"bar": fmt.Errorf("sad install 2"),
+		}}
+	c.Check(e.Error(), Equals, `cannot refresh or install:
+snap "foo": sad refresh 1
+snap "bar": sad install 2`)
+
+	e = &SnapActionError{
+		NoResults: true,
+		Other:     []error{fmt.Errorf("other error")},
+	}
+	c.Check(e.Error(), Equals, `cannot refresh or install: other error`)
+
+	e = &SnapActionError{
+		Other: []error{fmt.Errorf("other error 1"), fmt.Errorf("other error 2")},
+	}
+	c.Check(e.Error(), Equals, `cannot refresh or install:
+* other error 1
+* other error 2`)
+
+	e = &SnapActionError{
+		Install: map[string]error{
+			"bar": fmt.Errorf("sad install"),
+		},
+		Other: []error{fmt.Errorf("other error 1"), fmt.Errorf("other error 2")},
+	}
+	c.Check(e.Error(), Equals, `cannot refresh or install:
+snap "bar": sad install
+* other error 1
+* other error 2`)
+
+	e = &SnapActionError{
+		NoResults: true,
+	}
+	c.Check(e.Error(), Equals, "no install/refresh information results from the store")
+}
+
+func (s *storeTestSuite) TestSnapActionRefreshesBothAuths(c *C) {
+	// snap action (install/refresh) has is its own custom way to
+	// signal macaroon refreshes that allows to do a best effort
+	// with the available results
+
+	refresh, err := makeTestRefreshDischargeResponse()
+	c.Assert(err, IsNil)
+	c.Check(s.user.StoreDischarges[0], Not(Equals), refresh)
+
+	// mock refresh response
+	refreshDischargeEndpointHit := false
+	mockSSOServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, fmt.Sprintf(`{"discharge_macaroon": "%s"}`, refresh))
+		refreshDischargeEndpointHit = true
+	}))
+	defer mockSSOServer.Close()
+	UbuntuoneRefreshDischargeAPI = mockSSOServer.URL + "/tokens/refresh"
+
+	refreshSessionRequested := false
+	expiredAuth := `Macaroon root="expired-session-macaroon"`
+	n := 0
+	// mock store response
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.UserAgent(), Equals, userAgent)
+
+		switch r.URL.Path {
+		case snapActionPath:
+			n++
+			type errObj struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			}
+			var errors []errObj
+
+			authorization := r.Header.Get("Authorization")
+			c.Check(authorization, Equals, s.expectedAuthorization(c, s.user))
+			if s.user.StoreDischarges[0] != refresh {
+				errors = append(errors, errObj{Code: "user-authorization-needs-refresh"})
+			}
+
+			devAuthorization := r.Header.Get("Snap-Device-Authorization")
+			if devAuthorization == "" {
+				c.Fatalf("device authentication missing")
+			} else if devAuthorization == expiredAuth {
+				errors = append(errors, errObj{Code: "device-authorization-needs-refresh"})
+			} else {
+				c.Check(devAuthorization, Equals, `Macaroon root="refreshed-session-macaroon"`)
+			}
+
+			errorsJSON, err := json.Marshal(errors)
+			c.Assert(err, IsNil)
+
+			io.WriteString(w, fmt.Sprintf(`{
+  "results": [{
+     "result": "refresh",
+     "instance-key": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+     "name": "hello-world",
+     "snap": {
+       "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+       "name": "hello-world",
+       "revision": 26,
+       "version": "6.1",
+       "publisher": {
+          "id": "canonical",
+          "name": "canonical",
+          "title": "Canonical"
+       }
+     }
+  }],
+  "error-list": %s
+}`, errorsJSON))
+		case authNoncesPath:
+			io.WriteString(w, `{"nonce": "1234567890:9876543210"}`)
+		case authSessionPath:
+			// sanity of request
+			jsonReq, err := ioutil.ReadAll(r.Body)
+			c.Assert(err, IsNil)
+			var req map[string]string
+			err = json.Unmarshal(jsonReq, &req)
+			c.Assert(err, IsNil)
+			c.Check(strings.HasPrefix(req["device-session-request"], "type: device-session-request\n"), Equals, true)
+			c.Check(strings.HasPrefix(req["serial-assertion"], "type: serial\n"), Equals, true)
+			c.Check(strings.HasPrefix(req["model-assertion"], "type: model\n"), Equals, true)
+
+			authorization := r.Header.Get("X-Device-Authorization")
+			if authorization == "" {
+				c.Fatalf("expecting only refresh")
+			} else {
+				c.Check(authorization, Equals, expiredAuth)
+				io.WriteString(w, `{"macaroon": "refreshed-session-macaroon"}`)
+				refreshSessionRequested = true
+			}
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+
+	// make sure device session is expired
+	s.device.SessionMacaroon = "expired-session-macaroon"
+	authContext := &testAuthContext{c: c, device: s.device, user: s.user}
+	sto := New(&Config{
+		StoreBaseURL: mockServerURL,
+	}, authContext)
+
+	results, err := sto.SnapAction(context.TODO(), []*CurrentSnap{
+		{
+			Name:            "hello-world",
+			SnapID:          helloWorldSnapID,
+			TrackingChannel: "beta",
+			Revision:        snap.R(1),
+			RefreshedDate:   helloRefreshedDate,
+		},
+	}, []*SnapAction{
+		{
+			Action: "refresh",
+			SnapID: helloWorldSnapID,
+		},
+	}, s.user, nil)
+	c.Assert(err, IsNil)
+	c.Assert(results, HasLen, 1)
+	c.Assert(results[0].Name(), Equals, "hello-world")
+	c.Check(refreshDischargeEndpointHit, Equals, true)
+	c.Check(refreshSessionRequested, Equals, true)
+	c.Check(n, Equals, 2)
 }

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2017 Canonical Ltd
+ * Copyright (C) 2014-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -55,6 +55,10 @@ func (Store) LookupRefresh(*store.RefreshCandidate, *auth.UserState) (*snap.Info
 
 func (Store) ListRefresh(context.Context, []*store.RefreshCandidate, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error) {
 	panic("Store.ListRefresh not expected")
+}
+
+func (Store) SnapAction(context.Context, []*store.CurrentSnap, []*store.SnapAction, *auth.UserState, *store.RefreshOptions) ([]*snap.Info, error) {
+	panic("Store.SnapAction not expected")
 }
 
 func (Store) Download(context.Context, string, string, *snap.DownloadInfo, progress.Meter, *auth.UserState) error {

--- a/tests/lib/fakestore/store/store_test.go
+++ b/tests/lib/fakestore/store/store_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2015 Canonical Ltd
+ * Copyright (C) 2014-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -49,12 +49,12 @@ var _ = Suite(&storeTestSuite{})
 
 var defaultAddr = "localhost:23321"
 
-func getSha(fn string) string {
-	snapDigest, _, err := asserts.SnapFileSHA3_384(fn)
+func getSha(fn string) (string, uint64) {
+	snapDigest, size, err := asserts.SnapFileSHA3_384(fn)
 	if err != nil {
 		panic(err)
 	}
-	return hexify(snapDigest)
+	return hexify(snapDigest), size
 }
 
 func (s *storeTestSuite) SetUpTest(c *C) {
@@ -127,6 +127,7 @@ func (s *storeTestSuite) TestDetailsEndpointWithAssertions(c *C) {
 
 	var body map[string]interface{}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
+	sha3_384, _ := getSha(snapFn)
 	c.Check(body, DeepEquals, map[string]interface{}{
 		"architecture":      []interface{}{"all"},
 		"snap_id":           "xidididididididididididididididid",
@@ -137,7 +138,7 @@ func (s *storeTestSuite) TestDetailsEndpointWithAssertions(c *C) {
 		"download_url":      s.store.URL() + "/download/foo_7_all.snap",
 		"version":           "7",
 		"revision":          float64(77),
-		"download_sha3_384": getSha(snapFn),
+		"download_sha3_384": sha3_384,
 	})
 }
 
@@ -151,6 +152,7 @@ func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 
 	var body map[string]interface{}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
+	sha3_384, _ := getSha(snapFn)
 	c.Check(body, DeepEquals, map[string]interface{}{
 		"architecture":      []interface{}{"all"},
 		"snap_id":           "",
@@ -161,7 +163,7 @@ func (s *storeTestSuite) TestDetailsEndpoint(c *C) {
 		"download_url":      s.store.URL() + "/download/foo_1_all.snap",
 		"version":           "1",
 		"revision":          float64(424242),
-		"download_sha3_384": getSha(snapFn),
+		"download_sha3_384": sha3_384,
 	})
 }
 
@@ -183,6 +185,7 @@ func (s *storeTestSuite) TestBulkEndpoint(c *C) {
 		} `json:"_embedded"`
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
+	sha3_384, _ := getSha(snapFn)
 	c.Check(body.Top.Cat, DeepEquals, []map[string]interface{}{{
 		"architecture":      []interface{}{"all"},
 		"snap_id":           "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
@@ -193,7 +196,7 @@ func (s *storeTestSuite) TestBulkEndpoint(c *C) {
 		"download_url":      s.store.URL() + "/download/test-snapd-tools_1_all.snap",
 		"version":           "1",
 		"revision":          float64(424242),
-		"download_sha3_384": getSha(snapFn),
+		"download_sha3_384": sha3_384,
 	}})
 }
 
@@ -214,6 +217,7 @@ func (s *storeTestSuite) TestBulkEndpointWithAssertions(c *C) {
 		} `json:"_embedded"`
 	}
 	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
+	sha3_384, _ := getSha(snapFn)
 	c.Check(body.Top.Cat, DeepEquals, []map[string]interface{}{{
 		"architecture":      []interface{}{"all"},
 		"snap_id":           "xidididididididididididididididid",
@@ -224,7 +228,7 @@ func (s *storeTestSuite) TestBulkEndpointWithAssertions(c *C) {
 		"download_url":      s.store.URL() + "/download/foo_10_all.snap",
 		"version":           "10",
 		"revision":          float64(99),
-		"download_sha3_384": getSha(snapFn),
+		"download_sha3_384": sha3_384,
 	}})
 }
 
@@ -389,4 +393,170 @@ func (s *storeTestSuite) TestAssertionsEndpointNotFound(c *C) {
 	err = dec.Decode(&respObj)
 	c.Assert(err, IsNil)
 	c.Check(respObj["status"], Equals, float64(404))
+}
+
+func (s *storeTestSuite) TestSnapActionEndpoint(c *C) {
+	snapFn := s.makeTestSnap(c, "name: test-snapd-tools\nversion: 1")
+
+	resp, err := s.StorePostJSON("/v2/snaps/refresh", []byte(`{
+"context": [{"instance-key":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw","snap-id":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw","tracking-channel":"stable","revision":1}],
+"actions": [{"action":"refresh","instance-key":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw","snap-id":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw"}]
+}`))
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, Equals, 200)
+	var body struct {
+		Results []map[string]interface{}
+	}
+	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
+	c.Check(body.Results, HasLen, 1)
+	sha3_384, size := getSha(snapFn)
+	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+		"result":       "refresh",
+		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
+		"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
+		"name":         "test-snapd-tools",
+		"snap": map[string]interface{}{
+			"architectures": []interface{}{"all"},
+			"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
+			"name":          "test-snapd-tools",
+			"publisher": map[string]interface{}{
+				"username": "canonical",
+				"id":       "canonical",
+			},
+			"download": map[string]interface{}{
+				"url":      s.store.URL() + "/download/test-snapd-tools_1_all.snap",
+				"sha3-384": sha3_384,
+				"size":     float64(size),
+			},
+			"version":  "1",
+			"revision": float64(424242),
+		},
+	})
+}
+
+func (s *storeTestSuite) TestSnapActionEndpointWithAssertions(c *C) {
+	snapFn := s.makeTestSnap(c, "name: foo\nversion: 10")
+	s.makeAssertions(c, snapFn, "foo", "xidididididididididididididididid", "foo-devel", "foo-devel-id", 99)
+
+	resp, err := s.StorePostJSON("/v2/snaps/refresh", []byte(`{
+"context": [{"instance-key":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw","snap-id":"xidididididididididididididididid","tracking-channel":"stable","revision":1}],
+"actions": [{"action":"refresh","instance-key":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw","snap-id":"xidididididididididididididididid"}]
+}`))
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, Equals, 200)
+	var body struct {
+		Results []map[string]interface{}
+	}
+	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
+	c.Check(body.Results, HasLen, 1)
+	sha3_384, size := getSha(snapFn)
+	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+		"result":       "refresh",
+		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
+		"snap-id":      "xidididididididididididididididid",
+		"name":         "foo",
+		"snap": map[string]interface{}{
+			"architectures": []interface{}{"all"},
+			"snap-id":       "xidididididididididididididididid",
+			"name":          "foo",
+			"publisher": map[string]interface{}{
+				"username": "foo-devel",
+				"id":       "foo-devel-id",
+			},
+			"download": map[string]interface{}{
+				"url":      s.store.URL() + "/download/foo_10_all.snap",
+				"sha3-384": sha3_384,
+				"size":     float64(size),
+			},
+			"version":  "10",
+			"revision": float64(99),
+		},
+	})
+}
+
+func (s *storeTestSuite) TestSnapActionEndpointRefreshAll(c *C) {
+	snapFn := s.makeTestSnap(c, "name: test-snapd-tools\nversion: 1")
+
+	resp, err := s.StorePostJSON("/v2/snaps/refresh", []byte(`{
+"context": [{"instance-key":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw","snap-id":"eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw","tracking-channel":"stable","revision":1}],
+"actions": [{"action":"refresh-all"}]
+}`))
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, Equals, 200)
+	var body struct {
+		Results []map[string]interface{}
+	}
+	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
+	c.Check(body.Results, HasLen, 1)
+	sha3_384, size := getSha(snapFn)
+	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+		"result":       "refresh",
+		"instance-key": "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
+		"snap-id":      "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
+		"name":         "test-snapd-tools",
+		"snap": map[string]interface{}{
+			"architectures": []interface{}{"all"},
+			"snap-id":       "eFe8BTR5L5V9F7yHeMAPxkEr2NdUXMtw",
+			"name":          "test-snapd-tools",
+			"publisher": map[string]interface{}{
+				"username": "canonical",
+				"id":       "canonical",
+			},
+			"download": map[string]interface{}{
+				"url":      s.store.URL() + "/download/test-snapd-tools_1_all.snap",
+				"sha3-384": sha3_384,
+				"size":     float64(size),
+			},
+			"version":  "1",
+			"revision": float64(424242),
+		},
+	})
+}
+
+func (s *storeTestSuite) TestSnapActionEndpointWithAssertionsInstall(c *C) {
+	snapFn := s.makeTestSnap(c, "name: foo\nversion: 10")
+	s.makeAssertions(c, snapFn, "foo", "xidididididididididididididididid", "foo-devel", "foo-devel-id", 99)
+
+	resp, err := s.StorePostJSON("/v2/snaps/refresh", []byte(`{
+"context": [],
+"actions": [{"action":"install","instance-key":"foo","name":"foo"}]
+}`))
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	c.Assert(resp.StatusCode, Equals, 200)
+	var body struct {
+		Results []map[string]interface{}
+	}
+	c.Assert(json.NewDecoder(resp.Body).Decode(&body), IsNil)
+	c.Check(body.Results, HasLen, 1)
+	sha3_384, size := getSha(snapFn)
+	c.Check(body.Results[0], DeepEquals, map[string]interface{}{
+		"result":       "install",
+		"instance-key": "foo",
+		"snap-id":      "xidididididididididididididididid",
+		"name":         "foo",
+		"snap": map[string]interface{}{
+			"architectures": []interface{}{"all"},
+			"snap-id":       "xidididididididididididididididid",
+			"name":          "foo",
+			"publisher": map[string]interface{}{
+				"username": "foo-devel",
+				"id":       "foo-devel-id",
+			},
+			"download": map[string]interface{}{
+				"url":      s.store.URL() + "/download/foo_10_all.snap",
+				"sha3-384": sha3_384,
+				"size":     float64(size),
+			},
+			"version":  "10",
+			"revision": float64(99),
+		},
+	})
 }


### PR DESCRIPTION
This makes sure non-base snaps wait for core (source of snapctl etc) and possibly their base if those are being updated in the same multi-snap refresh change, otherwise the current link of core or the base could go away and break running hooks or services of the snap during the snap own refresh process.

The issue is more general than this, but this covers the auto-refresh case for example.