### PR TITLE
overlord,systemd: store snap revision in mount units

### DIFF
--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -37,7 +37,7 @@ func addMountUnit(s *snap.Info, meter progress.Meter) error {
 	whereDir := dirs.StripRootDir(s.MountDir())
 
 	sysd := systemd.New(dirs.GlobalRootDir, meter)
-	mountUnitName, err := sysd.WriteMountUnitFile(s.Name(), squashfsPath, whereDir, "squashfs")
+	mountUnitName, err := sysd.WriteMountUnitFile(s.Name(), s.Revision.String(), squashfsPath, whereDir, "squashfs")
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -77,7 +77,7 @@ func (s *mountunitSuite) TestAddMountUnit(c *C) {
 	un := fmt.Sprintf("%s.mount", systemd.EscapeUnitNamePath(filepath.Join(dirs.StripRootDir(dirs.SnapMountDir), "foo", "13")))
 	c.Assert(filepath.Join(dirs.SnapServicesDir, un), testutil.FileEquals, fmt.Sprintf(`
 [Unit]
-Description=Mount unit for foo
+Description=Mount unit for foo, revision 13
 Before=snapd.service
 
 [Mount]

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -111,7 +111,7 @@ type Systemd interface {
 	Restart(service string, timeout time.Duration) error
 	Status(services ...string) ([]*ServiceStatus, error)
 	LogReader(services []string, n string, follow bool) (io.ReadCloser, error)
-	WriteMountUnitFile(name, what, where, fstype string) (string, error)
+	WriteMountUnitFile(name, revision, what, where, fstype string) (string, error)
 	Mask(service string) error
 	Unmask(service string) error
 }
@@ -434,7 +434,7 @@ func MountUnitPath(baseDir string) string {
 	return filepath.Join(dirs.SnapServicesDir, escapedPath+".mount")
 }
 
-func (s *systemd) WriteMountUnitFile(name, what, where, fstype string) (string, error) {
+func (s *systemd) WriteMountUnitFile(name, revision, what, where, fstype string) (string, error) {
 	options := []string{"nodev"}
 	if fstype == "squashfs" {
 		options = append(options, "ro", "x-gdu.hide")
@@ -455,7 +455,7 @@ func (s *systemd) WriteMountUnitFile(name, what, where, fstype string) (string, 
 	}
 
 	c := fmt.Sprintf(`[Unit]
-Description=Mount unit for %s
+Description=Mount unit for %s, revision %s
 Before=snapd.service
 
 [Mount]
@@ -466,7 +466,7 @@ Options=%s
 
 [Install]
 WantedBy=multi-user.target
-`, name, what, where, fstype, strings.Join(options, ","))
+`, name, revision, what, where, fstype, strings.Join(options, ","))
 
 	mu := MountUnitPath(where)
 	return filepath.Base(mu), osutil.AtomicWriteFile(mu, []byte(c), 0644, 0)

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -463,13 +463,13 @@ func (s *SystemdTestSuite) TestWriteMountUnit(c *C) {
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", mockSnapPath, "/apps/foo/1.0", "squashfs")
+	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", "42", mockSnapPath, "/apps/foo/1.0", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
 	c.Assert(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(`
 [Unit]
-Description=Mount unit for foo
+Description=Mount unit for foo, revision 42
 Before=snapd.service
 
 [Mount]
@@ -486,13 +486,13 @@ WantedBy=multi-user.target
 func (s *SystemdTestSuite) TestWriteMountUnitForDirs(c *C) {
 	// a directory instead of a file produces a different output
 	snapDir := c.MkDir()
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foodir", snapDir, "/apps/foo/1.0", "squashfs")
+	mountUnitName, err := New("", nil).WriteMountUnitFile("foodir", "x1", snapDir, "/apps/foo/1.0", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
 	c.Assert(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(`
 [Unit]
-Description=Mount unit for foodir
+Description=Mount unit for foodir, revision x1
 Before=snapd.service
 
 [Mount]
@@ -528,13 +528,13 @@ exit 0
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", mockSnapPath, "/apps/foo/1.0", "squashfs")
+	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", "x1", mockSnapPath, "/apps/foo/1.0", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
 	c.Check(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(`
 [Unit]
-Description=Mount unit for foo
+Description=Mount unit for foo, revision x1
 Before=snapd.service
 
 [Mount]
@@ -566,13 +566,13 @@ exit 0
 	err = ioutil.WriteFile(mockSnapPath, nil, 0644)
 	c.Assert(err, IsNil)
 
-	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", mockSnapPath, "/apps/foo/1.0", "squashfs")
+	mountUnitName, err := New("", nil).WriteMountUnitFile("foo", "x1", mockSnapPath, "/apps/foo/1.0", "squashfs")
 	c.Assert(err, IsNil)
 	defer os.Remove(mountUnitName)
 
 	c.Assert(filepath.Join(dirs.SnapServicesDir, mountUnitName), testutil.FileEquals, fmt.Sprintf(`
 [Unit]
-Description=Mount unit for foo
+Description=Mount unit for foo, revision x1
 Before=snapd.service
 
 [Mount]


### PR DESCRIPTION
This patch changes the description of the systemd mount unit so that it
now refers to both the snap name and the snap revision.

When a snap refreshes the last three revisions seen are kept on disk.
When the system is shutting down or whenever someone is interacting with
systemd the identical descriptions of said mount units may be confusing.
To avoid the confusion the description now reads: "Mount unit for
snap-name, revision 123".

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
