### PR TITLE
cmd/snap-update-ns: add helper for checking for read-only filesystems

### DIFF
--- a/cmd/snap-update-ns/export_test.go
+++ b/cmd/snap-update-ns/export_test.go
@@ -62,6 +62,7 @@ type SystemCalls interface {
 	Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error)
 	Unmount(target string, flags int) error
 	Fstat(fd int, buf *syscall.Stat_t) error
+	Fstatfs(fd int, buf *syscall.Statfs_t) error
 }
 
 // MockSystemCalls replaces real system calls with those of the argument.
@@ -81,6 +82,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	oldSysSymlinkat := sysSymlinkat
 	oldReadlinkat := sysReadlinkat
 	oldFstat := sysFstat
+	oldFstatfs := sysFstatfs
 	oldSysFchdir := sysFchdir
 	oldSysLstat := sysLstat
 
@@ -99,6 +101,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 	sysSymlinkat = sc.Symlinkat
 	sysReadlinkat = sc.Readlinkat
 	sysFstat = sc.Fstat
+	sysFstatfs = sc.Fstatfs
 	sysFchdir = sc.Fchdir
 	sysLstat = sc.SysLstat
 
@@ -118,6 +121,7 @@ func MockSystemCalls(sc SystemCalls) (restore func()) {
 		sysSymlinkat = oldSysSymlinkat
 		sysReadlinkat = oldReadlinkat
 		sysFstat = oldFstat
+		sysFstatfs = oldFstatfs
 		sysFchdir = oldSysFchdir
 		sysLstat = oldSysLstat
 	}

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -35,6 +35,12 @@ import (
 // not available through syscall
 const (
 	umountNoFollow = 8
+	// StReadOnly is the equivalent of ST_RDONLY
+	StReadOnly = 1
+	// SquashfsMagic is the equivalent of SQUASHFS_MAGIC
+	SquashfsMagic = 0x73717368
+	// Ext4Magic is the equivalent of EXT4_SUPER_MAGIC
+	Ext4Magic = 0xef53
 )
 
 // For mocking everything during testing.
@@ -59,6 +65,27 @@ var (
 
 	ioutilReadDir = ioutil.ReadDir
 )
+
+// IsReadOnly returns true if a directory is ready only.
+//
+// Directories are read only when they reside on file systems mounted in read
+// only mode or when the underlying file system itself is inherently read only.
+func IsReadOnly(dirFd int, dirName string) (bool, error) {
+	var fsData syscall.Statfs_t
+	if err := sysFstatfs(dirFd, &fsData); err != nil {
+		return false, fmt.Errorf("cannot fstatfs %q: %s", dirName, err)
+	}
+	// If something is mounted with f_flags & ST_RDONLY then is read-only.
+	if fsData.Flags&StReadOnly == StReadOnly {
+		return true, nil
+	}
+	// If something is a known read-only file-system then it is safe.
+	// Older copies of snapd were not mounting squashfs as read only.
+	if fsData.Type == SquashfsMagic {
+		return true, nil
+	}
+	return false, nil
+}
 
 // ReadOnlyFsError is an error encapsulating encountered EROFS.
 type ReadOnlyFsError struct {

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -51,6 +51,7 @@ var (
 	sysUnmount    = syscall.Unmount
 	sysFchown     = sys.Fchown
 	sysFstat      = syscall.Fstat
+	sysFstatfs    = syscall.Fstatfs
 	sysSymlinkat  = osutil.Symlinkat
 	sysReadlinkat = osutil.Readlinkat
 	sysFchdir     = syscall.Fchdir

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -759,6 +759,53 @@ func (s *utilsSuite) TestSecureOpenPathRoot(c *C) {
 	})
 }
 
+func (s *utilsSuite) TestIsReadOnlyFstatfsError(c *C) {
+	path := "/some/path"
+	s.sys.InsertFault("fstatfs 3 <ptr>", errTesting)
+	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer s.sys.Close(fd)
+	result, err := update.IsReadOnly(fd, path)
+	c.Assert(err, ErrorMatches, `cannot fstatfs "/some/path": testing`)
+	c.Assert(result, Equals, false)
+}
+
+func (s *utilsSuite) TestIsReadOnlySquashfsMountedRo(c *C) {
+	statfs := syscall.Statfs_t{Type: update.SquashfsMagic, Flags: update.StReadOnly}
+	path := "/some/path"
+	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
+	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer s.sys.Close(fd)
+	result, err := update.IsReadOnly(fd, path)
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, true)
+}
+
+func (s *utilsSuite) TestIsReadOnlySquashfsMountedRw(c *C) {
+	statfs := syscall.Statfs_t{Type: update.SquashfsMagic}
+	path := "/some/path"
+	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
+	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer s.sys.Close(fd)
+	result, err := update.IsReadOnly(fd, path)
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, true)
+}
+
+func (s *utilsSuite) TestIsReadOnlyExt4MountedRw(c *C) {
+	statfs := syscall.Statfs_t{Type: update.Ext4Magic}
+	path := "/some/path"
+	s.sys.InsertFstatfsResult("fstatfs 3 <ptr>", statfs)
+	fd, err := s.sys.Open(path, syscall.O_DIRECTORY, 0)
+	c.Assert(err, IsNil)
+	defer s.sys.Close(fd)
+	result, err := update.IsReadOnly(fd, path)
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, false)
+}
+
 func (s *realSystemSuite) TestSecureOpenPathDirectory(c *C) {
 	path := filepath.Join(c.MkDir(), "test")
 	c.Assert(os.Mkdir(path, 0755), IsNil)


### PR DESCRIPTION
This patch adds a simple helper that checks if a directory is read only
in a way that sandboxed processes cannot overcome. This will be used in
upcoming trespassing checks where attempts to write to read only
directories are honored as they trigger EROFS which is handled by the
construction of a writable mimic.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>