### PR TITLE
cmd/snap: handle distros with no version ID

### DIFF
--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -67,6 +67,9 @@ func printVersions() error {
 	fmt.Fprintf(w, "snapd\t%s\n", sv.Version)
 	fmt.Fprintf(w, "series\t%s\n", sv.Series)
 	if sv.OnClassic {
+		if sv.OSVersionID == "" {
+			sv.OSVersionID = "-"
+		}
 		fmt.Fprintf(w, "%s\t%s\n", sv.OSID, sv.OSVersionID)
 	}
 	if sv.KernelVersion != "" {

--- a/cmd/snap/cmd_version_test.go
+++ b/cmd/snap/cmd_version_test.go
@@ -57,3 +57,18 @@ func (s *SnapSuite) TestVersionCommandOnAllSnap(c *C) {
 	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
+
+func (s *SnapSuite) TestVersionCommandOnClassicNoOsVersion(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"on-classic": true,"os-release":{"id":"arch","version-id":""},"series":"56","version":"7.89"}}`)
+	})
+	restore := mockArgs("snap", "version")
+	defer restore()
+	restore = mockVersion("4.56")
+	defer restore()
+
+	_, err := snap.Parser().ParseArgs([]string{"version"})
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\narch    -\n")
+	c.Assert(s.Stderr(), Equals, "")
+}


### PR DESCRIPTION
Distros like Arch do not set VERSION in /etc/os-release, in which case our output of `snap version` would look awkward.

The patch makes snap version look like this:
```
$ snap version
snap    2.32.4.r649.g833a374bf-1
snapd   2.32.4.r649.g833a374bf-1
series  16
arch    -
kernel  4.15.15-1-ARCH
```

