### PR TITLE
tests: fix user mounts test for external systems

### DIFF
--- a/tests/main/user-mounts/task.yaml
+++ b/tests/main/user-mounts/task.yaml
@@ -12,7 +12,7 @@ execute: |
     . $TESTSLIB/dirs.sh
 
     echo "Create XDG_RUNTIME_DIR for test user"
-    USER_RUNTIME_DIR=/run/user/12345
+    USER_RUNTIME_DIR=/run/user/"$(id -u test)"
     mkdir -p $USER_RUNTIME_DIR || true
     rm -rf $USER_RUNTIME_DIR/*
     chmod u=rwX,go= $USER_RUNTIME_DIR


### PR DESCRIPTION
For external devices the test used is not created with is 12345, so we
need to use its id to match its XDG_RUNTIME_DIR.

This test is failing on dragonboard and cm3 running edge.
