### PR TITLE
cmd/snap: user session application autostart v3 (2.32)

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -233,28 +233,16 @@ func antialias(snapApp string, args []string) (string, []string) {
 	return actualApp, argsOut
 }
 
-func getSnapInfo(snapName string, revision snap.Revision) (*snap.Info, error) {
+func getSnapInfo(snapName string, revision snap.Revision) (info *snap.Info, err error) {
 	if revision.Unset() {
-		curFn := filepath.Join(dirs.SnapMountDir, snapName, "current")
-		realFn, err := os.Readlink(curFn)
-		if err != nil {
-			return nil, fmt.Errorf("cannot find current revision for snap %s: %s", snapName, err)
-		}
-		rev := filepath.Base(realFn)
-		revision, err = snap.ParseRevision(rev)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read revision %s: %s", rev, err)
-		}
+		info, err = snap.ReadCurrentInfo(snapName)
+	} else {
+		info, err = snap.ReadInfo(snapName, &snap.SideInfo{
+			Revision: revision,
+		})
 	}
 
-	info, err := snap.ReadInfo(snapName, &snap.SideInfo{
-		Revision: revision,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return info, nil
+	return info, err
 }
 
 func createOrUpdateUserDataSymlink(info *snap.Info, usr *user.User) error {

--- a/cmd/snap/cmd_userd.go
+++ b/cmd/snap/cmd_userd.go
@@ -33,6 +33,8 @@ import (
 
 type cmdUserd struct {
 	userd userd.Userd
+
+	Autostart bool `long:"autostart"`
 }
 
 var shortUserdHelp = i18n.G("Start the userd service")
@@ -44,16 +46,19 @@ func init() {
 		longUserdHelp,
 		func() flags.Commander {
 			return &cmdUserd{}
-		},
-		nil,
-		[]argDesc{},
-	)
+		}, map[string]string{
+			"autostart": i18n.G("Autostart user applications"),
+		}, nil)
 	cmd.hidden = true
 }
 
 func (x *cmdUserd) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
+	}
+
+	if x.Autostart {
+		return x.runAutostart()
 	}
 
 	if err := x.userd.Init(); err != nil {
@@ -71,4 +76,11 @@ func (x *cmdUserd) Execute(args []string) error {
 	}
 
 	return x.userd.Stop()
+}
+
+func (x *cmdUserd) runAutostart() error {
+	if err := userd.AutostartSessionApps(); err != nil {
+		return fmt.Errorf("autostart failed for the following apps:\n%v", err)
+	}
+	return nil
 }

--- a/data/Makefile
+++ b/data/Makefile
@@ -2,3 +2,4 @@ all install clean:
 	$(MAKE) -C systemd $@
 	$(MAKE) -C dbus $@
 	$(MAKE) -C env $@
+	$(MAKE) -C desktop $@

--- a/data/desktop/Makefile
+++ b/data/desktop/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+BINDIR = /usr/bin
+SYSCONFXDGAUTOSTARTDIR = /etc/xdg/autostart
+
+SOURCES = snap-userd-autostart.desktop.in
+DESKTOP_FILES = $(SOURCES:.in=)
+
+.PHONY: all
+all: $(DESKTOP_FILES)
+
+.PHONY: install
+install: $(DESKTOP_FILES)
+	# NOTE: old (e.g. 14.04) GNU coreutils doesn't -D with -t
+	install -d -m 0755 $(DESTDIR)/$(SYSCONFXDGAUTOSTARTDIR)
+	install -m 0644 -t $(DESTDIR)/$(SYSCONFXDGAUTOSTARTDIR) $^
+
+.PHONY: clean
+clean:
+	rm -f $(DESKTOP_FILES)
+
+%: %.in
+	cat $< | \
+		sed s:@bindir@:$(BINDIR):g | \
+		cat > $@

--- a/data/desktop/snap-userd-autostart.desktop.in
+++ b/data/desktop/snap-userd-autostart.desktop.in
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Snap user application autostart helper
+Comment=Helper program for launching snap applications that are configured to start automatically.
+Exec=@bindir@/snap userd --autostart
+Type=Application

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -113,6 +113,9 @@ const (
 	// are in the snap confinement environment.
 	CoreLibExecDir   = "/usr/lib/snapd"
 	CoreSnapMountDir = "/snap"
+
+	// Directory with snap data inside user's home
+	UserHomeSnapDir = "snap"
 )
 
 var (
@@ -179,7 +182,7 @@ func SetRootDir(rootdir string) {
 	}
 
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
-	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/snap/")
+	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/", UserHomeSnapDir)
 	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
 	SnapConfineAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "snap-confine")
 	AppArmorCacheDir = filepath.Join(rootdir, "/var/cache/apparmor")

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -606,6 +606,7 @@ popd
 %{_unitdir}/snapd.autoimport.service
 %{_datadir}/dbus-1/services/io.snapcraft.Launcher.service
 %{_datadir}/polkit-1/actions/io.snapcraft.snapd.policy
+%{_sysconfdir}/xdg/autostart/snap-userd-autostart.desktop
 %config(noreplace) %{_sysconfdir}/sysconfig/snapd
 %dir %{_sharedstatedir}/snapd
 %dir %{_sharedstatedir}/snapd/assertions

--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -313,6 +313,7 @@ fi
 %{_mandir}/man1/snap.1.gz
 /usr/share/dbus-1/services/io.snapcraft.Launcher.service
 /usr/share/dbus-1/services/io.snapcraft.Settings.service
+%{_sysconfdir}/xdg/autostart/snap-userd-autostart.desktop
 
 %changelog
 

--- a/snap/info.go
+++ b/snap/info.go
@@ -304,12 +304,12 @@ func (s *Info) DataDir() string {
 
 // UserDataDir returns the user-specific data directory of the snap.
 func (s *Info) UserDataDir(home string) string {
-	return filepath.Join(home, "snap", s.Name(), s.Revision.String())
+	return filepath.Join(home, dirs.UserHomeSnapDir, s.Name(), s.Revision.String())
 }
 
 // UserCommonDataDir returns the user-specific data directory common across revision of the snap.
 func (s *Info) UserCommonDataDir(home string) string {
-	return filepath.Join(home, "snap", s.Name(), "common")
+	return filepath.Join(home, dirs.UserHomeSnapDir, s.Name(), "common")
 }
 
 // CommonDataDir returns the data directory common across revisions of the snap.
@@ -760,6 +760,22 @@ func ReadInfo(name string, si *SideInfo) (*Info, error) {
 	}
 
 	return info, nil
+}
+
+// ReadCurrentInfo reads the snap information from the installed snap in 'current' revision
+func ReadCurrentInfo(snapName string) (*Info, error) {
+	curFn := filepath.Join(dirs.SnapMountDir, snapName, "current")
+	realFn, err := os.Readlink(curFn)
+	if err != nil {
+		return nil, fmt.Errorf("cannot find current revision for snap %s: %s", snapName, err)
+	}
+	rev := filepath.Base(realFn)
+	revision, err := ParseRevision(rev)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read revision %s: %s", rev, err)
+	}
+
+	return ReadInfo(snapName, &SideInfo{Revision: revision})
 }
 
 // ReadInfoFromSnapFile reads the snap information from the given File

--- a/snap/info.go
+++ b/snap/info.go
@@ -571,6 +571,8 @@ type AppInfo struct {
 	Before []string
 
 	Timer *TimerInfo
+
+	Autostart string
 }
 
 // ScreenshotInfo provides information about a screenshot.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -83,6 +83,8 @@ type appYaml struct {
 	Before []string `yaml:"before,omitempty"`
 
 	Timer string `yaml:"timer,omitempty"`
+
+	Autostart string `yaml:"autostart,omitempty"`
 }
 
 type hookYaml struct {
@@ -300,6 +302,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			RefreshMode:     yApp.RefreshMode,
 			Before:          yApp.Before,
 			After:           yApp.After,
+			Autostart:       yApp.Autostart,
 		}
 		if len(y.Plugs) > 0 || len(yApp.PlugNames) > 0 {
 			app.Plugs = make(map[string]*PlugInfo)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1670,3 +1670,30 @@ apps:
 	app := info.Apps["foo"]
 	c.Check(app.Timer, DeepEquals, &snap.TimerInfo{App: app, Timer: "mon,10:00-12:00"})
 }
+
+func (s *YamlSuite) TestSnapYamlAppAutostart(c *C) {
+	yAutostart := []byte(`name: wat
+version: 42
+apps:
+ foo:
+   command: bin/foo
+   autostart: foo.desktop
+
+`)
+	info, err := snap.InfoFromSnapYaml(yAutostart)
+	c.Assert(err, IsNil)
+	app := info.Apps["foo"]
+	c.Check(app.Autostart, Equals, "foo.desktop")
+
+	yNoAutostart := []byte(`name: wat
+version: 42
+apps:
+ foo:
+   command: bin/foo
+
+`)
+	info, err = snap.InfoFromSnapYaml(yNoAutostart)
+	c.Assert(err, IsNil)
+	app = info.Apps["foo"]
+	c.Check(app.Autostart, Equals, "")
+}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -195,6 +195,23 @@ func (s *infoSuite) TestReadInfo(c *C) {
 	c.Check(snapInfo2, DeepEquals, snapInfo1)
 }
 
+func (s *infoSuite) TestReadCurrentInfo(c *C) {
+	si := &snap.SideInfo{Revision: snap.R(42)}
+
+	snapInfo1 := snaptest.MockSnapCurrent(c, sampleYaml, si)
+
+	snapInfo2, err := snap.ReadCurrentInfo("sample")
+	c.Assert(err, IsNil)
+
+	c.Check(snapInfo2.Name(), Equals, "sample")
+	c.Check(snapInfo2.Revision, Equals, snap.R(42))
+	c.Check(snapInfo2, DeepEquals, snapInfo1)
+
+	snapInfo3, err := snap.ReadCurrentInfo("not-sample")
+	c.Check(snapInfo3, IsNil)
+	c.Assert(err, ErrorMatches, `cannot find current revision for snap not-sample:.*`)
+}
+
 func (s *infoSuite) TestInstallDate(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(1)}
 	info := snaptest.MockSnap(c, sampleYaml, si)

--- a/snap/snaptest/snaptest.go
+++ b/snap/snaptest/snaptest.go
@@ -68,6 +68,18 @@ func MockSnap(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
 	return snapInfo
 }
 
+// MockSnapCurrent does the same as MockSnap but additionally creates the
+// 'current' symlink.
+//
+// The caller is responsible for mocking root directory with dirs.SetRootDir()
+// and for altering the overlord state if required.
+func MockSnapCurrent(c *check.C, yamlText string, sideInfo *snap.SideInfo) *snap.Info {
+	si := MockSnap(c, yamlText, sideInfo)
+	err := os.Symlink(si.MountDir(), filepath.Join(si.MountDir(), "../current"))
+	c.Assert(err, check.IsNil)
+	return si
+}
+
 // MockInfo parses the given snap.yaml text and returns a validated snap.Info object including the optional SideInfo.
 //
 // The result is just kept in memory, there is nothing kept on disk. If that is

--- a/snap/snaptest/snaptest_test.go
+++ b/snap/snaptest/snaptest_test.go
@@ -72,6 +72,20 @@ func (s *snapTestSuite) TestMockSnap(c *C) {
 	c.Check(snapInfo.Plugs["network"].Interface, Equals, "network")
 }
 
+func (s *snapTestSuite) TestMockSnapCurrent(c *C) {
+	snapInfo := snaptest.MockSnapCurrent(c, sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
+	// Data from YAML is used
+	c.Check(snapInfo.Name(), Equals, "sample")
+	// Data from SideInfo is used
+	c.Check(snapInfo.Revision, Equals, snap.R(42))
+	// The YAML is placed on disk
+	c.Check(filepath.Join(dirs.SnapMountDir, "sample", "42", "meta", "snap.yaml"),
+		testutil.FileEquals, sampleYaml)
+	link, err := os.Readlink(filepath.Join(dirs.SnapMountDir, "sample", "current"))
+	c.Check(err, IsNil)
+	c.Check(link, Equals, filepath.Join(dirs.SnapMountDir, "sample", "42"))
+}
+
 func (s *snapTestSuite) TestMockInfo(c *C) {
 	snapInfo := snaptest.MockInfo(c, sampleYaml, &snap.SideInfo{Revision: snap.R(42)})
 	// Data from YAML is used

--- a/strutil/shlex/shlex.go
+++ b/strutil/shlex/shlex.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package shlex implements a simple lexer which splits input in to tokens using
+shell-style rules for quoting and commenting.
+
+The basic use case uses the default ASCII lexer to split a string into sub-strings:
+
+  shlex.Split("one \"two three\" four") -> []string{"one", "two three", "four"}
+
+To process a stream of strings:
+
+  l := NewLexer(os.Stdin)
+  for ; token, err := l.Next(); err != nil {
+  	// process token
+  }
+
+To access the raw token stream (which includes tokens for comments):
+
+  t := NewTokenizer(os.Stdin)
+  for ; token, err := t.Next(); err != nil {
+	// process token
+  }
+
+*/
+package shlex
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// TokenType is a top-level token classification: A word, space, comment, unknown.
+type TokenType int
+
+// runeTokenClass is the type of a UTF-8 character classification: A quote, space, escape.
+type runeTokenClass int
+
+// the internal state used by the lexer state machine
+type lexerState int
+
+// Token is a (type, value) pair representing a lexographical token.
+type Token struct {
+	tokenType TokenType
+	value     string
+}
+
+// Equal reports whether tokens a, and b, are equal.
+// Two tokens are equal if both their types and values are equal. A nil token can
+// never be equal to another token.
+func (a *Token) Equal(b *Token) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.tokenType != b.tokenType {
+		return false
+	}
+	return a.value == b.value
+}
+
+// Named classes of UTF-8 runes
+const (
+	spaceRunes            = " \t\r\n"
+	escapingQuoteRunes    = `"`
+	nonEscapingQuoteRunes = "'"
+	escapeRunes           = `\`
+	commentRunes          = "#"
+)
+
+// Classes of rune token
+const (
+	unknownRuneClass runeTokenClass = iota
+	spaceRuneClass
+	escapingQuoteRuneClass
+	nonEscapingQuoteRuneClass
+	escapeRuneClass
+	commentRuneClass
+	eofRuneClass
+)
+
+// Classes of lexographic token
+const (
+	UnknownToken TokenType = iota
+	WordToken
+	SpaceToken
+	CommentToken
+)
+
+// Lexer state machine states
+const (
+	startState           lexerState = iota // no runes have been seen
+	inWordState                            // processing regular runes in a word
+	escapingState                          // we have just consumed an escape rune; the next rune is literal
+	escapingQuotedState                    // we have just consumed an escape rune within a quoted string
+	quotingEscapingState                   // we are within a quoted string that supports escaping ("...")
+	quotingState                           // we are within a string that does not support escaping ('...')
+	commentState                           // we are within a comment (everything following an unquoted or unescaped #
+)
+
+// tokenClassifier is used for classifying rune characters.
+type tokenClassifier map[rune]runeTokenClass
+
+func (typeMap tokenClassifier) addRuneClass(runes string, tokenType runeTokenClass) {
+	for _, runeChar := range runes {
+		typeMap[runeChar] = tokenType
+	}
+}
+
+// newDefaultClassifier creates a new classifier for ASCII characters.
+func newDefaultClassifier() tokenClassifier {
+	t := tokenClassifier{}
+	t.addRuneClass(spaceRunes, spaceRuneClass)
+	t.addRuneClass(escapingQuoteRunes, escapingQuoteRuneClass)
+	t.addRuneClass(nonEscapingQuoteRunes, nonEscapingQuoteRuneClass)
+	t.addRuneClass(escapeRunes, escapeRuneClass)
+	t.addRuneClass(commentRunes, commentRuneClass)
+	return t
+}
+
+// ClassifyRune classifiees a rune
+func (t tokenClassifier) ClassifyRune(runeVal rune) runeTokenClass {
+	return t[runeVal]
+}
+
+// Lexer turns an input stream into a sequence of tokens. Whitespace and comments are skipped.
+type Lexer Tokenizer
+
+// NewLexer creates a new lexer from an input stream.
+func NewLexer(r io.Reader) *Lexer {
+
+	return (*Lexer)(NewTokenizer(r))
+}
+
+// Next returns the next word, or an error. If there are no more words,
+// the error will be io.EOF.
+func (l *Lexer) Next() (string, error) {
+	for {
+		token, err := (*Tokenizer)(l).Next()
+		if err != nil {
+			return "", err
+		}
+		switch token.tokenType {
+		case WordToken:
+			return token.value, nil
+		case CommentToken:
+			// skip comments
+		default:
+			return "", fmt.Errorf("Unknown token type: %v", token.tokenType)
+		}
+	}
+}
+
+// Tokenizer turns an input stream into a sequence of typed tokens
+type Tokenizer struct {
+	input      bufio.Reader
+	classifier tokenClassifier
+}
+
+// NewTokenizer creates a new tokenizer from an input stream.
+func NewTokenizer(r io.Reader) *Tokenizer {
+	input := bufio.NewReader(r)
+	classifier := newDefaultClassifier()
+	return &Tokenizer{
+		input:      *input,
+		classifier: classifier}
+}
+
+// scanStream scans the stream for the next token using the internal state machine.
+// It will panic if it encounters a rune which it does not know how to handle.
+func (t *Tokenizer) scanStream() (*Token, error) {
+	state := startState
+	var tokenType TokenType
+	var value []rune
+	var nextRune rune
+	var nextRuneType runeTokenClass
+	var err error
+
+	for {
+		nextRune, _, err = t.input.ReadRune()
+		nextRuneType = t.classifier.ClassifyRune(nextRune)
+
+		if err == io.EOF {
+			nextRuneType = eofRuneClass
+			err = nil
+		} else if err != nil {
+			return nil, err
+		}
+
+		switch state {
+		case startState: // no runes read yet
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						return nil, io.EOF
+					}
+				case spaceRuneClass:
+					{
+					}
+				case escapingQuoteRuneClass:
+					{
+						tokenType = WordToken
+						state = quotingEscapingState
+					}
+				case nonEscapingQuoteRuneClass:
+					{
+						tokenType = WordToken
+						state = quotingState
+					}
+				case escapeRuneClass:
+					{
+						tokenType = WordToken
+						state = escapingState
+					}
+				case commentRuneClass:
+					{
+						tokenType = CommentToken
+						state = commentState
+					}
+				default:
+					{
+						tokenType = WordToken
+						value = append(value, nextRune)
+						state = inWordState
+					}
+				}
+			}
+		case inWordState: // in a regular word
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case spaceRuneClass:
+					{
+						t.input.UnreadRune()
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case escapingQuoteRuneClass:
+					{
+						state = quotingEscapingState
+					}
+				case nonEscapingQuoteRuneClass:
+					{
+						state = quotingState
+					}
+				case escapeRuneClass:
+					{
+						state = escapingState
+					}
+				default:
+					{
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case escapingState: // the rune after an escape character
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						err = fmt.Errorf("EOF found after escape character")
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				default:
+					{
+						state = inWordState
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case escapingQuotedState: // the next rune after an escape character, in double quotes
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						err = fmt.Errorf("EOF found after escape character")
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				default:
+					{
+						state = quotingEscapingState
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case quotingEscapingState: // in escaping double quotes
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						err = fmt.Errorf("EOF found when expecting closing quote")
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case escapingQuoteRuneClass:
+					{
+						state = inWordState
+					}
+				case escapeRuneClass:
+					{
+						state = escapingQuotedState
+					}
+				default:
+					{
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case quotingState: // in non-escaping single quotes
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						err = fmt.Errorf("EOF found when expecting closing quote")
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case nonEscapingQuoteRuneClass:
+					{
+						state = inWordState
+					}
+				default:
+					{
+						value = append(value, nextRune)
+					}
+				}
+			}
+		case commentState: // in a comment
+			{
+				switch nextRuneType {
+				case eofRuneClass:
+					{
+						token := &Token{
+							tokenType: tokenType,
+							value:     string(value)}
+						return token, err
+					}
+				case spaceRuneClass:
+					{
+						if nextRune == '\n' {
+							state = startState
+							token := &Token{
+								tokenType: tokenType,
+								value:     string(value)}
+							return token, err
+						} else {
+							value = append(value, nextRune)
+						}
+					}
+				default:
+					{
+						value = append(value, nextRune)
+					}
+				}
+			}
+		default:
+			{
+				return nil, fmt.Errorf("Unexpected state: %v", state)
+			}
+		}
+	}
+}
+
+// Next returns the next token in the stream.
+func (t *Tokenizer) Next() (*Token, error) {
+	return t.scanStream()
+}
+
+// Split partitions a string into a slice of strings.
+func Split(s string) ([]string, error) {
+	l := NewLexer(strings.NewReader(s))
+	subStrings := make([]string, 0)
+	for {
+		word, err := l.Next()
+		if err != nil {
+			if err == io.EOF {
+				return subStrings, nil
+			}
+			return subStrings, err
+		}
+		subStrings = append(subStrings, word)
+	}
+}

--- a/strutil/shlex/shlex_test.go
+++ b/strutil/shlex/shlex_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shlex
+
+import (
+	"strings"
+	"testing"
+)
+
+var (
+	// one two "three four" "five \"six\"" seven#eight # nine # ten
+	// eleven 'twelve\'
+	testString = "one two \"three four\" \"five \\\"six\\\"\" seven#eight # nine # ten\n eleven 'twelve\\' thirteen=13 fourteen/14"
+)
+
+func TestClassifier(t *testing.T) {
+	classifier := newDefaultClassifier()
+	tests := map[rune]runeTokenClass{
+		' ':  spaceRuneClass,
+		'"':  escapingQuoteRuneClass,
+		'\'': nonEscapingQuoteRuneClass,
+		'#':  commentRuneClass}
+	for runeChar, want := range tests {
+		got := classifier.ClassifyRune(runeChar)
+		if got != want {
+			t.Errorf("ClassifyRune(%v) -> %v. Want: %v", runeChar, got, want)
+		}
+	}
+}
+
+func TestTokenizer(t *testing.T) {
+	testInput := strings.NewReader(testString)
+	expectedTokens := []*Token{
+		&Token{WordToken, "one"},
+		&Token{WordToken, "two"},
+		&Token{WordToken, "three four"},
+		&Token{WordToken, "five \"six\""},
+		&Token{WordToken, "seven#eight"},
+		&Token{CommentToken, " nine # ten"},
+		&Token{WordToken, "eleven"},
+		&Token{WordToken, "twelve\\"},
+		&Token{WordToken, "thirteen=13"},
+		&Token{WordToken, "fourteen/14"}}
+
+	tokenizer := NewTokenizer(testInput)
+	for i, want := range expectedTokens {
+		got, err := tokenizer.Next()
+		if err != nil {
+			t.Error(err)
+		}
+		if !got.Equal(want) {
+			t.Errorf("Tokenizer.Next()[%v] of %q -> %v. Want: %v", i, testString, got, want)
+		}
+	}
+}
+
+func TestLexer(t *testing.T) {
+	testInput := strings.NewReader(testString)
+	expectedStrings := []string{"one", "two", "three four", "five \"six\"", "seven#eight", "eleven", "twelve\\", "thirteen=13", "fourteen/14"}
+
+	lexer := NewLexer(testInput)
+	for i, want := range expectedStrings {
+		got, err := lexer.Next()
+		if err != nil {
+			t.Error(err)
+		}
+		if got != want {
+			t.Errorf("Lexer.Next()[%v] of %q -> %v. Want: %v", i, testString, got, want)
+		}
+	}
+}
+
+func TestSplit(t *testing.T) {
+	want := []string{"one", "two", "three four", "five \"six\"", "seven#eight", "eleven", "twelve\\", "thirteen=13", "fourteen/14"}
+	got, err := Split(testString)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(want) != len(got) {
+		t.Errorf("Split(%q) -> %v. Want: %v", testString, got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("Split(%q)[%v] -> %v. Want: %v", testString, i, got[i], want[i])
+		}
+	}
+}

--- a/strutil/shlex/shlex_test.go
+++ b/strutil/shlex/shlex_test.go
@@ -45,16 +45,16 @@ func TestClassifier(t *testing.T) {
 func TestTokenizer(t *testing.T) {
 	testInput := strings.NewReader(testString)
 	expectedTokens := []*Token{
-		&Token{WordToken, "one"},
-		&Token{WordToken, "two"},
-		&Token{WordToken, "three four"},
-		&Token{WordToken, "five \"six\""},
-		&Token{WordToken, "seven#eight"},
-		&Token{CommentToken, " nine # ten"},
-		&Token{WordToken, "eleven"},
-		&Token{WordToken, "twelve\\"},
-		&Token{WordToken, "thirteen=13"},
-		&Token{WordToken, "fourteen/14"}}
+		{WordToken, "one"},
+		{WordToken, "two"},
+		{WordToken, "three four"},
+		{WordToken, "five \"six\""},
+		{WordToken, "seven#eight"},
+		{CommentToken, " nine # ten"},
+		{WordToken, "eleven"},
+		{WordToken, "twelve\\"},
+		{WordToken, "thirteen=13"},
+		{WordToken, "fourteen/14"}}
 
 	tokenizer := NewTokenizer(testInput)
 	for i, want := range expectedTokens {

--- a/tests/lib/snaps/test-snapd-xdg-autostart/bin/foobar
+++ b/tests/lib/snaps/test-snapd-xdg-autostart/bin/foobar
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+dump_autostart() {
+    dfpath="$SNAP_USER_DATA/.config/autostart/foo.desktop"
+
+    test -e "$dfpath" && return
+
+    echo "generating autostart file $dfpath"
+
+    mkdir -p $SNAP_USER_DATA/.config/autostart
+    cat <<EOF > $dfpath
+[Desktop Entry]
+Name=foo autostart
+Exec=/foo/bar/baz/bin/foobar --autostart a b c
+EOF
+}
+
+case "$1" in
+    --autostart)
+        echo "autostarting with args '$@'" | tee $SNAP_USER_DATA/foo-autostarted
+        ;;
+    *)
+        echo "regular run with args '$@'"
+        dump_autostart
+        ;;
+esac

--- a/tests/lib/snaps/test-snapd-xdg-autostart/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-xdg-autostart/meta/snap.yaml
@@ -1,0 +1,6 @@
+name: test-snapd-xdg-autostart
+version: 1.0
+apps:
+  foo:
+    command: bin/foobar
+    autostart: foo.desktop

--- a/tests/main/snap-userd-desktop-app-autostart/task.yaml
+++ b/tests/main/snap-userd-desktop-app-autostart/task.yaml
@@ -1,0 +1,29 @@
+summary: Check that snap userd can autostart user session applications
+
+execute: |
+    echo "When the snap is installed"
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-xdg-autostart
+
+    # run the app directly, it will dump a *.desktop file
+    snap run test-snapd-xdg-autostart.foo
+
+    echo "And snap application autostart file exists"
+    test -e ~/snap/test-snapd-xdg-autostart/current/.config/autostart/foo.desktop
+
+    echo "Applications can be automatically started by snap userd --autostart"
+
+    test ! -e ~/snap/test-xdg-snap-autostart/current/foo-autostarted
+    snap userd --autostart > autostart.log 2>&1
+
+    # when app is autostarted it dumps a file at $SNAP_USER_DATA/foo-autostarted,
+    # applications are forked by userd, but userd does not wait for them
+    for i in `seq 20`; do
+        test -e ~/snap/test-snapd-xdg-autostart/current/foo-autostarted && break
+        sleep 1
+    done
+    test -e ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
+
+restore: |
+    rm -f ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
+    rm -f ~/snap/test-snapd-xdg-autostart/current/.config/autostart/foo.desktop

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -1,0 +1,202 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package userd
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil/shlex"
+)
+
+// expandDesktopFields processes the input string and expands any %<char>
+// patterns. '%%' expands to '%', all other patterns expand to empty strings.
+func expandDesktopFields(in string) string {
+	raw := []rune(in)
+	out := make([]rune, 0, len(raw))
+
+	var hasKey bool
+	for _, r := range raw {
+		if hasKey {
+			hasKey = false
+			// only allow %% -> % expansion, drop other keys
+			if r == '%' {
+				out = append(out, r)
+			}
+			continue
+		} else if r == '%' {
+			hasKey = true
+			continue
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+// Note: consider wrappers/desktop.go if we start parsing more than Exec line
+func findExec(desktopFileContent []byte) (string, error) {
+	scanner := bufio.NewScanner(bytes.NewBuffer(desktopFileContent))
+	execCmd := ""
+	for scanner.Scan() {
+		bline := scanner.Bytes()
+
+		if !bytes.HasPrefix(bline, []byte("Exec=")) {
+			continue
+		}
+
+		full := string(bline[len("Exec="):])
+		execCmd = expandDesktopFields(full)
+		break
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	execCmd = strings.TrimSpace(execCmd)
+	if execCmd == "" {
+		return "", fmt.Errorf("Exec not found or invalid")
+	}
+	return execCmd, nil
+}
+
+func autostartCmd(snapName, desktopFilePath string) (*exec.Cmd, error) {
+	desktopFile := filepath.Base(desktopFilePath)
+
+	info, err := snap.ReadCurrentInfo(snapName)
+	if err != nil {
+		return nil, err
+	}
+
+	var app *snap.AppInfo
+	for _, candidate := range info.Apps {
+		if candidate.Autostart == desktopFile {
+			app = candidate
+			break
+		}
+	}
+	if app == nil {
+		return nil, fmt.Errorf("cannot match desktop file with snap %s applications", snapName)
+	}
+
+	content, err := ioutil.ReadFile(desktopFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE: Ignore all fields and just look for Exec=..., this also means
+	// that fields with meaning such as TryExec, X-GNOME-Autostart and so on
+	// are ignored
+
+	command, err := findExec(content)
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine startup command for application %s in snap %s: %v", app.Name, snapName, err)
+	}
+	logger.Debugf("exec line: %v", command)
+
+	split, err := shlex.Split(command)
+	if err != nil {
+		return nil, fmt.Errorf("invalid application startup command: %v", err)
+	}
+
+	// NOTE: Ignore the actual argv[0] in Exec=.. line and replace it with a
+	// command of the snap application. Any arguments passed in the Exec=..
+	// line to the original command are preserved.
+	cmd := exec.Command(app.WrapperPath(), split[1:]...)
+	return cmd, nil
+}
+
+// failedAutostartError keeps track of errors that occurred when starting an
+// application for a specific desktop file, desktop file name is as a key
+type failedAutostartError map[string]error
+
+func (f failedAutostartError) Error() string {
+	var out bytes.Buffer
+
+	dfiles := make([]string, 0, len(f))
+	for desktopFile := range f {
+		dfiles = append(dfiles, desktopFile)
+	}
+	sort.Strings(dfiles)
+	for _, desktopFile := range dfiles {
+		fmt.Fprintf(&out, "- %q: %v\n", desktopFile, f[desktopFile])
+	}
+	return out.String()
+}
+
+var userCurrent = user.Current
+
+// AutostartSessionApps starts applications which have placed their desktop
+// files in $SNAP_USER_DATA/.config/autostart
+//
+// NOTE: By the spec, the actual path is $SNAP_USER_DATA/${XDG_CONFIG_DIR}/autostart
+func AutostartSessionApps() error {
+	usr, err := userCurrent()
+	if err != nil {
+		return err
+	}
+
+	usrSnapDir := filepath.Join(usr.HomeDir, dirs.UserHomeSnapDir)
+
+	glob := filepath.Join(usrSnapDir, "*/current/.config/autostart/*.desktop")
+	matches, err := filepath.Glob(glob)
+	if err != nil {
+		return err
+	}
+
+	failedApps := make(failedAutostartError)
+	for _, desktopFilePath := range matches {
+		desktopFile := filepath.Base(desktopFilePath)
+		logger.Debugf("autostart desktop file %v", desktopFile)
+
+		// /home/foo/snap/some-snap/current/.config/autostart/some-app.desktop ->
+		//    some-snap/current/.config/autostart/some-app.desktop
+		noHomePrefix := strings.TrimPrefix(desktopFilePath, usrSnapDir+"/")
+		// some-snap/current/.config/autostart/some-app.desktop -> some-snap
+		snapName := noHomePrefix[0:strings.IndexByte(noHomePrefix, '/')]
+
+		logger.Debugf("snap name: %q", snapName)
+
+		cmd, err := autostartCmd(snapName, desktopFilePath)
+		if err != nil {
+			failedApps[desktopFile] = err
+			continue
+		}
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		if err := cmd.Start(); err != nil {
+			failedApps[desktopFile] = fmt.Errorf("cannot autostart %q: %v", desktopFile, err)
+		}
+	}
+	if len(failedApps) > 0 {
+		return failedApps
+	}
+	return nil
+}

--- a/userd/autostart_test.go
+++ b/userd/autostart_test.go
@@ -1,0 +1,244 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package userd_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+	"github.com/snapcore/snapd/userd"
+)
+
+type autostartSuite struct {
+	dir                string
+	autostartDir       string
+	userDir            string
+	userCurrentRestore func()
+}
+
+var _ = Suite(&autostartSuite{})
+
+func (s *autostartSuite) SetUpTest(c *C) {
+	s.dir = c.MkDir()
+	dirs.SetRootDir(s.dir)
+	snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {})
+
+	s.userDir = path.Join(s.dir, "home")
+	s.autostartDir = path.Join(s.userDir, ".config", "autostart")
+	s.userCurrentRestore = userd.MockUserCurrent(func() (*user.User, error) {
+		return &user.User{HomeDir: s.userDir}, nil
+	})
+
+	err := os.MkdirAll(s.autostartDir, 0755)
+	c.Assert(err, IsNil)
+}
+
+func (s *autostartSuite) TearDownTest(c *C) {
+	s.dir = c.MkDir()
+	dirs.SetRootDir("/")
+	if s.userCurrentRestore != nil {
+		s.userCurrentRestore()
+	}
+}
+
+func (s *autostartSuite) TestFindExec(c *C) {
+	allGood := `[Desktop Entry]
+Exec=foo --bar
+`
+	allGoodWithFlags := `[Desktop Entry]
+Exec=foo --bar "%%p" %U %D +%s %%
+`
+	noExec := `[Desktop Entry]
+Type=Application
+`
+	emptyExec := `[Desktop Entry]
+Exec=
+`
+	onlySpacesExec := `[Desktop Entry]
+Exec=
+`
+	for i, tc := range []struct {
+		in  string
+		out string
+		err string
+	}{{
+		in:  allGood,
+		out: "foo --bar",
+	}, {
+		in:  noExec,
+		err: "Exec not found or invalid",
+	}, {
+		in:  emptyExec,
+		err: "Exec not found or invalid",
+	}, {
+		in:  onlySpacesExec,
+		err: "Exec not found or invalid",
+	}, {
+		in:  allGoodWithFlags,
+		out: `foo --bar "%p"   + %`,
+	}} {
+		c.Logf("tc %d", i)
+
+		cmd, err := userd.FindExec([]byte(tc.in))
+		if tc.err != "" {
+			c.Check(cmd, Equals, "")
+			c.Check(err, ErrorMatches, tc.err)
+		} else {
+			c.Check(err, IsNil)
+			c.Check(cmd, Equals, tc.out)
+		}
+	}
+}
+
+var mockYaml = `name: snapname
+version: 1.0
+apps:
+ foo:
+  command: run-app
+  autostart: foo-stable.desktop
+`
+
+func (s *autostartSuite) TestTryAutostartAppValid(c *C) {
+	si := snaptest.MockSnapCurrent(c, mockYaml, &snap.SideInfo{Revision: snap.R("x2")})
+
+	appWrapperPath := si.Apps["foo"].WrapperPath()
+	err := os.MkdirAll(filepath.Dir(appWrapperPath), 0755)
+	c.Assert(err, IsNil)
+
+	appCmd := testutil.MockCommand(c, appWrapperPath, "")
+	defer appCmd.Restore()
+
+	fooDesktopFile := filepath.Join(s.autostartDir, "foo-stable.desktop")
+	writeFile(c, fooDesktopFile,
+		[]byte(`[Desktop Entry]
+Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
+`))
+
+	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
+	c.Assert(err, IsNil)
+	c.Assert(cmd.Path, Equals, appWrapperPath)
+
+	err = cmd.Start()
+	c.Assert(err, IsNil)
+	cmd.Wait()
+
+	c.Assert(appCmd.Calls(), DeepEquals,
+		[][]string{
+			{
+				filepath.Base(appWrapperPath),
+				"-a",
+				"-b",
+				"--foo=a b c",
+				"-z",
+				"dev",
+			},
+		})
+}
+
+func (s *autostartSuite) TestTryAutostartAppNoMatchingApp(c *C) {
+	snaptest.MockSnapCurrent(c, mockYaml, &snap.SideInfo{Revision: snap.R("x2")})
+
+	fooDesktopFile := filepath.Join(s.autostartDir, "foo-no-match.desktop")
+	writeFile(c, fooDesktopFile,
+		[]byte(`[Desktop Entry]
+Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
+`))
+
+	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
+	c.Assert(cmd, IsNil)
+	c.Assert(err, ErrorMatches, `cannot match desktop file with snap snapname applications`)
+}
+
+func (s *autostartSuite) TestTryAutostartAppNoSnap(c *C) {
+	fooDesktopFile := filepath.Join(s.autostartDir, "foo-stable.desktop")
+	writeFile(c, fooDesktopFile,
+		[]byte(`[Desktop Entry]
+Exec=this-is-ignored -a -b --foo="a b c" -z "dev"
+`))
+
+	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
+	c.Assert(cmd, IsNil)
+	c.Assert(err, ErrorMatches, `cannot find current revision for snap snapname.*`)
+}
+
+func (s *autostartSuite) TestTryAutostartAppBadExec(c *C) {
+	snaptest.MockSnapCurrent(c, mockYaml, &snap.SideInfo{Revision: snap.R("x2")})
+
+	fooDesktopFile := filepath.Join(s.autostartDir, "foo-stable.desktop")
+	writeFile(c, fooDesktopFile,
+		[]byte(`[Desktop Entry]
+Foo=bar
+`))
+
+	cmd, err := userd.AutostartCmd("snapname", fooDesktopFile)
+	c.Assert(cmd, IsNil)
+	c.Assert(err, ErrorMatches, `cannot determine startup command for application foo in snap snapname: Exec not found or invalid`)
+}
+
+func writeFile(c *C, path string, content []byte) {
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(path, content, 0644)
+	c.Assert(err, IsNil)
+}
+
+func (s *autostartSuite) TestTryAutostartMany(c *C) {
+	var mockYamlTemplate = `name: {snap}
+version: 1.0
+apps:
+ foo:
+  command: run-app
+  autostart: foo-stable.desktop
+`
+
+	snaptest.MockSnapCurrent(c, strings.Replace(mockYamlTemplate, "{snap}", "a-foo", -1),
+		&snap.SideInfo{Revision: snap.R("x2")})
+	snaptest.MockSnapCurrent(c, strings.Replace(mockYamlTemplate, "{snap}", "b-foo", -1),
+		&snap.SideInfo{Revision: snap.R("x2")})
+	writeFile(c, filepath.Join(s.userDir, "snap/a-foo/current/.config/autostart/foo-stable.desktop"),
+		[]byte(`[Desktop Entry]
+Foo=bar
+`))
+	writeFile(c, filepath.Join(s.userDir, "snap/b-foo/current/.config/autostart/no-match.desktop"),
+		[]byte(`[Desktop Entry]
+Exec=no-snap
+`))
+	writeFile(c, filepath.Join(s.userDir, "snap/c-foo/current/.config/autostart/no-snap.desktop"),
+		[]byte(`[Desktop Entry]
+Exec=no-snap
+`))
+
+	err := userd.AutostartSessionApps()
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, `- "foo-stable.desktop": cannot determine startup command for application foo in snap a-foo: Exec not found or invalid
+- "no-match.desktop": cannot match desktop file with snap b-foo applications
+- "no-snap.desktop": cannot find current revision for snap c-foo: readlink.*no such file or directory
+`)
+}

--- a/userd/export_test.go
+++ b/userd/export_test.go
@@ -20,11 +20,16 @@
 package userd
 
 import (
+	"os/user"
+
 	"github.com/godbus/dbus"
 )
 
 var (
 	SnapFromPid = snapFromPid
+
+	FindExec     = findExec
+	AutostartCmd = autostartCmd
 )
 
 func MockSnapFromSender(f func(*dbus.Conn, dbus.Sender) (string, error)) func() {
@@ -32,5 +37,13 @@ func MockSnapFromSender(f func(*dbus.Conn, dbus.Sender) (string, error)) func() 
 	snapFromSender = f
 	return func() {
 		snapFromSender = origSnapFromSender
+	}
+}
+
+func MockUserCurrent(f func() (*user.User, error)) func() {
+	origUserCurrent := userCurrent
+	userCurrent = f
+	return func() {
+		userCurrent = origUserCurrent
 	}
 }


### PR DESCRIPTION
Add support for `snap userd --autostart`. The command is expected to be run as part of user session startup and is responsible for starting snap applications that have placed a proper `*.desktop` file in `$SNAP_USER_DATA/.config/autostart`. The desktop file is matched against `autostart` declaration in snap's YAML.

For details see https://forum.snapcraft.io/t/development-sprint-march-5th-2018/4345/2

This is #4942 for 2.32