### PR TITLE
snap: run snap-confine from the re-exec location

### DIFF
--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -679,13 +679,23 @@ func (x *cmdRun) runCmdUnderStrace(origCmd, env []string) error {
 
 func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook string, args []string) error {
 	snapConfine := filepath.Join(dirs.DistroLibExecDir, "snap-confine")
-	// if we re-exec, we must run the snap-confine from the core snap
+	// if we re-exec, we must run the snap-confine from the core/snapd snap
 	// as well, if they get out of sync, havoc will happen
 	if isReexeced() {
-		// run snap-confine from the core snap. that will work because
-		// snap-confine on the core snap is mostly statically linked
-		// (except libudev and libc)
-		snapConfine = filepath.Join(dirs.SnapMountDir, "core/current", dirs.CoreLibExecDir, "snap-confine")
+		exe, err := osReadlink("/proc/self/exe")
+		if err != nil {
+			return err
+		}
+		// snapBase will be "/snap/{core,snapd}/$rev/" because
+		// the snap binary is always under usr/bin/snap
+		snapBase, err := filepath.Abs(filepath.Join(filepath.Dir(exe), "..", ".."))
+		if err != nil {
+			return err
+		}
+		// Run snap-confine from the core/snapd snap. That
+		// will work because snap-confine on the core/snapd snap is
+		// mostly statically linked (except libudev and libc)
+		snapConfine = filepath.Join(snapBase, dirs.CoreLibExecDir, "snap-confine")
 	}
 
 	if !osutil.FileExists(snapConfine) {
@@ -693,7 +703,7 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 			logger.Noticef("WARNING: skipping running hook %q of snap %q: missing snap-confine", hook, info.Name())
 			return nil
 		}
-		return fmt.Errorf(i18n.G("missing snap-confine: try updating your snapd package"))
+		return fmt.Errorf(i18n.G("missing snap-confine: try updating your core/snapd package"))
 	}
 
 	if err := createUserDataDirs(info); err != nil {

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -682,16 +682,14 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, securityTag, snapApp, hook stri
 	// if we re-exec, we must run the snap-confine from the core/snapd snap
 	// as well, if they get out of sync, havoc will happen
 	if isReexeced() {
+		// exe is something like /snap/{snapd,core}/123/usr/bin/snap
 		exe, err := osReadlink("/proc/self/exe")
 		if err != nil {
 			return err
 		}
 		// snapBase will be "/snap/{core,snapd}/$rev/" because
-		// the snap binary is always under usr/bin/snap
-		snapBase, err := filepath.Abs(filepath.Join(filepath.Dir(exe), "..", ".."))
-		if err != nil {
-			return err
-		}
+		// the snap binary is always at $root/usr/bin/snap
+		snapBase := filepath.Clean(filepath.Join(filepath.Dir(exe), "..", ".."))
 		// Run snap-confine from the core/snapd snap. That
 		// will work because snap-confine on the core/snapd snap is
 		// mostly statically linked (except libudev and libc)

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -205,9 +205,9 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 	// So
 	//   /snap/core/111/usr/lib/snapd/snap-confine
 	// becomes
-	//   snap-confine.snap.core.111.usr.lib.snapd.snap-confine
-	patchedProfileName := "snap-confine." + strings.Replace(snapConfineInCore[1:], "/", ".", -1)
-	patchedProfileGlob := strings.Replace(patchedProfileName, "."+info.Revision.String()+".", ".*.", 1)
+	//   snap-confine.core.111
+	patchedProfileName := fmt.Sprintf("snap-confine.%s.%s", info.Name(), info.Revision)
+	patchedProfileGlob := fmt.Sprintf("snap-confine.%s.*", info.Name())
 
 	// Return information for EnsureDirState that describes the re-exec profile for snap-confine.
 	content = map[string]*osutil.FileState{

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -203,9 +203,9 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 	// "snap-update-ns.*" that is already used there
 	//
 	// So
-	//             /snap/core/111/usr/lib/snapd/snap-confine
+	//   /snap/core/111/usr/lib/snapd/snap-confine
 	// becomes
-	// snap-confine.snap.core.111.usr.lib.snapd.snap-confine
+	//   snap-confine.snap.core.111.usr.lib.snapd.snap-confine
 	patchedProfileName := "snap-confine." + strings.Replace(snapConfineInCore[1:], "/", ".", -1)
 	patchedProfileGlob := strings.Replace(patchedProfileName, "."+info.Revision.String()+".", ".*.", 1)
 
@@ -220,7 +220,7 @@ func snapConfineFromSnapProfile(info *snap.Info) (dir, glob string, content map[
 	return dirs.SnapAppArmorDir, patchedProfileGlob, content, nil
 }
 
-// setupSnapConfineReexec will setup apparmor profiles on the hosts
+// setupSnapConfineReexec will setup apparmor profiles inside the host's
 // /var/lib/snapd/apparmor/profiles directory. This is needed for
 // running snap-confine from the core or snapd snap.
 //

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -631,8 +630,8 @@ func (s *backendSuite) TestSnapConfineProfile(c *C) {
 	s.writeVanillaSnapConfineProfile(c, coreInfo)
 	// We expect to see the same profile, just anchored at a different directory.
 	expectedProfileDir := filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/apparmor/profiles")
-	expectedProfileName := "snap-confine." + strings.Replace(filepath.Join(coreInfo.MountDir(), "usr/lib/snapd/snap-confine")[1:], "/", ".", -1)
-	expectedProfileGlob := strings.Replace(expectedProfileName, "."+coreInfo.Revision.String()+".", ".*.", -1)
+	expectedProfileName := "snap-confine.core.111"
+	expectedProfileGlob := "snap-confine.core.*"
 	expectedProfileText := fmt.Sprintf(`#include <tunables/global>
 %s/usr/lib/snapd/snap-confine (attach_disconnected) {
     # We run privileged, so be fanatical about what we include and don't use
@@ -666,8 +665,8 @@ func (s *backendSuite) TestSnapConfineProfileFromSnapdSnap(c *C) {
 
 	// We expect to see the same profile, just anchored at a different directory.
 	expectedProfileDir := filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/apparmor/profiles")
-	expectedProfileName := strings.Replace("snap-confine."+filepath.Join(snapdInfo.MountDir(), "usr/lib/snapd/snap-confine")[1:], "/", ".", -1)
-	expectedProfileGlob := strings.Replace(expectedProfileName, "."+snapdInfo.Revision.String()+".", ".*.", -1)
+	expectedProfileName := "snap-confine.snapd.222"
+	expectedProfileGlob := "snap-confine.snapd.*"
 	expectedProfileText := fmt.Sprintf(`#include <tunables/global>
 %s/usr/lib/snapd/snap-confine (attach_disconnected) {
     # We run privileged, so be fanatical about what we include and don't use
@@ -700,7 +699,7 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecCleans(c *C) {
 	coreInfo := snaptest.MockInfo(c, coreYaml, &snap.SideInfo{Revision: snap.R(111)})
 	s.writeVanillaSnapConfineProfile(c, coreInfo)
 
-	canaryName := strings.Replace("snap-confine"+filepath.Join(dirs.SnapMountDir, "/core/2718/usr/lib/snapd/snap-confine"), "/", ".", -1)
+	canaryName := "snap-confine.core.2718"
 	canary := filepath.Join(dirs.SnapAppArmorDir, canaryName)
 	err := os.MkdirAll(filepath.Dir(canary), 0755)
 	c.Assert(err, IsNil)
@@ -732,7 +731,7 @@ func (s *backendSuite) TestSetupHostSnapConfineApparmorForReexecWritesNew(c *C) 
 	newAA, err := filepath.Glob(filepath.Join(dirs.SnapAppArmorDir, "*"))
 	c.Assert(err, IsNil)
 	c.Assert(newAA, HasLen, 1)
-	c.Check(newAA[0], Matches, `.*/var/lib/snapd/apparmor/profiles/.*.snap.core.111.usr.lib.snapd.snap-confine`)
+	c.Check(newAA[0], Matches, `.*/var/lib/snapd/apparmor/profiles/snap-confine.core.111`)
 
 	// This is the key, rewriting "/usr/lib/snapd/snap-confine
 	c.Check(newAA[0], testutil.FileContains, "/snap/core/111/usr/lib/snapd/snap-confine (attach_disconnected) {")

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	SnapConfineFromCoreProfile = snapConfineFromCoreProfile
+	SnapConfineFromSnapProfile = snapConfineFromSnapProfile
 	ProfileGlobs               = profileGlobs
 	NsProfile                  = nsProfile
 )

--- a/tests/main/security-setuid-root/task.yaml
+++ b/tests/main/security-setuid-root/task.yaml
@@ -16,12 +16,12 @@ prepare: |
     . $TESTSLIB/snaps.sh
     install_local test-snapd-tools
     echo "Ensure the snap-confine profiles on core are not loaded"
-    for p in /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine; do
+    for p in /var/lib/snapd/apparmor/profiles/snap-confine.*; do
         apparmor_parser -R "$p"
     done
 restore: |
     echo "Ensure the snap-confine profiles are restored"
-    for p in /etc/apparmor.d/snap.core.*.usr.lib.snapd.snap-confine; do
+    for p in /var/lib/snapd/apparmor/profiles/snap-confine.*; do
         apparmor_parser -r $p
     done
 execute: |

--- a/tests/main/snap-confine-from-core/task.yaml
+++ b/tests/main/snap-confine-from-core/task.yaml
@@ -50,23 +50,23 @@ execute: |
     fi
 
     echo "Ensure snapd generates the right apparmor profile on restart"
-    PROFILES="$(find /etc/apparmor.d/ -maxdepth 1 -name "snap.core.*.snap-confine")"
+    PROFILES="$(find /var/lib/snapd/apparmor/profiles/ -maxdepth 1 -name "snap-confine.*")"
     if [ -z "$PROFILES" ]; then
         echo "cannot find apparmor profiles for snap-confine from core"
         echo "test broken"
-        ls -al /etc/apparmor.d
+        ls -al /var/lib/snapd/apparmor/profiles
         exit 1
     fi
 
     echo "Force system-key change"
     systemd_stop_units snapd.service snapd.socket
     printf '{"version":1}' > /var/lib/snapd/system-key
-    rm -f /etc/apparmor.d/snap.core.*.snap-confine
+    rm -f /var/lib/snapd/apparmor/profiles/snap-confine.*
     systemctl start snapd.service snapd.socket
     wait_for_service snapd.service
 
     echo "Ensure this also re-generates the snap-confine from core profile"
-    PROFILES="$(find /etc/apparmor.d/ -maxdepth 1 -name "snap.core.*.snap-confine")"
+    PROFILES="$(find /var/lib/snapd/apparmor/profiles/ -maxdepth 1 -name "snap-confine.*")"
     if [ -z "$PROFILES" ]; then
         echo "apparmor profiles for snap-confine from core were not re-generated"
         echo "test broken"


### PR DESCRIPTION
When snap re-execs we no longer always re-exec into /snap/core/...
but it will soon be possible to re-exec into /snap/snapd/... as
well. This means that snap-confine needs to be picked from the
same re-exec location, we can no longer hardcode core here.

The extra complication is that we need to generate an apparmor profile
for the snap-confine from the snapd snap. On classic we use /etc/apparmor.d
but this is not writable on core (and contains subdirs so making it writable
is not ideal). So we switch writing the profile into the snap profiles directory
with a custom prefix `snap-confine.` on both core and classic.