### PR TITLE
snap: fix `snap interface --attrs` output when numbers are used

### DIFF
--- a/cmd/snap/cmd_interface.go
+++ b/cmd/snap/cmd_interface.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -179,7 +180,7 @@ func (x *cmdInterface) showAttrs(w io.Writer, attrs map[string]interface{}, inde
 	for _, name := range names {
 		value := attrs[name]
 		switch value.(type) {
-		case string, int, bool:
+		case string, bool, json.Number:
 			fmt.Fprintf(w, "%s  %s:\t%v\n", indent, name, value)
 		}
 	}

--- a/cmd/snap/cmd_interface_test.go
+++ b/cmd/snap/cmd_interface_test.go
@@ -218,6 +218,7 @@ func (s *SnapSuite) TestInterfaceDetailsAndAttrs(c *C) {
 						"header":   "pin-array",
 						"location": "internal",
 						"path":     "/dev/ttyS0",
+						"number":   "1",
 					},
 				}},
 			}},
@@ -235,6 +236,7 @@ func (s *SnapSuite) TestInterfaceDetailsAndAttrs(c *C) {
 		"  - gizmo-gadget:debug-serial-port (serial port for debugging):\n" +
 		"      header:   pin-array\n" +
 		"      location: internal\n" +
+		"      number:   1\n" +
 		"      path:     /dev/ttyS0\n"
 	c.Assert(s.Stdout(), Equals, expectedStdout)
 	c.Assert(s.Stderr(), Equals, "")

--- a/cmd/snap/cmd_interface_test.go
+++ b/cmd/snap/cmd_interface_test.go
@@ -218,7 +218,7 @@ func (s *SnapSuite) TestInterfaceDetailsAndAttrs(c *C) {
 						"header":   "pin-array",
 						"location": "internal",
 						"path":     "/dev/ttyS0",
-						"number":   "1",
+						"number":   1,
 					},
 				}},
 			}},


### PR DESCRIPTION
This is a drive-by PR. While @pedronis reviewed #5157 he noticed
that the handling of json.Number is not consistent and that the
`snap interface --attr` does not handle numbers correctly.
