### PR TITLE
cmd/libsnap: fix compile error on more restrictive gcc

### DIFF
--- a/cmd/libsnap-confine-private/locking-test.c
+++ b/cmd/libsnap-confine-private/locking-test.c
@@ -32,6 +32,12 @@ static void sc_set_lock_dir(const char *dir)
 	sc_lock_dir = dir;
 }
 
+// A variant of unsetenv that is compatible with GDestroyNotify
+static void my_unsetenv(const char *k)
+{
+	unsetenv(k);
+}
+
 // Use temporary directory for locking.
 //
 // The directory is automatically reset to the real value at the end of the
@@ -50,7 +56,7 @@ static const char *sc_test_use_fake_lock_dir(void)
 		g_test_queue_free(lock_dir);
 		g_assert_cmpint(setenv("SNAP_CONFINE_LOCK_DIR", lock_dir, 0),
 				==, 0);
-		g_test_queue_destroy((GDestroyNotify) unsetenv,
+		g_test_queue_destroy((GDestroyNotify) my_unsetenv,
 				     "SNAP_CONFINE_LOCK_DIR");
 		g_test_queue_destroy((GDestroyNotify) rm_rf_tmp, lock_dir);
 	}

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -188,10 +188,10 @@ static void test_sc_snap_name_validate(void)
 	g_assert_null(err);
 
 	// In case we switch to a regex, here's a test that could break things.
-	const char *good_bad_name = "u-94903713687486543234157734673284536758";
-	char varname[41] = { 0 };
-	for (int i = 3; i <= 40; i++) {
-		g_assert_nonnull(strncpy(varname, good_bad_name, i));
+	const char good_bad_name[] = "u-94903713687486543234157734673284536758";
+	char varname[sizeof good_bad_name] = { 0 };
+	for (size_t i = 3; i <= sizeof varname - 1; i++) {
+		g_assert_nonnull(memcpy(varname, good_bad_name, i));
 		varname[i] = 0;
 		g_test_message("checking valid snap name: >%s<", varname);
 		sc_snap_name_validate(varname, &err);

--- a/cmd/libsnap-confine-private/utils-test.c
+++ b/cmd/libsnap-confine-private/utils-test.c
@@ -102,13 +102,17 @@ static void test_die_with_errno(void)
 // A variant of rmdir that is compatible with GDestroyNotify
 static void my_rmdir(const char *path)
 {
-  rmdir(path);
+	if (rmdir(path) != 0) {
+		die("cannot rmdir %s", path);
+	}
 }
 
 // A variant of chdir that is compatible with GDestroyNotify
 static void my_chdir(const char *path)
 {
-  chdir(path);
+	if (chdir(path) != 0) {
+		die("cannot change dir to %s", path);
+	}
 }
 
 /**

--- a/cmd/libsnap-confine-private/utils-test.c
+++ b/cmd/libsnap-confine-private/utils-test.c
@@ -99,6 +99,18 @@ static void test_die_with_errno(void)
 	g_test_trap_assert_stderr("death message: Operation not permitted\n");
 }
 
+// A variant of rmdir that is compatible with GDestroyNotify
+static void my_rmdir(const char *path)
+{
+  rmdir(path);
+}
+
+// A variant of chdir that is compatible with GDestroyNotify
+static void my_chdir(const char *path)
+{
+  chdir(path);
+}
+
 /**
  * Perform the rest of testing in a ephemeral directory.
  *
@@ -114,9 +126,9 @@ static void g_test_in_ephemeral_dir(void)
 	g_assert_cmpint(err, ==, 0);
 
 	g_test_queue_free(temp_dir);
-	g_test_queue_destroy((GDestroyNotify) rmdir, temp_dir);
+	g_test_queue_destroy((GDestroyNotify) my_rmdir, temp_dir);
 	g_test_queue_free(orig_dir);
-	g_test_queue_destroy((GDestroyNotify) chdir, orig_dir);
+	g_test_queue_destroy((GDestroyNotify) my_chdir, orig_dir);
 }
 
 /**
@@ -130,7 +142,7 @@ static void _test_sc_nonfatal_mkpath(const gchar * dirname,
 				   G_FILE_TEST_IS_DIR));
 	// Use sc_nonfatal_mkpath to create the directory and ensure that it worked
 	// as expected.
-	g_test_queue_destroy((GDestroyNotify) rmdir, (char *)dirname);
+	g_test_queue_destroy((GDestroyNotify) my_rmdir, (char *)dirname);
 	int err = sc_nonfatal_mkpath(dirname, 0755);
 	g_assert_cmpint(err, ==, 0);
 	g_assert_cmpint(errno, ==, 0);
@@ -143,7 +155,7 @@ static void _test_sc_nonfatal_mkpath(const gchar * dirname,
 	g_assert_cmpint(errno, ==, EEXIST);
 	// Now create a sub-directory of the original directory and observe the
 	// results. We should no longer see errno of EEXIST!
-	g_test_queue_destroy((GDestroyNotify) rmdir, (char *)subdirname);
+	g_test_queue_destroy((GDestroyNotify) my_rmdir, (char *)subdirname);
 	err = sc_nonfatal_mkpath(subdirname, 0755);
 	g_assert_cmpint(err, ==, 0);
 	g_assert_cmpint(errno, ==, 0);

--- a/cmd/snap-confine/ns-support-test.c
+++ b/cmd/snap-confine/ns-support-test.c
@@ -35,6 +35,12 @@ static void sc_set_ns_dir(const char *dir)
 	sc_ns_dir = dir;
 }
 
+// A variant of unsetenv that is compatible with GDestroyNotify
+static void my_unsetenv(const char *k)
+{
+	unsetenv(k);
+}
+
 // Use temporary directory for namespace groups.
 //
 // The directory is automatically reset to the real value at the end of the
@@ -53,7 +59,7 @@ static const char *sc_test_use_fake_ns_dir(void)
 		g_test_queue_free(ns_dir);
 		g_assert_cmpint(setenv("SNAP_CONFINE_NS_DIR", ns_dir, 0), ==,
 				0);
-		g_test_queue_destroy((GDestroyNotify) unsetenv,
+		g_test_queue_destroy((GDestroyNotify) my_unsetenv,
 				     "SNAP_CONFINE_NS_DIR");
 		g_test_queue_destroy((GDestroyNotify) rm_rf_tmp, ns_dir);
 	}


### PR DESCRIPTION
This fixes return type discrepancy between unsetenv and GDestroyNotify

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
