### PR TITLE
store, image: have 'snap download' use v2/refresh action=download

### DIFF
--- a/cmd/snap/cmd_download.go
+++ b/cmd/snap/cmd_download.go
@@ -100,6 +100,9 @@ func (x *cmdDownload) Execute(args []string) error {
 	if x.Revision == "" {
 		revision = snap.R(0)
 	} else {
+		if x.Channel != "" {
+			return fmt.Errorf(i18n.G("cannot specify both channel and revision"))
+		}
 		var err error
 		revision, err = snap.ParseRevision(x.Revision)
 		if err != nil {

--- a/image/helpers.go
+++ b/image/helpers.go
@@ -225,12 +225,16 @@ func (tsto *ToolingStore) DownloadSnap(name string, revision snap.Revision, opts
 		Action:   "download",
 		Name:     name,
 		Revision: revision,
-		Channel:  opts.Channel,
 	}}
+
+	if revision.Unset() {
+		actions[0].Channel = opts.Channel
+	}
 
 	snaps, err := sto.SnapAction(context.TODO(), nil, actions, tsto.user, nil)
 	if err != nil {
-		return "", nil, fmt.Errorf("cannot find snap %q: %v", name, err)
+		// err will be 'cannot download snap "foo": <reasons>'
+		return "", nil, err
 	}
 	snap := snaps[0]
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -119,6 +119,8 @@ type SnapActionError struct {
 	Refresh map[string]error
 	// Install errors by snap name.
 	Install map[string]error
+	// Download errors by snap name.
+	Download map[string]error
 	// Other errors.
 	Other []error
 }
@@ -126,31 +128,50 @@ type SnapActionError struct {
 func (e SnapActionError) Error() string {
 	nRefresh := len(e.Refresh)
 	nInstall := len(e.Install)
+	nDownload := len(e.Download)
 	nOther := len(e.Other)
 
 	// single error
-	if nRefresh+nInstall+nOther == 1 {
+	if nRefresh+nInstall+nDownload+nOther == 1 {
 		if nOther == 0 {
-			op := "refresh"
-			errs := e.Refresh
-			if nInstall > 0 {
+			var op string
+			var errs map[string]error
+			switch {
+			case nRefresh > 0:
+				op = "refresh"
+				errs = e.Refresh
+			case nInstall > 0:
 				op = "install"
 				errs = e.Install
+			case nDownload > 0:
+				op = "download"
+				errs = e.Download
 			}
 			for name, e := range errs {
 				return fmt.Sprintf("cannot %s snap %q: %v", op, name, e)
 			}
 		} else {
-			return fmt.Sprintf("cannot refresh or install: %v", e.Other[0])
+			return fmt.Sprintf("cannot refresh, install, or download: %v", e.Other[0])
 		}
 	}
 
-	header := "cannot refresh:"
-	if nInstall > 0 {
-		header = "cannot install:"
-	}
-	if nOther > 0 || (nInstall > 0 && nRefresh > 0) {
-		header = "cannot refresh or install:"
+	header := "cannot refresh, install, or download:"
+	if nOther == 0 {
+		// at least one of nDownload, nInstall, or nRefresh is > 0
+		switch {
+		case nDownload == 0 && nRefresh == 0:
+			header = "cannot install:"
+		case nDownload == 0 && nInstall == 0:
+			header = "cannot refresh:"
+		case nDownload == 0:
+			header = "cannot refresh or install:"
+		case nRefresh == 0 && nInstall == 0:
+			header = "cannot download:"
+		case nInstall == 0:
+			header = "cannot refresh or download:"
+		case nRefresh == 0:
+			header = "cannot install or download:"
+		}
 	}
 	es := []string{header}
 
@@ -159,6 +180,10 @@ func (e SnapActionError) Error() string {
 	}
 
 	for name, e := range e.Install {
+		es = append(es, fmt.Sprintf("snap %q: %v", name, e))
+	}
+
+	for name, e := range e.Download {
 		es = append(es, fmt.Sprintf("snap %q: %v", name, e))
 	}
 

--- a/store/errors.go
+++ b/store/errors.go
@@ -163,10 +163,10 @@ func (e SnapActionError) Error() string {
 			header = "cannot install:"
 		case nDownload == 0 && nInstall == 0:
 			header = "cannot refresh:"
-		case nDownload == 0:
-			header = "cannot refresh or install:"
 		case nRefresh == 0 && nInstall == 0:
 			header = "cannot download:"
+		case nDownload == 0:
+			header = "cannot refresh or install:"
 		case nInstall == 0:
 			header = "cannot refresh or download:"
 		case nRefresh == 0:

--- a/store/store.go
+++ b/store/store.go
@@ -2219,15 +2219,19 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 		}
 
 		instanceKey := a.SnapID
-		switch a.Action {
-		case "install":
-			installNum++
-			instanceKey = fmt.Sprintf("install-%d", installNum)
-			installKeys[instanceKey] = true
-		case "download":
-			downloadNum++
-			instanceKey = fmt.Sprintf("download-%d", downloadNum)
-			downloadKeys[instanceKey] = true
+		if a.Action == "install" || a.Action == "download" {
+			if !a.Revision.Unset() {
+				a.Channel = ""
+			}
+			if a.Action == "install" {
+				installNum++
+				instanceKey = fmt.Sprintf("install-%d", installNum)
+				installKeys[instanceKey] = true
+			} else {
+				downloadNum++
+				instanceKey = fmt.Sprintf("download-%d", downloadNum)
+				downloadKeys[instanceKey] = true
+			}
 		}
 
 		aJSON := &snapActionJSON{

--- a/store/store.go
+++ b/store/store.go
@@ -2083,6 +2083,15 @@ type SnapAction struct {
 	Epoch    *snap.Epoch
 }
 
+func isValidAction(action string) bool {
+	switch action {
+	case "download", "install", "refresh":
+		return true
+	default:
+		return false
+	}
+}
+
 type snapActionJSON struct {
 	Action           string      `json:"action"`
 	InstanceKey      string      `json:"instance-key"`
@@ -2209,6 +2218,10 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 	downloadKeys := make(map[string]bool, len(actions))
 	actionJSONs := make([]*snapActionJSON, len(actions))
 	for i, a := range actions {
+		if !isValidAction(a.Action) {
+			return nil, fmt.Errorf("internal error: unsupported action %q", a.Action)
+		}
+
 		var ignoreValidation *bool
 		if a.Flags&SnapActionIgnoreValidation != 0 {
 			var t = true


### PR DESCRIPTION
This moves 'snap download' (i.e. image/) to use the v2 store api, with
the ad-hoc 'download' action on the refresh endpoint.
