### PR TITLE
snap: snap.AppInfo is now a fmt.Stringer

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -617,6 +617,10 @@ func (timer *TimerInfo) File() string {
 	return filepath.Join(dirs.SnapServicesDir, timer.App.SecurityTag()+".timer")
 }
 
+func (app *AppInfo) String() string {
+	return JoinSnapApp(app.Snap.Name(), app.Name)
+}
+
 // SecurityTag returns application-specific security tag.
 //
 // Security tags are used by various security subsystems as "profile names" and

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -802,6 +802,16 @@ apps:
 	c.Check(info.Apps["app1"].IsService(), Equals, false)
 }
 
+func (s *infoSuite) TestAppInfoStringer(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`name: asnap
+apps:
+  one:
+   daemon: simple
+`))
+	c.Assert(err, IsNil)
+	c.Check(fmt.Sprintf("%q", info.Apps["one"]), Equals, `"asnap.one"`)
+}
+
 func (s *infoSuite) TestSocketFile(c *C) {
 	info, err := snap.InfoFromSnapYaml([]byte(`name: pans
 apps:


### PR DESCRIPTION
With this change you can now pass a `snap.AppInfo` (or even a
`[]*snap.AppInfo`) to a `%s` or `%q` and it will do the right thing.

Without this, we're doing the above anyway :-) and getting
nasty entries in the log like
```
DEBUG: StopServices called for [%!q(*snap.AppInfo=&{0xc821331340 …
```
