### PR TITLE
tests: go must be installed as a classic snap

### DIFF
--- a/packaging/ubuntu-16.04/tests/integrationtests
+++ b/packaging/ubuntu-16.04/tests/integrationtests
@@ -37,7 +37,7 @@ elif apt -qq list snapd | grep -q -- -updates; then
 fi
 
 # Spread will only buid with recent go
-snap install go
+snap install --classic go
 
 # and now run spread against localhost
 # shellcheck disable=SC1091


### PR DESCRIPTION
Trivial fix (was actually part of my tree but missed the push) for the snap install of go in the adt testing.