### PR TITLE
cmd/snap: check with snapd for unknown sections

### DIFF
--- a/cmd/snap/cmd_find.go
+++ b/cmd/snap/cmd_find.go
@@ -97,21 +97,36 @@ func (s SectionName) Complete(match string) []flags.Completion {
 	return ret
 }
 
-func getSections() (sections []string, err error) {
-	if cachedSections, err := os.Open(dirs.SnapSectionsFile); err == nil {
-		// try loading from cached sections file
-		defer cachedSections.Close()
+func cachedSections() (sections []string, err error) {
+	cachedSections, err := os.Open(dirs.SnapSectionsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer cachedSections.Close()
 
-		r := bufio.NewScanner(cachedSections)
-		sections = make([]string, 0, 10)
-		for r.Scan() {
-			sections = append(sections, r.Text())
-		}
-		if r.Err() == nil && len(sections) > 0 {
-			return sections, nil
-		}
+	r := bufio.NewScanner(cachedSections)
+	for r.Scan() {
+		sections = append(sections, r.Text())
+	}
+	if r.Err() != nil {
+		return nil, r.Err()
 	}
 
+	return sections, nil
+}
+
+func getSections() (sections []string, err error) {
+	// try loading from cached sections file
+	sections, err = cachedSections()
+	if err != nil {
+		return nil, err
+	}
+	if sections != nil {
+		return sections, nil
+	}
 	// fallback to listing from the daemon
 	cli := Client()
 	return cli.Sections()
@@ -183,13 +198,20 @@ func (x *cmdFind) Execute(args []string) error {
 	cli := Client()
 
 	if x.Section != "" && x.Section != "featured" {
-		sections, err := getSections()
+		sections, err := cachedSections()
 		if err != nil {
 			return err
 		}
 		if !strutil.ListContains(sections, string(x.Section)) {
-			// TRANSLATORS: the %q is the (quoted) name of the section the user entered
-			return fmt.Errorf(i18n.G("No matching section %q, use --section to list existing sections"), x.Section)
+			// try the store just in case it was added in the last 24 hours
+			sections, err = cli.Sections()
+			if err != nil {
+				return err
+			}
+			if !strutil.ListContains(sections, string(x.Section)) {
+				// TRANSLATORS: the %q is the (quoted) name of the section the user entered
+				return fmt.Errorf(i18n.G("No matching section %q, use --section to list existing sections"), x.Section)
+			}
 		}
 	}
 

--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -519,4 +519,5 @@ Please try 'snap find --section=<selected section>'
 `)
 
 	s.ResetStdStreams()
+	c.Check(numHits, check.Equals, 1)
 }

--- a/cmd/snap/cmd_find_test.go
+++ b/cmd/snap/cmd_find_test.go
@@ -486,8 +486,15 @@ func (s *SnapSuite) TestFindSnapNotFoundInSection(c *check.C) {
 }
 
 func (s *SnapSuite) TestFindSnapCachedSection(c *check.C) {
+	numHits := 0
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		c.Fatalf("not expecting any requests")
+		numHits++
+		c.Check(numHits, check.Equals, 1)
+		c.Check(r.URL.Path, check.Equals, "/v2/sections")
+		EncodeResponseBody(c, w, map[string]interface{}{
+			"type":   "sync",
+			"result": []string{"sec1", "sec2", "sec3"},
+		})
 	})
 
 	os.MkdirAll(path.Dir(dirs.SnapSectionsFile), 0755)


### PR DESCRIPTION
if the user does `snap find --section=foo` and `foo` isn't in the
section cache, check with snapd. Maybe it was added in the last 24
hours.
