### PR TITLE
tests: drop `linux-image-extra-$(uname -r)` install in 18.04

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -56,7 +56,7 @@ backends:
             - ubuntu-16.04-64:
                 workers: 8
             - ubuntu-18.04-64:
-                image: ubuntu-os-cloud-devel/daily-ubuntu-1804-bionic-v20180421
+                image: ubuntu-os-cloud-devel/daily-ubuntu-1804-bionic-v20180424
                 workers: 6
 
             - ubuntu-core-16-64:

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -494,7 +494,6 @@ pkg_dependencies_ubuntu_classic(){
             ;;
         ubuntu-18.04-64)
             echo "
-                linux-image-extra-$(uname -r)
                 squashfs-tools
                 "
             ;;


### PR DESCRIPTION
The `linux-image-extra-*` packages were removed in 18.04 and replaced with the `linux-modules-extra-*` packages. This broke the tests. Skipping the install of the package is enough, the modules we need are all installed already in our GCE image.

Based on #5093