### PR TITLE
interfaces/default,process-control: miscellaneous signal policy fixes

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -398,6 +398,10 @@ var defaultTemplate = `
   # Allow apps from the same package to signal each other via signals
   signal peer=snap.@{SNAP_NAME}.*,
 
+  # Allow receiving signals from all snaps (and focus on mediating sending of
+  # signals)
+  signal (receive) peer=snap.*,
+
   # for 'udevadm trigger --verbose --dry-run --tag-match=snappy-assign'
   /{,s}bin/udevadm ixr,
   /etc/udev/udev.conf r,

--- a/interfaces/builtin/process_control.go
+++ b/interfaces/builtin/process_control.go
@@ -42,7 +42,7 @@ const processControlConnectedPlugAppArmor = `
 capability sys_resource,
 capability sys_nice,
 
-signal,
+signal (send),
 `
 
 const processControlConnectedPlugSecComp = `


### PR DESCRIPTION
interfaces/default: allow receiving signals from snaps (we still mediate send)
    
In the case of signal mediation with AppArmor, there are two processes involved
which may be differently confined and so for signals to successfully be sent to
another process, the sender needs a rule to send to the receiver's security
label and the receiver needs a rule to receive from the sender's security
label. In the general upstream case, it is correct for AppArmor to mediate the
sender and receiver processes because AppArmor doesn't dictate how policy is
written and applied on the system.
    
The AppArmor policy snapd generates for snaps currently:
* allows receiving from unconfined via the AppArmor base abstraction
* allows sending and receiving to oneself via the AppArmor base abstraction
* allows sending and receiving to any of the snap's processes via the snapd
  default AppArmor template
* allows sending (and receiving) to any process via the snapd process-control
  interface
    
What the above is missing are corresponding receive rules so that a snap can
receive a signal from another snap that has the process-control interface
connected (eg, the htop snap is currently unable to send signals to other
snaps).
    
While we could add fine-grained receive rules to all snaps to receive signal
from only those snaps with the process-control interface connected, we can
simplify the implementation with the understanding that since snapd manages the
policy for all snaps, we can just add a default 'signal receive peer=snap.*' to
all policy and AppArmor will continue to block snaps from sending signals to
each other (snaps won't have the needed send rule without connecting the
process-control interface).
    
Reference:
https://forum.snapcraft.io/t/htop-snap-unable-to-signal-aa-enforced-processes/5222/8


In addition to the above:

interfaces/process-control: only allow sending to other processes
    
The process-control interface previously used a bare signal rule which in
addition to allowing sending to all processes also allowed receiving from all
processes. Refine this rule to simply 'signal (send)' to make snaps plugging
the process-control to behave the same as other snaps with regard to receiving
signals (ie, we can still receive from unconfined and our snap's processes but
not from random non-snap-but-still-confined processes).