### PR TITLE
Makefile: add initial makefile with live-check command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+# live-check observes all .go files outside of the vendor tree and whenever any
+# of them changes runs "go test ./..." which tests the whole tree. This is
+# handy to keep running in a separate window (on a 2nd monitor perhaps) while
+# editing code as it allows one to not have to switch to another application to
+# see the general status of unit tests.
+.PHONY: live-check
+live-check:
+	find -name "*.go" \! -path "./vendor/*" | entr -c go test ./...


### PR DESCRIPTION
This patch adds a top-level makefile that contains just one command,
live-check, for running unit tests live, alongside your code editor.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
