### PR TITLE
snapstate: revert the addition of "reconnect" task

### DIFF
--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -349,8 +349,8 @@ func (s *servicectlSuite) TestQueuedCommandsUpdateMany(c *C) {
 	sort.Strings(installed)
 	c.Check(installed, DeepEquals, []string{"other-snap", "test-snap"})
 	c.Assert(tts, HasLen, 2)
-	c.Assert(tts[0].Tasks(), HasLen, 19)
-	c.Assert(tts[1].Tasks(), HasLen, 19)
+	c.Assert(tts[0].Tasks(), HasLen, 18)
+	c.Assert(tts[1].Tasks(), HasLen, 18)
 	chg.AddAll(tts[0])
 	chg.AddAll(tts[1])
 
@@ -378,11 +378,11 @@ func (s *servicectlSuite) TestQueuedCommandsUpdateMany(c *C) {
 
 	for i := 1; i <= 2; i++ {
 		laneTasks := chg.LaneTasks(i)
-		c.Assert(laneTasks, HasLen, 22)
-		c.Check(laneTasks[18].Summary(), Matches, `Run configure hook of .* snap if present`)
-		c.Check(laneTasks[19].Summary(), Equals, "stop of [test-snap.test-service]")
-		c.Check(laneTasks[20].Summary(), Equals, "start of [test-snap.test-service]")
-		c.Check(laneTasks[21].Summary(), Equals, "restart of [test-snap.test-service]")
+		c.Assert(laneTasks, HasLen, 21)
+		c.Check(laneTasks[17].Summary(), Matches, `Run configure hook of .* snap if present`)
+		c.Check(laneTasks[18].Summary(), Equals, "stop of [test-snap.test-service]")
+		c.Check(laneTasks[19].Summary(), Equals, "start of [test-snap.test-service]")
+		c.Check(laneTasks[20].Summary(), Equals, "restart of [test-snap.test-service]")
 	}
 }
 

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -518,40 +518,6 @@ func (m *InterfaceManager) doDisconnect(task *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-// doReconnect creates a set of tasks for connecting the interface and running its hooks
-func (m *InterfaceManager) doReconnect(task *state.Task, _ *tomb.Tomb) error {
-	st := task.State()
-	st.Lock()
-	defer st.Unlock()
-
-	snapsup, err := snapstate.TaskSnapSetup(task)
-	if err != nil {
-		return err
-	}
-
-	snapName := snapsup.Name()
-	connections, err := m.repo.Connections(snapName)
-	if err != nil {
-		return err
-	}
-
-	chg := task.Change()
-	connectts := state.NewTaskSet()
-	for _, conn := range connections {
-		ts, err := ConnectOnInstall(st, chg, task, conn.PlugRef.Snap, conn.PlugRef.Name, conn.SlotRef.Snap, conn.SlotRef.Name)
-		if err != nil {
-			return err
-		}
-		connectts.AddAll(ts)
-	}
-
-	snapstate.InjectTasks(task, connectts)
-	task.SetStatus(state.DoneStatus)
-
-	st.EnsureBefore(0)
-	return nil
-}
-
 func (m *InterfaceManager) undoConnect(task *state.Task, _ *tomb.Tomb) error {
 	st := task.State()
 	st.Lock()

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -71,7 +71,6 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, extraInterfaces
 
 	runner.AddHandler("connect", m.doConnect, m.undoConnect)
 	runner.AddHandler("disconnect", m.doDisconnect, nil)
-	runner.AddHandler("reconnect", m.doReconnect, nil)
 	runner.AddHandler("setup-profiles", m.doSetupProfiles, m.undoSetupProfiles)
 	runner.AddHandler("remove-profiles", m.doRemoveProfiles, m.doSetupProfiles)
 	runner.AddHandler("discard-conns", m.doDiscardConns, m.undoDiscardConns)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -190,13 +190,6 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		prev = setupSecurityPhase2
 	}
 
-	// on refresh re-connect existing connections and run their interface hooks (if applicable)
-	if snapst.IsInstalled() {
-		reconnectTask := st.NewTask("reconnect", fmt.Sprintf(i18n.G("Reconnect interfaces for snap %q"), snapsup.Name()))
-		addTask(reconnectTask)
-		prev = reconnectTask
-	}
-
 	// auto-connections
 	autoConnect := st.NewTask("auto-connect", fmt.Sprintf(i18n.G("Automatically connect eligible plugs and slots of snap %q"), snapsup.Name()))
 	addTask(autoConnect)

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -359,7 +359,6 @@ func verifyUpdateTasks(c *C, opts, discards int, ts *state.TaskSet, st *state.St
 		expected = append(expected, "setup-profiles")
 	}
 	expected = append(expected,
-		"reconnect",
 		"auto-connect",
 		"set-auto-aliases",
 		"setup-aliases",
@@ -551,7 +550,6 @@ func (s *snapmgrTestSuite) testRevertTasksFullFlags(flags fullFlags, c *C) {
 		"unlink-current-snap",
 		"setup-profiles",
 		"link-snap",
-		"reconnect",
 		"auto-connect",
 		"set-auto-aliases",
 		"setup-aliases",
@@ -1015,7 +1013,6 @@ func (s *snapmgrTestSuite) TestRevertCreatesNoGCTasks(c *C) {
 		"unlink-current-snap",
 		"setup-profiles",
 		"link-snap",
-		"reconnect",
 		"auto-connect",
 		"set-auto-aliases",
 		"setup-aliases",
@@ -2171,7 +2168,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 	verifyStopReason(c, ts, "refresh")
 
 	// check post-refresh hook
-	task = ts.Tasks()[15]
+	task = ts.Tasks()[14]
 	c.Assert(task.Kind(), Equals, "run-hook")
 	c.Assert(task.Summary(), Matches, `Run post-refresh hook of "services-snap" snap if present`)
 
@@ -4066,7 +4063,7 @@ func (s *snapmgrTestSuite) TestUpdateOneAutoAliasesScenarios(c *C) {
 		}
 		if scenario.update {
 			first := tasks[j]
-			j += 19
+			j += 18
 			c.Check(first.Kind(), Equals, "prerequisites")
 			wait := false
 			if expectedPruned["other-snap"]["aliasA"] {
@@ -6136,7 +6133,6 @@ validate-snap: Done
 link-snap: Error
  INFO unlink
  ERROR fail
-reconnect: Hold
 auto-connect: Hold
 set-auto-aliases: Hold
 setup-aliases: Hold
@@ -6153,7 +6149,6 @@ validate-snap: Done
 link-snap: Error
  INFO unlink
  ERROR fail
-reconnect: Hold
 auto-connect: Hold
 set-auto-aliases: Hold
 setup-aliases: Hold

--- a/tests/main/interfaces-hooks/task.yaml
+++ b/tests/main/interfaces-hooks/task.yaml
@@ -53,20 +53,4 @@ execute: |
 
     echo "Verify static and dynamic attributes have expected values"
     check_attributes
-
-    rm -f "$CONSUMER_DATA/prepare-plug-consumer-done" "$PRODUCER_DATA/prepare-slot-producer-done" "$CONSUMER_DATA/connect-plug-consumer-done" "$PRODUCER_DATA/connect-slot-producer-done"
-
-    systemctl start snapd.service snapd.socket
-    echo "Verify that hooks are re-run on update and attributes in the state get updated"
-    install_local basic-iface-hooks-consumer
-
-    echo "Ensure the hooks were executed again"
-    check_hooks_were_run
-
-    # stop snapd before inspecting state.json
-    systemctl stop snapd.service snapd.socket
-
-    check_attributes
-    jq -r '.data["conns"]["basic-iface-hooks-consumer:consumer basic-iface-hooks-producer:producer"]["plug-dynamic"]["exec-count"]' /var/lib/snapd/state.json | MATCH "2"
-
     systemctl start snapd.service snapd.socket


### PR DESCRIPTION
Revert the change that introduced "reconnect" logic, until fixed.
