### PR TITLE
tests: smaller fixes for Arch tests

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -10,12 +10,12 @@ pkgname=snapd
 pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd')
 optdepends=('bash-completion: bash completion support')
-pkgver=2.32.5.r619.g3c932a4c5
+pkgver=2.32.5.r734.gd79c34ba4
 pkgrel=1
 arch=('x86_64')
 url="https://github.com/snapcore/snapd"
 license=('GPL3')
-makedepends=('git' 'go-pie' 'go-tools' 'libseccomp' 'libcap' 'systemd' 'xfsprogs' 'python-docutils')
+makedepends=('git' 'go' 'go-tools' 'libseccomp' 'libcap' 'systemd' 'xfsprogs' 'python-docutils')
 # the following checkdepends are only required for static checks and unit tests,
 # unit tests are currently enabled
 checkdepends=('python' 'squashfs-tools' 'shellcheck')
@@ -68,15 +68,16 @@ build() {
   cd "$GOPATH/src/${_gourl}"
   XDG_CONFIG_HOME="$srcdir" ./get-deps.sh
 
-  gobuild="go build -x -v"
+  gobuild="go build -x -v -buildmode=pie"
+  gobuild_static="go build -x -v -buildmode=pie -ldflags=-extldflags=-static"
   # Build/install snap and snapd
   $gobuild -o $GOPATH/bin/snap $GOFLAGS "${_gourl}/cmd/snap"
   $gobuild -o $GOPATH/bin/snapctl $GOFLAGS "${_gourl}/cmd/snapctl"
   $gobuild -o $GOPATH/bin/snapd $GOFLAGS "${_gourl}/cmd/snapd"
   $gobuild -o $GOPATH/bin/snap-seccomp $GOFLAGS "${_gourl}/cmd/snap-seccomp"
   # build snap-exec and snap-update-ns completely static for base snaps
-  $gobuild -o $GOPATH/bin/snap-update-ns -ldflags '-extldflags "-static"' $GOFLAGS "${_gourl}/cmd/snap-update-ns"
-  CGO_ENABLED=0 $gobuild -o $GOPATH/bin/snap-exec $GOFLAGS "${_gourl}/cmd/snap-exec"
+  $gobuild_static -o $GOPATH/bin/snap-update-ns $GOFLAGS "${_gourl}/cmd/snap-update-ns"
+  $gobuild_static -o $GOPATH/bin/snap-exec $GOFLAGS "${_gourl}/cmd/snap-exec"
 
   # Generate data files such as real systemd units, dbus service, environment
   # setup helpers out of the available templates
@@ -108,7 +109,7 @@ check() {
   # here as they are designed to pass on a clean tree, before anything else is
   # done, not after building the tree.
   # ./run-checks --static
-  make -C cmd -k check
+  TMPDIR=/tmp make -C cmd -k check
 
   mv $srcdir/xxx-info data/info
 }
@@ -165,6 +166,9 @@ package() {
   install -dm700 "$pkgdir/var/lib/snapd/cache"
 
   make -C cmd install DESTDIR="$pkgdir/"
+  # move snapd-generator to systemd generators
+  install -dm755 "$pkgdir/usr/lib/systemd/system-generators"
+  mv "$pkgdir/usr/lib/snapd/snapd-generator" "$pkgdir/usr/lib/systemd/system-generators/"
 
   # Install man file
   mkdir -p "$pkgdir/usr/share/man/man1"

--- a/tests/regression/lp-1618683/task.yaml
+++ b/tests/regression/lp-1618683/task.yaml
@@ -1,8 +1,4 @@
 summary: Check that user namespace can be unshared within snap apps
-systems:
-    # Arch does not have CONFIG_USER_NS in the default kernel (yet!), see
-    # https://bugs.archlinux.org/index.php?do=details&task_id=36969 for details
-    - -arch-*
 details: |
     Snap-confine used to "leak" the root filesystem directory across the
     pivot_root call. This caused checks in the kernel to fail and resulted in


### PR DESCRIPTION
Support for `CONFIG_USER_NS` is now enabled in the default kernel package, meaning we can enable `tests/regression/lp-1618683`. 

Also, make sure that we install `go-pie` since it's used for building the package anyway.
