### PR TITLE
many: fix "refresh-mode: sig{term,hup,usr[12]}" via KillMode=process

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -553,6 +553,26 @@ type TimerInfo struct {
 	Timer string
 }
 
+// RefreshModeType is the type for the "refresh-mode:" of a snap app
+type RefreshModeType string
+
+func (rm RefreshModeType) KillMode() string {
+	switch rm {
+	case "sigterm", "sighup", "sigusr1", "sigusr2":
+		return "process"
+	}
+	return ""
+}
+
+func (rm RefreshModeType) Valid() error {
+	switch rm {
+	case "", "endure", "restart", "sigterm", "sigterm-all", "sighup", "sighup-all", "sigusr1", "sigusr1-all", "sigusr2", "sigusr2-all":
+		// valid
+		return nil
+	}
+	return fmt.Errorf(`"refresh-mode" field contains invalid value %q`, rm)
+}
+
 // AppInfo provides information about a app.
 type AppInfo struct {
 	Snap *Info
@@ -568,7 +588,7 @@ type AppInfo struct {
 	PostStopCommand string
 	RestartCond     RestartCondition
 	Completer       string
-	RefreshMode     string
+	RefreshMode     RefreshModeType
 
 	// TODO: this should go away once we have more plumbing and can change
 	// things vs refactor

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -67,7 +67,7 @@ type appYaml struct {
 	PostStopCommand string          `yaml:"post-stop-command,omitempty"`
 	StopTimeout     timeout.Timeout `yaml:"stop-timeout,omitempty"`
 	Completer       string          `yaml:"completer,omitempty"`
-	RefreshMode     string          `yaml:"refresh-mode,omitempty"`
+	RefreshMode     RefreshModeType `yaml:"refresh-mode,omitempty"`
 
 	RestartCond RestartCondition `yaml:"restart-condition,omitempty"`
 	SlotNames   []string         `yaml:"slots,omitempty"`

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -929,3 +929,24 @@ func (s *infoSuite) TestExpandSnapVariables(c *C) {
 	c.Assert(info.ExpandSnapVariables("$SNAP_COMMON/stuff"), Equals, "/var/snap/foo/common/stuff")
 	c.Assert(info.ExpandSnapVariables("$GARBAGE/rocks"), Equals, "/rocks")
 }
+
+func (s *infoSuite) TestRefreshModeTypeKillMode(c *C) {
+	for _, t := range []struct {
+		refreshMode string
+		killMode    string
+	}{
+		{"", ""},
+		{"endure", ""},
+		{"restart", ""},
+		{"sigterm", "process"},
+		{"sigterm-all", ""},
+		{"sighup", "process"},
+		{"sighup-all", ""},
+		{"sigusr1", "process"},
+		{"sigusr1-all", ""},
+		{"sigusr2", "process"},
+		{"sigusr2-all", ""},
+	} {
+		c.Check(snap.RefreshModeType(t.refreshMode).KillMode(), Equals, t.killMode)
+	}
+}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -555,11 +555,8 @@ func ValidateApp(app *AppInfo) error {
 	}
 
 	// validate refresh-mode
-	switch app.RefreshMode {
-	case "", "endure", "restart", "sigterm", "sigterm-all", "sighup", "sighup-all", "sigusr1", "sigusr1-all", "sigusr2", "sigusr2-all":
-		// valid
-	default:
-		return fmt.Errorf(`"refresh-mode" field contains invalid value %q`, app.RefreshMode)
+	if err := app.RefreshMode.Valid(); err != nil {
+		return err
 	}
 	if app.RefreshMode != "" && app.Daemon == "" {
 		return fmt.Errorf(`"refresh-mode" cannot be used for %q, only for services`, app.Name)

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -428,7 +428,7 @@ func (s *ValidateSuite) TestAppDaemonValue(c *C) {
 func (s *ValidateSuite) TestAppRefreshMode(c *C) {
 	// check services
 	for _, t := range []struct {
-		refresh string
+		refresh RefreshModeType
 		ok      bool
 	}{
 		// good

--- a/tests/lib/snaps/test-snapd-service/bin/start-refresh-mode-sigterm
+++ b/tests/lib/snaps/test-snapd-service/bin/start-refresh-mode-sigterm
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+echo "start-refresh-mode-sigkill"
+
+echo "running a process"
+sleep 3133731337

--- a/tests/lib/snaps/test-snapd-service/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service/meta/snap.yaml
@@ -54,3 +54,11 @@ apps:
         stop-command: bin/stop-refresh-mode sigusr2-all
         daemon: simple
         refresh-mode: sigusr2-all
+    test-snapd-sigterm-service:
+        command: bin/start-refresh-mode-sigterm
+        daemon: simple
+        refresh-mode: sigterm
+    test-snapd-sigterm-all-service:
+        command: bin/start-refresh-mode-sigterm
+        daemon: simple
+        refresh-mode: sigterm-all

--- a/tests/main/snap-service-refresh-mode-sigkill/task.yaml
+++ b/tests/main/snap-service-refresh-mode-sigkill/task.yaml
@@ -1,0 +1,26 @@
+summary: "Check that refresh-modes sigkill works"
+
+kill-timeout: 3m
+
+execute: |
+    echo "When the service snap is installed"
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-service
+
+    refresh_modes="sigterm sigterm-all"
+    for s in $refresh_modes; do
+        systemctl show -p ActiveState snap.test-snapd-service.test-snapd-${s}-service | MATCH "ActiveState=active"
+    done
+
+    echo "we expect two sleep processes (children) from the two sigterm services"
+    n=$(ps afx | grep 3133731337 | grep -v grep | wc -l)
+    [ "$n" = "2" ]
+
+    echo "When it is re-installed one process uses sigterm, the other sigterm-all"
+    install_local test-snapd-service
+
+    echo "After reinstall the sigterm-all service and all children got killed"
+    echo "but the sigterm service only got a kill for the main process "
+    echo "and one sleep is still alive"
+    n=$(ps afx | grep 3133731337 | grep -v grep | wc -l)
+    [ "$n" = "3" ]

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -421,6 +421,9 @@ RemainAfterExit={{.Remain}}
 BusName={{.App.BusName}}
 {{- end}}
 {{- if not .App.Sockets}}
+{{- if .KillMode}}
+KillMode={{.KillMode}}
+{{- end}}
 
 [Install]
 WantedBy={{.ServicesTarget}}
@@ -454,6 +457,7 @@ WantedBy={{.ServicesTarget}}
 		PrerequisiteTarget string
 		MountUnit          string
 		Remain             string
+		KillMode           string
 		Before             []string
 		After              []string
 
@@ -468,8 +472,10 @@ WantedBy={{.ServicesTarget}}
 		PrerequisiteTarget: systemd.PrerequisiteTarget,
 		MountUnit:          filepath.Base(systemd.MountUnitPath(appInfo.Snap.MountDir())),
 		Remain:             remain,
-		Before:             genServiceNames(appInfo.Snap, appInfo.Before),
-		After:              genServiceNames(appInfo.Snap, appInfo.After),
+		KillMode:           appInfo.RefreshMode.KillMode(),
+
+		Before: genServiceNames(appInfo.Snap, appInfo.Before),
+		After:  genServiceNames(appInfo.Snap, appInfo.After),
 
 		// systemd runs as PID 1 so %h will not work.
 		Home: "/root",

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -542,3 +542,24 @@ func (s *servicesWrapperGenSuite) TestTimerGenerateSchedules(c *C) {
 		}
 	}
 }
+
+func (s *servicesWrapperGenSuite) TestKillModeSig(c *C) {
+	for _, rm := range []string{"sigterm", "sighup", "sigusr1", "sigusr2"} {
+		service := &snap.AppInfo{
+			Snap: &snap.Info{
+				SuggestedName: "snap",
+				Version:       "0.3.4",
+				SideInfo:      snap.SideInfo{Revision: snap.R(44)},
+			},
+			Name:        "app",
+			Command:     "bin/foo start",
+			Daemon:      "simple",
+			RefreshMode: RefreshModeType(rm),
+		}
+
+		generatedWrapper, err := wrappers.GenerateSnapServiceFile(service)
+		c.Assert(err, IsNil)
+
+		c.Assert(string(generatedWrapper), testutil.Contains, "\nKillMode=process\n")
+	}
+}


### PR DESCRIPTION
When the main process of a unit gets killed systemd will also kill
all the other processes in the cgroup. So the current approach of
using "systemctl kill --kill-who=main snap-service" is not sufficient
to keep the child processes alive. We need to add "KillMode=process"
to the unit. The side effect of this is that a normal stop also no
longer stops all processes in the cgroup. AFAICT there is no option
to have both (kill only kills main, stop stops all).
