### PR TITLE
tests: fix lxd test - --auto now sets up networking

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -62,7 +62,7 @@ execute: |
     echo "Ensure we can get network"
     lxd.lxc network create testbr0
     lxd.lxc network attach testbr0 my-ubuntu eth0
-    lxd.lxc exec my-ubuntu dhclient eth0
+    lxd.lxc exec my-ubuntu dhclient
 
     echo "Cleanup container"
     lxd.lxc exec my-ubuntu -- apt autoremove --purge -y snapd ubuntu-core-launcher

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -59,11 +59,6 @@ execute: |
     echo "Ensure we can run things inside"
     lxd.lxc exec my-ubuntu echo hello | MATCH hello
 
-    echo "Ensure we can get network"
-    lxd.lxc network create testbr0
-    lxd.lxc network attach testbr0 my-ubuntu eth0
-    lxd.lxc exec my-ubuntu dhclient
-
     echo "Cleanup container"
     lxd.lxc exec my-ubuntu -- apt autoremove --purge -y snapd ubuntu-core-launcher
 


### PR DESCRIPTION
The current spread tests fails in the lxd test right now. This PR should fix that.