### PR TITLE
tests: wait more time until snap start to be downloaded

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -20,7 +20,7 @@ execute: |
                 break
             fi
         fi
-        sleep .5
+        sleep 1
     done
 
     if [ ! -f "$partial" ] || [ "$(stat -c%s "$partial")" -eq 0 ]; then


### PR DESCRIPTION
Sporadically we see the econnreset test failing because the snap doesn't
start downloading. This change is adding more time to that wait.

Errors:
https://travis-ci.org/snapcore/snapd/builds/387708744
https://travis-ci.org/snapcore/snapd/builds/387744554
