### PR TITLE
overlord/configstate: add watchdog options

### DIFF
--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -80,6 +80,7 @@ var (
 
 	SnapBinariesDir     string
 	SnapServicesDir     string
+	SnapSystemdConfDir  string
 	SnapDesktopFilesDir string
 	SnapBusPolicyDir    string
 
@@ -227,6 +228,7 @@ func SetRootDir(rootdir string) {
 
 	SnapBinariesDir = filepath.Join(SnapMountDir, "bin")
 	SnapServicesDir = filepath.Join(rootdir, "/etc/systemd/system")
+	SnapSystemdConfDir = filepath.Join(rootdir, "/etc/systemd/system.conf.d")
 	SnapBusPolicyDir = filepath.Join(rootdir, "/etc/dbus-1/system.d")
 
 	SystemApparmorDir = filepath.Join(rootdir, "/etc/apparmor.d")

--- a/overlord/configstate/configcore/corecfg.go
+++ b/overlord/configstate/configcore/corecfg.go
@@ -87,6 +87,9 @@ func Run(tr Conf) error {
 	if err := validateExperimentalSettings(tr); err != nil {
 		return err
 	}
+	if err := validateWatchdogOptions(tr); err != nil {
+		return err
+	}
 	// FIXME: ensure the user cannot set "core seed.loaded"
 
 	// capture cloud information
@@ -117,6 +120,10 @@ func Run(tr Conf) error {
 	}
 	// proxy.{http,https,ftp}
 	if err := handleProxyConfiguration(tr); err != nil {
+		return err
+	}
+	// watchdog.{runtime-timeout,shutdown-timeout}
+	if err := handleWatchdogConfiguration(tr); err != nil {
 		return err
 	}
 

--- a/overlord/configstate/configcore/watchdog.go
+++ b/overlord/configstate/configcore/watchdog.go
@@ -42,7 +42,7 @@ func init() {
 
 func updateWatchdogConfig(config map[string]uint) error {
 	dir := dirs.SnapSystemdConfDir
-	name := "10-ubuntu-core-watchdog.conf"
+	name := "10-snapd-watchdog.conf"
 	dirContent := make(map[string]*osutil.FileState, 1)
 
 	configStr := []string{}

--- a/overlord/configstate/configcore/watchdog.go
+++ b/overlord/configstate/configcore/watchdog.go
@@ -1,0 +1,146 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+var watchdogConfigKeys = map[string]bool{
+	"RuntimeWatchdogSec":  true,
+	"ShutdownWatchdogSec": true,
+}
+
+func init() {
+	// add supported configuration of this module
+	supportedConfigurations["core.watchdog.runtime-timeout"] = true
+	supportedConfigurations["core.watchdog.shutdown-timeout"] = true
+}
+
+func watchdogConfEnvironment() string {
+	return filepath.Join(dirs.SnapSystemdConfDir, "10-ubuntu-core-watchdog.conf")
+}
+
+func updateWatchdogConfig(config map[string]uint) error {
+	path := watchdogConfEnvironment()
+
+	configStr := []string{}
+	for k, v := range config {
+		if v > 0 {
+			configStr = append(configStr, fmt.Sprintf("%s=%d\n", k, v))
+		}
+	}
+	if len(configStr) == 0 {
+		// No config, remove file
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+
+	// We order the variables to have predictable output
+	sort.Strings(configStr)
+	content := "[Manager]\n" + strings.Join(configStr, "")
+
+	// Compare with current file, go on only if different content
+	if cfgFile, err := os.Open(path); err == nil {
+		defer cfgFile.Close()
+
+		current, err := ioutil.ReadAll(cfgFile)
+		if err != nil {
+			return err
+		}
+
+		if content == string(current) {
+			return nil
+		}
+	}
+
+	if err := os.MkdirAll(dirs.SnapSystemdConfDir, 0755); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, []byte(content), 0644)
+}
+
+func handleWatchdogConfiguration(tr Conf) error {
+	config := map[string]uint{}
+
+	for _, key := range []string{"runtime-timeout", "shutdown-timeout"} {
+		output, err := coreCfg(tr, "watchdog."+key)
+		if err != nil {
+			return err
+		}
+		secs, err := getSystemdConfSeconds(output)
+		if err != nil {
+			return fmt.Errorf("cannot set timer to %q: %v", output, err)
+		}
+		switch key {
+		case "runtime-timeout":
+			config["RuntimeWatchdogSec"] = secs
+		case "shutdown-timeout":
+			config["ShutdownWatchdogSec"] = secs
+		}
+	}
+
+	if err := updateWatchdogConfig(config); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getSystemdConfSeconds(timeStr string) (uint, error) {
+	if timeStr == "" {
+		return 0, nil
+	}
+
+	dur, err := time.ParseDuration(timeStr)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse %q: %v", timeStr, err)
+	}
+	if dur < 0 {
+		return 0, fmt.Errorf("cannot use negative duration %q: %v", timeStr, err)
+	}
+
+	return uint(dur.Seconds()), nil
+}
+
+func validateWatchdogOptions(tr Conf) error {
+	for _, key := range []string{"runtime-timeout", "shutdown-timeout"} {
+		option, err := coreCfg(tr, "watchdog."+key)
+		if err != nil {
+			return err
+		}
+		if _, err = getSystemdConfSeconds(option); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -47,7 +47,7 @@ func (s *watchdogSuite) SetUpTest(c *C) {
 	s.configcoreSuite.SetUpTest(c)
 
 	dirs.SetRootDir(c.MkDir())
-	s.mockEtcEnvironment = filepath.Join(dirs.SnapSystemdConfDir, "10-ubuntu-core-watchdog.conf")
+	s.mockEtcEnvironment = filepath.Join(dirs.SnapSystemdConfDir, "10-snapd-watchdog.conf")
 	err := os.MkdirAll(dirs.SnapSystemdConfDir, 0755)
 	c.Assert(err, IsNil)
 }

--- a/overlord/configstate/configcore/watchdog_test.go
+++ b/overlord/configstate/configcore/watchdog_test.go
@@ -1,0 +1,181 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/configstate/configcore"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type watchdogSuite struct {
+	configcoreSuite
+
+	mockEtcEnvironment string
+}
+
+var _ = Suite(&watchdogSuite{})
+
+func (s *watchdogSuite) SetUpTest(c *C) {
+	s.configcoreSuite.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.mockEtcEnvironment = filepath.Join(dirs.GlobalRootDir,
+		"/etc/systemd/system.conf.d/10-ubuntu-core-watchdog.conf")
+	err := os.MkdirAll(filepath.Dir(s.mockEtcEnvironment), 0755)
+	c.Assert(err, IsNil)
+}
+
+func (s *watchdogSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *watchdogSuite) TestConfigureWatchdog(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	for option, val := range map[string]string{"runtime-timeout": "10", "shutdown-timeout": "60"} {
+
+		err := configcore.Run(&mockConf{
+			state: s.state,
+			conf: map[string]interface{}{
+				fmt.Sprintf("watchdog.%s", option): val + "s",
+			},
+		})
+		c.Assert(err, IsNil)
+
+		var systemdOption string
+		switch option {
+		case "runtime-timeout":
+			systemdOption = "RuntimeWatchdogSec"
+		case "shutdown-timeout":
+			systemdOption = "ShutdownWatchdogSec"
+		}
+		c.Check(s.mockEtcEnvironment, testutil.FileEquals,
+			fmt.Sprintf("[Manager]\n%s=%s\n", systemdOption, val))
+	}
+}
+
+func (s *watchdogSuite) TestConfigureWatchdogUnits(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	times := []int{56, 432}
+	type timeUnit struct {
+		unit  string
+		toSec int
+	}
+
+	for _, tunit := range []timeUnit{{"s", 1}, {"m", 60}, {"h", 3600}} {
+		err := configcore.Run(&mockConf{
+			state: s.state,
+			conf: map[string]interface{}{
+				"watchdog.runtime-timeout":  fmt.Sprintf("%d", times[0]) + tunit.unit,
+				"watchdog.shutdown-timeout": fmt.Sprintf("%d", times[1]) + tunit.unit,
+			},
+		})
+		c.Assert(err, IsNil)
+		c.Check(s.mockEtcEnvironment, testutil.FileEquals, "[Manager]\n"+
+			fmt.Sprintf("RuntimeWatchdogSec=%d\n", times[0]*tunit.toSec)+
+			fmt.Sprintf("ShutdownWatchdogSec=%d\n", times[1]*tunit.toSec))
+	}
+}
+
+func (s *watchdogSuite) TestConfigureWatchdogAll(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	times := []int{10, 100}
+	err := configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"watchdog.runtime-timeout":  fmt.Sprintf("%ds", times[0]),
+			"watchdog.shutdown-timeout": fmt.Sprintf("%ds", times[1]),
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.mockEtcEnvironment, testutil.FileEquals, "[Manager]\n"+
+		fmt.Sprintf("RuntimeWatchdogSec=%d\n", times[0])+
+		fmt.Sprintf("ShutdownWatchdogSec=%d\n", times[1]))
+}
+
+func (s *watchdogSuite) TestConfigureWatchdogBadFormat(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	type badValErr struct {
+		val string
+		err string
+	}
+	for _, badVal := range []badValErr{{"BAD", ".*invalid duration.*"},
+		{"-5s", ".*negative duration.*"},
+		{"34k", ".*unknown unit.*"}} {
+		err := configcore.Run(&mockConf{
+			state: s.state,
+			conf: map[string]interface{}{
+				"watchdog.runtime-timeout": badVal.val,
+			},
+		})
+		c.Assert(err, ErrorMatches, badVal.err)
+	}
+}
+
+func (s *watchdogSuite) TestConfigureWatchdogNoFileUpdate(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	times := []int{10, 100}
+	content := "[Manager]\n" +
+		fmt.Sprintf("RuntimeWatchdogSec=%d\n", times[0]) +
+		fmt.Sprintf("ShutdownWatchdogSec=%d\n", times[1])
+	err := ioutil.WriteFile(s.mockEtcEnvironment, []byte(content), 0644)
+	c.Assert(err, IsNil)
+
+	info, err := os.Stat(s.mockEtcEnvironment)
+	c.Assert(err, IsNil)
+
+	fileModTime := info.ModTime()
+
+	// To make sure the times will defer if the file is newly written
+	time.Sleep(100 * time.Millisecond)
+
+	err = configcore.Run(&mockConf{
+		state: s.state,
+		conf: map[string]interface{}{
+			"watchdog.runtime-timeout":  fmt.Sprintf("%ds", times[0]),
+			"watchdog.shutdown-timeout": fmt.Sprintf("%ds", times[1]),
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Check(s.mockEtcEnvironment, testutil.FileEquals, content)
+
+	info, err = os.Stat(s.mockEtcEnvironment)
+	c.Assert(err, IsNil)
+	c.Assert(info.ModTime(), Equals, fileModTime)
+}

--- a/tests/main/core-watchdog/task.yaml
+++ b/tests/main/core-watchdog/task.yaml
@@ -3,7 +3,7 @@ summary: Check that the core.watchdog settings work
 systems: [ubuntu-core-16-*]
 
 environment:
-    WATCHDOG_FILE: /etc/systemd/system.conf.d/10-ubuntu-core-watchdog.conf
+    WATCHDOG_FILE: /etc/systemd/system.conf.d/10-snapd-watchdog.conf
 
 restore: |
     rm -f "$WATCHDOG_FILE"

--- a/tests/main/core-watchdog/task.yaml
+++ b/tests/main/core-watchdog/task.yaml
@@ -1,6 +1,6 @@
 summary: Check that the core.watchdog settings work
 
-systems: [ubuntu-core-*]
+systems: [ubuntu-core-16-*]
 
 environment:
     WATCHDOG_FILE: /etc/systemd/system.conf.d/10-ubuntu-core-watchdog.conf
@@ -23,7 +23,7 @@ execute: |
     cat $WATCHDOG_FILE | MATCH ShutdownWatchdogSec=3600
 
     echo "Unsetting removes the file"
-    snap set core watchdog.runtime-timeout=0s
+    snap set core watchdog.runtime-timeout=
     snap set core watchdog.shutdown-timeout=0s
     if [ -f $WATCHDOG_FILE ]; then
         echo "Empty watchdog config should remove config file but did not"

--- a/tests/main/core-watchdog/task.yaml
+++ b/tests/main/core-watchdog/task.yaml
@@ -1,0 +1,31 @@
+summary: Check that the core.watchdog settings work
+
+systems: [ubuntu-core-*]
+
+environment:
+    WATCHDOG_FILE: /etc/systemd/system.conf.d/10-ubuntu-core-watchdog.conf
+
+restore: |
+    rm -f $WATCHDOG_FILE
+
+prepare: |
+    if [ -f $WATCHDOG_FILE ]; then
+        echo "Watchdog file already present, testbed not clean"
+        exit 1
+    fi
+
+execute: |
+    echo "Ensure snap service watchdog works"
+    snap set core watchdog.runtime-timeout=1m
+    cat $WATCHDOG_FILE | MATCH RuntimeWatchdogSec=60
+    
+    snap set core watchdog.shutdown-timeout=1h
+    cat $WATCHDOG_FILE | MATCH ShutdownWatchdogSec=3600
+
+    echo "Unsetting removes the file"
+    snap set core watchdog.runtime-timeout=0s
+    snap set core watchdog.shutdown-timeout=0s
+    if [ -f $WATCHDOG_FILE ]; then
+        echo "Empty watchdog config should remove config file but did not"
+        exit 1
+    fi

--- a/tests/main/core-watchdog/task.yaml
+++ b/tests/main/core-watchdog/task.yaml
@@ -6,10 +6,10 @@ environment:
     WATCHDOG_FILE: /etc/systemd/system.conf.d/10-ubuntu-core-watchdog.conf
 
 restore: |
-    rm -f $WATCHDOG_FILE
+    rm -f "$WATCHDOG_FILE"
 
 prepare: |
-    if [ -f $WATCHDOG_FILE ]; then
+    if [ -f "$WATCHDOG_FILE" ]; then
         echo "Watchdog file already present, testbed not clean"
         exit 1
     fi
@@ -17,15 +17,15 @@ prepare: |
 execute: |
     echo "Ensure snap service watchdog works"
     snap set core watchdog.runtime-timeout=1m
-    cat $WATCHDOG_FILE | MATCH RuntimeWatchdogSec=60
+    MATCH RuntimeWatchdogSec=60 < "$WATCHDOG_FILE"
     
     snap set core watchdog.shutdown-timeout=1h
-    cat $WATCHDOG_FILE | MATCH ShutdownWatchdogSec=3600
+    MATCH ShutdownWatchdogSec=3600 <  "$WATCHDOG_FILE"
 
     echo "Unsetting removes the file"
     snap set core watchdog.runtime-timeout=
     snap set core watchdog.shutdown-timeout=0s
-    if [ -f $WATCHDOG_FILE ]; then
+    if [ -f "$WATCHDOG_FILE" ]; then
         echo "Empty watchdog config should remove config file but did not"
         exit 1
     fi


### PR DESCRIPTION
Add options to configure systemd to use the hardware watchdog when
available. The new options are watchdog.runtime and watchdog.shutdown,
which correspond to systemd config options RuntimeWatchdogSec and
ShutdownWatchdogSec. See systemd-system.conf(5) for more information.

Related forum post: https://forum.snapcraft.io/t/hardware-watchdog-on-ubuntu-core/5695