### PR TITLE
many: fix various issues reported by shellcheck

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -103,7 +103,7 @@ purge() {
                 find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
                 # timer files
                 find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
-                    systemctl_stop "$(basename $f)"
+                    systemctl_stop "$(basename "$f")"
                     rm -f "$f"
                 done
             fi

--- a/packaging/ubuntu-14.04/snapd.postrm
+++ b/packaging/ubuntu-14.04/snapd.postrm
@@ -71,7 +71,7 @@ if [ "$1" = "purge" ]; then
             find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
             # timer files
             find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
-                systemctl_stop "$(basename $f)"
+                systemctl_stop "$(basename "$f")"
                 rm -f "$f"
             done
         fi

--- a/packaging/ubuntu-16.04/snapd.postrm
+++ b/packaging/ubuntu-16.04/snapd.postrm
@@ -74,7 +74,7 @@ if [ "$1" = "purge" ]; then
             find /etc/dbus-1/system.d -name "snap.${snap}.*.conf" -execdir rm -f "{}" \;
             # timer files
             find /etc/systemd/system -name "snap.${snap}.*.timer" | while read -r f; do
-                systemctl_stop "$(basename $f)"
+                systemctl_stop "$(basename "$f")"
                 rm -f "$f"
             done
         fi

--- a/run-checks
+++ b/run-checks
@@ -226,6 +226,7 @@ if [ "$UNIT" = 1 ]; then
     # tests
     echo Running tests from "$PWD"
     if dpkg --compare-versions "$(go version | awk '$3 ~ /^go[0-9]/ {print substr($3, 3)}')" ge 1.10; then
+        # shellcheck disable=SC2046
         $goctest -v -coverprofile=.coverage/coverage.out -covermode="$COVERMODE" $(go list ./... | grep -v '/vendor/' )
     else
         for pkg in $(go list ./... | grep -v '/vendor/' ); do

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -389,14 +389,14 @@ EOF
         mkdir -p /mnt/system-data/etc/systemd/system/multi-user.target.wants
         for f in group gshadow passwd shadow; do
             # the passwd from core without root
-            grep -v "^root:" "$UNPACKD/etc/$f" > /mnt/system-data/root/test-etc/$f
+            grep -v "^root:" "$UNPACKD/etc/$f" > /mnt/system-data/root/test-etc/"$f"
             # append this systems root user so that linode can connect
-            grep "^root:" /etc/$f >> /mnt/system-data/root/test-etc/$f
+            grep "^root:" /etc/"$f" >> /mnt/system-data/root/test-etc/"$f"
 
             # make sure the group is as expected
-            chgrp --reference "$UNPACKD/etc/$f" /mnt/system-data/root/test-etc/$f
+            chgrp --reference "$UNPACKD/etc/$f" /mnt/system-data/root/test-etc/"$f"
             # now bind mount read-only those passwd files on boot
-            cat <<EOF > /mnt/system-data/etc/systemd/system/etc-$f.mount
+            cat >/mnt/system-data/etc/systemd/system/etc-"$f".mount <<EOF
 [Unit]
 Description=Mount root/test-etc/$f over system etc/$f
 Before=ssh.service
@@ -410,14 +410,14 @@ Options=bind,ro
 [Install]
 WantedBy=multi-user.target
 EOF
-            ln -s /etc/systemd/system/etc-$f.mount /mnt/system-data/etc/systemd/system/multi-user.target.wants/etc-$f.mount
+            ln -s /etc/systemd/system/etc-"$f".mount /mnt/system-data/etc/systemd/system/multi-user.target.wants/etc-"$f".mount
 
             # create /var/lib/extrausers/$f
             # append ubuntu, test user for the testing
-            cp -a "$UNPACKD/var/lib/extrausers/$f" /mnt/system-data/var/lib/extrausers/$f
-            tail -n2 /etc/$f >> /mnt/system-data/var/lib/extrausers/$f
+            cp -a "$UNPACKD/var/lib/extrausers/$f" /mnt/system-data/var/lib/extrausers/"$f"
+            tail -n2 /etc/"$f" >> /mnt/system-data/var/lib/extrausers/"$f"
             # check test was copied
-            cat /mnt/system-data/var/lib/extrausers/$f| MATCH "^test:"
+            MATCH "^test:" </mnt/system-data/var/lib/extrausers/"$f"
 
         done
 

--- a/tests/lib/snaps/test-snapd-xdg-autostart/bin/foobar
+++ b/tests/lib/snaps/test-snapd-xdg-autostart/bin/foobar
@@ -7,8 +7,8 @@ dump_autostart() {
 
     echo "generating autostart file $dfpath"
 
-    mkdir -p $SNAP_USER_DATA/.config/autostart
-    cat <<EOF > $dfpath
+    mkdir -p "$SNAP_USER_DATA"/.config/autostart
+    cat >"$dfpath" <<EOF
 [Desktop Entry]
 Name=foo autostart
 Exec=/foo/bar/baz/bin/foobar --autostart a b c
@@ -17,10 +17,10 @@ EOF
 
 case "$1" in
     --autostart)
-        echo "autostarting with args '$@'" | tee $SNAP_USER_DATA/foo-autostarted
+        echo "autostarting with args '$*'" | tee "$SNAP_USER_DATA"/foo-autostarted
         ;;
     *)
-        echo "regular run with args '$@'"
+        echo "regular run with args '$*'"
         dump_autostart
         ;;
 esac

--- a/tests/lib/systemd.sh
+++ b/tests/lib/systemd.sh
@@ -48,7 +48,7 @@ systemd_stop_units() {
                     echo "$unit unit not active"
                     exit 1
                 fi
-                retries=$(( $retries - 1 ))
+                retries=$(( retries - 1 ))
                 sleep 1
             done
 


### PR DESCRIPTION
The fixes range from typical missing quote on a variable to more subtle
use of echo "stuff '$@'" that should use $* instead (we want one
argument, not a list). There are several less commonly encountered
issues as well, such as the irrelevance of $ inside arithmetic
expressions.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>