### PR TITLE
interfaces/joystick: force use of the device cgroup with joystick interface

### DIFF
--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -71,9 +71,15 @@ const joystickConnectedPlugAppArmor = `
 // purpose. In other words, in practice, users with such devices will have
 // updated their udev rules to set ENV{ID_INPUT_JOYSTICK}="" to make it work,
 // which means this rule will no longer match.
+//
+// Because of the unconditional /dev/input/event[0-9]* AppArmor rule, we need
+// to ensure that the device cgroup is in effect even when there are no
+// joysticks present so that we don't give away all input to the snap. Use
+// /dev/full for this purpose.
 var joystickConnectedPlugUDev = []string{
 	`KERNEL=="js[0-9]*"`,
 	`KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_INPUT_JOYSTICK}=="1"`,
+	`KERNEL=="full", SUBSYSTEM=="mem"`,
 }
 
 func init() {

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -91,11 +91,13 @@ func (s *JoystickInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *JoystickInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 3)
+	c.Assert(spec.Snippets(), HasLen, 4)
 	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
 KERNEL=="js[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
 KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_INPUT_JOYSTICK}=="1", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
+KERNEL=="full", SUBSYSTEM=="mem", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
 }
 


### PR DESCRIPTION
Because of the unconditional /dev/input/event[0-9]* AppArmor rule, we need
to ensure that the device cgroup is in effect even when there are no
joysticks present so that we don't give away all input to the snap. Use
/dev/full for this purpose.

The defect is not in any released version of snapd, but we need to either
include this or revert https://github.com/snapcore/snapd/pull/5203 from 2.33 and master.