### PR TITLE
configstate: deny configuration of base snaps and for the "snapd" snap

### DIFF
--- a/daemon/api_mock_test.go
+++ b/daemon/api_mock_test.go
@@ -50,7 +50,8 @@ func (s *apiSuite) mockSnap(c *C, yamlText string) *snap.Info {
 				SnapID:   "ididid",
 			},
 		},
-		Current: snapInfo.Revision,
+		Current:  snapInfo.Revision,
+		SnapType: string(snapInfo.Type),
 	})
 
 	// Put the snap into the interface repository

--- a/overlord/configstate/configstate.go
+++ b/overlord/configstate/configstate.go
@@ -47,21 +47,41 @@ func ConfigureHookTimeout() time.Duration {
 	return timeout
 }
 
+func canConfigure(st *state.State, snapName string) error {
+	// the "core" snap/pseudonym can always be configured as it
+	// is handled internally
+	if snapName == "core" {
+		return nil
+	}
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(st, snapName, &snapst)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+
+	if !snapst.IsInstalled() {
+		return &snap.NotInstalledError{Snap: snapName}
+	}
+
+	// bases cannot be configured for now
+	typ, err := snapst.Type()
+	if err != nil {
+		return err
+	}
+	if typ == snap.TypeBase {
+		return fmt.Errorf("cannot configure snap %q because it is of type 'base'", snapName)
+	}
+
+	return nil
+}
+
 // ConfigureInstalled returns a taskset to apply the given
 // configuration patch for an installed snap. It returns
 // snap.NotInstalledError if the snap is not installed.
 func ConfigureInstalled(st *state.State, snapName string, patch map[string]interface{}, flags int) (*state.TaskSet, error) {
-	// core is handled internally and can be configured before
-	// being installed
-	if snapName != "core" {
-		var snapst snapstate.SnapState
-		err := snapstate.Get(st, snapName, &snapst)
-		if err != nil && err != state.ErrNoState {
-			return nil, err
-		}
-		if !snapst.IsInstalled() {
-			return nil, &snap.NotInstalledError{Snap: snapName}
-		}
+	if err := canConfigure(st, snapName); err != nil {
+		return nil, err
 	}
 
 	taskset := Configure(st, snapName, patch, flags)

--- a/overlord/configstate/configstate.go
+++ b/overlord/configstate/configstate.go
@@ -64,6 +64,11 @@ func canConfigure(st *state.State, snapName string) error {
 		return &snap.NotInstalledError{Snap: snapName}
 	}
 
+	// the "snapd" snap cannot be configured yet
+	if snapName == "snapd" {
+		return fmt.Errorf(`cannot configure the "snapd" snap, please use "system" instead`)
+	}
+
 	// bases cannot be configured for now
 	typ, err := snapst.Type()
 	if err != nil {

--- a/overlord/configstate/configstate_test.go
+++ b/overlord/configstate/configstate_test.go
@@ -175,6 +175,23 @@ func (s *tasksetsSuite) TestConfigureDenyBases(c *C) {
 	c.Check(err, ErrorMatches, `cannot configure snap "test-base" because it is of type 'base'`)
 }
 
+func (s *tasksetsSuite) TestConfigureDenySnapd(c *C) {
+	patch := map[string]interface{}{"foo": "bar"}
+	s.state.Lock()
+	defer s.state.Unlock()
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "snapd", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		Active:   true,
+		SnapType: "app",
+	})
+
+	_, err := configstate.ConfigureInstalled(s.state, "snapd", patch, 0)
+	c.Check(err, ErrorMatches, `cannot configure the "snapd" snap, please use "system" instead`)
+}
+
 type configcoreHijackSuite struct {
 	o     *overlord.Overlord
 	state *state.State

--- a/overlord/configstate/configstate_test.go
+++ b/overlord/configstate/configstate_test.go
@@ -79,8 +79,9 @@ func (s *tasksetsSuite) TestConfigureInstalled(c *C) {
 		Sequence: []*snap.SideInfo{
 			{RealName: "test-snap", Revision: snap.R(1)},
 		},
-		Current: snap.R(1),
-		Active:  true,
+		Current:  snap.R(1),
+		Active:   true,
+		SnapType: "app",
 	})
 	s.state.Unlock()
 
@@ -155,6 +156,23 @@ func (s *tasksetsSuite) TestConfigureNotInstalled(c *C) {
 	// core can be configure before being installed
 	_, err = configstate.ConfigureInstalled(s.state, "core", patch, 0)
 	c.Check(err, IsNil)
+}
+
+func (s *tasksetsSuite) TestConfigureDenyBases(c *C) {
+	patch := map[string]interface{}{"foo": "bar"}
+	s.state.Lock()
+	defer s.state.Unlock()
+	snapstate.Set(s.state, "test-base", &snapstate.SnapState{
+		Sequence: []*snap.SideInfo{
+			{RealName: "test-base", Revision: snap.R(1)},
+		},
+		Current:  snap.R(1),
+		Active:   true,
+		SnapType: "base",
+	})
+
+	_, err := configstate.ConfigureInstalled(s.state, "test-base", patch, 0)
+	c.Check(err, ErrorMatches, `cannot configure snap "test-base" because it is of type 'base'`)
 }
 
 type configcoreHijackSuite struct {

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -248,6 +248,8 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		typ = snap.TypeBase
 	case "snap-content-plug-id":
 		name = "snap-content-plug"
+	case "snapd-id":
+		name = "snapd"
 	default:
 		panic(fmt.Sprintf("refresh: unknown snap-id: %s", cand.snapID))
 	}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -162,8 +162,11 @@ func (f *fakeStore) snapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.I
 	confinement := snap.StrictConfinement
 
 	typ := snap.TypeApp
-	if spec.Name == "core" || spec.Name == "some-core" {
+	switch spec.Name {
+	case "core", "some-core":
 		typ = snap.TypeOS
+	case "some-base":
+		typ = snap.TypeBase
 	}
 
 	if spec.Name == "snap-unknown" {

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -58,9 +58,10 @@ type SnapManager struct {
 // SnapSetup holds the necessary snap details to perform most snap manager tasks.
 type SnapSetup struct {
 	// FIXME: rename to RequestedChannel to convey the meaning better
-	Channel string `json:"channel,omitempty"`
-	UserID  int    `json:"user-id,omitempty"`
-	Base    string `json:"base,omitempty"`
+	Channel string    `json:"channel,omitempty"`
+	UserID  int       `json:"user-id,omitempty"`
+	Base    string    `json:"base,omitempty"`
+	Type    snap.Type `json:"type,omitempty"`
 
 	// FIXME: implement rename of this as suggested in
 	//  https://github.com/snapcore/snapd/pull/4103#discussion_r169569717

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -291,6 +291,8 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 	}
 
 	// we do not support configuration for bases or the "snapd" snap yet
+	// TODO: we don't need maybeCore anymore we can look at
+	//      snapsup.Type now
 	if snapsup.Type != snap.TypeBase && snapsup.Name() != "snapd" {
 		configSet := ConfigureSnap(st, snapsup.Name(), confFlags)
 		configSet.WaitAll(ts)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -290,8 +290,8 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		confFlags |= UseConfigDefaults
 	}
 
-	// we do not support configuration for bases yet
-	if snapsup.Type != snap.TypeBase {
+	// we do not support configuration for bases or the "snapd" snap yet
+	if snapsup.Type != snap.TypeBase && snapsup.Name() != "snapd" {
 		configSet := ConfigureSnap(st, snapsup.Name(), confFlags)
 		configSet.WaitAll(ts)
 		ts.AddAll(configSet)

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -290,9 +290,12 @@ func doInstall(st *state.State, snapst *SnapState, snapsup *SnapSetup, flags int
 		confFlags |= UseConfigDefaults
 	}
 
-	configSet := ConfigureSnap(st, snapsup.Name(), confFlags)
-	configSet.WaitAll(ts)
-	ts.AddAll(configSet)
+	// we do not support configuration for bases yet
+	if snapsup.Type != snap.TypeBase {
+		configSet := ConfigureSnap(st, snapsup.Name(), confFlags)
+		configSet.WaitAll(ts)
+		ts.AddAll(configSet)
+	}
 
 	return ts, nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -622,6 +622,7 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, channel string, flags
 		SnapPath: path,
 		Channel:  channel,
 		Flags:    flags.ForSnapSetup(),
+		Type:     info.Type,
 	}
 
 	return doInstall(st, &snapst, snapsup, instFlags)
@@ -671,6 +672,7 @@ func Install(st *state.State, name, channel string, revision snap.Revision, user
 		Flags:        flags.ForSnapSetup(),
 		DownloadInfo: &info.DownloadInfo,
 		SideInfo:     &info.SideInfo,
+		Type:         info.Type,
 	}
 
 	return doInstall(st, &snapst, snapsup, needsMaybeCore(info.Type))
@@ -828,6 +830,7 @@ func doUpdate(st *state.State, names []string, updates []*snap.Info, params func
 			Flags:        flags.ForSnapSetup(),
 			DownloadInfo: &update.DownloadInfo,
 			SideInfo:     &update.SideInfo,
+			Type:         update.Type,
 		}
 
 		ts, err := doInstall(st, snapst, snapsup, needsMaybeCore(update.Type))

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9959,6 +9959,28 @@ func (s *snapmgrTestSuite) TestNoConfigureForBasesTask(c *C) {
 	ts, err = snapstate.Update(s.state, "some-base", "", snap.R(0), s.user.ID, snapstate.Flags{})
 	c.Assert(err, IsNil)
 	c.Check(hasConfigureTask(ts), Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestNoConfigureForSnapdSnap(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// but snapd do not for install
+	ts, err := snapstate.Install(s.state, "snapd", "some-channel", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Check(hasConfigureTask(ts), Equals, false)
+
+	// or for refresh
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active:   true,
+		Channel:  "edge",
+		Sequence: []*snap.SideInfo{{RealName: "snapd", SnapID: "snapd-id", Revision: snap.R(1)}},
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+	ts, err = snapstate.Update(s.state, "snapd", "", snap.R(0), s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Check(hasConfigureTask(ts), Equals, false)
 
 }
 

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9926,8 +9926,8 @@ func (s *snapmgrTestSuite) TestInjectTasksWithNullChange(c *C) {
 }
 
 func hasConfigureTask(ts *state.TaskSet) bool {
-	for _, t := range ts.Tasks() {
-		if t.Kind() == "run-hook" && strings.HasPrefix(t.Summary(), "Run configure hook of") {
+	for _, tk := range taskKinds(ts.Tasks()) {
+		if tk == "run-hook[configure]" {
 			return true
 		}
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9984,6 +9984,31 @@ func (s *snapmgrTestSuite) TestNoConfigureForSnapdSnap(c *C) {
 
 }
 
+func (s snapmgrTestSuite) TestCanLoadOldSnapSetupWithoutType(c *C) {
+	// ensure we don't crash when loading a SnapSetup json without
+	// a type set
+	oldSnapSetup := []byte(`{
+ "snap-path":"/some/path",
+ "side-info": {
+    "channel": "edge",
+    "name": "some-snap",
+    "revision": "1",
+    "snap-id": "some-snap-id"
+ }
+}`)
+	var snapsup snapstate.SnapSetup
+	err := json.Unmarshal(oldSnapSetup, &snapsup)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.SnapPath, Equals, "/some/path")
+	c.Check(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
+		Channel:  "edge",
+		RealName: "some-snap",
+		Revision: snap.R(1),
+		SnapID:   "some-snap-id",
+	})
+	c.Check(snapsup.Type, Equals, snap.Type(""))
+}
+
 type canDisableSuite struct{}
 
 var _ = Suite(&canDisableSuite{})

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1799,6 +1799,7 @@ func (s *snapmgrTestSuite) TestInstallRunThrough(c *C) {
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -1954,6 +1955,7 @@ func (s *snapmgrTestSuite) TestInstallWithRevisionRunThrough(c *C) {
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "some-snap",
@@ -2160,6 +2162,7 @@ func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
 			DownloadURL: "https://some-server.com/some/path.snap",
 		},
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "services-snap",
@@ -4234,6 +4237,7 @@ version: 1.0`)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		SnapPath: mockSnap,
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "mock",
@@ -4326,6 +4330,7 @@ version: 1.0`)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		SnapPath: mockSnap,
 		SideInfo: snapsup.SideInfo,
+		Type:     snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, &snap.SideInfo{
 		RealName: "mock",
@@ -4503,6 +4508,7 @@ version: 1.0`)
 		Flags: snapstate.Flags{
 			Required: true,
 		},
+		Type: snap.TypeApp,
 	})
 	c.Assert(snapsup.SideInfo, DeepEquals, si)
 


### PR DESCRIPTION
As discussed in #5259 this disables configuration for bases and for the snapd snap. We will use the "core" configuration (even if core is not installed) for all system related config for now.