### PR TITLE
snapcraft: run with DEB_BUILD_OPTIONS=nocheck

### DIFF
--- a/get-deps.sh
+++ b/get-deps.sh
@@ -23,10 +23,13 @@ fi
 echo Obtaining dependencies
 govendor sync
 
-unused="$(govendor list +unused)"
-if [ "$unused" != "" ]; then
-    echo "Found unused ./vendor packages:"
-    echo "$unused"
-    echo "Please fix via 'govendor remove +unused'"
-    exit 1
+
+if [ "$1" != "--skip-unused-check" ]; then
+    unused="$(govendor list +unused)"
+    if [ "$unused" != "" ]; then
+        echo "Found unused ./vendor packages:"
+        echo "$unused"
+        echo "Please fix via 'govendor remove +unused'"
+        exit 1
+    fi
 fi

--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -33,7 +33,7 @@ class XBuildDeb(snapcraft.BasePlugin):
         super().build()
         self.run(["sudo", "apt-get", "build-dep", "-y", "./"])
         # XXX: get this from "debian/gbp.conf:postexport"
-        self.run(["./get-deps.sh"])
+        self.run(["./get-deps.sh", "--skip-unused-check"])
         env=os.environ.copy()
         if os.getuid() == 0:
             # disable running the tests during the build when run as root

--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -33,9 +33,14 @@ class XBuildDeb(snapcraft.BasePlugin):
         self.run(["sudo", "apt-get", "build-dep", "-y", "./"])
         # XXX: get this from "debian/gbp.conf:postexport"
         self.run(["./get-deps.sh"])
+        env=os.environ
+        if os.getuid() == 0:
+            # disable running the tests during the build when run as root
+            # because quite a few of them will break
+            env["DEB_BUILD_OPTIONS"] = "nocheck"
         # run the real build, -ptrue means run "true" to sign the package.
         # Newer dpkg-buildpackage has "--no-sign" but not the xenial version
-        self.run(["dpkg-buildpackage", "-ptrue"])
+        self.run(["dpkg-buildpackage", "-ptrue"], env=env)
         # and "install" into the right place
         snapd_deb = glob.glob("../snapd_*.deb")[0]
         self.run(["dpkg-deb", "-x", os.path.abspath(snapd_deb), self.installdir])

--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -34,7 +34,7 @@ class XBuildDeb(snapcraft.BasePlugin):
         self.run(["sudo", "apt-get", "build-dep", "-y", "./"])
         # XXX: get this from "debian/gbp.conf:postexport"
         self.run(["./get-deps.sh"])
-        env=os.environ
+        env=os.environ.copy()
         if os.getuid() == 0:
             # disable running the tests during the build when run as root
             # because quite a few of them will break

--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -30,6 +30,7 @@ patch_snapcraft()
 class XBuildDeb(snapcraft.BasePlugin):
 
     def build(self):
+        super().build()
         self.run(["sudo", "apt-get", "build-dep", "-y", "./"])
         # XXX: get this from "debian/gbp.conf:postexport"
         self.run(["./get-deps.sh"])
@@ -38,10 +39,9 @@ class XBuildDeb(snapcraft.BasePlugin):
             # disable running the tests during the build when run as root
             # because quite a few of them will break
             env["DEB_BUILD_OPTIONS"] = "nocheck"
-        # run the real build, -ptrue means run "true" to sign the package.
-        # Newer dpkg-buildpackage has "--no-sign" but not the xenial version
-        self.run(["dpkg-buildpackage", "-ptrue"], env=env)
+        # run the real build
+        self.run(["dpkg-buildpackage"], env=env)
         # and "install" into the right place
-        snapd_deb = glob.glob("../snapd_*.deb")[0]
+        snapd_deb = glob.glob("parts/snapd/snapd_*.deb")
         self.run(["dpkg-deb", "-x", os.path.abspath(snapd_deb), self.installdir])
 

--- a/parts/plugins/x_builddeb.py
+++ b/parts/plugins/x_builddeb.py
@@ -42,6 +42,6 @@ class XBuildDeb(snapcraft.BasePlugin):
         # run the real build
         self.run(["dpkg-buildpackage"], env=env)
         # and "install" into the right place
-        snapd_deb = glob.glob("parts/snapd/snapd_*.deb")
+        snapd_deb = glob.glob("parts/snapd/snapd_*.deb")[0]
         self.run(["dpkg-deb", "-x", os.path.abspath(snapd_deb), self.installdir])
 

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -1,0 +1,10 @@
+summary: Ensure snapd builds as a snap
+
+# this is what the snapcraft builder on launchpad uses
+systems: [ubuntu-16.04-64]
+
+execute: |
+    echo "Installing snapscraft"
+    apt install -y snapcraft
+    cd $PROJECT_PATH
+    snapcraft

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -1,7 +1,10 @@
 summary: Ensure snapd builds as a snap
 
-# this is what the snapcraft builder on launchpad uses
+# This is what the snapcraft builder on launchpad uses.
 systems: [ubuntu-16.04-64]
+
+restore: |
+    apt autoremove -y snapcraft
 
 execute: |
     echo "Installing snapscraft"


### PR DESCRIPTION
When building the snap run with DEB_BUILD_OPTIONS=nocheck to
skip running the testsuite as root.

This finally makes the snapd snap build in my test xenial root environment. As full root a bunch of tests fail that check for permissions and file open errors etc.