### PR TITLE
interfaces/tpm: Allow access to the kernel resource manager

### DIFF
--- a/interfaces/builtin/tpm.go
+++ b/interfaces/builtin/tpm.go
@@ -31,11 +31,16 @@ const tpmBaseDeclarationSlots = `
 
 const tpmConnectedPlugAppArmor = `
 # Description: for those who need to talk to the system TPM chip over /dev/tpm0
+# and kernel TPM resource manager /dev/tpmrm0 (4.12+)
 
 /dev/tpm0 rw,
+/dev/tpmrm0 rw,
 `
 
-var tpmConnectedPlugUDev = []string{`KERNEL=="tpm[0-9]*"`}
+var tpmConnectedPlugUDev = []string{
+	`KERNEL=="tpm[0-9]*"`,
+	`KERNEL=="tpmrm[0-9]*"`,
+}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/tpm_test.go
+++ b/interfaces/builtin/tpm_test.go
@@ -90,9 +90,11 @@ func (s *TpmInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *TpmInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets(), testutil.Contains, `# tpm
 KERNEL=="tpm[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# tpm
+KERNEL=="tpmrm[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
 }
 


### PR DESCRIPTION
Allow access to the in-kernel resource manager (/dev/tpmrm0) on recent kernels (at least v4.12)