### PR TITLE
daemon: fix unit tests on arch

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -740,6 +740,8 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	defer restore()
 	restore = release.MockForcedDevmode(true)
 	defer restore()
+	// reload dirs for release info to have effect
+	dirs.SetRootDir(dirs.GlobalRootDir)
 
 	buildID, err := osutil.MyBuildID()
 	c.Assert(err, check.IsNil)
@@ -792,6 +794,8 @@ func (s *apiSuite) TestSysInfoLegacyRefresh(c *check.C) {
 	defer restore()
 	restore = release.MockForcedDevmode(true)
 	defer restore()
+	// reload dirs for release info to have effect
+	dirs.SetRootDir(dirs.GlobalRootDir)
 
 	// set the legacy refresh schedule
 	st := d.overlord.State()


### PR DESCRIPTION
On Arch (or other distros where snap mount point is not /snap), the system-info
test fails as 'classic' is not returned in the list of confinement options. The
reason is that dirs.SetRootDir() comes before release.MockReleaseInfo() call and
we end up with host specific snap mount dir path. Make sure to reload the root
directory path before querying the API to ensure stable output.
