### PR TITLE
tests: skip interfaces-content test on core devices

### DIFF
--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -1,5 +1,11 @@
 summary: Ensure that the content sharing interface works.
 
+# This test purges the state which causes the device to reinitialize
+# with (potentially) a different core snap. Running this on core will
+# also trigger a reboot in the middle of the tests because the new
+# core will be applied. So skip the test on core devices.
+systems: [-ubuntu-core-16-*]
+
 details: |
     The content-sharing interface interface allows a snap to access contents from
     other snap


### PR DESCRIPTION
This test purges the state which causes the device to reinitialize
with (potentially) a different core snap. Running this on core will
also trigger a reboot in the middle of the tests because the new
core will be applied. So skip the test on core devices.
