### PR TITLE
cmd/snap-update-ns: add PathIterator

### DIFF
--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -690,8 +690,12 @@ type PathIterator struct {
 
 // NewPathIterator returns an iterator for traversing the given path.
 // The path is passed through filepath.Clean automatically.
-func NewPathIterator(path string) *PathIterator {
-	return &PathIterator{path: filepath.Clean(path)}
+func NewPathIterator(path string) (*PathIterator, error) {
+	cleanPath := filepath.Clean(path)
+	if path != cleanPath {
+		return nil, fmt.Errorf("cannot iterate over unclean path %q", path)
+	}
+	return &PathIterator{path: cleanPath}, nil
 }
 
 // Path returns the path being traversed.

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -865,20 +865,14 @@ func (s *realSystemSuite) TestSecureOpenPathSymlinkedParent(c *C) {
 }
 
 func (s *realSystemSuite) TestPathIteratorEmpty(c *C) {
-	iter := update.NewPathIterator("")
-	c.Assert(iter.Path(), Equals, ".")
-
-	c.Assert(iter.Next(), Equals, true)
-	c.Assert(iter.CurrentBase(), Equals, "")
-	c.Assert(iter.CurrentPath(), Equals, ".")
-	c.Assert(iter.CurrentName(), Equals, ".")
-	c.Assert(iter.CurrentCleanName(), Equals, ".")
-
-	c.Assert(iter.Next(), Equals, false)
+	iter, err := update.NewPathIterator("")
+	c.Assert(err, ErrorMatches, `cannot iterate over unclean path ""`)
+	c.Assert(iter, IsNil)
 }
 
 func (s *realSystemSuite) TestPathIteratorFilename(c *C) {
-	iter := update.NewPathIterator("foo")
+	iter, err := update.NewPathIterator("foo")
+	c.Assert(err, IsNil)
 	c.Assert(iter.Path(), Equals, "foo")
 
 	c.Assert(iter.Next(), Equals, true)
@@ -891,7 +885,8 @@ func (s *realSystemSuite) TestPathIteratorFilename(c *C) {
 }
 
 func (s *realSystemSuite) TestPathIteratorRelative(c *C) {
-	iter := update.NewPathIterator("foo/bar")
+	iter, err := update.NewPathIterator("foo/bar")
+	c.Assert(err, IsNil)
 	c.Assert(iter.Path(), Equals, "foo/bar")
 
 	c.Assert(iter.Next(), Equals, true)
@@ -910,7 +905,8 @@ func (s *realSystemSuite) TestPathIteratorRelative(c *C) {
 }
 
 func (s *realSystemSuite) TestPathIteratorAbsoluteClean(c *C) {
-	iter := update.NewPathIterator("/foo/bar")
+	iter, err := update.NewPathIterator("/foo/bar")
+	c.Assert(err, IsNil)
 	c.Assert(iter.Path(), Equals, "/foo/bar")
 
 	c.Assert(iter.Next(), Equals, true)
@@ -935,32 +931,14 @@ func (s *realSystemSuite) TestPathIteratorAbsoluteClean(c *C) {
 }
 
 func (s *realSystemSuite) TestPathIteratorAbsoluteUnclean(c *C) {
-	iter := update.NewPathIterator("/foo/bar/")
-	c.Assert(iter.Path(), Equals, "/foo/bar")
-
-	c.Assert(iter.Next(), Equals, true)
-	c.Assert(iter.CurrentBase(), Equals, "")
-	c.Assert(iter.CurrentPath(), Equals, "/")
-	c.Assert(iter.CurrentName(), Equals, "/")
-	c.Assert(iter.CurrentCleanName(), Equals, "")
-
-	c.Assert(iter.Next(), Equals, true)
-	c.Assert(iter.CurrentBase(), Equals, "/")
-	c.Assert(iter.CurrentPath(), Equals, "/foo/")
-	c.Assert(iter.CurrentName(), Equals, "foo/")
-	c.Assert(iter.CurrentCleanName(), Equals, "foo")
-
-	c.Assert(iter.Next(), Equals, true)
-	c.Assert(iter.CurrentBase(), Equals, "/foo/")
-	c.Assert(iter.CurrentPath(), Equals, "/foo/bar")
-	c.Assert(iter.CurrentName(), Equals, "bar")
-	c.Assert(iter.CurrentCleanName(), Equals, "bar")
-
-	c.Assert(iter.Next(), Equals, false)
+	iter, err := update.NewPathIterator("/foo/bar/")
+	c.Assert(err, ErrorMatches, `cannot iterate over unclean path "/foo/bar/"`)
+	c.Assert(iter, IsNil)
 }
 
 func (s *realSystemSuite) TestPathIteratorRootDir(c *C) {
-	iter := update.NewPathIterator("/")
+	iter, err := update.NewPathIterator("/")
+	c.Assert(err, IsNil)
 	c.Assert(iter.Path(), Equals, "/")
 
 	c.Assert(iter.Next(), Equals, true)
@@ -973,26 +951,14 @@ func (s *realSystemSuite) TestPathIteratorRootDir(c *C) {
 }
 
 func (s *realSystemSuite) TestPathIteratorUncleanPath(c *C) {
-	iter := update.NewPathIterator("///some/../junk")
-	c.Assert(iter.Path(), Equals, "/junk")
-
-	c.Assert(iter.Next(), Equals, true)
-	c.Assert(iter.CurrentBase(), Equals, "")
-	c.Assert(iter.CurrentPath(), Equals, "/")
-	c.Assert(iter.CurrentName(), Equals, "/")
-	c.Assert(iter.CurrentCleanName(), Equals, "")
-
-	c.Assert(iter.Next(), Equals, true)
-	c.Assert(iter.CurrentBase(), Equals, "/")
-	c.Assert(iter.CurrentPath(), Equals, "/junk")
-	c.Assert(iter.CurrentName(), Equals, "junk")
-	c.Assert(iter.CurrentCleanName(), Equals, "junk")
-
-	c.Assert(iter.Next(), Equals, false)
+	iter, err := update.NewPathIterator("///some/../junk")
+	c.Assert(err, ErrorMatches, `cannot iterate over unclean path ".*"`)
+	c.Assert(iter, IsNil)
 }
 
 func (s *realSystemSuite) TestPathIteratorUnicode(c *C) {
-	iter := update.NewPathIterator("/zażółć/gęślą/jaźń")
+	iter, err := update.NewPathIterator("/zażółć/gęślą/jaźń")
+	c.Assert(err, IsNil)
 	c.Assert(iter.Path(), Equals, "/zażółć/gęślą/jaźń")
 
 	c.Assert(iter.Next(), Equals, true)
@@ -1023,7 +989,8 @@ func (s *realSystemSuite) TestPathIteratorUnicode(c *C) {
 }
 
 func (s *realSystemSuite) TestPathIteratorExample(c *C) {
-	iter := update.NewPathIterator("/some/path/there")
+	iter, err := update.NewPathIterator("/some/path/there")
+	c.Assert(err, IsNil)
 	for iter.Next() {
 		_ = iter.CurrentBase()
 		_ = iter.CurrentPath()

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -865,102 +865,169 @@ func (s *realSystemSuite) TestSecureOpenPathSymlinkedParent(c *C) {
 }
 
 func (s *realSystemSuite) TestPathIteratorEmpty(c *C) {
-	pi := update.NewPathIterator("")
-	c.Assert(pi.Path(), Equals, ".")
+	iter := update.NewPathIterator("")
+	c.Assert(iter.Path(), Equals, ".")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, ".")
-	c.Assert(pi.Segment(), Equals, ".")
-	c.Assert(pi.CleanSegment(), Equals, ".")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "")
+	c.Assert(iter.CurrentPath(), Equals, ".")
+	c.Assert(iter.CurrentName(), Equals, ".")
+	c.Assert(iter.CurrentCleanName(), Equals, ".")
 
-	c.Assert(pi.Next(), Equals, false)
+	c.Assert(iter.Next(), Equals, false)
 }
 
 func (s *realSystemSuite) TestPathIteratorFilename(c *C) {
-	pi := update.NewPathIterator("foo")
-	c.Assert(pi.Path(), Equals, "foo")
+	iter := update.NewPathIterator("foo")
+	c.Assert(iter.Path(), Equals, "foo")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, "foo")
-	c.Assert(pi.Segment(), Equals, "foo")
-	c.Assert(pi.CleanSegment(), Equals, "foo")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "")
+	c.Assert(iter.CurrentPath(), Equals, "foo")
+	c.Assert(iter.CurrentName(), Equals, "foo")
+	c.Assert(iter.CurrentCleanName(), Equals, "foo")
 
-	c.Assert(pi.Next(), Equals, false)
+	c.Assert(iter.Next(), Equals, false)
 }
 
 func (s *realSystemSuite) TestPathIteratorRelative(c *C) {
-	pi := update.NewPathIterator("foo/bar")
-	c.Assert(pi.Path(), Equals, "foo/bar")
+	iter := update.NewPathIterator("foo/bar")
+	c.Assert(iter.Path(), Equals, "foo/bar")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, "foo/")
-	c.Assert(pi.Segment(), Equals, "foo/")
-	c.Assert(pi.CleanSegment(), Equals, "foo")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "")
+	c.Assert(iter.CurrentPath(), Equals, "foo/")
+	c.Assert(iter.CurrentName(), Equals, "foo/")
+	c.Assert(iter.CurrentCleanName(), Equals, "foo")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, "foo/bar")
-	c.Assert(pi.Segment(), Equals, "bar")
-	c.Assert(pi.CleanSegment(), Equals, "bar")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "foo/")
+	c.Assert(iter.CurrentPath(), Equals, "foo/bar")
+	c.Assert(iter.CurrentName(), Equals, "bar")
+	c.Assert(iter.CurrentCleanName(), Equals, "bar")
 
-	c.Assert(pi.Next(), Equals, false)
+	c.Assert(iter.Next(), Equals, false)
 }
 
-func (s *realSystemSuite) TestPathIteratorAbsolute(c *C) {
-	pi := update.NewPathIterator("/foo/bar")
-	c.Assert(pi.Path(), Equals, "/foo/bar")
+func (s *realSystemSuite) TestPathIteratorAbsoluteClean(c *C) {
+	iter := update.NewPathIterator("/foo/bar")
+	c.Assert(iter.Path(), Equals, "/foo/bar")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, "/")
-	c.Assert(pi.Segment(), Equals, "/")
-	c.Assert(pi.CleanSegment(), Equals, "")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "")
+	c.Assert(iter.CurrentPath(), Equals, "/")
+	c.Assert(iter.CurrentName(), Equals, "/")
+	c.Assert(iter.CurrentCleanName(), Equals, "")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, "/foo/")
-	c.Assert(pi.Segment(), Equals, "foo/")
-	c.Assert(pi.CleanSegment(), Equals, "foo")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/")
+	c.Assert(iter.CurrentPath(), Equals, "/foo/")
+	c.Assert(iter.CurrentName(), Equals, "foo/")
+	c.Assert(iter.CurrentCleanName(), Equals, "foo")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, "/foo/bar")
-	c.Assert(pi.Segment(), Equals, "bar")
-	c.Assert(pi.CleanSegment(), Equals, "bar")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/foo/")
+	c.Assert(iter.CurrentPath(), Equals, "/foo/bar")
+	c.Assert(iter.CurrentName(), Equals, "bar")
+	c.Assert(iter.CurrentCleanName(), Equals, "bar")
 
-	c.Assert(pi.Next(), Equals, false)
+	c.Assert(iter.Next(), Equals, false)
+}
+
+func (s *realSystemSuite) TestPathIteratorAbsoluteUnclean(c *C) {
+	iter := update.NewPathIterator("/foo/bar/")
+	c.Assert(iter.Path(), Equals, "/foo/bar")
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "")
+	c.Assert(iter.CurrentPath(), Equals, "/")
+	c.Assert(iter.CurrentName(), Equals, "/")
+	c.Assert(iter.CurrentCleanName(), Equals, "")
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/")
+	c.Assert(iter.CurrentPath(), Equals, "/foo/")
+	c.Assert(iter.CurrentName(), Equals, "foo/")
+	c.Assert(iter.CurrentCleanName(), Equals, "foo")
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/foo/")
+	c.Assert(iter.CurrentPath(), Equals, "/foo/bar")
+	c.Assert(iter.CurrentName(), Equals, "bar")
+	c.Assert(iter.CurrentCleanName(), Equals, "bar")
+
+	c.Assert(iter.Next(), Equals, false)
 }
 
 func (s *realSystemSuite) TestPathIteratorRootDir(c *C) {
-	pi := update.NewPathIterator("/")
-	c.Assert(pi.Path(), Equals, "/")
+	iter := update.NewPathIterator("/")
+	c.Assert(iter.Path(), Equals, "/")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, "/")
-	c.Assert(pi.Segment(), Equals, "/")
-	c.Assert(pi.CleanSegment(), Equals, "")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "")
+	c.Assert(iter.CurrentPath(), Equals, "/")
+	c.Assert(iter.CurrentName(), Equals, "/")
+	c.Assert(iter.CurrentCleanName(), Equals, "")
 
-	c.Assert(pi.Next(), Equals, false)
+	c.Assert(iter.Next(), Equals, false)
 }
 
 func (s *realSystemSuite) TestPathIteratorUncleanPath(c *C) {
-	pi := update.NewPathIterator("///some/../junk")
-	c.Assert(pi.Path(), Equals, "/junk")
+	iter := update.NewPathIterator("///some/../junk")
+	c.Assert(iter.Path(), Equals, "/junk")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, "/")
-	c.Assert(pi.Segment(), Equals, "/")
-	c.Assert(pi.CleanSegment(), Equals, "")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "")
+	c.Assert(iter.CurrentPath(), Equals, "/")
+	c.Assert(iter.CurrentName(), Equals, "/")
+	c.Assert(iter.CurrentCleanName(), Equals, "")
 
-	c.Assert(pi.Next(), Equals, true)
-	c.Assert(pi.PathSoFar(), Equals, "/junk")
-	c.Assert(pi.Segment(), Equals, "junk")
-	c.Assert(pi.CleanSegment(), Equals, "junk")
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/")
+	c.Assert(iter.CurrentPath(), Equals, "/junk")
+	c.Assert(iter.CurrentName(), Equals, "junk")
+	c.Assert(iter.CurrentCleanName(), Equals, "junk")
 
-	c.Assert(pi.Next(), Equals, false)
+	c.Assert(iter.Next(), Equals, false)
+}
+
+func (s *realSystemSuite) TestPathIteratorUnicode(c *C) {
+	iter := update.NewPathIterator("/zażółć/gęślą/jaźń")
+	c.Assert(iter.Path(), Equals, "/zażółć/gęślą/jaźń")
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "")
+	c.Assert(iter.CurrentPath(), Equals, "/")
+	c.Assert(iter.CurrentName(), Equals, "/")
+	c.Assert(iter.CurrentCleanName(), Equals, "")
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/")
+	c.Assert(iter.CurrentPath(), Equals, "/zażółć/")
+	c.Assert(iter.CurrentName(), Equals, "zażółć/")
+	c.Assert(iter.CurrentCleanName(), Equals, "zażółć")
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/zażółć/")
+	c.Assert(iter.CurrentPath(), Equals, "/zażółć/gęślą/")
+	c.Assert(iter.CurrentName(), Equals, "gęślą/")
+	c.Assert(iter.CurrentCleanName(), Equals, "gęślą")
+
+	c.Assert(iter.Next(), Equals, true)
+	c.Assert(iter.CurrentBase(), Equals, "/zażółć/gęślą/")
+	c.Assert(iter.CurrentPath(), Equals, "/zażółć/gęślą/jaźń")
+	c.Assert(iter.CurrentName(), Equals, "jaźń")
+	c.Assert(iter.CurrentCleanName(), Equals, "jaźń")
+
+	c.Assert(iter.Next(), Equals, false)
 }
 
 func (s *realSystemSuite) TestPathIteratorExample(c *C) {
-	pi := update.NewPathIterator("/some/path/there")
-	for pi.Next() {
-		_ = pi.PathSoFar()
-		_ = pi.Segment()
-		_ = pi.CleanSegment()
+	iter := update.NewPathIterator("/some/path/there")
+	for iter.Next() {
+		_ = iter.CurrentBase()
+		_ = iter.CurrentPath()
+		_ = iter.CurrentName()
+		_ = iter.CurrentCleanName()
 	}
 }

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -863,3 +863,104 @@ func (s *realSystemSuite) TestSecureOpenPathSymlinkedParent(c *C) {
 	c.Check(fd, Equals, -1)
 	c.Check(err, ErrorMatches, "not a directory")
 }
+
+func (s *realSystemSuite) TestPathIteratorEmpty(c *C) {
+	pi := update.NewPathIterator("")
+	c.Assert(pi.Path(), Equals, ".")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, ".")
+	c.Assert(pi.Segment(), Equals, ".")
+	c.Assert(pi.CleanSegment(), Equals, ".")
+
+	c.Assert(pi.Next(), Equals, false)
+}
+
+func (s *realSystemSuite) TestPathIteratorFilename(c *C) {
+	pi := update.NewPathIterator("foo")
+	c.Assert(pi.Path(), Equals, "foo")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, "foo")
+	c.Assert(pi.Segment(), Equals, "foo")
+	c.Assert(pi.CleanSegment(), Equals, "foo")
+
+	c.Assert(pi.Next(), Equals, false)
+}
+
+func (s *realSystemSuite) TestPathIteratorRelative(c *C) {
+	pi := update.NewPathIterator("foo/bar")
+	c.Assert(pi.Path(), Equals, "foo/bar")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, "foo/")
+	c.Assert(pi.Segment(), Equals, "foo/")
+	c.Assert(pi.CleanSegment(), Equals, "foo")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, "foo/bar")
+	c.Assert(pi.Segment(), Equals, "bar")
+	c.Assert(pi.CleanSegment(), Equals, "bar")
+
+	c.Assert(pi.Next(), Equals, false)
+}
+
+func (s *realSystemSuite) TestPathIteratorAbsolute(c *C) {
+	pi := update.NewPathIterator("/foo/bar")
+	c.Assert(pi.Path(), Equals, "/foo/bar")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, "/")
+	c.Assert(pi.Segment(), Equals, "/")
+	c.Assert(pi.CleanSegment(), Equals, "")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, "/foo/")
+	c.Assert(pi.Segment(), Equals, "foo/")
+	c.Assert(pi.CleanSegment(), Equals, "foo")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, "/foo/bar")
+	c.Assert(pi.Segment(), Equals, "bar")
+	c.Assert(pi.CleanSegment(), Equals, "bar")
+
+	c.Assert(pi.Next(), Equals, false)
+}
+
+func (s *realSystemSuite) TestPathIteratorRootDir(c *C) {
+	pi := update.NewPathIterator("/")
+	c.Assert(pi.Path(), Equals, "/")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, "/")
+	c.Assert(pi.Segment(), Equals, "/")
+	c.Assert(pi.CleanSegment(), Equals, "")
+
+	c.Assert(pi.Next(), Equals, false)
+}
+
+func (s *realSystemSuite) TestPathIteratorUncleanPath(c *C) {
+	pi := update.NewPathIterator("///some/../junk")
+	c.Assert(pi.Path(), Equals, "/junk")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, "/")
+	c.Assert(pi.Segment(), Equals, "/")
+	c.Assert(pi.CleanSegment(), Equals, "")
+
+	c.Assert(pi.Next(), Equals, true)
+	c.Assert(pi.PathSoFar(), Equals, "/junk")
+	c.Assert(pi.Segment(), Equals, "junk")
+	c.Assert(pi.CleanSegment(), Equals, "junk")
+
+	c.Assert(pi.Next(), Equals, false)
+}
+
+func (s *realSystemSuite) TestPathIteratorExample(c *C) {
+	pi := update.NewPathIterator("/some/path/there")
+	for pi.Next() {
+		_ = pi.PathSoFar()
+		_ = pi.Segment()
+		_ = pi.CleanSegment()
+	}
+}


### PR DESCRIPTION
This patch adds a helper utility for iterating through file paths that I
haven't found anywhere in the standard directory. My intent is to use it
as more efficient and less error prone version of the "segments" logic
that is used throughout this code.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
