### PR TITLE
cmd/snap-mgmt: remove system key on purge

### DIFF
--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -146,6 +146,7 @@ purge() {
     rm -rf /var/lib/snapd/cookie/*
     rm -rf /var/lib/snapd/cache/*
     rm -f /var/lib/snapd/state.json
+    rm -f /var/lib/snapd/system-key
 
     echo "Removing snapd catalog cache"
     rm -f /var/cache/snapd/*

--- a/tests/main/snap-mgmt/task.yaml
+++ b/tests/main/snap-mgmt/task.yaml
@@ -66,6 +66,8 @@ execute: |
 
     echo "State file is gone"
     ! test -f /var/lib/snapd/state.json
+    echo "And so is the system key"
+    ! test -f /var/lib/snapd/system-key
 
     echo "Preserved namespaces directory is not mounted"
     ! cat /proc/mounts | MATCH "/run/snapd/ns"


### PR DESCRIPTION
When purging, make sure to remove system-key too.
