### PR TITLE
overlord/snapstate:  poll for up to 10s if a snap is unexpectedly not mounted in doMountSnap (2.32)

### DIFF
--- a/overlord/snapstate/backend.go
+++ b/overlord/snapstate/backend.go
@@ -55,7 +55,7 @@ type StoreService interface {
 
 type managerBackend interface {
 	// install releated
-	SetupSnap(snapFilePath string, si *snap.SideInfo, meter progress.Meter) error
+	SetupSnap(snapFilePath string, si *snap.SideInfo, meter progress.Meter) (snap.Type, error)
 	CopySnapData(newSnap, oldSnap *snap.Info, meter progress.Meter) error
 	LinkSnap(info *snap.Info) error
 	StartServices(svcs []*snap.AppInfo, meter progress.Meter) error

--- a/overlord/snapstate/backend/setup_test.go
+++ b/overlord/snapstate/backend/setup_test.go
@@ -80,8 +80,9 @@ func (s *setupSuite) TestSetupDoUndoSimple(c *C) {
 		Revision: snap.R(14),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	snapType, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
+	c.Check(snapType, Equals, snap.TypeApp)
 
 	// after setup the snap file is in the right dir
 	c.Assert(osutil.FileExists(filepath.Join(dirs.SnapBlobDir, "hello_14.snap")), Equals, true)
@@ -131,8 +132,9 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	snapType, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
+	c.Check(snapType, Equals, snap.TypeKernel)
 	l, _ := filepath.Glob(filepath.Join(bootloader.Dir(), "*"))
 	c.Assert(l, HasLen, 1)
 
@@ -175,11 +177,11 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
 
 	// retry run
-	err = s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err = s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
 
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
@@ -224,7 +226,7 @@ type: kernel
 		Revision: snap.R(140),
 	}
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, IsNil)
 
 	minInfo := snap.MinimalPlaceInfo("kernel", snap.R(140))
@@ -264,7 +266,7 @@ func (s *setupSuite) TestSetupCleanupAfterFail(c *C) {
 	})
 	defer r()
 
-	err := s.be.SetupSnap(snapPath, &si, progress.Null)
+	_, err := s.be.SetupSnap(snapPath, &si, progress.Null)
 	c.Assert(err, ErrorMatches, "failed")
 
 	// everything is gone

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -515,7 +515,7 @@ func (f *fakeSnappyBackend) OpenSnapFile(snapFilePath string, si *snap.SideInfo)
 	return &snap.Info{SuggestedName: name, Architectures: []string{"all"}}, f.emptyContainer, nil
 }
 
-func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p progress.Meter) error {
+func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p progress.Meter) (snap.Type, error) {
 	p.Notify("setup-snap")
 	revno := snap.R(0)
 	if si != nil {
@@ -526,14 +526,21 @@ func (f *fakeSnappyBackend) SetupSnap(snapFilePath string, si *snap.SideInfo, p 
 		name:  snapFilePath,
 		revno: revno,
 	})
-	return nil
+	snapType := snap.TypeApp
+	switch si.RealName {
+	case "core":
+		snapType = snap.TypeOS
+	case "gadget":
+		snapType = snap.TypeGadget
+	}
+	return snapType, nil
 }
 
 func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info, error) {
-	if name == "borken" {
+	if name == "borken" && si.Revision == snap.R(2) {
 		return nil, errors.New(`cannot read info for "borken" snap`)
 	}
-	if name == "not-there" {
+	if name == "not-there" && si.Revision == snap.R(2) {
 		return nil, &snap.NotFoundError{Snap: name, Revision: si.Revision}
 	}
 	// naive emulation for now, always works

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -533,6 +533,9 @@ func (f *fakeSnappyBackend) ReadInfo(name string, si *snap.SideInfo) (*snap.Info
 	if name == "borken" {
 		return nil, errors.New(`cannot read info for "borken" snap`)
 	}
+	if name == "not-there" {
+		return nil, &snap.NotFoundError{Snap: name, Revision: si.Revision}
+	}
 	// naive emulation for now, always works
 	info := &snap.Info{
 		SuggestedName: name,

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -84,10 +84,10 @@ func (m *SnapManager) AddAdhocTaskHandler(adhoc string, do, undo func(*state.Tas
 	m.runner.AddHandler(adhoc, do, undo)
 }
 
-func MockReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, error)) (restore func()) {
-	old := readInfo
-	readInfo = mock
-	return func() { readInfo = old }
+func MockSnapReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, error)) (restore func()) {
+	old := snapReadInfo
+	snapReadInfo = mock
+	return func() { snapReadInfo = old }
 }
 
 func MockRevisionDate(mock func(info *snap.Info) time.Time) (restore func()) {

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -90,6 +90,12 @@ func MockSnapReadInfo(mock func(name string, si *snap.SideInfo) (*snap.Info, err
 	return func() { snapReadInfo = old }
 }
 
+func MockMountPollInterval(intv time.Duration) (restore func()) {
+	old := mountPollInterval
+	mountPollInterval = intv
+	return func() { mountPollInterval = old }
+}
+
 func MockRevisionDate(mock func(info *snap.Info) time.Time) (restore func()) {
 	old := revisionDate
 	if mock == nil {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -430,6 +430,10 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
+var (
+	mountPollInterval = 1 * time.Second
+)
+
 func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	t.State().Lock()
 	snapsup, snapst, err := snapSetupAndState(t)
@@ -457,13 +461,30 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// double check that the snap is mounted
-	if _, err := readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken); err != nil {
+	var readInfoErr error
+	for i := 0; i < 10; i++ {
+		_, readInfoErr = readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken)
+		if readInfoErr == nil {
+			break
+		}
+		if _, ok := readInfoErr.(*snap.NotFoundError); !ok {
+			break
+		}
+		// snap not found, seems is not mounted yet
+		msg := fmt.Sprintf("expected snap %q revision %v to be mounted but is not", snapsup.Name(), snapsup.Revision())
+		readInfoErr = fmt.Errorf("cannot proceed, %s", msg)
+		if i == 0 {
+			logger.Noticef(msg)
+		}
+		time.Sleep(mountPollInterval)
+	}
+	if readInfoErr != nil {
 		if err := m.backend.UndoSetupSnap(snapsup.placeInfo(), snapType, pb); err != nil {
 			t.State().Lock()
 			t.Errorf("cannot undo partial setup snap %q: %v", snapsup.Name(), err)
 			t.State().Unlock()
 		}
-		return err
+		return readInfoErr
 	}
 
 	// set snapst type for undoMountSnap

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -456,7 +456,7 @@ func (m *SnapManager) doMountSnap(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	// set snapst type for undoMountSnap
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo)
+	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, errorOnBroken)
 	if err != nil {
 		return err
 	}
@@ -569,7 +569,7 @@ func (m *SnapManager) doCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo)
+	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, 0)
 	if err != nil {
 		return err
 	}
@@ -591,7 +591,7 @@ func (m *SnapManager) undoCopySnapData(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo)
+	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, 0)
 	if err != nil {
 		return err
 	}
@@ -691,7 +691,7 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	newInfo, err := readInfo(snapsup.Name(), cand)
+	newInfo, err := readInfo(snapsup.Name(), cand, 0)
 	if err != nil {
 		return err
 	}
@@ -865,7 +865,7 @@ func (m *SnapManager) undoLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	snapst.JailMode = oldJailMode
 	snapst.Classic = oldClassic
 
-	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo)
+	newInfo, err := readInfo(snapsup.Name(), snapsup.SideInfo, 0)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -53,7 +53,7 @@ func (s *discardSnapSuite) SetUpTest(c *C) {
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	s.reset = snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	s.reset = snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 }
 
 func (s *discardSnapSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/handlers_download_test.go
+++ b/overlord/snapstate/handlers_download_test.go
@@ -59,7 +59,7 @@ func (s *downloadSnapSuite) SetUpTest(c *C) {
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	s.reset = snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	s.reset = snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 }
 
 func (s *downloadSnapSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -77,7 +77,7 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	resetReadInfo := snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	resetReadInfo := snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 	s.reset = func() {
 		resetReadInfo()
 		dirs.SetRootDir("/")

--- a/overlord/snapstate/handlers_mount_test.go
+++ b/overlord/snapstate/handlers_mount_test.go
@@ -21,6 +21,7 @@ package snapstate_test
 
 import (
 	"path/filepath"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -212,6 +213,9 @@ func (s *mountSnapSuite) TestDoMountSnapError(c *C) {
 }
 
 func (s *mountSnapSuite) TestDoMountSnapErrorNotFound(c *C) {
+	r := snapstate.MockMountPollInterval(10 * time.Millisecond)
+	defer r()
+
 	v1 := "name: not-there\nversion: 1.0\n"
 	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)
 
@@ -248,7 +252,7 @@ func (s *mountSnapSuite) TestDoMountSnapErrorNotFound(c *C) {
 
 	s.state.Lock()
 
-	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot find installed snap "not-there" at revision 2.*`)
+	c.Check(chg.Err(), ErrorMatches, `(?s).*cannot proceed, expected snap "not-there" revision 2 to be mounted but is not.*`)
 
 	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
 		{
@@ -264,6 +268,75 @@ func (s *mountSnapSuite) TestDoMountSnapErrorNotFound(c *C) {
 			op:    "undo-setup-snap",
 			name:  filepath.Join(dirs.SnapMountDir, "not-there/2"),
 			stype: "app",
+		},
+	})
+}
+
+func (s *mountSnapSuite) TestDoMountNotMountedRetryRetry(c *C) {
+	r := snapstate.MockMountPollInterval(10 * time.Millisecond)
+	defer r()
+	n := 0
+	slowMountedReadInfo := func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		n++
+		if n < 3 {
+			return nil, &snap.NotFoundError{Snap: "not-there", Revision: si.Revision}
+		}
+		return &snap.Info{
+			SideInfo: *si,
+		}, nil
+	}
+
+	r1 := snapstate.MockSnapReadInfo(slowMountedReadInfo)
+	defer r1()
+
+	v1 := "name: not-there\nversion: 1.0\n"
+	testSnap := snaptest.MakeTestSnapWithFiles(c, v1, nil)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	si1 := &snap.SideInfo{
+		RealName: "not-there",
+		Revision: snap.R(1),
+	}
+	si2 := &snap.SideInfo{
+		RealName: "not-there",
+		Revision: snap.R(2),
+	}
+	snapstate.Set(s.state, "not-there", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{si1},
+		Current:  si1.Revision,
+		SnapType: "app",
+	})
+
+	t := s.state.NewTask("mount-snap", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: si2,
+		SnapPath: testSnap,
+	})
+	chg := s.state.NewChange("dummy", "...")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	for i := 0; i < 3; i++ {
+		s.snapmgr.Ensure()
+		s.snapmgr.Wait()
+	}
+
+	s.state.Lock()
+
+	c.Check(chg.IsReady(), Equals, true)
+	c.Check(chg.Err(), IsNil)
+
+	c.Check(s.fakeBackend.ops, DeepEquals, fakeOps{
+		{
+			op:  "current",
+			old: filepath.Join(dirs.SnapMountDir, "not-there/1"),
+		},
+		{
+			op:    "setup-snap",
+			name:  testSnap,
+			revno: snap.R(2),
 		},
 	})
 }

--- a/overlord/snapstate/handlers_prepare_test.go
+++ b/overlord/snapstate/handlers_prepare_test.go
@@ -52,7 +52,7 @@ func (s *prepareSnapSuite) SetUpTest(c *C) {
 
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	reset1 := snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	reset1 := snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 	s.reset = func() {
 		dirs.SetRootDir("/")
 		reset1()

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -64,7 +64,7 @@ func (s *prereqSuite) SetUpTest(c *C) {
 	s.snapmgr.AddForeignTaskHandlers(s.fakeBackend)
 	snapstate.SetSnapManagerBackend(s.snapmgr, s.fakeBackend)
 
-	s.reset = snapstate.MockReadInfo(s.fakeBackend.ReadInfo)
+	s.reset = snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo)
 }
 
 func (s *prereqSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -1128,8 +1128,8 @@ func infoForUpdate(st *state.State, snapst *SnapState, name, channel string, rev
 		return updateToRevisionInfo(st, snapst, revision, userID)
 	}
 
-	// refresh-to-local
-	return readInfo(name, sideInfo)
+	// refresh-to-local, this assumes the snap revision is mounted
+	return readInfo(name, sideInfo, errorOnBroken)
 }
 
 // AutoRefreshAssertions allows to hook fetching of important assertions
@@ -1643,7 +1643,7 @@ func Info(st *state.State, name string, revision snap.Revision) (*snap.Info, err
 
 	for i := len(snapst.Sequence) - 1; i >= 0; i-- {
 		if si := snapst.Sequence[i]; si.Revision == revision {
-			return readInfo(name, si)
+			return readInfo(name, si, 0)
 		}
 	}
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -116,7 +116,7 @@ func (s *snapmgrTestSuite) SetUpTest(c *C) {
 
 	s.o.AddManager(s.snapmgr)
 
-	s.BaseTest.AddCleanup(snapstate.MockReadInfo(s.fakeBackend.ReadInfo))
+	s.BaseTest.AddCleanup(snapstate.MockSnapReadInfo(s.fakeBackend.ReadInfo))
 	s.BaseTest.AddCleanup(snapstate.MockOpenSnapFile(s.fakeBackend.OpenSnapFile))
 	revDate := func(info *snap.Info) time.Time {
 		if info.Revision.Local() {
@@ -7552,7 +7552,7 @@ func (s *snapmgrTestSuite) TestConfigDefaults(c *C) {
 	defer r()
 
 	// using MockSnap, we want to read the bits on disk
-	snapstate.MockReadInfo(snap.ReadInfo)
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -7644,7 +7644,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaults(c *C) {
 	makeInstalledMockCoreSnap(c)
 
 	// using MockSnap, we want to read the bits on disk
-	snapstate.MockReadInfo(snap.ReadInfo)
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -7674,7 +7674,7 @@ func (s *snapmgrTestSuite) TestInstallPathSkipConfigure(c *C) {
 	makeInstalledMockCoreSnap(c)
 
 	// using MockSnap, we want to read the bits on disk
-	snapstate.MockReadInfo(snap.ReadInfo)
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -7697,7 +7697,7 @@ func (s *snapmgrTestSuite) TestGadgetDefaultsInstalled(c *C) {
 	makeInstalledMockCoreSnap(c)
 
 	// using MockSnap, we want to read the bits on disk
-	snapstate.MockReadInfo(snap.ReadInfo)
+	snapstate.MockSnapReadInfo(snap.ReadInfo)
 
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
This also includes turning readInfo in doMountSnap into a proper check and undoing on error.