### PR TITLE
tests: enable fedora 28 again

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -79,7 +79,6 @@ backends:
             - fedora-28-64:
                 image: fedora-28-64-selinux-permissive
                 workers: 4
-                manual: true
 
             - opensuse-42.3-64:
                 image: opensuse-cloud/opensuse-leap-42-3-v20180116


### PR DESCRIPTION
The repo seems to be working well again. Before it was set as manual
because the repo was so slow and it was causing timeouts updating the
system.
