### PR TITLE
packaging: filter out verbose flags from "dh-golang"

### DIFF
--- a/packaging/build-tools/go
+++ b/packaging/build-tools/go
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+# This wrapper is put in $PATH, ahead of the real "go" tool to work around
+# some, er, curious, choices done by the Debian packaging helper scripts that
+# pass verbose flag to "go generate" which in turns prints every single file in
+# the source tree on a separate line. This easily dominates the build log,
+# possibly exceeding the 4MB mark that travis chooses to keep by default.
+
+# The real go is passed as an environment variable SNAPD_VANILLA_GO.
+
+import sys 
+import os
+
+if __name__ == "__main__":
+    go = os.getenv("SNAPD_VANILLA_GO")
+    args = [arg for arg in sys.argv if arg != "-v"]
+    os.execl(go, *args)

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -133,7 +133,7 @@ override_dh_auto_build:
 	cp -a cmd/snap/test-data/*.gpg _build/src/$(DH_GOPKG)/cmd/snap/test-data/
 
 	# this is the main go build
-	dh_auto_build -- $(BUILDFLAGS) $(TAGS) $(GCCGOFLAGS)
+	SNAPD_VANILLA_GO=$$(which go) PATH="$$(pwd)/packaging/build-tools/:$$PATH" dh_auto_build -- $(BUILDFLAGS) $(TAGS) $(GCCGOFLAGS)
 
 	# (static linking on powerpc with cgo is broken)
 ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),powerpc)


### PR DESCRIPTION
dh-golang calls "go install", "go test" and "go generate" with "-v" to
unconditionally enable verbose mode. This may saturate the 4MB limit
that travis puts on log files. To get some actually _useful_ output,
filter the -v argument out.

Since this is a RFC I only applied this to Ubuntu but I can make it work
for other packaging wrappers.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
