### PR TITLE
osutil,interfaces: use uint32 for uid, gid

### DIFF
--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -80,7 +80,7 @@ func mountEntryFromLayout(layout *snap.Layout) osutil.MountEntry {
 		entry.Options = []string{osutil.XSnapdKindSymlink(), osutil.XSnapdSymlink(oldname)}
 	}
 
-	var uid int
+	var uid uint32
 	// Only root is allowed here until we support custom users. Root is default.
 	switch layout.User {
 	case "root", "":
@@ -90,7 +90,7 @@ func mountEntryFromLayout(layout *snap.Layout) osutil.MountEntry {
 		entry.Options = append(entry.Options, osutil.XSnapdUser(uid))
 	}
 
-	var gid int
+	var gid uint32
 	// Only root is allowed here until we support custom groups. Root is default.
 	// This is validated in spec.go.
 	switch layout.Group {

--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -372,12 +372,12 @@ func XSnapdOriginLayout() string {
 }
 
 // XSnapdUser returns the string "x-snapd.user=%d".
-func XSnapdUser(uid int) string {
+func XSnapdUser(uid uint32) string {
 	return fmt.Sprintf("x-snapd.user=%d", uid)
 }
 
 // XSnapdGroup returns the string "x-snapd.group=%d".
-func XSnapdGroup(gid int) string {
+func XSnapdGroup(gid uint32) string {
 	return fmt.Sprintf("x-snapd.group=%d", gid)
 }
 


### PR DESCRIPTION
The real system type is unsigned integer so use that consistently.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
