### PR TITLE
cmd: generalize locking to global, snap and per-user locks

### DIFF
--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -63,10 +63,10 @@ static const char *sc_test_use_fake_lock_dir(void)
 static void test_sc_lock_unlock(void)
 {
 	const char *lock_dir = sc_test_use_fake_lock_dir();
-	int fd = sc_lock("foo");
+	int fd = sc_lock_generic("foo", 123);
 	// Construct the name of the lock file
 	char *lock_file SC_CLEANUP(sc_cleanup_string) = NULL;
-	lock_file = g_strdup_printf("%s/foo.lock", lock_dir);
+	lock_file = g_strdup_printf("%s/foo.123.lock", lock_dir);
 	// Open the lock file again to obtain a separate file descriptor.
 	// According to flock(2) locks are associated with an open file table entry
 	// so this descriptor will be separate and can compete for the same lock.
@@ -80,7 +80,7 @@ static void test_sc_lock_unlock(void)
 	g_assert_cmpint(err, ==, -1);
 	g_assert_cmpint(saved_errno, ==, EWOULDBLOCK);
 	// Unlock the lock.
-	sc_unlock("foo", fd);
+	sc_unlock(fd);
 	// Re-attempt the locking operation. This time it should succeed.
 	err = flock(lock_fd, LOCK_EX | LOCK_NB);
 	g_assert_cmpint(err, ==, 0);

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -102,7 +102,7 @@ static int sc_lock_generic(const char *scope, uid_t uid)
 	char lock_fname[PATH_MAX] = { 0 };
 	if (uid == 0) {
 		// The root user doesn't have a per-user mount namespace.
-		// Doing so would be confusing for services wich use $SNAP_DATA
+		// Doing so would be confusing for services which use $SNAP_DATA
 		// as home, and not in $SNAP_USER_DATA.
 		sc_must_snprintf(lock_fname, sizeof lock_fname, "%s/%s.lock",
 				 sc_lock_dir, scope ? : "");

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -84,7 +84,7 @@ void sc_disable_sanity_timeout(void)
 
 static const char *sc_lock_dir = SC_LOCK_DIR;
 
-static int sc_lock_generic(const char *scope, int uid)
+static int sc_lock_generic(const char *scope, uid_t uid)
 {
 	// Create (if required) and open the lock directory.
 	debug("creating lock directory %s (if missing)", sc_lock_dir);
@@ -143,7 +143,7 @@ int sc_lock_snap(const char *snap_name)
 	return sc_lock_generic(snap_name, 0);
 }
 
-int sc_lock_snap_user(const char *snap_name, int uid)
+int sc_lock_snap_user(const char *snap_name, uid_t uid)
 {
 	return sc_lock_generic(snap_name, uid);
 }

--- a/cmd/libsnap-confine-private/locking.c
+++ b/cmd/libsnap-confine-private/locking.c
@@ -101,6 +101,9 @@ static int sc_lock_generic(const char *scope, int uid)
 	// Construct the name of the lock file.
 	char lock_fname[PATH_MAX] = { 0 };
 	if (uid == 0) {
+		// The root user doesn't have a per-user mount namespace.
+		// Doing so would be confusing for services wich use $SNAP_DATA
+		// as home, and not in $SNAP_USER_DATA.
 		sc_must_snprintf(lock_fname, sizeof lock_fname, "%s/%s.lock",
 				 sc_lock_dir, scope ? : "");
 	} else {

--- a/cmd/libsnap-confine-private/locking.h
+++ b/cmd/libsnap-confine-private/locking.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2017-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -18,16 +18,9 @@
 #define SNAP_CONFINE_LOCKING_H
 
 /**
- * Obtain a flock-based, exclusive lock.
+ * Obtain a flock-based, exclusive, globally scoped, lock.
  *
- * The scope may be the name of a snap or NULL (global lock).  Each subsequent
- * argument is of type sc_locked_fn and gets called with the scope argument.
- * The function guarantees that a filesystem lock is reliably acquired and
- * released on call to sc_unlock() immediately upon process death.
- *
- * The actual lock is placed in "/run/snapd/ns" and is either called
- * "/run/snapd/ns/.lock" if scope is NULL or
- * "/run/snapd/ns/$scope.lock" otherwise.
+ * The actual lock is placed in "/run/snap/ns/.lock"
  *
  * If the lock cannot be acquired for three seconds (via
  * sc_enable_sanity_timeout) then the function fails and the process dies.
@@ -35,29 +28,42 @@
  * The return value needs to be passed to sc_unlock(), there is no need to
  * check for errors as the function will die() on any problem.
  **/
-int sc_lock(const char *scope);
+int sc_lock_global(void);
+
+/**
+ * Obtain a flock-based, exclusive, snap-scoped, lock.
+ *
+ * The actual lock is placed in "/run/snapd/ns/$SNAP_NAME.lock"
+ * It should be acquired only when holding the global lock.
+ *
+ * If the lock cannot be acquired for three seconds (via
+ * sc_enable_sanity_timeout) then the function fails and the process dies.
+ *
+ * The return value needs to be passed to sc_unlock(), there is no need to
+ * check for errors as the function will die() on any problem.
+ **/
+int sc_lock_snap(const char *snap_name);
+
+/**
+ * Obtain a flock-based, exclusive, snap-scoped, lock.
+ *
+ * The actual lock is placed in "/run/snapd/ns/$SNAP_NAME.$UID.lock"
+ * It should be acquired only when holding the snap-specific lock.
+ *
+ * If the lock cannot be acquired for three seconds (via
+ * sc_enable_sanity_timeout) then the function fails and the process dies.
+ * The return value needs to be passed to sc_unlock(), there is no need to
+ * check for errors as the function will die() on any problem.
+ **/
+int sc_lock_snap_user(const char *snap_name, int uid);
 
 /**
  * Release a flock-based lock.
  *
- * This function simply unlocks the lock and closes the file descriptor.
+ * All kinds of locks can be unlocked the same way. This function simply
+ * unlocks the lock and closes the file descriptor.
  **/
-void sc_unlock(const char *scope, int lock_fd);
-
-/**
- * Obtain a flock-based, exclusive, globally scoped, lock.
- *
- * This function is exactly like sc_lock(NULL), that is the acquired lock is
- * not specific to any snap but global.
- **/
-int sc_lock_global(void);
-
-/**
- * Release a flock-based, globally scoped, lock
- *
- * This function is exactly like sc_unlock(NULL, lock_fd).
- **/
-void sc_unlock_global(int lock_fd);
+void sc_unlock(int lock_fd);
 
 /**
  * Enable a sanity-check timeout.

--- a/cmd/libsnap-confine-private/locking.h
+++ b/cmd/libsnap-confine-private/locking.h
@@ -17,6 +17,15 @@
 #ifndef SNAP_CONFINE_LOCKING_H
 #define SNAP_CONFINE_LOCKING_H
 
+// Include config.h which pulls in _GNU_SOURCE which in turn allows sys/types.h
+// to define O_PATH. Since locking.h is included from locking.c this is
+// required to see O_PATH there.
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <sys/types.h>
+
 /**
  * Obtain a flock-based, exclusive, globally scoped, lock.
  *
@@ -55,7 +64,7 @@ int sc_lock_snap(const char *snap_name);
  * The return value needs to be passed to sc_unlock(), there is no need to
  * check for errors as the function will die() on any problem.
  **/
-int sc_lock_snap_user(const char *snap_name, int uid);
+int sc_lock_snap_user(const char *snap_name, uid_t uid);
 
 /**
  * Release a flock-based lock.

--- a/cmd/snap-confine/snap-confine.c
+++ b/cmd/snap-confine/snap-confine.c
@@ -217,7 +217,7 @@ int main(int argc, char **argv)
 			sc_ensure_shared_snap_mount();
 			debug("unsharing snap namespace directory");
 			sc_initialize_ns_groups();
-			sc_unlock_global(global_lock_fd);
+			sc_unlock(global_lock_fd);
 
 			// Find and open snap-update-ns from the same
 			// path as where we (snap-confine) were
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
 			snap_update_ns_fd = sc_open_snap_update_ns();
 
 			// Do per-snap initialization.
-			int snap_lock_fd = sc_lock(snap_name);
+			int snap_lock_fd = sc_lock_snap(snap_name);
 			debug("initializing mount namespace: %s", snap_name);
 			struct sc_ns_group *group = NULL;
 			group = sc_open_ns_group(snap_name, 0);
@@ -276,7 +276,7 @@ int main(int argc, char **argv)
 				}
 			}
 
-			sc_unlock(snap_name, snap_lock_fd);
+			sc_unlock(snap_lock_fd);
 
 			// Reset path as we cannot rely on the path from the host OS to
 			// make sense. The classic distribution may use any PATH that makes

--- a/cmd/snap-discard-ns/snap-discard-ns.c
+++ b/cmd/snap-discard-ns/snap-discard-ns.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
 		die("Usage: %s snap-name", argv[0]);
 	const char *snap_name = argv[1];
 
-	int snap_lock_fd = sc_lock(snap_name);
+	int snap_lock_fd = sc_lock_snap(snap_name);
 	debug("initializing mount namespace: %s", snap_name);
 	struct sc_ns_group *group =
 	    sc_open_ns_group(snap_name, SC_NS_FAIL_GRACEFULLY);
@@ -50,6 +50,6 @@ int main(int argc, char **argv)
 		}
 	}
 
-	sc_unlock(snap_name, snap_lock_fd);
+	sc_unlock(snap_lock_fd);
 	return 0;
 }


### PR DESCRIPTION
We will need to lock per-user mount namespaces soon so I wanted to
generalize the locking functions and make them simpler to use. There's a
lock function per purpose (global, per-snap, per-snap-user) and just one
unlock function for all three.

The existing call sites were adjusted.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
