### PR TITLE
tests: econnreset - relax check for download start, match either download or assertion retry attempt

### DIFF
--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -15,12 +15,12 @@ execute: |
     su -c "/usr/bin/env SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &
 
     echo "Wait until the download started"
-    for _ in $(seq 40); do
+    for _ in $(seq 80); do
         partial=$(find . -name 'test-snapd-huge_*.snap.partial' | head -1)
         if [ -n "$partial" ] && [ "$(stat -c%s "$partial")" -gt "$(( 1 ))" ]; then
             break
         fi
-        sleep .5
+        sleep .1
     done
 
     if [ ! -f "$partial" ] || [ "$(stat -c%s "$partial")" -eq 0 ]; then
@@ -34,13 +34,12 @@ execute: |
 
     echo "Check that we retried"
     for _ in $(seq 20); do
-        # Match either download or assertion fetching retry
-        if MATCH 'Retrying.*, attempt 2' < snap-download.log; then
+        if MATCH 'Retrying.*\.snap, attempt 2' < snap-download.log; then
             break
         fi
         sleep .5
     done
-    MATCH 'Retrying.*, attempt 2' < snap-download.log
+    MATCH 'Retrying.*\.snap, attempt 2' < snap-download.log
 
     # Note that the download will not be successful because of the nature of
     # the netfilter testbed. When snap download retries the next attempt will

--- a/tests/main/econnreset/task.yaml
+++ b/tests/main/econnreset/task.yaml
@@ -14,13 +14,13 @@ execute: |
     rm -f test-snapd-huge_*
     su -c "/usr/bin/env SNAPD_DEBUG=1 snap download --edge test-snapd-huge 2>snap-download.log" test &
 
-    echo "Wait until the download started and downloaded more than 1 MB"
+    echo "Wait until the download started"
     for _ in $(seq 40); do
         partial=$(find . -name 'test-snapd-huge_*.snap.partial' | head -1)
-        if [ -n "$partial" ] && [ "$(stat -c%s "$partial")" -gt "$(( 1024 * 1024 ))" ]; then
+        if [ -n "$partial" ] && [ "$(stat -c%s "$partial")" -gt "$(( 1 ))" ]; then
             break
         fi
-        sleep 1
+        sleep .5
     done
 
     if [ ! -f "$partial" ] || [ "$(stat -c%s "$partial")" -eq 0 ]; then
@@ -34,12 +34,13 @@ execute: |
 
     echo "Check that we retried"
     for _ in $(seq 20); do
-        if MATCH 'Retrying.*\.snap, attempt 2' < snap-download.log; then
+        # Match either download or assertion fetching retry
+        if MATCH 'Retrying.*, attempt 2' < snap-download.log; then
             break
         fi
         sleep .5
     done
-    MATCH 'Retrying.*\.snap, attempt 2' < snap-download.log
+    MATCH 'Retrying.*, attempt 2' < snap-download.log
 
     # Note that the download will not be successful because of the nature of
     # the netfilter testbed. When snap download retries the next attempt will


### PR DESCRIPTION
Relax the check by matching either download retry or assertion fetching retry attempt and also wait for a shorter time for start of the download. I think we might be hitting a small window where the download is very fast and completes before iptables rule kicks in, in which case we only see retries on assertion fetch - that could explain why this test passes sometimes and matches retry attempt#2 of the download step.

Yes, this doesn't completely eliminate the racy nature of this test.
