### PR TITLE
snap: improve error for snaps not available in the given context

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -377,6 +377,7 @@ const (
 	ErrorKindSnapNeedsClassic       = "snap-needs-classic"
 	ErrorKindSnapNeedsClassicSystem = "snap-needs-classic-system"
 	ErrorKindNoUpdateAvailable      = "snap-no-update-available"
+	ErrorKindRevisionNotAvailable   = "snap-revision-not-available"
 
 	ErrorKindNotSnap = "snap-not-a-snap"
 

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -121,10 +121,10 @@ func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (stri
 			}
 		}
 	case client.ErrorKindRevisionNotAvailable:
-		// TRANSLATORS: %%q will become a %q for the snap name
+		// TRANSLATORS: %q and %[1]s refer to the same thing (a snap name).
 		msg = i18n.G(`
-snap not found in the given context. Please use "snap info %s" to list available releases.
-`)
+snap %q not found in the given context.
+Please use 'snap info %[1]s' to list available releases.`)
 	case client.ErrorKindSnapAlreadyInstalled:
 		isError = false
 		msg = i18n.G(`snap %q is already installed, see 'snap help refresh'`)

--- a/cmd/snap/error.go
+++ b/cmd/snap/error.go
@@ -120,6 +120,11 @@ func errorToCmdMessage(snapName string, e error, opts *client.SnapOptions) (stri
 				msg = fmt.Sprintf(i18n.G("snap %%q not found (at least in channel %q)"), opts.Channel)
 			}
 		}
+	case client.ErrorKindRevisionNotAvailable:
+		// TRANSLATORS: %%q will become a %q for the snap name
+		msg = i18n.G(`
+snap not found in the given context. Please use "snap info %s" to list available releases.
+`)
 	case client.ErrorKindSnapAlreadyInstalled:
 		isError = false
 		msg = i18n.G(`snap %q is already installed, see 'snap help refresh'`)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1188,12 +1188,11 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 			return InternalError("store.SnapNotFound with %d snaps", len(inst.Snaps))
 		}
 	case store.ErrRevisionNotAvailable:
+		// store.ErrRevisionNotAvailable should only be returned for
+		// individual snap queries; in all other cases something's wrong
 		switch len(inst.Snaps) {
 		case 1:
 			return SnapRevisionNotAvailable(inst.Snaps[0], err)
-		// store.ErrRevisionNotAvailable should only be
-		// returned for individual snap queries; in all other
-		// cases something's wrong
 		case 0:
 			return InternalError("store.RevisionNotAvailable with no snap given")
 		default:

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1176,13 +1176,7 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 	var snapName string
 
 	switch err {
-	case store.ErrSnapNotFound, store.ErrRevisionNotAvailable:
-		// TODO: treating ErrRevisionNotAvailable the same as
-		// ErrSnapNotFound preserves the old error handling
-		// behavior of the REST API and the snap command.  We
-		// should revisit this once the store returns more
-		// precise errors and makes it possible to distinguish
-		// the why a revision wasn't available.
+	case store.ErrSnapNotFound:
 		switch len(inst.Snaps) {
 		case 1:
 			return SnapNotFound(inst.Snaps[0], err)
@@ -1192,6 +1186,18 @@ func (inst *snapInstruction) errToResponse(err error) Response {
 			return InternalError("store.SnapNotFound with no snap given")
 		default:
 			return InternalError("store.SnapNotFound with %d snaps", len(inst.Snaps))
+		}
+	case store.ErrRevisionNotAvailable:
+		switch len(inst.Snaps) {
+		case 1:
+			return SnapRevisionNotAvailable(inst.Snaps[0], err)
+		// store.ErrRevisionNotAvailable should only be
+		// returned for individual snap queries; in all other
+		// cases something's wrong
+		case 0:
+			return InternalError("store.RevisionNotAvailable with no snap given")
+		default:
+			return InternalError("store.RevisionNotAvailable with %d snaps", len(inst.Snaps))
 		}
 	case store.ErrNoUpdateAvailable:
 		kind = errorKindSnapNoUpdateAvailable

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -137,6 +137,8 @@ const (
 	errorKindSnapLocal             = errorKind("snap-local")
 	errorKindSnapNoUpdateAvailable = errorKind("snap-no-update-available")
 
+	errorKindSnapRevisionNotAvailable = errorKind("snap-revision-not-available")
+
 	errorKindNotSnap = errorKind("snap-not-a-snap")
 
 	errorKindSnapNeedsDevMode       = errorKind("snap-needs-devmode")
@@ -344,6 +346,22 @@ func SnapNotFound(snapName string, err error) Response {
 		Result: &errorResult{
 			Message: err.Error(),
 			Kind:    errorKindSnapNotFound,
+			Value:   snapName,
+		},
+		Status: 404,
+	}
+}
+
+// SnapRevisionNotAvailable is an error responder used when an
+// operation is requested for which no revivision can be found
+// in the given context (e.g. request an install from a stable
+// channel when this channel is empty).
+func SnapRevisionNotAvailable(snapName string, err error) Response {
+	return &resp{
+		Type: ResponseTypeError,
+		Result: &errorResult{
+			Message: err.Error(),
+			Kind:    errorKindSnapRevisionNotAvailable,
 			Value:   snapName,
 		},
 		Status: 404,

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -123,7 +123,24 @@ func installInfo(st *state.State, name, channel string, revision snap.Revision, 
 	res, err := theStore.SnapAction(context.TODO(), curSnaps, []*store.SnapAction{action}, user, nil)
 	st.Lock()
 
-	return singleActionResult(name, action.Action, res, err)
+	si, err := singleActionResult(name, action.Action, res, err)
+	// TODO: Ideally the store would provide better error reporting
+	//       right now it sends store.ErrRevisionNotAvailable when
+	//       a snap is in a different channel and also when it is
+	//       not available for the given architecture. Once the
+	//       store differentiates between those we can just do
+	//       `return singleActionResult(name, action.Action, res, err)`
+	//       here.
+	if channel != "" && err == store.ErrRevisionNotAvailable {
+		st.Unlock()
+		_, err1 := theStore.SnapInfo(store.SnapSpec{Name: name, AnyChannel: true}, user)
+		st.Lock()
+		if err1 != nil {
+			return nil, store.ErrSnapNotFound
+		}
+	}
+	return si, err
+
 }
 
 func updateInfo(st *state.State, snapst *SnapState, opts *updateInfoOpts, userID int) (*snap.Info, error) {

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -61,3 +61,21 @@ execute: |
         exit 1
     fi
     MATCH 'cannot install "ubuntu-core", please use "core" instead' < stderr.out
+
+    echo "============================================"
+
+    echo "Install a snap that is only available in the edge channel"
+    if snap install test-snapd-only-in-edge 2>stderr.out; then
+        echo "Installing test-snapd-only-in-edge should fail but did not"
+        exit 1
+    fi
+    MATCH 'error: snap not found in the given context.' < stderr.out
+
+    echo "Install a snap not available for the given architecture"
+    if [ "$(uname -m)" = "x86_64" ]; then
+        if snap install pi3-kernel 2>stderr.out; then
+            echo "Installing pi3-kernel should fail on amd64 systems but did not"
+            exit 1
+        fi
+        MATCH 'error: snap "pi3-kernel" not found' < stderr.out
+    fi

--- a/tests/main/install-errors/task.yaml
+++ b/tests/main/install-errors/task.yaml
@@ -69,7 +69,8 @@ execute: |
         echo "Installing test-snapd-only-in-edge should fail but did not"
         exit 1
     fi
-    MATCH 'error: snap not found in the given context.' < stderr.out
+    MATCH 'error: snap "test-snapd-only-in-edge" not found in the given context.' < stderr.out
+    MATCH "use 'snap info test-snapd-only-in-edge' to list" < stderr.out
 
     echo "Install a snap not available for the given architecture"
     if [ "$(uname -m)" = "x86_64" ]; then

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -28,7 +28,7 @@ execute: |
     ( snap install --channel beta $DEVMODE_SNAP 2>&1 && exit 1 || true ) | MATCH -z "${expected// /[[:space:]]+}"
 
     echo "Install devmode snap from stable"
-    expected="error: snap not found in the given context. Please"
+    expected='error: snap "'"$DEVMODE_SNAP"'" not found in the given context.'
     actual=$(snap install --devmode $DEVMODE_SNAP 2>&1 && exit 1 || true)
     echo "$actual" | grep -Pzq "$expected"
 

--- a/tests/main/install-store/task.yaml
+++ b/tests/main/install-store/task.yaml
@@ -28,7 +28,7 @@ execute: |
     ( snap install --channel beta $DEVMODE_SNAP 2>&1 && exit 1 || true ) | MATCH -z "${expected// /[[:space:]]+}"
 
     echo "Install devmode snap from stable"
-    expected="snap \"${DEVMODE_SNAP}\" not found"
+    expected="error: snap not found in the given context. Please"
     actual=$(snap install --devmode $DEVMODE_SNAP 2>&1 && exit 1 || true)
     echo "$actual" | grep -Pzq "$expected"
 


### PR DESCRIPTION
When we have a snap in the store that is not available in the
channel that the user requested we currently show a "not-found"
error. But it is better to display more meaningful information.

The store provides a more meaningful error code now, so we use
it. This is a resurrect from #4443.

Fixes https://bugs.launchpad.net/snapstore/+bug/1665787

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
