### PR TITLE
overlord/snapstate: don't panic in a corner case interaction of cleanup tasks and pruning

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -59,6 +59,9 @@ func TaskSnapSetup(t *state.Task) (*SnapSetup, error) {
 	}
 
 	ts := t.State().Task(id)
+	if ts == nil {
+		return nil, fmt.Errorf("internal error: tasks are being pruned")
+	}
 	if err := ts.Get("snap-setup", &snapsup); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This should ideally never return nil, but because cleanups are orthogonal to readiness - they happen after - and pruning code considers only readiness, there is a small chance that a cleanup task will use this helper while all the tasks has been already removed from state.

For large pruneWait and cleanup tasks that ignore errors this is only a theoretical concern but it can be provoked by setting very low pruneWait durations.