### PR TITLE
overlord/snapstate: use the readInfo in doMountSnap as a check only, undo if it errors

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -55,7 +55,7 @@ type StoreService interface {
 
 type managerBackend interface {
 	// install releated
-	SetupSnap(snapFilePath string, si *snap.SideInfo, meter progress.Meter) error
+	SetupSnap(snapFilePath string, si *snap.SideInfo, meter progress.Meter) (snap.Type, error)
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 	LinkSnap(info *snap.Info) error
 	StartServices(svcs []*snap.AppInfo, meter progress.Meter) error

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -80,8 +80,9 @@ func (s *setupSuite) TestSetupDoUndoSimple(c *C) {
 		Revision: snap.R(14),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	snapType, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
+	c.Check(snapType, Equals, snap.TypeApp)
 
 	// after setup the snap file is in the right dir
 	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello_14.snap")), Equals, true)
@@ -131,8 +132,9 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	snapType, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
+	c.Check(snapType, Equals, snap.TypeKernel)
 	l, _ := filepath.Glob(filepath.Join(bootloader.Dir(), "*"))
 	c.Assert(l, HasLen, 1)
 
@@ -175,11 +177,11 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
 
 	// retry run
-	err = s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err = s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
 
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
@@ -224,7 +226,7 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
 
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
@@ -264,7 +266,7 @@ func (s *setupSuite) TestSetupCleanupAfterFail(c *C) {
 	})
 	defer r()
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, ErrorMatches, "failed")
 
 	// everything is gone

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -515,7 +515,7 @@ func (f *fakeSnappyBackend) OpenSnapFile(snapFilePath string, si *snap.SideInfo)
 	return &snap.Info{SuggestedName: name, Architectures: []string{"all"}}, f.emptyContainer, nil
 }
 
-func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p progress.Meter) error {
+func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p progress.Meter) (snap.Type, error) {
 	p.Notify("setup-snap")
 	revno := snap.R(0)
 	if si != nil {
@@ -526,14 +526,21 @@ func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p 
 		name:  snapFilePath,
 		revno: revno,
 	})
-	return nil
+	snapType := snap.TypeApp
+	switch si.RealName {
+	case "core":
+		snapType = snap.TypeOS
+	case "gadget":
+		snapType = snap.TypeGadget
+	}
+	return snapType, nil
 }
 
 func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info, error) {
-	if name == "borken" {
+	if name == "borken" && si.Revision == snap.R(2) {
 		return nil, errors.New(`cannot read info for "borken" snap`)
 	}
-	if name == "not-there" {
+	if name == "not-there" && si.Revision == snap.R(2) {
 		return nil, &snap.NotFoundError{Snap: name, Revision: si.Revision}
 	}
 	// naive emulation for now, always works

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -533,6 +533,9 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 	if name == "borken" {
 		return nil, errors.New(`cannot read info for "borken" snap`)
 	}
+	if name == "not-there" {
+		return nil, &snap.NotFoundError{Snap: name, Revision: si.Revision}
+	}
 	// naive emulation for now, always works
 	info := &snap.Info{
 		SuggestedName: name,

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -84,10 +84,10 @@ func (m *SnapManager) AddAdhocTaskHandler(adhoc string, do, undo func(*state.Tas
 	m.runner.AddHandler(adhoc, do, undo)
 }
 
-func MockReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, error)) (restore func()) {
-	old := readInfo
-	readInfo = mock
-	return func() { readInfo = old }
+func MockSnapReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, error)) (restore func()) {
+	old := snapReadInfo
+	snapReadInfo = mock
+	return func() { snapReadInfo = old }
 }
 
 func MockRevisionDate(mock func(info *snap.Info) time.Time) (restore func()) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -459,7 +459,7 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// set snapst type for undoMountSnap
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo)
+	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken)
 	if err != nil {
 		return err
 	}
@@ -572,7 +572,7 @@ func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo)
+	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, 0)
 	if err != nil {
 		return err
 	}
@@ -594,7 +594,7 @@ func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo)
+	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, 0)
 	if err != nil {
 		return err
 	}
@@ -694,7 +694,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	newInfo, err := readInfo(snapsup.Name(), cand)
+	newInfo, err := readInfo(snapsup.Name(), cand, 0)
 	if err != nil {
 		return err
 	}
@@ -868,7 +868,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.JailMode = oldJailMode
 	snapst.Classic = oldClassic
 
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo)
+	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, 0)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -454,18 +454,24 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	pb := NewTaskProgressAdapterUnlocked(t)
 	// TODO Use snapsup.Revision() to obtain the right info to mount
 	//      instead of assuming the candidate is the right one.
-	if err := m.backend.SetupSnap(snapsup.SnapPath, snapsup.SideInfo, pb); err != nil {
-		return err
-	}
-
-	// set snapst type for undoMountSnap
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken)
+	snapType, err := m.backend.SetupSnap(snapsup.SnapPath, snapsup.SideInfo, pb)
 	if err != nil {
 		return err
 	}
 
+	// double check that the snap is mounted
+	if _, err := readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken); err != nil {
+		if err := m.backend.UndoSetupSnap(snapsup.placeInfo(), snapType, pb); err != nil {
+			t.State().Lock()
+			t.Errorf("cannot undo partial setup snap %q: %v", snapsup.Name(), err)
+			t.State().Unlock()
+		}
+		return err
+	}
+
+	// set snapst type for undoMountSnap
 	t.State().Lock()
-	t.Set("snap-type", newInfo.Type)
+	t.Set("snap-type", snapType)
 	t.State().Unlock()
 
 	if snapsup.Flags.RemoveSnapPath {

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -53,7 +53,7 @@ func (s *discardSnapSuite) SetUpTest(c *C) {
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	s.reset = snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	s.reset = snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 }
 
 func (s *discardSnapSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -59,7 +59,7 @@ func (s *downloadSnapSuite) SetUpTest(c *C) {
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	s.reset = snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	s.reset = snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 }
 
 func (s *downloadSnapSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -77,7 +77,7 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	resetReadInfo := snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	resetReadInfo := snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 	s.reset = func() {
 		resetReadInfo()
 		dirs.SetRootDir("/")

--- a/overlord/snapstate/handlers_prepare_test.go
+++ b/overlord/snapstate/handlers_prepare_test.go
@@ -52,7 +52,7 @@ func (s *prepareSnapSuite) SetUpTest(c *C) {
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	reset1 := snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	reset1 := snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 	s.reset = func() {
 		dirs.SetRootDir("/")
 		reset1()

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -64,7 +64,7 @@ func (s *prereqSuite) SetUpTest(c *C) {
 	s.snapmgr.AddForeignTaskHandlers(s.fakeBackend)
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	s.reset = snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	s.reset = snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 }
 
 func (s *prereqSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1131,8 +1131,8 @@ func infoForUpdate(st *state.State, snapst *SnapState, name, channel string, rev
 		return updateToRevisionInfo(st, snapst, revision, userID)
 	}
 
-	// refresh-to-local
-	return readInfo(name, sideInfo)
+	// refresh-to-local, this assumes the snap revision is mounted
+	return readInfo(name, sideInfo, errorOnBroken)
 }
 
 // AutoRefreshAssertions allows to hook fetching of important assertions
@@ -1646,7 +1646,7 @@ func Info(st *state.State, name string, revision snap.Revision) (*snap.Info, err
 
 	for i := len(snapst.Sequence) - 1; i >= 0; i-- {
 		if si := snapst.Sequence[i]; si.Revision == revision {
-			return readInfo(name, si)
+			return readInfo(name, si, 0)
 		}
 	}
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -116,7 +116,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 
 	s.o.AddManager(s.snapmgr)
 
-	s.BaseTest.AddCleanup(snapstate.MockReadInfo(s.fakeBackend.ReadInfo))
+	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo))
 	s.BaseTest.AddCleanup(snapstate.MockOpenSnapFile(s.fakeBackend.OpenSnapFile))
 	revDate := func(info *snap.Info) time.Time {
 		if info.Revision.Local() {
@@ -7587,7 +7587,7 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 	defer r()
 
 	// using MockSnap, we want to read the bits on disk
-	snapstate.MockReadInfo(snap.ReadInfo)
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -7679,7 +7679,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaults(c *C) {
 	makeInstalledMockCoreSnap(c)
 
 	// using MockSnap, we want to read the bits on disk
-	snapstate.MockReadInfo(snap.ReadInfo)
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -7709,7 +7709,7 @@ func (s *snapmgrTestSuite) TestInstallPathSkipConfigure(c *C) {
 	makeInstalledMockCoreSnap(c)
 
 	// using MockSnap, we want to read the bits on disk
-	snapstate.MockReadInfo(snap.ReadInfo)
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -7732,7 +7732,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaultsInstalled(c *C) {
 	makeInstalledMockCoreSnap(c)
 
 	// using MockSnap, we want to read the bits on disk
-	snapstate.MockReadInfo(snap.ReadInfo)
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
based on #5036