### PR TITLE
interfaces/builtin/docker: use commonInterface over specific struct

### DIFF
--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -19,13 +19,6 @@
 
 package builtin
 
-import (
-	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/apparmor"
-	"github.com/snapcore/snapd/interfaces/seccomp"
-	"github.com/snapcore/snapd/snap"
-)
-
 const dockerSummary = `allows access to Docker socket`
 
 const dockerBaseDeclarationSlots = `
@@ -51,34 +44,12 @@ bind
 socket AF_NETLINK - NETLINK_GENERIC
 `
 
-type dockerInterface struct{}
-
-func (iface *dockerInterface) Name() string {
-	return "docker"
-}
-
-func (iface *dockerInterface) StaticInfo() interfaces.StaticInfo {
-	return interfaces.StaticInfo{
-		Summary:              dockerSummary,
-		BaseDeclarationSlots: dockerBaseDeclarationSlots,
-	}
-}
-
-func (iface *dockerInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	spec.AddSnippet(dockerConnectedPlugAppArmor)
-	return nil
-}
-
-func (iface *dockerInterface) SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	spec.AddSnippet(dockerConnectedPlugSecComp)
-	return nil
-}
-
-func (iface *dockerInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
-	// allow what declarations allowed
-	return true
-}
-
 func init() {
-	registerIface(&dockerInterface{})
+	registerIface(&commonInterface{
+		name:                  "docker",
+		summary:               dockerSummary,
+		baseDeclarationSlots:  dockerBaseDeclarationSlots,
+		connectedPlugAppArmor: dockerConnectedPlugAppArmor,
+		connectedPlugSecComp:  dockerConnectedPlugSecComp,
+	})
 }


### PR DESCRIPTION
This change just simplifies the `docker` interface implementation to use the `commonInterface` struct.

Note that because the interface still isn't implicit, one has to do 
```
snap connect docker:docker-cli  docker:docker-daemon
```
in order for the docker snap to work.