### PR TITLE
systemd: add helper for opening stream file descriptors to the journal

### DIFF
--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -50,3 +50,11 @@ func MockOsutilStreamCommand(f func(string, ...string) (io.ReadCloser, error)) f
 	osutilStreamCommand = f
 	return func() { osutilStreamCommand = old }
 }
+
+func MockJournalStdoutPath(path string) func() {
+	oldPath := journalStdoutPath
+	journalStdoutPath = path
+	return func() {
+		journalStdoutPath = oldPath
+	}
+}

--- a/systemd/journal.go
+++ b/systemd/journal.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package systemd
+
+import (
+	"bytes"
+	"fmt"
+	"log/syslog"
+	"net"
+	"os"
+)
+
+var journalStdoutPath = "/run/systemd/journal/stdout"
+
+// NewJournalStreamFile creates log stream file descriptor to the journal. The
+// semantics is identical to that of sd_journal_stream_fd(3) call.
+func NewJournalStreamFile(identifier string, priority syslog.Priority, levelPrefix bool) (*os.File, error) {
+	conn, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: journalStdoutPath})
+	if err != nil {
+		return nil, err
+	}
+	// does not affect *os.File created through conn.File() later on
+	defer conn.Close()
+
+	if err := conn.CloseRead(); err != nil {
+		return nil, err
+	}
+
+	// header contents taken from the original systemd code:
+	// https://github.com/systemd/systemd/blob/97a33b126c845327a3a19d6e66f05684823868fb/src/journal/journal-send.c#L395
+	header := bytes.Buffer{}
+	header.WriteString(identifier)
+	header.WriteByte('\n')
+	header.WriteByte('\n')
+	header.WriteByte(byte('0') + byte(priority))
+	header.WriteByte('\n')
+	var prefix int
+	if levelPrefix {
+		prefix = 1
+	}
+	header.WriteByte(byte('0') + byte(prefix))
+	header.WriteByte('\n')
+	header.WriteByte('0')
+	header.WriteByte('\n')
+	header.WriteByte('0')
+	header.WriteByte('\n')
+	header.WriteByte('0')
+	header.WriteByte('\n')
+
+	if _, err := conn.Write(header.Bytes()); err != nil {
+		return nil, fmt.Errorf("failed to write header: %v", err)
+	}
+
+	f, err := conn.File()
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/systemd/journal_test.go
+++ b/systemd/journal_test.go
@@ -1,0 +1,79 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package systemd_test
+
+import (
+	"log/syslog"
+	"net"
+	"path"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/snapcore/snapd/systemd"
+)
+
+type journalTestSuite struct{}
+
+var _ = Suite(&journalTestSuite{})
+
+func (j *journalTestSuite) TestStreamFileErrorNoPath(c *C) {
+	restore := MockJournalStdoutPath(path.Join(c.MkDir(), "fake-journal"))
+	defer restore()
+
+	jout, err := NewJournalStreamFile("foobar", syslog.LOG_INFO, false)
+	c.Assert(err, ErrorMatches, ".*no such file or directory")
+	c.Assert(jout, IsNil)
+}
+
+func (j *journalTestSuite) TestStreamFileHeader(c *C) {
+	fakePath := path.Join(c.MkDir(), "fake-journal")
+	restore := MockJournalStdoutPath(fakePath)
+	defer restore()
+
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: fakePath})
+	c.Assert(err, IsNil)
+	defer listener.Close()
+
+	go func() {
+		// see https://github.com/systemd/systemd/blob/97a33b126c845327a3a19d6e66f05684823868fb/src/journal/journal-send.c#L424
+		conn, err := listener.AcceptUnix()
+		c.Assert(err, IsNil)
+		defer conn.Close()
+
+		expectedHdrLen := len("foobar") + 1 + 1 + 2 + 2 + 2 + 2 + 2
+		hdrBuf := make([]byte, expectedHdrLen)
+		hdrLen, err := conn.Read(hdrBuf)
+		c.Assert(err, IsNil)
+		c.Assert(hdrLen, Equals, expectedHdrLen)
+		c.Check(hdrBuf, Equals, []byte("foobar\n\n6\n0\n0\n0\n0\n"))
+
+		data := make([]byte, 4096)
+		_, err = conn.Read(hdrBuf)
+		c.Assert(err, IsNil)
+		c.Check(data, Equals, []byte("hello from unit tests"))
+	}()
+
+	jout, err := NewJournalStreamFile("foobar", syslog.LOG_INFO, false)
+	c.Assert(err, IsNil)
+	c.Assert(jout, NotNil)
+
+	jout.WriteString("hello from unit tests")
+	defer jout.Close()
+}


### PR DESCRIPTION
Introduce a helper function for opening stream file descriptors for logging into
journal. Mimic the semantics of sd_journal_stream_fd(3).
