### PR TITLE
interfaces: add juju-client-observe for 2.33

### DIFF
--- a/interfaces/builtin/juju_client_observe.go
+++ b/interfaces/builtin/juju_client_observe.go
@@ -1,0 +1,46 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const jujuClientObserveSummary = `allows read access to juju client configuration`
+
+const jujuClientObserveBaseDeclarationSlots = `
+  juju-client-observe:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const jujuClientObserveConnectedPlugAppArmor = `
+# Description: Can access juju client configuration
+owner @{HOME}/.local/share/juju/{,**} r,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "juju-client-observe",
+		summary:               jujuClientObserveSummary,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  jujuClientObserveBaseDeclarationSlots,
+		connectedPlugAppArmor: jujuClientObserveConnectedPlugAppArmor,
+		reservedForOS:         true,
+	})
+}

--- a/interfaces/builtin/juju_client_observe_test.go
+++ b/interfaces/builtin/juju_client_observe_test.go
@@ -1,0 +1,99 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type JujuClientObserveInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&JujuClientObserveInterfaceSuite{
+	iface: builtin.MustInterface("juju-client-observe"),
+})
+
+const jujuClientObserveConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+  plugs: [juju-client-observe]
+`
+
+const jujuClientObserveCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  juju-client-observe:
+`
+
+func (s *JujuClientObserveInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, jujuClientObserveConsumerYaml, nil, "juju-client-observe")
+	s.slot, s.slotInfo = MockConnectedSlot(c, jujuClientObserveCoreYaml, nil, "juju-client-observe")
+}
+
+func (s *JujuClientObserveInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "juju-client-observe")
+}
+
+func (s *JujuClientObserveInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+	slot := &snap.SlotInfo{
+		Snap:      &snap.Info{SuggestedName: "some-snap"},
+		Name:      "juju-client-observe",
+		Interface: "juju-client-observe",
+	}
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		"juju-client-observe slots are reserved for the core snap")
+}
+
+func (s *JujuClientObserveInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *JujuClientObserveInterfaceSuite) TestAppArmorSpec(c *C) {
+	spec := &apparmor.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner @{HOME}/.local/share/juju/{,**} r,\n")
+}
+
+func (s *JujuClientObserveInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows read access to juju client configuration`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "juju-client-observe")
+}
+
+func (s *JujuClientObserveInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -122,6 +122,9 @@ apps:
   joystick:
     command: bin/run
     plugs: [ joystick ]
+  juju-client-observe:
+    command: bin/run
+    plugs: [ juju-client-observe ]
   kernel-module-control:
     command: bin/run
     plugs: [ kernel-module-control ]


### PR DESCRIPTION
Reference:
https://forum.snapcraft.io/t/classic-confinement-for-bootstack-ops-snap/5524
