### PR TITLE
tests: detect kernel oops during tests and abort tests in this case

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -466,6 +466,14 @@ restore_project_each() {
         cat /proc/meminfo
         exit 1
     fi
+
+    # Check for kernel oops during the tests
+    if dmesg|grep "Oops: "; then
+        echo "A kernel oops happened during the tests, test results will be unreliable"
+        echo "Dmesg debug output:"
+        dmesg
+        exit 1
+    fi
 }
 
 restore_project() {


### PR DESCRIPTION
I noticed some issues today running on a beta kernel in xenial so it might be a good idea to add a test for oopses during the tests.