### PR TITLE
snapstate: support restarting snapd from the snapd snap on core18

### DIFF
--- a/boot/kernel_os.go
+++ b/boot/kernel_os.go
@@ -155,8 +155,9 @@ func SetNextBoot(s *snap.Info) error {
 	})
 }
 
-// KernelOsBaseRebootRequired returns whether a reboot is required to swith to the given OS or kernel snap.
-func KernelOsBaseRebootRequired(s *snap.Info) bool {
+// ChangeRequiresReboot returns whether a reboot is required to switch
+// to the given OS, base or kernel snap.
+func ChangeRequiresReboot(s *snap.Info) bool {
 	if s.Type != snap.TypeKernel && s.Type != snap.TypeOS && s.Type != snap.TypeBase {
 		return false
 	}

--- a/boot/kernel_os_test.go
+++ b/boot/kernel_os_test.go
@@ -178,7 +178,7 @@ func (s *kernelOSSuite) TestSetNextBootForCore(c *C) {
 		"snap_mode":     "try",
 	})
 
-	c.Check(boot.KernelOsBaseRebootRequired(info), Equals, true)
+	c.Check(boot.ChangeRequiresReboot(info), Equals, true)
 }
 
 func (s *kernelOSSuite) TestSetNextBootWithBaseForCore(c *C) {
@@ -198,7 +198,7 @@ func (s *kernelOSSuite) TestSetNextBootWithBaseForCore(c *C) {
 		"snap_mode":     "try",
 	})
 
-	c.Check(boot.KernelOsBaseRebootRequired(info), Equals, true)
+	c.Check(boot.ChangeRequiresReboot(info), Equals, true)
 }
 
 func (s *kernelOSSuite) TestSetNextBootForKernel(c *C) {
@@ -220,11 +220,11 @@ func (s *kernelOSSuite) TestSetNextBootForKernel(c *C) {
 
 	s.bootloader.BootVars["snap_kernel"] = "krnl_40.snap"
 	s.bootloader.BootVars["snap_try_kernel"] = "krnl_42.snap"
-	c.Check(boot.KernelOsBaseRebootRequired(info), Equals, true)
+	c.Check(boot.ChangeRequiresReboot(info), Equals, true)
 
 	// simulate good boot
 	s.bootloader.BootVars["snap_kernel"] = "krnl_42.snap"
-	c.Check(boot.KernelOsBaseRebootRequired(info), Equals, false)
+	c.Check(boot.ChangeRequiresReboot(info), Equals, false)
 }
 
 func (s *kernelOSSuite) TestSetNextBootForKernelForTheSameKernel(c *C) {

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -1163,6 +1163,15 @@ snaps:
 	err = s.overlord.Settle(settleTimeout)
 	st.Lock()
 	c.Assert(err, IsNil)
+
+	// at this point snapd is "restarting", pretend the restart has
+	// happened
+	c.Assert(chg.Status(), Equals, state.DoingStatus)
+	state.MockRestarting(st, state.RestartUnset)
+	st.Unlock()
+	err = s.overlord.Settle(settleTimeout)
+	st.Lock()
+	c.Assert(err, IsNil)
 	c.Assert(chg.Status(), Equals, state.DoneStatus)
 
 	// verify

--- a/overlord/snapstate/booted_test.go
+++ b/overlord/snapstate/booted_test.go
@@ -28,7 +28,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot/boottest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/overlord"
@@ -84,9 +83,7 @@ func (bs *bootedSuite) SetUpTest(c *C) {
 	snapstate.AutoAliases = func(*state.State, *snap.Info) (map[string]string, error) {
 		return nil, nil
 	}
-	snapstate.Model = func(*state.State) (*asserts.Model, error) {
-		return nil, nil
-	}
+	snapstate.MockModel()
 }
 
 func (bs *bootedSuite) TearDownTest(c *C) {

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -196,15 +196,15 @@ func ByKindOrder(snaps ...*snap.Info) []*snap.Info {
 	return snaps
 }
 
-func MockModelWithBase(baseName string) func() {
+func MockModelWithBase(baseName string) (restore func()) {
 	return mockModel(baseName)
 }
 
-func MockModel() func() {
+func MockModel() (restore func()) {
 	return mockModel("")
 }
 
-func mockModel(baseName string) func() {
+func mockModel(baseName string) (restore func()) {
 	oldModel := Model
 
 	base := ""

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -21,11 +21,13 @@ package snapstate
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"time"
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
 )
@@ -192,4 +194,45 @@ func MockIsOnMeteredConnection(mock func() (bool, error)) func() {
 func ByKindOrder(snaps ...*snap.Info) []*snap.Info {
 	sort.Sort(byKind(snaps))
 	return snaps
+}
+
+func MockModelWithBase(baseName string) func() {
+	return mockModel(baseName)
+}
+
+func MockModel() func() {
+	return mockModel("")
+}
+
+func mockModel(baseName string) func() {
+	oldModel := Model
+
+	base := ""
+	if baseName != "" {
+		base = fmt.Sprintf("\nbase: %s", baseName)
+	}
+	mod := fmt.Sprintf(`type: model
+authority-id: brand
+series: 16
+brand-id: brand
+model: baz-3000
+architecture: armhf
+gadget: brand-gadget
+kernel: kernel%s
+timestamp: 2018-01-01T08:00:00+00:00
+sign-key-sha3-384: Jv8_JiHiIzJVcO9M55pPdqSDWUvuhfDIBJUS-3VW7F_idjix7Ffn5qMxB21ZQuij
+
+AXNpZw==
+`, base)
+	a, err := asserts.Decode([]byte(mod))
+	if err != nil {
+		panic(err)
+	}
+
+	Model = func(*state.State) (*asserts.Model, error) {
+		return a.(*asserts.Model), nil
+	}
+	return func() {
+		Model = oldModel
+	}
 }

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -821,17 +821,38 @@ func (m *SnapManager) doLinkSnap(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-// maybeRestart will schedule a reboot or restart as needed for the just linked
-// snap with info if it's a core or kernel snap.
+// maybeRestart will schedule a reboot or restart as needed for the
+// just linked snap with info if it's a core or snapd or kernel snap.
 func maybeRestart(t *state.Task, info *snap.Info) {
 	st := t.State()
+
+	// TODO: once classic uses the snapd snap we need to restart
+	//       here too
 	if release.OnClassic && info.Type == snap.TypeOS {
 		t.Logf("Requested daemon restart.")
 		st.RequestRestart(state.RestartDaemon)
 	}
-	if !release.OnClassic && boot.KernelOsBaseRebootRequired(info) {
-		t.Logf("Requested system restart.")
-		st.RequestRestart(state.RestartSystem)
+
+	if !release.OnClassic {
+		// On a core system we may need a full reboot if
+		// core/base or the kernel changes.
+		if boot.KernelOsBaseRebootRequired(info) {
+			t.Logf("Requested system restart.")
+			st.RequestRestart(state.RestartSystem)
+			return
+		}
+		// On core systems that use a base snap we need to restart
+		// snapd when the snapd snap changes.
+		model, err := Model(st)
+		if err != nil {
+			logger.Noticef("cannot get model assertion: %v", model)
+			return
+		}
+		if model.Base() != "" && info.Name() == "snapd" {
+			t.Logf("Requested daemon restart (snapd snap).")
+			st.RequestRestart(state.RestartDaemon)
+			return
+		}
 	}
 }
 

--- a/overlord/snapstate/handlers_link_test.go
+++ b/overlord/snapstate/handlers_link_test.go
@@ -82,6 +82,8 @@ func (s *linkSnapSuite) SetUpTest(c *C) {
 		resetReadInfo()
 		dirs.SetRootDir("/")
 	}
+
+	snapstate.MockModel()
 }
 
 func (s *linkSnapSuite) TearDownTest(c *C) {
@@ -357,6 +359,118 @@ func (s *linkSnapSuite) TestDoLinkSnapSuccessCoreRestarts(c *C) {
 	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon})
 	c.Check(t.Log(), HasLen, 1)
 	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart\.`)
+}
+
+func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdRestartsOnCoreWithBase(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	restore = snapstate.MockModelWithBase("core18")
+	defer restore()
+
+	s.state.Lock()
+	si := &snap.SideInfo{
+		RealName: "snapd",
+		Revision: snap.R(22),
+	}
+	t := s.state.NewTask("link-snap", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: si,
+	})
+	s.state.NewChange("dummy", "...").AddTask(t)
+
+	s.state.Unlock()
+
+	s.snapmgr.Ensure()
+	s.snapmgr.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "snapd", &snapst)
+	c.Assert(err, IsNil)
+
+	typ, err := snapst.Type()
+	c.Check(err, IsNil)
+	c.Check(typ, Equals, snap.TypeApp)
+
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	c.Check(s.stateBackend.restartRequested, DeepEquals, []state.RestartType{state.RestartDaemon})
+	c.Check(t.Log(), HasLen, 1)
+	c.Check(t.Log()[0], Matches, `.*INFO Requested daemon restart \(snapd snap\)\.`)
+}
+
+func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdNoRestartWithoutBase(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.state.Lock()
+	si := &snap.SideInfo{
+		RealName: "snapd",
+		Revision: snap.R(22),
+	}
+	t := s.state.NewTask("link-snap", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: si,
+	})
+	s.state.NewChange("dummy", "...").AddTask(t)
+
+	s.state.Unlock()
+
+	s.snapmgr.Ensure()
+	s.snapmgr.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "snapd", &snapst)
+	c.Assert(err, IsNil)
+
+	typ, err := snapst.Type()
+	c.Check(err, IsNil)
+	c.Check(typ, Equals, snap.TypeApp)
+
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	c.Check(s.stateBackend.restartRequested, IsNil)
+	c.Check(t.Log(), HasLen, 0)
+}
+
+func (s *linkSnapSuite) TestDoLinkSnapSuccessSnapdNoRestartOnClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	s.state.Lock()
+	si := &snap.SideInfo{
+		RealName: "snapd",
+		Revision: snap.R(22),
+	}
+	t := s.state.NewTask("link-snap", "test")
+	t.Set("snap-setup", &snapstate.SnapSetup{
+		SideInfo: si,
+	})
+	s.state.NewChange("dummy", "...").AddTask(t)
+
+	s.state.Unlock()
+
+	s.snapmgr.Ensure()
+	s.snapmgr.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var snapst snapstate.SnapState
+	err := snapstate.Get(s.state, "snapd", &snapst)
+	c.Assert(err, IsNil)
+
+	typ, err := snapst.Type()
+	c.Check(err, IsNil)
+	c.Check(typ, Equals, snap.TypeApp)
+
+	c.Check(t.Status(), Equals, state.DoneStatus)
+	c.Check(s.stateBackend.restartRequested, IsNil)
+	c.Check(t.Log(), HasLen, 0)
 }
 
 func (s *linkSnapSuite) TestDoUndoLinkSnapSequenceDidNotHaveCandidate(c *C) {


### PR DESCRIPTION
On core systems we need to restart snapd when the snapd snap is
changed *if* we use a base snap. This PR enables this.
