### PR TITLE
cmd/snap-update-ns: add support for ignoring mounts with missing source/target

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -73,7 +73,7 @@ func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change
 	// create the parent directory and then the final element relative to it.
 	// The traversed space may be writable so we just try to create things
 	// first.
-	kind, _ := c.Entry.OptStr("x-snapd.kind")
+	kind := c.Entry.XSnapdKind()
 
 	// TODO: re-factor this, if possible, with inspection and preemptive
 	// creation after the current release ships. This should be possible but
@@ -84,7 +84,7 @@ func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change
 	case "file":
 		err = sec.MkfileAll(path, mode, uid, gid)
 	case "symlink":
-		target, _ := c.Entry.OptStr("x-snapd.symlink")
+		target := c.Entry.XSnapdSymlink()
 		if target == "" {
 			err = fmt.Errorf("cannot create symlink with empty target")
 		} else {
@@ -111,7 +111,7 @@ func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change
 func (c *Change) ensureTarget(sec *Secure) ([]*Change, error) {
 	var changes []*Change
 
-	kind, _ := c.Entry.OptStr("x-snapd.kind")
+	kind := c.Entry.XSnapdKind()
 	path := c.Entry.Dir
 
 	// We use lstat to ensure that we don't follow a symlink in case one was
@@ -159,7 +159,7 @@ func (c *Change) ensureSource(sec *Secure) error {
 		return nil
 	}
 
-	kind, _ := c.Entry.OptStr("x-snapd.kind")
+	kind := c.Entry.XSnapdKind()
 	path := c.Entry.Name
 	fi, err := osLstat(path)
 
@@ -238,7 +238,7 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 	var err error
 	switch c.Action {
 	case Mount:
-		kind, _ := c.Entry.OptStr("x-snapd.kind")
+		kind := c.Entry.XSnapdKind()
 		switch kind {
 		case "symlink":
 			// symlinks are handled in createInode directly, nothing to do here.
@@ -256,14 +256,14 @@ func (c *Change) lowLevelPerform(sec *Secure) error {
 		}
 		return err
 	case Unmount:
-		kind, _ := c.Entry.OptStr("x-snapd.kind")
+		kind := c.Entry.XSnapdKind()
 		switch kind {
 		case "symlink":
 			err = osRemove(c.Entry.Dir)
 			logger.Debugf("remove %q (error: %v)", c.Entry.Dir, err)
 		case "", "file":
 			flags := umountNoFollow
-			if c.Entry.OptBool("x-snapd.detach") {
+			if c.Entry.XSnapdDetach() {
 				flags |= syscall.MNT_DETACH
 			}
 			err = sysUnmount(c.Entry.Dir, flags)

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -188,8 +188,9 @@ func applyProfile(snapName string, currentBefore, desired *osutil.MountProfile, 
 			// We need to collect synthesized changes and store them.
 			if change.Entry.XSnapdOrigin() == "layout" {
 				return nil, err
+			} else if err != ErrIgnoredMissingMount {
+				logger.Noticef("cannot change mount namespace of snap %q according to change %s: %s", snapName, change, err)
 			}
-			logger.Noticef("cannot change mount namespace of snap %q according to change %s: %s", snapName, change, err)
 			continue
 		}
 

--- a/cmd/snap-update-ns/main_test.go
+++ b/cmd/snap-update-ns/main_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -30,6 +31,7 @@ import (
 
 	update "github.com/snapcore/snapd/cmd/snap-update-ns"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -37,13 +39,19 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type mainSuite struct {
+	testutil.BaseTest
 	sec *update.Secure
+	log *bytes.Buffer
 }
 
 var _ = Suite(&mainSuite{})
 
 func (s *mainSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
 	s.sec = &update.Secure{}
+	buf, restore := logger.MockLogger()
+	s.BaseTest.AddCleanup(restore)
+	s.log = buf
 }
 
 func (s *mainSuite) TestComputeAndSaveChanges(c *C) {
@@ -259,6 +267,49 @@ func (s *mainSuite) TestApplyingLayoutChanges(c *C) {
 	// The error was not ignored, we bailed out.
 	c.Assert(update.ComputeAndSaveChanges(snapName, s.sec), ErrorMatches, "testing")
 
+	c.Check(currentProfilePath, testutil.FileEquals, "")
+}
+
+func (s *mainSuite) TestApplyIgnoredMissingMount(c *C) {
+	dirs.SetRootDir(c.MkDir())
+	defer dirs.SetRootDir("/")
+
+	const snapName = "mysnap"
+	const currentProfileContent = ""
+	const desiredProfileContent = "/source /target none bind,x-snapd.ignore-missing 0 0"
+
+	currentProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapRunNsDir, snapName)
+	desiredProfilePath := fmt.Sprintf("%s/snap.%s.fstab", dirs.SnapMountPolicyDir, snapName)
+
+	c.Assert(os.MkdirAll(filepath.Dir(currentProfilePath), 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Dir(desiredProfilePath), 0755), IsNil)
+	c.Assert(ioutil.WriteFile(currentProfilePath, []byte(currentProfileContent), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(desiredProfilePath, []byte(desiredProfileContent), 0644), IsNil)
+
+	n := -1
+	restore := update.MockChangePerform(func(chg *update.Change, sec *update.Secure) ([]*update.Change, error) {
+		n++
+		switch n {
+		case 0:
+			c.Assert(chg, DeepEquals, &update.Change{
+				Action: update.Mount,
+				Entry: osutil.MountEntry{
+					Name:    "/source",
+					Dir:     "/target",
+					Type:    "none",
+					Options: []string{"bind", "x-snapd.ignore-missing"},
+				},
+			})
+			return nil, update.ErrIgnoredMissingMount
+		default:
+			panic(fmt.Sprintf("unexpected call n=%d, chg: %v", n, *chg))
+		}
+	})
+	defer restore()
+
+	// The error was ignored, and no mount was recorded in the profile
+	c.Assert(update.ComputeAndSaveChanges(snapName, s.sec), IsNil)
+	c.Check(s.log.String(), Equals, "")
 	c.Check(currentProfilePath, testutil.FileEquals, "")
 }
 

--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -378,6 +378,14 @@ func (e *MountEntry) XSnapdDetach() bool {
 	return e.OptBool("x-snapd.detach")
 }
 
+// XSnapdSymlink returns the target for a symlink mount entry.
+//
+// For non-symlinks an empty string is returned.
+func (e *MountEntry) XSnapdSymlink() string {
+	val, _ := e.OptStr("x-snapd.symlink")
+	return val
+}
+
 // XSnapdNeededBy returns the string "x-snapd.needed-by=..." with the given path appended.
 func XSnapdNeededBy(path string) string {
 	return fmt.Sprintf("x-snapd.needed-by=%s", path)

--- a/osutil/mountentry.go
+++ b/osutil/mountentry.go
@@ -386,6 +386,17 @@ func (e *MountEntry) XSnapdSymlink() string {
 	return val
 }
 
+// XSnapdIgnoreMissing returns true if a mount entry should be ignored
+// if the source or target are missing.
+//
+// By default, snap-update-ns will try to create missing source and
+// target paths when processing a mount entry.  In some cases, this
+// behaviour is not desired and it would be better to ignore the mount
+// entry when the source or target are missing.
+func (e *MountEntry) XSnapdIgnoreMissing() bool {
+	return e.OptBool("x-snapd.ignore-missing")
+}
+
 // XSnapdNeededBy returns the string "x-snapd.needed-by=..." with the given path appended.
 func XSnapdNeededBy(path string) string {
 	return fmt.Sprintf("x-snapd.needed-by=%s", path)
@@ -434,4 +445,9 @@ func XSnapdMode(mode uint32) string {
 // XSnapdSymlink returns the string "x-snapd.symlink=%s".
 func XSnapdSymlink(oldname string) string {
 	return fmt.Sprintf("x-snapd.symlink=%s", oldname)
+}
+
+// XSnapdIgnoreMissing returns the string "x-snapd.ignore-missing".
+func XSnapdIgnoreMissing() string {
+	return "x-snapd.ignore-missing"
 }

--- a/osutil/mountentry_test.go
+++ b/osutil/mountentry_test.go
@@ -412,3 +412,18 @@ func (s *entrySuite) TestXSnapdSymlink(c *C) {
 	e = &osutil.MountEntry{Options: []string{osutil.XSnapdSymlink("target")}}
 	c.Assert(e.XSnapdSymlink(), Equals, "target")
 }
+
+func (s *entrySuite) TestXSnapdIgnoreMissing(c *C) {
+	// By default entries will not have the ignore missing flag set
+	e := &osutil.MountEntry{}
+	c.Assert(e.XSnapdIgnoreMissing(), Equals, false)
+
+	// A mount entry can specify that it should be ignored if the
+	// mount source or target are missing with the
+	// x-snapd.ignore-missing option.
+	e = &osutil.MountEntry{Options: []string{osutil.XSnapdIgnoreMissing()}}
+	c.Assert(e.XSnapdIgnoreMissing(), Equals, true)
+
+	// There's a helper function that returns this option string.
+	c.Assert(osutil.XSnapdIgnoreMissing(), Equals, "x-snapd.ignore-missing")
+}

--- a/osutil/mountentry_test.go
+++ b/osutil/mountentry_test.go
@@ -402,3 +402,13 @@ func (s *entrySuite) TestXSnapdKind(c *C) {
 	// There's a helper function that returns this option string.
 	c.Assert(osutil.XSnapdKindSymlink(), Equals, "x-snapd.kind=symlink")
 }
+
+func (s *entrySuite) TestXSnapdSymlink(c *C) {
+	// Entries without the x-snapd.symlink key return an empty string
+	e := &osutil.MountEntry{}
+	c.Assert(e.XSnapdSymlink(), Equals, "")
+
+	// A mount entry can list a symlink target
+	e = &osutil.MountEntry{Options: []string{osutil.XSnapdSymlink("target")}}
+	c.Assert(e.XSnapdSymlink(), Equals, "target")
+}


### PR DESCRIPTION
This is intended to support the xdg-document-portal support in the desktop interface (PR #5115).  To support xdg-document-portal, we need to set up a user mount for the document portal.

However, on systems without the portal services installed (or if the user has somehow disabled the document portal), we don't want to prevent them from running applications using the desktop interface or print a scary warning.  We also don't want snap-update-ns to try and create the missing mount source or target directories.

This change is intended to address that by adding a new private mount option to ignore the mount entry when the source or target is missing.