### PR TITLE
testutil: syscall sequence checker

### DIFF
--- a/testutil/checkers.go
+++ b/testutil/checkers.go
@@ -225,3 +225,65 @@ func (c *deepContainsChecker) Check(params []interface{}, names []string) (resul
 		return false, fmt.Sprintf("%T is not a supported container", container)
 	}
 }
+
+type syscallsEqualChecker struct {
+	*check.CheckerInfo
+}
+
+// SyscallsEqual checks that one sequence of system calls is equal to another.
+var SyscallsEqual check.Checker = &syscallsEqualChecker{
+	CheckerInfo: &check.CheckerInfo{Name: "SyscallsEqual", Params: []string{"actualList", "expectedList"}},
+}
+
+func (c *syscallsEqualChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	actualList, ok := params[0].([]CallResultError)
+	if !ok {
+		return false, "left-hand-side argument must be of type []CallResultError"
+	}
+	expectedList, ok := params[1].([]CallResultError)
+	if !ok {
+		return false, "right-hand-side argument must be of type []CallResultError"
+	}
+
+	for i, actual := range actualList {
+		if i >= len(expectedList) {
+			return false, fmt.Sprintf("system call #%d %#q unexpectedly present, got %d system call(s) but expected only %d",
+				i, actual.C, len(actualList), len(expectedList))
+		}
+		expected := expectedList[i]
+		if actual.C != expected.C {
+			return false, fmt.Sprintf("system call #%d differs in operation, actual %#q, expected %#q", i, actual.C, expected.C)
+		}
+		if !reflect.DeepEqual(actual, expected) {
+			switch {
+			case actual.E == nil && expected.E == nil && !reflect.DeepEqual(actual.R, expected.R):
+				// The call succeeded but not like we expected.
+				return false, fmt.Sprintf("system call #%d %#q differs in result, actual: %#v, expected: %#v",
+					i, actual.C, actual.R, expected.R)
+			case actual.E != nil && expected.E != nil && !reflect.DeepEqual(actual.E, expected.E):
+				// The call failed but not like we expected.
+				return false, fmt.Sprintf("system call #%d %#q differs in error, actual: %s, expected: %s",
+					i, actual.C, actual.E, expected.E)
+			case actual.E != nil && expected.E == nil && expected.R == nil:
+				// The call failed but we expected it to succeed.
+				return false, fmt.Sprintf("system call #%d %#q unexpectedly failed, actual error: %s", i, actual.C, actual.E)
+			case actual.E != nil && expected.E == nil && expected.R != nil:
+				// The call failed but we expected it to succeed with some result.
+				return false, fmt.Sprintf("system call #%d %#q unexpectedly failed, actual error: %s, expected result: %#v", i, actual.C, actual.E, expected.R)
+			case actual.E == nil && expected.E != nil && actual.R == nil:
+				// The call succeeded with some result but we expected it to fail.
+				return false, fmt.Sprintf("system call #%d %#q unexpectedly succeeded, expected error: %s", i, actual.C, expected.E)
+			case actual.E == nil && expected.E != nil && actual.R != nil:
+				// The call succeeded but we expected it to fail.
+				return false, fmt.Sprintf("system call #%d %#q unexpectedly succeeded, actual result: %#v, expected error: %s", i, actual.C, actual.R, expected.E)
+			default:
+				panic("unexpected call-result-error case")
+			}
+		}
+	}
+	if len(actualList) < len(expectedList) && len(expectedList) > 0 {
+		return false, fmt.Sprintf("system call #%d %#q unexpectedly absent, got only %d system call(s) but expected %d",
+			len(actualList), expectedList[len(actualList)].C, len(actualList), len(expectedList))
+	}
+	return true, ""
+}

--- a/testutil/checkers_test.go
+++ b/testutil/checkers_test.go
@@ -27,6 +27,7 @@
 package testutil
 
 import (
+	"errors"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
@@ -328,4 +329,50 @@ func (s *CheckersS) TestFileMatches(c *check.C) {
 	testCheck(c, FileMatches, false, `Can't read file "": open : no such file or directory`, "", "")
 	testCheck(c, FileMatches, false, "Filename must be a string", 42, ".*")
 	testCheck(c, FileMatches, false, "Regex must be a string", filename, 1)
+}
+
+func (s *CheckersS) TestSystemCallSequenceEqual(c *check.C) {
+	c.Assert([]CallResultError{}, SyscallsEqual, []CallResultError{})
+	c.Assert([]CallResultError{}, SyscallsEqual, []CallResultError(nil))
+	c.Assert([]CallResultError{{C: `foo`}}, SyscallsEqual, []CallResultError{{C: `foo`}})
+	c.Assert([]CallResultError{{C: `foo`}, {C: `bar`}}, SyscallsEqual, []CallResultError{{C: `foo`}, {C: `bar`}})
+	c.Assert([]CallResultError{{C: `foo`, R: 123}}, SyscallsEqual, []CallResultError{{C: `foo`, R: 123}})
+	c.Assert([]CallResultError{{C: `foo`, E: errors.New("bad")}}, SyscallsEqual, []CallResultError{{C: `foo`, E: errors.New("bad")}})
+
+	// Wrong argument types.
+	testCheck(c, SyscallsEqual, false, "left-hand-side argument must be of type []CallResultError",
+		true, []CallResultError{{C: `bar`}})
+	testCheck(c, SyscallsEqual, false, "right-hand-side argument must be of type []CallResultError",
+		[]CallResultError{{C: `bar`}}, true)
+	// Different system call operations.
+	testCheck(c, SyscallsEqual, false, "system call #0 differs in operation, actual `foo`, expected `bar`",
+		[]CallResultError{{C: `foo`}}, []CallResultError{{C: `bar`}})
+	// Different system call results.
+	testCheck(c, SyscallsEqual, false, "system call #0 `foo` differs in result, actual: 1, expected: 2",
+		[]CallResultError{{C: `foo`, R: 1}}, []CallResultError{{C: `foo`, R: 2}})
+	// Different system call errors.
+	testCheck(c, SyscallsEqual, false, "system call #0 `foo` differs in error, actual: barf, expected: bork",
+		[]CallResultError{{C: `foo`, E: errors.New("barf")}}, []CallResultError{{C: `foo`, E: errors.New("bork")}})
+	// Unexpected success with non-nil result.
+	testCheck(c, SyscallsEqual, false, "system call #0 `foo` unexpectedly succeeded, actual result: 1, expected error: broken",
+		[]CallResultError{{C: `foo`, R: 1}}, []CallResultError{{C: `foo`, E: errors.New("broken")}})
+	// Unexpected success with nil result.
+	testCheck(c, SyscallsEqual, false, "system call #0 `foo` unexpectedly succeeded, expected error: broken",
+		[]CallResultError{{C: `foo`}}, []CallResultError{{C: `foo`, E: errors.New("broken")}})
+	// Unexpected failure with expected non-nil result.
+	testCheck(c, SyscallsEqual, false, "system call #0 `foo` unexpectedly failed, actual error: broken, expected result: 1",
+		[]CallResultError{{C: `foo`, E: errors.New("broken")}}, []CallResultError{{C: `foo`, R: 1}})
+	// Unexpected failure with expected nil result.
+	testCheck(c, SyscallsEqual, false, "system call #0 `foo` unexpectedly failed, actual error: broken",
+		[]CallResultError{{C: `foo`, E: errors.New("broken")}}, []CallResultError{{C: `foo`}})
+	// More system calls than expected.
+	testCheck(c, SyscallsEqual, false, "system call #1 `bar` unexpectedly present, got 2 system call(s) but expected only 1",
+		[]CallResultError{{C: `foo`}, {C: `bar`}}, []CallResultError{{C: `foo`}})
+	testCheck(c, SyscallsEqual, false, "system call #0 `foo` unexpectedly present, got 2 system call(s) but expected only 0",
+		[]CallResultError{{C: `foo`}, {C: `bar`}}, []CallResultError{})
+	// Fewer system calls than expected.
+	testCheck(c, SyscallsEqual, false, "system call #1 `bar` unexpectedly absent, got only 1 system call(s) but expected 2",
+		[]CallResultError{{C: `foo`}}, []CallResultError{{C: `foo`}, {C: `bar`}})
+	testCheck(c, SyscallsEqual, false, "system call #0 `foo` unexpectedly absent, got only 0 system call(s) but expected 1",
+		[]CallResultError{}, []CallResultError{{C: `foo`}})
 }


### PR DESCRIPTION
This patch adds a new checker that aids in testing sequences of system
calls. Unlike the default DeepEquals checker it stops at the first
mismatching system call result / error object, giving useful information
that is easier to read than the full output of the expected vs actual
results that can be, sometimes, very long.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
