### PR TITLE
boot: clear "snap_mode" when needed (2.32)

### DIFF
--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -128,11 +128,22 @@ func SetNextBoot(s *snap.Info) error {
 
 	// check if we actually need to do anything, i.e. the exact same
 	// kernel/core revision got installed again (e.g. firstboot)
-	m, err := bootloader.GetBootVars(goodBoot)
+	// and we are not in any special boot mode
+	m, err := bootloader.GetBootVars("snap_mode", goodBoot)
 	if err != nil {
 		return err
 	}
 	if m[goodBoot] == blobName {
+		// If we were in "try" mode before and now switch to
+		// the good core/kernel again, make sure to clean the
+		// snap_mode here. This also mitigates
+		// https://forum.snapcraft.io/t//5253
+		if m["snap_mode"] != "" {
+			return bootloader.SetBootVars(map[string]string{
+				"snap_mode": "",
+				nextBoot:    "",
+			})
+		}
 		return nil
 	}
 

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -217,12 +217,16 @@ func (s *kernelOSSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {
 	info.Revision = snap.R(40)
 
 	s.bootloader.BootVars["snap_kernel"] = "krnl_40.snap"
+	s.bootloader.BootVars["snap_try_kernel"] = "krnl_99.snap"
+	s.bootloader.BootVars["snap_mode"] = "try"
 
 	err := boot.SetNextBoot(info)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.bootloader.BootVars, DeepEquals, map[string]string{
-		"snap_kernel": "krnl_40.snap",
+		"snap_kernel":     "krnl_40.snap",
+		"snap_try_kernel": "",
+		"snap_mode":       "",
 	})
 }
 


### PR DESCRIPTION
When we set the next boot to an already good boot {core,os} we
need to clear the snap_mode as well. Otherwise the system still
tries to reboot for now good reason.

This also mitigates the corruption we see in
https://forum.snapcraft.io/t//5253 because:

1. snapd refreshes, sets snap_mode=try
2. reboot
3. uboot writes corrupted uboot.env with snap_mode=trying
4. fsck.vfat runs and renames (incorrectly) corrupted uboot.env
   to fsck0000.000:uboot.env which looks to linux vfat like a
   duplicated file
5. snapd reads uboot.env which is the "old" file with snap_mode=try
6. snapd assumes something went wrong and reverts to the previous
   revison of the core but SetNextBoot sees that snap_core is
   identical to the blob that is requested and does nothing. However
   this leaves the "try" and "snap_try_core=" intact so on reboot
   uboot will try the now removed core. With this patch the
   snap_mode and snap_try_core is also cleared and we do boot into
   the previous good core again.IBUTING.md)?
