### PR TITLE
tests: cherry-pick more GCE commits

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -59,6 +59,10 @@ backends:
                 image: ubuntu-16.04-64
                 workers: 6
 
+            - debian-9-64:
+                image: debian-9-stretch
+                workers: 6
+
             - opensuse-42.2-64:
                 image: opensuse-leap-42-2
                 workers: 4
@@ -80,9 +84,6 @@ backends:
             HTTP_PROXY: null
             HTTPS_PROXY: null
         systems:
-            - debian-9-64:
-                kernel: GRUB 2
-                workers: 6
             - debian-sid-64:
                 kernel: GRUB 2
                 workers: 6

--- a/spread.yaml
+++ b/spread.yaml
@@ -88,7 +88,6 @@ backends:
         systems:
             - fedora-27-64:
                 workers: 4
-                # Fedora CI disabled because of unexplained golang bug breaking every build.
                 manual: true
             - fedora-26-64:
                 workers: 4

--- a/spread.yaml
+++ b/spread.yaml
@@ -60,8 +60,10 @@ backends:
                 workers: 6
 
             - debian-9-64:
-                image: debian-9-stretch
                 workers: 6
+            - debian-sid-64:
+                workers: 6
+                manual: true
 
             - opensuse-42.2-64:
                 image: opensuse-leap-42-2
@@ -84,11 +86,6 @@ backends:
             HTTP_PROXY: null
             HTTPS_PROXY: null
         systems:
-            - debian-sid-64:
-                kernel: GRUB 2
-                workers: 6
-                manual: true
-
             - fedora-27-64:
                 workers: 4
                 # Fedora CI disabled because of unexplained golang bug breaking every build.

--- a/tests/main/interfaces-avahi-observe/task.yaml
+++ b/tests/main/interfaces-avahi-observe/task.yaml
@@ -48,5 +48,5 @@ execute: |
     snap interfaces | MATCH "$CONNECTED_PATTERN"
 
     echo "Then the snap is able to access avahi provided info"
-    hostname=$(cat /etc/hostname)
+    hostname=$(hostname)
     generic-consumer.cmd $avahi_dbus_call | MATCH "$hostname"

--- a/tests/main/interfaces-timeserver-control/task.yaml
+++ b/tests/main/interfaces-timeserver-control/task.yaml
@@ -4,6 +4,11 @@ details: |
     This test makes sure that a snap using the timeserver-control interface
     can access timeserver information and update it.
 
+# Debian sid is skipped because "timedatectl set-ntp" fails with the error:
+# "Failed to set ntp: Message recipient disconnected from message bus without replying"
+# A workaround is to make "systemctl enable --now systemd-timesyncd.service" instead
+systems: [-debian-sid-*]
+
 prepare: |
     . $TESTSLIB/snaps.sh
 


### PR DESCRIPTION
We currently see 2.32 failing consistently in the remaining linode tests. This PR cherry-picks more commits from master to make 2.32 test cleanly again.