### PR TITLE
interfaces/builtin: add new cuda-support interface

### DIFF
--- a/interfaces/builtin/cuda_support.go
+++ b/interfaces/builtin/cuda_support.go
@@ -12,6 +12,7 @@ unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
 /dev/nvidia-uvm wr,
 /dev/nvidiactl wr,
 /{dev,run}/shm/cuda.* rw,
+/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcuda*.so{,.*} rm, 
 `
 
 const cudaSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/cuda_support.go
+++ b/interfaces/builtin/cuda_support.go
@@ -1,0 +1,34 @@
+package builtin
+
+const cudaSupportConnectedPlugAppArmor = `
+# Description: CUDA requires being able to read/write to some nvidia devices
+
+@{PROC}/sys/vm/mmap_min_addr r,
+@{PROC}/devices r,
+@{PROC}/modules r,
+@{PROC}/driver/nvidia/params r,
+/sys/devices/system/memory/block_size_bytes r,
+unix (bind,listen) type=seqpacket addr="@cuda-uvmfd-[0-9a-f]*",
+/dev/nvidia-uvm wr,
+/dev/nvidiactl wr,
+/{dev,run}/shm/cuda.* rw,
+`
+
+const cudaSupportConnectedPlugSecComp = `
+# Description: allow running operations on GPU devices
+# necessary as cuda tries to create /dev/nvidia-uvm-tools with mknod
+mknod - |S_IFCHR
+`
+
+const cudaSupportSummary = `allows access to NVIDIA devices using CUDA`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "cuda-support",
+		summary:               cudaSupportSummary,
+		connectedPlugAppArmor: cudaSupportConnectedPlugAppArmor,
+		connectedPlugSecComp:  cudaSupportConnectedPlugSecComp,
+		implicitOnClassic:     true,
+		implicitOnCore:        true,
+	})
+}

--- a/interfaces/builtin/cuda_support_test.go
+++ b/interfaces/builtin/cuda_support_test.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type CUDAInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+const cudaMockPlugSnapInfoYaml = `name: cuda
+version: 1.0
+apps:
+ app:
+  command: foo
+  plugs: [cuda-support]
+`
+
+var _ = Suite(&CUDAInterfaceSuite{
+	iface: builtin.MustInterface("cuda-support"),
+})
+
+func (s *CUDAInterfaceSuite) SetUpTest(c *C) {
+	s.slotInfo = &snap.SlotInfo{
+		Snap: &snap.Info{
+			SuggestedName: "cuda-support",
+		},
+		Interface: "cuda-support",
+	}
+	s.slot = interfaces.NewConnectedSlot(s.slotInfo, nil)
+	plugSnap := snaptest.MockInfo(c, cudaMockPlugSnapInfoYaml, nil)
+	s.plugInfo = plugSnap.Plugs["cuda-support"]
+	s.plug = interfaces.NewConnectedPlug(s.plugInfo, nil)
+}
+
+func (s *CUDAInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "cuda-support")
+}
+
+func (s *CUDAInterfaceSuite) TestConnectedPlugSnippet(c *C) {
+	apparmorSpec := &apparmor.Specification{}
+	err := apparmorSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.cuda.app"})
+	c.Assert(apparmorSpec.SnippetForTag("snap.cuda.app"), testutil.Contains, `/dev/nvidia-uvm`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.cuda.app"), testutil.Contains, `/dev/nvidiactl`)
+	c.Assert(apparmorSpec.SnippetForTag("snap.cuda.app"), testutil.Contains, `/{dev,run}/shm/cuda.*`)
+
+	seccompSpec := &seccomp.Specification{}
+	err = seccompSpec.AddConnectedPlug(s.iface, s.plug, s.slot)
+	c.Assert(err, IsNil)
+	c.Assert(seccompSpec.SecurityTags(), DeepEquals, []string{"snap.cuda.app"})
+	c.Check(seccompSpec.SnippetForTag("snap.cuda.app"), testutil.Contains, "mknod\n")
+}
+
+func (s *CUDAInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *CUDAInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *CUDAInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -36,7 +36,6 @@ const openglConnectedPlugAppArmor = `
 /var/lib/snapd/lib/gl{,32}/** rm,
 
 # Bi-arch distribution nvidia support
-/var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libcuda*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvidia*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}tls/libnvidia*.so{,.*} rm,
 /var/lib/snapd/hostfs/{,usr/}lib{,32,64,x32}/{,@{multiarch}/}libnvcuvid.so{,.*} rm,

--- a/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-policy-app-consumer/meta/snap.yaml
@@ -53,6 +53,9 @@ apps:
   core-support:
     command: bin/run
     plugs: [ core-support ]
+  cuda-support:
+    command: bin/run
+    plugs: [ cuda-support ]
   cups-control:
     command: bin/run
     plugs: [ cups-control ]


### PR DESCRIPTION
While some CUDA specific apparmor code was added to the `opengl` interface in this [PR](https://github.com/snapcore/snapd/pull/5189), there are more permissions that other CUDA programs require, and so I thought that these warranted a new CUDA specific interface. If desired, this could instead be applied to the `opengl` or some other interface, but the devices accessed here are NVIDIA specific so it made the most sense to me to put them in their own interface. Or alternatively, some of the opengl snippets could also be copied into this interface so that a snap that just uses CUDA plugs into `cuda-support` and doesn't need `opengl`.

Example denial for the seccomp:
```
[pid  4349] mknod("/dev/nvidia-uvm-tools", S_IFCHR|0666, makedev(238, 1)) = -1 EPERM (Operation not permitted)
```
Note that the samples seem to run fine without the mknod permission, so if it's too dangerous then it can be removed from the seccomp...

## Testing
To test these, I built a `cuda-samples` snap which bundles almost all of the CUDA samples included with the SDK and allows running them in a test suite. That snap can be found here : https://github.com/anonymouse64/cuda-samples-snap and I would like to integrate that with some automated testing, but I'm not sure how best to go about that as some of the commands create a new x11 window that has to be clicked on or otherwise closed via UI which complicates an automated spread test for example. To test this interface with that snap, after building the snap I do:
```
sudo snap install --jailmode --dangerous cuda-samples*.snap
sudo snap connect cuda-samples:hardware-observe
sudo snap connect cuda-samples:cuda-support
cuda-samples test
# then click on the windows as they come up to close them
```
Some of the sample programs require input files that are copied into the snap, and some of them fail for other reasons that I don't yet understand but I don't think are related to snapd confinement. One such group of samples are the `nvrtc` samples, which seem to fail for reasons not related to confinement (I don't see anything go by in the denials while running but the runtime compilation fails).
Also note you need to have a NVIDIA GPU and appropriate drivers installed to test using the snap. I wasn't able to get noveau drivers to work with CUDA, I had to install the proprietary NVIDIA drivers.