### PR TITLE
get-deps: work with an unset GOPATH too

### DIFF
--- a/get-deps.sh
+++ b/get-deps.sh
@@ -1,6 +1,17 @@
 #!/bin/sh
 
-set -eu
+set -e
+
+HERE=$(pwd)
+
+if [ "$GOPATH" = "" ]; then
+    export GOPATH=$(mktemp -d)
+    trap "rm -rf $GOPATH" EXIT
+
+    mkdir -p $GOPATH/src/github.com/snapcore/
+    ln -s $(pwd) $GOPATH/src/github.com/snapcore/snapd
+    cd $GOPATH/src/github.com/snapcore/snapd
+fi
 
 if ! which govendor >/dev/null;then
     export PATH="$PATH:${GOPATH%%:*}/bin"

--- a/get-deps.sh
+++ b/get-deps.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-HERE=$(pwd)
-
 if [ "$GOPATH" = "" ]; then
     export GOPATH=$(mktemp -d)
     trap "rm -rf $GOPATH" EXIT


### PR DESCRIPTION
When snapd is build as a snap the environment will not have a
valid GOPATH. Deal with it by setting up a temp gopath and
make sure that the govendor sync code will pull the go pkgs
into the right place.

This should fix the build of the snapd snap on LP.