### PR TITLE
tests/main/{snap-repair,ubuntu-core-services}: add debug information

### DIFF
--- a/tests/main/snap-repair/task.yaml
+++ b/tests/main/snap-repair/task.yaml
@@ -24,3 +24,4 @@ debug: |
     systemctl list-timers --all
     ls -l /lib/systemd/system/snapd* || true
     systemctl show snapd.snap-repair.timer
+    journalctl -u snapd.snap-repair.timer -u snapd.snap-repair.service

--- a/tests/main/snap-repair/task.yaml
+++ b/tests/main/snap-repair/task.yaml
@@ -20,5 +20,7 @@ execute: |
     "${LIBEXECDIR}"/snapd/snap-repair run
 
 debug: |
+    date
     systemctl list-timers --all
-    ls /usr/lib/systemd/system/snapd*
+    ls -l /lib/systemd/system/snapd* || true
+    systemctl show snapd.snap-repair.timer

--- a/tests/main/snap-repair/task.yaml
+++ b/tests/main/snap-repair/task.yaml
@@ -19,4 +19,6 @@ execute: |
     echo "Check that snap-repair can be run"
     "${LIBEXECDIR}"/snapd/snap-repair run
 
-    
+debug: |
+    systemctl list-timers --all
+    ls /usr/lib/systemd/system/snapd*

--- a/tests/main/ubuntu-core-services/task.yaml
+++ b/tests/main/ubuntu-core-services/task.yaml
@@ -15,3 +15,7 @@ execute: |
     for timer in snapd.snap-repair.timer; do
         systemctl is-active $timer
     done
+
+debug: |
+      systemctl list-timers --all
+      ls /usr/lib/systemd/system/snapd*

--- a/tests/main/ubuntu-core-services/task.yaml
+++ b/tests/main/ubuntu-core-services/task.yaml
@@ -17,5 +17,7 @@ execute: |
     done
 
 debug: |
-      systemctl list-timers --all
-      ls /usr/lib/systemd/system/snapd*
+    date
+    systemctl list-timers --all
+    ls -l /lib/systemd/system/snapd* || true
+    systemctl show snapd.snap-repair.timer

--- a/tests/main/ubuntu-core-services/task.yaml
+++ b/tests/main/ubuntu-core-services/task.yaml
@@ -21,3 +21,4 @@ debug: |
     systemctl list-timers --all
     ls -l /lib/systemd/system/snapd* || true
     systemctl show snapd.snap-repair.timer
+    journalctl -u snapd.snap-repair.timer -u snapd.snap-repair.service


### PR DESCRIPTION
The following failure occurs randomly in the tests:
```
2018-06-07 23:53:57 Error executing google:ubuntu-core-16-64:tests/main/snap-repair : 
-----
+ . /home/gopath/src/github.com/snapcore/snapd/tests/lib/dirs.sh
++ export SNAP_MOUNT_DIR=/snap
++ SNAP_MOUNT_DIR=/snap
++ export LIBEXECDIR=/usr/lib
++ LIBEXECDIR=/usr/lib
++ export MEDIA_DIR=/media
++ MEDIA_DIR=/media
++ case "$SPREAD_SYSTEM" in
+ grep -q ID=ubuntu-core /etc/os-release
+ echo 'Check that the snap-repair timer is active'
Check that the snap-repair timer is active
+ MATCH snapd.snap-repair.timer
+ systemctl list-timers
error: pattern not found, got:
NEXT                         LEFT       LAST PASSED UNIT                         ACTIVATES
Fri 2018-06-08 00:07:10 UTC  13min left n/a  n/a    systemd-tmpfiles-clean.timer systemd-tmpfiles-clean.service

1 timers listed.
Pass --all to see loaded but inactive timers, too.
```
The PR attempts to collect some debug information.