### PR TITLE
interfaces/builtin: initial version of the anbox-support interface

### DIFF
--- a/interfaces/builtin/anbox_support.go
+++ b/interfaces/builtin/anbox_support.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const anboxSupportSummary = `allows operating as the Anbox container management service`
+
+const anboxSupportBaseDeclarationPlugs = `
+  anbox-support:
+    allow-installation: false
+    deny-auto-connection: true
+`
+
+const anboxSupportBaseDeclarationSlots = `
+  anbox-support:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const anboxSupportConnectedPlugAppArmor = `
+# Description: Can change to any apparmor profile (including unconfined) thus
+# giving access to all resources of the system so anbox may manage what to give
+# to its containers. This gives device ownership to connected snaps.
+@{PROC}/**/attr/current r,
+/usr/sbin/aa-exec ux,
+
+# Allow discovering the os-release of the host
+/var/lib/snapd/hostfs/{etc,usr/lib}/os-release r,
+`
+
+const anboxSupportConnectedPlugSecComp = `
+# Description: Can access all syscalls of the system so anbox may manage what to
+# give to its containers, giving device ownership to connected snaps.
+@unrestricted
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "anbox-support",
+		summary:               anboxSupportSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  anboxSupportBaseDeclarationSlots,
+		baseDeclarationPlugs:  anboxSupportBaseDeclarationPlugs,
+		connectedPlugAppArmor: anboxSupportConnectedPlugAppArmor,
+		connectedPlugSecComp:  anboxSupportConnectedPlugSecComp,
+		reservedForOS:         true,
+	})
+}

--- a/interfaces/builtin/anbox_support_test.go
+++ b/interfaces/builtin/anbox_support_test.go
@@ -1,0 +1,113 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type anboxSupportInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&anboxSupportInterfaceSuite{
+	iface: builtin.MustInterface("anbox-support"),
+})
+
+const anboxSupportConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [anbox-support]
+`
+
+const anboxSupportCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  anbox-support:
+`
+
+func (s *anboxSupportInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, anboxSupportConsumerYaml, nil, "anbox-support")
+	s.slot, s.slotInfo = MockConnectedSlot(c, anboxSupportCoreYaml, nil, "anbox-support")
+}
+
+func (s *anboxSupportInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "anbox-support")
+}
+
+func (s *anboxSupportInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "anbox-support",
+		Interface: "anbox-support",
+	}
+
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		"anbox-support slots are reserved for the core snap")
+}
+
+func (s *anboxSupportInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *anboxSupportInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/usr/sbin/aa-exec ux,\n")
+}
+
+func (s *anboxSupportInterfaceSuite) TestSecCompSpec(c *C) {
+	spec := &seccomp.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "@unrestricted\n")
+}
+
+func (s *anboxSupportInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows operating as the anbox service`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "anbox-support")
+	c.Assert(si.BaseDeclarationPlugs, testutil.Contains, "anbox-support")
+}
+
+func (s *anboxSupportInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)
+}
+
+func (s *anboxSupportInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -144,6 +144,7 @@ func (s *baseDeclSuite) TestAutoConnection(c *C) {
 		"core-support":  true,
 		"home":          true,
 		"lxd-support":   true,
+		"anbox-support": true,
 		"snapd-control": true,
 		"dummy":         true,
 	}
@@ -196,6 +197,7 @@ func (s *baseDeclSuite) TestAutoConnectPlugSlot(c *C) {
 	// these have more complex or in flux policies and have their
 	// own separate tests
 	snowflakes := map[string]bool{
+		"anbox-support":   true,
 		"classic-support": true,
 		"content":         true,
 		"home":            true,
@@ -330,6 +332,39 @@ plugs:
 	err := cand.CheckAutoConnect()
 	c.Check(err, NotNil)
 	c.Assert(err, ErrorMatches, "auto-connection not allowed by plug rule of interface \"lxd-support\" for \"notlxd\" snap")
+}
+
+func (s *baseDeclSuite) TestAutoConnectionAnboxSupportOverride(c *C) {
+	// by default, don't auto-connect
+	cand := s.connectCand(c, "anbox-support", "", "")
+	err := cand.CheckAutoConnect()
+	c.Check(err, NotNil)
+
+	plugsSlots := `
+plugs:
+  anbox-support:
+    allow-auto-connection: true
+`
+
+	anboxDecl := s.mockSnapDecl(c, "anbox", "Nr9K6UJaIOD8wHpDEQl16nabFFt9LLEQ", "morphis", plugsSlots)
+	cand.PlugSnapDeclaration = anboxDecl
+	err = cand.CheckAutoConnect()
+	c.Check(err, IsNil)
+}
+
+func (s *baseDeclSuite) TestAutoConnectionAnboxSupportOverrideRevoke(c *C) {
+	cand := s.connectCand(c, "anbox-support", "", "")
+	plugsSlots := `
+plugs:
+  anbox-support:
+    allow-auto-connection: false
+`
+
+	anboxDecl := s.mockSnapDecl(c, "notanbox", "Nr9K6UJaIOD8wHpDEQl16nabFFt9LLEQ", "morphis", plugsSlots)
+	cand.PlugSnapDeclaration = anboxDecl
+	err := cand.CheckAutoConnect()
+	c.Check(err, NotNil)
+	c.Assert(err, ErrorMatches, "auto-connection not allowed by plug rule of interface \"anbox-support\" for \"notanbox\" snap")
 }
 
 func (s *baseDeclSuite) TestAutoConnectionKernelModuleControlOverride(c *C) {
@@ -473,6 +508,7 @@ var (
 
 	slotInstallation = map[string][]string{
 		// other
+		"anbox-support":           {"core"},
 		"autopilot-introspection": {"core"},
 		"avahi-control":           {"app", "core"},
 		"avahi-observe":           {"app", "core"},
@@ -590,6 +626,7 @@ func (s *baseDeclSuite) TestPlugInstallation(c *C) {
 	all := builtin.Interfaces()
 
 	restricted := map[string]bool{
+		"anbox-support":         true,
 		"classic-support":       true,
 		"docker-support":        true,
 		"greengrass-support":    true,
@@ -715,6 +752,7 @@ func (s *baseDeclSuite) TestSanity(c *C) {
 	// given how the rules work this can be delicate,
 	// listed here to make sure that was a conscious decision
 	bothSides := map[string]bool{
+		"anbox-support":         true,
 		"classic-support":       true,
 		"core-support":          true,
 		"docker-support":        true,


### PR DESCRIPTION
This implements the anbox-support interface as a copy of the existing
lxd-support interface. Anbox consists mainly of two components: A
container manager (similar to LXD) and a so called session manager. The
container manager uses LXC to spawn a container for the Android
operating system and will used a AppArmor profile derived from the one
LXD uses for its containers to confine it.

The interface basically allows the container manager to escape
confinement.

----

This PR is basically to open up the discussion of how we want to confine the anbox snap. With this PR (and #5177) I am able to run Anbox fully confined. However the here implement anbox-support interface basically allows the Anbox container manager to escape from confinement. This is the very same as the lxd-support interface allows for the lxd snap (the PR is a simple copy of the lxd-support interface). 

The Anbox container manager has the job to start a container via LXC for the Android operating system and uses with recent (not yet merged changes) AppArmor to confine the Android LXC container. The profile used for this is derived from the one LXD uses to confine its containers (see https://github.com/morphis/anbox/blob/snap-confinement/data/apparmor/anbox-container.aa). The remaining changes to make the anbox snap strictly confined are here https://github.com/morphis/anbox/commit/bbc013ee411a5d58351e0d0d4e4dba403423fed6

I will leave this PR here to get initial feedback on the idea to confine Anbox this way. If there are objects and we want to go another route to confine it (if that is possible, leaving this up to @jdstrand) I am fine with that as well. Lets see where we end up :-)

In the near future I would like to get the anbox snap out of edge and away from devmode to make it a first class snap and this is one of the last road blocks for this.
