### PR TITLE
userd: set up journal logging streams for autostarted apps

### DIFF
--- a/tests/main/snap-userd-desktop-app-autostart/task.yaml
+++ b/tests/main/snap-userd-desktop-app-autostart/task.yaml
@@ -1,5 +1,8 @@
 summary: Check that snap userd can autostart user session applications
 
+# ubuntu-14.04: too old journalctl
+systems: [-ubuntu-14.04-*]
+
 execute: |
     echo "When the snap is installed"
     . $TESTSLIB/snaps.sh
@@ -14,6 +17,7 @@ execute: |
     echo "Applications can be automatically started by snap userd --autostart"
 
     test ! -e ~/snap/test-xdg-snap-autostart/current/foo-autostarted
+    cursor=$(journalctl --show-cursor -n 0 |grep cursor | cut -f3 -d' ')
     snap userd --autostart > autostart.log 2>&1
 
     # when app is autostarted it dumps a file at $SNAP_USER_DATA/foo-autostarted,
@@ -23,6 +27,9 @@ execute: |
         sleep 1
     done
     test -e ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
+
+    journalctl --flush
+    test "$(journalctl -t foo.desktop --after-cursor=$cursor | wc -l)" -eq 1
 
 restore: |
     rm -f ~/snap/test-snapd-xdg-autostart/current/foo-autostarted

--- a/tests/main/snap-userd-desktop-app-autostart/task.yaml
+++ b/tests/main/snap-userd-desktop-app-autostart/task.yaml
@@ -1,8 +1,5 @@
 summary: Check that snap userd can autostart user session applications
 
-# ubuntu-14.04: too old journalctl
-systems: [-ubuntu-14.04-*]
-
 execute: |
     echo "When the snap is installed"
     . $TESTSLIB/snaps.sh
@@ -17,7 +14,10 @@ execute: |
     echo "Applications can be automatically started by snap userd --autostart"
 
     test ! -e ~/snap/test-xdg-snap-autostart/current/foo-autostarted
-    cursor=$(journalctl --show-cursor -n 0 |grep cursor | cut -f3 -d' ')
+    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
+        # 14.04 journalctl does not have cursor support
+        cursor=$(journalctl --show-cursor -n 0 |grep cursor | cut -f3 -d' ')
+    fi
     snap userd --autostart > autostart.log 2>&1
 
     # when app is autostarted it dumps a file at $SNAP_USER_DATA/foo-autostarted,
@@ -28,8 +28,14 @@ execute: |
     done
     test -e ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
 
-    journalctl --flush
-    test "$(journalctl -t foo.desktop --after-cursor=$cursor | wc -l)" -eq 1
+    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
+        journalctl --flush
+        test "$(journalctl -t foo.desktop --after-cursor=$cursor | wc -l)" -eq 1
+    else
+        # 14.04 journalctl does not have cursor, neither --identifier support,
+        # nor --flush
+        test "$(journalctl | grep foo.desktop | wc -l)" -eq 1
+    fi
 
 restore: |
     rm -f ~/snap/test-snapd-xdg-autostart/current/foo-autostarted

--- a/userd/autostart.go
+++ b/userd/autostart.go
@@ -158,11 +158,13 @@ func makeStdStreams(identifier string) (stdout *os.File, stderr *os.File) {
 
 	stdout, err = systemd.NewJournalStreamFile(identifier, syslog.LOG_INFO, false)
 	if err != nil {
+		logger.Noticef("failed to set up stdout journal stream for %q: %v", identifier, err)
 		stdout = os.Stdout
 	}
 
 	stderr, err = systemd.NewJournalStreamFile(identifier, syslog.LOG_WARNING, false)
 	if err != nil {
+		logger.Noticef("failed to set up stderr journal stream for %q: %v", identifier, err)
 		stderr = os.Stderr
 	}
 


### PR DESCRIPTION
Add support for opening journal logging streams for autostarted apps. Mimic what gnome-session does and use desktop file basename as log identifier.

Logs that used to look like this:
```
Apr 09 09:59:15 corsair snap-userd-autostart.desktop[27498]: Feature redeclared; is this a duplicate flag?  media_devices
Apr 09 09:59:15 corsair snap-userd-autostart.desktop[27498]: Feature redeclared; is this a duplicate flag?  media_video
Apr 09 09:59:16 corsair snap-userd-autostart.desktop[27498]: sh: 1: xdg-mime: not found
Apr 09 09:59:17 corsair snap-userd-autostart.desktop[27498]: [Modules] Starting to install discord_vigilante...
Apr 09 09:59:17 corsair snap-userd-autostart.desktop[27498]: [Modules] Fetching discord_vigilante@0 from https://discordapp.com/api/modules/stable/discord_vigilante/0
```
Contain the proper identifier now:
```
Apr 11 11:36:17 corsair discord-stable.desktop[9211]: [Modules] Modules initializing
Apr 11 11:36:17 corsair discord-stable.desktop[9211]: [Modules] Distribution: remote
Apr 11 11:36:17 corsair discord-stable.desktop[9211]: [Modules] Host updates: enabled
Apr 11 11:36:17 corsair discord-stable.desktop[9211]: [Modules] Module updates: enabled
Apr 11 11:36:17 corsair discord-stable.desktop[9211]: [Modules] Module install path: /home/maciek/snap/discord/x1/.config/discord/0.0.4/modules
Apr 11 11:36:17 corsair discord-stable.desktop[9211]: [Modules] Module installed file path: /home/maciek/snap/discord/x1/.config/discord/0.0.4/modules/installed.json
```

This PR includes #5024 and will be rebased when #5024 lands in master.