### PR TITLE
tests: adding google-sru backend replacing linode-sur

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -87,6 +87,7 @@ backends:
                 workers: 4
 
     google-sru:
+        type: google
         key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
         location: computeengine/us-east1-b
         systems:

--- a/spread.yaml
+++ b/spread.yaml
@@ -86,6 +86,17 @@ backends:
             - arch-linux-64:
                 workers: 4
 
+    google-sru:
+        key: "$(HOST: echo $SPREAD_GOOGLE_KEY)"
+        location: computeengine/us-east1-b
+        systems:
+            - ubuntu-14.04-64:
+                workers: 4
+            - ubuntu-16.04-64:
+                workers: 4
+            - ubuntu-18.04-64:
+                workers: 4
+
     linode:
         key: "$(HOST: echo $SPREAD_LINODE_KEY)"
         plan: 4GB


### PR DESCRIPTION
As it was deleted linode-sru on #5047, now we are adding google-sru with the new
systems to validate during next sru cicle.
