### PR TITLE
snapcraft: use dpkg-buildpackage options that work in xenial

### DIFF
--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -33,8 +33,9 @@ class XBuildDeb(snapcraft.BasePlugin):
         self.run(["sudo", "apt-get", "build-dep", "-y", "./"])
         # XXX: get this from "debian/gbp.conf:postexport"
         self.run(["./get-deps.sh"])
-        # run the real build
-        self.run(["dpkg-buildpackage", "--no-sign"])
+        # run the real build, -ptrue means run "true" to sign the package.
+        # Newer dpkg-buildpackage has "--no-sign" but not the xenial version
+        self.run(["dpkg-buildpackage", "-ptrue"])
         # and "install" into the right place
         snapd_deb = glob.glob("../snapd_*.deb")[0]
         self.run(["dpkg-deb", "-x", os.path.abspath(snapd_deb), self.installdir])


### PR DESCRIPTION
The code used to use "--no-sign" however this is not yet available
in xenial so we need to use something compatible.
