### PR TITLE
cmd/snap-confine, interfaces/opengl: allow access to glvnd EGL vendor files

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -45,8 +45,10 @@
 #define SC_LIBGL_DIR   SC_LIB "/gl"
 #define SC_LIBGL32_DIR SC_LIB "/gl32"
 #define SC_VULKAN_DIR  SC_LIB "/vulkan"
+#define SC_GLVND_DIR  SC_LIB "/glvnd"
 
 #define SC_VULKAN_SOURCE_DIR "/usr/share/vulkan"
+#define SC_EGL_VENDOR_SOURCE_DIR "/usr/share/glvnd"
 
 // Location for NVIDIA vulkan files (including _wayland)
 static const char *vulkan_globs[] = {
@@ -55,6 +57,14 @@ static const char *vulkan_globs[] = {
 
 static const size_t vulkan_globs_len =
     sizeof vulkan_globs / sizeof *vulkan_globs;
+
+// Location of EGL vendor files
+static const char *egl_vendor_globs[] = {
+	"egl_vendor.d/*nvidia*.json",
+};
+
+static const size_t egl_vendor_globs_len =
+    sizeof egl_vendor_globs / sizeof *egl_vendor_globs;
 
 #if defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
 
@@ -497,6 +507,18 @@ static void sc_mount_vulkan(const char *rootfs_dir)
 					  vulkan_globs, vulkan_globs_len);
 }
 
+static void sc_mount_egl(const char *rootfs_dir)
+{
+	const char *egl_vendor_sources[] = { SC_EGL_VENDOR_SOURCE_DIR };
+	const size_t egl_vendor_sources_len =
+	    sizeof egl_vendor_sources / sizeof *egl_vendor_sources;
+
+	sc_mkdir_and_mount_and_glob_files(rootfs_dir, egl_vendor_sources,
+					  egl_vendor_sources_len, SC_GLVND_DIR,
+					  egl_vendor_globs,
+					  egl_vendor_globs_len);
+}
+
 void sc_mount_nvidia_driver(const char *rootfs_dir)
 {
 	/* If NVIDIA module isn't loaded, don't attempt to mount the drivers */
@@ -521,4 +543,5 @@ void sc_mount_nvidia_driver(const char *rootfs_dir)
 
 	// Common for both driver mechanisms
 	sc_mount_vulkan(rootfs_dir);
+	sc_mount_egl(rootfs_dir);
 }

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -271,6 +271,11 @@
     mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
     mount options=(remount ro) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/,
 
+    # GLVND EGL vendor
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/{,*} w,
+    mount fstype=tmpfs options=(rw nodev noexec) none -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
+    mount options=(remount ro) -> /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/,
+
     # create gl dirs as needed
     /tmp/snap.rootfs_*/ r,
     /tmp/snap.rootfs_*/var/ r,
@@ -281,6 +286,8 @@
     /tmp/snap.rootfs_*/var/lib/snapd/lib/gl{,32}/** rw,
     /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/ r,
     /tmp/snap.rootfs_*/var/lib/snapd/lib/vulkan/** rw,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/ r,
+    /tmp/snap.rootfs_*/var/lib/snapd/lib/glvnd/** rw,
 
     # for chroot on steroids, we use pivot_root as a better chroot that makes
     # apparmor rules behave the same on classic and outside of classic.

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -48,6 +48,11 @@ const openglConnectedPlugAppArmor = `
 /var/lib/snapd/lib/vulkan/** r,
 /var/lib/snapd/hostfs/usr/share/vulkan/icd.d/*nvidia*.json r,
 
+# Support reading the GLVND EGL vendor files
+/var/lib/snapd/lib/glvnd/ r,
+/var/lib/snapd/lib/glvnd/** r,
+/var/lib/snapd/hostfs/usr/share/glvnd/egl_vendor.d/*nvidia*.json r,
+
 # Main bi-arch GL libraries
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}{,nvidia*/}lib{GL,EGL,GLX}.so{,.*} rm,
 

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -23,19 +23,19 @@ prepare: |
 
     # mock nvidia libraries
     if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
-        mkdir -p /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls
-        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libGLX.so.0.0.1
-        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libGLX_nvidia.so.0.0.1
-        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libnvidia-glcore.so.123.456
-        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls/libnvidia-tls.so.123.456
-        echo "canary-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libnvidia-tls.so.123.456
+        mkdir -p /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX.so.0.0.1
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX_nvidia.so.0.0.1
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-glcore.so.123.456
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls/libnvidia-tls.so.123.456
+        echo "canary-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-tls.so.123.456
         if [[ "$(uname -m)" == x86_64 ]]; then
-            mkdir -p /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/tls
-            echo "canary-32-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/libGLX.so.0.0.1
-            echo "canary-32-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/libGLX_nvidia.so.0.0.1
-            echo "canary-32-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/libnvidia-glcore.so.123.456
-            echo "canary-32-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/tls/libnvidia-tls.so.123.456
-            echo "canary-32-triplet" >> /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/libnvidia-tls.so.123.456
+            mkdir -p /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX.so.0.0.1
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX_nvidia.so.0.0.1
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-glcore.so.123.456
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls/libnvidia-tls.so.123.456
+            echo "canary-32-triplet" >> /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-tls.so.123.456
         fi
     fi
     mkdir -p /usr/lib/nvidia-123/tls
@@ -54,7 +54,9 @@ prepare: |
     fi
 
 execute: |
+    #shellcheck source=tests/lib/dirs.sh
     . $TESTSLIB/dirs.sh
+    #shellcheck source=tests/lib/snaps.sh
     . $TESTSLIB/snaps.sh
 
     install_local test-snapd-policy-app-consumer
@@ -98,19 +100,19 @@ restore: |
     fi
 
     if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
-        rm -rf /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls
-        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libGLX.so.0.0.1
-        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libGLX_nvidia.so.0.0.1
-        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libnvidia-glcore.so.123.456
-        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls/libnvidia-tls.so.123.456
-        rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libnvidia-tls.so.123.456
+        rm -rf /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls
+        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX.so.0.0.1
+        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libGLX_nvidia.so.0.0.1
+        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-glcore.so.123.456
+        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/tls/libnvidia-tls.so.123.456
+        rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/libnvidia-tls.so.123.456
         if [[ "$(uname -m)" == x86_64 ]]; then
-            rm -rf /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/tls
-            rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/libGLX.so.0.0.1
-            rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/libGLX_nvidia.so.0.0.1
-            rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/libnvidia-glcore.so.123.456
-            rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/tls/libnvidia-tls.so.123.456
-            rm -f /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)/libnvidia-tls.so.123.456
+            rm -rf /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls
+            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX.so.0.0.1
+            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libGLX_nvidia.so.0.0.1
+            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-glcore.so.123.456
+            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/tls/libnvidia-tls.so.123.456
+            rm -f /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH -ai386)"/libnvidia-tls.so.123.456
         fi
     fi
     rm -rf /usr/lib/nvidia-123

--- a/tests/main/interfaces-opengl-nvidia/task.yaml
+++ b/tests/main/interfaces-opengl-nvidia/task.yaml
@@ -14,6 +14,13 @@ prepare: |
     mkdir -p /usr/share/vulkan/icd.d
     echo "canary-vulkan" > /usr/share/vulkan/icd.d/nvidia_icd.json
 
+    if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
+        # mock GLVND EGL vendor file
+        echo "Test GLVND EGL vendor files access"
+        mkdir -p /usr/share/glvnd/egl_vendor.d
+        echo "canary-egl" > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+    fi
+
     # mock nvidia libraries
     if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
         mkdir -p /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls
@@ -78,9 +85,17 @@ execute: |
     echo "And vulkan ICD file"
     snap run test-snapd-policy-app-consumer.opengl -c "cat /var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json" | MATCH canary-vulkan
 
+    if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
+        echo "And GLVND EGL vendor file"
+        snap run test-snapd-policy-app-consumer.opengl -c "cat /var/lib/snapd/lib/glvnd/egl_vendor.d/10_nvidia.json" | MATCH canary-egl
+    fi
+
 restore: |
     umount -t tmpfs /sys/module
     rm -rf /usr/share/vulkan
+    if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
+        rm -rf /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+    fi
 
     if [[ "$SPREAD_SYSTEM" == ubuntu-18.04-* ]]; then
         rm -rf /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/tls

--- a/tests/unit/spread-shellcheck/must
+++ b/tests/unit/spread-shellcheck/must
@@ -22,3 +22,4 @@ tests/main/classic-ubuntu-core-transition/task.yaml
 tests/main/completion/task.yaml
 tests/main/config-versions/task.yaml
 tests/main/install-closed-channel/task.yaml
+tests/main/interfaces-opengl-nvidia/task.yaml


### PR DESCRIPTION
EGL implementation can be chosen at runtime on glvnd enabled systems. For this to work, the runtime libraries need to have access to vendor files. Those are typically proivided under `/usr/share/glvnd/egl_vendor.d`. The patches make the files available int he mount namespace of a snap. 

Note that the client still needs to properly set `__EGL_VENDOR_LIBRARY_DIRS=/var/lib/snapd/lib/glvnd/egl_vendor.d` to point the glvnd stack to the right location. I'll try to push this change into [snapcraft-desktop-helpers](https://github.com/Ubuntu/snapcraft-desktop-helpers) repo.
