### PR TITLE
cmd/snap: make confinement mode part of `snap version` output

### DIFF
--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -51,30 +51,31 @@ func (cmd cmdVersion) Execute(args []string) error {
 }
 
 func printVersions() error {
-	sv, err := Client().ServerVersion()
+	si, err := Client().SysInfo()
 	if err != nil {
-		sv = &client.ServerVersion{
+		si = &client.SysInfo{
 			Version:     i18n.G("unavailable"),
 			Series:      "-",
-			OSID:        "-",
-			OSVersionID: "-",
+			OSRelease:   client.OSRelease{ID: "-", VersionID: "-"},
+			Confinement: "-",
 		}
 	}
 
 	w := tabWriter()
 
 	fmt.Fprintf(w, "snap\t%s\n", cmd.Version)
-	fmt.Fprintf(w, "snapd\t%s\n", sv.Version)
-	fmt.Fprintf(w, "series\t%s\n", sv.Series)
-	if sv.OnClassic {
-		if sv.OSVersionID == "" {
-			sv.OSVersionID = "-"
+	fmt.Fprintf(w, "snapd\t%s\n", si.Version)
+	fmt.Fprintf(w, "series\t%s\n", si.Series)
+	if si.OnClassic {
+		if si.OSRelease.VersionID == "" {
+			si.OSRelease.VersionID = "-"
 		}
-		fmt.Fprintf(w, "%s\t%s\n", sv.OSID, sv.OSVersionID)
+		fmt.Fprintf(w, "%s\t%s\n", si.OSRelease.ID, si.OSRelease.VersionID)
 	}
-	if sv.KernelVersion != "" {
-		fmt.Fprintf(w, "kernel\t%s\n", sv.KernelVersion)
+	if si.KernelVersion != "" {
+		fmt.Fprintf(w, "kernel\t%s\n", si.KernelVersion)
 	}
+	fmt.Fprintf(w, "confinement\t%s\n", si.Confinement)
 	w.Flush()
 
 	return err

--- a/cmd/snap/cmd_version_test.go
+++ b/cmd/snap/cmd_version_test.go
@@ -30,7 +30,7 @@ import (
 
 func (s *SnapSuite) TestVersionCommandOnClassic(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"on-classic":true,"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89"}}`)
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"on-classic":true,"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89","confinement":"strict"}}`)
 	})
 	restore := mockArgs("snap", "version")
 	defer restore()
@@ -39,13 +39,13 @@ func (s *SnapSuite) TestVersionCommandOnClassic(c *C) {
 
 	_, err := snap.Parser().ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\n")
+	c.Assert(s.Stdout(), Equals, "snap         4.56\nsnapd        7.89\nseries       56\nubuntu       12.34\nconfinement  strict\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
 func (s *SnapSuite) TestVersionCommandOnAllSnap(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89"}}`)
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89","confinement":"strict"}}`)
 	})
 	restore := mockArgs("snap", "--version")
 	defer restore()
@@ -54,13 +54,13 @@ func (s *SnapSuite) TestVersionCommandOnAllSnap(c *C) {
 
 	_, err := snap.Parser().ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\n")
+	c.Assert(s.Stdout(), Equals, "snap         4.56\nsnapd        7.89\nseries       56\nconfinement  strict\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
 func (s *SnapSuite) TestVersionCommandOnClassicNoOsVersion(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"on-classic": true,"os-release":{"id":"arch","version-id":""},"series":"56","version":"7.89"}}`)
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"on-classic": true,"os-release":{"id":"arch","version-id":""},"series":"56","version":"7.89","confinement":"partial"}}`)
 	})
 	restore := mockArgs("snap", "version")
 	defer restore()
@@ -69,6 +69,6 @@ func (s *SnapSuite) TestVersionCommandOnClassicNoOsVersion(c *C) {
 
 	_, err := snap.Parser().ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\narch    -\n")
+	c.Assert(s.Stdout(), Equals, "snap         4.56\nsnapd        7.89\nseries       56\narch         -\nconfinement  partial\n")
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/snap/main_test.go
+++ b/cmd/snap/main_test.go
@@ -223,7 +223,7 @@ func (s *SnapSuite) TestExtraArgs(c *C) {
 
 func (s *SnapSuite) TestVersionOnClassic(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"on-classic":true,"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89"}}`)
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"on-classic":true,"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89","confinement":"strict"}}`)
 	})
 	restore := mockArgs("snap", "--version")
 	defer restore()
@@ -231,13 +231,13 @@ func (s *SnapSuite) TestVersionOnClassic(c *C) {
 	defer restore()
 
 	c.Assert(func() { snap.RunMain() }, PanicMatches, `internal error: exitStatus\{0\} .*`)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\n")
+	c.Assert(s.Stdout(), Equals, "snap         4.56\nsnapd        7.89\nseries       56\nubuntu       12.34\nconfinement  strict\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
 func (s *SnapSuite) TestVersionOnAllSnap(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89"}}`)
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"os-release":{"id":"ubuntu","version-id":"12.34"},"series":"56","version":"7.89","confinement":"strict"}}`)
 	})
 	restore := mockArgs("snap", "--version")
 	defer restore()
@@ -245,7 +245,7 @@ func (s *SnapSuite) TestVersionOnAllSnap(c *C) {
 	defer restore()
 
 	c.Assert(func() { snap.RunMain() }, PanicMatches, `internal error: exitStatus\{0\} .*`)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\n")
+	c.Assert(s.Stdout(), Equals, "snap         4.56\nsnapd        7.89\nseries       56\nconfinement  strict\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 


### PR DESCRIPTION
This appears as:
(on Arch)
```
snap         2.32.4.r649.g833a374bf-1
snapd        2.32.4.r649.g833a374bf-1
series       16
arch         -
kernel       4.15.15-1-ARCH
confinement  partial
```
(on Ubuntu)
```

snap         1337.2.32.5
snapd        1337.2.32.5
series       16
ubuntu       18.04
kernel       4.15.0-1001-gcp
confinement  strict
```