### PR TITLE
tests: new utility to save and restore the snap state

### DIFF
--- a/tests/lib/boot.sh
+++ b/tests/lib/boot.sh
@@ -33,3 +33,15 @@ bootenv_unset() {
         fw_setenv "$var"
     fi
 }
+
+get_boot_path() {
+    if [ -d /boot/uboot/ ] && ! [ -z "$(ls -A /boot/uboot/)" ]; then
+        echo "/boot/uboot/"
+    elif [ -d /boot/grub/ ] && ! [ -z "$(ls -A /boot/grub/)" ]; then
+        echo "/boot/grub/"
+    else
+        echo "Cannot determine bootdir in /boot:"
+        ls /boot
+        exit 1
+    fi
+}

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -488,7 +488,7 @@ restore_project() {
     # We use a trick to accelerate prepare/restore code in certain suites. That
     # code uses a tarball to store the vanilla state. Here we just remove this
     # tarball.
-    rm -f "$SPREAD_PATH/snapd-state.tar.gz"
+    rm -f "$SPREAD_PATH/snapd-state.tar"
 
     # Remove all of the code we pushed and any build results. This removes
     # stale files and we cannot do incremental builds anyway so there's little

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -12,6 +12,9 @@ set -eux
 . "$TESTSLIB/boot.sh"
 # shellcheck source=tests/lib/spread-funcs.sh
 . "$TESTSLIB/spread-funcs.sh"
+# shellcheck source=tests/lib/state.sh
+. "$TESTSLIB/state.sh"
+
 
 disable_kernel_rate_limiting() {
     # kernel rate limiting hinders debugging security policy so turn it off
@@ -196,7 +199,7 @@ prepare_classic() {
     fi
 
     # Snapshot the state including core.
-    if [ ! -f "$SPREAD_PATH/snapd-state.tar.gz" ]; then
+    if [ ! -f "$SPREAD_PATH/snapd-state.tar" ]; then
         # Pre-cache a few heavy snaps so that they can be installed by tests
         # quickly. This relies on a behavior of snapd where .partial files are
         # used for resuming downloads.
@@ -246,7 +249,7 @@ prepare_classic() {
         snapd_env="/etc/environment /etc/systemd/system/snapd.service.d /etc/systemd/system/snapd.socket.d"
         snap_confine_profiles="$(ls /etc/apparmor.d/snap.core.* || true)"
         # shellcheck disable=SC2086
-        tar cf "$SPREAD_PATH"/snapd-state.tar.gz /var/lib/snapd "$SNAP_MOUNT_DIR" /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount /etc/systemd/system/multi-user.target.wants/"$escaped_snap_mount_dir"-*core*.mount $snap_confine_profiles $snapd_env
+        tar cf "$SPREAD_PATH"/snapd-state.tar /var/lib/snapd "$SNAP_MOUNT_DIR" /etc/systemd/system/"$escaped_snap_mount_dir"-*core*.mount /etc/systemd/system/multi-user.target.wants/"$escaped_snap_mount_dir"-*core*.mount $snap_confine_profiles $snapd_env
         systemctl daemon-reload # Workaround for http://paste.ubuntu.com/17735820/
         core="$(readlink -f "$SNAP_MOUNT_DIR/core/current")"
         # on 14.04 it is possible that the core snap is still mounted at this point, unmount
@@ -509,22 +512,9 @@ prepare_all_snap() {
     setup_systemd_snapd_overrides
 
     # Snapshot the fresh state (including boot/bootenv)
-    if [ ! -f "$SPREAD_PATH/snapd-state.tar.gz" ]; then
-        # we need to ensure that we also restore the boot environment
-        # fully for tests that break it
-        BOOT=""
-        if ls /boot/uboot/*; then
-            BOOT=/boot/uboot/
-        elif ls /boot/grub/*; then
-            BOOT=/boot/grub/
-        else
-            echo "Cannot determine bootdir in /boot:"
-            ls /boot
-            exit 1
-        fi
-
+    if [ ! -d $SNAPD_STATE_PATH ]; then
         systemctl stop snapd.service snapd.socket
-        tar cf "$SPREAD_PATH/snapd-state.tar.gz" /var/lib/snapd $BOOT /etc/systemd/system/snap-*core*.mount
+        save_all_snap_state
         systemctl start snapd.socket
     fi
 

--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -4,6 +4,9 @@ set -e -x
 
 # shellcheck source=tests/lib/dirs.sh
 . "$TESTSLIB/dirs.sh"
+# shellcheck source=tests/lib/state.sh
+. "$TESTSLIB/state.sh"
+
 
 # shellcheck source=tests/lib/systemd.sh
 . "$TESTSLIB/systemd.sh"
@@ -67,7 +70,7 @@ reset_classic() {
         rm -rf /etc/systemd/system/snapd.socket.d
 
         # Restore snapd state and start systemd service units
-        tar -C/ -xf "$SPREAD_PATH/snapd-state.tar.gz"
+        tar -C/ -xf "$SPREAD_PATH/snapd-state.tar"
         escaped_snap_mount_dir="$(systemd-escape --path "$SNAP_MOUNT_DIR")"
         mounts="$(systemctl list-unit-files --full | grep "^$escaped_snap_mount_dir[-.].*\.mount" | cut -f1 -d ' ')"
         services="$(systemctl list-unit-files --full | grep "^$escaped_snap_mount_dir[-.].*\.service" | cut -f1 -d ' ')"
@@ -96,7 +99,6 @@ reset_all_snap() {
     # remove all leftover snaps
     # shellcheck source=tests/lib/names.sh
     . "$TESTSLIB/names.sh"
-
     for snap in "$SNAP_MOUNT_DIR"/*; do
         snap="${snap:6}"
         case "$snap" in
@@ -116,8 +118,7 @@ reset_all_snap() {
 
     # ensure we have the same state as initially
     systemctl stop snapd.service snapd.socket
-    rm -rf /var/lib/snapd/*
-    tar -C/ -xf "$SPREAD_PATH/snapd-state.tar.gz"
+    restore_all_snap_state
     rm -rf /root/.snap
     if [ "$1" != "--keep-stopped" ]; then
         systemctl start snapd.service snapd.socket

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -1,34 +1,24 @@
-#!/bin/sh
+#!/bin/bash
 
 SNAPD_STATE_PATH="$SPREAD_PATH/snapd-state"
 
-get_boot_path() {
-    BOOT=""
-    if ls /boot/uboot/*; then
-        BOOT="/boot/uboot/"
-    elif ls /boot/grub/*; then
-        BOOT="/boot/grub/"
-    else
-        echo "Cannot determine bootdir in /boot:"
-        ls /boot
-        exit 1
-    fi
-}
+# shellcheck source=tests/lib/boot.sh
+. "$TESTSLIB/boot.sh"
 
 save_all_snap_state() {
-    get_boot_path
+    local boot_path="$(get_boot_path)"
     mkdir -p "$SNAPD_STATE_PATH"
     cp -rf /var/lib/snapd "$SNAPD_STATE_PATH/snapdlib"
-    cp -rf "$BOOT" "$SNAPD_STATE_PATH/boot"
+    cp -rf "$boot_path" "$SNAPD_STATE_PATH/boot"
     cp -f /etc/systemd/system/snap-*core*.mount "$SNAPD_STATE_PATH"
 }
 
 restore_all_snap_state() {
     # we need to ensure that we also restore the boot environment
     # fully for tests that break it
-    get_boot_path
+    local boot_path="$(get_boot_path)"
     rm -rf /var/lib/snapd/*
     cp -rf "$SNAPD_STATE_PATH"/snapdlib/* /var/lib/snapd
-    cp -rf "$SNAPD_STATE_PATH"/boot/* "$BOOT"
+    cp -rf "$SNAPD_STATE_PATH"/boot/* "$boot_path"
     cp -f "$SNAPD_STATE_PATH"/snap-*core*.mount  /etc/systemd/system
 }

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eux
+
+SNAPD_STATE_PATH="$SPREAD_PATH/snapd-state"
+
+get_boot_path() {
+	BOOT=""
+    if ls /boot/uboot/*; then
+        BOOT="/boot/uboot/"
+    elif ls /boot/grub/*; then
+        BOOT="/boot/grub/"
+    else
+        echo "Cannot determine bootdir in /boot:"
+        ls /boot
+        exit 1
+    fi
+}
+
+save_all_snap_state() {
+	get_boot_path
+    mkdir -p "$SNAPD_STATE_PATH"
+    cp -rf /var/lib/snapd "$SNAPD_STATE_PATH/snapdlib"
+    cp -rf "$BOOT" "$SNAPD_STATE_PATH/boot"
+    cp -f /etc/systemd/system/snap-*core*.mount "$SNAPD_STATE_PATH"
+}
+
+restore_all_snap_state() {
+    # we need to ensure that we also restore the boot environment
+    # fully for tests that break it
+	get_boot_path
+	rm -rf /var/lib/snapd/*
+    cp -rf "$SNAPD_STATE_PATH"/snapdlib/* /var/lib/snapd
+    cp -rf "$SNAPD_STATE_PATH"/boot/* "$BOOT"
+    cp -f "$SNAPD_STATE_PATH"/snap-*core*.mount  /etc/systemd/system
+}

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -7,6 +7,8 @@ SNAPD_STATE_PATH="$SPREAD_PATH/snapd-state"
 
 save_all_snap_state() {
     local boot_path="$(get_boot_path)"
+    test -n "$boot_path" || return 1
+
     mkdir -p "$SNAPD_STATE_PATH"
     cp -rf /var/lib/snapd "$SNAPD_STATE_PATH/snapdlib"
     cp -rf "$boot_path" "$SNAPD_STATE_PATH/boot"
@@ -17,6 +19,8 @@ restore_all_snap_state() {
     # we need to ensure that we also restore the boot environment
     # fully for tests that break it
     local boot_path="$(get_boot_path)"
+    test -n "$boot_path" || return 1
+
     rm -rf /var/lib/snapd/*
     cp -rf "$SNAPD_STATE_PATH"/snapdlib/* /var/lib/snapd
     cp -rf "$SNAPD_STATE_PATH"/boot/* "$boot_path"

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -1,11 +1,9 @@
-#!/bin/bash
-
-set -eux
+#!/bin/sh
 
 SNAPD_STATE_PATH="$SPREAD_PATH/snapd-state"
 
 get_boot_path() {
-	BOOT=""
+    BOOT=""
     if ls /boot/uboot/*; then
         BOOT="/boot/uboot/"
     elif ls /boot/grub/*; then
@@ -18,7 +16,7 @@ get_boot_path() {
 }
 
 save_all_snap_state() {
-	get_boot_path
+    get_boot_path
     mkdir -p "$SNAPD_STATE_PATH"
     cp -rf /var/lib/snapd "$SNAPD_STATE_PATH/snapdlib"
     cp -rf "$BOOT" "$SNAPD_STATE_PATH/boot"
@@ -28,8 +26,8 @@ save_all_snap_state() {
 restore_all_snap_state() {
     # we need to ensure that we also restore the boot environment
     # fully for tests that break it
-	get_boot_path
-	rm -rf /var/lib/snapd/*
+    get_boot_path
+    rm -rf /var/lib/snapd/*
     cp -rf "$SNAPD_STATE_PATH"/snapdlib/* /var/lib/snapd
     cp -rf "$SNAPD_STATE_PATH"/boot/* "$BOOT"
     cp -f "$SNAPD_STATE_PATH"/snap-*core*.mount  /etc/systemd/system


### PR DESCRIPTION
This reduces the time needed to restore the snapd state by the 50% of
the time needed aprox. For each restore this way is 10 seconds faster in
a pi2 or pi3 or dragonboard.

This change is reducing in 30 minutes the whole execution in the pi2.
old version: https://paste.ubuntu.com/p/vMYGKbjJJr/
new version: https://paste.ubuntu.com/p/Dh4mXrJdXj/
