### PR TITLE
configcore: validate experimental.layouts option

### DIFF
--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -50,11 +50,26 @@ func coreCfg(tr Conf, key string) (result string, err error) {
 	return fmt.Sprintf("%v", v), nil
 }
 
+func validateExperimentalSettings(tr Conf) error {
+	layoutsEnabled, err := coreCfg(tr, "experimental.layouts")
+	if err != nil {
+		return err
+	}
+	if layoutsEnabled != "" && layoutsEnabled != "true" && layoutsEnabled != "false" {
+		return fmt.Errorf("experimental.layouts can only be set to 'true' or 'false'")
+	}
+
+	return nil
+}
+
 func Run(tr Conf) error {
 	if err := validateProxyStore(tr); err != nil {
 		return err
 	}
 	if err := validateRefreshSchedule(tr); err != nil {
+		return err
+	}
+	if err := validateExperimentalSettings(tr); err != nil {
 		return err
 	}
 

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -61,8 +61,6 @@ func validateExperimentalSettings(tr Conf) error {
 	default:
 		return fmt.Errorf("experimental.layouts can only be set to 'true' or 'false'")
 	}
-
-	return nil
 }
 
 func Run(tr Conf) error {

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -55,7 +55,10 @@ func validateExperimentalSettings(tr Conf) error {
 	if err != nil {
 		return err
 	}
-	if layoutsEnabled != "" && layoutsEnabled != "true" && layoutsEnabled != "false" {
+	switch layoutsEnabled {
+	case "", "true", "false":
+		return nil
+	default:
 		return fmt.Errorf("experimental.layouts can only be set to 'true' or 'false'")
 	}
 

--- a/overlord/configstate/configcore/corecfg_test.go
+++ b/overlord/configstate/configcore/corecfg_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/systemd"
 )
@@ -94,4 +95,32 @@ func (s *configcoreSuite) SetUpTest(c *C) {
 // runCfgSuite tests configcore.Run()
 type runCfgSuite struct {
 	configcoreSuite
+}
+
+var _ = Suite(&runCfgSuite{})
+
+func (r *runCfgSuite) TestConfigureExperimentalSettingsInvalid(c *C) {
+	conf := &mockConf{
+		state: r.state,
+		conf: map[string]interface{}{
+			"experimental.layouts": "foo",
+		},
+	}
+
+	err := configcore.Run(conf)
+	c.Check(err, ErrorMatches, `experimental.layouts can only be set to 'true' or 'false'`)
+}
+
+func (r *runCfgSuite) TestConfigureExperimentalSettingsHappy(c *C) {
+	for _, t := range []string{"true", "false"} {
+		conf := &mockConf{
+			state: r.state,
+			conf: map[string]interface{}{
+				"experimental.layouts": t,
+			},
+		}
+
+		err := configcore.Run(conf)
+		c.Check(err, IsNil)
+	}
 }


### PR DESCRIPTION
This validates the "core.experimental.layouts" options and ensures
that the values passed are really boolean values.

This will fix the LP bug #1756317
