### PR TITLE
spread: switch fedora 28 to manual

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -79,6 +79,7 @@ backends:
             - fedora-28-64:
                 image: fedora-28-64-selinux-permissive
                 workers: 4
+                manual: true
 
             - opensuse-42.3-64:
                 image: opensuse-cloud/opensuse-leap-42-3-v20180116


### PR DESCRIPTION
Fedora repos seem to be under high load at the moment.

