### PR TITLE
FindSnapsWaitingFor helper.

### DIFF
--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -2875,3 +2875,72 @@ func (s *interfaceManagerSuite) TestSnapsWithSecurityProfiles(c *C) {
 		"snap3": snap.R(3),
 	})
 }
+
+func (s *interfaceManagerSuite) TestFindSnapsWaitingFor(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	makeSetup := func(t *state.Task, snapName string) {
+		t.Set("snap-setup", &snapstate.SnapSetup{SideInfo: &snap.SideInfo{
+			RealName: snapName},
+		})
+	}
+
+	// Task t3 waits for t1 and t2; task t4 waits for t3, task5 waits for task4
+	t1 := s.state.NewTask("a", "")
+	makeSetup(t1, "snap1")
+	t2 := s.state.NewTask("b", "")
+	makeSetup(t2, "snap2")
+
+	t3 := s.state.NewTask("c", "")
+	makeSetup(t3, "snap3")
+	t3.WaitFor(t1)
+	t3.WaitFor(t2)
+
+	t4 := s.state.NewTask("d", "")
+	makeSetup(t4, "snap4")
+	t4.WaitFor(t3)
+
+	// task t5 doesn't have snap setup
+	t5 := s.state.NewTask("e", "")
+	t5.WaitFor(t4)
+
+	snaps := ifacestate.FindSnapsWaitingFor(t1, "c")
+	c.Assert(snaps, DeepEquals, map[string]bool{
+		"snap3": true,
+	})
+
+	snaps = ifacestate.FindSnapsWaitingFor(t1, "d")
+	c.Assert(snaps, DeepEquals, map[string]bool{
+		"snap4": true,
+	})
+
+	snaps = ifacestate.FindSnapsWaitingFor(t1, "c", "d")
+	c.Assert(snaps, DeepEquals, map[string]bool{
+		"snap3": true,
+		"snap4": true,
+	})
+
+	// task t5 doesn't have snap setup, so nothing reported
+	snaps = ifacestate.FindSnapsWaitingFor(t1, "e")
+	c.Assert(len(snaps), Equals, 0)
+
+	snaps = ifacestate.FindSnapsWaitingFor(t1, "x")
+	c.Assert(len(snaps), Equals, 0)
+
+	snaps = ifacestate.FindSnapsWaitingFor(t4, "x")
+	c.Assert(len(snaps), Equals, 0)
+
+	// create cycle
+	t1 = s.state.NewTask("a", "")
+	makeSetup(t1, "snap1")
+	t2 = s.state.NewTask("b", "")
+	makeSetup(t2, "snap2")
+	t1.WaitFor(t2)
+	t2.WaitFor(t1)
+	snaps = ifacestate.FindSnapsWaitingFor(t1, "b")
+
+	c.Assert(snaps, DeepEquals, map[string]bool{
+		"snap2": true,
+	})
+}


### PR DESCRIPTION
Helper function that returns snap names of tasks of specific kind(s) that wait on given main task. The function recursively visits all halt tasks and collects snap names for task kinds we're after.
This is going to be used for fixing conflict resolution bug resulting in the issue we saw with reconect (and also autoconnect).
