### PR TITLE
testutil: rename UNMOUNT_NOFOLLOW to umountNoFollow

### DIFF
--- a/testutil/exec_test.go
+++ b/testutil/exec_test.go
@@ -29,6 +29,10 @@ type mockCommandSuite struct{}
 
 var _ = Suite(&mockCommandSuite{})
 
+const (
+	UmountNoFollow = umountNoFollow
+)
+
 func (s *mockCommandSuite) TestMockCommand(c *C) {
 	mock := MockCommand(c, "cmd", "true")
 	defer mock.Restore()

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -31,7 +31,7 @@ import (
 	"github.com/snapcore/snapd/osutil/sys"
 )
 
-const UMOUNT_NOFOLLOW = 8
+const umountNoFollow = 8
 
 // fakeFileInfo implements os.FileInfo for testing.
 //
@@ -140,8 +140,8 @@ func formatMountFlags(flags int) string {
 // Please expand the set of recognized flags as tests require.
 func formatUnmountFlags(flags int) string {
 	var fl []string
-	if flags&UMOUNT_NOFOLLOW == UMOUNT_NOFOLLOW {
-		flags ^= UMOUNT_NOFOLLOW
+	if flags&umountNoFollow == umountNoFollow {
+		flags ^= umountNoFollow
 		fl = append(fl, "UMOUNT_NOFOLLOW")
 	}
 	if flags&syscall.MNT_DETACH == syscall.MNT_DETACH {

--- a/testutil/lowlevel_test.go
+++ b/testutil/lowlevel_test.go
@@ -282,7 +282,7 @@ func (s *lowLevelSuite) TestMountFailure(c *C) {
 }
 
 func (s *lowLevelSuite) TestUnmountSuccess(c *C) {
-	err := s.sys.Unmount("target", testutil.UMOUNT_NOFOLLOW|syscall.MNT_DETACH)
+	err := s.sys.Unmount("target", testutil.UmountNoFollow|syscall.MNT_DETACH)
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "target" UMOUNT_NOFOLLOW|MNT_DETACH`})
 }


### PR DESCRIPTION
Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
