### PR TITLE
userd: add the "snap" scheme to the whitelist

### DIFF
--- a/tests/main/xdg-open/task.yaml
+++ b/tests/main/xdg-open/task.yaml
@@ -56,6 +56,7 @@ execute: |
     ensure_xdg_open_output "https://snapcraft.io"
     ensure_xdg_open_output "http://snapcraft.io"
     ensure_xdg_open_output "mailto:talk@snapcraft.io"
+    ensure_xdg_open_output "snap://snapcraft"
 
     # Ensure other schemes are not passed through
     rm /tmp/xdg-open-output

--- a/userd/launcher.go
+++ b/userd/launcher.go
@@ -53,7 +53,7 @@ const launcherIntrospectionXML = `
 </interface>`
 
 var (
-	allowedURLSchemes = []string{"http", "https", "mailto"}
+	allowedURLSchemes = []string{"http", "https", "mailto", "snap"}
 )
 
 // Launcher implements the 'io.snapcraft.Launcher' DBus interface.

--- a/userd/launcher_test.go
+++ b/userd/launcher_test.go
@@ -75,7 +75,7 @@ func (s *launcherSuite) TestOpenURLWithNotAllowedScheme(c *C) {
 }
 
 func (s *launcherSuite) TestOpenURLWithAllowedSchemeHappy(c *C) {
-	for _, schema := range []string{"http", "https", "mailto"} {
+	for _, schema := range []string{"http", "https", "mailto", "snap"} {
 		err := s.launcher.OpenURL(schema + "://snapcraft.io")
 		c.Assert(err, IsNil)
 		c.Assert(s.mockXdgOpen.Calls(), DeepEquals, [][]string{


### PR DESCRIPTION
This will allow opening links such as snap://snapcraft from a confined snap
(see https://bugzilla.mozilla.org/show_bug.cgi?id=1463091).