### PR TITLE
interfaces/raw-usb: also allow usb serial devices

### DIFF
--- a/interfaces/builtin/raw_usb.go
+++ b/interfaces/builtin/raw_usb.go
@@ -34,6 +34,9 @@ const rawusbConnectedPlugAppArmor = `
 # This gives privileged access to the system.
 /dev/bus/usb/[0-9][0-9][0-9]/[0-9][0-9][0-9] rw,
 
+# Allow access to all ttyUSB devices too
+/dev/ttyUSB[0-9]* rw,
+
 # Allow detection of usb devices. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,
 /sys/devices/pci**/usb[0-9]** r,
@@ -45,7 +48,10 @@ const rawusbConnectedPlugAppArmor = `
 /run/udev/data/+usb:* r,
 `
 
-var rawusbConnectedPlugUDev = []string{`SUBSYSTEM=="usb"`}
+var rawusbConnectedPlugUDev = []string{
+	`SUBSYSTEM=="usb"`,
+	`SUBSYSTEM=="tty", ENV{ID_BUS}=="usb"`,
+}
 
 func init() {
 	registerIface(&commonInterface{

--- a/interfaces/builtin/raw_usb_test.go
+++ b/interfaces/builtin/raw_usb_test.go
@@ -90,9 +90,11 @@ func (s *RawUsbInterfaceSuite) TestAppArmorSpec(c *C) {
 func (s *RawUsbInterfaceSuite) TestUDevSpec(c *C) {
 	spec := &udev.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), HasLen, 3)
 	c.Assert(spec.Snippets(), testutil.Contains, `# raw-usb
 SUBSYSTEM=="usb", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# raw-usb
+SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, `TAG=="snap_consumer_app", RUN+="/usr/lib/snapd/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`)
 }
 


### PR DESCRIPTION
USB serial devices like /dev/ttyUSB* were always meant to be included in this
transitional interface, but the code missed /dev/ttyUSB* AppArmor rules and
a matching udev rule to tag the devices (udev sets the SUBSYSTEM to tty for
USB serial devices so we use SUBSYSTEM=="tty", ENV{ID_BUS}=="usb" as the
conditional to tag only them for this interface).
