### PR TITLE
interfaces/home: remove redundant common interface assignment

### DIFF
--- a/interfaces/builtin/home.go
+++ b/interfaces/builtin/home.go
@@ -117,12 +117,11 @@ func (iface *homeInterface) AppArmorConnectedPlug(spec *apparmor.Specification, 
 
 func init() {
 	registerIface(&homeInterface{commonInterface{
-		name:                  "home",
-		summary:               homeSummary,
-		implicitOnCore:        true,
-		implicitOnClassic:     true,
-		baseDeclarationSlots:  homeBaseDeclarationSlots,
-		connectedPlugAppArmor: homeConnectedPlugAppArmor,
-		reservedForOS:         true,
+		name:                 "home",
+		summary:              homeSummary,
+		implicitOnCore:       true,
+		implicitOnClassic:    true,
+		baseDeclarationSlots: homeBaseDeclarationSlots,
+		reservedForOS:        true,
 	}})
 }


### PR DESCRIPTION
When working on something else I noticed that the home interface is still assigning to 
`connectedPlugAppArmor` when AppArmorConnectedPlug() is overriding commonInterface.