### PR TITLE
cmd/snap-confine: allow any base snap to provide /etc/alternatives

### DIFF
--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -198,7 +198,7 @@
     mount options=(rw slave) -> /tmp/snap.rootfs_*/usr/bin/snapctl,
 
     # /etc/alternatives (classic)
-    mount options=(rw bind) @SNAP_MOUNT_DIR@/{,ubuntu-}core/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
+    mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/etc/alternatives/ -> /tmp/snap.rootfs_*/etc/alternatives/,
     mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/etc/ssl/ -> /tmp/snap.rootfs_*/etc/ssl/,
     mount options=(rw bind) @SNAP_MOUNT_DIR@/*/*/etc/nsswitch.conf -> /tmp/snap.rootfs_*/etc/nsswitch.conf,
     # /etc/alternatives (core)


### PR DESCRIPTION
While working on an experimental base snap I realized that no other snap
(apart from core and ubuntu-core) can ship /etc/alternatives and hope it
to function. This patch corrects that.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>