### PR TITLE
tests: ubuntu 18.04 or higher does not need linux-image-extra-

### DIFF
--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -492,14 +492,9 @@ pkg_dependencies_ubuntu_classic(){
                 linux-image-extra-4.13.0-16-generic
                 "
             ;;
-        ubuntu-18.04-64)
-            echo "
-                squashfs-tools
-                "
-            ;;
         ubuntu-*)
             echo "
-                linux-image-extra-$(uname -r)
+                squashfs-tools
                 "
             ;;
         debian-*)


### PR DESCRIPTION
The tests did install the "linux-image-extra-$(uname -r)" package
on unknown ubuntu versions. However since 18.04 we don't need this
package anymore.

Since we cover all the previous dependencies explicitly this PR
makes the behaviour for ubuntu 18 (or higher) the default.

