### PR TITLE
cmd/libsnap-confine-private: introduce a helper for splitting snap name

### DIFF
--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -373,6 +373,20 @@ static void test_sc_snap_split_instance_name_basic(void)
 				    sizeof instance);
 	g_assert_cmpstr(name, ==, "");
 	g_assert_cmpstr(instance, ==, "");
+
+	memset(name, 0xff, sizeof name);
+	memset(instance, 0xff, sizeof instance);
+	sc_snap_split_instance_name("_", name, sizeof name, instance,
+                              sizeof instance);
+	g_assert_cmpstr(name, ==, "");
+	g_assert_cmpstr(instance, ==, "");
+
+	memset(name, 0xff, sizeof name);
+	memset(instance, 0xff, sizeof instance);
+	sc_snap_split_instance_name("foo_", name, sizeof name, instance,
+                              sizeof instance);
+	g_assert_cmpstr(name, ==, "foo");
+	g_assert_cmpstr(instance, ==, "");
 }
 
 static void __attribute__ ((constructor)) init(void)

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -231,7 +231,7 @@ static void test_sc_snap_drop_instance_key_short_dest(void)
 	if (g_test_subprocess()) {
 		char dest[10] = { 0 };
 		sc_snap_drop_instance_key("foo-foo-foo-foo-foo_bar", dest,
-					   sizeof dest);
+					  sizeof dest);
 		g_test_fail();
 		return;
 	}
@@ -377,14 +377,14 @@ static void test_sc_snap_split_instance_name_basic(void)
 	memset(name, 0xff, sizeof name);
 	memset(instance, 0xff, sizeof instance);
 	sc_snap_split_instance_name("_", name, sizeof name, instance,
-                              sizeof instance);
+				    sizeof instance);
 	g_assert_cmpstr(name, ==, "");
 	g_assert_cmpstr(instance, ==, "");
 
 	memset(name, 0xff, sizeof name);
 	memset(instance, 0xff, sizeof instance);
 	sc_snap_split_instance_name("foo_", name, sizeof name, instance,
-                              sizeof instance);
+				    sizeof instance);
 	g_assert_cmpstr(name, ==, "foo");
 	g_assert_cmpstr(instance, ==, "");
 }

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -214,10 +214,10 @@ static void test_sc_snap_name_validate__respects_error_protocol(void)
 	    ("snap name must use lower case letters, digits or dashes\n");
 }
 
-static void test_sc_snap_drop_instance_name_no_dest(void)
+static void test_sc_snap_drop_instance_key_no_dest(void)
 {
 	if (g_test_subprocess()) {
-		sc_snap_drop_instance_name("foo_bar", NULL, 0);
+		sc_snap_drop_instance_key("foo_bar", NULL, 0);
 		g_test_fail();
 		return;
 	}
@@ -226,11 +226,11 @@ static void test_sc_snap_drop_instance_name_no_dest(void)
 
 }
 
-static void test_sc_snap_drop_instance_name_short_dest(void)
+static void test_sc_snap_drop_instance_key_short_dest(void)
 {
 	if (g_test_subprocess()) {
 		char dest[10] = { 0 };
-		sc_snap_drop_instance_name("foo-foo-foo-foo-foo_bar", dest,
+		sc_snap_drop_instance_key("foo-foo-foo-foo-foo_bar", dest,
 					   sizeof dest);
 		g_test_fail();
 		return;
@@ -239,11 +239,11 @@ static void test_sc_snap_drop_instance_name_short_dest(void)
 	g_test_trap_assert_failed();
 }
 
-static void test_sc_snap_drop_instance_name_short_dest2(void)
+static void test_sc_snap_drop_instance_key_short_dest2(void)
 {
 	if (g_test_subprocess()) {
 		char dest[3] = { 0 };	// "foo" sans the nil byte
-		sc_snap_drop_instance_name("foo", dest, sizeof dest);
+		sc_snap_drop_instance_key("foo", dest, sizeof dest);
 		g_test_fail();
 		return;
 	}
@@ -251,11 +251,11 @@ static void test_sc_snap_drop_instance_name_short_dest2(void)
 	g_test_trap_assert_failed();
 }
 
-static void test_sc_snap_drop_instance_name_no_name(void)
+static void test_sc_snap_drop_instance_key_no_name(void)
 {
 	if (g_test_subprocess()) {
 		char dest[10] = { 0 };
-		sc_snap_drop_instance_name(NULL, dest, sizeof dest);
+		sc_snap_drop_instance_key(NULL, dest, sizeof dest);
 		g_test_fail();
 		return;
 	}
@@ -263,27 +263,27 @@ static void test_sc_snap_drop_instance_name_no_name(void)
 	g_test_trap_assert_failed();
 }
 
-static void test_sc_snap_drop_instance_name_basic(void)
+static void test_sc_snap_drop_instance_key_basic(void)
 {
 	char name[41] = { 0xff };
 
-	sc_snap_drop_instance_name("foo_bar", name, sizeof name);
+	sc_snap_drop_instance_key("foo_bar", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo");
 
 	memset(name, 0xff, sizeof name);
-	sc_snap_drop_instance_name("foo-bar_bar", name, sizeof name);
+	sc_snap_drop_instance_key("foo-bar_bar", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo-bar");
 
 	memset(name, 0xff, sizeof name);
-	sc_snap_drop_instance_name("foo-bar", name, sizeof name);
+	sc_snap_drop_instance_key("foo-bar", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo-bar");
 
 	memset(name, 0xff, sizeof name);
-	sc_snap_drop_instance_name("_baz", name, sizeof name);
+	sc_snap_drop_instance_key("_baz", name, sizeof name);
 	g_assert_cmpstr(name, ==, "");
 
 	memset(name, 0xff, sizeof name);
-	sc_snap_drop_instance_name("foo", name, sizeof name);
+	sc_snap_drop_instance_key("foo", name, sizeof name);
 	g_assert_cmpstr(name, ==, "foo");
 }
 
@@ -382,16 +382,16 @@ static void __attribute__ ((constructor)) init(void)
 			test_sc_snap_name_validate);
 	g_test_add_func("/snap/sc_snap_name_validate/respects_error_protocol",
 			test_sc_snap_name_validate__respects_error_protocol);
-	g_test_add_func("/snap/sc_snap_drop_instance_name/basic",
-			test_sc_snap_drop_instance_name_basic);
-	g_test_add_func("/snap/sc_snap_drop_instance_name/no_dest",
-			test_sc_snap_drop_instance_name_no_dest);
-	g_test_add_func("/snap/sc_snap_drop_instance_name/no_name",
-			test_sc_snap_drop_instance_name_no_name);
-	g_test_add_func("/snap/sc_snap_drop_instance_name/short_dest",
-			test_sc_snap_drop_instance_name_short_dest);
-	g_test_add_func("/snap/sc_snap_drop_instance_name/short_dest2",
-			test_sc_snap_drop_instance_name_short_dest2);
+	g_test_add_func("/snap/sc_snap_drop_instance_key/basic",
+			test_sc_snap_drop_instance_key_basic);
+	g_test_add_func("/snap/sc_snap_drop_instance_key/no_dest",
+			test_sc_snap_drop_instance_key_no_dest);
+	g_test_add_func("/snap/sc_snap_drop_instance_key/no_name",
+			test_sc_snap_drop_instance_key_no_name);
+	g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest",
+			test_sc_snap_drop_instance_key_short_dest);
+	g_test_add_func("/snap/sc_snap_drop_instance_key/short_dest2",
+			test_sc_snap_drop_instance_key_short_dest2);
 	g_test_add_func("/snap/sc_snap_split_instance_name/basic",
 			test_sc_snap_split_instance_name_basic);
 	g_test_add_func("/snap/sc_snap_split_instance_name/trailing_nil",

--- a/cmd/libsnap-confine-private/snap-test.c
+++ b/cmd/libsnap-confine-private/snap-test.c
@@ -316,7 +316,7 @@ static void test_sc_snap_split_instance_name_short_instance_dest(void)
 static void test_sc_snap_split_instance_name_basic(void)
 {
 	char name[41] = { 0xff };
-	char instance[11] = { 0xff };
+	char instance[20] = { 0xff };
 
 	sc_snap_split_instance_name("foo_bar", name, sizeof name, instance,
 				    sizeof instance);
@@ -359,6 +359,20 @@ static void test_sc_snap_split_instance_name_basic(void)
 	sc_snap_split_instance_name("foo_bar", NULL, 0, instance,
 				    sizeof instance);
 	g_assert_cmpstr(instance, ==, "bar");
+
+	memset(name, 0xff, sizeof name);
+	memset(instance, 0xff, sizeof instance);
+	sc_snap_split_instance_name("hello_world_surprise", name, sizeof name,
+				    instance, sizeof instance);
+	g_assert_cmpstr(name, ==, "hello");
+	g_assert_cmpstr(instance, ==, "world_surprise");
+
+	memset(name, 0xff, sizeof name);
+	memset(instance, 0xff, sizeof instance);
+	sc_snap_split_instance_name("", name, sizeof name, instance,
+				    sizeof instance);
+	g_assert_cmpstr(name, ==, "");
+	g_assert_cmpstr(instance, ==, "");
 }
 
 static void __attribute__ ((constructor)) init(void)

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -180,14 +180,14 @@ void sc_snap_split_instance_name(const char *name, char *snap_name,
 				 size_t instance_key_size)
 {
 	if (name == NULL) {
-		die("name not provided");
+		die("internal error: cannot split snap name when snap name is unset");
 	}
 	if (snap_name == NULL && instance_key == NULL) {
-		die("snap name and instance key are unset");
+		die("internal error: cannot split instance name when both snap name and instance key are unset");
 	}
 
 	const char *pos = strchr(name, '_');
-	const char *instance_key_start = NULL;
+	const char *instance_key_start = "";
 	size_t snap_name_len = 0;
 	size_t instance_key_len = 0;
 	if (pos == NULL) {
@@ -195,7 +195,7 @@ void sc_snap_split_instance_name(const char *name, char *snap_name,
 	} else {
 		snap_name_len = pos - name;
 		instance_key_start = pos + 1;
-		instance_key_len = strlen(name) - snap_name_len - 1;
+		instance_key_len = strlen(instance_key_start);
 	}
 
 	if (snap_name != NULL) {

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -169,39 +169,42 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 	sc_error_forward(errorp, err);
 }
 
-void sc_snap_drop_instance_name(const char *snap_name, char *base,
-				size_t base_size)
+void sc_snap_drop_instance_name(const char *name, char *snap_name,
+				size_t snap_name_size)
 {
-	sc_snap_split_instance_name(snap_name, base, base_size, NULL, 0);
+	sc_snap_split_instance_name(name, snap_name, snap_name_size, NULL, 0);
 }
 
-void sc_snap_split_instance_name(const char *snap_name, char *base,
-				 size_t base_size, char *instance_key,
+void sc_snap_split_instance_name(const char *name, char *snap_name,
+				 size_t snap_name_size, char *instance_key,
 				 size_t instance_key_size)
 {
-	if (snap_name == NULL || (base == NULL && instance_key == NULL)) {
-		die("base and instance key or snap name are unset");
+	if (name == NULL) {
+		die("name not provided");
+	}
+	if (snap_name == NULL && instance_key == NULL) {
+		die("snap name and instance key are unset");
 	}
 
-	const char *pos = strchr(snap_name, '_');
+	const char *pos = strchr(name, '_');
 	const char *instance_key_start = NULL;
-	size_t base_len = 0;
+	size_t snap_name_len = 0;
 	size_t instance_key_len = 0;
 	if (pos == NULL) {
-		base_len = strlen(snap_name);
+		snap_name_len = strlen(name);
 	} else {
-		base_len = pos - snap_name;
+		snap_name_len = pos - name;
 		instance_key_start = pos + 1;
-		instance_key_len = strlen(snap_name) - base_len - 1;
+		instance_key_len = strlen(name) - snap_name_len - 1;
 	}
 
-	if (base != NULL) {
-		if (base_len >= base_size) {
-			die("base buffer too small");
+	if (snap_name != NULL) {
+		if (snap_name_len >= snap_name_size) {
+			die("snap name buffer too small");
 		}
 
-		memcpy(base, snap_name, base_len);
-		base[base_len] = '\0';
+		memcpy(snap_name, name, snap_name_len);
+		snap_name[snap_name_len] = '\0';
 	}
 
 	if (instance_key != NULL) {

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -170,7 +170,7 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 }
 
 void sc_snap_drop_instance_key(const char *name, char *snap_name,
-				size_t snap_name_size)
+			       size_t snap_name_size)
 {
 	sc_snap_split_instance_name(name, snap_name, snap_name_size, NULL, 0);
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -172,22 +172,43 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 void sc_snap_drop_instance_name(const char *snap_name, char *base,
 				size_t base_size)
 {
-	if (snap_name == NULL || base == NULL) {
-		die("base or snap name unset");
+	sc_snap_split_instance_name(snap_name, base, base_size, NULL, 0);
+}
+
+void sc_snap_split_instance_name(const char *snap_name, char *base,
+				 size_t base_size, char *instance_key,
+				 size_t instance_key_size)
+{
+	if (snap_name == NULL || (base == NULL && instance_key == NULL)) {
+		die("base and instance key or snap name are unset");
 	}
 
 	const char *pos = strchr(snap_name, '_');
+	const char *instance_key_start = NULL;
 	size_t base_len = 0;
+	size_t instance_key_len = 0;
 	if (pos == NULL) {
 		base_len = strlen(snap_name);
 	} else {
 		base_len = pos - snap_name;
+		instance_key_start = pos + 1;
+		instance_key_len = strlen(snap_name) - base_len - 1;
 	}
 
-	if (base_len >= base_size) {
-		die("base buffer too small");
+	if (base != NULL) {
+		if (base_len >= base_size) {
+			die("base buffer too small");
+		}
+
+		memcpy(base, snap_name, base_len);
+		base[base_len] = '\0';
 	}
 
-	memcpy(base, snap_name, base_len);
-	base[base_len] = '\0';
+	if (instance_key != NULL) {
+		if (instance_key_len >= instance_key_size) {
+			die("instance key buffer too small");
+		}
+		memcpy(instance_key, instance_key_start, instance_key_len);
+		instance_key[instance_key_len] = '\0';
+	}
 }

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -169,31 +169,32 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 	sc_error_forward(errorp, err);
 }
 
-void sc_snap_drop_instance_key(const char *name, char *snap_name,
+void sc_snap_drop_instance_key(const char *instance_name, char *snap_name,
 			       size_t snap_name_size)
 {
-	sc_snap_split_instance_name(name, snap_name, snap_name_size, NULL, 0);
+	sc_snap_split_instance_name(instance_name, snap_name, snap_name_size,
+				    NULL, 0);
 }
 
-void sc_snap_split_instance_name(const char *name, char *snap_name,
+void sc_snap_split_instance_name(const char *instance_name, char *snap_name,
 				 size_t snap_name_size, char *instance_key,
 				 size_t instance_key_size)
 {
-	if (name == NULL) {
-		die("internal error: cannot split snap name when snap name is unset");
+	if (instance_name == NULL) {
+		die("internal error: cannot split instance name when it is unset");
 	}
 	if (snap_name == NULL && instance_key == NULL) {
 		die("internal error: cannot split instance name when both snap name and instance key are unset");
 	}
 
-	const char *pos = strchr(name, '_');
+	const char *pos = strchr(instance_name, '_');
 	const char *instance_key_start = "";
 	size_t snap_name_len = 0;
 	size_t instance_key_len = 0;
 	if (pos == NULL) {
-		snap_name_len = strlen(name);
+		snap_name_len = strlen(instance_name);
 	} else {
-		snap_name_len = pos - name;
+		snap_name_len = pos - instance_name;
 		instance_key_start = pos + 1;
 		instance_key_len = strlen(instance_key_start);
 	}
@@ -203,7 +204,7 @@ void sc_snap_split_instance_name(const char *name, char *snap_name,
 			die("snap name buffer too small");
 		}
 
-		memcpy(snap_name, name, snap_name_len);
+		memcpy(snap_name, instance_name, snap_name_len);
 		snap_name[snap_name_len] = '\0';
 	}
 

--- a/cmd/libsnap-confine-private/snap.c
+++ b/cmd/libsnap-confine-private/snap.c
@@ -169,7 +169,7 @@ void sc_snap_name_validate(const char *snap_name, struct sc_error **errorp)
 	sc_error_forward(errorp, err);
 }
 
-void sc_snap_drop_instance_name(const char *name, char *snap_name,
+void sc_snap_drop_instance_key(const char *name, char *snap_name,
 				size_t snap_name_size)
 {
 	sc_snap_split_instance_name(name, snap_name, snap_name_size, NULL, 0);

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -60,7 +60,7 @@ bool verify_security_tag(const char *security_tag, const char *snap_name);
 bool sc_is_hook_security_tag(const char *security_tag);
 
 /**
- * Extract snap name out of a snap with optional instance key string.
+ * Extract snap name out of an instance name.
  *
  * A snap may be installed multiple times in parallel under distinct instance names.
  * This function extracts the snap name out of a name that possibly contains a snap
@@ -68,22 +68,22 @@ bool sc_is_hook_security_tag(const char *security_tag);
  *
  * For example: snap_instance => snap, just-snap => just-snap
  **/
-void sc_snap_drop_instance_key(const char *name, char *snap_name,
+void sc_snap_drop_instance_key(const char *instance_name, char *snap_name,
 			       size_t snap_name_size);
 
 /**
- * Extract snap name and instance key out of a snap with optional instance name string.
+ * Extract snap name and instance key out of an instance name.
  *
  * A snap may be installed multiple times in parallel under distinct instance
- * names. This function extracts the snap name and instance key out of a name
- * that possibly contains a snap instance name. One of snap_name,
- * instance_key must be non-NULL.
+ * names. This function extracts the snap name and instance key out of the
+ * instance name. One of snap_name, instance_key must be non-NULL.
  *
  * For example:
- *    snap_instance => "snap"      & "instance"
- *    just-snap     => "just-snap" & ""
+ *   name_instance => "name" & "instance"
+ *   just-name     => "just-name" & ""
+ *
  **/
-void sc_snap_split_instance_name(const char *name, char *snap_name,
+void sc_snap_split_instance_name(const char *instance_name, char *snap_name,
 				 size_t snap_name_size, char *instance_key,
 				 size_t instance_key_size);
 

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -71,4 +71,19 @@ bool sc_is_hook_security_tag(const char *security_tag);
 void sc_snap_drop_instance_name(const char *snap_name, char *base,
 				size_t base_size);
 
+/**
+ * Extract snap name and instance key out of a snap with optional instance name string.
+ *
+ * A snap may be installed multiple times in parallel under distinct instance
+ * names. This function extracts the snap name and instance key out of a name
+ * that possibly contains a snap instance name.
+ *
+ * For example:
+ *    snap_instance => "snap"      & "instance"
+ *    just-snap     => "just-snap" & ""
+ **/
+void sc_snap_split_instance_name(const char *snap_name, char *base,
+				 size_t base_size, char *instance_key,
+				 size_t instance_key_size);
+
 #endif

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -68,22 +68,23 @@ bool sc_is_hook_security_tag(const char *security_tag);
  *
  * For example: snap_instance => snap, just-snap => just-snap
  **/
-void sc_snap_drop_instance_name(const char *snap_name, char *base,
-				size_t base_size);
+void sc_snap_drop_instance_name(const char *name, char *snap_name,
+				size_t snap_name_size);
 
 /**
  * Extract snap name and instance key out of a snap with optional instance name string.
  *
  * A snap may be installed multiple times in parallel under distinct instance
  * names. This function extracts the snap name and instance key out of a name
- * that possibly contains a snap instance name.
+ * that possibly contains a snap instance name. One of snap_name,
+ * instance_key must be non-NULL.
  *
  * For example:
  *    snap_instance => "snap"      & "instance"
  *    just-snap     => "just-snap" & ""
  **/
-void sc_snap_split_instance_name(const char *snap_name, char *base,
-				 size_t base_size, char *instance_key,
+void sc_snap_split_instance_name(const char *name, char *snap_name,
+				 size_t snap_name_size, char *instance_key,
 				 size_t instance_key_size);
 
 #endif

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -60,15 +60,15 @@ bool verify_security_tag(const char *security_tag, const char *snap_name);
 bool sc_is_hook_security_tag(const char *security_tag);
 
 /**
- * Extract snap name out of a snap with optional instance name string.
+ * Extract snap name out of a snap with optional instance key string.
  *
  * A snap may be installed multiple times in parallel under distinct instance names.
  * This function extracts the snap name out of a name that possibly contains a snap
- * instance name.
+ * instance key.
  *
  * For example: snap_instance => snap, just-snap => just-snap
  **/
-void sc_snap_drop_instance_name(const char *name, char *snap_name,
+void sc_snap_drop_instance_key(const char *name, char *snap_name,
 				size_t snap_name_size);
 
 /**

--- a/cmd/libsnap-confine-private/snap.h
+++ b/cmd/libsnap-confine-private/snap.h
@@ -69,7 +69,7 @@ bool sc_is_hook_security_tag(const char *security_tag);
  * For example: snap_instance => snap, just-snap => just-snap
  **/
 void sc_snap_drop_instance_key(const char *name, char *snap_name,
-				size_t snap_name_size);
+			       size_t snap_name_size);
 
 /**
  * Extract snap name and instance key out of a snap with optional instance name string.


### PR DESCRIPTION
Introduce a helper for splitting snap name into the name and instance key parts.


