### PR TITLE
interfaces/joystick: support modern evdev joysticks 2.33

### DIFF
--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -71,9 +71,15 @@ const joystickConnectedPlugAppArmor = `
 // purpose. In other words, in practice, users with such devices will have
 // updated their udev rules to set ENV{ID_INPUT_JOYSTICK}="" to make it work,
 // which means this rule will no longer match.
+//
+// Because of the unconditional /dev/input/event[0-9]* AppArmor rule, we need
+// to ensure that the device cgroup is in effect even when there are no
+// joysticks present so that we don't give away all input to the snap. Use
+// /dev/full for this purpose.
 var joystickConnectedPlugUDev = []string{
 	`KERNEL=="js[0-9]*"`,
 	`KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_INPUT_JOYSTICK}=="1"`,
+	`KERNEL=="full", SUBSYSTEM=="mem"`,
 }
 
 func init() {

--- a/interfaces/builtin/joystick.go
+++ b/interfaces/builtin/joystick.go
@@ -47,7 +47,7 @@ const joystickConnectedPlugAppArmor = `
 
 # Per https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/devices.txt
 # the minor is 65 and up so limit udev to that.
-/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*},
+/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*} r,
 
 # /dev/input/event* is unfortunately not namespaced and includes all input
 # devices, including keyboards and mice, which allows input sniffing and

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -85,14 +85,17 @@ func (s *JoystickInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/input/js{[0-9],[12][0-9],3[01]} rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*},`)
 }
 
 func (s *JoystickInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
 KERNEL=="js[0-9]*", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
+KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_INPUT_JOYSTICK}=="1", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
 }
 

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -85,7 +85,7 @@ func (s *JoystickInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/input/js{[0-9],[12][0-9],3[01]} rw,`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*},`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/run/udev/data/c13:{6[5-9],[7-9][0-9],[1-9][0-9][0-9]*} r,`)
 }
 
 func (s *JoystickInterfaceSuite) TestUDevSpec(c *C) {

--- a/interfaces/builtin/joystick_test.go
+++ b/interfaces/builtin/joystick_test.go
@@ -91,11 +91,13 @@ func (s *JoystickInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *JoystickInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 3)
+	c.Assert(spec.Snippets(), HasLen, 4)
 	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
 KERNEL=="js[0-9]*", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
 KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{ID_INPUT_JOYSTICK}=="1", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# joystick
+KERNEL=="full", SUBSYSTEM=="mem", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
 }
 


### PR DESCRIPTION
The evdev support and force device cgroup changes for 2.33. I will be adding a PR for a new spread test later today and can tack that on to this then or as a separate PR for 2.33 at your discretion.
