### PR TITLE
Revert "Skip test lp-1721518 for arch, snapd is failing to start afte…

### DIFF
--- a/tests/regression/lp-1721518/task.yaml
+++ b/tests/regression/lp-1721518/task.yaml
@@ -4,8 +4,6 @@ summary: Check that interfaces are listed after reboot the machine
 # not support our reboot logic
 backends: [-autopkgtest]
 
-systems: [-arch-linux-*]
-
 details: |
     This test checks if the interfaces are listed after the machine
     is rebooted. The test is also checking the interfaces after a 


### PR DESCRIPTION
…r reboot"

This reverts commit ea918b0104b56a93ba602a7fd196174080d130c2.

This revert is done because the main problem was fixed on the arch image by disabling the google shutdown service which was getting stuck during reboot. Also a forum post https://forum.snapcraft.io/t/snapd-taking-10-minutes-to-start-after-reboot-on-arch-linux/5289 was created to deal with the delay starting the snapd service after reboot. 



