### PR TITLE
interfaces/joystick: also support modern evdev joysticks and gamepads

### DIFF
--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -47,7 +47,7 @@ const joystickConnectedPlugAppArmor = `
 
 # Per https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt
 # the minor is 65 and up so limit udev to that.
-/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*},
+/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*} r,
 
 # /dev/input/event* is unfortunately not namespaced and includes all input
 # devices, including keyboards and mice, which allows input sniffing and

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -85,14 +85,17 @@ func (s *JoystickInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/input/js{[0-9],[12][0-9],3[01]} rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*},`)
 }
 
 func (s *JoystickInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
 KERNEL=="js[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
+KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_INPUT_JOYSTICK}=="1", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
 }
 

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -85,7 +85,7 @@ func (s *JoystickInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/input/js{[0-9],[12][0-9],3[01]} rw,`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*},`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*} r,`)
 }
 
 func (s *JoystickInterfaceSuite) TestUDevSpec(c *C) {


### PR DESCRIPTION
While all evdev input devices show up as /dev/input/event*, udev conveniently
sets ENV{ID_INPUT_JOYSTICK}="1" for joysticks, gamepads, etc (verified on
Ubuntu 14.04 LTS through 18.10 and Debian testing). As such, we can udev tag
to add only these evdev devices to the device cgroup and add a
/dev/input/event* glob AppArmor rule since other /dev/input/event* devices
aren't added to the device cgroup. In this manner, only the joystick evdev
devices are accessible to the snap.
    
Note, some input devices are known to come up as joysticks when they are not
and while this rule would tag them, on systems where this is happening the
device is non-functional for its intended purpose. In other words, in practice,
users with such devices will have updated their udev rules to set
ENV{ID_INPUT_JOYSTICK}="" to make the affected device work at all, which means
this rule will no longer match.