### PR TITLE
interfaces/udev: call 'udevadm settle --timeout=10' after triggering events

### DIFF
--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -99,6 +99,7 @@ func (s *backendSuite) TestInstallingSnapWritesAndLoadsRules(c *C) {
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
 			{"udevadm", "control", "--reload-rules"},
 			{"udevadm", "trigger"},
+			{"udevadm", "settle", "--timeout=10"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -127,6 +128,7 @@ func (s *backendSuite) TestInstallingSnapWithHookWritesAndLoadsRules(c *C) {
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
 			{"udevadm", "control", "--reload-rules"},
 			{"udevadm", "trigger"},
+			{"udevadm", "settle", "--timeout=10"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -167,6 +169,7 @@ func (s *backendSuite) TestRemovingSnapRemovesAndReloadsRules(c *C) {
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
 			{"udevadm", "control", "--reload-rules"},
 			{"udevadm", "trigger"},
+			{"udevadm", "settle", "--timeout=10"},
 		})
 	}
 }
@@ -189,6 +192,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreApps(c *C) {
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
 			{"udevadm", "control", "--reload-rules"},
 			{"udevadm", "trigger"},
+			{"udevadm", "settle", "--timeout=10"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -218,6 +222,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithMoreHooks(c *C) {
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
 			{"udevadm", "control", "--reload-rules"},
 			{"udevadm", "trigger"},
+			{"udevadm", "settle", "--timeout=10"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -241,6 +246,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerApps(c *C) {
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
 			{"udevadm", "control", "--reload-rules"},
 			{"udevadm", "trigger"},
+			{"udevadm", "settle", "--timeout=10"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -268,6 +274,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithFewerHooks(c *C) {
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
 			{"udevadm", "control", "--reload-rules"},
 			{"udevadm", "trigger"},
+			{"udevadm", "settle", "--timeout=10"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}
@@ -385,6 +392,7 @@ func (s *backendSuite) TestUpdatingSnapToOneWithoutSlots(c *C) {
 		c.Check(s.udevadmCmd.Calls(), DeepEquals, [][]string{
 			{"udevadm", "control", "--reload-rules"},
 			{"udevadm", "trigger"},
+			{"udevadm", "settle", "--timeout=10"},
 		})
 		s.RemoveSnap(c, snapInfo)
 	}

--- a/interfaces/udev/udev.go
+++ b/interfaces/udev/udev.go
@@ -24,10 +24,11 @@ import (
 	"os/exec"
 )
 
-// ReloadRules runs two commands that reload udev rule database.
+// ReloadRules runs three commands that reload udev rule database.
 //
 // The commands are: udevadm control --reload-rules
 //                   udevadm trigger
+//                   udevadm settle --timeout=3
 func ReloadRules() error {
 	output, err := exec.Command("udevadm", "control", "--reload-rules").CombinedOutput()
 	if err != nil {
@@ -37,5 +38,10 @@ func ReloadRules() error {
 	if err != nil {
 		return fmt.Errorf("cannot run udev triggers: %s\nudev output:\n%s", err, string(output))
 	}
+
+	// give our triggered events a chance to be handled before exiting.
+	// Ignore errors since we don't want to error on still pending events.
+	_ = exec.Command("udevadm", "settle", "--timeout=10").Run()
+
 	return nil
 }

--- a/interfaces/udev/udev_test.go
+++ b/interfaces/udev/udev_test.go
@@ -46,6 +46,7 @@ func (s *uDevSuite) TestReloadUDevRulesRunsUDevAdm(c *C) {
 	c.Assert(cmd.Calls(), DeepEquals, [][]string{
 		{"udevadm", "control", "--reload-rules"},
 		{"udevadm", "trigger"},
+		{"udevadm", "settle", "--timeout=10"},
 	})
 }
 


### PR DESCRIPTION
After an interface connect/disconnect, the udev backend calls udevadm to reload
the udev rules and then calls udevadm to trigger events so that existing
devices are udev tagged right away. udevadm trigger will not block so it is
possible that a snap will try to access a device before it is tagged. By
calling 'udevadm settle' we can block for a little while to allow the
events we triggered to be handled. Note that udevadm default timeout is 120
seconds, but udevadm settle will return very quickly when only a few events
need to be handled. Arbitrarily set the settle timeout to 10 seconds to not
block the snapd connect/disconnect for too long but to give udev a chance to
process snapd's newly added/removed rules.

Normally you don't need or want to call 'udevadm settle' but in the case of
snapd it is important when considering that AppArmor rules are updated and made
live to the system before the udev backend and before the triggered events are
all handled (since the AppArmor policy may allow more than the device cgroup
would otherwise allow). Ideally we would make these udevadm calls only once
(perhaps with a higher timeout since there could be more events to handle) and
before the AppArmor backend loads its new policy.
