### PR TITLE
overlord/ifacestate:  simplify checkConnectConflicts and also connect signature

### DIFF
--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -621,7 +621,6 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 
 	var newconns []*interfaces.ConnRef
 
-	chg := task.Change()
 	// Auto-connect all the plugs
 	for _, plug := range m.repo.Plugs(snapName) {
 		candidates := m.repo.AutoConnectCandidateSlots(snapName, plug.Name, autochecker.check)
@@ -666,7 +665,8 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 			continue
 		}
 
-		if err := checkConnectConflicts(st, chg, plug.Snap.Name(), slot.Snap.Name(), task); err != nil {
+		const auto = true
+		if err := checkConnectConflicts(st, plug.Snap.Name(), slot.Snap.Name(), auto); err != nil {
 			if _, retry := err.(*state.Retry); retry {
 				task.Logf("auto-connect of snap %q will be retried because of %q - %q conflict", snapName, plug.Snap.Name(), slot.Snap.Name())
 				return err // will retry
@@ -714,7 +714,8 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 				continue
 			}
 
-			if err := checkConnectConflicts(st, chg, plug.Snap.Name(), slot.Snap.Name(), task); err != nil {
+			const auto = true
+			if err := checkConnectConflicts(st, plug.Snap.Name(), slot.Snap.Name(), auto); err != nil {
 				if _, retry := err.(*state.Retry); retry {
 					task.Logf("auto-connect of snap %q will be retried because of %q - %q conflict", snapName, plug.Snap.Name(), slot.Snap.Name())
 					return err // will retry

--- a/overlord/ifacestate/handlers.go
+++ b/overlord/ifacestate/handlers.go
@@ -728,7 +728,8 @@ func (m *InterfaceManager) doAutoConnect(task *state.Task, _ *tomb.Tomb) error {
 
 	// Create connect tasks and interface hooks
 	for _, conn := range newconns {
-		ts, err := connect(st, task, conn.PlugRef.Snap, conn.PlugRef.Name, conn.SlotRef.Snap, conn.SlotRef.Name)
+		const auto = true
+		ts, err := connect(st, conn.PlugRef.Snap, conn.PlugRef.Name, conn.SlotRef.Snap, conn.SlotRef.Name, auto)
 		if err != nil {
 			return fmt.Errorf("internal error: auto-connect of %q failed: %s", conn, err)
 		}

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -141,10 +141,10 @@ func Connect(st *state.State, plugSnap, plugName, slotSnap, slotName string) (*s
 		return nil, err
 	}
 
-	return connect(st, nil, plugSnap, plugName, slotSnap, slotName)
+	return connect(st, plugSnap, plugName, slotSnap, slotName, notAuto)
 }
 
-func connect(st *state.State, mainTask *state.Task, plugSnap, plugName, slotSnap, slotName string) (*state.TaskSet, error) {
+func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, auto bool) (*state.TaskSet, error) {
 	// TODO: Store the intent-to-connect in the state so that we automatically
 	// try to reconnect on reboot (reconnection can fail or can connect with
 	// different parameters so we cannot store the actual connection details).
@@ -194,7 +194,7 @@ func connect(st *state.State, mainTask *state.Task, plugSnap, plugName, slotSnap
 
 	connectInterface.Set("slot", interfaces.SlotRef{Snap: slotSnap, Name: slotName})
 	connectInterface.Set("plug", interfaces.PlugRef{Snap: plugSnap, Name: plugName})
-	connectInterface.Set("auto", mainTask != nil && mainTask.Kind() == "auto-connect")
+	connectInterface.Set("auto", auto)
 
 	// Expose a copy of all plug and slot attributes coming from yaml to interface hooks. The hooks will be able
 	// to modify them but all attributes will be checked against assertions after the hooks are run.

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -136,12 +136,12 @@ func checkConnectConflicts(st *state.State, plugSnap, slotSnap string, auto bool
 // Connect returns a set of tasks for connecting an interface.
 //
 func Connect(st *state.State, plugSnap, plugName, slotSnap, slotName string) (*state.TaskSet, error) {
-	const notAuto = false
-	if err := checkConnectConflicts(st, plugSnap, slotSnap, notAuto); err != nil {
+	const auto = false
+	if err := checkConnectConflicts(st, plugSnap, slotSnap, auto); err != nil {
 		return nil, err
 	}
 
-	return connect(st, plugSnap, plugName, slotSnap, slotName, notAuto)
+	return connect(st, plugSnap, plugName, slotSnap, slotName, auto)
 }
 
 func connect(st *state.State, plugSnap, plugName, slotSnap, slotName string, auto bool) (*state.TaskSet, error) {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -346,7 +346,7 @@ func (s *interfaceManagerSuite) TestAutoconnectDoesntConflictOnInstallingDiffere
 	ignore, err := ifacestate.FindSymmetricAutoconnect(s.state, "consumer", "producer", t)
 	c.Assert(err, IsNil)
 	c.Assert(ignore, Equals, false)
-	c.Assert(ifacestate.CheckConnectConflicts(s.state, chg, "consumer", "producer", t), IsNil)
+	c.Assert(ifacestate.CheckConnectConflicts(s.state, "consumer", "producer", true), IsNil)
 
 	ts, err := ifacestate.ConnectPriv(s.state, t, "consumer", "plug", "producer", "slot")
 	c.Assert(err, IsNil)
@@ -385,7 +385,7 @@ func (s *interfaceManagerSuite) createAutoconnectChange(c *C, conflictingTask *s
 	c.Assert(err, IsNil)
 	c.Assert(ignore, Equals, false)
 
-	return ifacestate.CheckConnectConflicts(s.state, chg, "consumer", "producer", t2)
+	return ifacestate.CheckConnectConflicts(s.state, "consumer", "producer", true)
 }
 
 func (s *interfaceManagerSuite) testRetryError(c *C, err error) {

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -348,14 +348,14 @@ func (s *interfaceManagerSuite) TestAutoconnectDoesntConflictOnInstallingDiffere
 	c.Assert(ignore, Equals, false)
 	c.Assert(ifacestate.CheckConnectConflicts(s.state, "consumer", "producer", true), IsNil)
 
-	ts, err := ifacestate.ConnectPriv(s.state, t, "consumer", "plug", "producer", "slot")
+	ts, err := ifacestate.ConnectPriv(s.state, "consumer", "plug", "producer", "slot", true)
 	c.Assert(err, IsNil)
 	c.Assert(ts.Tasks(), HasLen, 5)
 	connectTask := ts.Tasks()[2]
 	c.Assert(connectTask.Kind(), Equals, "connect")
 	var auto bool
 	connectTask.Get("auto", &auto)
-	c.Assert(auto, Equals, auto)
+	c.Assert(auto, Equals, true)
 }
 
 func (s *interfaceManagerSuite) createAutoconnectChange(c *C, conflictingTask *state.Task) error {


### PR DESCRIPTION
Given that we do all conflict checks up-front in doAutoConnect which itself happen after the snap has been linked we don't have to worry anymore about self-conflicting.

Make the check for corresponding automatically generated "connect" tasks a bit more blunt.
