### PR TITLE
client, daemon: add a "mounted-from" entry to local snaps' JSON

### DIFF
--- a/client/packages.go
+++ b/client/packages.go
@@ -59,6 +59,7 @@ type Snap struct {
 	Contact          string        `json:"contact"`
 	License          string        `json:"license,omitempty"`
 	CommonIDs        []string      `json:"common-ids,omitempty"`
+	MountedFrom      string        `json:"mounted-from,omitempty"`
 
 	Prices      map[string]float64 `json:"prices,omitempty"`
 	Screenshots []Screenshot       `json:"screenshots,omitempty"`

--- a/daemon/snap.go
+++ b/daemon/snap.go
@@ -22,6 +22,7 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -340,6 +341,15 @@ func mapLocal(about aboutSnap) *client.Snap {
 		Title:            localSnap.Title(),
 		License:          localSnap.License,
 		CommonIDs:        localSnap.CommonIDs,
+		MountedFrom:      localSnap.MountFile(),
+	}
+
+	if result.TryMode {
+		// Readlink instead of EvalSymlinks because it's only expected
+		// to be one level, and should still resolve if the target does
+		// not exist (this might help e.g. snapcraft clean up after a
+		// prime dir)
+		result.MountedFrom, _ = os.Readlink(result.MountedFrom)
 	}
 
 	return result


### PR DESCRIPTION
"mounted-from" (or MountedFrom) will point to the snap blob when it's
a squashfs, or (more importantly) to the directory that is being
tried when it's a bind mount.

This is primarily to help snapcraft appropriately manage tried prime
directories.

See https://forum.snapcraft.io/t/5608