### PR TITLE
cmd/snap-update-ns: fix a leaking file descriptor in MkSymlink

### DIFF
--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -50,6 +50,11 @@ func (s *changeSuite) SetUpTest(c *C) {
 	s.sec = &update.Secure{}
 }
 
+func (s *changeSuite) TearDownTest(c *C) {
+	s.BaseTest.TearDownTest(c)
+	s.sys.CheckForStrayDescriptors(c)
+}
+
 func (s *changeSuite) TestFakeFileInfo(c *C) {
 	c.Assert(testutil.FileInfoDir.IsDir(), Equals, true)
 	c.Assert(testutil.FileInfoFile.IsDir(), Equals, false)
@@ -1706,6 +1711,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithGoodSymlinkPresent(c *C) {
 		`openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, // -> 4
 		`fstat 4 <ptr>`,
 		`readlinkat 4 "" <ptr>`,
+		`close 4`,
 		`close 3`,
 	})
 }
@@ -1727,6 +1733,7 @@ func (s *changeSuite) TestPerformCreateSymlinkWithBadSymlinkPresent(c *C) {
 		`openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, // -> 4
 		`fstat 4 <ptr>`,
 		`readlinkat 4 "" <ptr>`,
+		`close 4`,
 		`close 3`,
 	})
 }

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -300,6 +300,7 @@ func (sec *Secure) MkSymlink(dirFd int, dirName string, name string, oldname str
 			if err != nil {
 				return fmt.Errorf("cannot open existing file %q: %v", filepath.Join(dirName, name), err)
 			}
+			defer sysClose(objFd)
 			var statBuf syscall.Stat_t
 			err = sysFstat(objFd, &statBuf)
 			if err != nil {

--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -56,8 +56,8 @@ func (s *utilsSuite) SetUpTest(c *C) {
 }
 
 func (s *utilsSuite) TearDownTest(c *C) {
-	s.sys.CheckForStrayDescriptors(c)
 	s.BaseTest.TearDownTest(c)
+	s.sys.CheckForStrayDescriptors(c)
 }
 
 // secure-mkdir-all


### PR DESCRIPTION
The leak went unnoticed because the test suite didn't have the extra
call that checks for exactly that, leaks. The patch also reorders suite
cleanup logic so that mocking is undone before leak checking is
attempted in case the leak check fails.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
