### PR TITLE
tests: ensure interfaces-network-bind daemon is stopped early

### DIFF
--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -29,6 +29,15 @@ prepare: |
 
     EOF
 
+restore: |
+    # We had a runaway network-bind-consumer process that would generate
+    # so many log messages that "journalctl --sync" never finished causing
+    # tests to hang. By removing it explicitly we avoid this problem
+    # (journalctl --sync is happening in our setup/restore code before
+    #  the installed snaps are removed).
+    echo "Remove $SNAP_NAME to ensure that the service is really stopped"
+    snap remove $SNAP_NAME || true
+
 execute: |
     echo "The interface is connected by default"
     snap interfaces | MATCH ":network-bind .*$SNAP_NAME"


### PR DESCRIPTION
We had a runaway network-bind-consumer process that would generate
so many log messages that "journalctl --sync" never finished causing
tests to hang. By removing it explicitly in the interfaces-network-bind
test we avoid this problem.

