### PR TITLE
many: expose AppStream IDs (AKA common ID)

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -39,7 +39,7 @@ type AppInfo struct {
 	Daemon      string `json:"daemon,omitempty"`
 	Enabled     bool   `json:"enabled,omitempty"`
 	Active      bool   `json:"active,omitempty"`
-	CommonId    string `json:"common-id,omitempty"`
+	CommonID    string `json:"common-id,omitempty"`
 }
 
 // IsService returns true if the application is a background daemon.

--- a/client/apps.go
+++ b/client/apps.go
@@ -39,6 +39,7 @@ type AppInfo struct {
 	Daemon      string `json:"daemon,omitempty"`
 	Enabled     bool   `json:"enabled,omitempty"`
 	Active      bool   `json:"active,omitempty"`
+	CommonId    string `json:"common-id,omitempty"`
 }
 
 // IsService returns true if the application is a background daemon.

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -87,11 +87,11 @@ func (cs *clientSuite) TestClientServiceGetSad(c *check.C) {
 	}
 }
 
-func (cs *clientSuite) TestClientAppCommonId(c *check.C) {
+func (cs *clientSuite) TestClientAppCommonID(c *check.C) {
 	expected := []*client.AppInfo{{
 		Snap:     "foo",
 		Name:     "foo",
-		CommonId: "org.foo",
+		CommonID: "org.foo",
 	}}
 	buf, err := json.Marshal(expected)
 	c.Assert(err, check.IsNil)

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -87,6 +87,22 @@ func (cs *clientSuite) TestClientServiceGetSad(c *check.C) {
 	}
 }
 
+func (cs *clientSuite) TestClientAppCommonId(c *check.C) {
+	expected := []*client.AppInfo{{
+		Snap:     "foo",
+		Name:     "foo",
+		CommonId: "org.foo",
+	}}
+	buf, err := json.Marshal(expected)
+	c.Assert(err, check.IsNil)
+	cs.rsp = fmt.Sprintf(`{"type": "sync", "result": %s}`, buf)
+	for _, chkr := range appcheckers {
+		actual, err := chkr(cs, c)
+		c.Assert(err, check.IsNil)
+		c.Check(actual, check.DeepEquals, expected)
+	}
+}
+
 func testClientLogs(cs *clientSuite, c *check.C) ([]client.Log, error) {
 	ch, err := cs.cli.Logs([]string{"foo", "bar"}, client.LogOptions{N: -1, Follow: false})
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/logs")

--- a/client/packages.go
+++ b/client/packages.go
@@ -58,6 +58,7 @@ type Snap struct {
 	Broken           string        `json:"broken,omitempty"`
 	Contact          string        `json:"contact"`
 	License          string        `json:"license,omitempty"`
+	CommonIds        []string      `json:"common-ids,omitempty"`
 
 	Prices      map[string]float64 `json:"prices,omitempty"`
 	Screenshots []Screenshot       `json:"screenshots,omitempty"`

--- a/client/packages.go
+++ b/client/packages.go
@@ -58,7 +58,7 @@ type Snap struct {
 	Broken           string        `json:"broken,omitempty"`
 	Contact          string        `json:"contact"`
 	License          string        `json:"license,omitempty"`
-	CommonIds        []string      `json:"common-ids,omitempty"`
+	CommonIDs        []string      `json:"common-ids,omitempty"`
 
 	Prices      map[string]float64 `json:"prices,omitempty"`
 	Screenshots []Screenshot       `json:"screenshots,omitempty"`

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -121,7 +121,8 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 			"type": "app",
 			"version": "1.0.18",
 			"confinement": "strict",
-			"private": true
+			"private": true,
+                        "common-ids": ["org.funky.snap"]
 		}],
 		"suggested-currency": "GBP"
 	}`
@@ -144,6 +145,7 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 		Confinement:   client.StrictConfinement,
 		Private:       true,
 		DevMode:       false,
+		CommonIds:     []string{"org.funky.snap"},
 	}})
 }
 
@@ -197,7 +199,8 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
                         "screenshots": [
                             {"url":"http://example.com/shot1.png", "width":640, "height":480},
                             {"url":"http://example.com/shot2.png"}
-                        ]
+                        ],
+                        "common-ids": ["org.funky.snap"]
 		}
 	}`
 	pkg, _, err := cs.cli.Snap(pkgName)
@@ -227,6 +230,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 			{URL: "http://example.com/shot1.png", Width: 640, Height: 480},
 			{URL: "http://example.com/shot2.png"},
 		},
+		CommonIds: []string{"org.funky.snap"},
 	})
 }
 

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -145,7 +145,7 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 		Confinement:   client.StrictConfinement,
 		Private:       true,
 		DevMode:       false,
-		CommonIds:     []string{"org.funky.snap"},
+		CommonIDs:     []string{"org.funky.snap"},
 	}})
 }
 
@@ -230,7 +230,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 			{URL: "http://example.com/shot1.png", Width: 640, Height: 480},
 			{URL: "http://example.com/shot2.png"},
 		},
-		CommonIds: []string{"org.funky.snap"},
+		CommonIDs: []string{"org.funky.snap"},
 	})
 }
 

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -68,7 +68,7 @@ apps:
 	snapDir := makeSnapDirForPack(c, snapYaml)
 
 	_, err := snaprun.Parser().ParseArgs([]string{"pack", "--check-skeleton", snapDir})
-	c.Assert(err, check.ErrorMatches, `application "(bar|foo)" common-id "org.foo.foo" is not unique`)
+	c.Assert(err, check.ErrorMatches, `application ("bar" common-id "org.foo.foo" must be unique, already used by application "foo"|"foo" common-id "org.foo.foo" must be unique, already used by application "bar")`)
 }
 
 func (s *SnapSuite) TestPackPacksFailsForMissingPaths(c *check.C) {

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -55,6 +55,22 @@ apps:
 	c.Assert(err, check.ErrorMatches, "snap name cannot be empty")
 }
 
+func (s *SnapSuite) TestPackCheckSkeletonConflictingCommonID(c *check.C) {
+	// conflicting common-id
+	snapYaml := `name: foo
+version: foobar
+apps:
+  foo:
+    common-id: org.foo.foo
+  bar:
+    common-id: org.foo.foo
+`
+	snapDir := makeSnapDirForPack(c, snapYaml)
+
+	_, err := snaprun.Parser().ParseArgs([]string{"pack", "--check-skeleton", snapDir})
+	c.Assert(err, check.ErrorMatches, `application "(bar|foo)" common-id "org.foo.foo" is not unique`)
+}
+
 func (s *SnapSuite) TestPackPacksFailsForMissingPaths(c *check.C) {
 	_, r := logger.MockLogger()
 	defer r()

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -505,6 +505,9 @@ apps:
     command: some.cmd
   cmd2:
     command: other.cmd
+  cmd3:
+    command: other.cmd
+    common-id: org.foo.cmd
   svc1:
     command: somed1
     daemon: simple
@@ -604,6 +607,10 @@ UnitFileState=potatoes
 					// no desktop file
 					Snap: "foo", Name: "cmd2",
 				}, {
+					// has AppStream ID
+					Snap: "foo", Name: "cmd3",
+					CommonId: "org.foo.cmd",
+				}, {
 					// services
 					Snap: "foo", Name: "svc1",
 					Daemon:  "simple",
@@ -619,17 +626,17 @@ UnitFileState=potatoes
 					Daemon:  "oneshot",
 					Enabled: true,
 					Active:  true,
-				},
-				{
+				}, {
 					Snap: "foo", Name: "svc4",
 					Daemon:  "notify",
 					Enabled: false,
 					Active:  false,
 				},
 			},
-			Broken:  "",
-			Contact: "",
-			License: "GPL-3.0",
+			Broken:    "",
+			Contact:   "",
+			License:   "GPL-3.0",
+			CommonIds: []string{"org.foo.cmd"},
 		},
 		Meta: meta,
 	}
@@ -1631,6 +1638,28 @@ func (s *apiSuite) TestFindSection(c *check.C) {
 		Query:   "foo",
 		Section: "bar",
 	})
+}
+
+func (s *apiSuite) TestFindCommonId(c *check.C) {
+	s.daemon(c)
+
+	s.rsnaps = []*snap.Info{{
+		SideInfo: snap.SideInfo{
+			RealName: "store",
+		},
+		Publisher: "foo",
+		CommonIds: []string{"org.foo"},
+	}}
+	s.mockSnap(c, "name: store\nversion: 1.0")
+
+	req, err := http.NewRequest("GET", "/v2/find?name=foo", nil)
+	c.Assert(err, check.IsNil)
+
+	rsp := searchStore(findCmd, req, nil).(*resp)
+
+	snaps := snapList(rsp.Result)
+	c.Assert(snaps, check.HasLen, 1)
+	c.Check(snaps[0]["common-ids"], check.DeepEquals, []interface{}{"org.foo"})
 }
 
 func (s *apiSuite) TestFindOne(c *check.C) {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -609,7 +609,7 @@ UnitFileState=potatoes
 				}, {
 					// has AppStream ID
 					Snap: "foo", Name: "cmd3",
-					CommonId: "org.foo.cmd",
+					CommonID: "org.foo.cmd",
 				}, {
 					// services
 					Snap: "foo", Name: "svc1",
@@ -636,7 +636,7 @@ UnitFileState=potatoes
 			Broken:    "",
 			Contact:   "",
 			License:   "GPL-3.0",
-			CommonIds: []string{"org.foo.cmd"},
+			CommonIDs: []string{"org.foo.cmd"},
 		},
 		Meta: meta,
 	}
@@ -1640,7 +1640,7 @@ func (s *apiSuite) TestFindSection(c *check.C) {
 	})
 }
 
-func (s *apiSuite) TestFindCommonId(c *check.C) {
+func (s *apiSuite) TestFindCommonID(c *check.C) {
 	s.daemon(c)
 
 	s.rsnaps = []*snap.Info{{
@@ -1648,7 +1648,7 @@ func (s *apiSuite) TestFindCommonId(c *check.C) {
 			RealName: "store",
 		},
 		Publisher: "foo",
-		CommonIds: []string{"org.foo"},
+		CommonIDs: []string{"org.foo"},
 	}}
 	s.mockSnap(c, "name: store\nversion: 1.0")
 

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -271,8 +271,9 @@ func clientAppInfosFromSnapAppInfos(apps []*snap.AppInfo) []client.AppInfo {
 	out := make([]client.AppInfo, len(apps))
 	for i, app := range apps {
 		out[i] = client.AppInfo{
-			Snap: app.Snap.Name(),
-			Name: app.Name,
+			Snap:     app.Snap.Name(),
+			Name:     app.Name,
+			CommonId: app.CommonId,
 		}
 		if fn := app.DesktopFile(); osutil.FileExists(fn) {
 			out[i].DesktopFile = fn
@@ -338,6 +339,7 @@ func mapLocal(about aboutSnap) *client.Snap {
 		Contact:          localSnap.Contact,
 		Title:            localSnap.Title(),
 		License:          localSnap.License,
+		CommonIds:        localSnap.CommonIds,
 	}
 
 	return result
@@ -385,6 +387,7 @@ func mapRemote(remoteSnap *snap.Info) *client.Snap {
 		Prices:       remoteSnap.Prices,
 		Channels:     remoteSnap.Channels,
 		Tracks:       remoteSnap.Tracks,
+		CommonIds:    remoteSnap.CommonIds,
 	}
 
 	return result

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -273,7 +273,7 @@ func clientAppInfosFromSnapAppInfos(apps []*snap.AppInfo) []client.AppInfo {
 		out[i] = client.AppInfo{
 			Snap:     app.Snap.Name(),
 			Name:     app.Name,
-			CommonId: app.CommonId,
+			CommonID: app.CommonID,
 		}
 		if fn := app.DesktopFile(); osutil.FileExists(fn) {
 			out[i].DesktopFile = fn
@@ -339,7 +339,7 @@ func mapLocal(about aboutSnap) *client.Snap {
 		Contact:          localSnap.Contact,
 		Title:            localSnap.Title(),
 		License:          localSnap.License,
-		CommonIds:        localSnap.CommonIds,
+		CommonIDs:        localSnap.CommonIDs,
 	}
 
 	return result
@@ -387,7 +387,7 @@ func mapRemote(remoteSnap *snap.Info) *client.Snap {
 		Prices:       remoteSnap.Prices,
 		Channels:     remoteSnap.Channels,
 		Tracks:       remoteSnap.Tracks,
-		CommonIds:    remoteSnap.CommonIds,
+		CommonIDs:    remoteSnap.CommonIDs,
 	}
 
 	return result

--- a/snap/info.go
+++ b/snap/info.go
@@ -197,7 +197,7 @@ type Info struct {
 	Layout map[string]*Layout
 
 	// The list of common-ids from all apps of the snap
-	CommonIds []string
+	CommonIDs []string
 }
 
 // Layout describes a single element of the layout section.
@@ -640,7 +640,7 @@ type AppInfo struct {
 	// things vs refactor
 	// https://github.com/snapcore/snapd/pull/794#discussion_r58688496
 	BusName  string
-	CommonId string
+	CommonID string
 
 	Plugs   map[string]*PlugInfo
 	Slots   map[string]*SlotInfo

--- a/snap/info.go
+++ b/snap/info.go
@@ -195,6 +195,9 @@ type Info struct {
 	Tracks []string
 
 	Layout map[string]*Layout
+
+	// The list of common-ids from all apps of the snap
+	CommonIds []string
 }
 
 // Layout describes a single element of the layout section.
@@ -636,7 +639,8 @@ type AppInfo struct {
 	// TODO: this should go away once we have more plumbing and can change
 	// things vs refactor
 	// https://github.com/snapcore/snapd/pull/794#discussion_r58688496
-	BusName string
+	BusName  string
+	CommonId string
 
 	Plugs   map[string]*PlugInfo
 	Slots   map[string]*SlotInfo

--- a/snap/info.go
+++ b/snap/info.go
@@ -624,6 +624,7 @@ type AppInfo struct {
 	Name          string
 	LegacyAliases []string // FIXME: eventually drop this
 	Command       string
+	CommonID      string
 
 	Daemon          string
 	StopTimeout     timeout.Timeout
@@ -639,8 +640,7 @@ type AppInfo struct {
 	// TODO: this should go away once we have more plumbing and can change
 	// things vs refactor
 	// https://github.com/snapcore/snapd/pull/794#discussion_r58688496
-	BusName  string
-	CommonID string
+	BusName string
 
 	Plugs   map[string]*PlugInfo
 	Slots   map[string]*SlotInfo

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -75,7 +75,8 @@ type appYaml struct {
 	SlotNames   []string         `yaml:"slots,omitempty"`
 	PlugNames   []string         `yaml:"plugs,omitempty"`
 
-	BusName string `yaml:"bus-name,omitempty"`
+	BusName  string `yaml:"bus-name,omitempty"`
+	CommonId string `yaml:"common-id,omitempty"`
 
 	Environment strutil.OrderedMap `yaml:"environment,omitempty"`
 
@@ -299,6 +300,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			PostStopCommand: yApp.PostStopCommand,
 			RestartCond:     yApp.RestartCond,
 			BusName:         yApp.BusName,
+			CommonId:        yApp.CommonId,
 			Environment:     yApp.Environment,
 			Completer:       yApp.Completer,
 			StopMode:        yApp.StopMode,
@@ -368,6 +370,10 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 				App:   app,
 				Timer: yApp.Timer,
 			}
+		}
+		// collect all common IDs
+		if app.CommonId != "" {
+			snap.CommonIds = append(snap.CommonIds, app.CommonId)
 		}
 	}
 	return nil

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -76,7 +76,7 @@ type appYaml struct {
 	PlugNames   []string         `yaml:"plugs,omitempty"`
 
 	BusName  string `yaml:"bus-name,omitempty"`
-	CommonId string `yaml:"common-id,omitempty"`
+	CommonID string `yaml:"common-id,omitempty"`
 
 	Environment strutil.OrderedMap `yaml:"environment,omitempty"`
 
@@ -300,7 +300,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			PostStopCommand: yApp.PostStopCommand,
 			RestartCond:     yApp.RestartCond,
 			BusName:         yApp.BusName,
-			CommonId:        yApp.CommonId,
+			CommonID:        yApp.CommonID,
 			Environment:     yApp.Environment,
 			Completer:       yApp.Completer,
 			StopMode:        yApp.StopMode,
@@ -372,8 +372,8 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			}
 		}
 		// collect all common IDs
-		if app.CommonId != "" {
-			snap.CommonIds = append(snap.CommonIds, app.CommonId)
+		if app.CommonID != "" {
+			snap.CommonIDs = append(snap.CommonIDs, app.CommonID)
 		}
 	}
 	return nil

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1711,3 +1711,29 @@ apps:
 	app = info.Apps["foo"]
 	c.Check(app.Autostart, Equals, "")
 }
+
+func (s *YamlSuite) TestSnapYamlAppCommonId(c *C) {
+	yAutostart := []byte(`name: wat
+version: 42
+apps:
+ foo:
+   command: bin/foo
+   common-id: org.foo
+ bar:
+   command: bin/foo
+   common-id: org.bar
+ baz:
+   command: bin/foo
+
+`)
+	info, err := snap.InfoFromSnapYaml(yAutostart)
+	c.Assert(err, IsNil)
+	c.Check(info.Apps["foo"].CommonId, Equals, "org.foo")
+	c.Check(info.Apps["bar"].CommonId, Equals, "org.bar")
+	c.Check(info.Apps["baz"].CommonId, Equals, "")
+	c.Assert(info.CommonIds, HasLen, 2)
+	c.Assert((info.CommonIds[0] == "org.foo" && info.CommonIds[1] == "org.bar") ||
+		(info.CommonIds[1] == "org.foo" && info.CommonIds[0] == "org.bar"),
+		Equals,
+		true)
+}

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1712,7 +1712,7 @@ apps:
 	c.Check(app.Autostart, Equals, "")
 }
 
-func (s *YamlSuite) TestSnapYamlAppCommonId(c *C) {
+func (s *YamlSuite) TestSnapYamlAppCommonID(c *C) {
 	yAutostart := []byte(`name: wat
 version: 42
 apps:
@@ -1728,12 +1728,12 @@ apps:
 `)
 	info, err := snap.InfoFromSnapYaml(yAutostart)
 	c.Assert(err, IsNil)
-	c.Check(info.Apps["foo"].CommonId, Equals, "org.foo")
-	c.Check(info.Apps["bar"].CommonId, Equals, "org.bar")
-	c.Check(info.Apps["baz"].CommonId, Equals, "")
-	c.Assert(info.CommonIds, HasLen, 2)
-	c.Assert((info.CommonIds[0] == "org.foo" && info.CommonIds[1] == "org.bar") ||
-		(info.CommonIds[1] == "org.foo" && info.CommonIds[0] == "org.bar"),
+	c.Check(info.Apps["foo"].CommonID, Equals, "org.foo")
+	c.Check(info.Apps["bar"].CommonID, Equals, "org.bar")
+	c.Check(info.Apps["baz"].CommonID, Equals, "")
+	c.Assert(info.CommonIDs, HasLen, 2)
+	c.Assert((info.CommonIDs[0] == "org.foo" && info.CommonIDs[1] == "org.bar") ||
+		(info.CommonIDs[1] == "org.foo" && info.CommonIDs[0] == "org.bar"),
 		Equals,
 		true)
 }

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -788,13 +788,14 @@ func ValidateLayout(layout *Layout, constraints []LayoutConstraint) error {
 }
 
 func ValidateCommonIDs(info *Info) error {
-	seen := make(map[string]bool, len(info.Apps))
+	seen := make(map[string]string, len(info.Apps))
 	for _, app := range info.Apps {
 		if app.CommonID != "" {
-			if seen[app.CommonID] {
-				return fmt.Errorf("application %q common-id %q is not unique", app.Name, app.CommonID)
+			if other, was := seen[app.CommonID]; was {
+				return fmt.Errorf("application %q common-id %q must be unique, already used by application %q",
+					app.Name, app.CommonID, other)
 			}
-			seen[app.CommonID] = true
+			seen[app.CommonID] = app.Name
 		}
 	}
 	return nil

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -316,6 +316,11 @@ func Validate(info *Info) error {
 		}
 	}
 
+	// ensure that common-id(s) are unique
+	if err := ValidateCommonIDs(info); err != nil {
+		return err
+	}
+
 	return ValidateLayoutAll(info)
 }
 
@@ -778,6 +783,19 @@ func ValidateLayout(layout *Layout, constraints []LayoutConstraint) error {
 
 	if layout.Mode&01777 != layout.Mode {
 		return fmt.Errorf("layout %q uses invalid mode %#o", layout.Path, layout.Mode)
+	}
+	return nil
+}
+
+func ValidateCommonIDs(info *Info) error {
+	seen := make(map[string]bool, len(info.Apps))
+	for _, app := range info.Apps {
+		if app.CommonID != "" {
+			if seen[app.CommonID] {
+				return fmt.Errorf("application %q common-id %q is not unique", app.Name, app.CommonID)
+			}
+			seen[app.CommonID] = true
+		}
 	}
 	return nil
 }

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1301,7 +1301,7 @@ apps:
 		err  string
 	}{
 		{good, ""},
-		{bad, `application "(bar|foo)" common-id "org.foo.foo" is not unique`},
+		{bad, `application ("bar" common-id "org.foo.foo" must be unique, already used by application "foo"|"foo" common-id "org.foo.foo" must be unique, already used by application "bar")`},
 	} {
 		c.Logf("tc #%v", i)
 		info, err := InfoFromSnapYaml([]byte(tc.meta))

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1274,3 +1274,45 @@ base: bar
 	err = Validate(info)
 	c.Check(err, ErrorMatches, `cannot have "base" field on "base" snap "foo"`)
 }
+
+func (s *ValidateSuite) TestValidateCommonIDs(c *C) {
+	meta := `
+name: foo
+version: 1.0
+`
+	good := meta + `
+apps:
+  foo:
+    common-id: org.foo.foo
+  bar:
+    common-id: org.foo.bar
+  baz:
+`
+	bad := meta + `
+apps:
+  foo:
+    common-id: org.foo.foo
+  bar:
+    common-id: org.foo.foo
+  baz:
+`
+	for i, tc := range []struct {
+		meta string
+		err  string
+	}{
+		{good, ""},
+		{bad, `application "(bar|foo)" common-id "org.foo.foo" is not unique`},
+	} {
+		c.Logf("tc #%v", i)
+		info, err := InfoFromSnapYaml([]byte(tc.meta))
+		c.Assert(err, IsNil)
+
+		err = Validate(info)
+		if tc.err == "" {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, NotNil)
+			c.Check(err, ErrorMatches, tc.err)
+		}
+	}
+}

--- a/store/details.go
+++ b/store/details.go
@@ -72,7 +72,7 @@ type snapDetails struct {
 
 	ChannelMapList []channelMap `json:"channel_maps_list,omitempty"`
 
-	CommonIds []string `json:"common_ids,omitempty"`
+	CommonIDs []string `json:"common_ids,omitempty"`
 }
 
 // channelMap contains
@@ -138,7 +138,7 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.Contact = d.Contact
 	info.License = d.License
 	info.Base = d.Base
-	info.CommonIds = d.CommonIds
+	info.CommonIDs = d.CommonIDs
 
 	deltas := make([]snap.DeltaInfo, len(d.Deltas))
 	for i, d := range d.Deltas {

--- a/store/details.go
+++ b/store/details.go
@@ -71,6 +71,8 @@ type snapDetails struct {
 	Confinement string `json:"confinement"`
 
 	ChannelMapList []channelMap `json:"channel_maps_list,omitempty"`
+
+	CommonIds []string `json:"common_ids,omitempty"`
 }
 
 // channelMap contains
@@ -136,6 +138,7 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.Contact = d.Contact
 	info.License = d.License
 	info.Base = d.Base
+	info.CommonIds = d.CommonIds
 
 	deltas := make([]snap.DeltaInfo, len(d.Deltas))
 	for i, d := range d.Deltas {

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -54,6 +54,8 @@ type storeSnap struct {
 
 	// media
 	Media []storeSnapMedia `json:"media"`
+
+	CommonIds []string `json:"common-ids"`
 }
 
 type storeSnapDownload struct {
@@ -121,6 +123,7 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 		}
 		info.Deltas = deltas
 	}
+	info.CommonIds = d.CommonIds
 
 	// fill in the plug/slot data
 	if rawYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -55,7 +55,7 @@ type storeSnap struct {
 	// media
 	Media []storeSnapMedia `json:"media"`
 
-	CommonIds []string `json:"common-ids"`
+	CommonIDs []string `json:"common-ids"`
 }
 
 type storeSnapDownload struct {
@@ -123,7 +123,7 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 		}
 		info.Deltas = deltas
 	}
-	info.CommonIds = d.CommonIds
+	info.CommonIDs = d.CommonIDs
 
 	// fill in the plug/slot data
 	if rawYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -82,6 +82,7 @@ const (
   "base": "base-18",
   "confinement": "strict",
   "contact": "https://thingy.com",
+  "common-ids": ["org.thingy"],
   "created-at": "2018-01-26T11:38:35.536410+00:00",
   "description": "Useful thingy for thinging",
   "download": {
@@ -235,6 +236,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
 			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", Width: 600, Height: 200},
 		},
+		CommonIds: []string{"org.thingy"},
 	})
 
 	// validate the plugs/slots

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -236,7 +236,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
 			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", Width: 600, Height: 200},
 		},
-		CommonIds: []string{"org.thingy"},
+		CommonIDs: []string{"org.thingy"},
 	})
 
 	// validate the plugs/slots

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2621,7 +2621,7 @@ func (s *storeTestSuite) TestNoDetails(c *C) {
 }
 
 /* acquired via:
-curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://api.snapcraft.io/api/v1/snaps/search?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Clicense%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin&q=hello' | python -m json.tool | xsel -b
+curl -s -H "accept: application/hal+json" -H "X-Ubuntu-Release: 16" -H "X-Ubuntu-Device-Channel: edge" -H "X-Ubuntu-Wire-Protocol: 1" -H "X-Ubuntu-Architecture: amd64"  'https://api.snapcraft.io/api/v1/snaps/search?fields=anon_download_url%2Carchitecture%2Cchannel%2Cdownload_sha512%2Csummary%2Cdescription%2Cbinary_filesize%2Cdownload_url%2Cicon_url%2Clast_updated%2Clicense%2Cpackage_name%2Cprices%2Cpublisher%2Cratings_average%2Crevision%2Cscreenshot_urls%2Csnap_id%2Csupport_url%2Ctitle%2Ccontent%2Cversion%2Corigin%2Ccommon_ids&q=hello' | python -m json.tool | xsel -b
 Screenshot URLS set manually.
 */
 const MockSearchJSON = `{
@@ -2634,6 +2634,7 @@ const MockSearchJSON = `{
                 ],
                 "binary_filesize": 20480,
                 "channel": "edge",
+                "common_ids": [],
                 "content": "application",
                 "description": "This is a simple hello world example.",
                 "download_sha512": "4bf23ce93efa1f32f0aeae7ec92564b7b0f9f8253a0bd39b2741219c1be119bb676c21208c6845ccf995e6aabe791d3f28a733ebcbbc3171bb23f67981f4068e",
@@ -3131,6 +3132,47 @@ func (s *storeTestSuite) TestFindAuthFailed(c *C) {
 	c.Check(snaps[0].SnapID, Equals, helloWorldSnapID)
 	c.Check(snaps[0].Prices, DeepEquals, map[string]float64{"EUR": 2.99, "USD": 3.49})
 	c.Check(snaps[0].MustBuy, Equals, true)
+}
+
+func (s *storeTestSuite) TestFindCommonIds(c *C) {
+	n := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "GET", searchPath)
+		query := r.URL.Query()
+
+		name := query.Get("name")
+		q := query.Get("q")
+
+		switch n {
+		case 0:
+			c.Check(r.URL.Path, Matches, ".*/search")
+			c.Check(name, Equals, "")
+			c.Check(q, Equals, "foo")
+		default:
+			c.Fatalf("what? %d", n)
+		}
+
+		w.Header().Set("Content-Type", "application/hal+json")
+		w.WriteHeader(200)
+		io.WriteString(w, strings.Replace(MockSearchJSON,
+			`"common_ids": []`,
+			`"common_ids": ["org.hello"]`, -1))
+
+		n++
+	}))
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	serverURL, _ := url.Parse(mockServer.URL)
+	cfg := Config{
+		StoreBaseURL: serverURL,
+	}
+	sto := New(&cfg, nil)
+
+	infos, err := sto.Find(&Search{Query: "foo"}, nil)
+	c.Check(err, IsNil)
+	c.Assert(infos, HasLen, 1)
+	c.Check(infos[0].CommonIds, DeepEquals, []string{"org.hello"})
 }
 
 func (s *storeTestSuite) TestCurrentSnap(c *C) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3134,7 +3134,7 @@ func (s *storeTestSuite) TestFindAuthFailed(c *C) {
 	c.Check(snaps[0].MustBuy, Equals, true)
 }
 
-func (s *storeTestSuite) TestFindCommonIds(c *C) {
+func (s *storeTestSuite) TestFindCommonIDs(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "GET", searchPath)
@@ -3172,7 +3172,7 @@ func (s *storeTestSuite) TestFindCommonIds(c *C) {
 	infos, err := sto.Find(&Search{Query: "foo"}, nil)
 	c.Check(err, IsNil)
 	c.Assert(infos, HasLen, 1)
-	c.Check(infos[0].CommonIds, DeepEquals, []string{"org.hello"})
+	c.Check(infos[0].CommonIDs, DeepEquals, []string{"org.hello"})
 }
 
 func (s *storeTestSuite) TestCurrentSnap(c *C) {

--- a/tests/lib/snaps/test-snapd-appstreamid/bin/run
+++ b/tests/lib/snaps/test-snapd-appstreamid/bin/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec "$@"

--- a/tests/lib/snaps/test-snapd-appstreamid/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-appstreamid/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: test-snapd-appstreamid
+version: 1.0
+summary: Snap for testing snapd AppStream ID support
+description: |
+ Snap for testing snapd AppStream ID support
+confinement: strict
+
+apps:
+  foo:
+   command: bin/run
+   common-id: io.snapcraft.test-snapd-appstreamid.foo
+
+  bar:
+   command: bin/run
+   common-id: io.snapcraft.test-snapd-appstreamid.bar
+
+  baz:
+   command: bin/run
+
+parts:
+  bash:
+    plugin: dump
+    source: .
+    prime:
+      - bin/

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -1,4 +1,7 @@
 summary: Verify AppStream ID integration
+# ubuntu-*-32: the snap used in the test was published only for amd64
+# fedora: uses GNU netcat by default
+systems: [-ubuntu-16.04-32, -fedora-*]
 
 prepare: |
     snap install jq

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -1,0 +1,28 @@
+summary: Verify AppStream ID integration
+
+prepare: |
+    snap install jq
+
+restore: |
+    snap remove jq
+
+execute: |
+    echo "Verify that search results contain common-ids"
+    printf 'GET /v2/find?name=test-snapd-appstreamid HTTP/1.0\r\n\r\n' | \
+        nc -U -q 1 /run/snapd.socket| grep '{'| \
+        jq -r ' .result[0]["common-ids"] | sort | join (",")' | \
+        MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
+
+    snap install --edge test-snapd-appstreamid
+
+    echo "Verify that installed snap info contains common-ids"
+    printf 'GET /v2/snaps/test-snapd-appstreamid HTTP/1.0\r\n\r\n' | \
+        nc -U -q 1 /run/snapd.socket| grep '{'| \
+        jq -r ' .result["common-ids"] | sort | join(",")' | \
+        MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
+
+    echo "Verify that apps have their common-id set"
+    printf 'GET /v2/apps?names=test-snapd-appstreamid HTTP/1.0\r\n\r\n' | \
+        nc -U -q 1 /run/snapd.socket| grep '{'| \
+        jq -r ' .result | sort_by(.name) | [.[]."common-id"] | join(",")' | \
+        MATCH 'io.snapcraft.test-snapd-appstreamid.bar,,io.snapcraft.test-snapd-appstreamid.foo'

--- a/tests/unit/spread-shellcheck/must
+++ b/tests/unit/spread-shellcheck/must
@@ -44,3 +44,4 @@ tests/main/install-cache/task.yaml
 tests/main/install-errors/task.yaml
 tests/main/install-refresh-private/task.yaml
 tests/main/install-refresh-remove-hooks/task.yaml
+tests/main/appstream-id/task.yaml


### PR DESCRIPTION
The PR introduces AppStream IDs and makes them available through the local API.
 
Discussion: https://forum.snapcraft.io/t/support-for-appstream-id/2327
