### PR TITLE
cmd/snap-update-ns: use Secure.BindMount to bind mount files

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -244,10 +244,9 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 			// symlinks are handled in createInode directly, nothing to do here.
 		case "", "file":
 			flags, unparsed := osutil.MountOptsToCommonFlags(c.Entry.Options)
-			// If we're performing a bind mount on a
-			// regular directory, use the secureBindMount
-			// implementation
-			if flags&syscall.MS_BIND == syscall.MS_BIND && kind == "" {
+			// If we're performing a bind mount, use
+			// Secure.BindMount
+			if flags&syscall.MS_BIND == syscall.MS_BIND {
 				err = sec.BindMount(c.Entry.Name, c.Entry.Dir, uint(flags))
 			} else {
 				err = sysMount(c.Entry.Name, c.Entry.Dir, c.Entry.Type, uintptr(flags), strings.Join(unparsed, ","))

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -244,8 +244,7 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 			// symlinks are handled in createInode directly, nothing to do here.
 		case "", "file":
 			flags, unparsed := osutil.MountOptsToCommonFlags(c.Entry.Options)
-			// If we're performing a bind mount, use
-			// Secure.BindMount
+			// Use Secure.BindMount for bind mounts
 			if flags&syscall.MS_BIND == syscall.MS_BIND {
 				err = sec.BindMount(c.Entry.Name, c.Entry.Dir, uint(flags))
 			} else {

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -387,6 +387,8 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 	s.sys.InsertReadDirResult(`readdir "/rofs"`, nil)                                              // pretend /rofs is empty.
 	s.sys.InsertFault(`lstat "/tmp/.snap/rofs"`, syscall.ENOENT)
 	s.sys.InsertOsLstatResult(`lstat "/rofs"`, testutil.FileInfoDir)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 7 <ptr>`, syscall.Stat_t{})
 
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "device", Dir: "/rofs/target", Type: "type"}}
 	synth, err := chg.Perform(s.sec)
@@ -429,12 +431,14 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 		`lstat "/rofs"`,
 
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 4 <ptr>`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
 		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
 		`openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 7 <ptr>`,
 		`close 6`,
 		`close 5`,
 		`close 3`,
@@ -646,6 +650,8 @@ func (s *changeSuite) TestPerformDirectoryBindMountSourceLstatError(c *C) {
 func (s *changeSuite) TestPerformDirectoryBindMount(c *C) {
 	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoDir)
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoDir)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 5 <ptr>`, syscall.Stat_t{})
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
@@ -654,10 +660,12 @@ func (s *changeSuite) TestPerformDirectoryBindMount(c *C) {
 		`lstat "/target"`,
 		`lstat "/source"`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 4 <ptr>`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 5 <ptr>`,
 		`close 3`,
 		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
 		`close 5`,
@@ -669,6 +677,8 @@ func (s *changeSuite) TestPerformDirectoryBindMount(c *C) {
 func (s *changeSuite) TestPerformDirectoryBindMountWithError(c *C) {
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoDir)
 	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoDir)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 5 <ptr>`, syscall.Stat_t{})
 	s.sys.InsertFault(`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind"}}}
 	synth, err := chg.Perform(s.sec)
@@ -678,10 +688,12 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithError(c *C) {
 		`lstat "/target"`,
 		`lstat "/source"`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 4 <ptr>`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 5 <ptr>`,
 		`close 3`,
 		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
 		`close 5`,
@@ -693,6 +705,8 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithError(c *C) {
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPoint(c *C) {
 	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoDir)
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 5 <ptr>`, syscall.Stat_t{})
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
@@ -707,10 +721,12 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPoint(c *C) {
 		`close 3`,
 		`lstat "/source"`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 4 <ptr>`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 5 <ptr>`,
 		`close 3`,
 		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
 		`close 5`,
@@ -722,6 +738,8 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPoint(c *C) {
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSource(c *C) {
 	s.sys.InsertFault(`lstat "/source"`, syscall.ENOENT)
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoDir)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 5 <ptr>`, syscall.Stat_t{})
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
@@ -736,10 +754,12 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSource(c *C) {
 		`close 4`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 4 <ptr>`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 5 <ptr>`,
 		`close 3`,
 		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
 		`close 5`,
@@ -792,6 +812,9 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyB
 	s.sys.InsertFault(`lstat "/tmp/.snap/rofs"`, syscall.ENOENT)
 	s.sys.InsertOsLstatResult(`lstat "/rofs"`, testutil.FileInfoDir)
 	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoDir)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 7 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 6 <ptr>`, syscall.Stat_t{})
 
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/rofs/target", Options: []string{"bind"}}}
 	synth, err := chg.Perform(s.sec)
@@ -834,12 +857,14 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyB
 		`lstat "/rofs"`,
 
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 4 <ptr>`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
 		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
 		`openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 7 <ptr>`,
 		`close 6`,
 		`close 5`,
 		`close 3`,
@@ -867,11 +892,13 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyB
 
 		// mount the filesystem
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 4 <ptr>`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
 		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 5 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 5 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 6 <ptr>`,
 		`close 5`,
 		`close 3`,
 		`mount "/proc/self/fd/4" "/proc/self/fd/6" "" MS_BIND ""`,
@@ -1094,6 +1121,8 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPointAndReadOnlyBase(c
 	s.sys.InsertFault(`lstat "/tmp/.snap/rofs"`, syscall.ENOENT)
 	s.sys.InsertOsLstatResult(`lstat "/rofs"`, testutil.FileInfoDir)
 	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoFile)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 7 <ptr>`, syscall.Stat_t{})
 
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/rofs/target", Options: []string{"bind", "x-snapd.kind=file"}}}
 	synth, err := chg.Perform(s.sec)
@@ -1136,12 +1165,14 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPointAndReadOnlyBase(c
 		`lstat "/rofs"`,
 
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 4 <ptr>`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
 		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
 		`openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 7 <ptr>`,
 		`close 6`,
 		`close 5`,
 		`close 3`,
@@ -1343,6 +1374,8 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 	s.sys.InsertReadDirResult(`readdir "/rofs"`, nil)                      // pretend /rofs is empty.
 	s.sys.InsertFault(`lstat "/tmp/.snap/rofs"`, syscall.ENOENT)
 	s.sys.InsertOsLstatResult(`lstat "/rofs"`, testutil.FileInfoDir)
+	s.sys.InsertFstatResult(`fstat 4 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 7 <ptr>`, syscall.Stat_t{})
 
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "unused", Dir: "/rofs/name", Options: []string{"x-snapd.kind=symlink", "x-snapd.symlink=/oldname"}}}
 	synth, err := chg.Perform(s.sec)
@@ -1386,12 +1419,14 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 		`lstat "/rofs"`,
 
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 4 <ptr>`,
 		`close 3`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
 		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
 		`openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
+		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
+		`fstat 7 <ptr>`,
 		`close 6`,
 		`close 5`,
 		`close 3`,

--- a/cmd/snap-update-ns/secure_bindmount_test.go
+++ b/cmd/snap-update-ns/secure_bindmount_test.go
@@ -49,17 +49,21 @@ func (s *secureBindMountSuite) TearDownTest(c *C) {
 }
 
 func (s *secureBindMountSuite) TestMount(c *C) {
+	s.sys.InsertFstatResult(`fstat 5 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 6 <ptr>`, syscall.Stat_t{})
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND)
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 5
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
+		`fstat 5 <ptr>`,
 		`close 4`, // "/source"
 		`close 3`, // "/"
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 6
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
+		`fstat 6 <ptr>`,
 		`close 4`, // "/target"
 		`close 3`, // "/"
 		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`,
@@ -69,17 +73,21 @@ func (s *secureBindMountSuite) TestMount(c *C) {
 }
 
 func (s *secureBindMountSuite) TestMountRecursive(c *C) {
+	s.sys.InsertFstatResult(`fstat 5 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 6 <ptr>`, syscall.Stat_t{})
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND|syscall.MS_REC)
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 5
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
+		`fstat 5 <ptr>`,
 		`close 4`, // "/source"
 		`close 3`, // "/"
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 6
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
+		`fstat 6 <ptr>`,
 		`close 4`, // "/target"
 		`close 3`, // "/"
 		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND|MS_REC ""`,
@@ -89,23 +97,29 @@ func (s *secureBindMountSuite) TestMountRecursive(c *C) {
 }
 
 func (s *secureBindMountSuite) TestMountReadOnly(c *C) {
+	s.sys.InsertFstatResult(`fstat 5 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 6 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 7 <ptr>`, syscall.Stat_t{})
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND|syscall.MS_RDONLY)
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 5
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
+		`fstat 5 <ptr>`,
 		`close 4`, // "/source"
 		`close 3`, // "/"
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 6
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
+		`fstat 6 <ptr>`,
 		`close 4`, // "/target"
 		`close 3`, // "/"
 		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 7
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 7
+		`fstat 7 <ptr>`,
 		`close 4`, // "/target"
 		`close 3`, // "/"
 		`mount "none" "/proc/self/fd/7" "" MS_REMOUNT|MS_BIND|MS_RDONLY ""`,
@@ -128,18 +142,22 @@ func (s *secureBindMountSuite) TestMountReadOnlyRecursive(c *C) {
 }
 
 func (s *secureBindMountSuite) TestBindMountFails(c *C) {
+	s.sys.InsertFstatResult(`fstat 5 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 6 <ptr>`, syscall.Stat_t{})
 	s.sys.InsertFault(`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`, errTesting)
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND|syscall.MS_RDONLY)
 	c.Assert(err, ErrorMatches, "testing")
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 5
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
+		`fstat 5 <ptr>`,
 		`close 4`, // "/source"
 		`close 3`, // "/"
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 6
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
+		`fstat 6 <ptr>`,
 		`close 4`, // "/target"
 		`close 3`, // "/"
 		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`,
@@ -149,24 +167,30 @@ func (s *secureBindMountSuite) TestBindMountFails(c *C) {
 }
 
 func (s *secureBindMountSuite) TestRemountReadOnlyFails(c *C) {
+	s.sys.InsertFstatResult(`fstat 5 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 6 <ptr>`, syscall.Stat_t{})
+	s.sys.InsertFstatResult(`fstat 7 <ptr>`, syscall.Stat_t{})
 	s.sys.InsertFault(`mount "none" "/proc/self/fd/7" "" MS_REMOUNT|MS_BIND|MS_RDONLY ""`, errTesting)
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND|syscall.MS_RDONLY)
 	c.Assert(err, ErrorMatches, "testing")
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 5
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
+		`fstat 5 <ptr>`,
 		`close 4`, // "/source"
 		`close 3`, // "/"
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 6
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
+		`fstat 6 <ptr>`,
 		`close 4`, // "/target"
 		`close 3`, // "/"
 		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`,
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
 		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,    // -> 7
+		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 7
+		`fstat 7 <ptr>`,
 		`close 4`, // "/target"
 		`close 3`, // "/"
 		`mount "none" "/proc/self/fd/7" "" MS_REMOUNT|MS_BIND|MS_RDONLY ""`,

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -298,7 +298,7 @@ func (sec *Secure) MkSymlink(fd int, segments []string, segNum int, oldname stri
 			if err != nil {
 				return fmt.Errorf("cannot inspect existing file %q: %v", segment, err)
 			}
-			if statBuf.Mode&syscall.S_IFLNK != syscall.S_IFLNK {
+			if statBuf.Mode&syscall.S_IFMT != syscall.S_IFLNK {
 				return fmt.Errorf("cannot create symbolic link %q: existing file in the way", segment)
 			}
 			var n int

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -98,7 +98,7 @@ func (sec *Secure) OpenPath(path string) (int, error) {
 	// We use the following flags to open:
 	//  O_PATH: we don't intend to use the fd for IO
 	//  O_NOFOLLOW: don't follow symlinks
-	//  O_DIRECTORY: we expect to find directories
+	//  O_DIRECTORY: we expect to find directories (except for the leaf)
 	//  O_CLOEXEC: don't leak file descriptors over exec() boundaries
 	openFlags := sys.O_PATH | syscall.O_NOFOLLOW | syscall.O_DIRECTORY | syscall.O_CLOEXEC
 	var fd int

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -722,6 +722,8 @@ func (s *utilsSuite) TestSplitIntoSegments(c *C) {
 // secure-open-path
 
 func (s *utilsSuite) TestSecureOpenPath(c *C) {
+	stat := syscall.Stat_t{Mode: syscall.S_IFDIR}
+	s.sys.InsertFstatResult("fstat 5 <ptr>", stat)
 	fd, err := s.sec.OpenPath("/foo/bar")
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
@@ -729,31 +731,38 @@ func (s *utilsSuite) TestSecureOpenPath(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,       // -> 3
 		`openat 3 "foo" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "bar" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 5
+		`openat 4 "bar" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,             // -> 5
+		`fstat 5 <ptr>`,
 		`close 4`,
 		`close 3`,
 	})
 }
 
 func (s *utilsSuite) TestSecureOpenPathSingleSegment(c *C) {
+	stat := syscall.Stat_t{Mode: syscall.S_IFDIR}
+	s.sys.InsertFstatResult("fstat 4 <ptr>", stat)
 	fd, err := s.sec.OpenPath("/foo")
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	c.Assert(fd, Equals, 4)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,       // -> 3
-		`openat 3 "foo" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
+		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 3
+		`openat 3 "foo" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,       // -> 4
+		`fstat 4 <ptr>`,
 		`close 3`,
 	})
 }
 
 func (s *utilsSuite) TestSecureOpenPathRoot(c *C) {
+	stat := syscall.Stat_t{Mode: syscall.S_IFDIR}
+	s.sys.InsertFstatResult("fstat 3 <ptr>", stat)
 	fd, err := s.sec.OpenPath("/")
 	c.Assert(err, IsNil)
 	defer s.sys.Close(fd)
 	c.Assert(fd, Equals, 3)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 3
+		`fstat 3 <ptr>`,
 	})
 }
 
@@ -805,8 +814,14 @@ func (s *realSystemSuite) TestSecureOpenPathFile(c *C) {
 	c.Assert(ioutil.WriteFile(path, []byte("hello"), 0644), IsNil)
 
 	fd, err := s.sec.OpenPath(path)
-	c.Check(fd, Equals, -1)
-	c.Check(err, ErrorMatches, "not a directory")
+	c.Assert(err, IsNil)
+	defer syscall.Close(fd)
+
+	// Check that the file descriptor matches the file.
+	var pathStat, fdStat syscall.Stat_t
+	c.Assert(syscall.Stat(path, &pathStat), IsNil)
+	c.Assert(syscall.Fstat(fd, &fdStat), IsNil)
+	c.Check(pathStat, Equals, fdStat)
 }
 
 func (s *realSystemSuite) TestSecureOpenPathNotFound(c *C) {
@@ -827,7 +842,7 @@ func (s *realSystemSuite) TestSecureOpenPathSymlink(c *C) {
 
 	fd, err := s.sec.OpenPath(symlink)
 	c.Check(fd, Equals, -1)
-	c.Check(err, ErrorMatches, "not a directory")
+	c.Check(err, ErrorMatches, `".*" is a symbolic link`)
 }
 
 func (s *realSystemSuite) TestSecureOpenPathSymlinkedParent(c *C) {


### PR DESCRIPTION
This modifies `Secure.OpenPath` to handle any non-symlink (don't use `O_DIRECTORY` on the last segment, and add an `fstat` call to check the file type), and then updates `Change.lowLevelPerform` to unconditionally use `Secure.BindMount` for bind mounts.

I also made a small drive by fix to `Secure.MkSymlink`, where it was treating `S_IFLNK` as a bitfield flag rather than an enumeration value.