### PR TITLE
tests: adding fedora-28 to spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -75,6 +75,9 @@ backends:
             - fedora-27-64:
                 image: fedora-27-64-selinux-permissive
                 workers: 4
+            - fedora-28-64:
+                image: fedora-28-64-permissive
+                workers: 4
 
             - opensuse-42.3-64:
                 image: opensuse-cloud/opensuse-leap-42-3-v20180116


### PR DESCRIPTION
Fedora 28 will remain as manual until the system is used by more users than fedora 27.