### PR TITLE
tests: checking interfaces declaring the specific interface

### DIFF
--- a/tests/main/classic-ubuntu-core-transition-auth/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-auth/task.yaml
@@ -68,4 +68,4 @@ execute: |
     fi
 
     echo "Ensure interfaces are connected"
-    snap interfaces | MATCH ":core-support.*core:core-support-plug"
+    snap interfaces -i core-support | MATCH ":core-support.*core:core-support-plug"

--- a/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
@@ -17,7 +17,7 @@ debug: |
 execute: |
     echo "install a snap"
     snap install test-snapd-python-webserver
-    snap interfaces |MATCH ":network.*test-snapd-python-webserver"
+    snap interfaces -i network | MATCH ":network.*test-snapd-python-webserver"
 
     . "$TESTSLIB/names.sh"
     cp /var/lib/snapd/state.json /var/lib/snapd/state.json.old
@@ -70,7 +70,7 @@ execute: |
         echo "ubuntu-core still installed, transition failed"
         exit 1
     fi
-    snap interfaces |MATCH ":network.*test-snapd-python-webserver"
+    snap interfaces -i network | MATCH ":network.*test-snapd-python-webserver"
 
     echo "Ensure interfaces are connected"
-    snap interfaces | MATCH ":core-support.*core:core-support-plug"
+    snap interfaces -i core-support | MATCH ":core-support.*core:core-support-plug"

--- a/tests/main/classic-ubuntu-core-transition/task.yaml
+++ b/tests/main/classic-ubuntu-core-transition/task.yaml
@@ -56,8 +56,8 @@ execute: |
     snap install ./ubuntu-core_*.snap
 
     snap install test-snapd-python-webserver
-    snap interfaces | MATCH ":network +test-snapd-python-webserver"
-    snap interfaces | MATCH ":network-bind +.*test-snapd-python-webserver"
+    snap interfaces -i network | MATCH ":network +test-snapd-python-webserver"
+    snap interfaces -i network-bind | MATCH ":network-bind +.*test-snapd-python-webserver"
 
     echo "Ensure the webserver is working"
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
@@ -103,8 +103,8 @@ execute: |
         echo "ubuntu-core still installed, transition failed"
         exit 1
     fi
-    snap interfaces | MATCH ":network +test-snapd-python-webserver"
-    snap interfaces | MATCH ":network-bind +.*test-snapd-python-webserver"
+    snap interfaces -i network | MATCH ":network +test-snapd-python-webserver"
+    snap interfaces -i network-bind | MATCH ":network-bind +.*test-snapd-python-webserver"
     echo "Ensure the webserver is still working"
     wait_for_service snap.test-snapd-python-webserver.test-snapd-python-webserver
     curl http://localhost | MATCH "XKCD rocks"
@@ -115,7 +115,7 @@ execute: |
     curl http://localhost | MATCH "XKCD rocks"
 
     echo "Ensure interfaces are connected"
-    snap interfaces | MATCH ":core-support.*core:core-support-plug"
+    snap interfaces -i core-support | MATCH ":core-support.*core:core-support-plug"
 
     echo "Ensure snap set core works"
     snap set core system.power-key-action=ignore

--- a/tests/main/interfaces-accounts-service/task.yaml
+++ b/tests/main/interfaces-accounts-service/task.yaml
@@ -45,7 +45,7 @@ execute: |
       "{'Enabled': 'true', 'EmailAddress': 'test@example.com', 'Name': 'Test User', 'ImapHost': 'imap.example.com', 'SmtpHost': 'mail.example.com'}"
 
     echo "The interface is initially disconnected"
-    snap interfaces | MATCH "\- +test-snapd-accounts-service:accounts-service"
+    snap interfaces -i accounts-service | MATCH "\- +test-snapd-accounts-service:accounts-service"
     test-snapd-accounts-service.list-accounts && exit 1 || true
 
     echo "When the plug is connected"

--- a/tests/main/interfaces-autopilot-introspection/task.yaml
+++ b/tests/main/interfaces-autopilot-introspection/task.yaml
@@ -35,7 +35,7 @@ execute: |
     export $(cat dbus.env)
 
     echo "Then the plug is disconnected by default"
-    snap interfaces | MATCH "^\- +test-snapd-autopilot-consumer:autopilot-introspection"
+    snap interfaces -i autopilot-introspection | MATCH "^\- +test-snapd-autopilot-consumer:autopilot-introspection"
 
     echo "When the plug is connected"
     snap connect test-snapd-autopilot-consumer:autopilot-introspection

--- a/tests/main/interfaces-avahi-observe/task.yaml
+++ b/tests/main/interfaces-avahi-observe/task.yaml
@@ -29,7 +29,7 @@ execute: |
     avahi_dbus_call="dbus-send --system --print-reply --dest=org.freedesktop.Avahi / org.freedesktop.Avahi.Server.GetHostName"
 
     echo "Then the plug is disconnected by default"
-    snap interfaces | MATCH "^\- +generic-consumer:avahi-observe"
+    snap interfaces -i avahi-observe | MATCH "^\- +generic-consumer:avahi-observe"
 
     if [ "$(snap debug confinement)" = strict ] ; then
         echo "And the snap is not able to access avahi provided info"

--- a/tests/main/interfaces-bluetooth-control/task.yaml
+++ b/tests/main/interfaces-bluetooth-control/task.yaml
@@ -15,7 +15,7 @@ execute: |
     BTDEV="$(find /sys/devices/ -type d -name bluetooth)"
 
     echo "Then the plug is disconnected by default"
-    snap interfaces | MATCH "^\- +generic-consumer:bluetooth-control"
+    snap interfaces -i bluetooth-control | MATCH "^\- +generic-consumer:bluetooth-control"
 
     if [ "$(snap debug confinement)" = strict ] ; then
         echo "And the snap is not able to read usb"

--- a/tests/main/interfaces-browser-support/task.yaml
+++ b/tests/main/interfaces-browser-support/task.yaml
@@ -56,7 +56,7 @@ execute: |
        echo "If allow-sandbox is false then the plug is connected by default"
     else
        echo "If allow-sandbox is true then the plug is not connected by default"
-       snap interfaces | MATCH "\- +browser-support-consumer:browser-support"
+       snap interfaces -i browser-support | MATCH "\- +browser-support-consumer:browser-support"
 
        echo "Do connect it manually"
        snap connect browser-support-consumer:browser-support

--- a/tests/main/interfaces-content-empty-content-attr/task.yaml
+++ b/tests/main/interfaces-content-empty-content-attr/task.yaml
@@ -9,7 +9,7 @@ prepare: |
 
 execute: |
     echo "Then the snap is listed as connected"
-    snap interfaces | MATCH "test-snapd-content-slot-no-content-attr:shared-content +test-snapd-content-plug-no-content-attr"
+    snap interfaces -i content | MATCH "test-snapd-content-slot-no-content-attr:shared-content +test-snapd-content-plug-no-content-attr"
 
     echo "And fstab files are created"
     [ $(find /var/lib/snapd/mount -type f -name "*.fstab" | wc -l) -gt 0 ]

--- a/tests/main/interfaces-content/task.yaml
+++ b/tests/main/interfaces-content/task.yaml
@@ -31,7 +31,7 @@ execute: |
     snap list | MATCH  test-snapd-content-slot
 
     echo "Then the snap is listed as connected"
-    snap interfaces | grep -Pzq "test-snapd-content-slot:shared-content-slot +test-snapd-content-plug:shared-content-plug"
+    snap interfaces -i content | grep -Pzq "test-snapd-content-slot:shared-content-slot +test-snapd-content-plug:shared-content-plug"
 
     echo "And fstab files are created"
     [ $(find /var/lib/snapd/mount -type f -name "*.fstab" | wc -l) -gt 0 ]

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -47,7 +47,7 @@ debug: |
 
 execute: |
     echo "Then the plug is disconnected by default"
-    snap interfaces | MATCH "^\- +test-snapd-cups-control-consumer:cups-control"
+    snap interfaces -i cups-control | MATCH "^\- +test-snapd-cups-control-consumer:cups-control"
 
     echo "When the plug is connected"
     snap connect test-snapd-cups-control-consumer:cups-control

--- a/tests/main/interfaces-dbus/task.yaml
+++ b/tests/main/interfaces-dbus/task.yaml
@@ -40,7 +40,7 @@ execute: |
     done
 
     echo "And plug is disconnected by default"
-    snap interfaces | MATCH "^\- +test-snapd-dbus-consumer:dbus-test"
+    snap interfaces -i dbus | MATCH "^\- +test-snapd-dbus-consumer:dbus-test"
 
     if [ "$(snap debug confinement)" = partial ]; then
         exit 0

--- a/tests/main/interfaces-desktop/task.yaml
+++ b/tests/main/interfaces-desktop/task.yaml
@@ -17,7 +17,7 @@ execute: |
     files="/etc/xdg/user-dirs.conf /etc/xdg/user-dirs.defaults"
 
     echo "The plug is connected by default"
-    snap interfaces | MATCH ":desktop .*test-snapd-desktop"
+    snap interfaces -i desktop | MATCH ":desktop .*test-snapd-desktop"
 
     echo "Then the snap is able to desktop files and directories"
     test-snapd-desktop.check-files $files

--- a/tests/main/interfaces-firewall-control/task.yaml
+++ b/tests/main/interfaces-firewall-control/task.yaml
@@ -48,7 +48,7 @@ restore: |
 
 execute: |
     echo "Then the plug is disconnected by default"
-    snap interfaces | MATCH "^\- +firewall-control-consumer:firewall-control"
+    snap interfaces -i firewall-control | MATCH "^\- +firewall-control-consumer:firewall-control"
 
     echo "When the plug is connected"
     snap connect firewall-control-consumer:firewall-control

--- a/tests/main/interfaces-framebuffer/task.yaml
+++ b/tests/main/interfaces-framebuffer/task.yaml
@@ -12,7 +12,7 @@ prepare: |
 
 execute: |
     echo "The plug is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-framebuffer:framebuffer"
+    snap interfaces -i framebuffer | MATCH "\- +test-snapd-framebuffer:framebuffer"
 
     if [ ! -e /dev/fb0 ]; then
         echo "Framebuffer not available on /dev/fb0"

--- a/tests/main/interfaces-fuse_support/task.yaml
+++ b/tests/main/interfaces-fuse_support/task.yaml
@@ -38,7 +38,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-fuse-consumer:fuse-support"
+    snap interfaces -i fuse-support | MATCH "\- +test-snapd-fuse-consumer:fuse-support"
 
     if [ "$(snap debug confinement)" = strict ] ; then
         echo "Then the snap is not able to create a fuse file system"

--- a/tests/main/interfaces-gpg-keys/task.yaml
+++ b/tests/main/interfaces-gpg-keys/task.yaml
@@ -33,7 +33,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-gpg-keys:gpg-keys"
+    snap interfaces -i gpg-keys | MATCH "\- +test-snapd-gpg-keys:gpg-keys"
 
     echo "When the interface is connected"
     snap connect test-snapd-gpg-keys:gpg-keys

--- a/tests/main/interfaces-gpg-public-keys/task.yaml
+++ b/tests/main/interfaces-gpg-public-keys/task.yaml
@@ -32,7 +32,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-gpg-public-keys:gpg-public-keys"
+    snap interfaces -i gpg-public-keys | MATCH "\- +test-snapd-gpg-public-keys:gpg-public-keys"
 
     echo "When the interface is connected"
     snap connect test-snapd-gpg-public-keys:gpg-public-keys

--- a/tests/main/interfaces-gpio-memory-control/task.yaml
+++ b/tests/main/interfaces-gpio-memory-control/task.yaml
@@ -19,7 +19,7 @@ execute: |
     fi
 
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-gpio-memory-control:gpio-memory-control"
+    snap interfaces -i gpio-memory-control | MATCH "\- +test-snapd-gpio-memory-control:gpio-memory-control"
 
     echo "When the interface is connected"
     snap connect test-snapd-gpio-memory-control:gpio-memory-control

--- a/tests/main/interfaces-hardware-observe/task.yaml
+++ b/tests/main/interfaces-hardware-observe/task.yaml
@@ -20,7 +20,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +hardware-observe-consumer:hardware-observe"
+    snap interfaces -i hardware-observe | MATCH "\- +hardware-observe-consumer:hardware-observe"
 
     echo "When the plug is connected"
     snap connect hardware-observe-consumer:hardware-observe

--- a/tests/main/interfaces-hardware-random-control/task.yaml
+++ b/tests/main/interfaces-hardware-random-control/task.yaml
@@ -24,7 +24,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-hardware-random-control:hardware-random-control"
+    snap interfaces -i hardware-random-control | MATCH "\- +test-snapd-hardware-random-control:hardware-random-control"
 
     echo "When the plug is connected"
     snap connect test-snapd-hardware-random-control:hardware-random-control

--- a/tests/main/interfaces-hardware-random-observe/task.yaml
+++ b/tests/main/interfaces-hardware-random-observe/task.yaml
@@ -24,7 +24,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-hardware-random-observe:hardware-random-observe"
+    snap interfaces -i hardware-random-observe | MATCH "\- +test-snapd-hardware-random-observe:hardware-random-observe"
 
     echo "When the plug is connected"
     snap connect test-snapd-hardware-random-observe:hardware-random-observe

--- a/tests/main/interfaces-home/task.yaml
+++ b/tests/main/interfaces-home/task.yaml
@@ -37,13 +37,13 @@ restore: |
 execute: |
     if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
         echo "The interface is not connected by default"
-        snap interfaces | MATCH "^\- +home-consumer:home"
+        snap interfaces -i home | MATCH "^\- +home-consumer:home"
 
         echo "And the plug can be connected"
         snap connect home-consumer:home
     else
         echo "The interface is connected by default"
-        snap interfaces | MATCH ":home .*home-consumer"
+        snap interfaces -i home | MATCH ":home .*home-consumer"
 
         echo "When the plug is disconnected"
         snap disconnect home-consumer:home

--- a/tests/main/interfaces-kernel-module-control/task.yaml
+++ b/tests/main/interfaces-kernel-module-control/task.yaml
@@ -44,7 +44,7 @@ execute: |
     fi
 
     echo "The plug is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-kernel-module-consumer:kernel-module-control"
+    snap interfaces -i kernel-module-control | MATCH "\- +test-snapd-kernel-module-consumer:kernel-module-control"
 
     echo "When the plug is connected"
     snap connect test-snapd-kernel-module-consumer:kernel-module-control

--- a/tests/main/interfaces-kvm/task.yaml
+++ b/tests/main/interfaces-kvm/task.yaml
@@ -22,7 +22,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-kvm:kvm"
+    snap interfaces -i kvm | MATCH "\- +test-snapd-kvm:kvm"
 
     echo "When the interface is connected"
     snap connect test-snapd-kvm:kvm

--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -42,7 +42,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-libvirt-consumer:libvirt"
+    snap interfaces -i libvirt | MATCH "\- +test-snapd-libvirt-consumer:libvirt"
 
     echo "When the plug is connected"
     snap connect test-snapd-libvirt-consumer:libvirt

--- a/tests/main/interfaces-locale-control/task.yaml
+++ b/tests/main/interfaces-locale-control/task.yaml
@@ -57,7 +57,7 @@ execute: |
     fi
 
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +locale-control-consumer:locale-control"
+    snap interfaces -i locale-control | MATCH "\- +locale-control-consumer:locale-control"
 
     echo "When the plug is connected"
     snap connect locale-control-consumer:locale-control

--- a/tests/main/interfaces-location-control/task.yaml
+++ b/tests/main/interfaces-location-control/task.yaml
@@ -29,7 +29,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "^- +test-snapd-location-control-provider:location-control$"
+    snap interfaces -i location-control | MATCH "^- +test-snapd-location-control-provider:location-control$"
 
     echo "The interface can be connected"
     snap connect test-snapd-location-control-provider:location-control test-snapd-location-control-provider:location-control-test

--- a/tests/main/interfaces-log-observe/task.yaml
+++ b/tests/main/interfaces-log-observe/task.yaml
@@ -20,7 +20,7 @@ prepare: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +$SNAP_NAME:$PLUG"
+    snap interfaces -i log-observe | MATCH "\- +$SNAP_NAME:$PLUG"
 
     echo "When the plug is connected"
     snap connect $SNAP_NAME:$PLUG

--- a/tests/main/interfaces-mount-observe/task.yaml
+++ b/tests/main/interfaces-mount-observe/task.yaml
@@ -21,7 +21,7 @@ execute: |
     . $TESTSLIB/dirs.sh
 
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +mount-observe-consumer:mount-observe"
+    snap interfaces -i mount-observe | MATCH "\- +mount-observe-consumer:mount-observe"
 
     echo "When the plug is connected"
     snap connect mount-observe-consumer:mount-observe

--- a/tests/main/interfaces-netlink-audit/task.yaml
+++ b/tests/main/interfaces-netlink-audit/task.yaml
@@ -18,7 +18,7 @@ prepare: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-netlink-audit:netlink-audit"
+    snap interfaces -i netlink-audit | MATCH "\- +test-snapd-netlink-audit:netlink-audit"
 
     echo "When the interface is connected"
     snap connect test-snapd-netlink-audit:netlink-audit

--- a/tests/main/interfaces-netlink-connector/task.yaml
+++ b/tests/main/interfaces-netlink-connector/task.yaml
@@ -13,7 +13,7 @@ prepare: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-netlink-connector:netlink-connector"
+    snap interfaces -i netlink-connector | MATCH "\- +test-snapd-netlink-connector:netlink-connector"
 
     echo "When the interface is connected"
     snap connect test-snapd-netlink-connector:netlink-connector

--- a/tests/main/interfaces-network-bind/task.yaml
+++ b/tests/main/interfaces-network-bind/task.yaml
@@ -31,7 +31,7 @@ prepare: |
 
 execute: |
     echo "The interface is connected by default"
-    snap interfaces | MATCH ":network-bind .*$SNAP_NAME"
+    snap interfaces -i network-bind | MATCH ":network-bind .*$SNAP_NAME"
 
     echo "When the plug is disconnected"
     snap disconnect $SNAP_NAME:network-bind

--- a/tests/main/interfaces-network-control-tuntap/task.yaml
+++ b/tests/main/interfaces-network-control-tuntap/task.yaml
@@ -27,7 +27,7 @@ execute: |
     . "$TESTSLIB/network.sh"
 
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "^- +test-snapd-tuntap:network-control$"
+    snap interfaces -i network-control | MATCH "^- +test-snapd-tuntap:network-control$"
 
     if [ "$(snap debug confinement)" = strict ] ; then
         echo "And cannot allocate the $DEV device"

--- a/tests/main/interfaces-network-control/task.yaml
+++ b/tests/main/interfaces-network-control/task.yaml
@@ -49,7 +49,7 @@ execute: |
     INTERFACE=$(get_default_iface)
 
     echo "Then the plug disconnected by default"
-    snap interfaces | MATCH "^- +network-control-consumer:network-control$"
+    snap interfaces -i network-control | MATCH "^- +network-control-consumer:network-control$"
 
     echo "When the plug is connected"
     snap connect network-control-consumer:network-control

--- a/tests/main/interfaces-network-manager/task.yaml
+++ b/tests/main/interfaces-network-manager/task.yaml
@@ -29,7 +29,7 @@ execute: |
     done
 
     echo "The interface is connected by default"
-    snap interfaces | MATCH "network-manager:service .*network-manager:nmcli"
+    snap interfaces -i network-manager | MATCH "network-manager:service .*network-manager:nmcli"
 
     echo "And allows to add a new connection"
     conn_name=nmtest

--- a/tests/main/interfaces-network-observe/task.yaml
+++ b/tests/main/interfaces-network-observe/task.yaml
@@ -39,7 +39,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +network-observe-consumer:network-observe"
+    snap interfaces -i network-observe | MATCH "\- +network-observe-consumer:network-observe"
 
     echo "When the plug is connected"
     snap connect network-observe-consumer:network-observe

--- a/tests/main/interfaces-network-setup-control/task.yaml
+++ b/tests/main/interfaces-network-setup-control/task.yaml
@@ -1,4 +1,4 @@
-summary: Ensure that the desktop interface works.
+summary: Ensure that the network-setup-control interface works.
 
 details: |
     The network setup control interface allows to access the different netplan
@@ -22,7 +22,7 @@ execute: |
     dirs="/etc/netplan /etc/network"
 
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-check-fs-access:network-setup-control"
+    snap interfaces -i network-setup-control | MATCH "\- +test-snapd-check-fs-access:network-setup-control"
 
     echo "When the interface is connected"
     snap connect test-snapd-check-fs-access:network-setup-control

--- a/tests/main/interfaces-network-setup-observe/task.yaml
+++ b/tests/main/interfaces-network-setup-observe/task.yaml
@@ -1,4 +1,4 @@
-summary: Ensure that the desktop interface works.
+summary: Ensure that the network-setup-observe interface works.
 
 details: |
     The network setup observe interface allows to access the different netplan
@@ -20,7 +20,7 @@ execute: |
     dirs="/etc/netplan /etc/network"
 
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-check-fs-access:network-setup-observe"
+    snap interfaces -i network-setup-observe| MATCH "\- +test-snapd-check-fs-access:network-setup-observe"
 
     echo "When the interface is connected"
     snap connect test-snapd-check-fs-access:network-setup-observe

--- a/tests/main/interfaces-network-status/task.yaml
+++ b/tests/main/interfaces-network-status/task.yaml
@@ -29,7 +29,7 @@ restore: |
 
 execute: |
     echo "The interface is connected by default"
-    snap interfaces | MATCH "test-snapd-network-status-provider:network-status-test .*test-snapd-network-status-provider:network-status"
+    snap interfaces -i network-status | MATCH "test-snapd-network-status-provider:network-status-test .*test-snapd-network-status-provider:network-status"
 
     echo "Then wait until the dbus name is properly reserved"
     for i in $(seq 10); do

--- a/tests/main/interfaces-network/task.yaml
+++ b/tests/main/interfaces-network/task.yaml
@@ -37,7 +37,7 @@ restore: |
 
 execute: |
     echo "The interface is connected by default"
-    snap interfaces | MATCH ":network .*$SNAP_NAME"
+    snap interfaces -i network | MATCH ":network .*$SNAP_NAME"
 
     echo "When the plug is disconnected"
     snap disconnect $SNAP_NAME:network

--- a/tests/main/interfaces-openvswitch-support/task.yaml
+++ b/tests/main/interfaces-openvswitch-support/task.yaml
@@ -16,7 +16,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-openvswitch-support:openvswitch-support"
+    snap interfaces -i openvswitch-support | MATCH "\- +test-snapd-openvswitch-support:openvswitch-support"
 
     echo "When the interface is connected"
     snap connect test-snapd-openvswitch-support:openvswitch-support

--- a/tests/main/interfaces-openvswitch/task.yaml
+++ b/tests/main/interfaces-openvswitch/task.yaml
@@ -48,7 +48,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-openvswitch-consumer:openvswitch"
+    snap interfaces -i openvswitch | MATCH "\- +test-snapd-openvswitch-consumer:openvswitch"
 
     echo "When the plug is connected"
     snap connect test-snapd-openvswitch-consumer:openvswitch

--- a/tests/main/interfaces-password-manager-service/task.yaml
+++ b/tests/main/interfaces-password-manager-service/task.yaml
@@ -23,7 +23,7 @@ execute: |
     echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid
 
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-password-manager-consumer:password-manager-service"
+    snap interfaces -i password-manager-service | MATCH "\- +test-snapd-password-manager-consumer:password-manager-service"
 
     echo "When the plug is connected"
     snap connect test-snapd-password-manager-consumer:password-manager-service

--- a/tests/main/interfaces-physical-memory-observe/task.yaml
+++ b/tests/main/interfaces-physical-memory-observe/task.yaml
@@ -25,7 +25,7 @@ execute: |
     fi
 
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-physical-memory-observe:physical-memory-observe"
+    snap interfaces -i physical-memory-observe | MATCH "\- +test-snapd-physical-memory-observe:physical-memory-observe"
 
     echo "When the interface is connected"
     snap connect test-snapd-physical-memory-observe:physical-memory-observe

--- a/tests/main/interfaces-process-control/task.yaml
+++ b/tests/main/interfaces-process-control/task.yaml
@@ -23,7 +23,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +process-control-consumer:process-control"
+    snap interfaces -i process-control | MATCH "\- +process-control-consumer:process-control"
 
     echo "When the plug is connected"
     snap connect process-control-consumer:process-control

--- a/tests/main/interfaces-raw-usb/task.yaml
+++ b/tests/main/interfaces-raw-usb/task.yaml
@@ -12,7 +12,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-raw-usb:raw-usb"
+    snap interfaces -i raw-usb | MATCH "\- +test-snapd-raw-usb:raw-usb"
 
     echo "When the interface is connected"
     snap connect test-snapd-raw-usb:raw-usb

--- a/tests/main/interfaces-removable-media/task.yaml
+++ b/tests/main/interfaces-removable-media/task.yaml
@@ -37,7 +37,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-removable-media:removable-media"
+    snap interfaces -i removable-media | MATCH "\- +test-snapd-removable-media:removable-media"
 
     echo "When the interface is connected"
     snap connect test-snapd-removable-media:removable-media

--- a/tests/main/interfaces-shutdown-introspection/task.yaml
+++ b/tests/main/interfaces-shutdown-introspection/task.yaml
@@ -19,7 +19,7 @@ prepare: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +shutdown-introspection-consumer:shutdown"
+    snap interfaces -i shutdown | MATCH "\- +shutdown-introspection-consumer:shutdown"
 
     echo "When the plug is connected"
     snap connect shutdown-introspection-consumer:shutdown

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -60,7 +60,9 @@ execute: |
     fi
 
     snap install test-snapd-control-consumer
-    snap interfaces
+
+    echo "The interface is disconnected by default"
+    snap interfaces -i snapd-control | MATCH "\- +test-snapd-control-consumer:snapd-control-with-manage"
 
     echo "When the snapd-control-with-manage plug is connected"
     snap connect test-snapd-control-consumer:snapd-control-with-manage

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -61,8 +61,8 @@ execute: |
 
     snap install test-snapd-control-consumer
 
-    echo "The interface is disconnected by default"
-    snap interfaces -i snapd-control | MATCH "\- +test-snapd-control-consumer,test-snapd-control-consumer:snapd-control-with-manage"
+    echo "The interface is connected by default"
+    snap interfaces -i snapd-control | MATCH ":snapd-control .*test-snapd-control-consumer:snapd-control-with-manage"
 
     echo "When the snapd-control-with-manage plug is connected"
     snap connect test-snapd-control-consumer:snapd-control-with-manage

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -62,7 +62,7 @@ execute: |
     snap install test-snapd-control-consumer
 
     echo "The interface is disconnected by default"
-    snap interfaces -i snapd-control | MATCH "\- +test-snapd-control-consumer:snapd-control-with-manage"
+    snap interfaces -i snapd-control | MATCH "\- +test-snapd-control-consumer,test-snapd-control-consumer:snapd-control-with-manage"
 
     echo "When the snapd-control-with-manage plug is connected"
     snap connect test-snapd-control-consumer:snapd-control-with-manage

--- a/tests/main/interfaces-snapd-control/task.yaml
+++ b/tests/main/interfaces-snapd-control/task.yaml
@@ -23,7 +23,7 @@ restore: |
 
 execute: |
     echo "The interface is connected by default"
-    snap interfaces | MATCH ":snapd-control .*test-snapd-control-consumer"
+    snap interfaces -i snapd-control | MATCH ":snapd-control .*test-snapd-control-consumer"
 
     if [ "$(snap debug confinement)" = strict ] ; then
         echo "When the plug is disconnected"

--- a/tests/main/interfaces-ssh-keys/task.yaml
+++ b/tests/main/interfaces-ssh-keys/task.yaml
@@ -29,7 +29,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-ssh-keys:ssh-keys"
+    snap interfaces -i ssh-keys | MATCH "\- +test-snapd-ssh-keys:ssh-keys"
 
     echo "When the interface is connected"
     snap connect test-snapd-ssh-keys:ssh-keys

--- a/tests/main/interfaces-ssh-public-keys/task.yaml
+++ b/tests/main/interfaces-ssh-public-keys/task.yaml
@@ -30,7 +30,7 @@ restore: |
 
 execute: |
     echo "The interface is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-ssh-public-keys:ssh-public-keys"
+    snap interfaces -i ssh-public-keys | MATCH "\- +test-snapd-ssh-public-keys:ssh-public-keys"
     
     echo "When the interface is connected"
     snap connect test-snapd-ssh-public-keys:ssh-public-keys

--- a/tests/main/interfaces-system-observe/task.yaml
+++ b/tests/main/interfaces-system-observe/task.yaml
@@ -28,7 +28,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "^\- +test-snapd-system-observe-consumer:system-observe"
+    snap interfaces -i system-observe | MATCH "^\- +test-snapd-system-observe-consumer:system-observe"
 
     echo "When the interface is connected"
     snap connect test-snapd-system-observe-consumer:system-observe

--- a/tests/main/interfaces-time-control/task.yaml
+++ b/tests/main/interfaces-time-control/task.yaml
@@ -29,7 +29,7 @@ execute: |
     snap connect test-snapd-timedate-control-consumer:netlink-audit
 
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-timedate-control-consumer:time-control"
+    snap interfaces -i time-control | MATCH "\- +test-snapd-timedate-control-consumer:time-control"
 
     # When the interface is connected
     snap connect test-snapd-timedate-control-consumer:time-control

--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -25,7 +25,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-timedate-control-consumer:timeserver-control"
+    snap interfaces -i timeserver-control | MATCH "\- +test-snapd-timedate-control-consumer:timeserver-control"
 
     echo "When the interface is connected"
     snap connect test-snapd-timedate-control-consumer:timeserver-control

--- a/tests/main/interfaces-timezone-control/task.yaml
+++ b/tests/main/interfaces-timezone-control/task.yaml
@@ -20,7 +20,7 @@ restore: |
 
 execute: |
     echo "The interface is disconnected by default"
-    snap interfaces | MATCH "\- +test-snapd-timedate-control-consumer:timezone-control"
+    snap interfaces -i timezone-control | MATCH "\- +test-snapd-timedate-control-consumer:timezone-control"
 
     echo "When the interface is connected"
     snap connect test-snapd-timedate-control-consumer:timezone-control

--- a/tests/main/interfaces-uhid/task.yaml
+++ b/tests/main/interfaces-uhid/task.yaml
@@ -17,7 +17,7 @@ restore: |
 
 execute: |
     echo "The plug is not connected by default"
-    snap interfaces | MATCH "\- +test-snapd-uhid:uhid"
+    snap interfaces -i uhid | MATCH "\- +test-snapd-uhid:uhid"
 
     echo "When the plug is connected"
     snap connect test-snapd-uhid:uhid

--- a/tests/main/interfaces-upower-observe/task.yaml
+++ b/tests/main/interfaces-upower-observe/task.yaml
@@ -45,7 +45,7 @@ execute: |
     fi
 
     echo "The interface is connected by default"
-    snap interfaces | MATCH "$SLOT_PROVIDER:$SLOT_NAME .*test-snapd-upower-observe-consumer"
+    snap interfaces -i upower-observe | MATCH "$SLOT_PROVIDER:$SLOT_NAME .*test-snapd-upower-observe-consumer"
 
     echo "When the plug is connected the snap is able to dump info about the upower devices"
     expected="/org/freedesktop/UPower/devices/DisplayDevice.*"

--- a/tests/main/interfaces-wayland/task.yaml
+++ b/tests/main/interfaces-wayland/task.yaml
@@ -13,7 +13,7 @@ restore: |
 
 execute: |
     echo "The interface is connected by default"
-    snap interfaces | MATCH ":wayland .*test-snapd-wayland"
+    snap interfaces -i wayland | MATCH ":wayland .*test-snapd-wayland"
 
     echo "When the plug is connected"
     snap connect test-snapd-wayland:wayland

--- a/tests/main/security-devpts/task.yaml
+++ b/tests/main/security-devpts/task.yaml
@@ -10,7 +10,7 @@ execute: |
     install_local test-snapd-devpts
 
     echo "When no plugs are not connected"
-    if snap interfaces | MATCH ":physical-memory-observe .*test-snapd-devpts" ; then
+    if snap interfaces -i physical-memory-observe | MATCH ":physical-memory-observe .*test-snapd-devpts" ; then
         snap disconnect test-snapd-devpts:physical-memory-observe
     fi
 

--- a/tests/regression/lp-1721518/task.yaml
+++ b/tests/regression/lp-1721518/task.yaml
@@ -18,9 +18,9 @@ execute: |
     # install test-snapd-tools and reboot
     if [ "$SPREAD_REBOOT" = 0 ]; then
         snap install test-snapd-tools
-        snap interfaces | MATCH "$CONNECTED_PATTERN"
+        snap interfaces -i core-support | MATCH "$CONNECTED_PATTERN"
         REBOOT
     fi
 
     # Check interfaces are shown after install a snap and reboot
-    snap interfaces | MATCH "$CONNECTED_PATTERN"
+    snap interfaces -i core-support | MATCH "$CONNECTED_PATTERN"


### PR DESCRIPTION
This is done in the tests which are checking the interfaces information
in order to make them more robusts, making the test independent of other
plug:slots declared such it is happening in gadgets.

This work was suggested in another PR https://github.com/snapcore/snapd/pull/4721