### PR TITLE
tests: publish test-snapd-appstreamid for any architecture

### DIFF
--- a/tests/lib/snaps/test-snapd-appstreamid/bin/run
+++ b/tests/lib/snaps/test-snapd-appstreamid/bin/run
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 exec "$@"

--- a/tests/lib/snaps/test-snapd-appstreamid/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-appstreamid/meta/snap.yaml
@@ -1,25 +1,14 @@
 name: test-snapd-appstreamid
-version: 1.0
+version: 1.1
+architectures: ["all"]
 summary: Snap for testing snapd AppStream ID support
-description: |
- Snap for testing snapd AppStream ID support
-confinement: strict
 
 apps:
   foo:
    command: bin/run
    common-id: io.snapcraft.test-snapd-appstreamid.foo
-
   bar:
    command: bin/run
    common-id: io.snapcraft.test-snapd-appstreamid.bar
-
   baz:
    command: bin/run
-
-parts:
-  bash:
-    plugin: dump
-    source: .
-    prime:
-      - bin/

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -1,5 +1,5 @@
 summary: Verify AppStream ID integration
-# fedora-*: uses GNU netcat by default
+# fedora-*: uses nmap netcat by default (https://nmap.org/ncat/)
 systems: [-fedora-*]
 
 prepare: |

--- a/tests/main/appstream-id/task.yaml
+++ b/tests/main/appstream-id/task.yaml
@@ -1,8 +1,6 @@
 summary: Verify AppStream ID integration
-# ubuntu-*-32: the snap used in the test was published only for amd64
 # fedora-*: uses GNU netcat by default
-# ubuntu-core-16-arm-*: the snap used in the test was published only for amd64
-systems: [-ubuntu-*-32, -fedora-*, -ubuntu-core-16-arm-* ]
+systems: [-fedora-*]
 
 prepare: |
     snap install jq


### PR DESCRIPTION
This fixes the test failures in autopkgtest on arm64 and other
arches.
