### PR TITLE
interfaces: add Repository.AllInterfaces

### DIFF
--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -81,6 +81,19 @@ func (r *Repository) AddInterface(i Interface) error {
 	return nil
 }
 
+// AllInterfaces returns all the interfaces added to the repository, ordered by name.
+func (r *Repository) AllInterfaces() []Interface {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	ifaces := make([]Interface, 0, len(r.ifaces))
+	for _, iface := range r.ifaces {
+		ifaces = append(ifaces, iface)
+	}
+	sort.Sort(byInterfaceName(ifaces))
+	return ifaces
+}
+
 // InfoOptions describes options for Info.
 //
 // Names: return just this subset if non-empty.

--- a/interfaces/repo_test.go
+++ b/interfaces/repo_test.go
@@ -146,6 +146,25 @@ func (s *RepositorySuite) TestAddInterfaceInvalidName(c *C) {
 	c.Assert(s.emptyRepo.Interface(iface.Name()), IsNil)
 }
 
+// Tests for Repository.AllInterfaces()
+
+func (s *RepositorySuite) TestAllInterfaces(c *C) {
+	c.Assert(s.emptyRepo.AllInterfaces(), HasLen, 0)
+	c.Assert(s.testRepo.AllInterfaces(), DeepEquals, []Interface{s.iface})
+
+	// Add three interfaces in some non-sorted order.
+	i1 := &ifacetest.TestInterface{InterfaceName: "i1"}
+	i2 := &ifacetest.TestInterface{InterfaceName: "i2"}
+	i3 := &ifacetest.TestInterface{InterfaceName: "i3"}
+	c.Assert(s.emptyRepo.AddInterface(i3), IsNil)
+	c.Assert(s.emptyRepo.AddInterface(i1), IsNil)
+	c.Assert(s.emptyRepo.AddInterface(i2), IsNil)
+
+	// The result is always sorted.
+	c.Assert(s.emptyRepo.AllInterfaces(), DeepEquals, []Interface{i1, i2, i3})
+
+}
+
 func (s *RepositorySuite) TestAddBackend(c *C) {
 	backend := &ifacetest.TestSecurityBackend{BackendName: "test"}
 	c.Assert(s.emptyRepo.AddBackend(backend), IsNil)


### PR DESCRIPTION
This patch adds a helper method that returns all the interfaces that
were added to a repository. It will be used by upcoming refactoring of
implicit interfaces.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>
