### PR TITLE
tests: use journalctl cursors instead rotating logs

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -288,7 +288,9 @@ exclude:
 
 debug-each: |
     if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
-        . "$TESTSLIB"/journalctl.sh
+        # shellcheck source=tests/lib/journalctl.sh
+        . "$TESTSLIB/journalctl.sh"
+
         echo '# journal messages for snapd'
         get_journalctl_log -u snapd
         echo '# apparmor denials '

--- a/spread.yaml
+++ b/spread.yaml
@@ -288,8 +288,9 @@ exclude:
 
 debug-each: |
     if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
+        . "$TESTSLIB"/journalctl.sh
         echo '# journal messages for snapd'
-        journalctl -u snapd
+        get_journalctl_log -u snapd
         echo '# apparmor denials '
         dmesg --ctime | grep DENIED || true
         echo '# seccomp denials (kills) '

--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -3,14 +3,7 @@
 JOURNALCTL_CURSOR_FILE="${SPREAD_PATH}"/journalctl_cursor
 
 get_last_journalctl_cursor(){
-    # It is not being used journalctl json output because jq is not installed on
-    # core systems
-    if [ -z "$(which jq)" ]; then
-        cursor=$(journalctl --output=export -n1 | grep -e '__CURSOR=')
-        echo ${cursor#__CURSOR=}
-    else
-        journalctl --output=json -n1 | jq -r '.__CURSOR'
-    fi
+    journalctl --output=export -n1 | grep --binary-files=text -o '__CURSOR=.*' | sed -e 's/^__CURSOR=//'
 }
 
 start_new_journalctl_log(){
@@ -25,10 +18,11 @@ start_new_journalctl_log(){
 
 get_journalctl_log(){
     cursor=$(cat "$JOURNALCTL_CURSOR_FILE")
-    journalctl "$@" --cursor "$cursor"
+    get_journalctl_log_from_cursor "$cursor" "$@"
 }
 
 get_journalctl_log_from_cursor(){
     cursor=$1
+    shift
     journalctl "$@" --cursor "$cursor"
 }

--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -3,7 +3,10 @@
 JORNALCTL_CURSOR_FILE="${SPREAD_PATH}"/journalctl_cursor
 
 get_last_journalctl_cursor(){
-    journalctl --output=json -n1 | jq -r '.__CURSOR'
+    # It is not being used journalctl json output because jq is not installed on
+    # core systems
+    cursor=$(journalctl --output=export -n1 | grep -e '__CURSOR=')
+    echo ${cursor#*=}
 }
 
 start_new_journalctl_log(){

--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+JORNALCTL_CURSOR_FILE="${SPREAD_PATH}"/journalctl_cursor
+
+get_last_journalctl_cursor(){
+    journalctl --output=json -n1 | jq -r '.__CURSOR'
+}
+
+start_new_journalctl_log(){
+    cursor=$(get_last_journalctl_cursor)
+    if [ -z "$cursor" ]; then
+        echo "Empty journalctl cursor, exiting..."
+        exit 1
+    else
+        echo "$cursor" > "$JORNALCTL_CURSOR_FILE"
+    fi
+}
+
+get_journalctl_log(){
+    cursor=$(cat "$JORNALCTL_CURSOR_FILE")
+    journalctl "$@" --cursor "$cursor"
+}
+
+get_journalctl_log_from_cursor(){
+    cursor=$1
+    journalctl "$@" --cursor "$cursor"
+}

--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 
-JORNALCTL_CURSOR_FILE="${SPREAD_PATH}"/journalctl_cursor
+JOURNALCTL_CURSOR_FILE="${SPREAD_PATH}"/journalctl_cursor
 
 get_last_journalctl_cursor(){
     # It is not being used journalctl json output because jq is not installed on
     # core systems
-    cursor=$(journalctl --output=export -n1 | grep -e '__CURSOR=')
-    echo ${cursor#*=}
+    if [ -z "$(which jq)" ]; then
+        cursor=$(journalctl --output=export -n1 | grep -e '__CURSOR=')
+        echo ${cursor#__CURSOR=}
+    else
+        journalctl --output=json -n1 | jq -r '.__CURSOR'
+    fi
 }
 
 start_new_journalctl_log(){
@@ -15,12 +19,12 @@ start_new_journalctl_log(){
         echo "Empty journalctl cursor, exiting..."
         exit 1
     else
-        echo "$cursor" > "$JORNALCTL_CURSOR_FILE"
+        echo "$cursor" > "$JOURNALCTL_CURSOR_FILE"
     fi
 }
 
 get_journalctl_log(){
-    cursor=$(cat "$JORNALCTL_CURSOR_FILE")
+    cursor=$(cat "$JOURNALCTL_CURSOR_FILE")
     journalctl "$@" --cursor "$cursor"
 }
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -28,6 +28,10 @@ set -o pipefail
 # shellcheck source=tests/lib/spread-funcs.sh
 . "$TESTSLIB/spread-funcs.sh"
 
+# shellcheck source=tests/lib/journalctl.sh
+. "$TESTSLIB/journalctl.sh"
+
+
 ###
 ### Utility functions reused below.
 ###
@@ -369,34 +373,8 @@ prepare_project_each() {
     # We want to rotate the logs so that when inspecting or dumping them we
     # will just see logs since the test has started.
 
-    # Clear the systemd journal. Unfortunately the deputy-systemd on Ubuntu
-    # 14.04 does not know about --rotate or --vacuum-time so we need to remove
-    # the journal the hard way.
-    case "$SPREAD_SYSTEM" in
-        ubuntu-14.04-*)
-            # Force a log rotation with small size
-            sed -i.bak s/#SystemMaxUse=/SystemMaxUse=1K/g /etc/systemd/journald.conf
-            systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
-
-            # Restore the initial configuration and rotate logs
-            mv /etc/systemd/journald.conf.bak /etc/systemd/journald.conf
-            systemctl kill --kill-who=main --signal=SIGUSR2 systemd-journald.service
-
-            # Remove rotated journal logs
-            systemctl stop systemd-journald.service
-            find /run/log/journal/ -name "*@*.journal" -delete
-            systemctl start systemd-journald.service
-            ;;
-        *)
-            # per journalctl's implementation, --rotate and --sync 'override'
-            # each other if used in a single command, with the one appearing
-            # later being effective
-            journalctl --sync
-            journalctl --rotate
-            sleep .1
-            journalctl --vacuum-time=1ms
-            ;;
-    esac
+    # Reset systemd journal cursor.
+    start_new_journalctl_log
 
     # Clear the kernel ring buffer.
     dmesg -c > /dev/null

--- a/tests/lib/store.sh
+++ b/tests/lib/store.sh
@@ -5,6 +5,9 @@ STORE_CONFIG=/etc/systemd/system/snapd.service.d/store.conf
 # shellcheck source=tests/lib/systemd.sh
 . "$TESTSLIB/systemd.sh"
 
+# shellcheck source=tests/lib/journalctl.sh
+. "$TESTSLIB/journalctl.sh"
+
 _configure_store_backends(){
     systemctl stop snapd.service snapd.socket
     mkdir -p "$(dirname $STORE_CONFIG)"
@@ -76,7 +79,7 @@ setup_fake_store(){
 
     echo "fakestore service not started properly"
     netstat -ntlp | grep "127.0.0.1:11028" || true
-    journalctl -u fakestore || true
+    get_journalctl_log -u fakestore || true
     systemctl status fakestore || true
     exit 1
 }

--- a/tests/main/catalog-update/task.yaml
+++ b/tests/main/catalog-update/task.yaml
@@ -1,17 +1,19 @@
 summary: Ensure catalog update works
 
 execute: |
+    . "$TESTSLIB/journalctl.sh"
+
     echo "Ensure that catalog refresh happens on startup"
     for _ in $(seq 60); do
-        if journalctl -u snapd | MATCH "Catalog refresh"; then
+        if get_journalctl_log -u snapd | MATCH "Catalog refresh"; then
             break
         fi
         sleep 1
     done
-    journalctl -u snapd | MATCH "Catalog refresh"
+    get_journalctl_log -u snapd | MATCH "Catalog refresh"
 
     echo "Ensure that we don't log all catalog body data"
-    if journalctl -u snapd | MATCH "Tools for testing the snapd application"; then
+    if get_journalctl_log -u snapd | MATCH "Tools for testing the snapd application"; then
         echo "Catalog update is doing verbose http logging (it should not)."
         exit 1
     fi

--- a/tests/main/catalog-update/task.yaml
+++ b/tests/main/catalog-update/task.yaml
@@ -1,6 +1,7 @@
 summary: Ensure catalog update works
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     echo "Ensure that catalog refresh happens on startup"

--- a/tests/main/enable-disable-units-gpio/task.yaml
+++ b/tests/main/enable-disable-units-gpio/task.yaml
@@ -69,6 +69,7 @@ restore: |
     rm -rf $GPIO_MOCK_DIR /etc/systemd/system/gpio-mock.service /home/test/gpio-mock.sh
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/enable-disable-units-gpio/task.yaml
+++ b/tests/main/enable-disable-units-gpio/task.yaml
@@ -69,6 +69,8 @@ restore: |
     rm -rf $GPIO_MOCK_DIR /etc/systemd/system/gpio-mock.service /home/test/gpio-mock.sh
 
 execute: |
+    . "$TESTSLIB/journalctl.sh"
+
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
@@ -76,7 +78,7 @@ execute: |
 
     echo "Then the snap service units concerning the gpio device must be run before and after a reboot"
     expected="Unit snap.core.interface.gpio-100.service has finished starting up"
-    journalctl -xe --no-pager | MATCH "$expected"
+    get_journalctl_log -xe --no-pager | MATCH "$expected"
 
     if [ "$SPREAD_REBOOT" = "1" ]; then
         cat $GPIO_MOCK_DIR/export | MATCH "^100$"

--- a/tests/main/install-cache/task.yaml
+++ b/tests/main/install-cache/task.yaml
@@ -1,13 +1,15 @@
 summary: Check that download caching works
 
 execute: |
+    . "$TESTSLIB/journalctl.sh"
+
     snap install test-snapd-tools
     snap remove test-snapd-tools
     snap install test-snapd-tools
     for i in $(seq 10); do
-        if journalctl -u snapd | MATCH "using cache for .*/test-snapd-tools.*\.snap"; then
+        if get_journalctl_log -u snapd | MATCH "using cache for .*/test-snapd-tools.*\.snap"; then
             break
         fi
         sleep 1
     done
-    journalctl -u snapd | MATCH "using cache for .*/test-snapd-tools.*\.snap"
+    get_journalctl_log -u snapd | MATCH "using cache for .*/test-snapd-tools.*\.snap"

--- a/tests/main/install-cache/task.yaml
+++ b/tests/main/install-cache/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that download caching works
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     snap install test-snapd-tools

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -42,6 +42,7 @@ restore: |
     rm -rf $HOME/PDF $TEST_FILE print.error
 
 debug: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     systemctl status cups || true

--- a/tests/main/interfaces-cups-control/task.yaml
+++ b/tests/main/interfaces-cups-control/task.yaml
@@ -42,8 +42,10 @@ restore: |
     rm -rf $HOME/PDF $TEST_FILE print.error
 
 debug: |
+    . "$TESTSLIB/journalctl.sh"
+
     systemctl status cups || true
-    journalctl -u cpus || true
+    get_journalctl_log -u cpus || true
 
 execute: |
     echo "Then the plug is disconnected by default"

--- a/tests/main/interfaces-many/task.yaml
+++ b/tests/main/interfaces-many/task.yaml
@@ -4,6 +4,7 @@ summary: Ensure that commands run when their interfaces are connected
 priority: 100
 
 debug: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     # get the full journal to see any out-of-memory errors

--- a/tests/main/interfaces-many/task.yaml
+++ b/tests/main/interfaces-many/task.yaml
@@ -4,8 +4,10 @@ summary: Ensure that commands run when their interfaces are connected
 priority: 100
 
 debug: |
+    . "$TESTSLIB/journalctl.sh"
+
     # get the full journal to see any out-of-memory errors
-    journalctl
+    get_journalctl_log
 
 details: |
     Install a test snap that plugs as many interfaces as is possible and

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -54,6 +54,7 @@ debug: |
     jq .data.auth.device /var/lib/snapd/state.json
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     if [ "$TRUST_TEST_KEYS" = "false" ]; then

--- a/tests/main/interfaces-snapd-control-with-manage/task.yaml
+++ b/tests/main/interfaces-snapd-control-with-manage/task.yaml
@@ -54,6 +54,8 @@ debug: |
     jq .data.auth.device /var/lib/snapd/state.json
 
 execute: |
+    . "$TESTSLIB/journalctl.sh"
+
     if [ "$TRUST_TEST_KEYS" = "false" ]; then
         echo "This test needs test keys to be trusted"
         exit
@@ -72,7 +74,7 @@ execute: |
 
     echo "Then the core refresh.schedule can be set to 'managed'"
     snap set core refresh.schedule=managed
-    if journalctl -u snapd |grep 'cannot parse "managed"'; then
+    if get_journalctl_log -u snapd |grep 'cannot parse "managed"'; then
         echo "refresh.schedule=managed was not rejected as it should be"
         exit 1
     fi

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -23,8 +23,10 @@ restore: |
     lxd.lxc delete my-ubuntu
 
 debug: |
+    . "$TESTSLIB/journalctl.sh"
+
     # debug output from lxd
-    journalctl -u snap.lxd.daemon.service
+    get_journalctl_log -u snap.lxd.daemon.service
 
 execute: |
     if  [[ $(ls -1 "$GOHOME"/snapd_*.deb | wc -l || echo 0) -eq 0 ]]; then

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -23,6 +23,7 @@ restore: |
     lxd.lxc delete my-ubuntu
 
 debug: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     # debug output from lxd

--- a/tests/main/refresh-delta-from-core/task.yaml
+++ b/tests/main/refresh-delta-from-core/task.yaml
@@ -21,7 +21,9 @@ restore: |
     fi
 
 execute: |
+    . "$TESTSLIB/journalctl.sh"
+
     echo "When the snap is refreshed"
     snap refresh --beta $SNAP_NAME
     echo "Then deltas are successfully applied"
-    journalctl -u snapd | MATCH "Successfully applied delta"
+    get_journalctl_log -u snapd | MATCH "Successfully applied delta"

--- a/tests/main/refresh-delta-from-core/task.yaml
+++ b/tests/main/refresh-delta-from-core/task.yaml
@@ -21,6 +21,7 @@ restore: |
     fi
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     echo "When the snap is refreshed"

--- a/tests/main/refresh-delta/task.yaml
+++ b/tests/main/refresh-delta/task.yaml
@@ -19,6 +19,7 @@ prepare: |
     snap install --edge $SNAP_NAME
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     echo "When the snap is refreshed"

--- a/tests/main/refresh-delta/task.yaml
+++ b/tests/main/refresh-delta/task.yaml
@@ -19,8 +19,10 @@ prepare: |
     snap install --edge $SNAP_NAME
 
 execute: |
+    . "$TESTSLIB/journalctl.sh"
+
     echo "When the snap is refreshed"
     snap refresh --beta $SNAP_NAME
 
     echo "Then deltas are successfully applied"
-    journalctl -u snapd | MATCH "Successfully applied delta"
+    get_journalctl_log -u snapd | MATCH "Successfully applied delta"

--- a/tests/main/refresh-undo/task.yaml
+++ b/tests/main/refresh-undo/task.yaml
@@ -19,7 +19,8 @@ prepare: |
     snap pack $TESTSLIB/snaps/$SNAP_NAME_BAD
 
 debug: |
-    journalctl -u snap.test-snapd-service.service.service
+    . "$TESTSLIB"/journalctl.sh
+    get_journalctl_log -u snap.test-snapd-service.service.service
 
 execute: |
     wait_for_service_status() {

--- a/tests/main/refresh-undo/task.yaml
+++ b/tests/main/refresh-undo/task.yaml
@@ -19,6 +19,7 @@ prepare: |
     snap pack $TESTSLIB/snaps/$SNAP_NAME_BAD
 
 debug: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB"/journalctl.sh
     get_journalctl_log -u snap.test-snapd-service.service.service
 

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -14,6 +14,8 @@ restore: |
     chmod 4755 /usr/lib/snapd/snap-confine
 
 execute: |
+    . "$TESTSLIB/journalctl.sh"
+
     if [ "${SNAP_REEXEC:-}" = "0" ]; then
         echo "skipping test when SNAP_REEXEC is disabled"
         exit 0
@@ -21,7 +23,7 @@ execute: |
 
     echo "Ensure we re-exec by default"
     snap list
-    journalctl | MATCH "DEBUG: restarting into"
+    get_journalctl_log | MATCH "DEBUG: restarting into"
 
     echo "Ensure snap-confine from the core snap is run"
     # do not use "strace -f" for unknown reasons that hangs

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -14,6 +14,7 @@ restore: |
     chmod 4755 /usr/lib/snapd/snap-confine
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     if [ "${SNAP_REEXEC:-}" = "0" ]; then

--- a/tests/main/snap-service-refresh-mode/task.yaml
+++ b/tests/main/snap-service-refresh-mode/task.yaml
@@ -7,8 +7,10 @@ debug: |
     systemctl status snap.test-snapd-service.test-snapd-endure-service || true
 
 execute: |
+    . "$TESTSLIB/snaps.sh"
+    . "$TESTSLIB/journalctl.sh"
+
     echo "When the service snap is installed"
-    . $TESTSLIB/snaps.sh
     install_local test-snapd-service
 
     echo "We can see it running"
@@ -25,7 +27,7 @@ execute: |
 
     echo "Once the snap is removed, the service is stopped"
     snap remove test-snapd-service
-    journalctl | MATCH "stop endure"
+    get_journalctl_log | MATCH "stop endure"
 
 restore:
     rm -f *.pid || true

--- a/tests/main/snap-service-refresh-mode/task.yaml
+++ b/tests/main/snap-service-refresh-mode/task.yaml
@@ -7,7 +7,9 @@ debug: |
     systemctl status snap.test-snapd-service.test-snapd-endure-service || true
 
 execute: |
+    # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     echo "When the service snap is installed"

--- a/tests/main/snap-service-stop-mode/task.yaml
+++ b/tests/main/snap-service-stop-mode/task.yaml
@@ -12,8 +12,10 @@ debug: |
     done
 
 execute: |
+    . "$TESTSLIB/snaps.sh"
+    . "$TESTSLIB/journalctl.sh"
+
     echo "When the service snap is installed"
-    . $TESTSLIB/snaps.sh
     install_local test-snapd-service
 
     echo "We can see it running"
@@ -36,11 +38,11 @@ execute: |
         echo "and it got the right signal"
         echo "checking that the right signal was sent"
         sleep 1
-        journalctl -u snap.test-snapd-service.test-snapd-${s}-service | MATCH "got ${s%%-all}"
+        get_journalctl_log -u snap.test-snapd-service.test-snapd-${s}-service | MATCH "got ${s%%-all}"
     done
 
     echo "Regular services are restarted normally"
-    journalctl -u snap.test-snapd-service.test-snapd-service | MATCH "stop service"
+    get_journalctl_log -u snap.test-snapd-service.test-snapd-service | MATCH "stop service"
     systemctl show -p MainPID snap.test-snapd-service.test-snapd-service > new-main.pid
     test -e new-main.pid && test -e old-main.pid
     test "$(cat new-main.pid)" != "$(cat old-main.pid)"
@@ -48,7 +50,7 @@ execute: |
     echo "Once the snap is removed, all services are stopped"
     snap remove test-snapd-service
     for s in $stop_modes; do
-        journalctl | MATCH "stop ${s}"
+        get_journalctl_log | MATCH "stop ${s}"
     done
 
 restore: |

--- a/tests/main/snap-service-stop-mode/task.yaml
+++ b/tests/main/snap-service-stop-mode/task.yaml
@@ -12,7 +12,9 @@ debug: |
     done
 
 execute: |
+    # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     echo "When the service snap is installed"

--- a/tests/main/snap-userd-desktop-app-autostart/task.yaml
+++ b/tests/main/snap-userd-desktop-app-autostart/task.yaml
@@ -28,7 +28,13 @@ execute: |
         sleep 1
     done
     test -e ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
-    test "$(journalctl -t foo.desktop --cursor "$cursor" | wc -l)" -gt 1
+
+    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
+        test "$(journalctl -t foo.desktop --cursor "$cursor" | wc -l)" -gt 0
+    else
+        # 14.04 journalctl does not have cursor, neither --identifier support
+        test "$(journalctl | grep foo.desktop | wc -l)" -gt 0
+    fi
 
 restore: |
     rm -f ~/snap/test-snapd-xdg-autostart/current/foo-autostarted

--- a/tests/main/snap-userd-desktop-app-autostart/task.yaml
+++ b/tests/main/snap-userd-desktop-app-autostart/task.yaml
@@ -1,7 +1,9 @@
 summary: Check that snap userd can autostart user session applications
 
 execute: |
+    # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     echo "When the snap is installed"

--- a/tests/main/snap-userd-desktop-app-autostart/task.yaml
+++ b/tests/main/snap-userd-desktop-app-autostart/task.yaml
@@ -29,12 +29,7 @@ execute: |
     done
     test -e ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
 
-    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
-        test "$(journalctl -t foo.desktop --cursor "$cursor" | wc -l)" -gt 0
-    else
-        # 14.04 journalctl does not have cursor, neither --identifier support
-        test "$(journalctl | grep foo.desktop | wc -l)" -gt 0
-    fi
+    test "$(get_journalctl_log_from_cursor "$cursor" | grep foo.desktop | wc -l)" -gt 0
 
 restore: |
     rm -f ~/snap/test-snapd-xdg-autostart/current/foo-autostarted

--- a/tests/main/snap-userd-desktop-app-autostart/task.yaml
+++ b/tests/main/snap-userd-desktop-app-autostart/task.yaml
@@ -1,8 +1,10 @@
 summary: Check that snap userd can autostart user session applications
 
 execute: |
+    . "$TESTSLIB/snaps.sh"
+    . "$TESTSLIB/journalctl.sh"
+
     echo "When the snap is installed"
-    . $TESTSLIB/snaps.sh
     install_local test-snapd-xdg-autostart
 
     # run the app directly, it will dump a *.desktop file
@@ -14,10 +16,7 @@ execute: |
     echo "Applications can be automatically started by snap userd --autostart"
 
     test ! -e ~/snap/test-xdg-snap-autostart/current/foo-autostarted
-    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
-        # 14.04 journalctl does not have cursor support
-        cursor=$(journalctl --show-cursor -n 0 |grep cursor | cut -f3 -d' ')
-    fi
+    cursor=$(get_last_journalctl_cursor)
     snap userd --autostart > autostart.log 2>&1
 
     # when app is autostarted it dumps a file at $SNAP_USER_DATA/foo-autostarted,
@@ -27,15 +26,7 @@ execute: |
         sleep 1
     done
     test -e ~/snap/test-snapd-xdg-autostart/current/foo-autostarted
-
-    if [[ "$SPREAD_SYSTEM" != ubuntu-14.04-* ]]; then
-        journalctl --flush
-        test "$(journalctl -t foo.desktop --after-cursor=$cursor | wc -l)" -eq 1
-    else
-        # 14.04 journalctl does not have cursor, neither --identifier support,
-        # nor --flush
-        test "$(journalctl | grep foo.desktop | wc -l)" -eq 1
-    fi
+    test "$(journalctl -t foo.desktop --cursor "$cursor" | wc -l)" -gt 1
 
 restore: |
     rm -f ~/snap/test-snapd-xdg-autostart/current/foo-autostarted

--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -33,7 +33,9 @@ execute: |
         done
     }
 
+    # shellcheck source=tests/lib/snaps.sh
     . "$TESTSLIB/snaps.sh"
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     echo "When the service snap is installed"

--- a/tests/main/snapctl-services/task.yaml
+++ b/tests/main/snapctl-services/task.yaml
@@ -33,8 +33,10 @@ execute: |
         done
     }
 
+    . "$TESTSLIB/snaps.sh"
+    . "$TESTSLIB/journalctl.sh"
+
     echo "When the service snap is installed"
-    . $TESTSLIB/snaps.sh
     install_local test-snapd-service
 
     echo "We can see it running"
@@ -73,7 +75,7 @@ execute: |
     echo "Reinstalling the snap with configure hook calling snapctl restart works"
     snap set test-snapd-service command=restart
     install_local test-snapd-service
-    if journalctl|grep -q "error running snapctl"; then
+    if get_journalctl_log | MATCH "error running snapctl"; then
         echo "snapctl should not report errors"
         exit 1
     fi

--- a/tests/main/snapd-notify/task.yaml
+++ b/tests/main/snapd-notify/task.yaml
@@ -5,9 +5,11 @@ summary: Ensure snapd notify feature is working
 backends: [-external]
 
 execute: |
+    . "$TESTSLIB/journalctl.sh"
+
     for _ in $(seq 5); do
       if systemctl status snapd.service | MATCH "Active: active"; then
-          journalctl -u snapd | MATCH "activation done in"
+          get_journalctl_log -u snapd | MATCH "activation done in"
           exit
       fi
       sleep 1

--- a/tests/main/snapd-notify/task.yaml
+++ b/tests/main/snapd-notify/task.yaml
@@ -5,6 +5,7 @@ summary: Ensure snapd notify feature is working
 backends: [-external]
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     for _ in $(seq 5); do

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -29,7 +29,8 @@ execute: |
     echo "Ensure we re-exec by default"
     /usr/bin/env SNAPD_DEBUG=1 snap list 2>&1 | MATCH "DEBUG: restarting into"
 
-    . $TESTSLIB/dirs.sh
+    . "$TESTSLIB/dirs.sh"
+    . "$TESTSLIB/journalctl.sh"
 
     echo "Ensure that we do not re-exec into older versions"
     systemctl stop snapd.service snapd.socket
@@ -38,7 +39,7 @@ execute: |
     mount --bind /tmp/old-info $SNAP_MOUNT_DIR/core/current/usr/lib/snapd/info
     systemctl start snapd.service snapd.socket
     snap list
-    journalctl | MATCH "core snap \(at .*\) is older \(.*\) than distribution package"
+    get_journalctl_log | MATCH "core snap \(at .*\) is older \(.*\) than distribution package"
 
     echo "Revert back to normal"
     systemctl stop snapd.service snapd.socket

--- a/tests/main/snapd-reexec/task.yaml
+++ b/tests/main/snapd-reexec/task.yaml
@@ -29,7 +29,9 @@ execute: |
     echo "Ensure we re-exec by default"
     /usr/bin/env SNAPD_DEBUG=1 snap list 2>&1 | MATCH "DEBUG: restarting into"
 
+    # shellcheck source=tests/lib/dirs.sh
     . "$TESTSLIB/dirs.sh"
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     echo "Ensure that we do not re-exec into older versions"

--- a/tests/main/validate-container-failures/task.yaml
+++ b/tests/main/validate-container-failures/task.yaml
@@ -15,6 +15,7 @@ prepare: |
     chmod 0644 "$p/meta/hooks/what"
 
 execute: |
+    # shellcheck source=tests/lib/journalctl.sh
     . "$TESTSLIB/journalctl.sh"
 
     echo "Snap refuses to install"

--- a/tests/main/validate-container-failures/task.yaml
+++ b/tests/main/validate-container-failures/task.yaml
@@ -15,13 +15,15 @@ prepare: |
     chmod 0644 "$p/meta/hooks/what"
 
 execute: |
+    . "$TESTSLIB/journalctl.sh"
+
     echo "Snap refuses to install"
     snap try $TESTSLIB/snaps/$SNAP 2>error.log && exit 1 || true
     echo "The error tells you to ask the dev"
     tr -s "\n " " " < error.log | MATCH 'contact developer'
 
     echo "And the journal counts the ways"
-    journalctl -u snapd > journal.log
+    get_journalctl_log -u snapd > journal.log
     MATCH '"comp.sh" should be world-readable' < journal.log
     MATCH '"bin/bar" should be executable' < journal.log
     MATCH '"bin/foo" should be world-readable and executable' < journal.log


### PR DESCRIPTION
This change is intended to use journalctl cursors instead of rotating log files, and also to use a single implementation for all the systems (currently we have a different implementation for ubuntu 14.04).

This also deals with the issue generated with journalctl --sync where the
command hungs.