### PR TITLE
interface hooks: update old AutoConnect methods

### DIFF
--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -213,6 +213,10 @@ type legacyAutoConnect interface {
 	LegacyAutoConnect() bool
 }
 
+type oldAutoConnect interface {
+	AutoConnect(*interfaces.Plug, *interfaces.Slot) bool
+}
+
 type oldSanitizePlug1 interface {
 	SanitizePlug(plug *interfaces.Plug) error
 }
@@ -369,6 +373,7 @@ var allBadDefiners = []reflect.Type{
 	reflect.TypeOf((*snippetDefiner4)(nil)).Elem(),
 	// old auto-connect function
 	reflect.TypeOf((*legacyAutoConnect)(nil)).Elem(),
+	reflect.TypeOf((*oldAutoConnect)(nil)).Elem(),
 	// old sanitize methods
 	reflect.TypeOf((*oldSanitizePlug1)(nil)).Elem(),
 	reflect.TypeOf((*oldSanitizePlug2)(nil)).Elem(),

--- a/interfaces/builtin/alsa_test.go
+++ b/interfaces/builtin/alsa_test.go
@@ -105,8 +105,7 @@ func (s *AlsaInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *AlsaInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *AlsaInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/avahi_control.go
+++ b/interfaces/builtin/avahi_control.go
@@ -165,7 +165,7 @@ func (iface *avahiControlInterface) DBusPermanentSlot(spec *dbus.Specification, 
 	return nil
 }
 
-func (iface *avahiControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *avahiControlInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/avahi_control_test.go
+++ b/interfaces/builtin/avahi_control_test.go
@@ -192,9 +192,8 @@ func (s *AvahiControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *AvahiControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.coreSlotInfo}), Equals, true)
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.appSlotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.coreSlotInfo), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.appSlotInfo), Equals, true)
 }
 
 func (s *AvahiControlInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/avahi_observe.go
+++ b/interfaces/builtin/avahi_observe.go
@@ -460,7 +460,7 @@ func (iface *avahiObserveInterface) DBusPermanentSlot(spec *dbus.Specification, 
 	return nil
 }
 
-func (iface *avahiObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *avahiObserveInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/avahi_observe_test.go
+++ b/interfaces/builtin/avahi_observe_test.go
@@ -192,9 +192,8 @@ func (s *AvahiObserveInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *AvahiObserveInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.coreSlotInfo}), Equals, true)
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.appSlotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.coreSlotInfo), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.appSlotInfo), Equals, true)
 }
 
 func (s *AvahiObserveInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/bluez.go
+++ b/interfaces/builtin/bluez.go
@@ -262,7 +262,7 @@ func (iface *bluezInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 	return nil
 }
 
-func (iface *bluezInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *bluezInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/bluez_test.go
+++ b/interfaces/builtin/bluez_test.go
@@ -265,9 +265,8 @@ func (s *BluezInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *BluezInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.coreSlotInfo}), Equals, true)
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.appSlotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.coreSlotInfo), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.appSlotInfo), Equals, true)
 }
 
 func (s *BluezInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -138,7 +138,7 @@ func (iface *boolFileInterface) isGPIO(slot *snap.SlotInfo) bool {
 // candidate and declaration-based checks allow.
 //
 // By default we allow what declarations allowed.
-func (iface *boolFileInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *boolFileInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	return true
 }
 

--- a/interfaces/builtin/broadcom_asic_control_test.go
+++ b/interfaces/builtin/broadcom_asic_control_test.go
@@ -120,8 +120,7 @@ func (s *BroadcomAsicControlSuite) TestStaticInfo(c *C) {
 }
 
 func (s *BroadcomAsicControlSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *BroadcomAsicControlSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/browser_support.go
+++ b/interfaces/builtin/browser_support.go
@@ -335,7 +335,7 @@ func (iface *browserSupportInterface) SecCompConnectedPlug(spec *seccomp.Specifi
 	return nil
 }
 
-func (iface *browserSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *browserSupportInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	return true
 }
 

--- a/interfaces/builtin/camera_test.go
+++ b/interfaces/builtin/camera_test.go
@@ -105,8 +105,7 @@ func (s *CameraInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *CameraInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *CameraInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -99,7 +99,7 @@ func (iface *commonInterface) AppArmorConnectedPlug(spec *apparmor.Specification
 // candidate and declaration-based checks allow.
 //
 // By default we allow what declarations allowed.
-func (iface *commonInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *commonInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	return !iface.rejectAutoConnectPairs
 }
 

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -287,7 +287,7 @@ func (iface *contentInterface) AppArmorConnectedSlot(spec *apparmor.Specificatio
 	return nil
 }
 
-func (iface *contentInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (iface *contentInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/dbus.go
+++ b/interfaces/builtin/dbus.go
@@ -427,7 +427,7 @@ func (iface *dbusInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	return err
 }
 
-func (iface *dbusInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *dbusInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -221,7 +221,7 @@ func (iface *desktopInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-func (iface *desktopInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *desktopInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
 )
 
 const dockerSummary = `allows access to Docker socket`
@@ -73,7 +74,7 @@ func (iface *dockerInterface) SecCompConnectedPlug(spec *seccomp.Specification, 
 	return nil
 }
 
-func (iface *dockerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *dockerInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -583,7 +583,7 @@ func (iface *dockerSupportInterface) BeforePreparePlug(plug *snap.PlugInfo) erro
 	return nil
 }
 
-func (iface *dockerSupportInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *dockerSupportInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/dummy.go
+++ b/interfaces/builtin/dummy.go
@@ -88,7 +88,7 @@ func (iface *dummyInterface) AppArmorConnectedSlot(spec *apparmor.Specification,
 	return nil
 }
 
-func (iface *dummyInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *dummyInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	return true
 }
 

--- a/interfaces/builtin/firewall_control_test.go
+++ b/interfaces/builtin/firewall_control_test.go
@@ -115,8 +115,7 @@ func (s *FirewallControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *FirewallControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *FirewallControlInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/framebuffer_test.go
+++ b/interfaces/builtin/framebuffer_test.go
@@ -107,8 +107,7 @@ func (s *FramebufferInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *FramebufferInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *FramebufferInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/fuse_support_test.go
+++ b/interfaces/builtin/fuse_support_test.go
@@ -114,8 +114,7 @@ func (s *FuseSupportInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *FuseSupportInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *FuseSupportInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -264,7 +264,7 @@ func (iface *fwupdInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 	return nil
 }
 
-func (iface *fwupdInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *fwupdInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/gpg_keys_test.go
+++ b/interfaces/builtin/gpg_keys_test.go
@@ -95,8 +95,7 @@ func (s *GpgKeysInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *GpgKeysInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *GpgKeysInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/gpg_public_keys_test.go
+++ b/interfaces/builtin/gpg_public_keys_test.go
@@ -95,8 +95,7 @@ func (s *GpgPublicKeysInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *GpgPublicKeysInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *GpgPublicKeysInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/gpio.go
+++ b/interfaces/builtin/gpio.go
@@ -118,7 +118,7 @@ func (iface *gpioInterface) SystemdConnectedSlot(spec *systemd.Specification, pl
 	return spec.AddService(serviceName, service)
 }
 
-func (iface *gpioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *gpioInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/gpio_memory_control_test.go
+++ b/interfaces/builtin/gpio_memory_control_test.go
@@ -104,8 +104,7 @@ func (s *GpioMemoryControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *GpioMemoryControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *GpioMemoryControlInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/hardware_random_control_test.go
+++ b/interfaces/builtin/hardware_random_control_test.go
@@ -105,8 +105,7 @@ func (s *HardwareRandomControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *HardwareRandomControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *HardwareRandomControlInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/hardware_random_observe_test.go
+++ b/interfaces/builtin/hardware_random_observe_test.go
@@ -105,8 +105,7 @@ func (s *HardwareRandomObserveInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *HardwareRandomObserveInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *HardwareRandomObserveInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/hidraw.go
+++ b/interfaces/builtin/hidraw.go
@@ -189,7 +189,7 @@ SUBSYSTEM=="hidraw", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%04x", ATTRS{idProduct
 	return nil
 }
 
-func (iface *hidrawInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *hidrawInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/hostname_control_test.go
+++ b/interfaces/builtin/hostname_control_test.go
@@ -103,8 +103,7 @@ func (s *HostnameControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *HostnameControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 func (s *HostnameControlInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)

--- a/interfaces/builtin/i2c.go
+++ b/interfaces/builtin/i2c.go
@@ -114,7 +114,7 @@ func (iface *i2cInterface) UDevConnectedPlug(spec *udev.Specification, plug *int
 	return nil
 }
 
-func (iface *i2cInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *i2cInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// Allow what is allowed in the declarations
 	return true
 }

--- a/interfaces/builtin/iio.go
+++ b/interfaces/builtin/iio.go
@@ -126,7 +126,7 @@ func (iface *iioInterface) UDevConnectedPlug(spec *udev.Specification, plug *int
 	return nil
 }
 
-func (iface *iioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *iioInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// Allow what is allowed in the declarations
 	return true
 }

--- a/interfaces/builtin/io_ports_control_test.go
+++ b/interfaces/builtin/io_ports_control_test.go
@@ -113,8 +113,7 @@ func (s *ioPortsControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *ioPortsControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *ioPortsControlInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -105,8 +105,7 @@ func (s *JoystickInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *JoystickInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *JoystickInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/kernel_module_control_test.go
+++ b/interfaces/builtin/kernel_module_control_test.go
@@ -113,8 +113,7 @@ func (s *KernelModuleControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *KernelModuleControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *KernelModuleControlInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/kvm_test.go
+++ b/interfaces/builtin/kvm_test.go
@@ -110,8 +110,7 @@ func (s *kvmInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *kvmInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *kvmInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/location_control.go
+++ b/interfaces/builtin/location_control.go
@@ -246,7 +246,7 @@ func (iface *locationControlInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 	return nil
 }
 
-func (iface *locationControlInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *locationControlInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/location_observe.go
+++ b/interfaces/builtin/location_observe.go
@@ -300,7 +300,7 @@ func (iface *locationObserveInterface) AppArmorConnectedSlot(spec *apparmor.Spec
 	return nil
 }
 
-func (iface *locationObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *locationObserveInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/maliit.go
+++ b/interfaces/builtin/maliit.go
@@ -163,7 +163,7 @@ func (iface *maliitInterface) AppArmorConnectedSlot(spec *apparmor.Specification
 	return nil
 }
 
-func (iface *maliitInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *maliitInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/media_hub.go
+++ b/interfaces/builtin/media_hub.go
@@ -194,7 +194,7 @@ func (iface *mediaHubInterface) SecCompPermanentSlot(spec *seccomp.Specification
 	return nil
 }
 
-func (iface *mediaHubInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *mediaHubInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/mir.go
+++ b/interfaces/builtin/mir.go
@@ -147,7 +147,7 @@ func (iface *mirInterface) UDevPermanentSlot(spec *udev.Specification, slot *sna
 	return nil
 }
 
-func (iface *mirInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *mirInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	return true
 }
 

--- a/interfaces/builtin/modem_manager.go
+++ b/interfaces/builtin/modem_manager.go
@@ -1266,7 +1266,7 @@ func (iface *modemManagerInterface) SecCompPermanentSlot(spec *seccomp.Specifica
 	return nil
 }
 
-func (iface *modemManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *modemManagerInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/mpris.go
+++ b/interfaces/builtin/mpris.go
@@ -226,7 +226,7 @@ func (iface *mprisInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	return err
 }
 
-func (iface *mprisInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *mprisInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/network_control_test.go
+++ b/interfaces/builtin/network_control_test.go
@@ -113,8 +113,7 @@ func (s *NetworkControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *NetworkControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 func (s *NetworkControlInterfaceSuite) TestInterfaces(c *C) {
 	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)

--- a/interfaces/builtin/network_manager.go
+++ b/interfaces/builtin/network_manager.go
@@ -476,7 +476,7 @@ func (iface *networkManagerInterface) SecCompConnectedPlug(spec *seccomp.Specifi
 	return nil
 }
 
-func (iface *networkManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *networkManagerInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/network_status.go
+++ b/interfaces/builtin/network_status.go
@@ -144,7 +144,7 @@ func (iface *networkStatusInterface) DBusPermanentSlot(spec *dbus.Specification,
 	return nil
 }
 
-func (iface *networkStatusInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *networkStatusInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/ofono.go
+++ b/interfaces/builtin/ofono.go
@@ -352,7 +352,7 @@ func (iface *ofonoInterface) SecCompPermanentSlot(spec *seccomp.Specification, s
 	return nil
 }
 
-func (iface *ofonoInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *ofonoInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/online_accounts_service.go
+++ b/interfaces/builtin/online_accounts_service.go
@@ -134,7 +134,7 @@ func (iface *onlineAccountsServiceInterface) SecCompPermanentSlot(spec *seccomp.
 	return nil
 }
 
-func (iface *onlineAccountsServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (iface *onlineAccountsServiceInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
 	return true
 }
 

--- a/interfaces/builtin/opengl_test.go
+++ b/interfaces/builtin/opengl_test.go
@@ -106,8 +106,7 @@ func (s *OpenglInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *OpenglInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *OpenglInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/physical_memory_control_test.go
+++ b/interfaces/builtin/physical_memory_control_test.go
@@ -105,8 +105,7 @@ func (s *PhysicalMemoryControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *PhysicalMemoryControlInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/physical_memory_observe_test.go
+++ b/interfaces/builtin/physical_memory_observe_test.go
@@ -106,8 +106,7 @@ func (s *PhysicalMemoryObserveInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *PhysicalMemoryObserveInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/ppp_test.go
+++ b/interfaces/builtin/ppp_test.go
@@ -115,8 +115,7 @@ func (s *PppInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *PppInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *PppInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -172,7 +172,7 @@ func (iface *pulseAudioInterface) SecCompPermanentSlot(spec *seccomp.Specificati
 	return nil
 }
 
-func (iface *pulseAudioInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *pulseAudioInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	return true
 }
 

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -105,8 +105,7 @@ func (s *RawUsbInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *RawUsbInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *RawUsbInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/serial_port.go
+++ b/interfaces/builtin/serial_port.go
@@ -203,7 +203,7 @@ SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{idVendor}=="%04x", ATTRS{idProduct}==
 	return nil
 }
 
-func (iface *serialPortInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *serialPortInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/spi.go
+++ b/interfaces/builtin/spi.go
@@ -96,7 +96,7 @@ func (iface *spiInterface) UDevConnectedPlug(spec *udev.Specification, plug *int
 	return nil
 }
 
-func (iface *spiInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *spiInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// Allow what is allowed in the declarations
 	return true
 }

--- a/interfaces/builtin/ssh_keys_test.go
+++ b/interfaces/builtin/ssh_keys_test.go
@@ -95,8 +95,7 @@ func (s *SshKeysInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *SshKeysInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *SshKeysInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/ssh_public_keys_test.go
+++ b/interfaces/builtin/ssh_public_keys_test.go
@@ -95,8 +95,7 @@ func (s *SshPublicKeysInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *SshPublicKeysInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *SshPublicKeysInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/storage_framework_service.go
+++ b/interfaces/builtin/storage_framework_service.go
@@ -153,7 +153,7 @@ func (iface *storageFrameworkServiceInterface) SecCompPermanentSlot(spec *seccom
 	return nil
 }
 
-func (iface *storageFrameworkServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (iface *storageFrameworkServiceInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
 	return true
 }
 

--- a/interfaces/builtin/thumbnailer_service.go
+++ b/interfaces/builtin/thumbnailer_service.go
@@ -137,7 +137,7 @@ func (iface *thumbnailerServiceInterface) AppArmorConnectedSlot(spec *apparmor.S
 	return nil
 }
 
-func (iface *thumbnailerServiceInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (iface *thumbnailerServiceInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
 	return true
 }
 

--- a/interfaces/builtin/time_control_test.go
+++ b/interfaces/builtin/time_control_test.go
@@ -114,8 +114,7 @@ func (s *TimeControlInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *TimeControlInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *TimeControlInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -105,8 +105,7 @@ func (s *TpmInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *TpmInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *TpmInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/ubuntu_download_manager.go
+++ b/interfaces/builtin/ubuntu_download_manager.go
@@ -236,7 +236,7 @@ func (iface *ubuntuDownloadManagerInterface) AppArmorConnectedSlot(spec *apparmo
 	return nil
 }
 
-func (iface *ubuntuDownloadManagerInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *ubuntuDownloadManagerInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/udisks2.go
+++ b/interfaces/builtin/udisks2.go
@@ -423,7 +423,7 @@ func (iface *udisks2Interface) SecCompPermanentSlot(spec *seccomp.Specification,
 	return nil
 }
 
-func (iface *udisks2Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *udisks2Interface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -200,8 +200,7 @@ func (s *UDisks2InterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME: fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.slotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
 }
 
 func (s *UDisks2InterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/unity7.go
+++ b/interfaces/builtin/unity7.go
@@ -655,7 +655,7 @@ func (iface *unity7Interface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	return sanitizeSlotReservedForOS(iface, slot)
 }
 
-func (iface *unity7Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *unity7Interface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/unity8.go
+++ b/interfaces/builtin/unity8.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/snap"
 )
 
 const unity8Summary = `allows operating as or interacting with Unity 8`
@@ -113,7 +114,7 @@ func (iface *unity8Interface) AppArmorConnectedPlug(spec *apparmor.Specification
 	return nil
 }
 
-func (iface *unity8Interface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *unity8Interface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/unity8_pim_common.go
+++ b/interfaces/builtin/unity8_pim_common.go
@@ -165,7 +165,7 @@ func (iface *unity8PimCommonInterface) SecCompPermanentSlot(spec *seccomp.Specif
 	return nil
 }
 
-func (iface *unity8PimCommonInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *unity8PimCommonInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -274,7 +274,7 @@ func (iface *upowerObserveInterface) BeforePrepareSlot(slot *snap.SlotInfo) erro
 	return sanitizeSlotReservedForOSOrApp(iface, slot)
 }
 
-func (iface *upowerObserveInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *upowerObserveInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/wayland.go
+++ b/interfaces/builtin/wayland.go
@@ -160,7 +160,7 @@ func (iface *waylandInterface) UDevPermanentSlot(spec *udev.Specification, slot 
 	return nil
 }
 
-func (iface *waylandInterface) AutoConnect(*interfaces.Plug, *interfaces.Slot) bool {
+func (iface *waylandInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
 	// allow what declarations allowed
 	return true
 }

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -201,9 +201,8 @@ func (s *WaylandInterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *WaylandInterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.coreSlotInfo}), Equals, true)
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.classicSlotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.coreSlotInfo), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.classicSlotInfo), Equals, true)
 }
 
 func (s *WaylandInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/builtin/x11_test.go
+++ b/interfaces/builtin/x11_test.go
@@ -206,9 +206,8 @@ func (s *X11InterfaceSuite) TestStaticInfo(c *C) {
 }
 
 func (s *X11InterfaceSuite) TestAutoConnect(c *C) {
-	// FIXME fix AutoConnect methods to use ConnectedPlug/Slot
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.coreSlotInfo}), Equals, true)
-	c.Assert(s.iface.AutoConnect(&interfaces.Plug{PlugInfo: s.plugInfo}, &interfaces.Slot{SlotInfo: s.classicSlotInfo}), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.coreSlotInfo), Equals, true)
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.classicSlotInfo), Equals, true)
 }
 
 func (s *X11InterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -162,7 +162,7 @@ type Interface interface {
 	// implicitly auto-connected assuming they will be an
 	// unambiguous connection candidate and declaration-based checks
 	// allow.
-	AutoConnect(plug *Plug, slot *Slot) bool
+	AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool
 }
 
 // PlugSanitizer can be implemented by Interfaces that have reasons to sanitize their plugs.

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -38,7 +38,7 @@ type TestInterface struct {
 	InterfaceName       string
 	InterfaceStaticInfo interfaces.StaticInfo
 	// AutoConnectCallback is the callback invoked inside AutoConnect
-	AutoConnectCallback func(*interfaces.Plug, *interfaces.Slot) bool
+	AutoConnectCallback func(*snap.PlugInfo, *snap.SlotInfo) bool
 	// BeforePreparePlugCallback is the callback invoked inside BeforePreparePlug()
 	BeforePreparePlugCallback func(plug *snap.PlugInfo) error
 	// BeforePrepareSlotCallback is the callback invoked inside BeforePrepareSlot()
@@ -151,7 +151,7 @@ func (t *TestInterface) BeforeConnectSlot(slot *interfaces.ConnectedSlot) error 
 // AutoConnect returns whether plug and slot should be implicitly
 // auto-connected assuming they will be an unambiguous connection
 // candidate.
-func (t *TestInterface) AutoConnect(plug *interfaces.Plug, slot *interfaces.Slot) bool {
+func (t *TestInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
 	if t.AutoConnectCallback != nil {
 		return t.AutoConnectCallback(plug, slot)
 	}

--- a/interfaces/ifacetest/testiface_test.go
+++ b/interfaces/ifacetest/testiface_test.go
@@ -164,7 +164,7 @@ func (s *TestInterfaceSuite) TestSlotSnippet(c *C) {
 func (s *TestInterfaceSuite) TestAutoConnect(c *C) {
 	c.Check(s.iface.AutoConnect(nil, nil), Equals, true)
 
-	iface := &ifacetest.TestInterface{AutoConnectCallback: func(*interfaces.Plug, *interfaces.Slot) bool { return false }}
+	iface := &ifacetest.TestInterface{AutoConnectCallback: func(*snap.PlugInfo, *snap.SlotInfo) bool { return false }}
 
 	c.Check(iface.AutoConnect(nil, nil), Equals, false)
 }

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -992,16 +992,13 @@ func (r *Repository) AutoConnectCandidateSlots(plugSnapName, plugName string, po
 			}
 			iface := slotInfo.Interface
 
-			// FIXME: use ConnectedPlug/Slot for AutoConnect (once it's refactored to use tasks).
-			plug := &Plug{PlugInfo: plugInfo}
-			slot := &Slot{SlotInfo: slotInfo}
 			// declaration based checks disallow
 			ok, err := policyCheck(NewConnectedPlug(plugInfo, nil), NewConnectedSlot(slotInfo, nil))
 			if !ok || err != nil {
 				continue
 			}
 
-			if r.ifaces[iface].AutoConnect(plug, slot) {
+			if r.ifaces[iface].AutoConnect(plugInfo, slotInfo) {
 				candidates = append(candidates, slotInfo)
 			}
 		}
@@ -1028,16 +1025,13 @@ func (r *Repository) AutoConnectCandidatePlugs(slotSnapName, slotName string, po
 			}
 			iface := slotInfo.Interface
 
-			// FIXME: use ConnectedPlug/Slot for AutoConnect (once it's refactored to use tasks).
-			plug := &Plug{PlugInfo: plugInfo}
-			slot := &Slot{SlotInfo: slotInfo}
 			// declaration based checks disallow
 			ok, err := policyCheck(NewConnectedPlug(plugInfo, nil), NewConnectedSlot(slotInfo, nil))
 			if !ok || err != nil {
 				continue
 			}
 
-			if r.ifaces[iface].AutoConnect(plug, slot) {
+			if r.ifaces[iface].AutoConnect(plugInfo, slotInfo) {
 				candidates = append(candidates, plugInfo)
 			}
 		}

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -1776,7 +1776,7 @@ func contentPolicyCheck(plug *ConnectedPlug, slot *ConnectedSlot) (bool, error) 
 	return plug.Snap().PublisherID == slot.Snap().PublisherID, nil
 }
 
-func contentAutoConnect(plug *Plug, slot *Slot) bool {
+func contentAutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {
 	return plug.Attrs["content"] == slot.Attrs["content"]
 }
 


### PR DESCRIPTION
Update old AutoConnect methods to use PlugInfo, SlotInfo instead of no longer used interfaces.Plug/Slot types.

The old comment I put in the code suggested we would use ConnectedPlug and ConnectedSlot here. I think it doesn't make sense at the point we let interfaces decide if they want autoconnect (unless we decide to change this completely of course). We call into AutoConnect method of an interface when computing autoconnect candidates, before running any hooks, so we don't even have dynamic attributes. 

Note: I'm not dropping interfaces.Plug/Slot completely yet as dropping them would lead to slightly bigger change, it can be addressed separately.
