### PR TITLE
tests: skip "try" test on s390x

### DIFF
--- a/tests/main/try/task.yaml
+++ b/tests/main/try/task.yaml
@@ -1,6 +1,7 @@
 summary: Check that try command works
 
-systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*]
+# s390x does not have /dev/kmsg
+systems: [-ubuntu-core-16-*, -fedora-*, -opensuse-*, -arch-*, -ubuntu-*-s390x]
 
 environment:
     PORT: 8081


### PR DESCRIPTION
The s390x virtualization does not allow access to /dev/kmsg so
our test fails there.
