### PR TITLE
tests: reprioritise a few tests that are known to be slow

### DIFF
--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -14,6 +14,9 @@ backends: [-autopkgtest]
 # lxd downloads can be quite slow
 kill-timeout: 25m
 
+# Start before anything else as it can take a really long time.
+priority: 1000
+
 restore: |
     if  [[ $(ls -1 "$GOHOME"/snapd_*.deb | wc -l || echo 0) -eq 0 ]]; then
         exit

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -3,6 +3,9 @@ summary: Ensure snapd builds as a snap
 # This is what the snapcraft builder on launchpad uses.
 systems: [ubuntu-16.04-64]
 
+# Start early as it takes a long time.
+priority: 100
+
 restore: |
     apt autoremove -y snapcraft
 

--- a/tests/regression/lp-1721518/task.yaml
+++ b/tests/regression/lp-1721518/task.yaml
@@ -4,6 +4,9 @@ summary: Check that interfaces are listed after reboot the machine
 # not support our reboot logic
 backends: [-autopkgtest]
 
+# Start early as it takes a long time.
+priority: 100
+
 details: |
     This test checks if the interfaces are listed after the machine
     is rebooted. The test is also checking the interfaces after a 


### PR DESCRIPTION
We had a few slow tests that weren't tagged with a `priority`, resulting in test runs often waiting for these tests to finish instead of starting them earlier.