### PR TITLE
overlord/{config,snap}state: the number of inactive revisions is config

### DIFF
--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -53,8 +53,8 @@ func validateRefreshSchedule(tr Conf) error {
 		return err
 	}
 	if refreshKeepInactiveStr != "" {
-		if _, err := strconv.ParseUint(refreshKeepInactiveStr, 10, 8); err != nil {
-			return err
+		if n, err := strconv.ParseUint(refreshKeepInactiveStr, 10, 8); err != nil || (n < 1 || n > 20) {
+			return fmt.Errorf("keep-inactive must be a number between 1 and 20, not %q", refreshKeepInactiveStr)
 		}
 	}
 

--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -33,7 +33,7 @@ func init() {
 	supportedConfigurations["core.refresh.schedule"] = true
 	supportedConfigurations["core.refresh.timer"] = true
 	supportedConfigurations["core.refresh.metered"] = true
-	supportedConfigurations["core.refresh.keep-inactive"] = true
+	supportedConfigurations["core.refresh.retain"] = true
 }
 
 func validateRefreshSchedule(tr Conf) error {
@@ -49,13 +49,13 @@ func validateRefreshSchedule(tr Conf) error {
 		}
 	}
 
-	refreshKeepInactiveStr, err := coreCfg(tr, "refresh.keep-inactive")
+	refreshRetainStr, err := coreCfg(tr, "refresh.retain")
 	if err != nil {
 		return err
 	}
-	if refreshKeepInactiveStr != "" {
-		if n, err := strconv.ParseUint(refreshKeepInactiveStr, 10, 8); err != nil || (n < 1 || n > 20) {
-			return fmt.Errorf("keep-inactive must be a number between 1 and 20, not %q", refreshKeepInactiveStr)
+	if refreshRetainStr != "" {
+		if n, err := strconv.ParseUint(refreshRetainStr, 10, 8); err != nil || (n < 2 || n > 20) {
+			return fmt.Errorf("retain must be a number between 2 and 20, not %q", refreshRetainStr)
 		}
 	}
 

--- a/overlord/configstate/configcore/refresh.go
+++ b/overlord/configstate/configcore/refresh.go
@@ -21,6 +21,7 @@ package configcore
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/snapcore/snapd/overlord/devicestate"
@@ -31,6 +32,7 @@ func init() {
 	supportedConfigurations["core.refresh.hold"] = true
 	supportedConfigurations["core.refresh.schedule"] = true
 	supportedConfigurations["core.refresh.timer"] = true
+	supportedConfigurations["core.refresh.keep-inactive"] = true
 }
 
 func validateRefreshSchedule(tr Conf) error {
@@ -42,6 +44,16 @@ func validateRefreshSchedule(tr Conf) error {
 		// try legacy refresh.schedule setting if new-style
 		// refresh.timer is not set
 		if _, err = timeutil.ParseSchedule(refreshTimerStr); err != nil {
+			return err
+		}
+	}
+
+	refreshKeepInactiveStr, err := coreCfg(tr, "refresh.keep-inactive")
+	if err != nil {
+		return err
+	}
+	if refreshKeepInactiveStr != "" {
+		if _, err := strconv.ParseUint(refreshKeepInactiveStr, 10, 8); err != nil {
 			return err
 		}
 	}

--- a/overlord/configstate/configcore/refresh_test.go
+++ b/overlord/configstate/configcore/refresh_test.go
@@ -127,3 +127,43 @@ func (s *refreshSuite) TestConfigureRefreshHoldOnMeteredHappy(c *C) {
 	})
 	c.Assert(err, IsNil)
 }
+
+func (s *refreshSuite) TestConfigureRefreshRetainHappy(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"refresh.retain": "4",
+		},
+	})
+	c.Assert(err, IsNil)
+}
+
+func (s *refreshSuite) TestConfigureRefreshRetainUnderRange(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"refresh.retain": "1",
+		},
+	})
+	c.Assert(err, ErrorMatches, `retain must be a number between 2 and 20, not "1"`)
+}
+
+func (s *refreshSuite) TestConfigureRefreshRetainOverRange(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"refresh.retain": "100",
+		},
+	})
+	c.Assert(err, ErrorMatches, `retain must be a number between 2 and 20, not "100"`)
+}
+
+func (s *refreshSuite) TestConfigureRefreshRetainInvalid(c *C) {
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"refresh.retain": "invalid",
+		},
+	})
+	c.Assert(err, ErrorMatches, `retain must be a number between 2 and 20, not "invalid"`)
+}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -224,6 +224,11 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 
 	// Do not do that if we are reverting to a local revision
 	if snapst.IsInstalled() && !snapsup.Flags.Revert {
+		var maxInactive int
+		if err := config.NewTransaction(st).Get("core", "refresh.keep-inactive", &maxInactive); err != nil {
+			maxInactive = 2
+		}
+
 		seq := snapst.Sequence
 		currentIndex := snapst.LastIndex(snapst.Current)
 
@@ -255,7 +260,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		}
 
 		// normal garbage collect
-		for i := 0; i <= currentIndex-2; i++ {
+		for i := 0; i <= currentIndex-maxInactive; i++ {
 			si := seq[i]
 			if boot.InUse(snapsup.Name(), si.Revision) {
 				continue

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -224,10 +224,11 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 
 	// Do not do that if we are reverting to a local revision
 	if snapst.IsInstalled() && !snapsup.Flags.Revert {
-		var maxInactive int
-		if err := config.NewTransaction(st).Get("core", "refresh.keep-inactive", &maxInactive); err != nil {
-			maxInactive = 2
+		var retain int
+		if err := config.NewTransaction(st).Get("core", "refresh.retain", &retain); err != nil {
+			retain = 3
 		}
+		retain-- //  we're adding one
 
 		seq := snapst.Sequence
 		currentIndex := snapst.LastIndex(snapst.Current)
@@ -260,7 +261,7 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		}
 
 		// normal garbage collect
-		for i := 0; i <= currentIndex-maxInactive; i++ {
+		for i := 0; i <= currentIndex-retain; i++ {
 			si := seq[i]
 			if boot.InUse(snapsup.Name(), si.Revision) {
 				continue

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -7603,6 +7603,23 @@ func (s *snapmgrTestSuite) TestSeqTotalABAFailure(c *C) {
 	// gets nuked after all tasks succeeded).
 }
 
+func (s *snapmgrTestSuite) TestSeqRetainConf(c *C) {
+	revseq := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+	for i := 2; i <= 10; i++ {
+		// wot, me, hacky?
+		s.TearDownTest(c)
+		s.SetUpTest(c)
+		s.state.Lock()
+		tr := config.NewTransaction(s.state)
+		tr.Set("core", "refresh.retain", i)
+		tr.Commit()
+		s.state.Unlock()
+
+		s.testUpdateSequence(c, &opSeqOpts{before: revseq[:9], current: 9, via: 10, after: revseq[10-i:]})
+	}
+}
+
 func (s *snapmgrTestSuite) TestUpdateTasksWithOldCurrent(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()


### PR DESCRIPTION
With this change, an administrator can

    snap set system refresh.retain=2

to keep just two revisions of a snap on refresh, instead of the default of 3.

You can't set it lower than 2 for now, as it'd require a refactor of some gnarly codepaths; that might come later if there's demand for it.

This does not make it configurable *per snap*, which was also wanted.
