### PR TITLE
httputil: extra debug if an error is not retried

### DIFF
--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -94,6 +94,10 @@ func ShouldRetryError(attempt *retry.Attempt, err error) bool {
 		return true
 	}
 
+	if osutil.GetenvBool("SNAPD_DEBUG") {
+		logger.Debugf("Not retrying: %#v", err)
+	}
+
 	return false
 }
 


### PR DESCRIPTION
Print extra debug if we don't match any specific error we care about and decide not to retry - this might make it easier to understand the problem we occasionally hit with econnreset test.