### PR TITLE
snap,tests : don't fail if we cannot stat MountFile

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -799,6 +799,13 @@ func ReadInfo(name string, si *SideInfo) (*Info, error) {
 	}
 
 	st, err := os.Stat(MountFile(name, si.Revision))
+	if os.IsNotExist(err) {
+		// This can happen when "snap try" mode snap is moved around. The mount
+		// is still in place (it's a bind mount, it doesn't care about the
+		// source moving) but the symlink in /var/lib/snapd/snaps is now
+		// dangling.
+		return nil, &NotFoundError{Snap: name, Revision: si.Revision}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/snap/info.go
+++ b/snap/info.go
@@ -772,7 +772,10 @@ type NotFoundError struct {
 }
 
 func (e NotFoundError) Error() string {
-	return fmt.Sprintf("cannot find installed snap %q at revision %s (missing file: %q)", e.Snap, e.Revision, e.Path)
+	if e.Path != "" {
+		return fmt.Sprintf("cannot find installed snap %q at revision %s (missing file: %q)", e.Snap, e.Revision, e.Path)
+	}
+	return fmt.Sprintf("cannot find installed snap %q at revision %s", e.Snap, e.Revision)
 }
 
 func MockSanitizePlugsSlots(f func(snapInfo *Info)) (restore func()) {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -270,9 +270,8 @@ func (s *infoSuite) TestReadInfoUnfindable(c *C) {
 	c.Assert(ioutil.WriteFile(p, []byte(``), 0644), IsNil)
 
 	info, err := snap.ReadInfo("sample", si)
+	c.Assert(err, ErrorMatches, `cannot find installed snap "sample" at revision 42`)
 	c.Check(info, IsNil)
-	// TODO: maybe improve this error message
-	c.Check(err, ErrorMatches, ".* no such file or directory")
 }
 
 // makeTestSnap here can also be used to produce broken snaps (differently from snaptest.MakeTestSnapWithFiles)!

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -238,7 +238,7 @@ func (s *infoSuite) TestReadInfoNotFound(c *C) {
 	si := &snap.SideInfo{Revision: snap.R(42), EditedSummary: "esummary"}
 	info, err := snap.ReadInfo("sample", si)
 	c.Check(info, IsNil)
-	c.Check(err, ErrorMatches, `cannot find installed snap "sample" at revision 42`)
+	c.Check(err, ErrorMatches, `cannot find installed snap "sample" at revision 42 \(missing file: ".*/sample/42/meta/snap.yaml"\)`)
 }
 
 func (s *infoSuite) TestReadInfoUnreadable(c *C) {
@@ -270,7 +270,7 @@ func (s *infoSuite) TestReadInfoUnfindable(c *C) {
 	c.Assert(ioutil.WriteFile(p, []byte(``), 0644), IsNil)
 
 	info, err := snap.ReadInfo("sample", si)
-	c.Assert(err, ErrorMatches, `cannot find installed snap "sample" at revision 42`)
+	c.Assert(err, ErrorMatches, `cannot find installed snap "sample" at revision 42 \(missing file: ".*/var/lib/snapd/snaps/sample_42.snap"\)`)
 	c.Check(info, IsNil)
 }
 

--- a/tests/main/try-snap-goes-away/task.yaml
+++ b/tests/main/try-snap-goes-away/task.yaml
@@ -1,4 +1,7 @@
 summary: Check that snaps vanishing are handled gracefully
+details: |
+    Note that this test is subtly different from tests/regression/lp-1764977.
+    See the description of that test for details.
 
 environment:
     SNAP_NAME/test_snapd_tools: test-snapd-tools

--- a/tests/regression/lp-1764977/task.yaml
+++ b/tests/regression/lp-1764977/task.yaml
@@ -7,6 +7,12 @@ details: |
 
     Broken snaps should not affect snapd operations though, as that forms a
     denial-of-service attack and may keep machines from refreshing core.
+
+    Note that this test is subtly different from
+    tests/main/try-snap-goes-away. In our case the meta/snap.yaml file is
+    still present and can be read. In the other case it is removed when the
+    snap is removed (individual files are unlinked and disappear from the
+    bind-mounted view of the mounted snap).
 execute: |
     cp -a  $TESTSLIB/snaps/test-snapd-sh .
     snap try test-snapd-sh

--- a/tests/regression/lp-1764977/task.yaml
+++ b/tests/regression/lp-1764977/task.yaml
@@ -1,0 +1,22 @@
+summary: Broken snap doesn't break "snap list" and other operations
+details: |
+    Snap can enter the "broken" state when its meta/snap.yaml cannot be found.
+    Typically this means the snap is unmounted or that "snap try"-mode snap was
+    moved on disk and the symlink in /var/lib/snapd/snaps/ is no longer
+    working.
+
+    Broken snaps should not affect snapd operations though, as that forms a
+    denial-of-service attack and may keep machines from refreshing core.
+execute: |
+    cp -a  $TESTSLIB/snaps/test-snapd-sh .
+    snap try test-snapd-sh
+
+    snap list | MATCH test-snapd-sh
+    mv test-snapd-sh test-snapd-sh.moved
+    snap list # should not break
+    snap list test-snapd-sh | MATCH broken
+
+    mv test-snapd-sh.moved test-snapd-sh
+    snap list # should still just work
+    snap list test-snapd-sh | MATCH -v broken
+


### PR DESCRIPTION
The snap mount file may be a dangling symlink in case of try-mode snaps
that got moved around by the user. In those cases the snap is still
mounted so it doesn't show as broken but it cannot be stat'ed. Such
snaps will now show as broken as the returned error NotFoundError has
special meaning elsewhere in the code

Fixes: https://bugs.launchpad.net/snapd/+bug/1764977
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
