### PR TITLE
many: expose AppStream IDs (AKA common ID) (2.33)

### DIFF
--- a/client/apps.go
+++ b/client/apps.go
@@ -39,6 +39,7 @@ type AppInfo struct {
 	Daemon      string `json:"daemon,omitempty"`
 	Enabled     bool   `json:"enabled,omitempty"`
 	Active      bool   `json:"active,omitempty"`
+	CommonID    string `json:"common-id,omitempty"`
 }
 
 // IsService returns true if the application is a background daemon.

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -87,6 +87,22 @@ func (cs *clientSuite) TestClientServiceGetSad(c *check.C) {
 	}
 }
 
+func (cs *clientSuite) TestClientAppCommonID(c *check.C) {
+	expected := []*client.AppInfo{{
+		Snap:     "foo",
+		Name:     "foo",
+		CommonID: "org.foo",
+	}}
+	buf, err := json.Marshal(expected)
+	c.Assert(err, check.IsNil)
+	cs.rsp = fmt.Sprintf(`{"type": "sync", "result": %s}`, buf)
+	for _, chkr := range appcheckers {
+		actual, err := chkr(cs, c)
+		c.Assert(err, check.IsNil)
+		c.Check(actual, check.DeepEquals, expected)
+	}
+}
+
 func testClientLogs(cs *clientSuite, c *check.C) ([]client.Log, error) {
 	ch, err := cs.cli.Logs([]string{"foo", "bar"}, client.LogOptions{N: -1, Follow: false})
 	c.Check(cs.req.URL.Path, check.Equals, "/v2/logs")

--- a/client/packages.go
+++ b/client/packages.go
@@ -58,6 +58,7 @@ type Snap struct {
 	Broken           string        `json:"broken,omitempty"`
 	Contact          string        `json:"contact"`
 	License          string        `json:"license,omitempty"`
+	CommonIDs        []string      `json:"common-ids,omitempty"`
 
 	Prices      map[string]float64 `json:"prices,omitempty"`
 	Screenshots []Screenshot       `json:"screenshots,omitempty"`

--- a/client/packages_test.go
+++ b/client/packages_test.go
@@ -121,7 +121,8 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 			"type": "app",
 			"version": "1.0.18",
 			"confinement": "strict",
-			"private": true
+			"private": true,
+                        "common-ids": ["org.funky.snap"]
 		}],
 		"suggested-currency": "GBP"
 	}`
@@ -144,6 +145,7 @@ func (cs *clientSuite) TestClientSnaps(c *check.C) {
 		Confinement:   client.StrictConfinement,
 		Private:       true,
 		DevMode:       false,
+		CommonIDs:     []string{"org.funky.snap"},
 	}})
 }
 
@@ -197,7 +199,8 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
                         "screenshots": [
                             {"url":"http://example.com/shot1.png", "width":640, "height":480},
                             {"url":"http://example.com/shot2.png"}
-                        ]
+                        ],
+                        "common-ids": ["org.funky.snap"]
 		}
 	}`
 	pkg, _, err := cs.cli.Snap(pkgName)
@@ -227,6 +230,7 @@ func (cs *clientSuite) TestClientSnap(c *check.C) {
 			{URL: "http://example.com/shot1.png", Width: 640, Height: 480},
 			{URL: "http://example.com/shot2.png"},
 		},
+		CommonIDs: []string{"org.funky.snap"},
 	})
 }
 

--- a/cmd/snap/cmd_pack_test.go
+++ b/cmd/snap/cmd_pack_test.go
@@ -55,6 +55,22 @@ apps:
 	c.Assert(err, check.ErrorMatches, "snap name cannot be empty")
 }
 
+func (s *SnapSuite) TestPackCheckSkeletonConflictingCommonID(c *check.C) {
+	// conflicting common-id
+	snapYaml := `name: foo
+version: foobar
+apps:
+  foo:
+    common-id: org.foo.foo
+  bar:
+    common-id: org.foo.foo
+`
+	snapDir := makeSnapDirForPack(c, snapYaml)
+
+	_, err := snaprun.Parser().ParseArgs([]string{"pack", "--check-skeleton", snapDir})
+	c.Assert(err, check.ErrorMatches, `application ("bar" common-id "org.foo.foo" must be unique, already used by application "foo"|"foo" common-id "org.foo.foo" must be unique, already used by application "bar")`)
+}
+
 func (s *SnapSuite) TestPackPacksFailsForMissingPaths(c *check.C) {
 	_, r := logger.MockLogger()
 	defer r()

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -271,8 +271,9 @@ func clientAppInfosFromSnapAppInfos(apps []*snap.AppInfo) []client.AppInfo {
 	out := make([]client.AppInfo, len(apps))
 	for i, app := range apps {
 		out[i] = client.AppInfo{
-			Snap: app.Snap.Name(),
-			Name: app.Name,
+			Snap:     app.Snap.Name(),
+			Name:     app.Name,
+			CommonID: app.CommonID,
 		}
 		if fn := app.DesktopFile(); osutil.FileExists(fn) {
 			out[i].DesktopFile = fn
@@ -338,6 +339,7 @@ func mapLocal(about aboutSnap) *client.Snap {
 		Contact:          localSnap.Contact,
 		Title:            localSnap.Title(),
 		License:          localSnap.License,
+		CommonIDs:        localSnap.CommonIDs,
 	}
 
 	return result
@@ -385,6 +387,7 @@ func mapRemote(remoteSnap *snap.Info) *client.Snap {
 		Prices:       remoteSnap.Prices,
 		Channels:     remoteSnap.Channels,
 		Tracks:       remoteSnap.Tracks,
+		CommonIDs:    remoteSnap.CommonIDs,
 	}
 
 	return result

--- a/snap/info.go
+++ b/snap/info.go
@@ -195,6 +195,9 @@ type Info struct {
 	Tracks []string
 
 	Layout map[string]*Layout
+
+	// The list of common-ids from all apps of the snap
+	CommonIDs []string
 }
 
 // Layout describes a single element of the layout section.
@@ -621,6 +624,7 @@ type AppInfo struct {
 	Name          string
 	LegacyAliases []string // FIXME: eventually drop this
 	Command       string
+	CommonID      string
 
 	Daemon          string
 	StopTimeout     timeout.Timeout

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -75,7 +75,8 @@ type appYaml struct {
 	SlotNames   []string         `yaml:"slots,omitempty"`
 	PlugNames   []string         `yaml:"plugs,omitempty"`
 
-	BusName string `yaml:"bus-name,omitempty"`
+	BusName  string `yaml:"bus-name,omitempty"`
+	CommonID string `yaml:"common-id,omitempty"`
 
 	Environment strutil.OrderedMap `yaml:"environment,omitempty"`
 
@@ -299,6 +300,7 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 			PostStopCommand: yApp.PostStopCommand,
 			RestartCond:     yApp.RestartCond,
 			BusName:         yApp.BusName,
+			CommonID:        yApp.CommonID,
 			Environment:     yApp.Environment,
 			Completer:       yApp.Completer,
 			StopMode:        yApp.StopMode,
@@ -368,6 +370,10 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info) error {
 				App:   app,
 				Timer: yApp.Timer,
 			}
+		}
+		// collect all common IDs
+		if app.CommonID != "" {
+			snap.CommonIDs = append(snap.CommonIDs, app.CommonID)
 		}
 	}
 	return nil

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1711,3 +1711,29 @@ apps:
 	app = info.Apps["foo"]
 	c.Check(app.Autostart, Equals, "")
 }
+
+func (s *YamlSuite) TestSnapYamlAppCommonID(c *C) {
+	yAutostart := []byte(`name: wat
+version: 42
+apps:
+ foo:
+   command: bin/foo
+   common-id: org.foo
+ bar:
+   command: bin/foo
+   common-id: org.bar
+ baz:
+   command: bin/foo
+
+`)
+	info, err := snap.InfoFromSnapYaml(yAutostart)
+	c.Assert(err, IsNil)
+	c.Check(info.Apps["foo"].CommonID, Equals, "org.foo")
+	c.Check(info.Apps["bar"].CommonID, Equals, "org.bar")
+	c.Check(info.Apps["baz"].CommonID, Equals, "")
+	c.Assert(info.CommonIDs, HasLen, 2)
+	c.Assert((info.CommonIDs[0] == "org.foo" && info.CommonIDs[1] == "org.bar") ||
+		(info.CommonIDs[1] == "org.foo" && info.CommonIDs[0] == "org.bar"),
+		Equals,
+		true)
+}

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -316,6 +316,11 @@ func Validate(info *Info) error {
 		}
 	}
 
+	// ensure that common-id(s) are unique
+	if err := ValidateCommonIDs(info); err != nil {
+		return err
+	}
+
 	return ValidateLayoutAll(info)
 }
 
@@ -778,6 +783,20 @@ func ValidateLayout(layout *Layout, constraints []LayoutConstraint) error {
 
 	if layout.Mode&01777 != layout.Mode {
 		return fmt.Errorf("layout %q uses invalid mode %#o", layout.Path, layout.Mode)
+	}
+	return nil
+}
+
+func ValidateCommonIDs(info *Info) error {
+	seen := make(map[string]string, len(info.Apps))
+	for _, app := range info.Apps {
+		if app.CommonID != "" {
+			if other, was := seen[app.CommonID]; was {
+				return fmt.Errorf("application %q common-id %q must be unique, already used by application %q",
+					app.Name, app.CommonID, other)
+			}
+			seen[app.CommonID] = app.Name
+		}
 	}
 	return nil
 }

--- a/store/details.go
+++ b/store/details.go
@@ -71,6 +71,8 @@ type snapDetails struct {
 	Confinement string `json:"confinement"`
 
 	ChannelMapList []channelMap `json:"channel_maps_list,omitempty"`
+
+	CommonIDs []string `json:"common_ids,omitempty"`
 }
 
 // channelMap contains
@@ -136,6 +138,7 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	info.Contact = d.Contact
 	info.License = d.License
 	info.Base = d.Base
+	info.CommonIDs = d.CommonIDs
 
 	deltas := make([]snap.DeltaInfo, len(d.Deltas))
 	for i, d := range d.Deltas {

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -54,6 +54,8 @@ type storeSnap struct {
 
 	// media
 	Media []storeSnapMedia `json:"media"`
+
+	CommonIDs []string `json:"common-ids"`
 }
 
 type storeSnapDownload struct {
@@ -121,6 +123,7 @@ func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 		}
 		info.Deltas = deltas
 	}
+	info.CommonIDs = d.CommonIDs
 
 	// fill in the plug/slot data
 	if rawYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -82,6 +82,7 @@ const (
   "base": "base-18",
   "confinement": "strict",
   "contact": "https://thingy.com",
+  "common-ids": ["org.thingy"],
   "created-at": "2018-01-26T11:38:35.536410+00:00",
   "description": "Useful thingy for thinging",
   "download": {
@@ -235,6 +236,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_01.png"},
 			{URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/01/Thingy_02.png", Width: 600, Height: 200},
 		},
+		CommonIDs: []string{"org.thingy"},
 	})
 
 	// validate the plugs/slots

--- a/tests/lib/snaps/test-snapd-appstreamid/bin/run
+++ b/tests/lib/snaps/test-snapd-appstreamid/bin/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec "$@"

--- a/tests/lib/snaps/test-snapd-appstreamid/snapcraft.yaml
+++ b/tests/lib/snaps/test-snapd-appstreamid/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: test-snapd-appstreamid
+version: 1.0
+summary: Snap for testing snapd AppStream ID support
+description: |
+ Snap for testing snapd AppStream ID support
+confinement: strict
+
+apps:
+  foo:
+   command: bin/run
+   common-id: io.snapcraft.test-snapd-appstreamid.foo
+
+  bar:
+   command: bin/run
+   common-id: io.snapcraft.test-snapd-appstreamid.bar
+
+  baz:
+   command: bin/run
+
+parts:
+  bash:
+    plugin: dump
+    source: .
+    prime:
+      - bin/

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -1,0 +1,31 @@
+summary: Verify AppStream ID integration
+# ubuntu-*-32: the snap used in the test was published only for amd64
+# fedora: uses GNU netcat by default
+systems: [-ubuntu-16.04-32, -fedora-*]
+
+prepare: |
+    snap install jq
+
+restore: |
+    snap remove jq
+
+execute: |
+    echo "Verify that search results contain common-ids"
+    printf 'GET /v2/find?name=test-snapd-appstreamid HTTP/1.0\r\n\r\n' | \
+        nc -U -q 1 /run/snapd.socket| grep '{'| \
+        jq -r ' .result[0]["common-ids"] | sort | join (",")' | \
+        MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
+
+    snap install --edge test-snapd-appstreamid
+
+    echo "Verify that installed snap info contains common-ids"
+    printf 'GET /v2/snaps/test-snapd-appstreamid HTTP/1.0\r\n\r\n' | \
+        nc -U -q 1 /run/snapd.socket| grep '{'| \
+        jq -r ' .result["common-ids"] | sort | join(",")' | \
+        MATCH 'io.snapcraft.test-snapd-appstreamid.bar,io.snapcraft.test-snapd-appstreamid.foo'
+
+    echo "Verify that apps have their common-id set"
+    printf 'GET /v2/apps?names=test-snapd-appstreamid HTTP/1.0\r\n\r\n' | \
+        nc -U -q 1 /run/snapd.socket| grep '{'| \
+        jq -r ' .result | sort_by(.name) | [.[]."common-id"] | join(",")' | \
+        MATCH 'io.snapcraft.test-snapd-appstreamid.bar,,io.snapcraft.test-snapd-appstreamid.foo'

--- a/tests/unit/spread-shellcheck/must
+++ b/tests/unit/spread-shellcheck/must
@@ -44,3 +44,4 @@ tests/main/install-cache/task.yaml
 tests/main/install-errors/task.yaml
 tests/main/install-refresh-private/task.yaml
 tests/main/install-refresh-remove-hooks/task.yaml
+tests/main/appstream-id/task.yaml


### PR DESCRIPTION
Backport of #5199 to 2.33
