### PR TITLE
interfaces/docker-support: update for docker 18.05

### DIFF
--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -63,6 +63,8 @@ const dockerSupportConnectedPlugAppArmor = `
 # Socket for docker-container-shim
 unix (bind,listen) type=stream addr="@/containerd-shim/moby/*/shim.sock\x00",
 
+/{,var/}run/mount/utab r,
+
 # Wide read access to /proc, but somewhat limited writes for now
 @{PROC}/ r,
 @{PROC}/** r,

--- a/interfaces/builtin/docker_support.go
+++ b/interfaces/builtin/docker_support.go
@@ -60,6 +60,9 @@ const dockerSupportConnectedPlugAppArmor = `
 /{,var/}run/runc/       rw,
 /{,var/}run/runc/**     mrwklix,
 
+# Socket for docker-container-shim
+unix (bind,listen) type=stream addr="@/containerd-shim/moby/*/shim.sock\x00",
+
 # Wide read access to /proc, but somewhat limited writes for now
 @{PROC}/ r,
 @{PROC}/** r,


### PR DESCRIPTION
During the time between 17.09 (the most recent docker release to be snapped) and 18.05 release of docker community edition, docker now starts another background process and that process listens on `/containerd-shim/moby/$UUID/shim.sock\x00`. Note that the NUL byte at the end is important for reasons I don't entirely understand - other similar apparmor profiles for listening/binding on sockets don't need this NUL byte, but for some reason or another this one does (I couldn't get it to work without it there).

Regarding the access to `/run/mount/utab`; I can't say I know why the docker daemon now attempts to access this, but the `docker-support` interface already allows so much I don't see how this could be exploited in a way that's not already exploitable. But docker does seem to run fine without this there, so it could be removed if so desired.

Lastly, there is still a denial I see with `snappy-debug.security scanlog docker` for `kmod`:
```
[12799.114438] audit: type=1400 audit(1528490047.492:679): apparmor="DENIED" operation="exec" profile="snap.docker.dockerd" name="/bin/kmod" pid=4375 comm="dockerd" requested_mask="x" denied_mask="x" fsuid=0 ouid=0
```
but I'm not sure if this should be resolved or not, as the current daemon script implies that loading kernel modules directly from a snap always fails, and works around this [like so](https://github.com/docker/docker-snap/blob/master/bin/dockerd-wrapper#L43). 