### PR TITLE
spread: bump bionic snapshot date

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -56,7 +56,7 @@ backends:
             - ubuntu-16.04-64:
                 workers: 8
             - ubuntu-18.04-64:
-                image: ubuntu-os-cloud-devel/daily-ubuntu-1804-bionic-v20180421
+                image: ubuntu-os-cloud-devel/daily-ubuntu-1804-bionic-v20180424
                 workers: 6
 
             - ubuntu-core-16-64:


### PR DESCRIPTION
Older snapshots use a kernel that is no longer in the archive and thus
cannot be used with our testing setup that needs to install the
corresponding modules package.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
