### PR TITLE
image: set model.DisplayName() in bootenv as "snap_menuentry"

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -433,7 +433,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 		return err
 	}
 
-	if err := setBootvars(downloadedSnapsInfo); err != nil {
+	if err := setBootvars(downloadedSnapsInfo, model); err != nil {
 		return err
 	}
 
@@ -445,7 +445,7 @@ func bootstrapToRootDir(tsto *ToolingStore, model *asserts.Model, opts *Options,
 	return nil
 }
 
-func setBootvars(downloadedSnapsInfo map[string]*snap.Info) error {
+func setBootvars(downloadedSnapsInfo map[string]*snap.Info, model *asserts.Model) error {
 	// Set bootvars for kernel/core snaps so the system boots and
 	// does the first-time initialization. There is also no
 	// mounted kernel/core snap, but just the blobs.
@@ -463,6 +463,9 @@ func setBootvars(downloadedSnapsInfo map[string]*snap.Info) error {
 		"snap_mode":       "",
 		"snap_try_core":   "",
 		"snap_try_kernel": "",
+	}
+	if model.DisplayName() != "" {
+		m["snap_menuentry"] = model.DisplayName()
 	}
 	for _, fn := range snaps {
 		bootvar := ""

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -119,6 +119,7 @@ func (s *imageSuite) SetUpTest(c *C) {
 		"authority-id":   "my-brand",
 		"brand-id":       "my-brand",
 		"model":          "my-model",
+		"display-name":   "my display name",
 		"architecture":   "amd64",
 		"gadget":         "pc",
 		"kernel":         "pc-kernel",
@@ -445,10 +446,11 @@ func (s *imageSuite) TestBootstrapToRootDir(c *C) {
 	}
 
 	// check the bootloader config
-	m, err := s.bootloader.GetBootVars("snap_kernel", "snap_core")
+	m, err := s.bootloader.GetBootVars("snap_kernel", "snap_core", "snap_menuentry")
 	c.Assert(err, IsNil)
 	c.Check(m["snap_kernel"], Equals, "pc-kernel_2.snap")
 	c.Check(m["snap_core"], Equals, "core_3.snap")
+	c.Check(m["snap_menuentry"], Equals, "my display name")
 
 	c.Check(s.stderr.String(), Equals, "")
 }


### PR DESCRIPTION
Newer gadget snaps will ship with a grub configuration thatallows customizing the menu entry for an ubuntu core system.

This allows us to set e.g.:

    display-name: Ubuntu Core 18 (amd64)

in the new core18 model assertion and that will be displayedwhen a core18 system boots.

The corresponding PRs for the gadgets are:
https://github.com/snapcore/pc-amd64-gadget/pull/7
https://github.com/snapcore/pc-amd64-gadget/pull/7
(and they need reviews as well :)

This probably needs an ACK from niemeyer on the naming used.