### PR TITLE
many: fix false negatives reported by vet

### DIFF
--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -126,7 +126,7 @@ func (spec *Specification) AddSnapLayout(si *snap.Info) {
 	for _, path := range paths {
 		var buf bytes.Buffer
 		l := si.Layout[path]
-		fmt.Fprintf(&buf, "  # Layout %s\n", l)
+		fmt.Fprintf(&buf, "  # Layout %s\n", l.String())
 		path := si.ExpandSnapVariables(l.Path)
 		switch {
 		case l.Bind != "":

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -814,7 +814,7 @@ apps:
    daemon: simple
 `))
 	c.Assert(err, IsNil)
-	c.Check(fmt.Sprintf("%q", info.Apps["one"]), Equals, `"asnap.one"`)
+	c.Check(fmt.Sprintf("%q", info.Apps["one"].String()), Equals, `"asnap.one"`)
 }
 
 func (s *infoSuite) TestSocketFile(c *C) {


### PR DESCRIPTION
It seems that vet has issues with the Stringer interface and pointers.
To avoid this being raised in the future (though harmless), call String
explicitly in the two cases reported by vet.

interfaces/apparmor/spec.go:129: arg l for printf verb %s of wrong type: *github.com/snapcore/snapd/snap.Layout
snap/info_test.go:817: arg info.Apps["one"] for printf verb %q of wrong type: *github.com/snapcore/snapd/snap.AppInfo

Perhaps vet is concerned with a possible nil pointer?

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
