### PR TITLE
store: switch connectivity check to use v2/info

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -2390,8 +2390,10 @@ func (s *Store) snapConnCheck() ([]string, error) {
 	// NOTE: "core" is possibly the only snap that's sure to be in all stores
 	//       when we drop "core" in the move to snapd/core18/etc, change this
 	infoURL := s.endpointURL(path.Join(snapInfoEndpPath, "core"), url.Values{
-		"fields":       {"download"},
-		"architecture": {"amd64"},
+		// we only want the download URL
+		"fields": {"download"},
+		// we only need *one* (but can't filter by channel ... yet)
+		"architecture": {s.architecture},
 	})
 	hosts = append(hosts, infoURL.Host)
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -7083,7 +7083,7 @@ func (s *storeTestSuite) TestConnectivityCheckHappy(c *C) {
 		switch r.URL.Path {
 		case "/v2/snaps/info/core":
 			c.Check(r.Method, Equals, "GET")
-			c.Check(r.URL.Query().Encode(), DeepEquals, "architecture=amd64&fields=download")
+			c.Check(r.URL.Query(), DeepEquals, url.Values{"fields": {"download"}, "architecture": {arch.UbuntuArchitecture()}})
 			u, err := url.Parse("/download/core")
 			c.Assert(err, IsNil)
 			io.WriteString(w, fmt.Sprintf(`{"channel-map": [{"download": {"url": %q}}]}`, mockServerURL.ResolveReference(u).String()))

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -7081,12 +7081,12 @@ func (s *storeTestSuite) TestConnectivityCheckHappy(c *C) {
 	var mockServerURL *url.URL
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/v1/snaps/details/core":
+		case "/v2/snaps/info/core":
 			c.Check(r.Method, Equals, "GET")
-			c.Check(r.URL.Query().Encode(), DeepEquals, "fields=anon_download_url")
+			c.Check(r.URL.Query().Encode(), DeepEquals, "architecture=amd64&fields=download")
 			u, err := url.Parse("/download/core")
 			c.Assert(err, IsNil)
-			io.WriteString(w, fmt.Sprintf(`{"anon_download_url": %q}`, mockServerURL.ResolveReference(u).String()))
+			io.WriteString(w, fmt.Sprintf(`{"channel-map": [{"download": {"url": %q}}]}`, mockServerURL.ResolveReference(u).String()))
 		case "/download/core":
 			c.Check(r.Method, Equals, "HEAD")
 			w.WriteHeader(200)
@@ -7111,8 +7111,8 @@ func (s *storeTestSuite) TestConnectivityCheckHappy(c *C) {
 		mockServerURL.Host: true,
 	})
 	c.Check(seenPaths, DeepEquals, map[string]int{
-		"/api/v1/snaps/details/core": 1,
-		"/download/core":             1,
+		"/v2/snaps/info/core": 1,
+		"/download/core":      1,
 	})
 }
 
@@ -7121,7 +7121,7 @@ func (s *storeTestSuite) TestConnectivityCheckUnhappy(c *C) {
 	var mockServerURL *url.URL
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/v1/snaps/details/core":
+		case "/v2/snaps/info/core":
 			w.WriteHeader(500)
 		default:
 			c.Fatalf("unexpected request: %s", r.URL.String())
@@ -7145,6 +7145,6 @@ func (s *storeTestSuite) TestConnectivityCheckUnhappy(c *C) {
 	})
 	// three because retries
 	c.Check(seenPaths, DeepEquals, map[string]int{
-		"/api/v1/snaps/details/core": 3,
+		"/v2/snaps/info/core": 3,
 	})
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -7086,7 +7086,12 @@ func (s *storeTestSuite) TestConnectivityCheckHappy(c *C) {
 			c.Check(r.URL.Query(), DeepEquals, url.Values{"fields": {"download"}, "architecture": {arch.UbuntuArchitecture()}})
 			u, err := url.Parse("/download/core")
 			c.Assert(err, IsNil)
-			io.WriteString(w, fmt.Sprintf(`{"channel-map": [{"download": {"url": %q}}]}`, mockServerURL.ResolveReference(u).String()))
+			io.WriteString(w,
+				fmt.Sprintf(`{"channel-map": [{"download": {"url": %q}}, {"download": {"url": %q}}, {"download": {"url": %q}}]}`,
+					mockServerURL.ResolveReference(u).String(),
+					mockServerURL.String()+"/bogus1/",
+					mockServerURL.String()+"/bogus2/",
+				))
 		case "/download/core":
 			c.Check(r.Method, Equals, "HEAD")
 			w.WriteHeader(200)


### PR DESCRIPTION
This is the first use of the new v2/info endpoint. It uses abbreviated
structs to save a little bit of time & space in decoding compared to
the full decode that'll be needed for _actual_ info usage.
