### PR TITLE
cmd/snap: fix the message when snap.channel != snap.tracking

### DIFF
--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -282,7 +282,7 @@ func showDone(names []string, op string) error {
 		}
 		if snap.TrackingChannel != snap.Channel && snap.Channel != "" {
 			// TRANSLATORS: first %s is a channel name, following %s is a snap name, last %s is a channel name again.
-			fmt.Fprintf(Stdout, i18n.G("%s for %s is closed; temporarily forwarding to %s.\n"), snap.TrackingChannel, snap.Name, snap.Channel)
+			fmt.Fprintf(Stdout, i18n.G("Channel %s for %s is closed; temporarily forwarding to %s.\n"), snap.TrackingChannel, snap.Name, snap.Channel)
 		}
 	}
 

--- a/cmd/snap/cmd_snap_op.go
+++ b/cmd/snap/cmd_snap_op.go
@@ -281,8 +281,8 @@ func showDone(names []string, op string) error {
 			fmt.Fprintf(Stdout, "internal error: unknown op %q", op)
 		}
 		if snap.TrackingChannel != snap.Channel && snap.Channel != "" {
-			// TRANSLATORS: first %s is a snap name, following %s is a channel name
-			fmt.Fprintf(Stdout, i18n.G("Snap %s is no longer tracking %s.\n"), snap.Name, snap.TrackingChannel)
+			// TRANSLATORS: first %s is a channel name, following %s is a snap name, last %s is a channel name again.
+			fmt.Fprintf(Stdout, i18n.G("%s for %s is closed; temporarily forwarding to %s.\n"), snap.TrackingChannel, snap.Name, snap.Channel)
 		}
 	}
 

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -444,7 +444,7 @@ func (s *SnapOpSuite) TestRevertRunthrough(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	// tracking channel is "" in the test server
 	c.Check(s.Stdout(), check.Equals, `foo reverted to 1.0
- for foo is closed; temporarily forwarding to potato.
+Channel  for foo is closed; temporarily forwarding to potato.
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit

--- a/cmd/snap/cmd_snap_op_test.go
+++ b/cmd/snap/cmd_snap_op_test.go
@@ -444,7 +444,7 @@ func (s *SnapOpSuite) TestRevertRunthrough(c *check.C) {
 	c.Assert(rest, check.DeepEquals, []string{})
 	// tracking channel is "" in the test server
 	c.Check(s.Stdout(), check.Equals, `foo reverted to 1.0
-Snap foo is no longer tracking .
+ for foo is closed; temporarily forwarding to potato.
 `)
 	c.Check(s.Stderr(), check.Equals, "")
 	// ensure that the fake server api was actually hit

--- a/tests/main/install-closed-channel/task.yaml
+++ b/tests/main/install-closed-channel/task.yaml
@@ -6,4 +6,4 @@ details: |
 
 execute: |
     snap install --beta test-snapd-tools | MATCH '^Channel beta for test-snapd-tools is closed; temporarily forwarding to stable\.$'
-    snap info test-snapd-tools | MATCH tracking:.*beta
+    snap info test-snapd-tools | MATCH 'tracking:.*beta'

--- a/tests/main/install-closed-channel/task.yaml
+++ b/tests/main/install-closed-channel/task.yaml
@@ -5,5 +5,5 @@ details: |
     "forward" to the next available risk level.
 
 execute: |
-    snap install --beta test-snapd-tools | MATCH '^beta for test-snapd-tools is closed; temporarily forwarding to stable\.$'
+    snap install --beta test-snapd-tools | MATCH '^Channel beta for test-snapd-tools is closed; temporarily forwarding to stable\.$'
     snap info test-snapd-tools | MATCH tracking:.*beta

--- a/tests/main/install-closed-channel/task.yaml
+++ b/tests/main/install-closed-channel/task.yaml
@@ -1,0 +1,9 @@
+summary: Check that installing a snap from a closed channel DTRT
+
+details: |
+    When a snap is installed from a closed channel, we're supposed to
+    "forward" to the next available risk level.
+
+execute: |
+    snap install --beta test-snapd-tools | MATCH '^beta for test-snapd-tools is closed; temporarily forwarding to stable\.$'
+    snap info test-snapd-tools | MATCH tracking:.*beta

--- a/tests/unit/spread-shellcheck/must
+++ b/tests/unit/spread-shellcheck/must
@@ -21,3 +21,4 @@ tests/main/classic-ubuntu-core-transition-two-cores/task.yaml
 tests/main/classic-ubuntu-core-transition/task.yaml
 tests/main/completion/task.yaml
 tests/main/config-versions/task.yaml
+tests/main/install-closed-channel/task.yaml


### PR DESCRIPTION
also adds a spread test for same.

This fixes [lp:1739097](https://bugs.launchpad.net/snapd/+bug/1739097), as raised in [the forum](https://forum.snapcraft.io/t/refreshing-to-a-closed-channel/5423).