### PR TITLE
packaging: fix description

### DIFF
--- a/packaging/ubuntu-14.04/control
+++ b/packaging/ubuntu-14.04/control
@@ -86,8 +86,7 @@ Description: Daemon and tooling that enable snap packages
  enabling secure distribution of the latest apps and utilities for
  cloud, servers, desktops and the internet of things.
  .
- This is the CLI for snapd, a background service that takes care of
- snaps on the system. Start with 'snap list' to see installed snaps.
+ Start with 'snap list' to see installed snaps.
 
 Package: ubuntu-snappy
 Architecture: all

--- a/packaging/ubuntu-16.04/control
+++ b/packaging/ubuntu-16.04/control
@@ -80,8 +80,7 @@ Description: Daemon and tooling that enable snap packages
  enabling secure distribution of the latest apps and utilities for
  cloud, servers, desktops and the internet of things.
  .
- This is the CLI for snapd, a background service that takes care of
- snaps on the system. Start with 'snap list' to see installed snaps.
+ Start with 'snap list' to see installed snaps.
 
 Package: ubuntu-snappy
 Architecture: all

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,9 +5,8 @@ description: |
  'universal' packages that work across many different Linux systems,
  enabling secure distribution of the latest apps and utilities for
  cloud, servers, desktops and the internet of things.
-
- This is the CLI for snapd, a background service that takes care of
- snaps on the system. Start with 'snap list' to see installed snaps.
+ 
+ Start with 'snap list' to see installed snaps.
 version: set-by-version-script-thxbye
 version-script: |
   # extract the version from the debian/changelog


### PR DESCRIPTION
Pawel pointed out that the description of the deb/snap is slightly confusing. The original description is iirc from a  time when we had a "snapd" and "snap" package. So the snap deb described what part of the snapd system was in the package. However nowdays it is all one package so we don't need this description anymore (it is actually harmful).