### PR TITLE
interfaces/apparmor: workaround kernel memory leak

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -41,6 +41,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -60,6 +61,7 @@ var (
 	procSelfExe           = "/proc/self/exe"
 	isHomeUsingNFS        = osutil.IsHomeUsingNFS
 	isRootWritableOverlay = osutil.IsRootWritableOverlay
+	randInt               = rand.Int
 )
 
 // Backend is responsible for maintaining apparmor profiles for snaps and parts of snapd.
@@ -384,6 +386,8 @@ func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	// Compute the template by injecting special updateNS snippets.
 	policy := templatePattern.ReplaceAllStringFunc(updateNSTemplate, func(placeholder string) string {
 		switch placeholder {
+		case "###VAR###":
+			return updateNSTemplateVariables(snapInfo, release.OnClassic)
 		case "###SNAP_NAME###":
 			return snapInfo.Name()
 		case "###SNIPPETS###":
@@ -417,7 +421,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 	policy = templatePattern.ReplaceAllStringFunc(policy, func(placeholder string) string {
 		switch placeholder {
 		case "###VAR###":
-			return templateVariables(snapInfo, securityTag)
+			return templateVariables(snapInfo, securityTag, release.OnClassic)
 		case "###PROFILEATTACH###":
 			return fmt.Sprintf("profile \"%s\"", securityTag)
 		case "###SNIPPETS###":

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -384,7 +384,8 @@ const commonPrefix = `
 @{SNAP_NAME}="samba"
 @{SNAP_REVISION}="1"
 @{PROFILE_DBUS}="snap_2esamba_2esmbd"
-@{INSTALL_DIR}="/{,var/lib/snapd/}snap"`
+@{INSTALL_DIR}="/{,var/lib/snapd/}snap"
+@{RANDOM}="42"`
 
 var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// By default apparmor is enforcing mode.
@@ -437,6 +438,8 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 	restore = apparmor.MockIsHomeUsingNFS(func() (bool, error) { return false, nil })
 	defer restore()
 	restore = apparmor.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
+	defer restore()
+	restore = apparmor.MockRandInt()
 	defer restore()
 
 	// NOTE: replace the real template with a shorter variant

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -29,6 +29,12 @@ var (
 	SnapConfineFromCoreProfile = snapConfineFromCoreProfile
 )
 
+func MockRandInt() (restore func()) {
+	orig := randInt
+	randInt = func() int { return 42 }
+	return func() { randInt = orig }
+}
+
 // MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS
 func MockIsHomeUsingNFS(new func() (bool, error)) (restore func()) {
 	old := isHomeUsingNFS

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -35,6 +35,11 @@ var defaultTemplate = `
 ###VAR###
 
 ###PROFILEATTACH### (attach_disconnected) {
+  # Workaround for bug lp: #1750594. This rule is random and changes every time
+  # the profile is created. This avoids leaking kernel memory when an identical
+  # profile is loaded into the kernel.
+  /.bug/lp1750594/workaround.@{RANDOM} r,
+
   #include <abstractions/base>
   #include <abstractions/consoles>
   #include <abstractions/openssl>
@@ -462,6 +467,11 @@ var classicTemplate = `
 ###VAR###
 
 ###PROFILEATTACH### (attach_disconnected) {
+  # Workaround for bug lp: #1750594. This rule is random and changes every time
+  # the profile is created. This avoids leaking kernel memory when an identical
+  # profile is loaded into the kernel.
+  /.bug/lp1750594/workaround.@{RANDOM} r,
+
   # set file rules so that exec() inherits our profile unless there is
   # already a profile for it (eg, snap-confine)
   / rwkl,
@@ -538,9 +548,16 @@ var updateNSTemplate = `
 
 # vim:syntax=apparmor
 
+###VAR###
+
 #include <tunables/global>
 
 profile snap-update-ns.###SNAP_NAME### (attach_disconnected) {
+  # Workaround for bug lp: #1750594. This rule is random and changes every time
+  # the profile is created. This avoids leaking kernel memory when an identical
+  # profile is loaded into the kernel.
+  /.bug/lp1750594/workaround.@{RANDOM} r,
+
   # The next four rules mirror those above. We want to be able to read
   # and map snap-update-ns into memory but it may come from a variety of places.
   /usr/lib{,exec,64}/snapd/snap-update-ns mr,

--- a/interfaces/apparmor/template_vars.go
+++ b/interfaces/apparmor/template_vars.go
@@ -29,12 +29,35 @@ import (
 
 // templateVariables returns text defining apparmor variables that can be used in the
 // apparmor template and by apparmor snippets.
-func templateVariables(info *snap.Info, securityTag string) string {
+func templateVariables(info *snap.Info, securityTag string, onClassic bool) string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", info.Name())
 	fmt.Fprintf(&buf, "@{SNAP_REVISION}=\"%s\"\n", info.Revision)
 	fmt.Fprintf(&buf, "@{PROFILE_DBUS}=\"%s\"\n",
 		dbus.SafePath(securityTag))
-	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"/{,var/lib/snapd/}snap\"")
+	fmt.Fprintf(&buf, "@{INSTALL_DIR}=\"/{,var/lib/snapd/}snap\"\n")
+	if onClassic {
+		fmt.Fprintf(&buf, "@{RANDOM}=\"%d\"", randInt())
+	} else {
+		// Core devices are not affected by the kernel bug that
+		// this is a workaround for. It's not the best place to add
+		// this check but it's certainly the easiest one.
+		fmt.Fprintf(&buf, "@{RANDOM}=\"%d\"", 0)
+	}
+	return buf.String()
+}
+
+func updateNSTemplateVariables(info *snap.Info, onClassic bool) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "@{SNAP_NAME}=\"%s\"\n", info.Name())
+	fmt.Fprintf(&buf, "@{SNAP_REVISION}=\"%s\"\n", info.Revision)
+	if onClassic {
+		fmt.Fprintf(&buf, "@{RANDOM}=\"%d\"", randInt())
+	} else {
+		// Core devices are not affected by the kernel bug that
+		// this is a workaround for. It's not the best place to add
+		// this check but it's certainly the easiest one.
+		fmt.Fprintf(&buf, "@{RANDOM}=\"%d\"", 0)
+	}
 	return buf.String()
 }


### PR DESCRIPTION
This patch changes the apparmor backend to insert a randomized rule when
running on classic devices. Core devices are mostly on a kernel that is
not affected (4.4 and similar). Classic devices run various kernels,
specifically 4.13 and newer. Since 4.13 the kernel leaks a significant
amount of memory when an apparmor profile is loaded (with the intent to
replace an existing profile) but that profile is identical to the one
currently loaded.

To avoid this all apparmor profiles now contain a randomized component.
The component is set to zero on an unaffected kernel and to a random
integer otherwise. The integer is subsequently used to create an
apparmor profile rule for the path "/.bug/lp1750594/workaround.$RANDOM",
granting read permission.

Related-To: https://bugs.launchpad.net/apparmor/+bug/1750594
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
