### PR TITLE
overlord/snapstate: poll for up to 10s if a snap is unexpectedly not mounted in doMountSnap

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -55,7 +55,7 @@ type StoreService interface {
 
 type managerBackend interface {
 	// install releated
-	SetupSnap(snapFilePath string, si *snap.SideInfo, meter progress.Meter) error
+	SetupSnap(snapFilePath string, si *snap.SideInfo, meter progress.Meter) (snap.Type, error)
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 	LinkSnap(info *snap.Info) error
 	StartServices(svcs []*snap.AppInfo, meter progress.Meter) error

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -80,8 +80,9 @@ func (s *setupSuite) TestSetupDoUndoSimple(c *C) {
 		Revision: snap.R(14),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	snapType, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
+	c.Check(snapType, Equals, snap.TypeApp)
 
 	// after setup the snap file is in the right dir
 	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello_14.snap")), Equals, true)
@@ -131,8 +132,9 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	snapType, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
+	c.Check(snapType, Equals, snap.TypeKernel)
 	l, _ := filepath.Glob(filepath.Join(bootloader.Dir(), "*"))
 	c.Assert(l, HasLen, 1)
 
@@ -175,11 +177,11 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
 
 	// retry run
-	err = s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err = s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
 
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
@@ -224,7 +226,7 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
 
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
@@ -264,7 +266,7 @@ func (s *setupSuite) TestSetupCleanupAfterFail(c *C) {
 	})
 	defer r()
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, ErrorMatches, "failed")
 
 	// everything is gone

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -515,7 +515,7 @@ func (f *fakeSnappyBackend) OpenSnapFile(snapFilePath string, si *snap.SideInfo)
 	return &snap.Info{SuggestedName: name, Architectures: []string{"all"}}, f.emptyContainer, nil
 }
 
-func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p progress.Meter) error {
+func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p progress.Meter) (snap.Type, error) {
 	p.Notify("setup-snap")
 	revno := snap.R(0)
 	if si != nil {
@@ -526,14 +526,21 @@ func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p 
 		name:  snapFilePath,
 		revno: revno,
 	})
-	return nil
+	snapType := snap.TypeApp
+	switch si.RealName {
+	case "core":
+		snapType = snap.TypeOS
+	case "gadget":
+		snapType = snap.TypeGadget
+	}
+	return snapType, nil
 }
 
 func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info, error) {
-	if name == "borken" {
+	if name == "borken" && si.Revision == snap.R(2) {
 		return nil, errors.New(`cannot read info for "borken" snap`)
 	}
-	if name == "not-there" {
+	if name == "not-there" && si.Revision == snap.R(2) {
 		return nil, &snap.NotFoundError{Snap: name, Revision: si.Revision}
 	}
 	// naive emulation for now, always works

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -90,6 +90,12 @@ func MockSnapReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, err
 	return func() { snapReadInfo = old }
 }
 
+func MockMountPollInterval(intv time.Duration) (restore func()) {
+	old := mountPollInterval
+	mountPollInterval = intv
+	return func() { mountPollInterval = old }
+}
+
 func MockRevisionDate(mock func(info *snap.Info) time.Time) (restore func()) {
 	old := revisionDate
 	if mock == nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -433,6 +433,10 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
+var (
+	mountPollInterval = 1 * time.Second
+)
+
 func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	t.State().Lock()
 	snapsup, snapst, err := snapSetupAndState(t)
@@ -460,13 +464,30 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// double check that the snap is mounted
-	if _, err := readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken); err != nil {
+	var readInfoErr error
+	for i := 0; i < 10; i++ {
+		_, readInfoErr = readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken)
+		if readInfoErr == nil {
+			break
+		}
+		if _, ok := readInfoErr.(*snap.NotFoundError); !ok {
+			break
+		}
+		// snap not found, seems is not mounted yet
+		msg := fmt.Sprintf("expected snap %q revision %v to be mounted but is not", snapsup.Name(), snapsup.Revision())
+		readInfoErr = fmt.Errorf("cannot proceed, %s", msg)
+		if i == 0 {
+			logger.Noticef(msg)
+		}
+		time.Sleep(mountPollInterval)
+	}
+	if readInfoErr != nil {
 		if err := m.backend.UndoSetupSnap(snapsup.placeInfo(), snapType, pb); err != nil {
 			t.State().Lock()
 			t.Errorf("cannot undo partial setup snap %q: %v", snapsup.Name(), err)
 			t.State().Unlock()
 		}
-		return err
+		return readInfoErr
 	}
 
 	// set snapst type for undoMountSnap

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -454,18 +454,24 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	pb := NewTaskProgressAdapterUnlocked(t)
 	// TODO Use snapsup.Revision() to obtain the right info to mount
 	//      instead of assuming the candidate is the right one.
-	if err := m.backend.SetupSnap(snapsup.SnapPath, snapsup.SideInfo, pb); err != nil {
-		return err
-	}
-
-	// set snapst type for undoMountSnap
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken)
+	snapType, err := m.backend.SetupSnap(snapsup.SnapPath, snapsup.SideInfo, pb)
 	if err != nil {
 		return err
 	}
 
+	// double check that the snap is mounted
+	if _, err := readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken); err != nil {
+		if err := m.backend.UndoSetupSnap(snapsup.placeInfo(), snapType, pb); err != nil {
+			t.State().Lock()
+			t.Errorf("cannot undo partial setup snap %q: %v", snapsup.Name(), err)
+			t.State().Unlock()
+		}
+		return err
+	}
+
+	// set snapst type for undoMountSnap
 	t.State().Lock()
-	t.Set("snap-type", newInfo.Type)
+	t.Set("snap-type", snapType)
 	t.State().Unlock()
 
 	if snapsup.Flags.RemoveSnapPath {

--- a/overlord/snapstate/handlers_mount_test.go
+++ b/overlord/snapstate/handlers_mount_test.go
@@ -21,6 +21,7 @@ package snapstate_test
 
 import (
 	"path/filepath"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -212,6 +213,9 @@ func (s *mountSnapSuite) TestDoMountSnapError(c *C) {
 }
 
 func (s *mountSnapSuite) TestDoMountSnapErrorNotFound(c *C) {
+	r := snapstate.MockMountPollInterval(10 * time.Millisecond)
+	defer r()
+
 	v1 := "name: not-there\nversion: 1.0\n"
 	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)
 
@@ -248,7 +252,7 @@ func (s *mountSnapSuite) TestDoMountSnapErrorNotFound(c *C) {
 
 	s.state.Lock()
 
-	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot find installed snap "not-there" at revision 2.*`)
+	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot proceed, expected snap "not-there" revision 2 to be mounted but is not.*`)
 
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
@@ -264,6 +268,75 @@ func (s *mountSnapSuite) TestDoMountSnapErrorNotFound(c *C) {
 			op:    "undo-setup-snap",
 			name:  filepath.Join(dirs.SnapMountDir, "not-there/2"),
 			stype: "app",
+		},
+	})
+}
+
+func (s *mountSnapSuite) TestDoMountNotMountedRetryRetry(c *C) {
+	r := snapstate.MockMountPollInterval(10 * time.Millisecond)
+	defer r()
+	n := 0
+	slowMountedReadInfo := func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		n++
+		if n < 3 {
+			return nil, &snap.NotFoundError{Snap: "not-there", Revision: si.Revision}
+		}
+		return &snap.Info{
+			SideInfo: *si,
+		}, nil
+	}
+
+	r1 := snapstate.MockSnapReadInfo(slowMountedReadInfo)
+	defer r1()
+
+	v1 := "name: not-there\nversion: 1.0\n"
+	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	si1 := &snap.SideInfo{
+		RealName: "not-there",
+		Revision: snap.R(1),
+	}
+	si2 := &snap.SideInfo{
+		RealName: "not-there",
+		Revision: snap.R(2),
+	}
+	snapstate.Set(s.state, "not-there", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si1},
+		Current:  si1.Revision,
+		SnapType: "app",
+	})
+
+	t := s.state.NewTask("mount-snap", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: si2,
+		SnapPath: testSnap,
+	})
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.snapmgr.Ensure()
+		s.snapmgr.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(chg.IsReady(), Equals, true)
+	c.Check(chg.Err(), IsNil)
+
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op:  "current",
+			old: filepath.Join(dirs.SnapMountDir, "not-there/1"),
+		},
+		{
+			op:    "setup-snap",
+			name:  testSnap,
+			revno: snap.R(2),
 		},
 	})
 }


### PR DESCRIPTION
This is a bit of a belt&suspenders approach, until we have a reproducer, really understand the bug.

based on #5039, #5036