### PR TITLE
debian: update LP bug for the 2.32.5 SRU

### DIFF
--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,6 +1,6 @@
 snapd (2.32.5~14.04) trusty; urgency=medium
 
-  * New upstream release, LP: #1756173
+  * New upstream release, LP: #1765090
     - many: add "stop-mode: sig{term,hup,usr[12]}{,-all}" instead of
       conflating that with refresh-mode
     - overlord/snapstate:  poll for up to 10s if a snap is unexpectedly

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,6 +1,6 @@
 snapd (2.32.5) xenial; urgency=medium
 
-  * New upstream release, LP: #1756173
+  * New upstream release, LP: #1765090
     - many: add "stop-mode: sig{term,hup,usr[12]}{,-all}" instead of
       conflating that with refresh-mode
     - overlord/snapstate:  poll for up to 10s if a snap is unexpectedly


### PR DESCRIPTION
The 2.32.5 SRU got a new LP bug to make tracking easier and because
the previous 2.32 SRU is already released.

