### PR TITLE
testutil: record system call errors / return values

### DIFF
--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -158,13 +158,14 @@ func formatUnmountFlags(flags int) string {
 	return strings.Join(fl, "|")
 }
 
-// CallResult describes a system call and the corresponding result as strings
+// CallResultError describes a system call and the corresponding result or error.
 //
-// The field names stand for Call and Result respectively. They are abbreviated
-// due to the nature of their use (in large quantity).
-type CallResult struct {
+// The field names stand for Call, Result and Error respectively. They are
+// abbreviated due to the nature of their use (in large quantity).
+type CallResultError struct {
 	C string
 	R interface{}
+	E error
 }
 
 // SyscallRecorder stores which system calls were invoked.
@@ -174,7 +175,7 @@ type CallResult struct {
 // verification of file descriptors.
 type SyscallRecorder struct {
 	// History of all the system calls made.
-	rcalls []CallResult
+	rcalls []CallResultError
 	// Error function for a given system call.
 	errors map[string]func() error
 	// pre-arranged result of lstat, fstat and readdir calls.
@@ -238,7 +239,7 @@ func (sys *SyscallRecorder) Calls() []string {
 }
 
 // RCalls returns the sequence of mocked calls that have been made along with their results.
-func (sys *SyscallRecorder) RCalls() []CallResult {
+func (sys *SyscallRecorder) RCalls() []CallResultError {
 	return sys.rcalls
 }
 
@@ -251,9 +252,9 @@ func (sys *SyscallRecorder) rcall(call string, resultFn func(call string) (inter
 		val, err = resultFn(call)
 	}
 	if err != nil {
-		sys.rcalls = append(sys.rcalls, CallResult{C: call, R: err})
+		sys.rcalls = append(sys.rcalls, CallResultError{C: call, E: err})
 	} else {
-		sys.rcalls = append(sys.rcalls, CallResult{C: call, R: val})
+		sys.rcalls = append(sys.rcalls, CallResultError{C: call, R: val})
 	}
 	return val, err
 }

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -159,9 +159,12 @@ func formatUnmountFlags(flags int) string {
 }
 
 // CallResult describes a system call and the corresponding result as strings
+//
+// The field names stand for Call and Result respectively. They are abbreviated
+// due to the nature of their use (in large quantity).
 type CallResult struct {
-	Call   string
-	Result interface{}
+	C string
+	R interface{}
 }
 
 // SyscallRecorder stores which system calls were invoked.
@@ -229,7 +232,7 @@ func (sys *SyscallRecorder) Calls() []string {
 	}
 	calls := make([]string, 0, len(sys.rcalls))
 	for _, rc := range sys.rcalls {
-		calls = append(calls, rc.Call)
+		calls = append(calls, rc.C)
 	}
 	return calls
 }
@@ -248,9 +251,9 @@ func (sys *SyscallRecorder) rcall(call string, resultFn func(call string) (inter
 		val, err = resultFn(call)
 	}
 	if err != nil {
-		sys.rcalls = append(sys.rcalls, CallResult{Call: call, Result: err})
+		sys.rcalls = append(sys.rcalls, CallResult{C: call, R: err})
 	} else {
-		sys.rcalls = append(sys.rcalls, CallResult{Call: call, Result: val})
+		sys.rcalls = append(sys.rcalls, CallResult{C: call, R: val})
 	}
 	return val, err
 }

--- a/testutil/lowlevel.go
+++ b/testutil/lowlevel.go
@@ -158,6 +158,12 @@ func formatUnmountFlags(flags int) string {
 	return strings.Join(fl, "|")
 }
 
+// CallResult describes a system call and the corresponding result as strings
+type CallResult struct {
+	Call   string
+	Result interface{}
+}
+
 // SyscallRecorder stores which system calls were invoked.
 //
 // The recorder supports a small set of features useful for testing: injecting
@@ -165,7 +171,7 @@ func formatUnmountFlags(flags int) string {
 // verification of file descriptors.
 type SyscallRecorder struct {
 	// History of all the system calls made.
-	calls []string
+	rcalls []CallResult
 	// Error function for a given system call.
 	errors map[string]func() error
 	// pre-arranged result of lstat, fstat and readdir calls.
@@ -218,16 +224,35 @@ func (sys *SyscallRecorder) InsertFaultFunc(call string, fn func() error) {
 
 // Calls returns the sequence of mocked calls that have been made.
 func (sys *SyscallRecorder) Calls() []string {
-	return sys.calls
+	if len(sys.rcalls) == 0 {
+		return nil
+	}
+	calls := make([]string, 0, len(sys.rcalls))
+	for _, rc := range sys.rcalls {
+		calls = append(calls, rc.Call)
+	}
+	return calls
 }
 
-// call remembers that a given call has occurred and returns a pre-arranged error, if any
-func (sys *SyscallRecorder) call(call string) error {
-	sys.calls = append(sys.calls, call)
-	if fn := sys.errors[call]; fn != nil {
-		return fn()
+// RCalls returns the sequence of mocked calls that have been made along with their results.
+func (sys *SyscallRecorder) RCalls() []CallResult {
+	return sys.rcalls
+}
+
+// rcall remembers that a given call has occurred and returns a pre-arranged error or value, if any
+func (sys *SyscallRecorder) rcall(call string, resultFn func(call string) (interface{}, error)) (val interface{}, err error) {
+	if errorFn := sys.errors[call]; errorFn != nil {
+		err = errorFn()
 	}
-	return nil
+	if err == nil && resultFn != nil {
+		val, err = resultFn(call)
+	}
+	if err != nil {
+		sys.rcalls = append(sys.rcalls, CallResult{Call: call, Result: err})
+	} else {
+		sys.rcalls = append(sys.rcalls, CallResult{Call: call, Result: val})
+	}
+	return val, err
 }
 
 // allocFd assigns a file descriptor to a given operation.
@@ -271,61 +296,75 @@ func (sys *SyscallRecorder) CheckForStrayDescriptors(c *check.C) {
 // Open is a fake implementation of syscall.Open
 func (sys *SyscallRecorder) Open(path string, flags int, mode uint32) (int, error) {
 	call := fmt.Sprintf("open %q %s %#o", path, formatOpenFlags(flags), mode)
-	if err := sys.call(call); err != nil {
+	fd, err := sys.rcall(call, func(call string) (interface{}, error) {
+		return sys.allocFd(call), nil
+	})
+	if err != nil {
 		return -1, err
 	}
-	return sys.allocFd(call), nil
+	return fd.(int), nil
 }
 
 // Openat is a fake implementation of syscall.Openat
 func (sys *SyscallRecorder) Openat(dirfd int, path string, flags int, mode uint32) (int, error) {
 	call := fmt.Sprintf("openat %d %q %s %#o", dirfd, path, formatOpenFlags(flags), mode)
-	if _, ok := sys.fds[dirfd]; !ok {
-		sys.calls = append(sys.calls, call)
-		return -1, fmt.Errorf("attempting to openat with an invalid file descriptor %d", dirfd)
-	}
-	if err := sys.call(call); err != nil {
+	fd, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if _, ok := sys.fds[dirfd]; !ok {
+			return -1, fmt.Errorf("attempting to openat with an invalid file descriptor %d", dirfd)
+		}
+		return sys.allocFd(call), nil
+	})
+	if err != nil {
 		return -1, err
 	}
-	return sys.allocFd(call), nil
+	return fd.(int), nil
 }
 
 // Close is a fake implementation of syscall.Close
 func (sys *SyscallRecorder) Close(fd int) error {
-	if err := sys.call(fmt.Sprintf("close %d", fd)); err != nil {
-		return err
-	}
-	return sys.freeFd(fd)
+	call := fmt.Sprintf("close %d", fd)
+	_, err := sys.rcall(call, func(call string) (interface{}, error) {
+		return nil, sys.freeFd(fd)
+	})
+	return err
 }
 
 // Fchown is a fake implementation of syscall.Fchown
 func (sys *SyscallRecorder) Fchown(fd int, uid sys.UserID, gid sys.GroupID) error {
 	call := fmt.Sprintf("fchown %d %d %d", fd, uid, gid)
-	if _, ok := sys.fds[fd]; !ok {
-		sys.calls = append(sys.calls, call)
-		return fmt.Errorf("attempting to fchown an invalid file descriptor %d", fd)
-	}
-	return sys.call(call)
+	_, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if _, ok := sys.fds[fd]; !ok {
+			return nil, fmt.Errorf("attempting to fchown an invalid file descriptor %d", fd)
+		}
+		return nil, nil
+	})
+	return err
 }
 
 // Mkdirat is a fake implementation of syscall.Mkdirat
 func (sys *SyscallRecorder) Mkdirat(dirfd int, path string, mode uint32) error {
 	call := fmt.Sprintf("mkdirat %d %q %#o", dirfd, path, mode)
-	if _, ok := sys.fds[dirfd]; !ok {
-		sys.calls = append(sys.calls, call)
-		return fmt.Errorf("attempting to mkdirat with an invalid file descriptor %d", dirfd)
-	}
-	return sys.call(call)
+	_, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if _, ok := sys.fds[dirfd]; !ok {
+			return nil, fmt.Errorf("attempting to mkdirat with an invalid file descriptor %d", dirfd)
+		}
+		return nil, nil
+	})
+	return err
 }
 
 // Mount is a fake implementation of syscall.Mount
-func (sys *SyscallRecorder) Mount(source string, target string, fstype string, flags uintptr, data string) (err error) {
-	return sys.call(fmt.Sprintf("mount %q %q %q %s %q", source, target, fstype, formatMountFlags(int(flags)), data))
+func (sys *SyscallRecorder) Mount(source string, target string, fstype string, flags uintptr, data string) error {
+	call := fmt.Sprintf("mount %q %q %q %s %q", source, target, fstype, formatMountFlags(int(flags)), data)
+	_, err := sys.rcall(call, nil)
+	return err
 }
 
 // Unmount is a fake implementation of syscall.Unmount
-func (sys *SyscallRecorder) Unmount(target string, flags int) (err error) {
-	return sys.call(fmt.Sprintf("unmount %q %s", target, formatUnmountFlags(flags)))
+func (sys *SyscallRecorder) Unmount(target string, flags int) error {
+	call := fmt.Sprintf("unmount %q %s", target, formatUnmountFlags(flags))
+	_, err := sys.rcall(call, nil)
+	return err
 }
 
 // InsertOsLstatResult makes given subsequent call to OsLstat return the specified fake file info.
@@ -348,27 +387,32 @@ func (sys *SyscallRecorder) InsertSysLstatResult(call string, sb syscall.Stat_t)
 func (sys *SyscallRecorder) OsLstat(name string) (os.FileInfo, error) {
 	// NOTE the syscall.Lstat uses a different signature `lstat %q <ptr>`.
 	call := fmt.Sprintf("lstat %q", name)
-	if err := sys.call(call); err != nil {
+	val, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if fi, ok := sys.osLstats[call]; ok {
+			return fi, nil
+		}
+		panic(fmt.Sprintf("one of InsertOsLstatResult() or InsertFault() for %s must be used", call))
+	})
+	if err != nil {
 		return nil, err
 	}
-	if fi, ok := sys.osLstats[call]; ok {
-		return fi, nil
-	}
-	panic(fmt.Sprintf("one of InsertOsLstatResult() or InsertFault() for %s must be used", call))
+	return val.(os.FileInfo), err
 }
 
 // SysLstat is a fake implementation of syscall.Lstat
 func (sys *SyscallRecorder) SysLstat(name string, sb *syscall.Stat_t) error {
 	// NOTE the os.Lstat uses a different signature `lstat %q`.
 	call := fmt.Sprintf("lstat %q <ptr>", name)
-	if err := sys.call(call); err != nil {
-		return err
+	val, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if buf, ok := sys.sysLstats[call]; ok {
+			return buf, nil
+		}
+		panic(fmt.Sprintf("one of InsertSysLstatResult() or InsertFault() for %s must be used", call))
+	})
+	if err == nil && sb != nil {
+		*sb = val.(syscall.Stat_t)
 	}
-	if ssb, ok := sys.sysLstats[call]; ok {
-		*sb = ssb
-		return nil
-	}
-	panic(fmt.Sprintf("one of InsertSysLstatResult() or InsertFault() for %s must be used", call))
+	return err
 }
 
 // InsertFstatResult makes given subsequent call fstat return the specified stat buffer.
@@ -382,18 +426,19 @@ func (sys *SyscallRecorder) InsertFstatResult(call string, buf syscall.Stat_t) {
 // Fstat is a fake implementation of syscall.Fstat
 func (sys *SyscallRecorder) Fstat(fd int, buf *syscall.Stat_t) error {
 	call := fmt.Sprintf("fstat %d <ptr>", fd)
-	if _, ok := sys.fds[fd]; !ok {
-		sys.calls = append(sys.calls, call)
-		return fmt.Errorf("attempting to fstat with an invalid file descriptor %d", fd)
+	val, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if _, ok := sys.fds[fd]; !ok {
+			return nil, fmt.Errorf("attempting to fstat with an invalid file descriptor %d", fd)
+		}
+		if buf, ok := sys.fstats[call]; ok {
+			return buf, nil
+		}
+		panic(fmt.Sprintf("one of InsertFstatResult() or InsertFault() for %s must be used", call))
+	})
+	if err == nil && buf != nil {
+		*buf = val.(syscall.Stat_t)
 	}
-	if err := sys.call(call); err != nil {
-		return err
-	}
-	if b, ok := sys.fstats[call]; ok {
-		*buf = b
-		return nil
-	}
-	panic(fmt.Sprintf("one of InsertFstatResult() or InsertFault() for %s must be used", call))
+	return err
 }
 
 // InsertReadDirResult makes given subsequent call readdir return the specified fake file infos.
@@ -407,29 +452,35 @@ func (sys *SyscallRecorder) InsertReadDirResult(call string, infos []os.FileInfo
 // ReadDir is a fake implementation of os.ReadDir
 func (sys *SyscallRecorder) ReadDir(dirname string) ([]os.FileInfo, error) {
 	call := fmt.Sprintf("readdir %q", dirname)
-	if err := sys.call(call); err != nil {
-		return nil, err
+	val, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if fi, ok := sys.readdirs[call]; ok {
+			return fi, nil
+		}
+		panic(fmt.Sprintf("one of InsertReadDirResult() or InsertFault() for %s must be used", call))
+	})
+	if err == nil {
+		return val.([]os.FileInfo), nil
 	}
-	if fi, ok := sys.readdirs[call]; ok {
-		return fi, nil
-	}
-	panic(fmt.Sprintf("one of InsertReadDirResult() or InsertFault() for %s must be used", call))
+	return nil, err
 }
 
 // Symlink is a fake implementation of syscall.Symlink
 func (sys *SyscallRecorder) Symlink(oldname, newname string) error {
 	call := fmt.Sprintf("symlink %q -> %q", newname, oldname)
-	return sys.call(call)
+	_, err := sys.rcall(call, nil)
+	return err
 }
 
 // Symlinkat is a fake implementation of osutil.Symlinkat (syscall.Symlinkat is not exposed)
 func (sys *SyscallRecorder) Symlinkat(oldname string, dirfd int, newname string) error {
 	call := fmt.Sprintf("symlinkat %q %d %q", oldname, dirfd, newname)
-	if _, ok := sys.fds[dirfd]; !ok {
-		sys.calls = append(sys.calls, call)
-		return fmt.Errorf("attempting to symlinkat with an invalid file descriptor %d", dirfd)
-	}
-	return sys.call(call)
+	_, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if _, ok := sys.fds[dirfd]; !ok {
+			return nil, fmt.Errorf("attempting to symlinkat with an invalid file descriptor %d", dirfd)
+		}
+		return nil, nil
+	})
+	return err
 }
 
 // InsertReadlinkatResult makes given subsequent call to readlinkat return the specified oldname.
@@ -443,32 +494,37 @@ func (sys *SyscallRecorder) InsertReadlinkatResult(call, oldname string) {
 // Readlinkat is a fake implementation of osutil.Readlinkat (syscall.Readlinkat is not exposed)
 func (sys *SyscallRecorder) Readlinkat(dirfd int, path string, buf []byte) (int, error) {
 	call := fmt.Sprintf("readlinkat %d %q <ptr>", dirfd, path)
-	if _, ok := sys.fds[dirfd]; !ok {
-		sys.calls = append(sys.calls, call)
-		return 0, fmt.Errorf("attempting to readlinkat with an invalid file descriptor %d", dirfd)
-	}
-	if err := sys.call(call); err != nil {
-		return 0, err
-	}
-	if oldname, ok := sys.readlinkats[call]; ok {
-		n := copy(buf, oldname)
+	val, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if _, ok := sys.fds[dirfd]; !ok {
+			return nil, fmt.Errorf("attempting to readlinkat with an invalid file descriptor %d", dirfd)
+		}
+		if oldname, ok := sys.readlinkats[call]; ok {
+			return oldname, nil
+		}
+		panic(fmt.Sprintf("one of InsertReadlinkatResult() or InsertFault() for %s must be used", call))
+	})
+	if err == nil {
+		n := copy(buf, val.(string))
 		return n, nil
 	}
-	panic(fmt.Sprintf("one of InsertReadlinkatResult() or InsertFault() for %s must be used", call))
+	return 0, err
 }
 
 // Remove is a fake implementation of os.Remove
 func (sys *SyscallRecorder) Remove(name string) error {
 	call := fmt.Sprintf("remove %q", name)
-	return sys.call(call)
+	_, err := sys.rcall(call, nil)
+	return err
 }
 
 // Fchdir is a fake implementation of syscall.Fchdir
 func (sys *SyscallRecorder) Fchdir(fd int) error {
 	call := fmt.Sprintf("fchdir %d", fd)
-	if _, ok := sys.fds[fd]; !ok {
-		sys.calls = append(sys.calls, call)
-		return fmt.Errorf("attempting to fchdir with an invalid file descriptor %d", fd)
-	}
-	return sys.call(call)
+	_, err := sys.rcall(call, func(call string) (interface{}, error) {
+		if _, ok := sys.fds[fd]; !ok {
+			return nil, fmt.Errorf("attempting to fchdir with an invalid file descriptor %d", fd)
+		}
+		return nil, nil
+	})
+	return err
 }

--- a/testutil/lowlevel_test.go
+++ b/testutil/lowlevel_test.go
@@ -65,7 +65,7 @@ func (s *lowLevelSuite) TestOpenSuccess(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/some/path" O_NOFOLLOW|O_CLOEXEC|O_RDWR|O_CREAT|O_EXCL 0`, // -> 3
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/some/path" O_NOFOLLOW|O_CLOEXEC|O_RDWR|O_CREAT|O_EXCL 0`, R: 3},
 	})
 }
@@ -79,8 +79,8 @@ func (s *lowLevelSuite) TestOpenFailure(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/some/path" 0 0`, // -> ENOENT
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `open "/some/path" 0 0`, R: syscall.ENOENT},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `open "/some/path" 0 0`, E: syscall.ENOENT},
 	})
 }
 
@@ -104,9 +104,9 @@ func (s *lowLevelSuite) TestOpenVariableFailure(c *C) {
 		`open "/some/path" O_RDWR 0`, // -> EPERM
 		`open "/some/path" O_RDWR 0`, // -> 3
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `open "/some/path" O_RDWR 0`, R: syscall.ENOENT},
-		{C: `open "/some/path" O_RDWR 0`, R: syscall.EPERM},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `open "/some/path" O_RDWR 0`, E: syscall.ENOENT},
+		{C: `open "/some/path" O_RDWR 0`, E: syscall.EPERM},
 		{C: `open "/some/path" O_RDWR 0`, R: 3},
 	})
 }
@@ -137,10 +137,10 @@ func (s *lowLevelSuite) TestOpenCustomFailure(c *C) {
 		`open "/some/path" O_RDWR 0`, // -> 1 more
 		`open "/some/path" O_RDWR 0`, // -> 3
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `open "/some/path" O_RDWR 0`, R: fmt.Errorf("3 more")},
-		{C: `open "/some/path" O_RDWR 0`, R: fmt.Errorf("2 more")},
-		{C: `open "/some/path" O_RDWR 0`, R: fmt.Errorf("1 more")},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `open "/some/path" O_RDWR 0`, E: fmt.Errorf("3 more")},
+		{C: `open "/some/path" O_RDWR 0`, E: fmt.Errorf("2 more")},
+		{C: `open "/some/path" O_RDWR 0`, E: fmt.Errorf("1 more")},
 		{C: `open "/some/path" O_RDWR 0`, R: 3},
 	})
 }
@@ -154,7 +154,7 @@ func (s *lowLevelSuite) TestUnclosedFile(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`open "/some/path" O_RDWR 0`, // -> 3
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/some/path" O_RDWR 0`, R: 3},
 	})
 	c.Assert(s.sys.StrayDescriptorsError(), ErrorMatches,
@@ -166,8 +166,8 @@ func (s *lowLevelSuite) TestUnopenedFile(c *C) {
 	err := s.sys.Close(7)
 	c.Assert(err, ErrorMatches, "attempting to close a closed file descriptor 7")
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`close 7`})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `close 7`, R: fmt.Errorf("attempting to close a closed file descriptor 7")},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `close 7`, E: fmt.Errorf("attempting to close a closed file descriptor 7")},
 	})
 }
 
@@ -181,7 +181,7 @@ func (s *lowLevelSuite) TestCloseSuccess(c *C) {
 		`open "/some/path" O_RDWR 0`, // -> 3
 		`close 3`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/some/path" O_RDWR 0`, R: 3},
 		{C: `close 3`},
 	})
@@ -196,8 +196,8 @@ func (s *lowLevelSuite) TestCloseFailure(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`close 3`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `close 3`, R: syscall.ENOSYS},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `close 3`, E: syscall.ENOSYS},
 	})
 }
 
@@ -214,7 +214,7 @@ func (s *lowLevelSuite) TestOpenatSuccess(c *C) {
 		`close 4`,
 		`close 3`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/" O_DIRECTORY 0`, R: 3},
 		{C: `openat 3 "foo" O_DIRECTORY 0`, R: 4},
 		{C: `close 4`},
@@ -235,9 +235,9 @@ func (s *lowLevelSuite) TestOpenatFailure(c *C) {
 		`openat 3 "foo" O_DIRECTORY 0`, // -> ENOENT
 		`close 3`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/" O_DIRECTORY 0`, R: 3},
-		{C: `openat 3 "foo" O_DIRECTORY 0`, R: syscall.ENOENT},
+		{C: `openat 3 "foo" O_DIRECTORY 0`, E: syscall.ENOENT},
 		{C: `close 3`},
 	})
 }
@@ -249,8 +249,8 @@ func (s *lowLevelSuite) TestOpenatBadFd(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`openat 3 "foo" O_DIRECTORY 0`, // -> error
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `openat 3 "foo" O_DIRECTORY 0`, R: fmt.Errorf("attempting to openat with an invalid file descriptor 3")},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `openat 3 "foo" O_DIRECTORY 0`, E: fmt.Errorf("attempting to openat with an invalid file descriptor 3")},
 	})
 }
 
@@ -265,7 +265,7 @@ func (s *lowLevelSuite) TestFchownSuccess(c *C) {
 		`fchown 3 0 0`,
 		`close 3`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/" O_DIRECTORY 0`, R: 3},
 		{C: `fchown 3 0 0`},
 		{C: `close 3`},
@@ -284,9 +284,9 @@ func (s *lowLevelSuite) TestFchownFailure(c *C) {
 		`fchown 3 0 0`,           // -> EPERM
 		`close 3`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/" O_DIRECTORY 0`, R: 3},
-		{C: `fchown 3 0 0`, R: syscall.EPERM},
+		{C: `fchown 3 0 0`, E: syscall.EPERM},
 		{C: `close 3`},
 	})
 }
@@ -297,8 +297,8 @@ func (s *lowLevelSuite) TestFchownBadFd(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`fchown 3 0 0`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `fchown 3 0 0`, R: fmt.Errorf("attempting to fchown an invalid file descriptor 3")},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `fchown 3 0 0`, E: fmt.Errorf("attempting to fchown an invalid file descriptor 3")},
 	})
 }
 
@@ -313,7 +313,7 @@ func (s *lowLevelSuite) TestMkdiratSuccess(c *C) {
 		`mkdirat 3 "foo" 0755`,
 		`close 3`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/" O_DIRECTORY 0`, R: 3},
 		{C: `mkdirat 3 "foo" 0755`},
 		{C: `close 3`},
@@ -332,9 +332,9 @@ func (s *lowLevelSuite) TestMkdiratFailure(c *C) {
 		`mkdirat 3 "foo" 0755`,   // -> EPERM
 		`close 3`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/" O_DIRECTORY 0`, R: 3},
-		{C: `mkdirat 3 "foo" 0755`, R: syscall.EPERM},
+		{C: `mkdirat 3 "foo" 0755`, E: syscall.EPERM},
 		{C: `close 3`},
 	})
 }
@@ -345,8 +345,8 @@ func (s *lowLevelSuite) TestMkdiratBadFd(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`mkdirat 3 "foo" 0755`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `mkdirat 3 "foo" 0755`, R: fmt.Errorf("attempting to mkdirat with an invalid file descriptor 3")},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `mkdirat 3 "foo" 0755`, E: fmt.Errorf("attempting to mkdirat with an invalid file descriptor 3")},
 	})
 }
 
@@ -356,7 +356,7 @@ func (s *lowLevelSuite) TestMountSuccess(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`mount "source" "target" "fstype" MS_BIND|MS_REC|MS_RDONLY ""`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `mount "source" "target" "fstype" MS_BIND|MS_REC|MS_RDONLY ""`},
 	})
 }
@@ -368,8 +368,8 @@ func (s *lowLevelSuite) TestMountFailure(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`mount "source" "target" "fstype" 0 ""`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `mount "source" "target" "fstype" 0 ""`, R: syscall.EPERM},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `mount "source" "target" "fstype" 0 ""`, E: syscall.EPERM},
 	})
 }
 
@@ -377,7 +377,7 @@ func (s *lowLevelSuite) TestUnmountSuccess(c *C) {
 	err := s.sys.Unmount("target", testutil.UmountNoFollow|syscall.MNT_DETACH)
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "target" UMOUNT_NOFOLLOW|MNT_DETACH`})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `unmount "target" UMOUNT_NOFOLLOW|MNT_DETACH`},
 	})
 }
@@ -387,8 +387,8 @@ func (s *lowLevelSuite) TestUnmountFailure(c *C) {
 	err := s.sys.Unmount("target", 0)
 	c.Assert(err, ErrorMatches, "operation not permitted")
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "target" 0`})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `unmount "target" 0`, R: syscall.EPERM},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `unmount "target" 0`, E: syscall.EPERM},
 	})
 }
 
@@ -405,7 +405,7 @@ func (s *lowLevelSuite) TestOsLstatSuccess(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(fi, DeepEquals, testutil.FileInfoFile)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`lstat "/foo"`})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `lstat "/foo"`, R: testutil.FileInfoFile},
 	})
 }
@@ -418,8 +418,8 @@ func (s *lowLevelSuite) TestOsLstatFailure(c *C) {
 	c.Assert(err, ErrorMatches, "no such file or directory")
 	c.Assert(fi, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`lstat "/foo"`})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `lstat "/foo"`, R: syscall.ENOENT},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `lstat "/foo"`, E: syscall.ENOENT},
 	})
 }
 
@@ -440,7 +440,7 @@ func (s *lowLevelSuite) TestSysLstatSuccess(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`lstat "/foo" <ptr>`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `lstat "/foo" <ptr>`, R: syscall.Stat_t{Uid: 123}},
 	})
 }
@@ -456,8 +456,8 @@ func (s *lowLevelSuite) TestSysLstatFailure(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`lstat "/foo" <ptr>`, // -> ENOENT
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `lstat "/foo" <ptr>`, R: syscall.ENOENT},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `lstat "/foo" <ptr>`, E: syscall.ENOENT},
 	})
 }
 
@@ -476,8 +476,8 @@ func (s *lowLevelSuite) TestFstatBadFd(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`fstat 3 <ptr>`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `fstat 3 <ptr>`, R: fmt.Errorf("attempting to fstat with an invalid file descriptor 3")},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `fstat 3 <ptr>`, E: fmt.Errorf("attempting to fstat with an invalid file descriptor 3")},
 	})
 }
 
@@ -493,7 +493,7 @@ func (s *lowLevelSuite) TestFstatSuccess(c *C) {
 		`open "/foo" 0 0`, // -> 3
 		`fstat 3 <ptr>`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/foo" 0 0`, R: 3},
 		{C: `fstat 3 <ptr>`, R: syscall.Stat_t{Dev: 0xC0FE}},
 	})
@@ -511,9 +511,9 @@ func (s *lowLevelSuite) TestFstatFailure(c *C) {
 		`open "/foo" 0 0`, // -> 3
 		`fstat 3 <ptr>`,   // -> EPERM
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/foo" 0 0`, R: 3},
-		{C: `fstat 3 <ptr>`, R: syscall.EPERM},
+		{C: `fstat 3 <ptr>`, E: syscall.EPERM},
 	})
 }
 
@@ -534,7 +534,7 @@ func (s *lowLevelSuite) TestReadDirSuccess(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`readdir "/foo"`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `readdir "/foo"`, R: files},
 	})
 }
@@ -547,8 +547,8 @@ func (s *lowLevelSuite) TestReadDirFailure(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`readdir "/foo"`, // -> ENOENT
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `readdir "/foo"`, R: syscall.ENOENT},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `readdir "/foo"`, E: syscall.ENOENT},
 	})
 }
 
@@ -558,7 +558,7 @@ func (s *lowLevelSuite) TestSymlinkSuccess(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`symlink "newname" -> "oldname"`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `symlink "newname" -> "oldname"`},
 	})
 }
@@ -570,8 +570,8 @@ func (s *lowLevelSuite) TestSymlinkFailure(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`symlink "newname" -> "oldname"`, // -> EPERM
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `symlink "newname" -> "oldname"`, R: syscall.EPERM},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `symlink "newname" -> "oldname"`, E: syscall.EPERM},
 	})
 }
 
@@ -581,7 +581,7 @@ func (s *lowLevelSuite) TestRemoveSuccess(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`remove "file"`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `remove "file"`},
 	})
 }
@@ -594,8 +594,8 @@ func (s *lowLevelSuite) TestRemoveFailure(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`remove "file"`, // -> EPERM
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `remove "file"`, R: syscall.EPERM},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `remove "file"`, E: syscall.EPERM},
 	})
 }
 
@@ -605,8 +605,8 @@ func (s *lowLevelSuite) TestSymlinkatBadFd(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`symlinkat "/old" 3 "new"`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `symlinkat "/old" 3 "new"`, R: fmt.Errorf("attempting to symlinkat with an invalid file descriptor 3")},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `symlinkat "/old" 3 "new"`, E: fmt.Errorf("attempting to symlinkat with an invalid file descriptor 3")},
 	})
 }
 
@@ -619,7 +619,7 @@ func (s *lowLevelSuite) TestSymlinkatSuccess(c *C) {
 		`open "/foo" 0 0`,
 		`symlinkat "/old" 3 "new"`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/foo" 0 0`, R: 3},
 		{C: `symlinkat "/old" 3 "new"`},
 	})
@@ -635,9 +635,9 @@ func (s *lowLevelSuite) TestSymlinkatFailure(c *C) {
 		`open "/foo" 0 0`, // -> 3
 		`symlinkat "/old" 3 "new"`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
 		{C: `open "/foo" 0 0`, R: 3},
-		{C: `symlinkat "/old" 3 "new"`, R: syscall.EPERM},
+		{C: `symlinkat "/old" 3 "new"`, E: syscall.EPERM},
 	})
 }
 
@@ -657,8 +657,8 @@ func (s *lowLevelSuite) TestReadlinkatBadFd(c *C) {
 	c.Assert(s.sys.Calls(), DeepEquals, []string{
 		`readlinkat 3 "new" <ptr>`,
 	})
-	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{C: `readlinkat 3 "new" <ptr>`, R: fmt.Errorf("attempting to readlinkat with an invalid file descriptor 3")},
+	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
+		{C: `readlinkat 3 "new" <ptr>`, E: fmt.Errorf("attempting to readlinkat with an invalid file descriptor 3")},
 	})
 }
 

--- a/testutil/lowlevel_test.go
+++ b/testutil/lowlevel_test.go
@@ -66,7 +66,7 @@ func (s *lowLevelSuite) TestOpenSuccess(c *C) {
 		`open "/some/path" O_NOFOLLOW|O_CLOEXEC|O_RDWR|O_CREAT|O_EXCL 0`, // -> 3
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/some/path" O_NOFOLLOW|O_CLOEXEC|O_RDWR|O_CREAT|O_EXCL 0`, 3},
+		{C: `open "/some/path" O_NOFOLLOW|O_CLOEXEC|O_RDWR|O_CREAT|O_EXCL 0`, R: 3},
 	})
 }
 
@@ -80,7 +80,7 @@ func (s *lowLevelSuite) TestOpenFailure(c *C) {
 		`open "/some/path" 0 0`, // -> ENOENT
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/some/path" 0 0`, syscall.ENOENT},
+		{C: `open "/some/path" 0 0`, R: syscall.ENOENT},
 	})
 }
 
@@ -105,9 +105,9 @@ func (s *lowLevelSuite) TestOpenVariableFailure(c *C) {
 		`open "/some/path" O_RDWR 0`, // -> 3
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/some/path" O_RDWR 0`, syscall.ENOENT},
-		{`open "/some/path" O_RDWR 0`, syscall.EPERM},
-		{`open "/some/path" O_RDWR 0`, 3},
+		{C: `open "/some/path" O_RDWR 0`, R: syscall.ENOENT},
+		{C: `open "/some/path" O_RDWR 0`, R: syscall.EPERM},
+		{C: `open "/some/path" O_RDWR 0`, R: 3},
 	})
 }
 
@@ -138,10 +138,10 @@ func (s *lowLevelSuite) TestOpenCustomFailure(c *C) {
 		`open "/some/path" O_RDWR 0`, // -> 3
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/some/path" O_RDWR 0`, fmt.Errorf("3 more")},
-		{`open "/some/path" O_RDWR 0`, fmt.Errorf("2 more")},
-		{`open "/some/path" O_RDWR 0`, fmt.Errorf("1 more")},
-		{`open "/some/path" O_RDWR 0`, 3},
+		{C: `open "/some/path" O_RDWR 0`, R: fmt.Errorf("3 more")},
+		{C: `open "/some/path" O_RDWR 0`, R: fmt.Errorf("2 more")},
+		{C: `open "/some/path" O_RDWR 0`, R: fmt.Errorf("1 more")},
+		{C: `open "/some/path" O_RDWR 0`, R: 3},
 	})
 }
 
@@ -155,7 +155,7 @@ func (s *lowLevelSuite) TestUnclosedFile(c *C) {
 		`open "/some/path" O_RDWR 0`, // -> 3
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/some/path" O_RDWR 0`, 3},
+		{C: `open "/some/path" O_RDWR 0`, R: 3},
 	})
 	c.Assert(s.sys.StrayDescriptorsError(), ErrorMatches,
 		`unclosed file descriptor 3 \(open "/some/path" O_RDWR 0\)`)
@@ -167,7 +167,7 @@ func (s *lowLevelSuite) TestUnopenedFile(c *C) {
 	c.Assert(err, ErrorMatches, "attempting to close a closed file descriptor 7")
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`close 7`})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`close 7`, fmt.Errorf("attempting to close a closed file descriptor 7")},
+		{C: `close 7`, R: fmt.Errorf("attempting to close a closed file descriptor 7")},
 	})
 }
 
@@ -182,8 +182,8 @@ func (s *lowLevelSuite) TestCloseSuccess(c *C) {
 		`close 3`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/some/path" O_RDWR 0`, 3},
-		{`close 3`, nil},
+		{C: `open "/some/path" O_RDWR 0`, R: 3},
+		{C: `close 3`},
 	})
 	c.Assert(s.sys.StrayDescriptorsError(), IsNil)
 }
@@ -197,7 +197,7 @@ func (s *lowLevelSuite) TestCloseFailure(c *C) {
 		`close 3`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`close 3`, syscall.ENOSYS},
+		{C: `close 3`, R: syscall.ENOSYS},
 	})
 }
 
@@ -215,10 +215,10 @@ func (s *lowLevelSuite) TestOpenatSuccess(c *C) {
 		`close 3`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/" O_DIRECTORY 0`, 3},
-		{`openat 3 "foo" O_DIRECTORY 0`, 4},
-		{`close 4`, nil},
-		{`close 3`, nil},
+		{C: `open "/" O_DIRECTORY 0`, R: 3},
+		{C: `openat 3 "foo" O_DIRECTORY 0`, R: 4},
+		{C: `close 4`},
+		{C: `close 3`},
 	})
 }
 
@@ -236,9 +236,9 @@ func (s *lowLevelSuite) TestOpenatFailure(c *C) {
 		`close 3`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/" O_DIRECTORY 0`, 3},
-		{`openat 3 "foo" O_DIRECTORY 0`, syscall.ENOENT},
-		{`close 3`, nil},
+		{C: `open "/" O_DIRECTORY 0`, R: 3},
+		{C: `openat 3 "foo" O_DIRECTORY 0`, R: syscall.ENOENT},
+		{C: `close 3`},
 	})
 }
 
@@ -250,7 +250,7 @@ func (s *lowLevelSuite) TestOpenatBadFd(c *C) {
 		`openat 3 "foo" O_DIRECTORY 0`, // -> error
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`openat 3 "foo" O_DIRECTORY 0`, fmt.Errorf("attempting to openat with an invalid file descriptor 3")},
+		{C: `openat 3 "foo" O_DIRECTORY 0`, R: fmt.Errorf("attempting to openat with an invalid file descriptor 3")},
 	})
 }
 
@@ -266,9 +266,9 @@ func (s *lowLevelSuite) TestFchownSuccess(c *C) {
 		`close 3`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/" O_DIRECTORY 0`, 3},
-		{`fchown 3 0 0`, nil},
-		{`close 3`, nil},
+		{C: `open "/" O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
 	})
 }
 
@@ -285,9 +285,9 @@ func (s *lowLevelSuite) TestFchownFailure(c *C) {
 		`close 3`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/" O_DIRECTORY 0`, 3},
-		{`fchown 3 0 0`, syscall.EPERM},
-		{`close 3`, nil},
+		{C: `open "/" O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`, R: syscall.EPERM},
+		{C: `close 3`},
 	})
 }
 
@@ -298,7 +298,7 @@ func (s *lowLevelSuite) TestFchownBadFd(c *C) {
 		`fchown 3 0 0`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`fchown 3 0 0`, fmt.Errorf("attempting to fchown an invalid file descriptor 3")},
+		{C: `fchown 3 0 0`, R: fmt.Errorf("attempting to fchown an invalid file descriptor 3")},
 	})
 }
 
@@ -314,9 +314,9 @@ func (s *lowLevelSuite) TestMkdiratSuccess(c *C) {
 		`close 3`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/" O_DIRECTORY 0`, 3},
-		{`mkdirat 3 "foo" 0755`, nil},
-		{`close 3`, nil},
+		{C: `open "/" O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "foo" 0755`},
+		{C: `close 3`},
 	})
 }
 
@@ -333,18 +333,20 @@ func (s *lowLevelSuite) TestMkdiratFailure(c *C) {
 		`close 3`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/" O_DIRECTORY 0`, 3},
-		{`mkdirat 3 "foo" 0755`, syscall.EPERM},
-		{`close 3`, nil},
+		{C: `open "/" O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "foo" 0755`, R: syscall.EPERM},
+		{C: `close 3`},
 	})
 }
 
 func (s *lowLevelSuite) TestMkdiratBadFd(c *C) {
 	err := s.sys.Mkdirat(3, "foo", 0755)
 	c.Assert(err, ErrorMatches, "attempting to mkdirat with an invalid file descriptor 3")
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`mkdirat 3 "foo" 0755`})
+	c.Assert(s.sys.Calls(), DeepEquals, []string{
+		`mkdirat 3 "foo" 0755`,
+	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`mkdirat 3 "foo" 0755`, fmt.Errorf("attempting to mkdirat with an invalid file descriptor 3")},
+		{C: `mkdirat 3 "foo" 0755`, R: fmt.Errorf("attempting to mkdirat with an invalid file descriptor 3")},
 	})
 }
 
@@ -355,7 +357,7 @@ func (s *lowLevelSuite) TestMountSuccess(c *C) {
 		`mount "source" "target" "fstype" MS_BIND|MS_REC|MS_RDONLY ""`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`mount "source" "target" "fstype" MS_BIND|MS_REC|MS_RDONLY ""`, nil},
+		{C: `mount "source" "target" "fstype" MS_BIND|MS_REC|MS_RDONLY ""`},
 	})
 }
 
@@ -367,7 +369,7 @@ func (s *lowLevelSuite) TestMountFailure(c *C) {
 		`mount "source" "target" "fstype" 0 ""`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`mount "source" "target" "fstype" 0 ""`, syscall.EPERM},
+		{C: `mount "source" "target" "fstype" 0 ""`, R: syscall.EPERM},
 	})
 }
 
@@ -376,7 +378,7 @@ func (s *lowLevelSuite) TestUnmountSuccess(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "target" UMOUNT_NOFOLLOW|MNT_DETACH`})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`unmount "target" UMOUNT_NOFOLLOW|MNT_DETACH`, nil},
+		{C: `unmount "target" UMOUNT_NOFOLLOW|MNT_DETACH`},
 	})
 }
 
@@ -386,7 +388,7 @@ func (s *lowLevelSuite) TestUnmountFailure(c *C) {
 	c.Assert(err, ErrorMatches, "operation not permitted")
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "target" 0`})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`unmount "target" 0`, syscall.EPERM},
+		{C: `unmount "target" 0`, R: syscall.EPERM},
 	})
 }
 
@@ -404,7 +406,7 @@ func (s *lowLevelSuite) TestOsLstatSuccess(c *C) {
 	c.Assert(fi, DeepEquals, testutil.FileInfoFile)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`lstat "/foo"`})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`lstat "/foo"`, testutil.FileInfoFile},
+		{C: `lstat "/foo"`, R: testutil.FileInfoFile},
 	})
 }
 
@@ -417,7 +419,7 @@ func (s *lowLevelSuite) TestOsLstatFailure(c *C) {
 	c.Assert(fi, IsNil)
 	c.Assert(s.sys.Calls(), DeepEquals, []string{`lstat "/foo"`})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`lstat "/foo"`, syscall.ENOENT},
+		{C: `lstat "/foo"`, R: syscall.ENOENT},
 	})
 }
 
@@ -439,7 +441,7 @@ func (s *lowLevelSuite) TestSysLstatSuccess(c *C) {
 		`lstat "/foo" <ptr>`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`lstat "/foo" <ptr>`, syscall.Stat_t{Uid: 123}},
+		{C: `lstat "/foo" <ptr>`, R: syscall.Stat_t{Uid: 123}},
 	})
 }
 
@@ -455,7 +457,7 @@ func (s *lowLevelSuite) TestSysLstatFailure(c *C) {
 		`lstat "/foo" <ptr>`, // -> ENOENT
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`lstat "/foo" <ptr>`, syscall.ENOENT},
+		{C: `lstat "/foo" <ptr>`, R: syscall.ENOENT},
 	})
 }
 
@@ -475,7 +477,7 @@ func (s *lowLevelSuite) TestFstatBadFd(c *C) {
 		`fstat 3 <ptr>`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`fstat 3 <ptr>`, fmt.Errorf("attempting to fstat with an invalid file descriptor 3")},
+		{C: `fstat 3 <ptr>`, R: fmt.Errorf("attempting to fstat with an invalid file descriptor 3")},
 	})
 }
 
@@ -492,8 +494,8 @@ func (s *lowLevelSuite) TestFstatSuccess(c *C) {
 		`fstat 3 <ptr>`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/foo" 0 0`, 3},
-		{`fstat 3 <ptr>`, syscall.Stat_t{Dev: 0xC0FE}},
+		{C: `open "/foo" 0 0`, R: 3},
+		{C: `fstat 3 <ptr>`, R: syscall.Stat_t{Dev: 0xC0FE}},
 	})
 }
 
@@ -510,8 +512,8 @@ func (s *lowLevelSuite) TestFstatFailure(c *C) {
 		`fstat 3 <ptr>`,   // -> EPERM
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/foo" 0 0`, 3},
-		{`fstat 3 <ptr>`, syscall.EPERM},
+		{C: `open "/foo" 0 0`, R: 3},
+		{C: `fstat 3 <ptr>`, R: syscall.EPERM},
 	})
 }
 
@@ -533,7 +535,7 @@ func (s *lowLevelSuite) TestReadDirSuccess(c *C) {
 		`readdir "/foo"`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`readdir "/foo"`, files},
+		{C: `readdir "/foo"`, R: files},
 	})
 }
 
@@ -546,7 +548,7 @@ func (s *lowLevelSuite) TestReadDirFailure(c *C) {
 		`readdir "/foo"`, // -> ENOENT
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`readdir "/foo"`, syscall.ENOENT},
+		{C: `readdir "/foo"`, R: syscall.ENOENT},
 	})
 }
 
@@ -557,7 +559,7 @@ func (s *lowLevelSuite) TestSymlinkSuccess(c *C) {
 		`symlink "newname" -> "oldname"`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`symlink "newname" -> "oldname"`, nil},
+		{C: `symlink "newname" -> "oldname"`},
 	})
 }
 
@@ -569,7 +571,7 @@ func (s *lowLevelSuite) TestSymlinkFailure(c *C) {
 		`symlink "newname" -> "oldname"`, // -> EPERM
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`symlink "newname" -> "oldname"`, syscall.EPERM},
+		{C: `symlink "newname" -> "oldname"`, R: syscall.EPERM},
 	})
 }
 
@@ -580,7 +582,7 @@ func (s *lowLevelSuite) TestRemoveSuccess(c *C) {
 		`remove "file"`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`remove "file"`, nil},
+		{C: `remove "file"`},
 	})
 }
 
@@ -593,7 +595,7 @@ func (s *lowLevelSuite) TestRemoveFailure(c *C) {
 		`remove "file"`, // -> EPERM
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`remove "file"`, syscall.EPERM},
+		{C: `remove "file"`, R: syscall.EPERM},
 	})
 }
 
@@ -604,7 +606,7 @@ func (s *lowLevelSuite) TestSymlinkatBadFd(c *C) {
 		`symlinkat "/old" 3 "new"`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`symlinkat "/old" 3 "new"`, fmt.Errorf("attempting to symlinkat with an invalid file descriptor 3")},
+		{C: `symlinkat "/old" 3 "new"`, R: fmt.Errorf("attempting to symlinkat with an invalid file descriptor 3")},
 	})
 }
 
@@ -617,13 +619,9 @@ func (s *lowLevelSuite) TestSymlinkatSuccess(c *C) {
 		`open "/foo" 0 0`,
 		`symlinkat "/old" 3 "new"`,
 	})
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`open "/foo" 0 0`, // -> 3
-		`symlinkat "/old" 3 "new"`,
-	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/foo" 0 0`, 3},
-		{`symlinkat "/old" 3 "new"`, nil},
+		{C: `open "/foo" 0 0`, R: 3},
+		{C: `symlinkat "/old" 3 "new"`},
 	})
 }
 
@@ -638,8 +636,8 @@ func (s *lowLevelSuite) TestSymlinkatFailure(c *C) {
 		`symlinkat "/old" 3 "new"`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`open "/foo" 0 0`, 3},
-		{`symlinkat "/old" 3 "new"`, syscall.EPERM},
+		{C: `open "/foo" 0 0`, R: 3},
+		{C: `symlinkat "/old" 3 "new"`, R: syscall.EPERM},
 	})
 }
 
@@ -660,7 +658,7 @@ func (s *lowLevelSuite) TestReadlinkatBadFd(c *C) {
 		`readlinkat 3 "new" <ptr>`,
 	})
 	c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResult{
-		{`readlinkat 3 "new" <ptr>`, fmt.Errorf("attempting to readlinkat with an invalid file descriptor 3")},
+		{C: `readlinkat 3 "new" <ptr>`, R: fmt.Errorf("attempting to readlinkat with an invalid file descriptor 3")},
 	})
 }
 


### PR DESCRIPTION
This patch expands the facility for recording mocked system calls to also
record errors or return values. This allows to change code that just suggests a
return value to the reader to one that actively checks it:

Code such as:

```
    c.Assert(s.sys.Calls(), DeepEquals, []string{
	`open "/" O_DIRECTORY 0`,       // -> 3
	`openat 3 "foo" O_DIRECTORY 0`, // -> 4
	`close 4`,
	`close 3`,
    })
```

Becomes:

```
    c.Assert(s.sys.RCalls(), DeepEquals, []testutil.CallResultError{
	{C: `open "/" O_DIRECTORY 0`, R: 3},
	{C: `openat 3 "foo" O_DIRECTORY 0`, R: 4},
	{C: `close 4`},
	{C: `close 3`},
    })
```

All the internal unit tests are updated to check return values. The old
facility (sys.Calls()) is still available, as a derivative of the new data.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
