### PR TITLE
snap,wrappers: allow "external:{snapd,snapd.seeded}" for snap apps

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -394,7 +394,10 @@ func validateAppSocket(socket *SocketInfo) error {
 	return validateSocketAddr(socket, "listen-stream", socket.ListenStream)
 }
 
-func injectFakeExternalApps(apps map[string]*AppInfo) {
+// injectFakeExternalAppsForCycleChecks adds fake AppInfo structs
+// into the apps map so that the cycle detector can find cycles for
+// targets of the type "external:..."
+func injectFakeExternalAppsForCycleChecks(apps map[string]*AppInfo) {
 	for _, app := range apps {
 		var beforeAfter []string
 		beforeAfter = append(beforeAfter, app.Before...)
@@ -420,7 +423,7 @@ func validateAppOrderCycles(apps map[string]*AppInfo) error {
 
 	// inject fake apps for external targets to ensure we check for
 	// cycles there as well
-	injectFakeExternalApps(apps)
+	injectFakeExternalAppsForCycleChecks(apps)
 
 	for _, app := range apps {
 		for _, other := range app.After {

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -403,10 +403,16 @@ func validateAppOrderCycles(apps map[string]*AppInfo) error {
 
 	for _, app := range apps {
 		for _, other := range app.After {
+			if strings.HasPrefix(other, "external:") {
+				continue
+			}
 			predecessors[app.Name]++
 			successors[other] = append(successors[other], app.Name)
 		}
 		for _, other := range app.Before {
+			if strings.HasPrefix(other, "external:") {
+				continue
+			}
 			predecessors[other]++
 			successors[app.Name] = append(successors[app.Name], other)
 		}
@@ -454,6 +460,16 @@ func validateAppOrderCycles(apps map[string]*AppInfo) error {
 	return nil
 }
 
+// Whitelist of external systemd targets that a service can use
+// for before/after ordering. This is useful for e.g. classic snaps
+// that need to run snapd itself or that need to run commands from
+// snaps that are in the seed so they can only start working once
+// the seeded has happened.
+var allowedExternalServices = []string{
+	"snapd",
+	"snapd.seeded",
+}
+
 func validateAppOrderNames(app *AppInfo, dependencies []string) error {
 	// we must be a service to request ordering
 	if len(dependencies) > 0 && !app.IsService() {
@@ -461,6 +477,14 @@ func validateAppOrderNames(app *AppInfo, dependencies []string) error {
 	}
 
 	for _, dep := range dependencies {
+		if strings.HasPrefix(dep, "external:") {
+			shortName := strings.TrimPrefix(dep, "external:")
+			if !strutil.ListContains(allowedExternalServices, shortName) {
+				return fmt.Errorf("cannot use external name %q, only %s is allowed", shortName, strutil.Quoted(allowedExternalServices))
+			}
+			continue
+		}
+
 		// dependency is not defined
 		other, ok := app.Snap.Apps[dep]
 		if !ok {

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -984,7 +984,7 @@ apps:
 `
 
 	// happy
-	for _, external := range []string{"snapd", "snapd.seeded"} {
+	for _, external := range []string{"snapd.service", "snapd.seeded.service"} {
 		info, err := InfoFromSnapYaml([]byte(fmt.Sprintf(fmtMeta, external)))
 		c.Assert(err, IsNil)
 		err = Validate(info)
@@ -995,7 +995,7 @@ apps:
 	info, err := InfoFromSnapYaml([]byte(fmt.Sprintf(fmtMeta, "not-allowed")))
 	c.Assert(err, IsNil)
 	err = Validate(info)
-	c.Assert(err, ErrorMatches, `cannot use external name "not-allowed", only "snapd", "snapd.seeded" is allowed`)
+	c.Assert(err, ErrorMatches, `cannot use external name "not-allowed", only "snapd.service", "snapd.seeded.service" is allowed`)
 
 }
 
@@ -1111,6 +1111,17 @@ apps:
    daemon: dbus
    after: [foo, bar, baz]
 `)
+	// cycle with "external:"
+	externalCycle := []byte(`
+apps:
+ app-1:
+   before: [external:snapd.service]
+   after: [app-2]
+   daemon: forking
+ app-2:
+   after: [external:snapd.service]
+   daemon: forking
+`)
 
 	tcs := []struct {
 		name string
@@ -1153,8 +1164,13 @@ apps:
 	}, {
 		name: "self cycle",
 		desc: fooSelfCycle,
-		err:  `applications are part of a before/after cycle: foo`},
+		err:  `applications are part of a before/after cycle: foo`,
+	}, {
+		name: "external cycle",
+		desc: externalCycle,
+		err:  `applications are part of a before/after cycle: ((external:snapd.service|app-2|app-1)(, )?){3}`},
 	}
+
 	for _, tc := range tcs {
 		c.Logf("trying %q", tc.name)
 		info, err := InfoFromSnapYaml(append(meta, tc.desc...))

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -973,6 +973,32 @@ func (s *ValidateSuite) TestValidateSocketName(c *C) {
 	}
 }
 
+func (s *YamlSuite) TestValidateBeforeAfterExternal(c *C) {
+	fmtMeta := `
+name: foo
+version: 1.0
+apps:
+ foo:
+  after: [external:%s]
+  daemon: simple
+`
+
+	// happy
+	for _, external := range []string{"snapd", "snapd.seeded"} {
+		info, err := InfoFromSnapYaml([]byte(fmt.Sprintf(fmtMeta, external)))
+		c.Assert(err, IsNil)
+		err = Validate(info)
+		c.Assert(err, IsNil)
+	}
+
+	// unhappy
+	info, err := InfoFromSnapYaml([]byte(fmt.Sprintf(fmtMeta, "not-allowed")))
+	c.Assert(err, IsNil)
+	err = Validate(info)
+	c.Assert(err, ErrorMatches, `cannot use external name "not-allowed", only "snapd", "snapd.seeded" is allowed`)
+
+}
+
 func (s *YamlSuite) TestValidateAppStartupOrder(c *C) {
 	meta := []byte(`
 name: foo

--- a/wrappers/services.go
+++ b/wrappers/services.go
@@ -362,14 +362,14 @@ func genBeforeAfterServiceNames(snap *snap.Info, appNames []string) []string {
 	names := make([]string, 0, len(appNames))
 
 	for _, name := range appNames {
-		// referencing internal snap services if always fine
+		// referencing internal snap services is always fine
 		if app := snap.Apps[name]; app != nil {
 			names = append(names, app.ServiceName())
 		}
 		// snap/validate.go ensures `external:` is restricted by a
 		// whitelist
 		if strings.HasPrefix(name, "external:") {
-			names = append(names, strings.TrimPrefix(name, "external:")+".service")
+			names = append(names, strings.TrimPrefix(name, "external:"))
 		}
 	}
 	return names
@@ -383,7 +383,7 @@ Requires={{.MountUnit}}
 Wants={{.PrerequisiteTarget}}
 After={{.MountUnit}} {{.PrerequisiteTarget}}{{range .After}} {{.}}{{end}}
 {{- if .Before}}
-Before={{range .Before}}{{.}} {{end}}
+Before={{ StringsJoin .Before " " }}
 {{- end}}
 X-Snappy=yes
 
@@ -424,7 +424,9 @@ WantedBy={{.ServicesTarget}}
 {{- end}}
 `
 	var templateOut bytes.Buffer
-	t := template.Must(template.New("service-wrapper").Parse(serviceTemplate))
+	t := template.New("service-wrapper")
+	t = t.Funcs(template.FuncMap{"StringsJoin": strings.Join})
+	t = template.Must(t.Parse(serviceTemplate))
 
 	restartCond := appInfo.RestartCond.String()
 	if restartCond == "" {

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -281,8 +281,8 @@ func (s *servicesWrapperGenSuite) TestServiceAfterBefore(c *C) {
 Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
 Wants=network-online.target
-After=%s-snap-44.mount network-online.target snap.snap.bar.service snap.snap.zed.service
-Before=snap.snap.foo.service
+After=%s-snap-44.mount network-online.target snap.snap.bar.service snap.snap.zed.service snapd.service
+Before=snap.snap.foo.service snap.snap.foobar.service 
 X-Snappy=yes
 
 [Service]
@@ -319,13 +319,18 @@ WantedBy=multi-user.target
 					Snap:   &snap.Info{SuggestedName: "snap"},
 					Daemon: "forking",
 				},
+				"foobar": {
+					Name:   "foobar",
+					Snap:   &snap.Info{SuggestedName: "snap"},
+					Daemon: "simple",
+				},
 			},
 		},
 		Name:        "app",
 		Command:     "bin/foo start",
 		Daemon:      "simple",
-		Before:      []string{"foo"},
-		After:       []string{"bar", "zed"},
+		Before:      []string{"foo", "foobar"},
+		After:       []string{"bar", "zed", "external:snapd"},
 		StopTimeout: timeout.DefaultTimeout,
 	}
 

--- a/wrappers/services_gen_test.go
+++ b/wrappers/services_gen_test.go
@@ -282,7 +282,7 @@ Description=Service for snap application snap.app
 Requires=%s-snap-44.mount
 Wants=network-online.target
 After=%s-snap-44.mount network-online.target snap.snap.bar.service snap.snap.zed.service snapd.service
-Before=snap.snap.foo.service snap.snap.foobar.service 
+Before=snap.snap.foo.service snap.snap.foobar.service
 X-Snappy=yes
 
 [Service]
@@ -330,7 +330,7 @@ WantedBy=multi-user.target
 		Command:     "bin/foo start",
 		Daemon:      "simple",
 		Before:      []string{"foo", "foobar"},
-		After:       []string{"bar", "zed", "external:snapd"},
+		After:       []string{"bar", "zed", "external:snapd.service"},
 		StopTimeout: timeout.DefaultTimeout,
 	}
 


### PR DESCRIPTION
Some classic snaps need to order their services after snapd is
ready. This PR allows this via a new external: prefix in the
before/after keywords of snap services.

This also fixes a bug in the "before" handling which was stripping whitespace and broke before service lists with more than one member (they would all contactinated without whitespace in between).