### PR TITLE
errtracker: check for whoopsie.service instead of reading /etc/whoopsie (2.32)

### DIFF
--- a/errtracker/errtracker.go
+++ b/errtracker/errtracker.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mvo5/goconfigparser"
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/snapcore/snapd/arch"
@@ -57,8 +56,7 @@ var (
 	mockedHostSnapd = ""
 	mockedCoreSnapd = ""
 
-	snapConfineProfile  = "/etc/apparmor.d/usr.lib.snapd.snap-confine"
-	whoopsiePreferences = "/etc/whoopsie"
+	snapConfineProfile = "/etc/apparmor.d/usr.lib.snapd.snap-confine"
 
 	procCpuinfo     = "/proc/cpuinfo"
 	procSelfExe     = "/proc/self/exe"
@@ -70,22 +68,17 @@ var (
 )
 
 func whoopsieEnabled() bool {
-	cfg := goconfigparser.New()
-	err := cfg.ReadFile(whoopsiePreferences)
-	if os.IsNotExist(err) {
+	cmd := exec.Command("systemctl", "is-enabled", "whoopsie.service")
+	output, _ := cmd.CombinedOutput()
+	switch string(output) {
+	case "enabled\n":
+		return true
+	case "disabled\n":
+		return false
+	default:
+		logger.Debugf("unexpected output when checking for whoopsie.service (not installed?): %s", output)
 		return true
 	}
-	if err != nil {
-		logger.Noticef("cannot read whoopsie config %q: %v", whoopsiePreferences, err)
-		return true
-	}
-
-	reportMetricsEnabled, err := cfg.Getbool("General", "report_metrics")
-	if err != nil {
-		logger.Noticef("cannot parse whoopsie config %q: %v", whoopsiePreferences, err)
-		return true
-	}
-	return reportMetricsEnabled
 }
 
 // distroRelease returns a distro release as it is expected by daisy.ubuntu.com

--- a/errtracker/errtracker_test.go
+++ b/errtracker/errtracker_test.go
@@ -345,22 +345,16 @@ func (s *ErrtrackerTestSuite) TestReportRepair(c *C) {
 	c.Check(n, Equals, 1)
 }
 
-func (s *ErrtrackerTestSuite) TestReportWithWhoopsiePreferencesDisabled(c *C) {
-	mockWhoopsiePrefs := filepath.Join(c.MkDir(), "whoopsie")
-	err := ioutil.WriteFile(mockWhoopsiePrefs, []byte(`
-[General]
-report_metrics=false
-`), 0644)
-	c.Assert(err, IsNil)
-	restorer := errtracker.MockWhoopsiePreferences(mockWhoopsiePrefs)
-	defer restorer()
+func (s *ErrtrackerTestSuite) TestReportWithWhoopsieDisabled(c *C) {
+	mockCmd := testutil.MockCommand(c, "systemctl", "echo disabled; exit 1")
+	defer mockCmd.Restore()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		c.Fatalf("The server should not be hit from here")
 	}
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
-	restorer = errtracker.MockCrashDbURL(server.URL)
+	restorer := errtracker.MockCrashDbURL(server.URL)
 	defer restorer()
 
 	id, err := errtracker.Report("some-snap", "failed to do stuff", "[failed to do stuff]", nil)
@@ -477,4 +471,24 @@ func (s *ErrtrackerTestSuite) TestEnviron(c *C) {
 		"SHELL=/bin/sh",
 		"XDG_RUNTIME_DIR=<set>",
 	})
+}
+
+func (s *ErrtrackerTestSuite) TestReportWithNoWhoopsieInstalled(c *C) {
+	mockCmd := testutil.MockCommand(c, "systemctl", "echo Failed to get unit file state for whoopsie.service; exit 1")
+	defer mockCmd.Restore()
+
+	n := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "1234-oopsid")
+		n++
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+	restorer := errtracker.MockCrashDbURL(server.URL)
+	defer restorer()
+
+	id, err := errtracker.Report("some-snap", "failed to do stuff", "[failed to do stuff]", nil)
+	c.Check(err, IsNil)
+	c.Check(id, Equals, "1234-oopsid")
+	c.Check(n, Equals, 1)
 }

--- a/errtracker/export_test.go
+++ b/errtracker/export_test.go
@@ -71,14 +71,6 @@ func MockReExec(f func() string) (restorer func()) {
 	}
 }
 
-func MockWhoopsiePreferences(path string) (restorer func()) {
-	old := whoopsiePreferences
-	whoopsiePreferences = path
-	return func() {
-		whoopsiePreferences = old
-	}
-}
-
 func MockOsGetenv(f func(string) string) (restorer func()) {
 	old := osGetenv
 	osGetenv = f


### PR DESCRIPTION
The whoopsie upstream asked us to check for whoopsie.service instead
of reading /etc/whoopsie when checking if whoopsie is enabled or not.

This PR implements this check by doing what `whoopsie-preferences`
is doing when checking if whoopsie is enabled or not.
 
This is #5020 for 2.32