### PR TITLE
snap: do not use overly short timeout in `snap {start,stop,restart}` (2.32)

### DIFF
--- a/overlord/cmdstate/cmdmgr.go
+++ b/overlord/cmdstate/cmdmgr.go
@@ -61,19 +61,28 @@ func (m *CommandManager) Stop() {
 	m.runner.Stop()
 }
 
-var execTimeout = 5 * time.Second
+var defaultExecTimeout = 5 * time.Second
 
 func doExec(t *state.Task, tomb *tomb.Tomb) error {
 	var argv []string
+	var tout time.Duration
+
 	st := t.State()
 	st.Lock()
-	err := t.Get("argv", &argv)
+	err1 := t.Get("argv", &argv)
+	err2 := t.Get("timeout", &tout)
 	st.Unlock()
-	if err != nil {
-		return err
+	if err1 != nil {
+		return err1
+	}
+	if err2 != nil && err2 != state.ErrNoState {
+		return err2
+	}
+	if err2 == state.ErrNoState {
+		tout = defaultExecTimeout
 	}
 
-	if buf, err := osutil.RunAndWait(argv, nil, execTimeout, tomb); err != nil {
+	if buf, err := osutil.RunAndWait(argv, nil, tout, tomb); err != nil {
 		st.Lock()
 		t.Errorf("# %s\n%s", strings.Join(argv, " "), buf)
 		st.Unlock()

--- a/overlord/cmdstate/cmdstate.go
+++ b/overlord/cmdstate/cmdstate.go
@@ -22,12 +22,16 @@
 package cmdstate
 
 import (
+	"time"
+
 	"github.com/snapcore/snapd/overlord/state"
 )
 
-// Exec creates a task that will execute the given command.
-func Exec(st *state.State, summary string, argv []string) *state.TaskSet {
+// ExecWithTimeout creates a task that will execute the given command
+// with the given timeout.
+func ExecWithTimeout(st *state.State, summary string, argv []string, timeout time.Duration) *state.TaskSet {
 	t := st.NewTask("exec-command", summary)
 	t.Set("argv", argv)
+	t.Set("timeout", timeout)
 	return state.NewTaskSet(t)
 }

--- a/overlord/cmdstate/cmdstate_test.go
+++ b/overlord/cmdstate/cmdstate_test.go
@@ -71,7 +71,7 @@ func (s *cmdSuite) SetUpTest(c *check.C) {
 	s.rootdir = d
 	s.state = state.New(nil)
 	s.manager = cmdstate.Manager(s.state)
-	s.restore = cmdstate.MockExecTimeout(time.Second / 10)
+	s.restore = cmdstate.MockDefaultExecTimeout(time.Second / 10)
 }
 
 func (s *cmdSuite) TearDownTest(c *check.C) {
@@ -88,7 +88,7 @@ func (s *cmdSuite) TestExecTask(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 	argvIn := []string{"/bin/echo", "hello"}
-	tasks := cmdstate.Exec(s.state, "this is the summary", argvIn).Tasks()
+	tasks := cmdstate.ExecWithTimeout(s.state, "this is the summary", argvIn, time.Second/10).Tasks()
 	c.Assert(tasks, check.HasLen, 1)
 	task := tasks[0]
 	c.Check(task.Kind(), check.Equals, "exec-command")
@@ -103,7 +103,7 @@ func (s *cmdSuite) TestExecHappy(c *check.C) {
 	defer s.state.Unlock()
 
 	fn := filepath.Join(s.rootdir, "flag")
-	ts := cmdstate.Exec(s.state, "Doing the thing", []string{"touch", fn})
+	ts := cmdstate.ExecWithTimeout(s.state, "Doing the thing", []string{"touch", fn}, time.Second/10)
 	chg := s.state.NewChange("do-the-thing", "Doing the thing")
 	chg.AddAll(ts)
 
@@ -117,7 +117,7 @@ func (s *cmdSuite) TestExecSad(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	ts := cmdstate.Exec(s.state, "Doing the thing", []string{"sh", "-c", "echo hello; false"})
+	ts := cmdstate.ExecWithTimeout(s.state, "Doing the thing", []string{"sh", "-c", "echo hello; false"}, time.Second/10)
 	chg := s.state.NewChange("do-the-thing", "Doing the thing")
 	chg.AddAll(ts)
 
@@ -130,7 +130,7 @@ func (s *cmdSuite) TestExecAbort(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	ts := cmdstate.Exec(s.state, "Doing the thing", []string{"sleep", "1h"})
+	ts := cmdstate.ExecWithTimeout(s.state, "Doing the thing", []string{"sleep", "1h"}, time.Second/10)
 	chg := s.state.NewChange("do-the-thing", "Doing the thing")
 	chg.AddAll(ts)
 
@@ -152,7 +152,7 @@ func (s *cmdSuite) TestExecStop(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	ts := cmdstate.Exec(s.state, "Doing the thing", []string{"sleep", "1h"})
+	ts := cmdstate.ExecWithTimeout(s.state, "Doing the thing", []string{"sleep", "1h"}, time.Second/10)
 	chg := s.state.NewChange("do-the-thing", "Doing the thing")
 	chg.AddAll(ts)
 
@@ -170,7 +170,7 @@ func (s *cmdSuite) TestExecTimesOut(c *check.C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	ts := cmdstate.Exec(s.state, "Doing the thing", []string{"sleep", "1m"})
+	ts := cmdstate.ExecWithTimeout(s.state, "Doing the thing", []string{"sleep", "1m"}, time.Second/10)
 	chg := s.state.NewChange("do-the-thing", "Doing the thing")
 	chg.AddAll(ts)
 

--- a/overlord/cmdstate/export_test.go
+++ b/overlord/cmdstate/export_test.go
@@ -23,10 +23,10 @@ import (
 	"time"
 )
 
-func MockExecTimeout(t time.Duration) func() {
-	ot := execTimeout
-	execTimeout = t
+func MockDefaultExecTimeout(t time.Duration) func() {
+	ot := defaultExecTimeout
+	defaultExecTimeout = t
 	return func() {
-		execTimeout = ot
+		defaultExecTimeout = ot
 	}
 }

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -21,6 +21,7 @@ package servicestate
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/overlord/cmdstate"
@@ -107,5 +108,10 @@ func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction, conte
 		return nil, &ServiceActionConflictError{err}
 	}
 
-	return cmdstate.Exec(st, desc, argv), nil
+	// Give the systemctl a maximum time of 61 for now.
+	//
+	// Longer term we need to refactor this code and
+	// reuse the snapd/systemd and snapd/wrapper packages
+	// to control the timeout in a single place.
+	return cmdstate.ExecWithTimeout(st, desc, argv, 61*time.Second), nil
 }

--- a/tests/lib/snaps/test-snapd-service/bin/stop
+++ b/tests/lib/snaps/test-snapd-service/bin/stop
@@ -1,3 +1,7 @@
 #!/bin/sh
 
 echo "stop service"
+
+if [ -n "$1" ]; then
+    sleep "$1"
+fi

--- a/tests/lib/snaps/test-snapd-service/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-service/meta/snap.yaml
@@ -52,3 +52,8 @@ apps:
         stop-command: bin/stop-stop-mode endure
         daemon: simple
         refresh-mode: endure
+    test-snapd-service-refuses-to-stop:
+        command: bin/start
+        daemon: simple
+        stop-command: bin/stop 60
+        stop-timeout: 10s

--- a/tests/main/snap-service/task.yaml
+++ b/tests/main/snap-service/task.yaml
@@ -17,3 +17,12 @@ execute: |
     while ! systemctl status snap.test-snapd-service.test-snapd-service|grep "reloading reloading reloading"; do
         sleep 1
     done
+
+    echo "A snap that refuses to stop is killed eventually"
+    snap stop test-snapd-service.test-snapd-service-refuses-to-stop
+    # systemd in 14.04 does not provide the "Result: timeout" information
+    if [[ "$SPREAD_SYSTEM" == ubuntu-14.04-* ]]; then
+        systemctl status snap.test-snapd-service.test-snapd-service-refuses-to-stop|MATCH "code=killed"
+    else
+        systemctl status snap.test-snapd-service.test-snapd-service-refuses-to-stop|MATCH "Result: timeout"
+    fi


### PR DESCRIPTION
* snap: do not use overly short timeout in `snap {start,stop,restart}`

Right now we are using a timeout of 5s for `snap start/stop/restart`.
For many snaps this is too short so this PR increases the limit to
61s. This improves the situation while ensuring that snaps cannot
hold a hook "hostage" for a long time.

Longer term we need I think we to refactor servicestate.go to
reuse the existing systemd code in the `systemd` and `wrappers`
packages which handle stop-timeout correctly already. We just
need to be careful that we enforce sensible limits (and disucss
what "sensible" means).

