### PR TITLE
 devicestate: support seeding from a base snap instead of core 

### DIFF
--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -20,7 +20,6 @@
 package devicestate
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/snapasserts"
+	"github.com/snapcore/snapd/asserts/sysdb"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/osutil"
@@ -38,8 +38,6 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
-
-var errNothingToDo = errors.New("nothing to do")
 
 func installSeedSnap(st *state.State, sn *snap.SeedSnap, flags snapstate.Flags) (*state.TaskSet, error) {
 	if sn.Classic {
@@ -70,9 +68,9 @@ func installSeedSnap(st *state.State, sn *snap.SeedSnap, flags snapstate.Flags) 
 	return snapstate.InstallPath(st, &sideInfo, path, sn.Channel, flags)
 }
 
-func trivialSeeding(st *state.State, markSeeded *state.Task) []*state.TaskSet {
+func trivialSeeding(st *state.State, baseSnap string, markSeeded *state.Task) []*state.TaskSet {
 	// give the internal core config a chance to run
-	configTs := snapstate.ConfigureSnap(st, "core", 0)
+	configTs := snapstate.ConfigureSnap(st, baseSnap, 0)
 	markSeeded.WaitAll(configTs)
 	return []*state.TaskSet{configTs, state.NewTaskSet(markSeeded)}
 }
@@ -92,17 +90,19 @@ func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 
 	// ack all initial assertions
 	model, err := importAssertionsFromSeed(st)
-	if err == errNothingToDo {
-		return trivialSeeding(st, markSeeded), nil
-	}
 	if err != nil {
 		return nil, err
 	}
+	baseSnap := "core"
+	if model.Base() != "" {
+		baseSnap = model.Base()
+	}
 
+	assertSeedDir := filepath.Join(dirs.SnapSeedDir, "assertions")
 	seedYamlFile := filepath.Join(dirs.SnapSeedDir, "seed.yaml")
-	if release.OnClassic && !osutil.FileExists(seedYamlFile) {
+	if release.OnClassic && (!osutil.FileExists(seedYamlFile) || !osutil.FileExists(assertSeedDir)) {
 		// on classic it is ok to not seed any snaps
-		return trivialSeeding(st, markSeeded), nil
+		return trivialSeeding(st, baseSnap, markSeeded), nil
 	}
 
 	seed, err := snap.ReadSeedYaml(seedYamlFile)
@@ -128,19 +128,32 @@ func populateStateFromSeedImpl(st *state.State) ([]*state.TaskSet, error) {
 	tsAll := []*state.TaskSet{}
 	configTss := []*state.TaskSet{}
 
-	// if there are snaps to seed, core needs to be seeded too
+	// if there are snaps to seed, the snapd snap (if available) and
+	// the base (core or model.Base) needs to go first.
 	if len(seed.Snaps) != 0 {
-		coreSeed := seeding["core"]
-		if coreSeed == nil {
-			return nil, fmt.Errorf("cannot proceed without seeding core")
+		if _, ok := seeding["snapd"]; ok {
+			snapdSeed := seeding["snapd"]
+			ts, err := installSeedSnap(st, snapdSeed, snapstate.Flags{SkipConfigure: true})
+			if err != nil {
+				return nil, err
+			}
+			tsAll = append(tsAll, ts)
+			alreadySeeded["snapd"] = true
 		}
-		ts, err := installSeedSnap(st, coreSeed, snapstate.Flags{SkipConfigure: true})
+
+		baseSeed := seeding[baseSnap]
+		if baseSeed == nil {
+			return nil, fmt.Errorf("cannot proceed without seeding %q", baseSnap)
+		}
+		ts, err := installSeedSnap(st, baseSeed, snapstate.Flags{SkipConfigure: true})
 		if err != nil {
 			return nil, err
 		}
 		tsAll = append(tsAll, ts)
-		alreadySeeded["core"] = true
-		configTss = append(configTss, snapstate.ConfigureSnap(st, "core", snapstate.UseConfigDefaults))
+		alreadySeeded[baseSnap] = true
+
+		confFlags := snapstate.UseConfigDefaults | snapstate.IgnoreHookError | snapstate.TrackHookError
+		configTss = append(configTss, snapstate.ConfigureSnap(st, baseSnap, confFlags))
 	}
 
 	last := 0
@@ -236,8 +249,9 @@ func importAssertionsFromSeed(st *state.State) (*asserts.Model, error) {
 	assertSeedDir := filepath.Join(dirs.SnapSeedDir, "assertions")
 	dc, err := ioutil.ReadDir(assertSeedDir)
 	if release.OnClassic && os.IsNotExist(err) {
-		// on classic seeding is optional
-		return nil, errNothingToDo
+		// on classic seeding is optional but we still use the
+		// fallback model
+		return sysdb.GenericClassicModel(), nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("cannot read assert seed dir: %s", err)

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -166,7 +166,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYaml(c *C) {
 	st := ovld.State()
 
 	// add a bunch of assert files
-	assertsChain := s.makeModelAssertionChain(c, "my-model-classic")
+	assertsChain := s.makeModelAssertionChain(c, "my-model-classic", nil)
 	for i, as := range assertsChain {
 		fn := filepath.Join(dirs.SnapSeedDir, "assertions", strconv.Itoa(i))
 		err := ioutil.WriteFile(fn, asserts.Encode(as), 0644)
@@ -195,7 +195,7 @@ func (s *FirstBootTestSuite) TestPopulateFromSeedOnClassicNoSeedYamlWithCloudIns
 	st := s.overlord.State()
 
 	// add a bunch of assert files
-	assertsChain := s.makeModelAssertionChain(c, "my-model-classic")
+	assertsChain := s.makeModelAssertionChain(c, "my-model-classic", nil)
 	for i, as := range assertsChain {
 		fn := filepath.Join(dirs.SnapSeedDir, "assertions", strconv.Itoa(i))
 		err := ioutil.WriteFile(fn, asserts.Encode(as), 0644)
@@ -399,7 +399,7 @@ version: 1.0`
 	c.Assert(err, IsNil)
 
 	// add a model assertion and its chain
-	assertsChain := s.makeModelAssertionChain(c, "my-model", "foo")
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil, "foo")
 	for i, as := range assertsChain {
 		fn := filepath.Join(dirs.SnapSeedDir, "assertions", strconv.Itoa(i))
 		err := ioutil.WriteFile(fn, asserts.Encode(as), 0644)
@@ -618,7 +618,7 @@ version: 1.0`
 	writeAssertionsToFile("bar.asserts", []asserts.Assertion{devAcct, barDecl, barRev})
 
 	// add a model assertion and its chain
-	assertsChain := s.makeModelAssertionChain(c, "my-model")
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
 	writeAssertionsToFile("model.asserts", assertsChain)
 
 	// create a seed.yaml
@@ -695,7 +695,7 @@ snaps:
 	c.Check(pubAcct.AccountID(), Equals, "developerid")
 }
 
-func (s *FirstBootTestSuite) makeModelAssertion(c *C, modelStr string, reqSnaps ...string) *asserts.Model {
+func (s *FirstBootTestSuite) makeModelAssertion(c *C, modelStr string, extraHeaders map[string]interface{}, reqSnaps ...string) *asserts.Model {
 	headers := map[string]interface{}{
 		"series":       "16",
 		"authority-id": "my-brand",
@@ -705,6 +705,9 @@ func (s *FirstBootTestSuite) makeModelAssertion(c *C, modelStr string, reqSnaps 
 		"store":        "canonical",
 		"gadget":       "pc",
 		"timestamp":    time.Now().Format(time.RFC3339),
+	}
+	for k, v := range extraHeaders {
+		headers[k] = v
 	}
 	if strings.HasSuffix(modelStr, "-classic") {
 		headers["classic"] = "true"
@@ -723,7 +726,7 @@ func (s *FirstBootTestSuite) makeModelAssertion(c *C, modelStr string, reqSnaps 
 	return model.(*asserts.Model)
 }
 
-func (s *FirstBootTestSuite) makeModelAssertionChain(c *C, modName string, reqSnaps ...string) []asserts.Assertion {
+func (s *FirstBootTestSuite) makeModelAssertionChain(c *C, modName string, extraHeaders map[string]interface{}, reqSnaps ...string) []asserts.Assertion {
 	assertChain := []asserts.Assertion{}
 
 	brandAcct := assertstest.NewAccount(s.storeSigning, "my-brand", map[string]interface{}{
@@ -735,7 +738,7 @@ func (s *FirstBootTestSuite) makeModelAssertionChain(c *C, modName string, reqSn
 	brandAccKey := assertstest.NewAccountKey(s.storeSigning, brandAcct, nil, s.brandPrivKey.PublicKey(), "")
 	assertChain = append(assertChain, brandAccKey)
 
-	model := s.makeModelAssertion(c, modName, reqSnaps...)
+	model := s.makeModelAssertion(c, modName, extraHeaders, reqSnaps...)
 	assertChain = append(assertChain, model)
 
 	storeAccountKey := s.storeSigning.StoreAccountKey("")
@@ -777,7 +780,7 @@ version: 1.0`
 	c.Assert(err, IsNil)
 
 	// add a model assertion and its chain
-	assertsChain := s.makeModelAssertionChain(c, "my-model", "foo")
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil, "foo")
 	for i, as := range assertsChain {
 		fn := filepath.Join(dirs.SnapSeedDir, "assertions", strconv.Itoa(i))
 		err := ioutil.WriteFile(fn, asserts.Encode(as), 0644)
@@ -917,7 +920,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedClassicModelMismatch(c 
 	st := ovld.State()
 
 	// add a bunch of assert files
-	assertsChain := s.makeModelAssertionChain(c, "my-model")
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
 	for i, as := range assertsChain {
 		fn := filepath.Join(dirs.SnapSeedDir, "assertions", strconv.Itoa(i))
 		err := ioutil.WriteFile(fn, asserts.Encode(as), 0644)
@@ -938,7 +941,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedAllSnapsModelMismatch(c
 	st := ovld.State()
 
 	// add a bunch of assert files
-	assertsChain := s.makeModelAssertionChain(c, "my-model-classic")
+	assertsChain := s.makeModelAssertionChain(c, "my-model-classic", nil)
 	for i, as := range assertsChain {
 		fn := filepath.Join(dirs.SnapSeedDir, "assertions", strconv.Itoa(i))
 		err := ioutil.WriteFile(fn, asserts.Encode(as), 0644)
@@ -959,7 +962,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedHappy(c *C) {
 	st := ovld.State()
 
 	// add a bunch of assert files
-	assertsChain := s.makeModelAssertionChain(c, "my-model")
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
 	for i, as := range assertsChain {
 		fn := filepath.Join(dirs.SnapSeedDir, "assertions", strconv.Itoa(i))
 		err := ioutil.WriteFile(fn, asserts.Encode(as), 0644)
@@ -1000,7 +1003,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedMissingSig(c *C) {
 	defer st.Unlock()
 
 	// write out only the model assertion
-	assertsChain := s.makeModelAssertionChain(c, "my-model")
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
 	for _, as := range assertsChain {
 		if as.Type() == asserts.ModelType {
 			fn := filepath.Join(dirs.SnapSeedDir, "assertions", "model")
@@ -1022,12 +1025,12 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedTwoModelAsserts(c *C) {
 	defer st.Unlock()
 
 	// write out two model assertions
-	model := s.makeModelAssertion(c, "my-model")
+	model := s.makeModelAssertion(c, "my-model", nil)
 	fn := filepath.Join(dirs.SnapSeedDir, "assertions", "model")
 	err := ioutil.WriteFile(fn, asserts.Encode(model), 0644)
 	c.Assert(err, IsNil)
 
-	model2 := s.makeModelAssertion(c, "my-second-model")
+	model2 := s.makeModelAssertion(c, "my-second-model", nil)
 	fn = filepath.Join(dirs.SnapSeedDir, "assertions", "model2")
 	err = ioutil.WriteFile(fn, asserts.Encode(model2), 0644)
 	c.Assert(err, IsNil)
@@ -1043,7 +1046,7 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedNoModelAsserts(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	assertsChain := s.makeModelAssertionChain(c, "my-model")
+	assertsChain := s.makeModelAssertionChain(c, "my-model", nil)
 	for _, as := range assertsChain {
 		if as.Type() != asserts.ModelType {
 			fn := filepath.Join(dirs.SnapSeedDir, "assertions", "model")
@@ -1057,4 +1060,123 @@ func (s *FirstBootTestSuite) TestImportAssertionsFromSeedNoModelAsserts(c *C) {
 	// missing
 	_, err := devicestate.ImportAssertionsFromSeed(st)
 	c.Assert(err, ErrorMatches, "need a model assertion")
+}
+
+func (s *FirstBootTestSuite) makeCore18Snaps(c *C) (core18Fn, snapdFn string) {
+	files := [][]string{{"meta/hooks/configure", ""}}
+
+	core18Yaml := `name: core18
+version: 1.0
+type: base`
+	core18Fname, core18Decl, core18Rev := s.makeAssertedSnap(c, core18Yaml, files, snap.R(1), "canonical")
+	writeAssertionsToFile("core18.asserts", []asserts.Assertion{core18Rev, core18Decl})
+
+	snapdYaml := `name: snapd
+version: 1.0
+`
+	snapdFname, snapdDecl, snapdRev := s.makeAssertedSnap(c, snapdYaml, nil, snap.R(2), "canonical")
+	writeAssertionsToFile("snapd.asserts", []asserts.Assertion{snapdRev, snapdDecl})
+
+	return core18Fname, snapdFname
+}
+
+func (s *FirstBootTestSuite) TestPopulateFromSeedWithBaseHappy(c *C) {
+	bootloader := boottest.NewMockBootloader("mock", c.MkDir())
+	partition.ForceBootloader(bootloader)
+	defer partition.ForceBootloader(nil)
+	bootloader.SetBootVars(map[string]string{
+		"snap_core":   "core18_1.snap",
+		"snap_kernel": "pc-kernel_1.snap",
+	})
+
+	_, kernelFname, gadgetFname := s.makeCoreSnaps(c, false)
+	core18Fname, snapdFname := s.makeCore18Snaps(c)
+
+	devAcct := assertstest.NewAccount(s.storeSigning, "developer", map[string]interface{}{
+		"account-id": "developerid",
+	}, "")
+
+	devAcctFn := filepath.Join(dirs.SnapSeedDir, "assertions", "developer.account")
+	err := ioutil.WriteFile(devAcctFn, asserts.Encode(devAcct), 0644)
+	c.Assert(err, IsNil)
+
+	// add a model assertion and its chain
+	assertsChain := s.makeModelAssertionChain(c, "my-model", map[string]interface{}{"base": "core18"})
+	for i, as := range assertsChain {
+		fn := filepath.Join(dirs.SnapSeedDir, "assertions", strconv.Itoa(i))
+		err := ioutil.WriteFile(fn, asserts.Encode(as), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	// create a seed.yaml
+	content := []byte(fmt.Sprintf(`
+snaps:
+ - name: snapd
+   file: %s
+ - name: core18
+   file: %s
+ - name: pc-kernel
+   file: %s
+ - name: pc
+   file: %s
+`, snapdFname, core18Fname, kernelFname, gadgetFname))
+	err = ioutil.WriteFile(filepath.Join(dirs.SnapSeedDir, "seed.yaml"), content, 0644)
+	c.Assert(err, IsNil)
+
+	// run the firstboot stuff
+	st := s.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+	tsAll, err := devicestate.PopulateStateFromSeedImpl(st)
+	c.Assert(err, IsNil)
+
+	// now run the change and check the result
+	// use the expected kind otherwise settle with start another one
+	chg := st.NewChange("seed", "run the populate from seed changes")
+	for _, ts := range tsAll {
+		chg.AddAll(ts)
+	}
+	c.Assert(st.Changes(), HasLen, 1)
+
+	c.Assert(chg.Err(), IsNil)
+
+	// avoid device reg
+	chg1 := st.NewChange("become-operational", "init device")
+	chg1.SetStatus(state.DoingStatus)
+
+	st.Unlock()
+	err = s.overlord.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
+	c.Assert(chg.Status(), Equals, state.DoneStatus)
+
+	// verify
+	r, err := os.Open(dirs.SnapStateFile)
+	c.Assert(err, IsNil)
+	state, err := state.ReadState(nil, r)
+	c.Assert(err, IsNil)
+
+	state.Lock()
+	defer state.Unlock()
+	// check snapd, core18, kernel, gadget
+	_, err = snapstate.CurrentInfo(state, "snapd")
+	c.Check(err, IsNil)
+	_, err = snapstate.CurrentInfo(state, "core18")
+	c.Check(err, IsNil)
+	_, err = snapstate.CurrentInfo(state, "pc-kernel")
+	c.Check(err, IsNil)
+	_, err = snapstate.CurrentInfo(state, "pc")
+	c.Check(err, IsNil)
+
+	// and ensure state is now considered seeded
+	var seeded bool
+	err = state.Get("seeded", &seeded)
+	c.Assert(err, IsNil)
+	c.Check(seeded, Equals, true)
+
+	// check we set seed-time
+	var seedTime time.Time
+	err = state.Get("seed-time", &seedTime)
+	c.Assert(err, IsNil)
+	c.Check(seedTime.IsZero(), Equals, false)
 }

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -162,7 +162,8 @@ func (f *fakeStore) snapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 	confinement := snap.StrictConfinement
 
 	typ := snap.TypeApp
-	if spec.Name == "core" || spec.Name == "some-core" {
+	switch spec.Name {
+	case "core", "ubuntu-core", "some-core":
 		typ = snap.TypeOS
 	}
 

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -162,7 +162,7 @@ func (f *fakeStore) snapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 	confinement := snap.StrictConfinement
 
 	typ := snap.TypeApp
-	if spec.Name == "some-core" {
+	if spec.Name == "core" || spec.Name == "some-core" {
 		typ = snap.TypeOS
 	}
 

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -187,9 +187,14 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
-	// core/ubuntu-core can not have prerequisites
-	snapName := snapsup.Name()
-	if snapName == defaultCoreSnapName || snapName == "ubuntu-core" {
+	// os/base/kernel/gadget cannot have prerequisites other
+	// than the models default base (or core) which is installed anyway
+	switch snapsup.Type {
+	case snap.TypeOS, snap.TypeBase, snap.TypeKernel, snap.TypeGadget:
+		return nil
+	}
+	// snapd is special and has no prereqs
+	if snapsup.Name() == "snapd" {
 		return nil
 	}
 

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -58,9 +58,10 @@ type SnapManager struct {
 // SnapSetup holds the necessary snap details to perform most snap manager tasks.
 type SnapSetup struct {
 	// FIXME: rename to RequestedChannel to convey the meaning better
-	Channel string `json:"channel,omitempty"`
-	UserID  int    `json:"user-id,omitempty"`
-	Base    string `json:"base,omitempty"`
+	Channel string    `json:"channel,omitempty"`
+	UserID  int       `json:"user-id,omitempty"`
+	Base    string    `json:"base,omitempty"`
+	Type    snap.Type `json:"type,omitempty"`
 
 	// FIXME: implement rename of this as suggested in
 	//  https://github.com/snapcore/snapd/pull/4103#discussion_r169569717

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -299,6 +299,9 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 
 // ConfigureSnap returns a set of tasks to configure snapName as done during installation/refresh.
 func ConfigureSnap(st *state.State, snapName string, confFlags int) *state.TaskSet {
+	// FIXME: once https://github.com/snapcore/snapd/pull/5217 is
+	//        in we can check the model.Base() here
+	//
 	// This is slightly ugly, ideally we would check the type instead
 	// of hardcoding the name here. Unfortunately we do not have the
 	// type until we actually run the change.
@@ -622,6 +625,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, channel string, flags
 		SnapPath: path,
 		Channel:  channel,
 		Flags:    flags.ForSnapSetup(),
+		Type:     info.Type,
 	}
 
 	return doInstall(st, &snapst, snapsup, instFlags)
@@ -671,6 +675,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		Flags:        flags.ForSnapSetup(),
 		DownloadInfo: &info.DownloadInfo,
 		SideInfo:     &info.SideInfo,
+		Type:         info.Type,
 	}
 
 	return doInstall(st, &snapst, snapsup, needsMaybeCore(info.Type))
@@ -828,6 +833,7 @@ func doUpdate(st *state.State, names []string, updates []*snap.Info, params func
 			Flags:        flags.ForSnapSetup(),
 			DownloadInfo: &update.DownloadInfo,
 			SideInfo:     &update.SideInfo,
+			Type:         update.Type,
 		}
 
 		ts, err := doInstall(st, snapst, snapsup, needsMaybeCore(update.Type))
@@ -1625,6 +1631,7 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 			Channel:      oldSnapst.Channel,
 			DownloadInfo: &newInfo.DownloadInfo,
 			SideInfo:     &newInfo.SideInfo,
+			Type:         newInfo.Type,
 		}, maybeCore)
 		if err != nil {
 			return nil, err

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -8954,6 +8954,11 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 			name: filepath.Join(dirs.SnapMountDir, "core/11"),
 		},
 		{
+			op:    "setup-profiles:Doing",
+			name:  "core",
+			revno: snap.R(11),
+		},
+		{
 			op:    "auto-connect:Doing",
 			name:  "core",
 			revno: snap.R(11),
@@ -9023,7 +9028,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 		{
 			op:    "cleanup-trash",
 			name:  "core",
-			revno: snap.R(11),
+			revno: snap.R(42),
 		},
 		{
 			op:    "cleanup-trash",
@@ -9090,11 +9095,11 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreTwoSnapsRunThrough(c *C) {
 	len1 := len(chg1.Tasks())
 	len2 := len(chg2.Tasks())
 	if len1 > len2 {
-		c.Assert(chg1.Tasks(), HasLen, 26)
+		c.Assert(chg1.Tasks(), HasLen, 27)
 		c.Assert(chg2.Tasks(), HasLen, 13)
 	} else {
 		c.Assert(chg1.Tasks(), HasLen, 13)
-		c.Assert(chg2.Tasks(), HasLen, 26)
+		c.Assert(chg2.Tasks(), HasLen, 27)
 	}
 
 	// FIXME: add helpers and do a DeepEquals here for the operations

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1799,6 +1799,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -1954,6 +1955,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -2160,6 +2162,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "services-snap",
@@ -4234,6 +4237,7 @@ version: 1.0`)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		SnapPath: mockSnap,
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "mock",
@@ -4326,6 +4330,7 @@ version: 1.0`)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		SnapPath: mockSnap,
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "mock",
@@ -4503,6 +4508,7 @@ version: 1.0`)
 		Flags: snapstate.Flags{
 			Required: true,
 		},
+		Type: snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, si)
 
@@ -9037,7 +9043,7 @@ func (s *snapmgrTestSuite) TestInstallWithoutCoreRunThrough1(c *C) {
 		},
 	}
 	// start with an easier-to-read error if this fails:
-	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
+	c.Check(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	// compare the details without the cleanup tasks, the order is random
 	// as they run in parallel
 	opsLenWithoutCleanups := len(s.fakeBackend.ops) - 2


### PR DESCRIPTION
With core18 we support devices that use the model base snap to boot. A core snap is not needed here for booting.

This PR allows run the firstboot seeding fore bases. Together with #5204 (and the coresponding core18 update) this should allow to a limited bootstrap core18 (interfaces and configuration will be broken) still. 

