### PR TITLE
tests: fix snapd-repair.timer on ubuntu-core-snapd-run- from-snap test

### DIFF
--- a/tests/main/ubuntu-core-snapd-run-from-snap/task.yaml
+++ b/tests/main/ubuntu-core-snapd-run-from-snap/task.yaml
@@ -20,7 +20,7 @@ restore: |
     umount /snap/snapd/current/usr/lib/snapd || true
     # and ensure snapd is working (needed in restore)
     systemctl daemon-reload
-    systemctl start snapd.service snapd.socket
+    systemctl start snapd.service snapd.socket snapd.snap-repair.timer
 
 execute: |
     echo "Run the manage script (from the snap)"


### PR DESCRIPTION
The snap-repair.timer remains stopped after the ubuntu-core-snapd-run-
from-snap is executed, making fails other tests such as snap-repair.

This change is starting the timer during the restore phase.

To see this works you can run (1 worker and high priority for first test):
spread google:ubuntu-core-16-64:tests/main/ubuntu-core-snapd-run-from-
snap google:ubuntu-core-16-64:tests/main/snap-repair
