### PR TITLE
daemon: update unit tests to match current master

### DIFF
--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -4124,7 +4124,7 @@ func (s *apiSuite) TestDisconnectCoreSystemAlias(c *check.C) {
 	s.mockSnap(c, coreProducerYaml)
 
 	repo := d.overlord.InterfaceManager().Repository()
-	connRef := interfaces.ConnRef{
+	connRef := &interfaces.ConnRef{
 		PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "plug"},
 		SlotRef: interfaces.SlotRef{Snap: "core", Name: "slot"},
 	}


### PR DESCRIPTION
There was a certain time span between #5080 being last built and merging it,
meanwhile some incompatible changes entered master. Update the tests to
accommodate for API changes.


