### PR TITLE
interfaces/apparmor: allow bash and dash to be in /usr/bin/

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -92,8 +92,8 @@ var defaultTemplate = `
 
   # for bash 'binaries' (do *not* use abstractions/bash)
   # user-specific bash files
-  /bin/bash ixr,
-  /bin/dash ixr,
+  /{,usr/}bin/bash ixr,
+  /{,usr/}bin/dash ixr,
   /etc/bash.bashrc r,
   /etc/{passwd,group,nsswitch.conf} r,  # very common
   /etc/default/nss r,


### PR DESCRIPTION
This patch tweaks the base apparmor profile for all snaps to allow
execution of /usr/bin/{bash,dash}. On certain distributions, which can
act as a base snap, /bin is a symbolic link to /usr/bin so no rules for
/bin will function correctly.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
