### PR TITLE
cmd/snap: attempt to start the document portal if running with a session bus

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -608,7 +608,7 @@ func activateXdgDocumentPortal(info *snap.Info, snapApp, hook string) error {
 	//
 	// As the file is in $XDG_RUNTIME_DIR, it will be cleared over
 	// full logout/login or reboot cycles.
-	portalsUnavailableFile := filepath.Join(xdgRuntimeDir, ".snap-portals-unavailable")
+	portalsUnavailableFile := filepath.Join(xdgRuntimeDir, ".portals-unavailable")
 	if osutil.FileExists(portalsUnavailableFile) {
 		return nil
 	}
@@ -628,7 +628,7 @@ func activateXdgDocumentPortal(info *snap.Info, snapApp, hook string) error {
 			// We ignore errors here: if writing the file
 			// fails, we'll just try connecting to D-Bus
 			// again next time.
-			if err = ioutil.WriteFile(portalsUnavailableFile, []byte("no portals"), 0644); err != nil {
+			if err = ioutil.WriteFile(portalsUnavailableFile, []byte(""), 0644); err != nil {
 				logger.Noticef("WARNING: cannot write file at %s: %s", portalsUnavailableFile, err)
 			}
 			return nil

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -551,6 +551,14 @@ func migrateXauthority(info *snap.Info) (string, error) {
 
 func activateXdgDocumentPortal(info *snap.Info) error {
 	// Don't do anything for snaps that don't plug the desktop interface
+	//
+	// NOTE: This check is imperfect because we don't really know
+	// if the interface is connected or not but this is an
+	// acceptable compromise for not having to communicate with
+	// snapd in snap run. In a typical desktop session the
+	// document portal can be in use by many applications, not
+	// just by snaps, so this is at most, pre-emptively using some
+	// extra memory.
 	plugsDesktop := false
 	for _, plug := range info.Plugs {
 		if plug.Interface == "desktop" {
@@ -592,7 +600,7 @@ func activateXdgDocumentPortal(info *snap.Info) error {
 	actualMountPoint := strings.TrimRight(string(mountPoint), "\x00")
 	expectedMountPoint := fmt.Sprintf("%s/%d/doc", dirs.XdgRuntimeDirBase, os.Getuid())
 	if actualMountPoint != expectedMountPoint {
-		return fmt.Errorf("Expected portal at %#v, got %#v", expectedMountPoint, actualMountPoint)
+		return fmt.Errorf(i18n.G("Expected portal at %#v, got %#v"), expectedMountPoint, actualMountPoint)
 	}
 	return nil
 }

--- a/osutil/mount_darwin.go
+++ b/osutil/mount_darwin.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+// IsMounted is not implemented on darwin
+func IsMounted(baseDir string) (bool, error) {
+	return false, ErrDarwin
+}

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -115,6 +115,13 @@ Requires:       gpg2
 Requires:       openssh
 Requires:       squashfs
 
+# Old versions of xdg-document-portal can expose data belonging to
+# other confied apps.  Older OpenSUSE releases are unlikely to change,
+# so for now limit this to Tumbleweed.
+%if 0%{?suse_version} >= 1550
+Conflicts:      xdg-desktop-portal < 0.11
+%endif
+
 %{?systemd_requires}
 
 # TODO strip the C executables but don't strip the go executables

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -38,6 +38,9 @@ fedora_name_package() {
             printer-driver-cups-pdf)
                 echo "cups-pdf"
                 ;;
+            python3-gi)
+                echo "python3-gobject"
+                ;;
             *)
                 echo "$i"
                 ;;
@@ -70,6 +73,12 @@ opensuse_name_package() {
             printer-driver-cups-pdf)
                 echo "cups-pdf"
                 ;;
+            python3-dbus)
+                echo "python3-dbus-python"
+                ;;
+            python3-gi)
+                echo "python3-gobject"
+                ;;
             *)
                 echo "$i"
                 ;;
@@ -94,6 +103,12 @@ arch_name_package() {
             ;;
         man)
             echo "man-db"
+            ;;
+        python3-dbus)
+            echo "python-dbus"
+            ;;
+        python3-gi)
+            echo "python-gobject"
             ;;
         *)
             echo "$1"

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -74,7 +74,8 @@ opensuse_name_package() {
                 echo "cups-pdf"
                 ;;
             python3-dbus)
-                echo "python3-dbus-python"
+                # In OpenSUSE Leap 15, this is renamed to python3-dbus-python
+                echo "dbus-1-python3"
                 ;;
             python3-gi)
                 echo "python3-gobject"

--- a/tests/main/document-portal-activation/fake-document-portal.py
+++ b/tests/main/document-portal-activation/fake-document-portal.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+import dbus.service
+import dbus.mainloop.glib
+from gi.repository import GLib
+
+BUS_NAME = "org.freedesktop.portal.Documents"
+OBJECT_PATH = "/org/freedesktop/portal/documents"
+DOC_IFACE = "org.freedesktop.portal.Documents"
+
+class DocPortal(dbus.service.Object):
+    def __init__(self, connection, object_path, logfile, errorfile):
+        super(DocPortal, self).__init__(connection, object_path)
+        self._logfile = logfile
+        self._errorfile = errorfile
+
+    @property
+    def _report_error(self):
+        with open(self._errorfile, 'r') as fp:
+            return 'error' in fp.read()
+
+    @dbus.service.method(dbus_interface=DOC_IFACE, in_signature="",
+                         out_signature="ay")
+    def GetMountPoint(self):
+        with open(self._logfile, "a") as fp:
+            fp.write("GetMountPoint called\n")
+        if self._report_error:
+            raise dbus.DBusException("failure", name=DOC_IFACE + ".Error.Failed")
+        return b'/run/user/%d/doc\x00' % os.getuid()
+
+def main(argv):
+    logfile, errorfile = argv[1:]
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    main_loop = GLib.MainLoop()
+
+    bus = dbus.SessionBus()
+    # Make sure we quit when the bus shuts down
+    bus.add_signal_receiver(
+        main_loop.quit, signal_name="Disconnected",
+        path="/org/freedesktop/DBus/Local",
+        dbus_interface="org.freedesktop.DBus.Local")
+
+    portal = DocPortal(bus, OBJECT_PATH, logfile, errorfile)
+
+    # Allow other services to assume our bus name
+    bus_name = dbus.service.BusName(
+        BUS_NAME, bus, allow_replacement=True, replace_existing=True,
+        do_not_queue=True)
+
+    main_loop.run()
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/main/document-portal-activation/fake-document-portal.py
+++ b/tests/main/document-portal-activation/fake-document-portal.py
@@ -29,7 +29,7 @@ class DocPortal(dbus.service.Object):
             fp.write("GetMountPoint called\n")
         if self._report_error:
             raise dbus.DBusException("failure", name=DOC_IFACE + ".Error.Failed")
-        return b'/run/user/%d/doc\x00' % os.getuid()
+        return '/run/user/{}/doc\x00'.format(os.getuid()).encode('ASCII')
 
 def main(argv):
     logfile, errorfile = argv[1:]

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -20,7 +20,7 @@ description: |
 systems: [ "-ubuntu-core-*", "-amazon-linux-2-*" ]
 
 environment:
-  XDG_RUNTIME_DIR: /run/user/$(id -u)
+    XDG_RUNTIME_DIR: /run/user/$(id -u)
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh
@@ -31,6 +31,7 @@ prepare: |
     install_local test-snapd-tools
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
     mkdir -p "$XDG_RUNTIME_DIR"
+    rm -rf "${XDG_RUNTIME_DIR:?}/*" "${XDG_RUNTIME_DIR:?}/.[!.]*"
 
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh
@@ -58,7 +59,7 @@ execute: |
     [ "$(wc -c < stderr.log)" -eq 0 ]
 
     echo "The absence of the document portal service was recorded"
-    [ -f "$XDG_RUNTIME_DIR/.snap-portals-unavailable" ]
+    [ -f "$XDG_RUNTIME_DIR/.portals-unavailable" ]
 
     echo "Make the fake document portal activatable"
     cat << EOF > /usr/share/dbus-1/services/fake-document-portal.service
@@ -73,8 +74,8 @@ execute: |
     test-snapd-desktop.check-dirs "$user_data"
     ! MATCH "GetMountPoint called" < doc-portal.log
 
-    echo "Remove the .snap-portals-unavailable file to force a recheck"
-    rm "$XDG_RUNTIME_DIR/.snap-portals-unavailable"
+    echo "Remove the .portals-unavailable file to force a recheck"
+    rm "$XDG_RUNTIME_DIR/.portals-unavailable"
 
     echo "No output on stderr when running with a session bus and xdg-document-portal is present".
     test-snapd-desktop.check-dirs "$user_data" 2>stderr.log

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -25,10 +25,14 @@ prepare: |
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
 
 restore: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . $TESTSLIB/pkgdb.sh
     [ -f dbus-launch.pid ] && kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
     rm -f stderr.log doc-portal.log report-error.txt
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
+    distro_purge_package python3-dbus python3-gi
+    distro_auto_remove_packages
 
 execute: |
     echo "No output on stderr when running without a session bus"

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -14,7 +14,10 @@ description: |
     Furthermore, we don't want to print an error on systems where
     xdg-document-portal is not available.
 
-systems: [ -ubuntu-core-* ]
+# Disabled on Ubuntu Core because it doesn't provide the "desktop"
+# slot, and Amazon Linux because it doesn't have the required Python 3
+# packages to run the test.
+systems: [ "-ubuntu-core-*", "-amazon-linux-2-*" ]
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -19,6 +19,9 @@ description: |
 # packages to run the test.
 systems: [ "-ubuntu-core-*", "-amazon-linux-2-*" ]
 
+environment:
+  XDG_RUNTIME_DIR: /run/user/$(id -u)
+
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh
@@ -27,6 +30,7 @@ prepare: |
     install_local test-snapd-desktop
     install_local test-snapd-tools
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
+    mkdir -p "$XDG_RUNTIME_DIR"
 
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh
@@ -37,6 +41,7 @@ restore: |
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
     distro_purge_package python3-dbus python3-gi
     distro_auto_remove_packages
+    rm -rf "${XDG_RUNTIME_DIR:?}/*" "${XDG_RUNTIME_DIR:?}/.[!.]*"
 
 execute: |
     echo "No output on stderr when running without a session bus"
@@ -52,13 +57,24 @@ execute: |
     test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
     [ "$(wc -c < stderr.log)" -eq 0 ]
 
+    echo "The absence of the document portal service was recorded"
+    [ -f "$XDG_RUNTIME_DIR/.snap-portals-unavailable" ]
+
     echo "Make the fake document portal activatable"
     cat << EOF > /usr/share/dbus-1/services/fake-document-portal.service
     [D-BUS Service]
     Name=org.freedesktop.portal.Documents
     Exec=$(pwd)/fake-document-portal.py $(pwd)/doc-portal.log $(pwd)/report-error.txt
     EOF
+    : > doc-portal.log
     : > report-error.txt
+
+    echo "No attempt is made to activate the document portal due to the previous failure"
+    test-snapd-desktop.check-dirs "$user_data"
+    ! MATCH "GetMountPoint called" < doc-portal.log
+
+    echo "Remove the .snap-portals-unavailable file to force a recheck"
+    rm "$XDG_RUNTIME_DIR/.snap-portals-unavailable"
 
     echo "No output on stderr when running with a session bus and xdg-document-portal is present".
     test-snapd-desktop.check-dirs "$user_data" 2>stderr.log

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -1,0 +1,73 @@
+summary: Check that the document portal is activated when needed
+description: |
+    In order for xdg-document-portal to securely share files with a
+    confined applications, it must be started prior to setting up the
+    user mount namespace.  This is due to the daemon providing a FUSE
+    file system that needs to be bind mounted in the sandbox.
+
+    With that in mind, we don't want every snap invocation to try and
+    start the document portal.  Only in the following cases:
+
+        - a session bus is running
+        - the snap plugs the "desktop" interface
+
+    Furthermore, we don't want to print an error on systems where
+    xdg-document-portal is not available.
+
+systems: [ -ubuntu-core-* ]
+
+prepare: |
+    #shellcheck source=tests/lib/pkgdb.sh
+    . $TESTSLIB/pkgdb.sh
+    distro_install_package python3-dbus python3-gi
+    snap try "$TESTSLIB"/snaps/test-snapd-desktop
+    snap try "$TESTSLIB"/snaps/test-snapd-tools
+    rm -f /usr/share/dbus-1/services/fake-document-portal.service
+
+restore: |
+    [ -f dbus-launch.pid ] && kill "$(cat dbus-launch.pid)"
+    rm -f dbus-launch.pid
+    rm -f stderr.log doc-portal.log report-error.txt
+    rm -f /usr/share/dbus-1/services/fake-document-portal.service
+
+execute: |
+    echo "No output on stderr when running without a session bus"
+    user_data="$HOME/snap/test-snapd-desktop/current"
+    test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
+    [ "$(wc -c < stderr.log)" -eq 0 ]
+
+    echo "Starting session bus"
+    eval "$(dbus-launch --sh-syntax)"
+    echo "$DBUS_SESSION_BUS_PID" > dbus-launch.pid
+
+    echo "No output on stderr when running with a session bus, when xdg-document-portal is not present."
+    test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
+    [ "$(wc -c < stderr.log)" -eq 0 ]
+
+    echo "Make the fake document portal activatable"
+    cat << EOF > /usr/share/dbus-1/services/fake-document-portal.service
+    [D-BUS Service]
+    Name=org.freedesktop.portal.Documents
+    Exec=$(pwd)/fake-document-portal.py $(pwd)/doc-portal.log $(pwd)/report-error.txt
+    EOF
+    > report-error.txt
+
+    echo "No output on stderr when running with a session bus and xdg-document-portal is present".
+    test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
+    MATCH "GetMountPoint called" < doc-portal.log
+    [ "$(wc -c < stderr.log)" -eq 0 ]
+
+    echo "Putting fake document portal into failure mode"
+    echo "error" > report-error.txt
+    > doc-portal.log
+
+    echo "Failures from a running xdg-document-portal are reported"
+    test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
+    MATCH "GetMountPoint called" < doc-portal.log
+    MATCH "WARNING: cannot start document portal: failure" < stderr.log
+
+    echo "Snaps not using the desktop interface will not try to contact the document portal"
+    > doc-portal.log
+    test-snapd-tools.success 2>stderr.log
+    [ "$(wc -c < stderr.log)" -eq 0 ]
+    [ "$(wc -c < doc-portal.log)" -eq 0 ]

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -50,7 +50,7 @@ execute: |
     Name=org.freedesktop.portal.Documents
     Exec=$(pwd)/fake-document-portal.py $(pwd)/doc-portal.log $(pwd)/report-error.txt
     EOF
-    > report-error.txt
+    : > report-error.txt
 
     echo "No output on stderr when running with a session bus and xdg-document-portal is present".
     test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
@@ -59,7 +59,7 @@ execute: |
 
     echo "Putting fake document portal into failure mode"
     echo "error" > report-error.txt
-    > doc-portal.log
+    : > doc-portal.log
 
     echo "Failures from a running xdg-document-portal are reported"
     test-snapd-desktop.check-dirs "$user_data" 2>stderr.log
@@ -67,7 +67,7 @@ execute: |
     MATCH "WARNING: cannot start document portal: failure" < stderr.log
 
     echo "Snaps not using the desktop interface will not try to contact the document portal"
-    > doc-portal.log
+    : > doc-portal.log
     test-snapd-tools.success 2>stderr.log
     [ "$(wc -c < stderr.log)" -eq 0 ]
     [ "$(wc -c < doc-portal.log)" -eq 0 ]

--- a/tests/main/document-portal-activation/task.yaml
+++ b/tests/main/document-portal-activation/task.yaml
@@ -18,15 +18,16 @@ systems: [ -ubuntu-core-* ]
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh
-    . $TESTSLIB/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
+    . "$TESTSLIB"/snaps.sh
     distro_install_package python3-dbus python3-gi
-    snap try "$TESTSLIB"/snaps/test-snapd-desktop
-    snap try "$TESTSLIB"/snaps/test-snapd-tools
+    install_local test-snapd-desktop
+    install_local test-snapd-tools
     rm -f /usr/share/dbus-1/services/fake-document-portal.service
 
 restore: |
     #shellcheck source=tests/lib/pkgdb.sh
-    . $TESTSLIB/pkgdb.sh
+    . "$TESTSLIB"/pkgdb.sh
     [ -f dbus-launch.pid ] && kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
     rm -f stderr.log doc-portal.log report-error.txt


### PR DESCRIPTION
This is an early prototype, and maybe not the right way to implement the feature.

When starting a desktop application, we want to make sure xdg-document-portal is running (if it is installed), since we want its FUSE mount to be visible before trying to set up the user mount namespace.

Some points on the implementation:

1. Check that the snap has a plug for the `desktop` interface.  This doesn't check that the plug is actually connected, since `snap run` doesn't communicate with `snapd`.   But this shouldn't be harmful in the rare cases where a snap has the plug but it is disconnected.

2. give up early if `$DBUS_SESSION_BUS_ADDRESS` isn't set.  This avoids any attempts to auto-launch a session bus from cron jobs or root services.

3. If we get back a `ServiceUnknown` error, we assume xdg-document-portal isn't installed and continue without printing a warning.