### PR TITLE
snap: reject more layout locations

### DIFF
--- a/snap/validate.go
+++ b/snap/validate.go
@@ -690,7 +690,7 @@ func ValidateLayout(layout *Layout, constraints []LayoutConstraint) error {
 		return fmt.Errorf("layout %q uses invalid mount point: must be absolute and clean", layout.Path)
 	}
 
-	for _, path := range []string{"/proc", "/sys", "/dev", "/run", "/boot", "/lost+found", "/media"} {
+	for _, path := range []string{"/proc", "/sys", "/dev", "/run", "/boot", "/lost+found", "/media", "/var/lib/snapd", "/var/snap"} {
 		// We use the mountedTree constraint as this has the right semantics.
 		if mountedTree(path).IsOffLimits(mountPoint) {
 			return fmt.Errorf("layout %q in an off-limits area", layout.Path)

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -702,6 +702,12 @@ func (s *ValidateSuite) TestValidateLayout(c *C) {
 		ErrorMatches, `layout "/lost\+found" in an off-limits area`)
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/media", Type: "tmpfs"}, nil),
 		ErrorMatches, `layout "/media" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var/snap", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/var/snap" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var/lib/snapd", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/var/lib/snapd" in an off-limits area`)
+	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/var/lib/snapd/hostfs", Type: "tmpfs"}, nil),
+		ErrorMatches, `layout "/var/lib/snapd/hostfs" in an off-limits area`)
 
 	// Several valid layouts.
 	c.Check(ValidateLayout(&Layout{Snap: si, Path: "/foo", Type: "tmpfs", Mode: 01755}, nil), IsNil)


### PR DESCRIPTION
This patch adds the following entries to a list of off-limit layouts:
 - /var/lib/snapd/
 - /var/snap/

Those should not be needed for layouts because they interfere with
internal snapd state and state of other snaps, respectively. As such
layouts are designed to aid in porting software and no software has
legitimate reasons to poke into those places.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
