### PR TITLE
snap/env: fix env duplication logic

### DIFF
--- a/data/env/snapd.sh.in
+++ b/data/env/snapd.sh.in
@@ -1,14 +1,17 @@
 #!/bin/sh --this-shebang-is-just-here-to-inform-shellcheck--
 
 # Expand $PATH to include the directory where snappy applications go.
-if [ "${PATH#*/snap/bin}" = "${PATH}" ]; then
+if [ -n "${PATH##*@SNAP_MOUNT_DIR@/bin*}" ]; then
     export PATH=$PATH:@SNAP_MOUNT_DIR@/bin
 fi
 
 # desktop files (used by desktop environments within both X11 and Wayland) are
 # looked for in XDG_DATA_DIRS; make sure it includes the relevant directory for
 # snappy applications' desktop files.
-if [ "${XDG_DATA_DIRS#*/snapd/desktop}" = "${XDG_DATA_DIRS}" ]; then
-    export XDG_DATA_DIRS="${XDG_DATA_DIRS:-/usr/local/share:/usr/share}:/var/lib/snapd/desktop"
+if [ -z "$XDG_DATA_DIRS" ]; then
+    export XDG_DATA_DIRS="/usr/local/share:/usr/share"
+fi
+if [ -n "${XDG_DATA_DIRS##*/var/lib/snapd/desktop*}" ]; then
+    export XDG_DATA_DIRS="${XDG_DATA_DIRS}:/var/lib/snapd/desktop"
 fi
 

--- a/data/env/snapd.sh.in
+++ b/data/env/snapd.sh.in
@@ -1,17 +1,22 @@
 #!/bin/sh --this-shebang-is-just-here-to-inform-shellcheck--
 
 # Expand $PATH to include the directory where snappy applications go.
-if [ -n "${PATH##*@SNAP_MOUNT_DIR@/bin*}" ]; then
-    export PATH=$PATH:@SNAP_MOUNT_DIR@/bin
+snap_bin_path="@SNAP_MOUNT_DIR@/bin"
+if [ -n "${PATH##*${snap_bin_path}}" -a -n "${PATH##*${snap_bin_path}:*}" ]; then
+    export PATH=$PATH:${snap_bin_path}
 fi
 
-# desktop files (used by desktop environments within both X11 and Wayland) are
-# looked for in XDG_DATA_DIRS; make sure it includes the relevant directory for
-# snappy applications' desktop files.
+# Ensure base distro defaults xdg path are set if nothing filed up some
+# defaults yet.
 if [ -z "$XDG_DATA_DIRS" ]; then
     export XDG_DATA_DIRS="/usr/local/share:/usr/share"
 fi
-if [ -n "${XDG_DATA_DIRS##*/var/lib/snapd/desktop*}" ]; then
-    export XDG_DATA_DIRS="${XDG_DATA_DIRS}:/var/lib/snapd/desktop"
+
+# Desktop files (used by desktop environments within both X11 and Wayland) are
+# looked for in XDG_DATA_DIRS; make sure it includes the relevant directory for
+# snappy applications' desktop files.
+snap_xdg_path="/var/lib/snapd/desktop"
+if [ -n "${XDG_DATA_DIRS##*${snap_xdg_path}}" -a -n "${XDG_DATA_DIRS##*${snap_xdg_path}:*}" ]; then
+    export XDG_DATA_DIRS="${XDG_DATA_DIRS}:${snap_xdg_path}"
 fi
 


### PR DESCRIPTION
The snap insertion inside environment variables like PATH and XDG_DATA_DIRS
expects that the snap element is always the latest of the path, which isn't
necessarily the case.
Ensure we do substring detection following POSIX.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
