### PR TITLE
tests: skip appstream-id test for core systems 32 bits

### DIFF
--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -1,7 +1,7 @@
 summary: Verify AppStream ID integration
 # ubuntu-*-32: the snap used in the test was published only for amd64
 # fedora: uses GNU netcat by default
-systems: [-ubuntu-16.04-32, -fedora-*]
+systems: [-ubuntu-*-32, -fedora-*, -ubuntu-core-16-arm-*, ]
 
 prepare: |
     snap install jq

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -1,6 +1,7 @@
 summary: Verify AppStream ID integration
 # ubuntu-*-32: the snap used in the test was published only for amd64
-# fedora: uses GNU netcat by default
+# fedora-*: uses GNU netcat by default
+# ubuntu-core-16-arm-*: the snap used in the test was published only for amd64
 systems: [-ubuntu-*-32, -fedora-*, -ubuntu-core-16-arm-* ]
 
 prepare: |

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -1,7 +1,7 @@
 summary: Verify AppStream ID integration
 # ubuntu-*-32: the snap used in the test was published only for amd64
 # fedora: uses GNU netcat by default
-systems: [-ubuntu-*-32, -fedora-*, -ubuntu-core-16-arm-*, ]
+systems: [-ubuntu-*-32, -fedora-*, -ubuntu-core-16-arm-* ]
 
 prepare: |
     snap install jq


### PR DESCRIPTION
This affect both amd32 and arm based on test comments
