### PR TITLE
tests: shellcheck spread tasks

### DIFF
--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -1,18 +1,42 @@
 #!/bin/bash
 
+# Copyright (C) 2018 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# default shell for shellcheck
 SHELLCHECK_SHELL=${SHELLCHECK_SHELL:-bash}
+# set to non-empty to ignore all errors
 NO_FAIL=${NO_FAIL:-}
+# set to non empty to enable 'set -x'
 D=${D:-}
+# set to non-empty to enable verbose logging
 V=${V:-}
 # file with list of test file that must successfully validate, one file per line
 MUST_PASS=${MUST_PASS:-}
 
+set -e
+
 test -n "$D" && set -x
 
+logv() {
+    if [[ -z "$V" ]]; then return 0;  fi
+
+    echo "$@" >&2
+}
+
 log() {
-    if [[ -n "$V" ]]; then
-        echo "$@"
-    fi
+    echo "$@" >&2
 }
 
 check_file() {
@@ -21,11 +45,11 @@ check_file() {
     local failed
     file=$1
 
-    log "-- checking file $file"
+    logv "-- checking file $file"
     for k in $keys; do
-        log "--- checking section $k"
+        logv "--- checking section $k"
         if ! yq -r < "$file" ".[\"$k\"]" | shellcheck -s "$SHELLCHECK_SHELL" -x - ; then
-            echo "ERROR: $file: shellcheck failed in section '$k'"
+            log  "ERROR: $file: shellcheck failed in section '$k'"
             failed=1
         fi
     done
@@ -38,9 +62,9 @@ check_file() {
             # we need to drop the extra single quotes
             suite="${suite//\'/}"
             for k in $keys; do
-                log "--- checking $suite section $k"
+                logv "--- checking $suite section $k"
                 if ! yq -r < "$file" ".suites[\"$suite\"][\"$k\"]" | shellcheck -s "$SHELLCHECK_SHELL" -x - ; then
-                    echo "ERROR: $file: shellcheck failed in suite $suite section '$k'"
+                    log "ERROR: $file: shellcheck failed in suite $suite section '$k'"
                     failed=1
                 fi
             done
@@ -49,7 +73,7 @@ check_file() {
 
     if [[ "$failed" != 0 && -n "$MUST_PASS" ]] && ! grep -Eqx "$file" "$MUST_PASS" >/dev/null 2>&1 ; then
         failed=0
-        echo "WARNING: ignoring errors in file $file"
+        log "WARNING: ignoring errors in file $file"
     fi
     return $failed
 }
@@ -70,11 +94,12 @@ check_location() {
 }
 
 if ! which yq >/dev/null 2>&1; then
-    echo "please install 'yq'"
-    echo "eg: pip install --user yq"
+    log "please install 'yq'"
+    log "eg: pip install --user yq"
+    exit 1
 fi
 
-keys="prepare prepare-each restore restore-each debug execute"
+keys="prepare prepare-each restore restore-each debug debug-each execute repack"
 errored=0
 
 locations=( "$@" )
@@ -87,6 +112,7 @@ for loc in "${locations[@]}"; do
 done
 
 if [[ "$errored" == 1 && "$NO_FAIL" != "" ]]; then
+    log "WARNING: ignoring errors"
     exit 0
 fi
 

--- a/spread-shellcheck
+++ b/spread-shellcheck
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+SHELLCHECK_SHELL=${SHELLCHECK_SHELL:-bash}
+NO_FAIL=${NO_FAIL:-}
+D=${D:-}
+V=${V:-}
+# file with list of test file that must successfully validate, one file per line
+MUST_PASS=${MUST_PASS:-}
+
+test -n "$D" && set -x
+
+log() {
+    if [[ -n "$V" ]]; then
+        echo "$@"
+    fi
+}
+
+check_file() {
+    local k
+    local file
+    local failed
+    file=$1
+
+    log "-- checking file $file"
+    for k in $keys; do
+        log "--- checking section $k"
+        if ! yq -r < "$file" ".[\"$k\"]" | shellcheck -s "$SHELLCHECK_SHELL" -x - ; then
+            echo "ERROR: $file: shellcheck failed in section '$k'"
+            failed=1
+        fi
+    done
+
+    if [[ "$(basename "$file")" == spread.yaml ]]; then
+        # check suites
+        for suite in $(yq -cr < "$file" ".suites | keys | @sh"); do
+            # @sh filter will produce:
+            # 'tests/completion/' 'tests/main/' 'tests/nested/' 'tests/nightly/' ...
+            # we need to drop the extra single quotes
+            suite="${suite//\'/}"
+            for k in $keys; do
+                log "--- checking $suite section $k"
+                if ! yq -r < "$file" ".suites[\"$suite\"][\"$k\"]" | shellcheck -s "$SHELLCHECK_SHELL" -x - ; then
+                    echo "ERROR: $file: shellcheck failed in suite $suite section '$k'"
+                    failed=1
+                fi
+            done
+        done
+    fi
+
+    if [[ "$failed" != 0 && -n "$MUST_PASS" ]] && ! grep -Eqx "$file" "$MUST_PASS" >/dev/null 2>&1 ; then
+        failed=0
+        echo "WARNING: ignoring errors in file $file"
+    fi
+    return $failed
+}
+
+check_location() {
+    local location
+    local failed
+    location=$1
+    failed=0
+    if [[ -d "$1" ]]; then
+        while read -r f ; do
+            check_file "$f" || failed=1
+        done < <(find "$location" -name 'task.yaml' -o -name 'spread.yaml')
+    else
+        check_file "$1" || failed=1
+    fi
+    return $failed
+}
+
+if ! which yq >/dev/null 2>&1; then
+    echo "please install 'yq'"
+    echo "eg: pip install --user yq"
+fi
+
+keys="prepare prepare-each restore restore-each debug execute"
+errored=0
+
+locations=( "$@" )
+if [[ ${#locations[@]} == 0 ]]; then
+    locations=( . )
+fi
+
+for loc in "${locations[@]}"; do
+    check_location "$loc" || errored=1
+done
+
+if [[ "$errored" == 1 && "$NO_FAIL" != "" ]]; then
+    exit 0
+fi
+
+exit $errored

--- a/spread.yaml
+++ b/spread.yaml
@@ -349,8 +349,8 @@ prepare: |
     fi
 
     # Take the MATCH and REBOOT functions from spread and allow our shell scripts to use them.
-    type MATCH | tail -n +2 > $TESTSLIB/spread-funcs.sh
-    type REBOOT | tail -n +2 >> $TESTSLIB/spread-funcs.sh
+    type MATCH | tail -n +2 > "$TESTSLIB"/spread-funcs.sh
+    type REBOOT | tail -n +2 >> "$TESTSLIB"/spread-funcs.sh
 
     # NOTE: At this stage the source tree is available and no more special
     # considerations apply.
@@ -432,6 +432,7 @@ suites:
                 echo "skip upgrade tests while talking to the staging store"
                 exit 0
             fi
+            #shellcheck source=tests/lib/pkgdb.sh
             . $TESTSLIB/pkgdb.sh
             distro_purge_package snapd
             distro_purge_package snapd-xdg-open || true
@@ -456,14 +457,17 @@ suites:
             TRAVIS_TAG: "$(HOST: echo $TRAVIS_TAG)"
             COVERMODE: "$(HOST: echo $COVERMODE)"
         prepare: |
+            #shellcheck source=tests/lib/prepare.sh
             . $TESTSLIB/prepare.sh
             prepare_classic
         prepare-each: |
-            $TESTSLIB/reset.sh --reuse-core
+            "$TESTSLIB"/reset.sh --reuse-core
+            #shellcheck source=tests/lib/prepare.sh
             . $TESTSLIB/prepare.sh
             prepare_each_classic
         restore: |
-            $TESTSLIB/reset.sh --store
+            "$TESTSLIB"/reset.sh --store
+            #shellcheck source=tests/lib/pkgdb.sh
             . $TESTSLIB/pkgdb.sh
 
             distro_purge_package snapd
@@ -485,18 +489,22 @@ suites:
         # drop this blacklist.
         systems: [-fedora-*, -opensuse-*, -arch-*]
         prepare: |
-            . $TESTSLIB/prepare.sh
+            #shellcheck source=tests/lib/prepare.sh
+            . "$TESTSLIB"/prepare.sh
             if [[ "$SPREAD_SYSTEM" == ubuntu-core-16-* ]]; then
                 prepare_all_snap
             else
                 prepare_classic
             fi
         prepare-each: |
-            $TESTSLIB/reset.sh --reuse-core
+            #shellcheck source=tests/lib/reset.sh
+            "$TESTSLIB"/reset.sh --reuse-core
         restore: |
-            $TESTSLIB/reset.sh
+            #shellcheck source=tests/lib/reset.sh
+            "$TESTSLIB"/reset.sh
             if [[ "$SPREAD_SYSTEM" != ubuntu-core-16-* ]]; then
-                . $TESTSLIB/pkgdb.sh
+                #shellcheck source=tests/lib/pkgdb.sh
+                . "$TESTSLIB"/pkgdb.sh
                 distro_purge_package snapd
             fi
 
@@ -513,11 +521,13 @@ suites:
         kill-timeout: 2h
         manual: true
         prepare: |
+            #shellcheck source=tests/lib/pkgdb.sh
             . $TESTSLIB/pkgdb.sh
             distro_update_package_db
             distro_install_package snapd qemu genisoimage sshpass
             snap install --classic --beta ubuntu-image
         restore: |
+            #shellcheck source=tests/lib/pkgdb.sh
             . $TESTSLIB/pkgdb.sh
             distro_purge_package qemu genisoimage sshpass
             snap remove ubuntu-image

--- a/spread.yaml
+++ b/spread.yaml
@@ -272,13 +272,13 @@ repack: |
     # obtained directly from GitHub. There's nothing special about that reference,
     # other than it will often be in the local repository's history already.
     # The more recent the reference, the smaller the delta.
-    if ! echo $SPREAD_BACKENDS | grep linode; then
+    if ! echo "$SPREAD_BACKENDS" | grep linode; then
         cat <&3 >&4
-    elif ! git show-ref $DELTA_REF > /dev/null; then
+    elif ! git show-ref "$DELTA_REF" > /dev/null; then
         cat <&3 >&4
     else
         trap "rm -f delta-ref.tar current.delta" EXIT
-        git archive -o delta-ref.tar --format=tar --prefix=$DELTA_PREFIX $DELTA_REF
+        git archive -o delta-ref.tar --format=tar --prefix="$DELTA_PREFIX" "$DELTA_REF"
         xdelta3 -s delta-ref.tar <&3 > current.delta
         tar c current.delta >&4
     fi

--- a/tests/unit/spread-shellcheck/must
+++ b/tests/unit/spread-shellcheck/must
@@ -1,0 +1,3 @@
+# files listed here must successfuly validate
+spread.yaml
+tests/unit/spread-shellcheck/task.yaml

--- a/tests/unit/spread-shellcheck/must
+++ b/tests/unit/spread-shellcheck/must
@@ -1,3 +1,3 @@
-# files listed here must successfuly validate
+# files listed here must successfully validate
 spread.yaml
 tests/unit/spread-shellcheck/task.yaml

--- a/tests/unit/spread-shellcheck/task.yaml
+++ b/tests/unit/spread-shellcheck/task.yaml
@@ -19,5 +19,5 @@ restore: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB/pkgdb.sh"
 
-    pip remove yq || true
+    pip uninstall -y yq || true
     distro_purge_package python-pip shellcheck

--- a/tests/unit/spread-shellcheck/task.yaml
+++ b/tests/unit/spread-shellcheck/task.yaml
@@ -16,4 +16,8 @@ execute: |
     MUST_PASS="$testdir/must" ./spread-shellcheck spread.yaml tests
 
 restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
+
     pip remove yq || true
+    distro_purge_package python-pip shellcheck

--- a/tests/unit/spread-shellcheck/task.yaml
+++ b/tests/unit/spread-shellcheck/task.yaml
@@ -1,0 +1,19 @@
+summary: Verify spread task scripts with shellcheck
+
+# need a recent shellcheck version
+systems: [ubuntu-18.04-64]
+
+prepare: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . "$TESTSLIB/pkgdb.sh"
+    distro_install_package python-pip shellcheck
+    pip install --user yq
+
+execute: |
+    testdir=$PWD
+    cd "$SPREAD_PATH" || exit 1
+    export PATH="$PATH:$HOME/.local/bin"
+    MUST_PASS="$testdir/must" ./spread-shellcheck spread.yaml tests
+
+restore: |
+    pip remove yq || true


### PR DESCRIPTION
Introduce a helper script for passing spread task.yaml sections through shellcheck. The script can be used manually, by calling `./spread-shellcheck <path> [<path>]`, the path can be either a `{spread|task}.yaml` file, or a directory, in which case the tool will try to locate relevant spread files.

Additionally,  introduce a new test that verifies spread files under `tests/` and `spread.yaml`. The test comes with a file that lists files for which the checks must succeed. This will allow us to gradually introduce the checker. 

I have fixes for all the tasks in a separate branch right here: https://github.com/bboozzoo/snapd/commits/bboozzoo/spread-shellcheck-all Note that the diffstat of the last commit which carries the fixes is large (249 files changed, 1338 insertions, 797 deletions). Thus the fixes will be introduced and reviewd gradually over the course of several PRs.