### PR TITLE
packaging: fix incorrectly auto-generated changelog entry for 2.32.5

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -729,8 +729,7 @@ fi
    conflating that with refresh-mode
  - overlord/snapstate:  poll for up to 10s if a snap is unexpectedly
    not mounted in doMountSnap
- - daemon: support 'system' as nickname of the core snapchange it is
-   possible to do:
+ - daemon: support 'system' as nickname of the core snap
 
 * Wed Apr 11 2018 Michael Vogt <mvo@ubuntu.com>
 - New upstream release 2.32.4

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -5,8 +5,7 @@ snapd (2.32.5~14.04) trusty; urgency=medium
       conflating that with refresh-mode
     - overlord/snapstate:  poll for up to 10s if a snap is unexpectedly
       not mounted in doMountSnap
-    - daemon: support 'system' as nickname of the core snapchange it is
-      possible to do:
+    - daemon: support 'system' as nickname of the core snap
 
  -- Michael Vogt <michael.vogt@ubuntu.com>  Mon, 16 Apr 2018 11:41:48 +0200
 

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -5,8 +5,7 @@ snapd (2.32.5) xenial; urgency=medium
       conflating that with refresh-mode
     - overlord/snapstate:  poll for up to 10s if a snap is unexpectedly
       not mounted in doMountSnap
-    - daemon: support 'system' as nickname of the core snapchange it is
-      possible to do:
+    - daemon: support 'system' as nickname of the core snap
 
  -- Michael Vogt <michael.vogt@ubuntu.com>  Mon, 16 Apr 2018 11:41:48 +0200
 


### PR DESCRIPTION
Tiny fix for a incorrect auto-generated changelog entry.