### PR TITLE
interfaces/policy: test that base policy can be parsed

### DIFF
--- a/interfaces/policy/basedeclaration_test.go
+++ b/interfaces/policy/basedeclaration_test.go
@@ -863,6 +863,13 @@ revision: 0
 `)
 }
 
+func (s *baseDeclSuite) TestDoesNotPanic(c *C) {
+	// In case there are any issues in the actual interfaces we'd get a panic
+	// on snapd startup. This test prevents this from happing unnoticed.
+	_, err := policy.ComposeBaseDeclaration(builtin.Interfaces())
+	c.Assert(err, IsNil)
+}
+
 func (s *baseDeclSuite) TestBrowserSupportAllowSandbox(c *C) {
 	const plugYaml = `name: plug-snap
 version: 0


### PR DESCRIPTION
In case the base policy (which is assembled from the contributions of
all the interfaces) cannot be parsed and initialized we'd get a panic on
startup of snapd. Now we have an extra unit test that saves us the
trouble.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
