### PR TITLE
cmd/snap-update-ns: use RCall with SyscallsEqual

### DIFF
--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -791,7 +791,6 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSource(c *C) {
 
 // Change.Perform wants to create a directory bind mount but the mount point isn't there and cannot be created.
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointWithErrors(c *C) {
-	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoDir) // TODO: this line can be removed
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "target" 0755`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind"}}}
@@ -1252,7 +1251,6 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPoint(c *C) {
 
 // Change.Perform wants to create a directory bind mount but the mount point isn't there and cannot be created.
 func (s *changeSuite) TestPerformFileBindMountWithoutMountPointWithErrors(c *C) {
-	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoFile) // TODO: remove this line
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind", "x-snapd.kind=file"}}}
@@ -1425,7 +1423,6 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPointAndReadOnlyBase(c
 // Change.Perform wants to bind mount a file but there's a symlink in mount point.
 func (s *changeSuite) TestPerformFileBindMountWithSymlinkInMountPoint(c *C) {
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoSymlink)
-	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoFile) // TODO: remove this line
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind", "x-snapd.kind=file"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/target" as mount point: not a regular file`)

--- a/cmd/snap-update-ns/change_test.go
+++ b/cmd/snap-update-ns/change_test.go
@@ -21,6 +21,7 @@ package main_test
 
 import (
 	"errors"
+	"os"
 	"syscall"
 
 	. "gopkg.in/check.v1"
@@ -318,7 +319,9 @@ func (s *changeSuite) TestPerformFilesystemMountLstatError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot inspect "/target": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`lstat "/target"`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: errTesting},
+	})
 }
 
 // Change.Perform wants to mount a filesystem.
@@ -328,9 +331,9 @@ func (s *changeSuite) TestPerformFilesystemMount(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`mount "device" "/target" "type" 0 ""`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `mount "device" "/target" "type" 0 ""`},
 	})
 }
 
@@ -342,9 +345,9 @@ func (s *changeSuite) TestPerformFilesystemMountWithError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, Equals, errTesting)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`mount "device" "/target" "type" 0 ""`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `mount "device" "/target" "type" 0 ""`, E: errTesting},
 	})
 }
 
@@ -355,15 +358,15 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPoint(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "target" 0755`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`close 4`,
-		`close 3`,
-		`mount "device" "/target" "type" 0 ""`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "target" 0755`},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `mount "device" "/target" "type" 0 ""`},
 	})
 }
 
@@ -375,11 +378,11 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointWithErrors(c *C
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create directory "/target": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "target" 0755`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "target" 0755`, E: errTesting},
+		{C: `close 3`},
 	})
 }
 
@@ -405,71 +408,71 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 			Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/rofs/target", "mode=0755", "uid=0", "gid=0"}},
 		},
 	})
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		// sniff mount target
-		`lstat "/rofs/target"`,
+		{C: `lstat "/rofs/target"`, E: syscall.ENOENT},
 
 		// /rofs/target is missing, create it
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`mkdirat 4 "target" 0755`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `mkdirat 4 "target" 0755`, E: syscall.EROFS},
+		{C: `close 4`},
 
 		// error, read only filesystem, create a mimic
-		`lstat "/rofs" <ptr>`,
-		`readdir "/rofs"`,
-		`lstat "/tmp/.snap/rofs"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "tmp" 0755`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`mkdirat 4 ".snap" 0755`,
-		`openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 5 0 0`,
-		`close 4`,
-		`close 3`,
-		`mkdirat 5 "rofs" 0755`,
-		`openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 3 0 0`,
-		`close 3`,
-		`close 5`,
-		`lstat "/rofs"`,
+		{C: `lstat "/rofs" <ptr>`, R: syscall.Stat_t{Uid: 0, Gid: 0, Mode: 0755}},
+		{C: `readdir "/rofs"`, R: []os.FileInfo(nil)},
+		{C: `lstat "/tmp/.snap/rofs"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "tmp" 0755`},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `mkdirat 4 ".snap" 0755`},
+		{C: `openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 5},
+		{C: `fchown 5 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `mkdirat 5 "rofs" 0755`},
+		{C: `openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
+		{C: `close 5`},
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 7 <ptr>`,
-		`close 6`,
-		`close 5`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`,
-		`close 7`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 5},
+		{C: `openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 6},
+		{C: `openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 7},
+		{C: `fstat 7 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 6`},
+		{C: `close 5`},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
+		{C: `close 7`},
+		{C: `close 4`},
 
-		`lstat "/rofs"`,
-		`mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`,
-		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`,
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
+		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// mimic ready, re-try initial mkdir
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`mkdirat 4 "target" 0755`,
-		`openat 4 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 3 0 0`,
-		`close 3`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `mkdirat 4 "target" 0755`},
+		{C: `openat 4 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
+		{C: `close 4`},
 
 		// mount the filesystem
-		`mount "device" "/rofs/target" "type" 0 ""`,
+		{C: `mount "device" "/rofs/target" "type" 0 ""`},
 	})
 }
 
@@ -489,21 +492,21 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create writable mimic over "/rofs": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		// sniff mount target
-		`lstat "/rofs/target"`,
+		{C: `lstat "/rofs/target"`, E: syscall.ENOENT},
 
 		// /rofs/target is missing, create it
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`mkdirat 4 "target" 0755`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `mkdirat 4 "target" 0755`, E: syscall.EROFS},
+		{C: `close 4`},
 
 		// error, read only filesystem, create a mimic
-		`lstat "/rofs" <ptr>`,
-		`readdir "/rofs"`,
+		{C: `lstat "/rofs" <ptr>`, R: syscall.Stat_t{Uid: 0, Gid: 0, Mode: 0755}},
+		{C: `readdir "/rofs"`, E: errTesting},
 		// cannot create mimic, that's it
 	})
 }
@@ -524,29 +527,29 @@ func (s *changeSuite) TestPerformFilesystemMountWithoutMountPointAndReadOnlyBase
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create writable mimic over "/rofs": cannot create directory "/tmp/.snap": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		// sniff mount target
-		`lstat "/rofs/target"`,
+		{C: `lstat "/rofs/target"`, E: syscall.ENOENT},
 
 		// /rofs/target is missing, create it
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`mkdirat 4 "target" 0755`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `mkdirat 4 "target" 0755`, E: syscall.EROFS},
+		{C: `close 4`},
 
 		// error, read only filesystem, create a mimic
-		`lstat "/rofs" <ptr>`,
-		`readdir "/rofs"`,
-		`lstat "/tmp/.snap/rofs"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "tmp" 0755`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`mkdirat 4 ".snap" 0755`,
-		`close 4`,
-		`close 3`,
+		{C: `lstat "/rofs" <ptr>`, R: syscall.Stat_t{Uid: 0, Gid: 0, Mode: 0755}},
+		{C: `readdir "/rofs"`, R: []os.FileInfo(nil)},
+		{C: `lstat "/tmp/.snap/rofs"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "tmp" 0755`},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `mkdirat 4 ".snap" 0755`, E: errTesting},
+		{C: `close 4`},
+		{C: `close 3`},
 		// cannot create mimic, that's it
 	})
 }
@@ -558,8 +561,8 @@ func (s *changeSuite) TestPerformFilesystemMountWithSymlinkInMountPoint(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/target" as mount point: not a directory`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoSymlink},
 	})
 }
 
@@ -570,8 +573,8 @@ func (s *changeSuite) TestPerformFilesystemMountWithFileInMountPoint(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/target" as mount point: not a directory`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoFile},
 	})
 }
 
@@ -580,7 +583,9 @@ func (s *changeSuite) TestPerformFilesystemUnmount(c *C) {
 	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "device", Dir: "/target", Type: "type"}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "/target" UMOUNT_NOFOLLOW`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `unmount "/target" UMOUNT_NOFOLLOW`},
+	})
 	c.Assert(synth, HasLen, 0)
 }
 
@@ -589,7 +594,9 @@ func (s *changeSuite) TestPerformFilesystemDetch(c *C) {
 	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "/something", Dir: "/target", Options: []string{"x-snapd.detach"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "/target" UMOUNT_NOFOLLOW|MNT_DETACH`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `unmount "/target" UMOUNT_NOFOLLOW|MNT_DETACH`},
+	})
 	c.Assert(synth, HasLen, 0)
 }
 
@@ -599,7 +606,9 @@ func (s *changeSuite) TestPerformFilesystemUnmountError(c *C) {
 	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "device", Dir: "/target", Type: "type"}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, Equals, errTesting)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "/target" UMOUNT_NOFOLLOW`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `unmount "/target" UMOUNT_NOFOLLOW`, E: errTesting},
+	})
 	c.Assert(synth, HasLen, 0)
 }
 
@@ -610,9 +619,9 @@ func (s *changeSuite) TestPerformFilesystemMountWithOptions(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`mount "device" "/target" "type" MS_RDONLY "funky"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `mount "device" "/target" "type" MS_RDONLY "funky"`},
 	})
 }
 
@@ -623,9 +632,9 @@ func (s *changeSuite) TestPerformFilesystemMountWithSnapdSpecificOptions(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`mount "device" "/target" "type" MS_RDONLY ""`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `mount "device" "/target" "type" MS_RDONLY ""`},
 	})
 }
 
@@ -640,7 +649,9 @@ func (s *changeSuite) TestPerformDirectoryBindMountTargetLstatError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot inspect "/target": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`lstat "/target"`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: errTesting},
+	})
 }
 
 // Change.Perform wants to bind mount a directory but the source cannot be stat'ed.
@@ -651,9 +662,9 @@ func (s *changeSuite) TestPerformDirectoryBindMountSourceLstatError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot inspect "/source": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/source"`, E: errTesting},
 	})
 }
 
@@ -667,20 +678,20 @@ func (s *changeSuite) TestPerformDirectoryBindMount(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 5 <ptr>`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
-		`close 5`,
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/source"`, R: testutil.FileInfoDir},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`},
+		{C: `close 5`},
+		{C: `close 4`},
 	})
 }
 
@@ -695,20 +706,20 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, Equals, errTesting)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 5 <ptr>`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
-		`close 5`,
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/source"`, R: testutil.FileInfoDir},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`, E: errTesting},
+		{C: `close 5`},
+		{C: `close 4`},
 	})
 }
 
@@ -722,26 +733,26 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPoint(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "target" 0755`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`close 4`,
-		`close 3`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 5 <ptr>`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
-		`close 5`,
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "target" 0755`},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `lstat "/source"`, R: testutil.FileInfoDir},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`},
+		{C: `close 5`},
+		{C: `close 4`},
 	})
 }
 
@@ -755,43 +766,43 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSource(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "source" 0755`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`close 4`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 5 <ptr>`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
-		`close 5`,
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/source"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "source" 0755`},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`},
+		{C: `close 5`},
+		{C: `close 4`},
 	})
 }
 
 // Change.Perform wants to create a directory bind mount but the mount point isn't there and cannot be created.
 func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointWithErrors(c *C) {
-	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoDir)
+	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoDir) // TODO: this line can be removed
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`mkdirat 3 "target" 0755`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create directory "/target": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "target" 0755`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "target" 0755`, E: errTesting},
+		{C: `close 3`},
 	})
 }
 
@@ -804,12 +815,12 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceWithErrors(
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create directory "/source": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "source" 0755`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/source"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "source" 0755`, E: errTesting},
+		{C: `close 3`},
 	})
 }
 
@@ -837,86 +848,86 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountPointAndReadOnlyB
 			Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/rofs/target", "mode=0755", "uid=0", "gid=0"}},
 		},
 	})
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		// sniff mount target
-		`lstat "/rofs/target"`,
+		{C: `lstat "/rofs/target"`, E: syscall.ENOENT},
 
 		// /rofs/target is missing, create it
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`mkdirat 4 "target" 0755`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `mkdirat 4 "target" 0755`, E: syscall.EROFS},
+		{C: `close 4`},
 
 		// error, read only filesystem, create a mimic
-		`lstat "/rofs" <ptr>`,
-		`readdir "/rofs"`,
-		`lstat "/tmp/.snap/rofs"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "tmp" 0755`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`mkdirat 4 ".snap" 0755`,
-		`openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 5 0 0`,
-		`close 4`,
-		`close 3`,
-		`mkdirat 5 "rofs" 0755`,
-		`openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 3 0 0`,
-		`close 3`,
-		`close 5`,
-		`lstat "/rofs"`,
+		{C: `lstat "/rofs" <ptr>`, R: syscall.Stat_t{Uid: 0, Gid: 0, Mode: 0755}},
+		{C: `readdir "/rofs"`, R: []os.FileInfo(nil)},
+		{C: `lstat "/tmp/.snap/rofs"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "tmp" 0755`},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `mkdirat 4 ".snap" 0755`},
+		{C: `openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 5},
+		{C: `fchown 5 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `mkdirat 5 "rofs" 0755`},
+		{C: `openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
+		{C: `close 5`},
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 7 <ptr>`,
-		`close 6`,
-		`close 5`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`,
-		`close 7`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 5},
+		{C: `openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 6},
+		{C: `openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 7},
+		{C: `fstat 7 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 6`},
+		{C: `close 5`},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
+		{C: `close 7`},
+		{C: `close 4`},
 
-		`lstat "/rofs"`,
-		`mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`,
-		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`,
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
+		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// mimic ready, re-try initial mkdir
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`mkdirat 4 "target" 0755`,
-		`openat 4 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 3 0 0`,
-		`close 3`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `mkdirat 4 "target" 0755`},
+		{C: `openat 4 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
+		{C: `close 4`},
 
 		// sniff mount source
-		`lstat "/source"`,
+		{C: `lstat "/source"`, R: testutil.FileInfoDir},
 
 		// mount the filesystem
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 5 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 6 <ptr>`,
-		`close 5`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/6" "" MS_BIND ""`,
-		`close 6`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 5},
+		{C: `openat 5 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 6},
+		{C: `fstat 6 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 5`},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/6" "" MS_BIND ""`},
+		{C: `close 6`},
+		{C: `close 4`},
 	})
 }
 
@@ -932,15 +943,15 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceAndReadOnly
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot operate on read-only filesystem at /rofs`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,                                    // -> directory
-		`lstat "/rofs/source"`,                               // -> ENOENT
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,        // -> 3
-		`mkdirat 3 "rofs" 0755`,                              // EEXIST
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, // -> 4
-		`close 3`,
-		`mkdirat 4 "source" 0755`, // -> EROFS
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/rofs/source"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `mkdirat 4 "source" 0755`, E: syscall.EROFS},
+		{C: `close 4`},
 	})
 }
 
@@ -968,82 +979,82 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithoutMountSourceAndReadOnly
 			Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/rofs/source", "mode=0755", "uid=0", "gid=0"}},
 		},
 	})
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		// sniff mount target and source
-		`lstat "/target"`,
-		`lstat "/rofs/source"`,
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/rofs/source"`, E: syscall.ENOENT},
 
 		// /rofs/source is missing, create it
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`mkdirat 4 "source" 0755`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `mkdirat 4 "source" 0755`, E: syscall.EROFS},
+		{C: `close 4`},
 
 		// error /rofs is a read-only filesystem, create a mimic
-		`lstat "/rofs" <ptr>`,
-		`readdir "/rofs"`,
-		`lstat "/tmp/.snap/rofs"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "tmp" 0755`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`mkdirat 4 ".snap" 0755`,
-		`openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 5 0 0`,
-		`close 4`,
-		`close 3`,
-		`mkdirat 5 "rofs" 0755`,
-		`openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 3 0 0`,
-		`close 3`,
-		`close 5`,
-		`lstat "/rofs"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 7 <ptr>`,
-		`close 6`,
-		`close 5`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`,
-		`close 7`,
-		`close 4`,
-		`lstat "/rofs"`,
-		`mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`,
-		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`,
+		{C: `lstat "/rofs" <ptr>`, R: syscall.Stat_t{Mode: 0755}},
+		{C: `readdir "/rofs"`, R: []os.FileInfo(nil)},
+		{C: `lstat "/tmp/.snap/rofs"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "tmp" 0755`},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `mkdirat 4 ".snap" 0755`},
+		{C: `openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 5},
+		{C: `fchown 5 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `mkdirat 5 "rofs" 0755`},
+		{C: `openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
+		{C: `close 5`},
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 5},
+		{C: `openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 6},
+		{C: `openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 7},
+		{C: `fstat 7 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 6`},
+		{C: `close 5`},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
+		{C: `close 7`},
+		{C: `close 4`},
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
+		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// /rofs/source was missing (we checked earlier), create it
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`mkdirat 4 "source" 0755`,
-		`openat 4 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 3 0 0`,
-		`close 3`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `mkdirat 4 "source" 0755`},
+		{C: `openat 4 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
+		{C: `close 4`},
 
 		// bind mount /rofs/source -> /target
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 4 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 5 <ptr>`,
-		`close 4`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`mount "/proc/self/fd/5" "/proc/self/fd/4" "" MS_BIND ""`,
-		`close 4`,
-		`close 5`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/5" "/proc/self/fd/4" "" MS_BIND ""`},
+		{C: `close 4`},
+		{C: `close 5`},
 	})
 }
 
@@ -1054,8 +1065,8 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithSymlinkInMountPoint(c *C)
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/target" as mount point: not a directory`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoSymlink},
 	})
 }
 
@@ -1066,8 +1077,8 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithFileInMountPoint(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/target" as mount point: not a directory`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoFile},
 	})
 }
 
@@ -1079,9 +1090,9 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithSymlinkInMountSource(c *C
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/source" as bind-mount source: not a directory`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/source"`, R: testutil.FileInfoSymlink},
 	})
 }
 
@@ -1093,9 +1104,9 @@ func (s *changeSuite) TestPerformDirectoryBindMountWithFileInMountSource(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/source" as bind-mount source: not a directory`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/source"`, R: testutil.FileInfoFile},
 	})
 }
 
@@ -1104,7 +1115,9 @@ func (s *changeSuite) TestPerformDirectoryBindUnmount(c *C) {
 	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "/target" UMOUNT_NOFOLLOW`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `unmount "/target" UMOUNT_NOFOLLOW`},
+	})
 	c.Assert(synth, HasLen, 0)
 }
 
@@ -1114,7 +1127,9 @@ func (s *changeSuite) TestPerformDirectoryBindUnmountError(c *C) {
 	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, Equals, errTesting)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "/target" UMOUNT_NOFOLLOW`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `unmount "/target" UMOUNT_NOFOLLOW`, E: errTesting},
+	})
 	c.Assert(synth, HasLen, 0)
 }
 
@@ -1129,7 +1144,9 @@ func (s *changeSuite) TestPerformFileBindMountTargetLstatError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot inspect "/target": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`lstat "/target"`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: errTesting},
+	})
 }
 
 // Change.Perform wants to bind mount a file but the source cannot be stat'ed.
@@ -1140,9 +1157,9 @@ func (s *changeSuite) TestPerformFileBindMountSourceLstatError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot inspect "/source": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoFile},
+		{C: `lstat "/source"`, E: errTesting},
 	})
 }
 
@@ -1156,20 +1173,20 @@ func (s *changeSuite) TestPerformFileBindMount(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 5 <ptr>`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
-		`close 5`,
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoFile},
+		{C: `lstat "/source"`, R: testutil.FileInfoFile},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`},
+		{C: `close 5`},
+		{C: `close 4`},
 	})
 }
 
@@ -1184,20 +1201,20 @@ func (s *changeSuite) TestPerformFileBindMountWithError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, Equals, errTesting)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 5 <ptr>`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
-		`close 5`,
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoFile},
+		{C: `lstat "/source"`, R: testutil.FileInfoFile},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`, E: errTesting},
+		{C: `close 5`},
+		{C: `close 4`},
 	})
 }
 
@@ -1211,42 +1228,42 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPoint(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`,
-		`fchown 4 0 0`,
-		`close 4`,
-		`close 3`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 5 <ptr>`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
-		`close 5`,
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `lstat "/source"`, R: testutil.FileInfoFile},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`},
+		{C: `close 5`},
+		{C: `close 4`},
 	})
 }
 
 // Change.Perform wants to create a directory bind mount but the mount point isn't there and cannot be created.
 func (s *changeSuite) TestPerformFileBindMountWithoutMountPointWithErrors(c *C) {
-	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoFile)
+	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoFile) // TODO: remove this line
 	s.sys.InsertFault(`lstat "/target"`, syscall.ENOENT)
 	s.sys.InsertFault(`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, errTesting)
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind", "x-snapd.kind=file"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot open file "/target": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, E: errTesting},
+		{C: `close 3`},
 	})
 }
 
@@ -1260,25 +1277,25 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountSource(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`,
-		`fchown 4 0 0`,
-		`close 4`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 5 <ptr>`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`,
-		`close 5`,
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoFile},
+		{C: `lstat "/source"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/5" "" MS_BIND ""`},
+		{C: `close 5`},
+		{C: `close 4`},
 	})
 }
 
@@ -1291,12 +1308,12 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountSourceWithErrors(c *C)
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot open file "/source": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoFile},
+		{C: `lstat "/source"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, E: errTesting},
+		{C: `close 3`},
 	})
 }
 
@@ -1323,98 +1340,98 @@ func (s *changeSuite) TestPerformFileBindMountWithoutMountPointAndReadOnlyBase(c
 			Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/rofs/target", "mode=0755", "uid=0", "gid=0"}},
 		},
 	})
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		// sniff mount target
-		`lstat "/rofs/target"`,
+		{C: `lstat "/rofs/target"`, E: syscall.ENOENT},
 
 		// /rofs/target is missing, create it
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`openat 4 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `openat 4 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, E: syscall.EROFS},
+		{C: `close 4`},
 
 		// error, read only filesystem, create a mimic
-		`lstat "/rofs" <ptr>`,
-		`readdir "/rofs"`,
-		`lstat "/tmp/.snap/rofs"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "tmp" 0755`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`mkdirat 4 ".snap" 0755`,
-		`openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 5 0 0`,
-		`close 4`,
-		`close 3`,
-		`mkdirat 5 "rofs" 0755`,
-		`openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 3 0 0`,
-		`close 3`,
-		`close 5`,
-		`lstat "/rofs"`,
+		{C: `lstat "/rofs" <ptr>`, R: syscall.Stat_t{Mode: 0755}},
+		{C: `readdir "/rofs"`, R: []os.FileInfo(nil)},
+		{C: `lstat "/tmp/.snap/rofs"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "tmp" 0755`},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `mkdirat 4 ".snap" 0755`},
+		{C: `openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 5},
+		{C: `fchown 5 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `mkdirat 5 "rofs" 0755`},
+		{C: `openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
+		{C: `close 5`},
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 7 <ptr>`,
-		`close 6`,
-		`close 5`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`,
-		`close 7`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 5},
+		{C: `openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 6},
+		{C: `openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 7},
+		{C: `fstat 7 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 6`},
+		{C: `close 5`},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
+		{C: `close 7`},
+		{C: `close 4`},
 
-		`lstat "/rofs"`,
-		`mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`,
-		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`,
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
+		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// mimic ready, re-try initial mkdir
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
-		`openat 4 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`,
-		`fchown 3 0 0`,
-		`close 3`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
+		{C: `openat 4 "target" O_NOFOLLOW|O_CLOEXEC|O_CREAT|O_EXCL 0755`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
+		{C: `close 4`},
 
 		// sniff mount source
-		`lstat "/source"`,
+		{C: `lstat "/source"`, R: testutil.FileInfoFile},
 
 		// mount the filesystem
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 5 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 6 <ptr>`,
-		`close 5`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/6" "" MS_BIND ""`,
-		`close 6`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 5},
+		{C: `openat 5 "target" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 6},
+		{C: `fstat 6 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 5`},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/6" "" MS_BIND ""`},
+		{C: `close 6`},
+		{C: `close 4`},
 	})
 }
 
 // Change.Perform wants to bind mount a file but there's a symlink in mount point.
 func (s *changeSuite) TestPerformFileBindMountWithSymlinkInMountPoint(c *C) {
 	s.sys.InsertOsLstatResult(`lstat "/target"`, testutil.FileInfoSymlink)
-	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoFile)
+	s.sys.InsertOsLstatResult(`lstat "/source"`, testutil.FileInfoFile) // TODO: remove this line
 	chg := &update.Change{Action: update.Mount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind", "x-snapd.kind=file"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/target" as mount point: not a regular file`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoSymlink},
 	})
 }
 
@@ -1425,8 +1442,8 @@ func (s *changeSuite) TestPerformBindMountFileWithDirectoryInMountPoint(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/target" as mount point: not a regular file`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
 	})
 }
 
@@ -1438,9 +1455,9 @@ func (s *changeSuite) TestPerformFileBindMountWithSymlinkInMountSource(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/source" as bind-mount source: not a regular file`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoFile},
+		{C: `lstat "/source"`, R: testutil.FileInfoSymlink},
 	})
 }
 
@@ -1452,9 +1469,9 @@ func (s *changeSuite) TestPerformFileBindMountWithDirectoryInMountSource(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot use "/source" as bind-mount source: not a regular file`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoFile},
+		{C: `lstat "/source"`, R: testutil.FileInfoDir},
 	})
 }
 
@@ -1463,7 +1480,9 @@ func (s *changeSuite) TestPerformFileBindUnmount(c *C) {
 	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind", "x-snapd.kind=file"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "/target" UMOUNT_NOFOLLOW`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `unmount "/target" UMOUNT_NOFOLLOW`},
+	})
 	c.Assert(synth, HasLen, 0)
 }
 
@@ -1473,7 +1492,9 @@ func (s *changeSuite) TestPerformFileBindUnmountError(c *C) {
 	chg := &update.Change{Action: update.Unmount, Entry: osutil.MountEntry{Name: "/source", Dir: "/target", Options: []string{"bind", "x-snapd.kind=file"}}}
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, Equals, errTesting)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`unmount "/target" UMOUNT_NOFOLLOW`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `unmount "/target" UMOUNT_NOFOLLOW`, E: errTesting},
+	})
 	c.Assert(synth, HasLen, 0)
 }
 
@@ -1488,9 +1509,9 @@ func (s *changeSuite) TestPerformMountWithIgnoredMissingMountSource(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, Equals, update.ErrIgnoredMissingMount)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
-		`lstat "/source"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, R: testutil.FileInfoDir},
+		{C: `lstat "/source"`, E: syscall.ENOENT},
 	})
 }
 
@@ -1500,8 +1521,8 @@ func (s *changeSuite) TestPerformMountWithIgnoredMissingMountPoint(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, Equals, update.ErrIgnoredMissingMount)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/target"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/target"`, E: syscall.ENOENT},
 	})
 }
 
@@ -1516,7 +1537,9 @@ func (s *changeSuite) TestPerformCreateSymlinkNameLstatError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot inspect "/name": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`lstat "/name"`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/name"`, E: errTesting},
+	})
 }
 
 // Change.Perform wants to create a symlink.
@@ -1526,11 +1549,11 @@ func (s *changeSuite) TestPerformCreateSymlink(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/name"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`symlinkat "/oldname" 3 "name"`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/name"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `symlinkat "/oldname" 3 "name"`},
+		{C: `close 3`},
 	})
 }
 
@@ -1542,11 +1565,11 @@ func (s *changeSuite) TestPerformCreateSymlinkWithError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create symlink "/name": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/name"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`symlinkat "/oldname" 3 "name"`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/name"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `symlinkat "/oldname" 3 "name"`, E: errTesting},
+		{C: `close 3`},
 	})
 }
 
@@ -1557,8 +1580,8 @@ func (s *changeSuite) TestPerformCreateSymlinkWithNoTargetError(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create symlink with empty target: "/name"`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/name"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/name"`, E: syscall.ENOENT},
 	})
 }
 
@@ -1569,15 +1592,15 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDir(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/base/name"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "base" 0755`,
-		`openat 3 "base" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`close 3`,
-		`symlinkat "/oldname" 4 "name"`,
-		`close 4`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/base/name"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "base" 0755`},
+		{C: `openat 3 "base" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `close 3`},
+		{C: `symlinkat "/oldname" 4 "name"`},
+		{C: `close 4`},
 	})
 }
 
@@ -1589,11 +1612,11 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirWithErrors(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create directory "/base": testing`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/base/name"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "base" 0755`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/base/name"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "base" 0755`, E: errTesting},
+		{C: `close 3`},
 	})
 }
 
@@ -1618,67 +1641,67 @@ func (s *changeSuite) TestPerformCreateSymlinkWithoutBaseDirAndReadOnlyBase(c *C
 			Options: []string{"x-snapd.synthetic", "x-snapd.needed-by=/rofs/name", "mode=0755", "uid=0", "gid=0"}},
 		},
 	})
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
 		// sniff symlink name
-		`lstat "/rofs/name"`,
+		{C: `lstat "/rofs/name"`, E: syscall.ENOENT},
 
 		// create base name (/rofs)
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, // -> 3
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, // -> 4
-		`close 3`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
 		// create symlink
-		`symlinkat "/oldname" 4 "name"`, // (inserted fault happens here)
-		`close 4`,
+		{C: `symlinkat "/oldname" 4 "name"`, E: syscall.EROFS},
+		{C: `close 4`},
 
 		// error, read only filesystem, create a mimic
-		`lstat "/rofs" <ptr>`,
-		`readdir "/rofs"`,
-		`lstat "/tmp/.snap/rofs"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "tmp" 0755`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 4 0 0`,
-		`mkdirat 4 ".snap" 0755`,
-		`openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 5 0 0`,
-		`close 4`,
-		`close 3`,
-		`mkdirat 5 "rofs" 0755`,
-		`openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`fchown 3 0 0`,
-		`close 3`,
-		`close 5`,
-		`lstat "/rofs"`,
+		{C: `lstat "/rofs" <ptr>`, R: syscall.Stat_t{Mode: 0755}},
+		{C: `readdir "/rofs"`, R: []os.FileInfo(nil)},
+		{C: `lstat "/tmp/.snap/rofs"`, E: syscall.ENOENT},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "tmp" 0755`},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `fchown 4 0 0`},
+		{C: `mkdirat 4 ".snap" 0755`},
+		{C: `openat 4 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 5},
+		{C: `fchown 5 0 0`},
+		{C: `close 4`},
+		{C: `close 3`},
+		{C: `mkdirat 5 "rofs" 0755`},
+		{C: `openat 5 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `fchown 3 0 0`},
+		{C: `close 3`},
+		{C: `close 5`},
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
 
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 4 <ptr>`,
-		`close 3`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,
-		`openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,
-		`fstat 7 <ptr>`,
-		`close 6`,
-		`close 5`,
-		`close 3`,
-		`mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`,
-		`close 7`,
-		`close 4`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 3`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "tmp" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 5},
+		{C: `openat 5 ".snap" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 6},
+		{C: `openat 6 "rofs" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 7},
+		{C: `fstat 7 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 6`},
+		{C: `close 5`},
+		{C: `close 3`},
+		{C: `mount "/proc/self/fd/4" "/proc/self/fd/7" "" MS_BIND|MS_REC ""`},
+		{C: `close 7`},
+		{C: `close 4`},
 
-		`lstat "/rofs"`,
-		`mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`,
-		`unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`,
+		{C: `lstat "/rofs"`, R: testutil.FileInfoDir},
+		{C: `mount "tmpfs" "/rofs" "tmpfs" 0 "mode=0755,uid=0,gid=0"`},
+		{C: `unmount "/tmp/.snap/rofs" UMOUNT_NOFOLLOW|MNT_DETACH`},
 
 		// mimic ready, re-try initial base mkdir
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`mkdirat 3 "rofs" 0755`,
-		`openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,
-		`close 3`,
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `mkdirat 3 "rofs" 0755`, E: syscall.EEXIST},
+		{C: `openat 3 "rofs" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 4},
+		{C: `close 3`},
 		// create symlink
-		`symlinkat "/oldname" 4 "name"`, // (inserted fault happens here)
-		`close 4`,
+		{C: `symlinkat "/oldname" 4 "name"`},
+		{C: `close 4`},
 	})
 }
 
@@ -1689,8 +1712,8 @@ func (s *changeSuite) TestPerformCreateSymlinkWithFileInTheWay(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create symlink in "/name": existing file in the way`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/name"`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/name"`, R: testutil.FileInfoFile},
 	})
 }
 
@@ -1704,15 +1727,15 @@ func (s *changeSuite) TestPerformCreateSymlinkWithGoodSymlinkPresent(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/name"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,   // -> 3
-		`symlinkat "/oldname" 3 "name"`,                 // -> EEXIST
-		`openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, // -> 4
-		`fstat 4 <ptr>`,
-		`readlinkat 4 "" <ptr>`,
-		`close 4`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/name"`, R: testutil.FileInfoSymlink},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `symlinkat "/oldname" 3 "name"`, E: syscall.EEXIST},
+		{C: `openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{Mode: syscall.S_IFLNK}},
+		{C: `readlinkat 4 "" <ptr>`, R: "/oldname"},
+		{C: `close 4`},
+		{C: `close 3`},
 	})
 }
 
@@ -1726,15 +1749,15 @@ func (s *changeSuite) TestPerformCreateSymlinkWithBadSymlinkPresent(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot create symbolic link "/name": existing symbolic link in the way`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`lstat "/name"`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`,   // -> 3
-		`symlinkat "/oldname" 3 "name"`,                 // -> EEXIST
-		`openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, // -> 4
-		`fstat 4 <ptr>`,
-		`readlinkat 4 "" <ptr>`,
-		`close 4`,
-		`close 3`,
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `lstat "/name"`, R: testutil.FileInfoSymlink},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY 0`, R: 3},
+		{C: `symlinkat "/oldname" 3 "name"`, E: syscall.EEXIST},
+		{C: `openat 3 "name" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 4},
+		{C: `fstat 4 <ptr>`, R: syscall.Stat_t{Mode: syscall.S_IFLNK}},
+		{C: `readlinkat 4 "" <ptr>`, R: "/evil"},
+		{C: `close 4`},
+		{C: `close 3`},
 	})
 }
 
@@ -1743,7 +1766,9 @@ func (s *changeSuite) TestPerformRemoveSymlink(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{`remove "/name"`})
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `remove "/name"`},
+	})
 }
 
 // ###########
@@ -1756,7 +1781,7 @@ func (s *changeSuite) TestPerformUnknownAction(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, ErrorMatches, `cannot process mount change: unknown action: .*`)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), HasLen, 0)
+	c.Assert(s.sys.RCalls(), HasLen, 0)
 }
 
 // Change.Perform wants to keep a mount entry unchanged.
@@ -1765,5 +1790,5 @@ func (s *changeSuite) TestPerformKeep(c *C) {
 	synth, err := chg.Perform(s.sec)
 	c.Assert(err, IsNil)
 	c.Assert(synth, HasLen, 0)
-	c.Assert(s.sys.Calls(), HasLen, 0)
+	c.Assert(s.sys.RCalls(), HasLen, 0)
 }

--- a/cmd/snap-update-ns/secure_bindmount_test.go
+++ b/cmd/snap-update-ns/secure_bindmount_test.go
@@ -53,22 +53,22 @@ func (s *secureBindMountSuite) TestMount(c *C) {
 	s.sys.InsertFstatResult(`fstat 6 <ptr>`, syscall.Stat_t{})
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND)
 	c.Assert(err, IsNil)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
-		`fstat 5 <ptr>`,
-		`close 4`, // "/source"
-		`close 3`, // "/"
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
-		`fstat 6 <ptr>`,
-		`close 4`, // "/target"
-		`close 3`, // "/"
-		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`,
-		`close 6`, // "/target/dir"
-		`close 5`, // "/source/dir"
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/source"
+		{C: `close 3`}, // "/"
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 6},
+		{C: `fstat 6 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/target"
+		{C: `close 3`}, // "/"
+		{C: `mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`},
+		{C: `close 6`}, // "/target/dir"
+		{C: `close 5`}, // "/source/dir"
 	})
 }
 
@@ -77,22 +77,22 @@ func (s *secureBindMountSuite) TestMountRecursive(c *C) {
 	s.sys.InsertFstatResult(`fstat 6 <ptr>`, syscall.Stat_t{})
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND|syscall.MS_REC)
 	c.Assert(err, IsNil)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
-		`fstat 5 <ptr>`,
-		`close 4`, // "/source"
-		`close 3`, // "/"
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
-		`fstat 6 <ptr>`,
-		`close 4`, // "/target"
-		`close 3`, // "/"
-		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND|MS_REC ""`,
-		`close 6`, // "/target/dir"
-		`close 5`, // "/source/dir"
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/source"
+		{C: `close 3`}, // "/"
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 6},
+		{C: `fstat 6 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/target"
+		{C: `close 3`}, // "/"
+		{C: `mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND|MS_REC ""`},
+		{C: `close 6`}, // "/target/dir"
+		{C: `close 5`}, // "/source/dir"
 	})
 }
 
@@ -102,43 +102,43 @@ func (s *secureBindMountSuite) TestMountReadOnly(c *C) {
 	s.sys.InsertFstatResult(`fstat 7 <ptr>`, syscall.Stat_t{})
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND|syscall.MS_RDONLY)
 	c.Assert(err, IsNil)
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
-		`fstat 5 <ptr>`,
-		`close 4`, // "/source"
-		`close 3`, // "/"
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
-		`fstat 6 <ptr>`,
-		`close 4`, // "/target"
-		`close 3`, // "/"
-		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 7
-		`fstat 7 <ptr>`,
-		`close 4`, // "/target"
-		`close 3`, // "/"
-		`mount "none" "/proc/self/fd/7" "" MS_REMOUNT|MS_BIND|MS_RDONLY ""`,
-		`close 7`, // "/target/dir"
-		`close 6`, // "/target/dir"
-		`close 5`, // "/source/dir"
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/source"
+		{C: `close 3`}, // "/"
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 6},
+		{C: `fstat 6 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/target"
+		{C: `close 3`}, // "/"
+		{C: `mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 7},
+		{C: `fstat 7 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/target"
+		{C: `close 3`}, // "/"
+		{C: `mount "none" "/proc/self/fd/7" "" MS_REMOUNT|MS_BIND|MS_RDONLY ""`},
+		{C: `close 7`}, // "/target/dir"
+		{C: `close 6`}, // "/target/dir"
+		{C: `close 5`}, // "/source/dir"
 	})
 }
 
 func (s *secureBindMountSuite) TestBindFlagRequired(c *C) {
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_REC)
 	c.Assert(err, ErrorMatches, "cannot perform non-bind mount operation")
-	c.Check(s.sys.Calls(), DeepEquals, []string(nil))
+	c.Check(s.sys.RCalls(), HasLen, 0)
 }
 
 func (s *secureBindMountSuite) TestMountReadOnlyRecursive(c *C) {
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND|syscall.MS_RDONLY|syscall.MS_REC)
 	c.Assert(err, ErrorMatches, "cannot use MS_RDONLY and MS_REC together")
-	c.Check(s.sys.Calls(), DeepEquals, []string(nil))
+	c.Check(s.sys.RCalls(), HasLen, 0)
 }
 
 func (s *secureBindMountSuite) TestBindMountFails(c *C) {
@@ -147,22 +147,22 @@ func (s *secureBindMountSuite) TestBindMountFails(c *C) {
 	s.sys.InsertFault(`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`, errTesting)
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND|syscall.MS_RDONLY)
 	c.Assert(err, ErrorMatches, "testing")
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
-		`fstat 5 <ptr>`,
-		`close 4`, // "/source"
-		`close 3`, // "/"
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
-		`fstat 6 <ptr>`,
-		`close 4`, // "/target"
-		`close 3`, // "/"
-		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`,
-		`close 6`, // "/target/dir"
-		`close 5`, // "/source/dir"
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/source"
+		{C: `close 3`}, // "/"
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 6},
+		{C: `fstat 6 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/target"
+		{C: `close 3`}, // "/"
+		{C: `mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`, E: errTesting},
+		{C: `close 6`}, // "/target/dir"
+		{C: `close 5`}, // "/source/dir"
 	})
 }
 
@@ -173,30 +173,30 @@ func (s *secureBindMountSuite) TestRemountReadOnlyFails(c *C) {
 	s.sys.InsertFault(`mount "none" "/proc/self/fd/7" "" MS_REMOUNT|MS_BIND|MS_RDONLY ""`, errTesting)
 	err := s.sec.BindMount("/source/dir", "/target/dir", syscall.MS_BIND|syscall.MS_RDONLY)
 	c.Assert(err, ErrorMatches, "testing")
-	c.Assert(s.sys.Calls(), DeepEquals, []string{
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 5
-		`fstat 5 <ptr>`,
-		`close 4`, // "/source"
-		`close 3`, // "/"
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 6
-		`fstat 6 <ptr>`,
-		`close 4`, // "/target"
-		`close 3`, // "/"
-		`mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`,
-		`open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`,          // -> 3
-		`openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, // -> 4
-		`openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`,                // -> 7
-		`fstat 7 <ptr>`,
-		`close 4`, // "/target"
-		`close 3`, // "/"
-		`mount "none" "/proc/self/fd/7" "" MS_REMOUNT|MS_BIND|MS_RDONLY ""`,
-		`unmount "/proc/self/fd/7" UMOUNT_NOFOLLOW|MNT_DETACH`,
-		`close 7`, // "/target/dir"
-		`close 6`, // "/target/dir"
-		`close 5`, // "/source/dir"
+	c.Assert(s.sys.RCalls(), testutil.SyscallsEqual, []testutil.CallResultError{
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "source" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 5},
+		{C: `fstat 5 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/source"
+		{C: `close 3`}, // "/"
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 6},
+		{C: `fstat 6 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/target"
+		{C: `close 3`}, // "/"
+		{C: `mount "/proc/self/fd/5" "/proc/self/fd/6" "" MS_BIND ""`},
+		{C: `open "/" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 3},
+		{C: `openat 3 "target" O_NOFOLLOW|O_CLOEXEC|O_DIRECTORY|O_PATH 0`, R: 4},
+		{C: `openat 4 "dir" O_NOFOLLOW|O_CLOEXEC|O_PATH 0`, R: 7},
+		{C: `fstat 7 <ptr>`, R: syscall.Stat_t{}},
+		{C: `close 4`}, // "/target"
+		{C: `close 3`}, // "/"
+		{C: `mount "none" "/proc/self/fd/7" "" MS_REMOUNT|MS_BIND|MS_RDONLY ""`, E: errTesting},
+		{C: `unmount "/proc/self/fd/7" UMOUNT_NOFOLLOW|MNT_DETACH`},
+		{C: `close 7`}, // "/target/dir"
+		{C: `close 6`}, // "/target/dir"
+		{C: `close 5`}, // "/source/dir"
 	})
 }


### PR DESCRIPTION
This patch does two trivial changes, it switches all unit tests that
used Calls() (which return an slice of strings) to RCalls which returns
a slice of CallResultError structures. At the same time the assertion
used is switched from DeepEquals to SyscallsEqual.

This has the added benefit of checking return values and error values
and, in case something breaks, offers human-readable error messages.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
