### PR TITLE
interfaces/apparmor: use helper to load stray profile

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -42,7 +42,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -166,18 +165,12 @@ func (b *Backend) Initialize() error {
 	}
 
 	// We are not using apparmor.LoadProfile() because it uses other cache.
-	cmd := exec.Command("apparmor_parser", "--replace",
-		// Use no-expr-simplify since expr-simplify is actually slower on armhf (LP: #1383858)
-		"-O", "no-expr-simplify",
-		"--write-cache", "--cache-loc", dirs.SystemApparmorCacheDir,
-		profilePath)
-
-	if output, err := cmd.CombinedOutput(); err != nil {
+	if err := loadProfile(profilePath, dirs.SystemApparmorCacheDir); err != nil {
 		// When we cannot reload the profile then let's remove the generated
 		// policy. Maybe we have caused the problem so it's better to let other
 		// things work.
 		osutil.EnsureDirState(dirs.SnapConfineAppArmorDir, glob, nil)
-		return fmt.Errorf("cannot reload snap-confine apparmor profile: %v", osutil.OutputErr(output, err))
+		return fmt.Errorf("cannot reload snap-confine apparmor profile: %v", err)
 	}
 	return nil
 }

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -751,9 +751,10 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithNFS(c *C, profileF
 	c.Assert(cmd.Calls(), HasLen, 1)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{{
 		"apparmor_parser", "--replace",
-		"-O", "no-expr-simplify",
 		"--write-cache",
-		"--cache-loc", dirs.SystemApparmorCacheDir,
+		"-O", "no-expr-simplify",
+		"--cache-loc=" + dirs.SystemApparmorCacheDir,
+		"--quiet",
 		profilePath,
 	}})
 }
@@ -888,7 +889,7 @@ func (s *backendSuite) TestSetupSnapConfineGeneratedPolicyError3(c *C) {
 
 	// Setup generated policy for snap-confine.
 	err = (&apparmor.Backend{}).Initialize()
-	c.Assert(err, ErrorMatches, "cannot reload snap-confine apparmor profile: testing")
+	c.Assert(err, ErrorMatches, "cannot reload snap-confine apparmor profile: .*\n.*\ntesting\n")
 
 	// While created the policy file initially we also removed it so that
 	// no side-effects remain.
@@ -1045,9 +1046,10 @@ func (s *backendSuite) testSetupSnapConfineGeneratedPolicyWithOverlay(c *C, prof
 	c.Assert(cmd.Calls(), HasLen, 1)
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{{
 		"apparmor_parser", "--replace",
-		"-O", "no-expr-simplify",
 		"--write-cache",
-		"--cache-loc", dirs.SystemApparmorCacheDir,
+		"-O", "no-expr-simplify",
+		"--cache-loc=" + dirs.SystemApparmorCacheDir,
+		"--quiet",
 		profilePath,
 	}})
 }


### PR DESCRIPTION
A long time ago I ported all ad-hoc calls to apparmor_parser to go
through a helper function. At the time the location of the cache was
not something one could pass to the function so one of the original call
sites remained. Over time this limitation was lifted but that stray call
site was not updated to use the new function. This patch fixes it.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
