### PR TITLE
image: support refreshing soft-expired user macaroons in tooling

### DIFF
--- a/image/export_test.go
+++ b/image/export_test.go
@@ -38,3 +38,7 @@ var (
 func (tsto *ToolingStore) User() *auth.UserState {
 	return tsto.user
 }
+
+func ToolingAuthContext() auth.AuthContext {
+	return toolingAuthContext{}
+}

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -155,6 +155,7 @@ func parseSnapcraftLoginFile(authFn string, data []byte) (*authData, error) {
 	}, nil
 }
 
+// toolingAuthContext implements trivially auth.AuthContext except implementing UpdateUserAuth properly to be used to refresh a soft-expired user macaroon.
 type toolingAuthContext struct{}
 
 func (tac toolingAuthContext) CloudInfo() (*auth.CloudInfo, error) {

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -155,7 +155,9 @@ func parseSnapcraftLoginFile(authFn string, data []byte) (*authData, error) {
 	}, nil
 }
 
-// toolingAuthContext implements trivially auth.AuthContext except implementing UpdateUserAuth properly to be used to refresh a soft-expired user macaroon.
+// toolingAuthContext implements trivially auth.AuthContext except
+// implementing UpdateUserAuth properly to be used to refresh a
+// soft-expired user macaroon.
 type toolingAuthContext struct{}
 
 func (tac toolingAuthContext) CloudInfo() (*auth.CloudInfo, error) {


### PR DESCRIPTION
This is done by introducing an implementation of AuthContext that does the nothing, returns defaults except for supporting UpdateUserAuth.
