### PR TITLE
store: switch store.SnapInfo to use the new v2/info endpoint

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -698,8 +698,7 @@ func findOne(c *Command, r *http.Request, user *auth.UserState, name string) Res
 
 	theStore := getStore(c)
 	spec := store.SnapSpec{
-		Name:       name,
-		AnyChannel: true,
+		Name: name,
 	}
 	snapInfo, err := theStore.SnapInfo(spec, user)
 	switch err {

--- a/daemon/api_test.go
+++ b/daemon/api_test.go
@@ -113,9 +113,6 @@ type apiBaseSuite struct {
 
 func (s *apiBaseSuite) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
 	s.user = user
-	if !spec.AnyChannel {
-		return nil, fmt.Errorf("api is expected to set AnyChannel")
-	}
 	if len(s.rsnaps) > 0 {
 		return s.rsnaps[0], s.err
 	}

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -138,10 +138,6 @@ func (f *fakeStore) pokeStateLock() {
 }
 
 func (f *fakeStore) SnapInfo(spec store.SnapSpec, user *auth.UserState) (*snap.Info, error) {
-	if !spec.AnyChannel || spec.Channel != "" || !spec.Revision.Unset() {
-		panic("snapstate expected to use SnapInfo with SnapSpec.AnyChannel:true")
-	}
-
 	f.pokeStateLock()
 
 	sspec := snapSpec{

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -111,7 +111,7 @@ func installInfo(st *state.State, name, channel string, revision snap.Revision, 
 	//       here.
 	if channel != "" && err == store.ErrRevisionNotAvailable {
 		st.Unlock()
-		_, err1 := theStore.SnapInfo(store.SnapSpec{Name: name, AnyChannel: true}, user)
+		_, err1 := theStore.SnapInfo(store.SnapSpec{Name: name}, user)
 		st.Lock()
 		if err1 != nil {
 			return nil, store.ErrSnapNotFound

--- a/store/details.go
+++ b/store/details.go
@@ -20,9 +20,6 @@
 package store
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/snapcore/snapd/jsonutil/safejson"
 	"github.com/snapcore/snapd/snap"
 )
@@ -49,7 +46,6 @@ type snapDetails struct {
 	Revision       int      `json:"revision"` // store revisions are ints starting at 1
 	ScreenshotURLs []string `json:"screenshot_urls,omitempty"`
 	SnapID         string   `json:"snap_id"`
-	SnapYAML       string   `json:"snap_yaml_raw"`
 	License        string   `json:"license,omitempty"`
 	Base           string   `json:"base,omitempty"`
 
@@ -68,8 +64,6 @@ type snapDetails struct {
 
 	Private     bool   `json:"private"`
 	Confinement string `json:"confinement"`
-
-	ChannelMapList []channelMap `json:"channel_maps_list,omitempty"`
 
 	CommonIDs []string `json:"common_ids,omitempty"`
 }
@@ -140,53 +134,6 @@ func infoFromRemote(d *snapDetails) *snap.Info {
 	//        the "SupportURL" part of the if
 	if info.Contact == "" {
 		info.Contact = d.SupportURL
-	}
-
-	// fill in the plug/slot data
-	if rawYamlInfo, err := snap.InfoFromSnapYaml([]byte(d.SnapYAML)); err == nil {
-		if info.Plugs == nil {
-			info.Plugs = make(map[string]*snap.PlugInfo)
-		}
-		for k, v := range rawYamlInfo.Plugs {
-			info.Plugs[k] = v
-			info.Plugs[k].Snap = info
-		}
-		if info.Slots == nil {
-			info.Slots = make(map[string]*snap.SlotInfo)
-		}
-		for k, v := range rawYamlInfo.Slots {
-			info.Slots[k] = v
-			info.Slots[k].Snap = info
-		}
-	}
-
-	// fill in the tracks data
-	if len(d.ChannelMapList) > 0 {
-		info.Channels = make(map[string]*snap.ChannelSnapInfo)
-		info.Tracks = make([]string, len(d.ChannelMapList))
-		for i, cm := range d.ChannelMapList {
-			info.Tracks[i] = cm.Track
-			for _, ch := range cm.SnapDetails {
-				// nothing in this channel
-				if ch.Info == "" {
-					continue
-				}
-				var k string
-				if strings.HasPrefix(ch.Channel, cm.Track) {
-					k = ch.Channel
-				} else {
-					k = fmt.Sprintf("%s/%s", cm.Track, ch.Channel)
-				}
-				info.Channels[k] = &snap.ChannelSnapInfo{
-					Revision:    snap.R(ch.Revision),
-					Confinement: snap.ConfinementType(ch.Confinement),
-					Version:     ch.Version,
-					Channel:     ch.Channel,
-					Epoch:       ch.Epoch,
-					Size:        ch.DownloadSize,
-				}
-			}
-		}
 	}
 
 	return info

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -118,13 +118,14 @@ func infoFromStoreInfo(si *storeInfo) (*snap.Info, error) {
 	}
 
 	thisOne := si.ChannelMap[0]
+	thisSnap := thisOne.storeSnap // copy it as we're about to modify it
 	// here we assume that the ChannelSnapInfo can be populated with data
 	// that's in the channel map and not the outer snap. This is a
 	// reasonable assumption today, but copyNonZeroFrom can easily be
 	// changed to copy to a list if needed.
-	copyNonZeroFrom(&si.Snap, &thisOne.storeSnap)
+	copyNonZeroFrom(&si.Snap, &thisSnap)
 
-	info, err := infoFromStoreSnap(&thisOne.storeSnap)
+	info, err := infoFromStoreSnap(&thisSnap)
 	if err != nil {
 		return nil, err
 	}

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -111,7 +111,10 @@ type storeInfo struct {
 
 func infoFromStoreInfo(si *storeInfo) (*snap.Info, error) {
 	if len(si.ChannelMap) == 0 {
-		return nil, fmt.Errorf("internal error: store info missing channel map")
+		// if a snap has no released revisions, it _could_ be returned
+		// (currently no, but spec is purposely ambiguous)
+		// we treat it as a 'not found' for now at least
+		return nil, ErrSnapNotFound
 	}
 
 	thisOne := si.ChannelMap[0]

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -118,7 +118,7 @@ func infoFromStoreInfo(si *storeInfo) (*snap.Info, error) {
 	}
 
 	thisOne := si.ChannelMap[0]
-	// here we assumes that the ChannelSnapInfo can be populated with data
+	// here we assume that the ChannelSnapInfo can be populated with data
 	// that's in the channel map and not the outer snap. This is a
 	// reasonable assumption today, but copyNonZeroFrom can easily be
 	// changed to copy to a list if needed.

--- a/store/details_v2.go
+++ b/store/details_v2.go
@@ -87,6 +87,136 @@ type storeSnapMedia struct {
 	Height int64  `json:"height"`
 }
 
+// storeInfoChannel is the channel description included in info results
+type storeInfoChannel struct {
+	Architecture string `json:"architecture"`
+	Name         string `json:"name"`
+	Risk         string `json:"risk"`
+	Track        string `json:"track"`
+}
+
+// storeInfoChannelSnap is the snap-in-a-channel of which the channel map is made
+type storeInfoChannelSnap struct {
+	storeSnap
+	Channel storeInfoChannel `json:"channel"`
+}
+
+// storeInfo is the result of v2/info calls
+type storeInfo struct {
+	ChannelMap []*storeInfoChannelSnap `json:"channel-map"`
+	Snap       storeSnap               `json:"snap"`
+	Name       string                  `json:"name"`
+	SnapID     string                  `json:"snap-id"`
+}
+
+func infoFromStoreInfo(si *storeInfo) (*snap.Info, error) {
+	if len(si.ChannelMap) == 0 {
+		return nil, fmt.Errorf("internal error: store info missing channel map")
+	}
+
+	thisOne := si.ChannelMap[0]
+	// here we assumes that the ChannelSnapInfo can be populated with data
+	// that's in the channel map and not the outer snap. This is a
+	// reasonable assumption today, but copyNonZeroFrom can easily be
+	// changed to copy to a list if needed.
+	copyNonZeroFrom(&si.Snap, &thisOne.storeSnap)
+
+	info, err := infoFromStoreSnap(&thisOne.storeSnap)
+	if err != nil {
+		return nil, err
+	}
+	info.Channel = thisOne.Channel.Name
+	info.Channels = make(map[string]*snap.ChannelSnapInfo, len(si.ChannelMap))
+	seen := make(map[string]bool, len(si.ChannelMap))
+	for _, s := range si.ChannelMap {
+		ch := s.Channel
+		info.Channels[ch.Track+"/"+ch.Risk] = &snap.ChannelSnapInfo{
+			Revision:    snap.R(s.Revision),
+			Confinement: snap.ConfinementType(s.Confinement),
+			Version:     s.Version,
+			Channel:     ch.Name,
+			Epoch:       s.Epoch,
+			Size:        s.Download.Size,
+		}
+		if !seen[ch.Track] {
+			seen[ch.Track] = true
+			info.Tracks = append(info.Tracks, ch.Track)
+		}
+	}
+
+	return info, nil
+}
+
+// copy non-zero fields from src to dst
+func copyNonZeroFrom(src, dst *storeSnap) {
+	if len(src.Architectures) > 0 {
+		dst.Architectures = src.Architectures
+	}
+	if src.Base != "" {
+		dst.Base = src.Base
+	}
+	if src.Confinement != "" {
+		dst.Confinement = src.Confinement
+	}
+	if src.Contact != "" {
+		dst.Contact = src.Contact
+	}
+	if src.CreatedAt != "" {
+		dst.CreatedAt = src.CreatedAt
+	}
+	if src.Description.Clean() != "" {
+		dst.Description = src.Description
+	}
+	if src.Download.URL != "" {
+		dst.Download = src.Download
+	}
+	if src.Epoch.String() != "0" {
+		dst.Epoch = src.Epoch
+	}
+	if src.License != "" {
+		dst.License = src.License
+	}
+	if src.Name != "" {
+		dst.Name = src.Name
+	}
+	if len(src.Prices) > 0 {
+		dst.Prices = src.Prices
+	}
+	if src.Private {
+		dst.Private = src.Private
+	}
+	if src.Publisher.ID != "" {
+		dst.Publisher = src.Publisher
+	}
+	if src.Revision > 0 {
+		dst.Revision = src.Revision
+	}
+	if src.SnapID != "" {
+		dst.SnapID = src.SnapID
+	}
+	if src.SnapYAML != "" {
+		dst.SnapYAML = src.SnapYAML
+	}
+	if src.Summary.Clean() != "" {
+		dst.Summary = src.Summary
+	}
+	if src.Title.Clean() != "" {
+		dst.Title = src.Title
+	}
+	if src.Type != "" {
+		dst.Type = src.Type
+	}
+	if src.Version != "" {
+		dst.Version = src.Version
+	}
+	if len(src.Media) > 0 {
+		dst.Media = src.Media
+	}
+	if len(src.CommonIDs) > 0 {
+		dst.CommonIDs = src.CommonIDs
+	}
+}
+
 func infoFromStoreSnap(d *storeSnap) (*snap.Info, error) {
 	info := &snap.Info{}
 	info.RealName = d.Name

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -309,6 +309,13 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 
 // arg must be a pointer to a struct
 func fillStruct(a interface{}, c *C) {
+	if t := reflect.TypeOf(a); t.Kind() != reflect.Ptr || t.Elem().Kind() != reflect.Struct {
+		k := t.Kind()
+		if k == reflect.Ptr {
+			k = t.Elem().Kind()
+		}
+		c.Fatalf("first argument must be expected a pointer to a struct, not %s", k)
+	}
 	va := reflect.ValueOf(a)
 	n := va.Elem().NumField()
 	for i := 0; i < n; i++ {

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -281,8 +281,8 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		"BadInterfaces",
 		"Broken",
 		"MustBuy",
-		"Channels", // TODO: support coming later
-		"Tracks",   // TODO: support coming later
+		"Channels", // handled at a different level (see TestInfo)
+		"Tracks",   // handled at a different level (see TestInfo)
 		"Layout",
 		"SideInfo.Channel",
 		"DownloadInfo.AnonDownloadURL", // TODO: going away at some point

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -27,6 +27,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/jsonutil/safejson"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -304,4 +305,84 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 	}
 	x := reflect.ValueOf(info).Elem()
 	checker("", x)
+}
+
+// arg must be a pointer to a struct
+func fillStruct(a interface{}, c *C) {
+	va := reflect.ValueOf(a)
+	n := va.Elem().NumField()
+	for i := 0; i < n; i++ {
+		field := va.Elem().Field(i)
+		var x interface{}
+		switch field.Interface().(type) {
+		case string:
+			x = "foo"
+		case []string:
+			x = []string{"foo"}
+		case safejson.String:
+			var s safejson.String
+			c.Assert(json.Unmarshal([]byte(`"foo"`), &s), IsNil)
+			x = s
+		case safejson.Paragraph:
+			var p safejson.Paragraph
+			c.Assert(json.Unmarshal([]byte(`"foo"`), &p), IsNil)
+			x = p
+		case storeSnapDownload:
+			x = storeSnapDownload{
+				URL:      "http://example.com/foo",
+				Size:     42,
+				Sha3_384: "foo",
+			}
+		case snap.Epoch:
+			x = *snap.E("1")
+		case map[string]string:
+			x = map[string]string{"foo": "bar"}
+		case bool:
+			x = true
+		case storeAccount:
+			x = storeAccount{
+				ID:          "foo-id",
+				Username:    "foo",
+				DisplayName: "Foo Bar",
+			}
+		case int:
+			x = 42
+		case snap.Type:
+			x = snap.Type("invalid")
+		case []storeSnapMedia:
+			x = []storeSnapMedia{{
+				Type: "potato",
+				URL:  "http://example.com/foo.pot",
+			}}
+		default:
+			c.Fatalf("unhandled field type %T", field.Interface())
+		}
+		field.Set(reflect.ValueOf(x))
+	}
+}
+
+func (s *detailsV2Suite) TestCopyNonZero(c *C) {
+	// a is a storeSnap with everything non-zero
+	a := storeSnap{}
+	fillStruct(&a, c)
+	// b is all zeros
+	b := storeSnap{}
+
+	aCopy := a
+	bCopy := b
+
+	// sanity check
+	c.Check(a, DeepEquals, aCopy)
+	c.Check(b, DeepEquals, bCopy)
+	c.Check(a, Not(DeepEquals), b)
+
+	// copying from b to a does nothing:
+	copyNonZeroFrom(&b, &a)
+	c.Check(a, DeepEquals, aCopy)
+	c.Check(b, DeepEquals, bCopy)
+
+	// copying from a to b does its thing:
+	copyNonZeroFrom(&a, &b)
+	c.Check(a, DeepEquals, b)
+	c.Check(b, Not(DeepEquals), bCopy)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -1027,26 +1027,10 @@ func mustBuy(paid bool, bought bool) bool {
 // A SnapSpec describes a single snap wanted from SnapInfo
 type SnapSpec struct {
 	Name string
-
-	// XXX only left because a lot of the test logic in overlord/snapstate
-	//     uses this. I'll rewrite them in a separate PR. Nothing else
-	//     should be using it (and in particular nothing calling SnapInfo!)
-	Channel    string
-	Revision   snap.Revision
-	AnyChannel bool
 }
 
 // SnapInfo returns the snap.Info for the store-hosted snap matching the given spec, or an error.
 func (s *Store) SnapInfo(snapSpec SnapSpec, user *auth.UserState) (*snap.Info, error) {
-	if snapSpec.Channel != "" {
-		return nil, fmt.Errorf("internal error: Channel specified to SnapInfo")
-	}
-	if !snapSpec.Revision.Unset() {
-		return nil, fmt.Errorf("internal error: Revision specified to SnapInfo")
-	}
-	if !snapSpec.AnyChannel {
-		return nil, fmt.Errorf("internal error: AnyChannel not specified to SnapInfo")
-	}
 	query := url.Values{}
 	query.Set("fields", strings.Join(s.infoFields, ","))
 	query.Set("architecture", s.architecture)

--- a/store/store.go
+++ b/store/store.go
@@ -287,7 +287,7 @@ func init() {
 		panic(err)
 	}
 	defaultConfig.DetailFields = jsonutil.StructFields((*snapDetails)(nil), "snap_yaml_raw")
-	defaultConfig.InfoFields = jsonutil.StructFields((*storeSnap)(nil))
+	defaultConfig.InfoFields = jsonutil.StructFields((*storeSnap)(nil), "snap-yaml")
 }
 
 type searchResults struct {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2280,8 +2280,7 @@ func (s *storeTestSuite) TestInfo(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2360,8 +2359,7 @@ func (s *storeTestSuite) TestInfoDefaultChannelIsStable(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2391,8 +2389,7 @@ func (s *storeTestSuite) TestInfo500(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	_, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, NotNil)
@@ -2426,8 +2423,7 @@ func (s *storeTestSuite) TestInfo500once(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2465,8 +2461,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2542,8 +2537,7 @@ func (s *storeTestSuite) TestInfoNonDefaults(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2573,8 +2567,7 @@ func (s *storeTestSuite) TestStoreIDFromAuthContext(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2606,8 +2599,7 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContext(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2638,8 +2630,7 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContextURLFallback(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2668,8 +2659,7 @@ func (s *storeTestSuite) TestInfoOopses(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	_, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, ErrorMatches, `cannot get details for snap "hello-world": got unexpected HTTP status code 5.. via GET to "http://\S+" \[OOPS-[[:xdigit:]]*\]`)
@@ -2712,8 +2702,7 @@ func (s *storeTestSuite) TestNoInfo(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:       "no-such-pkg",
-		AnyChannel: true,
+		Name: "no-such-pkg",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, NotNil)
@@ -3625,8 +3614,7 @@ func (s *storeTestSuite) TestSuggestedCurrency(c *C) {
 
 	// we should soon have a suggested currency
 	spec := SnapSpec{
-		Name:       "hello-world",
-		AnyChannel: true,
+		Name: "hello-world",
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -4100,8 +4088,7 @@ func (s *storeTestSuite) TestBuy(c *C) {
 
 		// Find the snap first
 		spec := SnapSpec{
-			Name:       "hello-world",
-			AnyChannel: true,
+			Name: "hello-world",
 		}
 		snap, err := sto.SnapInfo(spec, s.user)
 		c.Assert(snap, NotNil)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -131,12 +131,18 @@ const (
 	searchPath         = "/api/v1/snaps/search"
 	sectionsPath       = "/api/v1/snaps/sections"
 	// v2
-	snapActionPath = "/v2/snaps/refresh"
+	snapActionPath  = "/v2/snaps/refresh"
+	infoPathPattern = "/v2/snaps/info/.*"
 )
 
 // Build details path for a snap name.
 func detailsPath(snapName string) string {
 	return strings.Replace(detailsPathPattern, ".*", snapName, 1)
+}
+
+// Build info path for a snap name.
+func infoPath(snapName string) string {
+	return strings.Replace(infoPathPattern, ".*", snapName, 1)
 }
 
 // Assert that a request is roughly as expected. Useful in fakes that should
@@ -2041,35 +2047,224 @@ const mockSingleOrderJSON = `{
   ]
 }`
 
-func (s *storeTestSuite) TestDetails(c *C) {
+/* acquired via
+
+http --pretty=format --print b https://api.snapcraft.io/v2/snaps/info/hello-world architecture==amd64 fields==architectures,base,confinement,contact,created-at,description,download,epoch,license,name,prices,private,publisher,revision,snap-id,snap-yaml,summary,title,type,version,media,common-ids Snap-Device-Series:16 | xsel -b
+
+on 2018-06-13. Then, by hand:
+- set prices to {"EUR": "0.99", "USD": "1.23"},
+- set base in first channel-map entry to "bogus-base",
+- set snap-yaml in first channel-map entry to the one from the 'edge', plus the following pastiche:
+apps:
+  content-plug:
+    command: bin/content-plug
+    plugs: [shared-content-plug]
+plugs:
+  shared-content-plug:
+    interface: content
+    target: import
+    content: mylib
+    default-provider: test-snapd-content-slot
+slots:
+  shared-content-slot:
+    interface: content
+    content: mylib
+    read:
+      - /
+
+*/
+const mockInfoJSON = `{
+    "channel-map": [
+        {
+            "architectures": [
+                "all"
+            ],
+            "base": "bogus-base",
+            "channel": {
+                "architecture": "amd64",
+                "name": "stable",
+                "risk": "stable",
+                "track": "latest"
+            },
+            "common-ids": [],
+            "confinement": "strict",
+            "created-at": "2016-07-12T16:37:23.960632+00:00",
+            "download": {
+                "deltas": [],
+                "sha3-384": "eed62063c04a8c3819eb71ce7d929cc8d743b43be9e7d86b397b6d61b66b0c3a684f3148a9dbe5821360ae32105c1bd9",
+                "size": 20480,
+                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap"
+            },
+            "epoch": {
+                "read": [
+                    0
+                ],
+                "write": [
+                    0
+                ]
+            },
+            "revision": 27,
+            "snap-yaml": "name: hello-world\nversion: 6.3\narchitectures: [ all ]\nsummary: The 'hello-world' of snaps\ndescription: |\n    This is a simple snap example that includes a few interesting binaries\n    to demonstrate snaps and their confinement.\n    * hello-world.env  - dump the env of commands run inside app sandbox\n    * hello-world.evil - show how snappy sandboxes binaries\n    * hello-world.sh   - enter interactive shell that runs in app sandbox\n    * hello-world      - simply output text\napps:\n env:\n   command: bin/env\n evil:\n   command: bin/evil\n sh:\n   command: bin/sh\n hello-world:\n   command: bin/echo\n content-plug:\n   command: bin/content-plug\n   plugs: [shared-content-plug]\nplugs:\n  shared-content-plug:\n    interface: content\n    target: import\n    content: mylib\n    default-provider: test-snapd-content-slot\nslots:\n  shared-content-slot:\n    interface: content\n    content: mylib\n    read:\n      - /\n",
+            "type": "app",
+            "version": "6.3"
+        },
+        {
+            "architectures": [
+                "all"
+            ],
+            "base": null,
+            "channel": {
+                "architecture": "amd64",
+                "name": "candidate",
+                "risk": "candidate",
+                "track": "latest"
+            },
+            "common-ids": [],
+            "confinement": "strict",
+            "created-at": "2016-07-12T16:37:23.960632+00:00",
+            "download": {
+                "deltas": [],
+                "sha3-384": "eed62063c04a8c3819eb71ce7d929cc8d743b43be9e7d86b397b6d61b66b0c3a684f3148a9dbe5821360ae32105c1bd9",
+                "size": 20480,
+                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap"
+            },
+            "epoch": {
+                "read": [
+                    0
+                ],
+                "write": [
+                    0
+                ]
+            },
+            "revision": 27,
+            "snap-yaml": "",
+            "type": "app",
+            "version": "6.3"
+        },
+        {
+            "architectures": [
+                "all"
+            ],
+            "base": null,
+            "channel": {
+                "architecture": "amd64",
+                "name": "beta",
+                "risk": "beta",
+                "track": "latest"
+            },
+            "common-ids": [],
+            "confinement": "strict",
+            "created-at": "2016-07-12T16:37:23.960632+00:00",
+            "download": {
+                "deltas": [],
+                "sha3-384": "eed62063c04a8c3819eb71ce7d929cc8d743b43be9e7d86b397b6d61b66b0c3a684f3148a9dbe5821360ae32105c1bd9",
+                "size": 20480,
+                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_27.snap"
+            },
+            "epoch": {
+                "read": [
+                    0
+                ],
+                "write": [
+                    0
+                ]
+            },
+            "revision": 27,
+            "snap-yaml": "",
+            "type": "app",
+            "version": "6.3"
+        },
+        {
+            "architectures": [
+                "all"
+            ],
+            "base": null,
+            "channel": {
+                "architecture": "amd64",
+                "name": "edge",
+                "risk": "edge",
+                "track": "latest"
+            },
+            "common-ids": [],
+            "confinement": "strict",
+            "created-at": "2017-11-20T07:59:46.563940+00:00",
+            "download": {
+                "deltas": [],
+                "sha3-384": "d888ed75a9071ace39fed922aa799cad4081de79fda650fbbf75e1bae780dae2c24a19aab8db5059c6ad0d0533d90c04",
+                "size": 20480,
+                "url": "https://api.snapcraft.io/api/v1/snaps/download/buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ_28.snap"
+            },
+            "epoch": {
+                "read": [
+                    0
+                ],
+                "write": [
+                    0
+                ]
+            },
+            "revision": 28,
+            "snap-yaml": "",
+            "type": "app",
+            "version": "6.3"
+        }
+    ],
+    "name": "hello-world",
+    "snap": {
+        "contact": "mailto:snappy-devel@lists.ubuntu.com",
+        "description": "This is a simple hello world example.",
+        "license": "MIT",
+        "media": [
+            {
+                "height": null,
+                "type": "icon",
+                "url": "https://dashboard.snapcraft.io/site_media/appmedia/2015/03/hello.svg_NZLfWbh.png",
+                "width": null
+            },
+            {
+                "height": null,
+                "type": "screenshot",
+                "url": "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/Screenshot_from_2018-06-14_09-33-31.png",
+                "width": null
+            }
+        ],
+        "name": "hello-world",
+        "prices": {"EUR": "0.99", "USD": "1.23"},
+        "private": false,
+        "publisher": {
+            "display-name": "Canonical",
+            "id": "canonical",
+            "username": "canonical"
+        },
+        "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ",
+        "summary": "The 'hello-world' of snaps",
+        "title": "Hello World"
+    },
+    "snap-id": "buPKUD3TKqCOgLEjjHx5kSiCpIs5cMuQ"
+}`
+
+func (s *storeTestSuite) TestInfo(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 		c.Check(r.UserAgent(), Equals, userAgent)
 
 		// check device authorization is set, implicitly checking doRequest was used
-		c.Check(r.Header.Get("X-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
+		c.Check(r.Header.Get("Snap-Device-Authorization"), Equals, `Macaroon root="device-macaroon"`)
 
 		// no store ID by default
-		storeID := r.Header.Get("X-Ubuntu-Store")
+		storeID := r.Header.Get("Snap-Device-Store")
 		c.Check(storeID, Equals, "")
 
 		c.Check(r.URL.Path, Matches, ".*/hello-world")
 
-		c.Check(r.URL.Query().Get("channel"), Equals, "edge")
-		c.Check(r.URL.Query().Get("fields"), Equals, "abc,def,snap_yaml_raw")
-
-		c.Check(r.Header.Get("X-Ubuntu-Series"), Equals, release.Series)
-		c.Check(r.Header.Get("X-Ubuntu-Architecture"), Equals, arch.UbuntuArchitecture())
-		c.Check(r.Header.Get("X-Ubuntu-Classic"), Equals, "false")
-
-		c.Check(r.Header.Get("X-Ubuntu-Confinement"), Equals, "")
+		query := r.URL.Query()
+		c.Check(query.Get("fields"), Equals, "abc,def")
+		c.Check(query.Get("architecture"), Equals, arch.UbuntuArchitecture())
 
 		w.Header().Set("X-Suggested-Currency", "GBP")
 		w.WriteHeader(200)
-
-		io.WriteString(w, MockDetailsJSON)
+		io.WriteString(w, mockInfoJSON)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -2078,16 +2273,15 @@ func (s *storeTestSuite) TestDetails(c *C) {
 	mockServerURL, _ := url.Parse(mockServer.URL)
 	cfg := Config{
 		StoreBaseURL: mockServerURL,
-		DetailFields: []string{"abc", "def"},
+		InfoFields:   []string{"abc", "def"},
 	}
 	authContext := &testAuthContext{c: c, device: s.device}
 	sto := New(&cfg, authContext)
 
 	// the actual test
 	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2099,21 +2293,21 @@ func (s *storeTestSuite) TestDetails(c *C) {
 	c.Check(result.Version, Equals, "6.3")
 	c.Check(result.Sha3_384, Matches, `[[:xdigit:]]{96}`)
 	c.Check(result.Size, Equals, int64(20480))
-	c.Check(result.Channel, Equals, "edge")
+	c.Check(result.Channel, Equals, "stable")
 	c.Check(result.Description(), Equals, "This is a simple hello world example.")
 	c.Check(result.Summary(), Equals, "The 'hello-world' of snaps")
-	c.Check(result.Title(), Equals, "Hello World")
-	c.Check(result.License, Equals, "GPL-3.0")
-	c.Assert(result.Prices, DeepEquals, map[string]float64{"EUR": 0.99, "USD": 1.23})
-	c.Assert(result.Paid, Equals, true)
-	c.Assert(result.Screenshots, DeepEquals, []snap.ScreenshotInfo{
+	c.Check(result.Title(), Equals, "Hello World") // TODO: have this updated to be different to the name
+	c.Check(result.License, Equals, "MIT")
+	c.Check(result.Prices, DeepEquals, map[string]float64{"EUR": 0.99, "USD": 1.23})
+	c.Check(result.Paid, Equals, true)
+	c.Check(result.Screenshots, DeepEquals, []snap.ScreenshotInfo{
 		{
-			URL: "https://myapps.developer.ubuntu.com/site_media/appmedia/2015/03/screenshot.png",
+			URL: "https://dashboard.snapcraft.io/site_media/appmedia/2018/06/Screenshot_from_2018-06-14_09-33-31.png",
 		},
 	})
 	c.Check(result.MustBuy, Equals, true)
 	c.Check(result.Contact, Equals, "mailto:snappy-devel@lists.ubuntu.com")
-	c.Check(result.Base, Equals, "bare-base")
+	c.Check(result.Base, Equals, "bogus-base")
 
 	// Make sure the epoch (currently not sent by the store) defaults to "0"
 	c.Check(result.Epoch.String(), Equals, "0")
@@ -2126,32 +2320,31 @@ func (s *storeTestSuite) TestDetails(c *C) {
 	c.Check(snap.Validate(result), IsNil)
 
 	// validate the plugs/slots
-	c.Check(result.Plugs, HasLen, 1)
+	c.Assert(result.Plugs, HasLen, 1)
 	plug := result.Plugs["shared-content-plug"]
 	c.Check(plug.Name, Equals, "shared-content-plug")
 	c.Check(plug.Snap, DeepEquals, result)
 	c.Check(plug.Apps, HasLen, 1)
 	c.Check(plug.Apps["content-plug"].Command, Equals, "bin/content-plug")
 
-	c.Check(result.Slots, HasLen, 1)
+	c.Assert(result.Slots, HasLen, 1)
 	slot := result.Slots["shared-content-slot"]
 	c.Check(slot.Name, Equals, "shared-content-slot")
 	c.Check(slot.Snap, DeepEquals, result)
-	c.Check(slot.Apps, HasLen, 1)
+	c.Check(slot.Apps, HasLen, 5)
 	c.Check(slot.Apps["content-plug"].Command, Equals, "bin/content-plug")
 }
 
-func (s *storeTestSuite) TestDetailsDefaultChannelIsStable(c *C) {
+func (s *storeTestSuite) TestInfoDefaultChannelIsStable(c *C) {
 	restore := release.MockOnClassic(false)
 	defer restore()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 		c.Check(r.URL.Path, Matches, ".*/hello-world")
 
-		c.Check(r.URL.Query().Get("channel"), Equals, "stable")
 		w.WriteHeader(200)
 
-		io.WriteString(w, strings.Replace(MockDetailsJSON, "edge", "stable", -1))
+		io.WriteString(w, mockInfoJSON)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -2167,7 +2360,8 @@ func (s *storeTestSuite) TestDetailsDefaultChannelIsStable(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name: "hello-world",
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2176,10 +2370,10 @@ func (s *storeTestSuite) TestDetailsDefaultChannelIsStable(c *C) {
 	c.Check(result.Channel, Equals, "stable")
 }
 
-func (s *storeTestSuite) TestDetails500(c *C) {
+func (s *storeTestSuite) TestInfo500(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 		n++
 		w.WriteHeader(500)
 	}))
@@ -2197,25 +2391,24 @@ func (s *storeTestSuite) TestDetails500(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	_, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, `cannot get details for snap "hello-world" in channel "edge": got unexpected HTTP status code 500 via GET to "http://.*?/details/hello-world\?channel=edge"`)
+	c.Assert(err, ErrorMatches, `cannot get details for snap "hello-world": got unexpected HTTP status code 500 via GET to "http://.*?/info/hello-world.*"`)
 	c.Assert(n, Equals, 5)
 }
 
-func (s *storeTestSuite) TestDetails500once(c *C) {
+func (s *storeTestSuite) TestInfo500once(c *C) {
 	var n = 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 		n++
 		if n > 1 {
 			w.Header().Set("X-Suggested-Currency", "GBP")
 			w.WriteHeader(200)
-			io.WriteString(w, MockDetailsJSON)
+			io.WriteString(w, mockInfoJSON)
 		} else {
 			w.WriteHeader(500)
 		}
@@ -2233,9 +2426,8 @@ func (s *storeTestSuite) TestDetails500once(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2243,21 +2435,18 @@ func (s *storeTestSuite) TestDetails500once(c *C) {
 	c.Assert(n, Equals, 2)
 }
 
-func (s *storeTestSuite) TestDetailsAndChannels(c *C) {
-	// this test will break and should be melded into TestDetails,
-	// above, when the store provides the channels as part of details
-
+func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 	n := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 		switch n {
 		case 0:
 			c.Check(r.URL.Path, Matches, ".*/hello-world")
-			c.Check(r.URL.Query().Get("channel"), Equals, "")
+
 			w.Header().Set("X-Suggested-Currency", "GBP")
 			w.WriteHeader(200)
 
-			io.WriteString(w, MockDetailsJSON)
+			io.WriteString(w, mockInfoJSON)
 		default:
 			c.Fatalf("unexpected request to %q", r.URL.Path)
 		}
@@ -2283,63 +2472,61 @@ func (s *storeTestSuite) TestDetailsAndChannels(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 1)
 	c.Check(result.Name(), Equals, "hello-world")
-	c.Check(result.Channels, DeepEquals, map[string]*snap.ChannelSnapInfo{
+	expected := map[string]*snap.ChannelSnapInfo{
 		"latest/stable": {
-			Revision:    snap.R(1),
-			Version:     "v1",
+			Revision:    snap.R(27),
+			Version:     "6.3",
 			Confinement: snap.StrictConfinement,
 			Channel:     "stable",
-			Size:        12345,
+			Size:        20480,
 			Epoch:       *snap.E("0"),
 		},
 		"latest/candidate": {
-			Revision:    snap.R(2),
-			Version:     "v2",
+			Revision:    snap.R(27),
+			Version:     "6.3",
 			Confinement: snap.StrictConfinement,
 			Channel:     "candidate",
-			Size:        12345,
+			Size:        20480,
 			Epoch:       *snap.E("0"),
 		},
 		"latest/beta": {
-			Revision:    snap.R(8),
-			Version:     "v8",
-			Confinement: snap.DevModeConfinement,
+			Revision:    snap.R(27),
+			Version:     "6.3",
+			Confinement: snap.StrictConfinement,
 			Channel:     "beta",
-			Size:        12345,
+			Size:        20480,
 			Epoch:       *snap.E("0"),
 		},
 		"latest/edge": {
-			Revision:    snap.R(9),
-			Version:     "v9",
-			Confinement: snap.DevModeConfinement,
+			Revision:    snap.R(28),
+			Version:     "6.3",
+			Confinement: snap.StrictConfinement,
 			Channel:     "edge",
-			Size:        12345,
+			Size:        20480,
 			Epoch:       *snap.E("0"),
 		},
-	})
+	}
+	for k, v := range result.Channels {
+		c.Check(v, DeepEquals, expected[k], Commentf("%q", k))
+	}
 
 	c.Check(snap.Validate(result), IsNil)
 }
 
-func (s *storeTestSuite) TestNonDefaults(c *C) {
+func (s *storeTestSuite) TestInfoNonDefaults(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
-		storeID := r.Header.Get("X-Ubuntu-Store")
-		c.Check(storeID, Equals, "foo")
+		assertRequest(c, r, "GET", infoPathPattern)
+		c.Check(r.Header.Get("Snap-Device-Store"), Equals, "foo")
+		c.Check(r.URL.Path, Matches, ".*/hello-world$")
 
-		c.Check(r.URL.Path, Matches, ".*/details/hello-world")
-
-		c.Check(r.URL.Query().Get("channel"), Equals, "edge")
-
-		c.Check(r.Header.Get("X-Ubuntu-Series"), Equals, "21")
-		c.Check(r.Header.Get("X-Ubuntu-Architecture"), Equals, "archXYZ")
-		c.Check(r.Header.Get("X-Ubuntu-Classic"), Equals, "true")
+		c.Check(r.Header.Get("Snap-Device-Series"), Equals, "21")
+		c.Check(r.URL.Query().Get("architecture"), Equals, "archXYZ")
 
 		w.WriteHeader(200)
-		io.WriteString(w, MockDetailsJSON)
+		io.WriteString(w, mockInfoJSON)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -2355,9 +2542,8 @@ func (s *storeTestSuite) TestNonDefaults(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2366,12 +2552,12 @@ func (s *storeTestSuite) TestNonDefaults(c *C) {
 
 func (s *storeTestSuite) TestStoreIDFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
-		storeID := r.Header.Get("X-Ubuntu-Store")
+		assertRequest(c, r, "GET", infoPathPattern)
+		storeID := r.Header.Get("Snap-Device-Store")
 		c.Check(storeID, Equals, "my-brand-store-id")
 
 		w.WriteHeader(200)
-		io.WriteString(w, MockDetailsJSON)
+		io.WriteString(w, mockInfoJSON)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -2387,9 +2573,8 @@ func (s *storeTestSuite) TestStoreIDFromAuthContext(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2398,10 +2583,10 @@ func (s *storeTestSuite) TestStoreIDFromAuthContext(c *C) {
 
 func (s *storeTestSuite) TestProxyStoreFromAuthContext(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 
 		w.WriteHeader(200)
-		io.WriteString(w, MockDetailsJSON)
+		io.WriteString(w, mockInfoJSON)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -2421,9 +2606,8 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContext(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -2432,10 +2616,10 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContext(c *C) {
 
 func (s *storeTestSuite) TestProxyStoreFromAuthContextURLFallback(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 
 		w.WriteHeader(200)
-		io.WriteString(w, MockDetailsJSON)
+		io.WriteString(w, mockInfoJSON)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -2454,57 +2638,18 @@ func (s *storeTestSuite) TestProxyStoreFromAuthContextURLFallback(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
 	c.Check(result.Name(), Equals, "hello-world")
 }
 
-func (s *storeTestSuite) TestRevision(c *C) {
+func (s *storeTestSuite) TestInfoOopses(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case ordersPath:
-			w.WriteHeader(404)
-		case detailsPath("hello-world"):
-			c.Check(r.URL.Query(), DeepEquals, url.Values{
-				"channel":  []string{""},
-				"revision": []string{"26"},
-			})
-			w.WriteHeader(200)
-			io.WriteString(w, MockDetailsJSON)
-		default:
-			c.Fatalf("unexpected request to %q", r.URL.Path)
-		}
-	}))
-	c.Assert(mockServer, NotNil)
-	defer mockServer.Close()
-
-	mockServerURL, _ := url.Parse(mockServer.URL)
-	cfg := DefaultConfig()
-	cfg.StoreBaseURL = mockServerURL
-	cfg.DetailFields = []string{}
-	sto := New(cfg, nil)
-
-	// the actual test
-	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(26),
-	}
-	result, err := sto.SnapInfo(spec, s.user)
-	c.Assert(err, IsNil)
-	c.Check(result.Name(), Equals, "hello-world")
-	c.Check(result.Revision, DeepEquals, snap.R(27))
-}
-
-func (s *storeTestSuite) TestDetailsOopses(c *C) {
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 		c.Check(r.URL.Path, Matches, ".*/hello-world")
-		c.Check(r.URL.Query().Get("channel"), Equals, "edge")
 
 		w.Header().Set("X-Oops-Id", "OOPS-d4f46f75a5bcc10edcacc87e1fc0119f")
 		w.WriteHeader(500)
@@ -2523,39 +2668,35 @@ func (s *storeTestSuite) TestDetailsOopses(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	_, err := sto.SnapInfo(spec, nil)
-	c.Assert(err, ErrorMatches, `cannot get details for snap "hello-world" in channel "edge": got unexpected HTTP status code 5.. via GET to "http://\S+" \[OOPS-[[:xdigit:]]*\]`)
+	c.Assert(err, ErrorMatches, `cannot get details for snap "hello-world": got unexpected HTTP status code 5.. via GET to "http://\S+" \[OOPS-[[:xdigit:]]*\]`)
 }
 
 /*
 acquired via
 
-http --pretty=format --print b https://api.snapcraft.io/api/v1/snaps/details/no:such:package X-Ubuntu-Series:16 fields==anon_download_url,architecture,channel,download_sha512,summary,description,binary_filesize,download_url,icon_url,last_updated,license,package_name,prices,publisher,ratings_average,revision,snap_id,support_url,title,content,version,origin,developer_id,private,confinement channel==edge | xsel -b
+http --pretty=format --print b https://api.snapcraft.io/v2/snaps/info/no:such:package architecture==amd64 fields==architectures,base,confinement,contact,created-at,description,download,epoch,license,name,prices,private,publisher,revision,snap-id,snap-yaml,summary,title,type,version,media,common-ids Snap-Device-Series:16 | xsel -b
 
-on 2016-07-03
-
-On Ubuntu, apt install httpie xsel (although you could get http from
-the http snap instead).
+on 2018-06-14
 
 */
 const MockNoDetailsJSON = `{
-    "errors": [
-        "No such package"
-    ],
-    "result": "error"
+    "error-list": [
+        {
+            "code": "resource-not-found",
+            "message": "No snap named 'no:such:package' found in series '16'."
+        }
+    ]
 }`
 
-func (s *storeTestSuite) TestNoDetails(c *C) {
+func (s *storeTestSuite) TestNoInfo(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 		c.Check(r.URL.Path, Matches, ".*/no-such-pkg")
 
-		q := r.URL.Query()
-		c.Check(q.Get("channel"), Equals, "edge")
 		w.WriteHeader(404)
 		io.WriteString(w, MockNoDetailsJSON)
 	}))
@@ -2571,9 +2712,8 @@ func (s *storeTestSuite) TestNoDetails(c *C) {
 
 	// the actual test
 	spec := SnapSpec{
-		Name:     "no-such-pkg",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "no-such-pkg",
+		AnyChannel: true,
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, NotNil)
@@ -3322,7 +3462,7 @@ func (s *storeTestSuite) TestNew(c *C) {
 	aStore := New(nil, nil)
 	c.Assert(aStore, NotNil)
 	// check for fields
-	c.Check(aStore.detailFields, DeepEquals, detailFields)
+	c.Check(aStore.detailFields, DeepEquals, defaultConfig.DetailFields)
 }
 
 var testAssertion = `type: snap-declaration
@@ -3464,11 +3604,11 @@ func (s *storeTestSuite) TestSuggestedCurrency(c *C) {
 	suggestedCurrency := "GBP"
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertRequest(c, r, "GET", detailsPathPattern)
+		assertRequest(c, r, "GET", infoPathPattern)
 		w.Header().Set("X-Suggested-Currency", suggestedCurrency)
 		w.WriteHeader(200)
 
-		io.WriteString(w, MockDetailsJSON)
+		io.WriteString(w, mockInfoJSON)
 	}))
 
 	c.Assert(mockServer, NotNil)
@@ -3485,9 +3625,8 @@ func (s *storeTestSuite) TestSuggestedCurrency(c *C) {
 
 	// we should soon have a suggested currency
 	spec := SnapSpec{
-		Name:     "hello-world",
-		Channel:  "edge",
-		Revision: snap.R(0),
+		Name:       "hello-world",
+		AnyChannel: true,
 	}
 	result, err := sto.SnapInfo(spec, nil)
 	c.Assert(err, IsNil)
@@ -3903,12 +4042,12 @@ func (s *storeTestSuite) TestBuy(c *C) {
 		purchaseServerPostCalled := false
 		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
-			case detailsPath("hello-world"):
+			case infoPath("hello-world"):
 				c.Assert(r.Method, Equals, "GET")
-				w.Header().Set("Content-Type", "application/hal+json")
+				w.Header().Set("Content-Type", "application/json")
 				w.Header().Set("X-Suggested-Currency", test.suggestedCurrency)
 				w.WriteHeader(200)
-				io.WriteString(w, MockDetailsJSON)
+				io.WriteString(w, mockInfoJSON)
 				searchServerCalled = true
 			case ordersPath:
 				c.Assert(r.Method, Equals, "GET")
@@ -3961,9 +4100,8 @@ func (s *storeTestSuite) TestBuy(c *C) {
 
 		// Find the snap first
 		spec := SnapSpec{
-			Name:     "hello-world",
-			Channel:  "edge",
-			Revision: snap.R(0),
+			Name:       "hello-world",
+			AnyChannel: true,
 		}
 		snap, err := sto.SnapInfo(spec, s.user)
 		c.Assert(snap, NotNil)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1915,6 +1915,7 @@ http --pretty=format --print b https://api.snapcraft.io/api/v1/snaps/details/hel
 on 2016-07-03. Then, by hand:
  * set prices to {"EUR": 0.99, "USD": 1.23}.
  * Screenshot URLS set manually.
+ * Set "private" to true.
 
 on 2017-11-20. Then, by hand:
  * add "snap_yaml_raw" from "test-snapd-content-plug"
@@ -2051,7 +2052,7 @@ const mockSingleOrderJSON = `{
 
 http --pretty=format --print b https://api.snapcraft.io/v2/snaps/info/hello-world architecture==amd64 fields==architectures,base,confinement,contact,created-at,description,download,epoch,license,name,prices,private,publisher,revision,snap-id,snap-yaml,summary,title,type,version,media,common-ids Snap-Device-Series:16 | xsel -b
 
-on 2018-06-13. Then, by hand:
+on 2018-06-13 (note snap-yaml is currently excluded from that list). Then, by hand:
 - set prices to {"EUR": "0.99", "USD": "1.23"},
 - set base in first channel-map entry to "bogus-base",
 - set snap-yaml in first channel-map entry to the one from the 'edge', plus the following pastiche:
@@ -2229,7 +2230,7 @@ const mockInfoJSON = `{
         ],
         "name": "hello-world",
         "prices": {"EUR": "0.99", "USD": "1.23"},
-        "private": false,
+        "private": true,
         "publisher": {
             "display-name": "Canonical",
             "id": "canonical",
@@ -2307,18 +2308,13 @@ func (s *storeTestSuite) TestInfo(c *C) {
 	c.Check(result.MustBuy, Equals, true)
 	c.Check(result.Contact, Equals, "mailto:snappy-devel@lists.ubuntu.com")
 	c.Check(result.Base, Equals, "bogus-base")
-
-	// Make sure the epoch (currently not sent by the store) defaults to "0"
 	c.Check(result.Epoch.String(), Equals, "0")
-
 	c.Check(sto.SuggestedCurrency(), Equals, "GBP")
-
-	// skip this one until the store supports it
-	// c.Check(result.Private, Equals, true)
+	c.Check(result.Private, Equals, true)
 
 	c.Check(snap.Validate(result), IsNil)
 
-	// validate the plugs/slots
+	// validate the plugs/slots (only here because we faked stuff in the JSON)
 	c.Assert(result.Plugs, HasLen, 1)
 	plug := result.Plugs["shared-content-plug"]
 	c.Check(plug.Name, Equals, "shared-content-plug")

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2552,6 +2552,7 @@ func (s *storeTestSuite) TestInfoAndChannels(c *C) {
 	for k, v := range result.Channels {
 		c.Check(v, DeepEquals, expected[k], Commentf("%q", k))
 	}
+	c.Check(result.Channels, HasLen, len(expected))
 
 	c.Check(snap.Validate(result), IsNil)
 }
@@ -2598,6 +2599,7 @@ func (s *storeTestSuite) TestInfoMoreChannels(c *C) {
 	for k, v := range result.Channels {
 		c.Check(v, DeepEquals, expected[k], Commentf("%q", k))
 	}
+	c.Check(result.Channels, HasLen, len(expected))
 	c.Check(result.Tracks, DeepEquals, []string{"latest", "1.10", "1.6", "1.7", "1.8", "1.9"})
 }
 


### PR DESCRIPTION
The new endpoint is rather different, but this preserves external
behaviour (for now).
