### PR TITLE
interfaces/apparmor: fix incorrect apparmor profile glob

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -260,6 +260,21 @@ func setupSnapConfineReexec(coreInfo *snap.Info) error {
 	return nil
 }
 
+// nsProfile returns name of the apparmor profile for snap-update-ns for a given snap.
+func nsProfile(snapName string) string {
+	return fmt.Sprintf("snap-update-ns.%s", snapName)
+}
+
+// profileGlobs returns a list of globs that describe the apparmor profiles of
+// a given snap.
+//
+// Currently the list is just a pair. The first glob describes profiles for all
+// apps and hooks while the second profile describes the snap-update-ns profile
+// for the whole snap.
+func profileGlobs(snapName string) []string {
+	return []string{interfaces.SecurityTagGlob(snapName), nsProfile(snapName)}
+}
+
 // Setup creates and loads apparmor profiles specific to a given snap.
 // The snap can be in developer mode to make security violations non-fatal to
 // the offending application process.
@@ -304,13 +319,12 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 		return fmt.Errorf("cannot obtain expected security files for snap %q: %s", snapName, err)
 	}
 	dir := dirs.SnapAppArmorDir
-	glob1 := fmt.Sprintf("snap*.%s*", snapInfo.Name())
-	glob2 := fmt.Sprintf("snap-update-ns.%s", snapInfo.Name())
+	globs := profileGlobs(snapInfo.Name())
 	cache := dirs.AppArmorCacheDir
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("cannot create directory for apparmor profiles %q: %s", dir, err)
 	}
-	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dir, []string{glob1, glob2}, content)
+	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dir, globs, content)
 	// NOTE: load all profiles instead of just the changed profiles.  We're
 	// relying on apparmor cache to make this efficient. This gives us
 	// certainty that each call to Setup ends up with working profiles.
@@ -333,10 +347,9 @@ func (b *Backend) Setup(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 // Remove removes and unloads apparmor profiles of a given snap.
 func (b *Backend) Remove(snapName string) error {
 	dir := dirs.SnapAppArmorDir
-	glob1 := fmt.Sprintf("snap*.%s*", snapName)
-	glob2 := fmt.Sprintf("snap-update-ns.%s", snapName)
+	globs := profileGlobs(snapName)
 	cache := dirs.AppArmorCacheDir
-	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dir, []string{glob1, glob2}, nil)
+	_, removed, errEnsure := osutil.EnsureDirStateGlobs(dir, globs, nil)
 	errUnload := unloadProfiles(removed, cache)
 	if errEnsure != nil {
 		return fmt.Errorf("cannot synchronize security files for snap %q: %s", snapName, errEnsure)
@@ -393,7 +406,7 @@ func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 	})
 
 	// Ensure that the snap-update-ns profile is on disk.
-	profileName := fmt.Sprintf("snap-update-ns.%s", snapInfo.Name())
+	profileName := nsProfile(snapInfo.Name())
 	content[profileName] = &osutil.FileState{
 		Content: []byte(policy),
 		Mode:    0644,

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -352,6 +352,63 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerHooks(c *C) {
 	}
 }
 
+const snapcraftPrYaml = `name: snapcraft-pr
+version: 1
+apps:
+  snapcraft-pr:
+    cmd: snapcraft-pr
+`
+
+const snapcraftYaml = `name: snapcraft
+version: 1
+apps:
+  snapcraft:
+    cmd: snapcraft
+`
+
+func (s *backendSuite) TestInstallingSnapDoesntBreakSnapsWithPrefixName(c *C) {
+	snapcraftProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.snapcraft.snapcraft")
+	snapcraftPrProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.snapcraft-pr.snapcraft-pr")
+	// Install snapcraft-pr and check that its profile was created.
+	s.InstallSnap(c, interfaces.ConfinementOptions{}, snapcraftPrYaml, 1)
+	_, err := os.Stat(snapcraftPrProfile)
+	c.Check(err, IsNil)
+
+	// Install snapcraft (sans the -pr suffix) and check that its profile was created.
+	// Check that this didn't remove the profile of snapcraft-pr installed earlier.
+	s.InstallSnap(c, interfaces.ConfinementOptions{}, snapcraftYaml, 1)
+	_, err = os.Stat(snapcraftProfile)
+	c.Check(err, IsNil)
+	_, err = os.Stat(snapcraftPrProfile)
+	c.Check(err, IsNil)
+}
+
+func (s *backendSuite) TestRemovingSnapDoesntBreakSnapsWIthPrefixName(c *C) {
+	snapcraftProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.snapcraft.snapcraft")
+	snapcraftPrProfile := filepath.Join(dirs.SnapAppArmorDir, "snap.snapcraft-pr.snapcraft-pr")
+
+	// Install snapcraft-pr and check that its profile was created.
+	s.InstallSnap(c, interfaces.ConfinementOptions{}, snapcraftPrYaml, 1)
+	_, err := os.Stat(snapcraftPrProfile)
+	c.Check(err, IsNil)
+
+	// Install snapcraft (sans the -pr suffix) and check that its profile was created.
+	// Check that this didn't remove the profile of snapcraft-pr installed earlier.
+	snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, snapcraftYaml, 1)
+	_, err = os.Stat(snapcraftProfile)
+	c.Check(err, IsNil)
+	_, err = os.Stat(snapcraftPrProfile)
+	c.Check(err, IsNil)
+
+	// Remove snapcraft (sans the -pr suffix) and check that its profile was removed.
+	// Check that this didn't remove the profile of snapcraft-pr installed earlier.
+	s.RemoveSnap(c, snapInfo)
+	_, err = os.Stat(snapcraftProfile)
+	c.Check(os.IsNotExist(err), Equals, true)
+	_, err = os.Stat(snapcraftPrProfile)
+	c.Check(err, IsNil)
+}
+
 func (s *backendSuite) TestRealDefaultTemplateIsNormallyUsed(c *C) {
 	restore := release.MockAppArmorLevel(release.FullAppArmor)
 	defer restore()
@@ -1133,4 +1190,13 @@ func (s *backendSuite) TestCasperOverlaySnippets(c *C) {
 		c.Check(profile, testutil.FileContains, scenario.overlaySnippet)
 		s.RemoveSnap(c, snapInfo)
 	}
+}
+
+func (s *backendSuite) TestProfileGlobs(c *C) {
+	globs := apparmor.ProfileGlobs("foo")
+	c.Assert(globs, DeepEquals, []string{"snap.foo.*", "snap-update-ns.foo"})
+}
+
+func (s *backendSuite) TestNsProfile(c *C) {
+	c.Assert(apparmor.NsProfile("foo"), Equals, "snap-update-ns.foo")
 }

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -27,6 +27,8 @@ import (
 
 var (
 	SnapConfineFromCoreProfile = snapConfineFromCoreProfile
+	ProfileGlobs               = profileGlobs
+	NsProfile                  = nsProfile
 )
 
 // MockIsHomeUsingNFS mocks the real implementation of osutil.IsHomeUsingNFS


### PR DESCRIPTION
This patch fixes a bug where a glob describing apparmor profiles for a
snap would match unrelated snap that happens to be a proper prefix of
the name of the snap in question.

What was missing was a dot between the snap name and the glob that
describes all applications and hooks. In the broken version it was
snap.$SNAP_NAME*.

For example, setting up security for "snapcraft" would nuke the profiles
of "snapcraft-pr".

This patch also includes small helper computes the name of the
snap-update-ns profile for a given snap.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
