### PR TITLE
tests: bring back one missing test in snap-service-stop-mode

### DIFF
--- a/tests/main/snap-service-stop-mode/task.yaml
+++ b/tests/main/snap-service-stop-mode/task.yaml
@@ -18,6 +18,7 @@ execute: |
 
     echo "We can see it running"
     systemctl status snap.test-snapd-service.test-snapd-service|MATCH "running"
+    systemctl show -p MainPID snap.test-snapd-service.test-snapd-service > old-main.pid
 
     stop_modes="sighup sighup-all sigusr1 sigusr1-all sigusr2 sigusr2-all"
     for s in $stop_modes; do
@@ -41,6 +42,7 @@ execute: |
     echo "Regular services are restarted normally"
     journalctl -u snap.test-snapd-service.test-snapd-service | MATCH "stop service"
     systemctl show -p MainPID snap.test-snapd-service.test-snapd-service > new-main.pid
+    test -e new-main.pid && test -e old-main.pid
     test "$(cat new-main.pid)" != "$(cat old-main.pid)"
 
     echo "Once the snap is removed, all services are stopped"


### PR DESCRIPTION
A tiny fix for master where during the rework of the test the old-main.pid got dropped (plus a whitespace fix).