### PR TITLE
tests: moving test helpers from sh to bash

### DIFF
--- a/tests/lib/dirs.sh
+++ b/tests/lib/dirs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export SNAP_MOUNT_DIR=/snap
 export LIBEXECDIR=/usr/lib

--- a/tests/lib/journalctl.sh
+++ b/tests/lib/journalctl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 JOURNALCTL_CURSOR_FILE="${SPREAD_PATH}"/journalctl_cursor
 

--- a/tests/lib/mkpinentry.sh
+++ b/tests/lib/mkpinentry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if gpg --version | MATCH "gpg \(GnuPG\) 1."; then
     echo "fake gpg pinentry not used for gpg v1"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # shellcheck source=tests/lib/systemd.sh
 . $TESTSLIB/systemd.sh

--- a/tests/lib/pinentry-fake.sh
+++ b/tests/lib/pinentry-fake.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/tests/lib/ramdisk.sh
+++ b/tests/lib/ramdisk.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 setup_ramdisk(){
     if [ ! -e /dev/ram0 ]; then
         mknod -m 660 /dev/ram0 b 1 0

--- a/tests/lib/state.sh
+++ b/tests/lib/state.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SNAPD_STATE_PATH="$SPREAD_PATH/tests/snapd-state"
 SNAPD_STATE_FILE="$SPREAD_PATH/tests/snapd-state.tar"

--- a/tests/lib/strings.sh
+++ b/tests/lib/strings.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 str_to_one_line(){
     echo "$1" | tr '\r\n' ' ' | tr -s ' '


### PR DESCRIPTION
As it was agreed with the team we are gonna use bash for the test
helpers instead of using sh in case bash is not required.
