### PR TITLE
tests: fix interfaces-network test for systems with partial confinement

### DIFF
--- a/tests/main/interfaces-network/task.yaml
+++ b/tests/main/interfaces-network/task.yaml
@@ -48,6 +48,10 @@ execute: |
     echo "Then the snap is able to access a network service"
     network-consumer http://127.0.0.1:$PORT | grep -Pqz "ok\n"
 
+    if [ "$(snap debug confinement)" = partial ] ; then
+        exit 0
+    fi
+
     echo "When the plug is disconnected"
     snap disconnect $SNAP_NAME:network
 


### PR DESCRIPTION
Currently this test is passing on debian but because there is a
connection error when tries to connect the snap to the service.

The test was modified to show the los when it works (shared in the next
link): https://paste.ubuntu.com/p/MHPCWjRMsv/

With the previous implementation the connection to the service worked
even if the interface was disconnected.

This test is currently failing on travis: 
https://travis-ci.org/snapcore/snapd/builds/372743575#L4544