### PR TITLE
cmd/snap-confine: include CUDA runtime libraries

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -97,6 +97,7 @@ static const char *nvidia_globs[] = {
 	"libXvMCNVIDIA.so*",
 	"libXvMCNVIDIA_dynamic.so*",
 	"libcuda.so*",
+	"libcudart.so*",
 	"libnvcuvid.so*",
 	"libnvidia-cfg.so*",
 	"libnvidia-compiler.so*",


### PR DESCRIPTION
The dynamic variant of CUDA runtime may be present on the host, make sure that
we pick it up.
