### PR TITLE
tests/lib/prepare-restore: fix upgrade/reboot handling on arch

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -281,8 +281,10 @@ prepare_project() {
                 REBOOT
             fi
         fi
-        if [[ "$SPREAD_REBOOT" != 1 ]]; then
-            echo "reboot did not work"
+        # double check we are running the installed kernel
+        # NOTE: arch kernels use ARCH as local version, eg. 4.16.13-2-ARCH
+        if [[ "$(pacman -Qi linux | grep '^Version' | awk '{print $3}')" != "$(uname -r | sed -e 's/-ARCH//')" ]]; then
+            echo "running unexpected kernel version $(uname -r)"
             exit 1
         fi
     fi


### PR DESCRIPTION
When running tests on arch we need to perform system upgrade. Since we do now
know what which packages were upgraded, a reboot is issued. Occasionally, when
the base image is recent enough, there may be no updates, in which case there
will be no reboot. Fix the reboot check, but do check if we are running the
installed kernel. Otherwise the tests will fail when attempting to mount snap
images.
