### PR TITLE
interfaces/apparmor: add 'mediate_deleted' profile flag for all snaps

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -360,10 +360,10 @@ func (b *Backend) Remove(snapName string) error {
 
 var (
 	templatePattern = regexp.MustCompile("(###[A-Z_]+###)")
-	attachPattern   = regexp.MustCompile(`\(attach_disconnected\)`)
+	attachPattern   = regexp.MustCompile(`\(attach_disconnected,mediate_deleted\)`)
 )
 
-const attachComplain = "(attach_disconnected,complain)"
+const attachComplain = "(attach_disconnected,mediate_deleted,complain)"
 
 func (b *Backend) deriveContent(spec *Specification, snapInfo *snap.Info, opts interfaces.ConfinementOptions) (content map[string]*osutil.FileState, err error) {
 	content = make(map[string]*osutil.FileState, len(snapInfo.Apps)+len(snapInfo.Hooks)+1)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -446,33 +446,33 @@ const commonPrefix = `
 var combineSnippetsScenarios = []combineSnippetsScenario{{
 	// By default apparmor is enforcing mode.
 	opts:    interfaces.ConfinementOptions{},
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\n\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,mediate_deleted) {\n\n}\n",
 }, {
 	// Snippets are injected in the space between "{" and "}"
 	opts:    interfaces.ConfinementOptions{},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected) {\nsnippet\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,mediate_deleted) {\nsnippet\n}\n",
 }, {
 	// DevMode switches apparmor to non-enforcing (complain) mode.
 	opts:    interfaces.ConfinementOptions{DevMode: true},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,mediate_deleted,complain) {\nsnippet\n}\n",
 }, {
 	// JailMode switches apparmor to enforcing mode even in the presence of DevMode.
 	opts:    interfaces.ConfinementOptions{DevMode: true},
 	snippet: "snippet",
-	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\nsnippet\n}\n",
+	content: commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,mediate_deleted,complain) {\nsnippet\n}\n",
 }, {
 	// Classic confinement (without jailmode) uses apparmor in complain mode by default and ignores all snippets.
 	opts:    interfaces.ConfinementOptions{Classic: true},
 	snippet: "snippet",
-	content: "\n#classic" + commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,complain) {\n\n}\n",
+	content: "\n#classic" + commonPrefix + "\nprofile \"snap.samba.smbd\" (attach_disconnected,mediate_deleted,complain) {\n\n}\n",
 }, {
 	// Classic confinement in JailMode uses enforcing apparmor.
 	opts:    interfaces.ConfinementOptions{Classic: true, JailMode: true},
 	snippet: "snippet",
 	content: commonPrefix + `
-profile "snap.samba.smbd" (attach_disconnected) {
+profile "snap.samba.smbd" (attach_disconnected,mediate_deleted) {
 
   # Read-only access to the core snap.
   @{INSTALL_DIR}/core/** r,
@@ -499,14 +499,14 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 	// NOTE: replace the real template with a shorter variant
 	restoreTemplate := apparmor.MockTemplate("\n" +
 		"###VAR###\n" +
-		"###PROFILEATTACH### (attach_disconnected) {\n" +
+		"###PROFILEATTACH### (attach_disconnected,mediate_deleted) {\n" +
 		"###SNIPPETS###\n" +
 		"}\n")
 	defer restoreTemplate()
 	restoreClassicTemplate := apparmor.MockClassicTemplate("\n" +
 		"#classic\n" +
 		"###VAR###\n" +
-		"###PROFILEATTACH### (attach_disconnected) {\n" +
+		"###PROFILEATTACH### (attach_disconnected,mediate_deleted) {\n" +
 		"###SNIPPETS###\n" +
 		"}\n")
 	defer restoreClassicTemplate()

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -34,7 +34,7 @@ var defaultTemplate = `
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   #include <abstractions/consoles>
   #include <abstractions/openssl>
@@ -475,7 +475,7 @@ var classicTemplate = `
 
 ###VAR###
 
-###PROFILEATTACH### (attach_disconnected) {
+###PROFILEATTACH### (attach_disconnected,mediate_deleted) {
   # set file rules so that exec() inherits our profile unless there is
   # already a profile for it (eg, snap-confine)
   / rwkl,


### PR DESCRIPTION
The 3.11 kernel introduced O_TMPFILE support. Since then, a pattern for
creating temporary files consists of using open(..., O_TMPFILE), unlink() and
then linkat() using the /proc/self/fd/<fd> interface (this is documented in
glibc's man page for open(2) and now used by Qt 5.10 to 'materialize' temporary
files). Currently, when any snap uses this pattern (strict, devmode or
classic), there is a 'l'ink AppArmor denial due to "Failed name lookup -
deleted entry".

To allow snaps to use this pattern, the 'mediate_deleted' profile flag can be
used to mediate this access as the last known name for the fd (eg, what the
kernel shows in /proc/self/fd/<fd> for the '(deleted)' fd). While this makes
this open/unlink/linkat technique work, it does mean that a process from the
snap will be able to open deleted files with open fds via the /proc interface.
On the surface this sounds like a problem because an application may intend the
open/unlink to make the file inaccessible to other processes, but since the
/proc/self/fd interface exists, other processes can access the fds. For this
reason, from the point of view of the application author, use of
mediate_deleted in snapd's policy is actually no worse then when running as a
non-snap. Importantly, in strict mode, AppArmor mediates accesses to other
task's fds via this proc interface via 'ptrace (read)' (readonly) and 'ptrace
(trace)' (read/write) which is denied by default so use of mediate_deleted
doesn't allow opening another snap's unlink()d files via proc.

References:
https://forum.snapcraft.io/t/qt-5-10-linkat-denials-broken-kde-snaps/5484/18
https://forum.snapcraft.io/t/qt5-kde-integration-in-vlc-snap-is-broken-due-to-linkat-denial/5465
https://launchpad.net/bugs/1772097