### PR TITLE
snapstate: fix assumptions about core in setup phase2

### DIFF
--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -497,6 +497,19 @@ func GuardCoreSetupProfilesPhase2(task *state.Task, snapsup *SnapSetup, snapInfo
 		if err != nil {
 			return false, err
 		}
+		// check what snap we use for booting
+		model, err := Model(task.State())
+		if err != nil {
+			return false, err
+		}
+		// if the boot snap does not match the "core" nothing
+		// to do
+		if model.Base() != "" && snapsup.Name() != model.Base() {
+			return false, nil
+		}
+		// Ensure there was no rollback. We need to check both
+		// name and revision because name might have changed from
+		// ubuntu-core -> core.
 		if snapsup.Name() != name || snapInfo.Revision != rev {
 			return false, fmt.Errorf("cannot finish core installation, there was a rollback across reboot")
 		}


### PR DESCRIPTION
When installing the core snap on an Ubuntu Core system the code
has the wrong assumption that we always boot from the "core" TypeOS
snap. This PR adds code to check what snap is used for booting.
