### PR TITLE
xdgopenproxy: skip TestOpenUnreadableFile when run as root

### DIFF
--- a/xdgopenproxy/xdgopenproxy_test.go
+++ b/xdgopenproxy/xdgopenproxy_test.go
@@ -104,6 +104,10 @@ func (s *xdgOpenSuite) TestOpenMissingFile(c *C) {
 }
 
 func (s *xdgOpenSuite) TestOpenUnreadableFile(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("test will not work for root")
+	}
+
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(ioutil.WriteFile(path, []byte("Hello world"), 0644), IsNil)
 	c.Assert(os.Chmod(path, 0), IsNil)


### PR DESCRIPTION
Trivial PR to skip snap build failure for the new snapd snap. The snap build runs as (real) root which leads to a testfailure.