### PR TITLE
spread: auto accept key changes when calling dnf makecache

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -312,7 +312,7 @@ prepare: |
         #
         # https://forum.snapcraft.io/t/issues-with-the-fedora-mirror-network/3489/
         sed -i -s -E -e 's@^#?baseurl=http://download.fedoraproject.org/@baseurl=http://dl.fedoraproject.org/@g' -e 's@^metalink=@#metalink@g' /etc/yum.repos.d/fedora*.repo
-        dnf --refresh makecache
+        dnf --refresh -y makecache
     fi
     # Unpack delta, or move content out of the prefixed directory (see rename and repack above).
     # (needs to be in spread.yaml directly because there's nothing else on the filesystem yet)


### PR DESCRIPTION
Google Cloud Packages repo had their GPG keys changed recently what cause the
the prompt to pop up the tests:
```
  Importing GPG key 0xA7317B0F:
   Userid     : "Google Cloud Packages Automatic Signing Key <gc-team@google.com>"
   Fingerprint: D0BC 747F D8CA F711 7500 D6FA 3746 C208 A731 7B0F
   From       : https://packages.cloud.google.com/yum/doc/yum-key.gpg
  Is this ok [y/N]:
```
