### PR TITLE
interfaces/apparmor: enable apparmor, even if partial

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -415,11 +415,7 @@ func addUpdateNSProfile(snapInfo *snap.Info, opts interfaces.ConfinementOptions,
 
 func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]*osutil.FileState) {
 	var policy string
-	// When partial AppArmor is detected, use the classic template for now. We could
-	// use devmode, but that could generate confusing log entries for users running
-	// snaps on systems with partial AppArmor support.
-	level := release.AppArmorLevel()
-	if level == release.PartialAppArmor || (opts.Classic && !opts.JailMode) {
+	if opts.Classic && !opts.JailMode {
 		policy = classicTemplate
 	} else {
 		policy = defaultTemplate
@@ -440,7 +436,7 @@ func addContent(securityTag string, snapInfo *snap.Info, opts interfaces.Confine
 				// and jailmode together. This snippet provides access to the core snap
 				// so that the dynamic linker and shared libraries can be used.
 				tagSnippets = classicJailmodeSnippet + "\n" + snippetForTag
-			} else if level == release.PartialAppArmor || (opts.Classic && !opts.JailMode) {
+			} else if opts.Classic && !opts.JailMode {
 				// When classic confinement (without jailmode) is in effect we
 				// are ignoring all apparmor snippets as they may conflict with
 				// the super-broad template we are starting with.


### PR DESCRIPTION
Apparmor parser can handle unknown constructs as does the kernel. It
should be safe to enable apparmor even if not all expected features are
available. This will improve the level of security to many classes of
applications that don't interact with apparmor features that have not
been mainlined yet.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
