### PR TITLE
tests: new parameter for the journalctl rate limit

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -359,11 +359,16 @@ prepare_project() {
     go get ./tests/lib/fakedevicesvc
     go get ./tests/lib/systemd-escape
 
-    # disable journald rate limiting
-    mkdir -p /etc/systemd/journald.conf.d/
+    # Disable journald rate limiting
+    # Check the RateLimitInterval key which id different depending on the systemd version
+    rate_limit_key="RateLimitIntervalSec"
+    if grep -q "RateLimitInterval=" /etc/systemd/journald.conf; then
+        rate_limit_key="RateLimitInterval"
+    fi
+
     cat <<-EOF > /etc/systemd/journald.conf.d/no-rate-limit.conf
     [Journal]
-    RateLimitIntervalSec=0
+    $rate_limit_key=0
     RateLimitBurst=0
 EOF
     systemctl restart systemd-journald.service


### PR DESCRIPTION
Depending on the version of systemd, the RateLimitIntervalSec is not
valid and RateLimitInterval is used instead.

On ubuntu 14.04 we can see some massages like:

May 23 02:11:44 may222252-515707 systemd-journal[28710]: Suppressed 121
messages from /system/snapd.service
May 23 02:12:48 may222252-515707 systemd-journal[28710]: Suppressed 147
messages from /system/snapd.service

This is making fail some tests like in:
https://travis-ci.org/snapcore/snapd/builds/380593274#L6003
