### PR TITLE
many: add "snap debug sandbox-features" and needed bits

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -434,8 +434,9 @@ type SysInfo struct {
 
 	KernelVersion string `json:"kernel-version,omitempty"`
 
-	Refresh     RefreshInfo `json:"refresh,omitempty"`
-	Confinement string      `json:"confinement"`
+	Refresh     RefreshInfo         `json:"refresh,omitempty"`
+	Confinement string              `json:"confinement"`
+	Sandbox     map[string][]string `json:"sandbox,omitempty"`
 }
 
 func (rsp *response) err() error {

--- a/client/client.go
+++ b/client/client.go
@@ -434,9 +434,9 @@ type SysInfo struct {
 
 	KernelVersion string `json:"kernel-version,omitempty"`
 
-	Refresh     RefreshInfo         `json:"refresh,omitempty"`
-	Confinement string              `json:"confinement"`
-	Sandbox     map[string][]string `json:"sandbox,omitempty"`
+	Refresh         RefreshInfo         `json:"refresh,omitempty"`
+	Confinement     string              `json:"confinement"`
+	SandboxFeatures map[string][]string `json:"sandbox-features,omitempty"`
 }
 
 func (rsp *response) err() error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -217,7 +217,8 @@ func (cs *clientSuite) TestClientSysInfo(c *C) {
                       "os-release": {"id": "ubuntu", "version-id": "16.04"},
                       "on-classic": true,
                       "build-id": "1234",
-                      "confinement": "strict"}}`
+                      "confinement": "strict",
+                      "sandbox": {"backend": ["tag-1", "tag-2"]}}}`
 	sysInfo, err := cs.cli.SysInfo()
 	c.Check(err, IsNil)
 	c.Check(sysInfo, DeepEquals, &client.SysInfo{
@@ -229,7 +230,10 @@ func (cs *clientSuite) TestClientSysInfo(c *C) {
 		},
 		OnClassic:   true,
 		Confinement: "strict",
-		BuildID:     "1234",
+		Sandbox: map[string][]string{
+			"backend": {"tag-1", "tag-2"},
+		},
+		BuildID: "1234",
 	})
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -218,7 +218,7 @@ func (cs *clientSuite) TestClientSysInfo(c *C) {
                       "on-classic": true,
                       "build-id": "1234",
                       "confinement": "strict",
-                      "sandbox": {"backend": ["tag-1", "tag-2"]}}}`
+                      "sandbox-features": {"backend": ["feature-1", "feature-2"]}}}`
 	sysInfo, err := cs.cli.SysInfo()
 	c.Check(err, IsNil)
 	c.Check(sysInfo, DeepEquals, &client.SysInfo{
@@ -230,8 +230,8 @@ func (cs *clientSuite) TestClientSysInfo(c *C) {
 		},
 		OnClassic:   true,
 		Confinement: "strict",
-		Sandbox: map[string][]string{
-			"backend": {"tag-1", "tag-2"},
+		SandboxFeatures: map[string][]string{
+			"backend": {"feature-1", "feature-2"},
 		},
 		BuildID: "1234",
 	})

--- a/cmd/snap/cmd_can_manage_refreshes.go
+++ b/cmd/snap/cmd_can_manage_refreshes.go
@@ -33,7 +33,7 @@ func init() {
 		"(internal) return if refresh.schedule=managed can be used",
 		func() flags.Commander {
 			return &cmdCanManageRefreshes{}
-		})
+		}, nil, nil)
 	cmd.hidden = true
 }
 

--- a/cmd/snap/cmd_confinement.go
+++ b/cmd/snap/cmd_confinement.go
@@ -36,7 +36,9 @@ partial or none) the system operates in.
 type cmdConfinement struct{}
 
 func init() {
-	addDebugCommand("confinement", shortConfinementHelp, longConfinementHelp, func() flags.Commander { return &cmdConfinement{} })
+	addDebugCommand("confinement", shortConfinementHelp, longConfinementHelp, func() flags.Commander {
+		return &cmdConfinement{}
+	}, nil, nil)
 }
 
 func (cmd cmdConfinement) Execute(args []string) error {

--- a/cmd/snap/cmd_ensure_state_soon.go
+++ b/cmd/snap/cmd_ensure_state_soon.go
@@ -31,7 +31,7 @@ func init() {
 		"(internal) trigger an ensure run in the state engine",
 		func() flags.Commander {
 			return &cmdEnsureStateSoon{}
-		})
+		}, nil, nil)
 	cmd.hidden = true
 }
 

--- a/cmd/snap/cmd_get_base_declaration.go
+++ b/cmd/snap/cmd_get_base_declaration.go
@@ -33,7 +33,7 @@ func init() {
 		"(internal) obtain the base declaration for all interfaces",
 		func() flags.Commander {
 			return &cmdGetBaseDeclaration{}
-		})
+		}, nil, nil)
 }
 
 func (x *cmdGetBaseDeclaration) Execute(args []string) error {

--- a/cmd/snap/cmd_sandbox.go
+++ b/cmd/snap/cmd_sandbox.go
@@ -61,7 +61,7 @@ func (cmd cmdSandbox) Execute(args []string) error {
 	w := tabWriter()
 	defer w.Flush()
 	for _, key := range keys {
-		fmt.Fprintf(w, "%s:\t%s\n", key, strings.Join(sandbox[key], ", "))
+		fmt.Fprintf(w, "%s:\t%s\n", key, strings.Join(sandbox[key], " "))
 	}
 
 	return nil

--- a/cmd/snap/cmd_sandbox.go
+++ b/cmd/snap/cmd_sandbox.go
@@ -1,0 +1,68 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"github.com/snapcore/snapd/i18n"
+
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+)
+
+var shortSandboxHelp = i18n.G("Print the details of the sandbox available on the system")
+var longSandboxHelp = i18n.G(`
+The sandbox command prints tags describing features of individual sandbox
+components used by snapd on a given system.
+`)
+
+type cmdSandbox struct{}
+
+func init() {
+	addDebugCommand("sandbox", shortSandboxHelp, longSandboxHelp, func() flags.Commander { return &cmdSandbox{} })
+}
+
+func (cmd cmdSandbox) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	cli := Client()
+	sysInfo, err := cli.SysInfo()
+	if err != nil {
+		return err
+	}
+	sandbox := sysInfo.Sandbox
+	keys := make([]string, 0, len(sandbox))
+	for key := range sandbox {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	w := tabWriter()
+	defer w.Flush()
+	for _, key := range keys {
+		fmt.Fprintf(w, "%s:\t%s\n", key, strings.Join(sandbox[key], ", "))
+	}
+
+	return nil
+}

--- a/cmd/snap/cmd_sandbox.go
+++ b/cmd/snap/cmd_sandbox.go
@@ -20,13 +20,13 @@
 package main
 
 import (
-	"github.com/snapcore/snapd/i18n"
-
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/i18n"
 )
 
 var shortSandboxHelp = i18n.G("Print the details of the sandbox available on the system")

--- a/cmd/snap/cmd_sandbox_features.go
+++ b/cmd/snap/cmd_sandbox_features.go
@@ -29,19 +29,19 @@ import (
 	"github.com/snapcore/snapd/i18n"
 )
 
-var shortSandboxHelp = i18n.G("Print the details of the sandbox available on the system")
-var longSandboxHelp = i18n.G(`
+var shortSandboxFeaturesHelp = i18n.G("Print sandbox features available on the system")
+var longSandboxFeaturesHelp = i18n.G(`
 The sandbox command prints tags describing features of individual sandbox
 components used by snapd on a given system.
 `)
 
-type cmdSandbox struct{}
+type cmdSandboxFeatures struct{}
 
 func init() {
-	addDebugCommand("sandbox", shortSandboxHelp, longSandboxHelp, func() flags.Commander { return &cmdSandbox{} })
+	addDebugCommand("sandbox-features", shortSandboxFeaturesHelp, longSandboxFeaturesHelp, func() flags.Commander { return &cmdSandboxFeatures{} })
 }
 
-func (cmd cmdSandbox) Execute(args []string) error {
+func (cmd cmdSandboxFeatures) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
@@ -51,17 +51,17 @@ func (cmd cmdSandbox) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	sandbox := sysInfo.Sandbox
-	keys := make([]string, 0, len(sandbox))
-	for key := range sandbox {
-		keys = append(keys, key)
+	sandboxFeatures := sysInfo.SandboxFeatures
+	backends := make([]string, 0, len(sandboxFeatures))
+	for backend := range sandboxFeatures {
+		backends = append(backends, backend)
 	}
-	sort.Strings(keys)
+	sort.Strings(backends)
 
 	w := tabWriter()
 	defer w.Flush()
-	for _, key := range keys {
-		fmt.Fprintf(w, "%s:\t%s\n", key, strings.Join(sandbox[key], " "))
+	for _, backend := range backends {
+		fmt.Fprintf(w, "%s:\t%s\n", backend, strings.Join(sandboxFeatures[backend], " "))
 	}
 
 	return nil

--- a/cmd/snap/cmd_sandbox_features.go
+++ b/cmd/snap/cmd_sandbox_features.go
@@ -36,11 +36,15 @@ components used by snapd on a given system.
 `)
 
 type cmdSandboxFeatures struct {
-	Required []string `long:"required"`
+	Required []string `long:"required" arg-name:"<backend feature>"`
 }
 
 func init() {
-	addDebugCommand("sandbox-features", shortSandboxFeaturesHelp, longSandboxFeaturesHelp, func() flags.Commander { return &cmdSandboxFeatures{} })
+	addDebugCommand("sandbox-features", shortSandboxFeaturesHelp, longSandboxFeaturesHelp, func() flags.Commander {
+		return &cmdSandboxFeatures{}
+	}, map[string]string{
+		"required": i18n.G("Ensure that given backend:feature is available"),
+	}, nil)
 }
 
 func (cmd cmdSandboxFeatures) Execute(args []string) error {

--- a/cmd/snap/cmd_sandbox_features_test.go
+++ b/cmd/snap/cmd_sandbox_features_test.go
@@ -28,11 +28,11 @@ import (
 	snap "github.com/snapcore/snapd/cmd/snap"
 )
 
-func (s *SnapSuite) TestSandbox(c *C) {
+func (s *SnapSuite) TestSandboxFeatures(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `{"type": "sync", "result": {"sandbox": {"apparmor": ["a", "b", "c"], "selinux": ["1", "2", "3"]}}}`)
+		fmt.Fprintln(w, `{"type": "sync", "result": {"sandbox-features": {"apparmor": ["a", "b", "c"], "selinux": ["1", "2", "3"]}}}`)
 	})
-	_, err := snap.Parser().ParseArgs([]string{"debug", "sandbox"})
+	_, err := snap.Parser().ParseArgs([]string{"debug", "sandbox-features"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
 		"apparmor:  a b c\n"+

--- a/cmd/snap/cmd_sandbox_test.go
+++ b/cmd/snap/cmd_sandbox_test.go
@@ -35,7 +35,7 @@ func (s *SnapSuite) TestSandbox(c *C) {
 	_, err := snap.Parser().ParseArgs([]string{"debug", "sandbox"})
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, ""+
-		"apparmor:  a, b, c\n"+
-		"selinux:   1, 2, 3\n")
+		"apparmor:  a b c\n"+
+		"selinux:   1 2 3\n")
 	c.Assert(s.Stderr(), Equals, "")
 }

--- a/cmd/snap/cmd_sandbox_test.go
+++ b/cmd/snap/cmd_sandbox_test.go
@@ -1,0 +1,41 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+
+	. "gopkg.in/check.v1"
+
+	snap "github.com/snapcore/snapd/cmd/snap"
+)
+
+func (s *SnapSuite) TestSandbox(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type": "sync", "result": {"sandbox": {"apparmor": ["a", "b", "c"], "selinux": ["1", "2", "3"]}}}`)
+	})
+	_, err := snap.Parser().ParseArgs([]string{"debug", "sandbox"})
+	c.Assert(err, IsNil)
+	c.Assert(s.Stdout(), Equals, ""+
+		"apparmor:  a, b, c\n"+
+		"selinux:   1, 2, 3\n")
+	c.Assert(s.Stderr(), Equals, "")
+}

--- a/cmd/snap/main.go
+++ b/cmd/snap/main.go
@@ -114,12 +114,14 @@ func addCommand(name, shortHelp, longHelp string, builder func() flags.Commander
 // addDebugCommand replaces parser.addCommand() in a way that is
 // compatible with re-constructing a pristine parser. It is meant for
 // adding debug commands.
-func addDebugCommand(name, shortHelp, longHelp string, builder func() flags.Commander) *cmdInfo {
+func addDebugCommand(name, shortHelp, longHelp string, builder func() flags.Commander, optDescs map[string]string, argDescs []argDesc) *cmdInfo {
 	info := &cmdInfo{
 		name:      name,
 		shortHelp: shortHelp,
 		longHelp:  longHelp,
 		builder:   builder,
+		optDescs:  optDescs,
+		argDescs:  argDescs,
 	}
 	debugCommands = append(debugCommands, info)
 	return info
@@ -247,6 +249,39 @@ snaps on the system. Start with 'snap list' to see installed snaps.`)
 			logger.Panicf("cannot add debug command %q: %v", c.name, err)
 		}
 		cmd.Hidden = c.hidden
+		opts := cmd.Options()
+		if c.optDescs != nil && len(opts) != len(c.optDescs) {
+			logger.Panicf("wrong number of option descriptions for %s: expected %d, got %d", c.name, len(opts), len(c.optDescs))
+		}
+		for _, opt := range opts {
+			name := opt.LongName
+			if name == "" {
+				name = string(opt.ShortName)
+			}
+			desc, ok := c.optDescs[name]
+			if !(c.optDescs == nil || ok) {
+				logger.Panicf("%s missing description for %s", c.name, name)
+			}
+			lintDesc(c.name, name, desc, opt.Description)
+			if desc != "" {
+				opt.Description = desc
+			}
+		}
+
+		args := cmd.Args()
+		if c.argDescs != nil && len(args) != len(c.argDescs) {
+			logger.Panicf("wrong number of argument descriptions for %s: expected %d, got %d", c.name, len(args), len(c.argDescs))
+		}
+		for i, arg := range args {
+			name, desc := arg.Name, ""
+			if c.argDescs != nil {
+				name = c.argDescs[i].name
+				desc = c.argDescs[i].desc
+			}
+			lintArg(c.name, name, desc, arg.Description)
+			arg.Name = name
+			arg.Description = desc
+		}
 	}
 	return parser
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -325,26 +325,26 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 	}
 
 	// Convey richer information about features of available security backends.
-	if tags := sandboxTags(c.d.overlord.InterfaceManager().Repository().Backends()); tags != nil {
-		m["sandbox"] = tags
+	if features := sandboxFeatures(c.d.overlord.InterfaceManager().Repository().Backends()); features != nil {
+		m["sandbox-features"] = features
 	}
 
 	return SyncResponse(m, nil)
 }
 
-func sandboxTags(backends []interfaces.SecurityBackend) map[string][]string {
-	sandbox := make(map[string][]string, len(backends))
+func sandboxFeatures(backends []interfaces.SecurityBackend) map[string][]string {
+	result := make(map[string][]string, len(backends))
 	for _, backend := range backends {
-		tags := backend.SandboxTags()
-		if len(tags) > 0 {
-			sort.Strings(tags)
-			sandbox[string(backend.Name())] = tags
+		features := backend.SandboxFeatures()
+		if len(features) > 0 {
+			sort.Strings(features)
+			result[string(backend.Name())] = features
 		}
 	}
-	if len(sandbox) == 0 {
+	if len(result) == 0 {
 		return nil
 	}
-	return sandbox
+	return result
 }
 
 // userResponseData contains the data releated to user creation/login/query

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -324,7 +324,27 @@ func sysInfo(c *Command, r *http.Request, user *auth.UserState) Response {
 		m["confinement"] = "strict"
 	}
 
+	// Convey richer information about features of available security backends.
+	if tags := sandboxTags(c.d.overlord.InterfaceManager().Repository().Backends()); tags != nil {
+		m["sandbox"] = tags
+	}
+
 	return SyncResponse(m, nil)
+}
+
+func sandboxTags(backends []interfaces.SecurityBackend) map[string][]string {
+	sandbox := make(map[string][]string, len(backends))
+	for _, backend := range backends {
+		tags := backend.SandboxTags()
+		if len(tags) > 0 {
+			sort.Strings(tags)
+			sandbox[string(backend.Name())] = tags
+		}
+	}
+	if len(sandbox) == 0 {
+		return nil
+	}
+	return sandbox
 }
 
 // userResponseData contains the data releated to user creation/login/query

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -801,6 +801,13 @@ func (s *apiSuite) TestSysInfoLegacyRefresh(c *check.C) {
 	tr.Commit()
 	st.Unlock()
 
+	// add a test security backend
+	err := d.overlord.InterfaceManager().Repository().AddBackend(&ifacetest.TestSecurityBackend{
+		BackendName:         "apparmor",
+		SandboxTagsCallback: func() []string { return []string{"tag-1", "tag-2"} },
+	})
+	c.Assert(err, check.IsNil)
+
 	buildID, err := osutil.MyBuildID()
 	c.Assert(err, check.IsNil)
 
@@ -827,6 +834,7 @@ func (s *apiSuite) TestSysInfoLegacyRefresh(c *check.C) {
 			"schedule": "00:00-9:00/12:00-13:00",
 		},
 		"confinement": "partial",
+		"sandbox":     map[string]interface{}{"apparmor": []interface{}{"tag-1", "tag-2"}},
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -803,8 +803,8 @@ func (s *apiSuite) TestSysInfoLegacyRefresh(c *check.C) {
 
 	// add a test security backend
 	err := d.overlord.InterfaceManager().Repository().AddBackend(&ifacetest.TestSecurityBackend{
-		BackendName:         "apparmor",
-		SandboxTagsCallback: func() []string { return []string{"tag-1", "tag-2"} },
+		BackendName:             "apparmor",
+		SandboxFeaturesCallback: func() []string { return []string{"feature-1", "feature-2"} },
 	})
 	c.Assert(err, check.IsNil)
 
@@ -833,8 +833,8 @@ func (s *apiSuite) TestSysInfoLegacyRefresh(c *check.C) {
 			// only the "schedule" field
 			"schedule": "00:00-9:00/12:00-13:00",
 		},
-		"confinement": "partial",
-		"sandbox":     map[string]interface{}{"apparmor": []interface{}{"tag-1", "tag-2"}},
+		"confinement":      "partial",
+		"sandbox-features": map[string]interface{}{"apparmor": []interface{}{"feature-1", "feature-2"}},
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -494,8 +494,8 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
 
-// SandboxTags returns the list of apparmor features supported by the kernel.
-func (b *Backend) SandboxTags() []string {
+// SandboxFeatures returns the list of apparmor features supported by the kernel.
+func (b *Backend) SandboxFeatures() []string {
 	features := kernelFeatures()
 	tags := make([]string, 0, len(features))
 	for _, feature := range features {

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -60,7 +60,7 @@ var (
 	procSelfExe           = "/proc/self/exe"
 	isHomeUsingNFS        = osutil.IsHomeUsingNFS
 	isRootWritableOverlay = osutil.IsRootWritableOverlay
-	sandboxTags           = release.AppArmorFeatures
+	kernelFeatures        = release.AppArmorFeatures
 )
 
 // Backend is responsible for maintaining apparmor profiles for snaps and parts of snapd.
@@ -496,5 +496,12 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 
 // SandboxTags returns the list of apparmor features supported by the kernel.
 func (b *Backend) SandboxTags() []string {
-	return sandboxTags()
+	features := kernelFeatures()
+	tags := make([]string, 0, len(features))
+	for _, feature := range features {
+		// Prepend "kernel:" to apparmor kernel features to namespace them and
+		// allow us to introduce our own tags later.
+		tags = append(tags, "kernel:"+feature)
+	}
+	return tags
 }

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -60,6 +60,7 @@ var (
 	procSelfExe           = "/proc/self/exe"
 	isHomeUsingNFS        = osutil.IsHomeUsingNFS
 	isRootWritableOverlay = osutil.IsRootWritableOverlay
+	sandboxTags           = release.AppArmorFeatures
 )
 
 // Backend is responsible for maintaining apparmor profiles for snaps and parts of snapd.
@@ -491,4 +492,9 @@ func unloadProfiles(profiles []string, cacheDir string) error {
 // NewSpecification returns a new, empty apparmor specification.
 func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
+}
+
+// SandboxTags returns the list of apparmor features supported by the kernel.
+func (b *Backend) SandboxTags() []string {
+	return sandboxTags()
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1202,8 +1202,8 @@ func (s *backendSuite) TestNsProfile(c *C) {
 }
 
 func (s *backendSuite) TestSandboxTags(c *C) {
-	restore := apparmor.MockSandboxTags(func() []string { return []string{"foo", "bar"} })
+	restore := apparmor.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
 	defer restore()
 
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"foo", "bar"})
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"kernel:foo", "kernel:bar"})
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1201,9 +1201,9 @@ func (s *backendSuite) TestNsProfile(c *C) {
 	c.Assert(apparmor.NsProfile("foo"), Equals, "snap-update-ns.foo")
 }
 
-func (s *backendSuite) TestSandboxTags(c *C) {
+func (s *backendSuite) TestSandboxFeatures(c *C) {
 	restore := apparmor.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
 	defer restore()
 
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"kernel:foo", "kernel:bar"})
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar"})
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1200,3 +1200,10 @@ func (s *backendSuite) TestProfileGlobs(c *C) {
 func (s *backendSuite) TestNsProfile(c *C) {
 	c.Assert(apparmor.NsProfile("foo"), Equals, "snap-update-ns.foo")
 }
+
+func (s *backendSuite) TestSandboxTags(c *C) {
+	restore := apparmor.MockSandboxTags(func() []string { return []string{"foo", "bar"} })
+	defer restore()
+
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"foo", "bar"})
+}

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -88,3 +88,11 @@ func MockClassicTemplate(fakeTemplate string) (restore func()) {
 func SetSpecScope(spec *Specification, securityTags []string) (restore func()) {
 	return spec.setScope(securityTags)
 }
+
+func MockSandboxTags(f func() []string) (resture func()) {
+	old := sandboxTags
+	sandboxTags = f
+	return func() {
+		sandboxTags = old
+	}
+}

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -89,10 +89,10 @@ func SetSpecScope(spec *Specification, securityTags []string) (restore func()) {
 	return spec.setScope(securityTags)
 }
 
-func MockSandboxTags(f func() []string) (resture func()) {
-	old := sandboxTags
-	sandboxTags = f
+func MockKernelFeatures(f func() []string) (resture func()) {
+	old := kernelFeatures
+	kernelFeatures = f
 	return func() {
-		sandboxTags = old
+		kernelFeatures = old
 	}
 }

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -91,4 +91,7 @@ type SecurityBackend interface {
 
 	// NewSpecification returns a new specification associated with this backend.
 	NewSpecification() Specification
+
+	// SandboxTags returns a list of tags that identify sandbox features.
+	SandboxTags() []string
 }

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -92,6 +92,6 @@ type SecurityBackend interface {
 	// NewSpecification returns a new specification associated with this backend.
 	NewSpecification() Specification
 
-	// SandboxTags returns a list of tags that identify sandbox features.
-	SandboxTags() []string
+	// SandboxFeatures returns a list of tags that identify sandbox features.
+	SandboxFeatures() []string
 }

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -171,5 +171,5 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 
 // SandboxTags returns list of features supported by snapd for dbus communication.
 func (b *Backend) SandboxTags() []string {
-	return []string{"mediated-bus-names"}
+	return []string{"mediated-bus-access"}
 }

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -169,7 +169,7 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
 
-// SandboxTags returns list of features supported by snapd for dbus communication.
-func (b *Backend) SandboxTags() []string {
+// SandboxFeatures returns list of features supported by snapd for dbus communication.
+func (b *Backend) SandboxFeatures() []string {
 	return []string{"mediated-bus-access"}
 }

--- a/interfaces/dbus/backend.go
+++ b/interfaces/dbus/backend.go
@@ -168,3 +168,8 @@ func addContent(securityTag string, snippet string, content map[string]*osutil.F
 func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
+
+// SandboxTags returns list of features supported by snapd for dbus communication.
+func (b *Backend) SandboxTags() []string {
+	return []string{"mediated-bus-names"}
+}

--- a/interfaces/dbus/backend_test.go
+++ b/interfaces/dbus/backend_test.go
@@ -274,3 +274,7 @@ func (s *backendSuite) TestAppBoundIfaces(c *C) {
 	_, err = os.Stat(filepath.Join(dirs.SnapBusPolicyDir, "snap.samba.nmbd.conf"))
 	c.Check(err, IsNil)
 }
+
+func (s *backendSuite) TestSandboxTags(c *C) {
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"mediated-bus-names"})
+}

--- a/interfaces/dbus/backend_test.go
+++ b/interfaces/dbus/backend_test.go
@@ -276,5 +276,5 @@ func (s *backendSuite) TestAppBoundIfaces(c *C) {
 }
 
 func (s *backendSuite) TestSandboxTags(c *C) {
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"mediated-bus-names"})
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"mediated-bus-access"})
 }

--- a/interfaces/dbus/backend_test.go
+++ b/interfaces/dbus/backend_test.go
@@ -275,6 +275,6 @@ func (s *backendSuite) TestAppBoundIfaces(c *C) {
 	c.Check(err, IsNil)
 }
 
-func (s *backendSuite) TestSandboxTags(c *C) {
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"mediated-bus-access"})
+func (s *backendSuite) TestSandboxFeatures(c *C) {
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"mediated-bus-access"})
 }

--- a/interfaces/ifacetest/backend.go
+++ b/interfaces/ifacetest/backend.go
@@ -35,6 +35,8 @@ type TestSecurityBackend struct {
 	SetupCallback func(snapInfo *snap.Info, opts interfaces.ConfinementOptions, repo *interfaces.Repository) error
 	// RemoveCallback is a callback that is optionally called in Remove
 	RemoveCallback func(snapName string) error
+	// SandboxTagsCallback is a callback that is optionally called in SandboxTags
+	SandboxTagsCallback func() []string
 }
 
 // TestSetupCall stores details about calls to TestSecurityBackend.Setup
@@ -75,4 +77,11 @@ func (b *TestSecurityBackend) Remove(snapName string) error {
 
 func (b *TestSecurityBackend) NewSpecification() interfaces.Specification {
 	return &Specification{}
+}
+
+func (b *TestSecurityBackend) SandboxTags() []string {
+	if b.SandboxTagsCallback == nil {
+		return nil
+	}
+	return b.SandboxTagsCallback()
 }

--- a/interfaces/ifacetest/backend.go
+++ b/interfaces/ifacetest/backend.go
@@ -35,8 +35,8 @@ type TestSecurityBackend struct {
 	SetupCallback func(snapInfo *snap.Info, opts interfaces.ConfinementOptions, repo *interfaces.Repository) error
 	// RemoveCallback is a callback that is optionally called in Remove
 	RemoveCallback func(snapName string) error
-	// SandboxTagsCallback is a callback that is optionally called in SandboxTags
-	SandboxTagsCallback func() []string
+	// SandboxFeaturesCallback is a callback that is optionally called in SandboxFeatures
+	SandboxFeaturesCallback func() []string
 }
 
 // TestSetupCall stores details about calls to TestSecurityBackend.Setup
@@ -79,9 +79,9 @@ func (b *TestSecurityBackend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
 
-func (b *TestSecurityBackend) SandboxTags() []string {
-	if b.SandboxTagsCallback == nil {
+func (b *TestSecurityBackend) SandboxFeatures() []string {
+	if b.SandboxFeaturesCallback == nil {
 		return nil
 	}
-	return b.SandboxTagsCallback()
+	return b.SandboxFeaturesCallback()
 }

--- a/interfaces/kmod/backend.go
+++ b/interfaces/kmod/backend.go
@@ -132,7 +132,7 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
 
-// SandboxTags returns the list of features supported by snapd for loading kernel modules.
-func (b *Backend) SandboxTags() []string {
+// SandboxFeatures returns the list of features supported by snapd for loading kernel modules.
+func (b *Backend) SandboxFeatures() []string {
 	return []string{"mediated-modprobe"}
 }

--- a/interfaces/kmod/backend.go
+++ b/interfaces/kmod/backend.go
@@ -131,3 +131,8 @@ func deriveContent(spec *Specification, snapInfo *snap.Info) (map[string]*osutil
 func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
+
+// SandboxTags returns the list of features supported by snapd for loading kernel modules.
+func (b *Backend) SandboxTags() []string {
+	return []string{"mediated-modprobe"}
+}

--- a/interfaces/kmod/backend_test.go
+++ b/interfaces/kmod/backend_test.go
@@ -131,3 +131,7 @@ func (s *backendSuite) TestSecurityIsStable(c *C) {
 		s.RemoveSnap(c, snapInfo)
 	}
 }
+
+func (s *backendSuite) TestSandboxTags(c *C) {
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"mediated-modprobe"})
+}

--- a/interfaces/kmod/backend_test.go
+++ b/interfaces/kmod/backend_test.go
@@ -132,6 +132,6 @@ func (s *backendSuite) TestSecurityIsStable(c *C) {
 	}
 }
 
-func (s *backendSuite) TestSandboxTags(c *C) {
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"mediated-modprobe"})
+func (s *backendSuite) TestSandboxFeatures(c *C) {
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"mediated-modprobe"})
 }

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -121,3 +121,17 @@ func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.
 func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
+
+// SandboxTags returns the list of features supported by snapd for composing mount namespaces.
+func (b *Backend) SandboxTags() []string {
+	return []string{
+		"freezer-cgroup-v1",       /* Snapd creates a freezer cgroup (v1) for each snap */
+		"layouts-beta",            /* Mount profiles take layout data into account (experimental) */
+		"mount-namespace",         /* Snapd creates a mount namespace for each snap */
+		"per-snap-persistency",    /* Per-snap profiles are persisted across invocations */
+		"per-snap-profiles",       /* Per-snap profiles allow changing mount namespace of a given snap */
+		"per-snap-updates",        /* Changes to per-snap mount profiles are applied instantly */
+		"per-snap-user-profiles",  /* Per-snap profiles allow changing mount namespace of a given snap for a given user */
+		"stale-base-invalidation", /* Mount namespaces that go stale because base snap changes are automatically invalidated */
+	}
+}

--- a/interfaces/mount/backend.go
+++ b/interfaces/mount/backend.go
@@ -122,8 +122,8 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
 
-// SandboxTags returns the list of features supported by snapd for composing mount namespaces.
-func (b *Backend) SandboxTags() []string {
+// SandboxFeatures returns the list of features supported by snapd for composing mount namespaces.
+func (b *Backend) SandboxFeatures() []string {
 	return []string{
 		"freezer-cgroup-v1",       /* Snapd creates a freezer cgroup (v1) for each snap */
 		"layouts-beta",            /* Mount profiles take layout data into account (experimental) */

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -170,8 +170,8 @@ func (s *backendSuite) TestSetupSetsupWithoutDir(c *C) {
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, mockSnapYaml, 0)
 }
 
-func (s *backendSuite) TestSandboxTags(c *C) {
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{
+func (s *backendSuite) TestSandboxFeatures(c *C) {
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{
 		"freezer-cgroup-v1",
 		"layouts-beta",
 		"mount-namespace",

--- a/interfaces/mount/backend_test.go
+++ b/interfaces/mount/backend_test.go
@@ -169,3 +169,16 @@ func (s *backendSuite) TestSetupSetsupWithoutDir(c *C) {
 	os.Remove(dirs.SnapMountPolicyDir)
 	s.InstallSnap(c, interfaces.ConfinementOptions{}, mockSnapYaml, 0)
 }
+
+func (s *backendSuite) TestSandboxTags(c *C) {
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{
+		"freezer-cgroup-v1",
+		"layouts-beta",
+		"mount-namespace",
+		"per-snap-persistency",
+		"per-snap-profiles",
+		"per-snap-updates",
+		"per-snap-user-profiles",
+		"stale-base-invalidation",
+	})
+}

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -49,8 +49,8 @@ import (
 )
 
 var (
-	osReadlink  = os.Readlink
-	sandboxTags = release.SecCompActions
+	osReadlink     = os.Readlink
+	kernelFeatures = release.SecCompActions
 )
 
 func seccompToBpfPath() string {
@@ -199,5 +199,12 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 
 // SandboxTags returns the list of seccomp features supported by the kernel.
 func (b *Backend) SandboxTags() []string {
-	return sandboxTags()
+	features := kernelFeatures()
+	tags := make([]string, 0, len(features))
+	for _, feature := range features {
+		// Prepend "kernel:" to apparmor kernel features to namespace them and
+		// allow us to introduce our own tags later.
+		tags = append(tags, "kernel:"+feature)
+	}
+	return tags
 }

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -200,11 +200,12 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 // SandboxTags returns the list of seccomp features supported by the kernel.
 func (b *Backend) SandboxTags() []string {
 	features := kernelFeatures()
-	tags := make([]string, 0, len(features))
+	tags := make([]string, 0, len(features)+1)
 	for _, feature := range features {
 		// Prepend "kernel:" to apparmor kernel features to namespace them and
 		// allow us to introduce our own tags later.
 		tags = append(tags, "kernel:"+feature)
 	}
+	tags = append(tags, "bpf-argument-filtering")
 	return tags
 }

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -48,7 +48,10 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-var osReadlink = os.Readlink
+var (
+	osReadlink  = os.Readlink
+	sandboxTags = release.SecCompActions
+)
 
 func seccompToBpfPath() string {
 	// FIXME: use cmd.InternalToolPath here once:
@@ -192,4 +195,9 @@ func addContent(securityTag string, opts interfaces.ConfinementOptions, snippetF
 // NewSpecification returns an empty seccomp specification.
 func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
+}
+
+// SandboxTags returns the list of seccomp features supported by the kernel.
+func (b *Backend) SandboxTags() []string {
+	return sandboxTags()
 }

--- a/interfaces/seccomp/backend.go
+++ b/interfaces/seccomp/backend.go
@@ -197,8 +197,8 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
 
-// SandboxTags returns the list of seccomp features supported by the kernel.
-func (b *Backend) SandboxTags() []string {
+// SandboxFeatures returns the list of seccomp features supported by the kernel.
+func (b *Backend) SandboxFeatures() []string {
 	features := kernelFeatures()
 	tags := make([]string, 0, len(features)+1)
 	for _, feature := range features {

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -387,8 +387,8 @@ func (s *backendSuite) TestSystemKeyRetLogUnsupported(c *C) {
 }
 
 func (s *backendSuite) TestSandboxTags(c *C) {
-	restore := seccomp.MockSandboxTags(func() []string { return []string{"foo", "bar"} })
+	restore := seccomp.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
 	defer restore()
 
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"foo", "bar"})
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"kernel:foo", "kernel:bar"})
 }

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -386,9 +386,9 @@ func (s *backendSuite) TestSystemKeyRetLogUnsupported(c *C) {
 	s.RemoveSnap(c, snapInfo)
 }
 
-func (s *backendSuite) TestSandboxTags(c *C) {
+func (s *backendSuite) TestSandboxFeatures(c *C) {
 	restore := seccomp.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
 	defer restore()
 
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"kernel:foo", "kernel:bar", "bpf-argument-filtering"})
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"kernel:foo", "kernel:bar", "bpf-argument-filtering"})
 }

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -390,5 +390,5 @@ func (s *backendSuite) TestSandboxTags(c *C) {
 	restore := seccomp.MockKernelFeatures(func() []string { return []string{"foo", "bar"} })
 	defer restore()
 
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"kernel:foo", "kernel:bar"})
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"kernel:foo", "kernel:bar", "bpf-argument-filtering"})
 }

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -385,3 +385,10 @@ func (s *backendSuite) TestSystemKeyRetLogUnsupported(c *C) {
 	c.Assert(profile+".src", Not(testutil.FileContains), "# complain mode logging unavailable\n")
 	s.RemoveSnap(c, snapInfo)
 }
+
+func (s *backendSuite) TestSandboxTags(c *C) {
+	restore := seccomp.MockSandboxTags(func() []string { return []string{"foo", "bar"} })
+	defer restore()
+
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{"foo", "bar"})
+}

--- a/interfaces/seccomp/export_test.go
+++ b/interfaces/seccomp/export_test.go
@@ -36,3 +36,11 @@ func MockOsReadlink(f func(string) (string, error)) (restore func()) {
 		osReadlink = realOsReadlink
 	}
 }
+
+func MockSandboxTags(f func() []string) (resture func()) {
+	old := sandboxTags
+	sandboxTags = f
+	return func() {
+		sandboxTags = old
+	}
+}

--- a/interfaces/seccomp/export_test.go
+++ b/interfaces/seccomp/export_test.go
@@ -37,10 +37,10 @@ func MockOsReadlink(f func(string) (string, error)) (restore func()) {
 	}
 }
 
-func MockSandboxTags(f func() []string) (resture func()) {
-	old := sandboxTags
-	sandboxTags = f
+func MockKernelFeatures(f func() []string) (resture func()) {
+	old := kernelFeatures
+	kernelFeatures = f
 	return func() {
-		sandboxTags = old
+		kernelFeatures = old
 	}
 }

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -126,6 +126,11 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
 
+// SandboxTags returns nil
+func (b *Backend) SandboxTags() []string {
+	return nil
+}
+
 // deriveContent computes .service files based on requests made to the specification.
 func deriveContent(spec *Specification, snapInfo *snap.Info) map[string]*osutil.FileState {
 	services := spec.Services()

--- a/interfaces/systemd/backend.go
+++ b/interfaces/systemd/backend.go
@@ -126,8 +126,8 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
 
-// SandboxTags returns nil
-func (b *Backend) SandboxTags() []string {
+// SandboxFeatures returns nil
+func (b *Backend) SandboxFeatures() []string {
 	return nil
 }
 

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -153,3 +153,7 @@ func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 		{"systemctl", "daemon-reload"},
 	})
 }
+
+func (s *backendSuite) TestSandboxTags(c *C) {
+	c.Assert(s.Backend.SandboxTags(), IsNil)
+}

--- a/interfaces/systemd/backend_test.go
+++ b/interfaces/systemd/backend_test.go
@@ -154,6 +154,6 @@ func (s *backendSuite) TestSettingUpSecurityWithFewerServices(c *C) {
 	})
 }
 
-func (s *backendSuite) TestSandboxTags(c *C) {
-	c.Assert(s.Backend.SandboxTags(), IsNil)
+func (s *backendSuite) TestSandboxFeatures(c *C) {
+	c.Assert(s.Backend.SandboxFeatures(), IsNil)
 }

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -151,8 +151,8 @@ func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
 
-// SandboxTags returns the list of features supported by snapd for mediating access to kernel devices.
-func (b *Backend) SandboxTags() []string {
+// SandboxFeatures returns the list of features supported by snapd for mediating access to kernel devices.
+func (b *Backend) SandboxFeatures() []string {
 	return []string{
 		"device-cgroup-v1", /* Snapd creates a device group (v1) for each snap */
 		"tagging",          /* Tagging dynamically associates new devices with specific snaps */

--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -150,3 +150,11 @@ func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info) (conte
 func (b *Backend) NewSpecification() interfaces.Specification {
 	return &Specification{}
 }
+
+// SandboxTags returns the list of features supported by snapd for mediating access to kernel devices.
+func (b *Backend) SandboxTags() []string {
+	return []string{
+		"device-cgroup-v1", /* Snapd creates a device group (v1) for each snap */
+		"tagging",          /* Tagging dynamically associates new devices with specific snaps */
+	}
+}

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -414,8 +414,8 @@ func (s *backendSuite) TestUpdatingSnapWithoutSlotsToOneWithoutSlots(c *C) {
 	}
 }
 
-func (s *backendSuite) TestSandboxTags(c *C) {
-	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{
+func (s *backendSuite) TestSandboxFeatures(c *C) {
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{
 		"device-cgroup-v1",
 		"tagging",
 	})

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -413,3 +413,10 @@ func (s *backendSuite) TestUpdatingSnapWithoutSlotsToOneWithoutSlots(c *C) {
 		s.RemoveSnap(c, snapInfo)
 	}
 }
+
+func (s *backendSuite) TestSandboxTags(c *C) {
+	c.Assert(s.Backend.SandboxTags(), DeepEquals, []string{
+		"device-cgroup-v1",
+		"tagging",
+	})
+}

--- a/tests/main/debug-sandbox/task.yaml
+++ b/tests/main/debug-sandbox/task.yaml
@@ -2,10 +2,12 @@ summary: Verify sandbox is correctly reported
 
 execute: |
     case "$SPREAD_SYSTEM" in
-    ubuntu-*|debian-*)
+    ubuntu-*)
         snap debug sandbox | MATCH "apparmor: .+"
         ;;
-    fedora-*)
+    fedora-*|debian-*|opensuse-*)
+        # Fedora because it uses SELinux
+        # Debian and openSUSE because partial apparmor is not enabled
         snap debug sandbox | MATCH -v "apparmor: .+"
         ;;
     esac

--- a/tests/main/debug-sandbox/task.yaml
+++ b/tests/main/debug-sandbox/task.yaml
@@ -1,0 +1,16 @@
+summary: Verify sandbox is correctly reported
+
+execute: |
+    case "$SPREAD_SYSTEM" in
+    ubuntu-*|debian-*)
+        snap debug sandbox | MATCH "apparmor: .+"
+        ;;
+    fedora-*)
+        snap debug sandbox | MATCH -v "apparmor: .+"
+        ;;
+    esac
+    snap debug sandbox | MATCH "dbus: .+"
+    snap debug sandbox | MATCH "kmod: .+"
+    snap debug sandbox | MATCH "mount: .+"
+    snap debug sandbox | MATCH "seccomp: .+"
+    snap debug sandbox | MATCH "udev: .+"

--- a/tests/main/debug-sandbox/task.yaml
+++ b/tests/main/debug-sandbox/task.yaml
@@ -3,16 +3,23 @@ summary: Verify sandbox is correctly reported
 execute: |
     case "$SPREAD_SYSTEM" in
     ubuntu-*)
-        snap debug sandbox | MATCH "apparmor: .+"
+        snap debug sandbox-features | MATCH "apparmor: .+"
         ;;
     fedora-*|debian-*|opensuse-*)
         # Fedora because it uses SELinux
         # Debian and openSUSE because partial apparmor is not enabled
-        snap debug sandbox | MATCH -v "apparmor: .+"
+        snap debug sandbox-features | MATCH -v "apparmor: .+"
         ;;
     esac
-    snap debug sandbox | MATCH "dbus: .+"
-    snap debug sandbox | MATCH "kmod: .+"
-    snap debug sandbox | MATCH "mount: .+"
-    snap debug sandbox | MATCH "seccomp: .+"
-    snap debug sandbox | MATCH "udev: .+"
+    snap debug sandbox-features | MATCH "dbus: .+"
+    snap debug sandbox-features | MATCH "kmod: .+"
+    snap debug sandbox-features | MATCH "mount: .+"
+    snap debug sandbox-features | MATCH "seccomp: .+"
+    snap debug sandbox-features | MATCH "udev: .+"
+
+    # The command can be used as script helper
+    snap debug sandbox-features --required kmod:mediated-modprobe
+    ! snap debug sandbox-features --required magic:evil-bit
+
+    # Multiple requirements may be listed
+    snap debug sandbox-features --required kmod:mediated-modprobe --required mount:stale-base-invalidation


### PR DESCRIPTION
This patch adds a way to inspect the features of the sandbox from a new
hidden, debugging command. The command shows a set of tags for each of
the security backends that are in use.

Having access to this command helps in two ways:

First of all, this is far more comprehensive and informative than the
very dry "partial" vs "full" output of "snap debug confinement". Snapd
offers a wide range of confinement technologies when used on a mainline
kernel and this should be celebrated.

Second of all having this allows us to write more precise tests. If a
test needs to be skipped because a specific thing is absent can now be
codified directly. This will allow both Debian and openSUSE to run far
more confinement-specific tests than we currently do simply because
"partial" apparmor is reported. Mainline kernel is very close to full
apparmor patch used by Ubuntu and the remaining differences don't apply
to many existing tests.

Technically this patch adds the key "sandbox", defined as a map of lists
of strings, to the sysinfo API and uses it in the new hidden command.
Each of the security backends can now optionally offer sandbox tags that
are associated with the backend name in the said map.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>