### PR TITLE
systemd: mock useFuse() so testsuite passes in container via lxd snap

### DIFF
--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -62,6 +62,9 @@ func (s *mountunitSuite) TearDownTest(c *C) {
 }
 
 func (s *mountunitSuite) TestAddMountUnit(c *C) {
+	restore := systemd.MockUseFuse(false)
+	defer restore()
+
 	info := &snap.Info{
 		SideInfo: snap.SideInfo{
 			RealName: "foo",

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -457,6 +457,9 @@ func (s *SystemdTestSuite) TestMountUnitPath(c *C) {
 }
 
 func (s *SystemdTestSuite) TestWriteMountUnit(c *C) {
+	restore := MockUseFuse(false)
+	defer restore()
+
 	mockSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
 	err := os.MkdirAll(filepath.Dir(mockSnapPath), 0755)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Running the snapd testsuite under lxd fails because useFuse() returns true which causes WriteMountUnitFile() to append options that aren't mocked in the testsuite.