### PR TITLE
tests: retry 'restarting into..' match in the snap-confine-from-core test

### DIFF
--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -24,6 +24,15 @@ execute: |
 
     echo "Ensure we re-exec by default"
     snap list
+
+    retry=10
+    while [ $retry -gt 0 ]; do
+      if get_journalctl_log | MATCH "DEBUG: restarting into" ; then
+          break
+      fi
+      sleep 1
+      retry=$(( retry - 1 ))
+    done
     get_journalctl_log | MATCH "DEBUG: restarting into"
 
     echo "Ensure snap-confine from the core snap is run"

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -25,13 +25,11 @@ execute: |
     echo "Ensure we re-exec by default"
     snap list
 
-    retry=10
-    while [ $retry -gt 0 ]; do
+    for _ in $(seq 10); do
       if get_journalctl_log | MATCH "DEBUG: restarting into" ; then
           break
       fi
       sleep 1
-      retry=$(( retry - 1 ))
     done
     get_journalctl_log | MATCH "DEBUG: restarting into"
 


### PR DESCRIPTION
This test has been a bit flaky recently. This is an attempt to improve it by re-trying the match. Since reproducing it is not easily possible I think we will need to see if it helps.