### PR TITLE
tests: add test to ensure /dev/input/event* for non-joysticks is denied - 2.33

### DIFF
--- a/tests/lib/snaps/test-snapd-event/bin/read-evdev-device
+++ b/tests/lib/snaps/test-snapd-event/bin/read-evdev-device
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+device_type="-event-kbd"
+if [ -n "$1" ]; then
+    device_type="$1"
+fi
+
+# Detect a device by looking in /dev/input/by-path to find the first device
+# matching the specified device_type
+evdev=$(find /dev/input/by-path/ -name "*$device_type" -ls | head -1 | sed 's#.* -> ../##')
+
+if [ -z "$evdev" ]; then
+    echo "No device detected. Aborting"
+    exit 1
+fi
+
+dev="/dev/input/$evdev"
+if [ ! -c "$dev" ]; then
+    echo "Detected device is not a character device. Aborting"
+    exit 1
+fi
+
+# Obtain an fd for the file
+exec 3<> "$dev"
+# Close the file
+exec 3>&-

--- a/tests/lib/snaps/test-snapd-event/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-event/meta/snap.yaml
@@ -1,0 +1,11 @@
+name: test-snapd-event
+version: 1.0
+summary: Test opening /dev/input/event* devices
+confinement: strict
+description: |
+  Trivial snap for testing opening /dev/input/event* devices
+apps:
+  test-snapd-event:
+    command: bin/read-evdev-device
+    plugs:
+    - joystick

--- a/tests/main/security-dev-input-event-denied/task.yaml
+++ b/tests/main/security-dev-input-event-denied/task.yaml
@@ -1,0 +1,55 @@
+summary: Ensure that /dev/input/event* is denied by default.
+
+details: |
+    The default policy disallows access to /dev/input/event*.
+
+    The joystick interface disallows access to /dev/input/event* for
+    non-joysticks.
+
+    The test checks the snap is not able to access /dev/input/event* with or
+    without the joystick interface connected. We do this since the
+    /dev/input/event* devices are sensitive and because the joystick interface
+    adds a /dev/input/event* AppArmor glob rule that relies entirely on the
+    device cgroup for enforcement.
+
+prepare: |
+    echo "Given the test-snapd-event snap is installed"
+    #shellcheck source=tests/lib/snaps.sh
+    . "$TESTSLIB"/snaps.sh
+    install_local test-snapd-event
+
+restore: |
+    rm -f call.error
+
+execute: |
+    echo "The joystick plug is not connected by default"
+    snap interfaces -i joystick | MATCH '\- +test-snapd-event:joystick'
+
+    if [ "$(snap debug confinement)" != "strict" ]; then
+        exit 0
+    fi
+
+    echo "Then the snap is not able to access an evdev keyboard"
+    if test-snapd-event "-event-kbd" 2>"${PWD}"/call.error; then
+        echo "Expected permission error calling evtest with disconnected plug"
+        exit 1
+    fi
+    # AppArmor is 'Permission denied' which is expected with default policy
+    MATCH "Permission denied" < call.error
+
+    echo "When the joystick plug is connected"
+    snap connect test-snapd-event:joystick
+    udevadm settle
+
+    # Note, '-event-kbd' devices aren't joysticks (those are -event-joystick
+    # (evdev event*) and -joystick (js*)) and therefore shouldn't be added to
+    # the device cgroup when the joystick interface is plugged.
+    echo "Then the snap is still not able to access an evdev keyboard"
+    if test-snapd-event "-event-kbd" 2>"${PWD}"/call.error; then
+        echo "Expected permission error calling evtest with connected joystick plug"
+        exit 1
+    fi
+    # device cgroup is 'Operation not permitted' which is expected when the
+    # joystick interface is connected since a keyboard shouldn't be added to
+    # the device cgroup.
+    MATCH "Operation not permitted" < call.error

--- a/tests/unit/spread-shellcheck/must
+++ b/tests/unit/spread-shellcheck/must
@@ -45,3 +45,4 @@ tests/main/install-errors/task.yaml
 tests/main/install-refresh-private/task.yaml
 tests/main/install-refresh-remove-hooks/task.yaml
 tests/main/appstream-id/task.yaml
+tests/main/security-dev-input-event-denied/task.yaml


### PR DESCRIPTION
https://github.com/snapcore/snapd/pull/5240 for 2.33.