### PR TITLE
tests: fix interfaces-calendar-service test when gvfsd-metadata loks the xdg dirctory

### DIFF
--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -7,9 +7,10 @@ systems:
     - -ubuntu-14.04-*
 
 environment:
-    XDG_CONFIG_HOME: $(pwd)/config
-    XDG_DATA_HOME: $(pwd)/share
-    XDG_CACHE_HOME: $(pwd)/cache
+    XDG: $(pwd)/xdg
+    XDG_CONFIG_HOME: $XDG/config
+    XDG_DATA_HOME: $XDG/share
+    XDG_CACHE_HOME: $XDG/cache
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh
@@ -21,7 +22,14 @@ prepare: |
 restore: |
     kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
-    rm -rf "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+    for i in $(seq 3); do
+        if rm -rf "$XDG"; then
+            exit 0
+        fi
+        sleep 1
+    done
+    echo "Could not be deleted: $XDG"
+    exit 1
 
 execute: |
     echo "Setting up D-Bus session bus"

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -22,6 +22,10 @@ prepare: |
 restore: |
     kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
+
+    # Retry until the xdg directory can be removed sucessfully
+    # The retry is needed because sporadically it is still locked and
+    # it needs more time until the we can remove it.
     for i in $(seq 3); do
         if rm -rf "$XDG"; then
             exit 0

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -28,7 +28,8 @@ restore: |
         fi
         sleep 1
     done
-    echo "Could not be deleted: $XDG"
+
+    echo "Directory $XDG could not be deleted"
     exit 1
 
 execute: |

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -23,18 +23,13 @@ restore: |
     kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
 
-    # Retry until the xdg directory can be removed successfully
-    # The retry is needed because sporadically the data inside is locked and
-    # it is needed more time until the we can remove it.
-    for i in $(seq 3); do
-        if rm -rf "$XDG"; then
-            exit 0
-        fi
-        sleep 1
-    done
-
-    echo "Directory $XDG could not be deleted"
-    exit 1
+    # In case the process gvfsd-metadata does not finish by itself, it is manually stopped
+    # The reason is that gvfsd-metadata locks the xdg/share/gvfs-metadata directory content
+    # producing an error when the xdg directory is removed.
+    if pid="$(pidof gvfsd-metadata)"; then
+        kill -9 "$pid" || true
+    fi
+    rm -rf "$XDG"
 
 execute: |
     echo "Setting up D-Bus session bus"

--- a/tests/main/interfaces-calendar-service/task.yaml
+++ b/tests/main/interfaces-calendar-service/task.yaml
@@ -23,9 +23,9 @@ restore: |
     kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
 
-    # Retry until the xdg directory can be removed sucessfully
-    # The retry is needed because sporadically it is still locked and
-    # it needs more time until the we can remove it.
+    # Retry until the xdg directory can be removed successfully
+    # The retry is needed because sporadically the data inside is locked and
+    # it is needed more time until the we can remove it.
     for i in $(seq 3); do
         if rm -rf "$XDG"; then
             exit 0

--- a/tests/main/interfaces-contacts-service/task.yaml
+++ b/tests/main/interfaces-contacts-service/task.yaml
@@ -7,9 +7,10 @@ systems:
     - -ubuntu-14.04-*
 
 environment:
-    XDG_CONFIG_HOME: $(pwd)/config
-    XDG_DATA_HOME: $(pwd)/share
-    XDG_CACHE_HOME: $(pwd)/cache
+    XDG: $(pwd)/xdg
+    XDG_CONFIG_HOME: $XDG/config
+    XDG_DATA_HOME: $XDG/share
+    XDG_CACHE_HOME: $XDG/cache
 
 prepare: |
     #shellcheck source=tests/lib/pkgdb.sh
@@ -21,7 +22,14 @@ prepare: |
 restore: |
     kill "$(cat dbus-launch.pid)"
     rm -f dbus-launch.pid
-    rm -rf "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+
+    # In case the process gvfsd-metadata does not finish by itself, it is manually stopped
+    # The reason is that gvfsd-metadata locks the xdg/share/gvfs-metadata directory content
+    # producing an error when the xdg directory is removed.
+    if pid="$(pidof gvfsd-metadata)"; then
+        kill -9 "$pid" || true
+    fi
+    rm -rf "$XDG"
 
 execute: |
     echo "Setting up D-Bus session bus"


### PR DESCRIPTION
It is failing trying to remove the xdg share directory.

Error:
https://paste.ubuntu.com/p/9P6jsm6b7t/
