### PR TITLE
osutil,interfaces,cmd: use less hardcoded strings

### DIFF
--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -66,7 +66,7 @@ func mountEntryFromLayout(layout *snap.Layout) osutil.MountEntry {
 	}
 	if layout.BindFile != "" {
 		mountSource := layout.Snap.ExpandSnapVariables(layout.BindFile)
-		entry.Options = []string{"bind", "rw", "x-snapd.kind=file"}
+		entry.Options = []string{"bind", "rw", osutil.XSnapdKindFile()}
 		entry.Name = mountSource
 	}
 

--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -356,6 +356,43 @@ func (e *MountEntry) XSnapdSynthetic() bool {
 	return e.OptBool("x-snapd.synthetic")
 }
 
+// XSnapdKind returns the kind of a given mount entry.
+//
+// There are three kinds of mount entries today: one for directories, one for
+// files and one for symlinks. The values are "", "file" and "symlink" respectively.
+//
+// Directories use the empty string (in fact they don't need the option at
+// all) as this was the default and is retained for backwards compatibility.
+func (e *MountEntry) XSnapdKind() string {
+	val, _ := e.OptStr("x-snapd.kind")
+	return val
+}
+
+// XSnapdDetach returns true if a mount entry should be detached rather than unmounted.
+//
+// Whenever we create a recursive bind mount we don't want to just unmount it
+// as it may have replicated additional mount entries. For simplicity and
+// race-free behavior we just detach such mount entries and let the kernel do
+// the rest.
+func (e *MountEntry) XSnapdDetach() bool {
+	return e.OptBool("x-snapd.detach")
+}
+
+// XSnapdNeededBy returns the string "x-snapd.needed-by=..." with the given path appended.
+func XSnapdNeededBy(path string) string {
+	return fmt.Sprintf("x-snapd.needed-by=%s", path)
+}
+
+// XSnapdSynthetic returns the string "x-snapd.synthetic".
+func XSnapdSynthetic() string {
+	return "x-snapd.synthetic"
+}
+
+// XSnapdDetach returns the string "x-snapd.detach".
+func XSnapdDetach() string {
+	return "x-snapd.detach"
+}
+
 // XSnapdKindSymlink returns the string "x-snapd.kind=symlink".
 func XSnapdKindSymlink() string {
 	return "x-snapd.kind=symlink"

--- a/osutil/mountentry_test.go
+++ b/osutil/mountentry_test.go
@@ -233,8 +233,6 @@ func (s *entrySuite) TestOptBool(c *C) {
 }
 
 func (s *entrySuite) TestOptionHelpers(c *C) {
-	c.Assert(osutil.XSnapdKindSymlink(), Equals, "x-snapd.kind=symlink")
-	c.Assert(osutil.XSnapdKindFile(), Equals, "x-snapd.kind=file")
 	c.Assert(osutil.XSnapdUser(1000), Equals, "x-snapd.user=1000")
 	c.Assert(osutil.XSnapdGroup(1000), Equals, "x-snapd.group=1000")
 	c.Assert(osutil.XSnapdMode(0755), Equals, "x-snapd.mode=0755")
@@ -340,6 +338,9 @@ func (s *entrySuite) TestXSnapdNeededBy(c *C) {
 	// The needed-by attribute parsed from the x-snapd.needed-by= option.
 	e = &osutil.MountEntry{Options: []string{"x-snap.id=foo", "x-snapd.needed-by=bar"}}
 	c.Assert(e.XSnapdNeededBy(), Equals, "bar")
+
+	// There's a helper function that returns this option string.
+	c.Assert(osutil.XSnapdNeededBy("foo"), Equals, "x-snapd.needed-by=foo")
 }
 
 func (s *entrySuite) TestXSnapdSynthetic(c *C) {
@@ -350,10 +351,9 @@ func (s *entrySuite) TestXSnapdSynthetic(c *C) {
 	// Tagging is done with x-snapd.synthetic option.
 	e = &osutil.MountEntry{Options: []string{"x-snapd.synthetic"}}
 	c.Assert(e.XSnapdSynthetic(), Equals, true)
-}
 
-func (s *entrySuite) TextXSnapdOriginLayout(c *C) {
-	c.Assert(osutil.XSnapdOriginLayout(), Equals, "x-snapd.origin=layout")
+	// There's a helper function that returns this option string.
+	c.Assert(osutil.XSnapdSynthetic(), Equals, "x-snapd.synthetic")
 }
 
 func (s *entrySuite) TestXSnapdOrigin(c *C) {
@@ -361,11 +361,44 @@ func (s *entrySuite) TestXSnapdOrigin(c *C) {
 	e := &osutil.MountEntry{}
 	c.Assert(e.XSnapdOrigin(), Equals, "")
 
-	// Origin can be indicated with the x-snapd.origin= option
-	e = &osutil.MountEntry{Options: []string{"x-snapd.origin=layout"}}
-	c.Assert(e.XSnapdOrigin(), Equals, "layout")
-
-	// The helpful helper for this constant actually works.
+	// Origin can be indicated with the x-snapd.origin= option.
 	e = &osutil.MountEntry{Options: []string{osutil.XSnapdOriginLayout()}}
 	c.Assert(e.XSnapdOrigin(), Equals, "layout")
+
+	// There's a helper function that returns this option string.
+	c.Assert(osutil.XSnapdOriginLayout(), Equals, "x-snapd.origin=layout")
+}
+
+func (s *entrySuite) TestXSnapdDetach(c *C) {
+	// Entries are not detached by default.
+	e := &osutil.MountEntry{}
+	c.Assert(e.XSnapdDetach(), Equals, false)
+
+	// Detach can be requested with the x-snapd.detach option.
+	e = &osutil.MountEntry{Options: []string{osutil.XSnapdDetach()}}
+	c.Assert(e.XSnapdDetach(), Equals, true)
+
+	// There's a helper function that returns this option string.
+	c.Assert(osutil.XSnapdDetach(), Equals, "x-snapd.detach")
+}
+
+func (s *entrySuite) TestXSnapdKind(c *C) {
+	// Entries have a kind (directory, file or symlink). Directory is spelled
+	// as an empty string though, for backwards compatibility.
+	e := &osutil.MountEntry{}
+	c.Assert(e.XSnapdKind(), Equals, "")
+
+	// A bind mount entry can refer to a file using the x-snapd.kind=file option string.
+	e = &osutil.MountEntry{Options: []string{osutil.XSnapdKindFile()}}
+	c.Assert(e.XSnapdKind(), Equals, "file")
+
+	// There's a helper function that returns this option string.
+	c.Assert(osutil.XSnapdKindFile(), Equals, "x-snapd.kind=file")
+
+	// A mount entry can create a symlink by using the x-snapd.kind=symlink option string.
+	e = &osutil.MountEntry{Options: []string{osutil.XSnapdKindSymlink()}}
+	c.Assert(e.XSnapdKind(), Equals, "symlink")
+
+	// There's a helper function that returns this option string.
+	c.Assert(osutil.XSnapdKindSymlink(), Equals, "x-snapd.kind=symlink")
 }


### PR DESCRIPTION
This patch changes various mount related code to use functions that
access or create various x-snapd.foo mount options. This should lessen
the chance of any typo sneaking past code reviews.

The test suite is also improved to be more consistent and complete with
regards to code coverage.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
