### PR TITLE
many: improve `snap wait` command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -259,7 +259,8 @@ func (client *Client) do(method, path string, query url.Values, headers map[stri
 
 // doSync performs a request to the given path using the specified HTTP method.
 // It expects a "sync" response from the API and on success decodes the JSON
-// response payload into the given value.
+// response payload into the given value using the "UseNumber" json decoding
+// which produces json.Numbers instead of float64 types for numbers.
 func (client *Client) doSync(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) (*ResultInfo, error) {
 	var rsp response
 	if err := client.do(method, path, query, headers, body, &rsp); err != nil {

--- a/client/conf.go
+++ b/client/conf.go
@@ -36,6 +36,8 @@ func (client *Client) SetConf(snapName string, patch map[string]interface{}) (ch
 }
 
 // Conf asks for a snap's current configuration.
+//
+// Note that the configuration may include json.Numbers.
 func (client *Client) Conf(snapName string, keys []string) (configuration map[string]interface{}, err error) {
 	// Prepare query
 	query := url.Values{}

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -21,6 +21,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"math/rand"
 	"reflect"
 	"time"
 
@@ -162,6 +164,19 @@ func (x *cmdWait) Execute(args []string) error {
 
 	snapName := string(x.Positional.Snap)
 	confKey := x.Positional.Key
+
+	if snapName == "godot" && confKey == "" {
+		switch rand.Intn(2) {
+		case 0:
+			fmt.Fprintf(Stdout, `"Let's go." "We can't." "Why not?" "We're waiting for Godot."`+"\n")
+		default:
+			fmt.Fprintf(Stdout, "Nothing happens. Nobody comes, nobody goes. It's awful.\n")
+		}
+		return nil
+	}
+	if confKey == "" {
+		return fmt.Errorf("need a <key> argument")
+	}
 
 	cli := Client()
 	for {

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -22,7 +22,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"reflect"
 	"time"
 
@@ -35,7 +34,7 @@ import (
 type cmdWait struct {
 	Positional struct {
 		Snap installedSnapName `required:"yes"`
-		Key  string
+		Key  string            `required:"yes"`
 	} `positional-args:"yes"`
 }
 
@@ -138,19 +137,6 @@ func (x *cmdWait) Execute(args []string) error {
 
 	snapName := string(x.Positional.Snap)
 	confKey := x.Positional.Key
-
-	if snapName == "godot" && confKey == "" {
-		switch rand.Intn(2) {
-		case 0:
-			fmt.Fprintf(Stdout, `"Let's go." "We can't." "Why not?" "We're waiting for Godot."`+"\n")
-		default:
-			fmt.Fprintf(Stdout, "Nothing happens. Nobody comes, nobody goes. It's awful.\n")
-		}
-		return nil
-	}
-	if confKey == "" {
-		return fmt.Errorf("need a <key> argument")
-	}
 
 	cli := Client()
 	for {

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -82,32 +82,16 @@ func trueishForJsonUnmarshalledValues(vi interface{}) (bool, error) {
 	case nil:
 		return false, nil
 	case bool:
-		if v == true {
-			return true, nil
-		} else {
-			return false, nil
-		}
+		return v, nil
 	case json.Number:
 		if i, err := v.Int64(); err == nil {
-			if i != 0 {
-				return true, nil
-			} else {
-				return false, nil
-			}
+			return i != 0, nil
 		}
 		if f, err := v.Float64(); err == nil {
-			if f != 0.0 {
-				return true, nil
-			} else {
-				return false, nil
-			}
+			return f != 0.0, nil
 		}
 	case string:
-		if v != "" {
-			return true, nil
-		} else {
-			return false, nil
-		}
+		return v != "", nil
 	}
 	// arrays/slices/maps
 	typ := reflect.TypeOf(vi)
@@ -119,11 +103,7 @@ func trueishForJsonUnmarshalledValues(vi interface{}) (bool, error) {
 		}
 		switch s.Kind() {
 		case reflect.Array, reflect.Slice, reflect.Map:
-			if s.Len() > 0 {
-				return true, nil
-			} else {
-				return false, nil
-			}
+			return s.Len() > 0, nil
 		}
 	}
 

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"encoding/json"
+	"reflect"
 	"time"
 
 	"github.com/jessevdk/go-flags"
@@ -75,7 +76,43 @@ func trueish(vi interface{}) bool {
 		if v > 0 {
 			return true
 		}
+	case int8:
+		if v > 0 {
+			return true
+		}
+	case int16:
+		if v > 0 {
+			return true
+		}
+	case int32:
+		if v > 0 {
+			return true
+		}
 	case int64:
+		if v > 0 {
+			return true
+		}
+	case uint:
+		if v > 0 {
+			return true
+		}
+	case uint8:
+		if v > 0 {
+			return true
+		}
+	case uint16:
+		if v > 0 {
+			return true
+		}
+	case uint32:
+		if v > 0 {
+			return true
+		}
+	case uint64:
+		if v > 0 {
+			return true
+		}
+	case uintptr:
 		if v > 0 {
 			return true
 		}
@@ -98,15 +135,23 @@ func trueish(vi interface{}) bool {
 		if v != "" {
 			return true
 		}
-	case []interface{}:
-		if len(v) > 0 {
-			return true
+	}
+	// arrays/slices/maps
+	typ := reflect.TypeOf(vi)
+	switch typ.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Map:
+		s := reflect.ValueOf(vi)
+		if s.Kind() == reflect.Ptr {
+			s = reflect.Indirect(s)
 		}
-	case map[string]interface{}:
-		if len(v) > 0 {
-			return true
+		switch s.Kind() {
+		case reflect.Array, reflect.Slice, reflect.Map:
+			if s.Len() > 0 {
+				return true
+			}
 		}
 	}
+
 	return false
 }
 

--- a/cmd/snap/cmd_wait.go
+++ b/cmd/snap/cmd_wait.go
@@ -67,7 +67,7 @@ func isNoOption(err error) bool {
 	return false
 }
 
-// trueish takes an interface{} and returns true if the interface value
+// trueishJSON takes an interface{} and returns true if the interface value
 // looks "true". For strings thats if len(string) > 0 for numbers that
 // they are != 0 and for maps/slices/arrays that they have elements.
 //
@@ -76,7 +76,7 @@ func isNoOption(err error) bool {
 // needs to becomes a generic "trueish" helper we need to resurrect
 // the code in 306ba60edfba8d6501060c6f773235d8c994a319 (and add nil
 // to it).
-func trueishForJsonUnmarshalledValues(vi interface{}) (bool, error) {
+func trueishJSON(vi interface{}) (bool, error) {
 	switch v := vi.(type) {
 	// limited to the types that json unmarhal can produce
 	case nil:
@@ -98,16 +98,13 @@ func trueishForJsonUnmarshalledValues(vi interface{}) (bool, error) {
 	switch typ.Kind() {
 	case reflect.Array, reflect.Slice, reflect.Map:
 		s := reflect.ValueOf(vi)
-		if s.Kind() == reflect.Ptr {
-			s = reflect.Indirect(s)
-		}
 		switch s.Kind() {
 		case reflect.Array, reflect.Slice, reflect.Map:
 			return s.Len() > 0, nil
 		}
 	}
 
-	return false, fmt.Errorf("cannot test type %T for trueishness", vi)
+	return false, fmt.Errorf("cannot test type %T for truth", vi)
 }
 
 func (x *cmdWait) Execute(args []string) error {
@@ -124,7 +121,7 @@ func (x *cmdWait) Execute(args []string) error {
 		if err != nil && !isNoOption(err) {
 			return err
 		}
-		res, err := trueishForJsonUnmarshalledValues(conf[confKey])
+		res, err := trueishJSON(conf[confKey])
 		if err != nil {
 			return err
 		}

--- a/cmd/snap/cmd_wait_test.go
+++ b/cmd/snap/cmd_wait_test.go
@@ -30,7 +30,7 @@ import (
 	snap "github.com/snapcore/snapd/cmd/snap"
 )
 
-func (s *SnapSuite) TestCmdWait(c *C) {
+func (s *SnapSuite) TestCmdWaitHappy(c *C) {
 	var seeded bool
 
 	restore := snap.MockWaitConfTimeout(10 * time.Millisecond)
@@ -57,6 +57,18 @@ func (s *SnapSuite) TestCmdWait(c *C) {
 	// 10 millisecond sleep actually takes much longer until the kernel
 	// hands control back to the process
 	c.Check(n > 2, Equals, true)
+}
+
+func (s *SnapSuite) TestCmdWaitMissingConfKey(c *C) {
+	n := 0
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		n++
+	})
+
+	_, err := snap.Parser().ParseArgs([]string{"wait", "snapName"})
+	c.Assert(err, ErrorMatches, "need a <key> argument")
+
+	c.Check(n, Equals, 0)
 }
 
 func (s *SnapSuite) TestTrueish(c *C) {

--- a/cmd/snap/cmd_wait_test.go
+++ b/cmd/snap/cmd_wait_test.go
@@ -73,99 +73,50 @@ func (s *SnapSuite) TestCmdWaitMissingConfKey(c *C) {
 
 func (s *SnapSuite) TestTrueish(c *C) {
 	tests := []struct {
-		v interface{}
-		b bool
+		v      interface{}
+		b      bool
+		errStr string
 	}{
+		// nil
+		{nil, false, ""},
 		// bool
-		{true, true},
-		{false, false},
-		// int
-		{int(1), true},
-		{int(2), true},
-		{int(0), false},
-		// int8
-		{int8(1), true},
-		{int8(2), true},
-		{int8(0), false},
-		// int16
-		{int16(1), true},
-		{int16(2), true},
-		{int16(0), false},
-		// int32
-		{int32(1), true},
-		{int32(2), true},
-		{int32(0), false},
-		// int64
-		{int64(1), true},
-		{int64(2), true},
-		{int64(0), false},
-		// uint
-		{uint(1), true},
-		{uint(2), true},
-		{uint(0), false},
-		// uint8
-		{uint8(1), true},
-		{uint8(2), true},
-		{uint8(0), false},
-		// uint16
-		{uint16(1), true},
-		{uint16(2), true},
-		{uint16(0), false},
-		// uint32
-		{uint32(1), true},
-		{uint32(2), true},
-		{uint32(0), false},
-		// uint64
-		{uint64(1), true},
-		{uint64(2), true},
-		{uint64(0), false},
-		// uintptr
-		{uintptr(1), true},
-		{uintptr(2), true},
-		{uintptr(0), false},
-		// byte
-		{byte(1), true},
-		{byte(2), true},
-		{byte(0), false},
-		// rune
-		{rune(1), true},
-		{rune(2), true},
-		{rune(0), false},
-		// float32
-		{float32(1.0), true},
-		{float32(2.0), true},
-		{float32(0.0), false},
-		// float64
-		{float64(1.0), true},
-		{float64(2.0), true},
-		{float64(0.0), false},
-		// no complex{64,128}
-		// ...
+		{true, true, ""},
+		{false, false, ""},
 		// string
-		{"a", true},
-		{"", false},
+		{"a", true, ""},
+		{"", false, ""},
 		// json.Number
-		{json.Number("1"), true},
-		{json.Number("0"), false},
-		{json.Number("1.0"), true},
-		{json.Number("0.0"), false},
+		{json.Number("1"), true, ""},
+		{json.Number("-1"), true, ""},
+		{json.Number("0"), false, ""},
+		{json.Number("1.0"), true, ""},
+		{json.Number("-1.0"), true, ""},
+		{json.Number("0.0"), false, ""},
 		// slices
-		{[]interface{}{"a"}, true},
-		{[]interface{}{}, false},
-		{[]string{"a"}, true},
-		{[]string{}, false},
+		{[]interface{}{"a"}, true, ""},
+		{[]interface{}{}, false, ""},
+		{[]string{"a"}, true, ""},
+		{[]string{}, false, ""},
 		// arrays
-		{[2]interface{}{"a", "b"}, true},
-		{[0]interface{}{}, false},
-		{[2]string{"a", "b"}, true},
-		{[0]string{}, false},
+		{[2]interface{}{"a", "b"}, true, ""},
+		{[0]interface{}{}, false, ""},
+		{[2]string{"a", "b"}, true, ""},
+		{[0]string{}, false, ""},
 		// maps
-		{map[string]interface{}{"a": "a"}, true},
-		{map[string]interface{}{}, false},
-		{map[interface{}]interface{}{"a": "a"}, true},
-		{map[interface{}]interface{}{}, false},
+		{map[string]interface{}{"a": "a"}, true, ""},
+		{map[string]interface{}{}, false, ""},
+		{map[interface{}]interface{}{"a": "a"}, true, ""},
+		{map[interface{}]interface{}{}, false, ""},
+		// invalid
+		{int(1), false, "cannot test type int for trueishness"},
 	}
 	for _, t := range tests {
-		c.Check(snap.Trueish(t.v), Equals, t.b, Commentf("unexpected result for %v (%T), did not get expected %v", t.v, t.v, t.b))
+		res, err := snap.TrueishForJsonUnmarshalledValues(t.v)
+		if t.errStr == "" {
+			c.Check(err, IsNil)
+		} else {
+			c.Check(err, ErrorMatches, t.errStr)
+		}
+		c.Check(res, Equals, t.b, Commentf("unexpected result for %v (%T), did not get expected %v", t.v, t.v, t.b))
 	}
 }

--- a/cmd/snap/cmd_wait_test.go
+++ b/cmd/snap/cmd_wait_test.go
@@ -66,7 +66,7 @@ func (s *SnapSuite) TestCmdWaitMissingConfKey(c *C) {
 	})
 
 	_, err := snap.Parser().ParseArgs([]string{"wait", "snapName"})
-	c.Assert(err, ErrorMatches, "need a <key> argument")
+	c.Assert(err, ErrorMatches, "the required argument `<key>` was not provided")
 
 	c.Check(n, Equals, 0)
 }

--- a/cmd/snap/cmd_wait_test.go
+++ b/cmd/snap/cmd_wait_test.go
@@ -173,7 +173,7 @@ func (s *SnapSuite) TestCmdWaitIntegration(c *C) {
 			// we waited once, then got a non-wait value
 			c.Check(n, Equals, 2)
 		} else {
-			// no waiting happend
+			// no waiting happened
 			c.Check(n, Equals, 1)
 		}
 	}

--- a/cmd/snap/cmd_wait_test.go
+++ b/cmd/snap/cmd_wait_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -56,4 +57,103 @@ func (s *SnapSuite) TestCmdWait(c *C) {
 	// 10 millisecond sleep actually takes much longer until the kernel
 	// hands control back to the process
 	c.Check(n > 2, Equals, true)
+}
+
+func (s *SnapSuite) TestTrueish(c *C) {
+	tests := []struct {
+		v interface{}
+		b bool
+	}{
+		// bool
+		{true, true},
+		{false, false},
+		// int
+		{int(1), true},
+		{int(2), true},
+		{int(0), false},
+		// int8
+		{int8(1), true},
+		{int8(2), true},
+		{int8(0), false},
+		// int16
+		{int16(1), true},
+		{int16(2), true},
+		{int16(0), false},
+		// int32
+		{int32(1), true},
+		{int32(2), true},
+		{int32(0), false},
+		// int64
+		{int64(1), true},
+		{int64(2), true},
+		{int64(0), false},
+		// uint
+		{uint(1), true},
+		{uint(2), true},
+		{uint(0), false},
+		// uint8
+		{uint8(1), true},
+		{uint8(2), true},
+		{uint8(0), false},
+		// uint16
+		{uint16(1), true},
+		{uint16(2), true},
+		{uint16(0), false},
+		// uint32
+		{uint32(1), true},
+		{uint32(2), true},
+		{uint32(0), false},
+		// uint64
+		{uint64(1), true},
+		{uint64(2), true},
+		{uint64(0), false},
+		// uintptr
+		{uintptr(1), true},
+		{uintptr(2), true},
+		{uintptr(0), false},
+		// byte
+		{byte(1), true},
+		{byte(2), true},
+		{byte(0), false},
+		// rune
+		{rune(1), true},
+		{rune(2), true},
+		{rune(0), false},
+		// float32
+		{float32(1.0), true},
+		{float32(2.0), true},
+		{float32(0.0), false},
+		// float64
+		{float64(1.0), true},
+		{float64(2.0), true},
+		{float64(0.0), false},
+		// no complex{64,128}
+		// ...
+		// string
+		{"a", true},
+		{"", false},
+		// json.Number
+		{json.Number("1"), true},
+		{json.Number("0"), false},
+		{json.Number("1.0"), true},
+		{json.Number("0.0"), false},
+		// slices
+		{[]interface{}{"a"}, true},
+		{[]interface{}{}, false},
+		{[]string{"a"}, true},
+		{[]string{}, false},
+		// arrays
+		{[2]interface{}{"a", "b"}, true},
+		{[0]interface{}{}, false},
+		{[2]string{"a", "b"}, true},
+		{[0]string{}, false},
+		// maps
+		{map[string]interface{}{"a": "a"}, true},
+		{map[string]interface{}{}, false},
+		{map[interface{}]interface{}{"a": "a"}, true},
+		{map[interface{}]interface{}{}, false},
+	}
+	for _, t := range tests {
+		c.Check(snap.Trueish(t.v), Equals, t.b, Commentf("unexpected result for %v (%T), did not get expected %v", t.v, t.v, t.b))
+	}
 }

--- a/cmd/snap/cmd_wait_test.go
+++ b/cmd/snap/cmd_wait_test.go
@@ -71,7 +71,7 @@ func (s *SnapSuite) TestCmdWaitMissingConfKey(c *C) {
 	c.Check(n, Equals, 0)
 }
 
-func (s *SnapSuite) TestTrueish(c *C) {
+func (s *SnapSuite) TestTrueishJSON(c *C) {
 	tests := []struct {
 		v      interface{}
 		b      bool
@@ -108,10 +108,10 @@ func (s *SnapSuite) TestTrueish(c *C) {
 		{map[interface{}]interface{}{"a": "a"}, true, ""},
 		{map[interface{}]interface{}{}, false, ""},
 		// invalid
-		{int(1), false, "cannot test type int for trueishness"},
+		{int(1), false, "cannot test type int for truth"},
 	}
 	for _, t := range tests {
-		res, err := snap.TrueishForJsonUnmarshalledValues(t.v)
+		res, err := snap.TrueishJSON(t.v)
 		if t.errStr == "" {
 			c.Check(err, IsNil)
 		} else {

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -33,17 +33,17 @@ import (
 var RunMain = run
 
 var (
-	CreateUserDataDirs = createUserDataDirs
-	ResolveApp         = resolveApp
-	IsReexeced         = isReexeced
-	MaybePrintServices = maybePrintServices
-	MaybePrintCommands = maybePrintCommands
-	SortByPath         = sortByPath
-	AdviseCommand      = adviseCommand
-	Antialias          = antialias
-	FormatChannel      = fmtChannel
-	PrintDescr         = printDescr
-	Trueish            = trueish
+	CreateUserDataDirs               = createUserDataDirs
+	ResolveApp                       = resolveApp
+	IsReexeced                       = isReexeced
+	MaybePrintServices               = maybePrintServices
+	MaybePrintCommands               = maybePrintCommands
+	SortByPath                       = sortByPath
+	AdviseCommand                    = adviseCommand
+	Antialias                        = antialias
+	FormatChannel                    = fmtChannel
+	PrintDescr                       = printDescr
+	TrueishForJsonUnmarshalledValues = trueishForJsonUnmarshalledValues
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -33,17 +33,17 @@ import (
 var RunMain = run
 
 var (
-	CreateUserDataDirs               = createUserDataDirs
-	ResolveApp                       = resolveApp
-	IsReexeced                       = isReexeced
-	MaybePrintServices               = maybePrintServices
-	MaybePrintCommands               = maybePrintCommands
-	SortByPath                       = sortByPath
-	AdviseCommand                    = adviseCommand
-	Antialias                        = antialias
-	FormatChannel                    = fmtChannel
-	PrintDescr                       = printDescr
-	TrueishForJsonUnmarshalledValues = trueishForJsonUnmarshalledValues
+	CreateUserDataDirs = createUserDataDirs
+	ResolveApp         = resolveApp
+	IsReexeced         = isReexeced
+	MaybePrintServices = maybePrintServices
+	MaybePrintCommands = maybePrintCommands
+	SortByPath         = sortByPath
+	AdviseCommand      = adviseCommand
+	Antialias          = antialias
+	FormatChannel      = fmtChannel
+	PrintDescr         = printDescr
+	TrueishJSON        = trueishJSON
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/cmd/snap/export_test.go
+++ b/cmd/snap/export_test.go
@@ -43,6 +43,7 @@ var (
 	Antialias          = antialias
 	FormatChannel      = fmtChannel
 	PrintDescr         = printDescr
+	Trueish            = trueish
 )
 
 func MockPollTime(d time.Duration) (restore func()) {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -405,7 +405,10 @@ func (m *DeviceManager) ensureSeedInConfig() error {
 			return nil
 		}
 
-		// sync seeding with the configuration state
+		// Sync seeding with the configuration state. We need to
+		// do this here to ensure that old systems which did not
+		// set the configuration on seeding get the configuration
+		// update too.
 		if err := markSeededInConfig(m.state); err != nil {
 			return err
 		}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2224,3 +2224,31 @@ func (s *deviceMgrSuite) TestReloadRegistered(c *C) {
 	}
 	c.Check(ok, Equals, true)
 }
+
+func (s *deviceMgrSuite) TestMarkSeededInConfig(c *C) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	// not seeded -> no config is set
+	s.state.Unlock()
+	s.mgr.Ensure()
+	s.state.Lock()
+
+	var seedLoaded bool
+	tr := config.NewTransaction(st)
+	tr.Get("core", "seed.loaded", &seedLoaded)
+	c.Check(seedLoaded, Equals, false)
+
+	// pretend we are seeded now
+	s.state.Set("seeded", true)
+
+	// seeded -> config got updated
+	s.state.Unlock()
+	s.mgr.Ensure()
+	s.state.Lock()
+
+	tr = config.NewTransaction(st)
+	tr.Get("core", "seed.loaded", &seedLoaded)
+	c.Check(seedLoaded, Equals, true)
+}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2230,6 +2230,14 @@ func (s *deviceMgrSuite) TestMarkSeededInConfig(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
+	// avoid device registration
+	auth.SetDevice(s.state, &auth.DeviceState{
+		Serial: "123",
+	})
+
+	// avoid full seeding
+	s.seeding()
+
 	// not seeded -> no config is set
 	s.state.Unlock()
 	s.mgr.Ensure()
@@ -2251,4 +2259,8 @@ func (s *deviceMgrSuite) TestMarkSeededInConfig(c *C) {
 	tr = config.NewTransaction(st)
 	tr.Get("core", "seed.loaded", &seedLoaded)
 	c.Check(seedLoaded, Equals, true)
+
+	// only the fake seeding change is in the state, no further
+	// changes
+	c.Check(s.state.Changes(), HasLen, 1)
 }


### PR DESCRIPTION
This is a followup for #5124 that implements the correct wait handling for more go datatypes and that also adds some missing error checks and better unit tests.