### PR TITLE
tests: move fedora 27 to manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -74,6 +74,7 @@ backends:
             - fedora-27-64:
                 image: fedora-27-64-selinux-permissive
                 workers: 4
+                manual: true
 
             - opensuse-42.2-64:
                 image: opensuse-leap-42-2


### PR DESCRIPTION
Most of the builds are failing in travis because of this error which
could be caused by high load due to fedora 28 which has been released.
quiet dnf -y install /home/gopath/snap-
confine-1337.2.32.6-0.fc27.x86_64.rpm ....
quiet: exit status 1. Output follows:
Error: Failed to synchronize cache for repo 'updates'
quiet: end of output.

errors:
https://travis-ci.org/snapcore/snapd/builds/377476600#L9138
https://travis-ci.org/snapcore/snapd/builds/377475886#L7770
