### PR TITLE
systemd: adjust TestWriteMountUnitForDirs() to use squashfs.MockUseFuse(false)

### DIFF
--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -488,6 +488,9 @@ WantedBy=multi-user.target
 }
 
 func (s *SystemdTestSuite) TestWriteMountUnitForDirs(c *C) {
+	restore := squashfs.MockUseFuse(false)
+	defer restore()
+
 	// a directory instead of a file produces a different output
 	snapDir := c.MkDir()
 	mountUnitName, err := New("", nil).WriteMountUnitFile("foodir", "x1", snapDir, "/snap/snapname/x1", "squashfs")


### PR DESCRIPTION
A test crept in that forgot to mock fuse. This makes the testsuite pass again on 16.04.