### PR TITLE
tests: add check for OOM error after each test

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -387,6 +387,19 @@ restore_project_each() {
         echo "Invalid udev file detected, test most likely broke it"
         exit 1
     fi
+
+    # Check if the OOM killer got invoked - if that is the case our tests
+    # will most likely not function correctly anymore. It looks like this
+    # happens with: https://forum.snapcraft.io/t/4101 and is a source of
+    # failure in the autopkgtest environment.
+    if dmesg|grep "oom-killer"; then
+        echo "oom-killer got invoked during the tests, this should not happen."
+        echo "Dmesg debug output:"
+        dmesg
+        echo "Meminfo debug output:"
+        cat /proc/meminfo
+        exit 1
+    fi
 }
 
 restore_project() {


### PR DESCRIPTION
We see errors in autopkgtest on bionic/i386 currently. Laney was
kind enough to do a debug run and he noticed that the OOM killer
was invoked during the run. The most likely reason for this is:
https://forum.snapcraft.io/t/oom-for-interfaces-many-on-bionic-i386/4101

But the error pattern in autopkgtest is confusing, when it happens
it will simply hang in "journalctl --sync" and eventually timeout.

This PR makes the error explicit.
