### PR TITLE
snapstate: make TestDoPrereqRetryWhenBaseInFlight less brittle

### DIFF
--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -247,16 +247,18 @@ func (s *prereqSuite) TestDoPrereqRetryWhenBaseInFlight(c *C) {
 	c.Check(t.Status(), Equals, state.DoingStatus)
 	c.Check(tCore.Status(), Equals, state.DoneStatus)
 
-	s.state.Unlock()
-	// wait the prereq-retry-timeout
-	for i := 0; i < 10; i++ {
+	// wait, we will hit prereq-retry-timeout eventually
+	// (this can take a while on very slow machines)
+	for i := 0; i < 50; i++ {
 		time.Sleep(10 * time.Millisecond)
+		s.state.Unlock()
 		s.snapmgr.Ensure()
 		s.snapmgr.Wait()
+		s.state.Lock()
+		if t.Status() == state.DoneStatus {
+			break
+		}
 	}
-	s.state.Lock()
-	defer s.state.Unlock()
-
 	c.Check(t.Status(), Equals, state.DoneStatus)
 }
 


### PR DESCRIPTION
The TestDoPrereqRetryWhenBaseInFlight was failing in the autopkgtest
environment. It looks like the reason is that the VMs that run the
test are very slow (due to load) and this results in the timeouts
to miss. Rework the test to give it more time and also to be more
uniform with the previous bits of the test.
