### PR TITLE
cmd/libsnap-confine-private: helper for extracting store snap name from local-name

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -229,9 +229,9 @@ static void test_sc_snap_drop_instance_name_no_dest(void)
 static void test_sc_snap_drop_instance_name_short_dest(void)
 {
 	if (g_test_subprocess()) {
-		char base[10] = { 0 };
-		sc_snap_drop_instance_name("foo-foo-foo-foo-foo_bar", base,
-					   sizeof base);
+		char dest[10] = { 0 };
+		sc_snap_drop_instance_name("foo-foo-foo-foo-foo_bar", dest,
+					   sizeof dest);
 		g_test_fail();
 		return;
 	}
@@ -242,8 +242,8 @@ static void test_sc_snap_drop_instance_name_short_dest(void)
 static void test_sc_snap_drop_instance_name_short_dest2(void)
 {
 	if (g_test_subprocess()) {
-		char base[3] = { 0 };	// "foo" sans the nil byte
-		sc_snap_drop_instance_name("foo", base, sizeof base);
+		char dest[3] = { 0 };	// "foo" sans the nil byte
+		sc_snap_drop_instance_name("foo", dest, sizeof dest);
 		g_test_fail();
 		return;
 	}
@@ -254,8 +254,8 @@ static void test_sc_snap_drop_instance_name_short_dest2(void)
 static void test_sc_snap_drop_instance_name_no_name(void)
 {
 	if (g_test_subprocess()) {
-		char base[10] = { 0 };
-		sc_snap_drop_instance_name(NULL, base, sizeof base);
+		char dest[10] = { 0 };
+		sc_snap_drop_instance_name(NULL, dest, sizeof dest);
 		g_test_fail();
 		return;
 	}

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -230,7 +230,20 @@ static void test_sc_snap_drop_instance_name_short_dest(void)
 {
 	if (g_test_subprocess()) {
 		char base[10] = { 0 };
-		sc_snap_drop_instance_name("foo-foo-foo-foo-foo_bar", base, sizeof base);
+		sc_snap_drop_instance_name("foo-foo-foo-foo-foo_bar", base,
+					   sizeof base);
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+}
+
+static void test_sc_snap_drop_instance_name_short_dest2(void)
+{
+	if (g_test_subprocess()) {
+		char base[3] = { 0 };	// "foo" sans the nil byte
+		sc_snap_drop_instance_name("foo", base, sizeof base);
 		g_test_fail();
 		return;
 	}
@@ -252,7 +265,7 @@ static void test_sc_snap_drop_instance_name_no_name(void)
 
 static void test_sc_snap_drop_instance_name_basic(void)
 {
-	char name[41] = {0xff};
+	char name[41] = { 0xff };
 
 	sc_snap_drop_instance_name("foo_bar", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo");
@@ -289,4 +302,6 @@ static void __attribute__ ((constructor)) init(void)
 			test_sc_snap_drop_instance_name_no_name);
 	g_test_add_func("/snap/sc_snap_drop_instance_name/short_dest",
 			test_sc_snap_drop_instance_name_short_dest);
+	g_test_add_func("/snap/sc_snap_drop_instance_name/short_dest2",
+			test_sc_snap_drop_instance_name_short_dest2);
 }

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -252,22 +252,26 @@ static void test_sc_snap_drop_instance_name_no_name(void)
 
 static void test_sc_snap_drop_instance_name_basic(void)
 {
-	char name[41] = { 0 };
+	char name[41] = {0xff};
 
 	sc_snap_drop_instance_name("foo_bar", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo");
 
-	memset(name, 0, sizeof name);
+	memset(name, 0xff, sizeof name);
 	sc_snap_drop_instance_name("foo-bar_bar", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo-bar");
 
-	memset(name, 0, sizeof name);
+	memset(name, 0xff, sizeof name);
 	sc_snap_drop_instance_name("foo-bar", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo-bar");
 
-	memset(name, 0, sizeof name);
+	memset(name, 0xff, sizeof name);
 	sc_snap_drop_instance_name("_baz", name, sizeof name);
 	g_assert_cmpstr(name, ==, "");
+
+	memset(name, 0xff, sizeof name);
+	sc_snap_drop_instance_name("foo", name, sizeof name);
+	g_assert_cmpstr(name, ==, "foo");
 }
 
 static void __attribute__ ((constructor)) init(void)

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -214,10 +214,10 @@ static void test_sc_snap_name_validate__respects_error_protocol(void)
 	    ("snap name must use lower case letters, digits or dashes\n");
 }
 
-static void test_sc_snap_name_base_no_dest(void)
+static void test_sc_snap_drop_instance_name_no_dest(void)
 {
 	if (g_test_subprocess()) {
-		sc_snap_name_base("foo_bar", NULL, 0);
+		sc_snap_drop_instance_name("foo_bar", NULL, 0);
 		g_test_fail();
 		return;
 	}
@@ -226,23 +226,11 @@ static void test_sc_snap_name_base_no_dest(void)
 
 }
 
-static void test_sc_snap_name_base_short_dest(void)
-{
-	if (g_test_subprocess()) {
-		char base[10] = { 0 };
-		sc_snap_name_base("foo-foo-foo-foo-foo_bar", base, sizeof base);
-		g_test_fail();
-		return;
-	}
-	g_test_trap_subprocess(NULL, 0, 0);
-	g_test_trap_assert_failed();
-}
-
-static void test_sc_snap_name_base_no_name(void)
+static void test_sc_snap_drop_instance_name_short_dest(void)
 {
 	if (g_test_subprocess()) {
 		char base[10] = { 0 };
-		sc_snap_name_base(NULL, base, sizeof base);
+		sc_snap_drop_instance_name("foo-foo-foo-foo-foo_bar", base, sizeof base);
 		g_test_fail();
 		return;
 	}
@@ -250,20 +238,36 @@ static void test_sc_snap_name_base_no_name(void)
 	g_test_trap_assert_failed();
 }
 
-static void test_sc_snap_name_base_basic(void)
+static void test_sc_snap_drop_instance_name_no_name(void)
 {
-	char base[41] = { 0 };
+	if (g_test_subprocess()) {
+		char base[10] = { 0 };
+		sc_snap_drop_instance_name(NULL, base, sizeof base);
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+}
 
-	sc_snap_name_base("foo_bar", base, sizeof base);
-	g_assert_cmpstr(base, ==, "foo");
+static void test_sc_snap_drop_instance_name_basic(void)
+{
+	char name[41] = { 0 };
 
-	memset(base, 0, sizeof base);
-	sc_snap_name_base("foo-bar_bar", base, sizeof base);
-	g_assert_cmpstr(base, ==, "foo-bar");
+	sc_snap_drop_instance_name("foo_bar", name, sizeof name);
+	g_assert_cmpstr(name, ==, "foo");
 
-	memset(base, 0, sizeof base);
-	sc_snap_name_base("foo-bar", base, sizeof base);
-	g_assert_cmpstr(base, ==, "foo-bar");
+	memset(name, 0, sizeof name);
+	sc_snap_drop_instance_name("foo-bar_bar", name, sizeof name);
+	g_assert_cmpstr(name, ==, "foo-bar");
+
+	memset(name, 0, sizeof name);
+	sc_snap_drop_instance_name("foo-bar", name, sizeof name);
+	g_assert_cmpstr(name, ==, "foo-bar");
+
+	memset(name, 0, sizeof name);
+	sc_snap_drop_instance_name("_baz", name, sizeof name);
+	g_assert_cmpstr(name, ==, "");
 }
 
 static void __attribute__ ((constructor)) init(void)
@@ -273,12 +277,12 @@ static void __attribute__ ((constructor)) init(void)
 			test_sc_snap_name_validate);
 	g_test_add_func("/snap/sc_snap_name_validate/respects_error_protocol",
 			test_sc_snap_name_validate__respects_error_protocol);
-	g_test_add_func("/snap/sc_snap_name_base/basic",
-			test_sc_snap_name_base_basic);
-	g_test_add_func("/snap/sc_snap_name_base/no_dest",
-			test_sc_snap_name_base_no_dest);
-	g_test_add_func("/snap/sc_snap_name_base/no_name",
-			test_sc_snap_name_base_no_name);
-	g_test_add_func("/snap/sc_snap_name_base/short_dest",
-			test_sc_snap_name_base_short_dest);
+	g_test_add_func("/snap/sc_snap_drop_instance_name/basic",
+			test_sc_snap_drop_instance_name_basic);
+	g_test_add_func("/snap/sc_snap_drop_instance_name/no_dest",
+			test_sc_snap_drop_instance_name_no_dest);
+	g_test_add_func("/snap/sc_snap_drop_instance_name/no_name",
+			test_sc_snap_drop_instance_name_no_name);
+	g_test_add_func("/snap/sc_snap_drop_instance_name/short_dest",
+			test_sc_snap_drop_instance_name_short_dest);
 }

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -214,6 +214,58 @@ static void test_sc_snap_name_validate__respects_error_protocol(void)
 	    ("snap name must use lower case letters, digits or dashes\n");
 }
 
+static void test_sc_snap_name_base_no_dest(void)
+{
+	if (g_test_subprocess()) {
+		sc_snap_name_base("foo_bar", NULL, 0);
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+
+}
+
+static void test_sc_snap_name_base_short_dest(void)
+{
+	if (g_test_subprocess()) {
+		char base[10] = { 0 };
+		sc_snap_name_base("foo-foo-foo-foo-foo_bar", base, sizeof base);
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+}
+
+static void test_sc_snap_name_base_no_name(void)
+{
+	if (g_test_subprocess()) {
+		char base[10] = { 0 };
+		sc_snap_name_base(NULL, base, sizeof base);
+		g_test_fail();
+		return;
+	}
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+}
+
+static void test_sc_snap_name_base_basic(void)
+{
+	char base[41] = { 0 };
+
+	sc_snap_name_base("foo_bar", base, sizeof base);
+	g_assert_cmpstr(base, ==, "foo");
+
+	memset(base, 0, sizeof base);
+	sc_snap_name_base("foo-bar_bar", base, sizeof base);
+	g_assert_cmpstr(base, ==, "foo-bar");
+
+	memset(base, 0, sizeof base);
+	sc_snap_name_base("foo-bar", base, sizeof base);
+	g_assert_cmpstr(base, ==, "foo-bar");
+}
+
 static void __attribute__ ((constructor)) init(void)
 {
 	g_test_add_func("/snap/verify_security_tag", test_verify_security_tag);
@@ -221,4 +273,12 @@ static void __attribute__ ((constructor)) init(void)
 			test_sc_snap_name_validate);
 	g_test_add_func("/snap/sc_snap_name_validate/respects_error_protocol",
 			test_sc_snap_name_validate__respects_error_protocol);
+	g_test_add_func("/snap/sc_snap_name_base/basic",
+			test_sc_snap_name_base_basic);
+	g_test_add_func("/snap/sc_snap_name_base/no_dest",
+			test_sc_snap_name_base_no_dest);
+	g_test_add_func("/snap/sc_snap_name_base/no_name",
+			test_sc_snap_name_base_no_name);
+	g_test_add_func("/snap/sc_snap_name_base/short_dest",
+			test_sc_snap_name_base_short_dest);
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -170,24 +170,24 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 }
 
 void sc_snap_drop_instance_name(const char *snap_name, char *base,
-				size_t base_len)
+				size_t base_size)
 {
 	if (snap_name == NULL || base == NULL) {
 		die("base or snap name unset");
 	}
 
 	const char *pos = strchr(snap_name, '_');
-	size_t blen = 0;
+	size_t base_len = 0;
 	if (pos == NULL) {
-		blen = strlen(snap_name);
+		base_len = strlen(snap_name);
 	} else {
-		blen = (pos - snap_name);
+		base_len = pos - snap_name;
 	}
 
-	if (blen >= base_len) {
+	if (base_len >= base_size) {
 		die("base buffer too small");
 	}
 
-	memcpy(base, snap_name, blen);
-	base[blen] = '\0';
+	memcpy(base, snap_name, base_len);
+	base[base_len] = '\0';
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -183,9 +183,10 @@ void sc_snap_drop_instance_name(const char *snap_name, char *base, size_t base_l
 		blen = (pos - snap_name);
 	}
 
-	if (blen > base_len) {
+	if (blen >= base_len) {
 		die("base buffer too small");
 	}
 
 	memcpy(base, snap_name, blen);
+  base[blen] = '\0';
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -169,10 +169,10 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 	sc_error_forward(errorp, err);
 }
 
-void sc_snap_name_base(const char *snap_name, char *base, size_t base_len)
+void sc_snap_drop_instance_name(const char *snap_name, char *base, size_t base_len)
 {
 	if (snap_name == NULL || base == NULL) {
-		die("base unset");
+		die("base or snap name unset");
 	}
 
 	const char *pos = strchr(snap_name, '_');
@@ -184,7 +184,7 @@ void sc_snap_name_base(const char *snap_name, char *base, size_t base_len)
 	}
 
 	if (blen > base_len) {
-		die("base or local key buffers too small");
+		die("base buffer too small");
 	}
 
 	memcpy(base, snap_name, blen);

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -168,3 +168,24 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
  out:
 	sc_error_forward(errorp, err);
 }
+
+void sc_snap_name_base(const char *snap_name, char *base, size_t base_len)
+{
+	if (snap_name == NULL || base == NULL) {
+		die("base unset");
+	}
+
+	const char *pos = strchr(snap_name, '_');
+	size_t blen = 0;
+	if (pos == NULL) {
+		blen = strlen(snap_name);
+	} else {
+		blen = (pos - snap_name);
+	}
+
+	if (blen > base_len) {
+		die("base or local key buffers too small");
+	}
+
+	memcpy(base, snap_name, blen);
+}

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -169,7 +169,8 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 	sc_error_forward(errorp, err);
 }
 
-void sc_snap_drop_instance_name(const char *snap_name, char *base, size_t base_len)
+void sc_snap_drop_instance_name(const char *snap_name, char *base,
+				size_t base_len)
 {
 	if (snap_name == NULL || base == NULL) {
 		die("base or snap name unset");
@@ -188,5 +189,5 @@ void sc_snap_drop_instance_name(const char *snap_name, char *base, size_t base_l
 	}
 
 	memcpy(base, snap_name, blen);
-  base[blen] = '\0';
+	base[blen] = '\0';
 }

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -62,6 +62,7 @@ bool sc_is_hook_security_tag(const char *security_tag);
 /**
  * Extract the base of snap name, discarding any assigned local key.
  **/
-void sc_snap_drop_instance_name(const char *snap_name, char *base, size_t base_len);
+void sc_snap_drop_instance_name(const char *snap_name, char *base,
+				size_t base_len);
 
 #endif

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -62,6 +62,6 @@ bool sc_is_hook_security_tag(const char *security_tag);
 /**
  * Extract the base of snap name, discarding any assigned local key.
  **/
-void sc_snap_name_base(const char *snap_name, char *base, size_t base_len);
+void sc_snap_drop_instance_name(const char *snap_name, char *base, size_t base_len);
 
 #endif

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -63,6 +63,6 @@ bool sc_is_hook_security_tag(const char *security_tag);
  * Extract the base of snap name, discarding any assigned local key.
  **/
 void sc_snap_drop_instance_name(const char *snap_name, char *base,
-				size_t base_len);
+				size_t base_size);
 
 #endif

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -60,7 +60,13 @@ bool verify_security_tag(const char *security_tag, const char *snap_name);
 bool sc_is_hook_security_tag(const char *security_tag);
 
 /**
- * Extract the base of snap name, discarding any assigned local key.
+ * Extract snap name out of a snap with optional instance name string.
+ *
+ * A snap may be installed multiple times in parallel under distinct instance names.
+ * This function extracts the snap name out of a name that possibly contains a snap
+ * instance name.
+ *
+ * For example: snap_instance => snap, just-snap => just-snap
  **/
 void sc_snap_drop_instance_name(const char *snap_name, char *base,
 				size_t base_size);

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -19,6 +19,7 @@
 #define SNAP_CONFINE_SNAP_H
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "error.h"
 
@@ -57,5 +58,10 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp);
 bool verify_security_tag(const char *security_tag, const char *snap_name);
 
 bool sc_is_hook_security_tag(const char *security_tag);
+
+/**
+ * Extract the base of snap name, discarding any assigned local key.
+ **/
+void sc_snap_name_base(const char *snap_name, char *base, size_t base_len);
 
 #endif


### PR DESCRIPTION
Parallel installation of snaps changes the snap names to be <name>_<instance>,
eg. hello-world_foo. Add a helper for extracting name of the snap given its
local name.
