### PR TITLE
tests: replace snap try when possible to speedup tests execution

### DIFF
--- a/tests/completion/indirect/task.yaml
+++ b/tests/completion/indirect/task.yaml
@@ -1,21 +1,20 @@
 summary: indirect completion
 
+environment:
+    SNAP_DIR: "${TESTSLIB}/snaps/test-snapd-complexion"
+
 prepare: |
-  (
-      cd ../../lib/snaps/test-snapd-complexion
-      snap try
-      mv test-snapd-complexion.bash-completer test-snapd-complexion.bash-completer.orig
-      cp "${SPREAD_PATH}/${SPREAD_SUITE}/${SPREAD_VARIANT}.complete" test-snapd-complexion.bash-completer
-      snap alias test-snapd-complexion cplx
-      snap alias test-snapd-complexion.two cplx2
-  )
+    . "${TESTSLIB}/snaps.sh"
+    install_local test-snapd-complexion
+
+    mv "${SNAP_DIR}/test-snapd-complexion.bash-completer" "${SNAP_DIR}/test-snapd-complexion.bash-completer.orig"
+    cp "${SPREAD_PATH}/${SPREAD_SUITE}/${SPREAD_VARIANT}.complete" "${SNAP_DIR}/test-snapd-complexion.bash-completer"
+    snap alias test-snapd-complexion cplx
+    snap alias test-snapd-complexion.two cplx2
 
 restore: |
-  (
-      cd ../../lib/snaps/test-snapd-complexion
-      mv test-snapd-complexion.bash-completer.orig test-snapd-complexion.bash-completer
-      snap remove test-snapd-complexion
-  )
+    mv "${SNAP_DIR}/test-snapd-complexion.bash-completer.orig" "${SNAP_DIR}/test-snapd-complexion.bash-completer"
+    snap remove test-snapd-complexion
 
 execute: |
   d="$PWD"

--- a/tests/completion/snippets/task.yaml
+++ b/tests/completion/snippets/task.yaml
@@ -1,19 +1,18 @@
 summary: indirect completion
 
+environment:
+    SNAP_DIR: "${TESTSLIB}/snaps/test-snapd-complexion"
+
 prepare: |
-  (
-      cd ../../lib/snaps/test-snapd-complexion
-      snap try
-      mv test-snapd-complexion.bash-completer test-snapd-complexion.bash-completer.orig
-      cp "${SPREAD_PATH}/${SPREAD_SUITE}/${SPREAD_VARIANT}.complete" test-snapd-complexion.bash-completer
-  )
+    . $TESTSLIB/snaps.sh
+    install_local test-snapd-complexion
+
+    mv "${SNAP_DIR}/test-snapd-complexion.bash-completer" "${SNAP_DIR}/test-snapd-complexion.bash-completer.orig"
+    cp "${SPREAD_PATH}/${SPREAD_SUITE}/${SPREAD_VARIANT}.complete" "${SNAP_DIR}/test-snapd-complexion.bash-completer"
 
 restore: |
-  (
-      cd ../../lib/snaps/test-snapd-complexion
-      mv test-snapd-complexion.bash-completer.orig test-snapd-complexion.bash-completer
-      snap remove test-snapd-complexion
-  )
+    mv "${SNAP_DIR}/test-snapd-complexion.bash-completer.orig" "${SNAP_DIR}/test-snapd-complexion.bash-completer"
+    snap remove test-snapd-complexion
 
 execute: |
   d="$PWD"

--- a/tests/main/interfaces-desktop/task.yaml
+++ b/tests/main/interfaces-desktop/task.yaml
@@ -10,7 +10,8 @@ systems: [-ubuntu-core-*]
 
 prepare: |
     echo "Given the desktop snap is installed"
-    snap try $TESTSLIB/snaps/test-snapd-desktop
+    . "${TESTSLIB}/snaps.sh"
+    install_local test-snapd-desktop
 
 execute: |
     dirs="/var/cache/fontconfig /usr/share/icons /usr/share/pixmaps"

--- a/tests/main/interfaces-framebuffer/task.yaml
+++ b/tests/main/interfaces-framebuffer/task.yaml
@@ -8,7 +8,8 @@ details: |
     The test also checks the interface connection and disconnection works properly.
 
 prepare: |
-    snap try $TESTSLIB/snaps/test-snapd-framebuffer
+    . "${TESTSLIB}/snaps.sh"
+    install_local test-snapd-framebuffer
 
 execute: |
     echo "The plug is not connected by default"

--- a/tests/main/interfaces-network-setup-control/task.yaml
+++ b/tests/main/interfaces-network-setup-control/task.yaml
@@ -10,10 +10,12 @@ details: |
 systems: [-ubuntu-core-*]
 
 prepare: |
+    . "${TESTSLIB}/snaps.sh"
+
     echo "Given the test-snapd-check-fs-access snap is installed"
     cp $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml.orig
     sed 's/\[\]/\[network-setup-control\]/g' -i $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml
-    snap try $TESTSLIB/snaps/test-snapd-check-fs-access
+    install_local test-snapd-check-fs-access
 
 restore: |
     cp $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml.orig $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml

--- a/tests/main/interfaces-network-setup-observe/task.yaml
+++ b/tests/main/interfaces-network-setup-observe/task.yaml
@@ -8,10 +8,12 @@ details: |
     are accessible through the interface.
 
 prepare: |
+    . "${TESTSLIB}/snaps.sh"
+
     echo "Given the test-snapd-check-fs-access snap is installed"
     cp $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml.orig
     sed 's/\[\]/\[network-setup-observe\]/g' -i $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml
-    snap try $TESTSLIB/snaps/test-snapd-check-fs-access
+    install_local test-snapd-check-fs-access
 
 restore: |
     cp $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml.orig $TESTSLIB/snaps/test-snapd-check-fs-access/meta/snap.yaml

--- a/tests/main/interfaces-physical-memory-observe/task.yaml
+++ b/tests/main/interfaces-physical-memory-observe/task.yaml
@@ -11,8 +11,10 @@ details: |
 systems: [-ubuntu-*]
 
 prepare: |
+    . "${TESTSLIB}/snaps.sh"
+
     echo "Given the physical-memory-observe snap is installed"
-    snap try $TESTSLIB/snaps/test-snapd-physical-memory-observe
+    install_local test-snapd-physical-memory-observe
 
 restore: |
     rm -f call.error


### PR DESCRIPTION
In a dragonboard snap try taked about 14 seconds and snap pack + snap
install --dangerous takes less than a second for the same snap (test-
snapd-tools)
I am using the branch sergiocazzolato:tests-performance to measure the time of each command takes in the different boards, and based on those results make changes to speed up the tests executions on boards which is taking 4.5 hours to be completed. 