### PR TITLE
cmd/snap-update-ns: introduce mimicRequired helper

### DIFF
--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -66,6 +66,18 @@ func (c Change) String() string {
 // changePerform is Change.Perform that can be mocked for testing.
 var changePerform func(*Change, *Secure) ([]*Change, error)
 
+// mimicRequired provides information if an error warrants a writable mimic.
+//
+// The returned path is the location where a mimic should be constructed.
+func mimicRequired(err error) (needsMimic bool, path string) {
+	switch err.(type) {
+	case *ReadOnlyFsError:
+		rofsErr := err.(*ReadOnlyFsError)
+		return true, rofsErr.Path
+	}
+	return false, ""
+}
+
 func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change, error) {
 	// If we've been asked to create a missing path, and the mount
 	// entry uses the ignore-missing option, return an error.
@@ -100,12 +112,12 @@ func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change
 	case "symlink":
 		err = sec.MksymlinkAll(path, mode, uid, gid, c.Entry.XSnapdSymlink())
 	}
-	if err2, ok := err.(MimicRequiredError); ok && pokeHoles {
-		// If the writing failed because the underlying file-system is read-only
-		// we can construct a writable mimic to fix that.
-		changes, err = createWritableMimic(err2.MimicPath(), path, sec)
+	if needsMimic, mimicPath := mimicRequired(err); needsMimic && pokeHoles {
+		// If the error can be recovered by using a writable mimic
+		// then construct one and try again.
+		changes, err = createWritableMimic(mimicPath, path, sec)
 		if err != nil {
-			err = fmt.Errorf("cannot create writable mimic over %q: %s", err2.MimicPath(), err)
+			err = fmt.Errorf("cannot create writable mimic over %q: %s", mimicPath, err)
 		} else {
 			// Try once again. Note that we care *just* about the error. We have already
 			// performed the hole poking and thus additional changes must be nil.

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -100,12 +100,12 @@ func (c *Change) createPath(path string, pokeHoles bool, sec *Secure) ([]*Change
 	case "symlink":
 		err = sec.MksymlinkAll(path, mode, uid, gid, c.Entry.XSnapdSymlink())
 	}
-	if err2, ok := err.(*ReadOnlyFsError); ok && pokeHoles {
+	if err2, ok := err.(MimicRequiredError); ok && pokeHoles {
 		// If the writing failed because the underlying file-system is read-only
 		// we can construct a writable mimic to fix that.
-		changes, err = createWritableMimic(err2.Path, path, sec)
+		changes, err = createWritableMimic(err2.MimicPath(), path, sec)
 		if err != nil {
-			err = fmt.Errorf("cannot create writable mimic over %q: %s", err2.Path, err)
+			err = fmt.Errorf("cannot create writable mimic over %q: %s", err2.MimicPath(), err)
 		} else {
 			// Try once again. Note that we care *just* about the error. We have already
 			// performed the hole poking and thus additional changes must be nil.

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -138,17 +138,6 @@ func (e *ReadOnlyFsError) Error() string {
 	return fmt.Sprintf("cannot operate on read-only filesystem at %s", e.Path)
 }
 
-// MimicPath returns the path of the directory where a mimic ought to be constructed.
-func (e *ReadOnlyFsError) MimicPath() string {
-	return e.Path
-}
-
-// MimicRequiredError describes errors that require construction of a writable mimic.
-type MimicRequiredError interface {
-	Error() string
-	MimicPath() string
-}
-
 // Secure is a helper for making filesystem operations free from certain kinds of attacks.
 type Secure struct{}
 

--- a/cmd/snap-update-ns/utils.go
+++ b/cmd/snap-update-ns/utils.go
@@ -138,6 +138,17 @@ func (e *ReadOnlyFsError) Error() string {
 	return fmt.Sprintf("cannot operate on read-only filesystem at %s", e.Path)
 }
 
+// MimicPath returns the path of the directory where a mimic ought to be constructed.
+func (e *ReadOnlyFsError) MimicPath() string {
+	return e.Path
+}
+
+// MimicRequiredError describes errors that require construction of a writable mimic.
+type MimicRequiredError interface {
+	Error() string
+	MimicPath() string
+}
+
 // Secure is a helper for making filesystem operations free from certain kinds of attacks.
 type Secure struct{}
 


### PR DESCRIPTION
…r compat

This patch makes ReadOnlyFsError compatible with the new MimicRequiredError
interface. This allows us to generalize the need for a mimic. This will be
used by the upcoming trespassing detector.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
