### PR TITLE
tests: build spread in the autopkgtests with a more recent go

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -36,11 +36,14 @@ elif apt -qq list snapd | grep -q -- -updates; then
     export SPREAD_CORE_CHANNEL=stable
 fi
 
+# Spread will only buid with recent go
+snap install go
+
 # and now run spread against localhost
 # shellcheck disable=SC1091
 . /etc/os-release
 export GOPATH=/tmp/go
-go get -u github.com/snapcore/spread/cmd/spread
+/snap/bin/go get -u github.com/snapcore/spread/cmd/spread
 /tmp/go/bin/spread -v "autopkgtest:${ID}-${VERSION_ID}-$(dpkg --print-architecture)"
 
 # store journal info for inspectsion


### PR DESCRIPTION
Our autopkgtest tests are currently failing in distros with go-1.6 because spread (via the crypto/ssh dependency) now requires a later version of go to build.

This PR builds spread with the current stable go via the go snap (which is also a nice test for snapd before the actual tests start :)

I tested this with a local autopkgtest run on 16.04 and it fixes the issue that spread fails to build.