### PR TITLE
cmd/snap-update-ns: add IsSnapdCreatedPrivateTmpfs and tests

### DIFF
--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -41,6 +41,8 @@ const (
 	SquashfsMagic = 0x73717368
 	// Ext4Magic is the equivalent of EXT4_SUPER_MAGIC
 	Ext4Magic = 0xef53
+	// TmpfsMagic is the equivalent of TMPFS_MAGIC
+	TmpfsMagic = 0x01021994
 )
 
 // For mocking everything during testing.
@@ -85,6 +87,49 @@ func IsReadOnly(dirFd int, dirName string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// IsTrustedTmpfs returns true if a directory belongs to a tmpfs mounted by snapd.
+//
+// The function inspects the directory (represented as both an open file
+// descriptor and the absolute path) and a list of changes that were applied to
+// the mount namespace. A directory is trusted if it is a tmpfs that was
+// mounted by snap-confine or snapd-update-ns. Note that sub-directories of a
+// trusted tmpfs are not considered trusted by this function.
+func IsTrustedTmpfs(dirFd int, dirName string, changes []*Change) (bool, error) {
+	var fsData syscall.Statfs_t
+	if err := sysFstatfs(dirFd, &fsData); err != nil {
+		return false, fmt.Errorf("cannot fstatfs %q: %s", dirName, err)
+	}
+	// If something is not a tmpfs it cannot be the trusted tmpfs we are looking for.
+	if fsData.Type != TmpfsMagic {
+		return false, nil
+	}
+	// Any of the past changes that mounted a tmpfs exactly at the directory we
+	// are inspecting is considered as trusted. This is conservative because it
+	// doesn't trust sub-directories of a trusted tmpfs. This approach is
+	// sufficient for the intended use.
+	//
+	// The algorithm goes over all the changes and picks up mount and unmount
+	// actions keeping track of what happened. The set of constraints in
+	// snap-update-ns and snapd prevent from mounting over an existing mount
+	// point so we don't need to consider e.g. a bind mount shadowing an active
+	// tmpfs.
+	mounted := false
+	for _, change := range changes {
+		if change.Entry.Type == "tmpfs" && change.Entry.Dir == dirName {
+			mounted = change.Action == Mount
+		}
+	}
+	if mounted {
+		return true, nil
+	}
+	// As a special exception, assume that a tmpfs over /var/lib is trusted.
+	// This tmpfs is created by snap-confine as a "quirk" to support a
+	// particular behavior of LXD.  Once the quirk is migrated to a mount
+	// profile (or removed entirely if no longer necessary) the following
+	// code fragment can go away.
+	return dirName == "/var/lib", nil
 }
 
 // ReadOnlyFsError is an error encapsulating encountered EROFS.

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -89,14 +89,14 @@ func IsReadOnly(dirFd int, dirName string) (bool, error) {
 	return false, nil
 }
 
-// IsTrustedTmpfs returns true if a directory belongs to a tmpfs mounted by snapd.
+// IsSnapdCreatedPrivateTmpfs returns true if a directory is a tmpfs mounted by snapd.
 //
 // The function inspects the directory (represented as both an open file
 // descriptor and the absolute path) and a list of changes that were applied to
 // the mount namespace. A directory is trusted if it is a tmpfs that was
 // mounted by snap-confine or snapd-update-ns. Note that sub-directories of a
 // trusted tmpfs are not considered trusted by this function.
-func IsTrustedTmpfs(dirFd int, dirName string, changes []*Change) (bool, error) {
+func IsSnapdCreatedPrivateTmpfs(dirFd int, dirName string, changes []*Change) (bool, error) {
 	var fsData syscall.Statfs_t
 	if err := sysFstatfs(dirFd, &fsData); err != nil {
 		return false, fmt.Errorf("cannot fstatfs %q: %s", dirName, err)

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -124,11 +124,11 @@ func IsTrustedTmpfs(dirFd int, dirName string, changes []*Change) (bool, error) 
 	if mounted {
 		return true, nil
 	}
-	// As a special exception, assume that a tmpfs over /var/lib is trusted.
-	// This tmpfs is created by snap-confine as a "quirk" to support a
-	// particular behavior of LXD.  Once the quirk is migrated to a mount
-	// profile (or removed entirely if no longer necessary) the following
-	// code fragment can go away.
+	// TODO: As a special exception, assume that a tmpfs over /var/lib is
+	// trusted. This tmpfs is created by snap-confine as a "quirk" to support
+	// a particular behavior of LXD.  Once the quirk is migrated to a mount
+	// profile (or removed entirely if no longer necessary) the following code
+	// fragment can go away.
 	return dirName == "/var/lib", nil
 }
 


### PR DESCRIPTION
This patch adds a simple helper for checking if a given directory is
a trusted tmpfs. A trusted tmpfs is one we are safe to write to without
affecting the host file system (that is, from the initial mount namespace
such writes will not be visible).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
