### PR TITLE
snap: don't include newline in hook environment

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -756,15 +756,12 @@ func (app *AppInfo) ServiceFile() string {
 
 // Env returns the app specific environment overrides
 func (app *AppInfo) Env() []string {
-	env := []string{}
 	appEnv := app.Snap.Environment.Copy()
 	for _, k := range app.Environment.Keys() {
 		appEnv.Set(k, app.Environment.Get(k))
 	}
-	for _, k := range appEnv.Keys() {
-		env = append(env, fmt.Sprintf("%s=%s", k, appEnv.Get(k)))
-	}
-	return env
+
+	return envFromMap(appEnv)
 }
 
 // IsService returns whether app represents a daemon/service.
@@ -782,11 +779,15 @@ func (hook *HookInfo) SecurityTag() string {
 
 // Env returns the hook-specific environment overrides
 func (hook *HookInfo) Env() []string {
+	return envFromMap(hook.Snap.Environment.Copy())
+}
+
+func envFromMap(envMap *strutil.OrderedMap) []string {
 	env := []string{}
-	hookEnv := hook.Snap.Environment.Copy()
-	for _, k := range hookEnv.Keys() {
-		env = append(env, fmt.Sprintf("%s=%s\n", k, hookEnv.Get(k)))
+	for _, k := range envMap.Keys() {
+		env = append(env, fmt.Sprintf("%s=%s", k, envMap.Get(k)))
 	}
+
 	return env
 }
 

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -478,6 +478,25 @@ apps:
 	})
 }
 
+func (s *infoSuite) TestHookTakesGlobalEnv(c *C) {
+	yaml := `name: foo
+version: 1.0
+type: app
+environment:
+ global-k: global-v
+hooks:
+ foo:
+`
+	info, err := snap.InfoFromSnapYaml([]byte(yaml))
+	c.Assert(err, IsNil)
+
+	env := info.Hooks["foo"].Env()
+	sort.Strings(env)
+	c.Check(env, DeepEquals, []string{
+		"global-k=global-v",
+	})
+}
+
 func (s *infoSuite) TestSplitSnapApp(c *C) {
 	for _, t := range []struct {
 		in  string


### PR DESCRIPTION
Currently, both hooks and apps use the global `environment`, if specified. However, they both use slightly different mechanisms of interpreting the environment: hooks append a newline, apps do not. The newline causes problems when the variable is used in the shell.

Fix this issue by creating a new function to evaluate the environment (that doesn't append a newline), and have both apps and hooks use it.