### PR TITLE
data/systemd: helper service for waking up the main snapd service

### DIFF
--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -11,6 +11,3 @@ ExecStart=@libexecdir@/snapd/snapd
 EnvironmentFile=-@SNAPD_ENVIRONMENT_FILE@
 Restart=always
 Type=notify
-
-[Install]
-WantedBy=multi-user.target

--- a/data/systemd/snapd.wakeup.service.in
+++ b/data/systemd/snapd.wakeup.service.in
@@ -6,6 +6,7 @@ Requires=snapd.socket
 
 [Service]
 ExecStart=@bindir@/snap version
+Type=idle
 
 [Install]
 WantedBy=multi-user.target

--- a/data/systemd/snapd.wakeup.service.in
+++ b/data/systemd/snapd.wakeup.service.in
@@ -3,6 +3,7 @@ Description=snapd helper for waking up the main service only when needed
 ConditionPathExists=|/var/lib/snapd/seed/seed.yaml
 ConditionPathExistsGlob=|@SNAP_MOUNT_DIR@/*/current
 Requires=snapd.socket
+After=snapd.socket
 
 [Service]
 ExecStart=@bindir@/snap version

--- a/data/systemd/snapd.wakeup.service.in
+++ b/data/systemd/snapd.wakeup.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=snapd helper for waking up the main service only when needed
+ConditionPathExists=|/var/lib/snapd/seed/seed.yaml
+ConditionPathExistsGlob=|@SNAP_MOUNT_DIR@/*/current
+Requires=snapd.socket
+
+[Service]
+ExecStart=@bindir@/snap version
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -50,7 +50,7 @@
 %global provider_prefix %{provider}.%{provider_tld}/%{project}/%{repo}
 %global import_path     %{provider_prefix}
 
-%global snappy_svcs     snapd.service snapd.socket snapd.autoimport.service
+%global snappy_svcs     snapd.service snapd.socket snapd.autoimport.service snapd.wakeup.service
 
 # Until we have a way to add more extldflags to gobuild macro...
 %if 0%{?fedora} >= 26
@@ -616,6 +616,7 @@ popd
 %{_sysconfdir}/profile.d/snapd.sh
 %{_unitdir}/snapd.socket
 %{_unitdir}/snapd.service
+%{_unitdir}/snapd.wakeup.service
 %{_unitdir}/snapd.autoimport.service
 %{_datadir}/dbus-1/services/io.snapcraft.Launcher.service
 %{_datadir}/dbus-1/services/io.snapcraft.Settings.service

--- a/packaging/opensuse-42.2/snapd.spec
+++ b/packaging/opensuse-42.2/snapd.spec
@@ -30,7 +30,7 @@
 %global with_test_keys 0
 %endif
 
-%define systemd_services_list snapd.socket snapd.service
+%define systemd_services_list snapd.socket snapd.service snapd.wakeup.service
 Name:           snapd
 Version:        2.32.3.2
 Release:        0
@@ -293,6 +293,7 @@ fi
 %{_mandir}/man5/snap-discard-ns.5.gz
 %{_unitdir}/snapd.service
 %{_unitdir}/snapd.socket
+%{_unitdir}/snapd.wakeup.service
 /usr/bin/snap
 /usr/bin/snapctl
 /usr/sbin/rcsnapd

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -42,6 +42,14 @@ execute: |
     distro_purge_package snapd
     distro_install_build_snapd
 
+    systemctl start snapd.service
+    wait_for_service snapd.service
+    # wait for snapd to populate state.json with data
+    for _ in $(seq 20); do
+        test "$(stat -c '%s' /var/lib/snapd/state.json)" -gt 0 && break || true
+    done
+    test "$(stat -c '%s' /var/lib/snapd/state.json)" -gt 0
+
     # modify daemon state to set ubuntu-core-transition-last-retry-time to the
     # current time to prevent the ubuntu-core transition before the test snap is
     # installed

--- a/tests/main/snapd-wakeup/task.yaml
+++ b/tests/main/snapd-wakeup/task.yaml
@@ -8,6 +8,7 @@ prepare: |
 
 execute: |
     systemctl is-enabled snapd.wakeup.service
+    ! systemctl is-enabled snapd.service
 
     . $TESTSLIB/dirs.sh
 
@@ -83,4 +84,4 @@ execute: |
     esac
 
 debug: |
-    systemctl status snapd.service snapd.socket snapd.wakeup.service
+    systemctl status snapd.service snapd.socket snapd.wakeup.service || true

--- a/tests/main/snapd-wakeup/task.yaml
+++ b/tests/main/snapd-wakeup/task.yaml
@@ -1,0 +1,86 @@
+summary: Check that snap wakeup service works correctly
+
+# only ubuntu for now, other distros have a maze of systemd presets that leave
+# snapd.wakeup.service disabled
+systems: [ubuntu-*]
+prepare: |
+    systemctl stop snapd.service
+
+execute: |
+    systemctl is-enabled snapd.wakeup.service
+
+    . $TESTSLIB/dirs.sh
+
+    case "$SPREAD_REBOOT" in
+        0)
+            # no seed, no snaps
+            echo "When the system has no seed, and has no snaps installed"
+            test "$(find $SNAP_MOUNT_DIR -name '*/current' | wc -l)" = 0
+            test ! -e /var/lib/snapd/seed/seed.yaml
+
+            # the service should be down
+            echo "The snapd service is expected to be dead"
+            systemctl show -p SubState  snapd.service | MATCH "SubState=dead"
+
+            # pretend the system has seed.yaml
+            mkdir -p /var/lib/snapd/seed
+            echo 'foo: bar' > /var/lib/snapd/seed/seed.yaml
+
+            REBOOT
+            ;;
+        1)
+            # seed, no snaps
+            echo "When the system has seed, but had no snaps installed"
+            test -e /var/lib/snapd/seed/seed.yaml
+
+            # service should have been woken up
+            echo "The snapd service is expected to be running"
+            for _ in $(seq 20); do
+                systemctl show -p SubState  snapd.service | MATCH "SubState=running" && break || true
+                sleep 1
+            done
+            systemctl show -p SubState  snapd.service | MATCH "SubState=running"
+
+            # install snaps
+            snap install test-snapd-tools
+
+            rm -rf /var/lib/snapd/seed/seed.yaml
+            REBOOT
+            ;;
+        2)
+            # no seed, snaps
+            echo "When the system has no seed, but has snaps installed"
+            test "$(find $SNAP_MOUNT_DIR -name 'current' | wc -l)" -gt 0
+            test ! -e /var/lib/snapd/seed/seed.yaml
+
+            # service should have been woken up
+            echo "The snapd service is expected to be running"
+            for _ in $(seq 20); do
+                systemctl show -p SubState  snapd.service | MATCH "SubState=running" && break || true
+                sleep 1
+            done
+            systemctl show -p SubState  snapd.service | MATCH "SubState=running"
+
+            systemctl stop snapd.socket snapd.service
+
+            $LIBEXECDIR/snapd/snap-mgmt --purge || :
+            # purge may remove $SNAP_MOUNT_DIR and /var/snap
+            mkdir -p $SNAP_MOUNT_DIR
+            mkdir -p /var/snap
+
+            REBOOT
+            ;;
+        3)
+            # no seed, no snaps
+            echo "When back to a state where the system has no seed, and has no snaps installed"
+            test "$(find $SNAP_MOUNT_DIR -name 'current' | wc -l)" = 0
+            test ! -e /var/lib/snapd/seed/seed.yaml
+
+            # the service should be down again
+            echo "The snapd service is expected to be dead too"
+            systemctl show -p SubState  snapd.service | MATCH "SubState=dead"
+            ;;
+    esac
+
+debug: |
+    systemctl status snapd.service snapd.socket snapd.wakeup.service


### PR DESCRIPTION
Helper service that wakes up the main snapd.service only when snaps are already
installed or a seed file is present.

Spread tests are a WIP