### PR TITLE
many: use ~/.config/snap if it exists, instead of ~/.snap

### DIFF
--- a/asserts/gpgkeypairmgr.go
+++ b/asserts/gpgkeypairmgr.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/snapcore/snapd/osutil"
@@ -44,7 +43,7 @@ func ensureGPGHomeDirectory() (string, error) {
 
 	homedir := os.Getenv("SNAP_GNUPG_HOME")
 	if homedir == "" {
-		homedir = filepath.Join(real.HomeDir, ".snap", "gnupg")
+		homedir = osutil.UserConfig(real, "gnupg")
 	}
 
 	if err := osutil.MkdirAllChown(homedir, 0700, uid, gid); err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -192,7 +193,9 @@ func (cs *clientSuite) TestClientWhoAmINobody(c *C) {
 }
 
 func (cs *clientSuite) TestClientWhoAmIRubbish(c *C) {
-	c.Assert(ioutil.WriteFile(client.TestStoreAuthFilename(os.Getenv("HOME")), []byte("rubbish"), 0644), IsNil)
+	usr, err := user.Current()
+	c.Assert(err, IsNil)
+	c.Assert(ioutil.WriteFile(client.TestStoreAuthFilename(usr), []byte("rubbish"), 0644), IsNil)
 
 	email, err := cs.cli.WhoAmI()
 	c.Check(err, NotNil)

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -2336,7 +2336,7 @@ func setupLocalUser(st *state.State, username, email string) error {
 	if err != nil {
 		return err
 	}
-	authDataFn := filepath.Join(user.HomeDir, ".snap", "auth.json")
+	authDataFn := osutil.UserConfig(user, "auth.json")
 	if err := osutil.MkdirAllChown(filepath.Dir(authDataFn), 0700, uid, gid); err != nil {
 		return err
 	}


### PR DESCRIPTION
Before this change we were storing auth.json and the asserts keyring in
~/.snap.

This ignores the xdg base directory standard, which says that a user's
config for an app should go in ~/.config, and its data in
~/.local/share/ (and cache in ~/.cache), all overridable by the
appropriate env vars.

Whether auth.json and the asserts keyring is config or data is up for
debate; I've gone with it being config. Sadly neither ssh nor gnupg
themselves follow the standard so I wasn't sure where to look. Config
and data are often hard to separate.

This change comes up when thinking through the warnings subsystem,
which requires a client-side nonce.
