### PR TITLE
interfaces/apparmor: allow killing snap-update-ns

### DIFF
--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -412,7 +412,7 @@ var defaultTemplate = `
   # signals)
   signal (receive) peer=snap.*,
 
-  # Allow receiving signals from unconfined world.
+  # Allow receiving signals from unconfined (eg, systemd)
   signal (receive) peer=unconfined,
 
   # for 'udevadm trigger --verbose --dry-run --tag-match=snappy-assign'

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -412,6 +412,9 @@ var defaultTemplate = `
   # signals)
   signal (receive) peer=snap.*,
 
+  # Allow receiving signals from unconfined world.
+  signal (receive) peer=unconfined,
+
   # for 'udevadm trigger --verbose --dry-run --tag-match=snappy-assign'
   /{,s}bin/udevadm ixr,
   /etc/udev/udev.conf r,


### PR DESCRIPTION
This patch adds a signal reception rule that allows signals delivery to
snap-update-ns processes when dispatched from the unconfined world.

This fixes the following denial

[Mon Jun 11 13:21:08 2018] audit: type=1400 audit(1528723268.368:2393): apparmor="DENIED" operation="signal" profile="snap-update-ns.test-snapd-service-watchdog" pid=1 comm="systemd" requested_mask="receive" denied_mask="receive" signal=abrt peer="unconfined"

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
