### PR TITLE
dirs: on opensuse store apparmor profiles in /etc/apparmor.d

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -183,7 +183,11 @@ func SetRootDir(rootdir string) {
 
 	SnapDataDir = filepath.Join(rootdir, "/var/snap")
 	SnapDataHomeGlob = filepath.Join(rootdir, "/home/*/", UserHomeSnapDir)
-	SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
+	if release.DistroLike("opensuse") {
+		SnapAppArmorDir = filepath.Join(rootdir, "/etc/apparmor.d")
+	} else {
+		SnapAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "profiles")
+	}
 	SnapConfineAppArmorDir = filepath.Join(rootdir, snappyDir, "apparmor", "snap-confine")
 	AppArmorCacheDir = filepath.Join(rootdir, "/var/cache/apparmor")
 	SnapAppArmorAdditionalDir = filepath.Join(rootdir, snappyDir, "apparmor", "additional")


### PR DESCRIPTION
This is a RFC patch for moving apparmor profiles from
/var/lib/snapd/apparmor/profiles to /etc/apparmor.d
when running on openSUSE and LIKE distributions.

The main motivation is that /var/lib/snapd/apparmor/profiles is not
supported by the apparmor init scripts on openSUSE. The situation is
that all the distributions essentially have their own stack of apparmor
init code, different from one another. A massive rewrite is ongoing that
will, amongst others, allow to easily say that snapd stores apparmor
profiles in a different directory but this is still work in progress
upstream and nowhere to be seen downstream.

In an effort to improve the status of apparmor support on openSUSE I
would propose that we merge this change. It was acked by the apparmor
maintained in openSUSE (cboltz) and is something we could deprecate and
phase out over time, as the improved init script for apparmor becomes
commonplace.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
