### PR TITLE
release-tools: handle the snapd-x.y.z version

### DIFF
--- a/release-tools/repack-debian-tarball.sh
+++ b/release-tools/repack-debian-tarball.sh
@@ -56,6 +56,8 @@ if [ -d "$scratch_dir/snapd.upstream" ]; then
 	top_dir=snapd.upstream
 elif [ -d "$scratch_dir/snappy.upstream" ]; then
 	top_dir=snappy.upstream
+elif [ -d "$scratch_dir/snapd-${upstream_version}" ]; then
+	top_dir=snapd-${upstream_version}
 else
 	echo "Unexpected contents of given tarball, expected snap{py,d}.upstream/"
 	exit 1


### PR DESCRIPTION
The tarballs made by the release manager now contain just a single
directory snapd-x.y.z, with the right version inside.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
