### PR TITLE
interfaces: remove Plug/Slot types

### DIFF
--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -196,15 +196,9 @@ func (s *AllSuite) TestEachInterfaceImplementsSomeBackendMethods(c *C) {
 
 // pre-specification snippet functions
 type snippetDefiner1 interface {
-	ConnectedPlugSnippet(plug *interfaces.Plug, slot *interfaces.Slot, sec interfaces.SecuritySystem) error
-}
-type snippetDefiner2 interface {
-	ConnectedSlotSnippet(plug *interfaces.Plug, slot *interfaces.Slot, sec interfaces.SecuritySystem) error
-}
-type snippetDefiner3 interface {
 	PermanentPlugSnippet(plug *snap.PlugInfo, sec interfaces.SecuritySystem) error
 }
-type snippetDefiner4 interface {
+type snippetDefiner2 interface {
 	PermanentSlotSnippet(slot *snap.SlotInfo, sec interfaces.SecuritySystem) error
 }
 
@@ -213,155 +207,11 @@ type legacyAutoConnect interface {
 	LegacyAutoConnect() bool
 }
 
-type oldAutoConnect interface {
-	AutoConnect(*interfaces.Plug, *interfaces.Slot) bool
-}
-
 type oldSanitizePlug1 interface {
-	SanitizePlug(plug *interfaces.Plug) error
-}
-type oldSanitizePlug2 interface {
 	SanitizePlug(plug *snap.PlugInfo) error
 }
 type oldSanitizeSlot1 interface {
-	SanitizeSlot(slot *interfaces.Slot) error
-}
-type oldSanitizeSlot2 interface {
 	SanitizeSlot(slot *snap.SlotInfo) error
-}
-
-// specification definers before the introduction of connection attributes
-type oldApparmorDefiner1 interface {
-	AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldApparmorDefiner2 interface {
-	AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldApparmorDefiner3 interface {
-	AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldApparmorDefiner4 interface {
-	AppArmorConnectedSlot(spec *apparmor.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldApparmorDefiner5 interface {
-	AppArmorPermanentPlug(spec *apparmor.Specification, plug *interfaces.Plug) error
-}
-type oldApparmorDefiner6 interface {
-	AppArmorPermanentSlot(spec *apparmor.Specification, slot *interfaces.Slot) error
-}
-
-type oldDbusDefiner1 interface {
-	DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldDbusDefiner2 interface {
-	DBusConnectedSlot(spec *dbus.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldDbusDefiner3 interface {
-	DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldDbusDefiner4 interface {
-	DBusConnectedSlot(spec *dbus.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldDbusDefiner5 interface {
-	DBusPermanentPlug(spec *dbus.Specification, plug *interfaces.Plug) error
-}
-type oldDbusDefiner6 interface {
-	DBusPermanentSlot(spec *dbus.Specification, slot *interfaces.Slot) error
-}
-
-type oldKmodDefiner1 interface {
-	KModConnectedPlug(spec *kmod.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldKmodDefiner2 interface {
-	KModConnectedSlot(spec *kmod.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldKmodDefiner3 interface {
-	KModConnectedPlug(spec *kmod.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldKmodDefiner4 interface {
-	KModConnectedSlot(spec *kmod.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldKmodDefiner5 interface {
-	KModPermanentPlug(spec *kmod.Specification, plug *interfaces.Plug) error
-}
-type oldKmodDefiner6 interface {
-	KModPermanentSlot(spec *kmod.Specification, slot *interfaces.Slot) error
-}
-
-type oldMountDefiner1 interface {
-	MountConnectedPlug(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldMountDefiner2 interface {
-	MountConnectedSlot(spec *mount.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldMountDefiner3 interface {
-	MountConnectedPlug(spec *mount.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldMountDefiner4 interface {
-	MountConnectedSlot(spec *mount.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldMountDefiner5 interface {
-	MountPermanentPlug(spec *mount.Specification, plug *interfaces.Plug) error
-}
-type oldMountDefiner6 interface {
-	MountPermanentSlot(spec *mount.Specification, slot *interfaces.Slot) error
-}
-
-type oldSeccompDefiner1 interface {
-	SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldSeccompDefiner2 interface {
-	SecCompConnectedSlot(spec *seccomp.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldSeccompDefiner3 interface {
-	SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldSeccompDefiner4 interface {
-	SecCompConnectedSlot(spec *seccomp.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldSeccompDefiner5 interface {
-	SecCompPermanentPlug(spec *seccomp.Specification, plug *interfaces.Plug) error
-}
-type oldSeccompDefiner6 interface {
-	SecCompPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error
-}
-
-type oldSystemdDefiner1 interface {
-	SystemdConnectedPlug(spec *systemd.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldSystemdDefiner2 interface {
-	SystemdConnectedSlot(spec *systemd.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldSystemdDefiner3 interface {
-	SystemdConnectedPlug(spec *systemd.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldSystemdDefiner4 interface {
-	SystemdConnectedSlot(spec *systemd.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldSystemdDefiner5 interface {
-	SystemdPermanentPlug(spec *seccomp.Specification, plug *interfaces.Plug) error
-}
-type oldSystemdDefiner6 interface {
-	SystemdPermanentSlot(spec *seccomp.Specification, slot *interfaces.Slot) error
-}
-
-type oldUdevDefiner1 interface {
-	UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldUdevDefiner2 interface {
-	UDevConnectedSlot(spec *udev.Specification, plug *interfaces.Plug, slot *interfaces.Slot) error
-}
-type oldUdevDefiner3 interface {
-	UDevConnectedPlug(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldUdevDefiner4 interface {
-	UDevConnectedSlot(spec *udev.Specification, plug *interfaces.Plug, plugAttrs map[string]interface{}, slot *interfaces.Slot, slotAttrs map[string]interface{}) error
-}
-type oldUdevDefiner5 interface {
-	UDevPermanentPlug(spec *udev.Specification, plug *interfaces.Plug) error
-}
-type oldUdevDefiner6 interface {
-	UDevPermanentSlot(spec *udev.Specification, slot *interfaces.Slot) error
 }
 
 // allBadDefiners contains all old/unused specification definers for all known backends.
@@ -369,59 +219,11 @@ var allBadDefiners = []reflect.Type{
 	// pre-specification snippet methods
 	reflect.TypeOf((*snippetDefiner1)(nil)).Elem(),
 	reflect.TypeOf((*snippetDefiner2)(nil)).Elem(),
-	reflect.TypeOf((*snippetDefiner3)(nil)).Elem(),
-	reflect.TypeOf((*snippetDefiner4)(nil)).Elem(),
 	// old auto-connect function
 	reflect.TypeOf((*legacyAutoConnect)(nil)).Elem(),
-	reflect.TypeOf((*oldAutoConnect)(nil)).Elem(),
 	// old sanitize methods
 	reflect.TypeOf((*oldSanitizePlug1)(nil)).Elem(),
-	reflect.TypeOf((*oldSanitizePlug2)(nil)).Elem(),
 	reflect.TypeOf((*oldSanitizeSlot1)(nil)).Elem(),
-	reflect.TypeOf((*oldSanitizeSlot2)(nil)).Elem(),
-	// pre-attribute definers
-	reflect.TypeOf((*oldApparmorDefiner1)(nil)).Elem(),
-	reflect.TypeOf((*oldApparmorDefiner2)(nil)).Elem(),
-	reflect.TypeOf((*oldApparmorDefiner3)(nil)).Elem(),
-	reflect.TypeOf((*oldApparmorDefiner4)(nil)).Elem(),
-	reflect.TypeOf((*oldApparmorDefiner5)(nil)).Elem(),
-	reflect.TypeOf((*oldApparmorDefiner6)(nil)).Elem(),
-	reflect.TypeOf((*oldDbusDefiner1)(nil)).Elem(),
-	reflect.TypeOf((*oldDbusDefiner2)(nil)).Elem(),
-	reflect.TypeOf((*oldDbusDefiner3)(nil)).Elem(),
-	reflect.TypeOf((*oldDbusDefiner4)(nil)).Elem(),
-	reflect.TypeOf((*oldDbusDefiner5)(nil)).Elem(),
-	reflect.TypeOf((*oldDbusDefiner6)(nil)).Elem(),
-	reflect.TypeOf((*oldKmodDefiner1)(nil)).Elem(),
-	reflect.TypeOf((*oldKmodDefiner2)(nil)).Elem(),
-	reflect.TypeOf((*oldKmodDefiner3)(nil)).Elem(),
-	reflect.TypeOf((*oldKmodDefiner4)(nil)).Elem(),
-	reflect.TypeOf((*oldKmodDefiner5)(nil)).Elem(),
-	reflect.TypeOf((*oldKmodDefiner6)(nil)).Elem(),
-	reflect.TypeOf((*oldMountDefiner1)(nil)).Elem(),
-	reflect.TypeOf((*oldMountDefiner2)(nil)).Elem(),
-	reflect.TypeOf((*oldMountDefiner3)(nil)).Elem(),
-	reflect.TypeOf((*oldMountDefiner4)(nil)).Elem(),
-	reflect.TypeOf((*oldMountDefiner5)(nil)).Elem(),
-	reflect.TypeOf((*oldMountDefiner6)(nil)).Elem(),
-	reflect.TypeOf((*oldSeccompDefiner1)(nil)).Elem(),
-	reflect.TypeOf((*oldSeccompDefiner2)(nil)).Elem(),
-	reflect.TypeOf((*oldSeccompDefiner3)(nil)).Elem(),
-	reflect.TypeOf((*oldSeccompDefiner4)(nil)).Elem(),
-	reflect.TypeOf((*oldSeccompDefiner5)(nil)).Elem(),
-	reflect.TypeOf((*oldSeccompDefiner6)(nil)).Elem(),
-	reflect.TypeOf((*oldSystemdDefiner1)(nil)).Elem(),
-	reflect.TypeOf((*oldSystemdDefiner2)(nil)).Elem(),
-	reflect.TypeOf((*oldSystemdDefiner3)(nil)).Elem(),
-	reflect.TypeOf((*oldSystemdDefiner4)(nil)).Elem(),
-	reflect.TypeOf((*oldSystemdDefiner5)(nil)).Elem(),
-	reflect.TypeOf((*oldSystemdDefiner6)(nil)).Elem(),
-	reflect.TypeOf((*oldUdevDefiner1)(nil)).Elem(),
-	reflect.TypeOf((*oldUdevDefiner2)(nil)).Elem(),
-	reflect.TypeOf((*oldUdevDefiner3)(nil)).Elem(),
-	reflect.TypeOf((*oldUdevDefiner4)(nil)).Elem(),
-	reflect.TypeOf((*oldUdevDefiner5)(nil)).Elem(),
-	reflect.TypeOf((*oldUdevDefiner6)(nil)).Elem(),
 }
 
 // Check that no interface defines older definer methods.

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -27,17 +27,6 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// Plug represents the potential of a given snap to connect to a slot.
-type Plug struct {
-	*snap.PlugInfo
-	Connections []SlotRef `json:"connections,omitempty"`
-}
-
-// Ref returns reference to a plug
-func (plug *Plug) Ref() PlugRef {
-	return PlugRef{Snap: plug.Snap.Name(), Name: plug.Name}
-}
-
 // Sanitize plug with a given snapd interface.
 func BeforePreparePlug(iface Interface, plugInfo *snap.PlugInfo) error {
 	if iface.Name() != plugInfo.Interface {
@@ -60,17 +49,6 @@ type PlugRef struct {
 // String returns the "snap:plug" representation of a plug reference.
 func (ref PlugRef) String() string {
 	return fmt.Sprintf("%s:%s", ref.Snap, ref.Name)
-}
-
-// Slot represents a capacity offered by a snap.
-type Slot struct {
-	*snap.SlotInfo
-	Connections []PlugRef `json:"connections,omitempty"`
-}
-
-// Ref returns reference to a slot
-func (slot *Slot) Ref() SlotRef {
-	return SlotRef{Snap: slot.Snap.Name(), Name: slot.Name}
 }
 
 // Sanitize slot with a given snapd interface.

--- a/interfaces/core_test.go
+++ b/interfaces/core_test.go
@@ -136,28 +136,12 @@ func (s *CoreSuite) TestValidateDBusBusName(c *C) {
 	c.Assert(err, ErrorMatches, `DBus bus name is too long \(must be <= 255\)`)
 }
 
-// Plug.Ref works as expected
-func (s *CoreSuite) TestPlugRef(c *C) {
-	plug := &Plug{PlugInfo: &snap.PlugInfo{Snap: &snap.Info{SuggestedName: "consumer"}, Name: "plug"}}
-	ref := plug.Ref()
-	c.Check(ref.Snap, Equals, "consumer")
-	c.Check(ref.Name, Equals, "plug")
-}
-
 // PlugRef.String works as expected
 func (s *CoreSuite) TestPlugRefString(c *C) {
 	ref := PlugRef{Snap: "snap", Name: "plug"}
 	c.Check(ref.String(), Equals, "snap:plug")
 	refPtr := &PlugRef{Snap: "snap", Name: "plug"}
 	c.Check(refPtr.String(), Equals, "snap:plug")
-}
-
-// Slot.Ref works as expected
-func (s *CoreSuite) TestSlotRef(c *C) {
-	slot := &Slot{SlotInfo: &snap.SlotInfo{Snap: &snap.Info{SuggestedName: "producer"}, Name: "slot"}}
-	ref := slot.Ref()
-	c.Check(ref.Snap, Equals, "producer")
-	c.Check(ref.Name, Equals, "slot")
 }
 
 // SlotRef.String works as expected

--- a/interfaces/json.go
+++ b/interfaces/json.go
@@ -34,23 +34,6 @@ type plugJSON struct {
 	Connections []SlotRef              `json:"connections,omitempty"`
 }
 
-// MarshalJSON returns the JSON encoding of plug.
-func (plug *Plug) MarshalJSON() ([]byte, error) {
-	var names []string
-	for name := range plug.Apps {
-		names = append(names, name)
-	}
-	return json.Marshal(&plugJSON{
-		Snap:        plug.Snap.Name(),
-		Name:        plug.Name,
-		Interface:   plug.Interface,
-		Attrs:       plug.Attrs,
-		Apps:        names,
-		Label:       plug.Label,
-		Connections: plug.Connections,
-	})
-}
-
 // slotJSON aids in marshaling Slot into JSON.
 type slotJSON struct {
 	Snap        string                 `json:"snap"`
@@ -60,23 +43,6 @@ type slotJSON struct {
 	Apps        []string               `json:"apps,omitempty"`
 	Label       string                 `json:"label,omitempty"`
 	Connections []PlugRef              `json:"connections,omitempty"`
-}
-
-// MarshalJSON returns the JSON encoding of slot.
-func (slot *Slot) MarshalJSON() ([]byte, error) {
-	var names []string
-	for name := range slot.Apps {
-		names = append(names, name)
-	}
-	return json.Marshal(&slotJSON{
-		Snap:        slot.Snap.Name(),
-		Name:        slot.Name,
-		Interface:   slot.Interface,
-		Attrs:       slot.Attrs,
-		Apps:        names,
-		Label:       slot.Label,
-		Connections: slot.Connections,
-	})
 }
 
 // interfaceInfoJSON aids in marshaling Info into JSON.

--- a/interfaces/json_test.go
+++ b/interfaces/json_test.go
@@ -29,94 +29,44 @@ import (
 )
 
 type JSONSuite struct {
-	plug *Plug
-	slot *Slot
+	plug *snap.PlugInfo
+	slot *snap.SlotInfo
 }
 
 var _ = Suite(&JSONSuite{
-	plug: &Plug{
-		PlugInfo: &snap.PlugInfo{
-			Snap:      &snap.Info{SuggestedName: "snap-name"},
-			Name:      "plug-name",
-			Interface: "interface",
-			Attrs:     map[string]interface{}{"key": "value"},
-			Apps: map[string]*snap.AppInfo{
-				"app-name": {
-					Name: "app-name",
-				},
+	plug: &snap.PlugInfo{
+		Snap:      &snap.Info{SuggestedName: "snap-name"},
+		Name:      "plug-name",
+		Interface: "interface",
+		Attrs:     map[string]interface{}{"key": "value"},
+		Apps: map[string]*snap.AppInfo{
+			"app-name": {
+				Name: "app-name",
 			},
-			Label: "label",
 		},
-		Connections: []SlotRef{{
-			Snap: "other-snap-name",
-			Name: "slot-name",
-		}},
+		Label: "label",
 	},
-	slot: &Slot{
-		SlotInfo: &snap.SlotInfo{
-			Snap:      &snap.Info{SuggestedName: "snap-name"},
-			Name:      "slot-name",
-			Interface: "interface",
-			Attrs:     map[string]interface{}{"key": "value"},
-			Apps: map[string]*snap.AppInfo{
-				"app-name": {
-					Name: "app-name",
-				},
+	slot: &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "snap-name"},
+		Name:      "slot-name",
+		Interface: "interface",
+		Attrs:     map[string]interface{}{"key": "value"},
+		Apps: map[string]*snap.AppInfo{
+			"app-name": {
+				Name: "app-name",
 			},
-			Label: "label",
 		},
-		Connections: []PlugRef{{
-			Snap: "other-snap-name",
-			Name: "plug-name",
-		}},
+		Label: "label",
 	},
 })
-
-func (s *JSONSuite) TestPlugMarshalJSON(c *C) {
-	data, err := json.Marshal(s.plug)
-	c.Assert(err, IsNil)
-	var repr map[string]interface{}
-	err = json.Unmarshal(data, &repr)
-	c.Assert(err, IsNil)
-	c.Check(repr, DeepEquals, map[string]interface{}{
-		"snap":      "snap-name",
-		"plug":      "plug-name",
-		"interface": "interface",
-		"attrs":     map[string]interface{}{"key": "value"},
-		"apps":      []interface{}{"app-name"},
-		"label":     "label",
-		"connections": []interface{}{
-			map[string]interface{}{"snap": "other-snap-name", "slot": "slot-name"},
-		},
-	})
-}
-
-func (s *JSONSuite) TestSlotMarshalJSON(c *C) {
-	data, err := json.Marshal(s.slot)
-	c.Assert(err, IsNil)
-	var repr map[string]interface{}
-	err = json.Unmarshal(data, &repr)
-	c.Assert(err, IsNil)
-	c.Check(repr, DeepEquals, map[string]interface{}{
-		"snap":      "snap-name",
-		"slot":      "slot-name",
-		"interface": "interface",
-		"attrs":     map[string]interface{}{"key": "value"},
-		"apps":      []interface{}{"app-name"},
-		"label":     "label",
-		"connections": []interface{}{
-			map[string]interface{}{"snap": "other-snap-name", "plug": "plug-name"},
-		},
-	})
-}
 
 func (s *JSONSuite) TestInfoMarshalJSON(c *C) {
 	ifaceInfo := &Info{
 		Name:    "iface",
 		Summary: "interface summary",
 		DocURL:  "http://example.org/",
-		Plugs:   []*snap.PlugInfo{s.plug.PlugInfo},
-		Slots:   []*snap.SlotInfo{s.slot.SlotInfo},
+		Plugs:   []*snap.PlugInfo{s.plug},
+		Slots:   []*snap.SlotInfo{s.slot},
 	}
 	data, err := json.Marshal(ifaceInfo)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Remove Plug/Slot data types that will no longer be used after #5208 lands.

Marking blocked for now until #5208 is merged.